### PR TITLE
perf(explorer): halve parallel canister calls on /e/address first paint

### DIFF
--- a/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
@@ -597,13 +597,42 @@
     }
 
     try {
+      // Wave 1 — identity + portfolio donut. 5 parallel calls. These populate
+      // the above-the-fold content; once they land, we set `loading = false`
+      // and the rest of the page fills in progressively as Wave 2 completes.
+      const [vaultsRes, configsRes, pricesRes, threePoolStateRes, threePoolLpRes] =
+        await Promise.all([
+          fetchVaultsByOwner(principal).catch(() => []),
+          fetchCollateralConfigs().catch(() => []),
+          fetchCollateralPrices().catch(() => new Map<string, number>()),
+          fetchThreePoolState().catch(() => null),
+          fetch3PoolLpBalance(principal).catch(() => 0n),
+        ]);
+
+      vaults = vaultsRes;
+      configs = configsRes;
+      priceMap = pricesRes;
+      threePoolState = threePoolStateRes;
+      threePoolLp = threePoolLpRes;
+      loading = false;
+
+      // Wave 2 — below-the-fold activity + relationships data. Runs in the
+      // background without blocking the render. Sections hydrate as their
+      // state variables update.
+      void loadBelowFoldData(principal, configsRes);
+    } catch (e) {
+      console.error('[address page] Failed to load data:', e);
+      error = 'Failed to load address data. The backend may be briefly unavailable.';
+      loading = false;
+    }
+  }
+
+  async function loadBelowFoldData(principal: Principal, configsRes: any[]) {
+    try {
+      // Wave 2a — 7 parallel calls. Everything the activity feed, LP
+      // positions, and subaccount relationships need.
       const [
-        vaultsRes,
         allVaultsRes,
-        configsRes,
-        pricesRes,
-        threePoolStateRes,
-        threePoolLpRes,
         ammPoolsRes,
         backendEventsRes,
         threePoolSwapsRes,
@@ -611,12 +640,7 @@
         icusdSubsRes,
         threeUsdSubsRes,
       ] = await Promise.all([
-        fetchVaultsByOwner(principal).catch(() => []),
         fetchAllVaults().catch(() => []),
-        fetchCollateralConfigs().catch(() => []),
-        fetchCollateralPrices().catch(() => new Map<string, number>()),
-        fetchThreePoolState().catch(() => null),
-        fetch3PoolLpBalance(principal).catch(() => 0n),
         fetchAmmPools().catch(() => []),
         fetchEventsByPrincipal(principal).catch(() => [] as [bigint, any][]),
         fetch3PoolSwapEventsByPrincipal(principal).catch(() => []),
@@ -625,12 +649,7 @@
         fetchThreeUsdSubaccounts(principal).catch(() => []),
       ]);
 
-      vaults = vaultsRes;
       allVaults = allVaultsRes;
-      configs = configsRes;
-      priceMap = pricesRes;
-      threePoolState = threePoolStateRes;
-      threePoolLp = threePoolLpRes;
       ammPools = ammPoolsRes;
       backendEvents = backendEventsRes;
       threePoolSwapEvents = threePoolSwapsRes;
@@ -638,7 +657,7 @@
       icusdSubaccounts = icusdSubsRes;
       threeUsdSubaccounts = threeUsdSubsRes;
 
-      // Second wave — depends on the pool + config lists above.
+      // Wave 2b — depends on the pool + config lists above.
       const ledgerSet = new Set<string>([CANISTER_IDS.ICUSD_LEDGER, CANISTER_IDS.THREEPOOL]);
       for (const cfg of configsRes) {
         const pid = cfg.ledger_canister_id?.toText?.() ?? String(cfg.ledger_canister_id ?? '');
@@ -688,10 +707,10 @@
       ammSwapEventsMatching = ammSwapFull.filter(matchesCaller);
       ammLiqEventsMatching = ammLiqFull.filter(matchesCaller);
     } catch (e) {
-      console.error('[address page] Failed to load data:', e);
-      error = 'Failed to load address data. The backend may be briefly unavailable.';
-    } finally {
-      loading = false;
+      // Below-fold errors don't surface as page-level failures — the affected
+      // sections will simply show empty states. The error still goes to the
+      // console for debugging.
+      console.error('[address page] Wave 2 load failed:', e);
     }
   }
 


### PR DESCRIPTION
## Summary
`/e/address/{principal}` used to fire 12 canister calls in parallel on `onMount` and blocked the entire page on all of them. This PR splits that into a 5-call critical wave + a 7-call below-the-fold wave, so first paint drops under the plan's "no more than 8 parallel" budget and the identity strip renders a full RTT sooner.

- **Wave 1** (5 parallel, blocks `loading`): vaults owned, collateral configs, collateral prices, 3pool state, 3pool LP balance. These populate the header strip and the portfolio donut.
- **Wave 2** (7 parallel, unblocked): all vaults, AMM pools, backend / 3pool-swap / 3pool-liquidity events by principal, icUSD + 3USD subaccount lists.
- **Wave 2b** (still unblocked): per-pool AMM LP balances, per-ledger ICRC balances, SP + AMM event filtering.

`loading` flips to `false` as soon as Wave 1 resolves. Svelte's reactivity hydrates the below-the-fold sections as Wave 2 lands; by the time a user scrolls, the data is usually there. Wave 2 errors stay inside the wave's own catch so a transient activity fetch failure no longer turns the whole header into an error state.

## What did not land

- **IDL bundle split.** I refactored `config.ts` to stop re-exporting 8 candid IDL factories and had each service import its own IDL directly, hoping Rollup would split the shared chunk per route. It net-regressed the shared chunk by ~12KB gzipped — the multi-used services still pull those IDLs into the same shared chunk, and the duplicated imports added noise. Reverted.
- **Lighthouse runs.** Hard to reproduce live-canister latency in a local lab, so I skipped the full Lighthouse pass. The parallel-count and bundle-size numbers below are what I measured; worth a proper mobile Lighthouse on a real network once this lands.

## Measurements

| Metric | Before | After |
|---|---|---|
| Parallel canister calls on /e/address first paint | 12 | **5** |
| Shared chunk (gzip) | 378KB | 378KB (unchanged) |
| Lightweight-charts | already lazy-loaded via `await import()` | same |
| TokenFlowSankey | pure SVG, no external dep | same |

## Follow-ups
- The ~380KB gzipped shared chunk is mostly `@dfinity/agent` + candid. A future PR could experiment with manual Rollup chunk boundaries to split the vendor bundle away from route code. Out of scope here.
- A future `rumi_analytics.get_address_summary(p)` endpoint (noted with an existing TODO in the source) would let us batch several of the Wave 2 calls into one. New endpoint is explicitly out of scope for this PR per the plan.

## Test plan
- [x] `svelte-check` passes with no new errors (32 errors, all pre-existing)
- [x] Build completes cleanly
- [x] Browser smoke: `/e/address/{principal}` renders Identity + Portfolio section as Wave 1 completes; Activity + Relationships hydrate shortly after
- [x] No regression on the Activity page (no changes to that route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)