### PR TITLE
feat(explorer): multi-hop swap rendering + 3pool v2 liquidity endpoints

### DIFF
--- a/src/declarations/rumi_3pool/rumi_3pool.did
+++ b/src/declarations/rumi_3pool/rumi_3pool.did
@@ -504,6 +504,8 @@ service : (ThreePoolInitArgs) -> {
   simulate_swap_path : (vec record { nat8; nat8; nat }) -> (variant { Ok : vec QuoteSwapResult; Err : ThreePoolError }) query;
   get_imbalance_history : (nat64, nat64) -> (vec ImbalanceSnapshot) query;
   get_swap_events_v2 : (nat64, nat64) -> (vec SwapEventV2) query;
+  get_liquidity_events_v2 : (nat64, nat64) -> (vec LiquidityEventV2) query;
+  get_liquidity_event_count_v2 : () -> (nat64) query;
 
   // Explorer endpoints (E1-E14)
   get_liquidity_events_by_principal : (principal, nat64, nat64) -> (vec LiquidityEventV2) query;

--- a/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
@@ -483,6 +483,8 @@ export interface _SERVICE {
     Array<SwapEventV2>
   >,
   'get_swap_events_v2' : ActorMethod<[bigint, bigint], Array<SwapEventV2>>,
+  'get_liquidity_events_v2' : ActorMethod<[bigint, bigint], Array<LiquidityEventV2>>,
+  'get_liquidity_event_count_v2' : ActorMethod<[], bigint>,
   'get_top_lps' : ActorMethod<[bigint], Array<[Principal, bigint, number]>>,
   'get_top_swappers' : ActorMethod<
     [StatsWindow, bigint],

--- a/src/declarations/rumi_3pool/rumi_3pool.did.js
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.js
@@ -547,6 +547,12 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(SwapEventV2)],
         ['query'],
       ),
+    'get_liquidity_events_v2' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidityEventV2)],
+        ['query'],
+      ),
+    'get_liquidity_event_count_v2' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_top_lps' : IDL.Func(
         [IDL.Nat64],
         [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat, IDL.Nat32))],

--- a/src/rumi_3pool/rumi_3pool.did
+++ b/src/rumi_3pool/rumi_3pool.did
@@ -504,6 +504,8 @@ service : (ThreePoolInitArgs) -> {
   simulate_swap_path : (vec record { nat8; nat8; nat }) -> (variant { Ok : vec QuoteSwapResult; Err : ThreePoolError }) query;
   get_imbalance_history : (nat64, nat64) -> (vec ImbalanceSnapshot) query;
   get_swap_events_v2 : (nat64, nat64) -> (vec SwapEventV2) query;
+  get_liquidity_events_v2 : (nat64, nat64) -> (vec LiquidityEventV2) query;
+  get_liquidity_event_count_v2 : () -> (nat64) query;
 
   // Explorer endpoints (E1-E14)
   get_liquidity_events_by_principal : (principal, nat64, nat64) -> (vec LiquidityEventV2) query;

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -1189,6 +1189,30 @@ pub fn get_imbalance_history(limit: u64, offset: u64) -> Vec<ImbalanceSnapshot> 
     })
 }
 
+/// Total number of v2 liquidity events.
+#[query]
+pub fn get_liquidity_event_count_v2() -> u64 {
+    storage::liq_v2::len()
+}
+
+/// Paginated newest-first read of the v2 liquidity event log.
+#[query]
+pub fn get_liquidity_events_v2(limit: u64, offset: u64) -> Vec<LiquidityEventV2> {
+    read_state(|s| {
+        let events = s.liquidity_events_v2();
+        let total = events.len() as u64;
+        if offset >= total {
+            return Vec::new();
+        }
+        let take = ((total - offset).min(limit)) as usize;
+        let end = (total - offset) as usize;
+        let start = end - take;
+        let mut out: Vec<LiquidityEventV2> = events[start..end].to_vec();
+        out.reverse();
+        out
+    })
+}
+
 /// Paginated newest-first read of the v2 swap event log.
 #[query]
 pub fn get_swap_events_v2(limit: u64, offset: u64) -> Vec<SwapEventV2> {

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -283,12 +283,12 @@ class ThreePoolService {
 
   async getLiquidityEvents(start: bigint, length: bigint): Promise<any[]> {
     const actor = await this.getQueryActor();
-    return await actor.get_liquidity_events(start, length) as any[];
+    return await actor.get_liquidity_events_v2(length, start) as any[];
   }
 
   async getLiquidityEventCount(): Promise<bigint> {
     const actor = await this.getQueryActor();
-    return await actor.get_liquidity_event_count() as bigint;
+    return await actor.get_liquidity_event_count_v2() as bigint;
   }
 
   async getAdminEvents(start: bigint, length: bigint): Promise<any[]> {

--- a/src/vault_frontend/src/lib/stores/explorerStore.ts
+++ b/src/vault_frontend/src/lib/stores/explorerStore.ts
@@ -4,7 +4,7 @@ import { Principal } from '@dfinity/principal';
 import { stabilityPoolService } from '$lib/services/stabilityPoolService';
 import { threePoolService } from '$lib/services/threePoolService';
 
-export type EventSource = 'backend' | 'stability_pool' | '3pool_swap' | '3pool_lp';
+export type EventSource = 'backend' | 'stability_pool' | '3pool_swap' | '3pool_lp' | 'multi_hop_swap';
 
 export interface UnifiedEvent {
 	source: EventSource;

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -537,6 +537,73 @@ export function formatStabilityPoolEvent(evt: any): FormattedEvent {
   };
 }
 
+// ─── Multi-Hop Swap Formatter ────────────────────────────────────────
+
+/**
+ * Format a merged multi-hop swap event.
+ * `merged` contains: direction ('stable_to_icp' | 'icp_to_stable'),
+ * the 3pool liquidity event, the AMM swap event, and derived amounts.
+ */
+export function formatMultiHopSwapEvent(merged: {
+  direction: 'stable_to_icp' | 'icp_to_stable';
+  liqEvent: any;
+  ammEvent: any;
+  stablecoinSymbol: string;
+  stablecoinAmount: string;
+  threeUsdAmount: string;
+  finalSymbol: string;
+  finalAmount: string;
+}): FormattedEvent {
+  const { direction, liqEvent, ammEvent, stablecoinSymbol, stablecoinAmount, threeUsdAmount, finalSymbol, finalAmount } = merged;
+  const fields: EventField[] = [];
+
+  if (direction === 'stable_to_icp') {
+    fields.push({ label: 'Deposited', value: `${stablecoinAmount} ${stablecoinSymbol}`, type: 'amount' });
+    fields.push({ label: '3Pool Output', value: `${threeUsdAmount} 3USD LP`, type: 'amount' });
+    fields.push({ label: 'AMM Output', value: `${finalAmount} ${finalSymbol}`, type: 'amount' });
+    fields.push({ label: 'Route', value: `${stablecoinSymbol} → 3Pool → AMM → ${finalSymbol}`, type: 'text' });
+  } else {
+    fields.push({ label: 'Swapped In', value: `${finalAmount} ${finalSymbol}`, type: 'amount' });
+    fields.push({ label: 'AMM Output', value: `${threeUsdAmount} 3USD LP`, type: 'amount' });
+    fields.push({ label: 'Redeemed', value: `${stablecoinAmount} ${stablecoinSymbol}`, type: 'amount' });
+    fields.push({ label: 'Route', value: `${finalSymbol} → AMM → 3Pool → ${stablecoinSymbol}`, type: 'text' });
+  }
+
+  // Pool IDs
+  const ammPoolId = ammEvent.pool_id ?? '';
+  if (ammPoolId) fields.push({ label: 'AMM Pool', value: String(ammPoolId), type: 'text' });
+
+  // Token ledgers
+  const ammTokenIn = ammEvent.token_in?.toText?.() ?? String(ammEvent.token_in ?? '');
+  const ammTokenOut = ammEvent.token_out?.toText?.() ?? String(ammEvent.token_out ?? '');
+  if (ammTokenIn) fields.push({ label: 'AMM Token In', value: shortenPrincipal(ammTokenIn), type: 'token', linkTarget: ammTokenIn });
+  if (ammTokenOut) fields.push({ label: 'AMM Token Out', value: shortenPrincipal(ammTokenOut), type: 'token', linkTarget: ammTokenOut });
+
+  // Caller
+  const callerText = ammEvent.caller?.toText?.() ?? liqEvent.caller?.toText?.() ?? null;
+  if (callerText) fields.push({ label: 'Caller', value: shortenPrincipal(callerText), type: 'address', linkTarget: callerText });
+
+  // Timestamp (use AMM event as canonical)
+  const ts = ammEvent.timestamp ?? liqEvent.timestamp;
+  if (ts) fields.push({ label: 'Timestamp', value: formatTimestamp(ts), type: 'timestamp', linkTarget: String(ts) });
+
+  // Sub-event references
+  fields.push({ label: '3Pool Event', value: `#${liqEvent.id ?? '?'}`, type: 'text' });
+  fields.push({ label: 'AMM Event', value: `#${ammEvent.id ?? '?'}`, type: 'text' });
+
+  const summary = direction === 'stable_to_icp'
+    ? `Swapped ${stablecoinAmount} ${stablecoinSymbol} → ${threeUsdAmount} 3USD → ${finalAmount} ${finalSymbol}`
+    : `Swapped ${finalAmount} ${finalSymbol} → ${threeUsdAmount} 3USD → ${stablecoinAmount} ${stablecoinSymbol}`;
+
+  return {
+    summary,
+    typeName: 'Multi-Hop Swap',
+    category: 'amm',
+    badgeColor: BADGE_COLORS.amm,
+    fields,
+  };
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────
 
 function getVariantKey(event: any): string {
@@ -956,16 +1023,16 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
     // ── Liquidations ────────────────────────────────────────────────
 
     case 'liquidate_vault': {
-      const ctPrincipal = vaultCollateral(d.vault_id);
-      const sym = getTokenSymbol(ctPrincipal);
+      const collPrincipal = vaultCollateral(d.vault_id);
+      const sym = getTokenSymbol(collPrincipal) || 'collateral';
       fields.push(vaultField(d.vault_id));
       if (d.mode) {
         const modeKey = typeof d.mode === 'object' ? Object.keys(d.mode)[0] : String(d.mode);
         fields.push(textField('Mode', modeKey));
       }
       if (d.icp_rate !== undefined) {
-        const rate = Number(d.icp_rate);
-        if (Number.isFinite(rate)) fields.push(textField(`${sym} Price`, `$${rate.toFixed(4)}`));
+        const num = Number(d.icp_rate);
+        if (Number.isFinite(num)) fields.push(textField(`${sym} Price`, `$${num.toFixed(4)}`));
       }
       pushIfPresent(fields, addressField('Liquidator', d.liquidator));
       if (ts) fields.push(timestampField(ts));
@@ -976,11 +1043,11 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
     }
 
     case 'partial_liquidate_vault': {
-      const ctPrincipal = vaultCollateral(d.vault_id);
-      const sym = getTokenSymbol(ctPrincipal);
-      const dec = getTokenDecimals(ctPrincipal);
+      const collPrincipal = vaultCollateral(d.vault_id);
+      const sym = getTokenSymbol(collPrincipal) || 'collateral';
+      const dec = getTokenDecimals(collPrincipal);
       const payment = fmtE8s(d.liquidator_payment);
-      const collateral = d.icp_to_liquidator != null ? formatTokenAmount(BigInt(d.icp_to_liquidator), dec) : '?';
+      const collateral = fmtE8s(d.icp_to_liquidator, dec);
       fields.push(vaultField(d.vault_id));
       fields.push(amountField('Debt Repaid', d.liquidator_payment));
       fields.push(amountField('Collateral to Liquidator', d.icp_to_liquidator, dec, sym));
@@ -991,8 +1058,10 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
       pushIfPresent(fields, addressField('Liquidator', d.liquidator));
       if (d.icp_rate !== undefined) {
         const rate = optValue(d.icp_rate);
-        const rateNum = rate !== undefined ? Number(rate) : NaN;
-        if (Number.isFinite(rateNum)) fields.push(textField(`${sym} Price`, `$${rateNum.toFixed(4)}`));
+        if (rate !== undefined) {
+          const num = Number(rate);
+          if (Number.isFinite(num)) fields.push(textField(`${sym} Price`, `$${num.toFixed(4)}`));
+        }
       }
       if (ts) fields.push(timestampField(ts));
       return {

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -19,9 +19,10 @@
 		getEventCategory, formatSwapEvent, formatAmmSwapEvent,
 		formatAmmLiquidityEvent, formatAmmAdminEvent,
 		format3PoolLiquidityEvent, format3PoolAdminEvent,
-		formatStabilityPoolEvent
+		formatStabilityPoolEvent, formatMultiHopSwapEvent
 	} from '$utils/explorerFormatters';
-	import { formatE8s, timeAgo, shortenPrincipal } from '$utils/explorerHelpers';
+	import { formatE8s, formatTokenAmount, timeAgo, shortenPrincipal, getTokenSymbol, getTokenDecimals } from '$utils/explorerHelpers';
+	import { CANISTER_IDS } from '$lib/config';
 
 	const PAGE_SIZE = 100;
 
@@ -40,7 +41,7 @@
 	interface DisplayEvent {
 		globalIndex: bigint;
 		event: any;
-		source: 'backend' | '3pool_swap' | 'amm_swap' | 'amm_liquidity' | 'amm_admin' | '3pool_liquidity' | '3pool_admin' | 'stability_pool';
+		source: 'backend' | '3pool_swap' | 'amm_swap' | 'amm_liquidity' | 'amm_admin' | '3pool_liquidity' | '3pool_admin' | 'stability_pool' | 'multi_hop_swap';
 		timestamp: number; // nanoseconds
 	}
 
@@ -79,6 +80,13 @@
 	// ── Principal extraction from any event type ──
 
 	function extractPrincipal(event: any, source: string): string | null {
+		// Multi-hop swap: extract caller from nested AMM event
+		if (source === 'multi_hop_swap') {
+			const caller = event.ammEvent?.caller ?? event.liqEvent?.caller;
+			if (caller?.toText) return caller.toText();
+			if (typeof caller === 'string' && caller.length > 10) return caller;
+			return null;
+		}
 		// Direct caller field (swap events, SP events, AMM liquidity/admin, 3Pool liquidity/admin)
 		const caller = event.caller;
 		if (caller) {
@@ -126,7 +134,143 @@
 		'3pool_liquidity': '3Pool',
 		'3pool_admin': '3Pool',
 		'stability_pool': 'SP',
+		'multi_hop_swap': 'Swap',
 	};
+
+	// 3Pool token index → symbol/decimals for multi-hop merging
+	const THREEPOOL_TOKENS: { symbol: string; decimals: number }[] = [
+		{ symbol: 'icUSD', decimals: 8 },
+		{ symbol: 'ckUSDT', decimals: 6 },
+		{ symbol: 'ckUSDC', decimals: 6 },
+	];
+
+	// 3USD LP token principal (the 3pool canister itself)
+	const THREEPOOL_PRINCIPAL = CANISTER_IDS.THREEPOOL;
+
+	/**
+	 * Merge correlated multi-hop swap events into single display events.
+	 *
+	 * Detects pairs where a 3pool_liquidity event and an amm_swap event share
+	 * the same caller and occur within 10 seconds, indicating a two-leg swap
+	 * routed through the swap router.
+	 *
+	 * stable_to_icp: AddLiquidity (stablecoin → 3USD) + AMM swap (3USD → ICP)
+	 * icp_to_stable: AMM swap (ICP → 3USD) + RemoveOneCoin (3USD → stablecoin)
+	 */
+	function mergeMultiHopEvents(events: DisplayEvent[]): DisplayEvent[] {
+		const MAX_GAP_NS = 10_000_000_000; // 10 seconds in nanoseconds
+
+		// Index liquidity and AMM swap events by caller for fast lookup
+		const liqEvents: DisplayEvent[] = [];
+		const ammEvents: DisplayEvent[] = [];
+		for (const de of events) {
+			if (de.source === '3pool_liquidity') liqEvents.push(de);
+			else if (de.source === 'amm_swap') ammEvents.push(de);
+		}
+
+		if (liqEvents.length === 0 || ammEvents.length === 0) return events;
+
+		const mergedSet = new Set<DisplayEvent>();
+		const mergedResults: DisplayEvent[] = [];
+
+		for (const liq of liqEvents) {
+			const liqCaller = liq.event.caller?.toText?.() ?? '';
+			if (!liqCaller) continue;
+
+			const action = liq.event.action ? Object.keys(liq.event.action)[0] : '';
+			const isAdd = action === 'AddLiquidity';
+			const isRemove = action === 'RemoveOneCoin';
+			if (!isAdd && !isRemove) continue;
+
+			// Find matching AMM swap: same caller, close timestamp
+			for (const amm of ammEvents) {
+				if (mergedSet.has(amm)) continue;
+				const ammCaller = amm.event.caller?.toText?.() ?? '';
+				if (ammCaller !== liqCaller) continue;
+
+				const gap = Math.abs(liq.timestamp - amm.timestamp);
+				if (gap > MAX_GAP_NS) continue;
+
+				// Verify the AMM swap involves 3USD LP token
+				const ammTokenIn = amm.event.token_in?.toText?.() ?? '';
+				const ammTokenOut = amm.event.token_out?.toText?.() ?? '';
+				const ammInvolves3USD = ammTokenIn === THREEPOOL_PRINCIPAL || ammTokenOut === THREEPOOL_PRINCIPAL;
+				if (!ammInvolves3USD) continue;
+
+				if (isAdd && ammTokenIn === THREEPOOL_PRINCIPAL) {
+					// stable_to_icp: AddLiquidity then AMM swap (3USD → other)
+					const amounts = liq.event.amounts ?? [];
+					let stableIdx = -1;
+					for (let i = 0; i < amounts.length; i++) {
+						if (Number(amounts[i]) > 0) { stableIdx = i; break; }
+					}
+					if (stableIdx < 0) continue;
+
+					const stableToken = THREEPOOL_TOKENS[stableIdx];
+					const stableAmount = formatE8s(amounts[stableIdx], stableToken.decimals);
+					const threeUsdAmount = formatE8s(liq.event.lp_amount, 8);
+					const finalSym = getTokenSymbol(ammTokenOut);
+					const finalAmount = amm.event.amount_out != null ? formatTokenAmount(BigInt(amm.event.amount_out), ammTokenOut) : '?';
+
+					mergedSet.add(liq);
+					mergedSet.add(amm);
+					mergedResults.push({
+						globalIndex: amm.globalIndex,
+						source: 'multi_hop_swap',
+						timestamp: Math.max(liq.timestamp, amm.timestamp),
+						event: {
+							direction: 'stable_to_icp',
+							liqEvent: liq.event,
+							ammEvent: amm.event,
+							stablecoinSymbol: stableToken.symbol,
+							stablecoinAmount: stableAmount,
+							threeUsdAmount,
+							finalSymbol: finalSym,
+							finalAmount,
+						},
+					});
+					break;
+				} else if (isRemove && ammTokenOut === THREEPOOL_PRINCIPAL) {
+					// icp_to_stable: AMM swap (other → 3USD) then RemoveOneCoin
+					const coinIndex = liq.event.coin_index?.[0] ?? 0;
+					const stableToken = THREEPOOL_TOKENS[coinIndex] ?? THREEPOOL_TOKENS[0];
+					const amounts = liq.event.amounts ?? [];
+					const stableAmount = amounts[coinIndex] != null ? formatE8s(amounts[coinIndex], stableToken.decimals) : '?';
+					const threeUsdAmount = formatE8s(liq.event.lp_amount, 8);
+					const otherToken = amm.event.token_in?.toText?.() ?? '';
+					const otherSym = getTokenSymbol(otherToken);
+					const otherAmount = amm.event.amount_in != null ? formatTokenAmount(BigInt(amm.event.amount_in), otherToken) : '?';
+
+					mergedSet.add(liq);
+					mergedSet.add(amm);
+					mergedResults.push({
+						globalIndex: amm.globalIndex,
+						source: 'multi_hop_swap',
+						timestamp: Math.max(liq.timestamp, amm.timestamp),
+						event: {
+							direction: 'icp_to_stable',
+							liqEvent: liq.event,
+							ammEvent: amm.event,
+							stablecoinSymbol: stableToken.symbol,
+							stablecoinAmount: stableAmount,
+							threeUsdAmount,
+							finalSymbol: otherSym,
+							finalAmount: otherAmount,
+						},
+					});
+					break;
+				}
+			}
+		}
+
+		if (mergedResults.length === 0) return events;
+
+		// Rebuild: keep unmerged events, add merged ones
+		const result = events.filter(e => !mergedSet.has(e));
+		result.push(...mergedResults);
+		result.sort((a, b) => b.timestamp - a.timestamp);
+		return result;
+	}
 
 	// ── Format event for display ──
 
@@ -139,6 +283,7 @@
 			case '3pool_liquidity': return format3PoolLiquidityEvent(de.event);
 			case '3pool_admin': return format3PoolAdminEvent(de.event);
 			case 'stability_pool': return formatStabilityPoolEvent(de.event);
+			case 'multi_hop_swap': return formatMultiHopSwapEvent(de.event);
 			default: return { summary: '', typeName: '', badgeColor: '' }; // handled by EventRow
 		}
 	}
@@ -222,12 +367,13 @@
 				all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'stability_pool', timestamp: extractTimestamp(e) });
 			}
 
-			// Sort by timestamp descending
-			all.sort((a, b) => b.timestamp - a.timestamp);
+			// Merge multi-hop swaps, then sort by timestamp descending
+			const merged = mergeMultiHopEvents(all);
+			merged.sort((a, b) => b.timestamp - a.timestamp);
 
-			totalCount = all.length;
+			totalCount = merged.length;
 			const start = p * PAGE_SIZE;
-			displayEvents = all.slice(start, start + PAGE_SIZE);
+			displayEvents = merged.slice(start, start + PAGE_SIZE);
 			currentPage = p;
 		} catch (e) {
 			error = 'Failed to load events.';
@@ -361,8 +507,8 @@
 				Number(threePoolLiqCount) > 0 ? fetch3PoolLiquidityEvents(0n, threePoolLiqCount) : Promise.resolve([]),
 			]);
 
-			// Merge and tag
-			const merged: DisplayEvent[] = [
+			// Tag all events
+			const tagged: DisplayEvent[] = [
 				...threePoolSwaps.map((e: any) => ({
 					globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_swap' as const, timestamp: extractTimestamp(e)
 				})),
@@ -377,7 +523,8 @@
 				})),
 			];
 
-			// Sort by timestamp descending
+			// Merge multi-hop swaps, then sort by timestamp descending
+			const merged = mergeMultiHopEvents(tagged);
 			merged.sort((a, b) => b.timestamp - a.timestamp);
 
 			totalCount = merged.length;
@@ -607,9 +754,12 @@
 							{@const formatted = formatDisplayEvent(de)}
 							{@const principal = extractPrincipal(de.event, de.source)}
 							{@const sourceLabel = SOURCE_LABELS[de.source] ?? de.source}
+							{@const detailHref = de.source === 'multi_hop_swap'
+								? `/explorer/dex/amm_swap/${de.event.ammEvent?.id ?? Number(de.globalIndex)}`
+								: `/explorer/dex/${de.source}/${Number(de.globalIndex)}`}
 							<tr class="border-b border-gray-700/50 hover:bg-gray-800/30 transition-colors group">
 								<td class="px-4 py-3">
-									<a href="/explorer/dex/{de.source}/{Number(de.globalIndex)}" class="text-xs text-blue-400 hover:text-blue-300 font-mono" title="{sourceLabel} Event #{Number(de.globalIndex)}">{sourceLabel} #{Number(de.globalIndex)}</a>
+									<a href={detailHref} class="text-xs text-blue-400 hover:text-blue-300 font-mono" title="{sourceLabel} Event #{Number(de.globalIndex)}">{sourceLabel} #{Number(de.globalIndex)}</a>
 								</td>
 								<td class="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">
 									{#if de.timestamp}
@@ -637,7 +787,7 @@
 								</td>
 								<td class="px-4 py-3 text-right">
 									<a
-										href="/explorer/dex/{de.source}/{Number(de.globalIndex)}"
+										href={detailHref}
 										class="text-xs text-blue-400 hover:text-blue-300 opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap"
 									>
 										Details &rarr;


### PR DESCRIPTION
## Summary
- 3pool backend: add \`get_liquidity_events_v2\` + \`get_liquidity_event_count_v2\` query endpoints (newest-first pagination).
- Frontend: \`threePoolService\` uses the v2 endpoints; \`explorerStore\` adds \`multi_hop_swap\` source; formatter renders multi-hop swap events with per-hop detail; activity page integrates the new source.

Context: picked up from the ICPswap pool integration session that was interrupted by context rollover.

## Test plan
- [ ] Deploy rumi_3pool canister (pre-deploy hook will run integration tests)
- [ ] Deploy vault_frontend
- [ ] Open /explorer/activity and confirm multi-hop swap events render correctly
- [ ] Confirm liquidity events still list with the v2 endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)