### PR TITLE
feat(analytics): add top-principals endpoints

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -1,3 +1,14 @@
+type AdminEventBreakdownQuery = record { window_ns : opt nat64 };
+type AdminEventBreakdownResponse = record {
+  labels : vec AdminEventLabelCount;
+  generated_at_ns : nat64;
+  window_ns : nat64;
+};
+type AdminEventLabelCount = record {
+  count : nat64;
+  label : text;
+  last_at_ns : opt nat64;
+};
 type ApyQuery = record { window_days : opt nat32 };
 type ApyResponse = record {
   lp_apy_pct : opt float64;
@@ -227,6 +238,22 @@ type ThreePoolSeriesResponse = record {
   rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
+type TopCounterpartiesQuery = record {
+  "principal" : principal;
+  limit : opt nat32;
+  window_ns : opt nat64;
+};
+type TopCounterpartiesResponse = record {
+  "principal" : principal;
+  rows : vec TopCounterpartyRow;
+  generated_at_ns : nat64;
+  window_ns : nat64;
+};
+type TopCounterpartyRow = record {
+  interaction_count : nat64;
+  volume_e8s : nat64;
+  counterparty : principal;
+};
 type TopHolderRow = record {
   "principal" : principal;
   balance_e8s : nat64;
@@ -240,6 +267,18 @@ type TopHoldersResponse = record {
   rows : vec TopHolderRow;
   total_holders : nat32;
   generated_at_ns : nat64;
+};
+type TopSpDepositorRow = record {
+  "principal" : principal;
+  total_deposited_e8s : nat64;
+  current_balance_e8s : nat64;
+  net_position_e8s : int64;
+};
+type TopSpDepositorsQuery = record { limit : opt nat32; window_ns : opt nat64 };
+type TopSpDepositorsResponse = record {
+  rows : vec TopSpDepositorRow;
+  generated_at_ns : nat64;
+  window_ns : nat64;
 };
 type TradeActivityQuery = record { window_secs : opt nat64 };
 type TradeActivityResponse = record {
@@ -282,6 +321,9 @@ type VolatilityResponse = record {
 };
 service : (InitArgs) -> {
   get_admin : () -> (principal) query;
+  get_admin_event_breakdown : (AdminEventBreakdownQuery) -> (
+      AdminEventBreakdownResponse,
+    ) query;
   get_apys : (ApyQuery) -> (ApyResponse) query;
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
@@ -296,7 +338,13 @@ service : (InitArgs) -> {
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
+  get_top_counterparties : (TopCounterpartiesQuery) -> (
+      TopCounterpartiesResponse,
+    ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
+  get_top_sp_depositors : (TopSpDepositorsQuery) -> (
+      TopSpDepositorsResponse,
+    ) query;
   get_trade_activity : (TradeActivityQuery) -> (TradeActivityResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_twap : (TwapQuery) -> (TwapResponse) query;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -2,6 +2,17 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface AdminEventBreakdownQuery { 'window_ns' : [] | [bigint] }
+export interface AdminEventBreakdownResponse {
+  'labels' : Array<AdminEventLabelCount>,
+  'generated_at_ns' : bigint,
+  'window_ns' : bigint,
+}
+export interface AdminEventLabelCount {
+  'count' : bigint,
+  'label' : string,
+  'last_at_ns' : [] | [bigint],
+}
 export interface ApyQuery { 'window_days' : [] | [number] }
 export interface ApyResponse {
   'lp_apy_pct' : [] | [number],
@@ -234,6 +245,22 @@ export interface ThreePoolSeriesResponse {
   'rows' : Array<Fast3PoolSnapshot>,
   'next_from_ts' : [] | [bigint],
 }
+export interface TopCounterpartiesQuery {
+  'principal' : Principal,
+  'limit' : [] | [number],
+  'window_ns' : [] | [bigint],
+}
+export interface TopCounterpartiesResponse {
+  'principal' : Principal,
+  'rows' : Array<TopCounterpartyRow>,
+  'generated_at_ns' : bigint,
+  'window_ns' : bigint,
+}
+export interface TopCounterpartyRow {
+  'interaction_count' : bigint,
+  'volume_e8s' : bigint,
+  'counterparty' : Principal,
+}
 export interface TopHolderRow {
   'principal' : Principal,
   'balance_e8s' : bigint,
@@ -250,6 +277,21 @@ export interface TopHoldersResponse {
   'rows' : Array<TopHolderRow>,
   'total_holders' : number,
   'generated_at_ns' : bigint,
+}
+export interface TopSpDepositorRow {
+  'principal' : Principal,
+  'total_deposited_e8s' : bigint,
+  'current_balance_e8s' : bigint,
+  'net_position_e8s' : bigint,
+}
+export interface TopSpDepositorsQuery {
+  'limit' : [] | [number],
+  'window_ns' : [] | [bigint],
+}
+export interface TopSpDepositorsResponse {
+  'rows' : Array<TopSpDepositorRow>,
+  'generated_at_ns' : bigint,
+  'window_ns' : bigint,
 }
 export interface TradeActivityQuery { 'window_secs' : [] | [bigint] }
 export interface TradeActivityResponse {
@@ -295,6 +337,10 @@ export interface VolatilityResponse {
 }
 export interface _SERVICE {
   'get_admin' : ActorMethod<[], Principal>,
+  'get_admin_event_breakdown' : ActorMethod<
+    [AdminEventBreakdownQuery],
+    AdminEventBreakdownResponse
+  >,
   'get_apys' : ActorMethod<[ApyQuery], ApyResponse>,
   'get_collector_health' : ActorMethod<[], CollectorHealth>,
   'get_cycle_series' : ActorMethod<[RangeQuery], CycleSeriesResponse>,
@@ -315,7 +361,15 @@ export interface _SERVICE {
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_swap_series' : ActorMethod<[RangeQuery], SwapSeriesResponse>,
   'get_three_pool_series' : ActorMethod<[RangeQuery], ThreePoolSeriesResponse>,
+  'get_top_counterparties' : ActorMethod<
+    [TopCounterpartiesQuery],
+    TopCounterpartiesResponse
+  >,
   'get_top_holders' : ActorMethod<[TopHoldersQuery], TopHoldersResponse>,
+  'get_top_sp_depositors' : ActorMethod<
+    [TopSpDepositorsQuery],
+    TopSpDepositorsResponse
+  >,
   'get_trade_activity' : ActorMethod<
     [TradeActivityQuery],
     TradeActivityResponse

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -7,6 +7,19 @@ export const idlFactory = ({ IDL }) => {
     'stability_pool' : IDL.Principal,
     'backend' : IDL.Principal,
   });
+  const AdminEventBreakdownQuery = IDL.Record({
+    'window_ns' : IDL.Opt(IDL.Nat64),
+  });
+  const AdminEventLabelCount = IDL.Record({
+    'count' : IDL.Nat64,
+    'label' : IDL.Text,
+    'last_at_ns' : IDL.Opt(IDL.Nat64),
+  });
+  const AdminEventBreakdownResponse = IDL.Record({
+    'labels' : IDL.Vec(AdminEventLabelCount),
+    'generated_at_ns' : IDL.Nat64,
+    'window_ns' : IDL.Nat64,
+  });
   const ApyQuery = IDL.Record({ 'window_days' : IDL.Opt(IDL.Nat32) });
   const ApyResponse = IDL.Record({
     'lp_apy_pct' : IDL.Opt(IDL.Float64),
@@ -199,6 +212,22 @@ export const idlFactory = ({ IDL }) => {
     'rows' : IDL.Vec(Fast3PoolSnapshot),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
+  const TopCounterpartiesQuery = IDL.Record({
+    'principal' : IDL.Principal,
+    'limit' : IDL.Opt(IDL.Nat32),
+    'window_ns' : IDL.Opt(IDL.Nat64),
+  });
+  const TopCounterpartyRow = IDL.Record({
+    'interaction_count' : IDL.Nat64,
+    'volume_e8s' : IDL.Nat64,
+    'counterparty' : IDL.Principal,
+  });
+  const TopCounterpartiesResponse = IDL.Record({
+    'principal' : IDL.Principal,
+    'rows' : IDL.Vec(TopCounterpartyRow),
+    'generated_at_ns' : IDL.Nat64,
+    'window_ns' : IDL.Nat64,
+  });
   const TopHoldersQuery = IDL.Record({
     'token' : IDL.Principal,
     'limit' : IDL.Opt(IDL.Nat32),
@@ -215,6 +244,21 @@ export const idlFactory = ({ IDL }) => {
     'rows' : IDL.Vec(TopHolderRow),
     'total_holders' : IDL.Nat32,
     'generated_at_ns' : IDL.Nat64,
+  });
+  const TopSpDepositorsQuery = IDL.Record({
+    'limit' : IDL.Opt(IDL.Nat32),
+    'window_ns' : IDL.Opt(IDL.Nat64),
+  });
+  const TopSpDepositorRow = IDL.Record({
+    'principal' : IDL.Principal,
+    'total_deposited_e8s' : IDL.Nat64,
+    'current_balance_e8s' : IDL.Nat64,
+    'net_position_e8s' : IDL.Int64,
+  });
+  const TopSpDepositorsResponse = IDL.Record({
+    'rows' : IDL.Vec(TopSpDepositorRow),
+    'generated_at_ns' : IDL.Nat64,
+    'window_ns' : IDL.Nat64,
   });
   const TradeActivityQuery = IDL.Record({ 'window_secs' : IDL.Opt(IDL.Nat64) });
   const TradeActivityResponse = IDL.Record({
@@ -294,6 +338,11 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'get_admin' : IDL.Func([], [IDL.Principal], ['query']),
+    'get_admin_event_breakdown' : IDL.Func(
+        [AdminEventBreakdownQuery],
+        [AdminEventBreakdownResponse],
+        ['query'],
+      ),
     'get_apys' : IDL.Func([ApyQuery], [ApyResponse], ['query']),
     'get_collector_health' : IDL.Func([], [CollectorHealth], ['query']),
     'get_cycle_series' : IDL.Func(
@@ -336,9 +385,19 @@ export const idlFactory = ({ IDL }) => {
         [ThreePoolSeriesResponse],
         ['query'],
       ),
+    'get_top_counterparties' : IDL.Func(
+        [TopCounterpartiesQuery],
+        [TopCounterpartiesResponse],
+        ['query'],
+      ),
     'get_top_holders' : IDL.Func(
         [TopHoldersQuery],
         [TopHoldersResponse],
+        ['query'],
+      ),
+    'get_top_sp_depositors' : IDL.Func(
+        [TopSpDepositorsQuery],
+        [TopSpDepositorsResponse],
         ['query'],
       ),
     'get_trade_activity' : IDL.Func(

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -1,3 +1,14 @@
+type AdminEventBreakdownQuery = record { window_ns : opt nat64 };
+type AdminEventBreakdownResponse = record {
+  labels : vec AdminEventLabelCount;
+  generated_at_ns : nat64;
+  window_ns : nat64;
+};
+type AdminEventLabelCount = record {
+  count : nat64;
+  label : text;
+  last_at_ns : opt nat64;
+};
 type ApyQuery = record { window_days : opt nat32 };
 type ApyResponse = record {
   lp_apy_pct : opt float64;
@@ -227,6 +238,22 @@ type ThreePoolSeriesResponse = record {
   rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
 };
+type TopCounterpartiesQuery = record {
+  "principal" : principal;
+  limit : opt nat32;
+  window_ns : opt nat64;
+};
+type TopCounterpartiesResponse = record {
+  "principal" : principal;
+  rows : vec TopCounterpartyRow;
+  generated_at_ns : nat64;
+  window_ns : nat64;
+};
+type TopCounterpartyRow = record {
+  interaction_count : nat64;
+  volume_e8s : nat64;
+  counterparty : principal;
+};
 type TopHolderRow = record {
   "principal" : principal;
   balance_e8s : nat64;
@@ -240,6 +267,18 @@ type TopHoldersResponse = record {
   rows : vec TopHolderRow;
   total_holders : nat32;
   generated_at_ns : nat64;
+};
+type TopSpDepositorRow = record {
+  "principal" : principal;
+  total_deposited_e8s : nat64;
+  current_balance_e8s : nat64;
+  net_position_e8s : int64;
+};
+type TopSpDepositorsQuery = record { limit : opt nat32; window_ns : opt nat64 };
+type TopSpDepositorsResponse = record {
+  rows : vec TopSpDepositorRow;
+  generated_at_ns : nat64;
+  window_ns : nat64;
 };
 type TradeActivityQuery = record { window_secs : opt nat64 };
 type TradeActivityResponse = record {
@@ -282,6 +321,9 @@ type VolatilityResponse = record {
 };
 service : (InitArgs) -> {
   get_admin : () -> (principal) query;
+  get_admin_event_breakdown : (AdminEventBreakdownQuery) -> (
+      AdminEventBreakdownResponse,
+    ) query;
   get_apys : (ApyQuery) -> (ApyResponse) query;
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
@@ -296,7 +338,13 @@ service : (InitArgs) -> {
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
+  get_top_counterparties : (TopCounterpartiesQuery) -> (
+      TopCounterpartiesResponse,
+    ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
+  get_top_sp_depositors : (TopSpDepositorsQuery) -> (
+      TopSpDepositorsResponse,
+    ) query;
   get_trade_activity : (TradeActivityQuery) -> (TradeActivityResponse) query;
   get_tvl_series : (RangeQuery) -> (TvlSeriesResponse) query;
   get_twap : (TwapQuery) -> (TwapResponse) query;

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -160,6 +160,21 @@ fn get_top_holders(query: types::TopHoldersQuery) -> types::TopHoldersResponse {
 }
 
 #[ic_cdk_macros::query]
+fn get_top_counterparties(query: types::TopCounterpartiesQuery) -> types::TopCounterpartiesResponse {
+    queries::live::get_top_counterparties(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_top_sp_depositors(query: types::TopSpDepositorsQuery) -> types::TopSpDepositorsResponse {
+    queries::live::get_top_sp_depositors(query)
+}
+
+#[ic_cdk_macros::query]
+fn get_admin_event_breakdown(query: types::AdminEventBreakdownQuery) -> types::AdminEventBreakdownResponse {
+    queries::live::get_admin_event_breakdown(query)
+}
+
+#[ic_cdk_macros::query]
 fn get_trade_activity(query: types::TradeActivityQuery) -> types::TradeActivityResponse {
     queries::live::get_trade_activity(query)
 }

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -533,6 +533,318 @@ pub fn compute_top_holders(
     }
 }
 
+// ─── Top Counterparties ───
+
+/// Default lookback when callers don't pass a window: 30 days.
+const DEFAULT_WINDOW_NS: u64 = 30 * 86_400 * NANOS_PER_SEC;
+
+/// Principal-ranking cache TTL: 30s.
+const TOP_PRINCIPALS_TTL_NS: u64 = 30 * NANOS_PER_SEC;
+
+/// Admin-breakdown cache TTL: 5 minutes (admin events are rare).
+const ADMIN_BREAKDOWN_TTL_NS: u64 = 5 * 60 * NANOS_PER_SEC;
+
+const TOP_PRINCIPALS_DEFAULT_LIMIT: u32 = 50;
+const TOP_PRINCIPALS_MAX_LIMIT: u32 = 200;
+const MAX_EVENT_LOAD: usize = 50_000;
+
+thread_local! {
+    static TOP_COUNTERPARTIES_CACHE: std::cell::RefCell<HashMap<(Principal, u64, u32), (u64, types::TopCounterpartiesResponse)>> =
+        std::cell::RefCell::new(HashMap::new());
+    static TOP_SP_DEPOSITORS_CACHE: std::cell::RefCell<HashMap<(u64, u32), (u64, types::TopSpDepositorsResponse)>> =
+        std::cell::RefCell::new(HashMap::new());
+    static ADMIN_BREAKDOWN_CACHE: std::cell::RefCell<HashMap<u64, (u64, types::AdminEventBreakdownResponse)>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+fn resolve_window_ns(window_ns: Option<u64>) -> u64 {
+    match window_ns {
+        Some(0) => DEFAULT_WINDOW_NS,
+        Some(w) => w,
+        None => DEFAULT_WINDOW_NS,
+    }
+}
+
+/// Whether a cached entry stamped at `cached_at_ns` is still fresh relative to
+/// `now_ns` and a `ttl_ns` lifetime. Extracted so cache behavior is unit-
+/// testable without needing a canister runtime.
+pub fn cache_is_fresh(cached_at_ns: u64, now_ns: u64, ttl_ns: u64) -> bool {
+    now_ns.saturating_sub(cached_at_ns) < ttl_ns
+}
+
+fn resolve_principal_limit(limit: Option<u32>) -> u32 {
+    let raw = limit.unwrap_or(TOP_PRINCIPALS_DEFAULT_LIMIT);
+    if raw == 0 { TOP_PRINCIPALS_DEFAULT_LIMIT } else { raw }
+        .clamp(1, TOP_PRINCIPALS_MAX_LIMIT)
+}
+
+pub fn get_top_counterparties(query: types::TopCounterpartiesQuery) -> types::TopCounterpartiesResponse {
+    let window_ns = resolve_window_ns(query.window_ns);
+    let limit = resolve_principal_limit(query.limit);
+    let now = ic_cdk::api::time();
+    let cache_key = (query.principal, window_ns, limit);
+
+    if let Some((ts, resp)) = TOP_COUNTERPARTIES_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
+        if cache_is_fresh(ts, now, TOP_PRINCIPALS_TTL_NS) {
+            return resp;
+        }
+    }
+
+    let from = now.saturating_sub(window_ns);
+    let vault_evs = storage::events::evt_vaults::range(from, now, MAX_EVENT_LOAD);
+    let swap_evs = storage::events::evt_swaps::range(from, now, MAX_EVENT_LOAD);
+    let liq_evs = storage::events::evt_liquidity::range(from, now, MAX_EVENT_LOAD);
+    let stab_evs = storage::events::evt_stability::range(from, now, MAX_EVENT_LOAD);
+
+    let (three_pool, amm) = state::read_state(|s| (s.sources.three_pool, s.sources.amm));
+    let sp = state::read_state(|s| s.sources.stability_pool);
+
+    // Build vault_id -> vault_owner from Opened events in this window. For
+    // historical redemption-vs-owner relationships we rely on open events also
+    // being in range; acceptable for the default window.
+    let mut vault_owners: HashMap<u64, Principal> = HashMap::new();
+    for e in &vault_evs {
+        if matches!(e.event_kind, storage::events::VaultEventKind::Opened) {
+            vault_owners.insert(e.vault_id, e.owner);
+        }
+    }
+
+    let rows = compute_top_counterparties(
+        query.principal,
+        &vault_evs,
+        &swap_evs,
+        &liq_evs,
+        &stab_evs,
+        &vault_owners,
+        three_pool,
+        amm,
+        sp,
+        limit as usize,
+    );
+
+    let resp = types::TopCounterpartiesResponse {
+        principal: query.principal,
+        window_ns,
+        generated_at_ns: now,
+        rows,
+    };
+    TOP_COUNTERPARTIES_CACHE.with(|c| {
+        c.borrow_mut().insert(cache_key, (now, resp.clone()));
+    });
+    resp
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compute_top_counterparties(
+    target: Principal,
+    vault_events: &[storage::events::AnalyticsVaultEvent],
+    swap_events: &[storage::events::AnalyticsSwapEvent],
+    liquidity_events: &[storage::events::AnalyticsLiquidityEvent],
+    stability_events: &[storage::events::AnalyticsStabilityEvent],
+    vault_owners: &HashMap<u64, Principal>,
+    three_pool: Principal,
+    amm: Principal,
+    stability_pool: Principal,
+    limit: usize,
+) -> Vec<types::TopCounterpartyRow> {
+    let mut cp: HashMap<Principal, (u64, u64)> = HashMap::new();
+    let mut bump = |p: Principal, vol: u64| {
+        let entry = cp.entry(p).or_insert((0, 0));
+        entry.0 = entry.0.saturating_add(1);
+        entry.1 = entry.1.saturating_add(vol);
+    };
+
+    for e in vault_events {
+        let owner_of_vault = vault_owners.get(&e.vault_id).copied();
+        let ev_actor = e.owner;
+        if ev_actor == target {
+            // Target acted on someone else's vault (e.g. a redemption) → the
+            // vault owner is the counterparty.
+            if let Some(actual_owner) = owner_of_vault {
+                if actual_owner != target {
+                    bump(actual_owner, e.amount);
+                }
+            }
+        } else if owner_of_vault == Some(target) {
+            // Someone else touched target's vault (liquidator, redeemer).
+            bump(ev_actor, e.amount);
+        }
+    }
+
+    for e in swap_events {
+        if e.caller == target {
+            let pool = match e.source {
+                storage::events::SwapSource::ThreePool => three_pool,
+                storage::events::SwapSource::Amm => amm,
+            };
+            bump(pool, e.amount_in);
+        }
+    }
+
+    for e in liquidity_events {
+        if e.caller == target {
+            let vol: u64 = e.amounts.iter().copied().fold(0u64, |acc, a| acc.saturating_add(a));
+            bump(three_pool, vol);
+        }
+    }
+
+    for e in stability_events {
+        if e.caller == target {
+            bump(stability_pool, e.amount);
+        }
+    }
+
+    let mut rows: Vec<(Principal, u64, u64)> = cp.into_iter()
+        .map(|(p, (c, v))| (p, c, v))
+        .collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+    rows.truncate(limit);
+    rows.into_iter().map(|(counterparty, interaction_count, volume_e8s)| {
+        types::TopCounterpartyRow { counterparty, interaction_count, volume_e8s }
+    }).collect()
+}
+
+/// Invalidate the cached counterparties for a principal. Kept for parity with
+/// PR #87's `invalidate_top_holders_cache`.
+#[allow(dead_code)]
+pub fn invalidate_top_counterparties_cache(principal: Principal) {
+    TOP_COUNTERPARTIES_CACHE.with(|c| {
+        c.borrow_mut().retain(|(p, _, _), _| *p != principal);
+    });
+}
+
+// ─── Top Stability Pool Depositors ───
+
+pub fn get_top_sp_depositors(query: types::TopSpDepositorsQuery) -> types::TopSpDepositorsResponse {
+    let window_ns = resolve_window_ns(query.window_ns);
+    let limit = resolve_principal_limit(query.limit);
+    let now = ic_cdk::api::time();
+    let cache_key = (window_ns, limit);
+
+    if let Some((ts, resp)) = TOP_SP_DEPOSITORS_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
+        if cache_is_fresh(ts, now, TOP_PRINCIPALS_TTL_NS) {
+            return resp;
+        }
+    }
+
+    let from = now.saturating_sub(window_ns);
+    let window_evs = storage::events::evt_stability::range(from, now, MAX_EVENT_LOAD);
+    let all_evs = storage::events::evt_stability::range(0, now, MAX_EVENT_LOAD);
+
+    let rows = compute_top_sp_depositors(&window_evs, &all_evs, limit as usize);
+
+    let resp = types::TopSpDepositorsResponse {
+        window_ns,
+        generated_at_ns: now,
+        rows,
+    };
+    TOP_SP_DEPOSITORS_CACHE.with(|c| {
+        c.borrow_mut().insert(cache_key, (now, resp.clone()));
+    });
+    resp
+}
+
+pub fn compute_top_sp_depositors(
+    window_events: &[storage::events::AnalyticsStabilityEvent],
+    all_events: &[storage::events::AnalyticsStabilityEvent],
+    limit: usize,
+) -> Vec<types::TopSpDepositorRow> {
+    use storage::events::StabilityAction;
+
+    // Windowed totals per principal.
+    let mut window_stats: HashMap<Principal, (u64, i64)> = HashMap::new();
+    for e in window_events {
+        let entry = window_stats.entry(e.caller).or_insert((0, 0));
+        match e.action {
+            StabilityAction::Deposit => {
+                entry.0 = entry.0.saturating_add(e.amount);
+                entry.1 = entry.1.saturating_add(e.amount as i64);
+            }
+            StabilityAction::Withdraw => {
+                entry.1 = entry.1.saturating_sub(e.amount as i64);
+            }
+            StabilityAction::ClaimReturns => {}
+        }
+    }
+
+    // All-time net balance per principal.
+    let mut lifetime_net: HashMap<Principal, i64> = HashMap::new();
+    for e in all_events {
+        let entry = lifetime_net.entry(e.caller).or_insert(0);
+        match e.action {
+            StabilityAction::Deposit => *entry = entry.saturating_add(e.amount as i64),
+            StabilityAction::Withdraw => *entry = entry.saturating_sub(e.amount as i64),
+            StabilityAction::ClaimReturns => {}
+        }
+    }
+
+    let mut rows: Vec<types::TopSpDepositorRow> = window_stats.into_iter()
+        .filter(|(_, (dep, _))| *dep > 0)
+        .map(|(principal, (total_deposited_e8s, net_position_e8s))| {
+            let current = lifetime_net.get(&principal).copied().unwrap_or(0);
+            let current_balance_e8s = if current < 0 { 0 } else { current as u64 };
+            types::TopSpDepositorRow {
+                principal,
+                total_deposited_e8s,
+                current_balance_e8s,
+                net_position_e8s,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| b.total_deposited_e8s.cmp(&a.total_deposited_e8s));
+    rows.truncate(limit);
+    rows
+}
+
+// ─── Admin Event Breakdown ───
+
+pub fn get_admin_event_breakdown(query: types::AdminEventBreakdownQuery) -> types::AdminEventBreakdownResponse {
+    let window_ns = resolve_window_ns(query.window_ns);
+    let now = ic_cdk::api::time();
+
+    if let Some((ts, resp)) = ADMIN_BREAKDOWN_CACHE.with(|c| c.borrow().get(&window_ns).cloned()) {
+        if now.saturating_sub(ts) < ADMIN_BREAKDOWN_TTL_NS {
+            return resp;
+        }
+    }
+
+    let from = now.saturating_sub(window_ns);
+    let events = storage::events::evt_admin::range(from, now, MAX_EVENT_LOAD);
+    let labels = compute_admin_event_breakdown(&events);
+
+    let resp = types::AdminEventBreakdownResponse {
+        window_ns,
+        generated_at_ns: now,
+        labels,
+    };
+    ADMIN_BREAKDOWN_CACHE.with(|c| {
+        c.borrow_mut().insert(window_ns, (now, resp.clone()));
+    });
+    resp
+}
+
+pub fn compute_admin_event_breakdown(
+    events: &[storage::events::AnalyticsAdminEvent],
+) -> Vec<types::AdminEventLabelCount> {
+    let mut agg: HashMap<String, (u64, u64)> = HashMap::new();
+    for e in events {
+        let entry = agg.entry(e.label.clone()).or_insert((0, 0));
+        entry.0 = entry.0.saturating_add(1);
+        if e.timestamp_ns > entry.1 {
+            entry.1 = e.timestamp_ns;
+        }
+    }
+    let mut rows: Vec<types::AdminEventLabelCount> = agg.into_iter()
+        .map(|(label, (count, last))| types::AdminEventLabelCount {
+            label,
+            count,
+            last_at_ns: if last > 0 { Some(last) } else { None },
+        })
+        .collect();
+    rows.sort_by(|a, b| b.count.cmp(&a.count).then(a.label.cmp(&b.label)));
+    rows
+}
+
 // ─── Protocol Summary ───
 
 pub fn get_protocol_summary() -> types::ProtocolSummary {
@@ -974,6 +1286,301 @@ mod tests {
         assert_eq!(res.total_holders, 0);
         assert!(res.rows.is_empty());
         assert_eq!(res.generated_at_ns, 7);
+    }
+
+    // ── Top counterparties ─────────────────────────────────────────────────
+
+    fn make_vault_event(vault_id: u64, owner: Principal, kind: crate::storage::events::VaultEventKind, amount: u64) -> crate::storage::events::AnalyticsVaultEvent {
+        crate::storage::events::AnalyticsVaultEvent {
+            timestamp_ns: 1_000,
+            source_event_id: 0,
+            vault_id,
+            owner,
+            event_kind: kind,
+            collateral_type: Principal::anonymous(),
+            amount,
+        }
+    }
+
+    fn make_liquidity_event(caller: Principal, amounts: Vec<u64>) -> crate::storage::events::AnalyticsLiquidityEvent {
+        crate::storage::events::AnalyticsLiquidityEvent {
+            timestamp_ns: 1_000,
+            source_event_id: 0,
+            caller,
+            action: crate::storage::events::LiquidityAction::Add,
+            amounts,
+            lp_amount: 0,
+            coin_index: None,
+            fee: None,
+        }
+    }
+
+    fn make_stability_event(caller: Principal, action: crate::storage::events::StabilityAction, amount: u64) -> crate::storage::events::AnalyticsStabilityEvent {
+        crate::storage::events::AnalyticsStabilityEvent {
+            timestamp_ns: 1_000,
+            source_event_id: 0,
+            caller,
+            action,
+            amount,
+        }
+    }
+
+    fn make_admin_event(label: &str, ts: u64) -> crate::storage::events::AnalyticsAdminEvent {
+        crate::storage::events::AnalyticsAdminEvent {
+            timestamp_ns: ts,
+            source_event_id: 0,
+            label: label.to_string(),
+        }
+    }
+
+    #[test]
+    fn top_counterparties_ranks_by_interactions_and_volume() {
+        use crate::storage::events::SwapSource;
+
+        let target = p(1);
+        let three_pool = p(100);
+        let amm = p(101);
+        let sp = p(102);
+
+        let swaps = vec![
+            AnalyticsSwapEvent {
+                timestamp_ns: 1_000, source: SwapSource::ThreePool, source_event_id: 0,
+                caller: target, token_in: p(50), token_out: p(51),
+                amount_in: 1_000, amount_out: 995, fee: 5,
+            },
+            AnalyticsSwapEvent {
+                timestamp_ns: 2_000, source: SwapSource::Amm, source_event_id: 1,
+                caller: target, token_in: p(60), token_out: p(61),
+                amount_in: 500, amount_out: 495, fee: 5,
+            },
+            AnalyticsSwapEvent {
+                timestamp_ns: 3_000, source: SwapSource::ThreePool, source_event_id: 2,
+                caller: target, token_in: p(50), token_out: p(51),
+                amount_in: 2_000, amount_out: 1_990, fee: 10,
+            },
+        ];
+
+        let rows = compute_top_counterparties(
+            target,
+            &[],
+            &swaps,
+            &[],
+            &[],
+            &HashMap::new(),
+            three_pool, amm, sp,
+            10,
+        );
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].counterparty, three_pool);
+        assert_eq!(rows[0].interaction_count, 2);
+        assert_eq!(rows[0].volume_e8s, 3_000);
+        assert_eq!(rows[1].counterparty, amm);
+        assert_eq!(rows[1].interaction_count, 1);
+    }
+
+    #[test]
+    fn top_counterparties_surfaces_other_principals_via_vault_ownership() {
+        use crate::storage::events::VaultEventKind;
+
+        let owner = p(1);
+        let redeemer = p(2);
+        let mut vault_owners = HashMap::new();
+        vault_owners.insert(42u64, owner);
+
+        let vault_events = vec![
+            make_vault_event(42, owner, VaultEventKind::Opened, 0),
+            // Redeemer acted on owner's vault.
+            make_vault_event(42, redeemer, VaultEventKind::Redeemed, 500),
+            // Owner acts on own vault — not a counterparty.
+            make_vault_event(42, owner, VaultEventKind::Borrowed, 100),
+        ];
+
+        let rows = compute_top_counterparties(
+            owner,
+            &vault_events,
+            &[],
+            &[],
+            &[],
+            &vault_owners,
+            p(100), p(101), p(102),
+            10,
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].counterparty, redeemer);
+        assert_eq!(rows[0].interaction_count, 1);
+        assert_eq!(rows[0].volume_e8s, 500);
+    }
+
+    #[test]
+    fn top_counterparties_respects_limit() {
+        let target = p(1);
+        let three_pool = p(100);
+        // Three separate liquidity events (all counted against the pool).
+        let events = vec![
+            make_liquidity_event(target, vec![100, 200]),
+            make_liquidity_event(target, vec![50]),
+            make_liquidity_event(target, vec![10]),
+        ];
+        // Pool is the only counterparty, so limit=1 is already the full result.
+        let rows = compute_top_counterparties(
+            target,
+            &[],
+            &[],
+            &events,
+            &[],
+            &HashMap::new(),
+            three_pool, p(101), p(102),
+            1,
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].interaction_count, 3);
+        assert_eq!(rows[0].volume_e8s, 360);
+    }
+
+    #[test]
+    fn top_counterparties_skips_events_unrelated_to_target() {
+        use crate::storage::events::SwapSource;
+        let target = p(1);
+        let other = p(2);
+        let swaps = vec![
+            AnalyticsSwapEvent {
+                timestamp_ns: 1_000, source: SwapSource::ThreePool, source_event_id: 0,
+                caller: other, token_in: p(50), token_out: p(51),
+                amount_in: 1_000, amount_out: 995, fee: 5,
+            },
+        ];
+        let rows = compute_top_counterparties(
+            target,
+            &[],
+            &swaps,
+            &[],
+            &[],
+            &HashMap::new(),
+            p(100), p(101), p(102),
+            10,
+        );
+        assert!(rows.is_empty());
+    }
+
+    // ── Top SP depositors ─────────────────────────────────────────────────
+
+    #[test]
+    fn top_sp_depositors_ranks_by_total_deposited_in_window() {
+        use crate::storage::events::StabilityAction;
+        let whale = p(1);
+        let shrimp = p(2);
+        let window_events = vec![
+            make_stability_event(whale, StabilityAction::Deposit, 1_000),
+            make_stability_event(whale, StabilityAction::Deposit, 500),
+            make_stability_event(whale, StabilityAction::Withdraw, 200),
+            make_stability_event(shrimp, StabilityAction::Deposit, 100),
+        ];
+        let rows = compute_top_sp_depositors(&window_events, &window_events, 10);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].principal, whale);
+        assert_eq!(rows[0].total_deposited_e8s, 1_500);
+        assert_eq!(rows[0].net_position_e8s, 1_300);
+        assert_eq!(rows[0].current_balance_e8s, 1_300);
+        assert_eq!(rows[1].principal, shrimp);
+        assert_eq!(rows[1].total_deposited_e8s, 100);
+    }
+
+    #[test]
+    fn top_sp_depositors_uses_all_events_for_current_balance() {
+        use crate::storage::events::StabilityAction;
+        let user = p(1);
+        let window = vec![
+            make_stability_event(user, StabilityAction::Deposit, 500),
+        ];
+        let all_time = vec![
+            make_stability_event(user, StabilityAction::Deposit, 1_000),
+            make_stability_event(user, StabilityAction::Withdraw, 400),
+            make_stability_event(user, StabilityAction::Deposit, 500),
+        ];
+        let rows = compute_top_sp_depositors(&window, &all_time, 10);
+        assert_eq!(rows[0].total_deposited_e8s, 500);
+        assert_eq!(rows[0].current_balance_e8s, 1_100);
+    }
+
+    #[test]
+    fn top_sp_depositors_respects_limit_and_drops_claim_only_principals() {
+        use crate::storage::events::StabilityAction;
+        let events: Vec<_> = (1u8..=10)
+            .map(|i| make_stability_event(p(i), StabilityAction::Deposit, (i as u64) * 100))
+            .chain(std::iter::once(make_stability_event(p(99), StabilityAction::ClaimReturns, 50)))
+            .collect();
+        let rows = compute_top_sp_depositors(&events, &events, 3);
+        assert_eq!(rows.len(), 3);
+        // Top three by amount: p(10)=1000, p(9)=900, p(8)=800
+        assert_eq!(rows[0].principal, p(10));
+        assert_eq!(rows[2].total_deposited_e8s, 800);
+        // The claim-only principal never appears in the deposits ranking.
+        assert!(rows.iter().all(|r| r.principal != p(99)));
+    }
+
+    #[test]
+    fn top_sp_depositors_empty_events_returns_empty() {
+        let rows = compute_top_sp_depositors(&[], &[], 10);
+        assert!(rows.is_empty());
+    }
+
+    // ── Admin event breakdown ─────────────────────────────────────────────
+
+    #[test]
+    fn admin_breakdown_counts_by_label_and_tracks_last_at() {
+        let events = vec![
+            make_admin_event("SetBorrowingFee", 1_000),
+            make_admin_event("SetBorrowingFee", 3_000),
+            make_admin_event("SetHealthyCr", 2_000),
+        ];
+        let rows = compute_admin_event_breakdown(&events);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].label, "SetBorrowingFee");
+        assert_eq!(rows[0].count, 2);
+        assert_eq!(rows[0].last_at_ns, Some(3_000));
+        assert_eq!(rows[1].label, "SetHealthyCr");
+        assert_eq!(rows[1].count, 1);
+    }
+
+    #[test]
+    fn admin_breakdown_sorts_count_desc_then_label() {
+        let events = vec![
+            make_admin_event("SetBorrowingFee", 1_000),
+            make_admin_event("SetHealthyCr", 2_000),
+            make_admin_event("AddCollateralType", 3_000),
+        ];
+        let rows = compute_admin_event_breakdown(&events);
+        // All count==1, sort by label asc as tiebreaker.
+        assert_eq!(rows[0].label, "AddCollateralType");
+        assert_eq!(rows[1].label, "SetBorrowingFee");
+        assert_eq!(rows[2].label, "SetHealthyCr");
+    }
+
+    #[test]
+    fn admin_breakdown_empty_returns_empty() {
+        assert!(compute_admin_event_breakdown(&[]).is_empty());
+    }
+
+    // ── Cache freshness ──────────────────────────────────────────────────
+
+    #[test]
+    fn cache_is_fresh_within_ttl_and_stale_after() {
+        // 30s TTL, stamp at t=1_000 (in the same ns units).
+        let ttl = 30 * NANOS_PER_SEC;
+        let cached_at = 1_000_000_000u64;
+        // Same instant → fresh.
+        assert!(cache_is_fresh(cached_at, cached_at, ttl));
+        // 29s later → still fresh.
+        assert!(cache_is_fresh(cached_at, cached_at + 29 * NANOS_PER_SEC, ttl));
+        // Exactly TTL later → stale (strict <).
+        assert!(!cache_is_fresh(cached_at, cached_at + ttl, ttl));
+        // 1 minute later → stale.
+        assert!(!cache_is_fresh(cached_at, cached_at + 60 * NANOS_PER_SEC, ttl));
+        // Now earlier than cached_at (clock skew/defensive) → saturating
+        // subtraction yields 0 which is < ttl → still fresh.
+        assert!(cache_is_fresh(cached_at + 5, cached_at, ttl));
     }
 
     #[test]

--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -185,9 +185,17 @@ pub enum BackendEvent {
     #[serde(rename = "set_borrowing_fee")]
     SetBorrowingFee {},
     #[serde(rename = "claim_liquidity_returns")]
-    ClaimLiquidityReturns {},
+    ClaimLiquidityReturns {
+        amount: u64,
+        caller: Principal,
+        timestamp: Option<u64>,
+    },
     #[serde(rename = "provide_liquidity")]
-    ProvideLiquidity {},
+    ProvideLiquidity {
+        amount: u64,
+        caller: Principal,
+        timestamp: Option<u64>,
+    },
     #[serde(rename = "set_rmr_ceiling_cr")]
     SetRmrCeilingCr {},
     #[serde(rename = "set_recovery_rate_curve")]
@@ -255,7 +263,11 @@ pub enum BackendEvent {
     #[serde(rename = "set_rate_curve_markers")]
     SetRateCurveMarkers {},
     #[serde(rename = "withdraw_liquidity")]
-    WithdrawLiquidity {},
+    WithdrawLiquidity {
+        amount: u64,
+        caller: Principal,
+        timestamp: Option<u64>,
+    },
     #[serde(rename = "admin_mint")]
     AdminMint {},
     #[serde(rename = "set_three_pool_canister")]
@@ -317,6 +329,102 @@ pub struct BackendVaultRecord {
     pub collateral_type: Principal,
     pub collateral_amount: u64,
     pub borrowed_icusd_amount: u64,
+}
+
+impl BackendEvent {
+    /// Canonical admin label (variant name) for admin/setter/init/upgrade
+    /// variants. Returns None for user-facing variants (vault, swap, stability,
+    /// redemption, etc.). Stable across Rust renames as long as this match
+    /// stays in sync with the backend enum.
+    pub fn admin_label(&self) -> Option<&'static str> {
+        use BackendEvent::*;
+        match self {
+            // User-facing / non-admin variants (they map to their own
+            // EventTypeFilter categories in the backend, not Admin):
+            OpenVault { .. }
+            | BorrowFromVault { .. }
+            | RepayToVault { .. }
+            | CollateralWithdrawn { .. }
+            | PartialCollateralWithdrawn { .. }
+            | WithdrawAndCloseVault { .. }
+            | VaultWithdrawnAndClosed { .. }
+            | DustForgiven { .. }
+            | RedemptionOnVaults { .. }
+            | RedemptionTransfered {}
+            | LiquidateVault { .. }
+            | PartialLiquidateVault { .. }
+            | RedistributeVault { .. }
+            | ProvideLiquidity { .. }
+            | WithdrawLiquidity { .. }
+            | ClaimLiquidityReturns { .. }
+            | AccrueInterest {}
+            | PriceUpdate {}
+            | AdminMint {}
+            | AdminSweepToTreasury {}
+            | CloseVault {}
+            | MarginTransfer {}
+            | AddMarginToVault {}
+            | AdminVaultCorrection {}
+            | AdminDebtCorrection {}
+            | ReserveRedemption {} => None,
+
+            // Lifecycle variants.
+            Init {} => Some("Init"),
+            Upgrade {} => Some("Upgrade"),
+
+            // Admin setters and config events (hit `_ => Admin` in backend
+            // type_filter).
+            SetBorrowingFee {} => Some("SetBorrowingFee"),
+            SetRmrCeilingCr {} => Some("SetRmrCeilingCr"),
+            SetRecoveryRateCurve {} => Some("SetRecoveryRateCurve"),
+            SetCkstableRepayFee {} => Some("SetCkstableRepayFee"),
+            SetTreasuryPrincipal {} => Some("SetTreasuryPrincipal"),
+            SetMaxPartialLiquidationRatio {} => Some("SetMaxPartialLiquidationRatio"),
+            SetRecoveryTargetCr {} => Some("SetRecoveryTargetCr"),
+            SetStableLedgerPrincipal {} => Some("SetStableLedgerPrincipal"),
+            SetRecoveryParameters {} => Some("SetRecoveryParameters"),
+            SetCollateralBorrowingFee {} => Some("SetCollateralBorrowingFee"),
+            SetCollateralLiquidationRatio {} => Some("SetCollateralLiquidationRatio"),
+            SetCollateralBorrowThreshold {} => Some("SetCollateralBorrowThreshold"),
+            SetCollateralLiquidationBonus {} => Some("SetCollateralLiquidationBonus"),
+            SetCollateralMinVaultDebt {} => Some("SetCollateralMinVaultDebt"),
+            SetCollateralLedgerFee {} => Some("SetCollateralLedgerFee"),
+            SetCollateralRedemptionFeeFloor {} => Some("SetCollateralRedemptionFeeFloor"),
+            SetCollateralRedemptionFeeCeiling {} => Some("SetCollateralRedemptionFeeCeiling"),
+            SetCollateralMinDeposit {} => Some("SetCollateralMinDeposit"),
+            SetCollateralDisplayColor {} => Some("SetCollateralDisplayColor"),
+            SetBotAllowedCollateralTypes {} => Some("SetBotAllowedCollateralTypes"),
+            SetRmrFloorCr {} => Some("SetRmrFloorCr"),
+            SetRmrCeiling {} => Some("SetRmrCeiling"),
+            SetGlobalIcusdMintCap {} => Some("SetGlobalIcusdMintCap"),
+            SetReserveRedemptionsEnabled {} => Some("SetReserveRedemptionsEnabled"),
+            SetMinIcusdAmount {} => Some("SetMinIcusdAmount"),
+            SetBorrowingFeeCurve {} => Some("SetBorrowingFeeCurve"),
+            SetInterestPoolShare {} => Some("SetInterestPoolShare"),
+            SetLiquidationProtocolShare {} => Some("SetLiquidationProtocolShare"),
+            UpdateCollateralConfig {} => Some("UpdateCollateralConfig"),
+            SetRateCurveMarkers {} => Some("SetRateCurveMarkers"),
+            SetThreePoolCanister {} => Some("SetThreePoolCanister"),
+            SetLiquidationBonus {} => Some("SetLiquidationBonus"),
+            UpdateCollateralStatus {} => Some("UpdateCollateralStatus"),
+            SetHealthyCr {} => Some("SetHealthyCr"),
+            SetRedemptionFeeCeiling {} => Some("SetRedemptionFeeCeiling"),
+            SetStabilityPoolPrincipal {} => Some("SetStabilityPoolPrincipal"),
+            SetInterestSplit {} => Some("SetInterestSplit"),
+            SetBotBudget {} => Some("SetBotBudget"),
+            SetRmrFloor {} => Some("SetRmrFloor"),
+            SetRedemptionFeeFloor {} => Some("SetRedemptionFeeFloor"),
+            SetInterestRate {} => Some("SetInterestRate"),
+            SetReserveRedemptionFee {} => Some("SetReserveRedemptionFee"),
+            SetLiquidationBotPrincipal {} => Some("SetLiquidationBotPrincipal"),
+            AddCollateralType {} => Some("AddCollateralType"),
+            SetStableTokenEnabled {} => Some("SetStableTokenEnabled"),
+            SetRecoveryCrMultiplier {} => Some("SetRecoveryCrMultiplier"),
+            SetCollateralDebtCeiling {} => Some("SetCollateralDebtCeiling"),
+            SetCollateralInterestRate {} => Some("SetCollateralInterestRate"),
+            SetCollateralRedemptionTier {} => Some("SetCollateralRedemptionTier"),
+        }
+    }
 }
 
 pub async fn get_events(

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -11,6 +11,8 @@ use super::{
     MEM_EVT_SWAPS_IDX, MEM_EVT_SWAPS_DATA,
     MEM_EVT_LIQUIDITY_IDX, MEM_EVT_LIQUIDITY_DATA,
     MEM_EVT_VAULTS_IDX, MEM_EVT_VAULTS_DATA,
+    MEM_EVT_STABILITY_IDX, MEM_EVT_STABILITY_DATA,
+    MEM_EVT_ADMIN_IDX, MEM_EVT_ADMIN_DATA,
 };
 
 // --- Enum types ---
@@ -47,6 +49,15 @@ pub enum LiquidityAction {
     Remove,
     RemoveOneCoin,
     Donate,
+}
+
+/// Stability pool activity kind. Deposit/Withdraw affect principal balance;
+/// ClaimReturns is a yield claim (ICP) that doesn't change icUSD position.
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum StabilityAction {
+    Deposit,
+    Withdraw,
+    ClaimReturns,
 }
 
 // --- Event row types ---
@@ -98,6 +109,26 @@ pub struct AnalyticsLiquidityEvent {
     pub fee: Option<u64>,
 }
 
+/// Mirror of backend stability-pool participation events (provide/withdraw/
+/// claim). Sourced from rumi_protocol_backend via the backend-event tailer.
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsStabilityEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub action: StabilityAction,
+    pub amount: u64,
+}
+
+/// Mirror of backend admin/setter events. Only label + timestamp are kept so
+/// the log stays small; admin events are rare (a handful per week).
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsAdminEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub label: String,
+}
+
 // --- Storable impls ---
 
 macro_rules! storable_candid {
@@ -118,6 +149,8 @@ storable_candid!(AnalyticsLiquidationEvent);
 storable_candid!(AnalyticsVaultEvent);
 storable_candid!(AnalyticsSwapEvent);
 storable_candid!(AnalyticsLiquidityEvent);
+storable_candid!(AnalyticsStabilityEvent);
+storable_candid!(AnalyticsAdminEvent);
 
 // --- StableLog instances ---
 
@@ -152,6 +185,22 @@ thread_local! {
                 get_memory(MEM_EVT_VAULTS_IDX),
                 get_memory(MEM_EVT_VAULTS_DATA),
             ).expect("init EVT_VAULTS log")
+        });
+
+    static EVT_STABILITY_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsStabilityEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_STABILITY_IDX),
+                get_memory(MEM_EVT_STABILITY_DATA),
+            ).expect("init EVT_STABILITY log")
+        });
+
+    static EVT_ADMIN_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsAdminEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_ADMIN_IDX),
+                get_memory(MEM_EVT_ADMIN_DATA),
+            ).expect("init EVT_ADMIN log")
         });
 }
 
@@ -206,6 +255,8 @@ evt_accessors!(evt_liquidations, EVT_LIQUIDATIONS_LOG, AnalyticsLiquidationEvent
 evt_accessors!(evt_swaps, EVT_SWAPS_LOG, AnalyticsSwapEvent);
 evt_accessors!(evt_liquidity, EVT_LIQUIDITY_LOG, AnalyticsLiquidityEvent);
 evt_accessors!(evt_vaults, EVT_VAULTS_LOG, AnalyticsVaultEvent);
+evt_accessors!(evt_stability, EVT_STABILITY_LOG, AnalyticsStabilityEvent);
+evt_accessors!(evt_admin, EVT_ADMIN_LOG, AnalyticsAdminEvent);
 
 // --- Tests ---
 
@@ -283,5 +334,33 @@ mod tests {
         let decoded = AnalyticsLiquidityEvent::from_bytes(bytes);
         assert_eq!(decoded.amounts, vec![100, 200, 300]);
         assert_eq!(decoded.fee, Some(5));
+    }
+
+    #[test]
+    fn stability_event_roundtrip() {
+        let evt = AnalyticsStabilityEvent {
+            timestamp_ns: 5_000_000,
+            source_event_id: 31,
+            caller: Principal::anonymous(),
+            action: StabilityAction::Deposit,
+            amount: 123_456_789,
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsStabilityEvent::from_bytes(bytes);
+        assert_eq!(decoded.amount, 123_456_789);
+        assert!(matches!(decoded.action, StabilityAction::Deposit));
+    }
+
+    #[test]
+    fn admin_event_roundtrip() {
+        let evt = AnalyticsAdminEvent {
+            timestamp_ns: 6_000_000,
+            source_event_id: 77,
+            label: "SetBorrowingFee".to_string(),
+        };
+        let bytes = evt.to_bytes();
+        let decoded = AnalyticsAdminEvent::from_bytes(bytes);
+        assert_eq!(decoded.label, "SetBorrowingFee");
+        assert_eq!(decoded.source_event_id, 77);
     }
 }

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -90,6 +90,10 @@ pub const MEM_EVT_LIQUIDITY_IDX: MemoryId = MemoryId::new(48);
 pub const MEM_EVT_LIQUIDITY_DATA: MemoryId = MemoryId::new(49);
 pub const MEM_EVT_VAULTS_IDX: MemoryId = MemoryId::new(50);
 pub const MEM_EVT_VAULTS_DATA: MemoryId = MemoryId::new(51);
+pub const MEM_EVT_STABILITY_IDX: MemoryId = MemoryId::new(52);
+pub const MEM_EVT_STABILITY_DATA: MemoryId = MemoryId::new(53);
+pub const MEM_EVT_ADMIN_IDX: MemoryId = MemoryId::new(54);
+pub const MEM_EVT_ADMIN_DATA: MemoryId = MemoryId::new(55);
 
 // BalanceTracker maps (Phase 4)
 pub const MEM_BAL_ICUSD: MemoryId = MemoryId::new(56);

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -1,4 +1,5 @@
-//! Backend event tailing. Routes events to EVT_LIQUIDATIONS and EVT_VAULTS.
+//! Backend event tailing. Routes events to EVT_LIQUIDATIONS, EVT_VAULTS,
+//! EVT_STABILITY (SP participation), and EVT_ADMIN (labeled setter events).
 
 use candid::Principal;
 use crate::{sources, state, storage};
@@ -192,7 +193,48 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 amount: *icusd_amount,
             });
         }
-        // All other variants (admin/config events) are not routed
-        _ => {}
+        ProvideLiquidity { amount, caller, timestamp } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                caller: *caller,
+                action: StabilityAction::Deposit,
+                amount: *amount,
+            });
+        }
+        WithdrawLiquidity { amount, caller, timestamp } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                caller: *caller,
+                action: StabilityAction::Withdraw,
+                amount: *amount,
+            });
+        }
+        ClaimLiquidityReturns { amount, caller, timestamp } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                caller: *caller,
+                action: StabilityAction::ClaimReturns,
+                amount: *amount,
+            });
+        }
+        // All other variants are either not surfaced (e.g. accrue, price) or
+        // admin setters. Admin-labeled variants get mirrored into evt_admin so
+        // the admin-breakdown endpoint can count them by label.
+        other => {
+            if let Some(label) = other.admin_label() {
+                // Admin variants decode as empty structs in our BackendEvent
+                // shadow type, so the event's own timestamp isn't available.
+                // Tailing runs every few minutes, so using now as an upper
+                // bound on "last seen at" is accurate within that window.
+                evt_admin::push(AnalyticsAdminEvent {
+                    timestamp_ns: ic_cdk::api::time(),
+                    source_event_id: event_id,
+                    label: label.to_string(),
+                });
+            }
+        }
     }
 }

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -267,3 +267,70 @@ pub struct TopHoldersResponse {
     /// decide between rendering the table and an empty state.
     pub source: String,
 }
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TopCounterpartiesQuery {
+    pub principal: Principal,
+    /// Lookback window in nanoseconds. `None` defaults to ~30 days.
+    pub window_ns: Option<u64>,
+    /// Max rows returned. Clamped to [1, 200]; `None` defaults to 50.
+    pub limit: Option<u32>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq)]
+pub struct TopCounterpartyRow {
+    pub counterparty: Principal,
+    pub interaction_count: u64,
+    pub volume_e8s: u64,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct TopCounterpartiesResponse {
+    pub principal: Principal,
+    pub window_ns: u64,
+    pub generated_at_ns: u64,
+    pub rows: Vec<TopCounterpartyRow>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TopSpDepositorsQuery {
+    pub window_ns: Option<u64>,
+    pub limit: Option<u32>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq)]
+pub struct TopSpDepositorRow {
+    pub principal: Principal,
+    /// Sum of deposit amounts inside the window.
+    pub total_deposited_e8s: u64,
+    /// All-time net position (deposits minus withdrawals across the full log).
+    pub current_balance_e8s: u64,
+    /// Window net position (deposits minus withdrawals inside the window).
+    pub net_position_e8s: i64,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct TopSpDepositorsResponse {
+    pub window_ns: u64,
+    pub generated_at_ns: u64,
+    pub rows: Vec<TopSpDepositorRow>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct AdminEventBreakdownQuery {
+    pub window_ns: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq)]
+pub struct AdminEventLabelCount {
+    pub label: String,
+    pub count: u64,
+    pub last_at_ns: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct AdminEventBreakdownResponse {
+    pub window_ns: u64,
+    pub generated_at_ns: u64,
+    pub labels: Vec<AdminEventLabelCount>,
+}


### PR DESCRIPTION
## Summary
- Three new ranking endpoints on `rumi_analytics` that unlock Explorer's relationship web: `get_top_counterparties`, `get_top_sp_depositors`, `get_admin_event_breakdown`.
- New stable logs `EVT_STABILITY` and `EVT_ADMIN` on memory IDs 52-55. Backend-events tailer now routes ProvideLiquidity/WithdrawLiquidity/ClaimLiquidityReturns into evt_stability, and all admin/setter variants into evt_admin keyed by a canonical CamelCase `admin_label` aligned with the backend's `_ => Admin` bucket.
- Each endpoint has its own TTL cache (30s for principal rankings, 5min for admin breakdown) and a pure `compute_*` helper that the unit tests drive.

## Context
Part of the Explorer IA redesign backlog (see [docs/superpowers/plans/2026-04-21-explorer-ia-redesign.md](docs/superpowers/plans/2026-04-21-explorer-ia-redesign.md)). Session A combines Tier 2 gaps #4 (counterparties) and #7 (SP depositors) plus Tier 3 #10 (labeled admin filter) because they share a single "top-N principal aggregator" shape. Mirrors PR #87's pattern (`get_top_holders` + TTL cache + pure helper + .did regen).

## Test plan
- [x] `cargo test --package rumi_analytics --lib` passes (60 tests, 14 new)
- [x] `cargo check --workspace --bins` clean (pre-existing `rumi_protocol_backend/tests/tests.rs` compile errors are unrelated to this PR)
- [x] `.did` regenerated from wasm via `candid-extractor`
- [x] `src/declarations/rumi_analytics/*` regenerated via `dfx generate rumi_analytics`
- [ ] Deploy to IC (post-merge of this PR, before PR 3 is written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)