### PR TITLE
fix(analytics): make Fast3PoolSnapshot.decimals optional

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -147,7 +147,7 @@ type ErrorCounters = record {
 };
 type Fast3PoolSnapshot = record {
   virtual_price : nat;
-  decimals : blob;
+  decimals : opt blob;
   timestamp_ns : nat64;
   lp_total_supply : nat;
   balances : vec nat;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -151,7 +151,7 @@ export interface ErrorCounters {
 }
 export interface Fast3PoolSnapshot {
   'virtual_price' : bigint,
-  'decimals' : Uint8Array | number[],
+  'decimals' : [] | [Uint8Array | number[]],
   'timestamp_ns' : bigint,
   'lp_total_supply' : bigint,
   'balances' : Array<bigint>,

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -242,7 +242,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const Fast3PoolSnapshot = IDL.Record({
     'virtual_price' : IDL.Nat,
-    'decimals' : IDL.Vec(IDL.Nat8),
+    'decimals' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'timestamp_ns' : IDL.Nat64,
     'lp_total_supply' : IDL.Nat,
     'balances' : IDL.Vec(IDL.Nat),

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -147,7 +147,7 @@ type ErrorCounters = record {
 };
 type Fast3PoolSnapshot = record {
   virtual_price : nat;
-  decimals : blob;
+  decimals : opt blob;
   timestamp_ns : nat64;
   lp_total_supply : nat;
   balances : vec nat;

--- a/src/rumi_analytics/src/collectors/fast.rs
+++ b/src/rumi_analytics/src/collectors/fast.rs
@@ -37,7 +37,7 @@ pub async fn run() -> Result<(), String> {
                 balances: tp.balances,
                 virtual_price: tp.virtual_price,
                 lp_total_supply: tp.lp_total_supply,
-                decimals: tp.decimals,
+                decimals: Some(tp.decimals),
             });
         }
         Err(e) => {

--- a/src/rumi_analytics/src/queries/address_value.rs
+++ b/src/rumi_analytics/src/queries/address_value.rs
@@ -127,23 +127,7 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
     let sp_evs = storage::events::evt_stability::range(0, now, MAX_EVENT_LOAD);
     let liquidity_evs = storage::events::evt_liquidity::range(0, now, MAX_EVENT_LOAD);
     let price_snaps = storage::fast::fast_prices::range(0, now, MAX_EVENT_LOAD);
-    // Fast3PoolSnapshot has older rows on mainnet whose decoder trips on a
-    // `decimals` field schema change. Reading only the latest snapshot sidesteps
-    // the migration cleanup; LP pricing then uses spot virtual_price, which
-    // drifts <1% across a 90-day window for a $1-pegged stable 3pool.
-    // TODO: make Fast3PoolSnapshot.decimals optional (or backfill old rows)
-    // and restore full historical range() once the data is clean.
-    let three_pool_snaps: Vec<storage::fast::Fast3PoolSnapshot> = {
-        let n = storage::fast::fast_3pool::len();
-        if n == 0 {
-            Vec::new()
-        } else {
-            match storage::fast::fast_3pool::get(n - 1) {
-                Some(snap) => vec![snap],
-                None => Vec::new(),
-            }
-        }
-    };
+    let three_pool_snaps = storage::fast::fast_3pool::range(0, now, MAX_EVENT_LOAD);
 
     let (icusd_ledger, three_pool) = state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
     let icusd_balance = storage::balance_tracker::all_balances(storage::balance_tracker::Token::IcUsd)
@@ -751,7 +735,7 @@ mod tests {
             balances: vec![],
             virtual_price,
             lp_total_supply: 0,
-            decimals: vec![],
+            decimals: Some(vec![]),
         }
     }
 

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -227,12 +227,14 @@ pub fn get_peg_status() -> Option<types::PegStatus> {
 }
 
 pub fn compute_peg_status(snap: &storage::fast::Fast3PoolSnapshot) -> types::PegStatus {
-    // Normalize all balances to a common scale (highest decimal).
-    let max_dec = snap.decimals.iter().copied().max().unwrap_or(8);
+    // Normalize all balances to a common scale (highest decimal). Legacy rows
+    // that pre-date the decimals field fall back to 8 per token (3pool standard).
+    let decimals = snap.decimals.as_deref().unwrap_or(&[]);
+    let max_dec = decimals.iter().copied().max().unwrap_or(8);
     let normalized: Vec<u128> = snap.balances.iter()
         .enumerate()
         .map(|(i, b)| {
-            let dec = snap.decimals.get(i).copied().unwrap_or(max_dec);
+            let dec = decimals.get(i).copied().unwrap_or(max_dec);
             let scale = 10u128.pow((max_dec - dec) as u32);
             b * scale
         })
@@ -1056,7 +1058,7 @@ mod tests {
             balances: vec![1_000_000, 1_000_000, 1_000_000],
             virtual_price: 100_000_000,
             lp_total_supply: 3_000_000,
-            decimals: vec![8, 8, 8],
+            decimals: Some(vec![8, 8, 8]),
         };
         let status = compute_peg_status(&snap);
         assert_eq!(status.balance_ratios.len(), 3);
@@ -1073,7 +1075,7 @@ mod tests {
             balances: vec![1_500_000, 1_000_000, 500_000],
             virtual_price: 100_000_000,
             lp_total_supply: 3_000_000,
-            decimals: vec![8, 8, 8],
+            decimals: Some(vec![8, 8, 8]),
         };
         let status = compute_peg_status(&snap);
         assert!((status.max_imbalance_pct - 50.0).abs() < 0.01);
@@ -1086,7 +1088,7 @@ mod tests {
             balances: vec![],
             virtual_price: 0,
             lp_total_supply: 0,
-            decimals: vec![],
+            decimals: Some(vec![]),
         };
         let status = compute_peg_status(&snap);
         assert!(status.balance_ratios.is_empty());
@@ -1100,10 +1102,30 @@ mod tests {
             balances: vec![10_000_000_000, 100_000_000, 100_000_000],
             virtual_price: 1_000_000_000_000_000_000,
             lp_total_supply: 300_000_000,
-            decimals: vec![8, 6, 6],
+            decimals: Some(vec![8, 6, 6]),
         };
         let status = compute_peg_status(&snap);
         assert!(status.max_imbalance_pct < 0.01, "expected near-zero imbalance, got {}", status.max_imbalance_pct);
+    }
+
+    #[test]
+    fn peg_status_handles_legacy_row_without_decimals() {
+        // Legacy rows decoded from pre-decimals bytes have `decimals = None`.
+        // compute_peg_status must treat the vec as empty and fall back to the
+        // 3pool default of 8 per token without panicking.
+        let snap = Fast3PoolSnapshot {
+            timestamp_ns: 1_000_000_000,
+            balances: vec![1_000_000, 1_000_000, 1_000_000],
+            virtual_price: 100_000_000,
+            lp_total_supply: 3_000_000,
+            decimals: None,
+        };
+        let status = compute_peg_status(&snap);
+        assert_eq!(status.balance_ratios.len(), 3);
+        for r in &status.balance_ratios {
+            assert!((r - 1.0).abs() < 0.001);
+        }
+        assert!(status.max_imbalance_pct < 0.01);
     }
 
     fn make_swap_rollup(fees: u64) -> DailySwapRollup {

--- a/src/rumi_analytics/src/storage/fast.rs
+++ b/src/rumi_analytics/src/storage/fast.rs
@@ -26,7 +26,9 @@ pub struct Fast3PoolSnapshot {
     pub balances: Vec<u128>,
     pub virtual_price: u128,
     pub lp_total_supply: u128,
-    pub decimals: Vec<u8>,
+    /// Per-token decimal scale. `None` on legacy rows that pre-date this field.
+    /// Readers fall back to `[8; N]` (3pool's standard precision).
+    pub decimals: Option<Vec<u8>>,
 }
 
 // --- Storable impls ---
@@ -117,3 +119,89 @@ macro_rules! fast_accessors {
 
 fast_accessors!(fast_prices, FAST_PRICES_LOG, FastPriceSnapshot);
 fast_accessors!(fast_3pool, FAST_3POOL_LOG, Fast3PoolSnapshot);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Schema used before the `decimals` field was introduced. Rows written on
+    /// mainnet under this shape must still decode under the current type.
+    #[derive(CandidType, Serialize, Deserialize)]
+    struct Fast3PoolSnapshotV0 {
+        timestamp_ns: u64,
+        balances: Vec<u128>,
+        virtual_price: u128,
+        lp_total_supply: u128,
+    }
+
+    #[test]
+    fn decodes_legacy_row_missing_decimals_field() {
+        let v0 = Fast3PoolSnapshotV0 {
+            timestamp_ns: 1_700_000_000_000_000_000,
+            balances: vec![1_234, 2_345, 3_456],
+            virtual_price: 1_000_000_000_000_000_000,
+            lp_total_supply: 7_035,
+        };
+        let bytes = Encode!(&v0).expect("encode legacy row");
+        let decoded: Fast3PoolSnapshot =
+            Decode!(&bytes, Fast3PoolSnapshot).expect("decode legacy row as current schema");
+        assert_eq!(decoded.timestamp_ns, 1_700_000_000_000_000_000);
+        assert_eq!(decoded.balances, vec![1_234, 2_345, 3_456]);
+        assert_eq!(decoded.virtual_price, 1_000_000_000_000_000_000);
+        assert_eq!(decoded.lp_total_supply, 7_035);
+        assert_eq!(decoded.decimals, None);
+    }
+
+    #[test]
+    fn current_row_round_trips_via_storable() {
+        let current = Fast3PoolSnapshot {
+            timestamp_ns: 1_800_000_000_000_000_000,
+            balances: vec![5, 10, 15],
+            virtual_price: 1_020_000_000_000_000_000,
+            lp_total_supply: 30,
+            decimals: Some(vec![8, 8, 8]),
+        };
+        let bytes = <Fast3PoolSnapshot as Storable>::to_bytes(&current);
+        let decoded = <Fast3PoolSnapshot as Storable>::from_bytes(bytes);
+        assert_eq!(decoded.timestamp_ns, current.timestamp_ns);
+        assert_eq!(decoded.balances, current.balances);
+        assert_eq!(decoded.virtual_price, current.virtual_price);
+        assert_eq!(decoded.lp_total_supply, current.lp_total_supply);
+        assert_eq!(decoded.decimals, Some(vec![8, 8, 8]));
+    }
+
+    #[test]
+    fn mixed_log_decodes_legacy_and_current_rows() {
+        // A "mixed" log on mainnet has older rows without `decimals` and newer
+        // rows with `Some(vec![...])`. The Storable::from_bytes path has to
+        // tolerate both shapes so that range() can iterate the full log.
+        let legacy = Fast3PoolSnapshotV0 {
+            timestamp_ns: 100,
+            balances: vec![1, 2, 3],
+            virtual_price: 1_000_000_000_000_000_000,
+            lp_total_supply: 6,
+        };
+        let current = Fast3PoolSnapshot {
+            timestamp_ns: 200,
+            balances: vec![4, 5, 6],
+            virtual_price: 1_010_000_000_000_000_000,
+            lp_total_supply: 15,
+            decimals: Some(vec![8, 8, 8]),
+        };
+
+        let legacy_bytes = Encode!(&legacy).expect("encode legacy");
+        let current_bytes = <Fast3PoolSnapshot as Storable>::to_bytes(&current);
+
+        let decoded_legacy: Fast3PoolSnapshot =
+            Decode!(&legacy_bytes, Fast3PoolSnapshot).expect("decode legacy");
+        let decoded_current =
+            <Fast3PoolSnapshot as Storable>::from_bytes(current_bytes);
+
+        let rows = vec![decoded_legacy, decoded_current];
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|r| r.timestamp_ns == 100 && r.decimals.is_none()));
+        assert!(rows
+            .iter()
+            .any(|r| r.timestamp_ns == 200 && r.decimals.as_deref() == Some(&[8, 8, 8][..])));
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces PR #99's single-snapshot workaround with the real schema fix: `Fast3PoolSnapshot.decimals` goes from `Vec<u8>` to `Option<Vec<u8>>` (`blob` -> `opt blob` in candid). Candid's opt-lifting subtype rule lets legacy rows (no decimals field) and mid-era rows (blob field) both decode under the new type, so `range()` over `fast_3pool_log` no longer traps on older rows.
- Reverts the address-value query's latest-snapshot shortcut back to `range()`, so the LP band on `/e/address/{principal}` reflects real per-timestamp virtual_price instead of spot.
- Adds four new unit tests: legacy decode (missing field -> `None`), current round-trip (`Some(vec)`), mixed-log decode tolerance, and peg-status tolerance of `None` decimals.

## Why
PR #98 introduced the first `range()` caller on `fast_3pool_log`. On mainnet, older rows pre-date the `decimals` field, so candid's subtyping panicked with ``"field decimals is not optional"``. PR #99 sidestepped with a latest-only read using spot virtual_price. This PR unblocks the general case so any future analytics endpoint that needs the full history can iterate the log without tripping the decoder.

## Test plan
- [x] `cargo test -p rumi_analytics --lib` — 93 unit tests pass (4 new)
- [x] `cargo check --workspace` clean
- [x] PocketIC integration tests pass except for `upgrade_preserves_supply_cache_and_tvl_log`, which fails identically on `main` (pre-existing flake, not a regression from this PR)
- [ ] Mainnet deploy and `dfx canister call rumi_analytics get_address_value_series` for a known principal — confirm no decode trap and that the LP band shows small virtual-price drift across a 90d window (Rob to authorize)

## Follow-ups
None for this PR. Once deployed, the address-value chart on `/e/address/{principal}` becomes historically accurate for the `three_pool_lp` band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)