### PR TITLE
feat(backend): add per-collateral parameter setters

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -695,8 +695,17 @@ service : (ProtocolArg) -> {
   set_borrowing_fee : (float64) -> (Result);
   set_borrowing_fee_curve : (opt text) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
+  set_collateral_borrow_threshold : (principal, float64) -> (Result);
   set_collateral_borrowing_fee : (principal, float64) -> (Result);
   set_collateral_debt_ceiling : (principal, nat64) -> (Result);
+  set_collateral_display_color : (principal, opt text) -> (Result);
+  set_collateral_ledger_fee : (principal, nat64) -> (Result);
+  set_collateral_liquidation_bonus : (principal, float64) -> (Result);
+  set_collateral_liquidation_ratio : (principal, float64) -> (Result);
+  set_collateral_min_deposit : (principal, nat64) -> (Result);
+  set_collateral_min_vault_debt : (principal, nat64) -> (Result);
+  set_collateral_redemption_fee_ceiling : (principal, float64) -> (Result);
+  set_collateral_redemption_fee_floor : (principal, float64) -> (Result);
   set_collateral_status : (principal, CollateralStatus) -> (Result);
   set_global_icusd_mint_cap : (nat64) -> (Result);
   set_healthy_cr : (principal, opt float64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -867,8 +867,26 @@ export interface _SERVICE {
   'set_borrowing_fee_curve' : ActorMethod<[[] | [string]], Result>,
   'set_bot_allowed_collateral_types' : ActorMethod<[Array<Principal>], Result>,
   'set_ckstable_repay_fee' : ActorMethod<[number], Result>,
+  'set_collateral_borrow_threshold' : ActorMethod<[Principal, number], Result>,
   'set_collateral_borrowing_fee' : ActorMethod<[Principal, number], Result>,
   'set_collateral_debt_ceiling' : ActorMethod<[Principal, bigint], Result>,
+  'set_collateral_display_color' : ActorMethod<
+    [Principal, [] | [string]],
+    Result
+  >,
+  'set_collateral_ledger_fee' : ActorMethod<[Principal, bigint], Result>,
+  'set_collateral_liquidation_bonus' : ActorMethod<[Principal, number], Result>,
+  'set_collateral_liquidation_ratio' : ActorMethod<[Principal, number], Result>,
+  'set_collateral_min_deposit' : ActorMethod<[Principal, bigint], Result>,
+  'set_collateral_min_vault_debt' : ActorMethod<[Principal, bigint], Result>,
+  'set_collateral_redemption_fee_ceiling' : ActorMethod<
+    [Principal, number],
+    Result
+  >,
+  'set_collateral_redemption_fee_floor' : ActorMethod<
+    [Principal, number],
+    Result
+  >,
   'set_collateral_status' : ActorMethod<[Principal, CollateralStatus], Result>,
   'set_global_icusd_mint_cap' : ActorMethod<[bigint], Result>,
   'set_healthy_cr' : ActorMethod<[Principal, [] | [number]], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -942,6 +942,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'set_ckstable_repay_fee' : IDL.Func([IDL.Float64], [Result], []),
+    'set_collateral_borrow_threshold' : IDL.Func(
+        [IDL.Principal, IDL.Float64],
+        [Result],
+        [],
+      ),
     'set_collateral_borrowing_fee' : IDL.Func(
         [IDL.Principal, IDL.Float64],
         [Result],
@@ -949,6 +954,46 @@ export const idlFactory = ({ IDL }) => {
       ),
     'set_collateral_debt_ceiling' : IDL.Func(
         [IDL.Principal, IDL.Nat64],
+        [Result],
+        [],
+      ),
+    'set_collateral_display_color' : IDL.Func(
+        [IDL.Principal, IDL.Opt(IDL.Text)],
+        [Result],
+        [],
+      ),
+    'set_collateral_ledger_fee' : IDL.Func(
+        [IDL.Principal, IDL.Nat64],
+        [Result],
+        [],
+      ),
+    'set_collateral_liquidation_bonus' : IDL.Func(
+        [IDL.Principal, IDL.Float64],
+        [Result],
+        [],
+      ),
+    'set_collateral_liquidation_ratio' : IDL.Func(
+        [IDL.Principal, IDL.Float64],
+        [Result],
+        [],
+      ),
+    'set_collateral_min_deposit' : IDL.Func(
+        [IDL.Principal, IDL.Nat64],
+        [Result],
+        [],
+      ),
+    'set_collateral_min_vault_debt' : IDL.Func(
+        [IDL.Principal, IDL.Nat64],
+        [Result],
+        [],
+      ),
+    'set_collateral_redemption_fee_ceiling' : IDL.Func(
+        [IDL.Principal, IDL.Float64],
+        [Result],
+        [],
+      ),
+    'set_collateral_redemption_fee_floor' : IDL.Func(
+        [IDL.Principal, IDL.Float64],
         [Result],
         [],
       ),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -695,8 +695,17 @@ service : (ProtocolArg) -> {
   set_borrowing_fee : (float64) -> (Result);
   set_borrowing_fee_curve : (opt text) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
+  set_collateral_borrow_threshold : (principal, float64) -> (Result);
   set_collateral_borrowing_fee : (principal, float64) -> (Result);
   set_collateral_debt_ceiling : (principal, nat64) -> (Result);
+  set_collateral_display_color : (principal, opt text) -> (Result);
+  set_collateral_ledger_fee : (principal, nat64) -> (Result);
+  set_collateral_liquidation_bonus : (principal, float64) -> (Result);
+  set_collateral_liquidation_ratio : (principal, float64) -> (Result);
+  set_collateral_min_deposit : (principal, nat64) -> (Result);
+  set_collateral_min_vault_debt : (principal, nat64) -> (Result);
+  set_collateral_redemption_fee_ceiling : (principal, float64) -> (Result);
+  set_collateral_redemption_fee_floor : (principal, float64) -> (Result);
   set_collateral_status : (principal, CollateralStatus) -> (Result);
   set_global_icusd_mint_cap : (nat64) -> (Result);
   set_healthy_cr : (principal, opt float64) -> (Result);

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -493,6 +493,69 @@ pub enum Event {
         timestamp: u64,
     },
 
+    /// Admin set per-collateral liquidation ratio.
+    #[serde(rename = "set_collateral_liquidation_ratio")]
+    SetCollateralLiquidationRatio {
+        collateral_type: CollateralType,
+        liquidation_ratio: String,
+    },
+
+    /// Admin set per-collateral borrow threshold ratio (recovery-mode trigger).
+    #[serde(rename = "set_collateral_borrow_threshold")]
+    SetCollateralBorrowThreshold {
+        collateral_type: CollateralType,
+        borrow_threshold_ratio: String,
+    },
+
+    /// Admin set per-collateral liquidation bonus.
+    #[serde(rename = "set_collateral_liquidation_bonus")]
+    SetCollateralLiquidationBonus {
+        collateral_type: CollateralType,
+        liquidation_bonus: String,
+    },
+
+    /// Admin set per-collateral minimum vault debt (dust threshold).
+    #[serde(rename = "set_collateral_min_vault_debt")]
+    SetCollateralMinVaultDebt {
+        collateral_type: CollateralType,
+        min_vault_debt: u64,
+    },
+
+    /// Admin set per-collateral ledger fee (native units).
+    #[serde(rename = "set_collateral_ledger_fee")]
+    SetCollateralLedgerFee {
+        collateral_type: CollateralType,
+        ledger_fee: u64,
+    },
+
+    /// Admin set per-collateral redemption fee floor.
+    #[serde(rename = "set_collateral_redemption_fee_floor")]
+    SetCollateralRedemptionFeeFloor {
+        collateral_type: CollateralType,
+        redemption_fee_floor: String,
+    },
+
+    /// Admin set per-collateral redemption fee ceiling.
+    #[serde(rename = "set_collateral_redemption_fee_ceiling")]
+    SetCollateralRedemptionFeeCeiling {
+        collateral_type: CollateralType,
+        redemption_fee_ceiling: String,
+    },
+
+    /// Admin set per-collateral minimum deposit amount (native units).
+    #[serde(rename = "set_collateral_min_deposit")]
+    SetCollateralMinDeposit {
+        collateral_type: CollateralType,
+        min_collateral_deposit: u64,
+    },
+
+    /// Admin set per-collateral display color (hex) for frontend.
+    #[serde(rename = "set_collateral_display_color")]
+    SetCollateralDisplayColor {
+        collateral_type: CollateralType,
+        display_color: Option<String>,
+    },
+
     /// Admin correction of vault debt to fix replay interest drift.
     #[serde(rename = "admin_debt_correction")]
     AdminDebtCorrection {
@@ -579,6 +642,15 @@ impl Event {
             Event::SetInterestSplit { .. } => false,
             Event::SetThreePoolCanister { .. } => false,
             Event::PriceUpdate { .. } => false,
+            Event::SetCollateralLiquidationRatio { .. } => false,
+            Event::SetCollateralBorrowThreshold { .. } => false,
+            Event::SetCollateralLiquidationBonus { .. } => false,
+            Event::SetCollateralMinVaultDebt { .. } => false,
+            Event::SetCollateralLedgerFee { .. } => false,
+            Event::SetCollateralRedemptionFeeFloor { .. } => false,
+            Event::SetCollateralRedemptionFeeCeiling { .. } => false,
+            Event::SetCollateralMinDeposit { .. } => false,
+            Event::SetCollateralDisplayColor { .. } => false,
             Event::AdminDebtCorrection { vault_id: vid, .. } => vid == filter_vault_id,
         }
     }
@@ -1067,6 +1139,61 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             },
             Event::PriceUpdate { .. } => {
                 // Price history only; no state mutation needed during replay.
+            },
+            Event::SetCollateralLiquidationRatio { collateral_type, liquidation_ratio } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    if let Ok(dec) = liquidation_ratio.parse::<Decimal>() {
+                        config.liquidation_ratio = Ratio::from(dec);
+                    }
+                }
+            },
+            Event::SetCollateralBorrowThreshold { collateral_type, borrow_threshold_ratio } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    if let Ok(dec) = borrow_threshold_ratio.parse::<Decimal>() {
+                        config.borrow_threshold_ratio = Ratio::from(dec);
+                    }
+                }
+            },
+            Event::SetCollateralLiquidationBonus { collateral_type, liquidation_bonus } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    if let Ok(dec) = liquidation_bonus.parse::<Decimal>() {
+                        config.liquidation_bonus = Ratio::from(dec);
+                    }
+                }
+            },
+            Event::SetCollateralMinVaultDebt { collateral_type, min_vault_debt } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    config.min_vault_debt = ICUSD::new(min_vault_debt);
+                }
+            },
+            Event::SetCollateralLedgerFee { collateral_type, ledger_fee } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    config.ledger_fee = ledger_fee;
+                }
+            },
+            Event::SetCollateralRedemptionFeeFloor { collateral_type, redemption_fee_floor } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    if let Ok(dec) = redemption_fee_floor.parse::<Decimal>() {
+                        config.redemption_fee_floor = Ratio::from(dec);
+                    }
+                }
+            },
+            Event::SetCollateralRedemptionFeeCeiling { collateral_type, redemption_fee_ceiling } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    if let Ok(dec) = redemption_fee_ceiling.parse::<Decimal>() {
+                        config.redemption_fee_ceiling = Ratio::from(dec);
+                    }
+                }
+            },
+            Event::SetCollateralMinDeposit { collateral_type, min_collateral_deposit } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    config.min_collateral_deposit = min_collateral_deposit;
+                }
+            },
+            Event::SetCollateralDisplayColor { collateral_type, display_color } => {
+                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                    config.display_color = display_color;
+                }
             },
             Event::AdminDebtCorrection { vault_id: vid, new_borrowed, new_accrued, .. } => {
                 if let Some(vault) = state.vault_id_to_vaults.get_mut(&vid) {
@@ -1755,6 +1882,134 @@ pub fn record_set_interest_rate(
     });
     if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
         config.interest_rate_apr = interest_rate_apr;
+    }
+}
+
+pub fn record_set_collateral_liquidation_ratio(
+    state: &mut State,
+    collateral_type: CollateralType,
+    liquidation_ratio: Ratio,
+) {
+    record_event(&Event::SetCollateralLiquidationRatio {
+        collateral_type,
+        liquidation_ratio: liquidation_ratio.0.to_string(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.liquidation_ratio = liquidation_ratio;
+    }
+}
+
+pub fn record_set_collateral_borrow_threshold(
+    state: &mut State,
+    collateral_type: CollateralType,
+    borrow_threshold_ratio: Ratio,
+) {
+    record_event(&Event::SetCollateralBorrowThreshold {
+        collateral_type,
+        borrow_threshold_ratio: borrow_threshold_ratio.0.to_string(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.borrow_threshold_ratio = borrow_threshold_ratio;
+        // Keep the stored (but largely derived) recovery_target_cr in sync.
+        config.recovery_target_cr = borrow_threshold_ratio * state.recovery_cr_multiplier;
+    }
+}
+
+pub fn record_set_collateral_liquidation_bonus(
+    state: &mut State,
+    collateral_type: CollateralType,
+    liquidation_bonus: Ratio,
+) {
+    record_event(&Event::SetCollateralLiquidationBonus {
+        collateral_type,
+        liquidation_bonus: liquidation_bonus.0.to_string(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.liquidation_bonus = liquidation_bonus;
+    }
+}
+
+pub fn record_set_collateral_min_vault_debt(
+    state: &mut State,
+    collateral_type: CollateralType,
+    min_vault_debt: u64,
+) {
+    record_event(&Event::SetCollateralMinVaultDebt {
+        collateral_type,
+        min_vault_debt,
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.min_vault_debt = ICUSD::new(min_vault_debt);
+    }
+}
+
+pub fn record_set_collateral_ledger_fee(
+    state: &mut State,
+    collateral_type: CollateralType,
+    ledger_fee: u64,
+) {
+    record_event(&Event::SetCollateralLedgerFee {
+        collateral_type,
+        ledger_fee,
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.ledger_fee = ledger_fee;
+    }
+}
+
+pub fn record_set_collateral_redemption_fee_floor(
+    state: &mut State,
+    collateral_type: CollateralType,
+    redemption_fee_floor: Ratio,
+) {
+    record_event(&Event::SetCollateralRedemptionFeeFloor {
+        collateral_type,
+        redemption_fee_floor: redemption_fee_floor.0.to_string(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.redemption_fee_floor = redemption_fee_floor;
+    }
+}
+
+pub fn record_set_collateral_redemption_fee_ceiling(
+    state: &mut State,
+    collateral_type: CollateralType,
+    redemption_fee_ceiling: Ratio,
+) {
+    record_event(&Event::SetCollateralRedemptionFeeCeiling {
+        collateral_type,
+        redemption_fee_ceiling: redemption_fee_ceiling.0.to_string(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.redemption_fee_ceiling = redemption_fee_ceiling;
+    }
+}
+
+pub fn record_set_collateral_min_deposit(
+    state: &mut State,
+    collateral_type: CollateralType,
+    min_collateral_deposit: u64,
+) {
+    record_event(&Event::SetCollateralMinDeposit {
+        collateral_type,
+        min_collateral_deposit,
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.min_collateral_deposit = min_collateral_deposit;
+    }
+}
+
+pub fn record_set_collateral_display_color(
+    state: &mut State,
+    collateral_type: CollateralType,
+    display_color: Option<String>,
+) {
+    record_event(&Event::SetCollateralDisplayColor {
+        collateral_type,
+        display_color: display_color.clone(),
+    });
+    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+        config.display_color = display_color;
     }
 }
 

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -1148,9 +1148,14 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
                 }
             },
             Event::SetCollateralBorrowThreshold { collateral_type, borrow_threshold_ratio } => {
-                if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
-                    if let Ok(dec) = borrow_threshold_ratio.parse::<Decimal>() {
-                        config.borrow_threshold_ratio = Ratio::from(dec);
+                if let Ok(dec) = borrow_threshold_ratio.parse::<Decimal>() {
+                    let new_ratio = Ratio::from(dec);
+                    // Snapshot the global multiplier before taking a mutable borrow of configs
+                    // so the replay path mirrors record_set_collateral_borrow_threshold exactly.
+                    let multiplier = state.recovery_cr_multiplier;
+                    if let Some(config) = state.collateral_configs.get_mut(&collateral_type) {
+                        config.borrow_threshold_ratio = new_ratio;
+                        config.recovery_target_cr = new_ratio * multiplier;
                     }
                 }
             },

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -3669,6 +3669,352 @@ async fn set_lst_haircut(
     Ok(())
 }
 
+/// Set the liquidation ratio for a specific collateral type (developer only).
+/// e.g. 1.25 = 125%. Must be strictly less than borrow_threshold_ratio.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_liquidation_ratio(
+    collateral_type: Principal,
+    liquidation_ratio: f64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set liquidation ratio".to_string(),
+        ));
+    }
+    if liquidation_ratio < 1.0 || liquidation_ratio > 5.0 {
+        return Err(ProtocolError::GenericError(format!(
+            "liquidation_ratio ({}) must be between 1.0 and 5.0",
+            liquidation_ratio
+        )));
+    }
+    let borrow_threshold = read_state(|s| {
+        s.collateral_configs
+            .get(&collateral_type)
+            .map(|c| c.borrow_threshold_ratio.to_f64())
+    });
+    let borrow_threshold = match borrow_threshold {
+        Some(bt) => bt,
+        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+    };
+    if liquidation_ratio >= borrow_threshold {
+        return Err(ProtocolError::GenericError(format!(
+            "liquidation_ratio ({}) must be strictly less than borrow_threshold_ratio ({})",
+            liquidation_ratio, borrow_threshold
+        )));
+    }
+    let ratio = Ratio::from(
+        Decimal::try_from(liquidation_ratio)
+            .map_err(|_| ProtocolError::GenericError("Invalid liquidation_ratio value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_liquidation_ratio(s, collateral_type, ratio);
+    });
+    log!(INFO, "[set_collateral_liquidation_ratio] collateral={}, liquidation_ratio={}", collateral_type, liquidation_ratio);
+    Ok(())
+}
+
+/// Set the borrow threshold ratio for a specific collateral type (developer only).
+/// e.g. 1.55 = 155%. Must be strictly greater than liquidation_ratio
+/// and strictly less than healthy_cr if healthy_cr is set.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_borrow_threshold(
+    collateral_type: Principal,
+    borrow_threshold_ratio: f64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set borrow threshold".to_string(),
+        ));
+    }
+    if borrow_threshold_ratio < 1.0 || borrow_threshold_ratio > 5.0 {
+        return Err(ProtocolError::GenericError(format!(
+            "borrow_threshold_ratio ({}) must be between 1.0 and 5.0",
+            borrow_threshold_ratio
+        )));
+    }
+    let (liq_ratio, healthy_cr) = read_state(|s| {
+        s.collateral_configs
+            .get(&collateral_type)
+            .map(|c| (
+                c.liquidation_ratio.to_f64(),
+                c.healthy_cr.map(|r| r.to_f64()),
+            ))
+            .unwrap_or((0.0, None))
+    });
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    if borrow_threshold_ratio <= liq_ratio {
+        return Err(ProtocolError::GenericError(format!(
+            "borrow_threshold_ratio ({}) must be strictly greater than liquidation_ratio ({})",
+            borrow_threshold_ratio, liq_ratio
+        )));
+    }
+    if let Some(hcr) = healthy_cr {
+        if borrow_threshold_ratio >= hcr {
+            return Err(ProtocolError::GenericError(format!(
+                "borrow_threshold_ratio ({}) must be strictly less than healthy_cr ({})",
+                borrow_threshold_ratio, hcr
+            )));
+        }
+    }
+    let ratio = Ratio::from(
+        Decimal::try_from(borrow_threshold_ratio)
+            .map_err(|_| ProtocolError::GenericError("Invalid borrow_threshold_ratio value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_borrow_threshold(s, collateral_type, ratio);
+    });
+    log!(INFO, "[set_collateral_borrow_threshold] collateral={}, borrow_threshold_ratio={}", collateral_type, borrow_threshold_ratio);
+    Ok(())
+}
+
+/// Set the liquidation bonus for a specific collateral type (developer only).
+/// e.g. 1.10 = 10% bonus. Range 1.0–1.5.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_liquidation_bonus(
+    collateral_type: Principal,
+    liquidation_bonus: f64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set liquidation bonus".to_string(),
+        ));
+    }
+    if liquidation_bonus < 1.0 || liquidation_bonus > 1.5 {
+        return Err(ProtocolError::GenericError(
+            "liquidation_bonus must be between 1.0 and 1.5".to_string(),
+        ));
+    }
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    let ratio = Ratio::from(
+        Decimal::try_from(liquidation_bonus)
+            .map_err(|_| ProtocolError::GenericError("Invalid liquidation_bonus value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_liquidation_bonus(s, collateral_type, ratio);
+    });
+    log!(INFO, "[set_collateral_liquidation_bonus] collateral={}, liquidation_bonus={}", collateral_type, liquidation_bonus);
+    Ok(())
+}
+
+/// Set the minimum vault debt (dust threshold) for a specific collateral type (developer only).
+/// `min_vault_debt` is in icUSD e8s.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_min_vault_debt(
+    collateral_type: Principal,
+    min_vault_debt: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set min vault debt".to_string(),
+        ));
+    }
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_min_vault_debt(s, collateral_type, min_vault_debt);
+    });
+    log!(INFO, "[set_collateral_min_vault_debt] collateral={}, min_vault_debt={}", collateral_type, min_vault_debt);
+    Ok(())
+}
+
+/// Set the ledger fee for a specific collateral type (developer only).
+/// `ledger_fee` is in the collateral token's native units.
+/// Note: the backend also auto-syncs this from BadFee errors during transfers.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_ledger_fee(
+    collateral_type: Principal,
+    ledger_fee: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set ledger fee".to_string(),
+        ));
+    }
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_ledger_fee(s, collateral_type, ledger_fee);
+    });
+    log!(INFO, "[set_collateral_ledger_fee] collateral={}, ledger_fee={}", collateral_type, ledger_fee);
+    Ok(())
+}
+
+/// Set the redemption fee floor for a specific collateral type (developer only).
+/// e.g. 0.005 = 0.5%. Must be ≤ redemption_fee_ceiling.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_redemption_fee_floor(
+    collateral_type: Principal,
+    redemption_fee_floor: f64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set redemption fee floor".to_string(),
+        ));
+    }
+    if redemption_fee_floor < 0.0 || redemption_fee_floor > 0.10 {
+        return Err(ProtocolError::GenericError(
+            "redemption_fee_floor must be between 0 and 0.10 (10%)".to_string(),
+        ));
+    }
+    let ceiling = read_state(|s| {
+        s.collateral_configs
+            .get(&collateral_type)
+            .map(|c| c.redemption_fee_ceiling.to_f64())
+    });
+    let ceiling = match ceiling {
+        Some(c) => c,
+        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+    };
+    if redemption_fee_floor > ceiling {
+        return Err(ProtocolError::GenericError(format!(
+            "redemption_fee_floor ({}) must be ≤ redemption_fee_ceiling ({})",
+            redemption_fee_floor, ceiling
+        )));
+    }
+    let ratio = Ratio::from(
+        Decimal::try_from(redemption_fee_floor)
+            .map_err(|_| ProtocolError::GenericError("Invalid redemption_fee_floor value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_redemption_fee_floor(s, collateral_type, ratio);
+    });
+    log!(INFO, "[set_collateral_redemption_fee_floor] collateral={}, redemption_fee_floor={}", collateral_type, redemption_fee_floor);
+    Ok(())
+}
+
+/// Set the redemption fee ceiling for a specific collateral type (developer only).
+/// e.g. 0.05 = 5%. Must be ≥ redemption_fee_floor. Range 0.0–0.50.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_redemption_fee_ceiling(
+    collateral_type: Principal,
+    redemption_fee_ceiling: f64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set redemption fee ceiling".to_string(),
+        ));
+    }
+    if redemption_fee_ceiling < 0.0 || redemption_fee_ceiling > 0.50 {
+        return Err(ProtocolError::GenericError(
+            "redemption_fee_ceiling must be between 0 and 0.50 (50%)".to_string(),
+        ));
+    }
+    let floor = read_state(|s| {
+        s.collateral_configs
+            .get(&collateral_type)
+            .map(|c| c.redemption_fee_floor.to_f64())
+    });
+    let floor = match floor {
+        Some(f) => f,
+        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+    };
+    if redemption_fee_ceiling < floor {
+        return Err(ProtocolError::GenericError(format!(
+            "redemption_fee_ceiling ({}) must be ≥ redemption_fee_floor ({})",
+            redemption_fee_ceiling, floor
+        )));
+    }
+    let ratio = Ratio::from(
+        Decimal::try_from(redemption_fee_ceiling)
+            .map_err(|_| ProtocolError::GenericError("Invalid redemption_fee_ceiling value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_redemption_fee_ceiling(s, collateral_type, ratio);
+    });
+    log!(INFO, "[set_collateral_redemption_fee_ceiling] collateral={}, redemption_fee_ceiling={}", collateral_type, redemption_fee_ceiling);
+    Ok(())
+}
+
+/// Set the minimum collateral deposit for a specific collateral type (developer only).
+/// `min_collateral_deposit` is in the collateral token's native units.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_min_deposit(
+    collateral_type: Principal,
+    min_collateral_deposit: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set min collateral deposit".to_string(),
+        ));
+    }
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_min_deposit(s, collateral_type, min_collateral_deposit);
+    });
+    log!(INFO, "[set_collateral_min_deposit] collateral={}, min_collateral_deposit={}", collateral_type, min_collateral_deposit);
+    Ok(())
+}
+
+/// Set the display color (hex) for a collateral type, used by frontend (developer only).
+/// Pass None to clear.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_display_color(
+    collateral_type: Principal,
+    display_color: Option<String>,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set display color".to_string(),
+        ));
+    }
+    if let Some(ref c) = display_color {
+        if !c.starts_with('#') || (c.len() != 4 && c.len() != 7 && c.len() != 9) {
+            return Err(ProtocolError::GenericError(
+                "display_color must be a hex color like #RGB, #RRGGBB, or #RRGGBBAA".to_string(),
+            ));
+        }
+    }
+    let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
+    if !exists {
+        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+    }
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_collateral_display_color(s, collateral_type, display_color.clone());
+    });
+    log!(INFO, "[set_collateral_display_color] collateral={}, display_color={:?}", collateral_type, display_color);
+    Ok(())
+}
+
 #[candid_method(query)]
 #[query]
 fn get_collateral_config(collateral_type: Principal) -> Option<rumi_protocol_backend::state::CollateralConfig> {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -3684,9 +3684,9 @@ async fn set_collateral_liquidation_ratio(
             "Only the developer principal can set liquidation ratio".to_string(),
         ));
     }
-    if liquidation_ratio < 1.0 || liquidation_ratio > 5.0 {
+    if liquidation_ratio <= 1.0 || liquidation_ratio > 5.0 {
         return Err(ProtocolError::GenericError(format!(
-            "liquidation_ratio ({}) must be between 1.0 and 5.0",
+            "liquidation_ratio ({}) must be > 1.0 and ≤ 5.0",
             liquidation_ratio
         )));
     }
@@ -3732,9 +3732,9 @@ async fn set_collateral_borrow_threshold(
             "Only the developer principal can set borrow threshold".to_string(),
         ));
     }
-    if borrow_threshold_ratio < 1.0 || borrow_threshold_ratio > 5.0 {
+    if borrow_threshold_ratio <= 1.0 || borrow_threshold_ratio > 5.0 {
         return Err(ProtocolError::GenericError(format!(
-            "borrow_threshold_ratio ({}) must be between 1.0 and 5.0",
+            "borrow_threshold_ratio ({}) must be > 1.0 and ≤ 5.0",
             borrow_threshold_ratio
         )));
     }


### PR DESCRIPTION
## Summary
- Adds 9 developer-only update endpoints for per-asset `CollateralConfig` fields: liquidation ratio, borrow threshold, liquidation bonus, min vault debt, ledger fee, redemption fee floor/ceiling, min deposit, display color.
- Each setter validates its own bounds plus cross-field invariants (`liquidation_ratio < borrow_threshold_ratio < healthy_cr`, `redemption_fee_floor ≤ redemption_fee_ceiling`).
- New `Event` variants + replay arms keep state deterministic on upgrade.

## Motivation
Primary driver: changing nICP's liquidation ratio without hand-encoding `Ratio` blobs through `update_collateral_config`. Full set unblocks future per-asset tuning from the CLI.

## Not included (intentional)
- `recovery_target_cr` — derived from `borrow_threshold_ratio × recovery_cr_multiplier` (see `main.rs:3679`, `state.rs:1233`). `set_collateral_borrow_threshold` keeps the stored value in sync.
- `price_source` — complex; LST haircut already covered by `set_lst_haircut`, and `update_collateral_config` remains the escape hatch.
- `ledger_canister_id`, `decimals` — immutable post-registration.

## Test plan
- [x] `cargo check -p rumi_protocol_backend` clean
- [x] `cargo test -p rumi_protocol_backend --lib` — 58 pass; 1 pre-existing failure (`test_borrow_fee_does_not_credit_liquidity_pool`, fails on main too, unrelated)
- [ ] Deploy to mainnet and call `set_collateral_liquidation_ratio` on nICP → 1.25 (**requires explicit authorization**)
- [ ] Verify via `get_collateral_config(nICP)` that ratio updated and no other fields changed
- [ ] Upgrade-replay sanity check (event log replays cleanly through the new variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)