### PR TITLE
feat(bot): replace KongSwap+3pool with ICPSwap single-hop swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5480,7 +5480,6 @@ name = "liquidation_bot"
 version = "0.1.0"
 dependencies = [
  "candid",
- "futures",
  "ic-canister-log 0.2.0 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
  "ic-cdk 0.12.2",
  "ic-cdk-macros 0.8.4",

--- a/docs/liquidation-bot-icpswap-migration.md
+++ b/docs/liquidation-bot-icpswap-migration.md
@@ -1,0 +1,119 @@
+# Liquidation Bot ICPSwap Migration Runbook
+
+Deploys the rewritten liquidation bot (KongSwap+3pool replaced with single-hop ICPSwap ICP->ckUSDC) and the backend cleanup (delete `bot_deposit_to_reserves`, add `admin_resolve_stuck_claim`).
+
+## Pre-deployment checklist
+
+- [ ] Verify no active bot claims: `dfx canister call rumi_protocol_backend get_bot_stats --network ic`
+  - `budget_remaining_e8s` should be 0 or the bot should have no pending vaults
+- [ ] Verify bot has no stuck liquidations in the old format
+
+## Step 1: Deploy the bot canister (upgrade, NOT reinstall)
+
+```bash
+dfx deploy liquidation_bot --network ic
+```
+
+The `post_upgrade` handler will:
+1. Rescue the legacy JSON blob from raw stable memory
+2. Initialize MemoryManager (writes header at offset 0)
+3. Migrate legacy `BotLiquidationEvent` entries into the new StableBTreeMap
+4. Mark `migrated_to_stable_structures = true`
+5. Start the 30-second timer
+
+## Step 2: Verify migration
+
+```bash
+# Should return the count of migrated legacy events
+dfx canister call liquidation_bot get_liquidation_count --network ic
+
+# Verify stats carried over
+dfx canister call liquidation_bot get_bot_stats --network ic
+```
+
+## Step 3: Set new config
+
+The old KongSwap/3pool fields are now optional. Set the new ICPSwap config:
+
+```bash
+dfx canister call liquidation_bot set_config '(record {
+  backend_principal = principal "tfesu-vyaaa-aaaap-qrd7a-cai";
+  treasury_principal = principal "tlg74-oiaaa-aaaap-qrd6a-cai";
+  admin = principal "<YOUR_ADMIN_PRINCIPAL>";
+  max_slippage_bps = 200 : nat16;
+  icp_ledger = principal "ryjl3-tyaaa-aaaaa-aaaba-cai";
+  ckusdc_ledger = principal "xevnm-gaaaa-aaaar-qafnq-cai";
+  icpswap_pool = principal "mohjv-bqaaa-aaaag-qjyia-cai";
+  icpswap_zero_for_one = null;
+  icp_fee_e8s = opt (10_000 : nat64);
+  ckusdc_fee_e6 = opt (10 : nat64);
+  three_pool_principal = null;
+  kong_swap_principal = null;
+  ckusdt_ledger = null;
+  icusd_ledger = null;
+})' --network ic
+```
+
+## Step 4: Resolve pool ordering
+
+Fetches ICPSwap pool metadata to determine if ICP is token0 or token1:
+
+```bash
+dfx canister call liquidation_bot admin_resolve_pool_ordering --network ic
+```
+
+## Step 5: Set infinite ICRC-2 approve
+
+Approves the ICPSwap pool to spend the bot's ICP (u128::MAX, no expiry):
+
+```bash
+dfx canister call liquidation_bot admin_approve_pool --network ic
+```
+
+## Step 6: Deploy backend
+
+```bash
+dfx deploy rumi_protocol_backend --network ic --argument '(variant { Upgrade = record { mode = null; description = opt "Delete bot_deposit_to_reserves, add admin_resolve_stuck_claim" } })'
+```
+
+## Step 7: Deploy frontend
+
+```bash
+dfx deploy vault_frontend --network ic
+```
+
+## Step 8: Re-enable bot liquidations
+
+Add ICP to the bot's allowed collateral types (if not already set):
+
+```bash
+dfx canister call rumi_protocol_backend set_bot_allowed_collateral_types '(vec { principal "ryjl3-tyaaa-aaaaa-aaaba-cai" })' --network ic
+```
+
+Set a budget if needed:
+
+```bash
+dfx canister call rumi_protocol_backend set_bot_budget '(50_000_000_000 : nat64)' --network ic
+```
+
+## Step 9: Monitor
+
+```bash
+# Watch for first liquidation
+dfx canister call liquidation_bot get_liquidations '(0 : nat64, 5 : nat64)' --network ic
+
+# Check for stuck liquidations
+dfx canister call liquidation_bot get_stuck_liquidations --network ic
+```
+
+## Candid breaking change
+
+`BotConfig` fields changed: `three_pool_principal`, `kong_swap_principal`, `ckusdt_ledger`, `icusd_ledger` are now `opt principal` (previously required `principal`). New required fields: `icpswap_pool`. Old dfx scripts that call `set_config` will need updating.
+
+## Rollback
+
+If something goes wrong:
+1. Re-deploy the old bot wasm: `dfx deploy liquidation_bot --network ic --wasm <path-to-old-wasm>`
+2. The old wasm's `post_upgrade` uses raw stable64_read, but MemoryManager has overwritten offset 0. **Rollback is NOT safe** after the new wasm has been deployed and upgraded.
+3. If rollback is needed, consider reinstalling the bot canister (this loses history but restores a clean state). The bot's history is informational only; no funds are at risk.
+4. The backend changes are backward-compatible (only deleted a dead endpoint and added a new one). No backend rollback needed.

--- a/docs/superpowers/plans/2026-04-08-liquidation-bot-icpswap-rework.md
+++ b/docs/superpowers/plans/2026-04-08-liquidation-bot-icpswap-rework.md
@@ -1,0 +1,1391 @@
+# Liquidation Bot ICPSwap Rework + Full History Implementation Plan (v3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dead KongSwap + 3pool liquidation path with a single ICPSwap ICP->ckUSDC swap that delivers ckUSDC directly into the backend canister's own ckUSDC ledger account, and add a full append-only per-liquidation history stored in the bot's stable memory.
+
+**Architecture:**
+- Bot swaps seized ICP -> ckUSDC on ICPSwap pool `mohjv-bqaaa-aaaag-qjyia-cai` using `depositFromAndSwap` + an infinite ICRC-2 approve, mirroring `rumi-arb-bot/src/arb_bot/src/swaps.rs`.
+- Bot transfers swap proceeds to the backend via a plain `icrc1_transfer` on the ckUSDC ledger. The backend already holds real ckUSDC balances from the existing `repay_to_vault_with_stable` feature (`vault.rs:888`); the new flow is structurally identical to a user doing a stable-repay, so the backend needs zero new deposit-verification logic.
+- `bot_claim_liquidation` and `bot_confirm_liquidation` are unchanged. Confirm already does pure state bookkeeping (no icUSD burn, no ledger transfer) and partial-claim semantics via `compute_partial_liquidation_cap` are preserved.
+- The cosmetic `bot_deposit_to_reserves` counter endpoint and the `bot_total_icusd_deposited_e8s` state field are deleted as dead code.
+- Bot migrates its state store from the current raw `stable64_write(0, ...)` JSON-blob pattern to `ic-stable-structures` with `MemoryManager`, for an append-only `StableBTreeMap<u64, LiquidationRecordVersioned>` that is upgrade-safe and effectively unbounded. The migration path is handled with an explicit legacy-blob rescue in `post_upgrade` before any `MemoryManager` access.
+
+**Failure Recovery Model:**
+- **Swap failure (before money changes form):** Bot still holds ICP. Return ICP to backend via `icrc1_transfer`, call `bot_cancel_liquidation`. Clean recovery, no risk.
+- **Transfer failure (swap succeeded, ckUSDC transfer to backend failed):** Bot holds ckUSDC, vault is locked. **No retry.** Immediately mark the claim as "stuck" in bot history. Admin resolves manually via `admin_sweep_ckusdc` (bot) and `admin_resolve_stuck_claim` (backend). This avoids the double-transfer bugs that retries caused previously.
+- **Confirm failure (ckUSDC delivered to backend, confirm call failed):** Idempotent (safe to repeat). Retry up to 5 times immediately. If all retries fail, mark as stuck. The backend's confirm is idempotent: it looks up the claim by vault_id, writes down debt, deletes claim. A second call with the same vault_id gets "no active claim" and fails harmlessly.
+
+**Tech Stack:** Rust, ic-cdk 0.12, ic-stable-structures 0.6.5, candid 0.10.6, icrc-ledger-types, pocket-ic 6.0 for integration tests.
+
+---
+
+## Key audit findings that shaped this plan
+
+Performed before writing v2; see chat log 2026-04-08 for citations.
+
+1. **`bot_confirm_liquidation` does NOT burn icUSD today.** It only subtracts `claim.debt_amount` from `vault.borrowed_icusd_amount` and `claim.collateral_amount` from `vault.collateral_amount` in state (`main.rs:1694-1695`). No `icrc1_transfer`, no burn. This code is already correct for the new reserve-backed model and does not need to change.
+2. **`bot_deposit_to_reserves` is a cosmetic counter.** It only increments `bot_total_icusd_deposited_e8s` (`main.rs:2080`). No ledger interaction. Dead code, to be deleted.
+3. **Claims are PARTIAL by default** via `compute_partial_liquidation_cap` at `state.rs:2275`, called from `main.rs:1610`. Partial claims stay partial in this rework. Only the minimum debt needed to restore vault health is liquidated. Do not rewrite confirm to use vault-zero semantics.
+4. **`compute_total_collateral_ratio` at `state.rs:1141` does not count ckUSDC/ckUSDT reserves.** This is a pre-existing bug relevant to the shipped `repay_to_vault_with_stable` feature as well. Per Rob: fix in a **separate follow-up PR**, not this one. This PR inherits the same accounting quirk that stable-repay already has.
+5. **Backend ckUSDC ledger account already holds real funds** via stable-repay (`vault.rs:980` calls `transfer_stable_from` -> `management.rs:613` ICRC-2 transfer_from into `protocol_account` subaccount None). No new reserve storage primitive needed.
+6. **Claims are physical ICRC-1 transfers.** `bot_claim_liquidation` (`main.rs:1628-1639`) calls `management::transfer_collateral` which does a real ICRC-1 transfer of ICP from the backend canister to the bot canister. The ICP physically moves.
+7. **ICPSwap `quote` and `depositFromAndSwap` take DIFFERENT arg types.** `quote` takes `SwapArgs` (3 fields: `amountIn`, `amountOutMinimum`, `zeroForOne`). `depositFromAndSwap` takes `DepositAndSwapArgs` (5 fields: adds `tokenInFee`, `tokenOutFee`). Plan v2 had this wrong; v3 uses correct types for each.
+8. **ICPSwap `metadata()` returns `Result_6` (wrapped `PoolMetadata`), not raw `PoolMetadata`.** Must unwrap the result variant. `PoolMetadata` has 9 fields (fee, key, liquidity, maxLiquidityPerTick, nextPositionId, sqrtPriceX96, tick, token0, token1).
+
+---
+
+## Scope
+
+**In scope (this PR)**
+- KongSwap + 3pool code removal from `liquidation_bot`
+- ICPSwap single-hop ICP->ckUSDC swap with quote + slippage + infinite approve
+- Bot -> backend ckUSDC delivery via plain `icrc1_transfer` (no new backend endpoint)
+- **Delete** `bot_deposit_to_reserves` endpoint and `bot_total_icusd_deposited_e8s` state field on backend
+- Bot migration to `ic-stable-structures` with `MemoryManager`, **including** a safe `post_upgrade` rescue of the legacy JSON blob at offset 0
+- `LiquidationRecordVersioned::V1` struct, stable map, next-id cell
+- Bot query endpoints: `get_liquidation`, `get_liquidations`, `get_liquidation_count`, `get_stuck_liquidations`
+- Bot admin endpoints: `admin_resolve_pool_ordering` (one-time call to cache `zeroForOne`), `admin_approve_pool` (one-time infinite ICRC-2 approve for ICP to ICPSwap pool), `admin_sweep_ckusdc` (emergency: transfer all bot ckUSDC to a target, optionally mark associated record as AdminResolved), `admin_retry_stuck_claim` (re-attempt confirm for a stuck claim)
+- Backend admin endpoint: `admin_resolve_stuck_claim` (force-clear a stuck bot claim, unlock vault, restore budget)
+- Candid updates for both canisters + declaration regen
+- PocketIC integration test with a stub ICPSwap pool canister
+- Docs: mainnet migration runbook
+
+**Out of scope (deferred)**
+- **CR math counting ckUSDC/ckUSDT reserves** (separate PR, fixes pre-existing stable-repay bug simultaneously)
+- Treasury split (liquidation bonus -> treasury canister)
+- Multi-collateral bot support
+- Analytics canister puller
+- Alerting/notification system for stuck claims
+- Any change to `bot_claim_liquidation` / `bot_confirm_liquidation` / `bot_cancel_liquidation` / `compute_partial_liquidation_cap`
+- Any change to icUSD ledger supply handling
+
+---
+
+## File Structure
+
+### Files created
+
+- `src/liquidation_bot/src/memory.rs` -- `MemoryManager` setup, `MemoryId` allocation, helpers for legacy-blob rescue
+- `src/liquidation_bot/src/history.rs` -- `LiquidationRecordVersioned`, `LiquidationRecordV1`, `LiquidationStatus`, stable-map accessors, record-writer helpers
+- `src/liquidation_bot/src/icpswap.rs` -- ICPSwap `depositFromAndSwap` + `quote` + `metadata` candid types and call wrappers (ported from `rumi-arb-bot/src/arb_bot/src/swaps.rs`)
+- `src/test_icpswap_stub/` -- tiny stub pool canister used only in pocket_ic tests
+- `docs/liquidation-bot-icpswap-migration.md` -- mainnet rollout runbook
+
+### Files modified
+
+- `src/liquidation_bot/src/state.rs` -- remove `three_pool_principal`, `kong_swap_principal`, `ckusdt_ledger`, `icusd_ledger` from `BotConfig`; add `icpswap_pool: Principal`, `icpswap_zero_for_one: Option<bool>`, `icp_fee_e8s: Option<u64>`, `ckusdc_fee_e6: Option<u64>`. Keep `ckusdc_ledger`. Replace raw `stable64_write`/`stable64_read` with `StableCell` in dedicated `MemoryId`. Legacy `BotLiquidationEvent` and `BotStats` kept for deserialization compatibility during migration, then deprecated.
+- `src/liquidation_bot/src/swap.rs` -- delete entire KongSwap + 3pool implementation; replace with `swap_icp_for_ckusdc` (calls ICPSwap `depositFromAndSwap`), `quote_icp_for_ckusdc` (calls ICPSwap `quote` with 3-field `SwapArgs`), `approve_infinite` (one-time `u128::MAX` ICRC-2 approve), `return_collateral_to_backend` (preserved from current code).
+- `src/liquidation_bot/src/process.rs` -- rewrite `process_pending`: single swap hop, transfer ckUSDC directly to backend, confirm with retry (5x for confirm only, zero retries for transfer), write `LiquidationRecord` at every phase transition (including failures). Delete all KongSwap/3pool helpers.
+- `src/liquidation_bot/src/lib.rs` -- wire `memory`/`history`/`icpswap` modules, add query/admin endpoints, rewrite `init` / `pre_upgrade` / `post_upgrade` for the stable-memory migration. Delete test endpoints that reference KongSwap/3pool (`test_swap_pipeline`, `test_force_liquidate`, `test_force_partial_liquidate` or rewrite them for new flow).
+- `src/liquidation_bot/liquidation_bot.did` -- remove KongSwap/3pool fields from `BotConfig`, add ICPSwap pool + fee cache fields, add new history query + admin endpoints, add `LiquidationRecordV1` type.
+- `src/rumi_protocol_backend/src/main.rs` -- **delete** `bot_deposit_to_reserves` endpoint (~2069-2084). **Add** `admin_resolve_stuck_claim` endpoint.
+- `src/rumi_protocol_backend/src/state.rs` -- **delete** `bot_total_icusd_deposited_e8s` field; keep `serde(default)` on adjacent fields to stay deserialization-compatible.
+- `src/rumi_protocol_backend/rumi_protocol_backend.did` -- remove `bot_deposit_to_reserves`, add `admin_resolve_stuck_claim`.
+- `src/rumi_protocol_backend/tests/pocket_ic_tests.rs` -- new end-to-end test.
+- `src/rumi_protocol_backend/src/api/bot_stats.rs` (or inline in `main.rs:2088-2097`) -- remove `total_icusd_deposited_e8s` field from `BotStatsResponse`.
+- Frontend files referencing deleted symbols (audit + update):
+  - `src/vault_frontend/src/routes/docs/liquidation-bot/+page.svelte`
+  - `src/vault_frontend/src/routes/explorer/+page.svelte`
+  - `src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte`
+
+### Files deleted
+
+None. (Code is removed in place; `swap.rs` stays as a file.)
+
+---
+
+## Cargo dependency changes
+
+- `src/liquidation_bot/Cargo.toml` -- remove `futures = "0.3"` (no longer needed; was only used for parallel KongSwap quotes)
+- `ic-stable-structures = "0.6.5"` already present, no change needed.
+
+---
+
+## Task Breakdown
+
+### Task 0: Branch setup
+- [ ] Create branch `feat/liquidation-bot-icpswap-rework` from `main`
+
+**Commit:** `chore: create liquidation bot ICPSwap rework branch`
+
+---
+
+### Task 1: Safe stable-memory foundation with legacy-blob rescue
+
+This is the riskiest change and must come first. The current bot uses raw `stable64_write(0, ...)` with an 8-byte length prefix. `MemoryManager::init` will write its own header at offset 0, destroying the legacy blob. We must rescue the blob BEFORE initializing MemoryManager.
+
+**Create `src/liquidation_bot/src/memory.rs`:**
+
+```rust
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::{DefaultMemoryImpl, StableCell, StableBTreeMap};
+use std::cell::RefCell;
+
+pub type Mem = VirtualMemory<DefaultMemoryImpl>;
+
+pub const MEM_ID_CONFIG: MemoryId = MemoryId::new(0);
+pub const MEM_ID_HISTORY: MemoryId = MemoryId::new(1);
+pub const MEM_ID_NEXT_ID: MemoryId = MemoryId::new(2);
+
+thread_local! {
+    pub static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+pub fn get_memory(id: MemoryId) -> Mem {
+    MEMORY_MANAGER.with(|mm| mm.borrow().get(id))
+}
+```
+
+**Rescue flow in `post_upgrade` (in `lib.rs`):**
+
+```rust
+#[post_upgrade]
+fn post_upgrade() {
+    // STEP 1: Rescue legacy JSON blob BEFORE MemoryManager::init runs.
+    // The thread_local MEMORY_MANAGER hasn't been accessed yet at this point.
+    // Read raw stable memory directly.
+    let size = ic_cdk::api::stable::stable64_size();
+    let legacy_state: Option<BotState> = if size > 0 {
+        let mut len_bytes = [0u8; 8];
+        ic_cdk::api::stable::stable64_read(0, &mut len_bytes);
+        let len = u64::from_le_bytes(len_bytes) as usize;
+        if len > 0 && len < 10_000_000 {
+            let mut bytes = vec![0u8; len];
+            ic_cdk::api::stable::stable64_read(8, &mut bytes);
+            serde_json::from_slice(&bytes).ok()
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // STEP 2: Now initialize MemoryManager. On first migration, this writes a new
+    // header at offset 0 (which is fine -- we already rescued the data above).
+    // On subsequent upgrades, MemoryManager::init is a read-or-create operation:
+    // it detects the existing header and reads it, so this is safe and idempotent.
+    memory::init_memory_manager();
+
+    // STEP 3: Write rescued config into the new StableCell, init heap state.
+    if let Some(state) = legacy_state {
+        // Migrate legacy events to new history map
+        history::migrate_legacy_events(&state.liquidation_events);
+        state::init_state(state);
+    } else {
+        // Already migrated on a prior upgrade -- load config from StableCell
+        state::load_config_from_stable();
+    }
+
+    // STEP 4: Set a flag so subsequent pre_upgrade uses the new path.
+    state::mutate_state(|s| s.migrated_to_stable_structures = true);
+
+    setup_timer();
+}
+```
+
+**Key safety points:**
+- `MEMORY_MANAGER` thread_local is lazy. It only initializes when first accessed. We do raw `stable64_read` BEFORE any access to `MEMORY_MANAGER` or any `get_memory()` call.
+- We also add `memory::init_memory_manager()` as an explicit function that forces the thread_local to initialize (simply calls `MEMORY_MANAGER.with(|_| {})`).
+- The `len < 10_000_000` guard prevents reading garbage if stable memory is in an unexpected state.
+
+**Update `pre_upgrade`:**
+
+```rust
+#[pre_upgrade]
+fn pre_upgrade() {
+    let migrated = state::read_state(|s| s.migrated_to_stable_structures);
+    if migrated {
+        // New path: save config to StableCell (history is already in StableBTreeMap)
+        state::save_config_to_stable();
+    } else {
+        // Legacy path: first upgrade hasn't happened yet
+        state::save_to_stable_memory();
+    }
+}
+```
+
+- [ ] Create `src/liquidation_bot/src/memory.rs` with MemoryManager, MemoryId constants
+- [ ] Add `migrated_to_stable_structures: bool` field (with `#[serde(default)]`) to `BotState`
+- [ ] Implement rescue logic in `post_upgrade`
+- [ ] Implement dual-path `pre_upgrade`
+- [ ] Unit test: serialize a BotState to bytes, write to a mock stable memory buffer, verify rescue reads it back correctly
+
+**Commit:** `feat(bot): add stable-structures MemoryManager with legacy blob rescue`
+
+---
+
+### Task 2: Liquidation history type + stable map
+
+**Create `src/liquidation_bot/src/history.rs`:**
+
+```rust
+use candid::{CandidType, Deserialize};
+use ic_stable_structures::{StableBTreeMap, StableCell, Storable};
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+use crate::memory;
+
+#[derive(CandidType, Clone, Debug, Deserialize, serde::Serialize)]
+pub enum LiquidationStatus {
+    /// Swap succeeded, ckUSDC transferred, confirm succeeded. Done.
+    Completed,
+    /// Swap failed. ICP returned to backend, claim cancelled. No loss.
+    SwapFailed,
+    /// Swap succeeded but ckUSDC transfer to backend failed.
+    /// Bot is holding ckUSDC. Needs manual admin resolution.
+    TransferFailed,
+    /// Swap + transfer succeeded but confirm failed after retries.
+    /// ckUSDC is in backend but vault still shows old debt. Needs admin resolution.
+    ConfirmFailed,
+    /// Claim itself failed. Nothing happened.
+    ClaimFailed,
+    /// Was stuck (TransferFailed or ConfirmFailed), but admin manually resolved it.
+    AdminResolved,
+}
+
+#[derive(CandidType, Clone, Debug, Deserialize, serde::Serialize)]
+pub struct LiquidationRecordV1 {
+    pub id: u64,
+    pub vault_id: u64,
+    pub timestamp: u64,
+    pub status: LiquidationStatus,
+
+    // Amounts (all in native units for their token)
+    pub collateral_claimed_e8s: u64,   // ICP claimed from backend
+    pub debt_to_cover_e8s: u64,        // icUSD debt this claim covers
+    pub icp_swapped_e8s: u64,          // ICP sent to ICPSwap
+    pub ckusdc_received_e6: u64,       // ckUSDC received from swap
+    pub ckusdc_transferred_e6: u64,    // ckUSDC successfully sent to backend
+    pub icp_to_treasury_e8s: u64,      // Liquidation bonus sent to treasury
+
+    // Price data
+    pub oracle_price_e8s: u64,         // ICP/USD price from backend at claim time
+    pub effective_price_e8s: u64,      // Actual swap price achieved
+    pub slippage_bps: i32,             // Slippage in basis points
+
+    // Error info
+    pub error_message: Option<String>,
+    pub confirm_retry_count: u8,       // How many confirm retries were attempted
+}
+
+#[derive(CandidType, Clone, Debug, Deserialize, serde::Serialize)]
+pub enum LiquidationRecordVersioned {
+    V1(LiquidationRecordV1),
+}
+
+// Storable impl: serialize as candid bytes
+impl Storable for LiquidationRecordVersioned {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(candid::encode_one(self).expect("Failed to encode record"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("Failed to decode record")
+    }
+    const BOUND: ic_stable_structures::storable::Bound =
+        ic_stable_structures::storable::Bound::Unbounded;
+}
+
+thread_local! {
+    static HISTORY: RefCell<StableBTreeMap<u64, LiquidationRecordVersioned, memory::Mem>> =
+        RefCell::new(StableBTreeMap::init(memory::get_memory(memory::MEM_ID_HISTORY)));
+
+    static NEXT_ID: RefCell<StableCell<u64, memory::Mem>> =
+        RefCell::new(StableCell::init(
+            memory::get_memory(memory::MEM_ID_NEXT_ID),
+            0u64,
+        ).expect("Failed to init NEXT_ID cell"));
+}
+
+pub fn next_id() -> u64 {
+    NEXT_ID.with(|c| {
+        let id = *c.borrow().get();
+        c.borrow_mut().set(id + 1).expect("Failed to increment NEXT_ID");
+        id
+    })
+}
+
+pub fn insert_record(record: LiquidationRecordVersioned) {
+    let id = match &record {
+        LiquidationRecordVersioned::V1(r) => r.id,
+    };
+    HISTORY.with(|h| h.borrow_mut().insert(id, record));
+}
+
+pub fn get_record(id: u64) -> Option<LiquidationRecordVersioned> {
+    HISTORY.with(|h| h.borrow().get(&id))
+}
+
+pub fn get_records(offset: u64, limit: u64) -> Vec<LiquidationRecordVersioned> {
+    HISTORY.with(|h| {
+        let map = h.borrow();
+        let count = NEXT_ID.with(|c| *c.borrow().get());
+        if count == 0 || offset >= count { return vec![]; }
+        // Return most recent first
+        let start = count.saturating_sub(offset + limit);
+        let end = count.saturating_sub(offset);
+        (start..end).filter_map(|id| map.get(&id)).collect()
+    })
+}
+
+pub fn record_count() -> u64 {
+    NEXT_ID.with(|c| *c.borrow().get())
+}
+
+/// Returns all records with TransferFailed or ConfirmFailed status.
+pub fn get_stuck_records() -> Vec<LiquidationRecordVersioned> {
+    HISTORY.with(|h| {
+        let map = h.borrow();
+        let count = NEXT_ID.with(|c| *c.borrow().get());
+        (0..count).filter_map(|id| {
+            let record = map.get(&id)?;
+            match &record {
+                LiquidationRecordVersioned::V1(r) => match r.status {
+                    LiquidationStatus::TransferFailed | LiquidationStatus::ConfirmFailed => Some(record),
+                    _ => None,
+                },
+            }
+        }).collect()
+    })
+}
+
+/// Update a record's status (used by admin resolution).
+pub fn update_record_status(id: u64, new_status: LiquidationStatus) {
+    HISTORY.with(|h| {
+        let mut map = h.borrow_mut();
+        if let Some(mut record) = map.get(&id) {
+            match &mut record {
+                LiquidationRecordVersioned::V1(ref mut r) => {
+                    r.status = new_status;
+                }
+            }
+            map.insert(id, record);
+        }
+    });
+}
+
+/// Migrate legacy BotLiquidationEvent entries into the new stable map.
+/// Called once during the first post_upgrade after migration.
+pub fn migrate_legacy_events(events: &[crate::state::BotLiquidationEvent]) {
+    for event in events {
+        let id = next_id();
+        let status = if event.success {
+            LiquidationStatus::Completed
+        } else {
+            LiquidationStatus::SwapFailed
+        };
+        let record = LiquidationRecordV1 {
+            id,
+            vault_id: event.vault_id,
+            timestamp: event.timestamp,
+            status,
+            collateral_claimed_e8s: event.collateral_received_e8s,
+            debt_to_cover_e8s: event.debt_covered_e8s,
+            icp_swapped_e8s: 0, // not tracked in legacy
+            ckusdc_received_e6: 0, // legacy used icUSD, not ckUSDC
+            ckusdc_transferred_e6: 0,
+            icp_to_treasury_e8s: event.collateral_to_treasury_e8s,
+            oracle_price_e8s: event.effective_price_e8s,
+            effective_price_e8s: event.effective_price_e8s,
+            slippage_bps: event.slippage_bps,
+            error_message: event.error_message.clone(),
+            confirm_retry_count: 0,
+        };
+        insert_record(LiquidationRecordVersioned::V1(record));
+    }
+}
+```
+
+- [ ] Create `src/liquidation_bot/src/history.rs`
+- [ ] Implement `Storable` for `LiquidationRecordVersioned`
+- [ ] Implement `migrate_legacy_events`
+- [ ] Implement query helpers: `next_id`, `insert_record`, `get_record`, `get_records`, `record_count`, `get_stuck_records`, `update_record_status`
+
+**Commit:** `feat(bot): add LiquidationRecordV1 history type with stable map`
+
+---
+
+### Task 3: ICPSwap integration module
+
+**Create `src/liquidation_bot/src/icpswap.rs`:**
+
+Port from `rumi-arb-bot/src/arb_bot/src/swaps.rs`. Key difference from plan v2: `quote` and `depositFromAndSwap` use DIFFERENT arg types.
+
+```rust
+use candid::{CandidType, Deserialize, Nat, Principal};
+
+// -- ICPSwap Types --
+
+/// Args for `depositFromAndSwap` (5 fields)
+#[derive(CandidType, Clone, Debug)]
+pub struct DepositAndSwapArgs {
+    #[serde(rename = "amountIn")]
+    pub amount_in: String,
+    #[serde(rename = "amountOutMinimum")]
+    pub amount_out_minimum: String,
+    #[serde(rename = "zeroForOne")]
+    pub zero_for_one: bool,
+    #[serde(rename = "tokenInFee")]
+    pub token_in_fee: Nat,
+    #[serde(rename = "tokenOutFee")]
+    pub token_out_fee: Nat,
+}
+
+/// Args for `quote` (3 fields -- different from DepositAndSwapArgs!)
+#[derive(CandidType, Clone, Debug)]
+pub struct SwapArgs {
+    #[serde(rename = "amountIn")]
+    pub amount_in: String,
+    #[serde(rename = "amountOutMinimum")]
+    pub amount_out_minimum: String,
+    #[serde(rename = "zeroForOne")]
+    pub zero_for_one: bool,
+}
+
+/// ICPSwap error variant
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum IcpSwapError {
+    CommonError,
+    InsufficientFunds,
+    InternalError(String),
+    UnsupportedToken(String),
+}
+
+/// Result from quote and depositFromAndSwap
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum IcpSwapResult {
+    #[serde(rename = "ok")]
+    Ok(Nat),
+    #[serde(rename = "err")]
+    Err(IcpSwapError),
+}
+
+impl std::fmt::Display for IcpSwapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IcpSwapError::CommonError => write!(f, "CommonError"),
+            IcpSwapError::InsufficientFunds => write!(f, "InsufficientFunds"),
+            IcpSwapError::InternalError(s) => write!(f, "InternalError: {}", s),
+            IcpSwapError::UnsupportedToken(s) => write!(f, "UnsupportedToken: {}", s),
+        }
+    }
+}
+
+// -- Pool metadata (used to determine token ordering) --
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct Token {
+    pub address: String,
+    pub standard: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct PoolMetadata {
+    pub fee: Nat,
+    pub key: String,
+    pub liquidity: Nat,
+    #[serde(rename = "maxLiquidityPerTick")]
+    pub max_liquidity_per_tick: Nat,
+    #[serde(rename = "nextPositionId")]
+    pub next_position_id: Nat,
+    #[serde(rename = "sqrtPriceX96")]
+    pub sqrt_price_x96: Nat,
+    pub tick: candid::Int,
+    pub token0: Token,
+    pub token1: Token,
+}
+
+/// metadata() returns Result_6 = variant { ok: PoolMetadata; err: Error }
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum MetadataResult {
+    #[serde(rename = "ok")]
+    Ok(PoolMetadata),
+    #[serde(rename = "err")]
+    Err(IcpSwapError),
+}
+
+// -- Call wrappers --
+
+/// Query a swap quote. Uses 3-field SwapArgs (NOT DepositAndSwapArgs).
+pub async fn quote(
+    pool: Principal,
+    amount_in: u64,
+    zero_for_one: bool,
+) -> Result<u64, String> {
+    let args = SwapArgs {
+        amount_in: amount_in.to_string(),
+        amount_out_minimum: "0".to_string(),
+        zero_for_one,
+    };
+
+    let result: Result<(IcpSwapResult,), _> =
+        ic_cdk::call(pool, "quote", (args,)).await;
+
+    match result {
+        Ok((IcpSwapResult::Ok(n),)) => {
+            Ok(n.0.to_string().parse::<u64>().unwrap_or(0))
+        }
+        Ok((IcpSwapResult::Err(e),)) => Err(format!("ICPSwap quote error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap quote call failed ({:?}): {}", code, msg)),
+    }
+}
+
+/// Execute a swap via depositFromAndSwap. Uses 5-field DepositAndSwapArgs.
+/// Requires prior ICRC-2 approval from the bot to the pool for the input token.
+pub async fn deposit_and_swap(
+    pool: Principal,
+    amount_in: u64,
+    min_amount_out: u64,
+    zero_for_one: bool,
+    token_in_fee: u64,
+    token_out_fee: u64,
+) -> Result<u64, String> {
+    let args = DepositAndSwapArgs {
+        amount_in: amount_in.to_string(),
+        amount_out_minimum: min_amount_out.to_string(),
+        zero_for_one,
+        token_in_fee: Nat::from(token_in_fee),
+        token_out_fee: Nat::from(token_out_fee),
+    };
+
+    let result: Result<(IcpSwapResult,), _> =
+        ic_cdk::call(pool, "depositFromAndSwap", (args,)).await;
+
+    match result {
+        Ok((IcpSwapResult::Ok(n),)) => {
+            Ok(n.0.to_string().parse::<u64>().unwrap_or(0))
+        }
+        Ok((IcpSwapResult::Err(e),)) => Err(format!("ICPSwap swap error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap swap call failed ({:?}): {}", code, msg)),
+    }
+}
+
+/// Fetch pool metadata to determine token ordering (which token is token0).
+pub async fn fetch_metadata(pool: Principal) -> Result<PoolMetadata, String> {
+    let result: Result<(MetadataResult,), _> =
+        ic_cdk::call(pool, "metadata", ()).await;
+
+    match result {
+        Ok((MetadataResult::Ok(m),)) => Ok(m),
+        Ok((MetadataResult::Err(e),)) => Err(format!("ICPSwap metadata error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap metadata call failed ({:?}): {}", code, msg)),
+    }
+}
+```
+
+- [ ] Create `src/liquidation_bot/src/icpswap.rs` with correct types for both `quote` (3-field) and `depositFromAndSwap` (5-field)
+- [ ] Implement `quote`, `deposit_and_swap`, `fetch_metadata` call wrappers
+- [ ] Define all ICPSwap candid types with correct `serde(rename)` for camelCase
+
+**Commit:** `feat(bot): add ICPSwap integration module with correct quote/swap types`
+
+---
+
+### Task 4: Swap module rewrite
+
+**Rewrite `src/liquidation_bot/src/swap.rs`:**
+
+Delete all KongSwap and 3pool code. Replace with:
+
+```rust
+use candid::{Nat, Principal};
+use ic_canister_log::log;
+use icrc_ledger_types::icrc1::account::Account;
+use icrc_ledger_types::icrc2::approve::ApproveArgs;
+
+use crate::icpswap;
+use crate::state::BotConfig;
+
+pub struct SwapResult {
+    pub ckusdc_received_e6: u64,
+    pub effective_price_e8s: u64,
+}
+
+/// One-time infinite ICRC-2 approve: bot approves the ICPSwap pool to spend ICP.
+/// Amount = u128::MAX, no expiry. Only needs to be called once per (token, spender) pair.
+pub async fn approve_infinite(
+    token_ledger: Principal,
+    spender: Principal,
+) -> Result<(), String> {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: Account { owner: spender, subaccount: None },
+        amount: Nat::from(u128::MAX),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+
+    let result: Result<(Result<Nat, icrc_ledger_types::icrc2::approve::ApproveError>,), _> =
+        ic_cdk::call(token_ledger, "icrc2_approve", (args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => Ok(()),
+        Ok((Err(e),)) => Err(format!("Approve failed: {:?}", e)),
+        Err((code, msg)) => Err(format!("Approve call failed: {:?} {}", code, msg)),
+    }
+}
+
+/// Quote how much ckUSDC we'd get for `icp_amount_e8s` ICP.
+pub async fn quote_icp_for_ckusdc(config: &BotConfig, icp_amount_e8s: u64) -> Result<u64, String> {
+    let zero_for_one = config.icpswap_zero_for_one
+        .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;
+
+    icpswap::quote(config.icpswap_pool, icp_amount_e8s, zero_for_one).await
+}
+
+/// Swap ICP for ckUSDC on ICPSwap. Returns ckUSDC received (e6 native units).
+///
+/// Flow: get quote -> apply slippage -> call depositFromAndSwap.
+/// Requires infinite approve to already be in place.
+pub async fn swap_icp_for_ckusdc(
+    config: &BotConfig,
+    icp_amount_e8s: u64,
+) -> Result<SwapResult, String> {
+    let zero_for_one = config.icpswap_zero_for_one
+        .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;
+
+    // Get quote
+    let quoted_output = icpswap::quote(
+        config.icpswap_pool,
+        icp_amount_e8s,
+        zero_for_one,
+    ).await?;
+
+    if quoted_output == 0 {
+        return Err("Quote returned zero output".to_string());
+    }
+
+    // Apply slippage tolerance
+    let min_output = apply_slippage(quoted_output, config.max_slippage_bps);
+
+    log!(crate::INFO, "ICPSwap quote: {} ICP e8s -> {} ckUSDC e6 (min: {})",
+        icp_amount_e8s, quoted_output, min_output);
+
+    // ICP fee = 10_000 e8s, ckUSDC fee = 10 e6 (configurable via cached fields)
+    let icp_fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let ckusdc_fee = config.ckusdc_fee_e6.unwrap_or(10);
+
+    // Execute swap
+    let received = icpswap::deposit_and_swap(
+        config.icpswap_pool,
+        icp_amount_e8s,
+        min_output,
+        zero_for_one,
+        icp_fee,
+        ckusdc_fee,
+    ).await?;
+
+    // Calculate effective price: (ckusdc_e6 * 100) / icp_e8s * 1e8
+    // = ckusdc_e6 * 10_000_000_000 / icp_e8s
+    // This gives price in e8 format (matching oracle price format)
+    let effective_price_e8s = if icp_amount_e8s > 0 {
+        (received as u128 * 10_000_000_000 / icp_amount_e8s as u128) as u64
+    } else {
+        0
+    };
+
+    log!(crate::INFO, "ICPSwap swap complete: {} ckUSDC e6 received, effective price {} e8s",
+        received, effective_price_e8s);
+
+    Ok(SwapResult {
+        ckusdc_received_e6: received,
+        effective_price_e8s,
+    })
+}
+
+/// Apply slippage tolerance: reduce expected output by max_slippage_bps basis points.
+fn apply_slippage(amount: u64, max_slippage_bps: u16) -> u64 {
+    let reduction = amount as u128 * max_slippage_bps as u128 / 10_000;
+    (amount as u128 - reduction) as u64
+}
+
+/// Transfer collateral (ICP) back to the backend canister.
+/// Used when swap fails and we need to return the claimed ICP.
+pub async fn return_collateral_to_backend(
+    config: &BotConfig,
+    amount_e8s: u64,
+    collateral_ledger: Principal,
+) -> Result<(), String> {
+    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let send_amount = amount_e8s.saturating_sub(fee);
+    if send_amount == 0 {
+        return Err("Collateral amount too small to cover transfer fee".to_string());
+    }
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account {
+            owner: config.backend_principal,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()), // dedup protection
+    };
+
+    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
+        ic_cdk::call(collateral_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => Ok(()),
+        Ok((Err(e),)) => Err(format!("Transfer error: {:?}", e)),
+        Err((code, msg)) => Err(format!("Transfer call failed: {:?} {}", code, msg)),
+    }
+}
+
+/// Transfer ckUSDC from bot to backend canister.
+/// This is a direct icrc1_transfer (bot sends from its own account, no approve needed).
+/// Returns the actual amount received by the backend (after fee subtraction).
+pub async fn transfer_ckusdc_to_backend(
+    config: &BotConfig,
+    amount_e6: u64,
+) -> Result<u64, String> {
+    let fee = config.ckusdc_fee_e6.unwrap_or(10);
+    let send_amount = amount_e6.saturating_sub(fee);
+    if send_amount == 0 {
+        return Err("ckUSDC amount too small to cover transfer fee".to_string());
+    }
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account {
+            owner: config.backend_principal,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()), // dedup protection
+    };
+
+    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
+        ic_cdk::call(config.ckusdc_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => Ok(send_amount),
+        Ok((Err(e),)) => Err(format!("ckUSDC transfer error: {:?}", e)),
+        Err((code, msg)) => Err(format!("ckUSDC transfer call failed: {:?} {}", code, msg)),
+    }
+}
+
+/// Transfer ICP to treasury (liquidation bonus).
+pub async fn transfer_icp_to_treasury(
+    config: &BotConfig,
+    amount_e8s: u64,
+) -> Result<(), String> {
+    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let send_amount = amount_e8s.saturating_sub(fee);
+    if send_amount == 0 {
+        return Ok(()); // dust amount, skip
+    }
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account {
+            owner: config.treasury_principal,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()), // dedup protection
+    };
+
+    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
+        ic_cdk::call(config.icp_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => {
+            log!(crate::INFO, "Transferred {} e8s ICP to treasury", send_amount);
+            Ok(())
+        }
+        Ok((Err(e),)) => Err(format!("ICP transfer to treasury failed: {:?}", e)),
+        Err((code, msg)) => Err(format!("ICP transfer call failed: {:?} {}", code, msg)),
+    }
+}
+```
+
+- [ ] Delete all KongSwap types and functions
+- [ ] Delete all 3pool types and functions
+- [ ] Implement `approve_infinite`, `quote_icp_for_ckusdc`, `swap_icp_for_ckusdc`
+- [ ] Implement `transfer_ckusdc_to_backend` (new: bot sends ckUSDC directly to backend, returns actual amount after fee)
+- [ ] Keep `return_collateral_to_backend` (adapted to use cached fee)
+- [ ] Keep `transfer_icp_to_treasury` (adapted)
+- [ ] Delete `swap_icp_for_stable` and `swap_stable_for_icusd`
+
+**Commit:** `feat(bot): rewrite swap module for ICPSwap single-hop ICP->ckUSDC`
+
+---
+
+### Task 5: Update BotConfig + state management
+
+**Modify `src/liquidation_bot/src/state.rs`:**
+
+```rust
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct BotConfig {
+    pub backend_principal: Principal,
+    pub treasury_principal: Principal,
+    pub admin: Principal,
+    pub max_slippage_bps: u16,
+    pub icp_ledger: Principal,
+    pub ckusdc_ledger: Principal,
+
+    // ICPSwap config (replaces kong_swap + three_pool)
+    pub icpswap_pool: Principal,
+
+    // Cached after admin_resolve_pool_ordering (determines swap direction)
+    #[serde(default)]
+    pub icpswap_zero_for_one: Option<bool>,
+
+    // Cached ledger fees (set by admin or auto-detected)
+    #[serde(default)]
+    pub icp_fee_e8s: Option<u64>,
+    #[serde(default)]
+    pub ckusdc_fee_e6: Option<u64>,
+
+    // Legacy fields kept for deserialization compatibility (ignored)
+    #[serde(default)]
+    pub three_pool_principal: Option<Principal>,
+    #[serde(default)]
+    pub kong_swap_principal: Option<Principal>,
+    #[serde(default)]
+    pub ckusdt_ledger: Option<Principal>,
+    #[serde(default)]
+    pub icusd_ledger: Option<Principal>,
+}
+```
+
+Note: Legacy fields use `Option` with `#[serde(default)]` so that both old-format (required fields) and new-format (absent fields) configs deserialize correctly. After one upgrade cycle, these can be removed.
+
+**Update save/load to use dedicated `VirtualMemory` region:**
+
+Replace raw `stable64_write`/`stable64_read` with a length-prefixed JSON write to `memory::get_memory(MEM_ID_CONFIG)`. Note: `StableCell` requires `Bound::Bounded` which doesn't work for variable-size JSON. Instead, write directly to the `VirtualMemory` with an 8-byte length prefix (same pattern as the legacy code, but scoped to a virtual memory region instead of raw offset 0). The `save_to_stable_memory` and `load_from_stable_memory` functions remain for the legacy path (first upgrade only).
+
+- [ ] Update `BotConfig` struct: remove required KongSwap/3pool fields, add ICPSwap fields, keep legacy as `Option` with `serde(default)`
+- [ ] Add `save_config_to_stable` and `load_config_from_stable` using StableCell
+- [ ] Keep legacy `save_to_stable_memory` and `load_from_stable_memory` for pre-migration path
+- [ ] Update `BotStats`: rename `total_icusd_burned_e8s` to `total_ckusdc_deposited_e6`, keep `serde(alias)` for backward compat
+
+**Commit:** `feat(bot): update BotConfig for ICPSwap, add StableCell config storage`
+
+---
+
+### Task 6: Backend cleanup -- delete dead code, add admin_resolve_stuck_claim
+
+**Modify `src/rumi_protocol_backend/src/main.rs`:**
+
+1. **Delete** `bot_deposit_to_reserves` endpoint (lines ~2069-2084)
+2. **Delete** `bot_total_icusd_deposited_e8s` from state.rs
+3. **Remove** `total_icusd_deposited_e8s` from `BotStatsResponse` and `get_bot_stats`
+4. **Add** `admin_resolve_stuck_claim` endpoint:
+
+```rust
+/// Admin-only: force-resolve a stuck bot claim. Used when the bot's ckUSDC transfer
+/// or confirm failed and the vault is stuck with bot_processing=true.
+///
+/// - `apply_debt_reduction = false`: TransferFailed case. ckUSDC never reached the backend,
+///   so vault debt stays as-is. Just unlocks vault and restores budget.
+/// - `apply_debt_reduction = true`: ConfirmFailed case. ckUSDC DID reach the backend,
+///   so also write down the vault's debt and collateral (same as what confirm would do).
+///
+/// The admin should ALWAYS try `admin_retry_stuck_claim` on the bot first.
+/// Use this only as a last resort after manually verifying fund positions.
+#[candid_method(update)]
+#[update]
+fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_dev = read_state(|s| s.developer_principal == Some(caller));
+    if !is_dev {
+        return Err(ProtocolError::GenericError("Unauthorized: developer only".to_string()));
+    }
+
+    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned())
+        .ok_or_else(|| ProtocolError::GenericError(format!(
+            "No active claim for vault #{}", vault_id
+        )))?;
+
+    mutate_state(|s| {
+        if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
+            if apply_debt_reduction {
+                // ConfirmFailed: ckUSDC reached backend, write down debt like confirm would
+                vault.borrowed_icusd_amount -= ICUSD::new(claim.debt_amount);
+                vault.collateral_amount = vault.collateral_amount.saturating_sub(claim.collateral_amount);
+                s.bot_total_debt_covered_e8s += claim.debt_amount;
+            }
+            vault.bot_processing = false;
+        }
+        if !apply_debt_reduction {
+            // TransferFailed: ckUSDC never arrived, restore budget
+            s.bot_budget_remaining_e8s += claim.debt_amount;
+        }
+        s.bot_claims.remove(&vault_id);
+    });
+
+    log!(INFO, "[admin_resolve_stuck_claim] Resolved stuck claim for vault #{}: debt={}, collateral={}, debt_reduced={}",
+        vault_id, claim.debt_amount, claim.collateral_amount, apply_debt_reduction);
+
+    Ok(())
+}
+```
+
+- [ ] Delete `bot_deposit_to_reserves` endpoint
+- [ ] Delete `bot_total_icusd_deposited_e8s` from state (with `serde(default)` for compat)
+- [ ] Remove `total_icusd_deposited_e8s` from `BotStatsResponse`
+- [ ] Add `admin_resolve_stuck_claim` endpoint (developer-only)
+- [ ] Update `rumi_protocol_backend.did`
+
+**Commit:** `feat(backend): delete bot_deposit_to_reserves, add admin_resolve_stuck_claim`
+
+---
+
+### Task 7: Rewrite process.rs -- single-hop flow with failure recovery
+
+**Rewrite `src/liquidation_bot/src/process.rs`:**
+
+The new flow:
+
+```
+claim -> swap ICP->ckUSDC -> transfer ckUSDC to backend -> confirm (with retry) -> treasury
+```
+
+Failure recovery:
+- **Swap fails:** return ICP, cancel claim. Record `SwapFailed`.
+- **Transfer fails:** Do NOT retry. Do NOT cancel (ICP is already gone, swapped to ckUSDC). Record `TransferFailed`. Log loudly. Admin resolves later.
+- **Confirm fails:** Retry up to 5 times immediately. If all fail, record `ConfirmFailed`. Log loudly. Admin resolves later.
+
+```rust
+use crate::{history, state, swap};
+use crate::history::{LiquidationRecordV1, LiquidationRecordVersioned, LiquidationStatus};
+// ... (BackendResult, BackendError, BotLiquidationResult types stay the same)
+
+const CONFIRM_ATTEMPTS: u8 = 5;
+
+pub async fn process_pending() {
+    let vault = state::mutate_state(|s| s.pending_vaults.pop());
+    let Some(vault) = vault else { return };
+
+    let config = match state::read_state(|s| s.config.clone()) {
+        Some(c) => c,
+        None => {
+            log!(crate::INFO, "Bot not configured, skipping vault #{}", vault.vault_id);
+            return;
+        }
+    };
+
+    log!(crate::INFO, "Processing vault #{}", vault.vault_id);
+    let record_id = history::next_id();
+    let timestamp = ic_cdk::api::time();
+
+    // -- Phase 1: CLAIM --
+    let liq_result = call_bot_claim_liquidation(&config, vault.vault_id).await;
+    let (collateral_amount, debt_covered, collateral_price) = match liq_result {
+        Ok(r) => (r.collateral_amount, r.debt_covered, r.collateral_price_e8s),
+        Err(e) => {
+            log!(crate::INFO, "Claim failed for vault #{}: {}", vault.vault_id, e);
+            write_record(record_id, vault.vault_id, timestamp, LiquidationStatus::ClaimFailed,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, Some(e), 0);
+            return;
+        }
+    };
+
+    // -- Phase 2: SWAP ICP -> ckUSDC --
+    let swap_amount = calculate_swap_amount(collateral_amount, debt_covered, collateral_price);
+    let swap_result = swap::swap_icp_for_ckusdc(&config, swap_amount).await;
+
+    let (ckusdc_received, effective_price) = match swap_result {
+        Ok(r) => (r.ckusdc_received_e6, r.effective_price_e8s),
+        Err(e) => {
+            log!(crate::INFO, "Swap failed for vault #{}: {}. Returning ICP.", vault.vault_id, e);
+            // Return ICP and cancel -- clean recovery
+            let _ = swap::return_collateral_to_backend(&config, collateral_amount, config.icp_ledger).await;
+            let _ = call_bot_cancel_liquidation(&config, vault.vault_id).await;
+            write_record(record_id, vault.vault_id, timestamp, LiquidationStatus::SwapFailed,
+                collateral_amount, debt_covered, swap_amount, 0, 0, 0,
+                collateral_price, 0, 0, Some(e), 0);
+            return;
+        }
+    };
+
+    let slippage_bps = calculate_slippage(effective_price, collateral_price);
+
+    // -- Phase 3: TRANSFER ckUSDC to backend --
+    // NO RETRY on transfer. If it fails, mark stuck immediately.
+    // Returns actual amount received by backend (after fee subtraction).
+    let transfer_result = swap::transfer_ckusdc_to_backend(&config, ckusdc_received).await;
+
+    let ckusdc_transferred = match transfer_result {
+        Ok(actual_sent) => actual_sent,
+        Err(e) => {
+            log!(crate::INFO,
+                "STUCK: ckUSDC transfer failed for vault #{}. Bot holding {} ckUSDC e6. Error: {}. Needs admin resolution.",
+                vault.vault_id, ckusdc_received, e);
+            write_record(record_id, vault.vault_id, timestamp, LiquidationStatus::TransferFailed,
+                collateral_amount, debt_covered, swap_amount, ckusdc_received, 0, 0,
+                collateral_price, effective_price, slippage_bps, Some(e), 0);
+            return;
+        }
+    };
+
+    // -- Phase 4: CONFIRM (with retry -- this is idempotent) --
+    let mut confirm_ok = false;
+    let mut confirm_retries: u8 = 0;
+    let mut last_confirm_err = String::new();
+
+    for attempt in 0..CONFIRM_ATTEMPTS {
+        match call_bot_confirm_liquidation(&config, vault.vault_id).await {
+            Ok(()) => {
+                confirm_ok = true;
+                confirm_retries = attempt;
+                break;
+            }
+            Err(e) => {
+                last_confirm_err = e;
+                confirm_retries = attempt;
+                if attempt + 1 < CONFIRM_ATTEMPTS {
+                    log!(crate::INFO, "Confirm attempt {}/{} failed for vault #{}: {}. Retrying.",
+                        attempt + 1, CONFIRM_ATTEMPTS, vault.vault_id, last_confirm_err);
+                }
+            }
+        }
+    }
+
+    if !confirm_ok {
+        log!(crate::INFO,
+            "STUCK: Confirm failed after {} attempts for vault #{}. ckUSDC is in backend but debt not written down. Error: {}. Needs admin resolution.",
+            CONFIRM_ATTEMPTS, vault.vault_id, last_confirm_err);
+        write_record(record_id, vault.vault_id, timestamp, LiquidationStatus::ConfirmFailed,
+            collateral_amount, debt_covered, swap_amount, ckusdc_received, ckusdc_transferred, 0,
+            collateral_price, effective_price, slippage_bps, Some(last_confirm_err), confirm_retries);
+        return;
+    }
+
+    // -- Phase 5: TREASURY (liquidation bonus) --
+    let icp_to_treasury = collateral_amount.saturating_sub(swap_amount);
+    if icp_to_treasury > 0 {
+        let _ = swap::transfer_icp_to_treasury(&config, icp_to_treasury).await;
+    }
+
+    // -- Phase 6: SUCCESS --
+    log!(crate::INFO, "Vault #{} liquidated: debt={} e8s, ckUSDC={} e6, treasury={} e8s ICP",
+        vault.vault_id, debt_covered, ckusdc_received, icp_to_treasury);
+
+    write_record(record_id, vault.vault_id, timestamp, LiquidationStatus::Completed,
+        collateral_amount, debt_covered, swap_amount, ckusdc_received, ckusdc_transferred,
+        icp_to_treasury, collateral_price, effective_price, slippage_bps, None, confirm_retries);
+
+    // Update legacy stats (for backward compat with existing explorer UI)
+    state::mutate_state(|s| {
+        s.stats.total_debt_covered_e8s += debt_covered;
+        s.stats.total_collateral_received_e8s += collateral_amount;
+        s.stats.total_collateral_to_treasury_e8s += icp_to_treasury;
+        s.stats.events_count += 1;
+    });
+}
+```
+
+**Note on confirm retries:** On the IC, you cannot `await` a sleep inside a single update call. The retries happen back-to-back with no delay. This is sufficient for transient network errors. If the issue is sustained (e.g., backend canister is stopped), no amount of delay within one call will help. Timer-based delayed retries can be added in a follow-up if needed.
+
+- [ ] Rewrite `process_pending` with the 6-phase flow
+- [ ] Implement no-retry for transfer, immediate-retry (5x) for confirm
+- [ ] Write `LiquidationRecord` at every phase transition
+- [ ] Delete all KongSwap/3pool helpers (`call_bot_deposit_to_reserves`, `swap_stable_for_icusd` references)
+- [ ] Keep `call_bot_claim_liquidation`, `call_bot_confirm_liquidation`, `call_bot_cancel_liquidation` (unchanged)
+- [ ] Keep `calculate_swap_amount` and `calculate_slippage` helpers
+- [ ] Delete public test wrappers: `call_bot_deposit_to_reserves_pub`, update remaining pub wrappers
+- [ ] Add `write_record` helper function
+
+**Commit:** `feat(bot): rewrite process.rs for single-hop ICPSwap with failure recovery`
+
+---
+
+### Task 8: Bot query + admin endpoints
+
+**Modify `src/liquidation_bot/src/lib.rs`:**
+
+Add new endpoints, update/delete old test endpoints.
+
+```rust
+// -- History query endpoints --
+
+#[query]
+fn get_liquidation(id: u64) -> Option<history::LiquidationRecordVersioned> {
+    history::get_record(id)
+}
+
+#[query]
+fn get_liquidations(offset: u64, limit: u64) -> Vec<history::LiquidationRecordVersioned> {
+    history::get_records(offset, limit)
+}
+
+#[query]
+fn get_liquidation_count() -> u64 {
+    history::record_count()
+}
+
+/// Returns all records with TransferFailed or ConfirmFailed status.
+/// Makes it easy for admin to see what needs manual resolution.
+#[query]
+fn get_stuck_liquidations() -> Vec<history::LiquidationRecordVersioned> {
+    history::get_stuck_records()
+}
+
+// -- Admin endpoints --
+
+/// One-time: fetch pool metadata to determine if ICP is token0 or token1.
+/// Sets `icpswap_zero_for_one` in config.
+#[update]
+async fn admin_resolve_pool_ordering() {
+    require_admin();
+    let pool = state::read_state(|s| s.config.as_ref().unwrap().icpswap_pool);
+    let icp_ledger = state::read_state(|s| s.config.as_ref().unwrap().icp_ledger);
+
+    let metadata = icpswap::fetch_metadata(pool).await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Failed to fetch metadata: {}", e)));
+
+    let icp_text = icp_ledger.to_text();
+    let zero_for_one = metadata.token0.address == icp_text;
+
+    state::mutate_state(|s| {
+        if let Some(ref mut config) = s.config {
+            config.icpswap_zero_for_one = Some(zero_for_one);
+        }
+    });
+
+    log!(INFO, "Pool ordering resolved: ICP is token{}, zeroForOne={}",
+        if zero_for_one { "0" } else { "1" }, zero_for_one);
+}
+
+/// One-time: set up infinite ICRC-2 approve for ICP to the ICPSwap pool.
+#[update]
+async fn admin_approve_pool() {
+    require_admin();
+    let (icp_ledger, pool) = state::read_state(|s| {
+        let c = s.config.as_ref().unwrap();
+        (c.icp_ledger, c.icpswap_pool)
+    });
+
+    swap::approve_infinite(icp_ledger, pool).await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Approve failed: {}", e)));
+
+    log!(INFO, "Infinite approve set: ICP ledger {} -> pool {}", icp_ledger, pool);
+}
+
+/// Emergency: transfer all bot ckUSDC to a target principal and mark the
+/// associated stuck liquidation record as AdminResolved.
+/// Used to recover stuck ckUSDC after a TransferFailed event.
+#[update]
+async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
+    require_admin();
+    let ckusdc_ledger = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_ledger);
+
+    // Query bot's ckUSDC balance
+    let balance_result: Result<(Nat,), _> =
+        ic_cdk::call(ckusdc_ledger, "icrc1_balance_of", (Account {
+            owner: ic_cdk::id(),
+            subaccount: None,
+        },)).await;
+
+    let balance = match balance_result {
+        Ok((b,)) => {
+            let val = b.0.to_string().parse::<u64>().unwrap_or(0);
+            if val == 0 {
+                ic_cdk::trap("Bot has zero ckUSDC balance");
+            }
+            val
+        }
+        Err((code, msg)) => ic_cdk::trap(&format!("Balance query failed: {:?} {}", code, msg)),
+    };
+
+    let fee = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_fee_e6.unwrap_or(10));
+    let send_amount = balance.saturating_sub(fee);
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account { owner: target, subaccount: None },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()), // dedup protection
+    };
+
+    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
+        ic_cdk::call(ckusdc_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(block),)) => {
+            log!(INFO, "Swept {} ckUSDC e6 to {}, block {}", send_amount, target, block);
+            // If a record_id was provided, update its status to AdminResolved
+            if let Some(id) = record_id {
+                history::update_record_status(id, history::LiquidationStatus::AdminResolved);
+                log!(INFO, "Marked record #{} as AdminResolved", id);
+            }
+        }
+        Ok((Err(e),)) => ic_cdk::trap(&format!("Sweep transfer failed: {:?}", e)),
+        Err((code, msg)) => ic_cdk::trap(&format!("Sweep call failed: {:?} {}", code, msg)),
+    }
+}
+
+/// Retry confirm for a stuck claim (after TransferFailed where ckUSDC was
+/// manually swept to the backend, or after a transient ConfirmFailed).
+#[update]
+async fn admin_retry_stuck_claim(vault_id: u64) {
+    require_admin();
+    let config = state::read_state(|s| s.config.clone()).expect("Not configured");
+
+    match process::call_bot_confirm_liquidation_pub(&config, vault_id).await {
+        Ok(()) => {
+            log!(INFO, "admin_retry_stuck_claim: confirmed vault #{}", vault_id);
+        }
+        Err(e) => {
+            ic_cdk::trap(&format!("Confirm still failing for vault #{}: {}", vault_id, e));
+        }
+    }
+}
+```
+
+**Delete or rewrite test endpoints:**
+- `test_swap_pipeline` -- delete (references KongSwap + 3pool)
+- `test_force_liquidate` -- rewrite to use new single-hop flow (or delete if admin_retry + manual testing is sufficient)
+- `test_force_partial_liquidate` -- same treatment
+
+- [ ] Add `get_liquidation`, `get_liquidations`, `get_liquidation_count`, `get_stuck_liquidations` query endpoints
+- [ ] Add `admin_resolve_pool_ordering`, `admin_approve_pool`, `admin_sweep_ckusdc`, `admin_retry_stuck_claim` admin endpoints
+- [ ] Delete or rewrite `test_swap_pipeline`, `test_force_liquidate`, `test_force_partial_liquidate`
+- [ ] Wire `mod memory; mod history; mod icpswap;` in lib.rs
+
+**Commit:** `feat(bot): add history queries + admin endpoints for ICPSwap and stuck claims`
+
+---
+
+### Task 9: Candid updates + declaration regeneration
+
+- [ ] Update `src/liquidation_bot/liquidation_bot.did`:
+  - Remove `three_pool_principal`, `kong_swap_principal`, `ckusdt_ledger`, `icusd_ledger` from BotConfig
+  - Add `icpswap_pool`, `icpswap_zero_for_one`, `icp_fee_e8s`, `ckusdc_fee_e6`
+  - Add `LiquidationRecordV1`, `LiquidationStatus`, `LiquidationRecordVersioned` types
+  - Add `get_liquidation`, `get_liquidations`, `get_liquidation_count`, `get_stuck_liquidations` query methods
+  - Add `admin_resolve_pool_ordering`, `admin_approve_pool`, `admin_sweep_ckusdc`, `admin_retry_stuck_claim` update methods
+  - Remove `test_swap_pipeline` and related test endpoints (or update)
+- [ ] Update `src/rumi_protocol_backend/rumi_protocol_backend.did`:
+  - Remove `bot_deposit_to_reserves`
+  - Remove `total_icusd_deposited_e8s` from `BotStatsResponse`
+  - Add `admin_resolve_stuck_claim`
+- [ ] Regenerate declarations: `dfx generate liquidation_bot && dfx generate rumi_protocol_backend`
+
+**Commit:** `chore: update candid interfaces and regenerate declarations`
+
+---
+
+### Task 10: Frontend audit -- fix references to deleted symbols
+
+The following frontend files reference `total_icusd_deposited_e8s` (being deleted from `BotStatsResponse`):
+
+- `src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte` (lines 12, 69, 133, 137)
+  - Line 137 computes "deficit" from `total_debt_covered_e8s - total_icusd_deposited_e8s` -- remove or replace
+- `src/vault_frontend/src/routes/explorer/+page.svelte` (line ~1263)
+- `src/vault_frontend/src/routes/docs/liquidation-bot/+page.svelte` (line ~85)
+
+- [ ] Remove/replace references to `total_icusd_deposited_e8s` in `LiquidationBotTab.svelte`
+- [ ] Remove "deficit" computation or replace with meaningful metric from new history
+- [ ] Fix `explorer/+page.svelte` reference
+- [ ] Fix `docs/liquidation-bot/+page.svelte` reference
+- [ ] Verify no other frontend files reference deleted symbols: `grep -r "icusd_deposited\|bot_deposit_to_reserves\|kong_swap\|three_pool" src/vault_frontend/`
+
+**Commit:** `fix(frontend): remove references to deleted bot stats fields`
+
+---
+
+### Task 11: PocketIC end-to-end test
+
+Create a stub ICPSwap pool canister that implements `quote`, `depositFromAndSwap`, and `metadata` with hardcoded responses. Test the full flow: claim -> swap -> transfer -> confirm.
+
+- [ ] Create `src/test_icpswap_stub/` canister with hardcoded ICPSwap responses
+- [ ] Write integration test in `pocket_ic_tests` or a new `pocket_ic_bot_tests` file:
+  - Test happy path: vault -> claim -> swap -> transfer -> confirm -> verify vault debt reduced
+  - Test swap failure: stub returns error -> verify ICP returned, claim cancelled
+  - Test transfer failure: mock ckUSDC transfer failure -> verify record written with `TransferFailed`
+  - Test confirm retry: first confirm call fails, second succeeds -> verify `Completed` with `confirm_retry_count > 0`
+- [ ] Verify legacy migration: create bot with old-format state, upgrade, verify history map populated
+
+**Commit:** `test(bot): PocketIC end-to-end test for ICPSwap liquidation flow`
+
+---
+
+### Task 12: Mainnet migration runbook
+
+**Create `docs/liquidation-bot-icpswap-migration.md`:**
+
+Document the exact steps for deploying this upgrade to mainnet:
+
+1. Build the new bot wasm
+2. Deploy as upgrade (NOT reinstall): `dfx deploy liquidation_bot --network ic`
+3. Verify legacy state migrated: `dfx canister call liquidation_bot get_liquidation_count --network ic`
+4. Set new config with ICPSwap pool: `dfx canister call liquidation_bot set_config '(...)' --network ic`
+5. Resolve pool ordering: `dfx canister call liquidation_bot admin_resolve_pool_ordering --network ic`
+6. Set infinite approve: `dfx canister call liquidation_bot admin_approve_pool --network ic`
+7. Deploy backend with `bot_deposit_to_reserves` deleted + `admin_resolve_stuck_claim` added
+8. Re-add ICP to `bot_allowed_collateral_types` on backend to activate the bot
+9. Monitor first liquidation via `get_liquidations`
+
+- [ ] Write runbook
+- [ ] Include rollback instructions (re-deploy old wasm, state is backward-compatible)
+- [ ] Document Candid breaking change: `BotConfig` fields changed from required to optional. After upgrade, `set_config` calls must use the new format (ICPSwap fields instead of KongSwap/3pool). Old dfx scripts will not work.
+
+**Commit:** `docs: mainnet migration runbook for liquidation bot ICPSwap rework`
+
+---
+
+### Task 13: Final verification + PR
+
+- [ ] `cargo build --target wasm32-unknown-unknown --release -p liquidation_bot`
+- [ ] `cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend`
+- [ ] `cargo test` (unit tests)
+- [ ] `POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_tests` (integration)
+- [ ] Review all changed files for consistency
+- [ ] Create PR against `main`
+
+**Commit:** N/A (PR creation)
+
+---
+
+## Known issues inherited from the shipped protocol (NOT fixed in this PR)
+
+1. **`compute_total_collateral_ratio` does not count ckUSDC/ckUSDT reserves.** This is a pre-existing issue relevant to `repay_to_vault_with_stable` as well, and is being addressed in a separate follow-up PR (PR2). This PR's new liquidation flow will add to protocol ckUSDC reserves in exactly the same way the stable-repay feature already does, so it inherits the same accounting quirk with no additional blast radius.
+
+2. **Confirm retry is immediate (no delay).** On the IC, you cannot `await` a sleep within a single update call. The 5 retries happen back-to-back. If the issue is a brief network hiccup, immediate retries may all fail. Timer-based delayed retries can be added in a follow-up if this proves insufficient in practice.
+
+---
+
+## Task dependencies
+
+```
+Task 0 (branch)
+  |
+Task 1 (memory foundation) --> Task 2 (history types) --> Task 7 (process.rs)
+  |                                                             |
+Task 5 (BotConfig)          --> Task 3 (icpswap module)  --> Task 4 (swap module) --> Task 7
+  |                                                                                      |
+Task 6 (backend cleanup)   ------------------------------------------------------------> Task 8 (endpoints)
+                                                                                         |
+                                                                                    Task 9 (candid + decl)
+                                                                                         |
+                                                                                    Task 10 (frontend)
+                                                                                         |
+                                                                                    Task 11 (tests)
+                                                                                         |
+                                                                                    Task 12 (runbook)
+                                                                                         |
+                                                                                    Task 13 (PR)
+```
+
+Tasks 1, 5, and 6 can be started in parallel.
+Tasks 3 and 4 can be done in parallel with Task 2.
+Task 7 depends on Tasks 1-5 (needs memory, history, icpswap, swap, and config all ready).
+Tasks 8-13 are sequential.

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -72,7 +72,6 @@ type BotStatsResponse = record {
   liquidation_bot_principal : opt principal;
   budget_total_e8s : nat64;
   budget_start_timestamp : nat64;
-  total_icusd_deposited_e8s : nat64;
 };
 type CandidVault = record {
   collateral_amount : nat64;
@@ -680,7 +679,7 @@ service : (ProtocolArg) -> {
   bot_cancel_liquidation : (nat64) -> (Result);
   bot_claim_liquidation : (nat64) -> (Result_3);
   bot_confirm_liquidation : (nat64) -> (Result);
-  bot_deposit_to_reserves : (nat64) -> (Result);
+  admin_resolve_stuck_claim : (nat64, bool) -> (Result);
   claim_liquidity_returns : () -> (Result_1);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_vault : (nat64) -> (Result_4);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -34,7 +34,6 @@ export interface BotStatsResponse {
   'liquidation_bot_principal' : [] | [Principal],
   'budget_total_e8s' : bigint,
   'budget_start_timestamp' : bigint,
-  'total_icusd_deposited_e8s' : bigint,
 }
 export interface CandidVault {
   'collateral_amount' : bigint,
@@ -831,12 +830,12 @@ export interface _SERVICE {
     Result_11
   >,
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
+  'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
   'borrow_from_vault' : ActorMethod<[VaultArg], Result_2>,
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,
   'bot_claim_liquidation' : ActorMethod<[bigint], Result_3>,
   'bot_confirm_liquidation' : ActorMethod<[bigint], Result>,
-  'bot_deposit_to_reserves' : ActorMethod<[bigint], Result>,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
   'clear_stuck_operations' : ActorMethod<[[] | [Principal]], Result_1>,
   'close_vault' : ActorMethod<[bigint], Result_4>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -145,7 +145,6 @@ export const idlFactory = ({ IDL }) => {
     'liquidation_bot_principal' : IDL.Opt(IDL.Principal),
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
-    'total_icusd_deposited_e8s' : IDL.Nat64,
   });
   const CollateralStatus = IDL.Variant({
     'Paused' : IDL.Null,
@@ -794,12 +793,12 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
+    'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
     'borrow_from_vault' : IDL.Func([VaultArg], [Result_2], []),
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_3], []),
     'bot_confirm_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
-    'bot_deposit_to_reserves' : IDL.Func([IDL.Nat64], [Result], []),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
     'clear_stuck_operations' : IDL.Func(
         [IDL.Opt(IDL.Principal)],

--- a/src/liquidation_bot/Cargo.toml
+++ b/src/liquidation_bot/Cargo.toml
@@ -17,4 +17,3 @@ serde_json = "1.0"
 ic-cdk-macros = "0.8.3"
 ic-canister-log = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 icrc-ledger-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
-futures = "0.3"

--- a/src/liquidation_bot/liquidation_bot.did
+++ b/src/liquidation_bot/liquidation_bot.did
@@ -1,37 +1,28 @@
 type BotConfig = record {
   backend_principal : principal;
-  three_pool_principal : principal;
-  kong_swap_principal : principal;
   treasury_principal : principal;
   admin : principal;
   max_slippage_bps : nat16;
   icp_ledger : principal;
   ckusdc_ledger : principal;
-  ckusdt_ledger : principal;
-  icusd_ledger : principal;
+  icpswap_pool : principal;
+  icpswap_zero_for_one : opt bool;
+  icp_fee_e8s : opt nat64;
+  ckusdc_fee_e6 : opt nat64;
+  // Legacy fields (ignored, kept for deserialization compat)
+  three_pool_principal : opt principal;
+  kong_swap_principal : opt principal;
+  ckusdt_ledger : opt principal;
+  icusd_ledger : opt principal;
 };
 
 type BotInitArgs = record {
   config : BotConfig;
 };
 
-type BotLiquidationEvent = record {
-  timestamp : nat64;
-  vault_id : nat64;
-  debt_covered_e8s : nat64;
-  collateral_received_e8s : nat64;
-  icusd_burned_e8s : nat64;
-  collateral_to_treasury_e8s : nat64;
-  swap_route : text;
-  effective_price_e8s : nat64;
-  slippage_bps : int32;
-  success : bool;
-  error_message : opt text;
-};
-
 type BotStats = record {
   total_debt_covered_e8s : nat64;
-  total_icusd_burned_e8s : nat64;
+  total_ckusdc_deposited_e6 : nat64;
   total_collateral_received_e8s : nat64;
   total_collateral_to_treasury_e8s : nat64;
   events_count : nat64;
@@ -46,31 +37,70 @@ type LiquidatableVaultInfo = record {
   collateral_price_e8s : nat64;
 };
 
-type TestSwapResult = record {
-  icp_input_e8s : nat64;
-  stable_output_native : nat64;
-  stable_route : text;
-  icusd_output_e8s : nat64;
-  icusd_sent_to : text;
+type LiquidationStatus = variant {
+  Completed;
+  SwapFailed;
+  TransferFailed;
+  ConfirmFailed;
+  ClaimFailed;
+  AdminResolved;
 };
 
-type TestForceResult = record {
+type LiquidationRecordV1 = record {
+  id : nat64;
   vault_id : nat64;
-  collateral_received_e8s : nat64;
-  debt_covered_e8s : nat64;
-  stable_output_native : nat64;
-  stable_route : text;
-  icusd_output_e8s : nat64;
-  icusd_deposited_to_reserves : bool;
+  timestamp : nat64;
+  status : LiquidationStatus;
+  collateral_claimed_e8s : nat64;
+  debt_to_cover_e8s : nat64;
+  icp_swapped_e8s : nat64;
+  ckusdc_received_e6 : nat64;
+  ckusdc_transferred_e6 : nat64;
   icp_to_treasury_e8s : nat64;
+  oracle_price_e8s : nat64;
+  effective_price_e8s : nat64;
+  slippage_bps : int32;
+  error_message : opt text;
+  confirm_retry_count : nat8;
+};
+
+type LiquidationRecordVersioned = variant {
+  V1 : LiquidationRecordV1;
+};
+
+type BotAdminAction = variant {
+  ConfigUpdated;
+  VaultsNotified : record { count : nat64 };
+};
+
+type BotAdminEvent = record {
+  timestamp : nat64;
+  caller : text;
+  action : BotAdminAction;
 };
 
 service : (BotInitArgs) -> {
+  // Core
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> ();
-  get_bot_stats : () -> (BotStats) query;
-  get_liquidation_events : (nat64, nat64) -> (vec BotLiquidationEvent) query;
   set_config : (BotConfig) -> ();
-  test_swap_pipeline : (nat64) -> (TestSwapResult);
-  test_force_liquidate : (nat64) -> (TestForceResult);
-  test_force_partial_liquidate : (nat64) -> (TestForceResult);
+
+  // Stats
+  get_bot_stats : () -> (BotStats) query;
+
+  // History
+  get_liquidation : (nat64) -> (opt LiquidationRecordVersioned) query;
+  get_liquidations : (nat64, nat64) -> (vec LiquidationRecordVersioned) query;
+  get_liquidation_count : () -> (nat64) query;
+  get_stuck_liquidations : () -> (vec LiquidationRecordVersioned) query;
+  get_liquidation_events : (nat64, nat64) -> (vec LiquidationRecordVersioned) query;
+
+  // Admin events
+  get_admin_events : (nat64, nat64) -> (vec BotAdminEvent) query;
+  get_admin_event_count : () -> (nat64) query;
+
+  // Admin actions
+  admin_resolve_pool_ordering : () -> ();
+  admin_approve_pool : () -> ();
+  admin_sweep_ckusdc : (principal, opt nat64) -> ();
+  admin_retry_stuck_claim : (nat64) -> ();
 };

--- a/src/liquidation_bot/src/history.rs
+++ b/src/liquidation_bot/src/history.rs
@@ -109,6 +109,7 @@ pub fn get_record(id: u64) -> Option<LiquidationRecordVersioned> {
 }
 
 pub fn get_records(offset: u64, limit: u64) -> Vec<LiquidationRecordVersioned> {
+    let limit = limit.min(1000);
     HISTORY.with(|h| {
         let borrow = h.borrow();
         let map = borrow.as_ref().expect("History not initialized");
@@ -116,7 +117,7 @@ pub fn get_records(offset: u64, limit: u64) -> Vec<LiquidationRecordVersioned> {
         if count == 0 || offset >= count {
             return vec![];
         }
-        let start = count.saturating_sub(offset + limit);
+        let start = count.saturating_sub(offset.saturating_add(limit));
         let end = count.saturating_sub(offset);
         (start..end).filter_map(|id| map.get(&id)).collect()
     })

--- a/src/liquidation_bot/src/history.rs
+++ b/src/liquidation_bot/src/history.rs
@@ -1,0 +1,197 @@
+use candid::{CandidType, Deserialize};
+use ic_stable_structures::{StableBTreeMap, StableCell, Storable};
+use serde::Serialize;
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+use crate::memory;
+
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum LiquidationStatus {
+    Completed,
+    SwapFailed,
+    TransferFailed,
+    ConfirmFailed,
+    ClaimFailed,
+    AdminResolved,
+}
+
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
+pub struct LiquidationRecordV1 {
+    pub id: u64,
+    pub vault_id: u64,
+    pub timestamp: u64,
+    pub status: LiquidationStatus,
+
+    pub collateral_claimed_e8s: u64,
+    pub debt_to_cover_e8s: u64,
+    pub icp_swapped_e8s: u64,
+    pub ckusdc_received_e6: u64,
+    pub ckusdc_transferred_e6: u64,
+    pub icp_to_treasury_e8s: u64,
+
+    pub oracle_price_e8s: u64,
+    pub effective_price_e8s: u64,
+    pub slippage_bps: i32,
+
+    pub error_message: Option<String>,
+    pub confirm_retry_count: u8,
+}
+
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
+pub enum LiquidationRecordVersioned {
+    V1(LiquidationRecordV1),
+}
+
+impl Storable for LiquidationRecordVersioned {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(candid::encode_one(self).expect("Failed to encode record"))
+    }
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).expect("Failed to decode record")
+    }
+    const BOUND: ic_stable_structures::storable::Bound =
+        ic_stable_structures::storable::Bound::Unbounded;
+}
+
+thread_local! {
+    static HISTORY: RefCell<Option<StableBTreeMap<u64, LiquidationRecordVersioned, memory::Mem>>> =
+        RefCell::new(None);
+
+    static NEXT_ID: RefCell<Option<StableCell<u64, memory::Mem>>> =
+        RefCell::new(None);
+}
+
+/// Initialize history storage. Must be called after memory::init_memory_manager().
+pub fn init_history() {
+    HISTORY.with(|h| {
+        *h.borrow_mut() = Some(StableBTreeMap::init(
+            memory::get_memory(memory::MEM_ID_HISTORY),
+        ));
+    });
+    NEXT_ID.with(|c| {
+        *c.borrow_mut() = Some(
+            StableCell::init(memory::get_memory(memory::MEM_ID_NEXT_ID), 0u64)
+                .expect("Failed to init NEXT_ID cell"),
+        );
+    });
+}
+
+pub fn next_id() -> u64 {
+    NEXT_ID.with(|c| {
+        let mut borrow = c.borrow_mut();
+        let cell = borrow.as_mut().expect("History not initialized");
+        let id = *cell.get();
+        cell.set(id + 1).expect("Failed to increment NEXT_ID");
+        id
+    })
+}
+
+pub fn insert_record(record: LiquidationRecordVersioned) {
+    let id = match &record {
+        LiquidationRecordVersioned::V1(r) => r.id,
+    };
+    HISTORY.with(|h| {
+        h.borrow_mut()
+            .as_mut()
+            .expect("History not initialized")
+            .insert(id, record);
+    });
+}
+
+pub fn get_record(id: u64) -> Option<LiquidationRecordVersioned> {
+    HISTORY.with(|h| {
+        h.borrow()
+            .as_ref()
+            .expect("History not initialized")
+            .get(&id)
+    })
+}
+
+pub fn get_records(offset: u64, limit: u64) -> Vec<LiquidationRecordVersioned> {
+    HISTORY.with(|h| {
+        let borrow = h.borrow();
+        let map = borrow.as_ref().expect("History not initialized");
+        let count = record_count();
+        if count == 0 || offset >= count {
+            return vec![];
+        }
+        let start = count.saturating_sub(offset + limit);
+        let end = count.saturating_sub(offset);
+        (start..end).filter_map(|id| map.get(&id)).collect()
+    })
+}
+
+pub fn record_count() -> u64 {
+    NEXT_ID.with(|c| {
+        *c.borrow()
+            .as_ref()
+            .expect("History not initialized")
+            .get()
+    })
+}
+
+pub fn get_stuck_records() -> Vec<LiquidationRecordVersioned> {
+    HISTORY.with(|h| {
+        let borrow = h.borrow();
+        let map = borrow.as_ref().expect("History not initialized");
+        let count = record_count();
+        (0..count)
+            .filter_map(|id| {
+                let record = map.get(&id)?;
+                match &record {
+                    LiquidationRecordVersioned::V1(r) => match r.status {
+                        LiquidationStatus::TransferFailed
+                        | LiquidationStatus::ConfirmFailed => Some(record),
+                        _ => None,
+                    },
+                }
+            })
+            .collect()
+    })
+}
+
+pub fn update_record_status(id: u64, new_status: LiquidationStatus) {
+    HISTORY.with(|h| {
+        let mut borrow = h.borrow_mut();
+        let map = borrow.as_mut().expect("History not initialized");
+        if let Some(mut record) = map.get(&id) {
+            match &mut record {
+                LiquidationRecordVersioned::V1(ref mut r) => {
+                    r.status = new_status;
+                }
+            }
+            map.insert(id, record);
+        }
+    });
+}
+
+/// Migrate legacy BotLiquidationEvent entries into the new stable map.
+pub fn migrate_legacy_events(events: &[crate::state::BotLiquidationEvent]) {
+    for event in events {
+        let id = next_id();
+        let status = if event.success {
+            LiquidationStatus::Completed
+        } else {
+            LiquidationStatus::SwapFailed
+        };
+        let record = LiquidationRecordV1 {
+            id,
+            vault_id: event.vault_id,
+            timestamp: event.timestamp,
+            status,
+            collateral_claimed_e8s: event.collateral_received_e8s,
+            debt_to_cover_e8s: event.debt_covered_e8s,
+            icp_swapped_e8s: 0,
+            ckusdc_received_e6: 0,
+            ckusdc_transferred_e6: 0,
+            icp_to_treasury_e8s: event.collateral_to_treasury_e8s,
+            oracle_price_e8s: event.effective_price_e8s,
+            effective_price_e8s: event.effective_price_e8s,
+            slippage_bps: event.slippage_bps,
+            error_message: event.error_message.clone(),
+            confirm_retry_count: 0,
+        };
+        insert_record(LiquidationRecordVersioned::V1(record));
+    }
+}

--- a/src/liquidation_bot/src/history.rs
+++ b/src/liquidation_bot/src/history.rs
@@ -131,23 +131,30 @@ pub fn record_count() -> u64 {
     })
 }
 
+/// Returns stuck records (TransferFailed or ConfirmFailed), scanning from newest first.
+/// Capped at 100 results to avoid hitting the instruction limit on large histories.
 pub fn get_stuck_records() -> Vec<LiquidationRecordVersioned> {
+    const MAX_RESULTS: usize = 100;
     HISTORY.with(|h| {
         let borrow = h.borrow();
         let map = borrow.as_ref().expect("History not initialized");
         let count = record_count();
-        (0..count)
-            .filter_map(|id| {
-                let record = map.get(&id)?;
+        let mut results = Vec::new();
+        for id in (0..count).rev() {
+            if results.len() >= MAX_RESULTS {
+                break;
+            }
+            if let Some(record) = map.get(&id) {
                 match &record {
                     LiquidationRecordVersioned::V1(r) => match r.status {
                         LiquidationStatus::TransferFailed
-                        | LiquidationStatus::ConfirmFailed => Some(record),
-                        _ => None,
+                        | LiquidationStatus::ConfirmFailed => results.push(record),
+                        _ => {}
                     },
                 }
-            })
-            .collect()
+            }
+        }
+        results
     })
 }
 
@@ -167,7 +174,10 @@ pub fn update_record_status(id: u64, new_status: LiquidationStatus) {
 }
 
 /// Migrate legacy BotLiquidationEvent entries into the new stable map.
+/// Capped at 500 entries to avoid trapping in post_upgrade due to instruction limit.
+/// In practice the bot has far fewer legacy events than this.
 pub fn migrate_legacy_events(events: &[crate::state::BotLiquidationEvent]) {
+    let events = if events.len() > 500 { &events[..500] } else { events };
     for event in events {
         let id = next_id();
         let status = if event.success {

--- a/src/liquidation_bot/src/icpswap.rs
+++ b/src/liquidation_bot/src/icpswap.rs
@@ -150,5 +150,12 @@ pub async fn fetch_metadata(pool: Principal) -> Result<PoolMetadata, String> {
 }
 
 fn nat_to_u64(n: &Nat) -> u64 {
-    n.0.to_string().parse::<u64>().unwrap_or(0)
+    let s = n.0.to_string();
+    match s.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => {
+            ic_canister_log::log!(crate::INFO, "WARNING: Nat value {} overflows u64, clamping to MAX", s);
+            u64::MAX
+        }
+    }
 }

--- a/src/liquidation_bot/src/icpswap.rs
+++ b/src/liquidation_bot/src/icpswap.rs
@@ -1,0 +1,154 @@
+use candid::{CandidType, Deserialize, Nat, Principal};
+
+// -- ICPSwap Types --
+
+/// Args for `depositFromAndSwap` (5 fields).
+#[derive(CandidType, Clone, Debug, serde::Serialize)]
+pub struct DepositAndSwapArgs {
+    #[serde(rename = "amountIn")]
+    pub amount_in: String,
+    #[serde(rename = "amountOutMinimum")]
+    pub amount_out_minimum: String,
+    #[serde(rename = "zeroForOne")]
+    pub zero_for_one: bool,
+    #[serde(rename = "tokenInFee")]
+    pub token_in_fee: Nat,
+    #[serde(rename = "tokenOutFee")]
+    pub token_out_fee: Nat,
+}
+
+/// Args for `quote` (3 fields, different from DepositAndSwapArgs).
+#[derive(CandidType, Clone, Debug, serde::Serialize)]
+pub struct SwapArgs {
+    #[serde(rename = "amountIn")]
+    pub amount_in: String,
+    #[serde(rename = "amountOutMinimum")]
+    pub amount_out_minimum: String,
+    #[serde(rename = "zeroForOne")]
+    pub zero_for_one: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum IcpSwapError {
+    CommonError,
+    InsufficientFunds,
+    InternalError(String),
+    UnsupportedToken(String),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum IcpSwapResult {
+    #[serde(rename = "ok")]
+    Ok(Nat),
+    #[serde(rename = "err")]
+    Err(IcpSwapError),
+}
+
+impl std::fmt::Display for IcpSwapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IcpSwapError::CommonError => write!(f, "CommonError"),
+            IcpSwapError::InsufficientFunds => write!(f, "InsufficientFunds"),
+            IcpSwapError::InternalError(s) => write!(f, "InternalError: {}", s),
+            IcpSwapError::UnsupportedToken(s) => write!(f, "UnsupportedToken: {}", s),
+        }
+    }
+}
+
+// -- Pool metadata --
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct Token {
+    pub address: String,
+    pub standard: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct PoolMetadata {
+    pub fee: Nat,
+    pub key: String,
+    pub liquidity: Nat,
+    #[serde(rename = "maxLiquidityPerTick")]
+    pub max_liquidity_per_tick: Nat,
+    #[serde(rename = "nextPositionId")]
+    pub next_position_id: Nat,
+    #[serde(rename = "sqrtPriceX96")]
+    pub sqrt_price_x96: Nat,
+    pub tick: candid::Int,
+    pub token0: Token,
+    pub token1: Token,
+}
+
+/// metadata() returns variant { ok: PoolMetadata; err: Error }
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum MetadataResult {
+    #[serde(rename = "ok")]
+    Ok(PoolMetadata),
+    #[serde(rename = "err")]
+    Err(IcpSwapError),
+}
+
+// -- Call wrappers --
+
+/// Query a swap quote. Uses 3-field SwapArgs.
+pub async fn quote(
+    pool: Principal,
+    amount_in: u64,
+    zero_for_one: bool,
+) -> Result<u64, String> {
+    let args = SwapArgs {
+        amount_in: amount_in.to_string(),
+        amount_out_minimum: "0".to_string(),
+        zero_for_one,
+    };
+
+    let result: Result<(IcpSwapResult,), _> = ic_cdk::call(pool, "quote", (args,)).await;
+
+    match result {
+        Ok((IcpSwapResult::Ok(n),)) => Ok(nat_to_u64(&n)),
+        Ok((IcpSwapResult::Err(e),)) => Err(format!("ICPSwap quote error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap quote call failed ({:?}): {}", code, msg)),
+    }
+}
+
+/// Execute a swap via depositFromAndSwap. Uses 5-field DepositAndSwapArgs.
+pub async fn deposit_and_swap(
+    pool: Principal,
+    amount_in: u64,
+    min_amount_out: u64,
+    zero_for_one: bool,
+    token_in_fee: u64,
+    token_out_fee: u64,
+) -> Result<u64, String> {
+    let args = DepositAndSwapArgs {
+        amount_in: amount_in.to_string(),
+        amount_out_minimum: min_amount_out.to_string(),
+        zero_for_one,
+        token_in_fee: Nat::from(token_in_fee),
+        token_out_fee: Nat::from(token_out_fee),
+    };
+
+    let result: Result<(IcpSwapResult,), _> =
+        ic_cdk::call(pool, "depositFromAndSwap", (args,)).await;
+
+    match result {
+        Ok((IcpSwapResult::Ok(n),)) => Ok(nat_to_u64(&n)),
+        Ok((IcpSwapResult::Err(e),)) => Err(format!("ICPSwap swap error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap swap call failed ({:?}): {}", code, msg)),
+    }
+}
+
+/// Fetch pool metadata to determine token ordering.
+pub async fn fetch_metadata(pool: Principal) -> Result<PoolMetadata, String> {
+    let result: Result<(MetadataResult,), _> = ic_cdk::call(pool, "metadata", ()).await;
+
+    match result {
+        Ok((MetadataResult::Ok(m),)) => Ok(m),
+        Ok((MetadataResult::Err(e),)) => Err(format!("ICPSwap metadata error: {}", e)),
+        Err((code, msg)) => Err(format!("ICPSwap metadata call failed ({:?}): {}", code, msg)),
+    }
+}
+
+fn nat_to_u64(n: &Nat) -> u64 {
+    n.0.to_string().parse::<u64>().unwrap_or(0)
+}

--- a/src/liquidation_bot/src/lib.rs
+++ b/src/liquidation_bot/src/lib.rs
@@ -1,13 +1,16 @@
-use candid::{CandidType, Deserialize, Nat};
+use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use ic_canister_log::{declare_log_buffer, log};
 use icrc_ledger_types::icrc1::account::Account;
 
-mod state;
+mod history;
+mod icpswap;
+mod memory;
 mod process;
+mod state;
 mod swap;
 
-use state::{BotAdminAction, BotAdminEvent, BotConfig, BotLiquidationEvent, BotState, LiquidatableVaultInfo};
+use state::{BotAdminAction, BotAdminEvent, BotConfig, BotState, LiquidatableVaultInfo};
 
 declare_log_buffer!(name = INFO, capacity = 1000);
 
@@ -18,8 +21,11 @@ pub struct BotInitArgs {
 
 #[init]
 fn init(args: BotInitArgs) {
+    memory::init_memory_manager();
+    history::init_history();
     state::init_state(BotState {
         config: Some(args.config),
+        migrated_to_stable_structures: true,
         ..Default::default()
     });
     setup_timer();
@@ -27,12 +33,65 @@ fn init(args: BotInitArgs) {
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    state::save_to_stable_memory();
+    let migrated = state::read_state(|s| s.migrated_to_stable_structures);
+    if migrated {
+        state::save_config_to_stable();
+    } else {
+        state::save_to_stable_memory();
+    }
 }
 
 #[post_upgrade]
 fn post_upgrade() {
-    state::load_from_stable_memory();
+    // STEP 1: Rescue legacy JSON blob BEFORE MemoryManager::init.
+    // Raw stable64_read is safe here because MemoryManager hasn't been initialized yet.
+    let size = ic_cdk::api::stable::stable64_size();
+    let legacy_state: Option<BotState> = if size > 0 {
+        let mut len_bytes = [0u8; 8];
+        ic_cdk::api::stable::stable64_read(0, &mut len_bytes);
+        let len = u64::from_le_bytes(len_bytes) as usize;
+        if len > 0 && len < 10_000_000 {
+            let mut bytes = vec![0u8; len];
+            ic_cdk::api::stable::stable64_read(8, &mut bytes);
+            serde_json::from_slice(&bytes).ok()
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // STEP 2: Initialize MemoryManager. On first migration this writes a new header
+    // at offset 0 (fine, we already rescued above). On subsequent upgrades it reads
+    // the existing header (non-destructive, idempotent).
+    memory::init_memory_manager();
+    history::init_history();
+
+    // STEP 3: Decide migration path.
+    if let Some(ref state) = legacy_state {
+        if !state.migrated_to_stable_structures {
+            // First upgrade after migration: move legacy events into stable map
+            log!(INFO, "Migrating {} legacy events to stable map", state.liquidation_events.len());
+            history::migrate_legacy_events(&state.liquidation_events);
+        }
+    }
+
+    // STEP 4: Load state.
+    if let Some(legacy) = legacy_state {
+        if legacy.migrated_to_stable_structures {
+            // Already migrated, but the pre_upgrade wrote config to MEM_ID_CONFIG.
+            // The legacy_state we read from offset 0 is stale. Load from StableCell instead.
+            state::load_config_from_stable();
+        } else {
+            // First migration: use the rescued state, mark as migrated.
+            state::init_state(legacy);
+            state::mutate_state(|s| s.migrated_to_stable_structures = true);
+        }
+    } else {
+        // No legacy state found at all. Try new-format config.
+        state::load_config_from_stable();
+    }
+
     setup_timer();
 }
 
@@ -43,12 +102,12 @@ fn setup_timer() {
     );
 }
 
+// ---- Core endpoints ----
+
 #[update]
 fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) {
     let caller = ic_cdk::api::caller();
-    let backend = state::read_state(|s| {
-        s.config.as_ref().map(|c| c.backend_principal)
-    });
+    let backend = state::read_state(|s| s.config.as_ref().map(|c| c.backend_principal));
     if Some(caller) != backend {
         log!(INFO, "Rejected notification from unauthorized caller: {}", caller);
         return;
@@ -71,22 +130,14 @@ fn get_bot_stats() -> state::BotStats {
 }
 
 #[query]
-fn get_liquidation_events(offset: u64, limit: u64) -> Vec<BotLiquidationEvent> {
-    state::read_state(|s| {
-        let len = s.liquidation_events.len();
-        let start = (len as u64).saturating_sub(offset + limit) as usize;
-        let end = (len as u64).saturating_sub(offset) as usize;
-        s.liquidation_events[start..end].to_vec()
-    })
-}
-
-#[query]
 fn get_admin_events(offset: u64, limit: u64) -> Vec<state::BotAdminEvent> {
     state::read_state(|s| {
         let len = s.admin_events.len();
         let start = (len as u64).saturating_sub(offset + limit) as usize;
         let end = (len as u64).saturating_sub(offset) as usize;
-        if start >= end { return vec![]; }
+        if start >= end {
+            return vec![];
+        }
         s.admin_events[start..end].to_vec()
     })
 }
@@ -98,45 +149,47 @@ fn get_admin_event_count() -> u64 {
 
 #[update]
 fn set_config(config: BotConfig) {
-    let caller = ic_cdk::api::caller();
-    let is_admin = state::read_state(|s| {
-        s.config.as_ref().map(|c| c.admin == caller).unwrap_or(false)
-    });
-    if !is_admin {
-        ic_cdk::trap("Unauthorized: only admin can set config");
-    }
+    require_admin();
     state::mutate_state(|s| {
         s.config = Some(config);
         s.admin_events.push(BotAdminEvent {
             timestamp: ic_cdk::api::time(),
-            caller: caller.to_text(),
+            caller: ic_cdk::api::caller().to_text(),
             action: BotAdminAction::ConfigUpdated,
         });
     });
 }
 
-// ─── Test Functions ───
+// ---- History query endpoints ----
 
-#[derive(CandidType, Deserialize)]
-pub struct TestSwapResult {
-    pub icp_input_e8s: u64,
-    pub stable_output_native: u64,
-    pub stable_route: String,
-    pub icusd_output_e8s: u64,
-    pub icusd_sent_to: String,
+#[query]
+fn get_liquidation(id: u64) -> Option<history::LiquidationRecordVersioned> {
+    history::get_record(id)
 }
 
-#[derive(CandidType, Deserialize)]
-pub struct TestForceResult {
-    pub vault_id: u64,
-    pub collateral_received_e8s: u64,
-    pub debt_covered_e8s: u64,
-    pub stable_output_native: u64,
-    pub stable_route: String,
-    pub icusd_output_e8s: u64,
-    pub icusd_deposited_to_reserves: bool,
-    pub icp_to_treasury_e8s: u64,
+#[query]
+fn get_liquidations(offset: u64, limit: u64) -> Vec<history::LiquidationRecordVersioned> {
+    history::get_records(offset, limit)
 }
+
+#[query]
+fn get_liquidation_count() -> u64 {
+    history::record_count()
+}
+
+#[query]
+fn get_stuck_liquidations() -> Vec<history::LiquidationRecordVersioned> {
+    history::get_stuck_records()
+}
+
+// ---- Legacy query (backward compat, delegates to new history) ----
+
+#[query]
+fn get_liquidation_events(offset: u64, limit: u64) -> Vec<history::LiquidationRecordVersioned> {
+    history::get_records(offset, limit)
+}
+
+// ---- Admin endpoints ----
 
 fn require_admin() {
     let caller = ic_cdk::api::caller();
@@ -144,282 +197,132 @@ fn require_admin() {
         s.config.as_ref().map(|c| c.admin == caller).unwrap_or(false)
     });
     if !is_admin {
-        ic_cdk::trap("Unauthorized: only admin can call test functions");
+        ic_cdk::trap("Unauthorized: only admin can call this function");
     }
 }
 
-/// Test the swap pipeline: ICP → ckStable → icUSD.
-/// Send ICP to the bot first, then call this. The icUSD output is sent back to the caller.
+/// One-time: fetch pool metadata to determine if ICP is token0 or token1.
 #[update]
-async fn test_swap_pipeline(amount_e8s: u64) -> TestSwapResult {
+async fn admin_resolve_pool_ordering() {
     require_admin();
+    let (pool, icp_ledger) = state::read_state(|s| {
+        let c = s.config.as_ref().unwrap();
+        (c.icpswap_pool, c.icp_ledger)
+    });
 
-    let config = state::read_state(|s| s.config.clone())
-        .expect("Bot not configured");
+    let metadata = icpswap::fetch_metadata(pool)
+        .await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Failed to fetch metadata: {}", e)));
 
-    log!(INFO, "[test_swap_pipeline] Starting with {} e8s ICP", amount_e8s);
+    let icp_text = icp_ledger.to_text();
+    let zero_for_one = metadata.token0.address == icp_text;
 
-    // Step 1: ICP → ckStable (KongSwap)
-    let stable_result = swap::swap_icp_for_stable(&config, amount_e8s).await;
-    let (stable_amount, _stable_token, route) = match stable_result {
-        Ok(r) => {
-            log!(INFO, "[test_swap_pipeline] KongSwap OK: {} native via {}", r.output_amount, r.route);
-            (r.output_amount, r.target_token, r.route)
+    state::mutate_state(|s| {
+        if let Some(ref mut config) = s.config {
+            config.icpswap_zero_for_one = Some(zero_for_one);
         }
-        Err(e) => ic_cdk::trap(&format!("KongSwap failed: {}", e)),
+    });
+
+    log!(
+        INFO,
+        "Pool ordering resolved: ICP is token{}, zeroForOne={}",
+        if zero_for_one { "0" } else { "1" },
+        zero_for_one
+    );
+}
+
+/// One-time: set up infinite ICRC-2 approve for ICP to the ICPSwap pool.
+#[update]
+async fn admin_approve_pool() {
+    require_admin();
+    let (icp_ledger, pool) = state::read_state(|s| {
+        let c = s.config.as_ref().unwrap();
+        (c.icp_ledger, c.icpswap_pool)
+    });
+
+    swap::approve_infinite(icp_ledger, pool)
+        .await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Approve failed: {}", e)));
+
+    log!(INFO, "Infinite approve set: ICP ledger {} -> pool {}", icp_ledger, pool);
+}
+
+/// Emergency: transfer all bot ckUSDC to a target principal.
+/// Optionally mark an associated history record as AdminResolved.
+#[update]
+async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
+    require_admin();
+    let ckusdc_ledger = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_ledger);
+
+    let balance_result: Result<(Nat,), _> = ic_cdk::call(
+        ckusdc_ledger,
+        "icrc1_balance_of",
+        (Account {
+            owner: ic_cdk::id(),
+            subaccount: None,
+        },),
+    )
+    .await;
+
+    let balance = match balance_result {
+        Ok((b,)) => {
+            let val: u64 = b.0.to_string().parse().unwrap_or(0);
+            if val == 0 {
+                ic_cdk::trap("Bot has zero ckUSDC balance");
+            }
+            val
+        }
+        Err((code, msg)) => ic_cdk::trap(&format!("Balance query failed: {:?} {}", code, msg)),
     };
 
-    // Step 2: ckStable → icUSD (3pool)
-    let icusd_amount = match swap::swap_stable_for_icusd(&config, stable_amount, _stable_token).await {
-        Ok(amount) => {
-            log!(INFO, "[test_swap_pipeline] 3pool OK: {} e8s icUSD", amount);
-            amount
-        }
-        Err(e) => ic_cdk::trap(&format!("3pool swap failed: {}", e)),
-    };
+    let fee = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_fee_e6.unwrap_or(10));
+    let send_amount = balance.saturating_sub(fee);
 
-    // Step 3: Send icUSD back to caller
-    let caller = ic_cdk::api::caller();
     let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
         from_subaccount: None,
-        to: Account { owner: caller, subaccount: None },
-        amount: Nat::from(icusd_amount),
+        to: Account {
+            owner: target,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
         fee: None,
         memo: None,
-        created_at_time: None,
+        created_at_time: Some(ic_cdk::api::time()),
     };
 
-    let sent_to = match ic_cdk::call::<_, (Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,)>(
-        config.icusd_ledger, "icrc1_transfer", (transfer_args,)
-    ).await {
-        Ok((Ok(_),)) => {
-            log!(INFO, "[test_swap_pipeline] Sent {} e8s icUSD to {}", icusd_amount, caller);
-            format!("{}", caller)
-        }
-        Ok((Err(e),)) => {
-            log!(INFO, "[test_swap_pipeline] icUSD transfer failed: {:?}, keeping in bot", e);
-            "bot (transfer failed)".to_string()
-        }
-        Err((code, msg)) => {
-            log!(INFO, "[test_swap_pipeline] icUSD transfer call failed: {:?} {}", code, msg);
-            "bot (call failed)".to_string()
-        }
-    };
+    let result: Result<
+        (Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,),
+        _,
+    > = ic_cdk::call(ckusdc_ledger, "icrc1_transfer", (transfer_args,)).await;
 
-    TestSwapResult {
-        icp_input_e8s: amount_e8s,
-        stable_output_native: stable_amount,
-        stable_route: route,
-        icusd_output_e8s: icusd_amount,
-        icusd_sent_to: sent_to,
+    match result {
+        Ok((Ok(block),)) => {
+            log!(INFO, "Swept {} ckUSDC e6 to {}, block {}", send_amount, target, block);
+            if let Some(id) = record_id {
+                history::update_record_status(id, history::LiquidationStatus::AdminResolved);
+                log!(INFO, "Marked record #{} as AdminResolved", id);
+            }
+        }
+        Ok((Err(e),)) => ic_cdk::trap(&format!("Sweep transfer failed: {:?}", e)),
+        Err((code, msg)) => ic_cdk::trap(&format!("Sweep call failed: {:?} {}", code, msg)),
     }
 }
 
-/// Force-liquidate a vault (bypasses health ratio check on backend).
-/// Uses the two-phase claim/confirm/cancel pattern.
+/// Retry confirm for a stuck claim.
 #[update]
-async fn test_force_liquidate(vault_id: u64) -> TestForceResult {
+async fn admin_retry_stuck_claim(vault_id: u64) {
     require_admin();
+    let config = state::read_state(|s| s.config.clone()).expect("Not configured");
 
-    let config = state::read_state(|s| s.config.clone())
-        .expect("Bot not configured");
-
-    log!(INFO, "[test_force_liquidate] Force-liquidating vault #{}", vault_id);
-
-    // Step 1: Call dev_force_bot_liquidate (now uses claim pattern — locks vault, gets collateral)
-    let liq_result: Result<(process::BackendResult<process::BotLiquidationResult>,), _> =
-        ic_cdk::call(config.backend_principal, "dev_force_bot_liquidate", (vault_id,)).await;
-
-    let (collateral_amount, debt_covered, collateral_price) = match liq_result {
-        Ok((process::BackendResult::Ok(r),)) => {
-            log!(INFO, "[test_force_liquidate] Claimed {} e8s collateral, {} e8s debt", r.collateral_amount, r.debt_covered);
-            (r.collateral_amount, r.debt_covered, r.collateral_price_e8s)
-        }
-        Ok((process::BackendResult::Err(e),)) => ic_cdk::trap(&format!("dev_force_bot_liquidate error: {}", e)),
-        Err((code, msg)) => ic_cdk::trap(&format!("dev_force_bot_liquidate call failed: {:?} {}", code, msg)),
-    };
-
-    // Step 2: Swap ICP → ckStable
-    let swap_amount = process::calculate_swap_amount(collateral_amount, debt_covered, collateral_price);
-    let stable_result = swap::swap_icp_for_stable(&config, swap_amount).await;
-    let (stable_amount, stable_token, route) = match stable_result {
-        Ok(r) => {
-            log!(INFO, "[test_force_liquidate] KongSwap OK: {} native via {}", r.output_amount, r.route);
-            (r.output_amount, r.target_token, r.route)
-        }
-        Err(e) => {
-            // Cancel and trap
-            let _ = process::call_bot_cancel_liquidation_pub(&config, vault_id).await;
-            ic_cdk::trap(&format!("KongSwap failed (claim cancelled): {}", e));
-        }
-    };
-
-    // Step 3: ckStable → icUSD
-    let icusd_amount = match swap::swap_stable_for_icusd(&config, stable_amount, stable_token).await {
-        Ok(amount) => amount,
-        Err(e) => {
-            let _ = process::call_bot_cancel_liquidation_pub(&config, vault_id).await;
-            ic_cdk::trap(&format!("3pool swap failed (claim cancelled): {}", e));
-        }
-    };
-
-    // Step 4: Deposit icUSD to backend reserves
-    let deposited = match process::call_bot_deposit_to_reserves_pub(&config, icusd_amount).await {
-        Ok(()) => true,
-        Err(e) => {
-            log!(INFO, "[test_force_liquidate] Deposit failed: {}", e);
-            false
-        }
-    };
-
-    // Step 5: CONFIRM the liquidation (finalize vault state)
-    let confirmed = match process::call_bot_confirm_liquidation_pub(&config, vault_id).await {
+    match process::call_bot_confirm_liquidation(&config, vault_id).await {
         Ok(()) => {
-            log!(INFO, "[test_force_liquidate] Confirmed liquidation for vault #{}", vault_id);
-            true
+            log!(INFO, "admin_retry_stuck_claim: confirmed vault #{}", vault_id);
         }
         Err(e) => {
-            log!(INFO, "[test_force_liquidate] Confirm failed: {}", e);
-            false
+            ic_cdk::trap(&format!(
+                "Confirm still failing for vault #{}: {}",
+                vault_id, e
+            ));
         }
-    };
-
-    // Step 6: Send remaining ICP to treasury
-    let icp_to_treasury = collateral_amount.saturating_sub(swap_amount);
-    if icp_to_treasury > 0 {
-        let _ = process::transfer_icp_to_treasury_pub(&config, icp_to_treasury).await;
-    }
-
-    // Log event
-    state::mutate_state(|s| {
-        s.stats.events_count += 1;
-        s.liquidation_events.push(BotLiquidationEvent {
-            timestamp: ic_cdk::api::time(),
-            vault_id,
-            debt_covered_e8s: debt_covered,
-            collateral_received_e8s: collateral_amount,
-            icusd_burned_e8s: icusd_amount,
-            collateral_to_treasury_e8s: icp_to_treasury,
-            swap_route: route.clone(),
-            effective_price_e8s: 0,
-            slippage_bps: 0,
-            success: confirmed && deposited,
-            error_message: if confirmed { Some("test_force_liquidate".to_string()) } else { Some("confirm failed".to_string()) },
-        });
-    });
-
-    TestForceResult {
-        vault_id,
-        collateral_received_e8s: collateral_amount,
-        debt_covered_e8s: debt_covered,
-        stable_output_native: stable_amount,
-        stable_route: route,
-        icusd_output_e8s: icusd_amount,
-        icusd_deposited_to_reserves: deposited,
-        icp_to_treasury_e8s: icp_to_treasury,
-    }
-}
-
-/// Force a PARTIAL liquidation of a vault (bypasses health ratio check, uses partial cap).
-/// Same as test_force_liquidate but calls dev_force_partial_bot_liquidate on backend.
-#[update]
-async fn test_force_partial_liquidate(vault_id: u64) -> TestForceResult {
-    require_admin();
-
-    let config = state::read_state(|s| s.config.clone())
-        .expect("Bot not configured");
-
-    log!(INFO, "[test_force_partial_liquidate] Partial-liquidating vault #{}", vault_id);
-
-    // Step 1: Call dev_force_partial_bot_liquidate (uses partial cap, skips CR check)
-    let liq_result: Result<(process::BackendResult<process::BotLiquidationResult>,), _> =
-        ic_cdk::call(config.backend_principal, "dev_force_partial_bot_liquidate", (vault_id,)).await;
-
-    let (collateral_amount, debt_covered, collateral_price) = match liq_result {
-        Ok((process::BackendResult::Ok(r),)) => {
-            log!(INFO, "[test_force_partial_liquidate] Claimed {} e8s collateral, {} e8s debt", r.collateral_amount, r.debt_covered);
-            (r.collateral_amount, r.debt_covered, r.collateral_price_e8s)
-        }
-        Ok((process::BackendResult::Err(e),)) => ic_cdk::trap(&format!("dev_force_partial_bot_liquidate error: {}", e)),
-        Err((code, msg)) => ic_cdk::trap(&format!("dev_force_partial_bot_liquidate call failed: {:?} {}", code, msg)),
-    };
-
-    // Step 2: Swap ICP → ckStable
-    let swap_amount = process::calculate_swap_amount(collateral_amount, debt_covered, collateral_price);
-    let stable_result = swap::swap_icp_for_stable(&config, swap_amount).await;
-    let (stable_amount, stable_token, route) = match stable_result {
-        Ok(r) => {
-            log!(INFO, "[test_force_partial_liquidate] KongSwap OK: {} native via {}", r.output_amount, r.route);
-            (r.output_amount, r.target_token, r.route)
-        }
-        Err(e) => {
-            let _ = process::call_bot_cancel_liquidation_pub(&config, vault_id).await;
-            ic_cdk::trap(&format!("KongSwap failed (claim cancelled): {}", e));
-        }
-    };
-
-    // Step 3: ckStable → icUSD
-    let icusd_amount = match swap::swap_stable_for_icusd(&config, stable_amount, stable_token).await {
-        Ok(amount) => amount,
-        Err(e) => {
-            let _ = process::call_bot_cancel_liquidation_pub(&config, vault_id).await;
-            ic_cdk::trap(&format!("3pool swap failed (claim cancelled): {}", e));
-        }
-    };
-
-    // Step 4: Deposit icUSD to backend reserves
-    let deposited = match process::call_bot_deposit_to_reserves_pub(&config, icusd_amount).await {
-        Ok(()) => true,
-        Err(e) => {
-            log!(INFO, "[test_force_partial_liquidate] Deposit failed: {}", e);
-            false
-        }
-    };
-
-    // Step 5: CONFIRM the liquidation
-    let confirmed = match process::call_bot_confirm_liquidation_pub(&config, vault_id).await {
-        Ok(()) => {
-            log!(INFO, "[test_force_partial_liquidate] Confirmed liquidation for vault #{}", vault_id);
-            true
-        }
-        Err(e) => {
-            log!(INFO, "[test_force_partial_liquidate] Confirm failed: {}", e);
-            false
-        }
-    };
-
-    // Step 6: Send remaining ICP to treasury
-    let icp_to_treasury = collateral_amount.saturating_sub(swap_amount);
-    if icp_to_treasury > 0 {
-        let _ = process::transfer_icp_to_treasury_pub(&config, icp_to_treasury).await;
-    }
-
-    // Log event
-    state::mutate_state(|s| {
-        s.stats.events_count += 1;
-        s.liquidation_events.push(BotLiquidationEvent {
-            timestamp: ic_cdk::api::time(),
-            vault_id,
-            debt_covered_e8s: debt_covered,
-            collateral_received_e8s: collateral_amount,
-            icusd_burned_e8s: icusd_amount,
-            collateral_to_treasury_e8s: icp_to_treasury,
-            swap_route: route.clone(),
-            effective_price_e8s: 0,
-            slippage_bps: 0,
-            success: confirmed && deposited,
-            error_message: if confirmed { Some("test_force_partial_liquidate".to_string()) } else { Some("confirm failed".to_string()) },
-        });
-    });
-
-    TestForceResult {
-        vault_id,
-        collateral_received_e8s: collateral_amount,
-        debt_covered_e8s: debt_covered,
-        stable_output_native: stable_amount,
-        stable_route: route,
-        icusd_output_e8s: icusd_amount,
-        icusd_deposited_to_reserves: deposited,
-        icp_to_treasury_e8s: icp_to_treasury,
     }
 }

--- a/src/liquidation_bot/src/lib.rs
+++ b/src/liquidation_bot/src/lib.rs
@@ -181,9 +181,10 @@ fn get_bot_stats() -> state::BotStats {
 
 #[query]
 fn get_admin_events(offset: u64, limit: u64) -> Vec<state::BotAdminEvent> {
+    let limit = limit.min(1000);
     state::read_state(|s| {
         let len = s.admin_events.len();
-        let start = (len as u64).saturating_sub(offset + limit) as usize;
+        let start = (len as u64).saturating_sub(offset.saturating_add(limit)) as usize;
         let end = (len as u64).saturating_sub(offset) as usize;
         if start >= end {
             return vec![];
@@ -273,7 +274,7 @@ async fn admin_resolve_pool_ordering() {
     let _guard = ProcessingGuard::acquire()
         .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let (pool, icp_ledger) = state::read_state(|s| {
-        let c = s.config.as_ref().unwrap();
+        let c = s.config.as_ref().expect("Config not set");
         (c.icpswap_pool, c.icp_ledger)
     });
 
@@ -305,7 +306,7 @@ async fn admin_approve_pool() {
     let _guard = ProcessingGuard::acquire()
         .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let (icp_ledger, pool) = state::read_state(|s| {
-        let c = s.config.as_ref().unwrap();
+        let c = s.config.as_ref().expect("Config not set");
         (c.icp_ledger, c.icpswap_pool)
     });
 
@@ -323,7 +324,9 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
     require_admin();
     let _guard = ProcessingGuard::acquire()
         .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
-    let ckusdc_ledger = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_ledger);
+    let ckusdc_ledger = state::read_state(|s| {
+        s.config.as_ref().expect("Config not set").ckusdc_ledger
+    });
 
     let balance_result: Result<(Nat,), _> = ic_cdk::call(
         ckusdc_ledger,
@@ -337,7 +340,7 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
 
     let balance = match balance_result {
         Ok((b,)) => {
-            let val: u64 = b.0.to_string().parse().unwrap_or(0);
+            let val: u64 = b.0.to_string().parse().unwrap_or(u64::MAX);
             if val == 0 {
                 ic_cdk::trap("Bot has zero ckUSDC balance");
             }
@@ -346,7 +349,7 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
         Err((code, msg)) => ic_cdk::trap(&format!("Balance query failed: {:?} {}", code, msg)),
     };
 
-    let fee = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_fee_e6.unwrap_or(10));
+    let fee = state::read_state(|s| s.config.as_ref().expect("Config not set").ckusdc_fee_e6.unwrap_or(10));
     let send_amount = balance.saturating_sub(fee);
 
     let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {

--- a/src/liquidation_bot/src/lib.rs
+++ b/src/liquidation_bot/src/lib.rs
@@ -72,6 +72,9 @@ fn pre_upgrade() {
 fn post_upgrade() {
     // STEP 1: Rescue legacy JSON blob BEFORE MemoryManager::init.
     // Raw stable64_read is safe here because MemoryManager hasn't been initialized yet.
+    // On second+ upgrades, offset 0 contains the MemoryManager header (magic 0x4D474943 + version).
+    // Interpreted as a little-endian u64, this exceeds 10_000_000, so the len check below
+    // correctly returns None and we fall through to load_config_from_stable().
     let size = ic_cdk::api::stable::stable64_size();
     let legacy_state: Option<BotState> = if size > 0 {
         let mut len_bytes = [0u8; 8];
@@ -386,6 +389,21 @@ async fn admin_retry_stuck_claim(vault_id: u64) {
 
     match process::call_bot_confirm_liquidation(&config, vault_id).await {
         Ok(()) => {
+            // Find and update the stuck record for this vault
+            let count = history::record_count();
+            for id in (0..count).rev() {
+                if let Some(record) = history::get_record(id) {
+                    match &record {
+                        history::LiquidationRecordVersioned::V1(r) => {
+                            if r.vault_id == vault_id && r.status == history::LiquidationStatus::ConfirmFailed {
+                                history::update_record_status(id, history::LiquidationStatus::Completed);
+                                log!(INFO, "admin_retry_stuck_claim: marked record #{} as Completed", id);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
             log!(INFO, "admin_retry_stuck_claim: confirmed vault #{}", vault_id);
         }
         Err(e) => {

--- a/src/liquidation_bot/src/lib.rs
+++ b/src/liquidation_bot/src/lib.rs
@@ -2,6 +2,7 @@ use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use ic_canister_log::{declare_log_buffer, log};
 use icrc_ledger_types::icrc1::account::Account;
+use std::cell::RefCell;
 
 mod history;
 mod icpswap;
@@ -13,6 +14,32 @@ mod swap;
 use state::{BotAdminAction, BotAdminEvent, BotConfig, BotState, LiquidatableVaultInfo};
 
 declare_log_buffer!(name = INFO, capacity = 1000);
+
+thread_local! {
+    /// Reentrancy guard: true while process_pending or an admin async endpoint is running.
+    static PROCESSING: RefCell<bool> = RefCell::new(false);
+}
+
+struct ProcessingGuard;
+
+impl ProcessingGuard {
+    fn acquire() -> Result<Self, &'static str> {
+        PROCESSING.with(|p| {
+            let mut flag = p.borrow_mut();
+            if *flag {
+                return Err("Already processing");
+            }
+            *flag = true;
+            Ok(Self)
+        })
+    }
+}
+
+impl Drop for ProcessingGuard {
+    fn drop(&mut self) {
+        PROCESSING.with(|p| *p.borrow_mut() = false);
+    }
+}
 
 #[derive(CandidType, Deserialize)]
 pub struct BotInitArgs {
@@ -102,6 +129,24 @@ fn setup_timer() {
     );
 }
 
+// ---- Inspect message (cycle optimization, NOT a security boundary) ----
+
+#[ic_cdk_macros::inspect_message]
+fn inspect_message() {
+    let method = ic_cdk::api::call::method_name();
+    match method.as_str() {
+        // Admin/auth methods: reject anonymous to save cycles on Candid decoding
+        "set_config" | "admin_resolve_pool_ordering" | "admin_approve_pool"
+        | "admin_sweep_ckusdc" | "admin_retry_stuck_claim" => {
+            if ic_cdk::api::caller() != Principal::anonymous() {
+                ic_cdk::api::call::accept_message();
+            }
+        }
+        // All other methods (queries, notify from backend): accept
+        _ => ic_cdk::api::call::accept_message(),
+    }
+}
+
 // ---- Core endpoints ----
 
 #[update]
@@ -114,12 +159,14 @@ fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) {
     }
     let count = vaults.len();
     state::mutate_state(|s| {
+        // Replace (not append): backend sends the full current set each cycle.
         s.pending_vaults = vaults;
         s.admin_events.push(BotAdminEvent {
             timestamp: ic_cdk::api::time(),
             caller: caller.to_text(),
             action: BotAdminAction::VaultsNotified { count: count as u64 },
         });
+        trim_admin_events(&mut s.admin_events);
     });
     log!(INFO, "Received {} liquidatable vaults from backend", count);
 }
@@ -147,6 +194,17 @@ fn get_admin_event_count() -> u64 {
     state::read_state(|s| s.admin_events.len() as u64)
 }
 
+/// Cap admin_events to prevent unbounded heap growth.
+/// Keeps the most recent MAX entries, discards oldest.
+const MAX_ADMIN_EVENTS: usize = 10_000;
+
+fn trim_admin_events(events: &mut Vec<BotAdminEvent>) {
+    if events.len() > MAX_ADMIN_EVENTS {
+        let drain_count = events.len() - MAX_ADMIN_EVENTS;
+        events.drain(..drain_count);
+    }
+}
+
 #[update]
 fn set_config(config: BotConfig) {
     require_admin();
@@ -157,6 +215,7 @@ fn set_config(config: BotConfig) {
             caller: ic_cdk::api::caller().to_text(),
             action: BotAdminAction::ConfigUpdated,
         });
+        trim_admin_events(&mut s.admin_events);
     });
 }
 
@@ -193,6 +252,9 @@ fn get_liquidation_events(offset: u64, limit: u64) -> Vec<history::LiquidationRe
 
 fn require_admin() {
     let caller = ic_cdk::api::caller();
+    if caller == Principal::anonymous() {
+        ic_cdk::trap("Anonymous caller not allowed");
+    }
     let is_admin = state::read_state(|s| {
         s.config.as_ref().map(|c| c.admin == caller).unwrap_or(false)
     });
@@ -205,6 +267,8 @@ fn require_admin() {
 #[update]
 async fn admin_resolve_pool_ordering() {
     require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let (pool, icp_ledger) = state::read_state(|s| {
         let c = s.config.as_ref().unwrap();
         (c.icpswap_pool, c.icp_ledger)
@@ -235,6 +299,8 @@ async fn admin_resolve_pool_ordering() {
 #[update]
 async fn admin_approve_pool() {
     require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let (icp_ledger, pool) = state::read_state(|s| {
         let c = s.config.as_ref().unwrap();
         (c.icp_ledger, c.icpswap_pool)
@@ -252,6 +318,8 @@ async fn admin_approve_pool() {
 #[update]
 async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
     require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let ckusdc_ledger = state::read_state(|s| s.config.as_ref().unwrap().ckusdc_ledger);
 
     let balance_result: Result<(Nat,), _> = ic_cdk::call(
@@ -312,6 +380,8 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
 #[update]
 async fn admin_retry_stuck_claim(vault_id: u64) {
     require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
     let config = state::read_state(|s| s.config.clone()).expect("Not configured");
 
     match process::call_bot_confirm_liquidation(&config, vault_id).await {

--- a/src/liquidation_bot/src/memory.rs
+++ b/src/liquidation_bot/src/memory.rs
@@ -1,0 +1,33 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
+
+pub type Mem = VirtualMemory<DefaultMemoryImpl>;
+
+pub const MEM_ID_CONFIG: MemoryId = MemoryId::new(0);
+pub const MEM_ID_HISTORY: MemoryId = MemoryId::new(1);
+pub const MEM_ID_NEXT_ID: MemoryId = MemoryId::new(2);
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<Option<MemoryManager<DefaultMemoryImpl>>> =
+        RefCell::new(None);
+}
+
+/// Explicitly initialize the MemoryManager. Must be called AFTER any legacy
+/// stable memory rescue, because MemoryManager::init writes its own header
+/// at offset 0 on first use (on subsequent calls it reads the existing header
+/// and is non-destructive/idempotent).
+pub fn init_memory_manager() {
+    MEMORY_MANAGER.with(|mm| {
+        *mm.borrow_mut() = Some(MemoryManager::init(DefaultMemoryImpl::default()));
+    });
+}
+
+pub fn get_memory(id: MemoryId) -> Mem {
+    MEMORY_MANAGER.with(|mm| {
+        mm.borrow()
+            .as_ref()
+            .expect("MemoryManager not initialized. Call init_memory_manager() first.")
+            .get(id)
+    })
+}

--- a/src/liquidation_bot/src/process.rs
+++ b/src/liquidation_bot/src/process.rs
@@ -136,12 +136,12 @@ pub async fn process_pending() {
         match call_bot_confirm_liquidation(&config, vault.vault_id).await {
             Ok(()) => {
                 confirm_ok = true;
-                confirm_retries = attempt;
+                confirm_retries = attempt + 1;
                 break;
             }
             Err(e) => {
                 last_confirm_err = e;
-                confirm_retries = attempt;
+                confirm_retries = attempt + 1;
                 if attempt + 1 < CONFIRM_ATTEMPTS {
                     log!(crate::INFO, "Confirm attempt {}/{} failed for vault #{}: {}. Retrying.",
                         attempt + 1, CONFIRM_ATTEMPTS, vault.vault_id, last_confirm_err);

--- a/src/liquidation_bot/src/process.rs
+++ b/src/liquidation_bot/src/process.rs
@@ -42,6 +42,11 @@ impl std::fmt::Display for BackendError {
 }
 
 pub async fn process_pending() {
+    let _guard = match crate::ProcessingGuard::acquire() {
+        Ok(g) => g,
+        Err(_) => return, // Another liquidation is already in flight
+    };
+
     let vault = state::mutate_state(|s| s.pending_vaults.pop());
     let Some(vault) = vault else { return };
 

--- a/src/liquidation_bot/src/process.rs
+++ b/src/liquidation_bot/src/process.rs
@@ -1,11 +1,13 @@
-use candid::{CandidType, Deserialize, Nat, Principal};
+use candid::{CandidType, Deserialize};
 use ic_canister_log::log;
-use icrc_ledger_types::icrc1::account::Account;
 
-use crate::state::{self, BotConfig, BotLiquidationEvent, LiquidatableVaultInfo};
+use crate::history::{self, LiquidationRecordV1, LiquidationRecordVersioned, LiquidationStatus};
+use crate::state::{self, BotConfig};
 use crate::swap;
 
-/// Result returned by the backend's `bot_claim_liquidation` and `dev_force_bot_liquidate` endpoints.
+const CONFIRM_ATTEMPTS: u8 = 5;
+
+/// Result returned by the backend's `bot_claim_liquidation` endpoint.
 #[derive(CandidType, Deserialize, Debug)]
 pub struct BotLiquidationResult {
     pub vault_id: u64,
@@ -14,7 +16,6 @@ pub struct BotLiquidationResult {
     pub collateral_price_e8s: u64,
 }
 
-/// Wrapper for backend Result variant.
 #[derive(CandidType, Deserialize, Debug)]
 pub enum BackendResult<T> {
     #[serde(rename = "Ok")]
@@ -53,121 +54,152 @@ pub async fn process_pending() {
     };
 
     log!(crate::INFO, "Processing vault #{}", vault.vault_id);
+    let record_id = history::next_id();
+    let timestamp = ic_cdk::api::time();
 
-    // Phase 1: CLAIM the vault (gets collateral, locks vault, but debt unchanged)
+    // -- Phase 1: CLAIM --
     let liq_result = call_bot_claim_liquidation(&config, vault.vault_id).await;
     let (collateral_amount, debt_covered, collateral_price) = match liq_result {
         Ok(r) => (r.collateral_amount, r.debt_covered, r.collateral_price_e8s),
         Err(e) => {
-            log_failed_event(&vault, &format!("bot_claim_liquidation failed: {}", e));
+            log!(crate::INFO, "Claim failed for vault #{}: {}", vault.vault_id, e);
+            write_record(LiquidationRecordV1 {
+                id: record_id, vault_id: vault.vault_id, timestamp,
+                status: LiquidationStatus::ClaimFailed,
+                collateral_claimed_e8s: 0, debt_to_cover_e8s: 0, icp_swapped_e8s: 0,
+                ckusdc_received_e6: 0, ckusdc_transferred_e6: 0, icp_to_treasury_e8s: 0,
+                oracle_price_e8s: 0, effective_price_e8s: 0, slippage_bps: 0,
+                error_message: Some(e), confirm_retry_count: 0,
+            });
             return;
         }
     };
 
-    // Phase 2: Try to swap collateral → icUSD
-    let swap_amount = calculate_swap_amount_internal(collateral_amount, debt_covered, collateral_price);
-    let swap_result = swap::swap_icp_for_stable(&config, swap_amount).await;
+    // -- Phase 2: SWAP ICP -> ckUSDC --
+    let swap_amount = calculate_swap_amount(collateral_amount, debt_covered, collateral_price);
+    let swap_result = swap::swap_icp_for_ckusdc(&config, swap_amount).await;
 
-    let (stable_amount, stable_token, route) = match swap_result {
-        Ok(r) => (r.output_amount, r.target_token, r.route),
+    let (ckusdc_received, effective_price) = match swap_result {
+        Ok(r) => (r.ckusdc_received_e6, r.effective_price_e8s),
         Err(e) => {
-            // SWAP FAILED — return collateral and cancel the claim
-            log!(crate::INFO, "DEX swap failed for vault #{}: {}. Returning collateral and cancelling.", vault.vault_id, e);
-
-            if let Err(return_err) = return_collateral_to_backend(&config, collateral_amount, vault.collateral_type).await {
-                log!(crate::INFO, "WARNING: Failed to return collateral for vault #{}: {}", vault.vault_id, return_err);
-            }
-
-            if let Err(cancel_err) = call_bot_cancel_liquidation(&config, vault.vault_id).await {
-                log!(crate::INFO, "WARNING: Failed to cancel claim for vault #{}: {}", vault.vault_id, cancel_err);
-            }
-
-            log_failed_event(&vault, &format!("DEX swap failed (claim cancelled): {}", e));
+            log!(crate::INFO, "Swap failed for vault #{}: {}. Returning ICP.", vault.vault_id, e);
+            let _ = swap::return_collateral_to_backend(&config, collateral_amount, config.icp_ledger).await;
+            let _ = call_bot_cancel_liquidation(&config, vault.vault_id).await;
+            write_record(LiquidationRecordV1 {
+                id: record_id, vault_id: vault.vault_id, timestamp,
+                status: LiquidationStatus::SwapFailed,
+                collateral_claimed_e8s: collateral_amount, debt_to_cover_e8s: debt_covered,
+                icp_swapped_e8s: swap_amount, ckusdc_received_e6: 0, ckusdc_transferred_e6: 0,
+                icp_to_treasury_e8s: 0, oracle_price_e8s: collateral_price,
+                effective_price_e8s: 0, slippage_bps: 0,
+                error_message: Some(e), confirm_retry_count: 0,
+            });
             return;
         }
     };
 
-    // Phase 2b: ckStable → icUSD (3pool)
-    let icusd_result = swap::swap_stable_for_icusd(&config, stable_amount, stable_token).await;
-    let icusd_amount = match icusd_result {
-        Ok(amount) => amount,
-        Err(e) => {
-            // 3pool swap failed — we already swapped ICP to ckStable, can't easily reverse that.
-            // Cancel the claim so the stability pool can handle the vault.
-            // The bot keeps the ckStable (can be manually recovered).
-            log!(crate::INFO, "3pool swap failed for vault #{}: {}. Cancelling claim.", vault.vault_id, e);
-
-            if let Err(cancel_err) = call_bot_cancel_liquidation(&config, vault.vault_id).await {
-                log!(crate::INFO, "WARNING: Failed to cancel claim for vault #{}: {}", vault.vault_id, cancel_err);
-            }
-
-            log_failed_event(&vault, &format!("3pool swap failed (claim cancelled, ckStable held by bot): {}", e));
-            return;
-        }
-    };
-
-    // Phase 2c: Deposit icUSD to backend reserves
-    if let Err(e) = call_bot_deposit_to_reserves(&config, icusd_amount).await {
-        log!(crate::INFO, "deposit_to_reserves failed for vault #{}: {}. Cancelling claim.", vault.vault_id, e);
-        if let Err(cancel_err) = call_bot_cancel_liquidation(&config, vault.vault_id).await {
-            log!(crate::INFO, "WARNING: Failed to cancel claim for vault #{}: {}", vault.vault_id, cancel_err);
-        }
-        log_failed_event(&vault, &format!("deposit_to_reserves failed (claim cancelled): {}", e));
-        return;
-    }
-
-    // Phase 3: CONFIRM — everything succeeded, finalize the liquidation
-    if let Err(e) = call_bot_confirm_liquidation(&config, vault.vault_id).await {
-        log!(crate::INFO, "CRITICAL: bot_confirm_liquidation failed for vault #{}: {}. icUSD already deposited!", vault.vault_id, e);
-        log_failed_event(&vault, &format!("CRITICAL: confirm failed after deposit: {}", e));
-        return;
-    }
-
-    // Phase 4: Send remaining ICP to treasury (liquidation bonus)
-    let icp_to_treasury = collateral_amount.saturating_sub(swap_amount);
-    if icp_to_treasury > 0 {
-        let _ = transfer_icp_to_treasury(&config, icp_to_treasury).await;
-    }
-
-    // Phase 5: Log success
-    let effective_price = if swap_amount > 0 {
-        (stable_amount as u128 * 100_000_000 / swap_amount as u128) as u64
-    } else {
-        0
-    };
     let slippage_bps = calculate_slippage(effective_price, collateral_price);
 
+    // -- Phase 3: TRANSFER ckUSDC to backend (NO RETRY) --
+    let transfer_result = swap::transfer_ckusdc_to_backend(&config, ckusdc_received).await;
+
+    let ckusdc_transferred = match transfer_result {
+        Ok(actual_sent) => actual_sent,
+        Err(e) => {
+            log!(crate::INFO,
+                "STUCK: ckUSDC transfer failed for vault #{}. Bot holding {} ckUSDC e6. Error: {}. Needs admin resolution.",
+                vault.vault_id, ckusdc_received, e);
+            write_record(LiquidationRecordV1 {
+                id: record_id, vault_id: vault.vault_id, timestamp,
+                status: LiquidationStatus::TransferFailed,
+                collateral_claimed_e8s: collateral_amount, debt_to_cover_e8s: debt_covered,
+                icp_swapped_e8s: swap_amount, ckusdc_received_e6: ckusdc_received,
+                ckusdc_transferred_e6: 0, icp_to_treasury_e8s: 0,
+                oracle_price_e8s: collateral_price, effective_price_e8s: effective_price,
+                slippage_bps, error_message: Some(e), confirm_retry_count: 0,
+            });
+            return;
+        }
+    };
+
+    // -- Phase 4: CONFIRM (with retry, idempotent) --
+    let mut confirm_ok = false;
+    let mut confirm_retries: u8 = 0;
+    let mut last_confirm_err = String::new();
+
+    for attempt in 0..CONFIRM_ATTEMPTS {
+        match call_bot_confirm_liquidation(&config, vault.vault_id).await {
+            Ok(()) => {
+                confirm_ok = true;
+                confirm_retries = attempt;
+                break;
+            }
+            Err(e) => {
+                last_confirm_err = e;
+                confirm_retries = attempt;
+                if attempt + 1 < CONFIRM_ATTEMPTS {
+                    log!(crate::INFO, "Confirm attempt {}/{} failed for vault #{}: {}. Retrying.",
+                        attempt + 1, CONFIRM_ATTEMPTS, vault.vault_id, last_confirm_err);
+                }
+            }
+        }
+    }
+
+    if !confirm_ok {
+        log!(crate::INFO,
+            "STUCK: Confirm failed after {} attempts for vault #{}. ckUSDC is in backend but debt not written down. Error: {}. Needs admin resolution.",
+            CONFIRM_ATTEMPTS, vault.vault_id, last_confirm_err);
+        write_record(LiquidationRecordV1 {
+            id: record_id, vault_id: vault.vault_id, timestamp,
+            status: LiquidationStatus::ConfirmFailed,
+            collateral_claimed_e8s: collateral_amount, debt_to_cover_e8s: debt_covered,
+            icp_swapped_e8s: swap_amount, ckusdc_received_e6: ckusdc_received,
+            ckusdc_transferred_e6: ckusdc_transferred, icp_to_treasury_e8s: 0,
+            oracle_price_e8s: collateral_price, effective_price_e8s: effective_price,
+            slippage_bps, error_message: Some(last_confirm_err), confirm_retry_count: confirm_retries,
+        });
+        return;
+    }
+
+    // -- Phase 5: TREASURY (liquidation bonus) --
+    let icp_to_treasury = collateral_amount.saturating_sub(swap_amount);
+    if icp_to_treasury > 0 {
+        let _ = swap::transfer_icp_to_treasury(&config, icp_to_treasury).await;
+    }
+
+    // -- Phase 6: SUCCESS --
+    log!(crate::INFO, "Vault #{} liquidated: debt={} e8s, ckUSDC={} e6, treasury={} e8s ICP",
+        vault.vault_id, debt_covered, ckusdc_received, icp_to_treasury);
+
+    write_record(LiquidationRecordV1 {
+        id: record_id, vault_id: vault.vault_id, timestamp,
+        status: LiquidationStatus::Completed,
+        collateral_claimed_e8s: collateral_amount, debt_to_cover_e8s: debt_covered,
+        icp_swapped_e8s: swap_amount, ckusdc_received_e6: ckusdc_received,
+        ckusdc_transferred_e6: ckusdc_transferred, icp_to_treasury_e8s: icp_to_treasury,
+        oracle_price_e8s: collateral_price, effective_price_e8s: effective_price,
+        slippage_bps, error_message: None, confirm_retry_count: confirm_retries,
+    });
+
+    // Update legacy stats for backward compat with explorer UI
     state::mutate_state(|s| {
         s.stats.total_debt_covered_e8s += debt_covered;
-        s.stats.total_icusd_burned_e8s += icusd_amount;
         s.stats.total_collateral_received_e8s += collateral_amount;
         s.stats.total_collateral_to_treasury_e8s += icp_to_treasury;
         s.stats.events_count += 1;
-        s.liquidation_events.push(BotLiquidationEvent {
-            timestamp: ic_cdk::api::time(),
-            vault_id: vault.vault_id,
-            debt_covered_e8s: debt_covered,
-            collateral_received_e8s: collateral_amount,
-            icusd_burned_e8s: icusd_amount,
-            collateral_to_treasury_e8s: icp_to_treasury,
-            swap_route: route,
-            effective_price_e8s: effective_price,
-            slippage_bps,
-            success: true,
-            error_message: None,
-        });
     });
-
-    log!(
-        crate::INFO,
-        "Vault #{} liquidated: debt={}, collateral={}, icUSD={}, treasury={}",
-        vault.vault_id, debt_covered, collateral_amount, icusd_amount, icp_to_treasury
-    );
 }
 
-// ─── Helper Functions ───
+// -- Helpers --
 
-async fn call_bot_claim_liquidation(config: &BotConfig, vault_id: u64) -> Result<BotLiquidationResult, String> {
+fn write_record(record: LiquidationRecordV1) {
+    history::insert_record(LiquidationRecordVersioned::V1(record));
+}
+
+async fn call_bot_claim_liquidation(
+    config: &BotConfig,
+    vault_id: u64,
+) -> Result<BotLiquidationResult, String> {
     let result: Result<(BackendResult<BotLiquidationResult>,), _> =
         ic_cdk::call(config.backend_principal, "bot_claim_liquidation", (vault_id,)).await;
 
@@ -178,7 +210,10 @@ async fn call_bot_claim_liquidation(config: &BotConfig, vault_id: u64) -> Result
     }
 }
 
-async fn call_bot_confirm_liquidation(config: &BotConfig, vault_id: u64) -> Result<(), String> {
+pub async fn call_bot_confirm_liquidation(
+    config: &BotConfig,
+    vault_id: u64,
+) -> Result<(), String> {
     let result: Result<(BackendResult<()>,), _> =
         ic_cdk::call(config.backend_principal, "bot_confirm_liquidation", (vault_id,)).await;
 
@@ -189,7 +224,10 @@ async fn call_bot_confirm_liquidation(config: &BotConfig, vault_id: u64) -> Resu
     }
 }
 
-async fn call_bot_cancel_liquidation(config: &BotConfig, vault_id: u64) -> Result<(), String> {
+async fn call_bot_cancel_liquidation(
+    config: &BotConfig,
+    vault_id: u64,
+) -> Result<(), String> {
     let result: Result<(BackendResult<()>,), _> =
         ic_cdk::call(config.backend_principal, "bot_cancel_liquidation", (vault_id,)).await;
 
@@ -200,107 +238,7 @@ async fn call_bot_cancel_liquidation(config: &BotConfig, vault_id: u64) -> Resul
     }
 }
 
-/// Transfer collateral back to the backend canister via direct icrc1_transfer.
-/// No approve needed — the bot is sending from its own account.
-/// Subtracts the ledger fee from the amount since the bot's balance is exactly `amount`.
-async fn return_collateral_to_backend(config: &BotConfig, amount: u64, collateral_ledger: Principal) -> Result<(), String> {
-    // Query the ledger fee so we send amount - fee (bot balance is exactly `amount`)
-    let fee_result: Result<(Nat,), _> =
-        ic_cdk::call(collateral_ledger, "icrc1_fee", ()).await;
-    let fee = match fee_result {
-        Ok((f,)) => u64::try_from(f.0).unwrap_or(10_000),
-        Err(_) => 10_000, // fallback to ICP default
-    };
-    let send_amount = amount.saturating_sub(fee);
-    if send_amount == 0 {
-        return Err("Collateral amount too small to cover transfer fee".to_string());
-    }
-
-    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
-        from_subaccount: None,
-        to: Account {
-            owner: config.backend_principal,
-            subaccount: None,
-        },
-        amount: Nat::from(send_amount),
-        fee: None,
-        memo: None,
-        created_at_time: None,
-    };
-
-    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
-        ic_cdk::call(collateral_ledger, "icrc1_transfer", (transfer_args,)).await;
-
-    match result {
-        Ok((Ok(_),)) => Ok(()),
-        Ok((Err(e),)) => Err(format!("Transfer error: {:?}", e)),
-        Err((code, msg)) => Err(format!("Transfer call failed: {:?} {}", code, msg)),
-    }
-}
-
-async fn call_bot_deposit_to_reserves(config: &BotConfig, amount_e8s: u64) -> Result<(), String> {
-    // First approve the backend to spend our icUSD
-    let approve_args = icrc_ledger_types::icrc2::approve::ApproveArgs {
-        from_subaccount: None,
-        spender: Account {
-            owner: config.backend_principal,
-            subaccount: None,
-        },
-        amount: Nat::from(amount_e8s * 2),
-        expected_allowance: None,
-        expires_at: Some(ic_cdk::api::time() + 300_000_000_000),
-        fee: None,
-        memo: None,
-        created_at_time: None,
-    };
-
-    let approve_result: Result<(Result<Nat, icrc_ledger_types::icrc2::approve::ApproveError>,), _> =
-        ic_cdk::call(config.icusd_ledger, "icrc2_approve", (approve_args,)).await;
-
-    match approve_result {
-        Ok((Ok(_),)) => {}
-        Ok((Err(e),)) => return Err(format!("icUSD approve failed: {:?}", e)),
-        Err((code, msg)) => return Err(format!("icUSD approve call failed: {:?} {}", code, msg)),
-    }
-
-    // Call bot_deposit_to_reserves on backend
-    let result: Result<(BackendResult<()>,), _> =
-        ic_cdk::call(config.backend_principal, "bot_deposit_to_reserves", (amount_e8s,)).await;
-
-    match result {
-        Ok((BackendResult::Ok(()),)) => Ok(()),
-        Ok((BackendResult::Err(e),)) => Err(format!("{}", e)),
-        Err((code, msg)) => Err(format!("{:?}: {}", code, msg)),
-    }
-}
-
-async fn transfer_icp_to_treasury(config: &BotConfig, amount_e8s: u64) -> Result<(), String> {
-    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
-        from_subaccount: None,
-        to: Account {
-            owner: config.treasury_principal,
-            subaccount: None,
-        },
-        amount: Nat::from(amount_e8s),
-        fee: None,
-        memo: None,
-        created_at_time: None,
-    };
-
-    let result: Result<(Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,), _> =
-        ic_cdk::call(config.icp_ledger, "icrc1_transfer", (transfer_args,)).await;
-
-    match result {
-        Ok((Ok(_),)) => {
-            log!(crate::INFO, "Transferred {} e8s ICP to treasury", amount_e8s);
-            Ok(())
-        }
-        Ok((Err(e),)) => Err(format!("ICP transfer to treasury failed: {:?}", e)),
-        Err((code, msg)) => Err(format!("ICP transfer call failed: {:?} {}", code, msg)),
-    }
-}
-
-fn calculate_swap_amount_internal(collateral_e8s: u64, debt_e8s: u64, collateral_price_e8s: u64) -> u64 {
+pub fn calculate_swap_amount(collateral_e8s: u64, debt_e8s: u64, collateral_price_e8s: u64) -> u64 {
     if collateral_price_e8s == 0 {
         return collateral_e8s;
     }
@@ -309,53 +247,10 @@ fn calculate_swap_amount_internal(collateral_e8s: u64, debt_e8s: u64, collateral
     with_buffer.min(collateral_e8s)
 }
 
-/// Calculate slippage in basis points between effective price and oracle price.
 fn calculate_slippage(effective_price_e8s: u64, oracle_price_e8s: u64) -> i32 {
     if oracle_price_e8s == 0 || effective_price_e8s == 0 {
         return 0;
     }
     let diff = oracle_price_e8s as i64 - effective_price_e8s as i64;
     (diff * 10_000 / oracle_price_e8s as i64) as i32
-}
-
-// ─── Public wrappers for test functions ───
-
-pub async fn call_bot_deposit_to_reserves_pub(config: &BotConfig, amount_e8s: u64) -> Result<(), String> {
-    call_bot_deposit_to_reserves(config, amount_e8s).await
-}
-
-pub async fn transfer_icp_to_treasury_pub(config: &BotConfig, amount_e8s: u64) -> Result<(), String> {
-    transfer_icp_to_treasury(config, amount_e8s).await
-}
-
-pub fn calculate_swap_amount(collateral_e8s: u64, debt_e8s: u64, collateral_price_e8s: u64) -> u64 {
-    calculate_swap_amount_internal(collateral_e8s, debt_e8s, collateral_price_e8s)
-}
-
-pub async fn call_bot_cancel_liquidation_pub(config: &BotConfig, vault_id: u64) -> Result<(), String> {
-    call_bot_cancel_liquidation(config, vault_id).await
-}
-
-pub async fn call_bot_confirm_liquidation_pub(config: &BotConfig, vault_id: u64) -> Result<(), String> {
-    call_bot_confirm_liquidation(config, vault_id).await
-}
-
-fn log_failed_event(vault: &LiquidatableVaultInfo, error: &str) {
-    log!(crate::INFO, "FAILED vault #{}: {}", vault.vault_id, error);
-    state::mutate_state(|s| {
-        s.stats.events_count += 1;
-        s.liquidation_events.push(BotLiquidationEvent {
-            timestamp: ic_cdk::api::time(),
-            vault_id: vault.vault_id,
-            debt_covered_e8s: 0,
-            collateral_received_e8s: 0,
-            icusd_burned_e8s: 0,
-            collateral_to_treasury_e8s: 0,
-            swap_route: String::new(),
-            effective_price_e8s: 0,
-            slippage_bps: 0,
-            success: false,
-            error_message: Some(error.to_string()),
-        });
-    });
 }

--- a/src/liquidation_bot/src/state.rs
+++ b/src/liquidation_bot/src/state.rs
@@ -1,19 +1,42 @@
 use candid::{CandidType, Deserialize, Principal};
+use ic_stable_structures::writer::Writer;
 use serde::Serialize;
 use std::cell::RefCell;
+
+use crate::memory;
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
 pub struct BotConfig {
     pub backend_principal: Principal,
-    pub three_pool_principal: Principal,
-    pub kong_swap_principal: Principal,
     pub treasury_principal: Principal,
     pub admin: Principal,
     pub max_slippage_bps: u16,
     pub icp_ledger: Principal,
     pub ckusdc_ledger: Principal,
-    pub ckusdt_ledger: Principal,
-    pub icusd_ledger: Principal,
+
+    // ICPSwap config (replaces kong_swap + three_pool)
+    pub icpswap_pool: Principal,
+
+    // Cached after admin_resolve_pool_ordering (determines swap direction)
+    #[serde(default)]
+    pub icpswap_zero_for_one: Option<bool>,
+
+    // Cached ledger fees (set by admin or auto-detected)
+    #[serde(default)]
+    pub icp_fee_e8s: Option<u64>,
+    #[serde(default)]
+    pub ckusdc_fee_e6: Option<u64>,
+
+    // Legacy fields kept for deserialization compatibility (ignored at runtime).
+    // Can be removed after one upgrade cycle.
+    #[serde(default)]
+    pub three_pool_principal: Option<Principal>,
+    #[serde(default)]
+    pub kong_swap_principal: Option<Principal>,
+    #[serde(default)]
+    pub ckusdt_ledger: Option<Principal>,
+    #[serde(default)]
+    pub icusd_ledger: Option<Principal>,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -34,7 +57,8 @@ pub struct BotLiquidationEvent {
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize, Default)]
 pub struct BotStats {
     pub total_debt_covered_e8s: u64,
-    pub total_icusd_burned_e8s: u64,
+    #[serde(default, alias = "total_icusd_burned_e8s")]
+    pub total_ckusdc_deposited_e6: u64,
     pub total_collateral_received_e8s: u64,
     pub total_collateral_to_treasury_e8s: u64,
     pub events_count: u64,
@@ -71,6 +95,8 @@ pub struct BotState {
     pub pending_vaults: Vec<LiquidatableVaultInfo>,
     #[serde(default)]
     pub admin_events: Vec<BotAdminEvent>,
+    #[serde(default)]
+    pub migrated_to_stable_structures: bool,
 }
 
 thread_local! {
@@ -94,6 +120,8 @@ where
 pub fn init_state(state: BotState) {
     STATE.with(|s| *s.borrow_mut() = Some(state));
 }
+
+// ---- Legacy stable memory (raw offset 0, used only for first migration) ----
 
 pub fn save_to_stable_memory() {
     STATE.with(|s| {
@@ -129,4 +157,47 @@ pub fn load_from_stable_memory() {
     ic_cdk::api::stable::stable64_read(8, &mut bytes);
     let state: BotState = serde_json::from_slice(&bytes).expect("Failed to deserialize state");
     init_state(state);
+}
+
+// ---- New stable memory (MemoryManager virtual region MEM_ID_CONFIG) ----
+
+pub fn save_config_to_stable() {
+    STATE.with(|s| {
+        let state = s.borrow();
+        let state = state.as_ref().expect("State not initialized");
+        let bytes = serde_json::to_vec(state).expect("Failed to serialize state");
+        let len = bytes.len() as u64;
+
+        let mut mem = memory::get_memory(memory::MEM_ID_CONFIG);
+        let mut writer = Writer::new(&mut mem, 0);
+        writer
+            .write(&len.to_le_bytes())
+            .expect("Failed to write config length");
+        writer
+            .write(&bytes)
+            .expect("Failed to write config bytes");
+    });
+}
+
+pub fn load_config_from_stable() {
+    let mem = memory::get_memory(memory::MEM_ID_CONFIG);
+
+    let mut len_bytes = [0u8; 8];
+    ic_stable_structures::Memory::read(&mem, 0, &mut len_bytes);
+    let len = u64::from_le_bytes(len_bytes) as usize;
+
+    if len == 0 || len > 10_000_000 {
+        init_state(BotState::default());
+        return;
+    }
+
+    let mut bytes = vec![0u8; len];
+    ic_stable_structures::Memory::read(&mem, 8, &mut bytes);
+    match serde_json::from_slice::<BotState>(&bytes) {
+        Ok(state) => init_state(state),
+        Err(e) => {
+            ic_canister_log::log!(crate::INFO, "Failed to deserialize config from stable: {}", e);
+            init_state(BotState::default());
+        }
+    }
 }

--- a/src/liquidation_bot/src/swap.rs
+++ b/src/liquidation_bot/src/swap.rs
@@ -1,389 +1,229 @@
-use candid::{CandidType, Deserialize, Nat, Principal};
+use candid::{Nat, Principal};
 use ic_canister_log::log;
 use icrc_ledger_types::icrc1::account::Account;
-use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
+use icrc_ledger_types::icrc2::approve::ApproveArgs;
 
+use crate::icpswap;
 use crate::state::BotConfig;
 
-#[derive(Debug)]
 pub struct SwapResult {
-    pub output_amount: u64,
-    pub route: String,
-    pub target_token: Principal,
+    pub ckusdc_received_e6: u64,
+    pub effective_price_e8s: u64,
 }
 
-#[derive(Debug)]
-pub enum SwapError {
-    SlippageExceeded { expected: u64, actual: u64 },
-    DexCallFailed(String),
-    InsufficientLiquidity,
-    ApproveFailed(String),
-}
-
-impl std::fmt::Display for SwapError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SwapError::SlippageExceeded { expected, actual } => {
-                write!(f, "Slippage exceeded: expected {} got {}", expected, actual)
-            }
-            SwapError::DexCallFailed(msg) => write!(f, "DEX call failed: {}", msg),
-            SwapError::InsufficientLiquidity => write!(f, "Insufficient liquidity"),
-            SwapError::ApproveFailed(msg) => write!(f, "Approve failed: {}", msg),
-        }
-    }
-}
-
-// ─── KongSwap Types ───
-
-// swap_amounts returns: variant { Ok : SwapAmountsReply; Err : text }
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub enum KongSwapAmountsResult {
-    Ok(KongSwapAmountsReply),
-    Err(String),
-}
-
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub struct KongSwapAmountsReply {
-    pub pay_chain: String,
-    pub pay_symbol: String,
-    pub pay_address: String,
-    pub pay_amount: Nat,
-    pub receive_chain: String,
-    pub receive_symbol: String,
-    pub receive_address: String,
-    pub receive_amount: Nat,
-    pub price: f64,
-    pub mid_price: f64,
-    pub slippage: f64,
-}
-
-// SwapArgs record for swap()
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub struct KongSwapArgs {
-    pub pay_token: String,
-    pub pay_amount: Nat,
-    pub pay_tx_id: Option<KongTxId>,
-    pub receive_token: String,
-    pub receive_amount: Option<Nat>,
-    pub receive_address: Option<String>,
-    pub max_slippage: Option<f64>,
-    pub referred_by: Option<String>,
-}
-
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub enum KongTxId {
-    BlockIndex(Nat),
-    TransactionId(String),
-}
-
-// swap returns: variant { Ok : SwapReply; Err : text }
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub enum KongSwapResult {
-    Ok(KongSwapReply),
-    Err(String),
-}
-
-#[derive(CandidType, Deserialize, Clone, Debug)]
-pub struct KongSwapReply {
-    pub tx_id: u64,
-    pub request_id: u64,
-    pub status: String,
-    pub pay_chain: String,
-    pub pay_address: String,
-    pub pay_symbol: String,
-    pub pay_amount: Nat,
-    pub receive_chain: String,
-    pub receive_address: String,
-    pub receive_symbol: String,
-    pub receive_amount: Nat,
-    pub mid_price: f64,
-    pub price: f64,
-    pub slippage: f64,
-}
-
-/// Format a canister principal as KongSwap token identifier: "IC.<principal>"
-fn kong_token_id(principal: Principal) -> String {
-    format!("IC.{}", principal.to_text())
-}
-
-/// Query KongSwap for a quote: ICP → target stablecoin.
-/// swap_amounts takes (text, nat, text) — three separate args.
-async fn kong_get_quote(
-    kong_principal: Principal,
-    icp_ledger: Principal,
-    target_ledger: Principal,
-    amount_e8s: u64,
-) -> Result<(u64, f64), SwapError> {
-    let pay_token = kong_token_id(icp_ledger);
-    let pay_amount = Nat::from(amount_e8s);
-    let receive_token = kong_token_id(target_ledger);
-
-    let result: Result<(KongSwapAmountsResult,), _> =
-        ic_cdk::call(kong_principal, "swap_amounts", (&pay_token, &pay_amount, &receive_token)).await;
-
-    match result {
-        Ok((KongSwapAmountsResult::Ok(reply),)) => {
-            let amount = nat_to_u64(&reply.receive_amount);
-            Ok((amount, reply.price))
-        }
-        Ok((KongSwapAmountsResult::Err(e),)) => {
-            Err(SwapError::DexCallFailed(e))
-        }
-        Err((code, msg)) => Err(SwapError::DexCallFailed(format!(
-            "KongSwap call failed ({:?}): {}",
-            code, msg
-        ))),
-    }
-}
-
-/// Execute a swap on KongSwap: ICP → target stablecoin.
-/// Uses icrc2_approve + swap (KongSwap does icrc2_transfer_from).
-async fn kong_execute_swap(
-    kong_principal: Principal,
-    icp_ledger: Principal,
-    target_ledger: Principal,
-    amount_e8s: u64,
-    max_slippage_bps: u16,
-) -> Result<(u64, f64), SwapError> {
-    // Subtract ICP ledger fee for approve + transfer_from overhead
-    let amount_e8s = amount_e8s.saturating_sub(20_000); // 0.0002 ICP buffer
-
-    // First, approve KongSwap to spend our ICP
-    let approve_args = ApproveArgs {
+/// One-time infinite ICRC-2 approve. Amount = u128::MAX, no expiry.
+pub async fn approve_infinite(
+    token_ledger: Principal,
+    spender: Principal,
+) -> Result<(), String> {
+    let args = ApproveArgs {
         from_subaccount: None,
         spender: Account {
-            owner: kong_principal,
+            owner: spender,
             subaccount: None,
         },
-        amount: Nat::from(amount_e8s * 2), // 2x buffer for fees
+        amount: Nat::from(u128::MAX),
         expected_allowance: None,
-        expires_at: Some(ic_cdk::api::time() + 300_000_000_000), // 5 min
+        expires_at: None,
         fee: None,
         memo: None,
         created_at_time: None,
     };
 
-    let approve_result: Result<(Result<Nat, ApproveError>,), _> =
-        ic_cdk::call(icp_ledger, "icrc2_approve", (approve_args,)).await;
-
-    match approve_result {
-        Ok((Ok(_),)) => {}
-        Ok((Err(e),)) => {
-            return Err(SwapError::ApproveFailed(format!("{:?}", e)));
-        }
-        Err((code, msg)) => {
-            return Err(SwapError::ApproveFailed(format!("{:?}: {}", code, msg)));
-        }
-    }
-
-    // KongSwap expects slippage as a percentage (e.g., 5.0 for 5%), not a fraction
-    let slippage_pct = max_slippage_bps as f64 / 100.0;
-    let args = KongSwapArgs {
-        pay_token: kong_token_id(icp_ledger),
-        pay_amount: Nat::from(amount_e8s),
-        pay_tx_id: None,
-        receive_token: kong_token_id(target_ledger),
-        receive_amount: None,
-        max_slippage: Some(slippage_pct),
-        receive_address: None,
-        referred_by: None,
-    };
-
-    let result: Result<(KongSwapResult,), _> =
-        ic_cdk::call(kong_principal, "swap", (args,)).await;
+    let result: Result<
+        (Result<Nat, icrc_ledger_types::icrc2::approve::ApproveError>,),
+        _,
+    > = ic_cdk::call(token_ledger, "icrc2_approve", (args,)).await;
 
     match result {
-        Ok((KongSwapResult::Ok(reply),)) => {
-            let amount = nat_to_u64(&reply.receive_amount);
-            Ok((amount, reply.price))
-        }
-        Ok((KongSwapResult::Err(e),)) => {
-            Err(SwapError::DexCallFailed(e))
-        }
-        Err((code, msg)) => Err(SwapError::DexCallFailed(format!(
-            "KongSwap swap call failed ({:?}): {}",
-            code, msg
-        ))),
+        Ok((Ok(_),)) => Ok(()),
+        Ok((Err(e),)) => Err(format!("Approve failed: {:?}", e)),
+        Err((code, msg)) => Err(format!("Approve call failed: {:?} {}", code, msg)),
     }
 }
 
-/// Swap ICP for the best-rate stablecoin (ckUSDC or ckUSDT) on KongSwap.
-pub async fn swap_icp_for_stable(
+/// Quote how much ckUSDC we'd get for `icp_amount_e8s` ICP.
+pub async fn quote_icp_for_ckusdc(config: &BotConfig, icp_amount_e8s: u64) -> Result<u64, String> {
+    let zero_for_one = config
+        .icpswap_zero_for_one
+        .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;
+
+    icpswap::quote(config.icpswap_pool, icp_amount_e8s, zero_for_one).await
+}
+
+/// Swap ICP for ckUSDC on ICPSwap.
+/// Flow: get quote -> apply slippage -> depositFromAndSwap.
+/// Requires infinite approve to already be in place.
+pub async fn swap_icp_for_ckusdc(
     config: &BotConfig,
-    amount_e8s: u64,
-) -> Result<SwapResult, SwapError> {
-    // Query both ckUSDC and ckUSDT quotes in parallel
-    let usdc_quote = kong_get_quote(
-        config.kong_swap_principal,
-        config.icp_ledger,
-        config.ckusdc_ledger,
-        amount_e8s,
+    icp_amount_e8s: u64,
+) -> Result<SwapResult, String> {
+    let zero_for_one = config
+        .icpswap_zero_for_one
+        .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;
+
+    let quoted_output =
+        icpswap::quote(config.icpswap_pool, icp_amount_e8s, zero_for_one).await?;
+
+    if quoted_output == 0 {
+        return Err("Quote returned zero output".to_string());
+    }
+
+    let min_output = apply_slippage(quoted_output, config.max_slippage_bps);
+
+    log!(
+        crate::INFO,
+        "ICPSwap quote: {} ICP e8s -> {} ckUSDC e6 (min: {})",
+        icp_amount_e8s,
+        quoted_output,
+        min_output
     );
-    let usdt_quote = kong_get_quote(
-        config.kong_swap_principal,
-        config.icp_ledger,
-        config.ckusdt_ledger,
-        amount_e8s,
-    );
 
-    let (usdc_result, usdt_result) = futures::future::join(usdc_quote, usdt_quote).await;
+    let icp_fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let ckusdc_fee = config.ckusdc_fee_e6.unwrap_or(10);
 
-    // Pick the better rate (higher output amount)
-    let (target_ledger, target_name, _quote_amount) = match (usdc_result, usdt_result) {
-        (Ok((usdc_amt, _)), Ok((usdt_amt, _))) => {
-            // Both are 6 decimals — compare directly
-            if usdc_amt >= usdt_amt {
-                log!(crate::INFO, "Best rate: ckUSDC ({} vs {} ckUSDT)", usdc_amt, usdt_amt);
-                (config.ckusdc_ledger, "ckUSDC", usdc_amt)
-            } else {
-                log!(crate::INFO, "Best rate: ckUSDT ({} vs {} ckUSDC)", usdt_amt, usdc_amt);
-                (config.ckusdt_ledger, "ckUSDT", usdt_amt)
-            }
-        }
-        (Ok((usdc_amt, _)), Err(e)) => {
-            log!(crate::INFO, "ckUSDT quote failed ({}), using ckUSDC", e);
-            (config.ckusdc_ledger, "ckUSDC", usdc_amt)
-        }
-        (Err(e), Ok((usdt_amt, _))) => {
-            log!(crate::INFO, "ckUSDC quote failed ({}), using ckUSDT", e);
-            (config.ckusdt_ledger, "ckUSDT", usdt_amt)
-        }
-        (Err(e1), Err(e2)) => {
-            return Err(SwapError::DexCallFailed(format!(
-                "Both quotes failed: ckUSDC={}, ckUSDT={}",
-                e1, e2
-            )));
-        }
-    };
-
-    // Execute the swap with the better rate
-    let (output_amount, _price) = kong_execute_swap(
-        config.kong_swap_principal,
-        config.icp_ledger,
-        target_ledger,
-        amount_e8s,
-        config.max_slippage_bps,
+    let received = icpswap::deposit_and_swap(
+        config.icpswap_pool,
+        icp_amount_e8s,
+        min_output,
+        zero_for_one,
+        icp_fee,
+        ckusdc_fee,
     )
     .await?;
 
+    // Effective price in e8 format: (ckusdc_e6 / icp_e8s) * 1e8
+    // = ckusdc_e6 * 1e2 * 1e8 / icp_e8s = ckusdc_e6 * 10_000_000_000 / icp_e8s
+    let effective_price_e8s = if icp_amount_e8s > 0 {
+        (received as u128 * 10_000_000_000 / icp_amount_e8s as u128) as u64
+    } else {
+        0
+    };
+
+    log!(
+        crate::INFO,
+        "ICPSwap swap complete: {} ckUSDC e6 received, effective price {} e8s",
+        received,
+        effective_price_e8s
+    );
+
     Ok(SwapResult {
-        output_amount,
-        route: format!("ICP→{}→icUSD", target_name),
-        target_token: target_ledger,
+        ckusdc_received_e6: received,
+        effective_price_e8s,
     })
 }
 
-/// Swap a stablecoin (ckUSDC or ckUSDT) for icUSD via our 3pool.
-/// 3pool token indices: 0=icUSD, 1=ckUSDT, 2=ckUSDC
-pub async fn swap_stable_for_icusd(
+fn apply_slippage(amount: u64, max_slippage_bps: u16) -> u64 {
+    let reduction = amount as u128 * max_slippage_bps as u128 / 10_000;
+    (amount as u128 - reduction) as u64
+}
+
+/// Transfer collateral (ICP) back to the backend canister.
+pub async fn return_collateral_to_backend(
     config: &BotConfig,
-    amount_native: u64,
-    stable_token: Principal,
-) -> Result<u64, SwapError> {
-    let token_index: u8 = if stable_token == config.ckusdc_ledger {
-        2
-    } else if stable_token == config.ckusdt_ledger {
-        1
-    } else {
-        return Err(SwapError::DexCallFailed(
-            "Unknown stablecoin for 3pool swap".to_string(),
-        ));
-    };
+    amount_e8s: u64,
+    collateral_ledger: Principal,
+) -> Result<(), String> {
+    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let send_amount = amount_e8s.saturating_sub(fee);
+    if send_amount == 0 {
+        return Err("Collateral amount too small to cover transfer fee".to_string());
+    }
 
-    // Subtract fee buffer: approve costs a fee, and transfer_from charges fee on top of amount
-    // ckUSDC/ckUSDT fees are ~10 native units, use 1000 as safe buffer (~$0.001)
-    let amount_native = amount_native.saturating_sub(1000);
-
-    // Approve 3pool to spend our stablecoin
-    let approve_args = ApproveArgs {
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
         from_subaccount: None,
-        spender: Account {
-            owner: config.three_pool_principal,
+        to: Account {
+            owner: config.backend_principal,
             subaccount: None,
         },
-        amount: Nat::from(amount_native * 2),
-        expected_allowance: None,
-        expires_at: Some(ic_cdk::api::time() + 300_000_000_000),
+        amount: Nat::from(send_amount),
         fee: None,
         memo: None,
-        created_at_time: None,
+        created_at_time: Some(ic_cdk::api::time()),
     };
 
-    let approve_result: Result<(Result<Nat, ApproveError>,), _> =
-        ic_cdk::call(stable_token, "icrc2_approve", (approve_args,)).await;
-
-    match approve_result {
-        Ok((Ok(_),)) => {}
-        Ok((Err(e),)) => {
-            return Err(SwapError::ApproveFailed(format!("3pool approve: {:?}", e)));
-        }
-        Err((code, msg)) => {
-            return Err(SwapError::ApproveFailed(format!(
-                "3pool approve call: {:?} {}",
-                code, msg
-            )));
-        }
-    }
-
-    // Calculate minimum output with slippage tolerance
-    // ckUSDC/ckUSDT (6 decimals) → icUSD (8 decimals): multiply by 100
-    let expected_e8s = amount_native as u128 * 100;
-    let slippage = expected_e8s * config.max_slippage_bps as u128 / 10_000;
-    let min_output_e8s = (expected_e8s - slippage) as u64;
-
-    // 3pool swap: swap(from_index, to_index, dx, min_dy)
-    #[derive(CandidType, Deserialize, Debug)]
-    enum ThreePoolResult {
-        Ok(Nat),
-        Err(ThreePoolError),
-    }
-
-    #[derive(CandidType, Deserialize, Debug)]
-    enum ThreePoolError {
-        InsufficientOutput {
-            expected_min: Nat,
-            actual: Nat,
-        },
-        InsufficientLiquidity,
-        InvalidCoinIndex,
-        ZeroAmount,
-        PoolEmpty,
-        SlippageExceeded,
-        TransferFailed {
-            token: String,
-            reason: String,
-        },
-        Unauthorized,
-        MathOverflow,
-        InvariantNotConverged,
-        PoolPaused,
-    }
-
-    let result: Result<(ThreePoolResult,), _> = ic_cdk::call(
-        config.three_pool_principal,
-        "swap",
-        (
-            token_index,
-            0u8, // to icUSD (index 0)
-            Nat::from(amount_native),
-            Nat::from(min_output_e8s),
-        ),
-    )
-    .await;
+    let result: Result<
+        (Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,),
+        _,
+    > = ic_cdk::call(collateral_ledger, "icrc1_transfer", (transfer_args,)).await;
 
     match result {
-        Ok((ThreePoolResult::Ok(amount),)) => Ok(nat_to_u64(&amount)),
-        Ok((ThreePoolResult::Err(e),)) => Err(SwapError::DexCallFailed(format!(
-            "3pool swap error: {:?}",
-            e
-        ))),
-        Err((code, msg)) => Err(SwapError::DexCallFailed(format!(
-            "3pool call failed ({:?}): {}",
-            code, msg
-        ))),
+        Ok((Ok(_),)) => Ok(()),
+        Ok((Err(e),)) => Err(format!("Transfer error: {:?}", e)),
+        Err((code, msg)) => Err(format!("Transfer call failed: {:?} {}", code, msg)),
     }
 }
 
-fn nat_to_u64(n: &Nat) -> u64 {
-    n.0.to_string().parse::<u64>().unwrap_or(0)
+/// Transfer ckUSDC from bot to backend canister.
+/// Returns the actual amount received by the backend (after fee subtraction).
+pub async fn transfer_ckusdc_to_backend(
+    config: &BotConfig,
+    amount_e6: u64,
+) -> Result<u64, String> {
+    let fee = config.ckusdc_fee_e6.unwrap_or(10);
+    let send_amount = amount_e6.saturating_sub(fee);
+    if send_amount == 0 {
+        return Err("ckUSDC amount too small to cover transfer fee".to_string());
+    }
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account {
+            owner: config.backend_principal,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()),
+    };
+
+    let result: Result<
+        (Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,),
+        _,
+    > = ic_cdk::call(config.ckusdc_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => Ok(send_amount),
+        Ok((Err(e),)) => Err(format!("ckUSDC transfer error: {:?}", e)),
+        Err((code, msg)) => Err(format!("ckUSDC transfer call failed: {:?} {}", code, msg)),
+    }
+}
+
+/// Transfer ICP to treasury (liquidation bonus).
+pub async fn transfer_icp_to_treasury(
+    config: &BotConfig,
+    amount_e8s: u64,
+) -> Result<(), String> {
+    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let send_amount = amount_e8s.saturating_sub(fee);
+    if send_amount == 0 {
+        return Ok(());
+    }
+
+    let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+        from_subaccount: None,
+        to: Account {
+            owner: config.treasury_principal,
+            subaccount: None,
+        },
+        amount: Nat::from(send_amount),
+        fee: None,
+        memo: None,
+        created_at_time: Some(ic_cdk::api::time()),
+    };
+
+    let result: Result<
+        (Result<Nat, icrc_ledger_types::icrc1::transfer::TransferError>,),
+        _,
+    > = ic_cdk::call(config.icp_ledger, "icrc1_transfer", (transfer_args,)).await;
+
+    match result {
+        Ok((Ok(_),)) => {
+            log!(crate::INFO, "Transferred {} e8s ICP to treasury", send_amount);
+            Ok(())
+        }
+        Ok((Err(e),)) => Err(format!("ICP transfer to treasury failed: {:?}", e)),
+        Err((code, msg)) => Err(format!("ICP transfer call failed: {:?} {}", code, msg)),
+    }
 }

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -72,7 +72,6 @@ type BotStatsResponse = record {
   liquidation_bot_principal : opt principal;
   budget_total_e8s : nat64;
   budget_start_timestamp : nat64;
-  total_icusd_deposited_e8s : nat64;
 };
 type CandidVault = record {
   collateral_amount : nat64;
@@ -680,7 +679,7 @@ service : (ProtocolArg) -> {
   bot_cancel_liquidation : (nat64) -> (Result);
   bot_claim_liquidation : (nat64) -> (Result_3);
   bot_confirm_liquidation : (nat64) -> (Result);
-  bot_deposit_to_reserves : (nat64) -> (Result);
+  admin_resolve_stuck_claim : (nat64, bool) -> (Result);
   claim_liquidity_returns : () -> (Result_1);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_vault : (nat64) -> (Result_4);

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1623,7 +1623,6 @@ pub struct BotStatsResponse {
     pub budget_remaining_e8s: u64,
     pub budget_start_timestamp: u64,
     pub total_debt_covered_e8s: u64,
-    pub total_icusd_deposited_e8s: u64,
 }
 
 #[candid_method(update)]
@@ -2206,26 +2205,6 @@ async fn dev_set_collateral_price(collateral_type: Principal, price_usd: f64) ->
     Ok(format!("Price for {} set to ${:.6} (was {:?})", collateral_type, price_usd, old_price))
 }
 
-/// Bot calls this after swapping collateral → icUSD to repay its obligation.
-#[candid_method(update)]
-#[update]
-async fn bot_deposit_to_reserves(amount_e8s: u64) -> Result<(), ProtocolError> {
-    let caller = ic_cdk::api::caller();
-    let is_bot = read_state(|s| {
-        s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
-    });
-    if !is_bot {
-        return Err(ProtocolError::GenericError(
-            "Caller is not the registered liquidation bot canister".to_string(),
-        ));
-    }
-    mutate_state(|s| {
-        s.bot_total_icusd_deposited_e8s += amount_e8s;
-    });
-    log!(INFO, "[bot_deposit_to_reserves] Bot deposited {} e8s icUSD to reserves", amount_e8s);
-    Ok(())
-}
-
 #[candid_method(query)]
 #[query]
 fn get_bot_stats() -> BotStatsResponse {
@@ -2235,8 +2214,49 @@ fn get_bot_stats() -> BotStatsResponse {
         budget_remaining_e8s: s.bot_budget_remaining_e8s,
         budget_start_timestamp: s.bot_budget_start_timestamp,
         total_debt_covered_e8s: s.bot_total_debt_covered_e8s,
-        total_icusd_deposited_e8s: s.bot_total_icusd_deposited_e8s,
     })
+}
+
+/// Admin-only: force-resolve a stuck bot claim. Used when the bot's ckUSDC transfer
+/// or confirm failed and the vault is stuck with bot_processing=true.
+///
+/// - `apply_debt_reduction = false`: TransferFailed case. ckUSDC never reached the backend,
+///   so vault debt stays as-is. Just unlocks vault and restores budget.
+/// - `apply_debt_reduction = true`: ConfirmFailed case. ckUSDC DID reach the backend,
+///   so also write down the vault's debt and collateral (same as what confirm would do).
+#[candid_method(update)]
+#[update]
+fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_dev = read_state(|s| s.developer_principal == caller);
+    if !is_dev {
+        return Err(ProtocolError::GenericError("Unauthorized: developer only".to_string()));
+    }
+
+    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned())
+        .ok_or_else(|| ProtocolError::GenericError(format!(
+            "No active claim for vault #{}", vault_id
+        )))?;
+
+    mutate_state(|s| {
+        if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
+            if apply_debt_reduction {
+                vault.borrowed_icusd_amount -= ICUSD::new(claim.debt_amount);
+                vault.collateral_amount = vault.collateral_amount.saturating_sub(claim.collateral_amount);
+                s.bot_total_debt_covered_e8s += claim.debt_amount;
+            }
+            vault.bot_processing = false;
+        }
+        if !apply_debt_reduction {
+            s.bot_budget_remaining_e8s += claim.debt_amount;
+        }
+        s.bot_claims.remove(&vault_id);
+    });
+
+    log!(INFO, "[admin_resolve_stuck_claim] Resolved stuck claim for vault #{}: debt={}, collateral={}, debt_reduced={}",
+        vault_id, claim.debt_amount, claim.collateral_amount, apply_debt_reduction);
+
+    Ok(())
 }
 
 // ---- Stable token repayment admin functions ----

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -700,7 +700,8 @@ pub struct State {
     pub bot_budget_remaining_e8s: u64,
     pub bot_budget_start_timestamp: u64,
     pub bot_total_debt_covered_e8s: u64,
-    pub bot_total_icusd_deposited_e8s: u64,
+    #[serde(default)]
+    pub bot_total_icusd_deposited_e8s: u64, // Dead field, kept for deserialization compat
     /// Which collateral types the bot is allowed to liquidate.
     /// Vaults with collateral not in this set are rejected by bot_liquidate,
     /// leaving the stability pool to handle them.

--- a/src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte
@@ -9,7 +9,6 @@
     budget_remaining_e8s: bigint;
     budget_start_timestamp: bigint;
     total_debt_covered_e8s: bigint;
-    total_icusd_deposited_e8s: bigint;
   }
 
   interface BotEvent {
@@ -66,7 +65,6 @@
         budget_remaining_e8s: raw.budget_remaining_e8s,
         budget_start_timestamp: raw.budget_start_timestamp,
         total_debt_covered_e8s: raw.total_debt_covered_e8s,
-        total_icusd_deposited_e8s: raw.total_icusd_deposited_e8s,
       };
     } catch (err: any) {
       console.error('Failed to load bot stats:', err);
@@ -125,16 +123,8 @@
       <h3 class="card-title">All-Time Stats</h3>
       <div class="stats-grid">
         <div class="stat">
-          <span class="stat-label">Debt Covered</span>
+          <span class="stat-label">Total Debt Covered</span>
           <span class="stat-value">{formatE8s(stats.total_debt_covered_e8s)} icUSD</span>
-        </div>
-        <div class="stat">
-          <span class="stat-label">icUSD Deposited</span>
-          <span class="stat-value">{formatE8s(stats.total_icusd_deposited_e8s)} icUSD</span>
-        </div>
-        <div class="stat">
-          <span class="stat-label">Deficit</span>
-          <span class="stat-value deficit">{formatE8s(BigInt(Number(stats.total_debt_covered_e8s) - Number(stats.total_icusd_deposited_e8s)))} icUSD</span>
         </div>
         <div class="stat">
           <span class="stat-label">Bot Canister</span>

--- a/src/vault_frontend/src/routes/docs/liquidation-bot/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/liquidation-bot/+page.svelte
@@ -80,10 +80,6 @@
           <span class="stat-label">Total debt covered (all time)</span>
           <span class="stat-value">{formatUsd(Number(stats.total_debt_covered_e8s))}</span>
         </div>
-        <div class="stat-row">
-          <span class="stat-label">Total icUSD deposited (all time)</span>
-          <span class="stat-value">{formatUsd(Number(stats.total_icusd_deposited_e8s))}</span>
-        </div>
       </div>
     {/if}
     <p>When the budget is exhausted, the bot stops liquidating and the stability pool and manual liquidators take over. The budget resets when the admin sets a new period.</p>


### PR DESCRIPTION
## Summary

- Rewrites the liquidation bot to use ICPSwap `depositFromAndSwap` for direct ICP->ckUSDC conversion, replacing the dead KongSwap+3pool two-hop path
- Migrates bot stable memory from raw `stable64_write` to `ic-stable-structures` with `MemoryManager`, including safe legacy blob rescue in `post_upgrade`
- Adds per-liquidation history (`LiquidationRecordVersioned::V1`) stored in a `StableBTreeMap`
- 6-phase liquidation flow: claim -> swap -> transfer (NO retry) -> confirm (5 retries, idempotent) -> treasury -> success
- Deletes dead `bot_deposit_to_reserves` backend endpoint, adds `admin_resolve_stuck_claim` for manual stuck-claim resolution
- New bot admin endpoints: `admin_resolve_pool_ordering`, `admin_approve_pool`, `admin_sweep_ckusdc`, `admin_retry_stuck_claim`
- Frontend: removes references to deleted `total_icusd_deposited_e8s` field

## Failure recovery model

| Phase | Failure | Recovery |
|-------|---------|----------|
| Swap | ICP still held by bot | Return ICP to backend, cancel claim |
| Transfer | Bot holds ckUSDC, vault locked | Mark stuck, admin sweeps via `admin_sweep_ckusdc` + `admin_resolve_stuck_claim` |
| Confirm | ckUSDC in backend, debt not written down | Retry 5x immediately (idempotent). If all fail, mark stuck for admin |

## New files

- `src/liquidation_bot/src/memory.rs` - MemoryManager setup
- `src/liquidation_bot/src/history.rs` - Stable BTreeMap history
- `src/liquidation_bot/src/icpswap.rs` - ICPSwap quote/swap wrappers
- `docs/liquidation-bot-icpswap-migration.md` - Mainnet migration runbook

## Deferred to follow-up PR

- Fix `compute_total_collateral_ratio` to count ckUSDC/ckUSDT reserves (pre-existing issue, not introduced here)
- PocketIC integration test with stub ICPSwap pool canister

## Test plan

- [x] `cargo build -p liquidation_bot --target wasm32-unknown-unknown` compiles clean
- [x] `cargo build -p rumi_protocol_backend --target wasm32-unknown-unknown` compiles clean
- [x] Frontend `svelte-check` passes (no new errors)
- [x] No remaining references to deleted symbols (`total_icusd_deposited_e8s`, `bot_deposit_to_reserves`)
- [ ] Deploy to mainnet per runbook in `docs/liquidation-bot-icpswap-migration.md`
- [ ] Monitor first liquidation via `get_liquidations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)