### PR TITLE
feat(analytics): add get_top_holders endpoint with TTL cache

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -114,6 +114,7 @@ type ErrorCounters = record {
 };
 type Fast3PoolSnapshot = record {
   virtual_price : nat;
+  decimals : blob;
   timestamp_ns : nat64;
   lp_total_supply : nat;
   balances : vec nat;
@@ -226,6 +227,20 @@ type ThreePoolSeriesResponse = record {
   rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
+type TopHolderRow = record {
+  "principal" : principal;
+  balance_e8s : nat64;
+  share_bps : nat32;
+};
+type TopHoldersQuery = record { token : principal; limit : opt nat32 };
+type TopHoldersResponse = record {
+  token : principal;
+  total_supply_e8s : nat64;
+  source : text;
+  rows : vec TopHolderRow;
+  total_holders : nat32;
+  generated_at_ns : nat64;
+};
 type TradeActivityQuery = record { window_secs : opt nat64 };
 type TradeActivityResponse = record {
   total_swaps : nat32;
@@ -281,6 +296,7 @@ service : (InitArgs) -> {
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
+  get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
   get_trade_activity : (TradeActivityQuery) -> (TradeActivityResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_twap : (TwapQuery) -> (TwapResponse) query;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -118,6 +118,7 @@ export interface ErrorCounters {
 }
 export interface Fast3PoolSnapshot {
   'virtual_price' : bigint,
+  'decimals' : Uint8Array | number[],
   'timestamp_ns' : bigint,
   'lp_total_supply' : bigint,
   'balances' : Array<bigint>,
@@ -233,6 +234,23 @@ export interface ThreePoolSeriesResponse {
   'rows' : Array<Fast3PoolSnapshot>,
   'next_from_ts' : [] | [bigint],
 }
+export interface TopHolderRow {
+  'principal' : Principal,
+  'balance_e8s' : bigint,
+  'share_bps' : number,
+}
+export interface TopHoldersQuery {
+  'token' : Principal,
+  'limit' : [] | [number],
+}
+export interface TopHoldersResponse {
+  'token' : Principal,
+  'total_supply_e8s' : bigint,
+  'source' : string,
+  'rows' : Array<TopHolderRow>,
+  'total_holders' : number,
+  'generated_at_ns' : bigint,
+}
 export interface TradeActivityQuery { 'window_secs' : [] | [bigint] }
 export interface TradeActivityResponse {
   'total_swaps' : number,
@@ -297,6 +315,7 @@ export interface _SERVICE {
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_swap_series' : ActorMethod<[RangeQuery], SwapSeriesResponse>,
   'get_three_pool_series' : ActorMethod<[RangeQuery], ThreePoolSeriesResponse>,
+  'get_top_holders' : ActorMethod<[TopHoldersQuery], TopHoldersResponse>,
   'get_trade_activity' : ActorMethod<
     [TradeActivityQuery],
     TradeActivityResponse

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -190,6 +190,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const Fast3PoolSnapshot = IDL.Record({
     'virtual_price' : IDL.Nat,
+    'decimals' : IDL.Vec(IDL.Nat8),
     'timestamp_ns' : IDL.Nat64,
     'lp_total_supply' : IDL.Nat,
     'balances' : IDL.Vec(IDL.Nat),
@@ -197,6 +198,23 @@ export const idlFactory = ({ IDL }) => {
   const ThreePoolSeriesResponse = IDL.Record({
     'rows' : IDL.Vec(Fast3PoolSnapshot),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
+  });
+  const TopHoldersQuery = IDL.Record({
+    'token' : IDL.Principal,
+    'limit' : IDL.Opt(IDL.Nat32),
+  });
+  const TopHolderRow = IDL.Record({
+    'principal' : IDL.Principal,
+    'balance_e8s' : IDL.Nat64,
+    'share_bps' : IDL.Nat32,
+  });
+  const TopHoldersResponse = IDL.Record({
+    'token' : IDL.Principal,
+    'total_supply_e8s' : IDL.Nat64,
+    'source' : IDL.Text,
+    'rows' : IDL.Vec(TopHolderRow),
+    'total_holders' : IDL.Nat32,
+    'generated_at_ns' : IDL.Nat64,
   });
   const TradeActivityQuery = IDL.Record({ 'window_secs' : IDL.Opt(IDL.Nat64) });
   const TradeActivityResponse = IDL.Record({
@@ -316,6 +334,11 @@ export const idlFactory = ({ IDL }) => {
     'get_three_pool_series' : IDL.Func(
         [RangeQuery],
         [ThreePoolSeriesResponse],
+        ['query'],
+      ),
+    'get_top_holders' : IDL.Func(
+        [TopHoldersQuery],
+        [TopHoldersResponse],
         ['query'],
       ),
     'get_trade_activity' : IDL.Func(

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -114,6 +114,7 @@ type ErrorCounters = record {
 };
 type Fast3PoolSnapshot = record {
   virtual_price : nat;
+  decimals : blob;
   timestamp_ns : nat64;
   lp_total_supply : nat;
   balances : vec nat;
@@ -226,6 +227,20 @@ type ThreePoolSeriesResponse = record {
   rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
+type TopHolderRow = record {
+  "principal" : principal;
+  balance_e8s : nat64;
+  share_bps : nat32;
+};
+type TopHoldersQuery = record { token : principal; limit : opt nat32 };
+type TopHoldersResponse = record {
+  token : principal;
+  total_supply_e8s : nat64;
+  source : text;
+  rows : vec TopHolderRow;
+  total_holders : nat32;
+  generated_at_ns : nat64;
+};
 type TradeActivityQuery = record { window_secs : opt nat64 };
 type TradeActivityResponse = record {
   total_swaps : nat32;
@@ -281,6 +296,7 @@ service : (InitArgs) -> {
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
+  get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
   get_trade_activity : (TradeActivityQuery) -> (TradeActivityResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_twap : (TwapQuery) -> (TwapResponse) query;

--- a/src/rumi_analytics/src/collectors/holders.rs
+++ b/src/rumi_analytics/src/collectors/holders.rs
@@ -108,10 +108,12 @@ pub async fn run() -> Result<(), String> {
     if balance_tracker::holder_count(Token::IcUsd) > 0 {
         let row = snapshot_token(Token::IcUsd, icusd_ledger, now);
         storage::holders::daily_holders_icusd::push(row);
+        crate::queries::live::invalidate_top_holders_cache(icusd_ledger);
     }
     if balance_tracker::holder_count(Token::ThreeUsd) > 0 {
         let row = snapshot_token(Token::ThreeUsd, three_pool, now);
         storage::holders::daily_holders_3usd::push(row);
+        crate::queries::live::invalidate_top_holders_cache(three_pool);
     }
     Ok(())
 }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -155,6 +155,11 @@ fn get_protocol_summary() -> types::ProtocolSummary {
 }
 
 #[ic_cdk_macros::query]
+fn get_top_holders(query: types::TopHoldersQuery) -> types::TopHoldersResponse {
+    queries::live::get_top_holders(query)
+}
+
+#[ic_cdk_macros::query]
 fn get_trade_activity(query: types::TradeActivityQuery) -> types::TradeActivityResponse {
     queries::live::get_trade_activity(query)
 }

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -404,6 +404,135 @@ pub fn compute_trade_activity(
     }
 }
 
+// ─── Top Holders ───
+
+/// TTL for the top-holders cache. Sorting can touch tens of thousands of
+/// accounts, so we serve repeat callers from cache for one minute.
+const TOP_HOLDERS_TTL_NS: u64 = 60 * NANOS_PER_SEC;
+
+const TOP_HOLDERS_DEFAULT_LIMIT: u32 = 50;
+const TOP_HOLDERS_MAX_LIMIT: u32 = 200;
+
+thread_local! {
+    static TOP_HOLDERS_CACHE: std::cell::RefCell<HashMap<(Principal, u32), (u64, types::TopHoldersResponse)>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+fn resolve_token(token: Principal) -> Option<storage::balance_tracker::Token> {
+    let (icusd_ledger, three_pool) = state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
+    if token == icusd_ledger {
+        Some(storage::balance_tracker::Token::IcUsd)
+    } else if token == three_pool {
+        Some(storage::balance_tracker::Token::ThreeUsd)
+    } else {
+        None
+    }
+}
+
+/// Invalidate the cached entries for a token. Call after the holder snapshot
+/// collector writes a new sample so the next caller sees fresh data.
+#[allow(dead_code)]
+pub fn invalidate_top_holders_cache(token: Principal) {
+    TOP_HOLDERS_CACHE.with(|cache| {
+        cache.borrow_mut().retain(|(t, _), _| *t != token);
+    });
+}
+
+pub fn get_top_holders(query: types::TopHoldersQuery) -> types::TopHoldersResponse {
+    let limit_raw = query.limit.unwrap_or(TOP_HOLDERS_DEFAULT_LIMIT);
+    let limit = if limit_raw == 0 { TOP_HOLDERS_DEFAULT_LIMIT } else { limit_raw }
+        .clamp(1, TOP_HOLDERS_MAX_LIMIT);
+
+    let now = ic_cdk::api::time();
+    let cache_key = (query.token, limit);
+
+    let cached = TOP_HOLDERS_CACHE.with(|cache| {
+        cache.borrow().get(&cache_key).cloned()
+    });
+    if let Some((cached_at, response)) = cached {
+        if now.saturating_sub(cached_at) < TOP_HOLDERS_TTL_NS {
+            return response;
+        }
+    }
+
+    let response = match resolve_token(query.token) {
+        Some(token) => {
+            let all = storage::balance_tracker::all_balances(token);
+            let total_supply = storage::balance_tracker::total_supply_tracked(token);
+            let by_principal = aggregate_by_principal(&all);
+            compute_top_holders(&by_principal, total_supply, limit as usize, query.token, now, "balance_tracker")
+        }
+        None => types::TopHoldersResponse {
+            token: query.token,
+            total_holders: 0,
+            total_supply_e8s: 0,
+            generated_at_ns: now,
+            rows: Vec::new(),
+            source: "unsupported".to_string(),
+        },
+    };
+
+    TOP_HOLDERS_CACHE.with(|cache| {
+        cache.borrow_mut().insert(cache_key, (now, response.clone()));
+    });
+
+    response
+}
+
+/// Sum balances per owner, dropping subaccount distinctions. Returned as an
+/// unsorted vector for the caller to rank.
+fn aggregate_by_principal(
+    accounts: &[(storage::balance_tracker::Account, u64)],
+) -> Vec<(Principal, u64)> {
+    let mut by_principal: HashMap<Principal, u64> = HashMap::new();
+    for (acct, balance) in accounts {
+        let entry = by_principal.entry(acct.owner).or_insert(0);
+        *entry = entry.saturating_add(*balance);
+    }
+    by_principal.into_iter().collect()
+}
+
+/// Pure helper: rank `holders` desc, take `limit`, compute share basis points
+/// against `total_supply`. Falls back to the sum of ranked balances when
+/// `total_supply` is zero, so share_bps stays meaningful for small datasets.
+pub fn compute_top_holders(
+    holders: &[(Principal, u64)],
+    total_supply: u64,
+    limit: usize,
+    token: Principal,
+    now_ns: u64,
+    source: &str,
+) -> types::TopHoldersResponse {
+    let mut sorted = holders.to_vec();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    let total_holders = sorted.len() as u32;
+    sorted.truncate(limit);
+
+    let denom: u128 = if total_supply > 0 {
+        total_supply as u128
+    } else {
+        sorted.iter().map(|(_, b)| *b as u128).sum::<u128>().max(1)
+    };
+
+    let rows: Vec<types::TopHolderRow> = sorted.into_iter().map(|(principal, balance)| {
+        let share = ((balance as u128).saturating_mul(10_000) / denom).min(10_000) as u32;
+        types::TopHolderRow {
+            principal,
+            balance_e8s: balance,
+            share_bps: share,
+        }
+    }).collect();
+
+    types::TopHoldersResponse {
+        token,
+        total_holders,
+        total_supply_e8s: total_supply,
+        generated_at_ns: now_ns,
+        rows,
+        source: source.to_string(),
+    }
+}
+
 // ─── Protocol Summary ───
 
 pub fn get_protocol_summary() -> types::ProtocolSummary {
@@ -786,5 +915,87 @@ mod tests {
         let res = compute_trade_activity(&[], 86_400);
         assert_eq!(res.total_swaps, 0);
         assert_eq!(res.avg_trade_size_e8s, 0);
+    }
+
+    fn p(byte: u8) -> Principal {
+        Principal::from_slice(&[byte; 29])
+    }
+
+    #[test]
+    fn top_holders_ranks_descending_and_computes_share() {
+        let token = p(99);
+        let holders = vec![
+            (p(1), 100),
+            (p(2), 400),
+            (p(3), 250),
+            (p(4), 250),
+        ];
+        let total_supply = 1_000;
+        let res = compute_top_holders(&holders, total_supply, 10, token, 12_345, "balance_tracker");
+
+        assert_eq!(res.token, token);
+        assert_eq!(res.total_holders, 4);
+        assert_eq!(res.total_supply_e8s, 1_000);
+        assert_eq!(res.generated_at_ns, 12_345);
+        assert_eq!(res.source, "balance_tracker");
+        assert_eq!(res.rows.len(), 4);
+        assert_eq!(res.rows[0].principal, p(2));
+        assert_eq!(res.rows[0].balance_e8s, 400);
+        assert_eq!(res.rows[0].share_bps, 4_000);
+        let lower_bps_sum: u32 = res.rows[1..].iter().map(|r| r.share_bps).sum();
+        assert_eq!(lower_bps_sum, 6_000);
+    }
+
+    #[test]
+    fn top_holders_truncates_to_limit_and_keeps_total_count() {
+        let token = p(99);
+        let holders: Vec<(Principal, u64)> = (0..30u8).map(|i| (p(i), 100 - i as u64)).collect();
+        let res = compute_top_holders(&holders, 0, 5, token, 0, "balance_tracker");
+        assert_eq!(res.total_holders, 30);
+        assert_eq!(res.rows.len(), 5);
+        assert_eq!(res.rows[0].balance_e8s, 100);
+        assert_eq!(res.rows[4].balance_e8s, 96);
+    }
+
+    #[test]
+    fn top_holders_falls_back_to_ranked_sum_when_supply_is_zero() {
+        let token = p(99);
+        let holders = vec![(p(1), 25), (p(2), 75)];
+        let res = compute_top_holders(&holders, 0, 10, token, 0, "balance_tracker");
+        assert_eq!(res.rows[0].principal, p(2));
+        assert_eq!(res.rows[0].share_bps, 7_500);
+        assert_eq!(res.rows[1].share_bps, 2_500);
+    }
+
+    #[test]
+    fn top_holders_empty_input_returns_empty_rows() {
+        let token = p(99);
+        let res = compute_top_holders(&[], 0, 10, token, 7, "balance_tracker");
+        assert_eq!(res.total_holders, 0);
+        assert!(res.rows.is_empty());
+        assert_eq!(res.generated_at_ns, 7);
+    }
+
+    #[test]
+    fn aggregate_by_principal_sums_subaccounts() {
+        use crate::storage::balance_tracker::Account;
+        let owner = p(7);
+        let other = p(8);
+        let mut sub_a = [0u8; 32];
+        sub_a[0] = 1;
+        let mut sub_b = [0u8; 32];
+        sub_b[0] = 2;
+        let accounts = vec![
+            (Account { owner, subaccount: None }, 100u64),
+            (Account { owner, subaccount: Some(sub_a) }, 50u64),
+            (Account { owner, subaccount: Some(sub_b) }, 25u64),
+            (Account { owner: other, subaccount: None }, 10u64),
+        ];
+        let mut by_p = aggregate_by_principal(&accounts);
+        by_p.sort_by_key(|(p, _)| *p);
+        let owner_total = by_p.iter().find(|(p, _)| *p == owner).map(|(_, b)| *b).unwrap();
+        let other_total = by_p.iter().find(|(p, _)| *p == other).map(|(_, b)| *b).unwrap();
+        assert_eq!(owner_total, 175);
+        assert_eq!(other_total, 10);
     }
 }

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -241,3 +241,29 @@ pub struct TradeActivityResponse {
     pub unique_traders: u32,
     pub avg_trade_size_e8s: u64,
 }
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TopHoldersQuery {
+    pub token: Principal,
+    pub limit: Option<u32>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq)]
+pub struct TopHolderRow {
+    pub principal: Principal,
+    pub balance_e8s: u64,
+    pub share_bps: u32,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct TopHoldersResponse {
+    pub token: Principal,
+    pub total_holders: u32,
+    pub total_supply_e8s: u64,
+    pub generated_at_ns: u64,
+    pub rows: Vec<TopHolderRow>,
+    /// "balance_tracker" when the token is tracked by analytics, "unsupported"
+    /// when the token has no holder data here. The frontend uses this to
+    /// decide between rendering the table and an empty state.
+    pub source: String,
+}


### PR DESCRIPTION
## Summary

Adds `analytics.get_top_holders({ token, limit })` so the upcoming `/e/token/{id}` page can render a Top Holders table and a holder-distribution pie chart from a single call. Implements Tier 1 backend gap #2 from the [Explorer IA Redesign plan](docs/superpowers/plans/2026-04-21-explorer-ia-redesign.md).

- Reuses the existing per-account `BalanceTracker` (StableBTreeMap) — no new collector pipeline.
- Subaccount balances are summed into their owning principal before ranking.
- `limit` is clamped to `[1, 200]` server-side and defaults to 50 when 0/unset.
- `share_bps` is computed against the tracked total supply; if supply is 0, falls back to the sum of the ranked balances so small datasets stay meaningful.
- Results are cached per `(token, limit)` for 60s. The cache is invalidated by the holder collector after each fresh sample.
- Tokens not tracked by this canister (collateral assets, ICP, etc.) return `total_holders: 0`, empty `rows`, `source: "unsupported"`. The frontend already calls `icrc1_total_supply` directly per ledger for the Identity strip, so this endpoint deliberately does not chain to it. (Cleaner: keeps the function a pure `query`, no inter-canister calls from a query.)

## Candid signature

```candid
type TopHolderRow = record {
  "principal" : principal;
  balance_e8s : nat64;
  share_bps : nat32;
};
type TopHoldersQuery = record { token : principal; limit : opt nat32 };
type TopHoldersResponse = record {
  token : principal;
  total_supply_e8s : nat64;
  source : text;
  rows : vec TopHolderRow;
  total_holders : nat32;
  generated_at_ns : nat64;
};

service : {
  get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
}
```

## Tests

5 new unit tests in `src/rumi_analytics/src/queries/live.rs`:
- `top_holders_ranks_descending_and_computes_share` — verifies sort order and share_bps math against known totals
- `top_holders_truncates_to_limit_and_keeps_total_count` — confirms `total_holders` reflects pre-truncation count
- `top_holders_falls_back_to_ranked_sum_when_supply_is_zero` — exercises the supply=0 path
- `top_holders_empty_input_returns_empty_rows`
- `aggregate_by_principal_sums_subaccounts` — proves subaccount collapse

Full unit suite: `cargo test --package rumi_analytics --lib` → 46 passed.

## Test plan

- [x] `cargo check --package rumi_analytics` clean
- [x] `cargo test --package rumi_analytics --lib` → 46/46 pass
- [x] `cargo build --target wasm32-unknown-unknown --release --package rumi_analytics` succeeds
- [x] `candid-extractor` output matches the committed `.did`
- [x] `dfx generate rumi_analytics` regenerates declarations cleanly
- [ ] Manual call against local replica with seeded data returns expected ranking (verify after deploy)

## Out of scope (separate work)

- Top movers 24h (Tier 2 backend gap)
- External token holder lists (ICP, ckETH — those live in their own index canisters)
- Token flow Sankey (Tier 2 gap #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)