### PR TITLE
feat(explorer): render AMM pools at parity with 3pool on /e/pool/{id}

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -257,10 +257,14 @@
         </thead>
         <tbody>
           {#each ammSummary as p}
-            <tr class="border-b border-white/[0.03]">
-              <td class="py-2 px-2 font-medium text-gray-200">{p.name}</td>
+            <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
+              <td class="py-2 px-2 font-medium">
+                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="text-indigo-300 hover:text-indigo-200">{p.name}</a>
+              </td>
               <td class="py-2 px-2 text-right tabular-nums text-gray-400">{(p.feeBps / 100).toFixed(2)}%</td>
-              <td class="py-2 px-2 text-gray-500 font-mono text-xs">{p.id}</td>
+              <td class="py-2 px-2 text-gray-500 font-mono text-xs">
+                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="hover:text-gray-300">{p.id}</a>
+              </td>
             </tr>
           {/each}
         </tbody>

--- a/src/vault_frontend/src/lib/services/ammService.ts
+++ b/src/vault_frontend/src/lib/services/ammService.ts
@@ -29,6 +29,14 @@ export interface SwapResult {
   fee: bigint;
 }
 
+// ── Analytics window variants (mirrors Candid AmmStatsWindow) ──
+
+export type AmmStatsWindow = 'Hour' | 'Day' | 'Week' | 'Month' | 'All';
+
+function windowToVariant(window: AmmStatsWindow): Record<string, null> {
+  return { [window]: null };
+}
+
 // ──────────────────────────────────────────────────────────────
 // Token metadata for AMM-tradeable tokens
 // ──────────────────────────────────────────────────────────────
@@ -234,6 +242,62 @@ class AmmService {
     return await actor.get_amm_admin_event_count();
   }
 
+  // ── Analytics (per-pool) ──
+  //
+  // Mirrors rumi_3pool's analytics surface so /e/pool/{id} can render
+  // AMM pools at parity. Queries key by the AMM pool_id (e.g.,
+  // "fohh4-…_ryjl3-…") and are served from a 60s TTL cache canister-side.
+
+  async getVolumeSeries(poolId: string, window: AmmStatsWindow, points: number): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_volume_series({ pool: poolId, window: windowToVariant(window), points });
+  }
+
+  async getBalanceSeries(poolId: string, window: AmmStatsWindow, points: number): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_balance_series({ pool: poolId, window: windowToVariant(window), points });
+  }
+
+  async getFeeSeries(poolId: string, window: AmmStatsWindow, points: number): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_fee_series({ pool: poolId, window: windowToVariant(window), points });
+  }
+
+  async getPoolStats(poolId: string, window: AmmStatsWindow): Promise<any> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_pool_stats({ pool: poolId, window: windowToVariant(window) });
+  }
+
+  async getTopSwappers(poolId: string, window: AmmStatsWindow, limit: number): Promise<Array<[Principal, bigint, bigint]>> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_top_swappers({ pool: poolId, window: windowToVariant(window), limit });
+  }
+
+  async getTopLps(poolId: string, limit: number): Promise<Array<[Principal, bigint, number]>> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_top_lps({ pool: poolId, limit });
+  }
+
+  async getSwapEventsByPrincipal(poolId: string, who: Principal, start: bigint, length: bigint): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_swap_events_by_principal({ pool: poolId, who, start, length });
+  }
+
+  async getLiquidityEventsByPrincipal(poolId: string, who: Principal, start: bigint, length: bigint): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_liquidity_events_by_principal({ pool: poolId, who, start, length });
+  }
+
+  async getSwapEventsByTimeRange(poolId: string, startNs: bigint, endNs: bigint, limit: bigint): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_amm_swap_events_by_time_range({
+      pool: poolId,
+      start_ns: startNs,
+      end_ns: endNs,
+      limit,
+    });
+  }
+
   // ── Mutations ──
 
   async swap(
@@ -416,7 +480,8 @@ class AmmService {
     if ('PoolCreationClosed' in err) return 'Pool creation is currently closed';
     if ('FeeBpsOutOfRange' in err) return 'Fee must be between 0.01% and 10%';
     if ('MaintenanceMode' in err) return 'AMM is in maintenance mode — swaps and deposits are temporarily disabled';
-    if ('ClaimNotFound' in err) return 'Claim not found — it may have already been resolved';
+    if ('ClaimNotFound' in err) return 'Claim not found (it may have already been resolved)';
+    if ('PoolBusy' in err) return 'Pool is busy with another transaction. Please try again in a moment.';
     return 'Unknown AMM error';
   }
 }

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -12,6 +12,7 @@ import { publicActor } from '$services/protocol/apiClient';
 import { stabilityPoolService } from '$services/stabilityPoolService';
 import { threePoolService } from '$services/threePoolService';
 import { ammService } from '$services/ammService';
+import type { AmmStatsWindow } from '$services/ammService';
 import { CANISTER_IDS, CONFIG } from '$lib/config';
 import type { _SERVICE as IcusdLedgerService } from '$declarations/icusd_ledger/icusd_ledger.did';
 import type { _SERVICE as IcusdIndexService } from '$declarations/icusd_index/icusd_index.did';
@@ -869,6 +870,154 @@ export async function fetchAmmAdminEventCount(): Promise<bigint> {
 	} catch (err) {
 		console.error('[explorerService] fetchAmmAdminEventCount failed:', err);
 		return 0n;
+	}
+}
+
+// ── AMM analytics (per-pool time series + rankings) ────────────────────────
+//
+// Mirrors the rumi_3pool analytics wrappers so /e/pool/{id} can branch on
+// pool source with minimal frontend code. All responses are cached 30s
+// client-side; the canister also caches 60s.
+
+export async function fetchAmmVolumeSeries(
+	poolId: string,
+	window: AmmStatsWindow = 'Week',
+	points: number = 100,
+): Promise<any[]> {
+	const key = `pool:amm:vol:${poolId}:${window}:${points}`;
+	const cached = getCached<any[]>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getVolumeSeries(poolId, window, points);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmVolumeSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmBalanceSeries(
+	poolId: string,
+	window: AmmStatsWindow = 'Week',
+	points: number = 100,
+): Promise<any[]> {
+	const key = `pool:amm:bal:${poolId}:${window}:${points}`;
+	const cached = getCached<any[]>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getBalanceSeries(poolId, window, points);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmBalanceSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmFeeSeries(
+	poolId: string,
+	window: AmmStatsWindow = 'Week',
+	points: number = 100,
+): Promise<any[]> {
+	const key = `pool:amm:fee:${poolId}:${window}:${points}`;
+	const cached = getCached<any[]>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getFeeSeries(poolId, window, points);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmFeeSeries failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmPoolStats(
+	poolId: string,
+	window: AmmStatsWindow = 'Week',
+): Promise<any | null> {
+	const key = `pool:amm:stats:${poolId}:${window}`;
+	const cached = getCached<any>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getPoolStats(poolId, window);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmPoolStats failed:', err);
+		return null;
+	}
+}
+
+export async function fetchAmmTopSwappers(
+	poolId: string,
+	window: AmmStatsWindow = 'Week',
+	limit: number = 10,
+): Promise<Array<[Principal, bigint, bigint]>> {
+	const key = `pool:amm:swappers:${poolId}:${window}:${limit}`;
+	const cached = getCached<Array<[Principal, bigint, bigint]>>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getTopSwappers(poolId, window, limit);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmTopSwappers failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmTopLps(
+	poolId: string,
+	limit: number = 10,
+): Promise<Array<[Principal, bigint, number]>> {
+	const key = `pool:amm:lps:${poolId}:${limit}`;
+	const cached = getCached<Array<[Principal, bigint, number]>>(key, TTL.POOL);
+	if (cached) return cached;
+	try {
+		const result = await ammService.getTopLps(poolId, limit);
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmTopLps failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmSwapEventsByPrincipal(
+	poolId: string,
+	who: Principal,
+	start: bigint,
+	length: bigint,
+): Promise<any[]> {
+	try {
+		return await ammService.getSwapEventsByPrincipal(poolId, who, start, length);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmSwapEventsByPrincipal failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmLiquidityEventsByPrincipal(
+	poolId: string,
+	who: Principal,
+	start: bigint,
+	length: bigint,
+): Promise<any[]> {
+	try {
+		return await ammService.getLiquidityEventsByPrincipal(poolId, who, start, length);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmLiquidityEventsByPrincipal failed:', err);
+		return [];
+	}
+}
+
+export async function fetchAmmSwapEventsByTimeRange(
+	poolId: string,
+	startNs: bigint,
+	endNs: bigint,
+	limit: bigint,
+): Promise<any[]> {
+	try {
+		return await ammService.getSwapEventsByTimeRange(poolId, startNs, endNs, limit);
+	} catch (err) {
+		console.error('[explorerService] fetchAmmSwapEventsByTimeRange failed:', err);
+		return [];
 	}
 }
 

--- a/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
@@ -22,15 +22,34 @@
     fetchThreePoolBalanceSeries,
     fetchThreePoolFeeSeries,
     fetchThreePoolVirtualPriceSeries,
+    fetchAmmPools,
+    fetchAmmVolumeSeries,
+    fetchAmmBalanceSeries,
+    fetchAmmFeeSeries,
+    fetchAmmPoolStats,
+    fetchAmmTopSwappers,
+    fetchAmmTopLps,
+    fetchAmmSwapEventsByTimeRange,
+    fetchAmmLiquidityEvents,
+    fetchAmmLiquidityEventCount,
   } from '$services/explorer/explorerService';
+  import { AMM_TOKENS } from '$services/ammService';
   import type { DisplayEvent } from '$utils/displayEvent';
   import { CANISTER_IDS } from '$lib/config';
 
-  const poolId = $derived($page.params.id);
+  const poolIdParam = $derived($page.params.id);
 
-  // Only 3pool supported in this step; AMM lands in Step 7.
-  const isThreePool = $derived(poolId === '3pool' || poolId === CANISTER_IDS.THREEPOOL);
+  // Pool source detection. 3pool is the literal string "3pool" or the 3pool
+  // canister id; anything else is looked up as an AMM pool id (e.g.,
+  // "fohh4-...cai_ryjl3-...cai").
+  const isThreePool = $derived(poolIdParam === '3pool' || poolIdParam === CANISTER_IDS.THREEPOOL);
+  const isAmm = $derived(!isThreePool);
 
+  // ── Shared state ─────────────────────────────────────────────────────────
+  let loading = $state(true);
+  let notFound = $state(false);
+
+  // ── 3pool state ──────────────────────────────────────────────────────────
   let status = $state<any>(null);
   let stats = $state<any>(null);
   let health = $state<any>(null);
@@ -42,9 +61,19 @@
   let balSeries = $state<any[]>([]);
   let feeSeries = $state<any[]>([]);
   let vpSeries = $state<any[]>([]);
-  let loading = $state(true);
-  let notFound = $state(false);
 
+  // ── AMM state ────────────────────────────────────────────────────────────
+  let ammPool = $state<any>(null);
+  let ammStats = $state<any>(null);
+  let ammTopLps = $state<Array<[any, bigint, number]>>([]);
+  let ammTopSwappers = $state<Array<[any, bigint, bigint]>>([]);
+  let ammSwapEvents = $state<any[]>([]);
+  let ammLiqEvents = $state<any[]>([]);
+  let ammVolSeries = $state<any[]>([]);
+  let ammBalSeries = $state<any[]>([]);
+  let ammFeeSeries = $state<any[]>([]);
+
+  // ── 3pool derived ────────────────────────────────────────────────────────
   const tokens = $derived(status?.tokens ?? []);
   const balances = $derived((status?.balances ?? []) as bigint[]);
   const totalSupply = $derived(status ? BigInt(status.lp_total_supply ?? 0) : 0n);
@@ -54,21 +83,48 @@
   const adminFeeBps = $derived(status ? Number(status.admin_fee_bps ?? 0) : 0);
   const imbalance = $derived(health ? Number(health.current_imbalance ?? 0) : 0);
 
+  // ── AMM derived ──────────────────────────────────────────────────────────
+  function tokenMetaFromPrincipal(p: any): { symbol: string; decimals: number; ledgerId: string; color: string } {
+    const id = p?.toText?.() ?? String(p);
+    const match = AMM_TOKENS.find((t) => t.ledgerId === id);
+    if (match) {
+      return { symbol: match.symbol, decimals: match.decimals, ledgerId: id, color: match.color };
+    }
+    return { symbol: shortenPrincipal(id), decimals: 8, ledgerId: id, color: '#94a3b8' };
+  }
+
+  const ammTokenA = $derived(ammPool ? tokenMetaFromPrincipal(ammPool.token_a) : null);
+  const ammTokenB = $derived(ammPool ? tokenMetaFromPrincipal(ammPool.token_b) : null);
+  const ammPoolName = $derived(
+    ammTokenA && ammTokenB ? `${ammTokenA.symbol} / ${ammTokenB.symbol}` : 'AMM Pool',
+  );
+  const ammReserveA = $derived(ammPool ? BigInt(ammPool.reserve_a ?? 0n) : 0n);
+  const ammReserveB = $derived(ammPool ? BigInt(ammPool.reserve_b ?? 0n) : 0n);
+  const ammLpSupply = $derived(ammPool ? BigInt(ammPool.total_lp_shares ?? 0n) : 0n);
+  const ammFeeBps = $derived(ammPool ? Number(ammPool.fee_bps ?? 0) : 0);
+
+  // Instantaneous spot price — a per b, derived from reserves.
+  const ammSpotPriceAPerB = $derived.by(() => {
+    if (!ammTokenA || !ammTokenB || ammReserveB === 0n) return 0;
+    const aNorm = Number(ammReserveA) / 10 ** ammTokenA.decimals;
+    const bNorm = Number(ammReserveB) / 10 ** ammTokenB.decimals;
+    return bNorm === 0 ? 0 : aNorm / bNorm;
+  });
+
+  // ── Shared formatters ────────────────────────────────────────────────────
   function formatReserve(raw: bigint, decimals: number): string {
     const divisor = 10n ** BigInt(decimals);
     const whole = raw / divisor;
     return Number(whole).toLocaleString();
   }
 
-  function formatLp(raw: bigint): string {
-    // 3USD LP token uses 8 decimals per project config.
-    const divisor = 10n ** 8n;
+  function formatLp(raw: bigint, decimals: number = 8): string {
+    const divisor = 10n ** BigInt(decimals);
     const whole = raw / divisor;
     return Number(whole).toLocaleString();
   }
 
   function formatVirtualPrice(raw: bigint): string {
-    // Virtual price uses 18 decimals in Curve convention.
     return (Number(raw) / 1e18).toFixed(6);
   }
 
@@ -77,11 +133,10 @@
   }
 
   function formatImbalance(val: number): string {
-    // imbalance is scaled by 1e18 in 3pool (normalized 18-dec precision)
     return `${(val / 1e16).toFixed(2)}%`;
   }
 
-  // Volume series: sum across tokens per bucket (each token is 18-dec normalized)
+  // ── 3pool series points ──────────────────────────────────────────────────
   const volPoints = $derived(
     volSeries.map((p: any) => ({
       t: Number(p.timestamp),
@@ -97,7 +152,6 @@
     feeSeries.map((p: any) => ({ t: Number(p.timestamp), v: Number(p.avg_fee_bps) / 100 })),
   );
 
-  // Balance series per token: pick one chart per token
   const balancePointsByToken = $derived.by(() => {
     if (!balSeries.length || !tokens.length) return [] as Array<{ symbol: string; points: { t: number; v: number }[] }>;
     return tokens.map((tok: any, i: number) => ({
@@ -109,65 +163,169 @@
     }));
   });
 
-  // ── Build DisplayEvents for the merged activity feed ─────────────────────
+  // ── AMM series points ────────────────────────────────────────────────────
+  // Volume series sums both tokens in native units. For a stable/volatile pair
+  // this is apples-and-oranges in absolute terms but tracks the shape of
+  // activity over time, which is the useful signal. We report the stable-side
+  // volume separately where it makes sense.
+  const ammVolPoints = $derived.by(() => {
+    if (!ammVolSeries.length || !ammTokenA || !ammTokenB) return [];
+    return ammVolSeries.map((p: any) => ({
+      t: Number(p.ts_ns) / 1_000_000, // ns → ms
+      v:
+        Number(p.volume_a_e8s) / 10 ** ammTokenA.decimals +
+        Number(p.volume_b_e8s) / 10 ** ammTokenB.decimals,
+    }));
+  });
+
+  const ammBalancePointsA = $derived.by(() => {
+    if (!ammBalSeries.length || !ammTokenA) return [];
+    return ammBalSeries.map((p: any) => ({
+      t: Number(p.ts_ns) / 1_000_000,
+      v: Number(p.reserve_a_e8s) / 10 ** ammTokenA.decimals,
+    }));
+  });
+
+  const ammBalancePointsB = $derived.by(() => {
+    if (!ammBalSeries.length || !ammTokenB) return [];
+    return ammBalSeries.map((p: any) => ({
+      t: Number(p.ts_ns) / 1_000_000,
+      v: Number(p.reserve_b_e8s) / 10 ** ammTokenB.decimals,
+    }));
+  });
+
+  const ammFeePoints = $derived.by(() => {
+    if (!ammFeeSeries.length || !ammTokenA || !ammTokenB) return [];
+    return ammFeeSeries.map((p: any) => ({
+      t: Number(p.ts_ns) / 1_000_000,
+      v:
+        Number(p.fees_a_e8s) / 10 ** ammTokenA.decimals +
+        Number(p.fees_b_e8s) / 10 ** ammTokenB.decimals,
+    }));
+  });
+
+  // ── Merged event feeds ───────────────────────────────────────────────────
   const mergedEvents = $derived.by((): DisplayEvent[] => {
     const out: DisplayEvent[] = [];
-    for (const evt of swapEvents) {
-      out.push({
-        event: evt,
-        globalIndex: BigInt(evt.id ?? 0),
-        source: '3pool_swap',
-        timestamp: Number(evt.timestamp ?? 0),
-      });
-    }
-    for (const evt of liqEvents) {
-      out.push({
-        event: evt,
-        globalIndex: BigInt(evt.id ?? 0),
-        source: '3pool_liquidity',
-        timestamp: Number(evt.timestamp ?? 0),
-      });
+    if (isThreePool) {
+      for (const evt of swapEvents) {
+        out.push({
+          event: evt,
+          globalIndex: BigInt(evt.id ?? 0),
+          source: '3pool_swap',
+          timestamp: Number(evt.timestamp ?? 0),
+        });
+      }
+      for (const evt of liqEvents) {
+        out.push({
+          event: evt,
+          globalIndex: BigInt(evt.id ?? 0),
+          source: '3pool_liquidity',
+          timestamp: Number(evt.timestamp ?? 0),
+        });
+      }
+    } else {
+      for (const evt of ammSwapEvents) {
+        out.push({
+          event: evt,
+          globalIndex: BigInt(evt.id ?? 0),
+          source: 'amm_swap',
+          timestamp: Number(evt.timestamp ?? 0),
+        });
+      }
+      for (const evt of ammLiqEvents) {
+        out.push({
+          event: evt,
+          globalIndex: BigInt(evt.id ?? 0),
+          source: 'amm_liquidity',
+          timestamp: Number(evt.timestamp ?? 0),
+        });
+      }
     }
     out.sort((a, b) => b.timestamp - a.timestamp);
     return out.slice(0, 40);
   });
 
+  // ── Data load ────────────────────────────────────────────────────────────
   onMount(async () => {
-    if (!isThreePool) {
-      notFound = true;
-      loading = false;
+    if (isThreePool) {
+      try {
+        const swapCount = await fetchSwapEventCount().catch(() => 0n);
+        const liqCount = await fetch3PoolLiquidityEventCount().catch(() => 0n);
+
+        const [s, st, h, lps, swappers, sev, lev, vol, bal, fees, vp] = await Promise.all([
+          fetchThreePoolStatus(),
+          fetchThreePoolStatsWindow('Last7d'),
+          fetchThreePoolHealth(),
+          fetchThreePoolTopLps(10n),
+          fetchThreePoolTopSwappers('Last7d', 10n),
+          swapCount > 0n
+            ? fetchThreePoolSwapEventsV2(swapCount > 50n ? swapCount - 50n : 0n, swapCount > 50n ? 50n : swapCount)
+            : Promise.resolve([]),
+          liqCount > 0n ? fetch3PoolLiquidityEvents(liqCount > 30n ? 30n : liqCount, 0n) : Promise.resolve([]),
+          fetchThreePoolVolumeSeries('Last7d', 3600n),
+          fetchThreePoolBalanceSeries('Last7d', 3600n),
+          fetchThreePoolFeeSeries('Last7d', 3600n),
+          fetchThreePoolVirtualPriceSeries('Last7d', 3600n),
+        ]);
+        status = s;
+        stats = st;
+        health = h;
+        topLps = lps as any;
+        topSwappers = swappers as any;
+        swapEvents = sev;
+        liqEvents = lev;
+        volSeries = vol;
+        balSeries = bal;
+        feeSeries = fees;
+        vpSeries = vp;
+      } finally {
+        loading = false;
+      }
       return;
     }
-    try {
-      const swapCount = await fetchSwapEventCount().catch(() => 0n);
-      const liqCount = await fetch3PoolLiquidityEventCount().catch(() => 0n);
 
-      const [s, st, h, lps, swappers, sev, lev, vol, bal, fees, vp] = await Promise.all([
-        fetchThreePoolStatus(),
-        fetchThreePoolStatsWindow('Last7d'),
-        fetchThreePoolHealth(),
-        fetchThreePoolTopLps(10n),
-        fetchThreePoolTopSwappers('Last7d', 10n),
-        swapCount > 0n
-          ? fetchThreePoolSwapEventsV2(swapCount > 50n ? swapCount - 50n : 0n, swapCount > 50n ? 50n : swapCount)
-          : Promise.resolve([]),
-        liqCount > 0n ? fetch3PoolLiquidityEvents(liqCount > 30n ? 30n : liqCount, 0n) : Promise.resolve([]),
-        fetchThreePoolVolumeSeries('Last7d', 3600n),
-        fetchThreePoolBalanceSeries('Last7d', 3600n),
-        fetchThreePoolFeeSeries('Last7d', 3600n),
-        fetchThreePoolVirtualPriceSeries('Last7d', 3600n),
-      ]);
-      status = s;
-      stats = st;
-      health = h;
-      topLps = lps as any;
-      topSwappers = swappers as any;
-      swapEvents = sev;
-      liqEvents = lev;
-      volSeries = vol;
-      balSeries = bal;
-      feeSeries = fees;
-      vpSeries = vp;
+    // AMM pool — look up by id in the pools list.
+    try {
+      const pools = await fetchAmmPools();
+      const pool = pools.find((p: any) => p.pool_id === poolIdParam);
+      if (!pool) {
+        notFound = true;
+        return;
+      }
+      ammPool = pool;
+
+      // Seven-day window of swap events for the activity feed.
+      const now = BigInt(Date.now()) * 1_000_000n;
+      const sevenDaysNs = 7n * 24n * 3_600n * 1_000_000_000n;
+      const liqCount = await fetchAmmLiquidityEventCount().catch(() => 0n);
+
+      const [statsResp, topLpsResp, topSwappersResp, swapsResp, liqsAll, volResp, balResp, feeResp] =
+        await Promise.all([
+          fetchAmmPoolStats(poolIdParam, 'Week'),
+          fetchAmmTopLps(poolIdParam, 10),
+          fetchAmmTopSwappers(poolIdParam, 'Week', 10),
+          fetchAmmSwapEventsByTimeRange(poolIdParam, now - sevenDaysNs, now, 100n),
+          // Liquidity events aren't per-pool yet in the old endpoint; filter client-side.
+          liqCount > 0n
+            ? fetchAmmLiquidityEvents(liqCount > 200n ? liqCount - 200n : 0n, liqCount > 200n ? 200n : liqCount)
+            : Promise.resolve([]),
+          fetchAmmVolumeSeries(poolIdParam, 'Week', 60),
+          fetchAmmBalanceSeries(poolIdParam, 'Week', 60),
+          fetchAmmFeeSeries(poolIdParam, 'Week', 60),
+        ]);
+
+      ammStats = statsResp;
+      ammTopLps = topLpsResp as any;
+      ammTopSwappers = topSwappersResp as any;
+      ammSwapEvents = swapsResp;
+      ammLiqEvents = (liqsAll as any[]).filter((e: any) => e.pool_id === poolIdParam);
+      ammVolSeries = volResp;
+      ammBalSeries = balResp;
+      ammFeeSeries = feeResp;
+    } catch (err) {
+      console.error('[pool page] AMM load failed:', err);
+      notFound = true;
     } finally {
       loading = false;
     }
@@ -175,136 +333,260 @@
 </script>
 
 <svelte:head>
-  <title>{isThreePool ? '3pool' : poolId} Pool | Rumi Explorer</title>
+  <title>{isThreePool ? '3pool' : ammPoolName || poolIdParam} Pool | Rumi Explorer</title>
 </svelte:head>
 
 <EntityShell
-  title={isThreePool ? '3pool (3USD)' : `Pool ${poolId}`}
-  subtitle={isThreePool ? 'Curve-style stableswap · icUSD / ckUSDC / ckUSDT' : undefined}
+  title={isThreePool ? '3pool (3USD)' : ammPoolName}
+  subtitle={isThreePool
+    ? 'Curve-style stableswap · icUSD / ckUSDC / ckUSDT'
+    : ammPool
+      ? `Constant-product AMM · ${formatBps(ammFeeBps)} fee`
+      : undefined}
   loading={loading}
-  error={notFound ? 'Only 3pool is currently supported as an entity page. AMM pool pages land in a later step.' : null}
+  error={notFound ? `Pool not found: ${poolIdParam}` : null}
 >
   {#snippet identity()}
-    <div class="flex flex-wrap items-center gap-3">
-      <StatusBadge status="Active" size="md" />
-      <span class="text-xs text-gray-500">Canister</span>
-      <EntityLink type="canister" value={CANISTER_IDS.THREEPOOL} label={shortenPrincipal(CANISTER_IDS.THREEPOOL)} />
-      <CopyButton text={CANISTER_IDS.THREEPOOL} />
-    </div>
+    {#if isThreePool}
+      <div class="flex flex-wrap items-center gap-3">
+        <StatusBadge status="Active" size="md" />
+        <span class="text-xs text-gray-500">Canister</span>
+        <EntityLink type="canister" value={CANISTER_IDS.THREEPOOL} label={shortenPrincipal(CANISTER_IDS.THREEPOOL)} />
+        <CopyButton text={CANISTER_IDS.THREEPOOL} />
+      </div>
 
-    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Amplification (A)</div>
-        <div class="text-lg font-mono text-white">{currentA || '--'}</div>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Amplification (A)</div>
+          <div class="text-lg font-mono text-white">{currentA || '--'}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Swap Fee</div>
+          <div class="text-lg font-mono text-white">{formatBps(swapFeeBps)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Admin Fee</div>
+          <div class="text-lg font-mono text-white">{formatBps(adminFeeBps)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Virtual Price</div>
+          <div class="text-lg font-mono text-white">{formatVirtualPrice(virtualPrice)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">LP Supply</div>
+          <div class="text-lg font-mono text-white">{formatLp(totalSupply, 8)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Imbalance</div>
+          <div class="text-lg font-mono text-white">{formatImbalance(imbalance)}</div>
+        </div>
       </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Swap Fee</div>
-        <div class="text-lg font-mono text-white">{formatBps(swapFeeBps)}</div>
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Admin Fee</div>
-        <div class="text-lg font-mono text-white">{formatBps(adminFeeBps)}</div>
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Virtual Price</div>
-        <div class="text-lg font-mono text-white">{formatVirtualPrice(virtualPrice)}</div>
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">LP Supply</div>
-        <div class="text-lg font-mono text-white">{formatLp(totalSupply)}</div>
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Imbalance</div>
-        <div class="text-lg font-mono text-white">{formatImbalance(imbalance)}</div>
-      </div>
-    </div>
 
-    <!-- Reserves table -->
-    <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl overflow-hidden">
-      <div class="px-5 py-3 border-b border-gray-700/50 flex items-center justify-between">
-        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Reserves</span>
-        {#if stats}
-          <span class="text-xs text-gray-500">{Number(stats.swap_count ?? 0n).toLocaleString()} swaps · {Number(stats.unique_swappers ?? 0n).toLocaleString()} unique swappers (7d)</span>
-        {/if}
+      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl overflow-hidden">
+        <div class="px-5 py-3 border-b border-gray-700/50 flex items-center justify-between">
+          <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Reserves</span>
+          {#if stats}
+            <span class="text-xs text-gray-500">
+              {Number(stats.swap_count ?? 0n).toLocaleString()} swaps · {Number(stats.unique_swappers ?? 0n).toLocaleString()} unique swappers (7d)
+            </span>
+          {/if}
+        </div>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-900/30">
+            <tr class="text-[10px] uppercase tracking-wider text-gray-500">
+              <th class="px-5 py-2 text-left">Token</th>
+              <th class="px-5 py-2 text-right">Balance</th>
+              <th class="px-5 py-2 text-right">Decimals</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each tokens as tok, i (tok.symbol)}
+              <tr class="border-t border-gray-700/30">
+                <td class="px-5 py-3">
+                  <EntityLink type="token" value={tok.ledger_id?.toText?.() ?? String(tok.ledger_id)} label={tok.symbol} />
+                </td>
+                <td class="px-5 py-3 text-right font-mono text-gray-200">
+                  {formatReserve(balances[i] ?? 0n, Number(tok.decimals))}
+                </td>
+                <td class="px-5 py-3 text-right text-gray-500">{Number(tok.decimals)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
       </div>
-      <table class="w-full text-sm">
-        <thead class="bg-gray-900/30">
-          <tr class="text-[10px] uppercase tracking-wider text-gray-500">
-            <th class="px-5 py-2 text-left">Token</th>
-            <th class="px-5 py-2 text-right">Balance</th>
-            <th class="px-5 py-2 text-right">Decimals</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each tokens as tok, i (tok.symbol)}
+    {:else if ammPool && ammTokenA && ammTokenB}
+      <div class="flex flex-wrap items-center gap-3">
+        <StatusBadge status={ammPool.paused ? 'Paused' : 'Active'} size="md" />
+        <span class="text-xs text-gray-500">Pool ID</span>
+        <span class="text-xs font-mono text-gray-300">{shortenPrincipal(poolIdParam)}</span>
+        <CopyButton text={poolIdParam} />
+      </div>
+
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Curve</div>
+          <div class="text-lg font-mono text-white">Constant product</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Swap Fee</div>
+          <div class="text-lg font-mono text-white">{formatBps(ammFeeBps)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">LP Supply</div>
+          <div class="text-lg font-mono text-white">{formatLp(ammLpSupply, 8)}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Spot {ammTokenA.symbol}/{ammTokenB.symbol}</div>
+          <div class="text-lg font-mono text-white">{ammSpotPriceAPerB > 0 ? ammSpotPriceAPerB.toFixed(6) : '--'}</div>
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Status</div>
+          <div class="text-lg font-mono text-white">{ammPool.paused ? 'Paused' : 'Active'}</div>
+        </div>
+      </div>
+
+      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl overflow-hidden">
+        <div class="px-5 py-3 border-b border-gray-700/50 flex items-center justify-between">
+          <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Reserves</span>
+          {#if ammStats}
+            <span class="text-xs text-gray-500">
+              {Number(ammStats.swap_count ?? 0).toLocaleString()} swaps · {Number(ammStats.unique_swappers ?? 0).toLocaleString()} swappers (7d)
+            </span>
+          {/if}
+        </div>
+        <table class="w-full text-sm">
+          <thead class="bg-gray-900/30">
+            <tr class="text-[10px] uppercase tracking-wider text-gray-500">
+              <th class="px-5 py-2 text-left">Token</th>
+              <th class="px-5 py-2 text-right">Balance</th>
+              <th class="px-5 py-2 text-right">Decimals</th>
+            </tr>
+          </thead>
+          <tbody>
             <tr class="border-t border-gray-700/30">
               <td class="px-5 py-3">
-                <EntityLink type="token" value={tok.ledger_id?.toText?.() ?? String(tok.ledger_id)} label={tok.symbol} />
+                <EntityLink type="token" value={ammTokenA.ledgerId} label={ammTokenA.symbol} />
               </td>
-              <td class="px-5 py-3 text-right font-mono text-gray-200">
-                {formatReserve(balances[i] ?? 0n, Number(tok.decimals))}
-              </td>
-              <td class="px-5 py-3 text-right text-gray-500">{Number(tok.decimals)}</td>
+              <td class="px-5 py-3 text-right font-mono text-gray-200">{formatReserve(ammReserveA, ammTokenA.decimals)}</td>
+              <td class="px-5 py-3 text-right text-gray-500">{ammTokenA.decimals}</td>
             </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
+            <tr class="border-t border-gray-700/30">
+              <td class="px-5 py-3">
+                <EntityLink type="token" value={ammTokenB.ledgerId} label={ammTokenB.symbol} />
+              </td>
+              <td class="px-5 py-3 text-right font-mono text-gray-200">{formatReserve(ammReserveB, ammTokenB.decimals)}</td>
+              <td class="px-5 py-3 text-right text-gray-500">{ammTokenB.decimals}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    {/if}
   {/snippet}
 
   {#snippet relationships()}
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-      <!-- Tokens -->
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Tokens</div>
-        {#each tokens as tok (tok.symbol)}
+    {#if isThreePool}
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Tokens</div>
+          {#each tokens as tok (tok.symbol)}
+            <div class="flex items-center justify-between text-sm">
+              <EntityLink type="token" value={tok.ledger_id?.toText?.() ?? String(tok.ledger_id)} label={tok.symbol} />
+              <span class="text-xs text-gray-500">{Number(tok.decimals)} dec</span>
+            </div>
+          {/each}
+        </div>
+
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Top LPs</div>
+          {#if topLps.length === 0}
+            <div class="text-xs text-gray-500">No LPs yet.</div>
+          {:else}
+            <ul class="space-y-1">
+              {#each topLps as row (row[0]?.toText?.() ?? String(row[0]))}
+                {@const principal = row[0]?.toText?.() ?? String(row[0])}
+                {@const bal = BigInt(row[1])}
+                {@const bps = Number(row[2])}
+                <li class="flex items-center justify-between text-xs">
+                  <EntityLink type="address" value={principal} />
+                  <span class="text-gray-400 font-mono">{formatLp(bal, 8)} LP · {(bps / 100).toFixed(1)}%</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Top Swappers (7d)</div>
+          {#if topSwappers.length === 0}
+            <div class="text-xs text-gray-500">No swaps in this window.</div>
+          {:else}
+            <ul class="space-y-1">
+              {#each topSwappers as row (row[0]?.toText?.() ?? String(row[0]))}
+                {@const principal = row[0]?.toText?.() ?? String(row[0])}
+                {@const count = Number(row[1])}
+                {@const volume = Number(row[2]) / 1e18}
+                <li class="flex items-center justify-between text-xs">
+                  <EntityLink type="address" value={principal} />
+                  <span class="text-gray-400 font-mono">{count} · ${volume.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      </div>
+    {:else if ammPool && ammTokenA && ammTokenB}
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Tokens in pool</div>
           <div class="flex items-center justify-between text-sm">
-            <EntityLink type="token" value={tok.ledger_id?.toText?.() ?? String(tok.ledger_id)} label={tok.symbol} />
-            <span class="text-xs text-gray-500">{Number(tok.decimals)} dec</span>
+            <EntityLink type="token" value={ammTokenA.ledgerId} label={ammTokenA.symbol} />
+            <span class="text-xs text-gray-500">{ammTokenA.decimals} dec</span>
           </div>
-        {/each}
-      </div>
+          <div class="flex items-center justify-between text-sm">
+            <EntityLink type="token" value={ammTokenB.ledgerId} label={ammTokenB.symbol} />
+            <span class="text-xs text-gray-500">{ammTokenB.decimals} dec</span>
+          </div>
+        </div>
 
-      <!-- Top LPs -->
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Top LPs</div>
-        {#if topLps.length === 0}
-          <div class="text-xs text-gray-500">No LPs yet.</div>
-        {:else}
-          <ul class="space-y-1">
-            {#each topLps as row (row[0]?.toText?.() ?? String(row[0]))}
-              {@const principal = row[0]?.toText?.() ?? String(row[0])}
-              {@const bal = BigInt(row[1])}
-              {@const bps = Number(row[2])}
-              <li class="flex items-center justify-between text-xs">
-                <EntityLink type="address" value={principal} />
-                <span class="text-gray-400 font-mono">{formatLp(bal)} LP · {(bps / 100).toFixed(1)}%</span>
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Top LPs</div>
+          {#if ammTopLps.length === 0}
+            <div class="text-xs text-gray-500">No LPs in this pool.</div>
+          {:else}
+            <ul class="space-y-1">
+              {#each ammTopLps as row (row[0]?.toText?.() ?? String(row[0]))}
+                {@const principal = row[0]?.toText?.() ?? String(row[0])}
+                {@const bal = BigInt(row[1])}
+                {@const bps = Number(row[2])}
+                <li class="flex items-center justify-between text-xs">
+                  <EntityLink type="address" value={principal} />
+                  <span class="text-gray-400 font-mono">{formatLp(bal, 8)} LP · {(bps / 100).toFixed(2)}%</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
 
-      <!-- Top swappers -->
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
-        <div class="text-[10px] uppercase tracking-wider text-gray-500">Top Swappers (7d)</div>
-        {#if topSwappers.length === 0}
-          <div class="text-xs text-gray-500">No swaps in this window.</div>
-        {:else}
-          <ul class="space-y-1">
-            {#each topSwappers as row (row[0]?.toText?.() ?? String(row[0]))}
-              {@const principal = row[0]?.toText?.() ?? String(row[0])}
-              {@const count = Number(row[1])}
-              {@const volume = Number(row[2]) / 1e18}
-              <li class="flex items-center justify-between text-xs">
-                <EntityLink type="address" value={principal} />
-                <span class="text-gray-400 font-mono">{count} · ${volume.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span>
-              </li>
-            {/each}
-          </ul>
-        {/if}
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 space-y-2">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">Top Swappers (7d)</div>
+          {#if ammTopSwappers.length === 0}
+            <div class="text-xs text-gray-500">No swaps in this window.</div>
+          {:else}
+            <ul class="space-y-1">
+              {#each ammTopSwappers as row (row[0]?.toText?.() ?? String(row[0]))}
+                {@const principal = row[0]?.toText?.() ?? String(row[0])}
+                {@const count = Number(row[1])}
+                {@const volumeA = Number(row[2]) / 10 ** ammTokenA.decimals}
+                <li class="flex items-center justify-between text-xs">
+                  <EntityLink type="address" value={principal} />
+                  <span class="text-gray-400 font-mono">{count} · {volumeA.toLocaleString(undefined, { maximumFractionDigits: 2 })} {ammTokenA.symbol}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
       </div>
-    </div>
+    {/if}
   {/snippet}
 
   {#snippet activity()}
@@ -330,49 +612,128 @@
           </tbody>
         </table>
       {/if}
+      {#if isAmm && ammPool}
+        <div class="px-5 py-3 border-t border-gray-700/50 text-right">
+          <a href={`/explorer/activity?pool=${encodeURIComponent(poolIdParam)}`} class="text-xs text-indigo-300 hover:text-indigo-200">
+            See all activity →
+          </a>
+        </div>
+      {/if}
     </div>
   {/snippet}
 
   {#snippet analytics()}
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
-        <MiniAreaChart
-          points={volPoints}
-          label="Volume (7d)"
-          color="#a78bfa"
-          fillColor="rgba(167, 139, 250, 0.12)"
-          valueFormat={(v) => `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
-        />
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
-        <MiniAreaChart
-          points={vpPoints}
-          label="Virtual Price (7d)"
-          color="#34d399"
-          fillColor="rgba(52, 211, 153, 0.12)"
-          valueFormat={(v) => v.toFixed(6)}
-        />
-      </div>
-      <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
-        <MiniAreaChart
-          points={feePoints}
-          label="Avg Fee bps (7d)"
-          color="#fbbf24"
-          fillColor="rgba(251, 191, 36, 0.12)"
-          valueFormat={(v) => `${v.toFixed(3)}%`}
-        />
-      </div>
-      {#each balancePointsByToken as bp (bp.symbol)}
+    {#if isThreePool}
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
           <MiniAreaChart
-            points={bp.points}
-            label={`${bp.symbol} balance (7d)`}
-            color="#60a5fa"
-            fillColor="rgba(96, 165, 250, 0.12)"
-            valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            points={volPoints}
+            label="Volume (7d)"
+            color="#a78bfa"
+            fillColor="rgba(167, 139, 250, 0.12)"
+            valueFormat={(v) => `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
           />
         </div>
-      {/each}
-    </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={vpPoints}
+            label="Virtual Price (7d)"
+            color="#34d399"
+            fillColor="rgba(52, 211, 153, 0.12)"
+            valueFormat={(v) => v.toFixed(6)}
+          />
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={feePoints}
+            label="Avg Fee bps (7d)"
+            color="#fbbf24"
+            fillColor="rgba(251, 191, 36, 0.12)"
+            valueFormat={(v) => `${v.toFixed(3)}%`}
+          />
+        </div>
+        {#each balancePointsByToken as bp (bp.symbol)}
+          <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+            <MiniAreaChart
+              points={bp.points}
+              label={`${bp.symbol} balance (7d)`}
+              color="#60a5fa"
+              fillColor="rgba(96, 165, 250, 0.12)"
+              valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            />
+          </div>
+        {/each}
+      </div>
+    {:else if ammPool && ammTokenA && ammTokenB}
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={ammVolPoints}
+            label={`Swap volume (7d, ${ammTokenA.symbol}+${ammTokenB.symbol} combined)`}
+            color="#a78bfa"
+            fillColor="rgba(167, 139, 250, 0.12)"
+            valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          />
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={ammFeePoints}
+            label="Fees collected (7d)"
+            color="#fbbf24"
+            fillColor="rgba(251, 191, 36, 0.12)"
+            valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+          />
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={ammBalancePointsA}
+            label={`${ammTokenA.symbol} reserve (7d)`}
+            color={ammTokenA.color}
+            fillColor={`${ammTokenA.color}22`}
+            valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          />
+        </div>
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+          <MiniAreaChart
+            points={ammBalancePointsB}
+            label={`${ammTokenB.symbol} reserve (7d)`}
+            color={ammTokenB.color}
+            fillColor={`${ammTokenB.color}22`}
+            valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          />
+        </div>
+        {#if ammStats}
+          <div class="lg:col-span-2 bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
+            <div class="text-[10px] uppercase tracking-wider text-gray-500 mb-3">Window stats · 7d</div>
+            <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 text-center">
+              <div>
+                <div class="text-lg font-mono text-white">{Number(ammStats.swap_count ?? 0).toLocaleString()}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">Swaps</div>
+              </div>
+              <div>
+                <div class="text-lg font-mono text-white">{Number(ammStats.unique_swappers ?? 0).toLocaleString()}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">Unique Swappers</div>
+              </div>
+              <div>
+                <div class="text-lg font-mono text-white">{Number(ammStats.unique_lps ?? 0).toLocaleString()}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">LP Holders</div>
+              </div>
+              <div>
+                <div class="text-lg font-mono text-white">{(Number(ammStats.volume_a_e8s ?? 0n) / 10 ** ammTokenA.decimals).toLocaleString(undefined, { maximumFractionDigits: 2 })}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">{ammTokenA.symbol} Volume</div>
+              </div>
+              <div>
+                <div class="text-lg font-mono text-white">{(Number(ammStats.volume_b_e8s ?? 0n) / 10 ** ammTokenB.decimals).toLocaleString(undefined, { maximumFractionDigits: 2 })}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">{ammTokenB.symbol} Volume</div>
+              </div>
+              <div>
+                <div class="text-lg font-mono text-white">{(Number(ammStats.fees_a_e8s ?? 0n) / 10 ** ammTokenA.decimals).toLocaleString(undefined, { maximumFractionDigits: 4 })}</div>
+                <div class="text-[10px] text-gray-500 uppercase tracking-wider">{ammTokenA.symbol} Fees</div>
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {/if}
   {/snippet}
 </EntityShell>


### PR DESCRIPTION
## Summary

Completes Step 7 — the final step of the Explorer IA redesign. With PR #89 deployed, \`/e/pool/{id}\` now branches on pool source and renders AMM pools using the same four-zone entity shell as 3pool.

**Pool resolution:** if the URL param is \`"3pool"\` or the 3pool canister id, the page uses the 3pool data path. Otherwise the param is treated as an AMM pool id and looked up in \`fetchAmmPools()\`. Unknown ids show a "Pool not found" state.

## Zones (AMM)

1. **Identity** — pool name (\`{tokenA}/{tokenB}\`), curve, fee tier, LP supply, spot price, paused flag, and a 2-row reserves table linking each token to \`/e/token/{id}\`
2. **Relationships** — tokens in pool (both → \`/e/token/{id}\`), top 10 LPs and top 10 Week-window swappers (all → \`/e/address/{principal}\`)
3. **Activity** — merged swap + liquidity events for this pool, plus a "See all activity" link that deep-links to \`/explorer/activity?pool=<id>\` (picked up by the facet bar from PR #85)
4. **Analytics** — swap volume, fees collected, two reserve timeseries (one per leg), and a 7d window-stats card showing volume/fees/swap count per side plus unique swappers and LP holders

## Changes

- **\`explorerService.ts\`** — nine new wrappers: \`fetchAmmVolumeSeries\`, \`fetchAmmBalanceSeries\`, \`fetchAmmFeeSeries\`, \`fetchAmmPoolStats\`, \`fetchAmmTopSwappers\`, \`fetchAmmTopLps\`, \`fetchAmmSwapEventsByPrincipal\`, \`fetchAmmLiquidityEventsByPrincipal\`, \`fetchAmmSwapEventsByTimeRange\`. Client-side 30s TTL cache mirrors the existing pool query pattern; canister-side cache is 60s.
- **\`ammService.ts\`** — corresponding typed methods on \`AmmService\` plus a small \`AmmStatsWindow\` type and \`windowToVariant\` helper. The \`formatError\` method now maps \`PoolBusy\` to a user-facing message (see note below).
- **\`/e/pool/[id]/+page.svelte\`** — branches \`onMount\` on pool source, shares \`EntityShell\` and component primitives, keeps 3pool rendering behavior unchanged.
- **\`DexsLens.svelte\`** — AMM pool rows in the DEXs lens now link to \`/e/pool/{id}\` (previously unlinked text).

## Note on \`PoolBusy\`

While reviewing the PR #89 deploy, I noticed \`PoolBusy\` (added to \`AmmError\` by the earlier security-hardening commit be1cfa8) hadn't actually reached the deployed canister until PR #89. That means the \`rumi_amm\` canister now can emit \`PoolBusy\` on concurrent-swap races, but the frontend didn't know about it — a rare race would surface as an unknown-variant decode error instead of a friendly message. Added an explicit handler in \`ammService.formatError\` so the frontend presents it cleanly. Low probability event in practice (swap race within microseconds on the same pool), but now handled.

## Test plan

- [x] \`svelte-check\` adds zero new errors/warnings (pre-existing errors unrelated to this PR)
- [x] \`npm run build\` produces \`dist/\` cleanly (\`_page.svelte.js\` for this route is 16.5 kB)
- [ ] Browser verification after deploy:
  - 3pool page (\`/explorer/e/pool/3pool\`) renders unchanged
  - AMM pool page (\`/explorer/e/pool/fohh4-yyaaa-aaaap-qtkpa-cai_ryjl3-tyaaa-aaaaa-aaaba-cai\`) shows all four zones populated
  - Clicking a Top LP → lands on \`/e/address/{principal}\`
  - Clicking a Top Swapper → lands on \`/e/address/{principal}\`
  - Clicking a token in Reserves or Relationships → lands on \`/e/token/{id}\`
  - "See all activity" → lands on \`/explorer/activity?pool=<id>\` with the facet pre-applied
  - Unknown pool id shows the "Pool not found" state
  - Old \`/explorer/markets/[id]\` redirect from PR #84 still routes here
  - DexsLens table rows navigate to \`/e/pool/{id}\` on click

## After this lands

The Explorer IA redesign plan (Steps 1–7) is complete. Remaining Tier 2/3 analytics backlog items in \`docs/superpowers/plans/2026-04-21-explorer-ia-redesign.md\` move to a separate post-redesign thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)