### PR TITLE
fix(analytics): avoid decoding legacy Fast3PoolSnapshot rows

### DIFF
--- a/src/rumi_analytics/src/queries/address_value.rs
+++ b/src/rumi_analytics/src/queries/address_value.rs
@@ -127,7 +127,23 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
     let sp_evs = storage::events::evt_stability::range(0, now, MAX_EVENT_LOAD);
     let liquidity_evs = storage::events::evt_liquidity::range(0, now, MAX_EVENT_LOAD);
     let price_snaps = storage::fast::fast_prices::range(0, now, MAX_EVENT_LOAD);
-    let three_pool_snaps = storage::fast::fast_3pool::range(0, now, MAX_EVENT_LOAD);
+    // Fast3PoolSnapshot has older rows on mainnet whose decoder trips on a
+    // `decimals` field schema change. Reading only the latest snapshot sidesteps
+    // the migration cleanup; LP pricing then uses spot virtual_price, which
+    // drifts <1% across a 90-day window for a $1-pegged stable 3pool.
+    // TODO: make Fast3PoolSnapshot.decimals optional (or backfill old rows)
+    // and restore full historical range() once the data is clean.
+    let three_pool_snaps: Vec<storage::fast::Fast3PoolSnapshot> = {
+        let n = storage::fast::fast_3pool::len();
+        if n == 0 {
+            Vec::new()
+        } else {
+            match storage::fast::fast_3pool::get(n - 1) {
+                Some(snap) => vec![snap],
+                None => Vec::new(),
+            }
+        }
+    };
 
     let (icusd_ledger, three_pool) = state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
     let icusd_balance = storage::balance_tracker::all_balances(storage::balance_tracker::Token::IcUsd)


### PR DESCRIPTION
## Summary
- PR #98 introduced the first call site that iterates the `fast_3pool` log with `range()`. On mainnet, older rows pre-date the `decimals` field addition so candid's subtyping check panics on decode (\"field decimals is not optional\"), trapping the whole query. Hit this during the post-merge mainnet deploy when the new `get_address_value_series` first ran against real data.
- Patch: only read the latest `Fast3PoolSnapshot` for virtual-price lookup. A stable 3pool's virtual price drifts <1% over 90 days so using spot for historical points is an acceptable v1 approximation.
- TODO left inline to make `decimals` optional (or backfill old rows) and restore full historical `range()` once the data is clean.

## Test plan
- [x] `cargo test --package rumi_analytics --lib queries::address_value` → 15 pass.
- [x] Rebuilt + shrunk + gzipped wasm (563 KB), redeployed to mainnet analytics.
- [x] `dfx canister call rumi_analytics get_address_value_series --network ic --query '(record { "principal" = principal "…"; window_ns = null; resolution_ns = null })'` returns 91 points with a populated icUSD band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)