### PR TITLE
fix(bot): unblock post_upgrade by defaulting icpswap_pool

### DIFF
--- a/src/liquidation_bot/src/state.rs
+++ b/src/liquidation_bot/src/state.rs
@@ -5,6 +5,13 @@ use std::cell::RefCell;
 
 use crate::memory;
 
+/// Sentinel used by `BotConfig.icpswap_pool` when an old serialized state has
+/// no `icpswap_pool` field. `swap.rs` checks for this and refuses to swap
+/// until admin sets a real principal via `set_config`.
+fn default_icpswap_pool() -> Principal {
+    Principal::anonymous()
+}
+
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
 pub struct BotConfig {
     pub backend_principal: Principal,
@@ -14,7 +21,19 @@ pub struct BotConfig {
     pub icp_ledger: Principal,
     pub ckusdc_ledger: Principal,
 
-    // ICPSwap config (replaces kong_swap + three_pool)
+    // ICPSwap config (replaces kong_swap + three_pool).
+    //
+    // Defaults to the anonymous principal so that pre-Apr-9 BotConfig blobs
+    // (which have no `icpswap_pool` field at all) still deserialize cleanly
+    // through the post_upgrade legacy-rescue path. Without this default the
+    // rescue's `serde_json::from_slice::<BotState>` returns Err, the post
+    // upgrade falls through to `load_config_from_stable`, and that traps on
+    // an empty MEM_ID_CONFIG region (rolling the upgrade back).
+    //
+    // Runtime guard: `swap.rs` rejects swaps when this is anonymous so the
+    // bot fails loudly instead of routing trades to nowhere. Admin must set
+    // a real pool via `set_config` before liquidations resume.
+    #[serde(default = "default_icpswap_pool")]
     pub icpswap_pool: Principal,
 
     // Cached after admin_resolve_pool_ordering (determines swap direction)
@@ -179,8 +198,80 @@ pub fn save_config_to_stable() {
     });
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression fence: a `BotState` JSON blob written by the pre-Apr-9 wasm
+    /// (no `icpswap_pool` field, with the legacy `kong_swap_principal` /
+    /// `three_pool_principal` / `ckusdt_ledger` / `icusd_ledger` fields, no
+    /// `migrated_to_stable_structures`) MUST deserialize cleanly into the
+    /// current `BotState`. Without `#[serde(default = "default_icpswap_pool")]`
+    /// on `BotConfig.icpswap_pool`, the deserialization fails, the post
+    /// upgrade legacy-rescue returns `None`, and the entire upgrade traps.
+    #[test]
+    fn legacy_pre_icpswap_state_deserializes() {
+        let legacy_blob = serde_json::json!({
+            "config": {
+                "backend_principal": "tfesu-vyaaa-aaaap-qrd7a-cai",
+                "three_pool_principal": "fohh4-yyaaa-aaaap-qtkpa-cai",
+                "kong_swap_principal": "2ipq2-uqaaa-aaaar-qailq-cai",
+                "treasury_principal": "tlg74-oiaaa-aaaap-qrd6a-cai",
+                "admin": "fd7h3-mgmok-dmojz-awmxl-k7eqn-37mcv-jjkxp-parnt-ehngl-l2z3m-kae",
+                "max_slippage_bps": 200,
+                "icp_ledger": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+                "ckusdc_ledger": "xevnm-gaaaa-aaaar-qafnq-cai",
+                "ckusdt_ledger": "cngnf-vqaaa-aaaar-qag4q-cai",
+                "icusd_ledger": "t6bor-paaaa-aaaap-qrd5q-cai"
+            },
+            "stats": {
+                "total_debt_covered_e8s": 0,
+                "total_icusd_burned_e8s": 0,
+                "total_collateral_received_e8s": 0,
+                "total_collateral_to_treasury_e8s": 0,
+                "events_count": 99
+            },
+            "liquidation_events": [],
+            "pending_vaults": [],
+            "admin_events": []
+        });
+
+        let bytes = serde_json::to_vec(&legacy_blob).expect("encode legacy blob");
+        let state: BotState =
+            serde_json::from_slice(&bytes).expect("legacy state must deserialize cleanly");
+
+        let config = state.config.expect("config preserved");
+        assert_eq!(
+            config.icpswap_pool,
+            Principal::anonymous(),
+            "icpswap_pool must default to the anonymous-principal sentinel"
+        );
+        assert_eq!(
+            config.three_pool_principal,
+            Some(Principal::from_text("fohh4-yyaaa-aaaap-qtkpa-cai").unwrap()),
+            "legacy three_pool_principal must round-trip via Option"
+        );
+        assert_eq!(state.stats.events_count, 99, "stats preserved");
+        assert!(
+            !state.migrated_to_stable_structures,
+            "legacy blob has no migration marker, must default to false so post_upgrade runs the StableBTreeMap migration"
+        );
+    }
+}
+
 pub fn load_config_from_stable() {
     let mem = memory::get_memory(memory::MEM_ID_CONFIG);
+
+    // MemoryManager allocates virtual addresses lazily — on the first upgrade
+    // after migration, MEM_ID_CONFIG has zero physical pages until a prior
+    // pre_upgrade has called `save_config_to_stable`. Reading at offset 0
+    // would panic with "out of bounds" and trap the entire upgrade. Bail out
+    // to a default state in that case (post_upgrade's other branches handle
+    // legacy rescue, so this is reached only when there genuinely is no data).
+    if ic_stable_structures::Memory::size(&mem) == 0 {
+        init_state(BotState::default());
+        return;
+    }
 
     let mut len_bytes = [0u8; 8];
     ic_stable_structures::Memory::read(&mem, 0, &mut len_bytes);

--- a/src/liquidation_bot/src/swap.rs
+++ b/src/liquidation_bot/src/swap.rs
@@ -42,8 +42,24 @@ pub async fn approve_infinite(
     }
 }
 
+/// Reject swaps when `icpswap_pool` is the anonymous-principal sentinel that
+/// `BotConfig` falls back to after a legacy-state migration where the field
+/// did not exist. Forces admin to call `set_config` with a real pool before
+/// any liquidation routes through ICPSwap.
+fn require_icpswap_pool_set(config: &BotConfig) -> Result<(), String> {
+    if config.icpswap_pool == Principal::anonymous() {
+        return Err(
+            "icpswap_pool not configured (defaulted from legacy migration). \
+             Admin must call set_config with a real ICPSwap pool principal."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Quote how much ckUSDC we'd get for `icp_amount_e8s` ICP.
 pub async fn quote_icp_for_ckusdc(config: &BotConfig, icp_amount_e8s: u64) -> Result<u64, String> {
+    require_icpswap_pool_set(config)?;
     let zero_for_one = config
         .icpswap_zero_for_one
         .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;
@@ -58,6 +74,7 @@ pub async fn swap_icp_for_ckusdc(
     config: &BotConfig,
     icp_amount_e8s: u64,
 ) -> Result<SwapResult, String> {
+    require_icpswap_pool_set(config)?;
     let zero_for_one = config
         .icpswap_zero_for_one
         .ok_or("Pool ordering not configured. Call admin_resolve_pool_ordering first.")?;


### PR DESCRIPTION
## Summary

Bot upgrades have been failing since the Apr-9 ICPSwap migration ([84099eb](https://github.com/RumiLabsXYZ/rumi-protocol-v2/commit/84099eb)) added a non-optional \`icpswap_pool: Principal\` field to \`BotConfig\`. The deployed bot's serialized state predates that field, so the new wasm's \`serde_json::from_slice::<BotState>\` in \`post_upgrade\` STEP 1 returns Err. The fallback then calls \`load_config_from_stable\` which traps on \"read out of bounds\" (MEM_ID_CONFIG has zero physical pages on the first migration upgrade), and the IC rolls the entire upgrade back. This is what blocked the Wave-3 ICRC-003 fix from landing on the bot.

Two changes in [state.rs](src/liquidation_bot/src/state.rs) and [swap.rs](src/liquidation_bot/src/swap.rs):

1. \`icpswap_pool\` defaults to \`Principal::anonymous()\` via \`#[serde(default = \"default_icpswap_pool\")]\` so legacy state deserializes cleanly. \`swap.rs\` adds \`require_icpswap_pool_set\` guarding \`quote_icp_for_ckusdc\` and \`swap_icp_for_ckusdc\` — they refuse to route trades when the field is the anonymous sentinel.

2. \`load_config_from_stable\` bails out to default state if \`MEM_ID_CONFIG.size() == 0\`, rather than trapping on the read. Defense in depth — after fix (1) the legacy-rescue branch should always succeed first.

## Regression fence

\`state::tests::legacy_pre_icpswap_state_deserializes\` constructs the pre-Apr-9 \`BotState\` JSON shape (with \`kong_swap_principal\`, no \`icpswap_pool\`, no \`migrated_to_stable_structures\`) and asserts the current type deserializes it cleanly with \`icpswap_pool\` defaulted. Any future \`BotConfig\` field added without \`serde(default)\` trips this test.

## Test plan

- [x] \`cargo test -p liquidation_bot --lib\` (1/1 pass — the new regression test)
- [x] \`cargo build -p liquidation_bot --target wasm32-unknown-unknown --release\` clean

## Operational note

After deploy, the bot's \`icpswap_pool\` config field will be \`anonymous-principal\` and the runtime guard will refuse to route liquidations through ICPSwap. Admin must call \`set_config\` (with the real ICPSwap pool principal) before liquidations resume via the bot. In the meantime, the stability pool handles them via the existing priority cascade.

This deploy also lands the Wave-3 ICRC-003 \`Duplicate\`-handling fix in the bot's three \`swap.rs\` transfer sites (\`return_collateral_to_backend\`, \`transfer_ckusdc_to_backend\`, \`transfer_icp_to_treasury\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)