### PR TITLE
fix(frontend): display actual dynamic fee for 3pool swaps

### DIFF
--- a/src/declarations/rumi_3pool/rumi_3pool.did
+++ b/src/declarations/rumi_3pool/rumi_3pool.did
@@ -59,6 +59,129 @@ type SwapEvent = record {
   fee : nat;
 };
 
+type LiquidityAction = variant {
+  AddLiquidity;
+  RemoveLiquidity;
+  RemoveOneCoin;
+  Donate;
+};
+
+type LiquidityEvent = record {
+  id : nat64;
+  timestamp : nat64;
+  caller : principal;
+  action : LiquidityAction;
+  amounts : vec nat;
+  lp_amount : nat;
+  coin_index : opt nat8;
+  fee : opt nat;
+};
+
+type FeeCurveParams = record {
+  min_fee_bps : nat16;
+  max_fee_bps : nat16;
+  imb_saturation : nat64;
+};
+
+type SwapEventV2 = record {
+  id : nat64;
+  timestamp : nat64;
+  caller : principal;
+  token_in : nat8;
+  token_out : nat8;
+  amount_in : nat;
+  amount_out : nat;
+  fee : nat;
+  fee_bps : nat16;
+  imbalance_before : nat64;
+  imbalance_after : nat64;
+  is_rebalancing : bool;
+  pool_balances_after : vec nat;
+  virtual_price_after : nat;
+  migrated : bool;
+};
+
+type LiquidityEventV2 = record {
+  id : nat64;
+  timestamp : nat64;
+  caller : principal;
+  action : LiquidityAction;
+  amounts : vec nat;
+  lp_amount : nat;
+  coin_index : opt nat8;
+  fee : opt nat;
+  fee_bps : opt nat16;
+  imbalance_before : nat64;
+  imbalance_after : nat64;
+  is_rebalancing : bool;
+  pool_balances_after : vec nat;
+  virtual_price_after : nat;
+  migrated : bool;
+};
+
+type QuoteSwapResult = record {
+  token_in : nat8;
+  token_out : nat8;
+  amount_in : nat;
+  amount_out : nat;
+  fee_native : nat;
+  fee_bps : nat16;
+  imbalance_before : nat64;
+  imbalance_after : nat64;
+  is_rebalancing : bool;
+  virtual_price_before : nat;
+  virtual_price_after : nat;
+};
+
+type PoolStateView = record {
+  balances : vec nat;
+  normalized_balances : vec nat;
+  imbalance : nat64;
+  virtual_price : nat;
+  lp_total_supply : nat;
+  fee_curve : FeeCurveParams;
+  amp : nat64;
+};
+
+type OptimalRebalanceQuote = record {
+  token_in : nat8;
+  token_out : nat8;
+  dx : nat;
+  amount_out : nat;
+  fee_bps : nat16;
+  imbalance_before : nat64;
+  imbalance_after : nat64;
+  profit_bps_estimate : nat64;
+};
+
+type ImbalanceEventKind = variant { Swap; Liquidity };
+
+type ImbalanceSnapshot = record {
+  timestamp : nat64;
+  imbalance_after : nat64;
+  virtual_price_after : nat;
+  event_kind : ImbalanceEventKind;
+};
+
+type ThreePoolAdminAction = variant {
+  RampA : record { future_a : nat64; future_a_time : nat64 };
+  StopRampA : record { frozen_a : nat64 };
+  WithdrawAdminFees : record { amounts : vec nat };
+  SetPaused : record { paused : bool };
+  SetSwapFee : record { fee_bps : nat64 };
+  SetAdminFee : record { fee_bps : nat64 };
+  AddAuthorizedBurnCaller : record { canister : principal };
+  RemoveAuthorizedBurnCaller : record { canister : principal };
+  FeeCurveParamsUpdated : record { old : opt FeeCurveParams; new : FeeCurveParams };
+};
+
+type ThreePoolAdminEvent = record {
+  id : nat64;
+  timestamp : nat64;
+  caller : principal;
+  action : ThreePoolAdminAction;
+};
+
 type AuthorizedRedeemAndBurnArgs = record {
   token_ledger : principal;
   token_amount : nat;
@@ -271,6 +394,77 @@ type TransferFromError = variant {
   GenericError : record { error_code : nat; message : text };
 };
 
+// ─── Explorer types ───
+
+type StatsWindow = variant {
+  Last24h;
+  Last7d;
+  Last30d;
+  AllTime;
+};
+
+type PoolStats = record {
+  swap_count : nat64;
+  swap_volume_per_token : vec nat;
+  total_fees_collected : vec nat;
+  unique_swappers : nat64;
+  liquidity_added_count : nat64;
+  liquidity_removed_count : nat64;
+  avg_fee_bps : nat32;
+  arb_swap_count : nat64;
+  arb_volume_per_token : vec nat;
+};
+
+type ImbalanceStats = record {
+  current : nat64;
+  min : nat64;
+  max : nat64;
+  avg : nat64;
+  samples : vec record { nat64; nat64 };
+};
+
+type FeeBucket = record {
+  min_bps : nat16;
+  max_bps : nat16;
+  swap_count : nat64;
+  volume_per_token : vec nat;
+};
+
+type FeeStats = record {
+  buckets : vec FeeBucket;
+  rebalancing_swap_count : nat64;
+  rebalancing_swap_pct : nat32;
+};
+
+type VolumePoint = record {
+  timestamp : nat64;
+  volume_per_token : vec nat;
+};
+
+type BalancePoint = record {
+  timestamp : nat64;
+  balances : vec nat;
+};
+
+type VirtualPricePoint = record {
+  timestamp : nat64;
+  virtual_price : nat;
+};
+
+type FeePoint = record {
+  timestamp : nat64;
+  avg_fee_bps : nat32;
+};
+
+type PoolHealth = record {
+  current_imbalance : nat64;
+  imbalance_trend_1h : int32;
+  last_swap_age_seconds : nat64;
+  fee_at_min : nat16;
+  fee_at_max_imbalance_swap : nat16;
+  arb_opportunity_score : nat8;
+};
+
 service : (ThreePoolInitArgs) -> {
   health : () -> (text) query;
   swap : (nat8, nat8, nat, nat) -> (variant { Ok : nat; Err : ThreePoolError });
@@ -280,6 +474,7 @@ service : (ThreePoolInitArgs) -> {
   donate : (nat8, nat) -> (variant { Ok; Err : ThreePoolError });
   get_pool_status : () -> (PoolStatus) query;
   get_lp_balance : (principal) -> (nat) query;
+  get_all_lp_holders : () -> (vec record { principal; nat }) query;
   calc_swap : (nat8, nat8, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_add_liquidity_query : (vec nat, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_remove_liquidity_query : (nat) -> (variant { Ok : vec nat; Err : ThreePoolError }) query;
@@ -292,11 +487,38 @@ service : (ThreePoolInitArgs) -> {
   set_paused : (bool) -> (variant { Ok; Err : ThreePoolError });
   set_swap_fee : (nat64) -> (variant { Ok; Err : ThreePoolError });
   set_admin_fee : (nat64) -> (variant { Ok; Err : ThreePoolError });
+  set_fee_curve_params : (FeeCurveParams) -> (variant { Ok; Err : ThreePoolError });
   add_authorized_burn_caller : (principal) -> (variant { Ok; Err : ThreePoolError });
   remove_authorized_burn_caller : (principal) -> (variant { Ok; Err : ThreePoolError });
   get_authorized_burn_callers : () -> (vec principal) query;
   get_swap_events : (nat64, nat64) -> (vec SwapEvent) query;
   get_swap_event_count : () -> (nat64) query;
+  get_liquidity_events : (nat64, nat64) -> (vec LiquidityEvent) query;
+  get_liquidity_event_count : () -> (nat64) query;
+  get_admin_events : (nat64, nat64) -> (vec ThreePoolAdminEvent) query;
+  get_admin_event_count : () -> (nat64) query;
+  quote_swap : (nat8, nat8, nat) -> (variant { Ok : QuoteSwapResult; Err : ThreePoolError }) query;
+  get_pool_state : () -> (PoolStateView) query;
+  get_fee_curve_params : () -> (FeeCurveParams) query;
+  quote_optimal_rebalance : (nat8, nat8) -> (variant { Ok : OptimalRebalanceQuote; Err : ThreePoolError }) query;
+  simulate_swap_path : (vec record { nat8; nat8; nat }) -> (variant { Ok : vec QuoteSwapResult; Err : ThreePoolError }) query;
+  get_imbalance_history : (nat64, nat64) -> (vec ImbalanceSnapshot) query;
+  get_swap_events_v2 : (nat64, nat64) -> (vec SwapEventV2) query;
+
+  // Explorer endpoints (E1-E14)
+  get_liquidity_events_by_principal : (principal, nat64, nat64) -> (vec LiquidityEventV2) query;
+  get_swap_events_by_principal : (principal, nat64, nat64) -> (vec SwapEventV2) query;
+  get_swap_events_by_time_range : (nat64, nat64, nat64) -> (vec SwapEventV2) query;
+  get_pool_stats : (StatsWindow) -> (PoolStats) query;
+  get_imbalance_stats : (StatsWindow) -> (ImbalanceStats) query;
+  get_fee_stats : (StatsWindow) -> (FeeStats) query;
+  get_top_swappers : (StatsWindow, nat64) -> (vec record { principal; nat64; nat }) query;
+  get_top_lps : (nat64) -> (vec record { principal; nat; nat32 }) query;
+  get_volume_series : (StatsWindow, nat64) -> (vec VolumePoint) query;
+  get_balance_series : (StatsWindow, nat64) -> (vec BalancePoint) query;
+  get_virtual_price_series : (StatsWindow, nat64) -> (vec VirtualPricePoint) query;
+  get_fee_series : (StatsWindow, nat64) -> (vec FeePoint) query;
+  get_pool_health : () -> (PoolHealth) query;
   authorized_redeem_and_burn : (AuthorizedRedeemAndBurnArgs) -> (variant { Ok : RedeemAndBurnResult; Err : ThreePoolError });
   icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (variant { Ok : ConsentInfo; Err : Icrc21Error });
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;

--- a/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
@@ -54,6 +54,10 @@ export interface AuthorizedRedeemAndBurnArgs {
   'max_slippage_bps' : number,
   'token_ledger' : Principal,
 }
+export interface BalancePoint {
+  'timestamp' : bigint,
+  'balances' : Array<bigint>,
+}
 export interface BlockWithId { 'id' : bigint, 'block' : Icrc3Value }
 export interface ConsentInfo {
   'metadata' : ConsentMessageMetadata,
@@ -87,6 +91,23 @@ export type DeviceSpec = { 'GenericDisplay' : null } |
     }
   };
 export interface ErrorInfo { 'description' : string }
+export interface FeeBucket {
+  'volume_per_token' : Array<bigint>,
+  'min_bps' : number,
+  'swap_count' : bigint,
+  'max_bps' : number,
+}
+export interface FeeCurveParams {
+  'max_fee_bps' : number,
+  'imb_saturation' : bigint,
+  'min_fee_bps' : number,
+}
+export interface FeePoint { 'timestamp' : bigint, 'avg_fee_bps' : number }
+export interface FeeStats {
+  'rebalancing_swap_count' : bigint,
+  'rebalancing_swap_pct' : number,
+  'buckets' : Array<FeeBucket>,
+}
 export interface GetArchivesArgs { 'from' : [] | [Principal] }
 export interface GetArchivesResult { 'archives' : Array<ArchiveInfo> }
 export interface GetBlocksArgs { 'start' : bigint, 'length' : bigint }
@@ -116,11 +137,95 @@ export type Icrc3Value = { 'Int' : bigint } |
   { 'Blob' : Uint8Array | number[] } |
   { 'Text' : string } |
   { 'Array' : Array<Icrc3Value> };
+export type ImbalanceEventKind = { 'Swap' : null } |
+  { 'Liquidity' : null };
+export interface ImbalanceSnapshot {
+  'imbalance_after' : bigint,
+  'virtual_price_after' : bigint,
+  'timestamp' : bigint,
+  'event_kind' : ImbalanceEventKind,
+}
+export interface ImbalanceStats {
+  'avg' : bigint,
+  'max' : bigint,
+  'min' : bigint,
+  'samples' : Array<[bigint, bigint]>,
+  'current' : bigint,
+}
 export interface LineDisplayPage { 'lines' : Array<string> }
+export type LiquidityAction = { 'AddLiquidity' : null } |
+  { 'Donate' : null } |
+  { 'RemoveOneCoin' : null } |
+  { 'RemoveLiquidity' : null };
+export interface LiquidityEvent {
+  'id' : bigint,
+  'fee' : [] | [bigint],
+  'action' : LiquidityAction,
+  'lp_amount' : bigint,
+  'amounts' : Array<bigint>,
+  'timestamp' : bigint,
+  'caller' : Principal,
+  'coin_index' : [] | [number],
+}
+export interface LiquidityEventV2 {
+  'id' : bigint,
+  'fee' : [] | [bigint],
+  'action' : LiquidityAction,
+  'imbalance_after' : bigint,
+  'is_rebalancing' : boolean,
+  'virtual_price_after' : bigint,
+  'lp_amount' : bigint,
+  'pool_balances_after' : Array<bigint>,
+  'fee_bps' : [] | [number],
+  'imbalance_before' : bigint,
+  'migrated' : boolean,
+  'amounts' : Array<bigint>,
+  'timestamp' : bigint,
+  'caller' : Principal,
+  'coin_index' : [] | [number],
+}
 export type MetadataValue = { 'Int' : bigint } |
   { 'Nat' : bigint } |
   { 'Blob' : Uint8Array | number[] } |
   { 'Text' : string };
+export interface OptimalRebalanceQuote {
+  'dx' : bigint,
+  'imbalance_after' : bigint,
+  'token_in' : number,
+  'profit_bps_estimate' : bigint,
+  'fee_bps' : number,
+  'imbalance_before' : bigint,
+  'amount_out' : bigint,
+  'token_out' : number,
+}
+export interface PoolHealth {
+  'imbalance_trend_1h' : number,
+  'current_imbalance' : bigint,
+  'fee_at_max_imbalance_swap' : number,
+  'last_swap_age_seconds' : bigint,
+  'arb_opportunity_score' : number,
+  'fee_at_min' : number,
+}
+export interface PoolStateView {
+  'amp' : bigint,
+  'imbalance' : bigint,
+  'virtual_price' : bigint,
+  'fee_curve' : FeeCurveParams,
+  'lp_total_supply' : bigint,
+  'balances' : Array<bigint>,
+  'normalized_balances' : Array<bigint>,
+}
+export interface PoolStats {
+  'liquidity_added_count' : bigint,
+  'liquidity_removed_count' : bigint,
+  'arb_swap_count' : bigint,
+  'swap_volume_per_token' : Array<bigint>,
+  'swap_count' : bigint,
+  'total_fees_collected' : Array<bigint>,
+  'arb_volume_per_token' : Array<bigint>,
+  'avg_fee_bps' : number,
+  'unique_swappers' : bigint,
+}
 export interface PoolStatus {
   'virtual_price' : bigint,
   'admin_fee_bps' : bigint,
@@ -130,12 +235,32 @@ export interface PoolStatus {
   'lp_total_supply' : bigint,
   'balances' : Array<bigint>,
 }
+export interface QuoteSwapResult {
+  'imbalance_after' : bigint,
+  'token_in' : number,
+  'is_rebalancing' : boolean,
+  'virtual_price_after' : bigint,
+  'fee_bps' : number,
+  'imbalance_before' : bigint,
+  'virtual_price_before' : bigint,
+  'amount_out' : bigint,
+  'amount_in' : bigint,
+  'token_out' : number,
+  'fee_native' : bigint,
+}
 export interface RedeemAndBurnResult {
   'lp_amount_burned' : bigint,
   'burn_block_index' : bigint,
   'token_amount_burned' : bigint,
 }
 export interface StandardRecord { 'url' : string, 'name' : string }
+/**
+ * ─── Explorer types ───
+ */
+export type StatsWindow = { 'AllTime' : null } |
+  { 'Last7d' : null } |
+  { 'Last24h' : null } |
+  { 'Last30d' : null };
 export interface SupportedBlockType { 'url' : string, 'block_type' : string }
 export interface SwapEvent {
   'id' : bigint,
@@ -146,6 +271,43 @@ export interface SwapEvent {
   'caller' : Principal,
   'amount_in' : bigint,
   'token_out' : number,
+}
+export interface SwapEventV2 {
+  'id' : bigint,
+  'fee' : bigint,
+  'imbalance_after' : bigint,
+  'token_in' : number,
+  'is_rebalancing' : boolean,
+  'virtual_price_after' : bigint,
+  'pool_balances_after' : Array<bigint>,
+  'fee_bps' : number,
+  'imbalance_before' : bigint,
+  'migrated' : boolean,
+  'amount_out' : bigint,
+  'timestamp' : bigint,
+  'caller' : Principal,
+  'amount_in' : bigint,
+  'token_out' : number,
+}
+export type ThreePoolAdminAction = { 'SetAdminFee' : { 'fee_bps' : bigint } } |
+  { 'RampA' : { 'future_a_time' : bigint, 'future_a' : bigint } } |
+  { 'StopRampA' : { 'frozen_a' : bigint } } |
+  { 'RemoveAuthorizedBurnCaller' : { 'canister' : Principal } } |
+  { 'WithdrawAdminFees' : { 'amounts' : Array<bigint> } } |
+  { 'SetSwapFee' : { 'fee_bps' : bigint } } |
+  {
+    'FeeCurveParamsUpdated' : {
+      'new' : FeeCurveParams,
+      'old' : [] | [FeeCurveParams],
+    }
+  } |
+  { 'AddAuthorizedBurnCaller' : { 'canister' : Principal } } |
+  { 'SetPaused' : { 'paused' : boolean } };
+export interface ThreePoolAdminEvent {
+  'id' : bigint,
+  'action' : ThreePoolAdminAction,
+  'timestamp' : bigint,
+  'caller' : Principal,
 }
 export type ThreePoolError = {
     'InsufficientOutput' : { 'actual' : bigint, 'expected_min' : bigint }
@@ -222,10 +384,18 @@ export type TransferFromError = {
   { 'CreatedInFuture' : { 'ledger_time' : bigint } } |
   { 'TooOld' : null } |
   { 'InsufficientFunds' : { 'balance' : bigint } };
+export interface VirtualPricePoint {
+  'virtual_price' : bigint,
+  'timestamp' : bigint,
+}
 export interface VirtualPriceSnapshot {
   'virtual_price' : bigint,
   'timestamp_secs' : bigint,
   'lp_total_supply' : bigint,
+}
+export interface VolumePoint {
+  'volume_per_token' : Array<bigint>,
+  'timestamp' : bigint,
 }
 export interface _SERVICE {
   'add_authorized_burn_caller' : ActorMethod<
@@ -268,12 +438,61 @@ export interface _SERVICE {
     { 'Ok' : null } |
       { 'Err' : ThreePoolError }
   >,
+  'get_admin_event_count' : ActorMethod<[], bigint>,
+  'get_admin_events' : ActorMethod<
+    [bigint, bigint],
+    Array<ThreePoolAdminEvent>
+  >,
   'get_admin_fees' : ActorMethod<[], Array<bigint>>,
+  'get_all_lp_holders' : ActorMethod<[], Array<[Principal, bigint]>>,
   'get_authorized_burn_callers' : ActorMethod<[], Array<Principal>>,
+  'get_balance_series' : ActorMethod<
+    [StatsWindow, bigint],
+    Array<BalancePoint>
+  >,
+  'get_fee_curve_params' : ActorMethod<[], FeeCurveParams>,
+  'get_fee_series' : ActorMethod<[StatsWindow, bigint], Array<FeePoint>>,
+  'get_fee_stats' : ActorMethod<[StatsWindow], FeeStats>,
+  'get_imbalance_history' : ActorMethod<
+    [bigint, bigint],
+    Array<ImbalanceSnapshot>
+  >,
+  'get_imbalance_stats' : ActorMethod<[StatsWindow], ImbalanceStats>,
+  'get_liquidity_event_count' : ActorMethod<[], bigint>,
+  'get_liquidity_events' : ActorMethod<[bigint, bigint], Array<LiquidityEvent>>,
+  /**
+   * Explorer endpoints (E1-E14)
+   */
+  'get_liquidity_events_by_principal' : ActorMethod<
+    [Principal, bigint, bigint],
+    Array<LiquidityEventV2>
+  >,
   'get_lp_balance' : ActorMethod<[Principal], bigint>,
+  'get_pool_health' : ActorMethod<[], PoolHealth>,
+  'get_pool_state' : ActorMethod<[], PoolStateView>,
+  'get_pool_stats' : ActorMethod<[StatsWindow], PoolStats>,
   'get_pool_status' : ActorMethod<[], PoolStatus>,
   'get_swap_event_count' : ActorMethod<[], bigint>,
   'get_swap_events' : ActorMethod<[bigint, bigint], Array<SwapEvent>>,
+  'get_swap_events_by_principal' : ActorMethod<
+    [Principal, bigint, bigint],
+    Array<SwapEventV2>
+  >,
+  'get_swap_events_by_time_range' : ActorMethod<
+    [bigint, bigint, bigint],
+    Array<SwapEventV2>
+  >,
+  'get_swap_events_v2' : ActorMethod<[bigint, bigint], Array<SwapEventV2>>,
+  'get_top_lps' : ActorMethod<[bigint], Array<[Principal, bigint, number]>>,
+  'get_top_swappers' : ActorMethod<
+    [StatsWindow, bigint],
+    Array<[Principal, bigint, bigint]>
+  >,
+  'get_virtual_price_series' : ActorMethod<
+    [StatsWindow, bigint],
+    Array<VirtualPricePoint>
+  >,
+  'get_volume_series' : ActorMethod<[StatsWindow, bigint], Array<VolumePoint>>,
   'get_vp_snapshots' : ActorMethod<[], Array<VirtualPriceSnapshot>>,
   'health' : ActorMethod<[], string>,
   'icrc10_supported_standards' : ActorMethod<[], Array<StandardRecord>>,
@@ -321,6 +540,16 @@ export interface _SERVICE {
   'icrc3_get_blocks' : ActorMethod<[Array<GetBlocksArgs>], GetBlocksResult>,
   'icrc3_get_tip_certificate' : ActorMethod<[], [] | [Icrc3DataCertificate]>,
   'icrc3_supported_block_types' : ActorMethod<[], Array<SupportedBlockType>>,
+  'quote_optimal_rebalance' : ActorMethod<
+    [number, number],
+    { 'Ok' : OptimalRebalanceQuote } |
+      { 'Err' : ThreePoolError }
+  >,
+  'quote_swap' : ActorMethod<
+    [number, number, bigint],
+    { 'Ok' : QuoteSwapResult } |
+      { 'Err' : ThreePoolError }
+  >,
   'ramp_a' : ActorMethod<
     [bigint, bigint],
     { 'Ok' : null } |
@@ -346,6 +575,11 @@ export interface _SERVICE {
     { 'Ok' : null } |
       { 'Err' : ThreePoolError }
   >,
+  'set_fee_curve_params' : ActorMethod<
+    [FeeCurveParams],
+    { 'Ok' : null } |
+      { 'Err' : ThreePoolError }
+  >,
   'set_paused' : ActorMethod<
     [boolean],
     { 'Ok' : null } |
@@ -354,6 +588,11 @@ export interface _SERVICE {
   'set_swap_fee' : ActorMethod<
     [bigint],
     { 'Ok' : null } |
+      { 'Err' : ThreePoolError }
+  >,
+  'simulate_swap_path' : ActorMethod<
+    [Array<[number, number, bigint]>],
+    { 'Ok' : Array<QuoteSwapResult> } |
       { 'Err' : ThreePoolError }
   >,
   'stop_ramp_a' : ActorMethod<[], { 'Ok' : null } | { 'Err' : ThreePoolError }>,

--- a/src/declarations/rumi_3pool/rumi_3pool.did.js
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.js
@@ -56,6 +56,137 @@ export const idlFactory = ({ IDL }) => {
     'burn_block_index' : IDL.Nat64,
     'token_amount_burned' : IDL.Nat,
   });
+  const FeeCurveParams = IDL.Record({
+    'max_fee_bps' : IDL.Nat16,
+    'imb_saturation' : IDL.Nat64,
+    'min_fee_bps' : IDL.Nat16,
+  });
+  const ThreePoolAdminAction = IDL.Variant({
+    'SetAdminFee' : IDL.Record({ 'fee_bps' : IDL.Nat64 }),
+    'RampA' : IDL.Record({
+      'future_a_time' : IDL.Nat64,
+      'future_a' : IDL.Nat64,
+    }),
+    'StopRampA' : IDL.Record({ 'frozen_a' : IDL.Nat64 }),
+    'RemoveAuthorizedBurnCaller' : IDL.Record({ 'canister' : IDL.Principal }),
+    'WithdrawAdminFees' : IDL.Record({ 'amounts' : IDL.Vec(IDL.Nat) }),
+    'SetSwapFee' : IDL.Record({ 'fee_bps' : IDL.Nat64 }),
+    'FeeCurveParamsUpdated' : IDL.Record({
+      'new' : FeeCurveParams,
+      'old' : IDL.Opt(FeeCurveParams),
+    }),
+    'AddAuthorizedBurnCaller' : IDL.Record({ 'canister' : IDL.Principal }),
+    'SetPaused' : IDL.Record({ 'paused' : IDL.Bool }),
+  });
+  const ThreePoolAdminEvent = IDL.Record({
+    'id' : IDL.Nat64,
+    'action' : ThreePoolAdminAction,
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Principal,
+  });
+  const StatsWindow = IDL.Variant({
+    'AllTime' : IDL.Null,
+    'Last7d' : IDL.Null,
+    'Last24h' : IDL.Null,
+    'Last30d' : IDL.Null,
+  });
+  const BalancePoint = IDL.Record({
+    'timestamp' : IDL.Nat64,
+    'balances' : IDL.Vec(IDL.Nat),
+  });
+  const FeePoint = IDL.Record({
+    'timestamp' : IDL.Nat64,
+    'avg_fee_bps' : IDL.Nat32,
+  });
+  const FeeBucket = IDL.Record({
+    'volume_per_token' : IDL.Vec(IDL.Nat),
+    'min_bps' : IDL.Nat16,
+    'swap_count' : IDL.Nat64,
+    'max_bps' : IDL.Nat16,
+  });
+  const FeeStats = IDL.Record({
+    'rebalancing_swap_count' : IDL.Nat64,
+    'rebalancing_swap_pct' : IDL.Nat32,
+    'buckets' : IDL.Vec(FeeBucket),
+  });
+  const ImbalanceEventKind = IDL.Variant({
+    'Swap' : IDL.Null,
+    'Liquidity' : IDL.Null,
+  });
+  const ImbalanceSnapshot = IDL.Record({
+    'imbalance_after' : IDL.Nat64,
+    'virtual_price_after' : IDL.Nat,
+    'timestamp' : IDL.Nat64,
+    'event_kind' : ImbalanceEventKind,
+  });
+  const ImbalanceStats = IDL.Record({
+    'avg' : IDL.Nat64,
+    'max' : IDL.Nat64,
+    'min' : IDL.Nat64,
+    'samples' : IDL.Vec(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
+    'current' : IDL.Nat64,
+  });
+  const LiquidityAction = IDL.Variant({
+    'AddLiquidity' : IDL.Null,
+    'Donate' : IDL.Null,
+    'RemoveOneCoin' : IDL.Null,
+    'RemoveLiquidity' : IDL.Null,
+  });
+  const LiquidityEvent = IDL.Record({
+    'id' : IDL.Nat64,
+    'fee' : IDL.Opt(IDL.Nat),
+    'action' : LiquidityAction,
+    'lp_amount' : IDL.Nat,
+    'amounts' : IDL.Vec(IDL.Nat),
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Principal,
+    'coin_index' : IDL.Opt(IDL.Nat8),
+  });
+  const LiquidityEventV2 = IDL.Record({
+    'id' : IDL.Nat64,
+    'fee' : IDL.Opt(IDL.Nat),
+    'action' : LiquidityAction,
+    'imbalance_after' : IDL.Nat64,
+    'is_rebalancing' : IDL.Bool,
+    'virtual_price_after' : IDL.Nat,
+    'lp_amount' : IDL.Nat,
+    'pool_balances_after' : IDL.Vec(IDL.Nat),
+    'fee_bps' : IDL.Opt(IDL.Nat16),
+    'imbalance_before' : IDL.Nat64,
+    'migrated' : IDL.Bool,
+    'amounts' : IDL.Vec(IDL.Nat),
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Principal,
+    'coin_index' : IDL.Opt(IDL.Nat8),
+  });
+  const PoolHealth = IDL.Record({
+    'imbalance_trend_1h' : IDL.Int32,
+    'current_imbalance' : IDL.Nat64,
+    'fee_at_max_imbalance_swap' : IDL.Nat16,
+    'last_swap_age_seconds' : IDL.Nat64,
+    'arb_opportunity_score' : IDL.Nat8,
+    'fee_at_min' : IDL.Nat16,
+  });
+  const PoolStateView = IDL.Record({
+    'amp' : IDL.Nat64,
+    'imbalance' : IDL.Nat64,
+    'virtual_price' : IDL.Nat,
+    'fee_curve' : FeeCurveParams,
+    'lp_total_supply' : IDL.Nat,
+    'balances' : IDL.Vec(IDL.Nat),
+    'normalized_balances' : IDL.Vec(IDL.Nat),
+  });
+  const PoolStats = IDL.Record({
+    'liquidity_added_count' : IDL.Nat64,
+    'liquidity_removed_count' : IDL.Nat64,
+    'arb_swap_count' : IDL.Nat64,
+    'swap_volume_per_token' : IDL.Vec(IDL.Nat),
+    'swap_count' : IDL.Nat64,
+    'total_fees_collected' : IDL.Vec(IDL.Nat),
+    'arb_volume_per_token' : IDL.Vec(IDL.Nat),
+    'avg_fee_bps' : IDL.Nat32,
+    'unique_swappers' : IDL.Nat64,
+  });
   const PoolStatus = IDL.Record({
     'virtual_price' : IDL.Nat,
     'admin_fee_bps' : IDL.Nat64,
@@ -75,42 +206,35 @@ export const idlFactory = ({ IDL }) => {
     'amount_in' : IDL.Nat,
     'token_out' : IDL.Nat8,
   });
+  const SwapEventV2 = IDL.Record({
+    'id' : IDL.Nat64,
+    'fee' : IDL.Nat,
+    'imbalance_after' : IDL.Nat64,
+    'token_in' : IDL.Nat8,
+    'is_rebalancing' : IDL.Bool,
+    'virtual_price_after' : IDL.Nat,
+    'pool_balances_after' : IDL.Vec(IDL.Nat),
+    'fee_bps' : IDL.Nat16,
+    'imbalance_before' : IDL.Nat64,
+    'migrated' : IDL.Bool,
+    'amount_out' : IDL.Nat,
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Principal,
+    'amount_in' : IDL.Nat,
+    'token_out' : IDL.Nat8,
+  });
+  const VirtualPricePoint = IDL.Record({
+    'virtual_price' : IDL.Nat,
+    'timestamp' : IDL.Nat64,
+  });
+  const VolumePoint = IDL.Record({
+    'volume_per_token' : IDL.Vec(IDL.Nat),
+    'timestamp' : IDL.Nat64,
+  });
   const VirtualPriceSnapshot = IDL.Record({
     'virtual_price' : IDL.Nat,
     'timestamp_secs' : IDL.Nat64,
     'lp_total_supply' : IDL.Nat,
-  });
-  const LiquidityAction = IDL.Variant({
-    'AddLiquidity' : IDL.Null,
-    'RemoveLiquidity' : IDL.Null,
-    'RemoveOneCoin' : IDL.Null,
-    'Donate' : IDL.Null,
-  });
-  const LiquidityEvent = IDL.Record({
-    'id' : IDL.Nat64,
-    'timestamp' : IDL.Nat64,
-    'caller' : IDL.Principal,
-    'action' : LiquidityAction,
-    'amounts' : IDL.Vec(IDL.Nat),
-    'lp_amount' : IDL.Nat,
-    'coin_index' : IDL.Opt(IDL.Nat8),
-    'fee' : IDL.Opt(IDL.Nat),
-  });
-  const ThreePoolAdminAction = IDL.Variant({
-    'RampA' : IDL.Record({ 'future_a' : IDL.Nat64, 'future_a_time' : IDL.Nat64 }),
-    'StopRampA' : IDL.Record({ 'frozen_a' : IDL.Nat64 }),
-    'WithdrawAdminFees' : IDL.Record({ 'amounts' : IDL.Vec(IDL.Nat) }),
-    'SetPaused' : IDL.Record({ 'paused' : IDL.Bool }),
-    'SetSwapFee' : IDL.Record({ 'fee_bps' : IDL.Nat64 }),
-    'SetAdminFee' : IDL.Record({ 'fee_bps' : IDL.Nat64 }),
-    'AddAuthorizedBurnCaller' : IDL.Record({ 'canister' : IDL.Principal }),
-    'RemoveAuthorizedBurnCaller' : IDL.Record({ 'canister' : IDL.Principal }),
-  });
-  const ThreePoolAdminEvent = IDL.Record({
-    'id' : IDL.Nat64,
-    'timestamp' : IDL.Nat64,
-    'caller' : IDL.Principal,
-    'action' : ThreePoolAdminAction,
   });
   const StandardRecord = IDL.Record({ 'url' : IDL.Text, 'name' : IDL.Text });
   const Account = IDL.Record({
@@ -283,6 +407,29 @@ export const idlFactory = ({ IDL }) => {
     'url' : IDL.Text,
     'block_type' : IDL.Text,
   });
+  const OptimalRebalanceQuote = IDL.Record({
+    'dx' : IDL.Nat,
+    'imbalance_after' : IDL.Nat64,
+    'token_in' : IDL.Nat8,
+    'profit_bps_estimate' : IDL.Nat64,
+    'fee_bps' : IDL.Nat16,
+    'imbalance_before' : IDL.Nat64,
+    'amount_out' : IDL.Nat,
+    'token_out' : IDL.Nat8,
+  });
+  const QuoteSwapResult = IDL.Record({
+    'imbalance_after' : IDL.Nat64,
+    'token_in' : IDL.Nat8,
+    'is_rebalancing' : IDL.Bool,
+    'virtual_price_after' : IDL.Nat,
+    'fee_bps' : IDL.Nat16,
+    'imbalance_before' : IDL.Nat64,
+    'virtual_price_before' : IDL.Nat,
+    'amount_out' : IDL.Nat,
+    'amount_in' : IDL.Nat,
+    'token_out' : IDL.Nat8,
+    'fee_native' : IDL.Nat,
+  });
   return IDL.Service({
     'add_authorized_burn_caller' : IDL.Func(
         [IDL.Principal],
@@ -324,13 +471,60 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
         [],
       ),
+    'get_admin_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_admin_events' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(ThreePoolAdminEvent)],
+        ['query'],
+      ),
     'get_admin_fees' : IDL.Func([], [IDL.Vec(IDL.Nat)], ['query']),
+    'get_all_lp_holders' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat))],
+        ['query'],
+      ),
     'get_authorized_burn_callers' : IDL.Func(
         [],
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
+    'get_balance_series' : IDL.Func(
+        [StatsWindow, IDL.Nat64],
+        [IDL.Vec(BalancePoint)],
+        ['query'],
+      ),
+    'get_fee_curve_params' : IDL.Func([], [FeeCurveParams], ['query']),
+    'get_fee_series' : IDL.Func(
+        [StatsWindow, IDL.Nat64],
+        [IDL.Vec(FeePoint)],
+        ['query'],
+      ),
+    'get_fee_stats' : IDL.Func([StatsWindow], [FeeStats], ['query']),
+    'get_imbalance_history' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(ImbalanceSnapshot)],
+        ['query'],
+      ),
+    'get_imbalance_stats' : IDL.Func(
+        [StatsWindow],
+        [ImbalanceStats],
+        ['query'],
+      ),
+    'get_liquidity_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_liquidity_events' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidityEvent)],
+        ['query'],
+      ),
+    'get_liquidity_events_by_principal' : IDL.Func(
+        [IDL.Principal, IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidityEventV2)],
+        ['query'],
+      ),
     'get_lp_balance' : IDL.Func([IDL.Principal], [IDL.Nat], ['query']),
+    'get_pool_health' : IDL.Func([], [PoolHealth], ['query']),
+    'get_pool_state' : IDL.Func([], [PoolStateView], ['query']),
+    'get_pool_stats' : IDL.Func([StatsWindow], [PoolStats], ['query']),
     'get_pool_status' : IDL.Func([], [PoolStatus], ['query']),
     'get_swap_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_swap_events' : IDL.Func(
@@ -338,18 +532,41 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(SwapEvent)],
         ['query'],
       ),
-    'get_liquidity_events' : IDL.Func(
-        [IDL.Nat64, IDL.Nat64],
-        [IDL.Vec(LiquidityEvent)],
+    'get_swap_events_by_principal' : IDL.Func(
+        [IDL.Principal, IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(SwapEventV2)],
         ['query'],
       ),
-    'get_liquidity_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
-    'get_admin_events' : IDL.Func(
-        [IDL.Nat64, IDL.Nat64],
-        [IDL.Vec(ThreePoolAdminEvent)],
+    'get_swap_events_by_time_range' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(SwapEventV2)],
         ['query'],
       ),
-    'get_admin_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_swap_events_v2' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(SwapEventV2)],
+        ['query'],
+      ),
+    'get_top_lps' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat, IDL.Nat32))],
+        ['query'],
+      ),
+    'get_top_swappers' : IDL.Func(
+        [StatsWindow, IDL.Nat64],
+        [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64, IDL.Nat))],
+        ['query'],
+      ),
+    'get_virtual_price_series' : IDL.Func(
+        [StatsWindow, IDL.Nat64],
+        [IDL.Vec(VirtualPricePoint)],
+        ['query'],
+      ),
+    'get_volume_series' : IDL.Func(
+        [StatsWindow, IDL.Nat64],
+        [IDL.Vec(VolumePoint)],
+        ['query'],
+      ),
     'get_vp_snapshots' : IDL.Func(
         [],
         [IDL.Vec(VirtualPriceSnapshot)],
@@ -424,6 +641,16 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(SupportedBlockType)],
         ['query'],
       ),
+    'quote_optimal_rebalance' : IDL.Func(
+        [IDL.Nat8, IDL.Nat8],
+        [IDL.Variant({ 'Ok' : OptimalRebalanceQuote, 'Err' : ThreePoolError })],
+        ['query'],
+      ),
+    'quote_swap' : IDL.Func(
+        [IDL.Nat8, IDL.Nat8, IDL.Nat],
+        [IDL.Variant({ 'Ok' : QuoteSwapResult, 'Err' : ThreePoolError })],
+        ['query'],
+      ),
     'ramp_a' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
@@ -449,6 +676,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
         [],
       ),
+    'set_fee_curve_params' : IDL.Func(
+        [FeeCurveParams],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
+        [],
+      ),
     'set_paused' : IDL.Func(
         [IDL.Bool],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
@@ -458,6 +690,16 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Nat64],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
         [],
+      ),
+    'simulate_swap_path' : IDL.Func(
+        [IDL.Vec(IDL.Tuple(IDL.Nat8, IDL.Nat8, IDL.Nat))],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Vec(QuoteSwapResult),
+            'Err' : ThreePoolError,
+          }),
+        ],
+        ['query'],
       ),
     'stop_ramp_a' : IDL.Func(
         [],

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -85,15 +85,16 @@ export async function resolveRoute(
   amountIn: bigint,
 ): Promise<SwapRoute> {
 
-  // Case 1: Stablecoin <-> Stablecoin (3pool swap)
+  // Case 1: Stablecoin <-> Stablecoin (3pool swap, dynamic fee)
   if (isStablecoin(from) && isStablecoin(to)) {
-    const output = await threePoolService.calcSwap(from.threePoolIndex, to.threePoolIndex, amountIn);
+    const quote = await threePoolService.quoteSwap(from.threePoolIndex, to.threePoolIndex, amountIn);
+    const feePct = (quote.fee_bps / 100).toFixed(2);
     return {
       type: 'three_pool_swap',
       pathDisplay: `${from.symbol} → ${to.symbol}`,
       hops: 1,
-      estimatedOutput: output,
-      feeDisplay: '0.20%',
+      estimatedOutput: quote.amount_out,
+      feeDisplay: `${feePct}%${quote.is_rebalancing ? ' (rebalancing)' : ''}`,
     };
   }
 

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -34,6 +34,20 @@ export interface VirtualPriceSnapshot {
   lp_total_supply: bigint;
 }
 
+export interface QuoteSwapResult {
+  token_in: number;
+  token_out: number;
+  amount_in: bigint;
+  amount_out: bigint;
+  fee_native: bigint;
+  fee_bps: number;
+  imbalance_before: bigint;
+  imbalance_after: bigint;
+  is_rebalancing: boolean;
+  virtual_price_before: bigint;
+  virtual_price_after: bigint;
+}
+
 // ──────────────────────────────────────────────────────────────
 // Token metadata for the 3pool (matches canister init config)
 // ──────────────────────────────────────────────────────────────
@@ -211,6 +225,15 @@ class ThreePoolService {
   async calcSwap(fromIndex: number, toIndex: number, dxRaw: bigint): Promise<bigint> {
     const actor = await this.getQueryActor();
     const result = await actor.calc_swap(fromIndex, toIndex, dxRaw) as { Ok: bigint } | { Err: any };
+    if ('Err' in result) {
+      throw new Error(this.formatError(result.Err));
+    }
+    return result.Ok;
+  }
+
+  async quoteSwap(fromIndex: number, toIndex: number, dxRaw: bigint): Promise<QuoteSwapResult> {
+    const actor = await this.getQueryActor();
+    const result = await actor.quote_swap(fromIndex, toIndex, dxRaw) as { Ok: QuoteSwapResult } | { Err: any };
     if ('Err' in result) {
       throw new Error(this.formatError(result.Err));
     }


### PR DESCRIPTION
## Summary
- The swap UI hardcoded \`feeDisplay: '0.20%'\` for every 3pool route, hiding the dynamic fee curve that's been live on mainnet since #58.
- Wire \`swapRouter\` Case 1 to call \`quote_swap\`, which returns the real \`fee_bps\` for the specific trade, plus an \`is_rebalancing\` flag.
- Add \`quoteSwap\` helper and \`QuoteSwapResult\` type to \`threePoolService\`.
- Regenerate \`rumi_3pool\` declarations (they were stale and missing the new \`quote_swap\` / \`get_fee_curve_params\` / \`quote_optimal_rebalance\` methods).

## Evidence the backend was already dynamic
Mainnet \`get_pool_status\` shows the pool is heavily imbalanced (icUSD ~1372 vs ckUSDT ~699 vs ckUSDC ~763 after precision scaling), and the two directions in the UI already returned asymmetric outputs (~0.36% cost away from balance, ~0.10% toward balance). Backend was correct, UI was lying.

## Test plan
- [ ] Open the swap UI, pick icUSD → ckUSDC, enter 100, confirm swap fee shows > 0.20%.
- [ ] Flip direction (ckUSDC → icUSD), confirm swap fee shows < 0.20% and displays "(rebalancing)".
- [ ] Change amount, confirm fee updates with each quote.
- [ ] Execute a small swap to confirm actual settlement matches quoted fee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)