### PR TITLE
feat(analytics): Phase 3+4 collectors, event tailing, and balance tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7177,6 +7177,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ciborium",
+ "futures",
  "ic-canister-log 0.2.0 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
  "ic-canisters-http-types",
  "ic-cdk 0.12.2",

--- a/docs/superpowers/plans/2026-04-09-analytics-phase4-event-tailing.md
+++ b/docs/superpowers/plans/2026-04-09-analytics-phase4-event-tailing.md
@@ -1,0 +1,2396 @@
+# Analytics Phase 4: Event Tailing & BalanceTracker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add cursor-based event tailing from 6 sources, ICRC-3 block replay for holder tracking, daily holder snapshots, historical backfill, and a collector health query to the rumi_analytics canister.
+
+**Architecture:** The 60s pull cycle polls source canisters for new events since the last cursor position, writing normalized events to EVT_* StableLogs and applying ICRC-3 block deltas to BalanceTracker StableBTreeMaps. A daily holder collector computes snapshot metrics (Gini, top-50, distribution buckets) from the BalanceTracker. Admin-gated backfill processes historical blocks in chunks via the pull cycle.
+
+**Tech Stack:** Rust, ic-cdk 0.12.0, ic-stable-structures 0.6.7, candid 0.10.6, futures 0.3
+
+**Spec:** `docs/superpowers/specs/2026-04-09-analytics-phase4-event-tailing-design.md`
+
+---
+
+## File Structure
+
+### New files
+- `src/rumi_analytics/src/storage/events.rs` -- EVT_* row types, Storable impls, StableLog instances, accessor modules
+- `src/rumi_analytics/src/storage/cursors.rs` -- StableCell<u64> cursor instances, read/write helpers
+- `src/rumi_analytics/src/storage/balance_tracker.rs` -- StableBTreeMap instances for BAL_* and FIRSTSEEN_*, apply_delta/get/iterate helpers
+- `src/rumi_analytics/src/storage/holders.rs` -- DailyHolderRow type, Storable impl, StableLog instances, accessor modules
+- `src/rumi_analytics/src/sources/amm.rs` -- Source wrapper for AMM swap event queries
+- `src/rumi_analytics/src/tailing/mod.rs` -- Module declaration for tailing functions
+- `src/rumi_analytics/src/tailing/backend_events.rs` -- Backend event tailing + routing to EVT_LIQUIDATIONS/EVT_VAULTS
+- `src/rumi_analytics/src/tailing/three_pool_swaps.rs` -- 3pool swap event tailing
+- `src/rumi_analytics/src/tailing/three_pool_liquidity.rs` -- 3pool liquidity event tailing
+- `src/rumi_analytics/src/tailing/amm_swaps.rs` -- AMM swap event tailing
+- `src/rumi_analytics/src/tailing/icrc3.rs` -- ICRC-3 block tailing + BalanceTracker update (shared by icusd + 3pool)
+- `src/rumi_analytics/src/collectors/holders.rs` -- Daily holder snapshot collector (Gini, top-50, distribution)
+
+### Modified files
+- `src/rumi_analytics/src/storage.rs` -- Split into `storage/mod.rs` re-exporting submodules; existing types stay
+- `src/rumi_analytics/src/sources/mod.rs` -- Add `pub mod amm;`
+- `src/rumi_analytics/src/sources/backend.rs` -- Add `get_events()` and `get_event_count()` wrappers
+- `src/rumi_analytics/src/sources/icusd_ledger.rs` -- Add `icrc3_get_blocks()` wrapper
+- `src/rumi_analytics/src/sources/three_pool.rs` -- Add `get_swap_events()`, `get_swap_event_count()`, `get_liquidity_events()`, `get_liquidity_event_count()`, `icrc3_get_blocks()` wrappers
+- `src/rumi_analytics/src/state.rs` -- Add Phase 4 fields to SlimState (cursor metadata, backfill flags, last_pull_cycle_ns)
+- `src/rumi_analytics/src/timers.rs` -- Expand pull_cycle with tail_* calls; add holders to daily_snapshot
+- `src/rumi_analytics/src/collectors/mod.rs` -- Add `pub mod holders;`
+- `src/rumi_analytics/src/types.rs` -- Add HolderSeriesResponse, CollectorHealth, CursorStatus, BalanceTrackerStats
+- `src/rumi_analytics/src/queries/historical.rs` -- Add get_holder_series
+- `src/rumi_analytics/src/lib.rs` -- Add get_holder_series, get_collector_health, start_backfill entry points
+- `src/rumi_analytics/rumi_analytics.did` -- Add all new types and methods
+- `src/rumi_analytics/tests/pocket_ic_analytics.rs` -- Phase 4 integration tests
+
+---
+
+## Task Dependency Graph
+
+Tasks 1-4 are foundational (storage + sources) and can be done in order. Tasks 5-8 are the tailing functions (depend on 1-4). Task 9 is the holder collector (depends on 1-4). Tasks 10-11 are wiring (depend on 5-9). Task 12 is the Candid interface. Task 13 is integration tests. Task 14 is deploy.
+
+---
+
+### Task 1: Split storage.rs into submodules + add cursor infrastructure
+
+The existing `storage.rs` is 437 lines and about to get much bigger. Split it into `storage/mod.rs` (re-exports + existing types) and new submodule files.
+
+**Files:**
+- Rename: `src/rumi_analytics/src/storage.rs` -> `src/rumi_analytics/src/storage/mod.rs`
+- Create: `src/rumi_analytics/src/storage/cursors.rs`
+
+**Context:** Existing storage.rs contains all MemoryId constants, SlimState, DailyTvlRow, DailyVaultSnapshotRow, DailyStabilityRow, their Storable impls, thread_local! declarations for MEMORY_MANAGER/SLIM_CELL/DAILY_*_LOG, and accessor modules (daily_tvl, daily_vaults, daily_stability). All of this stays in mod.rs. The MEMORY_MANAGER must be accessible from submodules.
+
+- [ ] **Step 1: Convert storage.rs to storage/mod.rs**
+
+Create directory `src/rumi_analytics/src/storage/` and move `storage.rs` to `storage/mod.rs`. Add submodule declarations at the bottom. Make `MEMORY_MANAGER` accessible to submodules by adding a helper function.
+
+Add to the end of `storage/mod.rs` (after existing code):
+
+```rust
+pub mod cursors;
+pub mod events;
+pub mod balance_tracker;
+pub mod holders;
+
+/// Get a virtual memory from the shared MemoryManager. Used by submodules.
+pub(crate) fn get_memory(id: MemoryId) -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(id))
+}
+```
+
+- [ ] **Step 2: Create cursors.rs**
+
+```rust
+//! Cursor StableCells for event tailing. Each cursor tracks the next event
+//! index to fetch from a source canister.
+
+use ic_stable_structures::StableCell;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_CURSOR_BACKEND_EVENTS, MEM_CURSOR_3POOL_SWAPS,
+    MEM_CURSOR_3POOL_LIQUIDITY, MEM_CURSOR_3POOL_BLOCKS,
+    MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_ICUSD_BLOCKS,
+};
+
+thread_local! {
+    static CURSOR_BACKEND_EVENTS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_BACKEND_EVENTS), 0u64)
+            .expect("init cursor backend_events")
+    );
+    static CURSOR_3POOL_SWAPS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_SWAPS), 0u64)
+            .expect("init cursor 3pool_swaps")
+    );
+    static CURSOR_3POOL_LIQUIDITY: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_LIQUIDITY), 0u64)
+            .expect("init cursor 3pool_liquidity")
+    );
+    static CURSOR_3POOL_BLOCKS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_BLOCKS), 0u64)
+            .expect("init cursor 3pool_blocks")
+    );
+    static CURSOR_AMM_SWAPS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_AMM_SWAPS), 0u64)
+            .expect("init cursor amm_swaps")
+    );
+    static CURSOR_ICUSD_BLOCKS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_ICUSD_BLOCKS), 0u64)
+            .expect("init cursor icusd_blocks")
+    );
+}
+
+/// Cursor identifiers matching MemoryIds. Used as keys in SlimState metadata maps.
+pub const CURSOR_ID_BACKEND_EVENTS: u8 = 1;
+pub const CURSOR_ID_3POOL_SWAPS: u8 = 2;
+pub const CURSOR_ID_3POOL_LIQUIDITY: u8 = 3;
+pub const CURSOR_ID_3POOL_BLOCKS: u8 = 4;
+pub const CURSOR_ID_AMM_SWAPS: u8 = 5;
+pub const CURSOR_ID_ICUSD_BLOCKS: u8 = 7;
+
+macro_rules! cursor_accessors {
+    ($mod_name:ident, $cell:ident) => {
+        pub mod $mod_name {
+            use super::*;
+            pub fn get() -> u64 {
+                $cell.with(|c| *c.borrow().get())
+            }
+            pub fn set(val: u64) {
+                $cell.with(|c| c.borrow_mut().set(val).expect(concat!("set cursor ", stringify!($mod_name))));
+            }
+        }
+    };
+}
+
+cursor_accessors!(backend_events, CURSOR_BACKEND_EVENTS);
+cursor_accessors!(three_pool_swaps, CURSOR_3POOL_SWAPS);
+cursor_accessors!(three_pool_liquidity, CURSOR_3POOL_LIQUIDITY);
+cursor_accessors!(three_pool_blocks, CURSOR_3POOL_BLOCKS);
+cursor_accessors!(amm_swaps, CURSOR_AMM_SWAPS);
+cursor_accessors!(icusd_blocks, CURSOR_ICUSD_BLOCKS);
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+Expected: No errors. (Warnings about unused submodules are fine since events.rs, balance_tracker.rs, holders.rs don't exist yet.)
+
+- [ ] **Step 4: Create empty placeholder submodules so it compiles clean**
+
+Create empty files for the modules declared in mod.rs that don't exist yet:
+
+`src/rumi_analytics/src/storage/events.rs`:
+```rust
+//! EVT_* event log types and StableLog instances. Populated in Task 2.
+```
+
+`src/rumi_analytics/src/storage/balance_tracker.rs`:
+```rust
+//! BalanceTracker StableBTreeMap instances. Populated in Task 3.
+```
+
+`src/rumi_analytics/src/storage/holders.rs`:
+```rust
+//! DailyHolderRow type and StableLog instances. Populated in Task 4.
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+Expected: No errors.
+
+- [ ] **Step 6: Run existing tests to confirm no regressions**
+
+Run: `cargo test -p rumi_analytics --lib 2>&1 | tail -5`
+Expected: All existing unit tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/ src/rumi_analytics/src/storage.rs
+git commit -m "refactor(analytics): split storage.rs into submodules + add cursor infrastructure"
+```
+
+Note: `git add` will pick up the deletion of `storage.rs` and creation of `storage/` automatically.
+
+---
+
+### Task 2: EVT_* event log types and StableLogs
+
+**Files:**
+- Create (populate): `src/rumi_analytics/src/storage/events.rs`
+
+**Context:** The spec defines 4 normalized event types: AnalyticsLiquidationEvent, AnalyticsVaultEvent, AnalyticsSwapEvent, AnalyticsLiquidityEvent. Each needs a Storable impl (Candid encoding, Bound::Unbounded), a StableLog in thread_local!, and an accessor module with push/len/get/range. Follow the exact pattern from `storage/mod.rs`'s daily_tvl module.
+
+- [ ] **Step 1: Write unit tests for event type serialization**
+
+Add to the bottom of `events.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+
+    #[test]
+    fn liquidation_event_roundtrip() {
+        let evt = AnalyticsLiquidationEvent {
+            timestamp_ns: 1_000_000,
+            source_event_id: 42,
+            vault_id: 7,
+            collateral_type: Principal::anonymous(),
+            collateral_amount: 500_000_000,
+            debt_amount: 100_000_000,
+            liquidation_kind: LiquidationKind::Full,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsLiquidationEvent::from_bytes(bytes);
+        assert_eq!(decoded.vault_id, 7);
+        assert_eq!(decoded.collateral_amount, 500_000_000);
+    }
+
+    #[test]
+    fn swap_event_roundtrip() {
+        let evt = AnalyticsSwapEvent {
+            timestamp_ns: 2_000_000,
+            source: SwapSource::ThreePool,
+            source_event_id: 10,
+            caller: Principal::anonymous(),
+            token_in: Principal::anonymous(),
+            token_out: Principal::anonymous(),
+            amount_in: 1_000_000,
+            amount_out: 999_000,
+            fee: 1_000,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsSwapEvent::from_bytes(bytes);
+        assert_eq!(decoded.amount_in, 1_000_000);
+        assert!(matches!(decoded.source, SwapSource::ThreePool));
+    }
+
+    #[test]
+    fn vault_event_roundtrip() {
+        let evt = AnalyticsVaultEvent {
+            timestamp_ns: 3_000_000,
+            source_event_id: 5,
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            event_kind: VaultEventKind::Opened,
+            collateral_type: Principal::anonymous(),
+            amount: 10_000_000_000,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsVaultEvent::from_bytes(bytes);
+        assert_eq!(decoded.vault_id, 1);
+        assert!(matches!(decoded.event_kind, VaultEventKind::Opened));
+    }
+
+    #[test]
+    fn liquidity_event_roundtrip() {
+        let evt = AnalyticsLiquidityEvent {
+            timestamp_ns: 4_000_000,
+            source_event_id: 20,
+            caller: Principal::anonymous(),
+            action: LiquidityAction::Add,
+            amounts: vec![100, 200, 300],
+            lp_amount: 500,
+            coin_index: None,
+            fee: Some(5),
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsLiquidityEvent::from_bytes(bytes);
+        assert_eq!(decoded.amounts, vec![100, 200, 300]);
+        assert_eq!(decoded.fee, Some(5));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cargo test -p rumi_analytics --lib events 2>&1 | tail -5`
+Expected: FAIL (types don't exist yet)
+
+- [ ] **Step 3: Implement event types, Storable impls, StableLogs, and accessor modules**
+
+Write the full `events.rs`:
+
+```rust
+//! EVT_* normalized event log types and StableLog instances.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_EVT_LIQUIDATIONS_IDX, MEM_EVT_LIQUIDATIONS_DATA,
+    MEM_EVT_SWAPS_IDX, MEM_EVT_SWAPS_DATA,
+    MEM_EVT_LIQUIDITY_IDX, MEM_EVT_LIQUIDITY_DATA,
+    MEM_EVT_VAULTS_IDX, MEM_EVT_VAULTS_DATA,
+};
+
+// --- Enum types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum LiquidationKind {
+    Full,
+    Partial,
+    Redistribution,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum VaultEventKind {
+    Opened,
+    Borrowed,
+    Repaid,
+    CollateralWithdrawn,
+    PartialCollateralWithdrawn,
+    WithdrawAndClose,
+    Closed,
+    DustForgiven,
+    Redeemed,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum SwapSource {
+    ThreePool,
+    Amm,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum LiquidityAction {
+    Add,
+    Remove,
+    RemoveOneCoin,
+    Donate,
+}
+
+// --- Event row types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsLiquidationEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub vault_id: u64,
+    pub collateral_type: Principal,
+    pub collateral_amount: u64,
+    pub debt_amount: u64,
+    pub liquidation_kind: LiquidationKind,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsVaultEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub vault_id: u64,
+    pub owner: Principal,
+    pub event_kind: VaultEventKind,
+    pub collateral_type: Principal,
+    pub amount: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsSwapEvent {
+    pub timestamp_ns: u64,
+    pub source: SwapSource,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub token_in: Principal,
+    pub token_out: Principal,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub fee: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsLiquidityEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub action: LiquidityAction,
+    pub amounts: Vec<u64>,
+    pub lp_amount: u64,
+    pub coin_index: Option<u8>,
+    pub fee: Option<u64>,
+}
+
+// --- Storable impls ---
+
+macro_rules! storable_candid {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<[u8]> {
+                Cow::Owned(Encode!(self).expect(concat!(stringify!($t), " encode")))
+            }
+            fn from_bytes(bytes: Cow<[u8]>) -> Self {
+                Decode!(bytes.as_ref(), Self).expect(concat!(stringify!($t), " decode"))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+storable_candid!(AnalyticsLiquidationEvent);
+storable_candid!(AnalyticsVaultEvent);
+storable_candid!(AnalyticsSwapEvent);
+storable_candid!(AnalyticsLiquidityEvent);
+
+// --- StableLog instances ---
+
+thread_local! {
+    static EVT_LIQUIDATIONS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsLiquidationEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_LIQUIDATIONS_IDX),
+                get_memory(MEM_EVT_LIQUIDATIONS_DATA),
+            ).expect("init EVT_LIQUIDATIONS log")
+        });
+
+    static EVT_SWAPS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsSwapEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_SWAPS_IDX),
+                get_memory(MEM_EVT_SWAPS_DATA),
+            ).expect("init EVT_SWAPS log")
+        });
+
+    static EVT_LIQUIDITY_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsLiquidityEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_LIQUIDITY_IDX),
+                get_memory(MEM_EVT_LIQUIDITY_DATA),
+            ).expect("init EVT_LIQUIDITY log")
+        });
+
+    static EVT_VAULTS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsVaultEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_VAULTS_IDX),
+                get_memory(MEM_EVT_VAULTS_DATA),
+            ).expect("init EVT_VAULTS log")
+        });
+}
+
+// --- Accessor modules ---
+
+macro_rules! evt_accessors {
+    ($mod_name:ident, $log:ident, $row_type:ty) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: $row_type) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<$row_type> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<$row_type> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts {
+                                break;
+                            }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+evt_accessors!(evt_liquidations, EVT_LIQUIDATIONS_LOG, AnalyticsLiquidationEvent);
+evt_accessors!(evt_swaps, EVT_SWAPS_LOG, AnalyticsSwapEvent);
+evt_accessors!(evt_liquidity, EVT_LIQUIDITY_LOG, AnalyticsLiquidityEvent);
+evt_accessors!(evt_vaults, EVT_VAULTS_LOG, AnalyticsVaultEvent);
+
+// Tests at the bottom (from Step 1)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rumi_analytics --lib events 2>&1 | tail -5`
+Expected: All 4 roundtrip tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/events.rs
+git commit -m "feat(analytics): add EVT_* event log types and StableLogs"
+```
+
+---
+
+### Task 3: BalanceTracker StableBTreeMap instances
+
+**Files:**
+- Create (populate): `src/rumi_analytics/src/storage/balance_tracker.rs`
+
+**Context:** Two balance maps (BAL_ICUSD MemoryId 56, BAL_3USD MemoryId 57) and two first-seen maps (FIRSTSEEN_ICUSD MemoryId 58, FIRSTSEEN_3USD MemoryId 59). Key is a Candid-encoded `Account` (Principal + optional subaccount). Value is u64. The balance tracker needs apply_transfer, apply_mint, apply_burn operations, plus iteration for the holder snapshot.
+
+Note: `ic-stable-structures` `StableBTreeMap` requires fixed-size keys when using `Bound::Bounded`. For variable-length Account keys, we use `Vec<u8>` as the key type with `Bound::Unbounded` which is NOT supported by StableBTreeMap. Instead, we encode the Account to a fixed-size byte array. An Account is at most 29 bytes (principal) + 32 bytes (subaccount) = 61 bytes. We'll use a 64-byte fixed buffer with length prefix.
+
+- [ ] **Step 1: Write unit tests**
+
+Add to the bottom of `balance_tracker.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+
+    #[test]
+    fn account_key_roundtrip() {
+        let acct = Account {
+            owner: Principal::anonymous(),
+            subaccount: None,
+        };
+        let key = AccountKey::from_account(&acct);
+        let decoded = key.to_account();
+        assert_eq!(decoded.owner, acct.owner);
+        assert_eq!(decoded.subaccount, acct.subaccount);
+    }
+
+    #[test]
+    fn account_key_with_subaccount_roundtrip() {
+        let mut sub = [0u8; 32];
+        sub[0] = 1;
+        sub[31] = 0xFF;
+        let acct = Account {
+            owner: Principal::anonymous(),
+            subaccount: Some(sub),
+        };
+        let key = AccountKey::from_account(&acct);
+        let decoded = key.to_account();
+        assert_eq!(decoded.owner, acct.owner);
+        assert_eq!(decoded.subaccount, Some(sub));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cargo test -p rumi_analytics --lib balance_tracker 2>&1 | tail -5`
+Expected: FAIL
+
+- [ ] **Step 3: Implement balance_tracker.rs**
+
+```rust
+//! BalanceTracker: StableBTreeMap-backed running balance and first-seen
+//! tracking for icUSD and 3USD holders.
+
+use candid::{Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use ic_stable_structures::StableBTreeMap;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{MEM_BAL_ICUSD, MEM_BAL_3USD, MEM_FIRSTSEEN_ICUSD, MEM_FIRSTSEEN_3USD};
+
+/// ICRC-1 Account: principal + optional 32-byte subaccount.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Account {
+    pub owner: Principal,
+    pub subaccount: Option<[u8; 32]>,
+}
+
+/// Fixed-size key for StableBTreeMap. Layout: 1 byte principal length,
+/// up to 29 bytes principal, 1 byte subaccount flag (0 or 1),
+/// 32 bytes subaccount (zeroed if absent). Total: 63 bytes.
+const ACCOUNT_KEY_LEN: usize = 63;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountKey(pub [u8; ACCOUNT_KEY_LEN]);
+
+impl AccountKey {
+    pub fn from_account(acct: &Account) -> Self {
+        let mut buf = [0u8; ACCOUNT_KEY_LEN];
+        let principal_bytes = acct.owner.as_slice();
+        buf[0] = principal_bytes.len() as u8;
+        buf[1..1 + principal_bytes.len()].copy_from_slice(principal_bytes);
+        match &acct.subaccount {
+            Some(sub) => {
+                buf[30] = 1;
+                buf[31..63].copy_from_slice(sub);
+            }
+            None => {
+                buf[30] = 0;
+                // bytes 31..63 stay zeroed
+            }
+        }
+        Self(buf)
+    }
+
+    pub fn to_account(&self) -> Account {
+        let plen = self.0[0] as usize;
+        let owner = Principal::from_slice(&self.0[1..1 + plen]);
+        let subaccount = if self.0[30] == 1 {
+            let mut sub = [0u8; 32];
+            sub.copy_from_slice(&self.0[31..63]);
+            Some(sub)
+        } else {
+            None
+        };
+        Account { owner, subaccount }
+    }
+
+    /// Extract just the owner Principal without constructing full Account.
+    pub fn owner(&self) -> Principal {
+        let plen = self.0[0] as usize;
+        Principal::from_slice(&self.0[1..1 + plen])
+    }
+}
+
+impl Storable for AccountKey {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let mut buf = [0u8; ACCOUNT_KEY_LEN];
+        buf.copy_from_slice(&bytes[..ACCOUNT_KEY_LEN]);
+        Self(buf)
+    }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: ACCOUNT_KEY_LEN as u32,
+        is_fixed_size: true,
+    };
+}
+
+/// u64 value wrapper for StableBTreeMap.
+impl Storable for BalVal {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.0.to_le_bytes().to_vec())
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes[..8]);
+        Self(u64::from_le_bytes(arr))
+    }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 8,
+        is_fixed_size: true,
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct BalVal(pub u64);
+
+thread_local! {
+    static BAL_ICUSD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_BAL_ICUSD))
+    );
+    static BAL_3USD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_BAL_3USD))
+    );
+    static FIRSTSEEN_ICUSD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_FIRSTSEEN_ICUSD))
+    );
+    static FIRSTSEEN_3USD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_FIRSTSEEN_3USD))
+    );
+}
+
+/// Which token's maps to operate on.
+#[derive(Clone, Copy, Debug)]
+pub enum Token { IcUsd, ThreeUsd }
+
+fn with_bal<F, R>(token: Token, f: F) -> R
+where F: FnOnce(&mut StableBTreeMap<AccountKey, BalVal, Memory>) -> R {
+    match token {
+        Token::IcUsd => BAL_ICUSD_MAP.with(|m| f(&mut m.borrow_mut())),
+        Token::ThreeUsd => BAL_3USD_MAP.with(|m| f(&mut m.borrow_mut())),
+    }
+}
+
+fn with_firstseen<F, R>(token: Token, f: F) -> R
+where F: FnOnce(&mut StableBTreeMap<AccountKey, BalVal, Memory>) -> R {
+    match token {
+        Token::IcUsd => FIRSTSEEN_ICUSD_MAP.with(|m| f(&mut m.borrow_mut())),
+        Token::ThreeUsd => FIRSTSEEN_3USD_MAP.with(|m| f(&mut m.borrow_mut())),
+    }
+}
+
+/// Record first-seen timestamp if not already set.
+fn maybe_set_firstseen(token: Token, key: &AccountKey, timestamp_ns: u64) {
+    with_firstseen(token, |map| {
+        if map.get(key).is_none() {
+            map.insert(key.clone(), BalVal(timestamp_ns));
+        }
+    });
+}
+
+/// Credit an account. Inserts if not present.
+pub fn credit(token: Token, acct: &Account, amount: u64, timestamp_ns: u64) {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| {
+        let current = map.get(&key).map(|v| v.0).unwrap_or(0);
+        map.insert(key.clone(), BalVal(current.saturating_add(amount)));
+    });
+    maybe_set_firstseen(token, &key, timestamp_ns);
+}
+
+/// Debit an account. Removes entry if balance reaches 0.
+pub fn debit(token: Token, acct: &Account, amount: u64) {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| {
+        let current = map.get(&key).map(|v| v.0).unwrap_or(0);
+        let new_bal = current.saturating_sub(amount);
+        if new_bal == 0 {
+            map.remove(&key);
+        } else {
+            map.insert(key, BalVal(new_bal));
+        }
+    });
+}
+
+/// Apply a transfer: debit sender (amount + fee), credit receiver (amount).
+pub fn apply_transfer(
+    token: Token,
+    from: &Account,
+    to: &Account,
+    amount: u64,
+    fee: u64,
+    timestamp_ns: u64,
+) {
+    debit(token, from, amount.saturating_add(fee));
+    credit(token, to, amount, timestamp_ns);
+}
+
+/// Apply a mint: credit receiver.
+pub fn apply_mint(token: Token, to: &Account, amount: u64, timestamp_ns: u64) {
+    credit(token, to, amount, timestamp_ns);
+}
+
+/// Apply a burn: debit sender.
+pub fn apply_burn(token: Token, from: &Account, amount: u64) {
+    debit(token, from, amount);
+}
+
+/// Get balance for a specific account.
+pub fn get_balance(token: Token, acct: &Account) -> u64 {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| map.get(&key).map(|v| v.0).unwrap_or(0))
+}
+
+/// Get total holder count for a token.
+pub fn holder_count(token: Token) -> u64 {
+    with_bal(token, |map| map.len())
+}
+
+/// Iterate all (account, balance) pairs. Collects into a Vec.
+/// For holder snapshot computation (Gini, top-N, buckets).
+pub fn all_balances(token: Token) -> Vec<(Account, u64)> {
+    with_bal(token, |map| {
+        map.iter().map(|(k, v)| (k.to_account(), v.0)).collect()
+    })
+}
+
+/// Get first-seen timestamp for an account, if tracked.
+pub fn get_firstseen(token: Token, acct: &Account) -> Option<u64> {
+    let key = AccountKey::from_account(acct);
+    with_firstseen(token, |map| map.get(&key).map(|v| v.0))
+}
+
+/// Count accounts whose first-seen timestamp falls in [from_ns, to_ns).
+pub fn count_new_holders(token: Token, from_ns: u64, to_ns: u64) -> u32 {
+    with_firstseen(token, |map| {
+        map.iter()
+            .filter(|(_, v)| v.0 >= from_ns && v.0 < to_ns)
+            .count() as u32
+    })
+}
+
+/// Get sum of all balances (for sanity check).
+pub fn total_supply_tracked(token: Token) -> u64 {
+    with_bal(token, |map| {
+        map.iter().map(|(_, v)| v.0).fold(0u64, |a, b| a.saturating_add(b))
+    })
+}
+
+// ... tests from Step 1 go here
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p rumi_analytics --lib balance_tracker 2>&1 | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/balance_tracker.rs
+git commit -m "feat(analytics): add BalanceTracker StableBTreeMap instances"
+```
+
+---
+
+### Task 4: DailyHolderRow type + StableLogs + holder snapshot collector
+
+**Files:**
+- Create (populate): `src/rumi_analytics/src/storage/holders.rs`
+- Create: `src/rumi_analytics/src/collectors/holders.rs`
+- Modify: `src/rumi_analytics/src/collectors/mod.rs`
+
+**Context:** DailyHolderRow stores daily holder metrics per token. The holder collector reads from the BalanceTracker to compute Gini coefficient, top 50 holders, distribution buckets, median balance, and new-holder count. Two StableLogs: DAILY_HOLDERS_ICUSD (MemoryIds 14/15) and DAILY_HOLDERS_3USD (MemoryIds 16/17).
+
+- [ ] **Step 1: Write unit tests for Gini + snapshot computation**
+
+In `src/rumi_analytics/src/collectors/holders.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gini_perfect_equality() {
+        // All same balance => Gini = 0
+        let balances = vec![100, 100, 100, 100];
+        assert_eq!(compute_gini_bps(&balances), 0);
+    }
+
+    #[test]
+    fn gini_perfect_inequality() {
+        // One holder has everything
+        let balances = vec![0, 0, 0, 1000];
+        // Gini should be close to 10000 (bps) for extreme inequality
+        let g = compute_gini_bps(&balances);
+        assert!(g > 7000, "expected high Gini, got {}", g);
+    }
+
+    #[test]
+    fn gini_moderate_inequality() {
+        let balances = vec![10, 20, 30, 40, 50];
+        let g = compute_gini_bps(&balances);
+        assert!(g > 0 && g < 5000, "expected moderate Gini, got {}", g);
+    }
+
+    #[test]
+    fn gini_empty() {
+        assert_eq!(compute_gini_bps(&[]), 0);
+    }
+
+    #[test]
+    fn gini_single() {
+        assert_eq!(compute_gini_bps(&[100]), 0);
+    }
+
+    #[test]
+    fn distribution_buckets_correct() {
+        // Buckets: 0-100, 100-1k, 1k-10k, 10k-100k, >100k (in tokens, but input is e8s)
+        let balances_e8s: Vec<u64> = vec![
+            50_0000_0000,       // 50 tokens -> bucket 0
+            500_0000_0000,      // 500 tokens -> bucket 1
+            5_000_0000_0000,    // 5,000 tokens -> bucket 2
+            50_000_0000_0000,   // 50,000 tokens -> bucket 3
+            500_000_0000_0000,  // 500,000 tokens -> bucket 4
+            10_0000_0000,       // 10 tokens -> bucket 0
+        ];
+        let buckets = compute_distribution_buckets(&balances_e8s);
+        assert_eq!(buckets, vec![2, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn top_n_extracts_correct_top() {
+        let holders = vec![
+            (candid::Principal::anonymous(), 100u64),
+            (candid::Principal::anonymous(), 500),
+            (candid::Principal::anonymous(), 200),
+        ];
+        let top = top_n_holders(&holders, 2);
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0].1, 500);
+        assert_eq!(top[1].1, 200);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cargo test -p rumi_analytics --lib holders 2>&1 | tail -5`
+Expected: FAIL
+
+- [ ] **Step 3: Implement holders storage type**
+
+In `src/rumi_analytics/src/storage/holders.rs`:
+
+```rust
+//! DailyHolderRow type and StableLog instances for icUSD and 3USD holder snapshots.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_DAILY_HOLDERS_ICUSD_IDX, MEM_DAILY_HOLDERS_ICUSD_DATA,
+    MEM_DAILY_HOLDERS_3USD_IDX, MEM_DAILY_HOLDERS_3USD_DATA,
+};
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyHolderRow {
+    pub timestamp_ns: u64,
+    pub token: Principal,
+    pub total_holders: u32,
+    pub total_supply_tracked_e8s: u64,
+    pub median_balance_e8s: u64,
+    pub top_50: Vec<(Principal, u64)>,
+    pub top_10_pct_bps: u32,
+    pub gini_bps: u32,
+    pub new_holders_today: u32,
+    pub distribution_buckets: Vec<u32>,
+}
+
+impl Storable for DailyHolderRow {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).expect("DailyHolderRow encode"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).expect("DailyHolderRow decode")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+thread_local! {
+    static DAILY_HOLDERS_ICUSD_LOG: RefCell<ic_stable_structures::StableLog<DailyHolderRow, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_HOLDERS_ICUSD_IDX),
+                get_memory(MEM_DAILY_HOLDERS_ICUSD_DATA),
+            ).expect("init DAILY_HOLDERS_ICUSD log")
+        });
+
+    static DAILY_HOLDERS_3USD_LOG: RefCell<ic_stable_structures::StableLog<DailyHolderRow, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_HOLDERS_3USD_IDX),
+                get_memory(MEM_DAILY_HOLDERS_3USD_DATA),
+            ).expect("init DAILY_HOLDERS_3USD log")
+        });
+}
+
+macro_rules! holder_accessors {
+    ($mod_name:ident, $log:ident) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: DailyHolderRow) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<DailyHolderRow> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<DailyHolderRow> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts { break; }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit { break; }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+holder_accessors!(daily_holders_icusd, DAILY_HOLDERS_ICUSD_LOG);
+holder_accessors!(daily_holders_3usd, DAILY_HOLDERS_3USD_LOG);
+```
+
+- [ ] **Step 4: Implement the holder collector**
+
+In `src/rumi_analytics/src/collectors/holders.rs`:
+
+```rust
+//! Daily holder snapshot collector. Reads BalanceTracker state and computes
+//! Gini coefficient, top-50, distribution buckets, median balance.
+
+use candid::Principal;
+use crate::{state, storage};
+use storage::balance_tracker::{self, Token};
+use storage::holders::DailyHolderRow;
+
+const NANOS_PER_DAY: u64 = 86_400_000_000_000;
+
+/// Distribution bucket thresholds in e8s (powers of 10 in token terms).
+const BUCKET_THRESHOLDS: [u64; 4] = [
+    100_0000_0000,       // 100 tokens
+    1_000_0000_0000,     // 1,000 tokens
+    10_000_0000_0000,    // 10,000 tokens
+    100_000_0000_0000,   // 100,000 tokens
+];
+
+pub fn compute_gini_bps(sorted_balances: &[u64]) -> u32 {
+    let n = sorted_balances.len();
+    if n <= 1 {
+        return 0;
+    }
+    let total: u128 = sorted_balances.iter().map(|&b| b as u128).sum();
+    if total == 0 {
+        return 0;
+    }
+    // Gini = (2 * sum(i * balance[i])) / (n * total) - (n + 1) / n
+    // Using 1-indexed: sum((2*i - n - 1) * balance[i]) / (n * total)
+    let n128 = n as u128;
+    let mut numerator: i128 = 0;
+    for (i, &bal) in sorted_balances.iter().enumerate() {
+        let rank = (i as i128 + 1) * 2 - n128 as i128 - 1;
+        numerator += rank * bal as i128;
+    }
+    let gini = numerator as f64 / (n128 as f64 * total as f64);
+    let gini_clamped = gini.clamp(0.0, 1.0);
+    (gini_clamped * 10_000.0) as u32
+}
+
+pub fn compute_distribution_buckets(balances_e8s: &[u64]) -> Vec<u32> {
+    let mut buckets = vec![0u32; BUCKET_THRESHOLDS.len() + 1];
+    for &bal in balances_e8s {
+        let idx = BUCKET_THRESHOLDS.iter().position(|&t| bal <= t).unwrap_or(BUCKET_THRESHOLDS.len());
+        buckets[idx] += 1;
+    }
+    buckets
+}
+
+pub fn top_n_holders(holders: &[(Principal, u64)], n: usize) -> Vec<(Principal, u64)> {
+    let mut sorted: Vec<_> = holders.to_vec();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.truncate(n);
+    sorted
+}
+
+fn compute_median(sorted: &[u64]) -> u64 {
+    let n = sorted.len();
+    if n == 0 { return 0; }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        let lo = sorted[n / 2 - 1] as u128;
+        let hi = sorted[n / 2] as u128;
+        ((lo + hi) / 2) as u64
+    }
+}
+
+fn snapshot_token(token: Token, token_principal: Principal, now_ns: u64) -> DailyHolderRow {
+    let all = balance_tracker::all_balances(token);
+
+    let total_holders = all.len() as u32;
+    let total_supply_tracked = balance_tracker::total_supply_tracked(token);
+
+    // Collect balances for stats, and (principal, balance) for top-N.
+    let mut balances: Vec<u64> = all.iter().map(|(_, b)| *b).collect();
+    let principal_balances: Vec<(Principal, u64)> = all.iter().map(|(a, b)| (a.owner.clone(), *b)).collect();
+
+    balances.sort_unstable();
+    let median = compute_median(&balances);
+    let gini = compute_gini_bps(&balances);
+    let buckets = compute_distribution_buckets(&balances);
+    let top_50 = top_n_holders(&principal_balances, 50);
+
+    // Top-10 concentration: sum of top 10 balances / total * 10000
+    let top_10_sum: u64 = {
+        let mut sorted_desc = balances.clone();
+        sorted_desc.sort_unstable_by(|a, b| b.cmp(a));
+        sorted_desc.iter().take(10).sum()
+    };
+    let top_10_pct = if total_supply_tracked > 0 {
+        ((top_10_sum as f64 / total_supply_tracked as f64) * 10_000.0) as u32
+    } else {
+        0
+    };
+
+    // New holders: first-seen within last 24h.
+    let day_start = now_ns.saturating_sub(NANOS_PER_DAY);
+    let new_holders = balance_tracker::count_new_holders(token, day_start, now_ns);
+
+    DailyHolderRow {
+        timestamp_ns: now_ns,
+        token: token_principal,
+        total_holders,
+        total_supply_tracked_e8s: total_supply_tracked,
+        median_balance_e8s: median,
+        top_50,
+        top_10_pct_bps: top_10_pct,
+        gini_bps: gini,
+        new_holders_today: new_holders,
+        distribution_buckets: buckets,
+    }
+}
+
+pub async fn run() -> Result<(), String> {
+    let (icusd_ledger, three_pool) = state::read_state(|s| {
+        (s.sources.icusd_ledger, s.sources.three_pool)
+    });
+
+    let now = ic_cdk::api::time();
+
+    // Only produce snapshots if the BalanceTracker has data (cursors have run).
+    if balance_tracker::holder_count(Token::IcUsd) > 0 {
+        let row = snapshot_token(Token::IcUsd, icusd_ledger, now);
+        storage::holders::daily_holders_icusd::push(row);
+    }
+
+    if balance_tracker::holder_count(Token::ThreeUsd) > 0 {
+        let row = snapshot_token(Token::ThreeUsd, three_pool, now);
+        storage::holders::daily_holders_3usd::push(row);
+    }
+
+    Ok(())
+}
+
+// ... tests from Step 1 go here
+```
+
+- [ ] **Step 5: Add `pub mod holders;` to collectors/mod.rs**
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p rumi_analytics --lib holders 2>&1 | tail -10`
+Expected: All holder tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/holders.rs src/rumi_analytics/src/collectors/holders.rs src/rumi_analytics/src/collectors/mod.rs
+git commit -m "feat(analytics): add DailyHolderRow + holder snapshot collector with Gini/top-50/buckets"
+```
+
+---
+
+### Task 5: Extend SlimState for Phase 4 metadata
+
+**Files:**
+- Modify: `src/rumi_analytics/src/storage/mod.rs` (SlimState struct)
+
+**Context:** Add cursor metadata (last_success, last_error, source_counts), backfill flags, and pull cycle tracking to SlimState. All new fields are `Option` or `Default` for backward compat with existing on-chain state (Candid record subtyping handles the upgrade).
+
+- [ ] **Step 1: Add Phase 4 fields to SlimState**
+
+In `src/rumi_analytics/src/storage/mod.rs`, add to the `SlimState` struct after `error_counters`:
+
+```rust
+    // Phase 4: Cursor metadata (persisted across upgrades)
+    pub cursor_last_success: Option<std::collections::HashMap<u8, u64>>,
+    pub cursor_last_error: Option<std::collections::HashMap<u8, String>>,
+    pub cursor_source_counts: Option<std::collections::HashMap<u8, u64>>,
+    // Phase 4: Backfill flags
+    pub backfill_active_icusd: Option<bool>,
+    pub backfill_active_3usd: Option<bool>,
+    // Phase 4: Pull cycle tracking
+    pub last_pull_cycle_ns: Option<u64>,
+```
+
+Update `Default` impl to include these with `None` values.
+
+- [ ] **Step 2: Verify it compiles and existing tests pass**
+
+Run: `cargo test -p rumi_analytics --lib 2>&1 | tail -5`
+Expected: All existing tests pass. The `Option` wrapping ensures Candid backward compat.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/mod.rs
+git commit -m "feat(analytics): extend SlimState with Phase 4 cursor metadata and backfill flags"
+```
+
+---
+
+### Task 6: Source wrappers for event tailing
+
+**Files:**
+- Modify: `src/rumi_analytics/src/sources/backend.rs` -- Add get_events, get_event_count
+- Modify: `src/rumi_analytics/src/sources/three_pool.rs` -- Add swap/liquidity event fetchers + icrc3_get_blocks
+- Modify: `src/rumi_analytics/src/sources/icusd_ledger.rs` -- Add icrc3_get_blocks
+- Create: `src/rumi_analytics/src/sources/amm.rs` -- AMM swap event fetchers
+- Modify: `src/rumi_analytics/src/sources/mod.rs` -- Add `pub mod amm;`
+
+**Context:** Each source wrapper follows the same pattern as existing ones in `backend.rs`: define a subset struct matching the Candid types, do an `ic_cdk::call`, map errors. For the backend Event type, we define a minimal subset enum covering only the variants we route. For ICRC-3, we need to decode the generic `ICRC3Value` tree.
+
+The backend's `Event` is a variant with 62 cases. We only deserialize the ones we care about. In Candid, unknown variant fields are ignored during deserialization if the Rust enum has a catch-all. We use `#[serde(other)]` for this.
+
+- [ ] **Step 1: Add backend event wrappers to sources/backend.rs**
+
+Add to `sources/backend.rs`:
+
+```rust
+// --- Event tailing (Phase 4) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetEventsArg {
+    pub start: u64,
+    pub length: u64,
+}
+
+/// Minimal subset of the backend Event variant. Only the variants we route
+/// to EVT_LIQUIDATIONS and EVT_VAULTS are deserialized; all others fall
+/// through to `Unknown`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum BackendEvent {
+    #[serde(rename = "open_vault")]
+    OpenVault {
+        block_index: u64,
+        vault: BackendVaultRecord,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "borrow_from_vault")]
+    BorrowFromVault {
+        block_index: u64,
+        vault_id: u64,
+        fee_amount: u64,
+        borrowed_amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "repay_to_vault")]
+    RepayToVault {
+        block_index: u64,
+        vault_id: u64,
+        repayed_amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "collateral_withdrawn")]
+    CollateralWithdrawn {
+        block_index: u64,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "partial_collateral_withdrawn")]
+    PartialCollateralWithdrawn {
+        block_index: u64,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "withdraw_and_close_vault")]
+    WithdrawAndCloseVault {
+        block_index: Option<u64>,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    VaultWithdrawnAndClosed {
+        vault_id: u64,
+        timestamp: u64,
+        caller: Principal,
+        amount: u64,
+    },
+    #[serde(rename = "dust_forgiven")]
+    DustForgiven {
+        vault_id: u64,
+        amount: u64,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "redemption_on_vaults")]
+    RedemptionOnVaults {
+        icusd_amount: u64,
+        icusd_block_index: u64,
+        owner: Principal,
+        fee_amount: u64,
+        collateral_type: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "liquidate_vault")]
+    LiquidateVault {
+        vault_id: u64,
+        liquidator: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "partial_liquidate_vault")]
+    PartialLiquidateVault {
+        protocol_fee_collateral: Option<u64>,
+        liquidator_payment: u64,
+        vault_id: u64,
+        liquidator: Option<Principal>,
+        icp_to_liquidator: u64,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "redistribute_vault")]
+    RedistributeVault {
+        vault_id: u64,
+        timestamp: Option<u64>,
+    },
+    // Catch-all for all other event variants we don't care about.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Vault record embedded in open_vault events.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct BackendVaultRecord {
+    pub vault_id: u64,
+    pub owner: Principal,
+    pub collateral_type: Principal,
+    pub collateral_amount: u64,
+    pub borrowed_icusd_amount: u64,
+}
+
+pub async fn get_events(
+    backend: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<BackendEvent>, String> {
+    let arg = GetEventsArg { start, length };
+    let (events,): (Vec<BackendEvent>,) = ic_cdk::call(backend, "get_events", (arg,))
+        .await
+        .map_err(|(code, msg)| format!("get_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_event_count(backend: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(backend, "get_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+```
+
+**Important note for the implementer:** The `#[serde(other)]` approach requires that Candid deserialization treats unknown variants as a catch-all. Test this carefully. If Candid does not support `#[serde(other)]` for variants (it may not), the alternative is to use `candid::IDLValue` for raw deserialization and manually match variant names. If `#[serde(other)]` doesn't work, change the approach: deserialize as `Vec<(u64, candid::IDLValue)>` using `get_events_filtered` instead, and pattern-match on variant names. Test during implementation.
+
+- [ ] **Step 2: Add 3pool event + ICRC-3 wrappers to sources/three_pool.rs**
+
+Add to `sources/three_pool.rs`:
+
+```rust
+// --- Event tailing (Phase 4) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolSwapEvent {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub token_in: u8,
+    pub token_out: u8,
+    pub amount_in: candid::Nat,
+    pub amount_out: candid::Nat,
+    pub fee: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ThreePoolLiquidityAction {
+    AddLiquidity,
+    RemoveLiquidity,
+    RemoveOneCoin,
+    Donate,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolLiquidityEvent {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub action: ThreePoolLiquidityAction,
+    pub amounts: Vec<candid::Nat>,
+    pub lp_amount: candid::Nat,
+    pub coin_index: Option<u8>,
+    pub fee: Option<candid::Nat>,
+}
+
+pub async fn get_swap_events(
+    three_pool: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<ThreePoolSwapEvent>, String> {
+    let (events,): (Vec<ThreePoolSwapEvent>,) =
+        ic_cdk::call(three_pool, "get_swap_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_swap_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_swap_event_count(three_pool: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(three_pool, "get_swap_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_swap_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+
+pub async fn get_liquidity_events(
+    three_pool: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<ThreePoolLiquidityEvent>, String> {
+    let (events,): (Vec<ThreePoolLiquidityEvent>,) =
+        ic_cdk::call(three_pool, "get_liquidity_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_liquidity_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_liquidity_event_count(three_pool: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(three_pool, "get_liquidity_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_liquidity_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+```
+
+- [ ] **Step 3: Add ICRC-3 block fetching to sources/icusd_ledger.rs**
+
+Add to `sources/icusd_ledger.rs`:
+
+```rust
+// --- ICRC-3 block tailing (Phase 4) ---
+
+use candid::Nat;
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetBlocksArg {
+    pub start: Nat,
+    pub length: Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct BlockWithId {
+    pub id: Nat,
+    pub block: icrc_ledger_types::icrc3::blocks::ICRC3Value,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetBlocksResult {
+    pub log_length: Nat,
+    pub blocks: Vec<BlockWithId>,
+    // archived_blocks omitted for now; added when archive following is implemented
+}
+
+pub async fn icrc3_get_blocks(
+    ledger: Principal,
+    start: u64,
+    length: u64,
+) -> Result<GetBlocksResult, String> {
+    let args = vec![GetBlocksArg {
+        start: Nat::from(start),
+        length: Nat::from(length),
+    }];
+    let (result,): (GetBlocksResult,) = ic_cdk::call(ledger, "icrc3_get_blocks", (args,))
+        .await
+        .map_err(|(code, msg)| format!("icrc3_get_blocks: {:?} {}", code, msg))?;
+    Ok(result)
+}
+```
+
+**Note for implementer:** Check if `icrc_ledger_types::icrc3::blocks::ICRC3Value` is available in the `icrc-ledger-types` crate at the pinned revision (fc278709). If not, define a local ICRC3Value enum:
+
+```rust
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ICRC3Value {
+    Blob(Vec<u8>),
+    Text(String),
+    Nat(Nat),
+    Int(candid::Int),
+    Array(Vec<ICRC3Value>),
+    Map(Vec<(String, ICRC3Value)>),
+}
+```
+
+- [ ] **Step 4: Create sources/amm.rs**
+
+```rust
+//! Source wrapper for rumi_amm event queries.
+
+use candid::{CandidType, Nat, Principal};
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct AmmSwapEvent {
+    pub id: u64,
+    pub caller: Principal,
+    pub pool_id: String,
+    pub token_in: Principal,
+    pub amount_in: Nat,
+    pub token_out: Principal,
+    pub amount_out: Nat,
+    pub fee: Nat,
+    pub timestamp: u64,
+}
+
+pub async fn get_amm_swap_events(
+    amm: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<AmmSwapEvent>, String> {
+    let (events,): (Vec<AmmSwapEvent>,) =
+        ic_cdk::call(amm, "get_amm_swap_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_amm_swap_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_amm_swap_event_count(amm: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(amm, "get_amm_swap_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_amm_swap_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+```
+
+- [ ] **Step 5: Add `pub mod amm;` to sources/mod.rs**
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_analytics/src/sources/
+git commit -m "feat(analytics): add source wrappers for event tailing (backend events, 3pool, AMM, ICRC-3)"
+```
+
+---
+
+### Task 7: Tailing module - custom event sources
+
+**Files:**
+- Create: `src/rumi_analytics/src/tailing/mod.rs`
+- Create: `src/rumi_analytics/src/tailing/backend_events.rs`
+- Create: `src/rumi_analytics/src/tailing/three_pool_swaps.rs`
+- Create: `src/rumi_analytics/src/tailing/three_pool_liquidity.rs`
+- Create: `src/rumi_analytics/src/tailing/amm_swaps.rs`
+- Modify: `src/rumi_analytics/src/lib.rs` -- Add `mod tailing;`
+
+**Context:** Each tailing function follows the cursor protocol: read cursor, check count, fetch batch, process, advance cursor. Backend events are routed to EVT_LIQUIDATIONS or EVT_VAULTS. 3pool swaps and AMM swaps go to EVT_SWAPS. 3pool liquidity goes to EVT_LIQUIDITY.
+
+The BATCH_SIZE is 500. Each function updates SlimState cursor metadata on success/failure.
+
+- [ ] **Step 1: Create tailing/mod.rs**
+
+```rust
+//! Event tailing functions. Each module implements a single cursor's
+//! fetch-process-advance cycle.
+
+pub mod backend_events;
+pub mod three_pool_swaps;
+pub mod three_pool_liquidity;
+pub mod amm_swaps;
+pub mod icrc3;
+
+pub const BATCH_SIZE: u64 = 500;
+pub const BACKFILL_BATCH_SIZE: u64 = 1000;
+```
+
+- [ ] **Step 2: Implement backend_events.rs**
+
+```rust
+//! Backend event tailing. Routes events to EVT_LIQUIDATIONS and EVT_VAULTS.
+
+use candid::Principal;
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::BATCH_SIZE;
+
+pub async fn run() {
+    let backend = state::read_state(|s| s.sources.backend);
+    let cursor = cursors::backend_events::get();
+
+    let count = match sources::backend::get_event_count(backend).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_backend] get_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.backend += 1;
+                update_cursor_error(&mut s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_BACKEND_EVENTS, count);
+    });
+
+    if count <= cursor {
+        return;
+    }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::backend::get_events(backend, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_backend] get_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.backend += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for (i, event) in events.iter().enumerate() {
+        let event_id = cursor + i as u64;
+        route_backend_event(event_id, event);
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::backend_events::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_BACKEND_EVENTS, ic_cdk::api::time());
+        });
+    }
+}
+
+fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
+    use sources::backend::BackendEvent::*;
+
+    match event {
+        // --- EVT_LIQUIDATIONS ---
+        LiquidateVault { vault_id, timestamp, .. } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(), // not available in this variant
+                collateral_amount: 0,
+                debt_amount: 0,
+                liquidation_kind: LiquidationKind::Full,
+            });
+        }
+        PartialLiquidateVault { vault_id, liquidator_payment, icp_to_liquidator, timestamp, .. } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(),
+                collateral_amount: *icp_to_liquidator,
+                debt_amount: *liquidator_payment,
+                liquidation_kind: LiquidationKind::Partial,
+            });
+        }
+        RedistributeVault { vault_id, timestamp } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(),
+                collateral_amount: 0,
+                debt_amount: 0,
+                liquidation_kind: LiquidationKind::Redistribution,
+            });
+        }
+
+        // --- EVT_VAULTS ---
+        OpenVault { vault, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: vault.vault_id,
+                owner: vault.owner,
+                event_kind: VaultEventKind::Opened,
+                collateral_type: vault.collateral_type,
+                amount: vault.collateral_amount,
+            });
+        }
+        BorrowFromVault { vault_id, borrowed_amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::Borrowed,
+                collateral_type: Principal::anonymous(),
+                amount: *borrowed_amount,
+            });
+        }
+        RepayToVault { vault_id, repayed_amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::Repaid,
+                collateral_type: Principal::anonymous(),
+                amount: *repayed_amount,
+            });
+        }
+        CollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::CollateralWithdrawn,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        PartialCollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::PartialCollateralWithdrawn,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        WithdrawAndCloseVault { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::WithdrawAndClose,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        VaultWithdrawnAndClosed { vault_id, timestamp, caller, amount } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: *timestamp,
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: *caller,
+                event_kind: VaultEventKind::Closed,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        DustForgiven { vault_id, amount, timestamp } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: Principal::anonymous(),
+                event_kind: VaultEventKind::DustForgiven,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        RedemptionOnVaults { icusd_amount, owner, collateral_type, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: 0, // redemptions affect multiple vaults
+                owner: *owner,
+                event_kind: VaultEventKind::Redeemed,
+                collateral_type: collateral_type.unwrap_or(Principal::anonymous()),
+                amount: *icusd_amount,
+            });
+        }
+
+        // All other variants (admin, config, etc.) - skip
+        Unknown => {}
+    }
+}
+
+// --- Cursor metadata helpers ---
+// These update the Option<HashMap> fields in SlimState.
+
+fn update_cursor_success(s: &mut storage::SlimState, cursor_id: u8, timestamp_ns: u64) {
+    let map = s.cursor_last_success.get_or_insert_with(Default::default);
+    map.insert(cursor_id, timestamp_ns);
+    // Clear error on success
+    if let Some(err_map) = &mut s.cursor_last_error {
+        err_map.remove(&cursor_id);
+    }
+}
+
+fn update_cursor_error(s: &mut storage::SlimState, cursor_id: u8, error: String) {
+    let map = s.cursor_last_error.get_or_insert_with(Default::default);
+    map.insert(cursor_id, error);
+}
+
+fn update_cursor_source_count(s: &mut storage::SlimState, cursor_id: u8, count: u64) {
+    let map = s.cursor_source_counts.get_or_insert_with(Default::default);
+    map.insert(cursor_id, count);
+}
+```
+
+- [ ] **Step 3: Implement three_pool_swaps.rs, three_pool_liquidity.rs, amm_swaps.rs**
+
+These follow the same cursor pattern. Each reads its cursor, calls its source, normalizes events to the analytics type, pushes to the appropriate EVT_* log.
+
+**three_pool_swaps.rs:** Converts 3pool token indices (0/1/2) to Principals. Hardcode the 3pool token ordering: index 0 = icUSD (t6bor-paaaa-aaaap-qrd5q-cai), index 1 = ckUSDT, index 2 = ckUSDC. Store a `THREE_POOL_TOKENS: [Principal; 3]` constant. Convert `Nat` amounts to `u64` via `nat_to_u64` helper (truncate, log warning on overflow).
+
+**amm_swaps.rs:** AMM events already have Principal-typed token_in/token_out, so no index resolution needed. Convert `Nat` amounts to `u64`.
+
+**three_pool_liquidity.rs:** Convert `LiquidityAction` from 3pool's variant to our `LiquidityAction`. Convert `Nat` amounts.
+
+Each file is ~80-100 lines following the same pattern as backend_events.rs. The implementer should reference backend_events.rs and adapt.
+
+- [ ] **Step 4: Add `mod tailing;` to lib.rs**
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/rumi_analytics/src/tailing/ src/rumi_analytics/src/lib.rs
+git commit -m "feat(analytics): add event tailing functions for backend, 3pool, and AMM sources"
+```
+
+---
+
+### Task 8: ICRC-3 block tailing + BalanceTracker integration
+
+**Files:**
+- Create: `src/rumi_analytics/src/tailing/icrc3.rs`
+
+**Context:** This is the most complex tailing function. It fetches ICRC-3 blocks, parses the generic `ICRC3Value` tree to extract transfer/mint/burn operations, and applies balance deltas to the BalanceTracker. Shared by both icusd_ledger and 3pool block tailing.
+
+The ICRC-3 block structure is a `Map` containing a `tx` field which is itself a `Map` with fields like `op` (operation type), `from`, `to`, `amt`, `fee`. The block-level `ts` field is the timestamp.
+
+- [ ] **Step 1: Write unit tests for ICRC-3 block parsing**
+
+Test the parser with hand-constructed ICRC3Value trees for transfer, mint, burn, and approve operations.
+
+- [ ] **Step 2: Implement icrc3.rs**
+
+```rust
+//! ICRC-3 block tailing. Fetches blocks from icusd_ledger or 3pool,
+//! parses transfer/mint/burn operations, applies to BalanceTracker.
+
+use candid::{Nat, Principal};
+use crate::{sources, state, storage};
+use storage::balance_tracker::{self, Account, Token};
+use storage::cursors;
+use super::{BATCH_SIZE, BACKFILL_BATCH_SIZE};
+
+/// Parse ICRC-3 blocks and apply balance deltas for icUSD.
+pub async fn tail_icusd_blocks() {
+    let ledger = state::read_state(|s| s.sources.icusd_ledger);
+    let is_backfill = state::read_state(|s| s.backfill_active_icusd.unwrap_or(false));
+    let batch = if is_backfill { BACKFILL_BATCH_SIZE } else { BATCH_SIZE };
+
+    tail_blocks(
+        ledger,
+        Token::IcUsd,
+        cursors::CURSOR_ID_ICUSD_BLOCKS,
+        || cursors::icusd_blocks::get(),
+        |v| cursors::icusd_blocks::set(v),
+        batch,
+        is_backfill,
+    ).await;
+}
+
+/// Parse ICRC-3 blocks and apply balance deltas for 3USD.
+pub async fn tail_3pool_blocks() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let is_backfill = state::read_state(|s| s.backfill_active_3usd.unwrap_or(false));
+    let batch = if is_backfill { BACKFILL_BATCH_SIZE } else { BATCH_SIZE };
+
+    tail_blocks(
+        three_pool,
+        Token::ThreeUsd,
+        cursors::CURSOR_ID_3POOL_BLOCKS,
+        || cursors::three_pool_blocks::get(),
+        |v| cursors::three_pool_blocks::set(v),
+        batch,
+        is_backfill,
+    ).await;
+}
+
+async fn tail_blocks<G, S>(
+    canister: Principal,
+    token: Token,
+    cursor_id: u8,
+    get_cursor: G,
+    set_cursor: S,
+    batch_size: u64,
+    is_backfill: bool,
+) where
+    G: Fn() -> u64,
+    S: Fn(u64),
+{
+    let cursor = get_cursor();
+
+    let result = match sources::icusd_ledger::icrc3_get_blocks(canister, cursor, batch_size).await {
+        Ok(r) => r,
+        Err(e) => {
+            ic_cdk::println!("[tail_icrc3] icrc3_get_blocks failed for {:?}: {}", token, e);
+            state::mutate_state(|s| {
+                match token {
+                    Token::IcUsd => s.error_counters.icusd_ledger += 1,
+                    Token::ThreeUsd => s.error_counters.three_pool += 1,
+                }
+            });
+            return;
+        }
+    };
+
+    let log_length = nat_to_u64(&result.log_length);
+
+    if result.blocks.is_empty() {
+        // Check if backfill is done
+        if is_backfill && cursor >= log_length {
+            clear_backfill_flag(token);
+        }
+        return;
+    }
+
+    let mut processed = 0u64;
+    for block_with_id in &result.blocks {
+        if let Err(e) = process_block(token, &block_with_id.block) {
+            ic_cdk::println!("[tail_icrc3] skipping malformed block: {}", e);
+        }
+        processed += 1;
+    }
+
+    if processed > 0 {
+        set_cursor(cursor + processed);
+        state::mutate_state(|s| {
+            let map = s.cursor_last_success.get_or_insert_with(Default::default);
+            map.insert(cursor_id, ic_cdk::api::time());
+            let cmap = s.cursor_source_counts.get_or_insert_with(Default::default);
+            cmap.insert(cursor_id, log_length);
+        });
+    }
+
+    // Auto-clear backfill when caught up
+    if is_backfill && (cursor + processed) >= log_length {
+        clear_backfill_flag(token);
+    }
+}
+
+fn clear_backfill_flag(token: Token) {
+    state::mutate_state(|s| {
+        match token {
+            Token::IcUsd => s.backfill_active_icusd = Some(false),
+            Token::ThreeUsd => s.backfill_active_3usd = Some(false),
+        }
+    });
+    ic_cdk::println!("[tail_icrc3] backfill complete for {:?}", token);
+}
+
+/// Parse a single ICRC-3 block and apply balance changes.
+fn process_block(token: Token, block: &sources::icusd_ledger::ICRC3Value) -> Result<(), String> {
+    // ICRC-3 blocks are Map values. Extract the `tx` field.
+    // Block structure: Map { "ts": Nat, "tx": Map { ... }, "btype": Text, ... }
+    // The implementer should extract fields from the ICRC3Value tree.
+    // This is a sketch; actual extraction depends on the ICRC3Value variant structure.
+
+    // Extract timestamp from block-level "ts" field
+    let timestamp_ns = extract_nat_field(block, "ts").unwrap_or(0);
+
+    // Extract the "tx" map
+    let tx = extract_map_field(block, "tx")
+        .ok_or_else(|| "missing tx field".to_string())?;
+
+    // Determine operation type from "btype" or from tx structure
+    let btype = extract_text_field(block, "btype").unwrap_or_default();
+
+    match btype.as_str() {
+        "1xfer" => {
+            let from = extract_account_field(&tx, "from")
+                .ok_or_else(|| "1xfer missing from".to_string())?;
+            let to = extract_account_field(&tx, "to")
+                .ok_or_else(|| "1xfer missing to".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1xfer missing amt".to_string())?;
+            let fee = extract_nat_field(&tx, "fee").unwrap_or(0);
+            balance_tracker::apply_transfer(token, &from, &to, amt, fee, timestamp_ns);
+        }
+        "1mint" => {
+            let to = extract_account_field(&tx, "to")
+                .ok_or_else(|| "1mint missing to".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1mint missing amt".to_string())?;
+            balance_tracker::apply_mint(token, &to, amt, timestamp_ns);
+        }
+        "1burn" => {
+            let from = extract_account_field(&tx, "from")
+                .ok_or_else(|| "1burn missing from".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1burn missing amt".to_string())?;
+            balance_tracker::apply_burn(token, &from, amt);
+        }
+        "2approve" => {
+            // No balance change
+        }
+        other => {
+            // Unknown block type, skip silently
+            ic_cdk::println!("[tail_icrc3] unknown btype: {}", other);
+        }
+    }
+
+    Ok(())
+}
+
+// --- ICRC3Value extraction helpers ---
+// These extract typed fields from the ICRC3Value::Map variant.
+// The exact implementation depends on the ICRC3Value enum definition.
+// The implementer must adapt these to the actual ICRC3Value type used
+// (either from icrc-ledger-types or locally defined).
+
+fn extract_map_field(
+    _value: &sources::icusd_ledger::ICRC3Value,
+    _field: &str,
+) -> Option<sources::icusd_ledger::ICRC3Value> {
+    // TODO: implement based on actual ICRC3Value structure
+    // Pattern: match Map variant, find entry with matching key
+    todo!("implement ICRC3Value map extraction")
+}
+
+fn extract_nat_field(
+    _value: &sources::icusd_ledger::ICRC3Value,
+    _field: &str,
+) -> Option<u64> {
+    todo!("implement ICRC3Value nat extraction")
+}
+
+fn extract_text_field(
+    _value: &sources::icusd_ledger::ICRC3Value,
+    _field: &str,
+) -> Option<String> {
+    todo!("implement ICRC3Value text extraction")
+}
+
+fn extract_account_field(
+    _value: &sources::icusd_ledger::ICRC3Value,
+    _field: &str,
+) -> Option<Account> {
+    // Account in ICRC-3 blocks is encoded as a Map with "owner" (blob) and optional "subaccount" (blob)
+    // or as an Array [owner_blob, subaccount_blob]
+    todo!("implement ICRC3Value account extraction")
+}
+
+fn nat_to_u64(nat: &Nat) -> u64 {
+    use candid::utils::decode_one;
+    nat.0.to_u64().unwrap_or(u64::MAX)
+}
+```
+
+**Important note for the implementer:** The `todo!()` functions MUST be implemented before this compiles. The ICRC3Value extraction logic depends on the exact ICRC3Value type available. If using `icrc-ledger-types`, check the actual enum variant names. If defining locally, match on `ICRC3Value::Map(entries)` where entries is `Vec<(String, ICRC3Value)>`, and for `Nat` values extract via `ICRC3Value::Nat(n)`. Account fields in ICRC-3 are typically encoded as arrays `[owner_blob]` or `[owner_blob, subaccount_blob]`.
+
+- [ ] **Step 3: Run unit tests for block parsing**
+
+Run: `cargo test -p rumi_analytics --lib icrc3 2>&1 | tail -10`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/rumi_analytics/src/tailing/icrc3.rs
+git commit -m "feat(analytics): add ICRC-3 block tailing with BalanceTracker integration"
+```
+
+---
+
+### Task 9: Wire tailing into pull cycle + add holders to daily snapshot
+
+**Files:**
+- Modify: `src/rumi_analytics/src/timers.rs`
+
+**Context:** Expand `pull_cycle()` to call all tailing functions sequentially. Add `collectors::holders::run()` to `daily_snapshot()`.
+
+- [ ] **Step 1: Update timers.rs**
+
+Replace `pull_cycle`:
+
+```rust
+async fn pull_cycle() {
+    refresh_supply_cache().await;
+
+    // Event tailing (Phase 4)
+    tailing::backend_events::run().await;
+    tailing::three_pool_swaps::run().await;
+    tailing::three_pool_liquidity::run().await;
+    tailing::amm_swaps::run().await;
+
+    // ICRC-3 block tailing (Phase 4)
+    tailing::icrc3::tail_icusd_blocks().await;
+    tailing::icrc3::tail_3pool_blocks().await;
+
+    // Update pull cycle timestamp
+    state::mutate_state(|s| {
+        s.last_pull_cycle_ns = Some(ic_cdk::api::time());
+    });
+}
+```
+
+Add the `tailing` import at the top of timers.rs:
+```rust
+use crate::{collectors, sources, state, tailing};
+```
+
+Update `daily_snapshot` to include holders:
+
+```rust
+async fn daily_snapshot() {
+    let (tvl_res, vaults_res, stability_res, holders_res) = futures::join!(
+        collectors::tvl::run(),
+        collectors::vaults::run(),
+        collectors::stability::run(),
+        collectors::holders::run(),
+    );
+
+    if let Err(e) = tvl_res {
+        ic_cdk::println!("rumi_analytics: daily TVL snapshot failed: {}", e);
+    }
+    if let Err(e) = vaults_res {
+        ic_cdk::println!("rumi_analytics: daily vault snapshot failed: {}", e);
+    }
+    if let Err(e) = stability_res {
+        ic_cdk::println!("rumi_analytics: daily stability snapshot failed: {}", e);
+    }
+    if let Err(e) = holders_res {
+        ic_cdk::println!("rumi_analytics: daily holder snapshot failed: {}", e);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_analytics/src/timers.rs
+git commit -m "feat(analytics): wire event tailing into pull cycle + holders into daily snapshot"
+```
+
+---
+
+### Task 10: Query endpoints + response types + get_collector_health + start_backfill
+
+**Files:**
+- Modify: `src/rumi_analytics/src/types.rs`
+- Modify: `src/rumi_analytics/src/queries/historical.rs`
+- Modify: `src/rumi_analytics/src/lib.rs`
+
+**Context:** Add `HolderSeriesResponse`, `CollectorHealth`, `CursorStatus`, `BalanceTrackerStats` to types.rs. Add `get_holder_series` to queries. Add `get_collector_health` and `start_backfill` entry points to lib.rs.
+
+- [ ] **Step 1: Add types to types.rs**
+
+```rust
+use crate::storage::holders::DailyHolderRow;
+
+#[derive(CandidType, Clone, Debug)]
+pub struct HolderSeriesResponse {
+    pub rows: Vec<DailyHolderRow>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct CollectorHealth {
+    pub cursors: Vec<CursorStatus>,
+    pub error_counters: crate::storage::ErrorCounters,
+    pub backfill_active: Vec<Principal>,
+    pub last_pull_cycle_ns: u64,
+    pub balance_tracker_stats: Vec<BalanceTrackerStats>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct CursorStatus {
+    pub name: String,
+    pub cursor_position: u64,
+    pub source_count: u64,
+    pub last_success_ns: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct BalanceTrackerStats {
+    pub token: Principal,
+    pub holder_count: u64,
+    pub total_tracked_e8s: u64,
+}
+```
+
+- [ ] **Step 2: Add get_holder_series to queries/historical.rs**
+
+```rust
+pub fn get_holder_series(query: RangeQuery, token: Principal) -> HolderSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+
+    // Determine which log to read based on token principal.
+    let icusd_ledger = crate::state::read_state(|s| s.sources.icusd_ledger);
+    let rows = if token == icusd_ledger {
+        storage::holders::daily_holders_icusd::range(from, to, limit)
+    } else {
+        storage::holders::daily_holders_3usd::range(from, to, limit)
+    };
+
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+
+    HolderSeriesResponse { rows, next_from_ts }
+}
+```
+
+- [ ] **Step 3: Add entry points to lib.rs**
+
+Add `get_holder_series`, `get_collector_health`, and `start_backfill` as canister methods.
+
+`get_collector_health` reads cursor positions from StableCells and metadata from SlimState.
+
+`start_backfill` is an update call gated to admin that sets `backfill_active_icusd` or `backfill_active_3usd` in SlimState.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check -p rumi_analytics 2>&1 | grep -E "^error"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/src/types.rs src/rumi_analytics/src/queries/historical.rs src/rumi_analytics/src/lib.rs
+git commit -m "feat(analytics): add holder series query, collector health, and backfill endpoints"
+```
+
+---
+
+### Task 11: Update Candid interface
+
+**Files:**
+- Modify: `src/rumi_analytics/rumi_analytics.did`
+
+**Context:** Add all new types and three new methods. The canister uses `ic_cdk::export_candid!()` to auto-generate the .did, so we may be able to just rebuild and copy the output. If not, manually add the types.
+
+- [ ] **Step 1: Build the canister to regenerate .did**
+
+Run: `cargo build -p rumi_analytics --target wasm32-unknown-unknown --release 2>&1 | tail -5`
+
+If `export_candid!()` generates the .did automatically, copy it from the build output.
+
+- [ ] **Step 2: Verify the .did contains the new types and methods**
+
+Check that the .did file includes: `CollectorHealth`, `CursorStatus`, `BalanceTrackerStats`, `DailyHolderRow`, `HolderSeriesResponse`, `LiquidationKind`, `VaultEventKind`, `SwapSource`, `LiquidityAction`, and the 4 Analytics*Event types. Check for the 3 new methods: `get_holder_series`, `get_collector_health`, `start_backfill`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_analytics/rumi_analytics.did
+git commit -m "feat(analytics): update candid interface with Phase 4 types and endpoints"
+```
+
+---
+
+### Task 12: PocketIC integration tests
+
+**Files:**
+- Modify: `src/rumi_analytics/tests/pocket_ic_analytics.rs`
+
+**Context:** Add tests for event tailing, ICRC-3 balance tracking, holder snapshots, collector health, backfill, error resilience, and upgrade preservation. These tests deploy the analytics canister alongside real backend/stability_pool/3pool/icusd_ledger wasm binaries in PocketIC, execute operations, advance time, and verify the analytics canister captured the expected data.
+
+The existing tests use `POCKET_IC_BIN` env var for the PocketIC binary path.
+
+- [ ] **Step 1: Add test-side type definitions**
+
+Add Candid types for `CollectorHealth`, `CursorStatus`, `BalanceTrackerStats`, `DailyHolderRow`, `HolderSeriesResponse` to the test file for query decoding.
+
+- [ ] **Step 2: Add test helper functions**
+
+Add `query_holder_series`, `query_collector_health`, `call_start_backfill` helpers.
+
+- [ ] **Step 3: Implement integration tests**
+
+Tests to add (from the spec):
+
+1. **collector_health_reports_cursor_positions**: Deploy analytics, advance past a pull cycle, query collector_health, verify cursor positions and last_success timestamps are non-zero.
+
+2. **icrc3_balance_tracking_mint_and_transfer**: Deploy analytics + icusd_ledger. Mint icUSD to account A. Advance past pull cycles. Verify BalanceTracker via collector_health stats (holder_count, total_tracked). Transfer from A to B. Advance. Verify both accounts tracked.
+
+3. **daily_holder_snapshot_computed**: After balance tracking is populated, advance past daily tick. Query get_holder_series. Verify total_holders, top_50 length, distribution_buckets.
+
+4. **backfill_processes_historical_blocks**: Pre-populate icusd_ledger with mints (done during setup). Deploy analytics. Call start_backfill. Advance through multiple 60s ticks. Verify BalanceTracker matches expected state. Verify backfill auto-cleared via collector_health.
+
+5. **error_resilience_partial_tailing**: Deploy analytics with an unreachable AMM canister. Advance past pull cycles. Verify other cursors still advanced (backend events etc.). Verify AMM error counter incremented.
+
+6. **upgrade_preserves_cursors_and_balances**: Populate cursors and BalanceTracker, upgrade canister, verify cursor positions and holder counts survive.
+
+- [ ] **Step 4: Run integration tests**
+
+Run: `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_analytics --test pocket_ic_analytics 2>&1 | tail -10`
+Expected: All tests pass (old and new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/tests/pocket_ic_analytics.rs
+git commit -m "test(analytics): add Phase 4 integration tests for event tailing, balance tracking, and holder snapshots"
+```
+
+---
+
+### Task 13: Final review and test run
+
+**Files:** None (review only)
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `cargo test -p rumi_analytics --lib 2>&1 | tail -10`
+Expected: All pass.
+
+- [ ] **Step 2: Run all integration tests**
+
+Run: `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_analytics 2>&1 | tail -10`
+Expected: All pass (unit + integration).
+
+- [ ] **Step 3: Build for mainnet**
+
+Run: `dfx build rumi_analytics --network ic 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Review all changed files**
+
+Review `git diff main..HEAD --stat` and spot-check key files for correctness.
+
+---
+
+### Task 14: Deploy to mainnet
+
+**Files:** None
+
+- [ ] **Step 1: Deploy**
+
+```bash
+dfx canister install rumi_analytics --network ic --mode upgrade --argument '(record { admin = principal "fd7h3-mgmok-dmojz-awmxl-k7eqn-37mcv-jjkxp-parnt-ehngl-l2z3m-kae"; backend = principal "tfesu-vyaaa-aaaap-qrd7a-cai"; icusd_ledger = principal "t6bor-paaaa-aaaap-qrd5q-cai"; three_pool = principal "fohh4-yyaaa-aaaap-qtkpa-cai"; stability_pool = principal "tmhzi-dqaaa-aaaap-qrd6q-cai"; amm = principal "ijlzs-2yaaa-aaaap-quaaq-cai" })'
+```
+
+- [ ] **Step 2: Verify new endpoints**
+
+```bash
+dfx canister call rumi_analytics get_collector_health --network ic
+dfx canister call rumi_analytics ping --network ic
+```
+
+- [ ] **Step 3: Start backfill for icUSD and 3USD**
+
+```bash
+dfx canister call rumi_analytics start_backfill '(principal "t6bor-paaaa-aaaap-qrd5q-cai")' --network ic
+dfx canister call rumi_analytics start_backfill '(principal "fohh4-yyaaa-aaaap-qtkpa-cai")' --network ic
+```
+
+- [ ] **Step 4: Monitor backfill progress**
+
+Wait a few minutes, then check:
+```bash
+dfx canister call rumi_analytics get_collector_health --network ic
+```
+
+Verify cursor positions are advancing and backfill flags clear when caught up.

--- a/docs/superpowers/plans/2026-04-09-analytics-phase4-event-tailing.md
+++ b/docs/superpowers/plans/2026-04-09-analytics-phase4-event-tailing.md
@@ -47,7 +47,7 @@
 
 ## Task Dependency Graph
 
-Tasks 1-4 are foundational (storage + sources) and can be done in order. Tasks 5-8 are the tailing functions (depend on 1-4). Task 9 is the holder collector (depends on 1-4). Tasks 10-11 are wiring (depend on 5-9). Task 12 is the Candid interface. Task 13 is integration tests. Task 14 is deploy.
+Tasks 1-4 are foundational (storage + sources) and can be done in order. Task 5 extends SlimState with Phase 4 fields (depends on 1). Tasks 6-8 are source wrappers and tailing functions (depend on 1-5). Task 9 is the holder collector (depends on 1-4). Tasks 10-11 are wiring (depend on 5-9). Task 12 is the Candid interface. Task 13 is integration tests. Task 14 is deploy.
 
 ---
 
@@ -657,7 +657,9 @@ impl Storable for AccountKey {
     };
 }
 
-/// u64 value wrapper for StableBTreeMap.
+#[derive(Clone, Debug)]
+pub struct BalVal(pub u64);
+
 impl Storable for BalVal {
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(self.0.to_le_bytes().to_vec())
@@ -672,9 +674,6 @@ impl Storable for BalVal {
         is_fixed_size: true,
     };
 }
-
-#[derive(Clone, Debug)]
-pub struct BalVal(pub u64);
 
 thread_local! {
     static BAL_ICUSD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
@@ -1367,7 +1366,7 @@ pub async fn get_event_count(backend: Principal) -> Result<u64, String> {
 }
 ```
 
-**Important note for the implementer:** The `#[serde(other)]` approach requires that Candid deserialization treats unknown variants as a catch-all. Test this carefully. If Candid does not support `#[serde(other)]` for variants (it may not), the alternative is to use `candid::IDLValue` for raw deserialization and manually match variant names. If `#[serde(other)]` doesn't work, change the approach: deserialize as `Vec<(u64, candid::IDLValue)>` using `get_events_filtered` instead, and pattern-match on variant names. Test during implementation.
+**Important note for the implementer:** Candid deserialization does NOT use serde's `#[serde(other)]`. The `candid::Deserialize` derive has its own mechanism. Test the `Unknown` catch-all variant immediately after writing this code. If Candid rejects unknown variants at deserialization time, switch to this alternative: define all 62 backend event variants explicitly (copy from the .did file), or deserialize as `Vec<candid::IDLValue>` and pattern-match variant names. The priority is: get it compiling and correctly handling unknown variants before moving on to the routing logic. If you need to switch to IDLValue, define a helper `fn try_extract_backend_event(val: &candid::IDLValue) -> Option<BackendEvent>` that matches on variant name strings.
 
 - [ ] **Step 2: Add 3pool event + ICRC-3 wrappers to sources/three_pool.rs**
 
@@ -1613,7 +1612,7 @@ pub async fn run() {
             ic_cdk::println!("[tail_backend] get_event_count failed: {}", e);
             state::mutate_state(|s| {
                 s.error_counters.backend += 1;
-                update_cursor_error(&mut s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+                update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e.clone());
             });
             return;
         }
@@ -2042,45 +2041,68 @@ fn process_block(token: Token, block: &sources::icusd_ledger::ICRC3Value) -> Res
 // The implementer must adapt these to the actual ICRC3Value type used
 // (either from icrc-ledger-types or locally defined).
 
-fn extract_map_field(
-    _value: &sources::icusd_ledger::ICRC3Value,
-    _field: &str,
-) -> Option<sources::icusd_ledger::ICRC3Value> {
-    // TODO: implement based on actual ICRC3Value structure
-    // Pattern: match Map variant, find entry with matching key
-    todo!("implement ICRC3Value map extraction")
+use sources::icusd_ledger::ICRC3Value;
+
+fn extract_map_field(value: &ICRC3Value, field: &str) -> Option<ICRC3Value> {
+    match value {
+        ICRC3Value::Map(entries) => entries
+            .iter()
+            .find(|(k, _)| k == field)
+            .map(|(_, v)| v.clone()),
+        _ => None,
+    }
 }
 
-fn extract_nat_field(
-    _value: &sources::icusd_ledger::ICRC3Value,
-    _field: &str,
-) -> Option<u64> {
-    todo!("implement ICRC3Value nat extraction")
+fn extract_nat_field(value: &ICRC3Value, field: &str) -> Option<u64> {
+    match extract_map_field(value, field)? {
+        ICRC3Value::Nat(n) => Some(nat_to_u64(&n)),
+        _ => None,
+    }
 }
 
-fn extract_text_field(
-    _value: &sources::icusd_ledger::ICRC3Value,
-    _field: &str,
-) -> Option<String> {
-    todo!("implement ICRC3Value text extraction")
+fn extract_text_field(value: &ICRC3Value, field: &str) -> Option<String> {
+    match extract_map_field(value, field)? {
+        ICRC3Value::Text(s) => Some(s),
+        _ => None,
+    }
 }
 
-fn extract_account_field(
-    _value: &sources::icusd_ledger::ICRC3Value,
-    _field: &str,
-) -> Option<Account> {
-    // Account in ICRC-3 blocks is encoded as a Map with "owner" (blob) and optional "subaccount" (blob)
-    // or as an Array [owner_blob, subaccount_blob]
-    todo!("implement ICRC3Value account extraction")
+fn extract_account_field(value: &ICRC3Value, field: &str) -> Option<Account> {
+    // Account in ICRC-3 blocks is encoded as a Map with "owner" (Blob) and optional "subaccount" (Blob),
+    // or as an Array [owner_blob] / [owner_blob, subaccount_blob].
+    let acct_val = extract_map_field(value, field)?;
+    match &acct_val {
+        ICRC3Value::Map(entries) => {
+            let owner_blob = entries.iter().find(|(k, _)| k == "owner")
+                .and_then(|(_, v)| match v { ICRC3Value::Blob(b) => Some(b.clone()), _ => None })?;
+            let owner = Principal::from_slice(&owner_blob);
+            let subaccount = entries.iter().find(|(k, _)| k == "subaccount")
+                .and_then(|(_, v)| match v { ICRC3Value::Blob(b) => {
+                    let mut sa = [0u8; 32];
+                    if b.len() == 32 { sa.copy_from_slice(b); Some(sa) } else { None }
+                }, _ => None });
+            Some(Account { owner, subaccount })
+        }
+        ICRC3Value::Array(arr) => {
+            let owner_blob = match arr.first()? { ICRC3Value::Blob(b) => b, _ => return None };
+            let owner = Principal::from_slice(owner_blob);
+            let subaccount = arr.get(1).and_then(|v| match v { ICRC3Value::Blob(b) => {
+                let mut sa = [0u8; 32]; if b.len() == 32 { sa.copy_from_slice(b); Some(sa) } else { None }
+            }, _ => None });
+            Some(Account { owner, subaccount })
+        }
+        _ => None,
+    }
 }
 
-fn nat_to_u64(nat: &Nat) -> u64 {
-    use candid::utils::decode_one;
+fn nat_to_u64(nat: &candid::Nat) -> u64 {
+    // candid::Nat wraps num_bigint::BigUint. Convert to u64, clamping to MAX.
+    use num_traits::ToPrimitive;
     nat.0.to_u64().unwrap_or(u64::MAX)
 }
 ```
 
-**Important note for the implementer:** The `todo!()` functions MUST be implemented before this compiles. The ICRC3Value extraction logic depends on the exact ICRC3Value type available. If using `icrc-ledger-types`, check the actual enum variant names. If defining locally, match on `ICRC3Value::Map(entries)` where entries is `Vec<(String, ICRC3Value)>`, and for `Nat` values extract via `ICRC3Value::Nat(n)`. Account fields in ICRC-3 are typically encoded as arrays `[owner_blob]` or `[owner_blob, subaccount_blob]`.
+**Important note for the implementer:** The ICRC3Value extraction helpers above assume a locally-defined ICRC3Value enum with variants `Map(Vec<(String, ICRC3Value)>)`, `Nat(candid::Nat)`, `Text(String)`, `Blob(Vec<u8>)`, `Array(Vec<ICRC3Value>)`. If using `icrc-ledger-types`, check the actual enum variant names and adapt accordingly. The `num_traits` crate must be in Cargo.toml for `ToPrimitive` in `nat_to_u64`.
 
 - [ ] **Step 3: Run unit tests for block parsing**
 

--- a/docs/superpowers/specs/2026-04-09-analytics-phase4-event-tailing-design.md
+++ b/docs/superpowers/specs/2026-04-09-analytics-phase4-event-tailing-design.md
@@ -1,0 +1,453 @@
+# rumi_analytics Phase 4: Event Tailing & BalanceTracker
+
+**Date**: 2026-04-09
+**Status**: Design
+**Prereqs**: Phase 3 (complete, deployed), Phase 1 (merged)
+
+## Context
+
+Phase 3 deployed three daily current-state collectors (TVL, vaults, stability). Phase 4 adds the event tailing backbone: cursor-based polling of source canisters every 60 seconds, mirroring events into local EVT_* StableLogs, ICRC-3 block replay for holder balance tracking, daily holder snapshots, historical backfill, and a collector health query.
+
+All source canister event interfaces already exist (confirmed in Phase 0 audit). No source canister changes needed.
+
+## Architecture Overview
+
+Every 60 seconds, the pull cycle checks each source canister for new events since the last cursor position, fetches them in bounded batches, and writes them to local EVT_* mirror logs. ICRC-3 block streams from icusd_ledger and 3pool feed a BalanceTracker that maintains running account balances.
+
+Six active cursor sources:
+
+| Cursor (StableCell) | MemoryId | Source Call | Destination |
+|---------------------|----------|------------|-------------|
+| Backend events | 1 | `backend.get_events()` | EVT_LIQUIDATIONS + EVT_VAULTS (routed by variant) |
+| 3pool swaps | 2 | `3pool.get_swap_events()` | EVT_SWAPS |
+| 3pool liquidity | 3 | `3pool.get_liquidity_events()` | EVT_LIQUIDITY |
+| 3pool blocks | 4 | `3pool.icrc3_get_blocks()` | BalanceTracker (BAL_3USD) |
+| AMM swaps | 5 | `amm.get_amm_swap_events()` | EVT_SWAPS |
+| icUSD blocks | 7 | `icusd_ledger.icrc3_get_blocks()` | BalanceTracker (BAL_ICUSD) |
+
+MEM_CURSOR_STABILITY_EVENTS (MemoryId 6) stays reserved but unused. Stability pool user events (deposit, withdraw, claim) are already captured by the Phase 3 daily snapshot, and the liquidation perspective comes from backend events.
+
+## Cursor Infrastructure
+
+Each cursor is a `StableCell<u64>` initialized to 0. The cursor represents the next event index to fetch (i.e., the cursor value = number of events already processed).
+
+**Cursor advancement protocol** (custom event sources):
+1. Read cursor value from StableCell
+2. Call source's count endpoint (e.g., `get_event_count()`)
+3. If count <= cursor, nothing to do
+4. Fetch `min(count - cursor, BATCH_SIZE)` events starting at cursor
+5. Process events (normalize, route, write to EVT_* log)
+6. Advance cursor to `cursor + events_processed`
+
+**Cursor advancement protocol** (ICRC-3 block sources):
+ICRC-3 has no separate count endpoint. Instead:
+1. Read cursor value from StableCell
+2. Call `icrc3_get_blocks(vec { record { start = cursor; length = BATCH_SIZE } })`
+3. The response includes `log_length` (total blocks). If no blocks returned, nothing to do.
+4. Process returned blocks (parse transfers, update BalanceTracker)
+5. Advance cursor to `cursor + blocks_processed`
+6. If `archived_blocks` entries are present, follow callbacks to fetch archived blocks (counts toward batch limit)
+
+The cursor only advances after a successful write. On error at any step, the cursor stays put and the next 60s tick retries from the same position. This makes the system idempotent and crash-safe.
+
+**BATCH_SIZE**: 500 events per cursor per tick. This keeps each inter-canister call bounded and leaves room for all 6 cursors to run within a single 60s window.
+
+## Event Tailing Sources
+
+### Backend Events (cursor 1)
+
+**Source**: `backend.get_events(record { start; length })` returns `vec Event`. The backend's `Event` type has 62 variants. We filter and route:
+
+**Routed to EVT_LIQUIDATIONS**:
+- `liquidate_vault` (full liquidation)
+- `partial_liquidate_vault` (partial liquidation)
+- `redistribute_vault` (redistribution)
+
+**Routed to EVT_VAULTS**:
+- `open_vault`
+- `borrow_from_vault`
+- `repay_to_vault`
+- `collateral_withdrawn`
+- `partial_collateral_withdrawn`
+- `withdraw_and_close_vault`
+- `VaultWithdrawnAndClosed`
+- `dust_forgiven`
+- `redemption_on_vaults`
+
+**Ignored**: All admin/config events (`set_borrowing_fee`, `price_update`, `set_min_collateral_ratio`, etc.). These are configuration changes, not user activity. The cursor still advances past them.
+
+### 3pool Swaps (cursor 2)
+
+**Source**: `3pool.get_swap_events(start, length)` returns `vec SwapEvent`.
+
+All events go to EVT_SWAPS. We use the V1 endpoint (V2 adds imbalance/rebalancing fields that we don't need for Phase 4 analytics, and V1 events are a strict subset).
+
+### 3pool Liquidity (cursor 3)
+
+**Source**: `3pool.get_liquidity_events(start, length)` returns `vec LiquidityEvent`.
+
+All events go to EVT_LIQUIDITY. Uses V1 endpoint for the same reason as swaps.
+
+### AMM Swaps (cursor 5)
+
+**Source**: `amm.get_amm_swap_events(start, length)` returns `vec AmmSwapEvent`.
+
+All events go to EVT_SWAPS (same log as 3pool swaps, but with a `source` discriminator).
+
+### ICRC-3 Block Tailing (cursors 4 and 7)
+
+**Sources**:
+- `icusd_ledger.icrc3_get_blocks(vec { record { start; length } })` (cursor 7)
+- `3pool.icrc3_get_blocks(vec { record { start; length } })` (cursor 4)
+
+These feed the BalanceTracker, not an EVT_* log. The tailing function:
+1. Fetches blocks from the cursor position
+2. Parses each `ICRC3Value` block to extract transfer operations
+3. For each transfer/mint/burn, applies balance deltas to the BalanceTracker
+4. Advances the cursor
+
+**ICRC-3 block parsing**: ICRC-1 blocks encode transactions as `Map` values. The `tx` field contains the operation. Standard block kinds:
+- `"1xfer"` (transfer): extract `from`, `to`, `amt`. Debit sender, credit receiver.
+- `"1mint"` (mint): extract `to`, `amt`. Credit receiver.
+- `"1burn"` (burn): extract `from`, `amt`. Debit sender.
+- `"2approve"` (approve): no balance change, skip.
+
+The parser extracts `Account` (principal + optional subaccount) and amount from the ICRC3Value tree. Malformed blocks are logged and skipped (cursor still advances).
+
+**Archive handling**: `icrc3_get_blocks` may return `archived_blocks` entries pointing to archive canisters. During backfill, we need to follow these. During steady-state tailing, recent blocks are typically in the main canister. The tailing function checks `archived_blocks` and follows callbacks if present.
+
+## EVT_* Storage Types
+
+We store normalized event types (not raw source events) to keep storage lean and provide a consistent interface for Phase 5 rollups.
+
+### EVT_LIQUIDATIONS (MemoryIds 44/45)
+
+```rust
+struct AnalyticsLiquidationEvent {
+    timestamp_ns: u64,
+    source_event_id: u64,       // backend event index
+    vault_id: u64,
+    collateral_type: Principal,
+    collateral_amount: u64,     // collateral seized
+    debt_amount: u64,           // debt covered
+    liquidation_kind: LiquidationKind, // Full, Partial, Redistribution
+}
+
+enum LiquidationKind { Full, Partial, Redistribution }
+```
+
+### EVT_VAULTS (MemoryIds 50/51)
+
+```rust
+struct AnalyticsVaultEvent {
+    timestamp_ns: u64,
+    source_event_id: u64,
+    vault_id: u64,
+    owner: Principal,
+    event_kind: VaultEventKind,
+    collateral_type: Principal,
+    amount: u64,                // collateral or debt amount, context-dependent
+}
+
+enum VaultEventKind {
+    Opened,
+    Borrowed,
+    Repaid,
+    CollateralWithdrawn,
+    PartialCollateralWithdrawn,
+    WithdrawAndClose,
+    Closed,
+    DustForgiven,
+    Redeemed,
+}
+```
+
+### EVT_SWAPS (MemoryIds 46/47)
+
+```rust
+struct AnalyticsSwapEvent {
+    timestamp_ns: u64,
+    source: SwapSource,         // ThreePool or AMM
+    source_event_id: u64,
+    caller: Principal,
+    token_in: Principal,        // for 3pool: derived from token index
+    token_out: Principal,
+    amount_in: u64,             // truncated from nat for 3pool
+    amount_out: u64,
+    fee: u64,
+}
+
+enum SwapSource { ThreePool, Amm }
+```
+
+For 3pool swaps, `token_in` and `token_out` are `nat8` indices (0/1/2). The source wrapper resolves these to Principals using the known 3pool token ordering (icUSD=0, ckUSDT=1, ckUSDC=2). The analytics canister hardcodes this mapping since the 3pool's token list is fixed at deploy time.
+
+### EVT_LIQUIDITY (MemoryIds 48/49)
+
+```rust
+struct AnalyticsLiquidityEvent {
+    timestamp_ns: u64,
+    source_event_id: u64,
+    caller: Principal,
+    action: LiquidityAction,    // Add, Remove, RemoveOneCoin, Donate
+    amounts: Vec<u64>,          // per-token amounts (truncated from nat)
+    lp_amount: u64,
+    coin_index: Option<u8>,     // for RemoveOneCoin: which token was removed
+    fee: Option<u64>,           // fee charged (truncated from nat)
+}
+
+enum LiquidityAction { Add, Remove, RemoveOneCoin, Donate }
+```
+
+All EVT_* types implement `Storable` with Candid encoding and `Bound::Unbounded` (same pattern as Phase 3's `DailyVaultSnapshotRow`).
+
+## BalanceTracker
+
+Two `StableBTreeMap<Vec<u8>, u64>` collections track current balances:
+
+| Map | MemoryId | Key | Value |
+|-----|----------|-----|-------|
+| BAL_ICUSD | 56 | Account (Principal + subaccount, Candid-encoded) | balance (u64, e8s) |
+| BAL_3USD | 57 | Account (Principal + subaccount, Candid-encoded) | balance (u64, e8s for 3USD) |
+
+And two `StableBTreeMap<Vec<u8>, u64>` for first-seen timestamps:
+
+| Map | MemoryId | Key | Value |
+|-----|----------|-----|-------|
+| FIRSTSEEN_ICUSD | 58 | Account (same encoding) | timestamp_ns when first seen |
+| FIRSTSEEN_3USD | 59 | Account (same encoding) | timestamp_ns when first seen |
+
+**Balance update logic** (per parsed ICRC-3 block):
+
+```
+match operation:
+  Transfer(from, to, amount):
+    bal[from] = bal[from].saturating_sub(amount)
+    bal[to] = bal[to].saturating_add(amount)
+    if bal[from] == 0: remove key (keeps map clean)
+    if firstseen[to] missing: set firstseen[to] = block_timestamp
+
+  Mint(to, amount):
+    bal[to] = bal[to].saturating_add(amount)
+    if firstseen[to] missing: set firstseen[to] = block_timestamp
+
+  Burn(from, amount):
+    bal[from] = bal[from].saturating_sub(amount)
+    if bal[from] == 0: remove key
+```
+
+**Key encoding**: The key is a Candid-encoded `Account` (principal + optional 32-byte subaccount). This gives deterministic ordering and compact representation. For most users, the subaccount is null (just the principal).
+
+**3pool balance note**: 3USD is an ICRC-2 token with 8 decimals, so balances are in e8s units, same as icUSD.
+
+**Fee handling**: ICRC-1 transfers deduct a fee from the sender. The block's `amt` field is the amount received by `to`. The fee is a separate field. For balance tracking: sender loses `amt + fee`, receiver gains `amt`. We parse both fields from the block.
+
+## Daily Holder Snapshots
+
+A new collector `collectors/holders.rs` runs on the daily timer (alongside TVL, vaults, stability). It reads the BalanceTracker maps and computes snapshot metrics.
+
+### DailyHolderRow (one per token per day)
+
+Stored in DAILY_HOLDERS_ICUSD (MemoryIds 14/15) and DAILY_HOLDERS_3USD (MemoryIds 16/17).
+
+```rust
+struct DailyHolderRow {
+    timestamp_ns: u64,
+    token: Principal,               // icUSD or 3USD ledger principal
+    total_holders: u32,             // accounts with balance > 0
+    total_supply_tracked_e8s: u64,  // sum of all balances (sanity check)
+    median_balance_e8s: u64,
+    top_50: Vec<(Principal, u64)>,  // top 50 by balance (principal, balance). Subaccount dropped (deliberate simplification; most users have null subaccount)
+    top_10_pct_bps: u32,            // % of supply held by top 10, in bps
+    gini_bps: u32,                  // Gini coefficient * 10000
+    new_holders_today: u32,         // firstseen within last 24h
+    distribution_buckets: Vec<u32>, // holder counts per bucket
+}
+```
+
+**Distribution buckets** (in e8s, powers of 10):
+- Bucket 0: 0 < balance <= 100_0000_0000 (0-100 tokens)
+- Bucket 1: 100-1,000 tokens
+- Bucket 2: 1,000-10,000 tokens
+- Bucket 3: 10,000-100,000 tokens
+- Bucket 4: > 100,000 tokens
+
+**Gini coefficient**: Computed by sorting all balances ascending, then:
+```
+gini = (2 * sum(i * balance[i] for i in 0..n)) / (n * sum(all_balances)) - (n + 1) / n
+```
+Result clamped to [0, 1] and stored as basis points (0 = perfect equality, 10000 = one holder has everything).
+
+**Computation cost**: Iterating a StableBTreeMap is O(n) in stable memory reads. For moderate holder counts (< 50,000) this is well within IC instruction limits. If holder counts grow very large in the future, we can sample or cache, but that's not needed now.
+
+**Storable impl**: Candid encoding, `Bound::Unbounded` (variable-length due to top_50 and distribution_buckets).
+
+## Historical Backfill
+
+On first deploy (or when adding a new ICRC-3 source), the cursors start at 0 but the ledgers may have thousands of historical blocks. The backfill mechanism replays these to populate the BalanceTracker.
+
+**Design**: Admin calls `start_backfill(token: Principal)` which sets a `backfill_active` flag in state for that token. While the flag is set, the corresponding ICRC-3 tailing function processes `BACKFILL_BATCH_SIZE` (1000) blocks per tick instead of the normal `BATCH_SIZE` (500). Once the cursor catches up to the ledger tip, the flag auto-clears and steady-state tailing resumes at normal batch size.
+
+**Idempotency**: The cursor itself is the progress marker. If the canister upgrades mid-backfill, the flag persists in SlimState, and the next post_upgrade resumes from the cursor position. No separate "backfill offset" needed.
+
+**Admin gating**: `start_backfill` is an update call restricted to the admin principal. It returns immediately; progress is observable via `get_collector_health()`.
+
+**Archive following**: During backfill, early blocks may be in archive canisters. The `icrc3_get_blocks` response includes `archived_blocks` with callbacks. The backfill tailing function follows these callbacks to fetch archived blocks. Each archive call counts toward the per-tick batch limit.
+
+**Expected backfill duration**: With ~10,000 historical blocks and 1000 blocks per 60s tick, full backfill takes roughly 10 minutes. Acceptable for a one-time operation.
+
+## Pull Cycle Structure
+
+The enhanced pull cycle runs sequentially to stay within instruction limits:
+
+```rust
+async fn pull_cycle() {
+    refresh_supply_cache().await;
+
+    // Event tailing (each is independent, but run sequentially for instruction budget)
+    tail_backend_events().await;
+    tail_3pool_swaps().await;
+    tail_3pool_liquidity().await;
+    tail_amm_swaps().await;
+
+    // ICRC-3 block tailing (feeds BalanceTracker)
+    tail_icusd_blocks().await;
+    tail_3pool_blocks().await;
+}
+```
+
+Each `tail_*` function is self-contained: reads its own cursor, fetches, processes, advances. If one fails, the others still run (errors logged, error counter incremented, cursor unchanged).
+
+**Concurrency note**: On IC, `futures::join!` interleaves calls but doesn't reduce total instruction cost. Running sequentially is simpler and avoids any ordering issues with shared state (e.g., EVT_SWAPS receives from both 3pool and AMM).
+
+## get_collector_health() Query
+
+New query endpoint exposing the internal state of the tailing system:
+
+```rust
+struct CollectorHealth {
+    cursors: Vec<CursorStatus>,
+    error_counters: ErrorCounters,   // existing from Phase 1
+    backfill_active: Vec<Principal>,  // tokens currently backfilling
+    last_pull_cycle_ns: u64,         // timestamp of last successful pull cycle
+    balance_tracker_stats: Vec<BalanceTrackerStats>,
+}
+
+struct CursorStatus {
+    name: String,           // e.g., "backend_events", "icusd_blocks"
+    cursor_position: u64,   // current cursor value
+    source_count: u64,      // last known source event count (0 if unknown)
+    last_success_ns: u64,   // timestamp of last successful fetch
+    last_error: Option<String>, // most recent error message, if any
+}
+
+struct BalanceTrackerStats {
+    token: Principal,
+    holder_count: u64,      // number of entries in the balance map
+    total_tracked_e8s: u64, // sum of all balances
+}
+```
+
+This is a query (no state mutation), so it's cheap. The `source_count` field is the last value seen from the count endpoint (cached in state during the pull cycle, not fetched on every health query).
+
+## State Extensions
+
+SlimState gains these fields:
+
+```rust
+// Cursor last-success timestamps (persisted across upgrades)
+cursor_last_success: HashMap<u8, u64>,  // cursor_id -> timestamp_ns
+cursor_last_error: HashMap<u8, String>, // cursor_id -> last error message
+cursor_source_counts: HashMap<u8, u64>, // cursor_id -> last known source count
+
+// Backfill flags
+backfill_active_icusd: bool,
+backfill_active_3usd: bool,
+
+// Pull cycle tracking
+last_pull_cycle_ns: u64,
+```
+
+The cursor StableCells (positions) are separate from SlimState since they're in their own MemoryIds. The metadata above (last success, errors) lives in SlimState for convenience.
+
+## Query Endpoints
+
+Two new query methods, same pagination pattern as existing series:
+
+- `get_holder_series(RangeQuery, token: Principal) -> HolderSeriesResponse`
+  - Returns `Vec<DailyHolderRow>` from DAILY_HOLDERS_ICUSD or DAILY_HOLDERS_3USD based on token principal
+- `get_collector_health() -> CollectorHealth`
+  - No parameters, returns current system state
+
+Response types:
+```
+HolderSeriesResponse { rows: Vec<DailyHolderRow>, next_from_ts: Option<u64> }
+```
+
+## Timer Wiring
+
+The daily_snapshot function gains a fourth collector call:
+
+```rust
+async fn daily_snapshot() {
+    let (tvl_res, vaults_res, stability_res, holders_res) = futures::join!(
+        collectors::tvl::run(),
+        collectors::vaults::run(),
+        collectors::stability::run(),
+        collectors::holders::run(),  // NEW
+    );
+    // ... log errors independently
+}
+```
+
+## Candid Interface Updates
+
+New types added to the `.did` file:
+- `CollectorHealth`, `CursorStatus`, `BalanceTrackerStats`
+- `DailyHolderRow`
+- `HolderSeriesResponse`
+- `LiquidationKind`, `VaultEventKind`, `SwapSource`, `LiquidityAction`
+- `AnalyticsLiquidationEvent`, `AnalyticsVaultEvent`, `AnalyticsSwapEvent`, `AnalyticsLiquidityEvent`
+
+New methods:
+- `get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query`
+- `get_collector_health : () -> (CollectorHealth) query`
+- `start_backfill : (principal) -> () ` (admin-gated update)
+
+## Error Handling
+
+- Each tailing function catches errors independently. A failed 3pool call does not prevent the AMM tail from running.
+- Per-source error counters (already in SlimState) are incremented on failure.
+- The most recent error message is cached in `cursor_last_error` for visibility in `get_collector_health()`.
+- Cursors never advance past an error. The next tick retries from the same position.
+- ICRC-3 blocks that fail to parse are logged and skipped (cursor advances past them). This is necessary because malformed/unknown block types should not stall the entire pipeline.
+
+## Testing
+
+PocketIC integration tests extending `pocket_ic_analytics.rs`:
+
+1. **Backend event tailing**: Deploy analytics + backend with fixture vaults. Execute vault operations (open, borrow, repay). Advance time past pull cycle. Verify EVT_VAULTS log contains expected events.
+
+2. **Liquidation event tailing**: Execute a liquidation on the backend. Advance time. Verify EVT_LIQUIDATIONS log contains the event with correct fields.
+
+3. **3pool swap event tailing**: Execute a swap on the 3pool. Advance time. Verify EVT_SWAPS log contains the event with `source = ThreePool`.
+
+4. **ICRC-3 balance tracking**: Deploy analytics + icusd_ledger. Mint icUSD to accounts, transfer between them. Advance time past multiple pull cycles. Verify BalanceTracker balances match expected values.
+
+5. **Daily holder snapshot**: After populating BalanceTracker, advance past daily tick. Query `get_holder_series`. Verify total_holders, top_50, distribution_buckets.
+
+6. **Collector health**: After tailing, call `get_collector_health()`. Verify cursor positions, last_success timestamps, zero errors.
+
+7. **Backfill**: Pre-populate icusd_ledger with historical mints. Deploy analytics. Call `start_backfill`. Advance time through multiple ticks. Verify BalanceTracker matches expected state and backfill flag auto-cleared.
+
+8. **Error resilience**: Deploy analytics with unavailable source canister. Advance time. Verify other cursors still advance, error counter incremented, `get_collector_health()` shows the error.
+
+9. **Upgrade preserves cursors + balances**: Populate cursors and BalanceTracker, upgrade canister, verify everything survives.
+
+## What This Does NOT Include
+
+- Event-derived daily rollups (Phase 5: liquidation/swap/fee summaries computed from EVT_* logs)
+- Fast/hourly snapshot tiers (Phase 5)
+- Live query layer with TWAPs, VWAPs, etc. (Phase 6)
+- HTTP series endpoints (Phase 7)
+- Frontend integration (Phase 7)

--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -19,10 +19,56 @@ type DailyTvlRow = record {
   total_icp_collateral_e8s : nat;
   total_icusd_supply_e8s : nat;
   system_collateral_ratio_bps : nat32;
+  stability_pool_deposits_e8s : opt nat64;
+  three_pool_reserve_0_e8s : opt nat;
+  three_pool_reserve_1_e8s : opt nat;
+  three_pool_reserve_2_e8s : opt nat;
+  three_pool_virtual_price_e18 : opt nat;
+  three_pool_lp_supply_e8s : opt nat;
 };
 
 type TvlSeriesResponse = record {
   rows : vec DailyTvlRow;
+  next_from_ts : opt nat64;
+};
+
+type CollateralStats = record {
+  collateral_type : principal;
+  vault_count : nat32;
+  total_collateral_e8s : nat64;
+  total_debt_e8s : nat64;
+  min_cr_bps : nat32;
+  max_cr_bps : nat32;
+  median_cr_bps : nat32;
+  price_usd_e8s : nat64;
+};
+
+type DailyVaultSnapshotRow = record {
+  timestamp_ns : nat64;
+  total_vault_count : nat32;
+  total_collateral_usd_e8s : nat64;
+  total_debt_e8s : nat64;
+  median_cr_bps : nat32;
+  collaterals : vec CollateralStats;
+};
+
+type VaultSeriesResponse = record {
+  rows : vec DailyVaultSnapshotRow;
+  next_from_ts : opt nat64;
+};
+
+type DailyStabilityRow = record {
+  timestamp_ns : nat64;
+  total_deposits_e8s : nat64;
+  total_depositors : nat64;
+  total_liquidations_executed : nat64;
+  total_interest_received_e8s : nat64;
+  stablecoin_balances : vec record { principal; nat64 };
+  collateral_gains : vec record { principal; nat64 };
+};
+
+type StabilitySeriesResponse = record {
+  rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
 };
 
@@ -45,5 +91,7 @@ service : (InitArgs) -> {
   ping : () -> (text) query;
   get_admin : () -> (principal) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
+  get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
+  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -1,97 +1,129 @@
-type InitArgs = record {
-  admin : principal;
-  backend : principal;
-  icusd_ledger : principal;
-  three_pool : principal;
-  stability_pool : principal;
-  amm : principal;
+type BalanceTrackerStats = record {
+  token : principal;
+  total_tracked_e8s : nat64;
+  holder_count : nat64;
 };
-
-type RangeQuery = record {
-  from_ts : opt nat64;
-  to_ts : opt nat64;
-  limit : opt nat32;
-  offset : opt nat64;
-};
-
-type DailyTvlRow = record {
-  timestamp_ns : nat64;
-  total_icp_collateral_e8s : nat;
-  total_icusd_supply_e8s : nat;
-  system_collateral_ratio_bps : nat32;
-  stability_pool_deposits_e8s : opt nat64;
-  three_pool_reserve_0_e8s : opt nat;
-  three_pool_reserve_1_e8s : opt nat;
-  three_pool_reserve_2_e8s : opt nat;
-  three_pool_virtual_price_e18 : opt nat;
-  three_pool_lp_supply_e8s : opt nat;
-};
-
-type TvlSeriesResponse = record {
-  rows : vec DailyTvlRow;
-  next_from_ts : opt nat64;
-};
-
 type CollateralStats = record {
-  collateral_type : principal;
-  vault_count : nat32;
   total_collateral_e8s : nat64;
-  total_debt_e8s : nat64;
-  min_cr_bps : nat32;
-  max_cr_bps : nat32;
   median_cr_bps : nat32;
   price_usd_e8s : nat64;
+  total_debt_e8s : nat64;
+  max_cr_bps : nat32;
+  collateral_type : principal;
+  min_cr_bps : nat32;
+  vault_count : nat32;
 };
-
+type CollectorHealth = record {
+  balance_tracker_stats : vec BalanceTrackerStats;
+  backfill_active : vec principal;
+  error_counters : ErrorCounters;
+  last_pull_cycle_ns : nat64;
+  cursors : vec CursorStatus;
+};
+type CursorStatus = record {
+  last_error : opt text;
+  source_count : nat64;
+  name : text;
+  last_success_ns : nat64;
+  cursor_position : nat64;
+};
+type DailyHolderRow = record {
+  total_supply_tracked_e8s : nat64;
+  token : principal;
+  new_holders_today : nat32;
+  timestamp_ns : nat64;
+  median_balance_e8s : nat64;
+  total_holders : nat32;
+  top_10_pct_bps : nat32;
+  top_50 : vec record { principal; nat64 };
+  distribution_buckets : vec nat32;
+  gini_bps : nat32;
+};
+type DailyStabilityRow = record {
+  collateral_gains : vec record { principal; nat64 };
+  timestamp_ns : nat64;
+  total_depositors : nat64;
+  stablecoin_balances : vec record { principal; nat64 };
+  total_deposits_e8s : nat64;
+  total_interest_received_e8s : nat64;
+  total_liquidations_executed : nat64;
+};
+type DailyTvlRow = record {
+  three_pool_reserve_0_e8s : opt nat;
+  timestamp_ns : nat64;
+  three_pool_reserve_2_e8s : opt nat;
+  three_pool_virtual_price_e18 : opt nat;
+  total_icusd_supply_e8s : nat;
+  system_collateral_ratio_bps : nat32;
+  total_icp_collateral_e8s : nat;
+  three_pool_reserve_1_e8s : opt nat;
+  stability_pool_deposits_e8s : opt nat64;
+  three_pool_lp_supply_e8s : opt nat;
+};
 type DailyVaultSnapshotRow = record {
   timestamp_ns : nat64;
+  median_cr_bps : nat32;
+  total_debt_e8s : nat64;
   total_vault_count : nat32;
   total_collateral_usd_e8s : nat64;
-  total_debt_e8s : nat64;
-  median_cr_bps : nat32;
   collaterals : vec CollateralStats;
 };
-
-type VaultSeriesResponse = record {
-  rows : vec DailyVaultSnapshotRow;
+type ErrorCounters = record {
+  amm : nat64;
+  three_pool : nat64;
+  icusd_ledger : nat64;
+  stability_pool : nat64;
+  backend : nat64;
+};
+type HolderSeriesResponse = record {
+  rows : vec DailyHolderRow;
   next_from_ts : opt nat64;
 };
-
-type DailyStabilityRow = record {
-  timestamp_ns : nat64;
-  total_deposits_e8s : nat64;
-  total_depositors : nat64;
-  total_liquidations_executed : nat64;
-  total_interest_received_e8s : nat64;
-  stablecoin_balances : vec record { principal; nat64 };
-  collateral_gains : vec record { principal; nat64 };
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : blob;
+  headers : vec record { text; text };
 };
-
+type HttpResponse = record {
+  body : blob;
+  headers : vec record { text; text };
+  status_code : nat16;
+};
+type InitArgs = record {
+  amm : principal;
+  three_pool : principal;
+  admin : principal;
+  icusd_ledger : principal;
+  stability_pool : principal;
+  backend : principal;
+};
+type RangeQuery = record {
+  to_ts : opt nat64;
+  from_ts : opt nat64;
+  offset : opt nat64;
+  limit : opt nat32;
+};
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
 };
-
-type HeaderField = record { text; text };
-
-type HttpRequest = record {
-  method : text;
-  url : text;
-  headers : vec HeaderField;
-  body : blob;
+type TvlSeriesResponse = record {
+  rows : vec DailyTvlRow;
+  next_from_ts : opt nat64;
 };
-
-type HttpResponse = record {
-  status_code : nat16;
-  headers : vec HeaderField;
-  body : blob;
+type VaultSeriesResponse = record {
+  rows : vec DailyVaultSnapshotRow;
+  next_from_ts : opt nat64;
 };
-
 service : (InitArgs) -> {
-  ping : () -> (text) query;
   get_admin : () -> (principal) query;
+  get_collector_health : () -> (CollectorHealth) query;
+  get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
+  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
-  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
+  ping : () -> (text) query;
+  start_backfill : (principal) -> (text);
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -2,6 +2,11 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface BalanceTrackerStats {
+  'token' : Principal,
+  'total_tracked_e8s' : bigint,
+  'holder_count' : bigint,
+}
 export interface CollateralStats {
   'total_collateral_e8s' : bigint,
   'median_cr_bps' : number,
@@ -11,6 +16,32 @@ export interface CollateralStats {
   'collateral_type' : Principal,
   'min_cr_bps' : number,
   'vault_count' : number,
+}
+export interface CollectorHealth {
+  'balance_tracker_stats' : Array<BalanceTrackerStats>,
+  'backfill_active' : Array<Principal>,
+  'error_counters' : ErrorCounters,
+  'last_pull_cycle_ns' : bigint,
+  'cursors' : Array<CursorStatus>,
+}
+export interface CursorStatus {
+  'last_error' : [] | [string],
+  'source_count' : bigint,
+  'name' : string,
+  'last_success_ns' : bigint,
+  'cursor_position' : bigint,
+}
+export interface DailyHolderRow {
+  'total_supply_tracked_e8s' : bigint,
+  'token' : Principal,
+  'new_holders_today' : number,
+  'timestamp_ns' : bigint,
+  'median_balance_e8s' : bigint,
+  'total_holders' : number,
+  'top_10_pct_bps' : number,
+  'top_50' : Array<[Principal, bigint]>,
+  'distribution_buckets' : Uint32Array | number[],
+  'gini_bps' : number,
 }
 export interface DailyStabilityRow {
   'collateral_gains' : Array<[Principal, bigint]>,
@@ -41,16 +72,26 @@ export interface DailyVaultSnapshotRow {
   'total_collateral_usd_e8s' : bigint,
   'collaterals' : Array<CollateralStats>,
 }
-export type HeaderField = [string, string];
+export interface ErrorCounters {
+  'amm' : bigint,
+  'three_pool' : bigint,
+  'icusd_ledger' : bigint,
+  'stability_pool' : bigint,
+  'backend' : bigint,
+}
+export interface HolderSeriesResponse {
+  'rows' : Array<DailyHolderRow>,
+  'next_from_ts' : [] | [bigint],
+}
 export interface HttpRequest {
   'url' : string,
   'method' : string,
   'body' : Uint8Array | number[],
-  'headers' : Array<HeaderField>,
+  'headers' : Array<[string, string]>,
 }
 export interface HttpResponse {
   'body' : Uint8Array | number[],
-  'headers' : Array<HeaderField>,
+  'headers' : Array<[string, string]>,
   'status_code' : number,
 }
 export interface InitArgs {
@@ -81,11 +122,17 @@ export interface VaultSeriesResponse {
 }
 export interface _SERVICE {
   'get_admin' : ActorMethod<[], Principal>,
+  'get_collector_health' : ActorMethod<[], CollectorHealth>,
+  'get_holder_series' : ActorMethod<
+    [RangeQuery, Principal],
+    HolderSeriesResponse
+  >,
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_tvl_series' : ActorMethod<[RangeQuery], TvlSeriesResponse>,
   'get_vault_series' : ActorMethod<[RangeQuery], VaultSeriesResponse>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'ping' : ActorMethod<[], string>,
+  'start_backfill' : ActorMethod<[Principal], string>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -2,11 +2,44 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
-export interface DailyTvlRow {
+export interface CollateralStats {
+  'total_collateral_e8s' : bigint,
+  'median_cr_bps' : number,
+  'price_usd_e8s' : bigint,
+  'total_debt_e8s' : bigint,
+  'max_cr_bps' : number,
+  'collateral_type' : Principal,
+  'min_cr_bps' : number,
+  'vault_count' : number,
+}
+export interface DailyStabilityRow {
+  'collateral_gains' : Array<[Principal, bigint]>,
   'timestamp_ns' : bigint,
+  'total_depositors' : bigint,
+  'stablecoin_balances' : Array<[Principal, bigint]>,
+  'total_deposits_e8s' : bigint,
+  'total_interest_received_e8s' : bigint,
+  'total_liquidations_executed' : bigint,
+}
+export interface DailyTvlRow {
+  'three_pool_reserve_0_e8s' : [] | [bigint],
+  'timestamp_ns' : bigint,
+  'three_pool_reserve_2_e8s' : [] | [bigint],
+  'three_pool_virtual_price_e18' : [] | [bigint],
   'total_icusd_supply_e8s' : bigint,
   'system_collateral_ratio_bps' : number,
   'total_icp_collateral_e8s' : bigint,
+  'three_pool_reserve_1_e8s' : [] | [bigint],
+  'stability_pool_deposits_e8s' : [] | [bigint],
+  'three_pool_lp_supply_e8s' : [] | [bigint],
+}
+export interface DailyVaultSnapshotRow {
+  'timestamp_ns' : bigint,
+  'median_cr_bps' : number,
+  'total_debt_e8s' : bigint,
+  'total_vault_count' : number,
+  'total_collateral_usd_e8s' : bigint,
+  'collaterals' : Array<CollateralStats>,
 }
 export type HeaderField = [string, string];
 export interface HttpRequest {
@@ -34,13 +67,23 @@ export interface RangeQuery {
   'offset' : [] | [bigint],
   'limit' : [] | [number],
 }
+export interface StabilitySeriesResponse {
+  'rows' : Array<DailyStabilityRow>,
+  'next_from_ts' : [] | [bigint],
+}
 export interface TvlSeriesResponse {
   'rows' : Array<DailyTvlRow>,
   'next_from_ts' : [] | [bigint],
 }
+export interface VaultSeriesResponse {
+  'rows' : Array<DailyVaultSnapshotRow>,
+  'next_from_ts' : [] | [bigint],
+}
 export interface _SERVICE {
   'get_admin' : ActorMethod<[], Principal>,
+  'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_tvl_series' : ActorMethod<[RangeQuery], TvlSeriesResponse>,
+  'get_vault_series' : ActorMethod<[RangeQuery], VaultSeriesResponse>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'ping' : ActorMethod<[], string>,
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -7,11 +7,53 @@ export const idlFactory = ({ IDL }) => {
     'stability_pool' : IDL.Principal,
     'backend' : IDL.Principal,
   });
+  const BalanceTrackerStats = IDL.Record({
+    'token' : IDL.Principal,
+    'total_tracked_e8s' : IDL.Nat64,
+    'holder_count' : IDL.Nat64,
+  });
+  const ErrorCounters = IDL.Record({
+    'amm' : IDL.Nat64,
+    'three_pool' : IDL.Nat64,
+    'icusd_ledger' : IDL.Nat64,
+    'stability_pool' : IDL.Nat64,
+    'backend' : IDL.Nat64,
+  });
+  const CursorStatus = IDL.Record({
+    'last_error' : IDL.Opt(IDL.Text),
+    'source_count' : IDL.Nat64,
+    'name' : IDL.Text,
+    'last_success_ns' : IDL.Nat64,
+    'cursor_position' : IDL.Nat64,
+  });
+  const CollectorHealth = IDL.Record({
+    'balance_tracker_stats' : IDL.Vec(BalanceTrackerStats),
+    'backfill_active' : IDL.Vec(IDL.Principal),
+    'error_counters' : ErrorCounters,
+    'last_pull_cycle_ns' : IDL.Nat64,
+    'cursors' : IDL.Vec(CursorStatus),
+  });
   const RangeQuery = IDL.Record({
     'to_ts' : IDL.Opt(IDL.Nat64),
     'from_ts' : IDL.Opt(IDL.Nat64),
     'offset' : IDL.Opt(IDL.Nat64),
     'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const DailyHolderRow = IDL.Record({
+    'total_supply_tracked_e8s' : IDL.Nat64,
+    'token' : IDL.Principal,
+    'new_holders_today' : IDL.Nat32,
+    'timestamp_ns' : IDL.Nat64,
+    'median_balance_e8s' : IDL.Nat64,
+    'total_holders' : IDL.Nat32,
+    'top_10_pct_bps' : IDL.Nat32,
+    'top_50' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'distribution_buckets' : IDL.Vec(IDL.Nat32),
+    'gini_bps' : IDL.Nat32,
+  });
+  const HolderSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailyHolderRow),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
   const DailyStabilityRow = IDL.Record({
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
@@ -64,20 +106,25 @@ export const idlFactory = ({ IDL }) => {
     'rows' : IDL.Vec(DailyVaultSnapshotRow),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
-  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
     'method' : IDL.Text,
     'body' : IDL.Vec(IDL.Nat8),
-    'headers' : IDL.Vec(HeaderField),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
   });
   const HttpResponse = IDL.Record({
     'body' : IDL.Vec(IDL.Nat8),
-    'headers' : IDL.Vec(HeaderField),
+    'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     'status_code' : IDL.Nat16,
   });
   return IDL.Service({
     'get_admin' : IDL.Func([], [IDL.Principal], ['query']),
+    'get_collector_health' : IDL.Func([], [CollectorHealth], ['query']),
+    'get_holder_series' : IDL.Func(
+        [RangeQuery, IDL.Principal],
+        [HolderSeriesResponse],
+        ['query'],
+      ),
     'get_stability_series' : IDL.Func(
         [RangeQuery],
         [StabilitySeriesResponse],
@@ -91,6 +138,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'ping' : IDL.Func([], [IDL.Text], ['query']),
+    'start_backfill' : IDL.Func([IDL.Principal], [IDL.Text], []),
   });
 };
 export const init = ({ IDL }) => {

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -13,14 +13,55 @@ export const idlFactory = ({ IDL }) => {
     'offset' : IDL.Opt(IDL.Nat64),
     'limit' : IDL.Opt(IDL.Nat32),
   });
-  const DailyTvlRow = IDL.Record({
+  const DailyStabilityRow = IDL.Record({
+    'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'timestamp_ns' : IDL.Nat64,
+    'total_depositors' : IDL.Nat64,
+    'stablecoin_balances' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'total_deposits_e8s' : IDL.Nat64,
+    'total_interest_received_e8s' : IDL.Nat64,
+    'total_liquidations_executed' : IDL.Nat64,
+  });
+  const StabilitySeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailyStabilityRow),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const DailyTvlRow = IDL.Record({
+    'three_pool_reserve_0_e8s' : IDL.Opt(IDL.Nat),
+    'timestamp_ns' : IDL.Nat64,
+    'three_pool_reserve_2_e8s' : IDL.Opt(IDL.Nat),
+    'three_pool_virtual_price_e18' : IDL.Opt(IDL.Nat),
     'total_icusd_supply_e8s' : IDL.Nat,
     'system_collateral_ratio_bps' : IDL.Nat32,
     'total_icp_collateral_e8s' : IDL.Nat,
+    'three_pool_reserve_1_e8s' : IDL.Opt(IDL.Nat),
+    'stability_pool_deposits_e8s' : IDL.Opt(IDL.Nat64),
+    'three_pool_lp_supply_e8s' : IDL.Opt(IDL.Nat),
   });
   const TvlSeriesResponse = IDL.Record({
     'rows' : IDL.Vec(DailyTvlRow),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const CollateralStats = IDL.Record({
+    'total_collateral_e8s' : IDL.Nat64,
+    'median_cr_bps' : IDL.Nat32,
+    'price_usd_e8s' : IDL.Nat64,
+    'total_debt_e8s' : IDL.Nat64,
+    'max_cr_bps' : IDL.Nat32,
+    'collateral_type' : IDL.Principal,
+    'min_cr_bps' : IDL.Nat32,
+    'vault_count' : IDL.Nat32,
+  });
+  const DailyVaultSnapshotRow = IDL.Record({
+    'timestamp_ns' : IDL.Nat64,
+    'median_cr_bps' : IDL.Nat32,
+    'total_debt_e8s' : IDL.Nat64,
+    'total_vault_count' : IDL.Nat32,
+    'total_collateral_usd_e8s' : IDL.Nat64,
+    'collaterals' : IDL.Vec(CollateralStats),
+  });
+  const VaultSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailyVaultSnapshotRow),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
@@ -37,7 +78,17 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'get_admin' : IDL.Func([], [IDL.Principal], ['query']),
+    'get_stability_series' : IDL.Func(
+        [RangeQuery],
+        [StabilitySeriesResponse],
+        ['query'],
+      ),
     'get_tvl_series' : IDL.Func([RangeQuery], [TvlSeriesResponse], ['query']),
+    'get_vault_series' : IDL.Func(
+        [RangeQuery],
+        [VaultSeriesResponse],
+        ['query'],
+      ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'ping' : IDL.Func([], [IDL.Text], ['query']),
   });

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -239,6 +239,45 @@ type Event = variant {
     collateral_type : principal;
     borrowing_fee : opt text;
   };
+  set_collateral_liquidation_ratio : record {
+    collateral_type : principal;
+    liquidation_ratio : text;
+  };
+  set_collateral_borrow_threshold : record {
+    collateral_type : principal;
+    borrow_threshold_ratio : text;
+  };
+  set_collateral_liquidation_bonus : record {
+    collateral_type : principal;
+    liquidation_bonus : text;
+  };
+  set_collateral_min_vault_debt : record {
+    collateral_type : principal;
+    min_vault_debt : nat64;
+  };
+  set_collateral_ledger_fee : record {
+    collateral_type : principal;
+    ledger_fee : nat64;
+  };
+  set_collateral_redemption_fee_floor : record {
+    collateral_type : principal;
+    redemption_fee_floor : text;
+  };
+  set_collateral_redemption_fee_ceiling : record {
+    collateral_type : principal;
+    redemption_fee_ceiling : text;
+  };
+  set_collateral_min_deposit : record {
+    collateral_type : principal;
+    min_collateral_deposit : nat64;
+  };
+  set_collateral_display_color : record {
+    collateral_type : principal;
+    display_color : opt text;
+  };
+  set_bot_allowed_collateral_types : record {
+    collateral_types : vec principal;
+  };
   margin_transfer : record { block_index : nat64; vault_id : nat64; timestamp : opt nat64 };
   admin_sweep_to_treasury : record {
     block_index : nat64;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -200,7 +200,19 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'reason' : string,
     }
   } |
+  {
+    'set_collateral_min_vault_debt' : {
+      'min_vault_debt' : bigint,
+      'collateral_type' : Principal,
+    }
+  } |
   { 'set_recovery_target_cr' : { 'rate' : string } } |
+  {
+    'set_collateral_redemption_fee_floor' : {
+      'redemption_fee_floor' : string,
+      'collateral_type' : Principal,
+    }
+  } |
   { 'init' : InitArg } |
   {
     'set_stable_ledger_principal' : {
@@ -213,6 +225,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'block_index' : bigint,
       'vault' : Vault,
       'timestamp' : [] | [bigint],
+    }
+  } |
+  {
+    'set_collateral_display_color' : {
+      'collateral_type' : Principal,
+      'display_color' : [] | [string],
     }
   } |
   {
@@ -244,6 +262,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'set_collateral_redemption_fee_ceiling' : {
+      'redemption_fee_ceiling' : string,
+      'collateral_type' : Principal,
+    }
+  } |
+  {
     'margin_transfer' : {
       'block_index' : bigint,
       'vault_id' : bigint,
@@ -261,6 +285,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'set_rmr_floor_cr' : { 'value' : string } } |
   { 'set_rmr_ceiling' : { 'value' : string } } |
   {
+    'set_collateral_liquidation_bonus' : {
+      'collateral_type' : Principal,
+      'liquidation_bonus' : string,
+    }
+  } |
+  {
     'set_global_icusd_mint_cap' : {
       'cap' : [] | [string],
       'amount' : [] | [string],
@@ -275,6 +305,11 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'fee_amount' : bigint,
       'caller' : [] | [Principal],
       'borrowed_amount' : bigint,
+    }
+  } |
+  {
+    'set_bot_allowed_collateral_types' : {
+      'collateral_types' : Array<Principal>,
     }
   } |
   { 'set_reserve_redemptions_enabled' : { 'enabled' : boolean } } |
@@ -314,6 +349,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'set_rate_curve_markers' : {
       'markers' : string,
       'collateral_type' : [] | [string],
+    }
+  } |
+  {
+    'set_collateral_liquidation_ratio' : {
+      'collateral_type' : Principal,
+      'liquidation_ratio' : string,
     }
   } |
   {
@@ -373,6 +414,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'set_collateral_min_deposit' : {
+      'min_collateral_deposit' : bigint,
+      'collateral_type' : Principal,
+    }
+  } |
+  {
     'update_collateral_status' : {
       'status' : CollateralStatus,
       'collateral_type' : Principal,
@@ -424,8 +471,20 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'set_collateral_borrow_threshold' : {
+      'borrow_threshold_ratio' : string,
+      'collateral_type' : Principal,
+    }
+  } |
+  {
     'add_collateral_type' : {
       'config' : CollateralConfig,
+      'collateral_type' : Principal,
+    }
+  } |
+  {
+    'set_collateral_ledger_fee' : {
+      'ledger_fee' : bigint,
       'collateral_type' : Principal,
     }
   } |

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -288,7 +288,15 @@ export const idlFactory = ({ IDL }) => {
       'old_amount' : IDL.Nat64,
       'reason' : IDL.Text,
     }),
+    'set_collateral_min_vault_debt' : IDL.Record({
+      'min_vault_debt' : IDL.Nat64,
+      'collateral_type' : IDL.Principal,
+    }),
     'set_recovery_target_cr' : IDL.Record({ 'rate' : IDL.Text }),
+    'set_collateral_redemption_fee_floor' : IDL.Record({
+      'redemption_fee_floor' : IDL.Text,
+      'collateral_type' : IDL.Principal,
+    }),
     'init' : InitArg,
     'set_stable_ledger_principal' : IDL.Record({
       'principal' : IDL.Principal,
@@ -298,6 +306,10 @@ export const idlFactory = ({ IDL }) => {
       'block_index' : IDL.Nat64,
       'vault' : Vault,
       'timestamp' : IDL.Opt(IDL.Nat64),
+    }),
+    'set_collateral_display_color' : IDL.Record({
+      'collateral_type' : IDL.Principal,
+      'display_color' : IDL.Opt(IDL.Text),
     }),
     'redemption_on_vaults' : IDL.Record({
       'icusd_amount' : IDL.Nat64,
@@ -321,6 +333,10 @@ export const idlFactory = ({ IDL }) => {
       'collateral_type' : IDL.Principal,
       'borrowing_fee' : IDL.Opt(IDL.Text),
     }),
+    'set_collateral_redemption_fee_ceiling' : IDL.Record({
+      'redemption_fee_ceiling' : IDL.Text,
+      'collateral_type' : IDL.Principal,
+    }),
     'margin_transfer' : IDL.Record({
       'block_index' : IDL.Nat64,
       'vault_id' : IDL.Nat64,
@@ -334,6 +350,10 @@ export const idlFactory = ({ IDL }) => {
     }),
     'set_rmr_floor_cr' : IDL.Record({ 'value' : IDL.Text }),
     'set_rmr_ceiling' : IDL.Record({ 'value' : IDL.Text }),
+    'set_collateral_liquidation_bonus' : IDL.Record({
+      'collateral_type' : IDL.Principal,
+      'liquidation_bonus' : IDL.Text,
+    }),
     'set_global_icusd_mint_cap' : IDL.Record({
       'cap' : IDL.Opt(IDL.Text),
       'amount' : IDL.Opt(IDL.Text),
@@ -346,6 +366,9 @@ export const idlFactory = ({ IDL }) => {
       'fee_amount' : IDL.Nat64,
       'caller' : IDL.Opt(IDL.Principal),
       'borrowed_amount' : IDL.Nat64,
+    }),
+    'set_bot_allowed_collateral_types' : IDL.Record({
+      'collateral_types' : IDL.Vec(IDL.Principal),
     }),
     'set_reserve_redemptions_enabled' : IDL.Record({ 'enabled' : IDL.Bool }),
     'set_min_icusd_amount' : IDL.Record({ 'amount' : IDL.Text }),
@@ -378,6 +401,10 @@ export const idlFactory = ({ IDL }) => {
     'set_rate_curve_markers' : IDL.Record({
       'markers' : IDL.Text,
       'collateral_type' : IDL.Opt(IDL.Text),
+    }),
+    'set_collateral_liquidation_ratio' : IDL.Record({
+      'collateral_type' : IDL.Principal,
+      'liquidation_ratio' : IDL.Text,
     }),
     'dust_forgiven' : IDL.Record({
       'vault_id' : IDL.Nat64,
@@ -422,6 +449,10 @@ export const idlFactory = ({ IDL }) => {
       'block_index' : IDL.Opt(IDL.Nat64),
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
+    }),
+    'set_collateral_min_deposit' : IDL.Record({
+      'min_collateral_deposit' : IDL.Nat64,
+      'collateral_type' : IDL.Principal,
     }),
     'update_collateral_status' : IDL.Record({
       'status' : CollateralStatus,
@@ -469,8 +500,16 @@ export const idlFactory = ({ IDL }) => {
       'timestamp' : IDL.Opt(IDL.Nat64),
       'liquidator' : IDL.Opt(IDL.Principal),
     }),
+    'set_collateral_borrow_threshold' : IDL.Record({
+      'borrow_threshold_ratio' : IDL.Text,
+      'collateral_type' : IDL.Principal,
+    }),
     'add_collateral_type' : IDL.Record({
       'config' : CollateralConfig,
+      'collateral_type' : IDL.Principal,
+    }),
+    'set_collateral_ledger_fee' : IDL.Record({
+      'ledger_fee' : IDL.Nat64,
       'collateral_type' : IDL.Principal,
     }),
     'set_stable_token_enabled' : IDL.Record({

--- a/src/rumi_analytics/Cargo.toml
+++ b/src/rumi_analytics/Cargo.toml
@@ -20,6 +20,7 @@ ic-canisters-http-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "
 serde = { version = "1.0.210", features = ["derive"] }
 serde_bytes = "0.11"
 ciborium = "0.2"
+futures = "0.3"
 
 [dev-dependencies]
 pocket-ic = "6.0.0"

--- a/src/rumi_analytics/Cargo.toml
+++ b/src/rumi_analytics/Cargo.toml
@@ -17,6 +17,7 @@ ic-canister-log = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709
 icrc-ledger-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 icrc-ledger-client-cdk = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 ic-canisters-http-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
+num-traits = "0.2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_bytes = "0.11"
 ciborium = "0.2"

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -19,10 +19,56 @@ type DailyTvlRow = record {
   total_icp_collateral_e8s : nat;
   total_icusd_supply_e8s : nat;
   system_collateral_ratio_bps : nat32;
+  stability_pool_deposits_e8s : opt nat64;
+  three_pool_reserve_0_e8s : opt nat;
+  three_pool_reserve_1_e8s : opt nat;
+  three_pool_reserve_2_e8s : opt nat;
+  three_pool_virtual_price_e18 : opt nat;
+  three_pool_lp_supply_e8s : opt nat;
 };
 
 type TvlSeriesResponse = record {
   rows : vec DailyTvlRow;
+  next_from_ts : opt nat64;
+};
+
+type CollateralStats = record {
+  collateral_type : principal;
+  vault_count : nat32;
+  total_collateral_e8s : nat64;
+  total_debt_e8s : nat64;
+  min_cr_bps : nat32;
+  max_cr_bps : nat32;
+  median_cr_bps : nat32;
+  price_usd_e8s : nat64;
+};
+
+type DailyVaultSnapshotRow = record {
+  timestamp_ns : nat64;
+  total_vault_count : nat32;
+  total_collateral_usd_e8s : nat64;
+  total_debt_e8s : nat64;
+  median_cr_bps : nat32;
+  collaterals : vec CollateralStats;
+};
+
+type VaultSeriesResponse = record {
+  rows : vec DailyVaultSnapshotRow;
+  next_from_ts : opt nat64;
+};
+
+type DailyStabilityRow = record {
+  timestamp_ns : nat64;
+  total_deposits_e8s : nat64;
+  total_depositors : nat64;
+  total_liquidations_executed : nat64;
+  total_interest_received_e8s : nat64;
+  stablecoin_balances : vec record { principal; nat64 };
+  collateral_gains : vec record { principal; nat64 };
+};
+
+type StabilitySeriesResponse = record {
+  rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
 };
 
@@ -45,5 +91,7 @@ service : (InitArgs) -> {
   ping : () -> (text) query;
   get_admin : () -> (principal) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
+  get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
+  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
 }

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -1,97 +1,129 @@
-type InitArgs = record {
-  admin : principal;
-  backend : principal;
-  icusd_ledger : principal;
-  three_pool : principal;
-  stability_pool : principal;
-  amm : principal;
+type BalanceTrackerStats = record {
+  token : principal;
+  total_tracked_e8s : nat64;
+  holder_count : nat64;
 };
-
-type RangeQuery = record {
-  from_ts : opt nat64;
-  to_ts : opt nat64;
-  limit : opt nat32;
-  offset : opt nat64;
-};
-
-type DailyTvlRow = record {
-  timestamp_ns : nat64;
-  total_icp_collateral_e8s : nat;
-  total_icusd_supply_e8s : nat;
-  system_collateral_ratio_bps : nat32;
-  stability_pool_deposits_e8s : opt nat64;
-  three_pool_reserve_0_e8s : opt nat;
-  three_pool_reserve_1_e8s : opt nat;
-  three_pool_reserve_2_e8s : opt nat;
-  three_pool_virtual_price_e18 : opt nat;
-  three_pool_lp_supply_e8s : opt nat;
-};
-
-type TvlSeriesResponse = record {
-  rows : vec DailyTvlRow;
-  next_from_ts : opt nat64;
-};
-
 type CollateralStats = record {
-  collateral_type : principal;
-  vault_count : nat32;
   total_collateral_e8s : nat64;
-  total_debt_e8s : nat64;
-  min_cr_bps : nat32;
-  max_cr_bps : nat32;
   median_cr_bps : nat32;
   price_usd_e8s : nat64;
+  total_debt_e8s : nat64;
+  max_cr_bps : nat32;
+  collateral_type : principal;
+  min_cr_bps : nat32;
+  vault_count : nat32;
 };
-
+type CollectorHealth = record {
+  balance_tracker_stats : vec BalanceTrackerStats;
+  backfill_active : vec principal;
+  error_counters : ErrorCounters;
+  last_pull_cycle_ns : nat64;
+  cursors : vec CursorStatus;
+};
+type CursorStatus = record {
+  last_error : opt text;
+  source_count : nat64;
+  name : text;
+  last_success_ns : nat64;
+  cursor_position : nat64;
+};
+type DailyHolderRow = record {
+  total_supply_tracked_e8s : nat64;
+  token : principal;
+  new_holders_today : nat32;
+  timestamp_ns : nat64;
+  median_balance_e8s : nat64;
+  total_holders : nat32;
+  top_10_pct_bps : nat32;
+  top_50 : vec record { principal; nat64 };
+  distribution_buckets : vec nat32;
+  gini_bps : nat32;
+};
+type DailyStabilityRow = record {
+  collateral_gains : vec record { principal; nat64 };
+  timestamp_ns : nat64;
+  total_depositors : nat64;
+  stablecoin_balances : vec record { principal; nat64 };
+  total_deposits_e8s : nat64;
+  total_interest_received_e8s : nat64;
+  total_liquidations_executed : nat64;
+};
+type DailyTvlRow = record {
+  three_pool_reserve_0_e8s : opt nat;
+  timestamp_ns : nat64;
+  three_pool_reserve_2_e8s : opt nat;
+  three_pool_virtual_price_e18 : opt nat;
+  total_icusd_supply_e8s : nat;
+  system_collateral_ratio_bps : nat32;
+  total_icp_collateral_e8s : nat;
+  three_pool_reserve_1_e8s : opt nat;
+  stability_pool_deposits_e8s : opt nat64;
+  three_pool_lp_supply_e8s : opt nat;
+};
 type DailyVaultSnapshotRow = record {
   timestamp_ns : nat64;
+  median_cr_bps : nat32;
+  total_debt_e8s : nat64;
   total_vault_count : nat32;
   total_collateral_usd_e8s : nat64;
-  total_debt_e8s : nat64;
-  median_cr_bps : nat32;
   collaterals : vec CollateralStats;
 };
-
-type VaultSeriesResponse = record {
-  rows : vec DailyVaultSnapshotRow;
+type ErrorCounters = record {
+  amm : nat64;
+  three_pool : nat64;
+  icusd_ledger : nat64;
+  stability_pool : nat64;
+  backend : nat64;
+};
+type HolderSeriesResponse = record {
+  rows : vec DailyHolderRow;
   next_from_ts : opt nat64;
 };
-
-type DailyStabilityRow = record {
-  timestamp_ns : nat64;
-  total_deposits_e8s : nat64;
-  total_depositors : nat64;
-  total_liquidations_executed : nat64;
-  total_interest_received_e8s : nat64;
-  stablecoin_balances : vec record { principal; nat64 };
-  collateral_gains : vec record { principal; nat64 };
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : blob;
+  headers : vec record { text; text };
 };
-
+type HttpResponse = record {
+  body : blob;
+  headers : vec record { text; text };
+  status_code : nat16;
+};
+type InitArgs = record {
+  amm : principal;
+  three_pool : principal;
+  admin : principal;
+  icusd_ledger : principal;
+  stability_pool : principal;
+  backend : principal;
+};
+type RangeQuery = record {
+  to_ts : opt nat64;
+  from_ts : opt nat64;
+  offset : opt nat64;
+  limit : opt nat32;
+};
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
 };
-
-type HeaderField = record { text; text };
-
-type HttpRequest = record {
-  method : text;
-  url : text;
-  headers : vec HeaderField;
-  body : blob;
+type TvlSeriesResponse = record {
+  rows : vec DailyTvlRow;
+  next_from_ts : opt nat64;
 };
-
-type HttpResponse = record {
-  status_code : nat16;
-  headers : vec HeaderField;
-  body : blob;
+type VaultSeriesResponse = record {
+  rows : vec DailyVaultSnapshotRow;
+  next_from_ts : opt nat64;
 };
-
 service : (InitArgs) -> {
-  ping : () -> (text) query;
   get_admin : () -> (principal) query;
+  get_collector_health : () -> (CollectorHealth) query;
+  get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
+  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
-  get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
+  ping : () -> (text) query;
+  start_backfill : (principal) -> (text);
 }

--- a/src/rumi_analytics/src/collectors/holders.rs
+++ b/src/rumi_analytics/src/collectors/holders.rs
@@ -1,0 +1,179 @@
+//! Daily holder snapshot collector. Reads BalanceTracker state and computes
+//! Gini coefficient, top-50, distribution buckets, median balance.
+
+use candid::Principal;
+use crate::{state, storage};
+use storage::balance_tracker::{self, Token};
+use storage::holders::DailyHolderRow;
+
+const NANOS_PER_DAY: u64 = 86_400_000_000_000;
+
+const BUCKET_THRESHOLDS: [u64; 4] = [
+    100_0000_0000,       // 100 tokens
+    1_000_0000_0000,     // 1,000 tokens
+    10_000_0000_0000,    // 10,000 tokens
+    100_000_0000_0000,   // 100,000 tokens
+];
+
+pub fn compute_gini_bps(sorted_balances: &[u64]) -> u32 {
+    let n = sorted_balances.len();
+    if n <= 1 { return 0; }
+    let total: u128 = sorted_balances.iter().map(|&b| b as u128).sum();
+    if total == 0 { return 0; }
+    let n128 = n as u128;
+    let mut numerator: i128 = 0;
+    for (i, &bal) in sorted_balances.iter().enumerate() {
+        let rank = (i as i128 + 1) * 2 - n128 as i128 - 1;
+        numerator += rank * bal as i128;
+    }
+    let gini = numerator as f64 / (n128 as f64 * total as f64);
+    let gini_clamped = gini.clamp(0.0, 1.0);
+    (gini_clamped * 10_000.0) as u32
+}
+
+pub fn compute_distribution_buckets(balances_e8s: &[u64]) -> Vec<u32> {
+    let mut buckets = vec![0u32; BUCKET_THRESHOLDS.len() + 1];
+    for &bal in balances_e8s {
+        let idx = BUCKET_THRESHOLDS.iter().position(|&t| bal <= t).unwrap_or(BUCKET_THRESHOLDS.len());
+        buckets[idx] += 1;
+    }
+    buckets
+}
+
+pub fn top_n_holders(holders: &[(Principal, u64)], n: usize) -> Vec<(Principal, u64)> {
+    let mut sorted: Vec<_> = holders.to_vec();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.truncate(n);
+    sorted
+}
+
+fn compute_median(sorted: &[u64]) -> u64 {
+    let n = sorted.len();
+    if n == 0 { return 0; }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        let lo = sorted[n / 2 - 1] as u128;
+        let hi = sorted[n / 2] as u128;
+        ((lo + hi) / 2) as u64
+    }
+}
+
+fn snapshot_token(token: Token, token_principal: Principal, now_ns: u64) -> DailyHolderRow {
+    let all = balance_tracker::all_balances(token);
+    let total_holders = all.len() as u32;
+    let total_supply_tracked = balance_tracker::total_supply_tracked(token);
+
+    let mut balances: Vec<u64> = all.iter().map(|(_, b)| *b).collect();
+    let principal_balances: Vec<(Principal, u64)> = all.iter().map(|(a, b)| (a.owner.clone(), *b)).collect();
+
+    balances.sort_unstable();
+    let median = compute_median(&balances);
+    let gini = compute_gini_bps(&balances);
+    let buckets = compute_distribution_buckets(&balances);
+    let top_50 = top_n_holders(&principal_balances, 50);
+
+    let top_10_sum: u64 = {
+        let mut sorted_desc = balances.clone();
+        sorted_desc.sort_unstable_by(|a, b| b.cmp(a));
+        sorted_desc.iter().take(10).sum()
+    };
+    let top_10_pct = if total_supply_tracked > 0 {
+        ((top_10_sum as f64 / total_supply_tracked as f64) * 10_000.0) as u32
+    } else { 0 };
+
+    let day_start = now_ns.saturating_sub(NANOS_PER_DAY);
+    let new_holders = balance_tracker::count_new_holders(token, day_start, now_ns);
+
+    DailyHolderRow {
+        timestamp_ns: now_ns,
+        token: token_principal,
+        total_holders,
+        total_supply_tracked_e8s: total_supply_tracked,
+        median_balance_e8s: median,
+        top_50,
+        top_10_pct_bps: top_10_pct,
+        gini_bps: gini,
+        new_holders_today: new_holders,
+        distribution_buckets: buckets,
+    }
+}
+
+pub async fn run() -> Result<(), String> {
+    let (icusd_ledger, three_pool) = state::read_state(|s| {
+        (s.sources.icusd_ledger, s.sources.three_pool)
+    });
+    let now = ic_cdk::api::time();
+
+    if balance_tracker::holder_count(Token::IcUsd) > 0 {
+        let row = snapshot_token(Token::IcUsd, icusd_ledger, now);
+        storage::holders::daily_holders_icusd::push(row);
+    }
+    if balance_tracker::holder_count(Token::ThreeUsd) > 0 {
+        let row = snapshot_token(Token::ThreeUsd, three_pool, now);
+        storage::holders::daily_holders_3usd::push(row);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gini_perfect_equality() {
+        let balances = vec![100, 100, 100, 100];
+        assert_eq!(compute_gini_bps(&balances), 0);
+    }
+
+    #[test]
+    fn gini_perfect_inequality() {
+        let balances = vec![0, 0, 0, 1000];
+        let g = compute_gini_bps(&balances);
+        assert!(g > 7000, "expected high Gini, got {}", g);
+    }
+
+    #[test]
+    fn gini_moderate_inequality() {
+        let balances = vec![10, 20, 30, 40, 50];
+        let g = compute_gini_bps(&balances);
+        assert!(g > 0 && g < 5000, "expected moderate Gini, got {}", g);
+    }
+
+    #[test]
+    fn gini_empty() {
+        assert_eq!(compute_gini_bps(&[]), 0);
+    }
+
+    #[test]
+    fn gini_single() {
+        assert_eq!(compute_gini_bps(&[100]), 0);
+    }
+
+    #[test]
+    fn distribution_buckets_correct() {
+        let balances_e8s: Vec<u64> = vec![
+            50_0000_0000,       // 50 tokens -> bucket 0
+            500_0000_0000,      // 500 tokens -> bucket 1
+            5_000_0000_0000,    // 5,000 tokens -> bucket 2
+            50_000_0000_0000,   // 50,000 tokens -> bucket 3
+            500_000_0000_0000,  // 500,000 tokens -> bucket 4
+            10_0000_0000,       // 10 tokens -> bucket 0
+        ];
+        let buckets = compute_distribution_buckets(&balances_e8s);
+        assert_eq!(buckets, vec![2, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn top_n_extracts_correct_top() {
+        let holders = vec![
+            (candid::Principal::anonymous(), 100u64),
+            (candid::Principal::anonymous(), 500),
+            (candid::Principal::anonymous(), 200),
+        ];
+        let top = top_n_holders(&holders, 2);
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0].1, 500);
+        assert_eq!(top[1].1, 200);
+    }
+}

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -1,3 +1,4 @@
 pub mod tvl;
 pub mod vaults;
 pub mod stability;
+pub mod holders;

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -1,1 +1,2 @@
 pub mod tvl;
+pub mod vaults;

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -1,2 +1,3 @@
 pub mod tvl;
 pub mod vaults;
+pub mod stability;

--- a/src/rumi_analytics/src/collectors/stability.rs
+++ b/src/rumi_analytics/src/collectors/stability.rs
@@ -1,0 +1,28 @@
+//! Daily stability pool snapshot collector.
+
+use crate::{sources, state, storage};
+
+pub async fn run() -> Result<(), String> {
+    let sp_id = state::read_state(|s| s.sources.stability_pool);
+
+    let status = match sources::stability_pool::get_pool_status(sp_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            state::mutate_state(|s| s.error_counters.stability_pool += 1);
+            return Err(e);
+        }
+    };
+
+    let row = storage::DailyStabilityRow {
+        timestamp_ns: ic_cdk::api::time(),
+        total_deposits_e8s: status.total_deposits_e8s,
+        total_depositors: status.total_depositors,
+        total_liquidations_executed: status.total_liquidations_executed,
+        total_interest_received_e8s: status.total_interest_received_e8s,
+        stablecoin_balances: status.stablecoin_balances,
+        collateral_gains: status.collateral_gains,
+    };
+    storage::daily_stability::push(row);
+
+    Ok(())
+}

--- a/src/rumi_analytics/src/collectors/tvl.rs
+++ b/src/rumi_analytics/src/collectors/tvl.rs
@@ -1,21 +1,69 @@
 //! Daily TVL collector.
 //!
-//! Reads current protocol status from the backend, builds a DailyTvlRow,
-//! appends it to the DAILY_TVL StableLog. On error, increments the backend
-//! error counter and returns Err so the caller can log it. Never panics,
+//! Reads current protocol status from the backend canister, stability pool, and
+//! 3pool concurrently. Backend failure aborts the entire row (no partial write).
+//! Stability pool and 3pool failures are soft: they log an error, increment the
+//! per-source error counter, and store None for those fields. Never panics,
 //! never writes a partial row.
 
 use crate::{sources, state, storage};
 
 pub async fn run() -> Result<(), String> {
-    let backend = state::read_state(|s| s.sources.backend);
-    let status = match sources::backend::get_protocol_status(backend).await {
+    let (backend_id, stability_pool_id, three_pool_id) = state::read_state(|s| {
+        (
+            s.sources.backend,
+            s.sources.stability_pool,
+            s.sources.three_pool,
+        )
+    });
+
+    // Fire all three queries concurrently.
+    let (backend_res, sp_res, tp_res) = futures::join!(
+        sources::backend::get_protocol_status(backend_id),
+        sources::stability_pool::get_pool_status(stability_pool_id),
+        sources::three_pool::get_pool_status(three_pool_id),
+    );
+
+    // Backend is required; abort on failure.
+    let status = match backend_res {
         Ok(s) => s,
         Err(e) => {
             state::mutate_state(|s| s.error_counters.backend += 1);
             return Err(e);
         }
     };
+
+    // Stability pool is optional; log and continue on failure.
+    let sp_deposits = match sp_res {
+        Ok(sp) => Some(sp.total_deposits_e8s),
+        Err(e) => {
+            ic_cdk::println!("[tvl] stability_pool error: {}", e);
+            state::mutate_state(|s| s.error_counters.stability_pool += 1);
+            None
+        }
+    };
+
+    // 3pool is optional; log and continue on failure.
+    let (tp_reserve_0, tp_reserve_1, tp_reserve_2, tp_virtual_price, tp_lp_supply) =
+        match tp_res {
+            Ok(tp) => {
+                let reserve_0 = tp.balances.first().copied();
+                let reserve_1 = tp.balances.get(1).copied();
+                let reserve_2 = tp.balances.get(2).copied();
+                (
+                    reserve_0,
+                    reserve_1,
+                    reserve_2,
+                    Some(tp.virtual_price),
+                    Some(tp.lp_total_supply),
+                )
+            }
+            Err(e) => {
+                ic_cdk::println!("[tvl] three_pool error: {}", e);
+                state::mutate_state(|s| s.error_counters.three_pool += 1);
+                (None, None, None, None, None)
+            }
+        };
 
     // Convert f64 CR (e.g. 1.85 = 185%) to basis points (18500).
     // Saturate at u32::MAX to be safe; the source CR is bounded by protocol logic.
@@ -27,12 +75,12 @@ pub async fn run() -> Result<(), String> {
         total_icp_collateral_e8s: status.total_icp_margin as u128,
         total_icusd_supply_e8s: status.total_icusd_borrowed as u128,
         system_collateral_ratio_bps: cr_bps,
-        stability_pool_deposits_e8s: None,
-        three_pool_reserve_0_e8s: None,
-        three_pool_reserve_1_e8s: None,
-        three_pool_reserve_2_e8s: None,
-        three_pool_virtual_price_e18: None,
-        three_pool_lp_supply_e8s: None,
+        stability_pool_deposits_e8s: sp_deposits,
+        three_pool_reserve_0_e8s: tp_reserve_0,
+        three_pool_reserve_1_e8s: tp_reserve_1,
+        three_pool_reserve_2_e8s: tp_reserve_2,
+        three_pool_virtual_price_e18: tp_virtual_price,
+        three_pool_lp_supply_e8s: tp_lp_supply,
     };
     storage::daily_tvl::push(row);
 

--- a/src/rumi_analytics/src/collectors/tvl.rs
+++ b/src/rumi_analytics/src/collectors/tvl.rs
@@ -27,6 +27,12 @@ pub async fn run() -> Result<(), String> {
         total_icp_collateral_e8s: status.total_icp_margin as u128,
         total_icusd_supply_e8s: status.total_icusd_borrowed as u128,
         system_collateral_ratio_bps: cr_bps,
+        stability_pool_deposits_e8s: None,
+        three_pool_reserve_0_e8s: None,
+        three_pool_reserve_1_e8s: None,
+        three_pool_reserve_2_e8s: None,
+        three_pool_virtual_price_e18: None,
+        three_pool_lp_supply_e8s: None,
     };
     storage::daily_tvl::push(row);
 

--- a/src/rumi_analytics/src/collectors/vaults.rs
+++ b/src/rumi_analytics/src/collectors/vaults.rs
@@ -1,0 +1,187 @@
+//! Daily vault snapshot collector.
+//!
+//! Queries get_all_vaults and get_collateral_totals concurrently, then builds
+//! per-collateral CR stats and a protocol-wide snapshot row. Both calls are
+//! required; failure of either aborts the snapshot and increments the backend
+//! error counter.
+
+use crate::{sources, state, storage};
+use std::collections::HashMap;
+
+/// Compute the median of an already-sorted slice of u32 values.
+/// For even-length slices, returns the average of the two middle values
+/// rounded down (integer division). Returns 0 for empty slices.
+pub fn median_of_sorted(sorted: &[u32]) -> u32 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        let lo = sorted[n / 2 - 1] as u64;
+        let hi = sorted[n / 2] as u64;
+        ((lo + hi) / 2) as u32
+    }
+}
+
+pub async fn run() -> Result<(), String> {
+    let backend_id = state::read_state(|s| s.sources.backend);
+
+    let (vaults_res, totals_res) = futures::join!(
+        sources::backend::get_all_vaults(backend_id),
+        sources::backend::get_collateral_totals(backend_id),
+    );
+
+    let vaults = match vaults_res {
+        Ok(v) => v,
+        Err(e) => {
+            state::mutate_state(|s| s.error_counters.backend += 1);
+            return Err(format!("[vaults] get_all_vaults failed: {}", e));
+        }
+    };
+
+    let collateral_totals = match totals_res {
+        Ok(t) => t,
+        Err(e) => {
+            state::mutate_state(|s| s.error_counters.backend += 1);
+            return Err(format!("[vaults] get_collateral_totals failed: {}", e));
+        }
+    };
+
+    // Build a price lookup from collateral_type -> price (f64).
+    let price_map: HashMap<candid::Principal, f64> = collateral_totals
+        .iter()
+        .map(|ct| (ct.collateral_type, ct.price))
+        .collect();
+
+    // For each vault with debt > 0, compute its CR in bps and group by
+    // collateral_type.
+    let mut crs_by_collateral: HashMap<candid::Principal, Vec<u32>> = HashMap::new();
+    let mut all_crs: Vec<u32> = Vec::new();
+
+    for vault in &vaults {
+        if vault.borrowed_icusd_amount == 0 {
+            continue;
+        }
+        let price = match price_map.get(&vault.collateral_type) {
+            Some(&p) => p,
+            None => continue,
+        };
+        let cr_bps = (vault.collateral_amount as f64 * price
+            / vault.borrowed_icusd_amount as f64
+            * 10_000.0)
+            .clamp(0.0, u32::MAX as f64) as u32;
+
+        crs_by_collateral
+            .entry(vault.collateral_type)
+            .or_default()
+            .push(cr_bps);
+        all_crs.push(cr_bps);
+    }
+
+    // Build per-collateral stats.
+    let mut collaterals: Vec<storage::CollateralStats> = Vec::new();
+    for ct in &collateral_totals {
+        let mut crs = crs_by_collateral
+            .remove(&ct.collateral_type)
+            .unwrap_or_default();
+        crs.sort_unstable();
+
+        let (min_cr_bps, max_cr_bps, median_cr_bps) = if crs.is_empty() {
+            (0u32, 0u32, 0u32)
+        } else {
+            (
+                *crs.first().unwrap(),
+                *crs.last().unwrap(),
+                median_of_sorted(&crs),
+            )
+        };
+
+        let price_usd_e8s = (ct.price * 1e8) as u64;
+
+        collaterals.push(storage::CollateralStats {
+            collateral_type: ct.collateral_type,
+            vault_count: crs.len() as u32,
+            total_collateral_e8s: ct.total_collateral,
+            total_debt_e8s: ct.total_debt,
+            min_cr_bps,
+            max_cr_bps,
+            median_cr_bps,
+            price_usd_e8s,
+        });
+    }
+
+    // Protocol-wide stats.
+    let total_vault_count = all_crs.len() as u32;
+
+    all_crs.sort_unstable();
+    let protocol_median_cr_bps = median_of_sorted(&all_crs);
+
+    // Total collateral USD value: sum of (total_collateral * price) for each
+    // collateral type, converted to e8s.
+    let total_collateral_usd_e8s: u64 = collateral_totals
+        .iter()
+        .map(|ct| (ct.total_collateral as f64 * ct.price * 1e8) as u64)
+        .fold(0u64, |acc, x| acc.saturating_add(x));
+
+    let total_debt_e8s: u64 = collateral_totals
+        .iter()
+        .map(|ct| ct.total_debt)
+        .fold(0u64, |acc, x| acc.saturating_add(x));
+
+    let row = storage::DailyVaultSnapshotRow {
+        timestamp_ns: ic_cdk::api::time(),
+        total_vault_count,
+        total_collateral_usd_e8s,
+        total_debt_e8s,
+        median_cr_bps: protocol_median_cr_bps,
+        collaterals,
+    };
+    storage::daily_vaults::push(row);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::median_of_sorted;
+
+    #[test]
+    fn empty_slice_returns_zero() {
+        assert_eq!(median_of_sorted(&[]), 0);
+    }
+
+    #[test]
+    fn single_element() {
+        assert_eq!(median_of_sorted(&[42]), 42);
+    }
+
+    #[test]
+    fn odd_length_picks_middle() {
+        assert_eq!(median_of_sorted(&[10, 20, 30]), 20);
+        assert_eq!(median_of_sorted(&[5, 15, 25, 35, 45]), 25);
+    }
+
+    #[test]
+    fn even_length_averages_two_middle_rounded_down() {
+        // [10, 20]: (10+20)/2 = 15
+        assert_eq!(median_of_sorted(&[10, 20]), 15);
+        // [10, 11]: (10+11)/2 = 10 (rounds down)
+        assert_eq!(median_of_sorted(&[10, 11]), 10);
+        // [1, 2, 3, 4]: middle pair is (2, 3), (2+3)/2 = 2
+        assert_eq!(median_of_sorted(&[1, 2, 3, 4]), 2);
+        // [100, 200, 300, 400]: (200+300)/2 = 250
+        assert_eq!(median_of_sorted(&[100, 200, 300, 400]), 250);
+    }
+
+    #[test]
+    fn large_values_do_not_overflow() {
+        // Two values near u32::MAX
+        let a = u32::MAX - 1;
+        let b = u32::MAX;
+        // (a + b) would overflow u32, but we cast to u64 first.
+        let expected = ((a as u64 + b as u64) / 2) as u32;
+        assert_eq!(median_of_sorted(&[a, b]), expected);
+    }
+}

--- a/src/rumi_analytics/src/collectors/vaults.rs
+++ b/src/rumi_analytics/src/collectors/vaults.rs
@@ -61,7 +61,8 @@ pub async fn run() -> Result<(), String> {
     let mut all_crs: Vec<u32> = Vec::new();
 
     for vault in &vaults {
-        if vault.borrowed_icusd_amount == 0 {
+        let debt = vault.borrowed_icusd_amount.saturating_add(vault.accrued_interest);
+        if debt == 0 {
             continue;
         }
         let price = match price_map.get(&vault.collateral_type) {
@@ -69,7 +70,7 @@ pub async fn run() -> Result<(), String> {
             None => continue,
         };
         let cr_bps = (vault.collateral_amount as f64 * price
-            / vault.borrowed_icusd_amount as f64
+            / debt as f64
             * 10_000.0)
             .clamp(0.0, u32::MAX as f64) as u32;
 
@@ -122,7 +123,7 @@ pub async fn run() -> Result<(), String> {
     // collateral type, converted to e8s.
     let total_collateral_usd_e8s: u64 = collateral_totals
         .iter()
-        .map(|ct| (ct.total_collateral as f64 * ct.price * 1e8) as u64)
+        .map(|ct| (ct.total_collateral as f64 * ct.price) as u64)
         .fold(0u64, |acc, x| acc.saturating_add(x));
 
     let total_debt_e8s: u64 = collateral_totals

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -10,6 +10,7 @@ mod collectors;
 mod sources;
 mod queries;
 mod timers;
+mod tailing;
 mod types;
 
 use crate::storage::{SlimState, SourceCanisterIds};

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -69,6 +69,16 @@ fn get_tvl_series(query: types::RangeQuery) -> types::TvlSeriesResponse {
 }
 
 #[ic_cdk_macros::query]
+fn get_vault_series(query: types::RangeQuery) -> types::VaultSeriesResponse {
+    queries::historical::get_vault_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_stability_series(query: types::RangeQuery) -> types::StabilitySeriesResponse {
+    queries::historical::get_stability_series(query)
+}
+
+#[ic_cdk_macros::query]
 fn http_request(req: ic_canisters_http_types::HttpRequest) -> ic_canisters_http_types::HttpResponse {
     http::http_request(req)
 }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -84,4 +84,92 @@ fn http_request(req: ic_canisters_http_types::HttpRequest) -> ic_canisters_http_
     http::http_request(req)
 }
 
+#[ic_cdk_macros::query]
+fn get_holder_series(query: types::RangeQuery, token: Principal) -> types::HolderSeriesResponse {
+    queries::historical::get_holder_series(query, token)
+}
+
+#[ic_cdk_macros::query]
+fn get_collector_health() -> types::CollectorHealth {
+    use storage::cursors;
+
+    let cursor_names: &[(u8, &str, fn() -> u64)] = &[
+        (cursors::CURSOR_ID_BACKEND_EVENTS, "backend_events", cursors::backend_events::get),
+        (cursors::CURSOR_ID_3POOL_SWAPS, "3pool_swaps", cursors::three_pool_swaps::get),
+        (cursors::CURSOR_ID_3POOL_LIQUIDITY, "3pool_liquidity", cursors::three_pool_liquidity::get),
+        (cursors::CURSOR_ID_3POOL_BLOCKS, "3pool_blocks", cursors::three_pool_blocks::get),
+        (cursors::CURSOR_ID_AMM_SWAPS, "amm_swaps", cursors::amm_swaps::get),
+        (cursors::CURSOR_ID_ICUSD_BLOCKS, "icusd_blocks", cursors::icusd_blocks::get),
+    ];
+
+    let (last_success_map, last_error_map, source_count_map, backfill_icusd, backfill_3usd, last_pull_ns, error_counters, icusd_ledger, three_pool) =
+        state::read_state(|s| (
+            s.cursor_last_success.clone().unwrap_or_default(),
+            s.cursor_last_error.clone().unwrap_or_default(),
+            s.cursor_source_counts.clone().unwrap_or_default(),
+            s.backfill_active_icusd.unwrap_or(false),
+            s.backfill_active_3usd.unwrap_or(false),
+            s.last_pull_cycle_ns.unwrap_or(0),
+            s.error_counters.clone(),
+            s.sources.icusd_ledger,
+            s.sources.three_pool,
+        ));
+
+    let cursors: Vec<types::CursorStatus> = cursor_names.iter().map(|(id, name, get_fn)| {
+        types::CursorStatus {
+            name: name.to_string(),
+            cursor_position: get_fn(),
+            source_count: source_count_map.get(id).copied().unwrap_or(0),
+            last_success_ns: last_success_map.get(id).copied().unwrap_or(0),
+            last_error: last_error_map.get(id).cloned(),
+        }
+    }).collect();
+
+    let mut backfill_active = Vec::new();
+    if backfill_icusd { backfill_active.push(icusd_ledger); }
+    if backfill_3usd { backfill_active.push(three_pool); }
+
+    let balance_tracker_stats = vec![
+        types::BalanceTrackerStats {
+            token: icusd_ledger,
+            holder_count: storage::balance_tracker::holder_count(storage::balance_tracker::Token::IcUsd),
+            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(storage::balance_tracker::Token::IcUsd),
+        },
+        types::BalanceTrackerStats {
+            token: three_pool,
+            holder_count: storage::balance_tracker::holder_count(storage::balance_tracker::Token::ThreeUsd),
+            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(storage::balance_tracker::Token::ThreeUsd),
+        },
+    ];
+
+    types::CollectorHealth {
+        cursors,
+        error_counters,
+        backfill_active,
+        last_pull_cycle_ns: last_pull_ns,
+        balance_tracker_stats,
+    }
+}
+
+#[ic_cdk_macros::update]
+fn start_backfill(token: Principal) -> String {
+    let admin = state::read_state(|s| s.admin);
+    let caller = ic_cdk::caller();
+    if caller != admin {
+        return format!("unauthorized: caller {} is not admin", caller);
+    }
+
+    let (icusd_ledger, three_pool) = state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
+
+    if token == icusd_ledger {
+        state::mutate_state(|s| s.backfill_active_icusd = Some(true));
+        "backfill started for icUSD".to_string()
+    } else if token == three_pool {
+        state::mutate_state(|s| s.backfill_active_3usd = Some(true));
+        "backfill started for 3USD".to_string()
+    } else {
+        format!("unknown token: {}", token)
+    }
+}
+
 ic_cdk::export_candid!();

--- a/src/rumi_analytics/src/queries/historical.rs
+++ b/src/rumi_analytics/src/queries/historical.rs
@@ -1,7 +1,7 @@
 //! Read-only paginated readers over StableLogs. Pure functions, no state mutation.
 
 use crate::storage;
-use crate::types::{RangeQuery, TvlSeriesResponse, VaultSeriesResponse, StabilitySeriesResponse};
+use crate::types::{RangeQuery, TvlSeriesResponse, VaultSeriesResponse, StabilitySeriesResponse, HolderSeriesResponse};
 
 pub fn get_tvl_series(query: RangeQuery) -> TvlSeriesResponse {
     let limit = query.resolved_limit() as usize;
@@ -45,6 +45,27 @@ pub fn get_stability_series(query: RangeQuery) -> StabilitySeriesResponse {
         None
     };
     StabilitySeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_holder_series(query: RangeQuery, token: candid::Principal) -> HolderSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+
+    let icusd_ledger = crate::state::read_state(|s| s.sources.icusd_ledger);
+    let rows = if token == icusd_ledger {
+        storage::holders::daily_holders_icusd::range(from, to, limit)
+    } else {
+        storage::holders::daily_holders_3usd::range(from, to, limit)
+    };
+
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+
+    HolderSeriesResponse { rows, next_from_ts }
 }
 
 #[cfg(test)]

--- a/src/rumi_analytics/src/queries/historical.rs
+++ b/src/rumi_analytics/src/queries/historical.rs
@@ -1,7 +1,7 @@
 //! Read-only paginated readers over StableLogs. Pure functions, no state mutation.
 
 use crate::storage;
-use crate::types::{RangeQuery, TvlSeriesResponse};
+use crate::types::{RangeQuery, TvlSeriesResponse, VaultSeriesResponse, StabilitySeriesResponse};
 
 pub fn get_tvl_series(query: RangeQuery) -> TvlSeriesResponse {
     let limit = query.resolved_limit() as usize;
@@ -19,6 +19,32 @@ pub fn get_tvl_series(query: RangeQuery) -> TvlSeriesResponse {
     };
 
     TvlSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_vault_series(query: RangeQuery) -> VaultSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::daily_vaults::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    VaultSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_stability_series(query: RangeQuery) -> StabilitySeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::daily_stability::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    StabilitySeriesResponse { rows, next_from_ts }
 }
 
 #[cfg(test)]

--- a/src/rumi_analytics/src/sources/amm.rs
+++ b/src/rumi_analytics/src/sources/amm.rs
@@ -1,0 +1,36 @@
+//! Source wrapper for rumi_amm event queries.
+
+use candid::{CandidType, Nat, Principal};
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct AmmSwapEvent {
+    pub id: u64,
+    pub caller: Principal,
+    pub pool_id: String,
+    pub token_in: Principal,
+    pub amount_in: Nat,
+    pub token_out: Principal,
+    pub amount_out: Nat,
+    pub fee: Nat,
+    pub timestamp: u64,
+}
+
+pub async fn get_amm_swap_events(
+    amm: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<AmmSwapEvent>, String> {
+    let (events,): (Vec<AmmSwapEvent>,) =
+        ic_cdk::call(amm, "get_amm_swap_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_amm_swap_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_amm_swap_event_count(amm: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(amm, "get_amm_swap_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_amm_swap_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}

--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -72,3 +72,135 @@ pub async fn get_collateral_totals(
         Err((code, msg)) => Err(format!("get_collateral_totals: {:?} {}", code, msg)),
     }
 }
+
+// --- Event tailing (Phase 4) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetEventsArg {
+    pub start: u64,
+    pub length: u64,
+}
+
+/// Minimal subset of the backend Event variant.
+/// Uses `#[serde(other)]` to catch variants we don't need to decode.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum BackendEvent {
+    #[serde(rename = "open_vault")]
+    OpenVault {
+        block_index: u64,
+        vault: BackendVaultRecord,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "borrow_from_vault")]
+    BorrowFromVault {
+        block_index: u64,
+        vault_id: u64,
+        fee_amount: u64,
+        borrowed_amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "repay_to_vault")]
+    RepayToVault {
+        block_index: u64,
+        vault_id: u64,
+        repayed_amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "collateral_withdrawn")]
+    CollateralWithdrawn {
+        block_index: u64,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "partial_collateral_withdrawn")]
+    PartialCollateralWithdrawn {
+        block_index: u64,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "withdraw_and_close_vault")]
+    WithdrawAndCloseVault {
+        block_index: Option<u64>,
+        vault_id: u64,
+        amount: u64,
+        caller: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    VaultWithdrawnAndClosed {
+        vault_id: u64,
+        timestamp: u64,
+        caller: Principal,
+        amount: u64,
+    },
+    #[serde(rename = "dust_forgiven")]
+    DustForgiven {
+        vault_id: u64,
+        amount: u64,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "redemption_on_vaults")]
+    RedemptionOnVaults {
+        icusd_amount: u64,
+        icusd_block_index: u64,
+        owner: Principal,
+        fee_amount: u64,
+        collateral_type: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "liquidate_vault")]
+    LiquidateVault {
+        vault_id: u64,
+        liquidator: Option<Principal>,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "partial_liquidate_vault")]
+    PartialLiquidateVault {
+        protocol_fee_collateral: Option<u64>,
+        liquidator_payment: u64,
+        vault_id: u64,
+        liquidator: Option<Principal>,
+        icp_to_liquidator: u64,
+        timestamp: Option<u64>,
+    },
+    #[serde(rename = "redistribute_vault")]
+    RedistributeVault {
+        vault_id: u64,
+        timestamp: Option<u64>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct BackendVaultRecord {
+    pub vault_id: u64,
+    pub owner: Principal,
+    pub collateral_type: Principal,
+    pub collateral_amount: u64,
+    pub borrowed_icusd_amount: u64,
+}
+
+pub async fn get_events(
+    backend: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<BackendEvent>, String> {
+    let arg = GetEventsArg { start, length };
+    let (events,): (Vec<BackendEvent>,) = ic_cdk::call(backend, "get_events", (arg,))
+        .await
+        .map_err(|(code, msg)| format!("get_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_event_count(backend: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(backend, "get_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}

--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -27,3 +27,48 @@ pub async fn get_protocol_status(backend: Principal) -> Result<ProtocolStatusSub
         Err((code, msg)) => Err(format!("get_protocol_status: {:?} {}", code, msg)),
     }
 }
+
+/// Subset of `CandidVault` that analytics needs. We deliberately decode only
+/// the fields we use; this insulates us from upstream additions to the type.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct CandidVaultSubset {
+    pub owner: Principal,
+    pub borrowed_icusd_amount: u64,
+    pub icp_margin_amount: u64,
+    pub vault_id: u64,
+    pub collateral_amount: u64,
+    pub collateral_type: Principal,
+    pub accrued_interest: u64,
+}
+
+pub async fn get_all_vaults(backend: Principal) -> Result<Vec<CandidVaultSubset>, String> {
+    let res: Result<(Vec<CandidVaultSubset>,), _> =
+        ic_cdk::api::call::call(backend, "get_all_vaults", ()).await;
+    match res {
+        Ok((vaults,)) => Ok(vaults),
+        Err((code, msg)) => Err(format!("get_all_vaults: {:?} {}", code, msg)),
+    }
+}
+
+/// Subset of `CollateralTotals` that analytics needs.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct CollateralTotalsSubset {
+    pub decimals: u8,
+    pub total_collateral: u64,
+    pub total_debt: u64,
+    pub collateral_type: Principal,
+    pub price: f64,
+    pub vault_count: u64,
+    pub symbol: String,
+}
+
+pub async fn get_collateral_totals(
+    backend: Principal,
+) -> Result<Vec<CollateralTotalsSubset>, String> {
+    let res: Result<(Vec<CollateralTotalsSubset>,), _> =
+        ic_cdk::api::call::call(backend, "get_collateral_totals", ()).await;
+    match res {
+        Ok((totals,)) => Ok(totals),
+        Err((code, msg)) => Err(format!("get_collateral_totals: {:?} {}", code, msg)),
+    }
+}

--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -81,10 +81,14 @@ pub struct GetEventsArg {
     pub length: u64,
 }
 
-/// Minimal subset of the backend Event variant.
-/// Uses `#[serde(other)]` to catch variants we don't need to decode.
+/// Backend Event variant. We enumerate ALL variants from the backend .did so
+/// that Candid deserialization succeeds for every event type. Variants we
+/// actually process have their fields; all others use empty structs (Candid
+/// skips extra record fields). This avoids reliance on `#[serde(other)]` which
+/// does not work reliably with the candid crate's deserializer.
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum BackendEvent {
+    // --- Variants we process ---
     #[serde(rename = "open_vault")]
     OpenVault {
         block_index: u64,
@@ -173,8 +177,137 @@ pub enum BackendEvent {
         vault_id: u64,
         timestamp: Option<u64>,
     },
-    #[serde(other)]
-    Unknown,
+    // --- Variants we don't process (empty structs skip all fields) ---
+    #[serde(rename = "init")]
+    Init {},
+    #[serde(rename = "upgrade")]
+    Upgrade {},
+    #[serde(rename = "set_borrowing_fee")]
+    SetBorrowingFee {},
+    #[serde(rename = "claim_liquidity_returns")]
+    ClaimLiquidityReturns {},
+    #[serde(rename = "provide_liquidity")]
+    ProvideLiquidity {},
+    #[serde(rename = "set_rmr_ceiling_cr")]
+    SetRmrCeilingCr {},
+    #[serde(rename = "set_recovery_rate_curve")]
+    SetRecoveryRateCurve {},
+    #[serde(rename = "set_ckstable_repay_fee")]
+    SetCkstableRepayFee {},
+    #[serde(rename = "set_treasury_principal")]
+    SetTreasuryPrincipal {},
+    #[serde(rename = "accrue_interest")]
+    AccrueInterest {},
+    #[serde(rename = "set_max_partial_liquidation_ratio")]
+    SetMaxPartialLiquidationRatio {},
+    #[serde(rename = "admin_vault_correction")]
+    AdminVaultCorrection {},
+    #[serde(rename = "set_recovery_target_cr")]
+    SetRecoveryTargetCr {},
+    #[serde(rename = "set_stable_ledger_principal")]
+    SetStableLedgerPrincipal {},
+    #[serde(rename = "set_recovery_parameters")]
+    SetRecoveryParameters {},
+    #[serde(rename = "set_collateral_borrowing_fee")]
+    SetCollateralBorrowingFee {},
+    #[serde(rename = "set_collateral_liquidation_ratio")]
+    SetCollateralLiquidationRatio {},
+    #[serde(rename = "set_collateral_borrow_threshold")]
+    SetCollateralBorrowThreshold {},
+    #[serde(rename = "set_collateral_liquidation_bonus")]
+    SetCollateralLiquidationBonus {},
+    #[serde(rename = "set_collateral_min_vault_debt")]
+    SetCollateralMinVaultDebt {},
+    #[serde(rename = "set_collateral_ledger_fee")]
+    SetCollateralLedgerFee {},
+    #[serde(rename = "set_collateral_redemption_fee_floor")]
+    SetCollateralRedemptionFeeFloor {},
+    #[serde(rename = "set_collateral_redemption_fee_ceiling")]
+    SetCollateralRedemptionFeeCeiling {},
+    #[serde(rename = "set_collateral_min_deposit")]
+    SetCollateralMinDeposit {},
+    #[serde(rename = "set_collateral_display_color")]
+    SetCollateralDisplayColor {},
+    #[serde(rename = "set_bot_allowed_collateral_types")]
+    SetBotAllowedCollateralTypes {},
+    #[serde(rename = "margin_transfer")]
+    MarginTransfer {},
+    #[serde(rename = "admin_sweep_to_treasury")]
+    AdminSweepToTreasury {},
+    #[serde(rename = "set_rmr_floor_cr")]
+    SetRmrFloorCr {},
+    #[serde(rename = "set_rmr_ceiling")]
+    SetRmrCeiling {},
+    #[serde(rename = "set_global_icusd_mint_cap")]
+    SetGlobalIcusdMintCap {},
+    #[serde(rename = "set_reserve_redemptions_enabled")]
+    SetReserveRedemptionsEnabled {},
+    #[serde(rename = "set_min_icusd_amount")]
+    SetMinIcusdAmount {},
+    #[serde(rename = "set_borrowing_fee_curve")]
+    SetBorrowingFeeCurve {},
+    #[serde(rename = "set_interest_pool_share")]
+    SetInterestPoolShare {},
+    #[serde(rename = "set_liquidation_protocol_share")]
+    SetLiquidationProtocolShare {},
+    #[serde(rename = "update_collateral_config")]
+    UpdateCollateralConfig {},
+    #[serde(rename = "set_rate_curve_markers")]
+    SetRateCurveMarkers {},
+    #[serde(rename = "withdraw_liquidity")]
+    WithdrawLiquidity {},
+    #[serde(rename = "admin_mint")]
+    AdminMint {},
+    #[serde(rename = "set_three_pool_canister")]
+    SetThreePoolCanister {},
+    #[serde(rename = "set_liquidation_bonus")]
+    SetLiquidationBonus {},
+    #[serde(rename = "reserve_redemption")]
+    ReserveRedemption {},
+    #[serde(rename = "close_vault")]
+    CloseVault {},
+    #[serde(rename = "update_collateral_status")]
+    UpdateCollateralStatus {},
+    #[serde(rename = "set_healthy_cr")]
+    SetHealthyCr {},
+    #[serde(rename = "set_redemption_fee_ceiling")]
+    SetRedemptionFeeCeiling {},
+    #[serde(rename = "add_margin_to_vault")]
+    AddMarginToVault {},
+    #[serde(rename = "set_stability_pool_principal")]
+    SetStabilityPoolPrincipal {},
+    #[serde(rename = "set_interest_split")]
+    SetInterestSplit {},
+    #[serde(rename = "set_bot_budget")]
+    SetBotBudget {},
+    #[serde(rename = "set_rmr_floor")]
+    SetRmrFloor {},
+    #[serde(rename = "set_redemption_fee_floor")]
+    SetRedemptionFeeFloor {},
+    #[serde(rename = "set_interest_rate")]
+    SetInterestRate {},
+    #[serde(rename = "set_reserve_redemption_fee")]
+    SetReserveRedemptionFee {},
+    #[serde(rename = "redemption_transfered")]
+    RedemptionTransfered {},
+    #[serde(rename = "set_liquidation_bot_principal")]
+    SetLiquidationBotPrincipal {},
+    #[serde(rename = "add_collateral_type")]
+    AddCollateralType {},
+    #[serde(rename = "set_stable_token_enabled")]
+    SetStableTokenEnabled {},
+    #[serde(rename = "set_recovery_cr_multiplier")]
+    SetRecoveryCrMultiplier {},
+    #[serde(rename = "price_update")]
+    PriceUpdate {},
+    #[serde(rename = "admin_debt_correction")]
+    AdminDebtCorrection {},
+    #[serde(rename = "set_collateral_debt_ceiling")]
+    SetCollateralDebtCeiling {},
+    #[serde(rename = "set_collateral_interest_rate")]
+    SetCollateralInterestRate {},
+    #[serde(rename = "set_collateral_redemption_tier")]
+    SetCollateralRedemptionTier {},
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]

--- a/src/rumi_analytics/src/sources/icusd_ledger.rs
+++ b/src/rumi_analytics/src/sources/icusd_ledger.rs
@@ -1,6 +1,7 @@
 //! Typed wrapper around icusd_ledger ICRC-1 queries.
 
-use candid::{Nat, Principal};
+use candid::{CandidType, Nat, Principal};
+use serde::Deserialize;
 
 pub async fn icrc1_total_supply(ledger: Principal) -> Result<u128, String> {
     let res: Result<(Nat,), _> = ic_cdk::api::call::call(ledger, "icrc1_total_supply", ()).await;
@@ -11,4 +12,42 @@ pub async fn icrc1_total_supply(ledger: Principal) -> Result<u128, String> {
             .map_err(|e| format!("icrc1_total_supply nat -> u128: {}", e)),
         Err((code, msg)) => Err(format!("icrc1_total_supply: {:?} {}", code, msg)),
     }
+}
+
+// --- ICRC-3 block tailing (Phase 4) ---
+
+pub use icrc_ledger_types::icrc::generic_value::ICRC3Value;
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetBlocksArg {
+    pub start: Nat,
+    pub length: Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct BlockWithId {
+    pub id: Nat,
+    pub block: ICRC3Value,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct GetBlocksResult {
+    pub log_length: Nat,
+    pub blocks: Vec<BlockWithId>,
+    // archived_blocks omitted for Phase 4
+}
+
+pub async fn icrc3_get_blocks(
+    ledger: Principal,
+    start: u64,
+    length: u64,
+) -> Result<GetBlocksResult, String> {
+    let args = vec![GetBlocksArg {
+        start: Nat::from(start),
+        length: Nat::from(length),
+    }];
+    let (result,): (GetBlocksResult,) = ic_cdk::call(ledger, "icrc3_get_blocks", (args,))
+        .await
+        .map_err(|(code, msg)| format!("icrc3_get_blocks: {:?} {}", code, msg))?;
+    Ok(result)
 }

--- a/src/rumi_analytics/src/sources/mod.rs
+++ b/src/rumi_analytics/src/sources/mod.rs
@@ -1,3 +1,4 @@
+pub mod amm;
 pub mod backend;
 pub mod icusd_ledger;
 pub mod stability_pool;

--- a/src/rumi_analytics/src/sources/mod.rs
+++ b/src/rumi_analytics/src/sources/mod.rs
@@ -1,2 +1,4 @@
 pub mod backend;
 pub mod icusd_ledger;
+pub mod stability_pool;
+pub mod three_pool;

--- a/src/rumi_analytics/src/sources/stability_pool.rs
+++ b/src/rumi_analytics/src/sources/stability_pool.rs
@@ -1,0 +1,34 @@
+//! Typed wrapper around rumi_stability_pool queries.
+//!
+//! Every function here returns Result<T, String> and never panics. Errors
+//! propagate up to the caller (collectors), which increment the per-source
+//! error counter and skip the snapshot for this tick.
+
+use candid::{CandidType, Deserialize, Principal};
+
+/// Subset of `StabilityPoolStatus` that analytics needs. We deliberately decode
+/// only the fields we use; this insulates us from upstream additions to the type.
+///
+/// IMPORTANT: candid decodes record types structurally by field name, so this
+/// minimal struct works as long as the source canister's StabilityPoolStatus
+/// includes these fields. Additional fields on the source side are ignored.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct StabilityPoolStatusSubset {
+    pub total_deposits_e8s: u64,
+    pub total_depositors: u64,
+    pub total_liquidations_executed: u64,
+    pub total_interest_received_e8s: u64,
+    pub stablecoin_balances: Vec<(Principal, u64)>,
+    pub collateral_gains: Vec<(Principal, u64)>,
+}
+
+pub async fn get_pool_status(
+    stability_pool: Principal,
+) -> Result<StabilityPoolStatusSubset, String> {
+    let res: Result<(StabilityPoolStatusSubset,), _> =
+        ic_cdk::api::call::call(stability_pool, "get_pool_status", ()).await;
+    match res {
+        Ok((status,)) => Ok(status),
+        Err((code, msg)) => Err(format!("get_pool_status: {:?} {}", code, msg)),
+    }
+}

--- a/src/rumi_analytics/src/sources/three_pool.rs
+++ b/src/rumi_analytics/src/sources/three_pool.rs
@@ -1,0 +1,63 @@
+//! Typed wrapper around rumi_3pool queries.
+//!
+//! Every function here returns Result<T, String> and never panics. Errors
+//! propagate up to the caller (collectors), which increment the per-source
+//! error counter and skip the snapshot for this tick.
+//!
+//! The 3pool .did uses `nat` (arbitrary precision) for balances, lp_total_supply,
+//! and virtual_price. We decode those as `candid::Nat` then convert to u128.
+
+use candid::{CandidType, Deserialize, Nat, Principal};
+
+/// Raw decoded form of `PoolStatus` using `candid::Nat` for arbitrary-precision
+/// fields. Never stored directly; converted to `ThreePoolStatusSubset` immediately.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct PoolStatusRaw {
+    pub balances: Vec<Nat>,
+    pub lp_total_supply: Nat,
+    pub current_a: u64,
+    pub virtual_price: Nat,
+    pub swap_fee_bps: u64,
+    pub admin_fee_bps: u64,
+}
+
+/// Converted form with all `nat` fields represented as `u128`.
+#[derive(Clone, Debug)]
+pub struct ThreePoolStatusSubset {
+    pub balances: Vec<u128>,
+    pub lp_total_supply: u128,
+    pub current_a: u64,
+    pub virtual_price: u128,
+    pub swap_fee_bps: u64,
+    pub admin_fee_bps: u64,
+}
+
+fn nat_to_u128(nat: Nat, field: &str) -> Result<u128, String> {
+    nat.0
+        .try_into()
+        .map_err(|e| format!("3pool {} nat -> u128: {}", field, e))
+}
+
+pub async fn get_pool_status(three_pool: Principal) -> Result<ThreePoolStatusSubset, String> {
+    let res: Result<(PoolStatusRaw,), _> =
+        ic_cdk::api::call::call(three_pool, "get_pool_status", ()).await;
+    match res {
+        Ok((raw,)) => {
+            let balances = raw
+                .balances
+                .into_iter()
+                .enumerate()
+                .map(|(i, n)| nat_to_u128(n, &format!("balances[{}]", i)))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ThreePoolStatusSubset {
+                balances,
+                lp_total_supply: nat_to_u128(raw.lp_total_supply, "lp_total_supply")?,
+                current_a: raw.current_a,
+                virtual_price: nat_to_u128(raw.virtual_price, "virtual_price")?,
+                swap_fee_bps: raw.swap_fee_bps,
+                admin_fee_bps: raw.admin_fee_bps,
+            })
+        }
+        Err((code, msg)) => Err(format!("get_pool_status: {:?} {}", code, msg)),
+    }
+}

--- a/src/rumi_analytics/src/sources/three_pool.rs
+++ b/src/rumi_analytics/src/sources/three_pool.rs
@@ -61,3 +61,75 @@ pub async fn get_pool_status(three_pool: Principal) -> Result<ThreePoolStatusSub
         Err((code, msg)) => Err(format!("get_pool_status: {:?} {}", code, msg)),
     }
 }
+
+// --- Event tailing (Phase 4) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolSwapEvent {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub token_in: u8,
+    pub token_out: u8,
+    pub amount_in: Nat,
+    pub amount_out: Nat,
+    pub fee: Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ThreePoolLiquidityAction {
+    AddLiquidity,
+    RemoveLiquidity,
+    RemoveOneCoin,
+    Donate,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolLiquidityEvent {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub action: ThreePoolLiquidityAction,
+    pub amounts: Vec<Nat>,
+    pub lp_amount: Nat,
+    pub coin_index: Option<u8>,
+    pub fee: Option<Nat>,
+}
+
+pub async fn get_swap_events(
+    three_pool: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<ThreePoolSwapEvent>, String> {
+    let (events,): (Vec<ThreePoolSwapEvent>,) =
+        ic_cdk::call(three_pool, "get_swap_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_swap_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_swap_event_count(three_pool: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(three_pool, "get_swap_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_swap_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+
+pub async fn get_liquidity_events(
+    three_pool: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<ThreePoolLiquidityEvent>, String> {
+    let (events,): (Vec<ThreePoolLiquidityEvent>,) =
+        ic_cdk::call(three_pool, "get_liquidity_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_liquidity_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_liquidity_event_count(three_pool: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(three_pool, "get_liquidity_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_liquidity_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}

--- a/src/rumi_analytics/src/storage.rs
+++ b/src/rumi_analytics/src/storage.rs
@@ -177,6 +177,13 @@ pub struct DailyTvlRow {
     pub total_icp_collateral_e8s: u128,
     pub total_icusd_supply_e8s: u128,
     pub system_collateral_ratio_bps: u32,
+    // Phase 3 additions (Option for backward compat with existing rows)
+    pub stability_pool_deposits_e8s: Option<u64>,
+    pub three_pool_reserve_0_e8s: Option<u128>,
+    pub three_pool_reserve_1_e8s: Option<u128>,
+    pub three_pool_reserve_2_e8s: Option<u128>,
+    pub three_pool_virtual_price_e18: Option<u128>,
+    pub three_pool_lp_supply_e8s: Option<u128>,
 }
 
 impl Storable for DailyTvlRow {
@@ -185,6 +192,61 @@ impl Storable for DailyTvlRow {
     }
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
         Decode!(bytes.as_ref(), Self).expect("DailyTvlRow decode")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+// --- CollateralStats, DailyVaultSnapshotRow, DailyStabilityRow ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct CollateralStats {
+    pub collateral_type: Principal,
+    pub vault_count: u32,
+    pub total_collateral_e8s: u64,
+    pub total_debt_e8s: u64,
+    pub min_cr_bps: u32,
+    pub max_cr_bps: u32,
+    pub median_cr_bps: u32,
+    pub price_usd_e8s: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyVaultSnapshotRow {
+    pub timestamp_ns: u64,
+    pub total_vault_count: u32,
+    pub total_collateral_usd_e8s: u64,
+    pub total_debt_e8s: u64,
+    pub median_cr_bps: u32,
+    pub collaterals: Vec<CollateralStats>,
+}
+
+impl Storable for DailyVaultSnapshotRow {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).expect("DailyVaultSnapshotRow encode"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).expect("DailyVaultSnapshotRow decode")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyStabilityRow {
+    pub timestamp_ns: u64,
+    pub total_deposits_e8s: u64,
+    pub total_depositors: u64,
+    pub total_liquidations_executed: u64,
+    pub total_interest_received_e8s: u64,
+    pub stablecoin_balances: Vec<(Principal, u64)>,
+    pub collateral_gains: Vec<(Principal, u64)>,
+}
+
+impl Storable for DailyStabilityRow {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).expect("DailyStabilityRow encode"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).expect("DailyStabilityRow decode")
     }
     const BOUND: Bound = Bound::Unbounded;
 }
@@ -207,6 +269,22 @@ thread_local! {
             let data = MEMORY_MANAGER.with(|m| m.borrow().get(MEM_DAILY_TVL_DATA));
             ic_stable_structures::StableLog::init(idx, data)
                 .expect("init DAILY_TVL log")
+        });
+
+    static DAILY_VAULTS_LOG: RefCell<ic_stable_structures::StableLog<DailyVaultSnapshotRow, Memory, Memory>> =
+        RefCell::new({
+            let idx = MEMORY_MANAGER.with(|m| m.borrow().get(MEM_DAILY_VAULTS_IDX));
+            let data = MEMORY_MANAGER.with(|m| m.borrow().get(MEM_DAILY_VAULTS_DATA));
+            ic_stable_structures::StableLog::init(idx, data)
+                .expect("init DAILY_VAULTS log")
+        });
+
+    static DAILY_STABILITY_LOG: RefCell<ic_stable_structures::StableLog<DailyStabilityRow, Memory, Memory>> =
+        RefCell::new({
+            let idx = MEMORY_MANAGER.with(|m| m.borrow().get(MEM_DAILY_STABILITY_IDX));
+            let data = MEMORY_MANAGER.with(|m| m.borrow().get(MEM_DAILY_STABILITY_DATA));
+            ic_stable_structures::StableLog::init(idx, data)
+                .expect("init DAILY_STABILITY log")
         });
 }
 
@@ -257,6 +335,86 @@ pub mod daily_tvl {
     pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<DailyTvlRow> {
         let mut out = Vec::new();
         DAILY_TVL_LOG.with(|log| {
+            let log = log.borrow();
+            let n = log.len();
+            for i in 0..n {
+                if let Some(row) = log.get(i) {
+                    if row.timestamp_ns >= to_ts {
+                        break;
+                    }
+                    if row.timestamp_ns >= from_ts {
+                        out.push(row);
+                        if out.len() >= limit {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        out
+    }
+}
+
+pub mod daily_vaults {
+    use super::*;
+
+    pub fn push(row: DailyVaultSnapshotRow) {
+        DAILY_VAULTS_LOG.with(|log| {
+            log.borrow_mut().append(&row).expect("append DAILY_VAULTS");
+        });
+    }
+
+    pub fn len() -> u64 {
+        DAILY_VAULTS_LOG.with(|log| log.borrow().len())
+    }
+
+    pub fn get(index: u64) -> Option<DailyVaultSnapshotRow> {
+        DAILY_VAULTS_LOG.with(|log| log.borrow().get(index))
+    }
+
+    pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<DailyVaultSnapshotRow> {
+        let mut out = Vec::new();
+        DAILY_VAULTS_LOG.with(|log| {
+            let log = log.borrow();
+            let n = log.len();
+            for i in 0..n {
+                if let Some(row) = log.get(i) {
+                    if row.timestamp_ns >= to_ts {
+                        break;
+                    }
+                    if row.timestamp_ns >= from_ts {
+                        out.push(row);
+                        if out.len() >= limit {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        out
+    }
+}
+
+pub mod daily_stability {
+    use super::*;
+
+    pub fn push(row: DailyStabilityRow) {
+        DAILY_STABILITY_LOG.with(|log| {
+            log.borrow_mut().append(&row).expect("append DAILY_STABILITY");
+        });
+    }
+
+    pub fn len() -> u64 {
+        DAILY_STABILITY_LOG.with(|log| log.borrow().len())
+    }
+
+    pub fn get(index: u64) -> Option<DailyStabilityRow> {
+        DAILY_STABILITY_LOG.with(|log| log.borrow().get(index))
+    }
+
+    pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<DailyStabilityRow> {
+        let mut out = Vec::new();
+        DAILY_STABILITY_LOG.with(|log| {
             let log = log.borrow();
             let n = log.len();
             for i in 0..n {

--- a/src/rumi_analytics/src/storage/balance_tracker.rs
+++ b/src/rumi_analytics/src/storage/balance_tracker.rs
@@ -1,0 +1,1 @@
+//! BalanceTracker StableBTreeMap instances. Populated in Task 3.

--- a/src/rumi_analytics/src/storage/balance_tracker.rs
+++ b/src/rumi_analytics/src/storage/balance_tracker.rs
@@ -1,1 +1,239 @@
-//! BalanceTracker StableBTreeMap instances. Populated in Task 3.
+//! BalanceTracker: StableBTreeMap-backed running balance and first-seen
+//! tracking for icUSD and 3USD holders.
+
+use candid::Principal;
+use ic_stable_structures::storable::{Bound, Storable};
+use ic_stable_structures::StableBTreeMap;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{MEM_BAL_ICUSD, MEM_BAL_3USD, MEM_FIRSTSEEN_ICUSD, MEM_FIRSTSEEN_3USD};
+
+/// ICRC-1 Account: principal + optional 32-byte subaccount.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Account {
+    pub owner: Principal,
+    pub subaccount: Option<[u8; 32]>,
+}
+
+/// Fixed-size key for StableBTreeMap. Layout: 1 byte principal length,
+/// up to 29 bytes principal, 1 byte subaccount flag (0 or 1),
+/// 32 bytes subaccount (zeroed if absent). Total: 63 bytes.
+const ACCOUNT_KEY_LEN: usize = 63;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountKey(pub [u8; ACCOUNT_KEY_LEN]);
+
+impl AccountKey {
+    pub fn from_account(acct: &Account) -> Self {
+        let mut buf = [0u8; ACCOUNT_KEY_LEN];
+        let principal_bytes = acct.owner.as_slice();
+        buf[0] = principal_bytes.len() as u8;
+        buf[1..1 + principal_bytes.len()].copy_from_slice(principal_bytes);
+        match &acct.subaccount {
+            Some(sub) => {
+                buf[30] = 1;
+                buf[31..63].copy_from_slice(sub);
+            }
+            None => {
+                buf[30] = 0;
+            }
+        }
+        Self(buf)
+    }
+
+    pub fn to_account(&self) -> Account {
+        let plen = self.0[0] as usize;
+        let owner = Principal::from_slice(&self.0[1..1 + plen]);
+        let subaccount = if self.0[30] == 1 {
+            let mut sub = [0u8; 32];
+            sub.copy_from_slice(&self.0[31..63]);
+            Some(sub)
+        } else {
+            None
+        };
+        Account { owner, subaccount }
+    }
+
+    pub fn owner(&self) -> Principal {
+        let plen = self.0[0] as usize;
+        Principal::from_slice(&self.0[1..1 + plen])
+    }
+}
+
+impl Storable for AccountKey {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let mut buf = [0u8; ACCOUNT_KEY_LEN];
+        buf.copy_from_slice(&bytes[..ACCOUNT_KEY_LEN]);
+        Self(buf)
+    }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: ACCOUNT_KEY_LEN as u32,
+        is_fixed_size: true,
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct BalVal(pub u64);
+
+impl Storable for BalVal {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.0.to_le_bytes().to_vec())
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(&bytes[..8]);
+        Self(u64::from_le_bytes(arr))
+    }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 8,
+        is_fixed_size: true,
+    };
+}
+
+thread_local! {
+    static BAL_ICUSD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_BAL_ICUSD))
+    );
+    static BAL_3USD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_BAL_3USD))
+    );
+    static FIRSTSEEN_ICUSD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_FIRSTSEEN_ICUSD))
+    );
+    static FIRSTSEEN_3USD_MAP: RefCell<StableBTreeMap<AccountKey, BalVal, Memory>> = RefCell::new(
+        StableBTreeMap::init(get_memory(MEM_FIRSTSEEN_3USD))
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Token { IcUsd, ThreeUsd }
+
+fn with_bal<F, R>(token: Token, f: F) -> R
+where F: FnOnce(&mut StableBTreeMap<AccountKey, BalVal, Memory>) -> R {
+    match token {
+        Token::IcUsd => BAL_ICUSD_MAP.with(|m| f(&mut m.borrow_mut())),
+        Token::ThreeUsd => BAL_3USD_MAP.with(|m| f(&mut m.borrow_mut())),
+    }
+}
+
+fn with_firstseen<F, R>(token: Token, f: F) -> R
+where F: FnOnce(&mut StableBTreeMap<AccountKey, BalVal, Memory>) -> R {
+    match token {
+        Token::IcUsd => FIRSTSEEN_ICUSD_MAP.with(|m| f(&mut m.borrow_mut())),
+        Token::ThreeUsd => FIRSTSEEN_3USD_MAP.with(|m| f(&mut m.borrow_mut())),
+    }
+}
+
+fn maybe_set_firstseen(token: Token, key: &AccountKey, timestamp_ns: u64) {
+    with_firstseen(token, |map| {
+        if map.get(key).is_none() {
+            map.insert(key.clone(), BalVal(timestamp_ns));
+        }
+    });
+}
+
+pub fn credit(token: Token, acct: &Account, amount: u64, timestamp_ns: u64) {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| {
+        let current = map.get(&key).map(|v| v.0).unwrap_or(0);
+        map.insert(key.clone(), BalVal(current.saturating_add(amount)));
+    });
+    maybe_set_firstseen(token, &key, timestamp_ns);
+}
+
+pub fn debit(token: Token, acct: &Account, amount: u64) {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| {
+        let current = map.get(&key).map(|v| v.0).unwrap_or(0);
+        let new_bal = current.saturating_sub(amount);
+        if new_bal == 0 {
+            map.remove(&key);
+        } else {
+            map.insert(key, BalVal(new_bal));
+        }
+    });
+}
+
+pub fn apply_transfer(token: Token, from: &Account, to: &Account, amount: u64, fee: u64, timestamp_ns: u64) {
+    debit(token, from, amount.saturating_add(fee));
+    credit(token, to, amount, timestamp_ns);
+}
+
+pub fn apply_mint(token: Token, to: &Account, amount: u64, timestamp_ns: u64) {
+    credit(token, to, amount, timestamp_ns);
+}
+
+pub fn apply_burn(token: Token, from: &Account, amount: u64) {
+    debit(token, from, amount);
+}
+
+pub fn get_balance(token: Token, acct: &Account) -> u64 {
+    let key = AccountKey::from_account(acct);
+    with_bal(token, |map| map.get(&key).map(|v| v.0).unwrap_or(0))
+}
+
+pub fn holder_count(token: Token) -> u64 {
+    with_bal(token, |map| map.len())
+}
+
+pub fn all_balances(token: Token) -> Vec<(Account, u64)> {
+    with_bal(token, |map| {
+        map.iter().map(|(k, v)| (k.to_account(), v.0)).collect()
+    })
+}
+
+pub fn get_firstseen(token: Token, acct: &Account) -> Option<u64> {
+    let key = AccountKey::from_account(acct);
+    with_firstseen(token, |map| map.get(&key).map(|v| v.0))
+}
+
+pub fn count_new_holders(token: Token, from_ns: u64, to_ns: u64) -> u32 {
+    with_firstseen(token, |map| {
+        map.iter()
+            .filter(|(_, v)| v.0 >= from_ns && v.0 < to_ns)
+            .count() as u32
+    })
+}
+
+pub fn total_supply_tracked(token: Token) -> u64 {
+    with_bal(token, |map| {
+        map.iter().map(|(_, v)| v.0).fold(0u64, |a, b| a.saturating_add(b))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+
+    #[test]
+    fn account_key_roundtrip() {
+        let acct = Account {
+            owner: Principal::anonymous(),
+            subaccount: None,
+        };
+        let key = AccountKey::from_account(&acct);
+        let decoded = key.to_account();
+        assert_eq!(decoded.owner, acct.owner);
+        assert_eq!(decoded.subaccount, acct.subaccount);
+    }
+
+    #[test]
+    fn account_key_with_subaccount_roundtrip() {
+        let mut sub = [0u8; 32];
+        sub[0] = 1;
+        sub[31] = 0xFF;
+        let acct = Account {
+            owner: Principal::anonymous(),
+            subaccount: Some(sub),
+        };
+        let key = AccountKey::from_account(&acct);
+        let decoded = key.to_account();
+        assert_eq!(decoded.owner, acct.owner);
+        assert_eq!(decoded.subaccount, Some(sub));
+    }
+}

--- a/src/rumi_analytics/src/storage/cursors.rs
+++ b/src/rumi_analytics/src/storage/cursors.rs
@@ -1,0 +1,68 @@
+//! Cursor StableCells for event tailing. Each cursor tracks the next event
+//! index to fetch from a source canister.
+
+use ic_stable_structures::StableCell;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_CURSOR_BACKEND_EVENTS, MEM_CURSOR_3POOL_SWAPS,
+    MEM_CURSOR_3POOL_LIQUIDITY, MEM_CURSOR_3POOL_BLOCKS,
+    MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_ICUSD_BLOCKS,
+};
+
+thread_local! {
+    static CURSOR_BACKEND_EVENTS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_BACKEND_EVENTS), 0u64)
+            .expect("init cursor backend_events")
+    );
+    static CURSOR_3POOL_SWAPS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_SWAPS), 0u64)
+            .expect("init cursor 3pool_swaps")
+    );
+    static CURSOR_3POOL_LIQUIDITY: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_LIQUIDITY), 0u64)
+            .expect("init cursor 3pool_liquidity")
+    );
+    static CURSOR_3POOL_BLOCKS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_BLOCKS), 0u64)
+            .expect("init cursor 3pool_blocks")
+    );
+    static CURSOR_AMM_SWAPS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_AMM_SWAPS), 0u64)
+            .expect("init cursor amm_swaps")
+    );
+    static CURSOR_ICUSD_BLOCKS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_ICUSD_BLOCKS), 0u64)
+            .expect("init cursor icusd_blocks")
+    );
+}
+
+/// Cursor identifiers matching MemoryIds. Used as keys in SlimState metadata maps.
+pub const CURSOR_ID_BACKEND_EVENTS: u8 = 1;
+pub const CURSOR_ID_3POOL_SWAPS: u8 = 2;
+pub const CURSOR_ID_3POOL_LIQUIDITY: u8 = 3;
+pub const CURSOR_ID_3POOL_BLOCKS: u8 = 4;
+pub const CURSOR_ID_AMM_SWAPS: u8 = 5;
+// 6 = MEM_CURSOR_STABILITY_EVENTS, reserved for future stability pool event tailing
+pub const CURSOR_ID_ICUSD_BLOCKS: u8 = 7;
+
+macro_rules! cursor_accessors {
+    ($mod_name:ident, $cell:ident) => {
+        pub mod $mod_name {
+            use super::*;
+            pub fn get() -> u64 {
+                $cell.with(|c| *c.borrow().get())
+            }
+            pub fn set(val: u64) {
+                $cell.with(|c| c.borrow_mut().set(val).expect(concat!("set cursor ", stringify!($mod_name))));
+            }
+        }
+    };
+}
+
+cursor_accessors!(backend_events, CURSOR_BACKEND_EVENTS);
+cursor_accessors!(three_pool_swaps, CURSOR_3POOL_SWAPS);
+cursor_accessors!(three_pool_liquidity, CURSOR_3POOL_LIQUIDITY);
+cursor_accessors!(three_pool_blocks, CURSOR_3POOL_BLOCKS);
+cursor_accessors!(amm_swaps, CURSOR_AMM_SWAPS);
+cursor_accessors!(icusd_blocks, CURSOR_ICUSD_BLOCKS);

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -1,1 +1,286 @@
-//! EVT_* event log types and StableLog instances. Populated in Task 2.
+//! EVT_* normalized event log types and StableLog instances.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_EVT_LIQUIDATIONS_IDX, MEM_EVT_LIQUIDATIONS_DATA,
+    MEM_EVT_SWAPS_IDX, MEM_EVT_SWAPS_DATA,
+    MEM_EVT_LIQUIDITY_IDX, MEM_EVT_LIQUIDITY_DATA,
+    MEM_EVT_VAULTS_IDX, MEM_EVT_VAULTS_DATA,
+};
+
+// --- Enum types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum LiquidationKind {
+    Full,
+    Partial,
+    Redistribution,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum VaultEventKind {
+    Opened,
+    Borrowed,
+    Repaid,
+    CollateralWithdrawn,
+    PartialCollateralWithdrawn,
+    WithdrawAndClose,
+    Closed,
+    DustForgiven,
+    Redeemed,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum SwapSource {
+    ThreePool,
+    Amm,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum LiquidityAction {
+    Add,
+    Remove,
+    RemoveOneCoin,
+    Donate,
+}
+
+// --- Event row types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsLiquidationEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub vault_id: u64,
+    pub collateral_type: Principal,
+    pub collateral_amount: u64,
+    pub debt_amount: u64,
+    pub liquidation_kind: LiquidationKind,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsVaultEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub vault_id: u64,
+    pub owner: Principal,
+    pub event_kind: VaultEventKind,
+    pub collateral_type: Principal,
+    pub amount: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsSwapEvent {
+    pub timestamp_ns: u64,
+    pub source: SwapSource,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub token_in: Principal,
+    pub token_out: Principal,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub fee: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsLiquidityEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub action: LiquidityAction,
+    pub amounts: Vec<u64>,
+    pub lp_amount: u64,
+    pub coin_index: Option<u8>,
+    pub fee: Option<u64>,
+}
+
+// --- Storable impls ---
+
+macro_rules! storable_candid {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<[u8]> {
+                Cow::Owned(Encode!(self).expect(concat!(stringify!($t), " encode")))
+            }
+            fn from_bytes(bytes: Cow<[u8]>) -> Self {
+                Decode!(bytes.as_ref(), Self).expect(concat!(stringify!($t), " decode"))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+storable_candid!(AnalyticsLiquidationEvent);
+storable_candid!(AnalyticsVaultEvent);
+storable_candid!(AnalyticsSwapEvent);
+storable_candid!(AnalyticsLiquidityEvent);
+
+// --- StableLog instances ---
+
+thread_local! {
+    static EVT_LIQUIDATIONS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsLiquidationEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_LIQUIDATIONS_IDX),
+                get_memory(MEM_EVT_LIQUIDATIONS_DATA),
+            ).expect("init EVT_LIQUIDATIONS log")
+        });
+
+    static EVT_SWAPS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsSwapEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_SWAPS_IDX),
+                get_memory(MEM_EVT_SWAPS_DATA),
+            ).expect("init EVT_SWAPS log")
+        });
+
+    static EVT_LIQUIDITY_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsLiquidityEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_LIQUIDITY_IDX),
+                get_memory(MEM_EVT_LIQUIDITY_DATA),
+            ).expect("init EVT_LIQUIDITY log")
+        });
+
+    static EVT_VAULTS_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsVaultEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_VAULTS_IDX),
+                get_memory(MEM_EVT_VAULTS_DATA),
+            ).expect("init EVT_VAULTS log")
+        });
+}
+
+// --- Accessor modules ---
+
+macro_rules! evt_accessors {
+    ($mod_name:ident, $log:ident, $row_type:ty) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: $row_type) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<$row_type> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<$row_type> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts {
+                                break;
+                            }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+evt_accessors!(evt_liquidations, EVT_LIQUIDATIONS_LOG, AnalyticsLiquidationEvent);
+evt_accessors!(evt_swaps, EVT_SWAPS_LOG, AnalyticsSwapEvent);
+evt_accessors!(evt_liquidity, EVT_LIQUIDITY_LOG, AnalyticsLiquidityEvent);
+evt_accessors!(evt_vaults, EVT_VAULTS_LOG, AnalyticsVaultEvent);
+
+// --- Tests ---
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+
+    #[test]
+    fn liquidation_event_roundtrip() {
+        let evt = AnalyticsLiquidationEvent {
+            timestamp_ns: 1_000_000,
+            source_event_id: 42,
+            vault_id: 7,
+            collateral_type: Principal::anonymous(),
+            collateral_amount: 500_000_000,
+            debt_amount: 100_000_000,
+            liquidation_kind: LiquidationKind::Full,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsLiquidationEvent::from_bytes(bytes);
+        assert_eq!(decoded.vault_id, 7);
+        assert_eq!(decoded.collateral_amount, 500_000_000);
+    }
+
+    #[test]
+    fn swap_event_roundtrip() {
+        let evt = AnalyticsSwapEvent {
+            timestamp_ns: 2_000_000,
+            source: SwapSource::ThreePool,
+            source_event_id: 10,
+            caller: Principal::anonymous(),
+            token_in: Principal::anonymous(),
+            token_out: Principal::anonymous(),
+            amount_in: 1_000_000,
+            amount_out: 999_000,
+            fee: 1_000,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsSwapEvent::from_bytes(bytes);
+        assert_eq!(decoded.amount_in, 1_000_000);
+        assert!(matches!(decoded.source, SwapSource::ThreePool));
+    }
+
+    #[test]
+    fn vault_event_roundtrip() {
+        let evt = AnalyticsVaultEvent {
+            timestamp_ns: 3_000_000,
+            source_event_id: 5,
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            event_kind: VaultEventKind::Opened,
+            collateral_type: Principal::anonymous(),
+            amount: 10_000_000_000,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsVaultEvent::from_bytes(bytes);
+        assert_eq!(decoded.vault_id, 1);
+        assert!(matches!(decoded.event_kind, VaultEventKind::Opened));
+    }
+
+    #[test]
+    fn liquidity_event_roundtrip() {
+        let evt = AnalyticsLiquidityEvent {
+            timestamp_ns: 4_000_000,
+            source_event_id: 20,
+            caller: Principal::anonymous(),
+            action: LiquidityAction::Add,
+            amounts: vec![100, 200, 300],
+            lp_amount: 500,
+            coin_index: None,
+            fee: Some(5),
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsLiquidityEvent::from_bytes(bytes);
+        assert_eq!(decoded.amounts, vec![100, 200, 300]);
+        assert_eq!(decoded.fee, Some(5));
+    }
+}

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -1,0 +1,1 @@
+//! EVT_* event log types and StableLog instances. Populated in Task 2.

--- a/src/rumi_analytics/src/storage/holders.rs
+++ b/src/rumi_analytics/src/storage/holders.rs
@@ -1,0 +1,1 @@
+//! DailyHolderRow type and StableLog instances. Populated in Task 4.

--- a/src/rumi_analytics/src/storage/holders.rs
+++ b/src/rumi_analytics/src/storage/holders.rs
@@ -1,1 +1,97 @@
-//! DailyHolderRow type and StableLog instances. Populated in Task 4.
+//! DailyHolderRow type and StableLog instances for icUSD and 3USD holder snapshots.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_DAILY_HOLDERS_ICUSD_IDX, MEM_DAILY_HOLDERS_ICUSD_DATA,
+    MEM_DAILY_HOLDERS_3USD_IDX, MEM_DAILY_HOLDERS_3USD_DATA,
+};
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyHolderRow {
+    pub timestamp_ns: u64,
+    pub token: Principal,
+    pub total_holders: u32,
+    pub total_supply_tracked_e8s: u64,
+    pub median_balance_e8s: u64,
+    pub top_50: Vec<(Principal, u64)>,
+    pub top_10_pct_bps: u32,
+    pub gini_bps: u32,
+    pub new_holders_today: u32,
+    pub distribution_buckets: Vec<u32>,
+}
+
+impl Storable for DailyHolderRow {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).expect("DailyHolderRow encode"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).expect("DailyHolderRow decode")
+    }
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+thread_local! {
+    static DAILY_HOLDERS_ICUSD_LOG: RefCell<ic_stable_structures::StableLog<DailyHolderRow, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_HOLDERS_ICUSD_IDX),
+                get_memory(MEM_DAILY_HOLDERS_ICUSD_DATA),
+            ).expect("init DAILY_HOLDERS_ICUSD log")
+        });
+
+    static DAILY_HOLDERS_3USD_LOG: RefCell<ic_stable_structures::StableLog<DailyHolderRow, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_HOLDERS_3USD_IDX),
+                get_memory(MEM_DAILY_HOLDERS_3USD_DATA),
+            ).expect("init DAILY_HOLDERS_3USD log")
+        });
+}
+
+macro_rules! holder_accessors {
+    ($mod_name:ident, $log:ident) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: DailyHolderRow) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<DailyHolderRow> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<DailyHolderRow> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts { break; }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit { break; }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+holder_accessors!(daily_holders_icusd, DAILY_HOLDERS_ICUSD_LOG);
+holder_accessors!(daily_holders_3usd, DAILY_HOLDERS_3USD_LOG);

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -434,3 +434,13 @@ pub mod daily_stability {
         out
     }
 }
+
+pub mod cursors;
+pub mod events;
+pub mod balance_tracker;
+pub mod holders;
+
+/// Get a virtual memory from the shared MemoryManager. Used by submodules.
+pub(crate) fn get_memory(id: MemoryId) -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(id))
+}

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -118,6 +118,15 @@ pub struct SlimState {
     pub last_daily_snapshot_ns: u64,
     /// Per-source error counters incremented on inter-canister call failures.
     pub error_counters: ErrorCounters,
+    // Phase 4: Cursor metadata (persisted across upgrades)
+    pub cursor_last_success: Option<std::collections::HashMap<u8, u64>>,
+    pub cursor_last_error: Option<std::collections::HashMap<u8, String>>,
+    pub cursor_source_counts: Option<std::collections::HashMap<u8, u64>>,
+    // Phase 4: Backfill flags
+    pub backfill_active_icusd: Option<bool>,
+    pub backfill_active_3usd: Option<bool>,
+    // Phase 4: Pull cycle tracking
+    pub last_pull_cycle_ns: Option<u64>,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -153,6 +162,12 @@ impl Default for SlimState {
             circulating_supply_3usd_e8s: None,
             last_daily_snapshot_ns: 0,
             error_counters: ErrorCounters::default(),
+            cursor_last_success: None,
+            cursor_last_error: None,
+            cursor_source_counts: None,
+            backfill_active_icusd: None,
+            backfill_active_3usd: None,
+            last_pull_cycle_ns: None,
         }
     }
 }

--- a/src/rumi_analytics/src/tailing/amm_swaps.rs
+++ b/src/rumi_analytics/src/tailing/amm_swaps.rs
@@ -1,0 +1,70 @@
+//! AMM swap event tailing. Writes to EVT_SWAPS.
+
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+fn nat_to_u64(n: &candid::Nat) -> u64 {
+    use num_traits::ToPrimitive;
+    n.0.to_u64().unwrap_or(u64::MAX)
+}
+
+pub async fn run() {
+    let amm = state::read_state(|s| s.sources.amm);
+    let cursor = cursors::amm_swaps::get();
+
+    let count = match sources::amm::get_amm_swap_event_count(amm).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_amm] get_amm_swap_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.amm += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_AMM_SWAPS, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_AMM_SWAPS, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::amm::get_amm_swap_events(amm, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_amm] get_amm_swap_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.amm += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_AMM_SWAPS, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for evt in &events {
+        evt_swaps::push(AnalyticsSwapEvent {
+            timestamp_ns: evt.timestamp,
+            source: SwapSource::Amm,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            token_in: evt.token_in,
+            token_out: evt.token_out,
+            amount_in: nat_to_u64(&evt.amount_in),
+            amount_out: nat_to_u64(&evt.amount_out),
+            fee: nat_to_u64(&evt.fee),
+        });
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::amm_swaps::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_AMM_SWAPS, ic_cdk::api::time());
+        });
+    }
+}

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -192,6 +192,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 amount: *icusd_amount,
             });
         }
-        Unknown => {}
+        // All other variants (admin/config events) are not routed
+        _ => {}
     }
 }

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -1,0 +1,197 @@
+//! Backend event tailing. Routes events to EVT_LIQUIDATIONS and EVT_VAULTS.
+
+use candid::Principal;
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+pub async fn run() {
+    let backend = state::read_state(|s| s.sources.backend);
+    let cursor = cursors::backend_events::get();
+
+    let count = match sources::backend::get_event_count(backend).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_backend] get_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.backend += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_BACKEND_EVENTS, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::backend::get_events(backend, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_backend] get_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.backend += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for (i, event) in events.iter().enumerate() {
+        let event_id = cursor + i as u64;
+        route_backend_event(event_id, event);
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::backend_events::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_BACKEND_EVENTS, ic_cdk::api::time());
+        });
+    }
+}
+
+fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
+    use sources::backend::BackendEvent::*;
+
+    match event {
+        LiquidateVault { vault_id, timestamp, .. } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(),
+                collateral_amount: 0,
+                debt_amount: 0,
+                liquidation_kind: LiquidationKind::Full,
+            });
+        }
+        PartialLiquidateVault { vault_id, liquidator_payment, icp_to_liquidator, timestamp, .. } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(),
+                collateral_amount: *icp_to_liquidator,
+                debt_amount: *liquidator_payment,
+                liquidation_kind: LiquidationKind::Partial,
+            });
+        }
+        RedistributeVault { vault_id, timestamp } => {
+            evt_liquidations::push(AnalyticsLiquidationEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                collateral_type: Principal::anonymous(),
+                collateral_amount: 0,
+                debt_amount: 0,
+                liquidation_kind: LiquidationKind::Redistribution,
+            });
+        }
+        OpenVault { vault, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: vault.vault_id,
+                owner: vault.owner,
+                event_kind: VaultEventKind::Opened,
+                collateral_type: vault.collateral_type,
+                amount: vault.collateral_amount,
+            });
+        }
+        BorrowFromVault { vault_id, borrowed_amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::Borrowed,
+                collateral_type: Principal::anonymous(),
+                amount: *borrowed_amount,
+            });
+        }
+        RepayToVault { vault_id, repayed_amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::Repaid,
+                collateral_type: Principal::anonymous(),
+                amount: *repayed_amount,
+            });
+        }
+        CollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::CollateralWithdrawn,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        PartialCollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::PartialCollateralWithdrawn,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        WithdrawAndCloseVault { vault_id, amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::WithdrawAndClose,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        VaultWithdrawnAndClosed { vault_id, timestamp, caller, amount } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: *timestamp,
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: *caller,
+                event_kind: VaultEventKind::Closed,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        DustForgiven { vault_id, amount, timestamp } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: Principal::anonymous(),
+                event_kind: VaultEventKind::DustForgiven,
+                collateral_type: Principal::anonymous(),
+                amount: *amount,
+            });
+        }
+        RedemptionOnVaults { icusd_amount, owner, collateral_type, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: 0,
+                owner: *owner,
+                event_kind: VaultEventKind::Redeemed,
+                collateral_type: collateral_type.unwrap_or(Principal::anonymous()),
+                amount: *icusd_amount,
+            });
+        }
+        Unknown => {}
+    }
+}

--- a/src/rumi_analytics/src/tailing/icrc3.rs
+++ b/src/rumi_analytics/src/tailing/icrc3.rs
@@ -1,0 +1,1 @@
+//! ICRC-3 block tailing. Populated in Task 8.

--- a/src/rumi_analytics/src/tailing/icrc3.rs
+++ b/src/rumi_analytics/src/tailing/icrc3.rs
@@ -1,1 +1,231 @@
-//! ICRC-3 block tailing. Populated in Task 8.
+//! ICRC-3 block tailing. Fetches blocks from icusd_ledger or 3pool,
+//! parses transfer/mint/burn operations, applies to BalanceTracker.
+
+use candid::Principal;
+use crate::{sources, state, storage};
+use storage::balance_tracker::{self, Account, Token};
+use storage::cursors;
+use sources::icusd_ledger::ICRC3Value;
+use super::{BATCH_SIZE, BACKFILL_BATCH_SIZE, update_cursor_success, update_cursor_source_count};
+
+pub async fn tail_icusd_blocks() {
+    let ledger = state::read_state(|s| s.sources.icusd_ledger);
+    let is_backfill = state::read_state(|s| s.backfill_active_icusd.unwrap_or(false));
+    let batch = if is_backfill { BACKFILL_BATCH_SIZE } else { BATCH_SIZE };
+
+    tail_blocks(
+        ledger,
+        Token::IcUsd,
+        cursors::CURSOR_ID_ICUSD_BLOCKS,
+        || cursors::icusd_blocks::get(),
+        |v| cursors::icusd_blocks::set(v),
+        batch,
+        is_backfill,
+    ).await;
+}
+
+pub async fn tail_3pool_blocks() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let is_backfill = state::read_state(|s| s.backfill_active_3usd.unwrap_or(false));
+    let batch = if is_backfill { BACKFILL_BATCH_SIZE } else { BATCH_SIZE };
+
+    tail_blocks(
+        three_pool,
+        Token::ThreeUsd,
+        cursors::CURSOR_ID_3POOL_BLOCKS,
+        || cursors::three_pool_blocks::get(),
+        |v| cursors::three_pool_blocks::set(v),
+        batch,
+        is_backfill,
+    ).await;
+}
+
+async fn tail_blocks<G, S>(
+    canister: Principal,
+    token: Token,
+    cursor_id: u8,
+    get_cursor: G,
+    set_cursor: S,
+    batch_size: u64,
+    is_backfill: bool,
+) where
+    G: Fn() -> u64,
+    S: Fn(u64),
+{
+    let cursor = get_cursor();
+
+    let result = match sources::icusd_ledger::icrc3_get_blocks(canister, cursor, batch_size).await {
+        Ok(r) => r,
+        Err(e) => {
+            ic_cdk::println!("[tail_icrc3] icrc3_get_blocks failed for {:?}: {}", token, e);
+            state::mutate_state(|s| {
+                match token {
+                    Token::IcUsd => s.error_counters.icusd_ledger += 1,
+                    Token::ThreeUsd => s.error_counters.three_pool += 1,
+                }
+            });
+            return;
+        }
+    };
+
+    let log_length = nat_to_u64(&result.log_length);
+
+    if result.blocks.is_empty() {
+        if is_backfill && cursor >= log_length {
+            clear_backfill_flag(token);
+        }
+        return;
+    }
+
+    let mut processed = 0u64;
+    for block_with_id in &result.blocks {
+        if let Err(e) = process_block(token, &block_with_id.block) {
+            ic_cdk::println!("[tail_icrc3] skipping malformed block: {}", e);
+        }
+        processed += 1;
+    }
+
+    if processed > 0 {
+        set_cursor(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursor_id, ic_cdk::api::time());
+            update_cursor_source_count(s, cursor_id, log_length);
+        });
+    }
+
+    if is_backfill && (cursor + processed) >= log_length {
+        clear_backfill_flag(token);
+    }
+}
+
+fn clear_backfill_flag(token: Token) {
+    state::mutate_state(|s| {
+        match token {
+            Token::IcUsd => s.backfill_active_icusd = Some(false),
+            Token::ThreeUsd => s.backfill_active_3usd = Some(false),
+        }
+    });
+    ic_cdk::println!("[tail_icrc3] backfill complete for {:?}", token);
+}
+
+fn process_block(token: Token, block: &ICRC3Value) -> Result<(), String> {
+    let timestamp_ns = extract_nat_field(block, "ts").unwrap_or(0);
+
+    let tx = extract_map_field(block, "tx")
+        .ok_or_else(|| "missing tx field".to_string())?;
+
+    let btype = extract_text_field(block, "btype").unwrap_or_default();
+
+    match btype.as_str() {
+        "1xfer" => {
+            let from = extract_account_field(&tx, "from")
+                .ok_or_else(|| "1xfer missing from".to_string())?;
+            let to = extract_account_field(&tx, "to")
+                .ok_or_else(|| "1xfer missing to".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1xfer missing amt".to_string())?;
+            let fee = extract_nat_field(&tx, "fee").unwrap_or(0);
+            balance_tracker::apply_transfer(token, &from, &to, amt, fee, timestamp_ns);
+        }
+        "1mint" => {
+            let to = extract_account_field(&tx, "to")
+                .ok_or_else(|| "1mint missing to".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1mint missing amt".to_string())?;
+            balance_tracker::apply_mint(token, &to, amt, timestamp_ns);
+        }
+        "1burn" => {
+            let from = extract_account_field(&tx, "from")
+                .ok_or_else(|| "1burn missing from".to_string())?;
+            let amt = extract_nat_field(&tx, "amt")
+                .ok_or_else(|| "1burn missing amt".to_string())?;
+            balance_tracker::apply_burn(token, &from, amt);
+        }
+        "2approve" => {
+            // No balance change
+        }
+        other => {
+            ic_cdk::println!("[tail_icrc3] unknown btype: {}", other);
+        }
+    }
+
+    Ok(())
+}
+
+// --- ICRC3Value extraction helpers ---
+// ICRC3Value::Map is BTreeMap<String, ICRC3Value>
+// ICRC3Value::Blob is serde_bytes::ByteBuf
+
+fn extract_map_field(value: &ICRC3Value, field: &str) -> Option<ICRC3Value> {
+    match value {
+        ICRC3Value::Map(entries) => entries.get(field).cloned(),
+        _ => None,
+    }
+}
+
+fn extract_nat_field(value: &ICRC3Value, field: &str) -> Option<u64> {
+    match extract_map_field(value, field)? {
+        ICRC3Value::Nat(n) => Some(nat_to_u64(&n)),
+        _ => None,
+    }
+}
+
+fn extract_text_field(value: &ICRC3Value, field: &str) -> Option<String> {
+    match extract_map_field(value, field)? {
+        ICRC3Value::Text(s) => Some(s),
+        _ => None,
+    }
+}
+
+fn extract_account_field(value: &ICRC3Value, field: &str) -> Option<Account> {
+    let acct_val = extract_map_field(value, field)?;
+    match &acct_val {
+        ICRC3Value::Map(entries) => {
+            let owner_blob = entries.get("owner")
+                .and_then(|v| match v { ICRC3Value::Blob(b) => Some(b), _ => None })?;
+            let owner = Principal::from_slice(owner_blob.as_ref());
+            let subaccount = entries.get("subaccount")
+                .and_then(|v| match v {
+                    ICRC3Value::Blob(b) => {
+                        let bytes = b.as_ref();
+                        if bytes.len() == 32 {
+                            let mut sa = [0u8; 32];
+                            sa.copy_from_slice(bytes);
+                            Some(sa)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                });
+            Some(Account { owner, subaccount })
+        }
+        ICRC3Value::Array(arr) => {
+            let owner_blob = match arr.first()? {
+                ICRC3Value::Blob(b) => b,
+                _ => return None,
+            };
+            let owner = Principal::from_slice(owner_blob.as_ref());
+            let subaccount = arr.get(1).and_then(|v| match v {
+                ICRC3Value::Blob(b) => {
+                    let bytes = b.as_ref();
+                    if bytes.len() == 32 {
+                        let mut sa = [0u8; 32];
+                        sa.copy_from_slice(bytes);
+                        Some(sa)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            });
+            Some(Account { owner, subaccount })
+        }
+        _ => None,
+    }
+}
+
+fn nat_to_u64(nat: &candid::Nat) -> u64 {
+    use num_traits::ToPrimitive;
+    nat.0.to_u64().unwrap_or(u64::MAX)
+}

--- a/src/rumi_analytics/src/tailing/icrc3.rs
+++ b/src/rumi_analytics/src/tailing/icrc3.rs
@@ -141,6 +141,10 @@ fn process_block(token: Token, block: &ICRC3Value) -> Result<(), String> {
                 .ok_or_else(|| "1xfer missing to".to_string())?;
             let amt = extract_nat_field(&tx, "amt")
                 .ok_or_else(|| "1xfer missing amt".to_string())?;
+            // NOTE: When fee is absent from the block, ICRC-1 charged the default
+            // fee. We default to 0 here, which may cause tracked sender balances
+            // to drift slightly high if the ledger's default fee is nonzero.
+            // Acceptable for analytics; revisit if precision matters.
             let fee = extract_nat_field(&tx, "fee").unwrap_or(0);
             balance_tracker::apply_transfer(token, &from, &to, amt, fee, timestamp_ns);
         }

--- a/src/rumi_analytics/src/tailing/icrc3.rs
+++ b/src/rumi_analytics/src/tailing/icrc3.rs
@@ -6,7 +6,7 @@ use crate::{sources, state, storage};
 use storage::balance_tracker::{self, Account, Token};
 use storage::cursors;
 use sources::icusd_ledger::ICRC3Value;
-use super::{BATCH_SIZE, BACKFILL_BATCH_SIZE, update_cursor_success, update_cursor_source_count};
+use super::{BATCH_SIZE, BACKFILL_BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
 
 pub async fn tail_icusd_blocks() {
     let ledger = state::read_state(|s| s.sources.icusd_ledger);
@@ -63,6 +63,7 @@ async fn tail_blocks<G, S>(
                     Token::IcUsd => s.error_counters.icusd_ledger += 1,
                     Token::ThreeUsd => s.error_counters.three_pool += 1,
                 }
+                update_cursor_error(s, cursor_id, e.clone());
             });
             return;
         }

--- a/src/rumi_analytics/src/tailing/icrc3.rs
+++ b/src/rumi_analytics/src/tailing/icrc3.rs
@@ -114,7 +114,24 @@ fn process_block(token: Token, block: &ICRC3Value) -> Result<(), String> {
     let tx = extract_map_field(block, "tx")
         .ok_or_else(|| "missing tx field".to_string())?;
 
-    let btype = extract_text_field(block, "btype").unwrap_or_default();
+    // Resolve block type. ICRC-3 canonical form puts it at the block level as
+    // "btype" (e.g., "1mint", "1xfer"). The DFINITY reference ic-icrc1-ledger
+    // and some older implementations instead put "op" inside the "tx" map
+    // (e.g., "mint", "burn", "xfer"). We handle both conventions.
+    let btype: String = if let Some(bt) = extract_text_field(block, "btype") {
+        bt
+    } else if let Some(op) = extract_text_field(&tx, "op") {
+        // Normalize "op" values to the ICRC-3 btype convention.
+        match op.as_str() {
+            "mint" => "1mint".to_string(),
+            "burn" => "1burn".to_string(),
+            "xfer" | "transfer" => "1xfer".to_string(),
+            "approve" => "2approve".to_string(),
+            other => other.to_string(),
+        }
+    } else {
+        String::new()
+    };
 
     match btype.as_str() {
         "1xfer" => {

--- a/src/rumi_analytics/src/tailing/mod.rs
+++ b/src/rumi_analytics/src/tailing/mod.rs
@@ -1,0 +1,34 @@
+//! Event tailing functions. Each module implements a single cursor's
+//! fetch-process-advance cycle.
+
+pub mod backend_events;
+pub mod three_pool_swaps;
+pub mod three_pool_liquidity;
+pub mod amm_swaps;
+pub mod icrc3;
+
+pub const BATCH_SIZE: u64 = 500;
+pub const BACKFILL_BATCH_SIZE: u64 = 1000;
+
+// --- Cursor metadata helpers ---
+// These update the Option<HashMap> fields in SlimState.
+
+use crate::storage;
+
+pub(crate) fn update_cursor_success(s: &mut storage::SlimState, cursor_id: u8, timestamp_ns: u64) {
+    let map = s.cursor_last_success.get_or_insert_with(Default::default);
+    map.insert(cursor_id, timestamp_ns);
+    if let Some(err_map) = &mut s.cursor_last_error {
+        err_map.remove(&cursor_id);
+    }
+}
+
+pub(crate) fn update_cursor_error(s: &mut storage::SlimState, cursor_id: u8, error: String) {
+    let map = s.cursor_last_error.get_or_insert_with(Default::default);
+    map.insert(cursor_id, error);
+}
+
+pub(crate) fn update_cursor_source_count(s: &mut storage::SlimState, cursor_id: u8, count: u64) {
+    let map = s.cursor_source_counts.get_or_insert_with(Default::default);
+    map.insert(cursor_id, count);
+}

--- a/src/rumi_analytics/src/tailing/three_pool_liquidity.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_liquidity.rs
@@ -1,0 +1,79 @@
+//! 3pool liquidity event tailing. Writes to EVT_LIQUIDITY.
+
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+fn nat_to_u64(n: &candid::Nat) -> u64 {
+    use num_traits::ToPrimitive;
+    n.0.to_u64().unwrap_or(u64::MAX)
+}
+
+fn convert_action(action: &sources::three_pool::ThreePoolLiquidityAction) -> LiquidityAction {
+    use sources::three_pool::ThreePoolLiquidityAction::*;
+    match action {
+        AddLiquidity => LiquidityAction::Add,
+        RemoveLiquidity => LiquidityAction::Remove,
+        RemoveOneCoin => LiquidityAction::RemoveOneCoin,
+        Donate => LiquidityAction::Donate,
+    }
+}
+
+pub async fn run() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let cursor = cursors::three_pool_liquidity::get();
+
+    let count = match sources::three_pool::get_liquidity_event_count(three_pool).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_liq] get_liquidity_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::three_pool::get_liquidity_events(three_pool, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_liq] get_liquidity_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for evt in &events {
+        evt_liquidity::push(AnalyticsLiquidityEvent {
+            timestamp_ns: evt.timestamp,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            action: convert_action(&evt.action),
+            amounts: evt.amounts.iter().map(|n| nat_to_u64(n)).collect(),
+            lp_amount: nat_to_u64(&evt.lp_amount),
+            coin_index: evt.coin_index,
+            fee: evt.fee.as_ref().map(|n| nat_to_u64(n)),
+        });
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::three_pool_liquidity::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, ic_cdk::api::time());
+        });
+    }
+}

--- a/src/rumi_analytics/src/tailing/three_pool_swaps.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_swaps.rs
@@ -6,14 +6,16 @@ use storage::cursors;
 use storage::events::*;
 use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
 
+// Mainnet token principals for 3pool indices 0/1/2.
 const THREE_POOL_TOKENS: [&str; 3] = [
     "t6bor-paaaa-aaaap-qrd5q-cai",  // icUSD
     "cngnf-vqaaa-aaaar-qag4q-cai",  // ckUSDT
     "xevnm-gaaaa-aaaar-qafnq-cai",  // ckUSDC
 ];
 
-fn token_principal(idx: u8) -> Principal {
-    Principal::from_text(THREE_POOL_TOKENS[idx as usize]).unwrap()
+fn token_principal(idx: u8) -> Option<Principal> {
+    THREE_POOL_TOKENS.get(idx as usize)
+        .and_then(|t| Principal::from_text(t).ok())
 }
 
 fn nat_to_u64(n: &candid::Nat) -> u64 {
@@ -58,13 +60,20 @@ pub async fn run() {
 
     let mut processed = 0u64;
     for evt in &events {
+        let (Some(token_in), Some(token_out)) =
+            (token_principal(evt.token_in), token_principal(evt.token_out))
+        else {
+            ic_cdk::println!("[tail_3pool_swaps] skipping event with out-of-range token index: in={} out={}", evt.token_in, evt.token_out);
+            processed += 1;
+            continue;
+        };
         evt_swaps::push(AnalyticsSwapEvent {
             timestamp_ns: evt.timestamp,
             source: SwapSource::ThreePool,
             source_event_id: evt.id,
             caller: evt.caller,
-            token_in: token_principal(evt.token_in),
-            token_out: token_principal(evt.token_out),
+            token_in,
+            token_out,
             amount_in: nat_to_u64(&evt.amount_in),
             amount_out: nat_to_u64(&evt.amount_out),
             fee: nat_to_u64(&evt.fee),

--- a/src/rumi_analytics/src/tailing/three_pool_swaps.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_swaps.rs
@@ -1,0 +1,81 @@
+//! 3pool swap event tailing. Writes to EVT_SWAPS.
+
+use candid::Principal;
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+const THREE_POOL_TOKENS: [&str; 3] = [
+    "t6bor-paaaa-aaaap-qrd5q-cai",  // icUSD
+    "cngnf-vqaaa-aaaar-qag4q-cai",  // ckUSDT
+    "xevnm-gaaaa-aaaar-qafnq-cai",  // ckUSDC
+];
+
+fn token_principal(idx: u8) -> Principal {
+    Principal::from_text(THREE_POOL_TOKENS[idx as usize]).unwrap()
+}
+
+fn nat_to_u64(n: &candid::Nat) -> u64 {
+    use num_traits::ToPrimitive;
+    n.0.to_u64().unwrap_or(u64::MAX)
+}
+
+pub async fn run() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let cursor = cursors::three_pool_swaps::get();
+
+    let count = match sources::three_pool::get_swap_event_count(three_pool).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_swaps] get_swap_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_SWAPS, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_3POOL_SWAPS, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::three_pool::get_swap_events(three_pool, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_swaps] get_swap_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_SWAPS, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for evt in &events {
+        evt_swaps::push(AnalyticsSwapEvent {
+            timestamp_ns: evt.timestamp,
+            source: SwapSource::ThreePool,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            token_in: token_principal(evt.token_in),
+            token_out: token_principal(evt.token_out),
+            amount_in: nat_to_u64(&evt.amount_in),
+            amount_out: nat_to_u64(&evt.amount_out),
+            fee: nat_to_u64(&evt.fee),
+        });
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::three_pool_swaps::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_3POOL_SWAPS, ic_cdk::api::time());
+        });
+    }
+}

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -1,7 +1,8 @@
 //! Timer wiring. Phase 3 populates the daily tier with three collectors.
+//! Phase 4 adds event tailing and ICRC-3 block tailing to the pull cycle.
 
 use std::time::Duration;
-use crate::{collectors, sources, state};
+use crate::{collectors, sources, state, tailing};
 
 pub fn setup_timers() {
     ic_cdk_timers::set_timer_interval(Duration::from_secs(60), || {
@@ -20,6 +21,21 @@ pub fn setup_timers() {
 
 async fn pull_cycle() {
     refresh_supply_cache().await;
+
+    // Event tailing (Phase 4)
+    tailing::backend_events::run().await;
+    tailing::three_pool_swaps::run().await;
+    tailing::three_pool_liquidity::run().await;
+    tailing::amm_swaps::run().await;
+
+    // ICRC-3 block tailing (Phase 4)
+    tailing::icrc3::tail_icusd_blocks().await;
+    tailing::icrc3::tail_3pool_blocks().await;
+
+    // Update pull cycle timestamp
+    state::mutate_state(|s| {
+        s.last_pull_cycle_ns = Some(ic_cdk::api::time());
+    });
 }
 
 async fn refresh_supply_cache() {
@@ -36,10 +52,11 @@ async fn refresh_supply_cache() {
 }
 
 async fn daily_snapshot() {
-    let (tvl_res, vaults_res, stability_res) = futures::join!(
+    let (tvl_res, vaults_res, stability_res, holders_res) = futures::join!(
         collectors::tvl::run(),
         collectors::vaults::run(),
         collectors::stability::run(),
+        collectors::holders::run(),
     );
 
     if let Err(e) = tvl_res {
@@ -50,5 +67,8 @@ async fn daily_snapshot() {
     }
     if let Err(e) = stability_res {
         ic_cdk::println!("rumi_analytics: daily stability snapshot failed: {}", e);
+    }
+    if let Err(e) = holders_res {
+        ic_cdk::println!("rumi_analytics: daily holder snapshot failed: {}", e);
     }
 }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -1,9 +1,6 @@
-//! Timer wiring. Phase 1 sets up all four tier intervals but only the daily
-//! tier (TVL collector) and the pull-cycle supply refresh do real work.
-//! Subsequent phases populate the other callbacks.
+//! Timer wiring. Phase 3 populates the daily tier with three collectors.
 
 use std::time::Duration;
-
 use crate::{collectors, sources, state};
 
 pub fn setup_timers() {
@@ -21,8 +18,6 @@ pub fn setup_timers() {
     });
 }
 
-/// Pull cycle: Phase 1 only refreshes the supply cache. Phase 4 extends this
-/// with event tailing across every source stream.
 async fn pull_cycle() {
     refresh_supply_cache().await;
 }
@@ -41,7 +36,19 @@ async fn refresh_supply_cache() {
 }
 
 async fn daily_snapshot() {
-    if let Err(e) = collectors::tvl::run().await {
+    let (tvl_res, vaults_res, stability_res) = futures::join!(
+        collectors::tvl::run(),
+        collectors::vaults::run(),
+        collectors::stability::run(),
+    );
+
+    if let Err(e) = tvl_res {
         ic_cdk::println!("rumi_analytics: daily TVL snapshot failed: {}", e);
+    }
+    if let Err(e) = vaults_res {
+        ic_cdk::println!("rumi_analytics: daily vault snapshot failed: {}", e);
+    }
+    if let Err(e) = stability_res {
+        ic_cdk::println!("rumi_analytics: daily stability snapshot failed: {}", e);
     }
 }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -22,15 +22,15 @@ pub fn setup_timers() {
 async fn pull_cycle() {
     refresh_supply_cache().await;
 
-    // Event tailing (Phase 4)
-    tailing::backend_events::run().await;
-    tailing::three_pool_swaps::run().await;
-    tailing::three_pool_liquidity::run().await;
-    tailing::amm_swaps::run().await;
-
-    // ICRC-3 block tailing (Phase 4)
-    tailing::icrc3::tail_icusd_blocks().await;
-    tailing::icrc3::tail_3pool_blocks().await;
+    // Event tailing (Phase 4) - all sources are independent, run concurrently.
+    futures::join!(
+        tailing::backend_events::run(),
+        tailing::three_pool_swaps::run(),
+        tailing::three_pool_liquidity::run(),
+        tailing::amm_swaps::run(),
+        tailing::icrc3::tail_icusd_blocks(),
+        tailing::icrc3::tail_3pool_blocks(),
+    );
 
     // Update pull cycle timestamp
     state::mutate_state(|s| {

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -3,7 +3,7 @@
 use candid::CandidType;
 use serde::Deserialize;
 
-use crate::storage::DailyTvlRow;
+use crate::storage::{DailyTvlRow, DailyVaultSnapshotRow, DailyStabilityRow};
 
 #[derive(CandidType, Deserialize, Clone, Debug, Default)]
 pub struct RangeQuery {
@@ -34,5 +34,17 @@ impl RangeQuery {
 #[derive(CandidType, Clone, Debug)]
 pub struct TvlSeriesResponse {
     pub rows: Vec<DailyTvlRow>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct VaultSeriesResponse {
+    pub rows: Vec<DailyVaultSnapshotRow>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct StabilitySeriesResponse {
+    pub rows: Vec<DailyStabilityRow>,
     pub next_from_ts: Option<u64>,
 }

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -48,3 +48,37 @@ pub struct StabilitySeriesResponse {
     pub rows: Vec<DailyStabilityRow>,
     pub next_from_ts: Option<u64>,
 }
+
+use candid::Principal;
+use crate::storage::holders::DailyHolderRow;
+
+#[derive(CandidType, Clone, Debug)]
+pub struct HolderSeriesResponse {
+    pub rows: Vec<DailyHolderRow>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct CollectorHealth {
+    pub cursors: Vec<CursorStatus>,
+    pub error_counters: crate::storage::ErrorCounters,
+    pub backfill_active: Vec<Principal>,
+    pub last_pull_cycle_ns: u64,
+    pub balance_tracker_stats: Vec<BalanceTrackerStats>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct CursorStatus {
+    pub name: String,
+    pub cursor_position: u64,
+    pub source_count: u64,
+    pub last_success_ns: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct BalanceTrackerStats {
+    pub token: Principal,
+    pub holder_count: u64,
+    pub total_tracked_e8s: u64,
+}

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -17,6 +17,74 @@ use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Princ
 use icrc_ledger_types::icrc1::account::Account;
 use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
 
+// Phase 4 test-side types (mirror rumi_analytics candid interface)
+
+#[derive(CandidType, Deserialize, Debug)]
+struct CollectorHealth {
+    cursors: Vec<CursorStatus>,
+    error_counters: ErrorCounters,
+    backfill_active: Vec<Principal>,
+    last_pull_cycle_ns: u64,
+    balance_tracker_stats: Vec<BalanceTrackerStats>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct CursorStatus {
+    name: String,
+    cursor_position: u64,
+    source_count: u64,
+    last_success_ns: u64,
+    last_error: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct ErrorCounters {
+    backend: u64,
+    icusd_ledger: u64,
+    three_pool: u64,
+    stability_pool: u64,
+    amm: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct BalanceTrackerStats {
+    token: Principal,
+    holder_count: u64,
+    total_tracked_e8s: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct DailyHolderRow {
+    timestamp_ns: u64,
+    token: Principal,
+    total_holders: u32,
+    total_supply_tracked_e8s: u64,
+    median_balance_e8s: u64,
+    top_50: Vec<(Principal, u64)>,
+    top_10_pct_bps: u32,
+    gini_bps: u32,
+    new_holders_today: u32,
+    distribution_buckets: Vec<u32>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct HolderSeriesResponse {
+    rows: Vec<DailyHolderRow>,
+    next_from_ts: Option<u64>,
+}
+
+// ICRC-1 TransferArg defined locally (icrc_ledger_types is a non-dev dep, but
+// we keep a local copy to avoid pulling in the full type with all its derives).
+#[derive(CandidType, Deserialize)]
+struct TransferArg {
+    from_subaccount: Option<[u8; 32]>,
+    to: Account,
+    fee: Option<candid::Nat>,
+    created_at_time: Option<u64>,
+    memo: Option<Vec<u8>>,
+    amount: candid::Nat,
+}
+
 // ─── ICRC-1 ledger init types (copied from rumi_amm tests) ───
 
 #[derive(CandidType, Deserialize)]
@@ -385,6 +453,48 @@ fn get_stability_series(env: &Env, q: RangeQueryArg) -> StabilitySeriesResponse 
     }
 }
 
+// ─── Phase 4 helpers ───
+
+fn get_collector_health(env: &Env) -> CollectorHealth {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_collector_health", encode_one(()).unwrap(),
+    ).expect("get_collector_health query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_collector_health rejected: {}", msg),
+    }
+}
+
+fn get_holder_series(env: &Env, q: RangeQueryArg, token: Principal) -> HolderSeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_holder_series",
+        encode_args((q, token)).expect("encode holder series args"),
+    ).expect("get_holder_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_holder_series rejected: {}", msg),
+    }
+}
+
+fn call_start_backfill(env: &Env, token: Principal) -> String {
+    let result = env.pic.update_call(
+        env.analytics, env.admin, "start_backfill",
+        encode_one(token).unwrap(),
+    ).expect("start_backfill update");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("start_backfill rejected: {}", msg),
+    }
+}
+
+/// Advance time and tick enough for the 60s pull cycle to fire and inter-canister calls to settle.
+fn advance_pull_cycle(env: &Env) {
+    env.pic.advance_time(std::time::Duration::from_secs(65));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+}
+
 // ─── Tests ───
 
 #[test]
@@ -551,4 +661,184 @@ fn upgrade_preserves_supply_cache_and_tvl_log() {
     assert_eq!(before_rows, after_rows, "TVL log lost rows on upgrade");
     assert_eq!(before_vault_rows, after_vault_rows, "vault log lost rows on upgrade");
     assert_eq!(before_supply, after_supply, "supply cache lost on upgrade");
+}
+
+// ─── Phase 4 Tests ───
+
+#[test]
+fn collector_health_reports_cursor_positions() {
+    let env = setup();
+    advance_pull_cycle(&env);
+
+    let health = get_collector_health(&env);
+
+    // Should have 6 cursors
+    assert_eq!(health.cursors.len(), 6, "expected 6 cursors");
+
+    // last_pull_cycle_ns should be non-zero after a pull cycle
+    assert!(health.last_pull_cycle_ns > 0, "last_pull_cycle_ns should be set");
+
+    // The icusd_blocks cursor should have advanced (the ledger has blocks from initial mint)
+    let icusd_cursor = health.cursors.iter().find(|c| c.name == "icusd_blocks");
+    assert!(icusd_cursor.is_some(), "icusd_blocks cursor should exist");
+    let icusd_cursor = icusd_cursor.unwrap();
+    assert!(icusd_cursor.cursor_position > 0, "icusd_blocks cursor should have advanced past initial mint block");
+
+    // Backend events cursor - the backend was deployed so there may be init events.
+    // At minimum, cursor should exist with position >= 0.
+    let be_cursor = health.cursors.iter().find(|c| c.name == "backend_events");
+    assert!(be_cursor.is_some(), "backend_events cursor should exist");
+
+    // balance_tracker_stats should have 2 entries (icUSD and 3USD)
+    assert_eq!(health.balance_tracker_stats.len(), 2, "should track 2 tokens");
+
+    // The icUSD tracker should show holders from the initial mint
+    let icusd_stats = health.balance_tracker_stats.iter().find(|s| s.token == env.icusd_ledger);
+    assert!(icusd_stats.is_some(), "icUSD stats should exist");
+    let icusd_stats = icusd_stats.unwrap();
+    assert!(icusd_stats.holder_count > 0, "should have at least 1 icUSD holder from initial mint");
+    assert!(icusd_stats.total_tracked_e8s > 0, "should have tracked icUSD supply");
+}
+
+#[test]
+fn icrc3_balance_tracking_after_transfer() {
+    let env = setup();
+    let user_a = Principal::self_authenticating(&[1, 2, 3, 4]); // same as holder in setup
+    let user_b = Principal::self_authenticating(&[10, 20, 30, 40]);
+
+    // First pull cycle picks up the initial mint
+    advance_pull_cycle(&env);
+
+    let health_before = get_collector_health(&env);
+    let icusd_before = health_before.balance_tracker_stats.iter()
+        .find(|s| s.token == env.icusd_ledger).unwrap();
+    let holders_before = icusd_before.holder_count;
+
+    // Transfer from user_a to user_b via the ledger
+    let transfer_arg = TransferArg {
+        from_subaccount: None,
+        to: Account { owner: user_b, subaccount: None },
+        fee: None,
+        created_at_time: None,
+        memo: None,
+        amount: candid::Nat::from(500_000_00000000u64),
+    };
+    let result = env.pic.update_call(
+        env.icusd_ledger, user_a, "icrc1_transfer",
+        encode_one(transfer_arg).unwrap(),
+    ).expect("icrc1_transfer");
+    match result {
+        WasmResult::Reply(_) => {},
+        WasmResult::Reject(msg) => panic!("transfer rejected: {}", msg),
+    }
+
+    // Next pull cycle picks up the transfer block
+    advance_pull_cycle(&env);
+
+    let health_after = get_collector_health(&env);
+    let icusd_after = health_after.balance_tracker_stats.iter()
+        .find(|s| s.token == env.icusd_ledger).unwrap();
+
+    // Should now have 2 holders (user_a and user_b)
+    assert!(icusd_after.holder_count > holders_before,
+        "holder count should increase after transfer to new account: before={}, after={}",
+        holders_before, icusd_after.holder_count);
+}
+
+#[test]
+fn daily_holder_snapshot_computed() {
+    let env = setup();
+
+    // Run pull cycles to populate balance tracker
+    advance_pull_cycle(&env);
+
+    // Advance past daily timer (86400s)
+    env.pic.advance_time(std::time::Duration::from_secs(86_400));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+
+    let resp = get_holder_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+        env.icusd_ledger,
+    );
+
+    assert!(!resp.rows.is_empty(), "should have at least one holder snapshot row");
+    let row = &resp.rows[0];
+    assert!(row.total_holders > 0, "total_holders should be > 0");
+    assert!(row.total_supply_tracked_e8s > 0, "total_supply should be > 0");
+    // distribution_buckets has one entry per bucket threshold plus one overflow bucket.
+    // The implementation uses 4 thresholds so there are 5 buckets total.
+    assert!(!row.distribution_buckets.is_empty(), "distribution_buckets should be non-empty");
+}
+
+#[test]
+fn start_backfill_requires_admin() {
+    let env = setup();
+    let non_admin = Principal::self_authenticating(&[99, 99, 99]);
+
+    // Non-admin call should return unauthorized message
+    let result = env.pic.update_call(
+        env.analytics, non_admin, "start_backfill",
+        encode_one(env.icusd_ledger).unwrap(),
+    ).expect("start_backfill update");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let msg: String = decode_one(&bytes).unwrap();
+            assert!(msg.contains("unauthorized"), "non-admin should get unauthorized: {}", msg);
+        }
+        WasmResult::Reject(msg) => panic!("unexpected reject: {}", msg),
+    }
+
+    // Admin call should succeed
+    let msg = call_start_backfill(&env, env.icusd_ledger);
+    assert!(msg.contains("backfill started"), "admin should succeed: {}", msg);
+
+    // Verify backfill is active in health
+    let health = get_collector_health(&env);
+    assert!(!health.backfill_active.is_empty(), "backfill should be active");
+}
+
+#[test]
+fn upgrade_preserves_phase4_state() {
+    let env = setup();
+
+    // Run pull cycles to populate cursors and balance tracker
+    advance_pull_cycle(&env);
+    advance_pull_cycle(&env);
+
+    let health_before = get_collector_health(&env);
+
+    // Upgrade the canister
+    env.pic.upgrade_canister(
+        env.analytics,
+        analytics_wasm(),
+        encode_one(AnalyticsInitArgs {
+            admin: env.admin,
+            backend: env.backend,
+            icusd_ledger: env.icusd_ledger,
+            three_pool: Principal::anonymous(),
+            stability_pool: Principal::anonymous(),
+            amm: Principal::anonymous(),
+        }).unwrap(),
+        Some(env.admin),
+    ).expect("upgrade analytics");
+
+    let health_after = get_collector_health(&env);
+
+    // Cursor positions should survive upgrade
+    for (before, after) in health_before.cursors.iter().zip(health_after.cursors.iter()) {
+        assert_eq!(before.cursor_position, after.cursor_position,
+            "cursor {} position changed on upgrade: {} -> {}",
+            before.name, before.cursor_position, after.cursor_position);
+    }
+
+    // Balance tracker should survive upgrade
+    for (before, after) in health_before.balance_tracker_stats.iter().zip(health_after.balance_tracker_stats.iter()) {
+        assert_eq!(before.holder_count, after.holder_count,
+            "holder count changed on upgrade for token {:?}", before.token);
+        assert_eq!(before.total_tracked_e8s, after.total_tracked_e8s,
+            "tracked supply changed on upgrade for token {:?}", before.token);
+    }
 }

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -123,11 +123,62 @@ struct DailyTvlRow {
     total_icp_collateral_e8s: candid::Nat,
     total_icusd_supply_e8s: candid::Nat,
     system_collateral_ratio_bps: u32,
+    stability_pool_deposits_e8s: Option<u64>,
+    three_pool_reserve_0_e8s: Option<candid::Nat>,
+    three_pool_reserve_1_e8s: Option<candid::Nat>,
+    three_pool_reserve_2_e8s: Option<candid::Nat>,
+    three_pool_virtual_price_e18: Option<candid::Nat>,
+    three_pool_lp_supply_e8s: Option<candid::Nat>,
 }
 
 #[derive(CandidType, Deserialize, Debug)]
 struct TvlSeriesResponse {
     rows: Vec<DailyTvlRow>,
+    next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct CollateralStats {
+    collateral_type: Principal,
+    vault_count: u32,
+    total_collateral_e8s: u64,
+    total_debt_e8s: u64,
+    min_cr_bps: u32,
+    max_cr_bps: u32,
+    median_cr_bps: u32,
+    price_usd_e8s: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct DailyVaultSnapshotRow {
+    timestamp_ns: u64,
+    total_vault_count: u32,
+    total_collateral_usd_e8s: u64,
+    total_debt_e8s: u64,
+    median_cr_bps: u32,
+    collaterals: Vec<CollateralStats>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct VaultSeriesResponse {
+    rows: Vec<DailyVaultSnapshotRow>,
+    next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct DailyStabilityRow {
+    timestamp_ns: u64,
+    total_deposits_e8s: u64,
+    total_depositors: u64,
+    total_liquidations_executed: u64,
+    total_interest_received_e8s: u64,
+    stablecoin_balances: Vec<(Principal, u64)>,
+    collateral_gains: Vec<(Principal, u64)>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct StabilitySeriesResponse {
+    rows: Vec<DailyStabilityRow>,
     next_from_ts: Option<u64>,
 }
 
@@ -314,6 +365,26 @@ fn get_tvl_series(env: &Env, q: RangeQueryArg) -> TvlSeriesResponse {
     }
 }
 
+fn get_vault_series(env: &Env, q: RangeQueryArg) -> VaultSeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_vault_series", encode_one(q).unwrap(),
+    ).expect("get_vault_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_vault_series rejected: {}", msg),
+    }
+}
+
+fn get_stability_series(env: &Env, q: RangeQueryArg) -> StabilitySeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_stability_series", encode_one(q).unwrap(),
+    ).expect("get_stability_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_stability_series rejected: {}", msg),
+    }
+}
+
 // ─── Tests ───
 
 #[test]
@@ -373,6 +444,62 @@ fn pagination_returns_next_cursor_when_full() {
 }
 
 #[test]
+fn tvl_extended_fields_none_when_sources_unavailable() {
+    let env = setup();
+    env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+
+    let resp = get_tvl_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+    );
+    assert!(!resp.rows.is_empty(), "TVL row should be written even with SP/3pool failures");
+    let row = &resp.rows[0];
+    assert!(row.stability_pool_deposits_e8s.is_none(), "SP should be None when unavailable");
+    assert!(row.three_pool_reserve_0_e8s.is_none(), "3pool reserve should be None when unavailable");
+}
+
+#[test]
+fn vault_snapshot_written_with_empty_protocol() {
+    let env = setup();
+    env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+
+    let resp = get_vault_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+    );
+    assert!(!resp.rows.is_empty(), "vault snapshot should be written even with 0 vaults");
+    let row = &resp.rows[0];
+    assert_eq!(row.total_vault_count, 0);
+    assert_eq!(row.total_debt_e8s, 0);
+    // With no vaults, each configured collateral type should report zero vault_count and zero debt.
+    for col in &row.collaterals {
+        assert_eq!(col.vault_count, 0, "expected zero vault_count per collateral with no vaults");
+        assert_eq!(col.total_debt_e8s, 0, "expected zero debt per collateral with no vaults");
+    }
+}
+
+#[test]
+fn stability_snapshot_skipped_when_source_unavailable() {
+    let env = setup();
+    env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+
+    let resp = get_stability_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+    );
+    assert!(resp.rows.is_empty(), "no stability row when source canister unavailable");
+}
+
+#[test]
 fn upgrade_preserves_supply_cache_and_tvl_log() {
     let env = setup();
     env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
@@ -386,6 +513,10 @@ fn upgrade_preserves_supply_cache_and_tvl_log() {
     )
     .rows
     .len();
+    let before_vault_rows = get_vault_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+    ).rows.len();
     let before_supply = http_get(&env, "/api/supply").body;
     assert!(before_rows > 0, "precondition: TVL log should have a row");
 
@@ -412,7 +543,12 @@ fn upgrade_preserves_supply_cache_and_tvl_log() {
     )
     .rows
     .len();
+    let after_vault_rows = get_vault_series(
+        &env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: None, offset: None },
+    ).rows.len();
     let after_supply = http_get(&env, "/api/supply").body;
     assert_eq!(before_rows, after_rows, "TVL log lost rows on upgrade");
+    assert_eq!(before_vault_rows, after_vault_rows, "vault log lost rows on upgrade");
     assert_eq!(before_supply, after_supply, "supply cache lost on upgrade");
 }

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -239,6 +239,45 @@ type Event = variant {
     collateral_type : principal;
     borrowing_fee : opt text;
   };
+  set_collateral_liquidation_ratio : record {
+    collateral_type : principal;
+    liquidation_ratio : text;
+  };
+  set_collateral_borrow_threshold : record {
+    collateral_type : principal;
+    borrow_threshold_ratio : text;
+  };
+  set_collateral_liquidation_bonus : record {
+    collateral_type : principal;
+    liquidation_bonus : text;
+  };
+  set_collateral_min_vault_debt : record {
+    collateral_type : principal;
+    min_vault_debt : nat64;
+  };
+  set_collateral_ledger_fee : record {
+    collateral_type : principal;
+    ledger_fee : nat64;
+  };
+  set_collateral_redemption_fee_floor : record {
+    collateral_type : principal;
+    redemption_fee_floor : text;
+  };
+  set_collateral_redemption_fee_ceiling : record {
+    collateral_type : principal;
+    redemption_fee_ceiling : text;
+  };
+  set_collateral_min_deposit : record {
+    collateral_type : principal;
+    min_collateral_deposit : nat64;
+  };
+  set_collateral_display_color : record {
+    collateral_type : principal;
+    display_color : opt text;
+  };
+  set_bot_allowed_collateral_types : record {
+    collateral_types : vec principal;
+  };
   margin_transfer : record { block_index : nat64; vault_id : nat64; timestamp : opt nat64 };
   admin_sweep_to_treasury : record {
     block_index : nat64;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -557,9 +557,6 @@ fn get_vault_history(vault_id: u64) -> Vec<Event> {
 #[candid_method(query)]
 #[query]
 fn get_events(args: GetEventsArg) -> Vec<Event> {
-    if ic_cdk::api::data_certificate().is_none() {
-        ic_cdk::trap("update call rejected");
-    }
     const MAX_EVENTS_PER_QUERY: usize = 2000;
 
     events()


### PR DESCRIPTION
## Summary

- **Phase 3**: Daily snapshot collectors for TVL (extended with 3pool/stability pool data), vault stats (per-collateral CR/debt), stability pool metrics, and holder distribution (Gini, top-50, buckets)
- **Phase 4**: Cursor-based event tailing on 60s pull cycle for 6 sources (backend events, 3pool swaps, 3pool liquidity, AMM swaps, icUSD blocks, 3USD blocks), BalanceTracker for real-time icUSD/3USD holder counts, ICRC-3 block parsing with dual format support, historical backfill, `get_collector_health()` observability endpoint
- **Bug fixes**: Backend `get_events` data_certificate guard removal (blocked inter-canister calls), Candid `#[serde(other)]` workaround (enumerate all ~74 Event variants explicitly), ICRC-3 dual-format block parsing (canonical `btype` vs DFINITY reference `op`-in-`tx`)
- **Deployed and verified on mainnet** (dtlu2-uqaaa-aaaap-qugcq-cai) -- all 6 cursors healthy, 26 icUSD holders / 8 3USD holders tracked

## Test plan

- [ ] 12 PocketIC integration tests pass (`cargo test --test pocket_ic_analytics`)
- [ ] `get_collector_health` shows all 6 cursors with `last_error = null`
- [ ] Backend events cursor catches up from 0 to ~21k events
- [ ] icUSD/3USD balance tracker stats match expected holder counts
- [ ] Daily holder snapshot computes Gini, top-50, distribution buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)