### PR TITLE
fix(vault-frontend): PositionStrip auto-load + mobile label fit

### DIFF
--- a/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
+++ b/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
@@ -1,8 +1,8 @@
 <!-- src/vault_frontend/src/lib/components/layout/PositionStrip.svelte -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { userVaults, isLoadingVaults } from '$lib/stores/appDataStore';
-  import { isConnected } from '$lib/stores/wallet';
+  import { appDataStore, userVaults, isLoadingVaults } from '$lib/stores/appDataStore';
+  import { isConnected, principal } from '$lib/stores/wallet';
   import { permissionStore } from '$lib/stores/permissionStore';
   import { collateralStore } from '$lib/stores/collateralStore';
   import { isDevelopment } from '$lib/config';
@@ -41,9 +41,26 @@
   $: canView = isDevelopment || $developerAccess || $isConnected
     || ($permissionStore.initialized && $permissionStore.canViewVaults);
 
+  // Auto-load user vaults on connect so the strip reflects the user's real
+  // position everywhere, not just after visiting /vaults. fetchUserVaults has
+  // built-in caching and request-deduplication, so reactive refires are cheap.
+  // Tracks whether we've ever attempted a fetch for this connection so the
+  // skeleton (not the CTA) shows during the initial load.
+  let hasAttemptedLoad = false;
+  $: if ($isConnected && $principal && !$isLoadingVaults) {
+    hasAttemptedLoad = true;
+    appDataStore.fetchUserVaults($principal).catch(err => {
+      console.error('PositionStrip: failed to load user vaults', err);
+    });
+  }
+  $: if (!$isConnected) hasAttemptedLoad = false;
+
   $: summary = aggregatePosition($userVaults, $collateralStore.collaterals);
   $: hasPosition = $userVaults.length > 0;
-  $: showSkeleton = $isConnected && $isLoadingVaults && $userVaults.length === 0;
+  // Show skeleton while loading OR while we haven't finished the first fetch
+  // for this connection yet. Prevents the CTA from flashing before data arrives.
+  $: showSkeleton = $isConnected && $userVaults.length === 0
+    && ($isLoadingVaults || !hasAttemptedLoad);
 
   // Expose the rendered height as a CSS variable on <html> so main-content
   // padding can compensate. Bound to the outer wrapper so it stays 0 when

--- a/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
+++ b/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
@@ -126,23 +126,29 @@
         on:click={toggle}
       >
         <span class="cell">
-          <span class="cell-label">Collateral</span>
+          <span class="cell-label label-full">Collateral</span>
+          <span class="cell-label label-short">Coll</span>
           <span class="cell-val">{summary.hasAnyMissingPrice ? '≈' : ''}{fmtUsd(summary.totalCollateralUsd)}</span>
         </span>
         <span class="divider" aria-hidden="true"></span>
         <span class="cell">
-          <span class="cell-label">Borrowed</span>
+          <span class="cell-label label-full">Borrowed</span>
+          <span class="cell-label label-short">Borr</span>
           <span class="cell-val">{fmtIcusd(summary.totalBorrowed)}<span class="cell-unit"> icUSD</span></span>
         </span>
         <span class="divider" aria-hidden="true"></span>
         <span class="cell">
-          <span class="cell-label">Overall CR</span>
+          <span class="cell-label label-full">Overall CR</span>
+          <span class="cell-label label-short">CR</span>
           <span class="cell-val health-{summary.healthTier}">{fmtCr(summary.overallCr)}</span>
         </span>
         {#if summary.healthTier !== 'unknown'}
           <span class="health-label health-{summary.healthTier}">{healthLabel(summary.healthTier)}</span>
         {/if}
-        <span class="caret" aria-hidden="true">{expanded ? 'Hide ▴' : 'Show breakdown ▾'}</span>
+        <span class="caret" aria-hidden="true">
+          <span class="caret-full">{expanded ? 'Hide ▴' : 'Show breakdown ▾'}</span>
+          <span class="caret-short">{expanded ? '▴' : '▾'}</span>
+        </span>
       </button>
 
       {#if expanded}
@@ -175,6 +181,7 @@
     left: 0;
     right: 0;
     z-index: 99;  /* below top-bar's 100, above page content */
+    overflow-x: hidden;  /* belt-and-suspenders against mobile overflow */
   }
   /* Only draw border/background when something is actually rendered.
      :not(:empty) keeps the outer invisible when the disconnected branch
@@ -211,13 +218,17 @@
     outline-offset: -2px;
   }
 
-  .cell { display: inline-flex; align-items: baseline; gap: 0.5rem; }
+  .cell { display: inline-flex; align-items: baseline; gap: 0.5rem; white-space: nowrap; }
   .cell-label {
     color: var(--rumi-text-muted);
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
+    white-space: nowrap;
   }
+  /* Desktop shows full labels, hides short; mobile flips (see @media below). */
+  .label-short { display: none; }
+  .caret-short { display: none; }
   .cell-val {
     color: var(--rumi-text-primary);
     font-weight: 600;
@@ -293,12 +304,17 @@
 
   /* Mobile */
   @media (max-width: 768px) {
-    .strip { padding: 0.375rem 0.75rem; gap: 0.75rem; font-size: 0.75rem; }
+    .strip { padding: 0.375rem 0.5rem; gap: 0.5rem; font-size: 0.75rem; }
     .divider { display: none; }
+    .cell { gap: 0.25rem; }
     .cell-label { font-size: 0.625rem; }
+    .label-full { display: none; }
+    .label-short { display: inline; }
     .cell-val { font-size: 0.8125rem; }
     .cell-unit { display: none; } /* "Borrowed 1,500" without " icUSD" suffix on mobile */
-    .caret { font-size: 0.6875rem; }
+    .caret { font-size: 0.8125rem; }
+    .caret-full { display: none; }
+    .caret-short { display: inline; }
     .health-label { display: none; } /* color alone carries meaning on mobile */
     .breakdown { padding: 0 0.75rem 0.5rem; gap: 0.375rem; }
     .pill { padding: 0.1875rem 0.5rem; font-size: 0.6875rem; }


### PR DESCRIPTION
Follow-ups on #75 surfaced after landing on mainnet.

## Summary
- **Auto-load on connect:** strip relied on /vaults being visited before userVaults populated. Users connecting on /borrow, /swap, /3usd etc. saw the "No active position" CTA flash even with active vaults. Strip now fires \`fetchUserVaults\` itself on connect (store has built-in cache + dedup) and tracks first-attempt with a local flag so the skeleton — not the CTA — shows during the initial fetch.
- **Mobile label fit:** at 375px the full labels (COLLATERAL, BORROWED, OVERALL CR, "Show breakdown ▾") overflowed horizontally, clipping cells and wrapping OVERALL CR to two lines. Swapped to short labels (COLL/BORR/CR) + glyph-only caret under 768px via paired spans toggled by CSS. Added \`white-space: nowrap\` on cells and \`overflow-x: hidden\` on the outer wrapper as a safety net.

## Test plan
- [x] \`svelte-check\` clean, \`npm run build\` clean
- [x] Deployed to mainnet, verified desktop still centers under nav
- [x] Verified mobile (iPhone viewport) — labels fit, no overflow, no wrap
- [ ] Verified skeleton → real data transition on /3usd without vaults-page visit
🤖 Generated with [Claude Code](https://claude.com/claude-code)