### PR TITLE
feat(backend): add server-side filtering to get_events_filtered

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -421,7 +421,34 @@ type VaultRedemption = record {
   collateral_seized : nat64;
 };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
-type GetEventsArg = record { start : nat64; length : nat64 };
+type EventTypeFilter = variant {
+  OpenVault;
+  CloseVault;
+  AdjustVault;
+  Borrow;
+  Repay;
+  Liquidation;
+  PartialLiquidation;
+  Redemption;
+  ReserveRedemption;
+  StabilityPoolDeposit;
+  StabilityPoolWithdraw;
+  AdminMint;
+  AdminSweepToTreasury;
+  Admin;
+  PriceUpdate;
+  AccrueInterest;
+};
+type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
+type GetEventsArg = record {
+  start : nat64;
+  length : nat64;
+  types : opt vec EventTypeFilter;
+  "principal" : opt principal;
+  collateral_token : opt principal;
+  time_range : opt EventTimeRange;
+  min_size_e8s : opt nat64;
+};
 type GetEventsFilteredResponse = record { total : nat64; events : vec record { nat64; Event } };
 type HttpRequest = record {
   url : text;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -496,8 +496,33 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   { 'set_recovery_cr_multiplier' : { 'multiplier' : string } };
+export interface EventTimeRange { 'start_ns' : bigint, 'end_ns' : bigint }
+export type EventTypeFilter = { 'StabilityPoolDeposit' : null } |
+  { 'AdminSweepToTreasury' : null } |
+  { 'AdminMint' : null } |
+  { 'AdjustVault' : null } |
+  { 'PartialLiquidation' : null } |
+  { 'OpenVault' : null } |
+  { 'StabilityPoolWithdraw' : null } |
+  { 'AccrueInterest' : null } |
+  { 'ReserveRedemption' : null } |
+  { 'Repay' : null } |
+  { 'Liquidation' : null } |
+  { 'Borrow' : null } |
+  { 'PriceUpdate' : null } |
+  { 'Admin' : null } |
+  { 'Redemption' : null } |
+  { 'CloseVault' : null };
 export interface Fees { 'redemption_fee' : number, 'borrowing_fee' : number }
-export interface GetEventsArg { 'start' : bigint, 'length' : bigint }
+export interface GetEventsArg {
+  'principal' : [] | [Principal],
+  'types' : [] | [Array<EventTypeFilter>],
+  'time_range' : [] | [EventTimeRange],
+  'start' : bigint,
+  'collateral_token' : [] | [Principal],
+  'length' : bigint,
+  'min_size_e8s' : [] | [bigint],
+}
 export interface GetEventsFilteredResponse {
   'total' : bigint,
   'events' : Array<[bigint, Event]>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -203,9 +203,36 @@ export const idlFactory = ({ IDL }) => {
     'owner' : IDL.Principal,
     'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
+  const EventTypeFilter = IDL.Variant({
+    'StabilityPoolDeposit' : IDL.Null,
+    'AdminSweepToTreasury' : IDL.Null,
+    'AdminMint' : IDL.Null,
+    'AdjustVault' : IDL.Null,
+    'PartialLiquidation' : IDL.Null,
+    'OpenVault' : IDL.Null,
+    'StabilityPoolWithdraw' : IDL.Null,
+    'AccrueInterest' : IDL.Null,
+    'ReserveRedemption' : IDL.Null,
+    'Repay' : IDL.Null,
+    'Liquidation' : IDL.Null,
+    'Borrow' : IDL.Null,
+    'PriceUpdate' : IDL.Null,
+    'Admin' : IDL.Null,
+    'Redemption' : IDL.Null,
+    'CloseVault' : IDL.Null,
+  });
+  const EventTimeRange = IDL.Record({
+    'start_ns' : IDL.Nat64,
+    'end_ns' : IDL.Nat64,
+  });
   const GetEventsArg = IDL.Record({
+    'principal' : IDL.Opt(IDL.Principal),
+    'types' : IDL.Opt(IDL.Vec(EventTypeFilter)),
+    'time_range' : IDL.Opt(EventTimeRange),
     'start' : IDL.Nat64,
+    'collateral_token' : IDL.Opt(IDL.Principal),
     'length' : IDL.Nat64,
+    'min_size_e8s' : IDL.Opt(IDL.Nat64),
   });
   const StableTokenType = IDL.Variant({
     'CKUSDC' : IDL.Null,

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -421,7 +421,34 @@ type VaultRedemption = record {
   collateral_seized : nat64;
 };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
-type GetEventsArg = record { start : nat64; length : nat64 };
+type EventTypeFilter = variant {
+  OpenVault;
+  CloseVault;
+  AdjustVault;
+  Borrow;
+  Repay;
+  Liquidation;
+  PartialLiquidation;
+  Redemption;
+  ReserveRedemption;
+  StabilityPoolDeposit;
+  StabilityPoolWithdraw;
+  AdminMint;
+  AdminSweepToTreasury;
+  Admin;
+  PriceUpdate;
+  AccrueInterest;
+};
+type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
+type GetEventsArg = record {
+  start : nat64;
+  length : nat64;
+  types : opt vec EventTypeFilter;
+  "principal" : opt principal;
+  collateral_token : opt principal;
+  time_range : opt EventTimeRange;
+  min_size_e8s : opt nat64;
+};
 type GetEventsFilteredResponse = record { total : nat64; events : vec record { nat64; Event } };
 type HttpRequest = record {
   url : text;

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -2,11 +2,12 @@ use crate::numeric::{Ratio, UsdIcp, ICUSD, ICP};
 use crate::state::{CollateralConfig, CollateralStatus, CollateralType, PendingMarginTransfer, RateCurveV2, State};
 use crate::storage::record_event;
 use crate::vault::Vault;
-use crate::{InitArg, Mode, StableTokenType, UpgradeArg};
+use crate::{EventTimeRange, EventTypeFilter, InitArg, Mode, StableTokenType, UpgradeArg};
 use candid::{CandidType, Principal};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 /// Per-vault breakdown of a redemption: how much icUSD was redeemed and how much
 /// collateral was seized from each individual vault.
@@ -664,6 +665,211 @@ impl Event {
     /// Returns true if this is a noisy periodic event (hidden from explorer).
     pub fn is_accrue_interest(&self) -> bool {
         matches!(self, Event::AccrueInterest { .. } | Event::PriceUpdate { .. })
+    }
+
+    /// Coarse type classification for the explorer's `types` facet.
+    /// All admin/setter variants collapse into `EventTypeFilter::Admin`.
+    pub fn type_filter(&self) -> EventTypeFilter {
+        match self {
+            Event::OpenVault { .. } => EventTypeFilter::OpenVault,
+            Event::CloseVault { .. }
+            | Event::WithdrawAndCloseVault { .. }
+            | Event::VaultWithdrawnAndClosed { .. } => EventTypeFilter::CloseVault,
+            Event::AddMarginToVault { .. }
+            | Event::CollateralWithdrawn { .. }
+            | Event::PartialCollateralWithdrawn { .. }
+            | Event::MarginTransfer { .. }
+            | Event::RedistributeVault { .. }
+            | Event::DustForgiven { .. }
+            | Event::AdminVaultCorrection { .. }
+            | Event::AdminDebtCorrection { .. } => EventTypeFilter::AdjustVault,
+            Event::BorrowFromVault { .. } => EventTypeFilter::Borrow,
+            Event::RepayToVault { .. } => EventTypeFilter::Repay,
+            Event::LiquidateVault { .. } => EventTypeFilter::Liquidation,
+            Event::PartialLiquidateVault { .. } => EventTypeFilter::PartialLiquidation,
+            Event::RedemptionOnVaults { .. } | Event::RedemptionTransfered { .. } => {
+                EventTypeFilter::Redemption
+            }
+            Event::ReserveRedemption { .. } => EventTypeFilter::ReserveRedemption,
+            Event::ProvideLiquidity { .. } => EventTypeFilter::StabilityPoolDeposit,
+            Event::WithdrawLiquidity { .. } | Event::ClaimLiquidityReturns { .. } => {
+                EventTypeFilter::StabilityPoolWithdraw
+            }
+            Event::AdminMint { .. } => EventTypeFilter::AdminMint,
+            Event::AdminSweepToTreasury { .. } => EventTypeFilter::AdminSweepToTreasury,
+            Event::PriceUpdate { .. } => EventTypeFilter::PriceUpdate,
+            Event::AccrueInterest { .. } => EventTypeFilter::AccrueInterest,
+            _ => EventTypeFilter::Admin,
+        }
+    }
+
+    /// Recorded timestamp in nanoseconds, when the event variant carries one.
+    /// Used by the time-range facet; events returning `None` are excluded
+    /// from time-filtered queries.
+    pub fn timestamp_ns(&self) -> Option<u64> {
+        match self {
+            Event::OpenVault { timestamp, .. }
+            | Event::CloseVault { timestamp, .. }
+            | Event::MarginTransfer { timestamp, .. }
+            | Event::LiquidateVault { timestamp, .. }
+            | Event::PartialLiquidateVault { timestamp, .. }
+            | Event::RedemptionOnVaults { timestamp, .. }
+            | Event::RedemptionTransfered { timestamp, .. }
+            | Event::RedistributeVault { timestamp, .. }
+            | Event::BorrowFromVault { timestamp, .. }
+            | Event::RepayToVault { timestamp, .. }
+            | Event::AddMarginToVault { timestamp, .. }
+            | Event::ProvideLiquidity { timestamp, .. }
+            | Event::WithdrawLiquidity { timestamp, .. }
+            | Event::ClaimLiquidityReturns { timestamp, .. }
+            | Event::CollateralWithdrawn { timestamp, .. }
+            | Event::PartialCollateralWithdrawn { timestamp, .. }
+            | Event::WithdrawAndCloseVault { timestamp, .. }
+            | Event::DustForgiven { timestamp, .. }
+            | Event::ReserveRedemption { timestamp, .. }
+            | Event::AdminMint { timestamp, .. }
+            | Event::AdminDebtCorrection { timestamp, .. } => *timestamp,
+            Event::VaultWithdrawnAndClosed { timestamp, .. } => Some(*timestamp),
+            Event::PriceUpdate { timestamp, .. } => Some(*timestamp),
+            Event::AccrueInterest { timestamp } => Some(*timestamp),
+            Event::SetBotBudget { start_timestamp, .. } => Some(*start_timestamp),
+            _ => None,
+        }
+    }
+
+    /// Collateral token referenced by this event, if any. For vault-id events
+    /// the collateral type isn't carried in the event itself, so the caller
+    /// passes `vault_lookup` (built once per query by walking `OpenVault`
+    /// events). Returns `None` for events with no collateral context.
+    pub fn collateral_token(&self, vault_lookup: &HashMap<u64, Principal>) -> Option<Principal> {
+        match self {
+            Event::OpenVault { vault, .. } => Some(vault.collateral_type),
+            Event::AddCollateralType { collateral_type, .. }
+            | Event::UpdateCollateralStatus { collateral_type, .. }
+            | Event::UpdateCollateralConfig { collateral_type, .. }
+            | Event::SetCollateralBorrowingFee { collateral_type, .. }
+            | Event::SetInterestRate { collateral_type, .. }
+            | Event::SetRecoveryParameters { collateral_type, .. }
+            | Event::SetCollateralLiquidationRatio { collateral_type, .. }
+            | Event::SetCollateralBorrowThreshold { collateral_type, .. }
+            | Event::SetCollateralLiquidationBonus { collateral_type, .. }
+            | Event::SetCollateralMinVaultDebt { collateral_type, .. }
+            | Event::SetCollateralLedgerFee { collateral_type, .. }
+            | Event::SetCollateralRedemptionFeeFloor { collateral_type, .. }
+            | Event::SetCollateralRedemptionFeeCeiling { collateral_type, .. }
+            | Event::SetCollateralMinDeposit { collateral_type, .. }
+            | Event::SetCollateralDisplayColor { collateral_type, .. }
+            | Event::PriceUpdate { collateral_type, .. } => Some(*collateral_type),
+            Event::RedemptionOnVaults { collateral_type, .. } => *collateral_type,
+            Event::ReserveRedemption { stable_token_ledger, .. } => Some(*stable_token_ledger),
+            Event::CloseVault { vault_id, .. }
+            | Event::MarginTransfer { vault_id, .. }
+            | Event::LiquidateVault { vault_id, .. }
+            | Event::PartialLiquidateVault { vault_id, .. }
+            | Event::RedistributeVault { vault_id, .. }
+            | Event::BorrowFromVault { vault_id, .. }
+            | Event::RepayToVault { vault_id, .. }
+            | Event::AddMarginToVault { vault_id, .. }
+            | Event::CollateralWithdrawn { vault_id, .. }
+            | Event::PartialCollateralWithdrawn { vault_id, .. }
+            | Event::VaultWithdrawnAndClosed { vault_id, .. }
+            | Event::WithdrawAndCloseVault { vault_id, .. }
+            | Event::DustForgiven { vault_id, .. }
+            | Event::AdminVaultCorrection { vault_id, .. }
+            | Event::AdminDebtCorrection { vault_id, .. } => vault_lookup.get(vault_id).copied(),
+            _ => None,
+        }
+    }
+
+    /// Primary "size" of this event in icUSD e8s (= USD e8s) for the size facet.
+    /// icUSD-denominated amounts pass through; ICP/collateral amounts are
+    /// converted using `icp_price_e8s` (current spot, in 1e8 USD per ICP).
+    /// Returns `None` for events with no meaningful magnitude (admin setters,
+    /// init/upgrade, accrue/price ticks); the size filter treats `None` as
+    /// "passes" so these events surface independent of the threshold.
+    /// Multi-collateral conversions use the ICP price as a v1 approximation.
+    pub fn size_e8s_usd(&self, icp_price_e8s: u64) -> Option<u64> {
+        let convert = |native_amount: u64| -> u64 {
+            ((native_amount as u128) * (icp_price_e8s as u128) / 100_000_000u128) as u64
+        };
+        match self {
+            Event::BorrowFromVault { borrowed_amount, .. } => Some(borrowed_amount.0),
+            Event::RepayToVault { repayed_amount, .. } => Some(repayed_amount.0),
+            Event::RedemptionOnVaults { icusd_amount, .. } => Some(icusd_amount.0),
+            Event::ReserveRedemption { icusd_amount, .. } => Some(icusd_amount.0),
+            Event::AdminMint { amount, .. } => Some(amount.0),
+            Event::DustForgiven { amount, .. } => Some(amount.0),
+            Event::ProvideLiquidity { amount, .. } => Some(amount.0),
+            Event::WithdrawLiquidity { amount, .. } => Some(amount.0),
+            Event::PartialLiquidateVault { liquidator_payment, .. } => Some(liquidator_payment.0),
+            Event::OpenVault { vault, .. } => Some(convert(vault.collateral_amount)),
+            Event::AddMarginToVault { margin_added, .. } => Some(convert(margin_added.0)),
+            Event::CollateralWithdrawn { amount, .. } => Some(convert(amount.0)),
+            Event::PartialCollateralWithdrawn { amount, .. } => Some(convert(amount.0)),
+            Event::WithdrawAndCloseVault { amount, .. } => Some(convert(amount.0)),
+            Event::VaultWithdrawnAndClosed { amount, .. } => Some(convert(amount.0)),
+            Event::ClaimLiquidityReturns { amount, .. } => Some(convert(amount.0)),
+            Event::AdminSweepToTreasury { amount, .. } => Some(*amount),
+            _ => None,
+        }
+    }
+
+    /// AND-combine all `get_events_filtered` facets and return whether this
+    /// event passes. Pure function — caller supplies the per-query lookup map
+    /// and a price snapshot.
+    #[allow(clippy::too_many_arguments)]
+    pub fn passes_filters(
+        &self,
+        types_set: Option<&HashSet<EventTypeFilter>>,
+        principal: Option<&Principal>,
+        collateral_token: Option<&Principal>,
+        time_range: Option<&EventTimeRange>,
+        min_size_e8s: Option<u64>,
+        vault_lookup: &HashMap<u64, Principal>,
+        icp_price_e8s: u64,
+    ) -> bool {
+        match types_set {
+            Some(set) => {
+                if !set.contains(&self.type_filter()) {
+                    return false;
+                }
+            }
+            None => {
+                if self.is_accrue_interest() {
+                    return false;
+                }
+            }
+        }
+
+        if let Some(p) = principal {
+            if !self.involves_principal(p) {
+                return false;
+            }
+        }
+
+        if let Some(token) = collateral_token {
+            match self.collateral_token(vault_lookup) {
+                Some(t) if t == *token => {}
+                _ => return false,
+            }
+        }
+
+        if let Some(range) = time_range {
+            match self.timestamp_ns() {
+                Some(ts) if ts >= range.start_ns && ts <= range.end_ns => {}
+                _ => return false,
+            }
+        }
+
+        if let Some(min_size) = min_size_e8s {
+            if let Some(size) = self.size_e8s_usd(icp_price_e8s) {
+                if size < min_size {
+                    return false;
+                }
+            }
+        }
+
+        true
     }
 
     /// Check if a given principal is involved in this event (as owner, caller, or liquidator).
@@ -2043,4 +2249,291 @@ pub fn record_price_update(collateral_type: CollateralType, price: Decimal, time
         price: price.to_string(),
         timestamp,
     });
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::*;
+    use crate::vault::Vault;
+
+    fn p(seed: u8) -> Principal {
+        Principal::self_authenticating([seed; 32])
+    }
+
+    fn caller_a() -> Principal { p(1) }
+    fn caller_b() -> Principal { p(2) }
+    fn icp_token() -> Principal { p(10) }
+    fn ckbtc_token() -> Principal { p(11) }
+
+    fn vault_with(id: u64, owner: Principal, ct: Principal, collateral_e8s: u64) -> Vault {
+        Vault {
+            owner,
+            vault_id: id,
+            collateral_type: ct,
+            collateral_amount: collateral_e8s,
+            borrowed_icusd_amount: ICUSD::new(0),
+            last_accrual_time: 0,
+            accrued_interest: ICUSD::new(0),
+            bot_processing: false,
+        }
+    }
+
+    fn open_vault_event(id: u64, owner: Principal, ct: Principal) -> Event {
+        Event::OpenVault {
+            vault: vault_with(id, owner, ct, 1_000_000_000),
+            block_index: 0,
+            timestamp: Some(1_000),
+        }
+    }
+
+    fn borrow_event(vault_id: u64, caller: Principal, amount_e8s: u64, ts: u64) -> Event {
+        Event::BorrowFromVault {
+            vault_id,
+            borrowed_amount: ICUSD::new(amount_e8s),
+            fee_amount: ICUSD::new(0),
+            block_index: 0,
+            caller: Some(caller),
+            timestamp: Some(ts),
+        }
+    }
+
+    fn repay_event(vault_id: u64, caller: Principal, amount_e8s: u64, ts: u64) -> Event {
+        Event::RepayToVault {
+            vault_id,
+            repayed_amount: ICUSD::new(amount_e8s),
+            block_index: 0,
+            caller: Some(caller),
+            timestamp: Some(ts),
+        }
+    }
+
+    fn liquidate_event(vault_id: u64, liquidator: Principal, ts: u64) -> Event {
+        Event::LiquidateVault {
+            vault_id,
+            mode: Mode::GeneralAvailability,
+            icp_rate: UsdIcp::new(Decimal::from(5u32)),
+            liquidator: Some(liquidator),
+            timestamp: Some(ts),
+        }
+    }
+
+    fn accrue_event(ts: u64) -> Event {
+        Event::AccrueInterest { timestamp: ts }
+    }
+
+    fn price_event(ct: Principal, ts: u64) -> Event {
+        Event::PriceUpdate { collateral_type: ct, price: "5.0".into(), timestamp: ts }
+    }
+
+    /// Build a vault_id → collateral_type lookup for tests.
+    fn lookup(entries: &[(u64, Principal)]) -> HashMap<u64, Principal> {
+        entries.iter().copied().collect()
+    }
+
+    // ── type_filter classification ────────────────────────────────────────
+
+    #[test]
+    fn type_filter_classifies_each_user_facing_variant() {
+        assert_eq!(open_vault_event(1, caller_a(), icp_token()).type_filter(), EventTypeFilter::OpenVault);
+        assert_eq!(borrow_event(1, caller_a(), 100, 0).type_filter(), EventTypeFilter::Borrow);
+        assert_eq!(repay_event(1, caller_a(), 100, 0).type_filter(), EventTypeFilter::Repay);
+        assert_eq!(liquidate_event(1, caller_a(), 0).type_filter(), EventTypeFilter::Liquidation);
+        assert_eq!(accrue_event(0).type_filter(), EventTypeFilter::AccrueInterest);
+        assert_eq!(price_event(icp_token(), 0).type_filter(), EventTypeFilter::PriceUpdate);
+
+        // Setter falls into Admin
+        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        assert_eq!(setter.type_filter(), EventTypeFilter::Admin);
+    }
+
+    // ── timestamp_ns ──────────────────────────────────────────────────────
+
+    #[test]
+    fn timestamp_ns_extracts_when_present_and_returns_none_otherwise() {
+        assert_eq!(borrow_event(1, caller_a(), 100, 12_345).timestamp_ns(), Some(12_345));
+        assert_eq!(accrue_event(7).timestamp_ns(), Some(7));
+
+        // Init has no timestamp.
+        let init = Event::Init(InitArg {
+            xrc_principal: p(0),
+            icusd_ledger_principal: p(0),
+            icp_ledger_principal: p(0),
+            fee_e8s: 0,
+            developer_principal: p(0),
+            treasury_principal: None,
+            stability_pool_principal: None,
+            ckusdt_ledger_principal: None,
+            ckusdc_ledger_principal: None,
+        });
+        assert_eq!(init.timestamp_ns(), None);
+    }
+
+    // ── collateral_token + vault lookup ───────────────────────────────────
+
+    #[test]
+    fn collateral_token_falls_back_to_vault_lookup_for_id_only_events() {
+        let lookup = lookup(&[(42, ckbtc_token())]);
+        let ev = borrow_event(42, caller_a(), 100, 0);
+        assert_eq!(ev.collateral_token(&lookup), Some(ckbtc_token()));
+
+        // Unknown vault id → None
+        let ev2 = borrow_event(99, caller_a(), 100, 0);
+        assert_eq!(ev2.collateral_token(&HashMap::new()), None);
+    }
+
+    #[test]
+    fn collateral_token_uses_event_field_for_open_vault() {
+        let ev = open_vault_event(1, caller_a(), ckbtc_token());
+        assert_eq!(ev.collateral_token(&HashMap::new()), Some(ckbtc_token()));
+    }
+
+    // ── size_e8s_usd conversions ──────────────────────────────────────────
+
+    #[test]
+    fn size_in_usd_passes_through_icusd_amounts() {
+        let ev = borrow_event(1, caller_a(), 250_000_000, 0); // 2.50 icUSD
+        assert_eq!(ev.size_e8s_usd(0), Some(250_000_000));
+    }
+
+    #[test]
+    fn size_in_usd_converts_icp_amounts_at_spot_price() {
+        // 1 ICP @ $5 = $5 = 500_000_000 e8s
+        let icp_e8s = 100_000_000u64;
+        let price_e8s = 500_000_000u64;
+        let ev = open_vault_event(1, caller_a(), icp_token());
+        let ev = if let Event::OpenVault { mut vault, block_index, timestamp } = ev {
+            vault.collateral_amount = icp_e8s;
+            Event::OpenVault { vault, block_index, timestamp }
+        } else { unreachable!() };
+        assert_eq!(ev.size_e8s_usd(price_e8s), Some(500_000_000));
+    }
+
+    #[test]
+    fn size_returns_none_for_admin_setters() {
+        let ev = Event::SetBorrowingFee { rate: "0.005".into() };
+        assert_eq!(ev.size_e8s_usd(500_000_000), None);
+    }
+
+    // ── passes_filters: each dimension in isolation ───────────────────────
+
+    #[test]
+    fn empty_filter_excludes_accrue_interest_and_price_update() {
+        let lookup = HashMap::new();
+        assert!(!accrue_event(0).passes_filters(None, None, None, None, None, &lookup, 0));
+        assert!(!price_event(icp_token(), 0).passes_filters(None, None, None, None, None, &lookup, 0));
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(None, None, None, None, None, &lookup, 0));
+    }
+
+    #[test]
+    fn explicit_type_set_includes_accrue_interest_when_requested() {
+        let lookup = HashMap::new();
+        let set: HashSet<_> = [EventTypeFilter::AccrueInterest].into_iter().collect();
+        assert!(accrue_event(0).passes_filters(Some(&set), None, None, None, None, &lookup, 0));
+        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, &lookup, 0));
+    }
+
+    #[test]
+    fn type_filter_or_combines_within_the_set() {
+        let lookup = HashMap::new();
+        let set: HashSet<_> = [EventTypeFilter::Borrow, EventTypeFilter::Repay].into_iter().collect();
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, &lookup, 0));
+        assert!(repay_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, &lookup, 0));
+        assert!(!liquidate_event(1, caller_a(), 0).passes_filters(Some(&set), None, None, None, None, &lookup, 0));
+    }
+
+    #[test]
+    fn principal_filter_matches_caller_or_owner() {
+        let lookup = HashMap::new();
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(None, Some(&caller_a()), None, None, None, &lookup, 0));
+        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(None, Some(&caller_b()), None, None, None, &lookup, 0));
+    }
+
+    #[test]
+    fn collateral_token_filter_matches_via_vault_lookup() {
+        let lookup = lookup(&[(1, ckbtc_token())]);
+        let ev = borrow_event(1, caller_a(), 100, 0);
+        assert!(ev.passes_filters(None, None, Some(&ckbtc_token()), None, None, &lookup, 0));
+        assert!(!ev.passes_filters(None, None, Some(&icp_token()), None, None, &lookup, 0));
+    }
+
+    #[test]
+    fn time_range_excludes_outside_window_and_no_timestamp_events() {
+        let lookup = HashMap::new();
+        let range = EventTimeRange { start_ns: 1_000, end_ns: 2_000 };
+
+        let inside = borrow_event(1, caller_a(), 100, 1_500);
+        let outside = borrow_event(1, caller_a(), 100, 5_000);
+        assert!(inside.passes_filters(None, None, None, Some(&range), None, &lookup, 0));
+        assert!(!outside.passes_filters(None, None, None, Some(&range), None, &lookup, 0));
+
+        let init = Event::Init(InitArg {
+            xrc_principal: p(0),
+            icusd_ledger_principal: p(0),
+            icp_ledger_principal: p(0),
+            fee_e8s: 0,
+            developer_principal: p(0),
+            treasury_principal: None,
+            stability_pool_principal: None,
+            ckusdt_ledger_principal: None,
+            ckusdc_ledger_principal: None,
+        });
+        // Init has no timestamp_ns → excluded by an active time_range.
+        assert!(!init.passes_filters(None, None, None, Some(&range), None, &lookup, 0));
+    }
+
+    #[test]
+    fn min_size_excludes_below_threshold_and_passes_unsized_events() {
+        let lookup = HashMap::new();
+        // Borrow $0.50 — under $1.00 threshold.
+        let small = borrow_event(1, caller_a(), 50_000_000, 0);
+        let big = borrow_event(1, caller_a(), 500_000_000, 0);
+        let threshold = 100_000_000u64; // $1.00 in e8s
+
+        assert!(!small.passes_filters(None, None, None, None, Some(threshold), &lookup, 0));
+        assert!(big.passes_filters(None, None, None, None, Some(threshold), &lookup, 0));
+
+        // Admin setter has no size — passes through any threshold.
+        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        assert!(setter.passes_filters(None, None, None, None, Some(u64::MAX), &lookup, 0));
+    }
+
+    // ── two-filter AND combinations ───────────────────────────────────────
+
+    #[test]
+    fn type_and_principal_combine_with_and_semantics() {
+        let lookup = HashMap::new();
+        let types: HashSet<_> = [EventTypeFilter::Borrow].into_iter().collect();
+
+        // Right type AND right principal → match
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&types), Some(&caller_a()), None, None, None, &lookup, 0,
+        ));
+        // Right type, wrong principal → reject
+        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&types), Some(&caller_b()), None, None, None, &lookup, 0,
+        ));
+        // Wrong type, right principal → reject
+        assert!(!repay_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&types), Some(&caller_a()), None, None, None, &lookup, 0,
+        ));
+    }
+
+    #[test]
+    fn time_and_token_combine_with_and_semantics() {
+        let lookup = lookup(&[(1, ckbtc_token())]);
+        let range = EventTimeRange { start_ns: 1_000, end_ns: 2_000 };
+
+        // In-window, right token → match
+        assert!(borrow_event(1, caller_a(), 100, 1_500).passes_filters(
+            None, None, Some(&ckbtc_token()), Some(&range), None, &lookup, 0,
+        ));
+        // Out-of-window, right token → reject
+        assert!(!borrow_event(1, caller_a(), 100, 9_999).passes_filters(
+            None, None, Some(&ckbtc_token()), Some(&range), None, &lookup, 0,
+        ));
+        // In-window, wrong token → reject
+        assert!(!borrow_event(1, caller_a(), 100, 1_500).passes_filters(
+            None, None, Some(&icp_token()), Some(&range), None, &lookup, 0,
+        ));
+    }
 }

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -193,13 +193,66 @@ pub struct StabilityPoolLiquidationResult {
     pub collateral_price_e8s: u64,
 }
 
-#[derive(candid::CandidType, Deserialize)]
+/// Coarse classification of an `Event` for the explorer's type facet.
+/// Each variant maps to one or more concrete `Event` cases via
+/// `Event::type_filter()`. Adding a new `Event` variant requires extending
+/// both the mapping there and (if needed) this enum.
+#[derive(candid::CandidType, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventTypeFilter {
+    OpenVault,
+    CloseVault,
+    AdjustVault,
+    Borrow,
+    Repay,
+    Liquidation,
+    PartialLiquidation,
+    Redemption,
+    ReserveRedemption,
+    StabilityPoolDeposit,
+    StabilityPoolWithdraw,
+    AdminMint,
+    AdminSweepToTreasury,
+    Admin,
+    PriceUpdate,
+    AccrueInterest,
+}
+
+/// Inclusive nanosecond timestamp window for the time facet.
+#[derive(candid::CandidType, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EventTimeRange {
+    pub start_ns: u64,
+    pub end_ns: u64,
+}
+
+#[derive(candid::CandidType, Deserialize, Default, Clone, Debug)]
 pub struct GetEventsArg {
     pub start: u64,
     pub length: u64,
+    /// OR-combined within the vec; AND with other filters. Empty vec or null
+    /// means "no filter on type" — preserves the legacy behavior of hiding
+    /// `AccrueInterest` and `PriceUpdate`. When non-empty, only events whose
+    /// `type_filter` matches one of the variants are returned (including
+    /// `AccrueInterest`/`PriceUpdate` if explicitly requested).
+    #[serde(default)]
+    pub types: Option<Vec<EventTypeFilter>>,
+    /// Match against the event's owner / caller / liquidator / target principal
+    /// using `Event::involves_principal`.
+    #[serde(default)]
+    pub principal: Option<Principal>,
+    /// Collateral token ledger principal. For vault-id events, resolved by
+    /// looking up the vault's collateral type at open time.
+    #[serde(default)]
+    pub collateral_token: Option<Principal>,
+    #[serde(default)]
+    pub time_range: Option<EventTimeRange>,
+    /// Minimum event size in icUSD e8s (= USD e8s). ICP/collateral amounts are
+    /// converted at the current spot price. Events with no meaningful size
+    /// pass through.
+    #[serde(default)]
+    pub min_size_e8s: Option<u64>,
 }
 
-#[derive(candid::CandidType)]
+#[derive(candid::CandidType, Clone)]
 pub struct GetEventsFilteredResponse {
     pub total: u64,
     pub events: Vec<(u64, crate::event::Event)>,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -8,7 +8,7 @@ use rumi_protocol_backend::{
     numeric::{ICUSD, ICP, Ratio, UsdIcp},
     state::{read_state, replace_state, Mode, State, RateCurveV2, DEFAULT_INTEREST_RATE_APR},
     vault::{CandidVault, OpenVaultSuccess, VaultArg},
-    Fees, GetEventsArg, ProtocolArg, ProtocolError, ProtocolStatus, SuccessWithFee,
+    EventTypeFilter, Fees, GetEventsArg, ProtocolArg, ProtocolError, ProtocolStatus, SuccessWithFee,
     ReserveRedemptionResult, ReserveBalance, CollateralTotals, CollateralInterestInfo, PerCollateralRateCurve,
     VaultArgWithToken, StableTokenType, InterestSplitArg,
     GetSnapshotsArg, ProtocolSnapshot, CollateralSnapshot,
@@ -596,8 +596,26 @@ fn get_event_count() -> u64 {
     rumi_protocol_backend::storage::count_events()
 }
 
-/// Return events excluding AccrueInterest, paginated newest-first.
-/// `start` is the page number (0-indexed), `length` is page size.
+/// Server-side filtered event query, paginated newest-first.
+/// `start` is the page number (0-indexed) into the *filtered* result set;
+/// `length` is page size (capped at `MAX_PAGE_SIZE`).
+///
+/// Filter semantics (all AND-combined):
+/// - `types`: empty/null preserves the legacy behavior of hiding
+///   `AccrueInterest`/`PriceUpdate`. When non-empty, only matching variants
+///   are included (those two are returnable if explicitly requested).
+/// - `principal`: matches via `Event::involves_principal`.
+/// - `collateral_token`: matches via `Event::collateral_token` using a
+///   per-query `vault_id → collateral_type` lookup built from `OpenVault`.
+/// - `time_range`: events with no `timestamp_ns` are excluded.
+/// - `min_size_e8s`: events with no `size_e8s_usd` pass through.
+///
+/// `total` is the matched count across the entire log (not the scanned slice),
+/// so the frontend can render accurate result counters.
+///
+/// Results are cached for `FILTERED_EVENTS_TTL_NS` (10s) keyed on the full
+/// filter spec + page, since events append continuously and stale results
+/// would hide just-recorded activity.
 #[candid_method(query)]
 #[query]
 fn get_events_filtered(args: GetEventsArg) -> GetEventsFilteredResponse {
@@ -606,17 +624,48 @@ fn get_events_filtered(args: GetEventsArg) -> GetEventsFilteredResponse {
     }
     const MAX_PAGE_SIZE: usize = 200;
     let page_size = MAX_PAGE_SIZE.min(args.length as usize);
-    let page = args.start as usize; // reinterpret `start` as page number
+    let page = args.start as usize;
 
-    // Collect all non-AccrueInterest events with their original indices
+    let now = ic_cdk::api::time();
+    let cache_key = filtered_events_cache_key(&args, page, page_size);
+    if let Some(cached) = read_filtered_events_cache(cache_key, now) {
+        return cached;
+    }
+
+    let vault_lookup = if args.collateral_token.is_some() {
+        build_vault_collateral_lookup()
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    let icp_price_e8s = read_state(|s| {
+        s.collateral_configs
+            .get(&s.icp_ledger_principal)
+            .and_then(|c| c.last_price)
+            .map(|p| (p * 100_000_000.0) as u64)
+            .unwrap_or(0)
+    });
+
+    let types_set: Option<std::collections::HashSet<EventTypeFilter>> = args.types
+        .as_ref()
+        .filter(|v| !v.is_empty())
+        .map(|v| v.iter().cloned().collect());
+
     let filtered: Vec<(u64, Event)> = events()
         .enumerate()
-        .filter(|(_, e)| !e.is_accrue_interest())
+        .filter(|(_, e)| e.passes_filters(
+            types_set.as_ref(),
+            args.principal.as_ref(),
+            args.collateral_token.as_ref(),
+            args.time_range.as_ref(),
+            args.min_size_e8s,
+            &vault_lookup,
+            icp_price_e8s,
+        ))
         .map(|(i, e)| (i as u64, e))
         .collect();
 
     let total = filtered.len() as u64;
-    // Reverse for newest-first, then paginate
     let start_idx = page * page_size;
     let page_events: Vec<(u64, Event)> = filtered.into_iter()
         .rev()
@@ -624,10 +673,73 @@ fn get_events_filtered(args: GetEventsArg) -> GetEventsFilteredResponse {
         .take(page_size)
         .collect();
 
-    GetEventsFilteredResponse {
+    let resp = GetEventsFilteredResponse {
         total,
         events: page_events,
+    };
+    write_filtered_events_cache(cache_key, now, &resp);
+    resp
+}
+
+/// Build `vault_id → collateral_type` by walking `OpenVault` events.
+/// Called only when the `collateral_token` filter is active. Cheap relative
+/// to the surrounding event scan since `OpenVault` is a small fraction of
+/// total events.
+fn build_vault_collateral_lookup() -> std::collections::HashMap<u64, Principal> {
+    let mut map = std::collections::HashMap::new();
+    for event in events() {
+        if let Event::OpenVault { vault, .. } = event {
+            map.insert(vault.vault_id, vault.collateral_type);
+        }
     }
+    map
+}
+
+const FILTERED_EVENTS_TTL_NS: u64 = 10 * 1_000_000_000;
+
+thread_local! {
+    static FILTERED_EVENTS_CACHE: std::cell::RefCell<
+        std::collections::HashMap<u64, (u64, GetEventsFilteredResponse)>
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+fn filtered_events_cache_key(args: &GetEventsArg, page: usize, page_size: usize) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    page.hash(&mut hasher);
+    page_size.hash(&mut hasher);
+    args.types.hash(&mut hasher);
+    args.principal.hash(&mut hasher);
+    args.collateral_token.hash(&mut hasher);
+    args.time_range.hash(&mut hasher);
+    args.min_size_e8s.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn read_filtered_events_cache(key: u64, now: u64) -> Option<GetEventsFilteredResponse> {
+    FILTERED_EVENTS_CACHE.with(|c| {
+        c.borrow().get(&key).and_then(|(at, resp)| {
+            if now.saturating_sub(*at) < FILTERED_EVENTS_TTL_NS {
+                Some(GetEventsFilteredResponse {
+                    total: resp.total,
+                    events: resp.events.clone(),
+                })
+            } else {
+                None
+            }
+        })
+    })
+}
+
+fn write_filtered_events_cache(key: u64, now: u64, resp: &GetEventsFilteredResponse) {
+    FILTERED_EVENTS_CACHE.with(|c| {
+        let snapshot = GetEventsFilteredResponse {
+            total: resp.total,
+            events: resp.events.clone(),
+        };
+        c.borrow_mut().insert(key, (now, snapshot));
+    });
 }
 
 /// Return all events involving a given principal (as owner, caller, or liquidator).

--- a/src/rumi_protocol_backend/src/tests.rs
+++ b/src/rumi_protocol_backend/src/tests.rs
@@ -70,9 +70,40 @@ proptest! {
             let result = crate::state::distribute_across_vaults(&vaults, target_vault);
             let icusd_distributed: ICUSD = result.iter().map(|e| e.icusd_share_amount).sum();
             let icp_distributed: ICP = result.iter().map(|e| e.icp_share_amount).sum();
-            
+
             assert_eq!(icusd_distributed, ICUSD::from(target_borrowed_icusd));
             assert_eq!(icp_distributed, ICP::from(target_icp_margin));
         }
+    }
+}
+
+#[cfg(test)]
+mod candid_compat {
+    use crate::GetEventsArg;
+    use candid::{decode_one, encode_one, CandidType, Deserialize};
+
+    /// Pre-extension wire shape: any client compiled before the new optional
+    /// filter fields were added still encodes a record with just `start` and
+    /// `length`. Decoding it as the extended `GetEventsArg` must succeed and
+    /// leave every new field as `None`.
+    #[derive(CandidType, Deserialize)]
+    struct LegacyGetEventsArg {
+        start: u64,
+        length: u64,
+    }
+
+    #[test]
+    fn legacy_two_field_arg_decodes_into_extended_struct() {
+        let legacy = LegacyGetEventsArg { start: 0, length: 100 };
+        let bytes = encode_one(&legacy).expect("encode legacy");
+        let decoded: GetEventsArg = decode_one(&bytes).expect("decode into extended");
+
+        assert_eq!(decoded.start, 0);
+        assert_eq!(decoded.length, 100);
+        assert!(decoded.types.is_none());
+        assert!(decoded.principal.is_none());
+        assert!(decoded.collateral_token.is_none());
+        assert!(decoded.time_range.is_none());
+        assert!(decoded.min_size_e8s.is_none());
     }
 }

--- a/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
+++ b/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
@@ -3230,7 +3230,7 @@ fn call_admin_mint(
 
 /// Helper: fetch all events from the protocol.
 fn fetch_events(pic: &PocketIc, protocol_id: Principal, start: u64, length: u64) -> Vec<Event> {
-    let arg = GetEventsArg { start, length };
+    let arg = GetEventsArg { start, length, ..Default::default() };
     let encoded = encode_args((arg,)).expect("Failed to encode get_events args");
 
     let result = pic


### PR DESCRIPTION
## Summary

Extends `get_events_filtered` with real filter parameters so the explorer's `/explorer/activity` page (PR #85) can push filters server-side instead of fetching the tail of every event stream and trimming client-side. This is the only Tier 1 backend gap remaining from the IA redesign — once this lands, PR 2 rewires the activity page to use it.

All filters AND-combined; existing `{start; length}` callers continue to work because Candid records are forward-compatible (extra optional fields default to `null` on the wire). A regression test pins this.

## New candid signature

```candid
type EventTypeFilter = variant {
  OpenVault; CloseVault; AdjustVault;
  Borrow; Repay;
  Liquidation; PartialLiquidation;
  Redemption; ReserveRedemption;
  StabilityPoolDeposit; StabilityPoolWithdraw;
  AdminMint; AdminSweepToTreasury;
  Admin;
  PriceUpdate; AccrueInterest;
};
type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
type GetEventsArg = record {
  start : nat64;
  length : nat64;
  types : opt vec EventTypeFilter;
  "principal" : opt principal;
  collateral_token : opt principal;
  time_range : opt EventTimeRange;
  min_size_e8s : opt nat64;
};
get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
```

## Filter semantics (all AND-combined)

- **`types`**: empty/null preserves the legacy behavior of hiding `AccrueInterest`/`PriceUpdate`. When non-empty, only matching variants surface (those two return-able if explicitly requested). Coarse classification — admin setters all collapse into `Admin`.
- **`principal`**: matches via the existing `Event::involves_principal` (owner / caller / liquidator / target — same logic `get_events_by_principal` uses).
- **`collateral_token`**: for vault-id events the collateral type isn't in the event itself, so we walk `OpenVault` events once per query to build a `vault_id → collateral_type` lookup. Cheap relative to the full event scan since `OpenVault` is a small fraction of total events.
- **`time_range`**: events with no `timestamp_ns` (Init/Upgrade/most setters) are excluded when this filter is active.
- **`min_size_e8s`**: icUSD-denominated amounts pass through; ICP/collateral amounts are converted at the **current spot ICP price** (snapshot at query time, not historical). Multi-collateral conversion uses ICP price as a v1 approximation. Events with no meaningful size (admin setters, init/upgrade) pass through any threshold.

## Pagination

`total` is the matched count across the entire log (not the scanned window) so the frontend can render accurate result counters. `start` cursors over filtered results; `length` capped at 200.

## Cache

Keyed on the full filter spec + page, 10s TTL. Trade-off: clients can see results up to 10s stale, but cache survives across event appends. Pattern matches PR #87's `get_top_holders` and PR #89's AMM caches.

## Test plan

- [x] `cargo test --package rumi_protocol_backend --lib filter_tests` — 16 new unit tests covering each filter dimension in isolation, AND combinations (type+principal, time+token), the empty-filter case (preserves today's behavior), and admin-setter pass-through.
- [x] `cargo test --package rumi_protocol_backend --lib tests::candid_compat` — wire-format regression: `{start; length}` payload encodes/decodes into the extended `GetEventsArg` with all new fields = `None`.
- [x] `cargo build --target wasm32-unknown-unknown --release --package rumi_protocol_backend` — clean build.
- [x] Existing `get_events`, `get_events_by_principal`, and the integration test that constructs `GetEventsArg { start, length, ..Default::default() }` continue to work.

```
running 16 tests
test event::filter_tests::collateral_token_uses_event_field_for_open_vault ... ok
test event::filter_tests::collateral_token_falls_back_to_vault_lookup_for_id_only_events ... ok
test event::filter_tests::collateral_token_filter_matches_via_vault_lookup ... ok
test event::filter_tests::empty_filter_excludes_accrue_interest_and_price_update ... ok
test event::filter_tests::explicit_type_set_includes_accrue_interest_when_requested ... ok
test event::filter_tests::min_size_excludes_below_threshold_and_passes_unsized_events ... ok
test event::filter_tests::principal_filter_matches_caller_or_owner ... ok
test event::filter_tests::size_in_usd_converts_icp_amounts_at_spot_price ... ok
test event::filter_tests::size_in_usd_passes_through_icusd_amounts ... ok
test event::filter_tests::size_returns_none_for_admin_setters ... ok
test event::filter_tests::time_and_token_combine_with_and_semantics ... ok
test event::filter_tests::time_range_excludes_outside_window_and_no_timestamp_events ... ok
test event::filter_tests::timestamp_ns_extracts_when_present_and_returns_none_otherwise ... ok
test event::filter_tests::type_and_principal_combine_with_and_semantics ... ok
test event::filter_tests::type_filter_or_combines_within_the_set ... ok
test event::filter_tests::type_filter_classifies_each_user_facing_variant ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 60 filtered out
```

## Out of scope

- Server-side filtering on 3pool / AMM / SP / treasury events (each canister already has its own per-principal / per-time-range queries; PR 2 will route per-source).
- Changes to `get_events`, `get_events_by_principal`, `get_event_count`.
- Pagination cursor changes (kept start/length offsets to keep the diff small).

## Notes

- The pre-existing `check_candid_interface_compatibility` bin test fails on `main` for unrelated drift (`stability_pool_liquidate_with_reserves` is in Rust but not in `.did`). My changes do not introduce new drift — both the auto-generated candid and the hand-edited `.did` agree on the new types. Spawned a separate task to clean up the unrelated drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)