### PR TITLE
chore(explorer): consistent empty + error states with retry

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/EmptyState.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EmptyState.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title?: string;
+    message?: string;
+    icon?: 'inbox' | 'search' | 'chart';
+    compact?: boolean;
+    children?: Snippet;
+  }
+
+  let {
+    title,
+    message = 'Nothing to show yet.',
+    icon = 'inbox',
+    compact = false,
+    children,
+  }: Props = $props();
+</script>
+
+<div class="flex flex-col items-center justify-center text-center gap-2 text-gray-500 {compact ? 'py-6' : 'py-12'}">
+  <div class="text-gray-600">
+    {#if icon === 'inbox'}
+      <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-4l-2 2H10l-2-2H4" />
+      </svg>
+    {:else if icon === 'search'}
+      <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+      </svg>
+    {:else}
+      <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l3 2 3-2v13M5 21h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
+      </svg>
+    {/if}
+  </div>
+  {#if title}<p class="text-sm font-medium text-gray-400">{title}</p>{/if}
+  <p class="text-sm">{message}</p>
+  {#if children}<div class="mt-1">{@render children()}</div>{/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/ErrorState.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/ErrorState.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title?: string;
+    message?: string;
+    onRetry?: () => void | Promise<void>;
+    retryLabel?: string;
+    compact?: boolean;
+    children?: Snippet;
+  }
+
+  let {
+    title = 'Something went wrong',
+    message = 'We could not load this data. The canister may be busy or briefly unavailable.',
+    onRetry,
+    retryLabel = 'Try again',
+    compact = false,
+    children,
+  }: Props = $props();
+
+  let retrying = $state(false);
+
+  async function handleRetry() {
+    if (!onRetry || retrying) return;
+    retrying = true;
+    try {
+      await onRetry();
+    } finally {
+      retrying = false;
+    }
+  }
+</script>
+
+<div class="flex flex-col items-center justify-center text-center gap-2 text-gray-400 {compact ? 'py-6' : 'py-12'}">
+  <div class="text-amber-400/80">
+    <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+    </svg>
+  </div>
+  <p class="text-sm font-medium text-gray-300">{title}</p>
+  <p class="text-sm text-gray-500 max-w-md">{message}</p>
+  {#if onRetry}
+    <button
+      type="button"
+      onclick={handleRetry}
+      disabled={retrying}
+      class="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-300 hover:text-blue-200 bg-blue-500/10 hover:bg-blue-500/15 border border-blue-500/30 rounded-md transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+    >
+      {#if retrying}
+        <span class="w-3.5 h-3.5 border-2 border-blue-300/30 border-t-blue-300 rounded-full animate-spin"></span>
+        Retrying…
+      {:else}
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+        {retryLabel}
+      {/if}
+    </button>
+  {/if}
+  {#if children}<div class="mt-1">{@render children()}</div>{/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/entity/EntityShell.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/entity/EntityShell.svelte
@@ -5,6 +5,7 @@
    * content is simply omitted.
    */
   import type { Snippet } from 'svelte';
+  import ErrorState from '$components/explorer/ErrorState.svelte';
 
   interface Props {
     title: string;
@@ -17,11 +18,12 @@
     analytics?: Snippet;
     loading?: boolean;
     error?: string | null;
+    onRetry?: () => void | Promise<void>;
   }
 
   let {
     title, subtitle, backHref = '/explorer', backLabel = 'Back to Explorer',
-    identity, relationships, activity, analytics, loading = false, error = null,
+    identity, relationships, activity, analytics, loading = false, error = null, onRetry,
   }: Props = $props();
 </script>
 
@@ -39,10 +41,12 @@
       <p>Loading {title}...</p>
     </div>
   {:else if error}
-    <div class="text-center py-16">
-      <p class="text-2xl font-bold text-gray-300 mb-2">{title}</p>
-      <p class="text-gray-500">{error}</p>
-      <a href={backHref} class="inline-block mt-4 text-blue-400 hover:underline text-sm">{backLabel}</a>
+    <div class="space-y-3">
+      <p class="text-2xl font-bold text-gray-300 text-center">{title}</p>
+      <ErrorState message={error} {onRetry} />
+      <p class="text-center">
+        <a href={backHref} class="text-sm text-blue-400 hover:underline">{backLabel}</a>
+      </p>
     </div>
   {:else}
     <header class="space-y-1">

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -6,6 +6,8 @@
 	import FacetBar from '$components/explorer/FacetBar.svelte';
 	import ActiveFilterChips from '$components/explorer/ActiveFilterChips.svelte';
 	import SavedViewsStrip, { type SavedView } from '$components/explorer/SavedViewsStrip.svelte';
+	import EmptyState from '$components/explorer/EmptyState.svelte';
+	import ErrorState from '$components/explorer/ErrorState.svelte';
 	import {
 		fetchEvents,
 		fetchSwapEvents, fetchSwapEventCount,
@@ -763,15 +765,29 @@
 			</div>
 		</div>
 	{:else if error}
-		<div class="text-center py-16">
-			<p class="text-red-400 text-sm">{error}</p>
-		</div>
+		<ErrorState
+			title="Could not load events"
+			message={error}
+			onRetry={() => loadEvents(facets)}
+		/>
 	{:else if visibleEvents.length === 0}
-		<div class="text-center py-16">
-			<p class="text-gray-500 text-sm">
-				{hasAnyFacet(facets) ? 'No events match the current filters.' : 'No events found.'}
-			</p>
-		</div>
+		<EmptyState
+			icon={hasAnyFacet(facets) ? 'search' : 'inbox'}
+			title={hasAnyFacet(facets) ? 'No matching events' : 'No activity yet'}
+			message={hasAnyFacet(facets)
+				? 'Try widening the time window or clearing a facet.'
+				: 'Once the protocol sees its first events they will stream in here.'}
+		>
+			{#if hasAnyFacet(facets)}
+				<button
+					type="button"
+					onclick={clearAll}
+					class="text-sm text-blue-400 hover:text-blue-300 underline-offset-2 hover:underline"
+				>
+					Clear all filters
+				</button>
+			{/if}
+		</EmptyState>
 	{:else}
 		<div class="explorer-card overflow-hidden p-0">
 			<MixedEventsTable

--- a/src/vault_frontend/src/routes/explorer/canister/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/canister/[id]/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import SearchBar from '$lib/components/explorer/SearchBar.svelte';
   import EntityLink from '$lib/components/explorer/EntityLink.svelte';
   import TokenBadge from '$lib/components/explorer/TokenBadge.svelte';
   import DataTable from '$lib/components/explorer/DataTable.svelte';
+  import ErrorState from '$lib/components/explorer/ErrorState.svelte';
   import { fetchEventsByPrincipal } from '$lib/stores/explorerStore';
   import { CANISTER_IDS } from '$lib/config';
   import { copyToClipboard } from '$lib/utils/principalHelpers';
@@ -42,6 +42,7 @@
   // ── State ──────────────────────────────────────────────────────────────────
   let events = $state<Array<{ event: any; globalIndex: number }>>([]);
   let eventsLoading = $state(true);
+  let eventsError = $state<string | null>(null);
   let copied = $state(false);
 
   // ── Derived ────────────────────────────────────────────────────────────────
@@ -87,8 +88,9 @@
   }
 
   // ── Load ───────────────────────────────────────────────────────────────────
-  onMount(async () => {
+  async function loadEvents() {
     eventsLoading = true;
+    eventsError = null;
     try {
       const id = $page.params.id;
       const result = await fetchEventsByPrincipal(id);
@@ -96,16 +98,17 @@
     } catch (e) {
       console.error('Failed to fetch canister events:', e);
       events = [];
+      eventsError = 'Could not fetch events for this canister. The backend may be briefly unavailable.';
     } finally {
       eventsLoading = false;
     }
-  });
+  }
+
+  onMount(loadEvents);
 </script>
 
 <div class="canister-page">
   <a href="/explorer" class="back-link">← Back to Explorer</a>
-
-  <div class="search-row"><SearchBar /></div>
 
   <!-- ── Header ───────────────────────────────────────────────────────────── -->
   <div class="canister-header">
@@ -206,11 +209,16 @@
         <span class="count-badge">{eventsSorted.length} events</span>
       {/if}
     </h2>
+    {#if eventsError}
+      <div class="glass-card overflow-hidden">
+        <ErrorState message={eventsError} onRetry={loadEvents} />
+      </div>
+    {:else}
     <div class="glass-card overflow-hidden">
       <DataTable
         columns={activityColumns}
-        rows={eventsSorted}
-        emptyMessage={eventsLoading ? 'Loading events…' : 'No protocol events found involving this canister.'}
+        data={eventsSorted}
+        emptyMessage="No protocol events found involving this canister."
         loading={eventsLoading}
       >
         {#snippet row(item: any, i: number)}
@@ -244,6 +252,7 @@
         {/snippet}
       </DataTable>
     </div>
+    {/if}
     <p class="note">Events are matched by principal — only events where this canister appears as caller or owner are shown.</p>
   </section>
 </div>

--- a/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
@@ -584,7 +584,9 @@
 
   // ── Data load ──────────────────────────────────────────────────────────────
 
-  onMount(async () => {
+  async function loadAddress() {
+    loading = true;
+    error = null;
     let principal: Principal;
     try {
       principal = Principal.fromText(principalStr);
@@ -687,11 +689,13 @@
       ammLiqEventsMatching = ammLiqFull.filter(matchesCaller);
     } catch (e) {
       console.error('[address page] Failed to load data:', e);
-      error = 'Failed to load address data. Please try again.';
+      error = 'Failed to load address data. The backend may be briefly unavailable.';
     } finally {
       loading = false;
     }
-  });
+  }
+
+  onMount(loadAddress);
 
   const pageTitle = $derived(
     knownCanister && canisterName ? canisterName : shortenPrincipal(principalStr),
@@ -706,6 +710,7 @@
   title="Address"
   loading={loading}
   error={error}
+  onRetry={loadAddress}
 >
   {#snippet identity()}
     <!-- Identity strip -->

--- a/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
@@ -96,7 +96,7 @@
     };
   });
 
-  onMount(async () => {
+  async function loadEvent() {
     loading = true;
     error = null;
     if (!parsed) {
@@ -189,7 +189,9 @@
     } catch (err) {
       console.error('[event] context load failed:', err);
     }
-  });
+  }
+
+  onMount(loadEvent);
 
   const timestampNs = $derived(display?.timestamp ?? 0);
   const blockIndex = $derived.by(() => {
@@ -207,6 +209,7 @@
   title={display ? `${display.formatted.typeName}${isBackend ? ` #${parsed?.id}` : ` ${display.sourceLabel ?? ''} #${parsed?.id}`}` : `Event ${rawId}`}
   loading={loading}
   error={error}
+  onRetry={loadEvent}
 >
   {#snippet identity()}
     {#if display}

--- a/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
@@ -49,7 +49,7 @@
 
   // ── Shared state ─────────────────────────────────────────────────────────
   let loading = $state(true);
-  let notFound = $state(false);
+  let error = $state<string | null>(null);
   let poolRoutes = $state<PoolRoute[]>([]);
 
   // ── 3pool state ──────────────────────────────────────────────────────────
@@ -260,7 +260,9 @@
   }
 
   // ── Data load ────────────────────────────────────────────────────────────
-  onMount(async () => {
+  async function loadPool() {
+    loading = true;
+    error = null;
     // Pool-routes fetch runs on both branches; 7d window matches top swappers.
     const ROUTES_WINDOW_NS = 7n * 86_400n * 1_000_000_000n;
     const routesPromise = fetchPoolRoutes(poolIdParam, ROUTES_WINDOW_NS, 10)
@@ -300,6 +302,9 @@
         feeSeries = fees;
         vpSeries = vp;
         poolRoutes = routes;
+      } catch (err) {
+        console.error('[pool page] 3pool load failed:', err);
+        error = 'Failed to load 3pool data. The canister may be briefly unavailable.';
       } finally {
         loading = false;
       }
@@ -311,7 +316,7 @@
       const pools = await fetchAmmPools();
       const pool = pools.find((p: any) => p.pool_id === poolIdParam);
       if (!pool) {
-        notFound = true;
+        error = `Pool ${poolIdParam} does not exist.`;
         return;
       }
       ammPool = pool;
@@ -348,11 +353,13 @@
       ammFeeSeries = feeResp;
     } catch (err) {
       console.error('[pool page] AMM load failed:', err);
-      notFound = true;
+      error = 'Failed to load pool data. The canister may be briefly unavailable.';
     } finally {
       loading = false;
     }
-  });
+  }
+
+  onMount(loadPool);
 </script>
 
 <svelte:head>
@@ -367,7 +374,8 @@
       ? `Constant-product AMM · ${formatBps(ammFeeBps)} fee`
       : undefined}
   loading={loading}
-  error={notFound ? `Pool not found: ${poolIdParam}` : null}
+  {error}
+  onRetry={loadPool}
 >
   {#snippet identity()}
     {#if isThreePool}

--- a/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
@@ -520,7 +520,9 @@
   const SP_EVENT_PULL = 500n;
   const THREE_POOL_SWAP_PULL = 500n;
 
-  onMount(async () => {
+  async function loadToken() {
+    loading = true;
+    error = null;
     let tokenPrincipalObj: Principal;
     try {
       tokenPrincipalObj = Principal.fromText(tokenPrincipal);
@@ -623,7 +625,9 @@
     } finally {
       loading = false;
     }
-  });
+  }
+
+  onMount(loadToken);
 </script>
 
 <EntityShell
@@ -631,6 +635,7 @@
   subtitle="{tokenName} · ledger {shortenPrincipal(tokenPrincipal)}"
   {loading}
   {error}
+  onRetry={loadToken}
 >
   {#snippet identity()}
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
@@ -34,7 +34,7 @@
   let loadingVault = $state(true);
   let loadingCore = $state(true);
   let loadingHistory = $state(true);
-  let vaultError = $state(false);
+  let loadError = $state<string | null>(null);
 
   const collateralPrincipalStr = $derived(
     vault?.collateral_type ? (vault.collateral_type.toString?.() ?? vault.collateral_type.toText?.() ?? String(vault.collateral_type)) : ''
@@ -387,7 +387,11 @@
     };
   }
 
-  onMount(async () => {
+  async function loadVault() {
+    loadingVault = true;
+    loadingCore = true;
+    loadingHistory = true;
+    loadError = null;
     const id = BigInt(vaultId);
     try {
       const [v, r, configs, prices, h, pseries] = await Promise.all([
@@ -401,7 +405,7 @@
       const histArr = Array.isArray(h) ? h : [];
       const resolved = v ?? synthesizeVaultFromHistory(vaultId, histArr);
       if (!resolved) {
-        vaultError = true;
+        loadError = `Vault #${vaultId} does not exist or has never recorded any events.`;
       } else {
         vault = resolved;
         interestRate = r;
@@ -418,12 +422,17 @@
             .catch(() => {});
         }
       }
+    } catch (err) {
+      console.error('[vault page] load error:', err);
+      loadError = 'Failed to load vault data. The backend may be briefly unavailable.';
     } finally {
       loadingVault = false;
       loadingCore = false;
       loadingHistory = false;
     }
-  });
+  }
+
+  onMount(loadVault);
 
   const statusLabel = $derived(isClosed ? 'Closed' : 'Active');
 </script>
@@ -435,7 +444,8 @@
 <EntityShell
   title={`Vault #${vaultId}`}
   loading={loadingVault}
-  error={vaultError ? `Vault #${vaultId} does not exist or could not be loaded.` : null}
+  error={loadError}
+  onRetry={loadVault}
 >
   {#snippet identity()}
     <div class="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
Consolidates the loading / empty / error state handling across every Explorer surface. Users now see a consistent friendly pattern everywhere a fetch can fail or come back empty, and they can retry a transient failure in place instead of reloading the page.

- New shared components: `EmptyState.svelte` (icon + title + message + optional CTA slot) and `ErrorState.svelte` (amber warning icon + retry button). Both under 60 lines, no new deps.
- Extended `EntityShell` with an `onRetry` prop. Every entity page (vault / token / address / pool / event) now extracts its loader from `onMount` and wires it up.
- Fixes four pre-existing inconsistencies surfaced by the audit:
  1. **Pool page** had a `notFound` boolean that merged "does not exist" with "fetch failed" under one message. Now they are distinct strings, and the 3pool branch's silent `try` / `finally` gained a catch.
  2. **Vault page** used `vaultError: boolean` ternary'd into a message string. Replaced with `loadError: string | null` directly.
  3. **Canister page** only console.error'd on fetch failure with no user feedback. Now shows an inline `ErrorState` + retry.
  4. **Canister page** also had two pre-existing type errors (`rows` instead of `data` on DataTable, redundant `<SearchBar />` with no `onSearch` prop) — fixed incidentally.
- **Activity page** empty state now differentiates "no activity anywhere" (inbox icon) from "your filter hit zero rows" (search icon + 'Clear all filters' link), and the error path has a retry button.

## What the new states look like

**Error state on a non-existent vault** (`/explorer/e/vault/99999`):
> Vault #99999 — amber warning icon — "Something went wrong" — "Vault #99999 does not exist or has never recorded any events." — [🔄 Try again] — Back to Explorer

**Empty state on a facet-filtered Activity page with no matches** (`/explorer/activity?type=liquidation&timeRange=24h`):
> Search icon — "No matching events" — "Try widening the time window or clearing a facet." — [Clear all filters]

## Why
The Explorer had two kinds of silent failures: a rejected promise that left the UI blank (no user action available), and heterogeneous empty tables that looked the same whether the query genuinely had zero rows or the filter was over-constrained. Retry + consistent language closes both.

## Test plan
- [x] `svelte-check` passes with no new errors (34 → 32, fixed 2 pre-existing)
- [x] Local preview verified the vault error state renders with the retry button
- [x] Local preview verified the Activity empty state renders with the Clear filters CTA
- [x] Protocol page continues to render correctly (no regression from EntityShell changes)
- [ ] Merge after review; mainnet deploy covered separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)