### PR TITLE
feat(explorer): push activity-page filters server-side per source

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -450,6 +450,7 @@ type GetEventsArg = record {
   min_size_e8s : opt nat64;
 };
 type GetEventsFilteredResponse = record { total : nat64; events : vec record { nat64; Event } };
+type GetSnapshotsArg = record { start : nat64; length : nat64 };
 type HttpRequest = record {
   url : text;
   method : text;
@@ -711,7 +712,7 @@ service : (ProtocolArg) -> {
   get_liquidation_protocol_share : () -> (float64) query;
   get_liquidity_status : (principal) -> (LiquidityStatus) query;
   get_min_icusd_amount : () -> (nat64) query;
-  get_protocol_snapshots : (GetEventsArg) -> (vec ProtocolSnapshot) query;
+  get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_status : () -> (ProtocolStatus) query;
   get_recovery_cr_multiplier : () -> (float64) query;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -527,6 +527,7 @@ export interface GetEventsFilteredResponse {
   'total' : bigint,
   'events' : Array<[bigint, Event]>,
 }
+export interface GetSnapshotsArg { 'start' : bigint, 'length' : bigint }
 export interface HttpRequest {
   'url' : string,
   'method' : string,
@@ -890,7 +891,7 @@ export interface _SERVICE {
   'get_min_icusd_amount' : ActorMethod<[], bigint>,
   'get_protocol_config' : ActorMethod<[], ProtocolConfig>,
   'get_protocol_snapshots' : ActorMethod<
-    [GetEventsArg],
+    [GetSnapshotsArg],
     Array<ProtocolSnapshot>
   >,
   'get_protocol_status' : ActorMethod<[], ProtocolStatus>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -605,6 +605,10 @@ export const idlFactory = ({ IDL }) => {
     'stability_pool_canister' : IDL.Opt(IDL.Principal),
     'rmr_floor_cr' : IDL.Float64,
   });
+  const GetSnapshotsArg = IDL.Record({
+    'start' : IDL.Nat64,
+    'length' : IDL.Nat64,
+  });
   const CollateralSnapshot = IDL.Record({
     'total_collateral' : IDL.Nat64,
     'total_debt' : IDL.Nat64,
@@ -890,7 +894,7 @@ export const idlFactory = ({ IDL }) => {
     'get_min_icusd_amount' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_protocol_config' : IDL.Func([], [ProtocolConfig], ['query']),
     'get_protocol_snapshots' : IDL.Func(
-        [GetEventsArg],
+        [GetSnapshotsArg],
         [IDL.Vec(ProtocolSnapshot)],
         ['query'],
       ),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -450,6 +450,7 @@ type GetEventsArg = record {
   min_size_e8s : opt nat64;
 };
 type GetEventsFilteredResponse = record { total : nat64; events : vec record { nat64; Event } };
+type GetSnapshotsArg = record { start : nat64; length : nat64 };
 type HttpRequest = record {
   url : text;
   method : text;
@@ -711,7 +712,7 @@ service : (ProtocolArg) -> {
   get_liquidation_protocol_share : () -> (float64) query;
   get_liquidity_status : (principal) -> (LiquidityStatus) query;
   get_min_icusd_amount : () -> (nat64) query;
-  get_protocol_snapshots : (GetEventsArg) -> (vec ProtocolSnapshot) query;
+  get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_status : () -> (ProtocolStatus) query;
   get_recovery_cr_multiplier : () -> (float64) query;

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -505,27 +505,72 @@ export async function fetchEventCount(): Promise<bigint> {
 }
 
 /**
- * Fetch events with their global indices using the filtered endpoint.
- * Returns { total, events: Array<[bigint, Event]> }.
+ * Server-side filter spec for `fetchEvents`. Each field is optional; when
+ * omitted the backend treats it as "no filter on this dimension". Maps 1:1
+ * to the backend's `GetEventsArg` opt fields. Built from the activity-page
+ * facet bar via `facetsToBackendFilters` in `$utils/eventFacets`.
+ */
+export interface BackendEventFilters {
+	types?: BackendEventTypeFilter[];
+	principal?: Principal;
+	collateral_token?: Principal;
+	time_range?: { start_ns: bigint; end_ns: bigint };
+	min_size_e8s?: bigint;
+}
+
+/** Mirrors the backend `EventTypeFilter` Candid variant. */
+export type BackendEventTypeFilter =
+	| 'OpenVault' | 'CloseVault' | 'AdjustVault'
+	| 'Borrow' | 'Repay'
+	| 'Liquidation' | 'PartialLiquidation'
+	| 'Redemption' | 'ReserveRedemption'
+	| 'StabilityPoolDeposit' | 'StabilityPoolWithdraw'
+	| 'AdminMint' | 'AdminSweepToTreasury'
+	| 'Admin' | 'PriceUpdate' | 'AccrueInterest';
+
+function backendFiltersCacheKey(f: BackendEventFilters | undefined): string {
+	if (!f) return 'none';
+	const parts: string[] = [];
+	if (f.types?.length) parts.push(`t=${[...f.types].sort().join(',')}`);
+	if (f.principal) parts.push(`p=${f.principal.toText()}`);
+	if (f.collateral_token) parts.push(`c=${f.collateral_token.toText()}`);
+	if (f.time_range) parts.push(`r=${f.time_range.start_ns}-${f.time_range.end_ns}`);
+	if (f.min_size_e8s != null) parts.push(`s=${f.min_size_e8s}`);
+	return parts.length ? parts.join('|') : 'none';
+}
+
+function toCandidVariant(v: BackendEventTypeFilter): Record<string, null> {
+	return { [v]: null };
+}
+
+/**
+ * Fetch events with their global indices using `get_events_filtered`.
+ * `page` cursors over the *filtered* result set; `pageSize` capped at 200
+ * by the backend. `total` reports the matched count across the entire log.
  *
- * get_events_filtered takes {start, length} where:
- *   - start = page number (0-indexed)
- *   - length = page size
- * It excludes AccrueInterest events automatically.
+ * Without `filters`, behavior matches the legacy tail-fetch (hides
+ * AccrueInterest/PriceUpdate). With `filters`, all fields AND-combined.
  */
 export async function fetchEvents(
 	page: bigint,
-	pageSize: bigint
+	pageSize: bigint,
+	filters?: BackendEventFilters,
 ): Promise<{ total: bigint; events: [bigint, any][] }> {
-	const key = `events:filtered:${page}:${pageSize}`;
+	const filterKey = backendFiltersCacheKey(filters);
+	const key = `events:filtered:${page}:${pageSize}:${filterKey}`;
 	const cached = getCached<{ total: bigint; events: [bigint, any][] }>(key, TTL.EVENTS);
 	if (cached) return cached;
 
 	try {
-		const result = await publicActor.get_events_filtered({
-			start: page,
-			length: pageSize
-		});
+		const arg: any = { start: page, length: pageSize };
+		// Candid `opt T` is `[]` (none) or `[T]` (some) on the JS side.
+		arg.types = filters?.types?.length ? [filters.types.map(toCandidVariant)] : [];
+		arg.principal = filters?.principal ? [filters.principal] : [];
+		arg.collateral_token = filters?.collateral_token ? [filters.collateral_token] : [];
+		arg.time_range = filters?.time_range ? [filters.time_range] : [];
+		arg.min_size_e8s = filters?.min_size_e8s != null ? [filters.min_size_e8s] : [];
+
+		const result = await publicActor.get_events_filtered(arg);
 		const data = { total: result.total, events: result.events ?? [] };
 		return setCache(key, data);
 	} catch (err) {

--- a/src/vault_frontend/src/lib/stores/explorerStore.ts
+++ b/src/vault_frontend/src/lib/stores/explorerStore.ts
@@ -36,7 +36,12 @@ export async function fetchEvents(page: number = 0) {
 		// {total, events: [(index, event)]} with newest-first pagination
 		const result = await publicActor.get_events_filtered({
 			start: BigInt(page),   // page number
-			length: BigInt(PAGE_SIZE)
+			length: BigInt(PAGE_SIZE),
+			types: [],
+			principal: [],
+			collateral_token: [],
+			time_range: [],
+			min_size_e8s: [],
 		});
 		explorerEventsTotalCount.set(Number(result.total));
 		// result.events is Vec<(u64, Event)> — tuples of (globalIndex, event)
@@ -59,7 +64,12 @@ export async function fetchEvents(page: number = 0) {
 			const length = Math.min(PAGE_SIZE, totalCount - (page * PAGE_SIZE));
 			const events = await publicActor.get_events({
 				start: BigInt(start),
-				length: BigInt(length)
+				length: BigInt(length),
+				types: [],
+				principal: [],
+				collateral_token: [],
+				time_range: [],
+				min_size_e8s: [],
 			});
 			const filtered = [...events].reverse().filter((e: any) => {
 				const key = Object.keys(e)[0];

--- a/src/vault_frontend/src/lib/utils/eventFacets.ts
+++ b/src/vault_frontend/src/lib/utils/eventFacets.ts
@@ -6,12 +6,15 @@
  *   $-equivalent size; its canonical type key).
  * - `Facets` is the URL-as-state shape for active filters.
  * - `parseFacetsFromUrl` / `buildFacetsQueryString` handle the round-trip.
- * - `matchesFacets(event_facets, active)` is the AND-combined predicate.
- *
- * TODO: swap to server-side once get_events_filtered accepts filter params
- * (Tier 1 gap #1 in docs/superpowers/plans/2026-04-21-explorer-ia-redesign.md).
+ * - `matchesFacets(event_facets, active)` is the AND-combined predicate run
+ *   over already-fetched events as a safety net for dimensions not yet
+ *   pushable per source.
+ * - `facetsToBackendFilters(facets)` and `pickPoolFetchStrategy(facets)`
+ *   translate the URL facet state into per-canister query args so the
+ *   activity page can dispatch server-side filters where supported.
  */
 
+import { Principal } from '@dfinity/principal';
 import { CANISTER_IDS } from '$lib/config';
 import {
   KNOWN_TOKENS,
@@ -19,6 +22,10 @@ import {
   getTokenDecimals,
 } from '$utils/explorerHelpers';
 import type { DisplayEvent } from '$utils/displayEvent';
+import type {
+  BackendEventFilters,
+  BackendEventTypeFilter,
+} from '$services/explorer/explorerService';
 
 // ─── Type facet options ───────────────────────────────────────────────
 
@@ -913,4 +920,182 @@ function structuredCloneFacets(f: Facets): Facets {
     time: { ...f.time },
     minSizeUsd: f.minSizeUsd,
   };
+}
+
+// ─── Server-side dispatch translation ─────────────────────────────────
+
+/**
+ * Map a frontend `TypeFacetKey` to the matching backend `EventTypeFilter`.
+ * Returns `null` for keys that don't correspond to a backend event variant
+ * (DEX swaps, stability-pool ops — those come from other canisters).
+ */
+function frontendTypeToBackend(t: TypeFacetKey): BackendEventTypeFilter | null {
+  switch (t) {
+    case 'open_vault': return 'OpenVault';
+    case 'close_vault':
+    case 'withdraw_and_close':
+      return 'CloseVault';
+    case 'add_margin':
+    case 'withdraw_collateral':
+    case 'partial_withdraw_collateral':
+    case 'margin_transfer':
+    case 'dust_forgiven':
+      return 'AdjustVault';
+    case 'borrow': return 'Borrow';
+    case 'repay': return 'Repay';
+    case 'full_liquidation': return 'Liquidation';
+    case 'partial_liquidation': return 'PartialLiquidation';
+    case 'redistribute': return 'AdjustVault';
+    case 'redemption':
+    case 'redemption_transfer':
+      return 'Redemption';
+    case 'reserve_redemption': return 'ReserveRedemption';
+    case 'admin': return 'Admin';
+    case 'system': return 'AccrueInterest';
+    default: return null;
+  }
+}
+
+/** Token principals the backend's `collateral_token` filter understands as
+ * collateral types (i.e. has price + appears as `collateral_type` on vaults).
+ * icUSD/3USD/ckUSDT/ckUSDC don't make sense as collateral filters and are
+ * left to the client-side post-pass. */
+function isCollateralLikeToken(principal: string): boolean {
+  if (principal === CANISTER_IDS.ICUSD_LEDGER) return false;
+  if (principal === CANISTER_IDS.THREEPOOL) return false;
+  if (principal === CANISTER_IDS.CKUSDT_LEDGER) return false;
+  if (principal === CANISTER_IDS.CKUSDC_LEDGER) return false;
+  return true;
+}
+
+/** Resolve absolute ns time-window from a `Facets.time` spec, or null. */
+export function resolveTimeWindowMs(time: Facets['time']): { fromMs: number; toMs: number } | null {
+  const nowMs = Date.now();
+  if (time.preset === 'all') {
+    if (time.fromMs == null && time.toMs == null) return null;
+    return { fromMs: time.fromMs ?? 0, toMs: time.toMs ?? nowMs };
+  }
+  if (time.preset === 'custom') {
+    if (time.fromMs == null && time.toMs == null) return null;
+    return { fromMs: time.fromMs ?? 0, toMs: time.toMs ?? nowMs };
+  }
+  const preset = TIME_PRESETS.find((p) => p.key === time.preset);
+  if (!preset?.durationMs) return null;
+  return { fromMs: nowMs - preset.durationMs, toMs: nowMs };
+}
+
+function timeWindowToNsRange(time: Facets['time']): { start_ns: bigint; end_ns: bigint } | null {
+  const window = resolveTimeWindowMs(time);
+  if (!window) return null;
+  return {
+    start_ns: BigInt(Math.max(0, window.fromMs)) * 1_000_000n,
+    end_ns: BigInt(Math.max(0, window.toMs)) * 1_000_000n,
+  };
+}
+
+function safePrincipalFromText(text: string): Principal | null {
+  try { return Principal.fromText(text); } catch { return null; }
+}
+
+/**
+ * Result of `facetsToBackendFilters` — `filters` are the args to pass to
+ * `fetchEvents`; `skip = true` means the active facets explicitly exclude
+ * every backend event variant (e.g. user only chose DEX types) so the
+ * caller should skip the backend fetch entirely.
+ */
+export interface BackendFilterPlan {
+  filters: BackendEventFilters | undefined;
+  skip: boolean;
+}
+
+/**
+ * Translate the URL facet state into a server-side filter spec for
+ * `get_events_filtered`. Dimensions the backend can't represent (e.g.
+ * multiple principals, icUSD-as-token) are dropped — the client-side
+ * `matchesFacets` post-pass enforces them.
+ */
+export function facetsToBackendFilters(facets: Facets): BackendFilterPlan {
+  const filters: BackendEventFilters = {};
+
+  // Types — collapse frontend keys to the coarser backend variants. If the
+  // user picked types but none map to backend events, signal `skip`.
+  if (facets.types.length > 0) {
+    const backendTypes = new Set<BackendEventTypeFilter>();
+    for (const t of facets.types) {
+      const b = frontendTypeToBackend(t);
+      if (b) backendTypes.add(b);
+    }
+    if (backendTypes.size === 0) return { filters: undefined, skip: true };
+    filters.types = [...backendTypes];
+  }
+
+  // Principal — backend filter accepts a single principal.
+  if (facets.principals.length === 1) {
+    const p = safePrincipalFromText(facets.principals[0]);
+    if (p) filters.principal = p;
+  }
+
+  // Collateral token — only push down for actual collateral tokens.
+  if (facets.tokens.length === 1 && isCollateralLikeToken(facets.tokens[0])) {
+    const p = safePrincipalFromText(facets.tokens[0]);
+    if (p) filters.collateral_token = p;
+  }
+
+  const range = timeWindowToNsRange(facets.time);
+  if (range) filters.time_range = range;
+
+  if (facets.minSizeUsd != null && facets.minSizeUsd > 0) {
+    filters.min_size_e8s = BigInt(Math.floor(facets.minSizeUsd * 1e8));
+  }
+
+  const hasAny =
+    filters.types?.length || filters.principal || filters.collateral_token ||
+    filters.time_range || filters.min_size_e8s != null;
+  return { filters: hasAny ? filters : undefined, skip: false };
+}
+
+/**
+ * Dispatch strategy for per-pool event sources (3pool + AMM). The activity
+ * page picks the most selective endpoint based on which facets are active:
+ * a single principal is the strongest narrowing signal, a time window is
+ * second, otherwise we tail-fetch.
+ */
+export type PoolFetchStrategy =
+  | { kind: 'principal'; principal: Principal }
+  | { kind: 'time'; startNs: bigint; endNs: bigint }
+  | { kind: 'tail' };
+
+export function pickPoolFetchStrategy(facets: Facets): PoolFetchStrategy {
+  if (facets.principals.length === 1) {
+    const p = safePrincipalFromText(facets.principals[0]);
+    if (p) return { kind: 'principal', principal: p };
+  }
+  const range = timeWindowToNsRange(facets.time);
+  if (range) return { kind: 'time', startNs: range.start_ns, endNs: range.end_ns };
+  return { kind: 'tail' };
+}
+
+/**
+ * True iff the user's type facets exclude every event from a given source.
+ * Lets the activity page skip per-source fetches that can't possibly match.
+ */
+export function sourceExcludedByTypeFacet(
+  source: 'backend' | '3pool' | 'amm' | 'stability_pool',
+  facets: Facets,
+): boolean {
+  if (facets.types.length === 0) return false;
+  const has = (key: TypeFacetKey) => facets.types.includes(key);
+  switch (source) {
+    case 'backend':
+      return facets.types.every((t) => frontendTypeToBackend(t) == null);
+    case '3pool':
+      return !has('3pool_swap') && !has('3pool_add_liquidity') && !has('3pool_remove_liquidity')
+        && !has('3pool_remove_one_coin') && !has('3pool_donate') && !has('multi_hop_swap');
+    case 'amm':
+      return !has('amm_swap') && !has('amm_add_liquidity') && !has('amm_remove_liquidity')
+        && !has('multi_hop_swap');
+    case 'stability_pool':
+      return !has('sp_deposit') && !has('sp_withdraw') && !has('sp_claim_collateral')
+        && !has('sp_deposit_as_3usd') && !has('sp_liquidation_executed') && !has('sp_other');
+  }
 }

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -15,6 +15,11 @@
 		fetch3PoolLiquidityEvents, fetch3PoolLiquidityEventCount,
 		fetch3PoolAdminEvents, fetch3PoolAdminEventCount,
 		fetchStabilityPoolEvents, fetchStabilityPoolEventCount,
+		fetch3PoolSwapEventsByPrincipal,
+		fetch3PoolLiquidityEventsByPrincipal,
+		fetchAmmSwapEventsByPrincipal,
+		fetchAmmLiquidityEventsByPrincipal,
+		fetchAmmSwapEventsByTimeRange,
 		fetchAllVaults,
 		fetchAmmPools,
 		fetchCollateralPrices,
@@ -30,6 +35,9 @@
 		buildFacetsQueryString,
 		emptyFacets,
 		hasAnyFacet,
+		facetsToBackendFilters,
+		pickPoolFetchStrategy,
+		sourceExcludedByTypeFacet,
 		type Facets,
 	} from '$utils/eventFacets';
 
@@ -331,116 +339,10 @@
 		return result;
 	}
 
-	// ── Load everything once on mount ────────────────────────────────────
+	// ── Loaders ─────────────────────────────────────────────────────────
 
-	async function loadEverything() {
-		loading = true;
-		error = null;
-		try {
-			const BACKEND_PAGE_SIZE = 200;
-			const [firstBatch, threePoolSwapCount, ammSwapCount, ammLiqCount, threePoolLiqCount, ammAdminCount, threePoolAdminCount, spCount, ammPools, prices] = await Promise.all([
-				fetchEvents(0n, BigInt(BACKEND_PAGE_SIZE)),
-				fetchSwapEventCount(),
-				fetchAmmSwapEventCount(),
-				fetchAmmLiquidityEventCount(),
-				fetch3PoolLiquidityEventCount(),
-				fetchAmmAdminEventCount(),
-				fetch3PoolAdminEventCount(),
-				fetchStabilityPoolEventCount(),
-				fetchAmmPools(),
-				fetchCollateralPrices(),
-			]);
-
-			priceMap = prices;
-
-			// Remaining backend pages
-			const allBackendEvents: [bigint, any][] = [...firstBatch.events];
-			const backendTotal = Number(firstBatch.total);
-			if (allBackendEvents.length < backendTotal) {
-				const remaining: Promise<{ total: bigint; events: [bigint, any][] }>[] = [];
-				for (let p = 1; p * BACKEND_PAGE_SIZE < backendTotal; p++) {
-					remaining.push(fetchEvents(BigInt(p), BigInt(BACKEND_PAGE_SIZE)));
-				}
-				const batches = await Promise.all(remaining);
-				for (const batch of batches) allBackendEvents.push(...batch.events);
-			}
-
-			const [threePoolSwaps, ammSwaps, ammLiqEvents, threePoolLiqEvents, ammAdminEvts, threePoolAdminEvts, spEvents] = await Promise.all([
-				Number(threePoolSwapCount) > 0 ? fetchSwapEvents(0n, threePoolSwapCount) : Promise.resolve([]),
-				Number(ammSwapCount) > 0 ? fetchAmmSwapEvents(0n, ammSwapCount) : Promise.resolve([]),
-				Number(ammLiqCount) > 0 ? fetchAmmLiquidityEvents(0n, ammLiqCount) : Promise.resolve([]),
-				Number(threePoolLiqCount) > 0 ? fetch3PoolLiquidityEvents(threePoolLiqCount, 0n) : Promise.resolve([]),
-				Number(ammAdminCount) > 0 ? fetchAmmAdminEvents(0n, ammAdminCount) : Promise.resolve([]),
-				Number(threePoolAdminCount) > 0 ? fetch3PoolAdminEvents(0n, threePoolAdminCount) : Promise.resolve([]),
-				Number(spCount) > 0 ? fetchStabilityPoolEvents(0n, spCount) : Promise.resolve([]),
-			]);
-
-			const filteredSp = spEvents.filter((e: any) => {
-				const et = e.event_type ?? {};
-				return !('InterestReceived' in et);
-			});
-
-			const all: DisplayEvent[] = [];
-			for (const [idx, evt] of allBackendEvents) {
-				all.push({ globalIndex: idx, event: evt, source: 'backend', timestamp: extractEventTimestamp(evt) });
-			}
-			for (const e of threePoolSwaps) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_swap', timestamp: extractEventTimestamp(e) });
-			for (const e of ammSwaps) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_swap', timestamp: extractEventTimestamp(e) });
-			for (const e of ammLiqEvents) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_liquidity', timestamp: extractEventTimestamp(e) });
-			for (const e of threePoolLiqEvents) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_liquidity', timestamp: extractEventTimestamp(e) });
-			for (const e of ammAdminEvts) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_admin', timestamp: extractEventTimestamp(e) });
-			for (const e of threePoolAdminEvts) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_admin', timestamp: extractEventTimestamp(e) });
-			for (const e of filteredSp) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'stability_pool', timestamp: extractEventTimestamp(e) });
-
-			const merged = mergeMultiHopEvents(all);
-			merged.sort((a, b) => b.timestamp - a.timestamp);
-			allEvents = merged;
-
-			// Extract facets once per event
-			const fmap = new Map<string, ReturnType<typeof extractFacets>>();
-			for (const de of merged) {
-				const key = `${de.source}:${String(de.globalIndex)}`;
-				fmap.set(key, extractFacets(de, priceMap, vaultCollateralMap, vaultOwnerMap));
-			}
-			eventFacetsByIndex = fmap;
-
-			// Build token + pool option lists from the observed data + known tokens
-			const tokenSet = new Set<string>();
-			const poolSet = new Set<string>();
-			for (const ef of fmap.values()) {
-				for (const t of ef.tokens) tokenSet.add(t);
-				for (const p of ef.pools) poolSet.add(p);
-			}
-			// Always include the canonical Rumi tokens so the dropdown is complete
-			for (const known of Object.keys(KNOWN_TOKENS)) tokenSet.add(known);
-
-			tokenOptions = [...tokenSet]
-				.map((principal) => ({ principal, label: getTokenSymbol(principal) }))
-				.sort((a, b) => a.label.localeCompare(b.label));
-
-			// Pool options: 3pool always first, then AMM pools
-			const ammPoolIds: string[] = ammPools.map((p: any) => p.pool_id);
-			for (const id of ammPoolIds) poolSet.add(id);
-			poolSet.add('3pool');
-			poolOptions = [...poolSet]
-				.map((id) => {
-					if (id === '3pool') return { id, label: 'Rumi 3Pool' };
-					const pool = ammPools.find((p: any) => p.pool_id === id);
-					if (pool) {
-						const a = getTokenSymbol(pool.token_a?.toText?.() ?? '');
-						const b = getTokenSymbol(pool.token_b?.toText?.() ?? '');
-						return { id, label: `AMM · ${a}/${b} (${id})` };
-					}
-					return { id, label: id };
-				})
-				.sort((a, b) => a.label.localeCompare(b.label));
-		} catch (e) {
-			console.error('[activity] loadEverything error:', e);
-			error = 'Failed to load events.';
-		} finally {
-			loading = false;
-		}
-	}
+	let knownAmmPools: any[] = [];
+	let activeRequestId = 0;
 
 	async function loadVaultMaps() {
 		try {
@@ -461,11 +363,244 @@
 		}
 	}
 
+	async function loadMetadata() {
+		try {
+			const [ammPools, prices] = await Promise.all([
+				fetchAmmPools(),
+				fetchCollateralPrices(),
+			]);
+			knownAmmPools = ammPools ?? [];
+			priceMap = prices;
+
+			// Pool options: 3pool always first, then AMM pools
+			const poolSet = new Set<string>();
+			for (const p of knownAmmPools) poolSet.add(p.pool_id);
+			poolSet.add('3pool');
+			poolOptions = [...poolSet]
+				.map((id) => {
+					if (id === '3pool') return { id, label: 'Rumi 3Pool' };
+					const pool = knownAmmPools.find((p: any) => p.pool_id === id);
+					if (pool) {
+						const a = getTokenSymbol(pool.token_a?.toText?.() ?? '');
+						const b = getTokenSymbol(pool.token_b?.toText?.() ?? '');
+						return { id, label: `AMM · ${a}/${b} (${id})` };
+					}
+					return { id, label: id };
+				})
+				.sort((a, b) => a.label.localeCompare(b.label));
+
+			// Token options: union of canonical Rumi tokens + observed event tokens.
+			// Reloads append observed tokens to this set.
+			rebuildTokenOptionsFrom(eventFacetsByIndex);
+		} catch (e) {
+			console.error('[activity] loadMetadata error:', e);
+		}
+	}
+
+	function rebuildTokenOptionsFrom(fmap: Map<string, ReturnType<typeof extractFacets>>) {
+		const tokenSet = new Set<string>();
+		for (const ef of fmap.values()) {
+			for (const t of ef.tokens) tokenSet.add(t);
+		}
+		for (const known of Object.keys(KNOWN_TOKENS)) tokenSet.add(known);
+		tokenOptions = [...tokenSet]
+			.map((principal) => ({ principal, label: getTokenSymbol(principal) }))
+			.sort((a, b) => a.label.localeCompare(b.label));
+	}
+
+	// ── Per-source dispatch ─────────────────────────────────────────────
+
+	async function fetchBackendEvents(activeFacets: Facets): Promise<[bigint, any][]> {
+		if (sourceExcludedByTypeFacet('backend', activeFacets)) return [];
+		const plan = facetsToBackendFilters(activeFacets);
+		if (plan.skip) return [];
+
+		// Server-side filter (or unfiltered tail if no facets). Page through
+		// matched results — backend caps `length` at 200 per call.
+		const PAGE_SIZE = 200n;
+		const MAX_PAGES = 25; // 5000 events upper bound — safety against runaway loops
+		const out: [bigint, any][] = [];
+		const first = await fetchEvents(0n, PAGE_SIZE, plan.filters);
+		out.push(...first.events);
+		const total = Number(first.total);
+		const pagesNeeded = Math.min(MAX_PAGES, Math.ceil(total / Number(PAGE_SIZE)));
+		if (pagesNeeded > 1) {
+			const promises: Promise<{ total: bigint; events: [bigint, any][] }>[] = [];
+			for (let p = 1; p < pagesNeeded; p++) {
+				promises.push(fetchEvents(BigInt(p), PAGE_SIZE, plan.filters));
+			}
+			const batches = await Promise.all(promises);
+			for (const b of batches) out.push(...b.events);
+		}
+		return out;
+	}
+
+	async function fetchThreePoolForFacets(activeFacets: Facets): Promise<{ swaps: any[]; liquidity: any[]; admin: any[] }> {
+		if (sourceExcludedByTypeFacet('3pool', activeFacets)) {
+			return { swaps: [], liquidity: [], admin: [] };
+		}
+		const strategy = pickPoolFetchStrategy(activeFacets);
+		const PRINCIPAL_LIMIT = 500n;
+
+		if (strategy.kind === 'principal') {
+			// Per-principal endpoints exist for swaps + liquidity. Admin events
+			// have no principal index — drop them since they wouldn't match.
+			const [swaps, liquidity] = await Promise.all([
+				fetch3PoolSwapEventsByPrincipal(strategy.principal, 0n, PRINCIPAL_LIMIT),
+				fetch3PoolLiquidityEventsByPrincipal(strategy.principal, 0n, PRINCIPAL_LIMIT),
+			]);
+			return { swaps, liquidity, admin: [] };
+		}
+
+		// time-only or tail: full fetch + client-side post-filter handles
+		// time narrowing. (3pool has a swap_by_time_range endpoint but no
+		// liquidity equivalent — keeping the dispatch symmetric.)
+		const [swapCount, liqCount, adminCount] = await Promise.all([
+			fetchSwapEventCount(),
+			fetch3PoolLiquidityEventCount(),
+			fetch3PoolAdminEventCount(),
+		]);
+		const [swaps, liquidity, admin] = await Promise.all([
+			Number(swapCount) > 0 ? fetchSwapEvents(0n, swapCount) : Promise.resolve([]),
+			Number(liqCount) > 0 ? fetch3PoolLiquidityEvents(liqCount, 0n) : Promise.resolve([]),
+			Number(adminCount) > 0 ? fetch3PoolAdminEvents(0n, adminCount) : Promise.resolve([]),
+		]);
+		return { swaps, liquidity, admin };
+	}
+
+	async function fetchAmmForFacets(activeFacets: Facets): Promise<{ swaps: any[]; liquidity: any[]; admin: any[] }> {
+		if (sourceExcludedByTypeFacet('amm', activeFacets)) {
+			return { swaps: [], liquidity: [], admin: [] };
+		}
+		const strategy = pickPoolFetchStrategy(activeFacets);
+		const PRINCIPAL_LIMIT = 500n;
+		const TIME_LIMIT = 500n;
+
+		if (strategy.kind === 'principal' && knownAmmPools.length > 0) {
+			// Fan out across pools — AMM endpoints are pool-keyed.
+			const swapPromises = knownAmmPools.map((p) =>
+				fetchAmmSwapEventsByPrincipal(p.pool_id, strategy.principal, 0n, PRINCIPAL_LIMIT));
+			const liqPromises = knownAmmPools.map((p) =>
+				fetchAmmLiquidityEventsByPrincipal(p.pool_id, strategy.principal, 0n, PRINCIPAL_LIMIT));
+			const [swapBatches, liqBatches] = await Promise.all([
+				Promise.all(swapPromises),
+				Promise.all(liqPromises),
+			]);
+			return {
+				swaps: swapBatches.flat(),
+				liquidity: liqBatches.flat(),
+				admin: [], // admin events skipped under principal filter
+			};
+		}
+
+		if (strategy.kind === 'time' && knownAmmPools.length > 0) {
+			// Swap-by-time endpoint exists per pool; no liquidity-by-time, so
+			// liquidity falls back to tail-fetch and gets caught by the
+			// client-side post-filter pass.
+			const swapPromises = knownAmmPools.map((p) =>
+				fetchAmmSwapEventsByTimeRange(p.pool_id, strategy.startNs, strategy.endNs, TIME_LIMIT));
+			const [liqCount, swapBatches] = await Promise.all([
+				fetchAmmLiquidityEventCount(),
+				Promise.all(swapPromises),
+			]);
+			const liquidity = Number(liqCount) > 0 ? await fetchAmmLiquidityEvents(0n, liqCount) : [];
+			return { swaps: swapBatches.flat(), liquidity, admin: [] };
+		}
+
+		// Tail fetch
+		const [swapCount, liqCount, adminCount] = await Promise.all([
+			fetchAmmSwapEventCount(),
+			fetchAmmLiquidityEventCount(),
+			fetchAmmAdminEventCount(),
+		]);
+		const [swaps, liquidity, admin] = await Promise.all([
+			Number(swapCount) > 0 ? fetchAmmSwapEvents(0n, swapCount) : Promise.resolve([]),
+			Number(liqCount) > 0 ? fetchAmmLiquidityEvents(0n, liqCount) : Promise.resolve([]),
+			Number(adminCount) > 0 ? fetchAmmAdminEvents(0n, adminCount) : Promise.resolve([]),
+		]);
+		return { swaps, liquidity, admin };
+	}
+
+	async function fetchSpForFacets(activeFacets: Facets): Promise<any[]> {
+		if (sourceExcludedByTypeFacet('stability_pool', activeFacets)) return [];
+		// SP has no per-principal/time index — always tail-fetch, client-side
+		// post-filter narrows. Flagged as a Tier 2 follow-up if it bottlenecks.
+		const spCount = await fetchStabilityPoolEventCount();
+		if (Number(spCount) === 0) return [];
+		const events = await fetchStabilityPoolEvents(0n, spCount);
+		return events.filter((e: any) => {
+			const et = e.event_type ?? {};
+			return !('InterestReceived' in et);
+		});
+	}
+
+	// ── Core load: dispatch per-source, merge, extract facets ───────────
+
+	async function loadEvents(activeFacets: Facets) {
+		const reqId = ++activeRequestId;
+		loading = true;
+		error = null;
+		try {
+			const [backendEvents, threePool, amm, spEvents] = await Promise.all([
+				fetchBackendEvents(activeFacets),
+				fetchThreePoolForFacets(activeFacets),
+				fetchAmmForFacets(activeFacets),
+				fetchSpForFacets(activeFacets),
+			]);
+
+			// Bail if a newer request started while we awaited.
+			if (reqId !== activeRequestId) return;
+
+			const all: DisplayEvent[] = [];
+			for (const [idx, evt] of backendEvents) {
+				all.push({ globalIndex: idx, event: evt, source: 'backend', timestamp: extractEventTimestamp(evt) });
+			}
+			for (const e of threePool.swaps) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_swap', timestamp: extractEventTimestamp(e) });
+			for (const e of threePool.liquidity) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_liquidity', timestamp: extractEventTimestamp(e) });
+			for (const e of threePool.admin) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: '3pool_admin', timestamp: extractEventTimestamp(e) });
+			for (const e of amm.swaps) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_swap', timestamp: extractEventTimestamp(e) });
+			for (const e of amm.liquidity) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_liquidity', timestamp: extractEventTimestamp(e) });
+			for (const e of amm.admin) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'amm_admin', timestamp: extractEventTimestamp(e) });
+			for (const e of spEvents) all.push({ globalIndex: BigInt(e.id ?? 0), event: e, source: 'stability_pool', timestamp: extractEventTimestamp(e) });
+
+			const merged = mergeMultiHopEvents(all);
+			merged.sort((a, b) => b.timestamp - a.timestamp);
+
+			const fmap = new Map<string, ReturnType<typeof extractFacets>>();
+			for (const de of merged) {
+				const key = `${de.source}:${String(de.globalIndex)}`;
+				fmap.set(key, extractFacets(de, priceMap, vaultCollateralMap, vaultOwnerMap));
+			}
+
+			if (reqId !== activeRequestId) return;
+			allEvents = merged;
+			eventFacetsByIndex = fmap;
+			rebuildTokenOptionsFrom(fmap);
+		} catch (e) {
+			if (reqId !== activeRequestId) return;
+			console.error('[activity] loadEvents error:', e);
+			error = 'Failed to load events.';
+		} finally {
+			if (reqId === activeRequestId) loading = false;
+		}
+	}
+
+	let metadataReady = $state(false);
+
 	onMount(async () => {
 		loadSavedViews();
-		// Load vault maps first so the facet extractor can use them
 		await loadVaultMaps();
-		await loadEverything();
+		await loadMetadata();
+		metadataReady = true;
+	});
+
+	// React to facet changes — re-dispatch per-source fetches so the bulk of
+	// filtering happens server-side. The `matchesFacets` post-pass below still
+	// runs to catch dimensions a given source can't filter on.
+	$effect(() => {
+		void currentParams; // depend on URL state
+		if (!metadataReady) return;
+		void loadEvents(facets);
 	});
 </script>
 

--- a/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
@@ -108,7 +108,7 @@
     try {
       if (parsed.source === 'backend') {
         const [results, vaults, count] = await Promise.all([
-          publicActor.get_events({ start: BigInt(parsed.id), length: 1n }),
+          publicActor.get_events({ start: BigInt(parsed.id), length: 1n, types: [], principal: [], collateral_token: [], time_range: [], min_size_e8s: [] }),
           fetchAllVaults().catch(() => []),
           fetchEventCount().catch(() => 0n),
         ]);
@@ -154,7 +154,7 @@
         const neighborhood = 25;
         const start = BigInt(Math.max(0, parsed.id - neighborhood));
         const len = BigInt(neighborhood * 2 + 1);
-        const results = await publicActor.get_events({ start, length: len });
+        const results = await publicActor.get_events({ start, length: len, types: [], principal: [], collateral_token: [], time_range: [], min_size_e8s: [] });
         for (let i = 0; i < results.length; i++) {
           const idx = Number(start) + i;
           if (idx === parsed.id) continue;

--- a/src/vault_frontend/src/routes/transparency/+page.svelte
+++ b/src/vault_frontend/src/routes/transparency/+page.svelte
@@ -25,7 +25,7 @@
       let eventIndex = 0;
 
       while (!done) {
-        const events: any[] = await publicActor.get_events({ start, length: pageSize });
+        const events: any[] = await publicActor.get_events({ start, length: pageSize, types: [], principal: [], collateral_token: [], time_range: [], min_size_e8s: [] });
         for (const event of events) {
           if ('admin_mint' in event) {
             const e = event.admin_mint;


### PR DESCRIPTION
## Summary

Closes Tier 1 backend gap #1 from the IA redesign by rewiring the `/explorer/activity` query layer to push filters server-side per canister, using the new `get_events_filtered` args from #91. The client-side `matchesFacets` post-pass stays as a safety net so dimensions any given source can't push down (icUSD as a token, multiple principals, SP under any narrow facet) are still honored.

The PR #85 TODO comment in `eventFacets.ts` that flagged this work is deleted.

## Per-source dispatch (from `pickPoolFetchStrategy` + `facetsToBackendFilters`)

| Source | Active facets → endpoint |
|---|---|
| Backend (RPB) | Always `get_events_filtered` with the matching subset of `{types, principal, collateral_token, time_range, min_size_e8s}`. Skipped entirely if user's type facets exclude every backend variant. |
| 3pool | Single principal → `get_swap_events_by_principal` + `get_liquidity_events_by_principal`. Otherwise tail-fetch. |
| AMM | Single principal → per-pool fan-out via `get_amm_swap/liquidity_events_by_principal`. Time window → per-pool `get_amm_swap_events_by_time_range`. Otherwise tail-fetch. |
| Stability pool | Always tail-fetch (no per-principal index exists yet — flagged as a Tier 2 follow-up if it bottlenecks). |

If no facets are active, every source falls back to the existing tail-fetch so the default Activity view is unchanged.

## Implementation notes

- `BackendEventFilters` mirrors the new backend `GetEventsArg` opt fields and is built from `Facets` via `facetsToBackendFilters`. Returns `{filters, skip}` so the activity page can drop the backend fetch entirely when the user picked DEX-only types.
- Frontend `TypeFacetKey` (~30 keys) collapses to backend `EventTypeFilter` (16 coarse variants) via a small switch in `eventFacets.ts`.
- The `tokens` facet only pushes `collateral_token` to the backend for actual collateral types — icUSD/3USD/ckUSDT/ckUSDC stay client-side.
- Multiple principals → falls back to client-side; the backend filter accepts at most one.
- `loadEvents(facets)` re-runs whenever `facets` change (via `$effect` on `currentParams`); a request-id token cancels stale fetches when the user changes facets quickly.
- Multi-hop swap merge logic is preserved — narrow fetches still pull both 3pool liquidity and AMM swap from the same principal/window so the pair-matching still works.

## Companion fix: GetSnapshotsArg in .did

`get_protocol_snapshots` is declared as `GetSnapshotsArg` in Rust but the `.did` had it as `GetEventsArg`. Pre-existing drift, but adding new `GetEventsArg` fields would have broken every snapshot caller without this fix. Added `GetSnapshotsArg = record { start; length }` to the `.did` and regenerated TS bindings.

## Verification (live on mainnet — frontend deployed at `tcfua-yaaaa-aaaap-qrd7q-cai`)

### 1. Heavy facet stack (`type:borrow,repay`, `token:icp`, `time:30d`)

URL: https://app.rumiprotocol.com/explorer/activity?type=borrow,repay&token=icp&time=30d

Result: **108 of 110 events**. Backend `get_events_filtered` returns 110 events matching the type+token+time filter; client-side post-pass narrows to 108 (drops 2 events that backend's `collateral_token=ICP` matched but client-side `token:icp` semantics don't, e.g. RedemptionTransfered with no collateral_type). Counter accurately reflects both server-side `total` and post-filter result.

Screenshot at `pr92-heavy-facet-stack.png` (in repo root).

### 2. Network tab — per-canister dispatch confirmed

When the heavy-facet URL above is loaded, requests fan out to multiple canisters:

| Canister | Endpoint hit |
|---|---|
| `tfesu-vyaaa-aaaap-qrd7a-cai` (backend) | `get_events_filtered` with the full filter args (paged) |
| `fohh4-yyaaa-aaaap-qtkpa-cai` (3pool) | tail-fetch counts + events (no principal active) |
| `ijlzs-2yaaa-aaaap-quaaq-cai` (AMM) | tail-fetch counts + events |
| `tmhzi-dqaaa-aaaap-qrd6q-cai` (SP) | count + tail events |

When a single principal is active (URL: https://app.rumiprotocol.com/explorer/activity?principal=ulapy-ysfkn-fobdy-nif4d-s5y22-s4wlq-bqkxm-4iznv-4r5qo-begk2-hae), the dispatch switches to per-principal endpoints — backend filter, 3pool `by_principal`, AMM per-pool `by_principal` fan-out. Result: **19 of 36 events** (36 from server-side fetches across sources, 19 after client-side post-filter). Screenshot at `pr92-principal-dispatch.png`.

### 3. Default view regression (no facets active)

URL: https://app.rumiprotocol.com/explorer/activity

Result: **1,069 of 1,069 events** — full event count across backend + 3pool + AMM + SP. Identical to behavior before this PR (tail-fetch for every source). Screenshot at `pr92-default-view-regression.png`.

### 4. Type-check + build

- `npx svelte-check` — no errors in any file I touched (`eventFacets.ts`, `explorerService.ts`, `activity/+page.svelte`). 34 remaining errors in the workspace are all pre-existing in unrelated files.
- `npm run build` (vite) — clean.
- `dfx deploy --network ic vault_frontend` — succeeded; canister upgraded.

## Out of scope (Tier 2/3 follow-ups)

- 3pool swap-by-time / liquidity-by-time push-down (frontend wrappers exist for AMM but not 3pool — admin/donate events still tail-fetch).
- Per-principal SP event index (currently tail-fetch + client-side filter).
- Pagination cursor refactor — kept the existing client-side `visibleRows` slicing; "Load more" still bumps the in-memory window. Backend now reports the *true* matched count via `total`, so the counter on the page is accurate even when not all results are loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)