### PR TITLE
feat(frontend): TLD-aware Launch App + mobile header cleanup

### DIFF
--- a/src/rumi_homepage/src/routes/+layout.svelte
+++ b/src/rumi_homepage/src/routes/+layout.svelte
@@ -2,7 +2,11 @@
   import { page } from '$app/stores';
   import '../app.css';
 
-  let appUrl = 'https://app.rumiprotocol.xyz';
+  // Match the app subdomain to the TLD of the current host so visitors stay
+  // on the domain they arrived from (.com → app.rumiprotocol.com, otherwise .xyz).
+  $: appUrl = $page.url.hostname.endsWith('rumiprotocol.com')
+    ? 'https://app.rumiprotocol.com'
+    : 'https://app.rumiprotocol.xyz';
 </script>
 
 <div class="min-h-screen flex flex-col relative z-10">

--- a/src/rumi_homepage/src/routes/+page.svelte
+++ b/src/rumi_homepage/src/routes/+page.svelte
@@ -1,5 +1,11 @@
 <script>
-  let appUrl = 'https://app.rumiprotocol.xyz';
+  import { page } from '$app/stores';
+
+  // Match the app subdomain to the TLD of the current host so visitors stay
+  // on the domain they arrived from (.com → app.rumiprotocol.com, otherwise .xyz).
+  $: appUrl = $page.url.hostname.endsWith('rumiprotocol.com')
+    ? 'https://app.rumiprotocol.com'
+    : 'https://app.rumiprotocol.xyz';
 
   // ── Single source of truth for supported collateral ──
   // Update this list when adding new assets. Everything else derives from it.

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -172,5 +172,15 @@
   .mob-item { display:flex;flex-direction:column;align-items:center;gap:0.125rem;padding:0.375rem 0.75rem;border-radius:0.375rem;color:var(--rumi-text-muted);text-decoration:none;font-size:0.625rem; }
   .mob-item svg { width:1.125rem;height:1.125rem; }
   .mob-item.active { color:var(--rumi-action); }
-  @media (max-width:768px) { .top-nav{display:none} .main-content{padding:4.25rem 1rem 5rem} .mobile-nav{display:flex} }
+  @media (max-width:768px) {
+    .top-nav{display:none}
+    .main-content{padding:4.25rem 1rem 5rem}
+    .mobile-nav{display:flex}
+    /* Social icons and beta chip duplicate footer content and crowd out the
+       wallet button on narrow screens — hide them here. */
+    .top-social{display:none}
+    .beta-chip{display:none}
+    .top-bar{padding:0 0.75rem}
+    .top-actions{gap:0.5rem}
+  }
 </style>


### PR DESCRIPTION
## Summary
- **Homepage**: Launch App buttons now respect the TLD of the current host. Visitors on rumiprotocol.com go to app.rumiprotocol.com; visitors on rumiprotocol.xyz go to app.rumiprotocol.xyz. Derived reactively from `\$page.url.hostname` so the same build serves both domains correctly.
- **Vault app**: On mobile (≤768px) the top bar hid the Connect Wallet button behind 5 social icons + beta chip. Those are now hidden on mobile (social links remain in the footer), padding/gap tightened, so the wallet button fits cleanly.

## Test plan
- [ ] Visit rumiprotocol.com — Launch App goes to app.rumiprotocol.com
- [ ] Visit rumiprotocol.xyz — Launch App goes to app.rumiprotocol.xyz
- [ ] On mobile viewport, app header shows RUMI logo + Connect Wallet without overflow
- [ ] Desktop header unchanged (social icons, beta chip still visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)