### PR TITLE
feat(analytics): Phase 5 - daily rollups and fast/hourly snapshot tiers

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -27,6 +27,18 @@ type CursorStatus = record {
   last_success_ns : nat64;
   cursor_position : nat64;
 };
+type CycleSeriesResponse = record {
+  rows : vec HourlyCycleSnapshot;
+  next_from_ts : opt nat64;
+};
+type DailyFeeRollup = record {
+  redemption_count : nat32;
+  borrow_count : nat32;
+  timestamp_ns : nat64;
+  swap_fees_e8s : nat64;
+  redemption_fees_e8s : opt nat64;
+  borrowing_fees_e8s : opt nat64;
+};
 type DailyHolderRow = record {
   total_supply_tracked_e8s : nat64;
   token : principal;
@@ -39,6 +51,15 @@ type DailyHolderRow = record {
   distribution_buckets : vec nat32;
   gini_bps : nat32;
 };
+type DailyLiquidationRollup = record {
+  total_debt_covered_e8s : nat64;
+  timestamp_ns : nat64;
+  total_collateral_seized_e8s : nat64;
+  redistribution_count : nat32;
+  by_collateral : vec record { principal; nat64 };
+  partial_count : nat32;
+  full_count : nat32;
+};
 type DailyStabilityRow = record {
   collateral_gains : vec record { principal; nat64 };
   timestamp_ns : nat64;
@@ -47,6 +68,16 @@ type DailyStabilityRow = record {
   total_deposits_e8s : nat64;
   total_interest_received_e8s : nat64;
   total_liquidations_executed : nat64;
+};
+type DailySwapRollup = record {
+  three_pool_fees_e8s : nat64;
+  timestamp_ns : nat64;
+  three_pool_swap_count : nat32;
+  amm_volume_e8s : nat64;
+  three_pool_volume_e8s : nat64;
+  amm_swap_count : nat32;
+  amm_fees_e8s : nat64;
+  unique_swappers : nat32;
 };
 type DailyTvlRow = record {
   three_pool_reserve_0_e8s : opt nat;
@@ -75,9 +106,33 @@ type ErrorCounters = record {
   stability_pool : nat64;
   backend : nat64;
 };
+type Fast3PoolSnapshot = record {
+  virtual_price : nat;
+  timestamp_ns : nat64;
+  lp_total_supply : nat;
+  balances : vec nat;
+};
+type FastPriceSnapshot = record {
+  timestamp_ns : nat64;
+  prices : vec record { principal; float64; text };
+};
+type FeeCurveSeriesResponse = record {
+  rows : vec HourlyFeeCurveSnapshot;
+  next_from_ts : opt nat64;
+};
+type FeeSeriesResponse = record {
+  rows : vec DailyFeeRollup;
+  next_from_ts : opt nat64;
+};
 type HolderSeriesResponse = record {
   rows : vec DailyHolderRow;
   next_from_ts : opt nat64;
+};
+type HourlyCycleSnapshot = record { timestamp_ns : nat64; cycle_balance : nat };
+type HourlyFeeCurveSnapshot = record {
+  collateral_stats : vec record { principal; nat64; nat64; float64 };
+  timestamp_ns : nat64;
+  system_cr_bps : nat32;
 };
 type HttpRequest = record {
   url : text;
@@ -98,6 +153,14 @@ type InitArgs = record {
   stability_pool : principal;
   backend : principal;
 };
+type LiquidationSeriesResponse = record {
+  rows : vec DailyLiquidationRollup;
+  next_from_ts : opt nat64;
+};
+type PriceSeriesResponse = record {
+  rows : vec FastPriceSnapshot;
+  next_from_ts : opt nat64;
+};
 type RangeQuery = record {
   to_ts : opt nat64;
   from_ts : opt nat64;
@@ -106,6 +169,14 @@ type RangeQuery = record {
 };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
+  next_from_ts : opt nat64;
+};
+type SwapSeriesResponse = record {
+  rows : vec DailySwapRollup;
+  next_from_ts : opt nat64;
+};
+type ThreePoolSeriesResponse = record {
+  rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
 type TvlSeriesResponse = record {
@@ -119,8 +190,15 @@ type VaultSeriesResponse = record {
 service : (InitArgs) -> {
   get_admin : () -> (principal) query;
   get_collector_health : () -> (CollectorHealth) query;
+  get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
+  get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
+  get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
+  get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;
+  get_price_series : (RangeQuery) -> (PriceSeriesResponse) query;
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
+  get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
+  get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -31,6 +31,18 @@ export interface CursorStatus {
   'last_success_ns' : bigint,
   'cursor_position' : bigint,
 }
+export interface CycleSeriesResponse {
+  'rows' : Array<HourlyCycleSnapshot>,
+  'next_from_ts' : [] | [bigint],
+}
+export interface DailyFeeRollup {
+  'redemption_count' : number,
+  'borrow_count' : number,
+  'timestamp_ns' : bigint,
+  'swap_fees_e8s' : bigint,
+  'redemption_fees_e8s' : [] | [bigint],
+  'borrowing_fees_e8s' : [] | [bigint],
+}
 export interface DailyHolderRow {
   'total_supply_tracked_e8s' : bigint,
   'token' : Principal,
@@ -43,6 +55,15 @@ export interface DailyHolderRow {
   'distribution_buckets' : Uint32Array | number[],
   'gini_bps' : number,
 }
+export interface DailyLiquidationRollup {
+  'total_debt_covered_e8s' : bigint,
+  'timestamp_ns' : bigint,
+  'total_collateral_seized_e8s' : bigint,
+  'redistribution_count' : number,
+  'by_collateral' : Array<[Principal, bigint]>,
+  'partial_count' : number,
+  'full_count' : number,
+}
 export interface DailyStabilityRow {
   'collateral_gains' : Array<[Principal, bigint]>,
   'timestamp_ns' : bigint,
@@ -51,6 +72,16 @@ export interface DailyStabilityRow {
   'total_deposits_e8s' : bigint,
   'total_interest_received_e8s' : bigint,
   'total_liquidations_executed' : bigint,
+}
+export interface DailySwapRollup {
+  'three_pool_fees_e8s' : bigint,
+  'timestamp_ns' : bigint,
+  'three_pool_swap_count' : number,
+  'amm_volume_e8s' : bigint,
+  'three_pool_volume_e8s' : bigint,
+  'amm_swap_count' : number,
+  'amm_fees_e8s' : bigint,
+  'unique_swappers' : number,
 }
 export interface DailyTvlRow {
   'three_pool_reserve_0_e8s' : [] | [bigint],
@@ -79,9 +110,36 @@ export interface ErrorCounters {
   'stability_pool' : bigint,
   'backend' : bigint,
 }
+export interface Fast3PoolSnapshot {
+  'virtual_price' : bigint,
+  'timestamp_ns' : bigint,
+  'lp_total_supply' : bigint,
+  'balances' : Array<bigint>,
+}
+export interface FastPriceSnapshot {
+  'timestamp_ns' : bigint,
+  'prices' : Array<[Principal, number, string]>,
+}
+export interface FeeCurveSeriesResponse {
+  'rows' : Array<HourlyFeeCurveSnapshot>,
+  'next_from_ts' : [] | [bigint],
+}
+export interface FeeSeriesResponse {
+  'rows' : Array<DailyFeeRollup>,
+  'next_from_ts' : [] | [bigint],
+}
 export interface HolderSeriesResponse {
   'rows' : Array<DailyHolderRow>,
   'next_from_ts' : [] | [bigint],
+}
+export interface HourlyCycleSnapshot {
+  'timestamp_ns' : bigint,
+  'cycle_balance' : bigint,
+}
+export interface HourlyFeeCurveSnapshot {
+  'collateral_stats' : Array<[Principal, bigint, bigint, number]>,
+  'timestamp_ns' : bigint,
+  'system_cr_bps' : number,
 }
 export interface HttpRequest {
   'url' : string,
@@ -102,6 +160,14 @@ export interface InitArgs {
   'stability_pool' : Principal,
   'backend' : Principal,
 }
+export interface LiquidationSeriesResponse {
+  'rows' : Array<DailyLiquidationRollup>,
+  'next_from_ts' : [] | [bigint],
+}
+export interface PriceSeriesResponse {
+  'rows' : Array<FastPriceSnapshot>,
+  'next_from_ts' : [] | [bigint],
+}
 export interface RangeQuery {
   'to_ts' : [] | [bigint],
   'from_ts' : [] | [bigint],
@@ -110,6 +176,14 @@ export interface RangeQuery {
 }
 export interface StabilitySeriesResponse {
   'rows' : Array<DailyStabilityRow>,
+  'next_from_ts' : [] | [bigint],
+}
+export interface SwapSeriesResponse {
+  'rows' : Array<DailySwapRollup>,
+  'next_from_ts' : [] | [bigint],
+}
+export interface ThreePoolSeriesResponse {
+  'rows' : Array<Fast3PoolSnapshot>,
   'next_from_ts' : [] | [bigint],
 }
 export interface TvlSeriesResponse {
@@ -123,11 +197,21 @@ export interface VaultSeriesResponse {
 export interface _SERVICE {
   'get_admin' : ActorMethod<[], Principal>,
   'get_collector_health' : ActorMethod<[], CollectorHealth>,
+  'get_cycle_series' : ActorMethod<[RangeQuery], CycleSeriesResponse>,
+  'get_fee_curve_series' : ActorMethod<[RangeQuery], FeeCurveSeriesResponse>,
+  'get_fee_series' : ActorMethod<[RangeQuery], FeeSeriesResponse>,
   'get_holder_series' : ActorMethod<
     [RangeQuery, Principal],
     HolderSeriesResponse
   >,
+  'get_liquidation_series' : ActorMethod<
+    [RangeQuery],
+    LiquidationSeriesResponse
+  >,
+  'get_price_series' : ActorMethod<[RangeQuery], PriceSeriesResponse>,
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
+  'get_swap_series' : ActorMethod<[RangeQuery], SwapSeriesResponse>,
+  'get_three_pool_series' : ActorMethod<[RangeQuery], ThreePoolSeriesResponse>,
   'get_tvl_series' : ActorMethod<[RangeQuery], TvlSeriesResponse>,
   'get_vault_series' : ActorMethod<[RangeQuery], VaultSeriesResponse>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -39,6 +39,37 @@ export const idlFactory = ({ IDL }) => {
     'offset' : IDL.Opt(IDL.Nat64),
     'limit' : IDL.Opt(IDL.Nat32),
   });
+  const HourlyCycleSnapshot = IDL.Record({
+    'timestamp_ns' : IDL.Nat64,
+    'cycle_balance' : IDL.Nat,
+  });
+  const CycleSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(HourlyCycleSnapshot),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const HourlyFeeCurveSnapshot = IDL.Record({
+    'collateral_stats' : IDL.Vec(
+      IDL.Tuple(IDL.Principal, IDL.Nat64, IDL.Nat64, IDL.Float64)
+    ),
+    'timestamp_ns' : IDL.Nat64,
+    'system_cr_bps' : IDL.Nat32,
+  });
+  const FeeCurveSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(HourlyFeeCurveSnapshot),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const DailyFeeRollup = IDL.Record({
+    'redemption_count' : IDL.Nat32,
+    'borrow_count' : IDL.Nat32,
+    'timestamp_ns' : IDL.Nat64,
+    'swap_fees_e8s' : IDL.Nat64,
+    'redemption_fees_e8s' : IDL.Opt(IDL.Nat64),
+    'borrowing_fees_e8s' : IDL.Opt(IDL.Nat64),
+  });
+  const FeeSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailyFeeRollup),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
   const DailyHolderRow = IDL.Record({
     'total_supply_tracked_e8s' : IDL.Nat64,
     'token' : IDL.Principal,
@@ -55,6 +86,27 @@ export const idlFactory = ({ IDL }) => {
     'rows' : IDL.Vec(DailyHolderRow),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
+  const DailyLiquidationRollup = IDL.Record({
+    'total_debt_covered_e8s' : IDL.Nat64,
+    'timestamp_ns' : IDL.Nat64,
+    'total_collateral_seized_e8s' : IDL.Nat64,
+    'redistribution_count' : IDL.Nat32,
+    'by_collateral' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'partial_count' : IDL.Nat32,
+    'full_count' : IDL.Nat32,
+  });
+  const LiquidationSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailyLiquidationRollup),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const FastPriceSnapshot = IDL.Record({
+    'timestamp_ns' : IDL.Nat64,
+    'prices' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Float64, IDL.Text)),
+  });
+  const PriceSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(FastPriceSnapshot),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
   const DailyStabilityRow = IDL.Record({
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'timestamp_ns' : IDL.Nat64,
@@ -66,6 +118,30 @@ export const idlFactory = ({ IDL }) => {
   });
   const StabilitySeriesResponse = IDL.Record({
     'rows' : IDL.Vec(DailyStabilityRow),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const DailySwapRollup = IDL.Record({
+    'three_pool_fees_e8s' : IDL.Nat64,
+    'timestamp_ns' : IDL.Nat64,
+    'three_pool_swap_count' : IDL.Nat32,
+    'amm_volume_e8s' : IDL.Nat64,
+    'three_pool_volume_e8s' : IDL.Nat64,
+    'amm_swap_count' : IDL.Nat32,
+    'amm_fees_e8s' : IDL.Nat64,
+    'unique_swappers' : IDL.Nat32,
+  });
+  const SwapSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(DailySwapRollup),
+    'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const Fast3PoolSnapshot = IDL.Record({
+    'virtual_price' : IDL.Nat,
+    'timestamp_ns' : IDL.Nat64,
+    'lp_total_supply' : IDL.Nat,
+    'balances' : IDL.Vec(IDL.Nat),
+  });
+  const ThreePoolSeriesResponse = IDL.Record({
+    'rows' : IDL.Vec(Fast3PoolSnapshot),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
   const DailyTvlRow = IDL.Record({
@@ -120,14 +196,41 @@ export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     'get_admin' : IDL.Func([], [IDL.Principal], ['query']),
     'get_collector_health' : IDL.Func([], [CollectorHealth], ['query']),
+    'get_cycle_series' : IDL.Func(
+        [RangeQuery],
+        [CycleSeriesResponse],
+        ['query'],
+      ),
+    'get_fee_curve_series' : IDL.Func(
+        [RangeQuery],
+        [FeeCurveSeriesResponse],
+        ['query'],
+      ),
+    'get_fee_series' : IDL.Func([RangeQuery], [FeeSeriesResponse], ['query']),
     'get_holder_series' : IDL.Func(
         [RangeQuery, IDL.Principal],
         [HolderSeriesResponse],
         ['query'],
       ),
+    'get_liquidation_series' : IDL.Func(
+        [RangeQuery],
+        [LiquidationSeriesResponse],
+        ['query'],
+      ),
+    'get_price_series' : IDL.Func(
+        [RangeQuery],
+        [PriceSeriesResponse],
+        ['query'],
+      ),
     'get_stability_series' : IDL.Func(
         [RangeQuery],
         [StabilitySeriesResponse],
+        ['query'],
+      ),
+    'get_swap_series' : IDL.Func([RangeQuery], [SwapSeriesResponse], ['query']),
+    'get_three_pool_series' : IDL.Func(
+        [RangeQuery],
+        [ThreePoolSeriesResponse],
         ['query'],
       ),
     'get_tvl_series' : IDL.Func([RangeQuery], [TvlSeriesResponse], ['query']),

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -27,6 +27,18 @@ type CursorStatus = record {
   last_success_ns : nat64;
   cursor_position : nat64;
 };
+type CycleSeriesResponse = record {
+  rows : vec HourlyCycleSnapshot;
+  next_from_ts : opt nat64;
+};
+type DailyFeeRollup = record {
+  redemption_count : nat32;
+  borrow_count : nat32;
+  timestamp_ns : nat64;
+  swap_fees_e8s : nat64;
+  redemption_fees_e8s : opt nat64;
+  borrowing_fees_e8s : opt nat64;
+};
 type DailyHolderRow = record {
   total_supply_tracked_e8s : nat64;
   token : principal;
@@ -39,6 +51,15 @@ type DailyHolderRow = record {
   distribution_buckets : vec nat32;
   gini_bps : nat32;
 };
+type DailyLiquidationRollup = record {
+  total_debt_covered_e8s : nat64;
+  timestamp_ns : nat64;
+  total_collateral_seized_e8s : nat64;
+  redistribution_count : nat32;
+  by_collateral : vec record { principal; nat64 };
+  partial_count : nat32;
+  full_count : nat32;
+};
 type DailyStabilityRow = record {
   collateral_gains : vec record { principal; nat64 };
   timestamp_ns : nat64;
@@ -47,6 +68,16 @@ type DailyStabilityRow = record {
   total_deposits_e8s : nat64;
   total_interest_received_e8s : nat64;
   total_liquidations_executed : nat64;
+};
+type DailySwapRollup = record {
+  three_pool_fees_e8s : nat64;
+  timestamp_ns : nat64;
+  three_pool_swap_count : nat32;
+  amm_volume_e8s : nat64;
+  three_pool_volume_e8s : nat64;
+  amm_swap_count : nat32;
+  amm_fees_e8s : nat64;
+  unique_swappers : nat32;
 };
 type DailyTvlRow = record {
   three_pool_reserve_0_e8s : opt nat;
@@ -75,9 +106,33 @@ type ErrorCounters = record {
   stability_pool : nat64;
   backend : nat64;
 };
+type Fast3PoolSnapshot = record {
+  virtual_price : nat;
+  timestamp_ns : nat64;
+  lp_total_supply : nat;
+  balances : vec nat;
+};
+type FastPriceSnapshot = record {
+  timestamp_ns : nat64;
+  prices : vec record { principal; float64; text };
+};
+type FeeCurveSeriesResponse = record {
+  rows : vec HourlyFeeCurveSnapshot;
+  next_from_ts : opt nat64;
+};
+type FeeSeriesResponse = record {
+  rows : vec DailyFeeRollup;
+  next_from_ts : opt nat64;
+};
 type HolderSeriesResponse = record {
   rows : vec DailyHolderRow;
   next_from_ts : opt nat64;
+};
+type HourlyCycleSnapshot = record { timestamp_ns : nat64; cycle_balance : nat };
+type HourlyFeeCurveSnapshot = record {
+  collateral_stats : vec record { principal; nat64; nat64; float64 };
+  timestamp_ns : nat64;
+  system_cr_bps : nat32;
 };
 type HttpRequest = record {
   url : text;
@@ -98,6 +153,14 @@ type InitArgs = record {
   stability_pool : principal;
   backend : principal;
 };
+type LiquidationSeriesResponse = record {
+  rows : vec DailyLiquidationRollup;
+  next_from_ts : opt nat64;
+};
+type PriceSeriesResponse = record {
+  rows : vec FastPriceSnapshot;
+  next_from_ts : opt nat64;
+};
 type RangeQuery = record {
   to_ts : opt nat64;
   from_ts : opt nat64;
@@ -106,6 +169,14 @@ type RangeQuery = record {
 };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
+  next_from_ts : opt nat64;
+};
+type SwapSeriesResponse = record {
+  rows : vec DailySwapRollup;
+  next_from_ts : opt nat64;
+};
+type ThreePoolSeriesResponse = record {
+  rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
 type TvlSeriesResponse = record {
@@ -119,8 +190,15 @@ type VaultSeriesResponse = record {
 service : (InitArgs) -> {
   get_admin : () -> (principal) query;
   get_collector_health : () -> (CollectorHealth) query;
+  get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
+  get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
+  get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
+  get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;
+  get_price_series : (RangeQuery) -> (PriceSeriesResponse) query;
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
+  get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
+  get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_vault_series : (RangeQuery) -> (VaultSeriesResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;

--- a/src/rumi_analytics/src/collectors/fast.rs
+++ b/src/rumi_analytics/src/collectors/fast.rs
@@ -1,0 +1,49 @@
+//! Fast (5-minute) snapshot collector. Captures collateral prices and 3pool state.
+
+use crate::{sources, state, storage};
+
+pub async fn run() -> Result<(), String> {
+    let (backend_id, three_pool_id) = state::read_state(|s| {
+        (s.sources.backend, s.sources.three_pool)
+    });
+
+    let (prices_res, pool_res) = futures::join!(
+        sources::backend::get_collateral_totals(backend_id),
+        sources::three_pool::get_pool_status(three_pool_id),
+    );
+
+    let now = ic_cdk::api::time();
+
+    match prices_res {
+        Ok(totals) => {
+            let prices = totals.into_iter()
+                .map(|t| (t.collateral_type, t.price, t.symbol))
+                .collect();
+            storage::fast::fast_prices::push(storage::fast::FastPriceSnapshot {
+                timestamp_ns: now,
+                prices,
+            });
+        }
+        Err(e) => {
+            ic_cdk::println!("[fast] get_collateral_totals error: {}", e);
+            state::mutate_state(|s| s.error_counters.backend += 1);
+        }
+    }
+
+    match pool_res {
+        Ok(tp) => {
+            storage::fast::fast_3pool::push(storage::fast::Fast3PoolSnapshot {
+                timestamp_ns: now,
+                balances: tp.balances,
+                virtual_price: tp.virtual_price,
+                lp_total_supply: tp.lp_total_supply,
+            });
+        }
+        Err(e) => {
+            ic_cdk::println!("[fast] get_pool_status error: {}", e);
+            state::mutate_state(|s| s.error_counters.three_pool += 1);
+        }
+    }
+
+    Ok(())
+}

--- a/src/rumi_analytics/src/collectors/hourly.rs
+++ b/src/rumi_analytics/src/collectors/hourly.rs
@@ -15,14 +15,17 @@ pub async fn run() -> Result<(), String> {
     match sources::backend::get_collateral_totals(backend_id).await {
         Ok(totals) => {
             let system_cr_bps = {
-                let total_coll_usd: f64 = totals.iter()
-                    .map(|t| t.total_collateral as f64 * t.price / 1e8)
+                // total_collateral is in raw e8s, price is USD per whole token.
+                // collateral_value_e8s = total_collateral * price (same as vaults.rs).
+                // total_debt is in icUSD e8s. CR = collateral_value / debt.
+                let total_coll_value: f64 = totals.iter()
+                    .map(|t| t.total_collateral as f64 * t.price)
                     .sum();
                 let total_debt: f64 = totals.iter()
                     .map(|t| t.total_debt as f64)
                     .sum();
                 if total_debt > 0.0 {
-                    ((total_coll_usd / total_debt) * 10_000.0).clamp(0.0, u32::MAX as f64) as u32
+                    ((total_coll_value / total_debt) * 10_000.0).clamp(0.0, u32::MAX as f64) as u32
                 } else {
                     0
                 }

--- a/src/rumi_analytics/src/collectors/hourly.rs
+++ b/src/rumi_analytics/src/collectors/hourly.rs
@@ -1,0 +1,46 @@
+//! Hourly snapshot collector. Captures cycle balance and fee curve state.
+
+use crate::{sources, state, storage};
+
+pub async fn run() -> Result<(), String> {
+    let backend_id = state::read_state(|s| s.sources.backend);
+    let now = ic_cdk::api::time();
+
+    let cycle_balance = ic_cdk::api::canister_balance128();
+    storage::hourly::hourly_cycles::push(storage::hourly::HourlyCycleSnapshot {
+        timestamp_ns: now,
+        cycle_balance,
+    });
+
+    match sources::backend::get_collateral_totals(backend_id).await {
+        Ok(totals) => {
+            let system_cr_bps = {
+                let total_coll_usd: f64 = totals.iter()
+                    .map(|t| t.total_collateral as f64 * t.price / 1e8)
+                    .sum();
+                let total_debt: f64 = totals.iter()
+                    .map(|t| t.total_debt as f64)
+                    .sum();
+                if total_debt > 0.0 {
+                    ((total_coll_usd / total_debt) * 10_000.0).clamp(0.0, u32::MAX as f64) as u32
+                } else {
+                    0
+                }
+            };
+            let collateral_stats = totals.into_iter()
+                .map(|t| (t.collateral_type, t.total_debt, t.total_collateral, t.price))
+                .collect();
+            storage::hourly::hourly_fee_curve::push(storage::hourly::HourlyFeeCurveSnapshot {
+                timestamp_ns: now,
+                system_cr_bps,
+                collateral_stats,
+            });
+        }
+        Err(e) => {
+            ic_cdk::println!("[hourly] get_collateral_totals error: {}", e);
+            state::mutate_state(|s| s.error_counters.backend += 1);
+        }
+    }
+
+    Ok(())
+}

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -2,3 +2,4 @@ pub mod tvl;
 pub mod vaults;
 pub mod stability;
 pub mod holders;
+pub mod rollups;

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -3,3 +3,4 @@ pub mod vaults;
 pub mod stability;
 pub mod holders;
 pub mod rollups;
+pub mod fast;

--- a/src/rumi_analytics/src/collectors/mod.rs
+++ b/src/rumi_analytics/src/collectors/mod.rs
@@ -4,3 +4,4 @@ pub mod stability;
 pub mod holders;
 pub mod rollups;
 pub mod fast;
+pub mod hourly;

--- a/src/rumi_analytics/src/collectors/rollups.rs
+++ b/src/rumi_analytics/src/collectors/rollups.rs
@@ -1,0 +1,123 @@
+//! Daily rollup collector. Scans EVT_* logs for events in the past 24h and
+//! produces summary rows for liquidations, swaps, and fees.
+//!
+//! This runs synchronously (no inter-canister calls) since all data is local.
+
+use candid::Principal;
+use std::collections::{HashMap, HashSet};
+use crate::storage;
+use storage::events::*;
+use storage::rollups;
+
+const DAY_NS: u64 = 86_400_000_000_000;
+
+pub fn run() {
+    let now = ic_cdk::api::time();
+    let day_start = now.saturating_sub(DAY_NS);
+
+    rollup_liquidations(now, day_start);
+    rollup_swaps(now, day_start);
+    rollup_fees(now, day_start);
+}
+
+fn rollup_liquidations(now: u64, day_start: u64) {
+    let events = evt_liquidations::range(day_start, now, usize::MAX);
+
+    let mut full_count: u32 = 0;
+    let mut partial_count: u32 = 0;
+    let mut redistribution_count: u32 = 0;
+    let mut total_collateral: u64 = 0;
+    let mut total_debt: u64 = 0;
+    let mut by_collateral: HashMap<Principal, u64> = HashMap::new();
+
+    for e in &events {
+        match e.liquidation_kind {
+            LiquidationKind::Full => full_count += 1,
+            LiquidationKind::Partial => partial_count += 1,
+            LiquidationKind::Redistribution => redistribution_count += 1,
+        }
+        total_collateral = total_collateral.saturating_add(e.collateral_amount);
+        total_debt = total_debt.saturating_add(e.debt_amount);
+        if e.collateral_type != Principal::anonymous() {
+            *by_collateral.entry(e.collateral_type).or_default() += e.collateral_amount;
+        }
+    }
+
+    let mut by_coll_vec: Vec<(Principal, u64)> = by_collateral.into_iter().collect();
+    by_coll_vec.sort_by(|a, b| b.1.cmp(&a.1));
+
+    rollups::daily_liquidations::push(rollups::DailyLiquidationRollup {
+        timestamp_ns: now,
+        full_count,
+        partial_count,
+        redistribution_count,
+        total_collateral_seized_e8s: total_collateral,
+        total_debt_covered_e8s: total_debt,
+        by_collateral: by_coll_vec,
+    });
+}
+
+fn rollup_swaps(now: u64, day_start: u64) {
+    let events = evt_swaps::range(day_start, now, usize::MAX);
+
+    let mut tp_count: u32 = 0;
+    let mut amm_count: u32 = 0;
+    let mut tp_volume: u64 = 0;
+    let mut amm_volume: u64 = 0;
+    let mut tp_fees: u64 = 0;
+    let mut amm_fees: u64 = 0;
+    let mut swappers: HashSet<Principal> = HashSet::new();
+
+    for e in &events {
+        swappers.insert(e.caller);
+        match e.source {
+            SwapSource::ThreePool => {
+                tp_count += 1;
+                tp_volume = tp_volume.saturating_add(e.amount_in);
+                tp_fees = tp_fees.saturating_add(e.fee);
+            }
+            SwapSource::Amm => {
+                amm_count += 1;
+                amm_volume = amm_volume.saturating_add(e.amount_in);
+                amm_fees = amm_fees.saturating_add(e.fee);
+            }
+        }
+    }
+
+    rollups::daily_swaps::push(rollups::DailySwapRollup {
+        timestamp_ns: now,
+        three_pool_swap_count: tp_count,
+        amm_swap_count: amm_count,
+        three_pool_volume_e8s: tp_volume,
+        amm_volume_e8s: amm_volume,
+        three_pool_fees_e8s: tp_fees,
+        amm_fees_e8s: amm_fees,
+        unique_swappers: swappers.len() as u32,
+    });
+}
+
+fn rollup_fees(now: u64, day_start: u64) {
+    let swap_events = evt_swaps::range(day_start, now, usize::MAX);
+    let vault_events = evt_vaults::range(day_start, now, usize::MAX);
+
+    let swap_fees: u64 = swap_events.iter().map(|e| e.fee).sum();
+    let mut borrow_count: u32 = 0;
+    let mut redemption_count: u32 = 0;
+
+    for e in &vault_events {
+        match e.event_kind {
+            VaultEventKind::Borrowed => borrow_count += 1,
+            VaultEventKind::Redeemed => redemption_count += 1,
+            _ => {}
+        }
+    }
+
+    rollups::daily_fees::push(rollups::DailyFeeRollup {
+        timestamp_ns: now,
+        borrowing_fees_e8s: None,
+        borrow_count,
+        swap_fees_e8s: swap_fees,
+        redemption_fees_e8s: None,
+        redemption_count,
+    });
+}

--- a/src/rumi_analytics/src/collectors/rollups.rs
+++ b/src/rumi_analytics/src/collectors/rollups.rs
@@ -39,7 +39,8 @@ fn rollup_liquidations(now: u64, day_start: u64) {
         total_collateral = total_collateral.saturating_add(e.collateral_amount);
         total_debt = total_debt.saturating_add(e.debt_amount);
         if e.collateral_type != Principal::anonymous() {
-            *by_collateral.entry(e.collateral_type).or_default() += e.collateral_amount;
+            let entry = by_collateral.entry(e.collateral_type).or_default();
+            *entry = entry.saturating_add(e.collateral_amount);
         }
     }
 

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -90,6 +90,41 @@ fn get_holder_series(query: types::RangeQuery, token: Principal) -> types::Holde
 }
 
 #[ic_cdk_macros::query]
+fn get_liquidation_series(query: types::RangeQuery) -> types::LiquidationSeriesResponse {
+    queries::historical::get_liquidation_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_swap_series(query: types::RangeQuery) -> types::SwapSeriesResponse {
+    queries::historical::get_swap_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_fee_series(query: types::RangeQuery) -> types::FeeSeriesResponse {
+    queries::historical::get_fee_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_price_series(query: types::RangeQuery) -> types::PriceSeriesResponse {
+    queries::historical::get_price_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_three_pool_series(query: types::RangeQuery) -> types::ThreePoolSeriesResponse {
+    queries::historical::get_three_pool_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_cycle_series(query: types::RangeQuery) -> types::CycleSeriesResponse {
+    queries::historical::get_cycle_series(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_fee_curve_series(query: types::RangeQuery) -> types::FeeCurveSeriesResponse {
+    queries::historical::get_fee_curve_series(query)
+}
+
+#[ic_cdk_macros::query]
 fn get_collector_health() -> types::CollectorHealth {
     use storage::cursors;
 

--- a/src/rumi_analytics/src/queries/historical.rs
+++ b/src/rumi_analytics/src/queries/historical.rs
@@ -1,27 +1,26 @@
 //! Read-only paginated readers over StableLogs. Pure functions, no state mutation.
 
 use crate::storage;
-use crate::types::{RangeQuery, TvlSeriesResponse, VaultSeriesResponse, StabilitySeriesResponse, HolderSeriesResponse};
+use crate::types;
+use crate::types::RangeQuery;
 
-pub fn get_tvl_series(query: RangeQuery) -> TvlSeriesResponse {
+pub fn get_tvl_series(query: RangeQuery) -> types::TvlSeriesResponse {
     let limit = query.resolved_limit() as usize;
     let from = query.resolved_from();
     let to = query.resolved_to();
 
     let rows = storage::daily_tvl::range(from, to, limit);
 
-    // If we returned exactly `limit` rows, more may exist: hand back a
-    // continuation cursor pointing one nanosecond past the last returned row.
     let next_from_ts = if rows.len() == limit && limit > 0 {
         rows.last().map(|r| r.timestamp_ns.saturating_add(1))
     } else {
         None
     };
 
-    TvlSeriesResponse { rows, next_from_ts }
+    types::TvlSeriesResponse { rows, next_from_ts }
 }
 
-pub fn get_vault_series(query: RangeQuery) -> VaultSeriesResponse {
+pub fn get_vault_series(query: RangeQuery) -> types::VaultSeriesResponse {
     let limit = query.resolved_limit() as usize;
     let from = query.resolved_from();
     let to = query.resolved_to();
@@ -31,10 +30,10 @@ pub fn get_vault_series(query: RangeQuery) -> VaultSeriesResponse {
     } else {
         None
     };
-    VaultSeriesResponse { rows, next_from_ts }
+    types::VaultSeriesResponse { rows, next_from_ts }
 }
 
-pub fn get_stability_series(query: RangeQuery) -> StabilitySeriesResponse {
+pub fn get_stability_series(query: RangeQuery) -> types::StabilitySeriesResponse {
     let limit = query.resolved_limit() as usize;
     let from = query.resolved_from();
     let to = query.resolved_to();
@@ -44,10 +43,10 @@ pub fn get_stability_series(query: RangeQuery) -> StabilitySeriesResponse {
     } else {
         None
     };
-    StabilitySeriesResponse { rows, next_from_ts }
+    types::StabilitySeriesResponse { rows, next_from_ts }
 }
 
-pub fn get_holder_series(query: RangeQuery, token: candid::Principal) -> HolderSeriesResponse {
+pub fn get_holder_series(query: RangeQuery, token: candid::Principal) -> types::HolderSeriesResponse {
     let limit = query.resolved_limit() as usize;
     let from = query.resolved_from();
     let to = query.resolved_to();
@@ -65,7 +64,98 @@ pub fn get_holder_series(query: RangeQuery, token: candid::Principal) -> HolderS
         None
     };
 
-    HolderSeriesResponse { rows, next_from_ts }
+    types::HolderSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_liquidation_series(query: RangeQuery) -> types::LiquidationSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::rollups::daily_liquidations::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::LiquidationSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_swap_series(query: RangeQuery) -> types::SwapSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::rollups::daily_swaps::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::SwapSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_fee_series(query: RangeQuery) -> types::FeeSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::rollups::daily_fees::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::FeeSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_price_series(query: RangeQuery) -> types::PriceSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::fast::fast_prices::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::PriceSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_three_pool_series(query: RangeQuery) -> types::ThreePoolSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::fast::fast_3pool::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::ThreePoolSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_cycle_series(query: RangeQuery) -> types::CycleSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::hourly::hourly_cycles::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::CycleSeriesResponse { rows, next_from_ts }
+}
+
+pub fn get_fee_curve_series(query: RangeQuery) -> types::FeeCurveSeriesResponse {
+    let limit = query.resolved_limit() as usize;
+    let from = query.resolved_from();
+    let to = query.resolved_to();
+    let rows = storage::hourly::hourly_fee_curve::range(from, to, limit);
+    let next_from_ts = if rows.len() == limit && limit > 0 {
+        rows.last().map(|r| r.timestamp_ns.saturating_add(1))
+    } else {
+        None
+    };
+    types::FeeCurveSeriesResponse { rows, next_from_ts }
 }
 
 #[cfg(test)]

--- a/src/rumi_analytics/src/storage/fast.rs
+++ b/src/rumi_analytics/src/storage/fast.rs
@@ -1,0 +1,117 @@
+//! Fast (5-minute) snapshot row types and StableLogs for prices and 3pool state.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_FAST_PRICES_IDX, MEM_FAST_PRICES_DATA,
+    MEM_FAST_3POOL_IDX, MEM_FAST_3POOL_DATA,
+};
+
+// --- Row types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct FastPriceSnapshot {
+    pub timestamp_ns: u64,
+    /// (collateral_principal, price_usd, symbol)
+    pub prices: Vec<(Principal, f64, String)>,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct Fast3PoolSnapshot {
+    pub timestamp_ns: u64,
+    pub balances: Vec<u128>,
+    pub virtual_price: u128,
+    pub lp_total_supply: u128,
+}
+
+// --- Storable impls ---
+
+macro_rules! storable_candid {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<[u8]> {
+                Cow::Owned(Encode!(self).expect(concat!(stringify!($t), " encode")))
+            }
+            fn from_bytes(bytes: Cow<[u8]>) -> Self {
+                Decode!(bytes.as_ref(), Self).expect(concat!(stringify!($t), " decode"))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+storable_candid!(FastPriceSnapshot);
+storable_candid!(Fast3PoolSnapshot);
+
+// --- StableLog instances ---
+
+thread_local! {
+    static FAST_PRICES_LOG: RefCell<ic_stable_structures::StableLog<FastPriceSnapshot, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_FAST_PRICES_IDX),
+                get_memory(MEM_FAST_PRICES_DATA),
+            ).expect("init FAST_PRICES log")
+        });
+
+    static FAST_3POOL_LOG: RefCell<ic_stable_structures::StableLog<Fast3PoolSnapshot, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_FAST_3POOL_IDX),
+                get_memory(MEM_FAST_3POOL_DATA),
+            ).expect("init FAST_3POOL log")
+        });
+}
+
+// --- Accessor modules ---
+
+macro_rules! fast_accessors {
+    ($mod_name:ident, $log:ident, $row_type:ty) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: $row_type) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<$row_type> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<$row_type> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts {
+                                break;
+                            }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+fast_accessors!(fast_prices, FAST_PRICES_LOG, FastPriceSnapshot);
+fast_accessors!(fast_3pool, FAST_3POOL_LOG, Fast3PoolSnapshot);

--- a/src/rumi_analytics/src/storage/hourly.rs
+++ b/src/rumi_analytics/src/storage/hourly.rs
@@ -1,0 +1,116 @@
+//! Hourly snapshot row types and StableLogs for cycle balances and fee curve state.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_HOURLY_CYCLES_IDX, MEM_HOURLY_CYCLES_DATA,
+    MEM_HOURLY_FEE_CURVE_IDX, MEM_HOURLY_FEE_CURVE_DATA,
+};
+
+// --- Row types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct HourlyCycleSnapshot {
+    pub timestamp_ns: u64,
+    pub cycle_balance: u128,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct HourlyFeeCurveSnapshot {
+    pub timestamp_ns: u64,
+    pub system_cr_bps: u32,
+    /// (collateral_principal, total_debt, total_collateral, price)
+    pub collateral_stats: Vec<(Principal, u64, u64, f64)>,
+}
+
+// --- Storable impls ---
+
+macro_rules! storable_candid {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<[u8]> {
+                Cow::Owned(Encode!(self).expect(concat!(stringify!($t), " encode")))
+            }
+            fn from_bytes(bytes: Cow<[u8]>) -> Self {
+                Decode!(bytes.as_ref(), Self).expect(concat!(stringify!($t), " decode"))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+storable_candid!(HourlyCycleSnapshot);
+storable_candid!(HourlyFeeCurveSnapshot);
+
+// --- StableLog instances ---
+
+thread_local! {
+    static HOURLY_CYCLES_LOG: RefCell<ic_stable_structures::StableLog<HourlyCycleSnapshot, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_HOURLY_CYCLES_IDX),
+                get_memory(MEM_HOURLY_CYCLES_DATA),
+            ).expect("init HOURLY_CYCLES log")
+        });
+
+    static HOURLY_FEE_CURVE_LOG: RefCell<ic_stable_structures::StableLog<HourlyFeeCurveSnapshot, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_HOURLY_FEE_CURVE_IDX),
+                get_memory(MEM_HOURLY_FEE_CURVE_DATA),
+            ).expect("init HOURLY_FEE_CURVE log")
+        });
+}
+
+// --- Accessor modules ---
+
+macro_rules! hourly_accessors {
+    ($mod_name:ident, $log:ident, $row_type:ty) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: $row_type) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<$row_type> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<$row_type> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts {
+                                break;
+                            }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+hourly_accessors!(hourly_cycles, HOURLY_CYCLES_LOG, HourlyCycleSnapshot);
+hourly_accessors!(hourly_fee_curve, HOURLY_FEE_CURVE_LOG, HourlyFeeCurveSnapshot);

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -454,6 +454,9 @@ pub mod cursors;
 pub mod events;
 pub mod balance_tracker;
 pub mod holders;
+pub mod rollups;
+pub mod fast;
+pub mod hourly;
 
 /// Get a virtual memory from the shared MemoryManager. Used by submodules.
 pub(crate) fn get_memory(id: MemoryId) -> Memory {

--- a/src/rumi_analytics/src/storage/rollups.rs
+++ b/src/rumi_analytics/src/storage/rollups.rs
@@ -1,0 +1,148 @@
+//! Daily rollup row types and StableLogs for liquidations, swaps, and fees.
+
+use candid::{CandidType, Decode, Encode, Principal};
+use ic_stable_structures::storable::{Bound, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use super::{Memory, get_memory};
+use super::{
+    MEM_DAILY_LIQUIDATIONS_IDX, MEM_DAILY_LIQUIDATIONS_DATA,
+    MEM_DAILY_SWAPS_IDX, MEM_DAILY_SWAPS_DATA,
+    MEM_DAILY_FEES_IDX, MEM_DAILY_FEES_DATA,
+};
+
+// --- Row types ---
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyLiquidationRollup {
+    pub timestamp_ns: u64,
+    pub full_count: u32,
+    pub partial_count: u32,
+    pub redistribution_count: u32,
+    pub total_collateral_seized_e8s: u64,
+    pub total_debt_covered_e8s: u64,
+    pub by_collateral: Vec<(Principal, u64)>,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailySwapRollup {
+    pub timestamp_ns: u64,
+    pub three_pool_swap_count: u32,
+    pub amm_swap_count: u32,
+    pub three_pool_volume_e8s: u64,
+    pub amm_volume_e8s: u64,
+    pub three_pool_fees_e8s: u64,
+    pub amm_fees_e8s: u64,
+    pub unique_swappers: u32,
+}
+
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct DailyFeeRollup {
+    pub timestamp_ns: u64,
+    /// None until EVT_VAULTS captures fee_amount for borrow events.
+    pub borrowing_fees_e8s: Option<u64>,
+    pub borrow_count: u32,
+    pub swap_fees_e8s: u64,
+    /// None until EVT_VAULTS captures fee_amount for redemption events.
+    pub redemption_fees_e8s: Option<u64>,
+    pub redemption_count: u32,
+}
+
+// --- Storable impls ---
+
+macro_rules! storable_candid {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<[u8]> {
+                Cow::Owned(Encode!(self).expect(concat!(stringify!($t), " encode")))
+            }
+            fn from_bytes(bytes: Cow<[u8]>) -> Self {
+                Decode!(bytes.as_ref(), Self).expect(concat!(stringify!($t), " decode"))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+storable_candid!(DailyLiquidationRollup);
+storable_candid!(DailySwapRollup);
+storable_candid!(DailyFeeRollup);
+
+// --- StableLog instances ---
+
+thread_local! {
+    static DAILY_LIQUIDATIONS_LOG: RefCell<ic_stable_structures::StableLog<DailyLiquidationRollup, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_LIQUIDATIONS_IDX),
+                get_memory(MEM_DAILY_LIQUIDATIONS_DATA),
+            ).expect("init DAILY_LIQUIDATIONS log")
+        });
+
+    static DAILY_SWAPS_LOG: RefCell<ic_stable_structures::StableLog<DailySwapRollup, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_SWAPS_IDX),
+                get_memory(MEM_DAILY_SWAPS_DATA),
+            ).expect("init DAILY_SWAPS log")
+        });
+
+    static DAILY_FEES_LOG: RefCell<ic_stable_structures::StableLog<DailyFeeRollup, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_DAILY_FEES_IDX),
+                get_memory(MEM_DAILY_FEES_DATA),
+            ).expect("init DAILY_FEES log")
+        });
+}
+
+// --- Accessor modules ---
+
+macro_rules! rollup_accessors {
+    ($mod_name:ident, $log:ident, $row_type:ty) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn push(row: $row_type) {
+                $log.with(|log| {
+                    log.borrow_mut().append(&row).expect(concat!("append ", stringify!($mod_name)));
+                });
+            }
+
+            pub fn len() -> u64 {
+                $log.with(|log| log.borrow().len())
+            }
+
+            pub fn get(index: u64) -> Option<$row_type> {
+                $log.with(|log| log.borrow().get(index))
+            }
+
+            pub fn range(from_ts: u64, to_ts: u64, limit: usize) -> Vec<$row_type> {
+                let mut out = Vec::new();
+                $log.with(|log| {
+                    let log = log.borrow();
+                    let n = log.len();
+                    for i in 0..n {
+                        if let Some(row) = log.get(i) {
+                            if row.timestamp_ns >= to_ts {
+                                break;
+                            }
+                            if row.timestamp_ns >= from_ts {
+                                out.push(row);
+                                if out.len() >= limit {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+                out
+            }
+        }
+    };
+}
+
+rollup_accessors!(daily_liquidations, DAILY_LIQUIDATIONS_LOG, DailyLiquidationRollup);
+rollup_accessors!(daily_swaps, DAILY_SWAPS_LOG, DailySwapRollup);
+rollup_accessors!(daily_fees, DAILY_FEES_LOG, DailyFeeRollup);

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -9,10 +9,10 @@ pub fn setup_timers() {
         ic_cdk::spawn(pull_cycle());
     });
     ic_cdk_timers::set_timer_interval(Duration::from_secs(300), || {
-        // Phase 5: fast snapshot.
+        ic_cdk::spawn(fast_snapshot());
     });
     ic_cdk_timers::set_timer_interval(Duration::from_secs(3600), || {
-        // Phase 5: hourly snapshot.
+        ic_cdk::spawn(hourly_snapshot());
     });
     ic_cdk_timers::set_timer_interval(Duration::from_secs(86400), || {
         ic_cdk::spawn(daily_snapshot());
@@ -70,5 +70,20 @@ async fn daily_snapshot() {
     }
     if let Err(e) = holders_res {
         ic_cdk::println!("rumi_analytics: daily holder snapshot failed: {}", e);
+    }
+
+    // Daily rollups (sync, no inter-canister calls)
+    collectors::rollups::run();
+}
+
+async fn fast_snapshot() {
+    if let Err(e) = collectors::fast::run().await {
+        ic_cdk::println!("rumi_analytics: fast snapshot failed: {}", e);
+    }
+}
+
+async fn hourly_snapshot() {
+    if let Err(e) = collectors::hourly::run().await {
+        ic_cdk::println!("rumi_analytics: hourly snapshot failed: {}", e);
     }
 }

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -59,6 +59,48 @@ pub struct HolderSeriesResponse {
 }
 
 #[derive(CandidType, Clone, Debug)]
+pub struct LiquidationSeriesResponse {
+    pub rows: Vec<crate::storage::rollups::DailyLiquidationRollup>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct SwapSeriesResponse {
+    pub rows: Vec<crate::storage::rollups::DailySwapRollup>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct FeeSeriesResponse {
+    pub rows: Vec<crate::storage::rollups::DailyFeeRollup>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct PriceSeriesResponse {
+    pub rows: Vec<crate::storage::fast::FastPriceSnapshot>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct ThreePoolSeriesResponse {
+    pub rows: Vec<crate::storage::fast::Fast3PoolSnapshot>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct CycleSeriesResponse {
+    pub rows: Vec<crate::storage::hourly::HourlyCycleSnapshot>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct FeeCurveSeriesResponse {
+    pub rows: Vec<crate::storage::hourly::HourlyFeeCurveSnapshot>,
+    pub next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
 pub struct CollectorHealth {
     pub cursors: Vec<CursorStatus>,
     pub error_counters: crate::storage::ErrorCounters,

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -453,6 +453,48 @@ fn get_stability_series(env: &Env, q: RangeQueryArg) -> StabilitySeriesResponse 
     }
 }
 
+// ─── Phase 5 test-side types ───
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestDailyLiquidationRollup {
+    timestamp_ns: u64,
+    full_count: u32,
+    partial_count: u32,
+    redistribution_count: u32,
+    total_collateral_seized_e8s: u64,
+    total_debt_covered_e8s: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestLiquidationSeriesResponse {
+    rows: Vec<TestDailyLiquidationRollup>,
+    next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestFastPriceSnapshot {
+    timestamp_ns: u64,
+    prices: Vec<(Principal, f64, String)>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestPriceSeriesResponse {
+    rows: Vec<TestFastPriceSnapshot>,
+    next_from_ts: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestHourlyCycleSnapshot {
+    timestamp_ns: u64,
+    cycle_balance: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct TestCycleSeriesResponse {
+    rows: Vec<TestHourlyCycleSnapshot>,
+    next_from_ts: Option<u64>,
+}
+
 // ─── Phase 4 helpers ───
 
 fn get_collector_health(env: &Env) -> CollectorHealth {
@@ -841,4 +883,125 @@ fn upgrade_preserves_phase4_state() {
         assert_eq!(before.total_tracked_e8s, after.total_tracked_e8s,
             "tracked supply changed on upgrade for token {:?}", before.token);
     }
+}
+
+// ─── Phase 5 helpers ───
+
+fn get_liquidation_series(env: &Env, q: RangeQueryArg) -> TestLiquidationSeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_liquidation_series", encode_one(q).unwrap(),
+    ).expect("get_liquidation_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_liquidation_series rejected: {}", msg),
+    }
+}
+
+fn get_price_series(env: &Env, q: RangeQueryArg) -> TestPriceSeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_price_series", encode_one(q).unwrap(),
+    ).expect("get_price_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_price_series rejected: {}", msg),
+    }
+}
+
+fn get_cycle_series(env: &Env, q: RangeQueryArg) -> TestCycleSeriesResponse {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_cycle_series", encode_one(q).unwrap(),
+    ).expect("get_cycle_series query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_cycle_series rejected: {}", msg),
+    }
+}
+
+// ─── Phase 5 Tests ───
+
+#[test]
+fn fast_snapshot_captures_prices() {
+    let env = setup();
+    // Advance past the 300s fast timer
+    env.pic.advance_time(std::time::Duration::from_secs(305));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+    let q = RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None };
+    let res = get_price_series(&env, q);
+    // Fast snapshot should have captured collateral prices from the backend
+    assert!(!res.rows.is_empty(), "expected at least one fast price snapshot");
+    assert!(res.rows[0].timestamp_ns > 0);
+}
+
+#[test]
+fn hourly_snapshot_captures_cycles() {
+    let env = setup();
+    // Advance past the 3600s hourly timer
+    env.pic.advance_time(std::time::Duration::from_secs(3605));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+    let q = RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None };
+    let res = get_cycle_series(&env, q);
+    assert!(!res.rows.is_empty(), "expected at least one hourly cycle snapshot");
+}
+
+#[test]
+fn daily_rollup_aggregates_events() {
+    let env = setup();
+    // First trigger a pull cycle to tail events
+    advance_pull_cycle(&env);
+    // Then trigger the daily snapshot (which includes rollups)
+    env.pic.advance_time(std::time::Duration::from_secs(86_400));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+    let q = RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None };
+    let res = get_liquidation_series(&env, q);
+    // Even with zero liquidation events, the rollup should produce a row
+    assert!(!res.rows.is_empty(), "expected daily liquidation rollup row");
+    assert_eq!(res.rows[0].full_count, 0);
+}
+
+#[test]
+fn upgrade_preserves_phase5_state() {
+    let env = setup();
+    // Trigger fast snapshot
+    env.pic.advance_time(std::time::Duration::from_secs(305));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+    // Trigger hourly snapshot
+    env.pic.advance_time(std::time::Duration::from_secs(3600));
+    for _ in 0..10 {
+        env.pic.tick();
+    }
+
+    let prices_before = get_price_series(&env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None });
+    let cycles_before = get_cycle_series(&env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None });
+
+    // Upgrade the canister
+    env.pic.upgrade_canister(
+        env.analytics,
+        analytics_wasm(),
+        encode_one(AnalyticsInitArgs {
+            admin: env.admin,
+            backend: env.backend,
+            icusd_ledger: env.icusd_ledger,
+            three_pool: Principal::anonymous(),
+            stability_pool: Principal::anonymous(),
+            amm: Principal::anonymous(),
+        }).unwrap(),
+        Some(env.admin),
+    ).expect("upgrade analytics");
+
+    let prices_after = get_price_series(&env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None });
+    let cycles_after = get_cycle_series(&env,
+        RangeQueryArg { from_ts: None, to_ts: None, limit: Some(10), offset: None });
+    assert_eq!(prices_before.rows.len(), prices_after.rows.len(), "price snapshots lost on upgrade");
+    assert_eq!(cycles_before.rows.len(), cycles_after.rows.len(), "cycle snapshots lost on upgrade");
 }


### PR DESCRIPTION
## Summary

- **Daily rollups**: Aggregate EVT_* event logs into DailyLiquidationRollup, DailySwapRollup, and DailyFeeRollup rows during the existing daily timer. Tracks liquidation counts/volumes by type and collateral, swap counts/volumes/fees by source, unique swappers, and borrow/redemption counts.
- **Fast (5min) snapshots**: Capture collateral prices from `get_collateral_totals` and 3pool state (balances, virtual_price, lp_total_supply) every 300s.
- **Hourly snapshots**: Capture canister cycle balance and system CR / per-collateral debt/collateral/price every 3600s.
- **7 new query endpoints**: `get_liquidation_series`, `get_swap_series`, `get_fee_series`, `get_price_series`, `get_three_pool_series`, `get_cycle_series`, `get_fee_curve_series` - all paginated with the existing RangeQuery pattern.
- **Bug fix**: Caught and fixed an incorrect `/1e8` in the hourly CR calculation during review.

## Test plan

- [x] 4 new PocketIC integration tests (fast snapshot, hourly snapshot, daily rollup, upgrade preservation)
- [x] All 16 integration tests pass (12 existing + 4 new)
- [x] Wasm builds clean (warnings only)
- [ ] Deploy to mainnet and verify endpoints return data after timer cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)