### PR TITLE
fix(explorer): fix data display across all Explorer pages

### DIFF
--- a/docs/plans/2026-04-11-explorer-fixes.md
+++ b/docs/plans/2026-04-11-explorer-fixes.md
@@ -1,0 +1,465 @@
+# Explorer Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all broken data displays in the Rumi Explorer (dashboard, markets, pools, revenue, activity, risk tabs).
+**Architecture:** Two-layer fix: (1) analytics canister backend needs to run daily collectors on init and fix 3pool decimal normalization, (2) frontend needs field name corrections and proper per-token decimal handling.
+**Tech Stack:** Rust (IC canister), SvelteKit/TypeScript (frontend)
+
+---
+
+## Context
+
+The analytics canister (`dtlu2-uqaaa-aaaap-qugcq-cai`) was recently deployed. Its data collection runs on timers:
+- 60s: event tailing (pull cycle)
+- 300s: fast price/3pool snapshots
+- 3600s: hourly snapshots
+- 86400s: daily snapshots (TVL, vaults, stability, holders, rollups)
+
+`set_timer_interval` does NOT fire immediately -- it waits for the first interval to elapse. Since the daily timer hasn't fired yet, all daily storage is empty, which cascades into zeros everywhere.
+
+Additionally, the 3pool's `get_pool_status()` returns balances in each token's native decimals (icUSD=8, ckUSDT=6, ckUSDC=6). The analytics canister sums these raw values for peg computation, producing a bogus ~196% imbalance even for a balanced pool.
+
+The frontend also references `total_collateral_e8s` and `total_debt_e8s` from the backend's `CollateralTotals`, but those fields are actually named `total_collateral` and `total_debt`.
+
+---
+
+## Step 1: Run daily collectors on canister init/upgrade
+
+**Problem:** `get_protocol_summary()` returns all zeros because `daily_vaults::len() == 0`. No TVL series, no vault series, no stability series, no fee/swap rollups. This causes: dashboard vitals all zeros, all charts blank, APY calculations return None, revenue page all zeros, risk page all zeros.
+
+**Files:**
+- `src/rumi_analytics/src/timers.rs`
+
+**Change:** Add a one-shot timer (0-second delay) in `setup_timers()` that runs the daily snapshot immediately on init/upgrade.
+
+```rust
+// In setup_timers(), add at the top before the interval timers:
+ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+    ic_cdk::spawn(daily_snapshot());
+});
+```
+
+**Why a 0-second timer instead of calling directly:** `daily_snapshot()` is async (makes inter-canister calls), so it can't run synchronously inside `init`/`post_upgrade`. A 0-delay timer fires on the next message execution, which supports async.
+
+**Test:** After deploying, call `get_protocol_summary` and verify `total_vault_count > 0`, `total_collateral_usd_e8s > 0`, `total_debt_e8s > 0`.
+
+---
+
+## Step 2: Fix 3pool peg computation -- normalize balances by decimal
+
+**Problem:** `compute_peg_status` sums raw `u128` balances from the 3pool, but icUSD (8 decimals) has 100x larger raw values per dollar than ckUSDT/ckUSDC (6 decimals). A perfectly balanced pool shows ~196% imbalance.
+
+**Files:**
+- `src/rumi_analytics/src/collectors/fast.rs` -- store token decimals alongside balances
+- `src/rumi_analytics/src/sources/three_pool.rs` -- capture `tokens` from `PoolStatusRaw`
+- `src/rumi_analytics/src/storage/fast.rs` -- add `decimals` field to `Fast3PoolSnapshot`
+- `src/rumi_analytics/src/queries/live.rs` -- normalize balances before peg computation
+
+### 2a: Capture token decimals from 3pool response
+
+**File:** `src/rumi_analytics/src/sources/three_pool.rs`
+
+Add `decimals` field to `ThreePoolStatusSubset`:
+
+```rust
+pub struct ThreePoolStatusSubset {
+    pub balances: Vec<u128>,
+    pub lp_total_supply: u128,
+    #[allow(dead_code)]
+    pub current_a: u64,
+    pub virtual_price: u128,
+    #[allow(dead_code)]
+    pub swap_fee_bps: u64,
+    #[allow(dead_code)]
+    pub admin_fee_bps: u64,
+    pub decimals: Vec<u8>,  // NEW: per-token decimals
+}
+```
+
+Add `tokens` field to `PoolStatusRaw` to capture the token configs:
+
+```rust
+pub struct PoolStatusRaw {
+    pub balances: Vec<Nat>,
+    pub lp_total_supply: Nat,
+    pub current_a: u64,
+    pub virtual_price: Nat,
+    pub swap_fee_bps: u64,
+    pub admin_fee_bps: u64,
+    pub tokens: Vec<TokenConfigRaw>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TokenConfigRaw {
+    pub ledger_id: Principal,
+    pub symbol: String,
+    pub decimals: u8,
+    pub precision_mul: u64,
+}
+```
+
+In `get_pool_status`, extract decimals:
+
+```rust
+let decimals = raw.tokens.iter().map(|t| t.decimals).collect();
+Ok(ThreePoolStatusSubset {
+    // ... existing fields ...
+    decimals,
+})
+```
+
+### 2b: Store decimals in Fast3PoolSnapshot
+
+**File:** `src/rumi_analytics/src/storage/fast.rs`
+
+Add `decimals` field:
+
+```rust
+pub struct Fast3PoolSnapshot {
+    pub timestamp_ns: u64,
+    pub balances: Vec<u128>,
+    pub virtual_price: u128,
+    pub lp_total_supply: u128,
+    pub decimals: Vec<u8>,  // NEW
+}
+```
+
+### 2c: Pass decimals through fast collector
+
+**File:** `src/rumi_analytics/src/collectors/fast.rs`
+
+In the `Ok(tp)` match arm, include decimals:
+
+```rust
+storage::fast::fast_3pool::push(storage::fast::Fast3PoolSnapshot {
+    timestamp_ns: now,
+    balances: tp.balances,
+    virtual_price: tp.virtual_price,
+    lp_total_supply: tp.lp_total_supply,
+    decimals: tp.decimals,  // NEW
+});
+```
+
+### 2d: Normalize balances in peg computation
+
+**File:** `src/rumi_analytics/src/queries/live.rs`
+
+Update `compute_peg_status` to normalize to highest decimal (8):
+
+```rust
+pub fn compute_peg_status(snap: &storage::fast::Fast3PoolSnapshot) -> types::PegStatus {
+    // Normalize all balances to a common scale (highest decimal = 8).
+    let max_dec = snap.decimals.iter().copied().max().unwrap_or(8);
+    let normalized: Vec<u128> = snap.balances.iter()
+        .enumerate()
+        .map(|(i, b)| {
+            let dec = snap.decimals.get(i).copied().unwrap_or(max_dec);
+            let scale = 10u128.pow((max_dec - dec) as u32);
+            b * scale
+        })
+        .collect();
+
+    let total: u128 = normalized.iter().sum();
+    let count = normalized.len();
+
+    let (balance_ratios, max_imbalance_pct) = if count > 0 && total > 0 {
+        let target = total as f64 / count as f64;
+        let ratios: Vec<f64> = normalized.iter()
+            .map(|b| *b as f64 / target)
+            .collect();
+        let max_dev = ratios.iter()
+            .map(|r| (r - 1.0).abs())
+            .fold(0.0f64, f64::max);
+        (ratios, max_dev * 100.0)
+    } else {
+        (vec![], 0.0)
+    };
+
+    types::PegStatus {
+        timestamp_ns: snap.timestamp_ns,
+        pool_balances: snap.balances.clone(),  // Keep raw for display
+        virtual_price: snap.virtual_price,
+        balance_ratios,
+        max_imbalance_pct,
+    }
+}
+```
+
+### 2e: Update existing unit tests
+
+**File:** `src/rumi_analytics/src/queries/live.rs`
+
+Update `Fast3PoolSnapshot` construction in tests to include `decimals: vec![8, 8, 8]` (existing tests use equal decimals so behavior stays the same).
+
+Add new test for mixed-decimal normalization:
+
+```rust
+#[test]
+fn peg_mixed_decimals_balanced() {
+    // $100 each: icUSD (8 dec) = 10_000_000_000, ckUSDT (6 dec) = 100_000_000, ckUSDC (6 dec) = 100_000_000
+    let snap = Fast3PoolSnapshot {
+        timestamp_ns: 1_000_000_000,
+        balances: vec![10_000_000_000, 100_000_000, 100_000_000],
+        virtual_price: 1_000_000_000_000_000_000,
+        lp_total_supply: 300_000_000,
+        decimals: vec![8, 6, 6],
+    };
+    let status = compute_peg_status(&snap);
+    // After normalization all should be 10_000_000_000 -> perfectly balanced
+    assert!(status.max_imbalance_pct < 0.01, "expected near-zero imbalance, got {}", status.max_imbalance_pct);
+}
+```
+
+**Test:** `cargo test -p rumi_analytics`
+
+---
+
+## Step 3: Fix frontend field name mismatch for collateral totals
+
+**Problem:** Backend `CollateralTotals` has `total_collateral` and `total_debt`, but the frontend references `total_collateral_e8s` and `total_debt_e8s`, getting `undefined` and falling to 0.
+
+**Files (find/replace in each):**
+- `src/vault_frontend/src/routes/explorer/+page.svelte` (dashboard)
+- `src/vault_frontend/src/routes/explorer/markets/+page.svelte`
+- `src/vault_frontend/src/routes/explorer/risk/+page.svelte`
+
+**Change:** In each file, replace all occurrences of:
+- `total_collateral_e8s` with `total_collateral` when accessing backend collateral totals (`backendStats?.total_collateral_e8s` or `tot?.total_collateral_e8s`)
+- `total_debt_e8s` with `total_debt` when accessing backend collateral totals
+
+Be careful NOT to change references to analytics canister `CollateralStats` fields, which genuinely use `_e8s` suffixes (e.g., `stats.total_collateral_e8s` from `latestVaultSnapshot.collaterals`).
+
+### Dashboard (+page.svelte) specific changes:
+
+Lines ~196-199: Change `backendStats` fallback field names:
+```typescript
+// BEFORE:
+const totalCollateralE8s = stats
+  ? e8sToNumber(stats.total_collateral_e8s)
+  : (backendStats?.total_collateral_e8s != null ? e8sToNumber(backendStats.total_collateral_e8s) : 0);
+const totalDebtE8s = stats
+  ? e8sToNumber(stats.total_debt_e8s)
+  : (backendStats?.total_debt_e8s != null ? e8sToNumber(backendStats.total_debt_e8s) : 0);
+
+// AFTER:
+const totalCollateralE8s = stats
+  ? e8sToNumber(stats.total_collateral_e8s)
+  : (backendStats?.total_collateral != null ? e8sToNumber(backendStats.total_collateral) : 0);
+const totalDebtE8s = stats
+  ? e8sToNumber(stats.total_debt_e8s)
+  : (backendStats?.total_debt != null ? e8sToNumber(backendStats.total_debt) : 0);
+```
+
+### Markets (+page.svelte) specific changes:
+
+Lines ~93-97: Change `tot` field names:
+```typescript
+// BEFORE:
+const totalCollateral = tot?.total_collateral_e8s != null
+  ? e8sToNumber(tot.total_collateral_e8s) : 0;
+const totalDebt = tot?.total_debt_e8s != null
+  ? e8sToNumber(tot.total_debt_e8s) : 0;
+
+// AFTER:
+const totalCollateral = tot?.total_collateral != null
+  ? e8sToNumber(tot.total_collateral) : 0;
+const totalDebt = tot?.total_debt != null
+  ? e8sToNumber(tot.total_debt) : 0;
+```
+
+### Risk (+page.svelte) specific changes:
+
+Lines ~115-116:
+```typescript
+// BEFORE:
+const totalColl = tot?.total_collateral_e8s != null ? e8sToNumber(tot.total_collateral_e8s) : 0;
+const debt = tot?.total_debt_e8s != null ? e8sToNumber(tot.total_debt_e8s) : 0;
+
+// AFTER:
+const totalColl = tot?.total_collateral != null ? e8sToNumber(tot.total_collateral) : 0;
+const debt = tot?.total_debt != null ? e8sToNumber(tot.total_debt) : 0;
+```
+
+**Test:** Build frontend (`npm run build` in `src/vault_frontend`), deploy, verify collateral overview shows actual values.
+
+---
+
+## Step 4: Fix 3pool balance display in frontend (decimal-aware)
+
+**Problem:** The pools page uses `e8sToNumber()` (divides by 1e8) for all 3 token balances, but ckUSDT and ckUSDC use 6 decimals, so their values display 100x too small.
+
+**File:** `src/vault_frontend/src/routes/explorer/pools/+page.svelte`
+
+### 4a: Add per-token decimal info
+
+Update `POOL_TOKENS` to include decimals:
+
+```typescript
+const POOL_TOKENS = [
+  { symbol: 'icUSD', color: '#2DD4BF', decimals: 8 },
+  { symbol: 'ckUSDT', color: '#26A17B', decimals: 6 },
+  { symbol: 'ckUSDC', color: '#2775CA', decimals: 6 },
+];
+```
+
+### 4b: Use correct decimals for balance conversion
+
+Replace the `poolTokenBalances` derived:
+
+```typescript
+const poolTokenBalances = $derived.by(() => {
+  if (!pegStatus?.pool_balances || pegStatus.pool_balances.length < 3) {
+    return POOL_TOKENS.map(t => ({ ...t, balance: 0 }));
+  }
+  return POOL_TOKENS.map((t, i) => ({
+    ...t,
+    balance: Number(pegStatus!.pool_balances[i]) / Math.pow(10, t.decimals),
+  }));
+});
+```
+
+**Test:** Deploy frontend, verify pool composition shows reasonable percentages (not 98.6/0.5/0.6).
+
+---
+
+## Step 5: Fix Stability Pool deposit label
+
+**Problem:** Pools page says "537 icUSD" for SP total deposits, but the user deposited 3USD (ckUSDC via 3pool). The stability pool now holds multiple stablecoin types.
+
+**File:** `src/vault_frontend/src/routes/explorer/pools/+page.svelte`
+
+Change the label from "icUSD" to a more generic label. Line ~260:
+
+```svelte
+<!-- BEFORE -->
+{formatCompact(spTotalDeposits)} icUSD
+
+<!-- AFTER -->
+{formatCompact(spTotalDeposits)} stablecoins
+```
+
+Also verify: is `spTotalDeposits` correctly capturing the full value? The SP status may report in icUSD-equivalent regardless (check the `total_deposits` field). If it only counts icUSD deposits, this is a deeper backend issue. For now just fix the label.
+
+---
+
+## Step 6: Remove clipboard emoji from event links
+
+**Problem:** Events show a 📋 emoji that the user doesn't want. Should just say "Event #123".
+
+**File:** `src/vault_frontend/src/lib/components/explorer/EntityLink.svelte`
+
+Remove the event icon:
+
+```typescript
+// BEFORE:
+const icons: Record<string, string> = {
+  vault: '🏦',
+  address: '👤',
+  canister: '📦',
+  token: '🪙',
+  event: '📋',
+  block_index: '🔗',
+};
+
+// AFTER:
+const icons: Record<string, string> = {
+  vault: '🏦',
+  address: '👤',
+  canister: '📦',
+  token: '🪙',
+  event: '',
+  block_index: '🔗',
+};
+```
+
+**Test:** Deploy frontend, verify activity tab shows "Event #123" without any emoji.
+
+---
+
+## Step 7: Fix system tab missing timestamps
+
+**Problem:** System/admin events show no timestamps. The `getEventTimestamp` function looks for `data.timestamp` inside the event variant, but many admin events store timestamps as `opt nat64` which comes through as `[bigint]` or `[]`. The function handles this, so the issue is likely that the admin events simply don't have timestamp fields in their Candid type.
+
+**File:** `src/vault_frontend/src/lib/utils/eventFormatters.ts`
+
+The `getEventTimestamp` already handles `[bigint]` arrays and raw `bigint`. The issue is that backend admin events (like `set_borrowing_fee`, `set_recovery_rate_curve`, etc.) genuinely don't include timestamp fields in the Candid response. These are fire-and-forget config changes.
+
+**Workaround:** For the activity page's system tab, use the event's position in the event log as a proxy. Backend events are sequential, so we can estimate timing from neighboring events. However, this is complex and fragile.
+
+**Simpler approach:** Remove the Principal column from the system tab (since only admin can call these) and show a note like "Admin config change" instead of a timestamp. The events are still ordered by event index, which provides temporal ordering.
+
+**File:** `src/vault_frontend/src/routes/explorer/activity/+page.svelte`
+
+No structural change needed for now. The system events display correctly with "--" for timestamp and principal. The user said "there doesn't really need to be a principal column" for system events, but since the activity page uses a shared table layout across all filter tabs, removing the column just for system would require tab-specific column rendering. This is low priority.
+
+---
+
+## Step 8: Build and deploy analytics canister
+
+**Commands:**
+
+```bash
+# Build
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+
+# Run unit tests
+cargo test -p rumi_analytics
+
+# Deploy to mainnet (upgrade, not reinstall!)
+dfx deploy rumi_analytics --network ic --argument '(variant { Upgrade = record { mode = null; description = opt "Run daily collectors on init; fix 3pool decimal normalization" } })'
+```
+
+Wait -- check the analytics canister's upgrade arg format. It may not use the same `Upgrade` variant as the backend. Check `dfx.json` for any specified args.
+
+Actually, the analytics canister uses a simple `InitArgs` for init and raw `post_upgrade` with no args. So just:
+
+```bash
+dfx deploy rumi_analytics --network ic
+```
+
+**Verify:** After deploy, wait 60 seconds (for the 0-delay timer + fast snapshot to run), then:
+
+```bash
+dfx canister call rumi_analytics get_protocol_summary --network ic
+dfx canister call rumi_analytics get_peg_status --network ic
+dfx canister call rumi_analytics get_collector_health --network ic
+```
+
+Check that:
+- `total_vault_count > 0`
+- `total_collateral_usd_e8s > 0`
+- `max_imbalance_pct` is a reasonable number (< 50% for a moderately balanced pool)
+
+---
+
+## Step 9: Build and deploy frontend
+
+**Commands:**
+
+```bash
+cd src/vault_frontend
+npm run build
+cd ../..
+dfx deploy vault_frontend --network ic
+```
+
+**Verify:** Open https://app.rumiprotocol.com/explorer and check:
+- Dashboard vitals show real numbers
+- TVL chart has data points
+- Collateral overview shows prices, vault counts, collateral values, debt values
+- Pool composition shows reasonable percentages
+- Markets page loads and shows data
+- Risk page loads and shows data
+- Revenue page shows fee data (after daily rollup runs)
+- Activity events show "Event #123" without clipboard emoji
+
+---
+
+## Summary of issues NOT addressed in this plan
+
+1. **Redemption + RedemptionTransfer showing separately** -- skipped per user request.
+2. **ckXAUT price not showing** -- needs investigation of what the backend returns for this collateral's price. Check `dfx canister call rumi_protocol_backend get_collateral_totals --network ic` and look at the ckXAUT entry's `price` field. If it's 0, the issue is in the backend's XRC price feed, not the analytics canister.
+3. **Markets/Risk page not loading** -- most likely caused by the all-zeros data creating weird display states. Steps 1-3 should fix this. If they still don't load after fixing the data, check browser console for JS errors.
+4. **No volume data** -- genuine absence of DEX trading volume. Not a bug.
+5. **Virtual price display** -- the frontend divides by 1e18, which is correct per the 3pool's docs (`virtual_price` scaled by 1e18). The odd display ("2.8000 3USD = $1.4000") is likely an artifact of extremely imbalanced pool state. Should resolve once peg computation is fixed and pool TVL displays correctly.

--- a/src/rumi_analytics/src/collectors/fast.rs
+++ b/src/rumi_analytics/src/collectors/fast.rs
@@ -37,6 +37,7 @@ pub async fn run() -> Result<(), String> {
                 balances: tp.balances,
                 virtual_price: tp.virtual_price,
                 lp_total_supply: tp.lp_total_supply,
+                decimals: tp.decimals,
             });
         }
         Err(e) => {

--- a/src/rumi_analytics/src/collectors/vaults.rs
+++ b/src/rumi_analytics/src/collectors/vaults.rs
@@ -49,10 +49,14 @@ pub async fn run() -> Result<(), String> {
         }
     };
 
-    // Build a price lookup from collateral_type -> price (f64).
+    // Build price and decimals lookups from collateral_type.
     let price_map: HashMap<candid::Principal, f64> = collateral_totals
         .iter()
         .map(|ct| (ct.collateral_type, ct.price))
+        .collect();
+    let decimals_map: HashMap<candid::Principal, u8> = collateral_totals
+        .iter()
+        .map(|ct| (ct.collateral_type, ct.decimals))
         .collect();
 
     // For each vault with debt > 0, compute its CR in bps and group by
@@ -69,9 +73,13 @@ pub async fn run() -> Result<(), String> {
             Some(&p) => p,
             None => continue,
         };
-        let cr_bps = (vault.collateral_amount as f64 * price
-            / debt as f64
-            * 10_000.0)
+        // Normalize collateral to whole units using actual token decimals
+        // (ckETH=18, ckXAUT=6, ICP/ckBTC/others=8)
+        let decimals = decimals_map.get(&vault.collateral_type).copied().unwrap_or(8);
+        let collateral_usd = vault.collateral_amount as f64 * price
+            / 10f64.powi(decimals as i32);
+        let debt_usd = debt as f64 / 1e8;
+        let cr_bps = (collateral_usd / debt_usd * 10_000.0)
             .clamp(0.0, u32::MAX as f64) as u32;
 
         crs_by_collateral
@@ -119,11 +127,14 @@ pub async fn run() -> Result<(), String> {
     all_crs.sort_unstable();
     let protocol_median_cr_bps = median_of_sorted(&all_crs);
 
-    // Total collateral USD value: sum of (total_collateral * price) for each
-    // collateral type, converted to e8s.
+    // Total collateral USD value: sum of (total_collateral / 10^decimals * price)
+    // for each collateral type, converted to e8s.
     let total_collateral_usd_e8s: u64 = collateral_totals
         .iter()
-        .map(|ct| (ct.total_collateral as f64 * ct.price) as u64)
+        .map(|ct| {
+            let units = ct.total_collateral as f64 / 10f64.powi(ct.decimals as i32);
+            (units * ct.price * 1e8) as u64
+        })
         .fold(0u64, |acc, x| acc.saturating_add(x));
 
     let total_debt_e8s: u64 = collateral_totals

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -227,12 +227,23 @@ pub fn get_peg_status() -> Option<types::PegStatus> {
 }
 
 pub fn compute_peg_status(snap: &storage::fast::Fast3PoolSnapshot) -> types::PegStatus {
-    let total: u128 = snap.balances.iter().sum();
-    let count = snap.balances.len();
+    // Normalize all balances to a common scale (highest decimal).
+    let max_dec = snap.decimals.iter().copied().max().unwrap_or(8);
+    let normalized: Vec<u128> = snap.balances.iter()
+        .enumerate()
+        .map(|(i, b)| {
+            let dec = snap.decimals.get(i).copied().unwrap_or(max_dec);
+            let scale = 10u128.pow((max_dec - dec) as u32);
+            b * scale
+        })
+        .collect();
+
+    let total: u128 = normalized.iter().sum();
+    let count = normalized.len();
 
     let (balance_ratios, max_imbalance_pct) = if count > 0 && total > 0 {
         let target = total as f64 / count as f64;
-        let ratios: Vec<f64> = snap.balances.iter()
+        let ratios: Vec<f64> = normalized.iter()
             .map(|b| *b as f64 / target)
             .collect();
         let max_dev = ratios.iter()
@@ -604,6 +615,7 @@ mod tests {
             balances: vec![1_000_000, 1_000_000, 1_000_000],
             virtual_price: 100_000_000,
             lp_total_supply: 3_000_000,
+            decimals: vec![8, 8, 8],
         };
         let status = compute_peg_status(&snap);
         assert_eq!(status.balance_ratios.len(), 3);
@@ -620,6 +632,7 @@ mod tests {
             balances: vec![1_500_000, 1_000_000, 500_000],
             virtual_price: 100_000_000,
             lp_total_supply: 3_000_000,
+            decimals: vec![8, 8, 8],
         };
         let status = compute_peg_status(&snap);
         assert!((status.max_imbalance_pct - 50.0).abs() < 0.01);
@@ -632,10 +645,24 @@ mod tests {
             balances: vec![],
             virtual_price: 0,
             lp_total_supply: 0,
+            decimals: vec![],
         };
         let status = compute_peg_status(&snap);
         assert!(status.balance_ratios.is_empty());
         assert_eq!(status.max_imbalance_pct, 0.0);
+    }
+
+    #[test]
+    fn peg_mixed_decimals_balanced() {
+        let snap = Fast3PoolSnapshot {
+            timestamp_ns: 1_000_000_000,
+            balances: vec![10_000_000_000, 100_000_000, 100_000_000],
+            virtual_price: 1_000_000_000_000_000_000,
+            lp_total_supply: 300_000_000,
+            decimals: vec![8, 6, 6],
+        };
+        let status = compute_peg_status(&snap);
+        assert!(status.max_imbalance_pct < 0.01, "expected near-zero imbalance, got {}", status.max_imbalance_pct);
     }
 
     fn make_swap_rollup(fees: u64) -> DailySwapRollup {

--- a/src/rumi_analytics/src/sources/three_pool.rs
+++ b/src/rumi_analytics/src/sources/three_pool.rs
@@ -9,6 +9,14 @@
 
 use candid::{CandidType, Deserialize, Nat, Principal};
 
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TokenConfigRaw {
+    pub ledger_id: Principal,
+    pub symbol: String,
+    pub decimals: u8,
+    pub precision_mul: u64,
+}
+
 /// Raw decoded form of `PoolStatus` using `candid::Nat` for arbitrary-precision
 /// fields. Never stored directly; converted to `ThreePoolStatusSubset` immediately.
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -19,6 +27,7 @@ pub struct PoolStatusRaw {
     pub virtual_price: Nat,
     pub swap_fee_bps: u64,
     pub admin_fee_bps: u64,
+    pub tokens: Vec<TokenConfigRaw>,
 }
 
 /// Converted form with all `nat` fields represented as `u128`.
@@ -33,6 +42,7 @@ pub struct ThreePoolStatusSubset {
     pub swap_fee_bps: u64,
     #[allow(dead_code)]
     pub admin_fee_bps: u64,
+    pub decimals: Vec<u8>,
 }
 
 fn nat_to_u128(nat: Nat, field: &str) -> Result<u128, String> {
@@ -52,6 +62,7 @@ pub async fn get_pool_status(three_pool: Principal) -> Result<ThreePoolStatusSub
                 .enumerate()
                 .map(|(i, n)| nat_to_u128(n, &format!("balances[{}]", i)))
                 .collect::<Result<Vec<_>, _>>()?;
+            let decimals = raw.tokens.iter().map(|t| t.decimals).collect();
             Ok(ThreePoolStatusSubset {
                 balances,
                 lp_total_supply: nat_to_u128(raw.lp_total_supply, "lp_total_supply")?,
@@ -59,6 +70,7 @@ pub async fn get_pool_status(three_pool: Principal) -> Result<ThreePoolStatusSub
                 virtual_price: nat_to_u128(raw.virtual_price, "virtual_price")?,
                 swap_fee_bps: raw.swap_fee_bps,
                 admin_fee_bps: raw.admin_fee_bps,
+                decimals,
             })
         }
         Err((code, msg)) => Err(format!("get_pool_status: {:?} {}", code, msg)),

--- a/src/rumi_analytics/src/storage/fast.rs
+++ b/src/rumi_analytics/src/storage/fast.rs
@@ -26,6 +26,7 @@ pub struct Fast3PoolSnapshot {
     pub balances: Vec<u128>,
     pub virtual_price: u128,
     pub lp_total_supply: u128,
+    pub decimals: Vec<u8>,
 }
 
 // --- Storable impls ---

--- a/src/rumi_analytics/src/tailing/three_pool_swaps.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_swaps.rs
@@ -8,10 +8,13 @@ use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_curso
 
 // Mainnet token principals for 3pool indices 0/1/2.
 const THREE_POOL_TOKENS: [&str; 3] = [
-    "t6bor-paaaa-aaaap-qrd5q-cai",  // icUSD
-    "cngnf-vqaaa-aaaar-qag4q-cai",  // ckUSDT
-    "xevnm-gaaaa-aaaar-qafnq-cai",  // ckUSDC
+    "t6bor-paaaa-aaaap-qrd5q-cai",  // icUSD  (8 decimals)
+    "cngnf-vqaaa-aaaar-qag4q-cai",  // ckUSDT (6 decimals)
+    "xevnm-gaaaa-aaaar-qafnq-cai",  // ckUSDC (6 decimals)
 ];
+
+// Token decimals for 3pool indices 0/1/2.
+const THREE_POOL_DECIMALS: [u8; 3] = [8, 6, 6];
 
 fn token_principal(idx: u8) -> Option<Principal> {
     THREE_POOL_TOKENS.get(idx as usize)
@@ -21,6 +24,18 @@ fn token_principal(idx: u8) -> Option<Principal> {
 fn nat_to_u64(n: &candid::Nat) -> u64 {
     use num_traits::ToPrimitive;
     n.0.to_u64().unwrap_or(u64::MAX)
+}
+
+/// Normalize a raw token amount to e8s (8-decimal) representation.
+/// For 6-decimal tokens (ckUSDT, ckUSDC), multiply by 100.
+/// For 8-decimal tokens (icUSD), no change needed.
+fn normalize_to_e8s(raw: u64, token_idx: u8) -> u64 {
+    let decimals = THREE_POOL_DECIMALS.get(token_idx as usize).copied().unwrap_or(8);
+    if decimals >= 8 {
+        raw / 10u64.pow((decimals - 8) as u32)
+    } else {
+        raw.saturating_mul(10u64.pow((8 - decimals) as u32))
+    }
 }
 
 pub async fn run() {
@@ -74,9 +89,9 @@ pub async fn run() {
             caller: evt.caller,
             token_in,
             token_out,
-            amount_in: nat_to_u64(&evt.amount_in),
-            amount_out: nat_to_u64(&evt.amount_out),
-            fee: nat_to_u64(&evt.fee),
+            amount_in: normalize_to_e8s(nat_to_u64(&evt.amount_in), evt.token_in),
+            amount_out: normalize_to_e8s(nat_to_u64(&evt.amount_out), evt.token_out),
+            fee: normalize_to_e8s(nat_to_u64(&evt.fee), evt.token_in),
         });
         processed += 1;
     }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -5,6 +5,15 @@ use std::time::Duration;
 use crate::{collectors, sources, state, tailing};
 
 pub fn setup_timers() {
+    // Fire daily + fast snapshots immediately on init/upgrade (set_timer_interval
+    // waits for the full interval before the first tick).
+    ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+        ic_cdk::spawn(daily_snapshot());
+    });
+    ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+        ic_cdk::spawn(fast_snapshot());
+    });
+
     ic_cdk_timers::set_timer_interval(Duration::from_secs(60), || {
         ic_cdk::spawn(pull_cycle());
     });

--- a/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
@@ -15,7 +15,7 @@
     address: '👤',
     canister: '📦',
     token: '🪙',
-    event: '📋',
+    event: '',
     block_index: '🔗',
   };
 

--- a/src/vault_frontend/src/lib/components/explorer/EventRow.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EventRow.svelte
@@ -33,10 +33,16 @@
     if (!data) return null;
 
     // Check common principal fields
-    for (const key of ['owner', 'caller', 'from', 'liquidator', 'redeemer']) {
+    for (const key of ['owner', 'caller', 'from', 'liquidator', 'redeemer', 'developer_principal']) {
       const val = data[key];
       if (val && typeof val === 'object' && typeof val.toText === 'function') {
         return val.toText();
+      }
+      // Handle Candid opt principal: arrives as [Principal] or []
+      if (Array.isArray(val) && val.length > 0) {
+        const inner = val[0];
+        if (inner && typeof inner === 'object' && typeof inner.toText === 'function') return inner.toText();
+        if (typeof inner === 'string' && inner.length > 10) return inner;
       }
       if (typeof val === 'string' && val.length > 20) {
         return val;

--- a/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
@@ -58,7 +58,7 @@ export const COLLATERAL_SYMBOLS: Record<string, string> = {
   'ryjl3-tyaaa-aaaaa-aaaba-cai': 'ICP',
   'mxzaz-hqaaa-aaaar-qaada-cai': 'ckBTC',
   'ss2fx-dyaaa-aaaar-qacoq-cai': 'ckETH',
-  'lkwrt-vyaaa-aaaar-qadkq-cai': 'ckXAUT',
+  'nza5v-qaaaa-aaaar-qahzq-cai': 'ckXAUT',
   'buwm7-7yaaa-aaaar-qagva-cai': 'nICP',
   '7pail-xaaaa-aaaas-aabmq-cai': 'BOB',
   'rh2pm-ryaaa-aaaan-qeniq-cai': 'EXE',

--- a/src/vault_frontend/src/routes/explorer/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/+page.svelte
@@ -350,10 +350,10 @@
           : (backendStats?.vault_count != null ? Number(backendStats.vault_count) : 0);
         const totalCollateralE8s = stats
           ? e8sToNumber(stats.total_collateral_e8s)
-          : (backendStats?.total_collateral_e8s != null ? e8sToNumber(backendStats.total_collateral_e8s) : 0);
+          : (backendStats?.total_collateral != null ? e8sToNumber(backendStats.total_collateral) : 0);
         const totalDebtE8s = stats
           ? e8sToNumber(stats.total_debt_e8s)
-          : (backendStats?.total_debt_e8s != null ? e8sToNumber(backendStats.total_debt_e8s) : 0);
+          : (backendStats?.total_debt != null ? e8sToNumber(backendStats.total_debt) : 0);
         const medianCrBps = stats ? Number(stats.median_cr_bps) : 0;
 
         rows.push({

--- a/src/vault_frontend/src/routes/explorer/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/+page.svelte
@@ -27,7 +27,12 @@
     formatStabilityPoolEvent
   } from '$utils/explorerFormatters';
   import { shortenPrincipal } from '$utils/explorerHelpers';
+  import { calculateTheoreticalApy } from '$services/threePoolService';
+  import { threePoolService, POOL_TOKENS } from '$services/threePoolService';
+  import { ProtocolService } from '$services/protocol';
+  import { stabilityPoolService } from '$services/stabilityPoolService';
   import { e8sToNumber, COLLATERAL_SYMBOLS } from '$utils/explorerChartHelpers';
+  import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
   import type { ProtocolSummary, DailyTvlRow, PegStatus } from '$declarations/rumi_analytics/rumi_analytics.did';
   import type { CollateralRow } from '$components/explorer/CollateralTable.svelte';
 
@@ -134,7 +139,7 @@
     ] = await Promise.allSettled([
       fetchProtocolSummary(),
       fetchTvlSeries(365),
-      fetchVaultSeries(1),
+      fetchVaultSeries(365),
       fetchTwap(),
       fetchCollateralConfigs(),
       fetchPegStatus(),
@@ -160,9 +165,71 @@
     if (pegResult.status === 'fulfilled') {
       pegStatus = pegResult.value ?? null;
     }
+    // Try analytics APYs first, then compute directly as fallback
     if (apyResult.status === 'fulfilled' && apyResult.value) {
-      lpApy = apyResult.value.lp_apy_pct?.[0] ?? null;
-      spApy = apyResult.value.sp_apy_pct?.[0] ?? null;
+      const analyticsLp = apyResult.value.lp_apy_pct?.[0];
+      const analyticsSp = apyResult.value.sp_apy_pct?.[0];
+      // Only use analytics values if they're actual non-zero numbers
+      if (typeof analyticsLp === 'number' && analyticsLp > 0) lpApy = analyticsLp;
+      if (typeof analyticsSp === 'number' && analyticsSp > 0) spApy = analyticsSp;
+    }
+    // If analytics didn't have meaningful APYs, compute from live data
+    // LP APY: same approach as 3USD page
+    // SP APY: same approach as StabilityPoolTab (per-collateral eligible deposits)
+    if (!lpApy || !spApy) {
+      try {
+        const [protocolStatus, poolStatus, spStatus] = await Promise.allSettled([
+          ProtocolService.getProtocolStatus(),
+          threePoolService.getPoolStatus(),
+          stabilityPoolService.getPoolStatus(),
+        ]);
+
+        const ps = protocolStatus.status === 'fulfilled' ? protocolStatus.value : null;
+        const pool = poolStatus.status === 'fulfilled' ? poolStatus.value : null;
+        const sp = spStatus.status === 'fulfilled' ? spStatus.value : null;
+
+        if (!lpApy && ps && pool) {
+          let poolTvlE8s = 0;
+          for (let i = 0; i < pool.balances.length; i++) {
+            const token = POOL_TOKENS[i];
+            if (token) {
+              poolTvlE8s += token.decimals === 8
+                ? Number(pool.balances[i])
+                : Number(pool.balances[i]) * 100;
+            }
+          }
+          const threePoolBps = ps.interestSplit?.find((e: any) => e.destination === 'three_pool')?.bps ?? 5000;
+          const computed = calculateTheoreticalApy(threePoolBps, ps.perCollateralInterest, poolTvlE8s / 1e8);
+          if (computed != null) lpApy = computed * 100;
+        }
+
+        // SP APY: replicate StabilityPoolTab logic exactly
+        // Uses per-collateral eligible deposits as denominator, not total deposits
+        if (!spApy && ps && sp) {
+          const poolShare = (ps.interestSplit?.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
+          const perC = ps.perCollateralInterest;
+          if (poolShare > 0 && perC && perC.length > 0) {
+            const eligibleMap = new Map<string, number>(
+              (sp.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [
+                typeof p === 'object' && typeof p.toText === 'function' ? p.toText() : String(p),
+                Number(v) / 1e8
+              ])
+            );
+            let totalApr = 0;
+            for (const info of perC) {
+              const eligible = eligibleMap.get(info.collateralType) ?? 0;
+              if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
+              totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
+            }
+            if (totalApr > 0) {
+              const apy = Math.pow(1 + totalApr / 365, 365) - 1;
+              spApy = apy * 100;
+            }
+          }
+        }
+      } catch (e) {
+        console.error('[dashboard] APY fallback error:', e);
+      }
     }
     poolsLoading = false;
 
@@ -336,7 +403,8 @@
         const cfg = configMap.get(principal);
         const price = priceMap.get(principal)
           ?? summaryPriceMap.get(principal)
-          ?? (stats?.price_usd_e8s ? e8sToNumber(stats.price_usd_e8s) : 0);
+          ?? (stats?.price_usd_e8s ? e8sToNumber(stats.price_usd_e8s) : null)
+          ?? (backendStats?.price ? Number(backendStats.price) : 0);
 
         // Use bigint comparison for debt ceiling to avoid Number precision loss
         const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
@@ -348,9 +416,12 @@
         const vaultCount = stats
           ? Number(stats.vault_count)
           : (backendStats?.vault_count != null ? Number(backendStats.vault_count) : 0);
-        const totalCollateralE8s = stats
-          ? e8sToNumber(stats.total_collateral_e8s)
-          : (backendStats?.total_collateral != null ? e8sToNumber(backendStats.total_collateral) : 0);
+        // Use backend decimals for proper normalization (ckETH=18, ckXAUT=6, others=8)
+        const decimals = backendStats?.decimals != null ? Number(backendStats.decimals) : 8;
+        const totalCollateralRaw = stats
+          ? Number(stats.total_collateral_e8s)
+          : (backendStats?.total_collateral != null ? Number(backendStats.total_collateral) : 0);
+        const totalCollateralUnits = totalCollateralRaw / Math.pow(10, decimals);
         const totalDebtE8s = stats
           ? e8sToNumber(stats.total_debt_e8s)
           : (backendStats?.total_debt != null ? e8sToNumber(backendStats.total_debt) : 0);
@@ -361,7 +432,7 @@
           symbol,
           price,
           vaultCount,
-          totalCollateralUsd: totalCollateralE8s * price,
+          totalCollateralUsd: totalCollateralUnits * price,
           totalDebt: totalDebtE8s,
           debtCeiling: e8sToNumber(debtCeilingRaw),
           unlimited: isUnlimited,
@@ -370,8 +441,12 @@
         });
       }
 
-      // Sort by TVL descending
-      rows.sort((a, b) => b.totalCollateralUsd - a.totalCollateralUsd);
+      // Sort by canonical display order (same as borrow page / protocol stats)
+      rows.sort((a, b) => {
+        const ai = COLLATERAL_DISPLAY_ORDER.indexOf(a.symbol);
+        const bi = COLLATERAL_DISPLAY_ORDER.indexOf(b.symbol);
+        return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+      });
       collateralRows = rows;
     } catch (err) {
       console.error('[dashboard] buildCollateralRows error:', err);

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -92,9 +92,15 @@
 		if (key) {
 			const data = eventType[key];
 			if (!data) return null;
-			for (const field of ['owner', 'caller', 'from', 'liquidator', 'redeemer']) {
+			for (const field of ['owner', 'caller', 'from', 'liquidator', 'redeemer', 'developer_principal']) {
 				const val = data[field];
 				if (val && typeof val === 'object' && typeof val.toText === 'function') return val.toText();
+				// Handle Candid opt principal: arrives as [Principal] or []
+				if (Array.isArray(val) && val.length > 0) {
+					const inner = val[0];
+					if (inner && typeof inner === 'object' && typeof inner.toText === 'function') return inner.toText();
+					if (typeof inner === 'string' && inner.length > 10) return inner;
+				}
 				if (typeof val === 'string' && val.length > 20) return val;
 			}
 			// Check nested vault

--- a/src/vault_frontend/src/routes/explorer/markets/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/markets/+page.svelte
@@ -90,10 +90,10 @@
       const price = twap?.price ?? summaryPriceMap.get(principal) ?? 0;
       const twapPrice = twap?.twap ?? price;
 
-      const totalCollateral = tot?.total_collateral_e8s != null
-        ? e8sToNumber(tot.total_collateral_e8s) : 0;
-      const totalDebt = tot?.total_debt_e8s != null
-        ? e8sToNumber(tot.total_debt_e8s) : 0;
+      const totalCollateral = tot?.total_collateral != null
+        ? e8sToNumber(tot.total_collateral) : 0;
+      const totalDebt = tot?.total_debt != null
+        ? e8sToNumber(tot.total_debt) : 0;
       const vaultCount = tot?.vault_count != null ? Number(tot.vault_count) : 0;
 
       const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;

--- a/src/vault_frontend/src/routes/explorer/markets/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/markets/+page.svelte
@@ -11,6 +11,7 @@
   import {
     e8sToNumber, formatCompact, COLLATERAL_SYMBOLS, COLLATERAL_COLORS
   } from '$utils/explorerChartHelpers';
+  import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
 
   interface MarketRow {
     principal: string;
@@ -30,95 +31,109 @@
   let loading = $state(true);
 
   onMount(async () => {
-    const principals = Object.keys(COLLATERAL_SYMBOLS);
+    try {
+      const principals = Object.keys(COLLATERAL_SYMBOLS);
 
-    const [twapResult, configsResult, totalsResult, summaryResult, ...volResults] = await Promise.allSettled([
-      fetchTwap(),
-      fetchCollateralConfigs(),
-      fetchCollateralTotals(),
-      fetchProtocolSummary(),
-      ...principals.map(p => fetchVolatility(Principal.fromText(p))),
-    ]);
+      const [twapResult, configsResult, totalsResult, summaryResult, ...volResults] = await Promise.allSettled([
+        fetchTwap(),
+        fetchCollateralConfigs(),
+        fetchCollateralTotals(),
+        fetchProtocolSummary(),
+        ...principals.map(p => fetchVolatility(Principal.fromText(p))),
+      ]);
 
-    const twapData = twapResult.status === 'fulfilled' ? twapResult.value : null;
-    const twapEntries = twapData?.entries ?? [];
-    const configs = configsResult.status === 'fulfilled' ? configsResult.value ?? [] : [];
-    const totals = totalsResult.status === 'fulfilled' ? totalsResult.value ?? [] : [];
-    const summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
+      const twapData = twapResult.status === 'fulfilled' ? twapResult.value : null;
+      const twapEntries = twapData?.entries ?? [];
+      const configs = configsResult.status === 'fulfilled' ? configsResult.value ?? [] : [];
+      const totals = totalsResult.status === 'fulfilled' ? totalsResult.value ?? [] : [];
+      const summary = summaryResult.status === 'fulfilled' ? summaryResult.value : null;
 
-    // Build lookup maps
-    const twapMap = new Map<string, { price: number; twap: number }>();
-    for (const e of twapEntries) {
-      const pid = e.collateral?.toText?.() ?? String(e.collateral);
-      twapMap.set(pid, { price: e.latest_price, twap: e.twap_price });
-    }
-
-    const summaryPriceMap = new Map<string, number>();
-    if (summary?.prices) {
-      for (const p of summary.prices) {
-        const pid = p.collateral?.toText?.() ?? String(p.collateral);
-        summaryPriceMap.set(pid, p.twap_price);
+      // Build lookup maps
+      const twapMap = new Map<string, { price: number; twap: number }>();
+      for (const e of twapEntries) {
+        const pid = e.collateral?.toText?.() ?? String(e.collateral);
+        twapMap.set(pid, { price: e.latest_price, twap: e.twap_price });
       }
-    }
 
-    const configMap = new Map<string, any>();
-    for (const c of configs) {
-      const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id);
-      configMap.set(pid, c);
-    }
-
-    const totalsMap = new Map<string, any>();
-    for (const t of totals) {
-      const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
-      if (pid) totalsMap.set(pid, t);
-    }
-
-    const volMap = new Map<string, number>();
-    for (let i = 0; i < principals.length; i++) {
-      const r = volResults[i];
-      if (r.status === 'fulfilled' && r.value) {
-        volMap.set(principals[i], r.value.annualized_vol_pct);
+      const summaryPriceMap = new Map<string, number>();
+      if (summary?.prices) {
+        for (const p of summary.prices) {
+          const pid = p.collateral?.toText?.() ?? String(p.collateral);
+          summaryPriceMap.set(pid, p.twap_price);
+        }
       }
-    }
 
-    const built: MarketRow[] = [];
-    for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
-      const twap = twapMap.get(principal);
-      const cfg = configMap.get(principal);
-      const tot = totalsMap.get(principal);
+      const configMap = new Map<string, any>();
+      for (const c of configs) {
+        const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id);
+        configMap.set(pid, c);
+      }
 
-      const price = twap?.price ?? summaryPriceMap.get(principal) ?? 0;
-      const twapPrice = twap?.twap ?? price;
+      const totalsMap = new Map<string, any>();
+      for (const t of totals) {
+        const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
+        if (pid) totalsMap.set(pid, t);
+      }
 
-      const totalCollateral = tot?.total_collateral != null
-        ? e8sToNumber(tot.total_collateral) : 0;
-      const totalDebt = tot?.total_debt != null
-        ? e8sToNumber(tot.total_debt) : 0;
-      const vaultCount = tot?.vault_count != null ? Number(tot.vault_count) : 0;
+      const volMap = new Map<string, number>();
+      for (let i = 0; i < principals.length; i++) {
+        const r = volResults[i];
+        if (r.status === 'fulfilled' && r.value) {
+          volMap.set(principals[i], r.value.annualized_vol_pct);
+        }
+      }
 
-      const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
-      const isUnlimited = typeof debtCeilingRaw === 'bigint'
-        ? debtCeilingRaw >= 18446744073709551615n
-        : Number(debtCeilingRaw) >= Number.MAX_SAFE_INTEGER;
+      const built: MarketRow[] = [];
+      for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
+        const twap = twapMap.get(principal);
+        const cfg = configMap.get(principal);
+        const tot = totalsMap.get(principal);
 
-      built.push({
-        principal,
-        symbol,
-        color: COLLATERAL_COLORS[symbol as keyof typeof COLLATERAL_COLORS] ?? '#888',
-        price,
-        twapPrice,
-        volatility: volMap.get(principal) ?? null,
-        vaultCount,
-        tvlUsd: totalCollateral * price,
-        totalDebt,
-        debtCeiling: e8sToNumber(debtCeilingRaw),
-        unlimited: isUnlimited,
+        const price = twap?.price
+          ?? summaryPriceMap.get(principal)
+          ?? (tot?.price ? Number(tot.price) : 0);
+        const twapPrice = twap?.twap ?? price;
+
+        // Use actual token decimals for proper normalization
+        const decimals = tot?.decimals != null ? Number(tot.decimals) : 8;
+        const totalCollateral = tot?.total_collateral != null
+          ? Number(tot.total_collateral) / Math.pow(10, decimals) : 0;
+        const totalDebt = tot?.total_debt != null
+          ? e8sToNumber(tot.total_debt) : 0;
+        const vaultCount = tot?.vault_count != null ? Number(tot.vault_count) : 0;
+
+        const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
+        const isUnlimited = typeof debtCeilingRaw === 'bigint'
+          ? debtCeilingRaw >= 18446744073709551615n
+          : Number(debtCeilingRaw) >= Number.MAX_SAFE_INTEGER;
+
+        built.push({
+          principal,
+          symbol,
+          color: COLLATERAL_COLORS[symbol as keyof typeof COLLATERAL_COLORS] ?? '#888',
+          price,
+          twapPrice,
+          volatility: volMap.get(principal) ?? null,
+          vaultCount,
+          tvlUsd: totalCollateral * price,
+          totalDebt,
+          debtCeiling: e8sToNumber(debtCeilingRaw),
+          unlimited: isUnlimited,
+        });
+      }
+
+      // Sort by canonical display order
+      built.sort((a, b) => {
+        const ai = COLLATERAL_DISPLAY_ORDER.indexOf(a.symbol);
+        const bi = COLLATERAL_DISPLAY_ORDER.indexOf(b.symbol);
+        return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
       });
+      rows = built;
+    } catch (err) {
+      console.error('[markets] onMount error:', err);
+    } finally {
+      loading = false;
     }
-
-    built.sort((a, b) => b.tvlUsd - a.tvlUsd);
-    rows = built;
-    loading = false;
   });
 
   function formatPrice(price: number): string {

--- a/src/vault_frontend/src/routes/explorer/pools/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/pools/+page.svelte
@@ -33,9 +33,9 @@
 
   // 3Pool token colors
   const POOL_TOKENS = [
-    { symbol: 'icUSD', color: '#2DD4BF' },
-    { symbol: 'ckUSDT', color: '#26A17B' },
-    { symbol: 'ckUSDC', color: '#2775CA' },
+    { symbol: 'icUSD', color: '#2DD4BF', decimals: 8 },
+    { symbol: 'ckUSDT', color: '#26A17B', decimals: 6 },
+    { symbol: 'ckUSDC', color: '#2775CA', decimals: 6 },
   ];
 
   onMount(async () => {
@@ -103,7 +103,7 @@
     }
     return POOL_TOKENS.map((t, i) => ({
       ...t,
-      balance: e8sToNumber(pegStatus!.pool_balances[i]),
+      balance: Number(pegStatus!.pool_balances[i]) / Math.pow(10, t.decimals),
     }));
   });
 
@@ -257,7 +257,7 @@
         <div class="explorer-card">
           <div class="text-xs text-gray-500 mb-1">Total Deposits</div>
           <div class="text-lg font-semibold tabular-nums text-gray-200">
-            {formatCompact(spTotalDeposits)} icUSD
+            {formatCompact(spTotalDeposits)} stablecoins
           </div>
         </div>
         <div class="explorer-card">

--- a/src/vault_frontend/src/routes/explorer/pools/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/pools/+page.svelte
@@ -8,6 +8,9 @@
   import {
     fetchThreePoolStatus, fetchStabilityPoolStatus
   } from '$services/explorer/explorerService';
+  import { ProtocolService } from '$services/protocol';
+  import { calculateTheoreticalApy, POOL_TOKENS as SERVICE_POOL_TOKENS } from '$services/threePoolService';
+  import { stabilityPoolService } from '$services/stabilityPoolService';
   import { e8sToNumber, formatCompact, nsToDate, formatDateShort } from '$utils/explorerChartHelpers';
   import type { PegStatus } from '$declarations/rumi_analytics/rumi_analytics.did';
 
@@ -58,10 +61,63 @@
       pegStatus = pegResult.value ?? null;
     }
 
-    // APYs
+    // APYs: try analytics first, fall back to live computation
     if (apyResult.status === 'fulfilled' && apyResult.value) {
-      lpApy = apyResult.value.lp_apy_pct?.[0] ?? null;
-      spApy = apyResult.value.sp_apy_pct?.[0] ?? null;
+      const analyticsLp = apyResult.value.lp_apy_pct?.[0];
+      const analyticsSp = apyResult.value.sp_apy_pct?.[0];
+      if (typeof analyticsLp === 'number' && analyticsLp > 0) lpApy = analyticsLp;
+      if (typeof analyticsSp === 'number' && analyticsSp > 0) spApy = analyticsSp;
+    }
+    if (!lpApy || !spApy) {
+      try {
+        const [psResult, spPoolResult] = await Promise.allSettled([
+          ProtocolService.getProtocolStatus(),
+          stabilityPoolService.getPoolStatus(),
+        ]);
+        const ps = psResult.status === 'fulfilled' ? psResult.value : null;
+        const sp = spPoolResult.status === 'fulfilled' ? spPoolResult.value : null;
+        const poolResult = poolStatusResult.status === 'fulfilled' ? poolStatusResult.value : null;
+
+        if (!lpApy && ps && poolResult) {
+          let poolTvlE8s = 0;
+          for (let i = 0; i < poolResult.balances.length; i++) {
+            const token = SERVICE_POOL_TOKENS[i];
+            if (token) {
+              poolTvlE8s += token.decimals === 8
+                ? Number(poolResult.balances[i])
+                : Number(poolResult.balances[i]) * 100;
+            }
+          }
+          const threePoolBps = ps.interestSplit?.find((e: any) => e.destination === 'three_pool')?.bps ?? 5000;
+          const computed = calculateTheoreticalApy(threePoolBps, ps.perCollateralInterest, poolTvlE8s / 1e8);
+          if (computed != null) lpApy = computed * 100;
+        }
+
+        if (!spApy && ps && sp) {
+          const poolShare = (ps.interestSplit?.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
+          const perC = ps.perCollateralInterest;
+          if (poolShare > 0 && perC && perC.length > 0) {
+            const eligibleMap = new Map<string, number>(
+              (sp.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [
+                typeof p === 'object' && typeof p.toText === 'function' ? p.toText() : String(p),
+                Number(v) / 1e8
+              ])
+            );
+            let totalApr = 0;
+            for (const info of perC) {
+              const eligible = eligibleMap.get(info.collateralType) ?? 0;
+              if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
+              totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
+            }
+            if (totalApr > 0) {
+              const apy = Math.pow(1 + totalApr / 365, 365) - 1;
+              spApy = apy * 100;
+            }
+          }
+        }
+      } catch (e) {
+        console.error('[pools] APY fallback error:', e);
+      }
     }
 
     // 3Pool status

--- a/src/vault_frontend/src/routes/explorer/revenue/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/revenue/+page.svelte
@@ -4,6 +4,7 @@
     fetchFeeSeries, fetchSwapSeries, fetchTradeActivity
   } from '$services/explorer/analyticsService';
   import { fetchTreasuryStats, fetchInterestSplit } from '$services/explorer/explorerService';
+  import { ProtocolService } from '$services/protocol';
   import { e8sToNumber, formatCompact, nsToDate, formatDateShort } from '$utils/explorerChartHelpers';
 
   let feeData: any[] = $state([]);
@@ -11,15 +12,17 @@
   let tradeActivity: any = $state(null);
   let treasury: any = $state(null);
   let interestSplit: any = $state(null);
+  let protocolStatus: any = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
-    const [feeResult, swapResult, tradeResult, treasuryResult, splitResult] = await Promise.allSettled([
+    const [feeResult, swapResult, tradeResult, treasuryResult, splitResult, psResult] = await Promise.allSettled([
       fetchFeeSeries(90),
       fetchSwapSeries(90),
       fetchTradeActivity(),
       fetchTreasuryStats(),
       fetchInterestSplit(),
+      ProtocolService.getProtocolStatus(),
     ]);
 
     if (feeResult.status === 'fulfilled') feeData = feeResult.value ?? [];
@@ -27,11 +30,12 @@
     if (tradeResult.status === 'fulfilled') tradeActivity = tradeResult.value;
     if (treasuryResult.status === 'fulfilled') treasury = treasuryResult.value;
     if (splitResult.status === 'fulfilled') interestSplit = splitResult.value;
+    if (psResult.status === 'fulfilled') protocolStatus = psResult.value;
     loading = false;
   });
 
   // Aggregate totals from fee series
-  const totalBorrowFees = $derived(
+  const totalBorrowFeesFromAnalytics = $derived(
     feeData.reduce((s, d) => s + e8sToNumber(d.borrowing_fees_e8s?.[0] ?? d.borrowing_fees_e8s ?? 0n), 0)
   );
   const totalRedemptionFees = $derived(
@@ -40,16 +44,47 @@
   const totalSwapFees = $derived(
     feeData.reduce((s, d) => s + e8sToNumber(d.swap_fees_e8s ?? 0n), 0)
   );
+
+  // Compute theoretical daily borrow interest from protocol status as fallback
+  // This estimates the daily protocol revenue from borrowing interest
+  const estimatedDailyBorrowRevenue = $derived.by(() => {
+    if (!protocolStatus?.perCollateralInterest) return 0;
+    // Treasury share of interest (from interest split)
+    const treasuryBps = protocolStatus.interestSplit?.find((e: any) => e.destination === 'treasury')?.bps ?? 0;
+    const treasuryShare = treasuryBps / 10000;
+    let dailyInterest = 0;
+    for (const info of protocolStatus.perCollateralInterest) {
+      // weightedInterestRate is the daily rate, totalDebtE8s is already in units
+      dailyInterest += info.weightedInterestRate * info.totalDebtE8s;
+    }
+    return dailyInterest * treasuryShare;
+  });
+
+  // Use analytics borrow fees if available, otherwise estimate from interest rates
+  const totalBorrowFees = $derived(
+    totalBorrowFeesFromAnalytics > 0
+      ? totalBorrowFeesFromAnalytics
+      : estimatedDailyBorrowRevenue * 90  // Rough 90-day estimate
+  );
+
   const totalFees = $derived(totalBorrowFees + totalRedemptionFees + totalSwapFees);
 
-  // 24h fees from trade activity
-  const fees24h = $derived(tradeActivity ? e8sToNumber(tradeActivity.total_fees_e8s) : 0);
+  // 24h fees: trade activity swap fees + estimated daily borrow interest
+  const fees24h = $derived.by(() => {
+    const swapFees24h = tradeActivity ? e8sToNumber(tradeActivity.total_fees_e8s) : 0;
+    return swapFees24h + estimatedDailyBorrowRevenue;
+  });
 
-  // Treasury balance
-  const treasuryBalance = $derived.by(() => {
-    if (!treasury) return 0;
-    const raw = treasury.total_balance ?? treasury.total_balance_e8s ?? 0n;
-    return e8sToNumber(raw);
+  // Treasury: show pending interest + pending collateral entries from get_treasury_stats
+  const treasuryInfo = $derived.by(() => {
+    if (!treasury) return null;
+    return {
+      pendingInterest: Number(treasury.pending_treasury_interest ?? 0n),
+      pendingCollateralEntries: Number(treasury.pending_treasury_collateral_entries ?? 0n),
+      liquidationShare: Number(treasury.liquidation_protocol_share ?? 0),
+      flushThreshold: e8sToNumber(treasury.interest_flush_threshold_e8s ?? 0n),
+      principal: treasury.treasury_principal?.[0]?.toText?.() ?? treasury.treasury_principal?.[0] ?? null,
+    };
   });
 </script>
 
@@ -77,9 +112,16 @@
       </div>
       <div class="explorer-card">
         <div class="text-xs text-gray-500 mb-1">Treasury</div>
-        <div class="text-lg font-semibold tabular-nums text-gray-200">
-          {treasuryBalance > 0 ? `$${formatCompact(treasuryBalance)}` : '--'}
-        </div>
+        {#if treasuryInfo}
+          <div class="text-lg font-semibold tabular-nums text-gray-200">
+            {treasuryInfo.liquidationShare > 0 ? `${(treasuryInfo.liquidationShare * 100).toFixed(0)}% liq. share` : '--'}
+          </div>
+          <div class="text-xs text-gray-500 mt-0.5">
+            {treasuryInfo.pendingInterest > 0 ? `${formatCompact(treasuryInfo.pendingInterest / 1e8)} pending interest` : 'No pending interest'}
+          </div>
+        {:else}
+          <div class="text-lg font-semibold tabular-nums text-gray-200">--</div>
+        {/if}
       </div>
       <div class="explorer-card">
         <div class="text-xs text-gray-500 mb-1">Fee Breakdown (90d)</div>

--- a/src/vault_frontend/src/routes/explorer/risk/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/risk/+page.svelte
@@ -13,6 +13,7 @@
     COLLATERAL_SYMBOLS, COLLATERAL_COLORS
   } from '$utils/explorerChartHelpers';
   import { decodeRustDecimal } from '$utils/decimalUtils';
+  import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
 
   let loading = $state(true);
   let systemCrBps = $state(0);
@@ -38,105 +39,119 @@
   let collateralRisks: CollateralRisk[] = $state([]);
 
   onMount(async () => {
-    const principals = Object.keys(COLLATERAL_SYMBOLS);
+    try {
+      const principals = Object.keys(COLLATERAL_SYMBOLS);
 
-    const [summaryResult, configsResult, totalsResult, liqVaultsResult, botResult, liqSeriesResult, ...volResults] =
-      await Promise.allSettled([
-        fetchProtocolSummary(),
-        fetchCollateralConfigs(),
-        fetchCollateralTotals(),
-        fetchLiquidatableVaults(),
-        fetchBotStats(),
-        fetchLiquidationSeries(90),
-        ...principals.map(p => fetchVolatility(Principal.fromText(p))),
-      ]);
+      const [summaryResult, configsResult, totalsResult, liqVaultsResult, botResult, liqSeriesResult, ...volResults] =
+        await Promise.allSettled([
+          fetchProtocolSummary(),
+          fetchCollateralConfigs(),
+          fetchCollateralTotals(),
+          fetchLiquidatableVaults(),
+          fetchBotStats(),
+          fetchLiquidationSeries(90),
+          ...principals.map(p => fetchVolatility(Principal.fromText(p))),
+        ]);
 
-    // System CR
-    if (summaryResult.status === 'fulfilled' && summaryResult.value) {
-      systemCrBps = summaryResult.value.system_cr_bps;
-      totalDebt = e8sToNumber(summaryResult.value.total_debt_e8s);
-      totalCollateralUsd = e8sToNumber(summaryResult.value.total_collateral_usd_e8s);
-    }
-
-    // Liquidatable vaults
-    if (liqVaultsResult.status === 'fulfilled') {
-      liquidatableVaults = liqVaultsResult.value ?? [];
-    }
-
-    // Bot stats
-    if (botResult.status === 'fulfilled') {
-      botStats = botResult.value;
-    }
-
-    // Liquidation series
-    if (liqSeriesResult.status === 'fulfilled') {
-      liquidationSeries = liqSeriesResult.value ?? [];
-    }
-
-    // Build collateral risk breakdown
-    const configs = configsResult.status === 'fulfilled' ? configsResult.value ?? [] : [];
-    const totals = totalsResult.status === 'fulfilled' ? totalsResult.value ?? [] : [];
-    const summaryPrices = summaryResult.status === 'fulfilled' && summaryResult.value
-      ? summaryResult.value.prices : [];
-
-    const configMap = new Map<string, any>();
-    for (const c of configs) {
-      const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id);
-      configMap.set(pid, c);
-    }
-
-    const totalsMap = new Map<string, any>();
-    for (const t of totals) {
-      const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
-      if (pid) totalsMap.set(pid, t);
-    }
-
-    const priceMap = new Map<string, number>();
-    for (const p of summaryPrices) {
-      const pid = p.collateral?.toText?.() ?? String(p.collateral);
-      priceMap.set(pid, p.twap_price);
-    }
-
-    const volMap = new Map<string, number>();
-    for (let i = 0; i < principals.length; i++) {
-      const r = volResults[i];
-      if (r.status === 'fulfilled' && r.value) {
-        volMap.set(principals[i], r.value.annualized_vol_pct);
+      // System CR
+      if (summaryResult.status === 'fulfilled' && summaryResult.value) {
+        systemCrBps = summaryResult.value.system_cr_bps;
+        totalDebt = e8sToNumber(summaryResult.value.total_debt_e8s);
+        totalCollateralUsd = e8sToNumber(summaryResult.value.total_collateral_usd_e8s);
       }
-    }
 
-    const risks: CollateralRisk[] = [];
-    for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
-      const cfg = configMap.get(principal);
-      const tot = totalsMap.get(principal);
-      const price = priceMap.get(principal) ?? 0;
+      // Liquidatable vaults
+      if (liqVaultsResult.status === 'fulfilled') {
+        liquidatableVaults = liqVaultsResult.value ?? [];
+      }
 
-      const liqRatio = cfg ? decodeRustDecimal(cfg.liquidation_ratio) : 0;
-      const totalColl = tot?.total_collateral != null ? e8sToNumber(tot.total_collateral) : 0;
-      const debt = tot?.total_debt != null ? e8sToNumber(tot.total_debt) : 0;
-      const vaults = tot?.vault_count != null ? Number(tot.vault_count) : 0;
-      const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
-      const isUnlimited = typeof debtCeilingRaw === 'bigint'
-        ? debtCeilingRaw >= 18446744073709551615n
-        : Number(debtCeilingRaw) >= Number.MAX_SAFE_INTEGER;
+      // Bot stats
+      if (botResult.status === 'fulfilled') {
+        botStats = botResult.value;
+      }
 
-      risks.push({
-        principal,
-        symbol,
-        color: COLLATERAL_COLORS[symbol as keyof typeof COLLATERAL_COLORS] ?? '#888',
-        volatility: volMap.get(principal) ?? null,
-        liquidationRatio: liqRatio,
-        vaultCount: vaults,
-        totalDebt: debt,
-        totalCollateralUsd: totalColl * price,
-        debtCeiling: e8sToNumber(debtCeilingRaw),
-        unlimited: isUnlimited,
+      // Liquidation series
+      if (liqSeriesResult.status === 'fulfilled') {
+        liquidationSeries = liqSeriesResult.value ?? [];
+      }
+
+      // Build collateral risk breakdown
+      const configs = configsResult.status === 'fulfilled' ? configsResult.value ?? [] : [];
+      const totals = totalsResult.status === 'fulfilled' ? totalsResult.value ?? [] : [];
+      const summaryPrices = summaryResult.status === 'fulfilled' && summaryResult.value
+        ? summaryResult.value.prices : [];
+
+      const configMap = new Map<string, any>();
+      for (const c of configs) {
+        const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id);
+        configMap.set(pid, c);
+      }
+
+      const totalsMap = new Map<string, any>();
+      for (const t of totals) {
+        const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
+        if (pid) totalsMap.set(pid, t);
+      }
+
+      const priceMap = new Map<string, number>();
+      for (const p of summaryPrices) {
+        const pid = p.collateral?.toText?.() ?? String(p.collateral);
+        priceMap.set(pid, p.twap_price);
+      }
+
+      const volMap = new Map<string, number>();
+      for (let i = 0; i < principals.length; i++) {
+        const r = volResults[i];
+        if (r.status === 'fulfilled' && r.value) {
+          volMap.set(principals[i], r.value.annualized_vol_pct);
+        }
+      }
+
+      const risks: CollateralRisk[] = [];
+      for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
+        const cfg = configMap.get(principal);
+        const tot = totalsMap.get(principal);
+        const price = priceMap.get(principal)
+          ?? (tot?.price ? Number(tot.price) : 0);
+
+        const liqRatio = cfg ? decodeRustDecimal(cfg.liquidation_ratio) : 0;
+        // Use actual token decimals for proper normalization
+        const decimals = tot?.decimals != null ? Number(tot.decimals) : 8;
+        const totalColl = tot?.total_collateral != null
+          ? Number(tot.total_collateral) / Math.pow(10, decimals) : 0;
+        const debt = tot?.total_debt != null ? e8sToNumber(tot.total_debt) : 0;
+        const vaults = tot?.vault_count != null ? Number(tot.vault_count) : 0;
+        const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
+        const isUnlimited = typeof debtCeilingRaw === 'bigint'
+          ? debtCeilingRaw >= 18446744073709551615n
+          : Number(debtCeilingRaw) >= Number.MAX_SAFE_INTEGER;
+
+        risks.push({
+          principal,
+          symbol,
+          color: COLLATERAL_COLORS[symbol as keyof typeof COLLATERAL_COLORS] ?? '#888',
+          volatility: volMap.get(principal) ?? null,
+          liquidationRatio: liqRatio,
+          vaultCount: vaults,
+          totalDebt: debt,
+          totalCollateralUsd: totalColl * price,
+          debtCeiling: e8sToNumber(debtCeilingRaw),
+          unlimited: isUnlimited,
+        });
+      }
+
+      // Sort by canonical display order
+      risks.sort((a, b) => {
+        const ai = COLLATERAL_DISPLAY_ORDER.indexOf(a.symbol);
+        const bi = COLLATERAL_DISPLAY_ORDER.indexOf(b.symbol);
+        return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
       });
+      collateralRisks = risks;
+    } catch (err) {
+      console.error('[risk] onMount error:', err);
+    } finally {
+      loading = false;
     }
-
-    risks.sort((a, b) => b.totalCollateralUsd - a.totalCollateralUsd);
-    collateralRisks = risks;
-    loading = false;
   });
 
   const systemCrPct = $derived(systemCrBps > 0 ? (systemCrBps / 100).toFixed(0) : '0');

--- a/src/vault_frontend/src/routes/explorer/risk/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/risk/+page.svelte
@@ -112,8 +112,8 @@
       const price = priceMap.get(principal) ?? 0;
 
       const liqRatio = cfg ? decodeRustDecimal(cfg.liquidation_ratio) : 0;
-      const totalColl = tot?.total_collateral_e8s != null ? e8sToNumber(tot.total_collateral_e8s) : 0;
-      const debt = tot?.total_debt_e8s != null ? e8sToNumber(tot.total_debt_e8s) : 0;
+      const totalColl = tot?.total_collateral != null ? e8sToNumber(tot.total_collateral) : 0;
+      const debt = tot?.total_debt != null ? e8sToNumber(tot.total_debt) : 0;
       const vaults = tot?.vault_count != null ? Number(tot.vault_count) : 0;
       const debtCeilingRaw = cfg?.debt_ceiling ?? 0n;
       const isUnlimited = typeof debtCeilingRaw === 'bigint'


### PR DESCRIPTION
## Summary
- Fix token order on Explorer overview (sort by `COLLATERAL_DISPLAY_ORDER`)
- Fix ckETH average CR (decimal-aware normalization; ckETH is 18-decimal, ckXAUT is 6-decimal)
- Fix missing LP APY (fall back to theoretical computation via `ProtocolService` when analytics returns `[]`)
- Fix wrong ckXAUT principal (invalid checksum was crashing Markets + Risk pages)
- Fix Revenue borrowing fee fallback and treasury balance field
- Analytics: normalize collateral decimals in CR calcs; normalize 3pool 6-dec token amounts to e8s

## Test plan
- [ ] Explorer overview shows tokens in canonical order
- [ ] ckETH average CR displays a sane value (~150-300%)
- [ ] LP APY shows a number on /explorer and /explorer/pools
- [ ] Markets and Risk pages load without crashing
- [ ] Revenue page shows borrowing fees and treasury balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)