### PR TITLE
Phase 7: HTTP API layer & frontend analytics integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,9 +7186,11 @@ dependencies = [
  "ic-stable-structures",
  "icrc-ledger-client-cdk",
  "icrc-ledger-types 0.1.8 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
+ "num-traits",
  "pocket-ic",
  "serde",
  "serde_bytes",
+ "serde_json",
 ]
 
 [[package]]

--- a/docs/superpowers/plans/2026-04-10-analytics-phase7-http-and-frontend.md
+++ b/docs/superpowers/plans/2026-04-10-analytics-phase7-http-and-frontend.md
@@ -1,0 +1,1149 @@
+# Phase 7: HTTP API Layer & Frontend Integration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose analytics data via HTTP API endpoints (CSV series, Prometheus metrics, health, supply) and integrate the analytics canister into the vault_frontend explorer.
+
+**Architecture:** The Rust HTTP handler (`http.rs`) is extended with CSV time-series endpoints, a Prometheus `/metrics` scrape target, and a JSON health endpoint. On the frontend, a new `analyticsService.ts` creates an anonymous actor for the analytics canister and exposes typed fetch functions with TTL caching. The explorer overview page is enhanced with analytics-sourced charts and a stats dashboard, and the holders page gains a historical trends section.
+
+**Tech Stack:** Rust (ic-cdk, ic_canisters_http_types), SvelteKit 5 (Svelte 5 runes), TypeScript, @dfinity/agent, inline SVG charts (no charting library).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/rumi_analytics/src/http.rs` | **MODIFY** - Add CSV series endpoints, Prometheus metrics, health JSON, events endpoint |
+| `src/rumi_analytics/src/http/csv.rs` | **CREATE** - CSV serialization helpers for each row type |
+| `src/rumi_analytics/src/http/metrics.rs` | **CREATE** - Prometheus text format builder |
+| `src/rumi_analytics/Cargo.toml` | **MODIFY** - Add `serde_json` dependency |
+| `src/rumi_analytics/src/lib.rs` | No changes needed (http_request already wired) |
+| `src/vault_frontend/src/lib/config.ts` | **MODIFY** - Add ANALYTICS canister ID |
+| `src/vault_frontend/src/lib/services/explorer/analyticsService.ts` | **CREATE** - Analytics canister actor + typed fetch functions with TTL cache |
+| `src/vault_frontend/src/routes/explorer/stats/+page.svelte` | **REWRITE** - Analytics dashboard (replace redirect stub) |
+| `src/vault_frontend/src/routes/explorer/+layout.svelte` | **MODIFY** - Add Stats nav link |
+| `src/vault_frontend/src/routes/explorer/+page.svelte` | **MODIFY** - Source chart data from analytics canister |
+| `src/vault_frontend/src/routes/explorer/holders/+page.svelte` | **MODIFY** - Add historical holder trends section |
+| `src/rumi_analytics/tests/pocket_ic_analytics.rs` | **MODIFY** - Add HTTP endpoint integration tests |
+
+---
+
+### Task 1: CSV Serialization Helpers
+
+**Files:**
+- Create: `src/rumi_analytics/src/http/csv.rs`
+- Modify: `src/rumi_analytics/src/http.rs` (convert to `src/rumi_analytics/src/http/mod.rs`)
+
+The existing `http.rs` is a flat file. We'll convert it to a module directory (`http/mod.rs` + `http/csv.rs` + `http/metrics.rs`) to keep things organized.
+
+- [ ] **Step 1: Create http directory and move http.rs to mod.rs**
+
+Rename `src/rumi_analytics/src/http.rs` to `src/rumi_analytics/src/http/mod.rs`. The content stays the same for now.
+
+Run: `mkdir -p src/rumi_analytics/src/http && mv src/rumi_analytics/src/http.rs src/rumi_analytics/src/http/mod.rs`
+
+- [ ] **Step 2: Build to verify the module rename didn't break anything**
+
+Run: `cargo build --target wasm32-unknown-unknown --release -p rumi_analytics 2>&1 | tail -5`
+Expected: compiles successfully
+
+- [ ] **Step 3: Create csv.rs with row-to-CSV functions**
+
+Create `src/rumi_analytics/src/http/csv.rs`:
+
+```rust
+//! CSV serialization for time-series row types. Each function takes a slice
+//! of rows and returns a complete CSV string with header line.
+
+use crate::storage;
+use candid::Principal;
+
+pub fn tvl_csv(rows: &[storage::DailyTvlRow]) -> String {
+    let mut out = String::from("timestamp_ns,total_icp_collateral_e8s,total_icusd_supply_e8s,system_cr_bps,stability_pool_deposits_e8s,three_pool_reserve_0_e8s,three_pool_reserve_1_e8s,three_pool_reserve_2_e8s\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            r.timestamp_ns,
+            r.total_icp_collateral_e8s,
+            r.total_icusd_supply_e8s,
+            r.system_collateral_ratio_bps,
+            r.stability_pool_deposits_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_0_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_1_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_2_e8s.map_or(String::new(), |v| v.to_string()),
+        ));
+    }
+    out
+}
+
+pub fn vault_csv(rows: &[storage::DailyVaultSnapshotRow]) -> String {
+    let mut out = String::from("timestamp_ns,total_vault_count,total_collateral_usd_e8s,total_debt_e8s,median_cr_bps\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{}\n",
+            r.timestamp_ns, r.total_vault_count, r.total_collateral_usd_e8s, r.total_debt_e8s, r.median_cr_bps,
+        ));
+    }
+    out
+}
+
+pub fn stability_csv(rows: &[storage::DailyStabilityRow]) -> String {
+    let mut out = String::from("timestamp_ns,total_deposits_e8s,total_depositors,total_liquidations_executed,total_interest_received_e8s\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{}\n",
+            r.timestamp_ns, r.total_deposits_e8s, r.total_depositors,
+            r.total_liquidations_executed, r.total_interest_received_e8s,
+        ));
+    }
+    out
+}
+
+pub fn swap_csv(rows: &[storage::rollups::DailySwapRollup]) -> String {
+    let mut out = String::from("timestamp_ns,three_pool_swap_count,amm_swap_count,three_pool_volume_e8s,amm_volume_e8s,three_pool_fees_e8s,amm_fees_e8s,unique_swappers\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            r.timestamp_ns, r.three_pool_swap_count, r.amm_swap_count,
+            r.three_pool_volume_e8s, r.amm_volume_e8s,
+            r.three_pool_fees_e8s, r.amm_fees_e8s, r.unique_swappers,
+        ));
+    }
+    out
+}
+
+pub fn liquidation_csv(rows: &[storage::rollups::DailyLiquidationRollup]) -> String {
+    let mut out = String::from("timestamp_ns,full_count,partial_count,redistribution_count,total_collateral_seized_e8s,total_debt_absorbed_e8s\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            r.timestamp_ns, r.full_count, r.partial_count, r.redistribution_count,
+            r.total_collateral_seized_e8s, r.total_debt_absorbed_e8s,
+        ));
+    }
+    out
+}
+
+pub fn fee_csv(rows: &[storage::rollups::DailyFeeRollup]) -> String {
+    let mut out = String::from("timestamp_ns,swap_fees_e8s,borrowing_fees_e8s,redemption_fees_e8s,borrow_count,redemption_count\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            r.timestamp_ns, r.swap_fees_e8s,
+            r.borrowing_fees_e8s.map_or(String::new(), |v| v.to_string()),
+            r.redemption_fees_e8s.map_or(String::new(), |v| v.to_string()),
+            r.borrow_count, r.redemption_count,
+        ));
+    }
+    out
+}
+
+pub fn price_csv(rows: &[storage::fast::FastPriceSnapshot]) -> String {
+    let mut out = String::from("timestamp_ns,collateral,price_usd,symbol\n");
+    for r in rows {
+        for (p, price, sym) in &r.prices {
+            out.push_str(&format!("{},{},{},{}\n", r.timestamp_ns, p, price, sym));
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Add `mod csv;` to http/mod.rs**
+
+Add at the top of `src/rumi_analytics/src/http/mod.rs`:
+```rust
+mod csv;
+```
+
+- [ ] **Step 5: Build to verify**
+
+Run: `cargo build --target wasm32-unknown-unknown --release -p rumi_analytics 2>&1 | tail -5`
+Expected: compiles successfully
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/rumi_analytics/src/http/
+git commit -m "refactor(analytics): convert http.rs to module directory, add CSV helpers"
+```
+
+---
+
+### Task 2: Prometheus Metrics Endpoint
+
+**Files:**
+- Create: `src/rumi_analytics/src/http/metrics.rs`
+- Modify: `src/rumi_analytics/src/http/mod.rs`
+
+- [ ] **Step 1: Create metrics.rs**
+
+Create `src/rumi_analytics/src/http/metrics.rs`:
+
+```rust
+//! Prometheus text format exposition. All gauges, no histograms.
+
+use crate::{state, storage};
+
+pub fn render() -> String {
+    let mut out = String::with_capacity(2048);
+
+    // Supply gauges
+    let icusd_supply = state::read_state(|s| s.circulating_supply_icusd_e8s).unwrap_or(0);
+    let threeusd_supply = state::read_state(|s| s.circulating_supply_3usd_e8s).unwrap_or(0);
+    gauge(&mut out, "rumi_icusd_supply_e8s", "icUSD circulating supply in e8s", icusd_supply as f64);
+    gauge(&mut out, "rumi_3usd_supply_e8s", "3USD circulating supply in e8s", threeusd_supply as f64);
+
+    // Latest vault snapshot
+    let vault_n = storage::daily_vaults::len();
+    if vault_n > 0 {
+        if let Some(v) = storage::daily_vaults::get(vault_n - 1) {
+            gauge(&mut out, "rumi_total_vault_count", "Total number of vaults", v.total_vault_count as f64);
+            gauge(&mut out, "rumi_total_collateral_usd_e8s", "Total collateral value in USD e8s", v.total_collateral_usd_e8s as f64);
+            gauge(&mut out, "rumi_total_debt_e8s", "Total icUSD debt in e8s", v.total_debt_e8s as f64);
+            gauge(&mut out, "rumi_system_cr_bps", "System collateral ratio in basis points", v.median_cr_bps as f64);
+        }
+    }
+
+    // Latest TVL
+    let tvl_n = storage::daily_tvl::len();
+    if tvl_n > 0 {
+        if let Some(t) = storage::daily_tvl::get(tvl_n - 1) {
+            gauge(&mut out, "rumi_total_icp_collateral_e8s", "Total ICP collateral in e8s", t.total_icp_collateral_e8s as f64);
+            gauge(&mut out, "rumi_total_icusd_supply_e8s", "Total icUSD supply from TVL snapshot", t.total_icusd_supply_e8s as f64);
+        }
+    }
+
+    // Error counters
+    let ec = state::read_state(|s| s.error_counters.clone());
+    counter(&mut out, "rumi_collector_errors_total", "backend", ec.backend);
+    counter(&mut out, "rumi_collector_errors_total", "icusd_ledger", ec.icusd_ledger);
+    counter(&mut out, "rumi_collector_errors_total", "three_pool", ec.three_pool);
+    counter(&mut out, "rumi_collector_errors_total", "stability_pool", ec.stability_pool);
+    counter(&mut out, "rumi_collector_errors_total", "amm", ec.amm);
+
+    // Storage sizes
+    gauge(&mut out, "rumi_storage_daily_tvl_rows", "Number of daily TVL rows", storage::daily_tvl::len() as f64);
+    gauge(&mut out, "rumi_storage_daily_vault_rows", "Number of daily vault rows", storage::daily_vaults::len() as f64);
+    gauge(&mut out, "rumi_storage_evt_swaps_rows", "Number of swap event rows", storage::events::evt_swaps::len() as f64);
+    gauge(&mut out, "rumi_storage_evt_liquidations_rows", "Number of liquidation event rows", storage::events::evt_liquidations::len() as f64);
+    gauge(&mut out, "rumi_storage_fast_prices_rows", "Number of fast price snapshots", storage::fast::fast_prices::len() as f64);
+
+    out
+}
+
+fn gauge(out: &mut String, name: &str, help: &str, value: f64) {
+    out.push_str(&format!("# HELP {} {}\n# TYPE {} gauge\n{} {}\n", name, help, name, name, value));
+}
+
+fn counter(out: &mut String, name: &str, label: &str, value: u64) {
+    // First call for a counter name should emit HELP/TYPE, but for simplicity
+    // we emit per-label since Prometheus is tolerant of repeated HELP lines.
+    out.push_str(&format!("{}{{source=\"{}\"}} {}\n", name, label, value));
+}
+```
+
+- [ ] **Step 2: Add `mod metrics;` to http/mod.rs and wire the `/metrics` route**
+
+In `src/rumi_analytics/src/http/mod.rs`, add:
+```rust
+mod metrics;
+```
+
+And add a match arm in `http_request`:
+```rust
+"/metrics" => {
+    let body = metrics::render();
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        .with_body_and_content_length(body)
+        .build()
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `cargo build --target wasm32-unknown-unknown --release -p rumi_analytics 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/rumi_analytics/src/http/metrics.rs src/rumi_analytics/src/http/mod.rs
+git commit -m "feat(analytics): add Prometheus /metrics endpoint"
+```
+
+---
+
+### Task 3: CSV Series and Health Endpoints
+
+**Files:**
+- Modify: `src/rumi_analytics/src/http/mod.rs`
+- Modify: `src/rumi_analytics/Cargo.toml`
+
+- [ ] **Step 1: Add serde_json dependency**
+
+Add to `src/rumi_analytics/Cargo.toml` under `[dependencies]`:
+```toml
+serde_json = "1"
+```
+
+- [ ] **Step 2: Wire all HTTP routes in mod.rs**
+
+Replace the `http_request` function in `src/rumi_analytics/src/http/mod.rs` with:
+
+```rust
+mod csv;
+mod metrics;
+
+use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
+use crate::{state, storage, types};
+
+pub fn http_request(req: HttpRequest) -> HttpResponse {
+    let path = req.url.split('?').next().unwrap_or("");
+    match path {
+        // Supply endpoints (existing)
+        "/api/supply" => supply_icusd_f64(),
+        "/api/supply/raw" => supply_icusd_raw(),
+
+        // Prometheus
+        "/metrics" => {
+            let body = metrics::render();
+            HttpResponseBuilder::ok()
+                .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                .with_body_and_content_length(body)
+                .build()
+        }
+
+        // Health
+        "/api/health" => health_json(),
+
+        // CSV series
+        "/api/series/tvl" => csv_response(csv::tvl_csv(&storage::daily_tvl::range(0, u64::MAX, 10_000))),
+        "/api/series/vaults" => csv_response(csv::vault_csv(&storage::daily_vaults::range(0, u64::MAX, 10_000))),
+        "/api/series/stability" => csv_response(csv::stability_csv(&storage::daily_stability::range(0, u64::MAX, 10_000))),
+        "/api/series/swaps" => csv_response(csv::swap_csv(&storage::rollups::daily_swaps::range(0, u64::MAX, 10_000))),
+        "/api/series/liquidations" => csv_response(csv::liquidation_csv(&storage::rollups::daily_liquidations::range(0, u64::MAX, 10_000))),
+        "/api/series/fees" => csv_response(csv::fee_csv(&storage::rollups::daily_fees::range(0, u64::MAX, 10_000))),
+        "/api/series/prices" => csv_response(csv::price_csv(&storage::fast::fast_prices::range(0, u64::MAX, 10_000))),
+
+        _ => HttpResponseBuilder::not_found().build(),
+    }
+}
+
+fn csv_response(body: String) -> HttpResponse {
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "text/csv; charset=utf-8")
+        .header("Access-Control-Allow-Origin", "*")
+        .with_body_and_content_length(body)
+        .build()
+}
+
+fn health_json() -> HttpResponse {
+    let last_daily = state::read_state(|s| s.last_daily_snapshot_ns);
+    let last_pull = state::read_state(|s| s.last_pull_cycle_ns).unwrap_or(0);
+    let ec = state::read_state(|s| s.error_counters.clone());
+    let now = ic_cdk::api::time();
+
+    let body = serde_json::json!({
+        "status": "ok",
+        "canister_time_ns": now,
+        "last_daily_snapshot_ns": last_daily,
+        "last_pull_cycle_ns": last_pull,
+        "error_counters": {
+            "backend": ec.backend,
+            "icusd_ledger": ec.icusd_ledger,
+            "three_pool": ec.three_pool,
+            "stability_pool": ec.stability_pool,
+            "amm": ec.amm,
+        },
+        "storage_rows": {
+            "daily_tvl": storage::daily_tvl::len(),
+            "daily_vaults": storage::daily_vaults::len(),
+            "evt_swaps": storage::events::evt_swaps::len(),
+            "evt_liquidations": storage::events::evt_liquidations::len(),
+            "fast_prices": storage::fast::fast_prices::len(),
+        }
+    });
+
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "application/json; charset=utf-8")
+        .header("Access-Control-Allow-Origin", "*")
+        .with_body_and_content_length(body.to_string())
+        .build()
+}
+```
+
+Keep the existing `supply_icusd_f64` and `supply_icusd_raw` private functions unchanged below.
+
+- [ ] **Step 3: Build to verify**
+
+Run: `cargo build --target wasm32-unknown-unknown --release -p rumi_analytics 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/rumi_analytics/Cargo.toml src/rumi_analytics/src/http/mod.rs
+git commit -m "feat(analytics): add CSV series, health JSON, and route all HTTP endpoints"
+```
+
+---
+
+### Task 4: HTTP Endpoint Integration Tests
+
+**Files:**
+- Modify: `src/rumi_analytics/tests/pocket_ic_analytics.rs`
+
+- [ ] **Step 1: Add HTTP endpoint tests**
+
+Add after the existing Phase 6 tests:
+
+```rust
+// ─── Phase 7 HTTP tests ───
+
+#[test]
+fn http_health_returns_json() {
+    let env = setup();
+    advance_pull_cycle(&env);
+
+    let resp = http_get(&env, "/api/health");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.contains("\"status\":\"ok\""), "health body: {}", body);
+    assert!(body.contains("\"storage_rows\""), "health body: {}", body);
+}
+
+#[test]
+fn http_metrics_returns_prometheus() {
+    let env = setup();
+    advance_pull_cycle(&env);
+
+    let resp = http_get(&env, "/metrics");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.contains("rumi_icusd_supply_e8s"), "metrics body missing supply gauge");
+}
+
+#[test]
+fn http_csv_tvl_returns_header() {
+    let env = setup();
+    // Trigger daily snapshot so there's at least one TVL row
+    advance_pull_cycle(&env);
+    env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
+    for _ in 0..10 { env.pic.tick(); }
+
+    let resp = http_get(&env, "/api/series/tvl");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.starts_with("timestamp_ns,"), "CSV should start with header, got: {}", &body[..50.min(body.len())]);
+    // Should have at least header + 1 data row
+    let lines: Vec<&str> = body.lines().collect();
+    assert!(lines.len() >= 2, "expected header + data row, got {} lines", lines.len());
+}
+
+#[test]
+fn http_not_found() {
+    let env = setup();
+    let resp = http_get(&env, "/nonexistent");
+    assert_eq!(resp.status_code, 404);
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test --test pocket_ic_analytics -- --nocapture 2>&1 | tail -10`
+Expected: all tests pass (24 total: 20 existing + 4 new)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_analytics/tests/pocket_ic_analytics.rs
+git commit -m "test(analytics): add Phase 7 HTTP endpoint integration tests"
+```
+
+---
+
+### Task 5: Frontend Analytics Service
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/config.ts`
+- Create: `src/vault_frontend/src/lib/services/explorer/analyticsService.ts`
+
+- [ ] **Step 1: Add analytics canister ID to config.ts**
+
+In `src/vault_frontend/src/lib/config.ts`, add to the `CANISTER_IDS` object:
+```typescript
+  ANALYTICS: "dtlu2-uqaaa-aaaap-qugcq-cai",
+```
+
+And add the IDL import at the top:
+```typescript
+import { idlFactory as analyticsIDL } from '$declarations/rumi_analytics/rumi_analytics.did.js';
+```
+
+And add to the `CONFIG` object (around line 43+, wherever the IDL references are):
+```typescript
+  analyticsIDL,
+```
+
+- [ ] **Step 2: Create analyticsService.ts**
+
+Create `src/vault_frontend/src/lib/services/explorer/analyticsService.ts`:
+
+```typescript
+/**
+ * analyticsService.ts — Typed data service for the rumi_analytics canister.
+ *
+ * Creates an anonymous actor and exposes fetch functions with TTL caching,
+ * following the same pattern as explorerService.ts.
+ */
+
+import { Actor, HttpAgent } from '@dfinity/agent';
+import { CANISTER_IDS, CONFIG } from '$lib/config';
+import type { _SERVICE } from '$declarations/rumi_analytics/rumi_analytics.did';
+
+// ── TTL constants (ms) ──────────────────────────────────────────────────────
+
+const TTL = {
+  SUMMARY: 15_000,
+  SERIES: 60_000,
+  FAST: 30_000,
+} as const;
+
+// ── Cache infrastructure ────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  data: T;
+  ts: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string, ttlMs: number): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.ts > ttlMs) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data as T;
+}
+
+function setCache<T>(key: string, data: T): T {
+  cache.set(key, { data, ts: Date.now() });
+  return data;
+}
+
+export function invalidateAnalyticsCache(prefix?: string): void {
+  if (!prefix) { cache.clear(); return; }
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+// ── Actor ───────────────────────────────────────────────────────────────────
+
+let _actor: _SERVICE | null = null;
+
+function getActor(): _SERVICE {
+  if (_actor) return _actor;
+  const agent = HttpAgent.createSync({ host: 'https://icp-api.io' });
+  _actor = Actor.createActor<_SERVICE>(CONFIG.analyticsIDL, {
+    agent,
+    canisterId: CANISTER_IDS.ANALYTICS,
+  });
+  return _actor;
+}
+
+// ── Typed query helpers ─────────────────────────────────────────────────────
+
+function rangeQuery(from?: bigint, to?: bigint, limit?: number) {
+  return {
+    from_ts: from !== undefined ? [from] : [],
+    to_ts: to !== undefined ? [to] : [],
+    limit: limit !== undefined ? [limit] : [],
+    offset: [],
+  };
+}
+
+// ── Public fetch functions ──────────────────────────────────────────────────
+
+export async function fetchProtocolSummary() {
+  const key = 'analytics:summary';
+  const cached = getCached<any>(key, TTL.SUMMARY);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_protocol_summary();
+    return setCache(key, result);
+  } catch (err) {
+    console.error('[analyticsService] fetchProtocolSummary failed:', err);
+    return null;
+  }
+}
+
+export async function fetchTvlSeries(limit = 365) {
+  const key = `analytics:tvl:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_tvl_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchTvlSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchVaultSeries(limit = 365) {
+  const key = `analytics:vaults:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_vault_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchVaultSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchStabilitySeries(limit = 365) {
+  const key = `analytics:stability:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_stability_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchStabilitySeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchSwapSeries(limit = 365) {
+  const key = `analytics:swaps:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_swap_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchSwapSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchFeeSeries(limit = 365) {
+  const key = `analytics:fees:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_fee_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchFeeSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchLiquidationSeries(limit = 365) {
+  const key = `analytics:liquidations:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_liquidation_series(rangeQuery(undefined, undefined, limit));
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchLiquidationSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchHolderSeries(token: string, limit = 365) {
+  const key = `analytics:holders:${token}:${limit}`;
+  const cached = getCached<any>(key, TTL.SERIES);
+  if (cached) return cached;
+
+  try {
+    const principal = typeof token === 'string' ? (await import('@dfinity/principal')).Principal.fromText(token) : token;
+    const result = await getActor().get_holder_series(rangeQuery(undefined, undefined, limit), principal);
+    return setCache(key, result.rows);
+  } catch (err) {
+    console.error('[analyticsService] fetchHolderSeries failed:', err);
+    return [];
+  }
+}
+
+export async function fetchTwap(windowSecs = 3600) {
+  const key = `analytics:twap:${windowSecs}`;
+  const cached = getCached<any>(key, TTL.FAST);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_twap({ window_secs: [BigInt(windowSecs)] });
+    return setCache(key, result);
+  } catch (err) {
+    console.error('[analyticsService] fetchTwap failed:', err);
+    return null;
+  }
+}
+
+export async function fetchApys(windowDays = 7) {
+  const key = `analytics:apys:${windowDays}`;
+  const cached = getCached<any>(key, TTL.FAST);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_apys({ window_days: [windowDays] });
+    return setCache(key, result);
+  } catch (err) {
+    console.error('[analyticsService] fetchApys failed:', err);
+    return null;
+  }
+}
+
+export async function fetchPegStatus() {
+  const key = 'analytics:peg';
+  const cached = getCached<any>(key, TTL.FAST);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_peg_status();
+    return setCache(key, result.length > 0 ? result[0] : null);
+  } catch (err) {
+    console.error('[analyticsService] fetchPegStatus failed:', err);
+    return null;
+  }
+}
+
+export async function fetchTradeActivity(windowSecs = 86400) {
+  const key = `analytics:trades:${windowSecs}`;
+  const cached = getCached<any>(key, TTL.FAST);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_trade_activity({ window_secs: [BigInt(windowSecs)] });
+    return setCache(key, result);
+  } catch (err) {
+    console.error('[analyticsService] fetchTradeActivity failed:', err);
+    return null;
+  }
+}
+
+export async function fetchCollectorHealth() {
+  const key = 'analytics:health';
+  const cached = getCached<any>(key, TTL.FAST);
+  if (cached) return cached;
+
+  try {
+    const result = await getActor().get_collector_health();
+    return setCache(key, result);
+  } catch (err) {
+    console.error('[analyticsService] fetchCollectorHealth failed:', err);
+    return null;
+  }
+}
+```
+
+- [ ] **Step 3: Verify frontend builds**
+
+Run: `cd src/vault_frontend && npm run build 2>&1 | tail -10`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/config.ts src/vault_frontend/src/lib/services/explorer/analyticsService.ts
+git commit -m "feat(frontend): add analyticsService with typed fetch functions for analytics canister"
+```
+
+---
+
+### Task 6: Explorer Stats Dashboard Page
+
+**Files:**
+- Rewrite: `src/vault_frontend/src/routes/explorer/stats/+page.svelte`
+- Modify: `src/vault_frontend/src/routes/explorer/+layout.svelte`
+
+- [ ] **Step 1: Add Stats link to layout navigation**
+
+In `src/vault_frontend/src/routes/explorer/+layout.svelte`, add to the `navLinks` array:
+```typescript
+{ href: '/explorer/stats', label: 'Stats', exact: false },
+```
+
+- [ ] **Step 2: Rewrite stats page**
+
+Replace `src/vault_frontend/src/routes/explorer/stats/+page.svelte` with a dashboard that shows:
+- Protocol summary (TVL, debt, CR, vault count, 24h volume)
+- Collateral prices with TWAPs
+- Peg status
+- APYs (LP + SP)
+- Trade activity
+- Collector health status
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import StatCard from '$components/explorer/StatCard.svelte';
+  import {
+    fetchProtocolSummary, fetchTwap, fetchPegStatus,
+    fetchApys, fetchTradeActivity, fetchCollectorHealth
+  } from '$services/explorer/analyticsService';
+  import { formatE8s, formatUsd, formatCR } from '$utils/explorerHelpers';
+
+  const E8S = 100_000_000;
+
+  let summary: any = $state(null);
+  let twap: any = $state(null);
+  let peg: any = $state(null);
+  let apys: any = $state(null);
+  let trades: any = $state(null);
+  let health: any = $state(null);
+  let loading = $state(true);
+  let error: string | null = $state(null);
+
+  onMount(async () => {
+    try {
+      const [s, t, p, a, tr, h] = await Promise.all([
+        fetchProtocolSummary(),
+        fetchTwap(3600),
+        fetchPegStatus(),
+        fetchApys(7),
+        fetchTradeActivity(86400),
+        fetchCollectorHealth(),
+      ]);
+      summary = s;
+      twap = t;
+      peg = p;
+      apys = a;
+      trades = tr;
+      health = h;
+    } catch (e: any) {
+      error = e.message || 'Failed to load analytics data';
+    } finally {
+      loading = false;
+    }
+  });
+
+  function fmtPct(v: number | undefined | null): string {
+    if (v == null) return '--';
+    return `${v.toFixed(2)}%`;
+  }
+
+  function fmtPrice(v: number | undefined | null): string {
+    if (v == null) return '--';
+    return `$${v.toFixed(4)}`;
+  }
+
+  function fmtBigE8s(v: bigint | number | undefined | null): string {
+    if (v == null) return '--';
+    return formatE8s(BigInt(v));
+  }
+</script>
+
+<svelte:head>
+  <title>Analytics | Rumi Explorer</title>
+</svelte:head>
+
+{#if loading}
+  <div class="flex items-center justify-center py-20">
+    <div class="h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"></div>
+  </div>
+{:else if error}
+  <div class="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-red-400">{error}</div>
+{:else}
+  <div class="space-y-8">
+    <!-- Protocol Summary -->
+    <section>
+      <h2 class="mb-4 text-lg font-semibold text-white">Protocol Overview</h2>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <StatCard label="Total TVL" value={summary ? fmtBigE8s(summary.total_collateral_usd_e8s) : '--'} />
+        <StatCard label="Total Debt" value={summary ? fmtBigE8s(summary.total_debt_e8s) : '--'} />
+        <StatCard label="System CR" value={summary ? formatCR(summary.system_cr_bps) : '--'} />
+        <StatCard label="Vaults" value={summary?.total_vault_count?.toString() ?? '--'} />
+        <StatCard label="24h Volume" value={summary ? fmtBigE8s(summary.volume_24h_e8s) : '--'} />
+      </div>
+    </section>
+
+    <!-- Prices -->
+    {#if summary?.prices?.length > 0}
+    <section>
+      <h2 class="mb-4 text-lg font-semibold text-white">Collateral Prices (1h TWAP)</h2>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {#each summary.prices as p}
+          <StatCard label={p.symbol} value={fmtPrice(p.twap_price)} sub="Latest: {fmtPrice(p.latest_price)}" />
+        {/each}
+      </div>
+    </section>
+    {/if}
+
+    <!-- Peg & APYs -->
+    <section>
+      <h2 class="mb-4 text-lg font-semibold text-white">Pool Health</h2>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard label="3pool Imbalance" value={peg ? fmtPct(peg.max_imbalance_pct) : '--'} />
+        <StatCard label="LP APY (7d)" value={apys ? fmtPct(apys.lp_apy_pct?.[0]) : '--'} />
+        <StatCard label="SP APY (7d)" value={apys ? fmtPct(apys.sp_apy_pct?.[0]) : '--'} />
+        <StatCard label="24h Swaps" value={trades?.total_swaps?.toString() ?? '--'} />
+      </div>
+    </section>
+
+    <!-- Trade Activity -->
+    {#if trades}
+    <section>
+      <h2 class="mb-4 text-lg font-semibold text-white">Trade Activity (24h)</h2>
+      <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard label="3pool Swaps" value={trades.three_pool_swaps?.toString() ?? '0'} />
+        <StatCard label="AMM Swaps" value={trades.amm_swaps?.toString() ?? '0'} />
+        <StatCard label="Total Fees" value={fmtBigE8s(trades.total_fees_e8s)} />
+        <StatCard label="Unique Traders" value={trades.unique_traders?.toString() ?? '0'} />
+      </div>
+    </section>
+    {/if}
+
+    <!-- Collector Health -->
+    {#if health}
+    <section>
+      <h2 class="mb-4 text-lg font-semibold text-white">Collector Health</h2>
+      <div class="overflow-x-auto rounded-lg border border-white/10">
+        <table class="w-full text-sm text-white/70">
+          <thead>
+            <tr class="border-b border-white/10 text-left text-xs uppercase text-white/40">
+              <th class="px-4 py-2">Cursor</th>
+              <th class="px-4 py-2">Position</th>
+              <th class="px-4 py-2">Source Count</th>
+              <th class="px-4 py-2">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each health.cursors as c}
+              <tr class="border-b border-white/5">
+                <td class="px-4 py-2 font-mono text-white/90">{c.name}</td>
+                <td class="px-4 py-2">{c.cursor_position.toString()}</td>
+                <td class="px-4 py-2">{c.source_count.toString()}</td>
+                <td class="px-4 py-2">
+                  {#if c.last_error?.[0]}
+                    <span class="text-red-400" title={c.last_error[0]}>Error</span>
+                  {:else}
+                    <span class="text-green-400">OK</span>
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    </section>
+    {/if}
+  </div>
+{/if}
+```
+
+- [ ] **Step 3: Verify frontend builds**
+
+Run: `cd src/vault_frontend && npm run build 2>&1 | tail -10`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/explorer/stats/+page.svelte src/vault_frontend/src/routes/explorer/+layout.svelte
+git commit -m "feat(frontend): add analytics stats dashboard page with nav link"
+```
+
+---
+
+### Task 7: Overview Page Analytics Integration
+
+**Files:**
+- Modify: `src/vault_frontend/src/routes/explorer/+page.svelte`
+
+Replace the "Section 7: Historical Charts" data source from `fetchAllSnapshots` (backend snapshots) to use `fetchTvlSeries` and `fetchVaultSeries` from `analyticsService`. This gives the overview page proper daily time-series data from the analytics canister instead of the backend's raw snapshots.
+
+- [ ] **Step 1: Add analytics imports and replace chart data source**
+
+In `src/vault_frontend/src/routes/explorer/+page.svelte`:
+
+Add import:
+```typescript
+import { fetchTvlSeries, fetchVaultSeries } from '$services/explorer/analyticsService';
+```
+
+Replace the Section 7 loading block (around line 490-499) from:
+```typescript
+const chartsPromise = (async () => {
+    allSnapshots = await fetchAllSnapshots();
+    ...
+})();
+```
+
+To:
+```typescript
+const chartsPromise = (async () => {
+    const [tvl, vaultSnaps] = await Promise.all([
+        fetchTvlSeries(365),
+        fetchVaultSeries(365),
+    ]);
+    allSnapshots = tvl.map((r: any) => ({
+        timestamp_ns: r.timestamp_ns,
+        total_icp_collateral_e8s: r.total_icp_collateral_e8s,
+        total_icusd_supply_e8s: r.total_icusd_supply_e8s,
+        system_collateral_ratio_bps: r.system_collateral_ratio_bps,
+    }));
+    chartsLoading = false;
+})();
+```
+
+This preserves the existing chart rendering code (tvlData, debtData, crData deriveds) which already reads from `allSnapshots`, while sourcing from analytics.
+
+- [ ] **Step 2: Verify frontend builds**
+
+Run: `cd src/vault_frontend && npm run build 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/explorer/+page.svelte
+git commit -m "feat(frontend): source overview charts from analytics canister"
+```
+
+---
+
+### Task 8: Holders Page Historical Trends
+
+**Files:**
+- Modify: `src/vault_frontend/src/routes/explorer/holders/+page.svelte`
+
+Add a "Holder Trends" section below the existing holder table that shows a chart of holder count over time, sourced from `get_holder_series`.
+
+- [ ] **Step 1: Add analytics import and trends section**
+
+In `src/vault_frontend/src/routes/explorer/holders/+page.svelte`, add import:
+```typescript
+import { fetchHolderSeries } from '$services/explorer/analyticsService';
+```
+
+Add state:
+```typescript
+let holderTrends: any[] = $state([]);
+let trendsLoading = $state(false);
+```
+
+Add a function to load trends (call it from the existing `loadHolders` after the holder data loads):
+```typescript
+async function loadTrends(token: TokenTab) {
+    trendsLoading = true;
+    try {
+        const ledger = token === 'icusd' ? CANISTER_IDS.ICUSD_LEDGER : CANISTER_IDS.THREEPOOL;
+        holderTrends = await fetchHolderSeries(ledger, 90);
+    } catch (e) {
+        console.error('[holders] trends load failed:', e);
+    } finally {
+        trendsLoading = false;
+    }
+}
+```
+
+Call `loadTrends(token)` at the end of `loadHolders`.
+
+Add an SVG chart section after the existing data table in the template:
+
+```svelte
+<!-- Holder Trends -->
+{#if holderTrends.length > 1}
+<section class="mt-8">
+  <h3 class="mb-3 text-base font-semibold text-white">Holder Count Over Time</h3>
+  <div class="rounded-lg border border-white/10 bg-gray-900/50 p-4">
+    {@const chartW = 600}
+    {@const chartH = 140}
+    {@const pad = 4}
+    {@const points = holderTrends.map((r: any) => ({
+      x: Number(r.timestamp_ns) / 1e9,
+      y: Number(r.total_holders)
+    }))}
+    {@const xMin = Math.min(...points.map((p: any) => p.x))}
+    {@const xMax = Math.max(...points.map((p: any) => p.x))}
+    {@const yMin = Math.min(...points.map((p: any) => p.y))}
+    {@const yMax = Math.max(...points.map((p: any) => p.y)) || 1}
+    {@const xRange = xMax - xMin || 1}
+    {@const yRange = yMax - yMin || 1}
+    <svg viewBox="0 0 {chartW} {chartH}" class="w-full h-auto" preserveAspectRatio="none">
+      <polyline
+        fill="none"
+        stroke="#6366f1"
+        stroke-width="2"
+        points={points.map((p: any) => {
+          const x = pad + ((p.x - xMin) / xRange) * (chartW - pad * 2);
+          const y = pad + (chartH - pad * 2) - ((p.y - yMin) / yRange) * (chartH - pad * 2);
+          return `${x},${y}`;
+        }).join(' ')}
+      />
+    </svg>
+    <div class="mt-1 flex justify-between text-xs text-white/30">
+      <span>{new Date(xMin * 1000).toLocaleDateString()}</span>
+      <span>Latest: {points[points.length - 1]?.y ?? 0} holders</span>
+      <span>{new Date(xMax * 1000).toLocaleDateString()}</span>
+    </div>
+  </div>
+</section>
+{/if}
+```
+
+- [ ] **Step 2: Verify frontend builds**
+
+Run: `cd src/vault_frontend && npm run build 2>&1 | tail -10`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/explorer/holders/+page.svelte
+git commit -m "feat(frontend): add historical holder trends chart from analytics canister"
+```
+
+---
+
+### Task 9: Regenerate Candid and Final Review
+
+- [ ] **Step 1: Rebuild wasm and regenerate candid (in case any changes)**
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -p rumi_analytics
+candid-extractor target/wasm32-unknown-unknown/release/rumi_analytics.wasm > src/rumi_analytics/rumi_analytics.did
+dfx generate rumi_analytics
+```
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run: `cargo test -p rumi_analytics -- --nocapture 2>&1 | tail -15`
+
+- [ ] **Step 3: Run full integration test suite**
+
+Run: `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test --test pocket_ic_analytics -- --nocapture 2>&1 | tail -10`
+
+- [ ] **Step 4: Run frontend build**
+
+Run: `cd src/vault_frontend && npm run build 2>&1 | tail -10`
+
+- [ ] **Step 5: Review all changed files for issues**
+
+- [ ] **Step 6: Fix any issues and recommit**
+
+---
+
+## Design Notes
+
+**Why CSV over JSON for /api/series/*:** CSV is smaller, streams naturally, and is directly ingestable by data tools (pandas, Excel, Grafana). The frontend uses the candid actor interface for typed data; the CSV endpoints are for external consumers and tooling.
+
+**Why not /api/events/since:** The spec mentions this endpoint, but the analytics canister already exposes `get_swap_series`, `get_liquidation_series`, etc. via candid queries. An HTTP events endpoint would duplicate that with worse typing. Deferred unless there's a specific consumer that needs it.
+
+**Why serde_json for health only:** The health endpoint benefits from JSON since it has nested objects. CSV endpoints use hand-rolled formatting which avoids pulling in serde_json for row types (they're already CandidType, not Serialize for JSON). The serde_json dep is only used for the health endpoint.
+
+**Frontend actor pattern:** `analyticsService.ts` follows the exact same pattern as `explorerService.ts` (TTL-based Map cache, anonymous HttpAgent, lazy actor creation) for consistency. No new patterns introduced.
+
+**StatCard reuse:** The stats page reuses the existing `StatCard` component from the explorer components, maintaining visual consistency with the overview page.

--- a/src/rumi_analytics/Cargo.toml
+++ b/src/rumi_analytics/Cargo.toml
@@ -19,6 +19,7 @@ icrc-ledger-client-cdk = { git = "https://github.com/Rumi-Protocol/ic", rev = "f
 ic-canisters-http-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 num-traits = "0.2"
 serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1"
 serde_bytes = "0.11"
 ciborium = "0.2"
 futures = "0.3"

--- a/src/rumi_analytics/src/http/csv.rs
+++ b/src/rumi_analytics/src/http/csv.rs
@@ -1,0 +1,204 @@
+//! CSV serialization helpers for analytics row types.
+//!
+//! Each function takes a slice of rows and returns a complete CSV string
+//! including a header line. Option fields emit an empty column when None.
+//! Vec fields (per-collateral breakdowns, prices, balances) are serialized as
+//! a single JSON-like column so the CSV remains rectangular.
+
+use crate::storage::{
+    DailyTvlRow, DailyVaultSnapshotRow, DailyStabilityRow,
+};
+use crate::storage::rollups::{DailySwapRollup, DailyLiquidationRollup, DailyFeeRollup};
+use crate::storage::fast::FastPriceSnapshot;
+
+// ── DailyTvlRow ─────────────────────────────────────────────────────────────
+
+pub fn tvl_to_csv(rows: &[DailyTvlRow]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,total_icp_collateral_e8s,total_icusd_supply_e8s,\
+system_collateral_ratio_bps,stability_pool_deposits_e8s,\
+three_pool_reserve_0_e8s,three_pool_reserve_1_e8s,three_pool_reserve_2_e8s,\
+three_pool_virtual_price_e18,three_pool_lp_supply_e8s\n",
+    );
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{},{}\n",
+            r.timestamp_ns,
+            r.total_icp_collateral_e8s,
+            r.total_icusd_supply_e8s,
+            r.system_collateral_ratio_bps,
+            r.stability_pool_deposits_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_0_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_1_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_reserve_2_e8s.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_virtual_price_e18.map_or(String::new(), |v| v.to_string()),
+            r.three_pool_lp_supply_e8s.map_or(String::new(), |v| v.to_string()),
+        ));
+    }
+    out
+}
+
+// ── DailyVaultSnapshotRow ────────────────────────────────────────────────────
+
+pub fn vaults_to_csv(rows: &[DailyVaultSnapshotRow]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,total_vault_count,total_collateral_usd_e8s,total_debt_e8s,\
+median_cr_bps,collaterals\n",
+    );
+    for r in rows {
+        // Serialize collaterals as a semicolon-separated list of
+        // principal:vault_count:collateral_e8s:debt_e8s:min_cr:max_cr:median_cr:price_e8s
+        // tuples so a single CSV column holds the full breakdown.
+        let collaterals: String = r
+            .collaterals
+            .iter()
+            .map(|c| {
+                format!(
+                    "{}:{}:{}:{}:{}:{}:{}:{}",
+                    c.collateral_type,
+                    c.vault_count,
+                    c.total_collateral_e8s,
+                    c.total_debt_e8s,
+                    c.min_cr_bps,
+                    c.max_cr_bps,
+                    c.median_cr_bps,
+                    c.price_usd_e8s,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(";");
+        out.push_str(&format!(
+            "{},{},{},{},{},\"{}\"\n",
+            r.timestamp_ns,
+            r.total_vault_count,
+            r.total_collateral_usd_e8s,
+            r.total_debt_e8s,
+            r.median_cr_bps,
+            collaterals,
+        ));
+    }
+    out
+}
+
+// ── DailyStabilityRow ────────────────────────────────────────────────────────
+
+pub fn stability_to_csv(rows: &[DailyStabilityRow]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,total_deposits_e8s,total_depositors,total_liquidations_executed,\
+total_interest_received_e8s,stablecoin_balances,collateral_gains\n",
+    );
+    for r in rows {
+        let sb: String = r
+            .stablecoin_balances
+            .iter()
+            .map(|(p, v)| format!("{}:{}", p, v))
+            .collect::<Vec<_>>()
+            .join(";");
+        let cg: String = r
+            .collateral_gains
+            .iter()
+            .map(|(p, v)| format!("{}:{}", p, v))
+            .collect::<Vec<_>>()
+            .join(";");
+        out.push_str(&format!(
+            "{},{},{},{},{},\"{}\",\"{}\"\n",
+            r.timestamp_ns,
+            r.total_deposits_e8s,
+            r.total_depositors,
+            r.total_liquidations_executed,
+            r.total_interest_received_e8s,
+            sb,
+            cg,
+        ));
+    }
+    out
+}
+
+// ── DailySwapRollup ──────────────────────────────────────────────────────────
+
+pub fn swaps_to_csv(rows: &[DailySwapRollup]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,three_pool_swap_count,amm_swap_count,three_pool_volume_e8s,\
+amm_volume_e8s,three_pool_fees_e8s,amm_fees_e8s,unique_swappers\n",
+    );
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            r.timestamp_ns,
+            r.three_pool_swap_count,
+            r.amm_swap_count,
+            r.three_pool_volume_e8s,
+            r.amm_volume_e8s,
+            r.three_pool_fees_e8s,
+            r.amm_fees_e8s,
+            r.unique_swappers,
+        ));
+    }
+    out
+}
+
+// ── DailyLiquidationRollup ───────────────────────────────────────────────────
+
+pub fn liquidations_to_csv(rows: &[DailyLiquidationRollup]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,full_count,partial_count,redistribution_count,\
+total_collateral_seized_e8s,total_debt_covered_e8s,by_collateral\n",
+    );
+    for r in rows {
+        let bc: String = r
+            .by_collateral
+            .iter()
+            .map(|(p, v)| format!("{}:{}", p, v))
+            .collect::<Vec<_>>()
+            .join(";");
+        out.push_str(&format!(
+            "{},{},{},{},{},{},\"{}\"\n",
+            r.timestamp_ns,
+            r.full_count,
+            r.partial_count,
+            r.redistribution_count,
+            r.total_collateral_seized_e8s,
+            r.total_debt_covered_e8s,
+            bc,
+        ));
+    }
+    out
+}
+
+// ── DailyFeeRollup ───────────────────────────────────────────────────────────
+
+pub fn fees_to_csv(rows: &[DailyFeeRollup]) -> String {
+    let mut out = String::from(
+        "timestamp_ns,borrowing_fees_e8s,borrow_count,swap_fees_e8s,\
+redemption_fees_e8s,redemption_count\n",
+    );
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{},{},{},{}\n",
+            r.timestamp_ns,
+            r.borrowing_fees_e8s.map_or(String::new(), |v| v.to_string()),
+            r.borrow_count,
+            r.swap_fees_e8s,
+            r.redemption_fees_e8s.map_or(String::new(), |v| v.to_string()),
+            r.redemption_count,
+        ));
+    }
+    out
+}
+
+// ── FastPriceSnapshot ────────────────────────────────────────────────────────
+
+pub fn fast_prices_to_csv(rows: &[FastPriceSnapshot]) -> String {
+    let mut out = String::from("timestamp_ns,prices\n");
+    for r in rows {
+        // Serialize as principal:price_usd:symbol tuples separated by semicolons.
+        let prices: String = r
+            .prices
+            .iter()
+            .map(|(p, price, sym)| format!("{}:{:.8}:{}", p, price, sym))
+            .collect::<Vec<_>>()
+            .join(";");
+        out.push_str(&format!("{},\"{}\"\n", r.timestamp_ns, prices));
+    }
+    out
+}

--- a/src/rumi_analytics/src/http/metrics.rs
+++ b/src/rumi_analytics/src/http/metrics.rs
@@ -1,0 +1,153 @@
+//! Prometheus text format metrics endpoint.
+//!
+//! Serves the canonical set of Rumi analytics gauges and counters at /metrics.
+//! All values are read from cached state — no inter-canister calls are made.
+
+use crate::{state, storage};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn gauge(out: &mut String, name: &str, help: &str, value: f64) {
+    out.push_str(&format!(
+        "# HELP {} {}\n# TYPE {} gauge\n{} {}\n",
+        name, help, name, name, value
+    ));
+}
+
+fn counter(out: &mut String, name: &str, help: &str, label: &str, value: f64) {
+    // Emit the HELP/TYPE header only once per metric family. The caller must
+    // push the header before the first labeled series and skip it for
+    // subsequent ones. We therefore split header emission from the series line.
+    let _ = (name, help, label, value); // suppress lint; see render() below
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn render() -> String {
+    let _ = counter; // silence dead-code warning; header logic is inline below
+
+    let mut out = String::with_capacity(2048);
+
+    // ── Supply gauges ────────────────────────────────────────────────────────
+    let (icusd_e8s, three_usd_e8s) = state::read_state(|s| {
+        (s.circulating_supply_icusd_e8s, s.circulating_supply_3usd_e8s)
+    });
+
+    gauge(
+        &mut out,
+        "rumi_icusd_supply_e8s",
+        "Circulating supply of icUSD in e8s",
+        icusd_e8s.unwrap_or(0) as f64,
+    );
+    gauge(
+        &mut out,
+        "rumi_3usd_supply_e8s",
+        "Circulating supply of 3USD in e8s",
+        three_usd_e8s.unwrap_or(0) as f64,
+    );
+
+    // ── Vault gauges (from latest DailyVaultSnapshotRow) ─────────────────────
+    let vault_len = storage::daily_vaults::len();
+    if vault_len > 0 {
+        if let Some(row) = storage::daily_vaults::get(vault_len - 1) {
+            gauge(
+                &mut out,
+                "rumi_total_vault_count",
+                "Total number of active vaults",
+                row.total_vault_count as f64,
+            );
+            gauge(
+                &mut out,
+                "rumi_total_collateral_usd_e8s",
+                "Total collateral value across all vaults in USD e8s",
+                row.total_collateral_usd_e8s as f64,
+            );
+            gauge(
+                &mut out,
+                "rumi_total_debt_e8s",
+                "Total icUSD debt across all vaults in e8s",
+                row.total_debt_e8s as f64,
+            );
+            gauge(
+                &mut out,
+                "rumi_system_cr_bps",
+                "System-wide median collateral ratio in basis points",
+                row.median_cr_bps as f64,
+            );
+        }
+    }
+
+    // ── TVL gauges (from latest DailyTvlRow) ─────────────────────────────────
+    let tvl_len = storage::daily_tvl::len();
+    if tvl_len > 0 {
+        if let Some(row) = storage::daily_tvl::get(tvl_len - 1) {
+            gauge(
+                &mut out,
+                "rumi_total_icp_collateral_e8s",
+                "Total ICP collateral deposited across all vaults in e8s",
+                row.total_icp_collateral_e8s as f64,
+            );
+            gauge(
+                &mut out,
+                "rumi_total_icusd_supply_e8s",
+                "Total icUSD supply as recorded in the daily TVL snapshot in e8s",
+                row.total_icusd_supply_e8s as f64,
+            );
+        }
+    }
+
+    // ── Error counters (labeled by source) ───────────────────────────────────
+    let ec = state::read_state(|s| s.error_counters.clone());
+
+    let counter_name = "rumi_collector_errors_total";
+    out.push_str(&format!(
+        "# HELP {} Cumulative collector errors by source canister\n# TYPE {} counter\n",
+        counter_name, counter_name
+    ));
+    for (source, value) in [
+        ("backend", ec.backend),
+        ("icusd_ledger", ec.icusd_ledger),
+        ("three_pool", ec.three_pool),
+        ("stability_pool", ec.stability_pool),
+        ("amm", ec.amm),
+    ] {
+        out.push_str(&format!(
+            "{}{{source=\"{}\"}} {}\n",
+            counter_name, source, value
+        ));
+    }
+
+    // ── Storage size gauges ───────────────────────────────────────────────────
+    gauge(
+        &mut out,
+        "rumi_storage_daily_tvl_rows",
+        "Number of rows in the daily TVL storage log",
+        storage::daily_tvl::len() as f64,
+    );
+    gauge(
+        &mut out,
+        "rumi_storage_daily_vault_rows",
+        "Number of rows in the daily vault snapshot storage log",
+        storage::daily_vaults::len() as f64,
+    );
+    gauge(
+        &mut out,
+        "rumi_storage_evt_swaps_rows",
+        "Number of rows in the swap events storage log",
+        storage::events::evt_swaps::len() as f64,
+    );
+    gauge(
+        &mut out,
+        "rumi_storage_evt_liquidations_rows",
+        "Number of rows in the liquidation events storage log",
+        storage::events::evt_liquidations::len() as f64,
+    );
+    gauge(
+        &mut out,
+        "rumi_storage_fast_prices_rows",
+        "Number of rows in the fast price snapshot storage log",
+        storage::fast::fast_prices::len() as f64,
+    );
+
+    out
+}

--- a/src/rumi_analytics/src/http/metrics.rs
+++ b/src/rumi_analytics/src/http/metrics.rs
@@ -14,18 +14,9 @@ fn gauge(out: &mut String, name: &str, help: &str, value: f64) {
     ));
 }
 
-fn counter(out: &mut String, name: &str, help: &str, label: &str, value: f64) {
-    // Emit the HELP/TYPE header only once per metric family. The caller must
-    // push the header before the first labeled series and skip it for
-    // subsequent ones. We therefore split header emission from the series line.
-    let _ = (name, help, label, value); // suppress lint; see render() below
-}
-
 // ── Public entry point ────────────────────────────────────────────────────────
 
 pub fn render() -> String {
-    let _ = counter; // silence dead-code warning; header logic is inline below
-
     let mut out = String::with_capacity(2048);
 
     // ── Supply gauges ────────────────────────────────────────────────────────

--- a/src/rumi_analytics/src/http/mod.rs
+++ b/src/rumi_analytics/src/http/mod.rs
@@ -3,6 +3,7 @@
 //! pull cycle keeps fresh.
 
 pub mod csv;
+pub mod metrics;
 
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 
@@ -13,6 +14,13 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
     match path {
         "/api/supply" => supply_icusd_f64(),
         "/api/supply/raw" => supply_icusd_raw(),
+        "/metrics" => {
+            let body = metrics::render();
+            HttpResponseBuilder::ok()
+                .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                .with_body_and_content_length(body)
+                .build()
+        }
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/src/rumi_analytics/src/http/mod.rs
+++ b/src/rumi_analytics/src/http/mod.rs
@@ -8,12 +8,21 @@ pub mod metrics;
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 
 use crate::state;
+use crate::storage;
 
 pub fn http_request(req: HttpRequest) -> HttpResponse {
     let path = req.url.split('?').next().unwrap_or("");
     match path {
         "/api/supply" => supply_icusd_f64(),
         "/api/supply/raw" => supply_icusd_raw(),
+        "/api/health" => health_json(),
+        "/api/series/tvl" => csv_response(csv::tvl_to_csv(&storage::daily_tvl::range(0, u64::MAX, 10_000))),
+        "/api/series/vaults" => csv_response(csv::vaults_to_csv(&storage::daily_vaults::range(0, u64::MAX, 10_000))),
+        "/api/series/stability" => csv_response(csv::stability_to_csv(&storage::daily_stability::range(0, u64::MAX, 10_000))),
+        "/api/series/swaps" => csv_response(csv::swaps_to_csv(&storage::rollups::daily_swaps::range(0, u64::MAX, 10_000))),
+        "/api/series/liquidations" => csv_response(csv::liquidations_to_csv(&storage::rollups::daily_liquidations::range(0, u64::MAX, 10_000))),
+        "/api/series/fees" => csv_response(csv::fees_to_csv(&storage::rollups::daily_fees::range(0, u64::MAX, 10_000))),
+        "/api/series/prices" => csv_response(csv::fast_prices_to_csv(&storage::fast::fast_prices::range(0, u64::MAX, 10_000))),
         "/metrics" => {
             let body = metrics::render();
             HttpResponseBuilder::ok()
@@ -23,6 +32,48 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
         }
         _ => HttpResponseBuilder::not_found().build(),
     }
+}
+
+fn csv_response(body: String) -> HttpResponse {
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "text/csv; charset=utf-8")
+        .header("Access-Control-Allow-Origin", "*")
+        .with_body_and_content_length(body)
+        .build()
+}
+
+fn health_json() -> HttpResponse {
+    let last_daily = state::read_state(|s| s.last_daily_snapshot_ns);
+    let last_pull = state::read_state(|s| s.last_pull_cycle_ns).unwrap_or(0);
+    let ec = state::read_state(|s| s.error_counters.clone());
+    let now = ic_cdk::api::time();
+
+    let body = serde_json::json!({
+        "status": "ok",
+        "canister_time_ns": now,
+        "last_daily_snapshot_ns": last_daily,
+        "last_pull_cycle_ns": last_pull,
+        "error_counters": {
+            "backend": ec.backend,
+            "icusd_ledger": ec.icusd_ledger,
+            "three_pool": ec.three_pool,
+            "stability_pool": ec.stability_pool,
+            "amm": ec.amm,
+        },
+        "storage_rows": {
+            "daily_tvl": storage::daily_tvl::len(),
+            "daily_vaults": storage::daily_vaults::len(),
+            "evt_swaps": storage::events::evt_swaps::len(),
+            "evt_liquidations": storage::events::evt_liquidations::len(),
+            "fast_prices": storage::fast::fast_prices::len(),
+        }
+    });
+
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "application/json; charset=utf-8")
+        .header("Access-Control-Allow-Origin", "*")
+        .with_body_and_content_length(body.to_string())
+        .build()
 }
 
 fn supply_icusd_f64() -> HttpResponse {

--- a/src/rumi_analytics/src/http/mod.rs
+++ b/src/rumi_analytics/src/http/mod.rs
@@ -1,0 +1,43 @@
+//! HTTP request handler. Runs in query context: never makes inter-canister
+//! calls. All values are served from cached state in SlimState which the 60s
+//! pull cycle keeps fresh.
+
+pub mod csv;
+
+use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
+
+use crate::state;
+
+pub fn http_request(req: HttpRequest) -> HttpResponse {
+    let path = req.url.split('?').next().unwrap_or("");
+    match path {
+        "/api/supply" => supply_icusd_f64(),
+        "/api/supply/raw" => supply_icusd_raw(),
+        _ => HttpResponseBuilder::not_found().build(),
+    }
+}
+
+fn supply_icusd_f64() -> HttpResponse {
+    let cached = state::read_state(|s| s.circulating_supply_icusd_e8s);
+    match cached {
+        Some(e8s) => {
+            let f = (e8s as f64) / 1e8;
+            HttpResponseBuilder::ok()
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .with_body_and_content_length(format!("{:.8}", f))
+                .build()
+        }
+        None => HttpResponseBuilder::server_error("supply not yet cached").build(),
+    }
+}
+
+fn supply_icusd_raw() -> HttpResponse {
+    let cached = state::read_state(|s| s.circulating_supply_icusd_e8s);
+    match cached {
+        Some(e8s) => HttpResponseBuilder::ok()
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .with_body_and_content_length(e8s.to_string())
+            .build(),
+        None => HttpResponseBuilder::server_error("supply not yet cached").build(),
+    }
+}

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -1176,3 +1176,52 @@ fn live_queries_survive_upgrade() {
     let summary_after = get_protocol_summary(&env);
     assert_eq!(summary_before.total_vault_count, summary_after.total_vault_count);
 }
+
+// ─── Phase 7 HTTP tests ───
+
+#[test]
+fn http_health_returns_json() {
+    let env = setup();
+    advance_pull_cycle(&env);
+
+    let resp = http_get(&env, "/api/health");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.contains("\"status\":\"ok\""), "health body: {}", body);
+    assert!(body.contains("\"storage_rows\""), "health body: {}", body);
+}
+
+#[test]
+fn http_metrics_returns_prometheus() {
+    let env = setup();
+    advance_pull_cycle(&env);
+
+    let resp = http_get(&env, "/metrics");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.contains("rumi_icusd_supply_e8s"), "metrics body missing supply gauge");
+}
+
+#[test]
+fn http_csv_tvl_returns_header() {
+    let env = setup();
+    // Trigger daily snapshot so there's at least one TVL row
+    advance_pull_cycle(&env);
+    env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));
+    for _ in 0..10 { env.pic.tick(); }
+
+    let resp = http_get(&env, "/api/series/tvl");
+    assert_eq!(resp.status_code, 200);
+    let body = String::from_utf8(resp.body).unwrap();
+    assert!(body.starts_with("timestamp_ns,"), "CSV should start with header, got: {}", &body[..50.min(body.len())]);
+    // Should have at least header + 1 data row
+    let lines: Vec<&str> = body.lines().collect();
+    assert!(lines.len() >= 2, "expected header + data row, got {} lines", lines.len());
+}
+
+#[test]
+fn http_not_found() {
+    let env = setup();
+    let resp = http_get(&env, "/nonexistent");
+    assert_eq!(resp.status_code, 404);
+}

--- a/src/vault_frontend/src/lib/config.ts
+++ b/src/vault_frontend/src/lib/config.ts
@@ -4,6 +4,7 @@ import { idlFactory as icusd_ledgerIDL } from '$declarations/icusd_ledger/icusd_
 import { idlFactory as threePoolIDL } from '$declarations/rumi_3pool/rumi_3pool.did.js';
 import { idlFactory as rumiAmmIDL } from '$declarations/rumi_amm/rumi_amm.did.js';
 import { idlFactory as icusdIndexIDL } from '$declarations/icusd_index/icusd_index.did.js';
+import { idlFactory as analyticsIDL } from '$declarations/rumi_analytics/rumi_analytics.did.js';
 
 // Canister IDs for production (Rumi Protocol v2 - mainnet)
 export const CANISTER_IDS = {
@@ -21,6 +22,8 @@ export const CANISTER_IDS = {
   THREEPOOL: "fohh4-yyaaa-aaaap-qtkpa-cai",
   // Rumi AMM (3USD/ICP constant-product pool)
   RUMI_AMM: "ijlzs-2yaaa-aaaap-quaaq-cai",
+  // Rumi Analytics (time-series data, protocol metrics)
+  ANALYTICS: "dtlu2-uqaaa-aaaap-qugcq-cai",
 } as const;
 
 // Canister IDs for local development
@@ -131,4 +134,5 @@ export const CONFIG = {
   threePoolIDL,
   rumiAmmIDL,
   icusdIndexIDL,
+  analyticsIDL,
 };

--- a/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
@@ -1,0 +1,299 @@
+/**
+ * analyticsService.ts — Typed fetch functions for the rumi_analytics canister.
+ *
+ * Uses TTL-based Map caching to avoid redundant canister calls within a
+ * short window. All calls are anonymous (no wallet required).
+ */
+
+import { Principal } from '@dfinity/principal';
+import { Actor, HttpAgent } from '@dfinity/agent';
+import { CANISTER_IDS, CONFIG } from '$lib/config';
+import type { _SERVICE as AnalyticsService } from '$declarations/rumi_analytics/rumi_analytics.did';
+import type {
+	ProtocolSummary,
+	TvlSeriesResponse,
+	VaultSeriesResponse,
+	StabilitySeriesResponse,
+	SwapSeriesResponse,
+	FeeSeriesResponse,
+	LiquidationSeriesResponse,
+	HolderSeriesResponse,
+	TwapResponse,
+	ApyResponse,
+	PegStatus,
+	TradeActivityResponse,
+	CollectorHealth,
+} from '$declarations/rumi_analytics/rumi_analytics.did';
+
+// ── TTL constants (ms) ───────────────────────────────────────────────────────
+
+const TTL = {
+	SUMMARY: 15_000,
+	SERIES: 60_000,
+	AGGREGATE: 30_000,
+} as const;
+
+// ── Cache infrastructure ─────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+	data: T;
+	ts: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string, ttlMs: number): T | null {
+	const entry = cache.get(key);
+	if (!entry) return null;
+	if (Date.now() - entry.ts > ttlMs) {
+		cache.delete(key);
+		return null;
+	}
+	return entry.data as T;
+}
+
+function setCache<T>(key: string, data: T): T {
+	cache.set(key, { data, ts: Date.now() });
+	return data;
+}
+
+/**
+ * Invalidate all cached entries, or only those whose key starts with `prefix`.
+ */
+export function invalidateAnalyticsCache(prefix?: string): void {
+	if (!prefix) {
+		cache.clear();
+		return;
+	}
+	for (const key of cache.keys()) {
+		if (key.startsWith(prefix)) cache.delete(key);
+	}
+}
+
+// ── Actor (lazy, anonymous) ──────────────────────────────────────────────────
+
+let _actor: AnalyticsService | null = null;
+
+function getActor(): AnalyticsService {
+	if (_actor) return _actor;
+
+	const agent = new HttpAgent({ host: 'https://icp-api.io' });
+
+	_actor = Actor.createActor<AnalyticsService>(CONFIG.analyticsIDL, {
+		agent,
+		canisterId: CANISTER_IDS.ANALYTICS,
+	});
+
+	return _actor;
+}
+
+// ── RangeQuery helper ────────────────────────────────────────────────────────
+
+function rangeQuery(from?: bigint, to?: bigint, limit?: number) {
+	return {
+		from_ts: from !== undefined ? [from] : [],
+		to_ts: to !== undefined ? [to] : [],
+		limit: limit !== undefined ? [limit] : [],
+		offset: [] as [],
+	};
+}
+
+// ── Protocol summary ─────────────────────────────────────────────────────────
+
+export async function fetchProtocolSummary(): Promise<ProtocolSummary | null> {
+	const key = 'analytics:summary';
+	const cached = getCached<ProtocolSummary>(key, TTL.SUMMARY);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_protocol_summary();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchProtocolSummary failed:', err);
+		return null;
+	}
+}
+
+// ── Time-series fetchers ─────────────────────────────────────────────────────
+
+export async function fetchTvlSeries(limit = 365): Promise<TvlSeriesResponse['rows']> {
+	const key = `analytics:tvl:${limit}`;
+	const cached = getCached<TvlSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_tvl_series(rangeQuery(undefined, undefined, limit));
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchTvlSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchVaultSeries(limit = 365): Promise<VaultSeriesResponse['rows']> {
+	const key = `analytics:vault:${limit}`;
+	const cached = getCached<VaultSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_vault_series(rangeQuery(undefined, undefined, limit));
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchVaultSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchStabilitySeries(limit = 365): Promise<StabilitySeriesResponse['rows']> {
+	const key = `analytics:stability:${limit}`;
+	const cached = getCached<StabilitySeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_stability_series(rangeQuery(undefined, undefined, limit));
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchStabilitySeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchSwapSeries(limit = 365): Promise<SwapSeriesResponse['rows']> {
+	const key = `analytics:swap:${limit}`;
+	const cached = getCached<SwapSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_swap_series(rangeQuery(undefined, undefined, limit));
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchSwapSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchFeeSeries(limit = 365): Promise<FeeSeriesResponse['rows']> {
+	const key = `analytics:fee:${limit}`;
+	const cached = getCached<FeeSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_fee_series(rangeQuery(undefined, undefined, limit));
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchFeeSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchLiquidationSeries(
+	limit = 365
+): Promise<LiquidationSeriesResponse['rows']> {
+	const key = `analytics:liquidation:${limit}`;
+	const cached = getCached<LiquidationSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_liquidation_series(
+			rangeQuery(undefined, undefined, limit)
+		);
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchLiquidationSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchHolderSeries(
+	token: Principal,
+	limit = 365
+): Promise<HolderSeriesResponse['rows']> {
+	const key = `analytics:holder:${token.toText()}:${limit}`;
+	const cached = getCached<HolderSeriesResponse['rows']>(key, TTL.SERIES);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_holder_series(
+			rangeQuery(undefined, undefined, limit),
+			token
+		);
+		return setCache(key, result.rows);
+	} catch (err) {
+		console.error('[analyticsService] fetchHolderSeries failed:', err);
+		return [];
+	}
+}
+
+// ── Aggregate / derived metrics ───────────────────────────────────────────────
+
+export async function fetchTwap(windowSecs = 3600): Promise<TwapResponse | null> {
+	const key = `analytics:twap:${windowSecs}`;
+	const cached = getCached<TwapResponse>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_twap({ window_secs: [BigInt(windowSecs)] });
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchTwap failed:', err);
+		return null;
+	}
+}
+
+export async function fetchApys(windowDays = 7): Promise<ApyResponse | null> {
+	const key = `analytics:apys:${windowDays}`;
+	const cached = getCached<ApyResponse>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_apys({ window_days: [windowDays] });
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchApys failed:', err);
+		return null;
+	}
+}
+
+export async function fetchPegStatus(): Promise<PegStatus | null> {
+	const key = 'analytics:peg';
+	const cached = getCached<PegStatus>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_peg_status();
+		const value = result.length > 0 ? result[0] : null;
+		if (value) setCache(key, value);
+		return value ?? null;
+	} catch (err) {
+		console.error('[analyticsService] fetchPegStatus failed:', err);
+		return null;
+	}
+}
+
+export async function fetchTradeActivity(windowSecs = 86400): Promise<TradeActivityResponse | null> {
+	const key = `analytics:trade_activity:${windowSecs}`;
+	const cached = getCached<TradeActivityResponse>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_trade_activity({ window_secs: [BigInt(windowSecs)] });
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchTradeActivity failed:', err);
+		return null;
+	}
+}
+
+export async function fetchCollectorHealth(): Promise<CollectorHealth | null> {
+	const key = 'analytics:collector_health';
+	const cached = getCached<CollectorHealth>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_collector_health();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchCollectorHealth failed:', err);
+		return null;
+	}
+}

--- a/src/vault_frontend/src/routes/explorer/+layout.svelte
+++ b/src/vault_frontend/src/routes/explorer/+layout.svelte
@@ -18,6 +18,7 @@
     { href: '/explorer', label: 'Overview', exact: true },
     { href: '/explorer/activity', label: 'Activity', exact: false },
     { href: '/explorer/holders', label: 'Holders', exact: false },
+    { href: '/explorer/stats', label: 'Stats', exact: false },
   ];
 
   function isActive(link: { href: string; exact: boolean }): boolean {

--- a/src/vault_frontend/src/routes/explorer/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/+page.svelte
@@ -12,10 +12,11 @@
     fetchAllVaults, fetchEventCount, fetchTreasuryStats,
     fetchInterestSplit, fetchBotStats, fetchStabilityPoolStatus,
     fetchThreePoolStatus, fetchEvents, fetchCollateralConfigs,
-    fetchLiquidatableVaults, fetchAllSnapshots,
+    fetchLiquidatableVaults,
     fetchAmmPools, fetchAmmSwapEventCount, fetchSwapEventCount,
     fetchProtocolConfig
   } from '$services/explorer/explorerService';
+  import { fetchVaultSeries } from '$services/explorer/analyticsService';
   import {
     formatE8s, formatUsd, formatCR, formatBps,
     getTokenSymbol, registerToken, classifyVaultHealth, healthColor
@@ -490,8 +491,12 @@
     // Section 7: Historical Charts
     const chartsPromise = (async () => {
       try {
-        const snapshots = await fetchAllSnapshots();
-        allSnapshots = snapshots ?? [];
+        const vaultData = await fetchVaultSeries(365);
+        allSnapshots = (vaultData ?? []).map((r: any) => ({
+          timestamp: r.timestamp_ns,
+          total_collateral_value_usd: r.total_collateral_usd_e8s,
+          total_debt: r.total_debt_e8s,
+        }));
       } catch (e) {
         console.error('[explorer] Charts load failed:', e);
         if (!isRefresh) chartsError = 'Failed to load historical data';

--- a/src/vault_frontend/src/routes/explorer/holders/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/holders/+page.svelte
@@ -5,6 +5,7 @@
   import StatCard from '$components/explorer/StatCard.svelte';
   import { fetchIcusdHolders, fetchThreeUsdHolders, type TokenHolder } from '$services/explorer/explorerService';
   import { formatE8s } from '$utils/explorerHelpers';
+  import { Principal } from '@dfinity/principal';
   import { CANISTER_IDS } from '$lib/config';
   import { fetchHolderSeries } from '$services/explorer/analyticsService';
 
@@ -99,8 +100,8 @@
   async function loadTrends(token: TokenTab) {
     trendsLoading = true;
     try {
-      const ledger = token === 'icusd' ? CANISTER_IDS.ICUSD_LEDGER : CANISTER_IDS.THREEPOOL;
-      holderTrends = await fetchHolderSeries(ledger, 90);
+      const ledgerId = token === 'icusd' ? CANISTER_IDS.ICUSD_LEDGER : CANISTER_IDS.THREEPOOL;
+      holderTrends = await fetchHolderSeries(Principal.fromText(ledgerId), 90);
     } catch (e) {
       console.error('[holders] trends load failed:', e);
       holderTrends = [];

--- a/src/vault_frontend/src/routes/explorer/holders/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/holders/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import DataTable from '$components/explorer/DataTable.svelte';
+  import EntityLink from '$components/explorer/EntityLink.svelte';
+  import StatCard from '$components/explorer/StatCard.svelte';
+  import { fetchIcusdHolders, fetchThreeUsdHolders, type TokenHolder } from '$services/explorer/explorerService';
+  import { formatE8s } from '$utils/explorerHelpers';
+  import { CANISTER_IDS } from '$lib/config';
+  import { fetchHolderSeries } from '$services/explorer/analyticsService';
+
+  type TokenTab = 'icusd' | '3usd';
+
+  let selectedToken: TokenTab = $state('icusd');
+  let holders: TokenHolder[] = $state([]);
+  let totalSupply = $state(0n);
+  let txCount = $state(0n);
+  let loading = $state(true);
+  let error: string | null = $state(null);
+  let holderTrends: any[] = $state([]);
+  let trendsLoading = $state(false);
+
+  const chartW = 600;
+  const chartH = 140;
+  const pad = 4;
+
+  let trendPoints = $derived(holderTrends.map((r: any) => ({
+    x: Number(r.timestamp_ns) / 1e9,
+    y: Number(r.total_holders)
+  })));
+  let trendXMin = $derived(trendPoints.length ? Math.min(...trendPoints.map((p) => p.x)) : 0);
+  let trendXMax = $derived(trendPoints.length ? Math.max(...trendPoints.map((p) => p.x)) : 1);
+  let trendYMin = $derived(trendPoints.length ? Math.min(...trendPoints.map((p) => p.y)) : 0);
+  let trendYMax = $derived(trendPoints.length ? (Math.max(...trendPoints.map((p) => p.y)) || 1) : 1);
+  let trendXRange = $derived(trendXMax - trendXMin || 1);
+  let trendYRange = $derived(trendYMax - trendYMin || 1);
+  let trendPolyline = $derived(trendPoints.map((p) => {
+    const x = pad + ((p.x - trendXMin) / trendXRange) * (chartW - pad * 2);
+    const y = pad + (chartH - pad * 2) - ((p.y - trendYMin) / trendYRange) * (chartH - pad * 2);
+    return `${x},${y}`;
+  }).join(' '));
+
+  // Known protocol canister principals for labeling
+  const PROTOCOL_LABELS: Record<string, string> = {
+    [CANISTER_IDS.PROTOCOL]: 'Rumi Backend',
+    [CANISTER_IDS.TREASURY]: 'Treasury',
+    [CANISTER_IDS.STABILITY_POOL]: 'Stability Pool',
+    [CANISTER_IDS.THREEPOOL]: '3pool',
+    [CANISTER_IDS.RUMI_AMM]: 'AMM',
+    [CANISTER_IDS.ICUSD_LEDGER]: 'icUSD Ledger',
+  };
+
+  const TOKEN_INFO: Record<TokenTab, { symbol: string; name: string }> = {
+    icusd: { symbol: 'icUSD', name: 'icUSD Stablecoin' },
+    '3usd': { symbol: '3USD', name: '3USD LP Token' },
+  };
+
+  let tokenInfo = $derived(TOKEN_INFO[selectedToken]);
+
+  const columns = $derived([
+    { key: 'rank', label: '#', align: 'center' as const, width: '60px' },
+    { key: 'account', label: 'Address', align: 'left' as const },
+    { key: 'label', label: 'Label', align: 'left' as const, width: '140px' },
+    { key: 'balanceNumber', label: `Balance (${tokenInfo.symbol})`, align: 'right' as const, sortable: true },
+    { key: 'share', label: 'Share', align: 'right' as const, width: '100px' },
+  ]);
+
+  function getLabel(principal: string): string {
+    return PROTOCOL_LABELS[principal] ?? '';
+  }
+
+  function formatShare(balance: bigint, total: bigint): string {
+    if (total === 0n) return '0%';
+    const pct = (Number(balance) / Number(total)) * 100;
+    if (pct < 0.01) return '<0.01%';
+    return `${pct.toFixed(2)}%`;
+  }
+
+  async function loadHolders(token: TokenTab) {
+    loading = true;
+    error = null;
+    try {
+      const result = token === 'icusd'
+        ? await fetchIcusdHolders()
+        : await fetchThreeUsdHolders();
+      holders = result.holders;
+      totalSupply = result.totalSupply;
+      txCount = result.txCount;
+    } catch (err) {
+      error = String(err);
+      holders = [];
+      totalSupply = 0n;
+      txCount = 0n;
+    } finally {
+      loading = false;
+    }
+    loadTrends(token);
+  }
+
+  async function loadTrends(token: TokenTab) {
+    trendsLoading = true;
+    try {
+      const ledger = token === 'icusd' ? CANISTER_IDS.ICUSD_LEDGER : CANISTER_IDS.THREEPOOL;
+      holderTrends = await fetchHolderSeries(ledger, 90);
+    } catch (e) {
+      console.error('[holders] trends load failed:', e);
+      holderTrends = [];
+    } finally {
+      trendsLoading = false;
+    }
+  }
+
+  function selectToken(token: TokenTab) {
+    if (token === selectedToken && !loading) return;
+    selectedToken = token;
+    loadHolders(token);
+  }
+
+  onMount(() => {
+    loadHolders(selectedToken);
+  });
+</script>
+
+<svelte:head>
+  <title>{tokenInfo.symbol} Holders | Rumi Explorer</title>
+</svelte:head>
+
+<!-- Header -->
+<div class="mb-6">
+  <h1 class="text-2xl font-bold text-white">Token Holders</h1>
+  <p class="text-sm text-gray-400 mt-1">
+    All accounts holding {tokenInfo.symbol}, ranked by balance. Derived from on-chain transaction history.
+  </p>
+</div>
+
+<!-- Token Selector -->
+<div class="flex gap-2 mb-6">
+  <button
+    onclick={() => selectToken('icusd')}
+    class="px-4 py-2 rounded-lg text-sm font-medium transition-colors
+           {selectedToken === 'icusd'
+             ? 'bg-indigo-500/20 text-indigo-300 border border-indigo-500/40'
+             : 'bg-gray-800/40 text-gray-400 border border-gray-700/50 hover:text-gray-200 hover:border-gray-600'}"
+  >
+    icUSD
+  </button>
+  <button
+    onclick={() => selectToken('3usd')}
+    class="px-4 py-2 rounded-lg text-sm font-medium transition-colors
+           {selectedToken === '3usd'
+             ? 'bg-indigo-500/20 text-indigo-300 border border-indigo-500/40'
+             : 'bg-gray-800/40 text-gray-400 border border-gray-700/50 hover:text-gray-200 hover:border-gray-600'}"
+  >
+    3USD
+  </button>
+</div>
+
+{#if error}
+  <div class="rounded-xl bg-red-500/10 border border-red-500/30 p-4 text-red-300 text-sm mb-6">
+    Failed to load holder data: {error}
+  </div>
+{/if}
+
+<!-- Summary Stats -->
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+  <StatCard
+    label="Holders"
+    value={loading ? '...' : holders.length.toLocaleString()}
+  />
+  <StatCard
+    label="Total Supply"
+    value={loading ? '...' : `${formatE8s(totalSupply)} ${tokenInfo.symbol}`}
+  />
+  <StatCard
+    label="Transactions"
+    value={loading ? '...' : txCount.toLocaleString()}
+  />
+  <StatCard
+    label="Top Holder Share"
+    value={loading || holders.length === 0 ? '...' : formatShare(holders[0].balance, totalSupply)}
+  />
+</div>
+
+<!-- Holders Table -->
+<DataTable {columns} data={holders} {loading} emptyMessage="No {tokenInfo.symbol} holders found">
+  {#snippet row(holder: TokenHolder, i: number)}
+    <tr class="border-b border-gray-700/30 hover:bg-white/[0.02] transition-colors">
+      <td class="px-4 py-3 text-center text-gray-500 text-sm">{i + 1}</td>
+      <td class="px-4 py-3">
+        <EntityLink type="address" value={holder.principal} short={true} />
+        {#if holder.subaccount}
+          <span class="ml-1 text-xs text-gray-500 font-mono" title="Subaccount: {holder.subaccount}">
+            (sub)
+          </span>
+        {/if}
+      </td>
+      <td class="px-4 py-3">
+        {#if getLabel(holder.principal)}
+          <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-indigo-500/20 text-indigo-300 border border-indigo-500/30">
+            {getLabel(holder.principal)}
+          </span>
+        {/if}
+      </td>
+      <td class="px-4 py-3 text-right font-mono text-sm text-gray-200">
+        {formatE8s(holder.balance)}
+      </td>
+      <td class="px-4 py-3 text-right text-sm text-gray-400">
+        {formatShare(holder.balance, totalSupply)}
+      </td>
+    </tr>
+  {/snippet}
+</DataTable>
+
+<!-- Holder Trends -->
+{#if holderTrends.length > 1}
+<section class="mt-8">
+  <h3 class="mb-3 text-base font-semibold text-white">Holder Count Over Time</h3>
+  <div class="rounded-lg border border-white/10 bg-gray-900/50 p-4">
+    <svg viewBox="0 0 {chartW} {chartH}" class="w-full h-auto" preserveAspectRatio="none">
+      <polyline
+        fill="none"
+        stroke="#6366f1"
+        stroke-width="2"
+        points={trendPolyline}
+      />
+    </svg>
+    <div class="mt-1 flex justify-between text-xs text-white/30">
+      <span>{new Date(trendXMin * 1000).toLocaleDateString()}</span>
+      <span>Latest: {trendPoints[trendPoints.length - 1]?.y ?? 0} holders</span>
+      <span>{new Date(trendXMax * 1000).toLocaleDateString()}</span>
+    </div>
+  </div>
+</section>
+{/if}

--- a/src/vault_frontend/src/routes/explorer/stats/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/stats/+page.svelte
@@ -1,5 +1,218 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
-	onMount(() => goto('/explorer', { replaceState: true }));
+  import { onMount } from 'svelte';
+  import StatCard from '$lib/components/explorer/StatCard.svelte';
+  import {
+    fetchProtocolSummary,
+    fetchApys,
+    fetchPegStatus,
+    fetchTradeActivity,
+    fetchCollectorHealth,
+  } from '$lib/services/explorer/analyticsService';
+  import { formatE8s, formatBps, timeAgo } from '$lib/utils/explorerHelpers';
+  import type {
+    ProtocolSummary,
+    ApyResponse,
+    PegStatus,
+    TradeActivityResponse,
+    CollectorHealth,
+  } from '$declarations/rumi_analytics/rumi_analytics.did';
+
+  // ── Inline helpers ───────────────────────────────────────────────────────────
+
+  function fmtPct(v: number | null | undefined): string {
+    if (v == null) return 'N/A';
+    return `${v.toFixed(2)}%`;
+  }
+
+  function fmtPrice(v: number | null | undefined): string {
+    if (v == null) return 'N/A';
+    return `$${v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+  }
+
+  // ── State ────────────────────────────────────────────────────────────────────
+
+  let loading = $state(true);
+  let error = $state(false);
+
+  let summary = $state<ProtocolSummary | null>(null);
+  let apys = $state<ApyResponse | null>(null);
+  let peg = $state<PegStatus | null>(null);
+  let trade = $state<TradeActivityResponse | null>(null);
+  let health = $state<CollectorHealth | null>(null);
+
+  // ── Load ─────────────────────────────────────────────────────────────────────
+
+  onMount(async () => {
+    try {
+      const results = await Promise.all([
+        fetchProtocolSummary(),
+        fetchApys(),
+        fetchPegStatus(),
+        fetchTradeActivity(),
+        fetchCollectorHealth(),
+      ]);
+      summary = results[0];
+      apys = results[1];
+      peg = results[2];
+      trade = results[3];
+      health = results[4];
+    } catch (err) {
+      console.error('[stats] load failed:', err);
+      error = true;
+    } finally {
+      loading = false;
+    }
+  });
+
+  // ── Derived display values ────────────────────────────────────────────────────
+
+  let tvl = $derived(summary ? `$${formatE8s(summary.total_collateral_usd_e8s)}` : 'N/A');
+  let totalDebt = $derived(summary ? formatE8s(summary.total_debt_e8s) + ' icUSD' : 'N/A');
+  let systemCR = $derived(summary ? formatBps(summary.system_cr_bps) : 'N/A');
+  let vaultCount = $derived(summary ? summary.total_vault_count.toLocaleString() : 'N/A');
+  let volume24h = $derived(summary ? `$${formatE8s(summary.volume_24h_e8s)}` : 'N/A');
+
+  let imbalance = $derived(peg ? `${peg.max_imbalance_pct.toFixed(2)}%` : 'N/A');
+  let lpApy = $derived(apys?.lp_apy_pct?.[0] != null ? fmtPct(apys.lp_apy_pct[0]) : (summary?.lp_apy_pct?.[0] != null ? fmtPct(summary.lp_apy_pct[0]) : 'N/A'));
+  let spApy = $derived(apys?.sp_apy_pct?.[0] != null ? fmtPct(apys.sp_apy_pct[0]) : (summary?.sp_apy_pct?.[0] != null ? fmtPct(summary.sp_apy_pct[0]) : 'N/A'));
+  let swaps24h = $derived(summary ? summary.swap_count_24h.toLocaleString() : 'N/A');
+
+  let tradeThreePool = $derived(trade ? trade.three_pool_swaps.toLocaleString() : 'N/A');
+  let tradeAmm = $derived(trade ? trade.amm_swaps.toLocaleString() : 'N/A');
+  let tradeFees = $derived(trade ? `$${formatE8s(trade.total_fees_e8s)}` : 'N/A');
+  let tradeTraders = $derived(trade ? trade.unique_traders.toLocaleString() : 'N/A');
 </script>
+
+<div class="space-y-8 {error ? 'border border-red-500/40 rounded-xl p-4' : ''}">
+
+  <!-- Page title -->
+  <div class="flex items-center justify-between">
+    <h1 class="text-xl font-semibold text-white">Protocol Stats</h1>
+    {#if summary}
+      <span class="text-xs text-gray-500">Updated {timeAgo(summary.timestamp_ns)}</span>
+    {/if}
+  </div>
+
+  {#if loading}
+    <!-- Loading spinner -->
+    <div class="flex items-center justify-center py-20">
+      <svg class="animate-spin h-8 w-8 text-indigo-400" viewBox="0 0 24 24" fill="none">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+      </svg>
+    </div>
+
+  {:else}
+
+    <!-- ── Section 1: Protocol Overview ── -->
+    <section>
+      <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Protocol Overview</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <StatCard label="Total TVL" value={tvl} />
+        <StatCard label="Total Debt" value={totalDebt} />
+        <StatCard label="System CR" value={systemCR} />
+        <StatCard label="Vaults" value={vaultCount} />
+        <StatCard label="24h Volume" value={volume24h} />
+      </div>
+    </section>
+
+    <!-- ── Section 2: Collateral Prices ── -->
+    {#if summary && summary.prices.length > 0}
+      <section>
+        <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Collateral Prices</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {#each summary.prices as entry}
+            <StatCard
+              label={entry.symbol}
+              value={fmtPrice(entry.twap_price)}
+              subtitle={`Latest: ${fmtPrice(entry.latest_price)} · ${entry.sample_count} samples`}
+            />
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    <!-- ── Section 3: Pool Health ── -->
+    <section>
+      <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Pool Health</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label="3pool Imbalance" value={imbalance} />
+        <StatCard label="LP APY" value={lpApy} />
+        <StatCard label="SP APY" value={spApy} />
+        <StatCard label="24h Swaps" value={swaps24h} />
+      </div>
+    </section>
+
+    <!-- ── Section 4: Trade Activity (24h window) ── -->
+    <section>
+      <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Trade Activity (24h)</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label="3pool Swaps" value={tradeThreePool} />
+        <StatCard label="AMM Swaps" value={tradeAmm} />
+        <StatCard label="Total Fees" value={tradeFees} />
+        <StatCard label="Unique Traders" value={tradeTraders} />
+      </div>
+    </section>
+
+    <!-- ── Section 5: Collector Health ── -->
+    {#if health}
+      <section>
+        <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Collector Health</h2>
+        <div class="overflow-x-auto rounded-xl border border-gray-700/50">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-gray-400 uppercase tracking-wide border-b border-gray-700/50">
+                <th class="px-4 py-3">Cursor</th>
+                <th class="px-4 py-3 text-right">Position</th>
+                <th class="px-4 py-3 text-right">Sources</th>
+                <th class="px-4 py-3 text-right">Last Success</th>
+                <th class="px-4 py-3 text-right">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each health.cursors as cursor}
+                <tr class="border-b border-gray-800/50 hover:bg-gray-800/30 transition-colors">
+                  <td class="px-4 py-3 font-mono text-white">{cursor.name}</td>
+                  <td class="px-4 py-3 text-right font-mono text-gray-300">{cursor.cursor_position.toLocaleString()}</td>
+                  <td class="px-4 py-3 text-right text-gray-300">{cursor.source_count.toLocaleString()}</td>
+                  <td class="px-4 py-3 text-right text-gray-400">
+                    {cursor.last_success_ns > 0n ? timeAgo(cursor.last_success_ns) : 'never'}
+                  </td>
+                  <td class="px-4 py-3 text-right">
+                    {#if cursor.last_error.length > 0}
+                      <span class="inline-flex items-center gap-1 text-red-400 font-medium" title={cursor.last_error[0]}>
+                        <span class="h-1.5 w-1.5 rounded-full bg-red-400 inline-block"></span>
+                        Error
+                      </span>
+                    {:else}
+                      <span class="inline-flex items-center gap-1 text-emerald-400 font-medium">
+                        <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 inline-block"></span>
+                        OK
+                      </span>
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+              {#if health.cursors.length === 0}
+                <tr>
+                  <td colspan="5" class="px-4 py-6 text-center text-gray-500">No cursor data available</td>
+                </tr>
+              {/if}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Error counters summary -->
+        <div class="mt-3 grid grid-cols-3 sm:grid-cols-5 gap-2">
+          {#each Object.entries(health.error_counters) as [source, count]}
+            <div class="bg-gray-800/40 border border-gray-700/40 rounded-lg px-3 py-2 text-center">
+              <p class="text-xs text-gray-400 capitalize">{source}</p>
+              <p class="text-sm font-mono font-bold {Number(count) > 0 ? 'text-red-400' : 'text-emerald-400'}">{Number(count)}</p>
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- **HTTP API**: CSV time-series endpoints (`/api/series/*`), Prometheus `/metrics`, JSON `/api/health`
- **Frontend**: `analyticsService.ts` with TTL-cached typed fetch functions, new Stats dashboard page, overview charts sourced from analytics canister, holder trends chart
- **Bug fix**: `fetchHolderSeries` was receiving a string instead of `Principal` (caught in systematic debugging)

### Backend (Rust)
- Restructured `http.rs` into module directory (`http/mod.rs` + `csv.rs` + `metrics.rs`)
- 7 CSV series endpoints for TVL, vaults, stability, swaps, liquidations, fees, prices
- Prometheus endpoint with supply gauges, vault/TVL metrics, error counters, storage sizes
- Health JSON endpoint with canister status, timestamps, error counters, storage row counts
- Added `serde_json` dependency for health endpoint
- 4 new PocketIC integration tests for HTTP endpoints

### Frontend (SvelteKit)
- Added analytics canister ID to `config.ts`
- Created `analyticsService.ts` with 13 typed fetch functions + TTL caching
- New `/explorer/stats` dashboard with protocol overview, collateral prices, pool health, trade activity, collector health table
- Overview page charts now source from analytics canister `fetchVaultSeries` instead of backend snapshots
- Holders page gains historical holder count SVG chart from `get_holder_series`

### Tests
- 40 unit tests: all pass
- 24 integration tests: all pass (4 new HTTP tests)
- Frontend build: clean

## Test plan
- [ ] Verify `/metrics` returns valid Prometheus text format
- [ ] Verify `/api/health` returns JSON with status/counters
- [ ] Verify `/api/series/tvl` returns CSV with header + data rows
- [ ] Verify Stats page loads and renders all sections
- [ ] Verify Overview charts still render correctly with analytics data source
- [ ] Verify Holders page trends chart loads without errors
- [ ] Run `cargo test -p rumi_analytics --lib`
- [ ] Run `POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_analytics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)