### PR TITLE
fix(auth): wave 2 audit hardening (AUTH-001, AUTH-002, SP-004, DOS-009)

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -683,11 +683,8 @@ service : (ProtocolArg) -> {
   claim_liquidity_returns : () -> (Result_1);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_vault : (nat64) -> (Result_4);
-  dev_force_bot_liquidate : (nat64) -> (Result_3);
-  dev_force_partial_bot_liquidate : (nat64) -> (Result_3);
-  dev_test_cascade_liquidation : (nat64) -> (Result_11);
-  dev_test_pool_only_liquidation : (nat64) -> (Result_11);
-  dev_set_collateral_price : (principal, float64) -> (Result_11);
+  // dev_* endpoints are gated behind cfg(feature = "test_endpoints") and not
+  // present in the mainnet wasm (audit 2026-04-22-28e9896 Wave 2, AUTH-002).
   enter_recovery_mode : () -> (Result);
   exit_recovery_mode : () -> (Result);
   freeze_protocol : () -> (Result);

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1923,6 +1923,11 @@ async fn bot_cancel_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
 
 /// Developer-only: force the bot to claim a vault for liquidation regardless of health ratio.
 /// Bypasses CR checks but still uses the two-phase claim pattern.
+///
+/// Compiled out of the mainnet wasm via `cfg(feature = "test_endpoints")` (audit
+/// 2026-04-22-28e9896 Wave 2, AUTH-002). The runtime caller gate below remains
+/// for the test build that does enable the feature.
+#[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
 async fn dev_force_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, ProtocolError> {
@@ -2018,6 +2023,9 @@ async fn dev_force_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, 
 /// Developer test: force a PARTIAL bot liquidation, bypassing the CR health check.
 /// Uses compute_partial_liquidation_cap to determine debt amount (same as bot_claim_liquidation)
 /// but skips the requirement that the vault be below the liquidation threshold.
+///
+/// Compiled out of the mainnet wasm via `cfg(feature = "test_endpoints")` (AUTH-002).
+#[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
 async fn dev_force_partial_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, ProtocolError> {
@@ -2114,6 +2122,9 @@ async fn dev_force_partial_bot_liquidate(vault_id: u64) -> Result<BotLiquidation
 
 /// Developer test: force a vault to be liquidated by the stability pool, bypassing the bot.
 /// Calls the stability pool's notify_liquidatable_vaults with just this vault.
+///
+/// Compiled out of the mainnet wasm via `cfg(feature = "test_endpoints")` (AUTH-002).
+#[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
 async fn dev_test_pool_only_liquidation(vault_id: u64) -> Result<String, ProtocolError> {
@@ -2176,6 +2187,9 @@ async fn dev_test_pool_only_liquidation(vault_id: u64) -> Result<String, Protoco
 
 /// Developer test: manually set the cached price for any collateral type.
 /// Bypasses XRC — useful for testing liquidation flows with synthetic assets.
+///
+/// Compiled out of the mainnet wasm via `cfg(feature = "test_endpoints")` (AUTH-002).
+#[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
 async fn dev_set_collateral_price(collateral_type: Principal, price_usd: f64) -> Result<String, ProtocolError> {

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -150,15 +150,21 @@ pub fn opt_in_collateral(collateral_type: Principal) -> Result<(), StabilityPool
 // ─── Liquidation (Push + Fallback) ───
 
 /// Called by the backend to push liquidatable vault notifications.
+///
+/// Restricted to the registered protocol canister (audit 2026-04-22-28e9896
+/// Wave 2, AUTH-001 / SP-004 / DOS-009). Any other caller would otherwise
+/// be able to feed fabricated `LiquidatableVaultInfo` entries through the
+/// SP's liquidation pipeline (cycle DoS + event-log pollution + interaction
+/// with the per-token bookkeeping path), so the gate matches the pattern
+/// used by `receive_interest_revenue` below.
 #[update]
 pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> Vec<LiquidationResult> {
-    // Optionally: validate caller is the protocol canister
     let caller = ic_cdk::api::caller();
     let expected = read_state(|s| s.protocol_canister_id);
     if caller != expected {
-        log!(INFO, "notify_liquidatable_vaults called by {} (expected {}). Allowing for now.",
+        log!(INFO, "notify_liquidatable_vaults: rejected caller {} (expected protocol {})",
             caller, expected);
-        // TODO: decide whether to enforce caller == protocol_canister_id
+        return Vec::new();
     }
     let vault_count = vaults.len() as u64;
     mutate_state(|s| s.push_event(caller, PoolEventType::LiquidationNotification { vault_count }));

--- a/src/stability_pool/tests/audit_pocs_auth_001_anon_caller.rs
+++ b/src/stability_pool/tests/audit_pocs_auth_001_anon_caller.rs
@@ -1,0 +1,217 @@
+//! AUTH-001 regression fence: notify_liquidatable_vaults must reject any caller
+//! that is not the registered protocol canister.
+//!
+//! Audit report: audit-reports/2026-04-22-28e9896/verification-results.md (AUTH-001).
+//! Bundles SP-004 and DOS-009 because all three are the same caller-gate hole on
+//! the same endpoint.
+//!
+//! Before the Wave-2 fix, `src/stability_pool/src/lib.rs:153-166` logged a warning
+//! and fell through when caller != protocol_canister_id. Any principal (including
+//! Principal::anonymous()) could feed fabricated LiquidatableVaultInfo entries
+//! through the SP's liquidation pipeline. The fix matches the receive_interest_revenue
+//! pattern: reject the caller and return an empty result vector.
+//!
+//! This integration test deploys the real SP canister, registers a stablecoin and
+//! a fake protocol principal, then calls notify_liquidatable_vaults from
+//! Principal::anonymous() with a fabricated vault entry. It asserts:
+//!  1. The call returns an empty Vec<LiquidationResult> (not Err, not panic, the
+//!     signature is infallible).
+//!  2. No LiquidationNotification event is appended to the pool event log
+//!     attributing the rejected call. Allowing rejected callers to write events
+//!     would itself be a DoS on the event log (DOS-009).
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Principal};
+use icrc_ledger_types::icrc1::account::Account;
+use pocket_ic::{PocketIcBuilder, WasmResult};
+use stability_pool::types::*;
+
+// ─── Candid types for ICRC-1 ledger init (same shape as pocket_ic_3usd.rs) ───
+
+#[derive(CandidType, Deserialize)]
+struct FeatureFlags { icrc2: bool }
+
+#[derive(CandidType, Deserialize)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize)]
+enum MetadataValue { Nat(candid::Nat), Int(candid::Int), Text(String), Blob(Vec<u8>) }
+
+#[derive(CandidType, Deserialize)]
+struct LedgerInitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: candid::Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, candid::Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize)]
+enum LedgerArg { Init(LedgerInitArgs) }
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn stability_pool_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/stability_pool.wasm").to_vec()
+}
+
+#[test]
+fn auth_001_anon_caller_rejected() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    let admin = Principal::self_authenticating(&[5, 6, 7, 8]);
+    let minting_account = Principal::self_authenticating(&[100, 100, 100]);
+    let fake_protocol = Principal::self_authenticating(&[9, 10, 11, 12]);
+    let attacker = Principal::anonymous();
+
+    // Deploy a single ckUSDT-like ledger, just enough to register a stablecoin.
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = LedgerInitArgs {
+        minting_account: Account { owner: minting_account, subaccount: None },
+        fee_collector_account: None,
+        transfer_fee: candid::Nat::from(0u64),
+        decimals: Some(6),
+        max_memo_length: Some(32),
+        token_name: "ckUSDT".to_string(),
+        token_symbol: "ckUSDT".to_string(),
+        metadata: vec![],
+        initial_balances: vec![],
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: admin,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).unwrap(),
+        None,
+    );
+
+    // Deploy the stability pool with `fake_protocol` as the registered protocol.
+    let sp_id = pic.create_canister();
+    pic.add_cycles(sp_id, 2_000_000_000_000);
+    pic.install_canister(
+        sp_id,
+        stability_pool_wasm(),
+        encode_one(StabilityPoolInitArgs {
+            protocol_canister_id: fake_protocol,
+            authorized_admins: vec![admin],
+        }).unwrap(),
+        None,
+    );
+
+    // Register the ckUSDT ledger as an active stablecoin so the call cannot
+    // bail out for a "no stablecoin registered" reason.
+    let register_result = pic.update_call(
+        sp_id,
+        admin,
+        "register_stablecoin",
+        encode_one(StablecoinConfig {
+            ledger_id,
+            symbol: "ckUSDT".to_string(),
+            decimals: 6,
+            priority: 2,
+            is_active: true,
+            transfer_fee: Some(0),
+            is_lp_token: None,
+            underlying_pool: None,
+        }).unwrap(),
+    ).expect("register_stablecoin call failed");
+    match register_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<(), StabilityPoolError> = decode_one(&bytes).expect("decode register");
+            r.expect("register_stablecoin error");
+        }
+        WasmResult::Reject(msg) => panic!("register_stablecoin rejected: {}", msg),
+    }
+
+    // Snapshot pool event count BEFORE the rejected call.
+    let events_before: u64 = match pic.query_call(
+        sp_id,
+        Principal::anonymous(),
+        "get_pool_event_count",
+        encode_args(()).unwrap(),
+    ) {
+        Ok(WasmResult::Reply(bytes)) => decode_one(&bytes).expect("decode count"),
+        Ok(WasmResult::Reject(msg)) => panic!("pool_event_count rejected: {}", msg),
+        Err(e) => panic!("pool_event_count failed: {:?}", e),
+    };
+
+    // Drive the attack: anonymous caller submits a fabricated liquidatable vault.
+    let fabricated = LiquidatableVaultInfo {
+        vault_id: 999_999,
+        collateral_type: ledger_id,
+        debt_amount: 100_000_000,
+        collateral_amount: 100_000_000,
+        recommended_liquidation_amount: 100_000_000,
+        collateral_price_e8s: 1_00000000,
+    };
+    let result = pic.update_call(
+        sp_id,
+        attacker,
+        "notify_liquidatable_vaults",
+        encode_one(vec![fabricated]).unwrap(),
+    ).expect("notify_liquidatable_vaults call failed at transport layer");
+
+    let liquidations: Vec<LiquidationResult> = match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode liquidation result"),
+        WasmResult::Reject(msg) => panic!(
+            "notify_liquidatable_vaults rejected at transport layer (expected empty Vec, got reject): {}",
+            msg
+        ),
+    };
+
+    assert!(
+        liquidations.is_empty(),
+        "AUTH-001: anonymous caller must produce no liquidation results (got {} entries)",
+        liquidations.len(),
+    );
+
+    // No event should have been written attributing the rejected call.
+    let events_after: u64 = match pic.query_call(
+        sp_id,
+        Principal::anonymous(),
+        "get_pool_event_count",
+        encode_args(()).unwrap(),
+    ) {
+        Ok(WasmResult::Reply(bytes)) => decode_one(&bytes).expect("decode count"),
+        Ok(WasmResult::Reject(msg)) => panic!("pool_event_count rejected: {}", msg),
+        Err(e) => panic!("pool_event_count failed: {:?}", e),
+    };
+
+    assert_eq!(
+        events_before, events_after,
+        "AUTH-001 / DOS-009: rejected calls must not append to the pool event log \
+         (event count went from {} to {})",
+        events_before, events_after,
+    );
+}


### PR DESCRIPTION
## Summary

Audit remediation **2026-04-22-28e9896 Wave 2** — auth quick wins. Bundles **AUTH-001**, **AUTH-002**, **SP-004**, **DOS-009** since the first three plus DOS-009 collapse onto two single-file edits.

### AUTH-001 / SP-004 / DOS-009 — `notify_liquidatable_vaults` caller gate

`src/stability_pool/src/lib.rs` previously logged "Allowing for now" and fell through when the caller was not the registered protocol canister. The endpoint now mirrors the `receive_interest_revenue` pattern: reject unauthorized callers and return `Vec::new()`. This also closes DOS-009 (event-log pollution from fabricated calls).

### AUTH-002 — `dev_*` endpoints cfg-gated

Four `dev_*` updates in `rumi_protocol_backend/src/main.rs` and a stale `.did` entry now sit behind `#[cfg(feature = "test_endpoints")]`:

- `dev_force_bot_liquidate`
- `dev_force_partial_bot_liquidate`
- `dev_test_pool_only_liquidation`
- `dev_set_collateral_price`

Mainnet builds (no `--features test_endpoints`) compile them out entirely. Verified by grepping the release wasm — zero `dev_*` exports. Test builds and `test_rumi_protocol_backend` can still enable them via the feature flag.

The `.did` also drops `dev_test_cascade_liquidation`, an entry that had no implementation (pre-existing bit-rot).

### Pre-deploy guard

`.claude/hooks/check-no-dev-endpoints.sh` is wired into `pre-deploy-test.sh`. It walks the backend source for any `#[update]` or `#[query]` whose name starts with `dev_` or `test_` and lacks a `cfg(...test_endpoints...)` gate, refusing the deploy if found. Caught one extra latent issue during development: `test_set_icp_price_e8s` and `set_test_icp_rate` in `test_helpers.rs` are already gated with `cfg(any(test, feature = "test_endpoints"))`, which the hook regex accepts.

## Regression fence

`src/stability_pool/tests/audit_pocs_auth_001_anon_caller.rs` deploys the SP in PocketIC, calls `notify_liquidatable_vaults` from `Principal::anonymous()` with a fabricated `LiquidatableVaultInfo`, and asserts:

1. The call returns an empty `Vec<LiquidationResult>`.
2. The pool event log count does not increase.

```
2021-05-06 19:17:10 INFO src/stability_pool/src/lib.rs:165 notify_liquidatable_vaults: rejected caller 2vxsx-fae (expected protocol mlnpm-...)
test auth_001_anon_caller_rejected ... ok
```

## Test plan

- [x] `cargo test -p stability_pool --lib` — 36/36 pass
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p stability_pool` (all SP tests) — 48/48 pass (36 lib + 4 SP-001 audit_pocs + 1 AUTH-001 audit_poc + 7 pocket_ic_3usd)
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p rumi_protocol_backend --test pocket_ic_tests` — 27/29 pass (same 2 pre-existing failures as Wave 1)
- [x] `cargo build --target wasm32-unknown-unknown --release` (default and `--features test_endpoints`) — clean
- [x] `strings target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm | grep dev_` — empty
- [x] `bash .claude/hooks/check-no-dev-endpoints.sh` against current code — passes

## Deploy

Not deploying in this PR. After merge, planned deploys:
- `dfx deploy rumi_stability_pool --network ic --argument '(record { protocol_canister_id = principal "tfesu-vyaaa-aaaap-qrd7a-cai"; authorized_admins = vec { principal "fd7h3-mgmok-..." } })'`
- `dfx deploy rumi_protocol_backend --network ic --argument '(variant { Upgrade = record { mode = null; description = opt "Wave 2 audit: cfg-gate dev_* endpoints" } })'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)