### PR TITLE
feat(vault-frontend): persistent position summary strip

### DIFF
--- a/docs/superpowers/specs/2026-04-14-position-summary-strip-design.md
+++ b/docs/superpowers/specs/2026-04-14-position-summary-strip-design.md
@@ -1,0 +1,212 @@
+# Position Summary Strip — Design
+
+**Date:** 2026-04-14
+**Status:** Approved, awaiting implementation plan
+**Scope:** `src/vault_frontend` only (no backend changes)
+
+## Problem
+
+Users can't see their overall position in the protocol without navigating to `/vaults` and mentally aggregating across multiple vault cards. There's no single glanceable answer to "how much collateral do I have, how much am I borrowing, and am I safe?" On pages like `/borrow`, `/swap`, or `/3usd`, the user has no indication of their existing position at all.
+
+## Goal
+
+Add a persistent, always-visible position summary on every authenticated page of the vault_frontend that shows:
+
+1. Total collateral value (USD, aggregated across all vaults and collateral types)
+2. Total icUSD borrowed (aggregated across all vaults)
+3. Overall collateral ratio, color-coded for health
+4. Per-collateral breakdown on demand (ICP, ckBTC, ckXAUT, future assets)
+
+## Non-Goals
+
+- Stability Pool deposits, 3USD LP positions, wallet balances — not in v1, can extend later.
+- Per-vault health or liquidation price — those stay on `VaultCard`.
+- Backend / canister changes — this is a pure frontend aggregation over existing `userVaults` data.
+- A dedicated "Portfolio" page (evaluated as option D during brainstorming, deferred).
+
+## Placement
+
+A thin strip directly under the top bar (`header.top-bar`) and above `main.main-content`. Persistent on every route when the user is connected and has at least one vault. Hidden when disconnected. Replaced with a CTA variant when connected with zero vaults.
+
+On mobile (≤768px) the strip sits between the top bar and the main content, above the existing bottom mobile nav.
+
+## States
+
+### 1. Connected + ≥1 vault — collapsed (default)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ COLLATERAL $4,218.42 │ BORROWED 1,500 icUSD │ CR 281% ▾     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- Three stat cells separated by thin vertical dividers.
+- `Show breakdown ▾` affordance on the right.
+- `CR` colored by tier: green ≥200%, amber 150–199%, red <150%.
+
+### 2. Connected + ≥1 vault — expanded
+
+Same top row, plus a breakdown row of per-collateral pills:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ COLLATERAL $4,218.42 │ BORROWED 1,500 icUSD │ CR 281% ▴     │
+│ ┌─ICP 1,250.00 ($3,037)─┐ ┌─ckBTC 0.0180 ($1,080)─┐ ┌─...┐  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- One pill per collateral type the user currently holds (zero-balance types omitted).
+- Each pill: asset dot/logo, symbol, native amount, USD value.
+- Expand state persisted in `localStorage` under `rumi:positionStrip:expanded` (boolean).
+
+### 3. Connected, zero vaults — CTA variant
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ No active position. Lock ICP, ckBTC, or ckXAUT as collateral│
+│ to mint icUSD.                         Open your first vault│→
+└─────────────────────────────────────────────────────────────┘
+```
+
+- Thin single-line pitch + link to `/` (the Borrow page).
+- Same height as the collapsed strip (~36px).
+
+### 4. Disconnected
+
+Strip is not rendered at all — no vertical space taken.
+
+### 5. Loading
+
+When `$isLoadingVaults && $userVaults.length === 0` on initial connect, show a skeleton version of state 1 (three grey placeholder cells, no caret). Avoids layout jump when data resolves.
+
+## Mobile Adaptation (≤768px)
+
+- Stat labels shortened (`COLL` / `BORR` / `CR`), values kept but USD-abbreviated (`$4.2k`) if > $1,000.
+- Dividers removed, tighter gap.
+- Expand caret becomes `▾` glyph only.
+- Expanded breakdown pills wrap to multiple rows.
+
+## Component Architecture
+
+New file: `src/vault_frontend/src/lib/components/layout/PositionStrip.svelte`
+
+```
+PositionStrip.svelte
+├─ reads $userVaults and $isLoadingVaults from appDataStore
+├─ reads $collateralStore for price + symbol lookup per collateral principal
+├─ reads $isConnected from wallet store
+├─ reads $permissionStore for view gating (same as vaults page)
+├─ derives { totalCollateralUsd, totalBorrowed, overallCr, perCollateral[] } reactively
+└─ renders one of: null (disconnected), skeleton (loading), cta (empty), collapsed, expanded
+```
+
+Mounted once in `src/vault_frontend/src/routes/+layout.svelte` between the existing `<header>` and `<main>` elements:
+
+```svelte
+<header class="top-bar">…</header>
+<PositionStrip />
+<main class="main-content"><slot /></main>
+```
+
+`main.main-content`'s top padding (`4.75rem` desktop, `4.25rem` mobile) must be reviewed — the strip adds vertical content in document flow, not overlaid, so main padding likely stays the same but the top-bar offset no longer needs to account for strip height since both are in flow.
+
+## Data Flow
+
+All data derives from existing stores — no new API endpoints.
+
+```
+appDataStore.userVaults ──┐
+collateralStore ──────────┼──► derived stats in PositionStrip
+wallet.isConnected ───────┘
+```
+
+### Derivations
+
+For each vault `v`:
+- `collateralPrincipal = v.collateralType || ICP_LEDGER`
+- `info = collateralStore.find(c => c.principal === collateralPrincipal)`
+- `priceUsd = info?.price ?? 0` (ICP falls back to `protocolStatus.lastIcpRate`)
+- `amount = v.collateralAmount ?? v.icpMargin`
+- `usdValue = amount * priceUsd`
+
+Aggregate:
+- `totalCollateralUsd = Σ usdValue`
+- `totalBorrowed = Σ v.borrowedIcusd`
+- `overallCr = totalBorrowed > 0 ? totalCollateralUsd / totalBorrowed : Infinity`
+
+Per-collateral breakdown (group by `collateralPrincipal`):
+- `{ symbol, logo, nativeAmount, usdValue }` per group
+- Omit groups where `nativeAmount === 0`
+- Order: by `usdValue` descending so largest position first
+
+### Health tiers
+
+- Green (`--rumi-safe`): `overallCr >= 2.0`
+- Amber (`--rumi-warning`): `1.5 <= overallCr < 2.0`
+- Red (`--rumi-danger`): `overallCr < 1.5`
+- Infinity (no debt): neutral/grey
+
+Note: these thresholds are aggregate across all vaults, not per-vault liquidation ratios. They're a heuristic for the overall strip color, not a liquidation signal — individual vault liquidation prices stay on VaultCard.
+
+## Styling
+
+- Background: `linear-gradient(180deg, rgba(167,139,250,0.04), rgba(52,211,153,0.02))` — subtle brand tint so it reads as an app-level chrome element, not a page content card.
+- Border: `border-bottom: 1px solid var(--rumi-border)` to separate from main content.
+- Height collapsed: ~36px desktop, ~32px mobile.
+- Height expanded: collapsed row + breakdown row (~72px desktop, wraps on mobile).
+- Fonts and colors reuse existing CSS custom properties (`--rumi-text-*`, `--rumi-bg-*`, `--rumi-safe`, etc.).
+
+## Interaction
+
+- **Click anywhere on the collapsed strip** (not just the caret) to expand. Same to collapse.
+- **Cursor: pointer** on the interactive row, cursor: default on pills.
+- **Transition**: height transition 150ms ease on expand/collapse for a gentle reveal.
+- **No modal, no overlay** — everything pushes page content down.
+- **Keyboard**: strip row is a `<button>` with `aria-expanded`, `aria-controls` pointing at the breakdown row.
+
+## Persistence
+
+Expand/collapse state in `localStorage` at key `rumi:positionStrip:expanded`. Default `false` (collapsed). Read on mount, write on toggle. No other local state.
+
+## Edge Cases
+
+- **Price not yet loaded**: show `—` for USD values and skip overall CR color (neutral). Component should not throw; missing price is explicit.
+- **One vault with zero debt** (pure collateral, nothing borrowed): `overallCr = ∞`. Show CR as `—` or "No debt" with neutral color; don't show 0% or Infinity%.
+- **Multiple vaults on same collateral type**: aggregate amounts per type in the breakdown (don't show one pill per vault).
+- **New collateral type with no price feed yet**: include in breakdown but show `—` for USD, exclude from total collateral USD so totals stay honest.
+- **Disconnected mid-session**: strip disappears immediately on `isConnected` flip.
+- **Empty state gate**: connected + `userVaults.length === 0` AND not loading → CTA. Loading → skeleton (never CTA) to avoid flashing the CTA before vaults resolve.
+
+## Accessibility
+
+- Button role with `aria-expanded`.
+- Health color is supplemented by a textual suffix in the expanded view (e.g., "281% · Healthy") so color isn't the sole carrier.
+- Contrast checked against existing surface colors.
+
+## Testing
+
+Unit-level (Vitest or Svelte testing library):
+
+- Derivation helpers (aggregation, CR, health tier) as pure functions in `PositionStrip.helpers.ts` or similar. Tested in isolation for:
+  - Single vault, multiple vaults, multiple collateral types
+  - Zero debt → Infinity CR
+  - Missing price → excluded from USD total
+  - Zero-balance collateral omitted from breakdown
+- Rendering smoke test for each state (disconnected, loading, empty, collapsed, expanded).
+
+Manual verification on mainnet deploy:
+
+- Connect wallet with known position, confirm totals match sum of VaultCards on /vaults.
+- Toggle expand/collapse, reload page, confirm state persists.
+- Observe mobile viewport at 375px, 414px.
+- Disconnect wallet, confirm strip hides.
+- Create first vault (or simulate with zero-vault account), confirm CTA variant.
+
+## Out of Scope (for later iterations)
+
+- Net position (collateral − borrowed) as a fourth stat.
+- Stability Pool deposits and 3USD LP positions rolled into totals.
+- Wallet balances (idle icUSD, idle collateral) shown alongside locked.
+- Sparkline or trend indicator (e.g., "+0.3% 24h").
+- Per-vault drill-down from the breakdown pills.
+- Different color themes or density modes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,198 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dfinity/agent": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
@@ -684,6 +876,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2230,6 +2440,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -2566,6 +2786,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2576,6 +2810,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -2603,6 +2851,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
@@ -2694,6 +2949,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -3275,6 +3543,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -3468,6 +3749,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3511,6 +3799,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3634,6 +3963,16 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "devOptional": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3642,6 +3981,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "devOptional": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3904,6 +4250,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4424,6 +4783,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -4571,6 +4940,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scule": {
       "version": "1.3.0",
@@ -4901,6 +5283,13 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -5128,6 +5517,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5147,6 +5556,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5219,6 +5654,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -5450,6 +5895,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5515,6 +6008,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",
@@ -5704,6 +6214,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-svelte": "^2.36.0",
         "globals": "^15.0.0",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5.1",
         "prettier": "^3.3.2",
         "prettier-plugin-svelte": "^3.2.6",

--- a/src/vault_frontend/package.json
+++ b/src/vault_frontend/package.json
@@ -34,6 +34,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.36.0",
 		"globals": "^15.0.0",
+		"jsdom": "^29.0.2",
 		"postcss": "^8.5.1",
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.6",

--- a/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
+++ b/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
@@ -1,0 +1,293 @@
+<!-- src/vault_frontend/src/lib/components/layout/PositionStrip.svelte -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { userVaults, isLoadingVaults } from '$lib/stores/appDataStore';
+  import { isConnected } from '$lib/stores/wallet';
+  import { permissionStore } from '$lib/stores/permissionStore';
+  import { collateralStore } from '$lib/stores/collateralStore';
+  import { isDevelopment } from '$lib/config';
+  import { developerAccess } from '$lib/stores/developer';
+  import { aggregatePosition } from './positionSummary';
+
+  const STORAGE_KEY = 'rumi:positionStrip:expanded';
+
+  let expanded = false;
+
+  onMount(() => {
+    try {
+      expanded = localStorage.getItem(STORAGE_KEY) === '1';
+    } catch {
+      // localStorage may be blocked; fall back to collapsed.
+      expanded = false;
+    }
+    return () => {
+      // Reset the CSS variable when the component unmounts.
+      if (typeof document !== 'undefined') {
+        document.documentElement.style.setProperty('--rumi-strip-height', '0px');
+      }
+    };
+  });
+
+  function toggle() {
+    expanded = !expanded;
+    try {
+      localStorage.setItem(STORAGE_KEY, expanded ? '1' : '0');
+    } catch {
+      // Ignore storage errors.
+    }
+  }
+
+  // Gate visibility by connection + view permission (same rules as /vaults).
+  $: canView = isDevelopment || $developerAccess || $isConnected
+    || ($permissionStore.initialized && $permissionStore.canViewVaults);
+
+  $: summary = aggregatePosition($userVaults, $collateralStore.collaterals);
+  $: hasPosition = $userVaults.length > 0;
+  $: showSkeleton = $isConnected && $isLoadingVaults && $userVaults.length === 0;
+
+  // Expose the rendered height as a CSS variable on <html> so main-content
+  // padding can compensate. Bound to the outer wrapper so it stays 0 when
+  // the component renders nothing (e.g., disconnected).
+  let stripHeight = 0;
+  $: if (typeof document !== 'undefined') {
+    document.documentElement.style.setProperty('--rumi-strip-height', `${stripHeight}px`);
+  }
+
+  // Formatters
+  const fmtUsd = (n: number) => n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+  const fmtIcusd = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  const fmtAmount = (n: number, decimals: number) => n.toLocaleString('en-US', { maximumFractionDigits: decimals });
+  const fmtCr = (cr: number) => Number.isFinite(cr) ? `${Math.round(cr * 100)}%` : '—';
+
+  // Decimals for breakdown display: BTC-like assets deserve more precision.
+  function displayDecimals(symbol: string): number {
+    if (/btc/i.test(symbol)) return 4;
+    if (/eth/i.test(symbol)) return 4;
+    if (/xaut/i.test(symbol)) return 3;
+    return 2;
+  }
+
+  function healthLabel(tier: string): string {
+    switch (tier) {
+      case 'safe': return 'Healthy';
+      case 'caution': return 'Caution';
+      case 'danger': return 'At risk';
+      case 'no-debt': return 'No debt';
+      default: return '';
+    }
+  }
+</script>
+
+<!-- Outer wrapper is always rendered (so stripHeight stays bound) but is
+     empty when there's nothing to show. position:fixed places it flush
+     below the fixed top bar (height 3.5rem). -->
+<div class="strip-outer" bind:clientHeight={stripHeight}>
+  {#if !$isConnected || !canView}
+    <!-- Disconnected or no permission -> render nothing (height stays 0). -->
+  {:else if showSkeleton}
+    <div class="strip skeleton" aria-hidden="true">
+      <div class="sk-cell"></div>
+      <div class="sk-div"></div>
+      <div class="sk-cell"></div>
+      <div class="sk-div"></div>
+      <div class="sk-cell"></div>
+    </div>
+  {:else if !hasPosition}
+    <div class="strip cta">
+      <span class="cta-headline">No active position.</span>
+      <span class="cta-sub">Lock ICP, ckBTC, or ckXAUT as collateral to mint icUSD.</span>
+      <a class="cta-link" href="/">Open your first vault →</a>
+    </div>
+  {:else}
+    <section class="strip-wrapper" class:is-expanded={expanded}>
+      <button
+        type="button"
+        class="strip interactive"
+        class:is-expanded={expanded}
+        aria-expanded={expanded}
+        aria-controls="position-breakdown"
+        on:click={toggle}
+      >
+        <span class="cell">
+          <span class="cell-label">Collateral</span>
+          <span class="cell-val">{summary.hasAnyMissingPrice ? '≈' : ''}{fmtUsd(summary.totalCollateralUsd)}</span>
+        </span>
+        <span class="divider" aria-hidden="true"></span>
+        <span class="cell">
+          <span class="cell-label">Borrowed</span>
+          <span class="cell-val">{fmtIcusd(summary.totalBorrowed)}<span class="cell-unit"> icUSD</span></span>
+        </span>
+        <span class="divider" aria-hidden="true"></span>
+        <span class="cell">
+          <span class="cell-label">Overall CR</span>
+          <span class="cell-val health-{summary.healthTier}">{fmtCr(summary.overallCr)}</span>
+        </span>
+        {#if summary.healthTier !== 'unknown'}
+          <span class="health-label health-{summary.healthTier}">{healthLabel(summary.healthTier)}</span>
+        {/if}
+        <span class="caret" aria-hidden="true">{expanded ? 'Hide ▴' : 'Show breakdown ▾'}</span>
+      </button>
+
+      {#if expanded}
+        <div class="breakdown" id="position-breakdown">
+          {#each summary.perCollateral as asset (asset.principal)}
+            <div class="pill">
+              <span class="pill-symbol">{asset.symbol}</span>
+              <span class="pill-amount">{fmtAmount(asset.nativeAmount, displayDecimals(asset.symbol))}</span>
+              {#if asset.hasPrice}
+                <span class="pill-usd">{fmtUsd(asset.usdValue)}</span>
+              {:else}
+                <span class="pill-usd pill-nopx">no price</span>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  /* The top bar is position:fixed; height 3.5rem; z-index 100. We place
+     the strip as position:fixed right below it at top:3.5rem. Its height
+     is bound reactively to the --rumi-strip-height CSS variable, and
+     .main-content's padding-top compensates via calc() (see +layout.svelte). */
+  .strip-outer {
+    position: fixed;
+    top: 3.5rem;
+    left: 0;
+    right: 0;
+    z-index: 99;  /* below top-bar's 100, above page content */
+  }
+  /* Only draw border/background when something is actually rendered.
+     :not(:empty) keeps the outer invisible when the disconnected branch
+     renders no DOM. */
+  .strip-outer:not(:empty) {
+    background: var(--rumi-bg-surface1);
+    border-bottom: 1px solid var(--rumi-border);
+  }
+  .strip-wrapper {
+    background: linear-gradient(180deg, rgba(167,139,250,0.05), rgba(52,211,153,0.02));
+  }
+  .strip {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 0.5rem 1.5rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    font-size: 0.8125rem;
+    min-height: 2.25rem;
+    box-sizing: border-box;
+  }
+  .strip.interactive {
+    width: 100%;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+  }
+  .strip.interactive:hover { background: rgba(167,139,250,0.04); }
+  .strip.interactive:focus-visible {
+    outline: 2px solid var(--rumi-action);
+    outline-offset: -2px;
+  }
+
+  .cell { display: inline-flex; align-items: baseline; gap: 0.5rem; }
+  .cell-label {
+    color: var(--rumi-text-muted);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .cell-val {
+    color: var(--rumi-text-primary);
+    font-weight: 600;
+    font-size: 0.9375rem;
+  }
+  .cell-unit { color: var(--rumi-text-muted); font-weight: 500; font-size: 0.75rem; }
+
+  .divider { width: 1px; height: 1.125rem; background: var(--rumi-border); }
+
+  .health-safe { color: var(--rumi-safe); }
+  .health-caution { color: #d9a53c; }
+  .health-danger { color: var(--rumi-danger); }
+  .health-no-debt { color: var(--rumi-text-secondary); }
+  .health-unknown { color: var(--rumi-text-muted); }
+
+  .health-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.125rem 0.4375rem;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.04);
+  }
+
+  .caret {
+    margin-left: auto;
+    color: var(--rumi-text-muted);
+    font-size: 0.75rem;
+  }
+
+  /* Breakdown row */
+  .breakdown {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem 0.625rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
+    background: rgba(20,26,46,0.6);
+    border: 1px solid var(--rumi-border);
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+  }
+  .pill-symbol { color: var(--rumi-text-secondary); font-weight: 500; }
+  .pill-amount { color: var(--rumi-text-primary); font-weight: 600; }
+  .pill-usd { color: var(--rumi-text-muted); font-size: 0.6875rem; }
+  .pill-nopx { font-style: italic; }
+
+  /* CTA variant */
+  .strip.cta {
+    gap: 0.625rem;
+    color: var(--rumi-text-secondary);
+  }
+  .cta-headline { color: var(--rumi-text-primary); font-weight: 600; }
+  .cta-sub { color: var(--rumi-text-muted); font-size: 0.75rem; }
+  .cta-link { margin-left: auto; color: var(--rumi-action); text-decoration: none; font-weight: 500; }
+  .cta-link:hover { text-decoration: underline; }
+
+  /* Skeleton */
+  .strip.skeleton { pointer-events: none; }
+  .sk-cell {
+    width: 7rem; height: 0.9375rem; border-radius: 4px;
+    background: linear-gradient(90deg, rgba(255,255,255,0.04), rgba(255,255,255,0.08), rgba(255,255,255,0.04));
+    background-size: 200% 100%;
+    animation: sk-shimmer 1.2s ease-in-out infinite;
+  }
+  .sk-div { width: 1px; height: 1.125rem; background: var(--rumi-border); }
+  @keyframes sk-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+  /* Mobile */
+  @media (max-width: 768px) {
+    .strip { padding: 0.375rem 0.75rem; gap: 0.75rem; font-size: 0.75rem; }
+    .divider { display: none; }
+    .cell-label { font-size: 0.625rem; }
+    .cell-val { font-size: 0.8125rem; }
+    .cell-unit { display: none; } /* "Borrowed 1,500" without " icUSD" suffix on mobile */
+    .caret { font-size: 0.6875rem; }
+    .health-label { display: none; } /* color alone carries meaning on mobile */
+    .breakdown { padding: 0 0.75rem 0.5rem; gap: 0.375rem; }
+    .pill { padding: 0.1875rem 0.5rem; font-size: 0.6875rem; }
+    .strip.cta .cta-sub { display: none; } /* keep CTA compact */
+  }
+</style>

--- a/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
+++ b/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
@@ -172,10 +172,9 @@
   .strip {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 1.25rem;
     padding: 0.5rem 1.5rem;
-    max-width: 1200px;
-    margin: 0 auto;
     font-size: 0.8125rem;
     min-height: 2.25rem;
     box-sizing: border-box;
@@ -227,16 +226,14 @@
   }
 
   .caret {
-    margin-left: auto;
     color: var(--rumi-text-muted);
     font-size: 0.75rem;
   }
 
   /* Breakdown row */
   .breakdown {
-    max-width: 1200px;
-    margin: 0 auto;
     padding: 0 1.5rem 0.625rem;
+    justify-content: center;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -263,7 +260,7 @@
   }
   .cta-headline { color: var(--rumi-text-primary); font-weight: 600; }
   .cta-sub { color: var(--rumi-text-muted); font-size: 0.75rem; }
-  .cta-link { margin-left: auto; color: var(--rumi-action); text-decoration: none; font-weight: 500; }
+  .cta-link { color: var(--rumi-action); text-decoration: none; font-weight: 500; }
   .cta-link:hover { text-decoration: underline; }
 
   /* Skeleton */

--- a/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import type { VaultDTO, CollateralInfo } from '../../services/types';
+import { CANISTER_IDS } from '../../config';
+import {
+  aggregatePosition,
+  healthTierFor,
+  resolveCollateralPrincipal,
+  getCollateralAmount,
+} from './positionSummary';
+
+const ICP = CANISTER_IDS.ICP_LEDGER;
+const CKBTC = 'mxzaz-hqaaa-aaaar-qaada-cai';
+const CKXAUT = 'nza5v-qaaaa-aaaar-qahzq-cai';
+
+function vault(overrides: Partial<VaultDTO>): VaultDTO {
+  return {
+    vaultId: 1,
+    owner: 'owner',
+    icpMargin: 0,
+    borrowedIcusd: 0,
+    collateralType: ICP,
+    collateralAmount: 0,
+    ...overrides,
+  } as VaultDTO;
+}
+
+function collateral(overrides: Partial<CollateralInfo>): CollateralInfo {
+  return {
+    principal: ICP,
+    symbol: 'ICP',
+    decimals: 8,
+    ledgerCanisterId: ICP,
+    price: 0,
+    priceTimestamp: 0,
+    minimumCr: 1.5,
+    liquidationCr: 1.33,
+    borrowingFee: 0,
+    liquidationBonus: 0.05,
+    recoveryTargetCr: 1.5,
+    interestRateApr: 0,
+    debtCeiling: 0,
+    minVaultDebt: 0,
+    minCollateralDeposit: 0,
+    ledgerFee: 10_000,
+    color: '#3b00b9',
+    status: 'Active',
+    ...overrides,
+  };
+}
+
+describe('healthTierFor', () => {
+  it('returns "safe" for CR >= 2.0', () => {
+    expect(healthTierFor(2.0)).toBe('safe');
+    expect(healthTierFor(2.81)).toBe('safe');
+    expect(healthTierFor(100)).toBe('safe');
+  });
+
+  it('returns "caution" for 1.5 <= CR < 2.0', () => {
+    expect(healthTierFor(1.5)).toBe('caution');
+    expect(healthTierFor(1.75)).toBe('caution');
+    expect(healthTierFor(1.9999)).toBe('caution');
+  });
+
+  it('returns "danger" for CR < 1.5', () => {
+    expect(healthTierFor(1.49)).toBe('danger');
+    expect(healthTierFor(1.0)).toBe('danger');
+    expect(healthTierFor(0.5)).toBe('danger');
+  });
+
+  it('returns "no-debt" for Infinity', () => {
+    expect(healthTierFor(Infinity)).toBe('no-debt');
+  });
+
+  it('returns "unknown" for NaN', () => {
+    expect(healthTierFor(NaN)).toBe('unknown');
+  });
+});
+
+describe('resolveCollateralPrincipal', () => {
+  it('returns collateralType when present', () => {
+    expect(resolveCollateralPrincipal(vault({ collateralType: CKBTC }))).toBe(CKBTC);
+  });
+
+  it('falls back to ICP ledger for legacy vaults with empty collateralType', () => {
+    expect(resolveCollateralPrincipal(vault({ collateralType: '' }))).toBe(ICP);
+  });
+});
+
+describe('getCollateralAmount', () => {
+  it('prefers collateralAmount', () => {
+    expect(getCollateralAmount(vault({ collateralAmount: 10, icpMargin: 5 }))).toBe(10);
+  });
+
+  it('falls back to icpMargin when collateralAmount is undefined', () => {
+    const v = vault({ icpMargin: 5 });
+    delete (v as any).collateralAmount;
+    expect(getCollateralAmount(v)).toBe(5);
+  });
+
+  it('returns 0 when both are undefined', () => {
+    const v = vault({});
+    delete (v as any).collateralAmount;
+    delete (v as any).icpMargin;
+    expect(getCollateralAmount(v)).toBe(0);
+  });
+});
+
+describe('aggregatePosition', () => {
+  it('returns zeros and Infinity CR for an empty vault list', () => {
+    const result = aggregatePosition([], []);
+    expect(result.totalCollateralUsd).toBe(0);
+    expect(result.totalBorrowed).toBe(0);
+    expect(result.overallCr).toBe(Infinity);
+    expect(result.healthTier).toBe('no-debt');
+    expect(result.perCollateral).toEqual([]);
+    expect(result.hasAnyMissingPrice).toBe(false);
+  });
+
+  it('aggregates a single ICP vault', () => {
+    const vaults = [vault({ vaultId: 1, collateralAmount: 100, borrowedIcusd: 500 })];
+    const collaterals = [collateral({ price: 5 })];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.totalCollateralUsd).toBe(500);
+    expect(result.totalBorrowed).toBe(500);
+    expect(result.overallCr).toBe(1);
+    expect(result.healthTier).toBe('danger');
+    expect(result.perCollateral).toEqual([
+      { principal: ICP, symbol: 'ICP', nativeAmount: 100, usdValue: 500, hasPrice: true },
+    ]);
+  });
+
+  it('aggregates multiple vaults on the same collateral type into one breakdown row', () => {
+    const vaults = [
+      vault({ vaultId: 1, collateralAmount: 100, borrowedIcusd: 200 }),
+      vault({ vaultId: 2, collateralAmount: 50, borrowedIcusd: 100 }),
+    ];
+    const collaterals = [collateral({ price: 5 })];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.totalCollateralUsd).toBe(750);      // 150 ICP * $5
+    expect(result.totalBorrowed).toBe(300);
+    expect(result.perCollateral).toHaveLength(1);
+    expect(result.perCollateral[0]).toMatchObject({ symbol: 'ICP', nativeAmount: 150, usdValue: 750 });
+  });
+
+  it('aggregates vaults across multiple collateral types and sorts by USD desc', () => {
+    const vaults = [
+      vault({ vaultId: 1, collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 }),
+      vault({ vaultId: 2, collateralType: CKBTC, collateralAmount: 0.1, borrowedIcusd: 300 }),
+      vault({ vaultId: 3, collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 50 }),
+    ];
+    const collaterals = [
+      collateral({ principal: ICP, symbol: 'ICP', price: 5 }),       // 100 * 5  = 500
+      collateral({ principal: CKBTC, symbol: 'ckBTC', price: 60000 }),// 0.1 * 60000 = 6000
+      collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 2000 }),// 1 * 2000 = 2000
+    ];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.totalCollateralUsd).toBe(8500);
+    expect(result.totalBorrowed).toBe(550);
+    expect(result.perCollateral.map(p => p.symbol)).toEqual(['ckBTC', 'ckXAUT', 'ICP']);
+  });
+
+  it('treats missing prices as $0 for the total and sets hasAnyMissingPrice', () => {
+    const vaults = [
+      vault({ vaultId: 1, collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 }),
+      vault({ vaultId: 2, collateralType: CKBTC, collateralAmount: 0.1, borrowedIcusd: 100 }),
+    ];
+    const collaterals = [collateral({ principal: ICP, price: 5 })]; // ckBTC missing
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.totalCollateralUsd).toBe(500);
+    expect(result.hasAnyMissingPrice).toBe(true);
+    const ckbtcRow = result.perCollateral.find(p => p.principal === CKBTC);
+    expect(ckbtcRow?.hasPrice).toBe(false);
+    expect(ckbtcRow?.usdValue).toBe(0);
+  });
+
+  it('omits zero-balance collateral types from the breakdown', () => {
+    const vaults = [
+      vault({ vaultId: 1, collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 }),
+      vault({ vaultId: 2, collateralType: CKBTC, collateralAmount: 0, borrowedIcusd: 0 }),
+    ];
+    const collaterals = [
+      collateral({ principal: ICP, price: 5 }),
+      collateral({ principal: CKBTC, symbol: 'ckBTC', price: 60000 }),
+    ];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.perCollateral.map(p => p.symbol)).toEqual(['ICP']);
+  });
+
+  it('returns Infinity CR when there is no debt (collateral-only vault)', () => {
+    const vaults = [vault({ collateralAmount: 100, borrowedIcusd: 0 })];
+    const collaterals = [collateral({ price: 5 })];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.overallCr).toBe(Infinity);
+    expect(result.healthTier).toBe('no-debt');
+  });
+
+  it('falls back to ICP ledger for legacy vaults with empty collateralType', () => {
+    const vaults = [vault({ collateralType: '', icpMargin: 100, collateralAmount: 100, borrowedIcusd: 500 })];
+    const collaterals = [collateral({ principal: ICP, symbol: 'ICP', price: 5 })];
+    const result = aggregatePosition(vaults, collaterals);
+    expect(result.perCollateral[0].principal).toBe(ICP);
+    expect(result.totalCollateralUsd).toBe(500);
+  });
+
+  it('uses a truncated principal as symbol fallback when CollateralInfo is missing', () => {
+    const vaults = [vault({ collateralType: CKBTC, collateralAmount: 0.1, borrowedIcusd: 0 })];
+    const result = aggregatePosition(vaults, []);
+    expect(result.perCollateral[0].symbol).toBe(CKBTC.slice(0, 5));
+  });
+});

--- a/src/vault_frontend/src/lib/components/layout/positionSummary.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.ts
@@ -1,0 +1,130 @@
+import type { VaultDTO, CollateralInfo } from '../../services/types';
+import { CANISTER_IDS } from '../../config';
+
+export type HealthTier = 'safe' | 'caution' | 'danger' | 'no-debt' | 'unknown';
+
+export interface AssetBreakdown {
+  principal: string;       // Ledger canister principal text
+  symbol: string;          // "ICP", "ckBTC", "ckXAUT"
+  nativeAmount: number;    // Sum of collateral across vaults of this type
+  usdValue: number;        // nativeAmount * priceUsd (0 if price unknown)
+  hasPrice: boolean;       // False if we had to treat this as $0 for totals
+}
+
+export interface PositionSummary {
+  totalCollateralUsd: number;
+  totalBorrowed: number;        // In icUSD (human-readable)
+  overallCr: number;            // Infinity when totalBorrowed === 0
+  healthTier: HealthTier;
+  perCollateral: AssetBreakdown[]; // Sorted by usdValue desc; zero-balance omitted
+  hasAnyMissingPrice: boolean;  // True if any collateral lacked a price
+}
+
+/**
+ * Resolve the collateral principal for a vault. Vaults created before the
+ * multi-collateral upgrade have an empty collateralType and should fall back
+ * to the ICP ledger.
+ */
+export function resolveCollateralPrincipal(vault: VaultDTO): string {
+  return vault.collateralType || CANISTER_IDS.ICP_LEDGER;
+}
+
+/**
+ * Return the vault's collateral amount in native units, preferring the
+ * multi-collateral field and falling back to the legacy icpMargin field.
+ */
+export function getCollateralAmount(vault: VaultDTO): number {
+  return vault.collateralAmount ?? vault.icpMargin ?? 0;
+}
+
+/**
+ * Look up collateral info by principal. Returns undefined if unknown.
+ */
+export function findCollateralInfo(
+  collaterals: CollateralInfo[],
+  principal: string,
+): CollateralInfo | undefined {
+  return collaterals.find(c => c.principal === principal);
+}
+
+/**
+ * Map a collateral ratio (as a ratio, e.g. 2.81 for 281%) to a health tier.
+ *   >= 2.0  -> safe
+ *   1.5..2  -> caution
+ *   < 1.5   -> danger
+ * Infinity (no debt) -> 'no-debt'. NaN -> 'unknown'.
+ *
+ * NOTE: This is an aggregate heuristic across all the user's vaults, not a
+ * per-vault liquidation signal. Individual vault liquidation prices are
+ * displayed on VaultCard.
+ */
+export function healthTierFor(cr: number): HealthTier {
+  if (!Number.isFinite(cr)) return cr === Infinity ? 'no-debt' : 'unknown';
+  if (cr >= 2.0) return 'safe';
+  if (cr >= 1.5) return 'caution';
+  return 'danger';
+}
+
+/**
+ * Aggregate a user's vaults into a single PositionSummary.
+ *
+ * Algorithm:
+ *  1. Group vaults by collateral principal.
+ *  2. For each group, sum native amounts and compute USD using the group's
+ *     price from CollateralInfo (or 0 if unknown). Track missing-price flag.
+ *  3. Totals = sum across groups (collateral USD) and across vaults (debt).
+ *  4. Overall CR = totalCollateralUsd / totalBorrowed (Infinity if no debt).
+ *  5. Emit per-collateral breakdown sorted by USD value desc, skipping
+ *     any group whose nativeAmount is 0.
+ */
+export function aggregatePosition(
+  vaults: VaultDTO[],
+  collaterals: CollateralInfo[],
+): PositionSummary {
+  // Group native amounts by principal.
+  const byPrincipal = new Map<string, number>();
+  let totalBorrowed = 0;
+
+  for (const v of vaults) {
+    const principal = resolveCollateralPrincipal(v);
+    const amount = getCollateralAmount(v);
+    byPrincipal.set(principal, (byPrincipal.get(principal) ?? 0) + amount);
+    totalBorrowed += v.borrowedIcusd || 0;
+  }
+
+  let totalCollateralUsd = 0;
+  let hasAnyMissingPrice = false;
+  const perCollateral: AssetBreakdown[] = [];
+
+  for (const [principal, nativeAmount] of byPrincipal) {
+    if (nativeAmount === 0) continue;
+    const info = findCollateralInfo(collaterals, principal);
+    const price = info?.price ?? 0;
+    const hasPrice = price > 0;
+    const usdValue = hasPrice ? nativeAmount * price : 0;
+    if (!hasPrice) hasAnyMissingPrice = true;
+    totalCollateralUsd += usdValue;
+    perCollateral.push({
+      principal,
+      symbol: info?.symbol ?? principal.slice(0, 5),
+      nativeAmount,
+      usdValue,
+      hasPrice,
+    });
+  }
+
+  perCollateral.sort((a, b) => b.usdValue - a.usdValue);
+
+  const overallCr = totalBorrowed > 0
+    ? totalCollateralUsd / totalBorrowed
+    : Infinity;
+
+  return {
+    totalCollateralUsd,
+    totalBorrowed,
+    overallCr,
+    healthTier: healthTierFor(overallCr),
+    perCollateral,
+    hasAnyMissingPrice,
+  };
+}

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { walletStore as wallet } from "../lib/stores/wallet";
   import { permissionStore } from "../lib/stores/permissionStore";
   import WalletConnector from "../lib/components/wallet/WalletConnector.svelte";
+  import PositionStrip from "../lib/components/layout/PositionStrip.svelte";
   import PriceDebug from "../lib/components/debug/PriceDebug.svelte";
   import WalletDebug from "../lib/components/debug/WalletDebug.svelte";
   import "../app.css";
@@ -76,6 +77,7 @@
     <WalletConnector />
   </div>
 </header>
+<PositionStrip />
 <ToastContainer />
 <main class="main-content"><slot /></main>
 <footer class="app-footer">
@@ -155,7 +157,7 @@
   .header-icon-link svg { width:0.875rem;height:0.875rem; }
 
   /* ── Main content ── */
-  .main-content { padding:4.75rem 2rem 2rem;min-height:100vh;position:relative;z-index:1;max-width:1200px;margin:0 auto; }
+  .main-content { padding:calc(4.75rem + var(--rumi-strip-height, 0px)) 2rem 2rem;min-height:100vh;position:relative;z-index:1;max-width:1200px;margin:0 auto; }
   .app-footer { padding:1.5rem 2rem;border-top:1px solid var(--rumi-border); }
   .footer-inner { max-width:1200px;margin:0 auto;display:flex;flex-direction:column;align-items:center;gap:0.75rem; }
   .footer-links { display:flex;flex-wrap:wrap;justify-content:center;gap:0.375rem 1.25rem; }
@@ -174,7 +176,7 @@
   .mob-item.active { color:var(--rumi-action); }
   @media (max-width:768px) {
     .top-nav{display:none}
-    .main-content{padding:4.25rem 1rem 5rem}
+    .main-content{padding:calc(4.25rem + var(--rumi-strip-height, 0px)) 1rem 5rem}
     .mobile-nav{display:flex}
     /* Social icons and beta chip duplicate footer content and crowd out the
        wallet button on narrow screens — hide them here. */

--- a/src/vault_frontend/src/tests/vitest-setup.ts
+++ b/src/vault_frontend/src/tests/vitest-setup.ts
@@ -1,0 +1,1 @@
+// Vitest setup file for vault_frontend tests

--- a/src/vault_frontend/vitest.config.ts
+++ b/src/vault_frontend/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
 
 export default defineConfig({
   plugins: [svelte({ hot: false })],
+  resolve: {
+    alias: {
+      '$declarations': path.resolve(__dirname, '../../declarations'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- Adds a persistent position strip mounted under the top bar on every authenticated page of vault_frontend, showing total collateral USD, total icUSD borrowed, and an aggregate CR color-coded by health tier.
- Expand/collapse reveals a per-collateral breakdown (one pill per collateral type with native amount and USD value), sorted by USD desc. State persists via `localStorage` under `rumi:positionStrip:expanded`.
- Hidden when disconnected; CTA variant when connected with zero vaults; skeleton while loading.

## Implementation notes
- Pure aggregation in `positionSummary.ts` (19 unit tests covering empty, single-vault, multi-collateral, missing-price, zero-balance, no-debt, legacy-fallback cases).
- Component is `position: fixed` at `top: 3.5rem` below the fixed top bar, writes its live `clientHeight` to `--rumi-strip-height` on `<html>`, and `.main-content` padding uses `calc(4.75rem + var(--rumi-strip-height, 0px))` to reserve space dynamically.
- Row content is flex-centered so the stats + caret read as one group beneath the centered nav block (earlier iteration stretched across 1200px which looked disconnected from the top bar).
- Test infra: added `jsdom` devDep + empty `vitest-setup.ts` (both referenced by existing `vitest.config.ts`) and a `\$declarations` alias for vitest to resolve imports reaching `src/lib/config.ts`.

## Test plan
- [x] 20/20 vitest tests pass (19 new + 1 pre-existing demo)
- [x] \`svelte-check\` introduces zero new errors
- [x] \`npm run build\` completes clean
- [x] Deployed to IC mainnet, verified visually in all rendered states
- [ ] Disconnect wallet → strip disappears, no reserved space
- [ ] Connect with vaults → collapsed strip, totals cross-check vs /vaults
- [ ] Expand → pills appear; reload → state persists
- [ ] Mobile viewport (≤768px) → compact layout, dividers hidden, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)