### PR TITLE
fix(audit-wave-4): pending-transfer lifecycle (LIQ-001, ICC-002, ICC-005, ICC-007)

### DIFF
--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -1118,7 +1118,12 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
                 state.upgrade(upgrade_args);
             }
             Event::MarginTransfer { vault_id, .. } => {
-                state.pending_margin_transfers.remove(&vault_id);
+                // Wave-4 LIQ-001: pending_margin_transfers is keyed by (vault_id, owner).
+                // The MarginTransfer event predates that change and doesn't carry owner,
+                // so on replay we drop every entry matching the vault_id. This is
+                // semantically equivalent to the legacy single-slot remove because the
+                // pending map is rebuilt by live ops, not by replay.
+                state.pending_margin_transfers.retain(|(vid, _), _| *vid != vault_id);
             }
             Event::CollateralWithdrawn { vault_id, amount, .. } => {
                 // Zero the vault's collateral during replay so that if a
@@ -1592,13 +1597,13 @@ pub fn record_close_vault(state: &mut State, vault_id: u64, block_index: Option<
     state.close_vault(vault_id);
 }
 
-pub fn record_margin_transfer(state: &mut State, vault_id: u64, block_index: u64) {
+pub fn record_margin_transfer(state: &mut State, vault_id: u64, owner: Principal, block_index: u64) {
     record_event(&Event::MarginTransfer {
         vault_id,
         block_index,
         timestamp: Some(now()),
     });
-    state.pending_margin_transfers.remove(&vault_id);
+    state.pending_margin_transfers.remove(&(vault_id, owner));
 }
 
 pub fn record_borrow_from_vault(

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -1041,9 +1041,67 @@ pub(crate) async fn process_pending_transfer() {
         }
     }
 
+    // Wave-4 ICC-007: durable refund queue from `redeem_reserves` double-failures.
+    // Each entry is keyed by the original burn block index (unique). We drive the
+    // retry through `transfer_icusd_with_nonce` so the icUSD ledger deduplicates
+    // if a previous attempt's reply was lost.
+    let pending_refunds = read_state(|s| {
+        s.pending_refunds
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect::<Vec<(u64, crate::state::PendingRefund)>>()
+    });
+
+    for (icusd_block_index, refund) in pending_refunds {
+        match crate::management::transfer_icusd_with_nonce(
+            crate::numeric::ICUSD::new(refund.amount_e8s),
+            refund.user,
+            refund.op_nonce,
+        ).await {
+            Ok(block_index) => {
+                log!(INFO,
+                    "[refunding] icUSD refund settled for {} (burn block {}, refund block {}, amount {})",
+                    refund.user, icusd_block_index, block_index, refund.amount_e8s
+                );
+                mutate_state(|s| { s.pending_refunds.remove(&icusd_block_index); });
+            }
+            Err(error) => {
+                log!(INFO,
+                    "[refunding] icUSD refund failed for {} (burn block {}): {}. Will retry.",
+                    refund.user, icusd_block_index, error
+                );
+                if let TransferError::BadFee { expected_fee } = error {
+                    // Refresh fee cache; do NOT increment retry count on BadFee.
+                    if let Ok(expected_fee_u64) = expected_fee.0.clone().try_into() {
+                        let icusd_ledger = read_state(|s| s.icusd_ledger_principal);
+                        crate::management::set_cached_fee(icusd_ledger, expected_fee_u64);
+                    }
+                } else {
+                    let retries = mutate_state(|s| {
+                        if let Some(r) = s.pending_refunds.get_mut(&icusd_block_index) {
+                            r.retry_count = r.retry_count.saturating_add(1);
+                            r.retry_count
+                        } else { 0 }
+                    });
+                    if retries >= MAX_PENDING_RETRIES {
+                        log!(INFO,
+                            "[refunding] CRITICAL: abandoning icUSD refund for {} (burn block {}) \
+                             after {} retries. Amount: {}. Manual reconciliation required.",
+                            refund.user, icusd_block_index, retries, refund.amount_e8s
+                        );
+                        mutate_state(|s| { s.pending_refunds.remove(&icusd_block_index); });
+                    }
+                }
+            }
+        }
+    }
+
     // Schedule another run if needed, but with better timing
     if read_state(|s| {
-        !s.pending_margin_transfers.is_empty() || !s.pending_excess_transfers.is_empty() || !s.pending_redemption_transfer.is_empty()
+        !s.pending_margin_transfers.is_empty()
+            || !s.pending_excess_transfers.is_empty()
+            || !s.pending_redemption_transfer.is_empty()
+            || !s.pending_refunds.is_empty()
     }) {
         // Schedule another check in 5 seconds
         log!(INFO, "[process_pending_transfer] Scheduling another transfer attempt in 5 seconds");

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -718,6 +718,19 @@ pub fn compute_collateral_ratio(vault: &Vault, _rate: UsdIcp, state: &state::Sta
     margin_value / vault.borrowed_icusd_amount
 }
 
+/// Drop a single pending-transfer entry from its owning map. Wave-4 ICC-005:
+/// after LIQ-001's `(vault_id, owner)` re-keying, every pending entry has a
+/// unique key, so abandon-paths are uniform across margin / excess / redemption.
+/// This helper exists to make that uniformity legible (and to stop callers
+/// from ever drifting back to `retain` over a vault_id range, which would
+/// over-remove sibling liquidators' entries).
+fn drop_pending<K: std::cmp::Ord>(
+    map: &mut std::collections::BTreeMap<K, crate::state::PendingMarginTransfer>,
+    key: &K,
+) {
+    map.remove(key);
+}
+
 pub(crate) async fn process_pending_transfer() {
     let _guard = match crate::guard::TimerLogicGuard::new() {
         Some(guard) => guard,
@@ -728,19 +741,29 @@ pub(crate) async fn process_pending_transfer() {
     };
 
     // Process pending margin transfers
+    //
+    // Wave-3 + Wave-4 cleanup contract:
+    //   * Success: `record_margin_transfer` writes a MarginTransfer event AND
+    //     removes the entry by `(vault_id, owner)` (event.rs).
+    //   * Skipped (margin <= fee): `drop_pending` drops the entry inline.
+    //   * Abandon (>= MAX_PENDING_RETRIES): `drop_pending` drops the entry inline.
+    //   * BadFee: refresh fee cache, do NOT drop. The next tick retries.
+    // Excess and redemption loops follow the same contract; redemption uses
+    // its own event recorder with the same removal semantics.
     let pending_transfers = read_state(|s| {
         // Log for visibility
         if !s.pending_margin_transfers.is_empty() {
-            log!(INFO, "[process_pending_transfer] Found {} pending margin transfers", 
+            log!(INFO, "[process_pending_transfer] Found {} pending margin transfers",
                  s.pending_margin_transfers.len());
         }
-        
+
         s.pending_margin_transfers
             .iter()
-            .map(|(vault_id, margin_transfer)| (*vault_id, *margin_transfer))
-            .collect::<Vec<(u64, PendingMarginTransfer)>>()
+            .map(|(key, margin_transfer)| (*key, *margin_transfer))
+            .collect::<Vec<((u64, candid::Principal), PendingMarginTransfer)>>()
     });
-    for (vault_id, transfer) in pending_transfers {
+    for (key, transfer) in pending_transfers {
+        let (vault_id, _key_owner) = key;
         // Look up per-collateral config for ledger and fee; fall back to global ICP defaults
         let (ledger, transfer_fee) = read_state(|s| {
             match s.get_collateral_config(&transfer.collateral_type) {
@@ -750,8 +773,8 @@ pub(crate) async fn process_pending_transfer() {
         });
 
         if transfer.margin <= transfer_fee {
-            log!(INFO, "[transfering_margins] Skipping vault {} - margin {} <= fee {}, removing", vault_id, transfer.margin, transfer_fee);
-            mutate_state(|s| { s.pending_margin_transfers.remove(&vault_id); });
+            log!(INFO, "[transfering_margins] Skipping vault {} owner {} - margin {} <= fee {}, removing", vault_id, transfer.owner, transfer.margin, transfer_fee);
+            mutate_state(|s| drop_pending(&mut s.pending_margin_transfers, &key));
             continue;
         }
         match crate::management::transfer_collateral_with_nonce(
@@ -770,7 +793,7 @@ pub(crate) async fn process_pending_transfer() {
                     transfer.owner,
                     ledger
                 );
-                mutate_state(|s| crate::event::record_margin_transfer(s, vault_id, block_index));
+                mutate_state(|s| crate::event::record_margin_transfer(s, vault_id, transfer.owner, block_index));
             }
             Err(error) => {
                 // Improved error logging with more details
@@ -810,7 +833,7 @@ pub(crate) async fn process_pending_transfer() {
                 } else {
                     // Increment retry count; abandon after MAX_PENDING_RETRIES
                     let retries = mutate_state(|s| {
-                        if let Some(t) = s.pending_margin_transfers.get_mut(&vault_id) {
+                        if let Some(t) = s.pending_margin_transfers.get_mut(&key) {
                             t.retry_count = t.retry_count.saturating_add(1);
                             t.retry_count
                         } else {
@@ -823,10 +846,10 @@ pub(crate) async fn process_pending_transfer() {
                              after {} retries. Owner: {}, amount: {}. Use recover_pending_transfer to retry manually.",
                             vault_id, retries, transfer.owner, transfer.margin
                         );
-                        mutate_state(|s| { s.pending_margin_transfers.remove(&vault_id); });
+                        mutate_state(|s| drop_pending(&mut s.pending_margin_transfers, &key));
                     } else {
-                        log!(INFO, "[transfering_margins] Will retry transfer for vault {} (attempt {}/{})",
-                            vault_id, retries, MAX_PENDING_RETRIES);
+                        log!(INFO, "[transfering_margins] Will retry transfer for vault {} owner {} (attempt {}/{})",
+                            vault_id, transfer.owner, retries, MAX_PENDING_RETRIES);
                     }
                 }
             }
@@ -837,11 +860,12 @@ pub(crate) async fn process_pending_transfer() {
     let pending_excess = read_state(|s| {
         s.pending_excess_transfers
             .iter()
-            .map(|(vault_id, transfer)| (*vault_id, *transfer))
-            .collect::<Vec<(u64, PendingMarginTransfer)>>()
+            .map(|(key, transfer)| (*key, *transfer))
+            .collect::<Vec<((u64, candid::Principal), PendingMarginTransfer)>>()
     });
 
-    for (vault_id, transfer) in pending_excess {
+    for (key, transfer) in pending_excess {
+        let (vault_id, _key_owner) = key;
         let (ledger, transfer_fee) = read_state(|s| {
             match s.get_collateral_config(&transfer.collateral_type) {
                 Some(config) => (config.ledger_canister_id, ICP::from(config.ledger_fee)),
@@ -850,8 +874,8 @@ pub(crate) async fn process_pending_transfer() {
         });
 
         if transfer.margin <= transfer_fee {
-            log!(INFO, "[transfering_excess] Skipping vault {} - margin {} <= fee {}, removing", vault_id, transfer.margin, transfer_fee);
-            mutate_state(|s| { s.pending_excess_transfers.remove(&vault_id); });
+            log!(INFO, "[transfering_excess] Skipping vault {} owner {} - margin {} <= fee {}, removing", vault_id, transfer.owner, transfer.margin, transfer_fee);
+            mutate_state(|s| drop_pending(&mut s.pending_excess_transfers, &key));
             continue;
         }
         match crate::management::transfer_collateral_with_nonce(
@@ -870,7 +894,7 @@ pub(crate) async fn process_pending_transfer() {
                     transfer.owner,
                     ledger
                 );
-                mutate_state(|s| { s.pending_excess_transfers.remove(&vault_id); });
+                mutate_state(|s| drop_pending(&mut s.pending_excess_transfers, &key));
             }
             Err(error) => {
                 log!(
@@ -904,7 +928,7 @@ pub(crate) async fn process_pending_transfer() {
                     // Don't increment retry counter on BadFee — refresh fee, retry next tick.
                 } else {
                     let retries = mutate_state(|s| {
-                        if let Some(t) = s.pending_excess_transfers.get_mut(&vault_id) {
+                        if let Some(t) = s.pending_excess_transfers.get_mut(&key) {
                             t.retry_count = t.retry_count.saturating_add(1);
                             t.retry_count
                         } else {
@@ -917,7 +941,7 @@ pub(crate) async fn process_pending_transfer() {
                              after {} retries. Owner: {}, amount: {}. Use recover_pending_transfer to retry manually.",
                             vault_id, retries, transfer.owner, transfer.margin
                         );
-                        mutate_state(|s| { s.pending_excess_transfers.remove(&vault_id); });
+                        mutate_state(|s| drop_pending(&mut s.pending_excess_transfers, &key));
                     }
                 }
             }
@@ -942,7 +966,7 @@ pub(crate) async fn process_pending_transfer() {
 
         if pending_transfer.margin <= transfer_fee {
             log!(INFO, "[transfering_redemptions] Skipping redemption {} - margin {} <= fee {}, removing", icusd_block_index, pending_transfer.margin, transfer_fee);
-            mutate_state(|s| { s.pending_redemption_transfer.remove(&icusd_block_index); });
+            mutate_state(|s| drop_pending(&mut s.pending_redemption_transfer, &icusd_block_index));
             continue;
         }
         match crate::management::transfer_collateral_with_nonce(
@@ -1010,7 +1034,7 @@ pub(crate) async fn process_pending_transfer() {
                              after {} retries. Owner: {}, amount: {}. Use recover_pending_transfer to retry manually.",
                             icusd_block_index, retries, pending_transfer.owner, pending_transfer.margin
                         );
-                        mutate_state(|s| { s.pending_redemption_transfer.remove(&icusd_block_index); });
+                        mutate_state(|s| drop_pending(&mut s.pending_redemption_transfer, &icusd_block_index));
                     }
                 }
             }

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -343,26 +343,31 @@ fn post_upgrade(arg: ProtocolArg) {
     // Wave-3 migration: backfill op_nonce on pending transfers carried over from
     // pre-Wave-3 snapshots so their retries get ledger-side dedup. Without this,
     // legacy entries stay at op_nonce: 0 (TooOld at the ledger) and never finish.
+    //
+    // Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are now
+    // keyed by (vault_id, owner). Legacy entries from pre-Wave-4 snapshots are
+    // re-keyed transparently by `state::deserialize_pending_keyed`, so by the time
+    // this block runs they already have tuple keys.
     mutate_state(|s| {
         let mut backfilled = 0u64;
-        let vault_ids: Vec<u64> = s.pending_margin_transfers.iter()
+        let margin_keys: Vec<(u64, candid::Principal)> = s.pending_margin_transfers.iter()
             .filter(|(_, t)| t.op_nonce == 0)
-            .map(|(id, _)| *id)
+            .map(|(k, _)| *k)
             .collect();
-        for id in vault_ids {
+        for k in margin_keys {
             let nonce = s.next_op_nonce();
-            if let Some(t) = s.pending_margin_transfers.get_mut(&id) {
+            if let Some(t) = s.pending_margin_transfers.get_mut(&k) {
                 t.op_nonce = nonce;
                 backfilled += 1;
             }
         }
-        let excess_ids: Vec<u64> = s.pending_excess_transfers.iter()
+        let excess_keys: Vec<(u64, candid::Principal)> = s.pending_excess_transfers.iter()
             .filter(|(_, t)| t.op_nonce == 0)
-            .map(|(id, _)| *id)
+            .map(|(k, _)| *k)
             .collect();
-        for id in excess_ids {
+        for k in excess_keys {
             let nonce = s.next_op_nonce();
-            if let Some(t) = s.pending_excess_transfers.get_mut(&id) {
+            if let Some(t) = s.pending_excess_transfers.get_mut(&k) {
                 t.op_nonce = nonce;
                 backfilled += 1;
             }
@@ -1218,10 +1223,91 @@ async fn stability_pool_liquidate_with_reserves(
         format!("Failed to pull 3USD from stability pool: {:?}", e)
     ))?;
 
-    // 3USD is now in our reserves subaccount — write down debt and release collateral
-    rumi_protocol_backend::vault::liquidate_vault_debt_already_burned(
+    // 3USD is now in our reserves subaccount, so write down debt and release collateral.
+    // Wave-4 ICC-002: if `liquidate_vault_debt_already_burned` returns Err after the
+    // pull above succeeded (vault closed mid-flight, paused, debt hit zero, etc.),
+    // the 3USD is stranded in our reserves subaccount and the SP's bookkeeping never
+    // got a chance to mark it consumed. Refund it so the SP's ledger balance and
+    // bookkeeping stay in sync.
+    match rumi_protocol_backend::vault::liquidate_vault_debt_already_burned(
         vault_id, icusd_debt_covered_e8s, caller, Some(three_usd_amount_e8s)
-    ).await
+    ).await {
+        Ok(success) => Ok(success),
+        Err(liq_error) => {
+            refund_3usd_to_stability_pool(
+                three_usd_ledger, caller, three_usd_amount_e8s, vault_id,
+            ).await;
+            Err(liq_error)
+        }
+    }
+}
+
+/// Refund a previously pulled 3USD amount from the protocol's reserves
+/// subaccount back to the stability pool. Used by `stability_pool_liquidate_with_reserves`
+/// when the second-stage backend call fails after `transfer_3usd_to_reserves`
+/// already moved tokens. Wave-4 ICC-002.
+///
+/// On success, logs the refund block index. On any failure (including BadFee or
+/// fee-too-large), logs CRITICAL so an operator can manually reconcile via
+/// `recover_pending_transfer` or a direct ICRC-1 transfer from the reserves
+/// subaccount. The refund itself uses Wave-3's idempotent transfer helper, so
+/// retries from the SP side won't double-credit even if the reply is dropped.
+async fn refund_3usd_to_stability_pool(
+    three_usd_ledger: Principal,
+    sp_caller: Principal,
+    amount_e8s: u64,
+    vault_id: u64,
+) {
+    use ic_canister_log::log;
+    use rumi_protocol_backend::logs::INFO;
+
+    let fee = match rumi_protocol_backend::management::get_or_refresh_fee(three_usd_ledger).await {
+        Ok(f) => f,
+        Err(e) => {
+            log!(INFO,
+                "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
+                 to SP {} aborted (could not fetch ledger fee: {}). Tokens stranded in reserves; \
+                 use admin tools to reconcile.",
+                amount_e8s, vault_id, sp_caller, e
+            );
+            return;
+        }
+    };
+    if amount_e8s <= fee {
+        log!(INFO,
+            "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
+             to SP {} aborted (amount does not cover ledger fee {}). Tokens stranded in reserves.",
+            amount_e8s, vault_id, sp_caller, fee
+        );
+        return;
+    }
+    let refund_amount = amount_e8s - fee;
+    let refund_nonce = mutate_state(|s| s.next_op_nonce());
+    let result = rumi_protocol_backend::management::transfer_idempotent(
+        three_usd_ledger,
+        Some(rumi_protocol_backend::management::protocol_3usd_reserves_subaccount()),
+        icrc_ledger_types::icrc1::account::Account { owner: sp_caller, subaccount: None },
+        refund_amount as u128,
+        refund_nonce,
+        None,
+    )
+    .await;
+    match result {
+        Ok(block) => {
+            log!(INFO,
+                "[stability_pool_liquidate_with_reserves] refunded {} 3USD (net of {} fee) to SP {} \
+                 for vault {} after liquidation rollback (block {})",
+                refund_amount, fee, sp_caller, vault_id, block
+            );
+        }
+        Err(e) => {
+            log!(INFO,
+                "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
+                 to SP {} FAILED: {:?}. Tokens stranded in reserves; reconcile manually.",
+                refund_amount, vault_id, sp_caller, e
+            );
+        }
+    }
 }
 
 /// Cumulative 3USD held in protocol reserves from stability pool liquidations (e8s).
@@ -1514,29 +1600,15 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 #[update]
 async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> {
     let caller = ic_cdk::caller();
-    
-    // Validate the caller is the owner of this pending transfer (check both maps)
-    let is_owner = read_state(|s| {
-        s.pending_margin_transfers
-            .get(&vault_id)
-            .map(|transfer| transfer.owner == caller)
-            .unwrap_or(false)
-        || s.pending_excess_transfers
-            .get(&vault_id)
-            .map(|transfer| transfer.owner == caller)
-            .unwrap_or(false)
-    });
 
-    if !is_owner {
-        return Err(ProtocolError::CallerNotOwner);
-    }
-
-    // Process the pending transfer immediately (check margin map first, then excess)
+    // Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are
+    // keyed by (vault_id, owner). Look up the entry that belongs to the caller.
+    let key = (vault_id, caller);
     let transfer_info = read_state(|s| {
-        if let Some(t) = s.pending_margin_transfers.get(&vault_id).cloned() {
+        if let Some(t) = s.pending_margin_transfers.get(&key).cloned() {
             Some(("margin", t))
         } else {
-            s.pending_excess_transfers.get(&vault_id).cloned().map(|t| ("excess", t))
+            s.pending_excess_transfers.get(&key).cloned().map(|t| ("excess", t))
         }
     });
 
@@ -1553,8 +1625,8 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
             // Margin too small to cover fee — clean it up
             mutate_state(|s| {
                 match source {
-                    "margin" => { s.pending_margin_transfers.remove(&vault_id); },
-                    _ => { s.pending_excess_transfers.remove(&vault_id); },
+                    "margin" => { s.pending_margin_transfers.remove(&key); },
+                    _ => { s.pending_excess_transfers.remove(&key); },
                 }
             });
             return Err(ProtocolError::GenericError(
@@ -1572,8 +1644,8 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
             Ok(block_index) => {
                 mutate_state(|s| {
                     match source {
-                        "margin" => { event::record_margin_transfer(s, vault_id, block_index); },
-                        _ => { s.pending_excess_transfers.remove(&vault_id); },
+                        "margin" => { event::record_margin_transfer(s, vault_id, caller, block_index); },
+                        _ => { s.pending_excess_transfers.remove(&key); },
                     }
                 });
                 Ok(true)
@@ -1590,7 +1662,7 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
             }
         }
     } else {
-        // No pending transfer found for this vault
+        // No pending transfer found for this caller + vault
         Err(ProtocolError::GenericError("No pending transfer found for this vault".to_string()))
     }
 }

--- a/src/rumi_protocol_backend/src/management.rs
+++ b/src/rumi_protocol_backend/src/management.rs
@@ -694,6 +694,22 @@ pub async fn transfer_icusd(amount: ICUSD, to: Principal) -> Result<u64, Transfe
     .await
 }
 
+/// Idempotent icUSD transfer with a caller-supplied op_nonce. Wave-4 ICC-007:
+/// used by the durable refund queue so retries reuse the same dedup tuple at
+/// the icUSD ledger across canister upgrades.
+pub async fn transfer_icusd_with_nonce(amount: ICUSD, to: Principal, op_nonce: u128) -> Result<u64, TransferError> {
+    let ledger = crate::state::read_state(|s| s.icusd_ledger_principal);
+    transfer_idempotent(
+        ledger,
+        None,
+        Account { owner: to, subaccount: None },
+        amount.to_u64() as u128,
+        op_nonce,
+        None,
+    )
+    .await
+}
+
 /// Query the ICRC-1 transfer fee for a given ledger canister.
 pub async fn get_ledger_fee(ledger: Principal) -> Result<u64, String> {
     let client = ICRC1Client {

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -529,9 +529,28 @@ pub struct PendingMarginTransfer {
     /// Wave-3 ICRC dedup nonce. Constructed once at first attempt via
     /// `State::next_op_nonce`; reused on every retry so the ledger sees the
     /// same `created_at_time` and deduplicates instead of double-spending.
-    /// Zero for entries from snapshots written before Wave-3 — those retry
-    /// without dedup (the prior behaviour, no regression).
+    /// Zero for entries from snapshots written before Wave-3 (those retry
+    /// without dedup, matching prior behaviour, no regression).
     #[serde(default)]
+    pub op_nonce: u128,
+}
+
+/// Wave-4 ICC-007: durable refund record for `redeem_reserves` failures.
+///
+/// When a reserve redemption pulls icUSD from the user (effectively burning it)
+/// but the ckStable transfer back fails AND the inline icUSD refund also fails,
+/// the user is left with nothing. Pre-Wave-4 the only recovery path was a
+/// CRITICAL log. Now the failure persists a `PendingRefund` keyed by the burn
+/// block index, and `process_pending_transfer` retries it until success or
+/// MAX_PENDING_RETRIES. The `op_nonce` is minted once and reused across retries
+/// so the icUSD ledger deduplicates if a previous retry's reply was lost.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, Serialize, Copy)]
+pub struct PendingRefund {
+    pub user: Principal,
+    /// icUSD amount to refund (in e8s).
+    pub amount_e8s: u64,
+    #[serde(default)]
+    pub retry_count: u8,
     pub op_nonce: u128,
 }
 
@@ -609,6 +628,10 @@ pub struct State {
     #[serde(deserialize_with = "deserialize_pending_keyed")]
     pub pending_excess_transfers: BTreeMap<(VaultId, Principal), PendingMarginTransfer>,
     pub pending_redemption_transfer: BTreeMap<u64, PendingMarginTransfer>,
+    /// Wave-4 ICC-007: durable refund queue for `redeem_reserves` failures,
+    /// keyed by the burn icUSD block index. Empty for pre-Wave-4 snapshots.
+    #[serde(default)]
+    pub pending_refunds: BTreeMap<u64, PendingRefund>,
     pub mode: Mode,
     pub fee: Ratio,
     pub developer_principal: Principal,
@@ -801,6 +824,7 @@ impl Default for State {
             pending_margin_transfers: BTreeMap::new(),
             pending_excess_transfers: BTreeMap::new(),
             pending_redemption_transfer: BTreeMap::new(),
+            pending_refunds: BTreeMap::new(),
             mode: Mode::default(),
             fee: Ratio::from(Decimal::ZERO),
             developer_principal: Principal::anonymous(),
@@ -898,6 +922,7 @@ impl From<InitArg> for State {
             developer_principal: args.developer_principal,
             principal_to_vault_ids: BTreeMap::new(),
             pending_redemption_transfer: BTreeMap::new(),
+            pending_refunds: BTreeMap::new(),
             vault_id_to_vaults: BTreeMap::new(),
             xrc_principal: args.xrc_principal,
             icusd_ledger_principal: args.icusd_ledger_principal,

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -541,6 +541,60 @@ thread_local! {
 }
 
 
+// Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are keyed
+// by (VaultId, Principal) so concurrent liquidators on the same vault each have
+// their own pending entry. Legacy snapshots (BTreeMap<VaultId, _>) are accepted
+// transparently via this Visitor and re-keyed using the entry's `owner`.
+//
+// We can't use `#[serde(untagged)]` here because ciborium's untagged-enum
+// dispatch doesn't reliably distinguish a CBOR map with integer keys from one
+// with array keys when both variants are themselves maps. Instead, we drive a
+// Visitor over MapAccess and decide per-entry: each key is deserialized as
+// `EitherKey`, which is a small two-variant enum that ciborium *does* handle
+// cleanly via deserialize_any (integer vs. array).
+fn deserialize_pending_keyed<'de, D>(
+    d: D,
+) -> Result<BTreeMap<(VaultId, Principal), PendingMarginTransfer>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use std::fmt;
+
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum EitherKey {
+        New((VaultId, Principal)),
+        Legacy(VaultId),
+    }
+
+    struct V;
+    impl<'de> serde::de::Visitor<'de> for V {
+        type Value = BTreeMap<(VaultId, Principal), PendingMarginTransfer>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a map of pending margin transfers (legacy u64 keys or new (u64, Principal) keys)")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut out = BTreeMap::new();
+            while let Some(key) = map.next_key::<EitherKey>()? {
+                let value: PendingMarginTransfer = map.next_value()?;
+                let final_key = match key {
+                    EitherKey::New(t) => t,
+                    EitherKey::Legacy(vault_id) => (vault_id, value.owner),
+                };
+                out.insert(final_key, value);
+            }
+            Ok(out)
+        }
+    }
+
+    d.deserialize_map(V)
+}
+
 // serde(default): when deserializing old CBOR that's missing fields added in a
 // later upgrade, serde fills those fields from Default::default() instead of
 // failing. This prevents fallback to event replay (which causes interest drift).
@@ -550,8 +604,10 @@ thread_local! {
 pub struct State {
     pub vault_id_to_vaults: BTreeMap<u64, Vault>,
     pub principal_to_vault_ids: BTreeMap<Principal, BTreeSet<u64>>,
-    pub pending_margin_transfers: BTreeMap<VaultId, PendingMarginTransfer>,
-    pub pending_excess_transfers: BTreeMap<VaultId, PendingMarginTransfer>,
+    #[serde(deserialize_with = "deserialize_pending_keyed")]
+    pub pending_margin_transfers: BTreeMap<(VaultId, Principal), PendingMarginTransfer>,
+    #[serde(deserialize_with = "deserialize_pending_keyed")]
+    pub pending_excess_transfers: BTreeMap<(VaultId, Principal), PendingMarginTransfer>,
     pub pending_redemption_transfer: BTreeMap<u64, PendingMarginTransfer>,
     pub mode: Mode,
     pub fee: Ratio,

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -2096,7 +2096,7 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         // Create pending transfer for liquidator reward
         let nonce = s.next_op_nonce();
         s.pending_margin_transfers.insert(
-            vault_id,
+            (vault_id, caller),
             PendingMarginTransfer {
                 owner: caller,
                 margin: collateral_to_liquidator,
@@ -2336,7 +2336,7 @@ pub async fn liquidate_vault_partial_with_stable(
         // Create pending transfer for liquidator reward
         let nonce = s.next_op_nonce();
         s.pending_margin_transfers.insert(
-            vault_id,
+            (vault_id, caller),
             PendingMarginTransfer {
                 owner: caller,
                 margin: collateral_to_liquidator,
@@ -2552,7 +2552,7 @@ pub async fn liquidate_vault_debt_already_burned(
 
         let nonce = s.next_op_nonce();
         s.pending_margin_transfers.insert(
-            vault_id,
+            (vault_id, caller),
             PendingMarginTransfer {
                 owner: caller,
                 margin: collateral_to_liquidator,
@@ -2749,7 +2749,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         // Create pending transfer for liquidator reward (minus protocol cut)
         let liquidator_nonce = s.next_op_nonce();
         s.pending_margin_transfers.insert(
-            vault_id,
+            (vault_id, caller),
             PendingMarginTransfer {
                 owner: caller,
                 margin: collateral_to_liquidator,
@@ -2765,7 +2765,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
             log!(INFO, "[liquidate_vault] Scheduling excess collateral return to vault owner");
             let excess_nonce = s.next_op_nonce();
             s.pending_excess_transfers.insert(
-                vault_id,
+                (vault_id, vault.owner),
                 PendingMarginTransfer {
                     owner: vault.owner,
                     margin: excess_collateral,
@@ -2839,25 +2839,29 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
 async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, String> {
     let mut processed_count = 0;
 
-    // Get pending transfers for this liquidation
+    // Wave-4 LIQ-001: collect every pending margin/excess entry whose key matches
+    // this vault_id. Concurrent liquidators on the same vault each have their own
+    // (vault_id, owner) key, so we iterate rather than do a single point lookup.
     let transfers_to_process = read_state(|s| {
         let mut transfers = Vec::new();
 
-        // Primary transfer (liquidator reward)
-        if let Some(transfer) = s.pending_margin_transfers.get(&vault_id) {
-            transfers.push(("margin", vault_id, transfer.clone()));
+        for ((vid, owner), transfer) in s.pending_margin_transfers.iter() {
+            if *vid == vault_id {
+                transfers.push(("margin", *vid, *owner, transfer.clone()));
+            }
         }
 
-        // Excess collateral transfer (if exists)
-        if let Some(transfer) = s.pending_excess_transfers.get(&vault_id) {
-            transfers.push(("excess", vault_id, transfer.clone()));
+        for ((vid, owner), transfer) in s.pending_excess_transfers.iter() {
+            if *vid == vault_id {
+                transfers.push(("excess", *vid, *owner, transfer.clone()));
+            }
         }
 
         transfers
     });
 
     // Process each transfer
-    for (transfer_type, transfer_id, transfer) in transfers_to_process {
+    for (transfer_type, transfer_vault_id, transfer_owner, transfer) in transfers_to_process {
         // Look up per-collateral ledger fee and canister ID
         let (ledger_fee, ledger_canister_id) = read_state(|s| {
             match s.get_collateral_config(&transfer.collateral_type) {
@@ -2867,11 +2871,13 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
         });
 
         if transfer.margin <= ledger_fee {
-            log!(INFO, "[immediate_transfer] Skipping {} transfer {} - margin {} <= fee {}, removing", transfer_type, transfer_id, transfer.margin.to_u64(), ledger_fee.to_u64());
+            log!(INFO, "[immediate_transfer] Skipping {} transfer {} owner {} - margin {} <= fee {}, removing",
+                transfer_type, transfer_vault_id, transfer_owner, transfer.margin.to_u64(), ledger_fee.to_u64());
             mutate_state(|s| {
+                let key = (transfer_vault_id, transfer_owner);
                 match transfer_type {
-                    "margin" => { s.pending_margin_transfers.remove(&transfer_id); },
-                    "excess" => { s.pending_excess_transfers.remove(&transfer_id); },
+                    "margin" => { s.pending_margin_transfers.remove(&key); },
+                    "excess" => { s.pending_excess_transfers.remove(&key); },
                     _ => {}
                 }
             });
@@ -2881,17 +2887,19 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
         let transfer_amount = transfer.margin - ledger_fee;
 
         log!(INFO, "[immediate_transfer] Processing {} transfer {} of {} collateral to {}",
-             transfer_type, transfer_id, transfer_amount.to_u64(), transfer.owner);
+             transfer_type, transfer_vault_id, transfer_amount.to_u64(), transfer.owner);
 
         match management::transfer_collateral_with_nonce(transfer_amount.to_u64(), transfer.owner, ledger_canister_id, transfer.op_nonce).await {
             Ok(block_index) => {
-                log!(INFO, "[immediate_transfer] Transfer {} successful, block: {}", transfer_id, block_index);
+                log!(INFO, "[immediate_transfer] Transfer {} owner {} successful, block: {}",
+                    transfer_vault_id, transfer_owner, block_index);
 
                 // Remove from the appropriate pending map
                 mutate_state(|s| {
+                    let key = (transfer_vault_id, transfer_owner);
                     match transfer_type {
-                        "margin" => { s.pending_margin_transfers.remove(&transfer_id); },
-                        "excess" => { s.pending_excess_transfers.remove(&transfer_id); },
+                        "margin" => { s.pending_margin_transfers.remove(&key); },
+                        "excess" => { s.pending_excess_transfers.remove(&key); },
                         _ => {}
                     }
                 });
@@ -2899,13 +2907,14 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
                 processed_count += 1;
             },
             Err(error) => {
-                log!(INFO, "[immediate_transfer] Transfer {} failed: {}. Will retry later", transfer_id, error);
+                log!(INFO, "[immediate_transfer] Transfer {} owner {} failed: {}. Will retry later",
+                    transfer_vault_id, transfer_owner, error);
                 // Leave in pending transfers for retry
-                return Err(format!("Transfer {} failed: {}", transfer_id, error));
+                return Err(format!("Transfer {} failed: {}", transfer_vault_id, error));
             }
         }
     }
-    
+
     Ok(processed_count)
 }
 
@@ -3161,7 +3170,7 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         // Create pending transfer for liquidator reward (minus protocol cut)
         let nonce = s.next_op_nonce();
         s.pending_margin_transfers.insert(
-            arg.vault_id,
+            (arg.vault_id, caller),
             PendingMarginTransfer {
                 owner: caller,
                 margin: collateral_to_liquidator,

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -255,17 +255,22 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
         .map_err(|e| ProtocolError::TransferFromError(e, icusd_amount.to_u64()))?;
 
     // Transfer ckStable to user from reserves.
-    // CRITICAL: If this fails we MUST refund the icUSD — otherwise the user
+    // CRITICAL: If this fails we MUST refund the icUSD, otherwise the user
     // loses funds with nothing received. ICP inter-canister calls are NOT
     // atomic, so we implement the saga/compensation pattern manually.
+    //
+    // Wave-4 ICC-007: if the inline refund itself fails, persist a
+    // `PendingRefund` keyed by `icusd_block_index`; `process_pending_transfer`
+    // retries it until success or MAX_PENDING_RETRIES. The op_nonce is minted
+    // once and reused across retries (idempotent at the icUSD ledger).
     if available_for_user > 0 {
         if let Err(transfer_err) = management::transfer_collateral(available_for_user, caller, stable_ledger).await {
             log!(crate::INFO,
                 "[redeem_reserves] ckStable transfer failed for {}: {:?}. Refunding {} icUSD.",
                 caller, transfer_err, icusd_amount.to_u64()
             );
-            // Attempt to refund icUSD (minus ledger fee which is deducted by the ledger)
-            match management::transfer_icusd(icusd_amount, caller).await {
+            let refund_nonce = mutate_state(|s| s.next_op_nonce());
+            match management::transfer_icusd_with_nonce(icusd_amount, caller, refund_nonce).await {
                 Ok(refund_block) => {
                     log!(crate::INFO,
                         "[redeem_reserves] Refunded {} icUSD to {} (block {})",
@@ -273,18 +278,30 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
                     );
                 }
                 Err(refund_err) => {
-                    // Both the ckStable send AND the refund failed.
-                    // Log a critical error — admin must manually resolve.
                     log!(crate::INFO,
-                        "[redeem_reserves] CRITICAL: ckStable transfer failed AND icUSD refund failed for {}! \
-                         Amount: {} icUSD. ckStable error: {:?}. Refund error: {:?}. \
-                         Manual intervention required.",
-                        caller, icusd_amount.to_u64(), transfer_err, refund_err
+                        "[redeem_reserves] ckStable transfer failed AND inline icUSD refund failed for {}! \
+                         Amount: {} icUSD, ckStable error: {:?}, refund error: {:?}. \
+                         Enqueueing durable refund (block {}).",
+                        caller, icusd_amount.to_u64(), transfer_err, refund_err, icusd_block_index
                     );
+                    mutate_state(|s| {
+                        s.pending_refunds.insert(
+                            icusd_block_index,
+                            crate::state::PendingRefund {
+                                user: caller,
+                                amount_e8s: icusd_amount.to_u64(),
+                                retry_count: 0,
+                                op_nonce: refund_nonce,
+                            },
+                        );
+                    });
+                    ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), || {
+                        ic_cdk::spawn(crate::process_pending_transfer())
+                    });
                 }
             }
             return Err(ProtocolError::GenericError(
-                format!("Reserve transfer failed — your icUSD has been refunded. Error: {:?}", transfer_err),
+                format!("Reserve transfer failed; your icUSD refund is in flight. Error: {:?}", transfer_err),
             ));
         }
     }

--- a/src/rumi_protocol_backend/tests/audit_pocs_icc_007_durable_refund.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_icc_007_durable_refund.rs
@@ -1,0 +1,143 @@
+//! ICC-007 regression fence: durable refund queue for `redeem_reserves` failures.
+//!
+//! Audit report: `audit-reports/2026-04-22-28e9896/raw-pass-results/icc.json`
+//! finding ICC-007.
+//!
+//! # What the bug was
+//!
+//! `redeem_reserves` pulls icUSD from the user (which the protocol effectively
+//! burns), then sends ckStable to the user. If the ckStable transfer fails,
+//! the saga refunds icUSD inline. If THAT inline refund also fails (subnet
+//! hiccup, ledger paused, etc.), the pre-Wave-4 code only logged CRITICAL and
+//! returned an error to the user. The user's icUSD was gone, the protocol
+//! held nothing for them, and recovery required manual operator action.
+//!
+//! # How this file tests it
+//!
+//! The Wave-4 fix adds a `pending_refunds: BTreeMap<u64, PendingRefund>` to
+//! State, persisted across upgrades. On double-failure `redeem_reserves`
+//! enqueues a `PendingRefund` keyed by the burn icUSD block index, with a
+//! stable `op_nonce` minted once and reused across retries.
+//! `process_pending_transfer` drains the queue via
+//! `transfer_icusd_with_nonce`, so the icUSD ledger deduplicates if a previous
+//! retry's reply was lost.
+//!
+//! These tests cover the state-level invariants:
+//!
+//!   * `icc_007_state_holds_pending_refund_keyed_by_burn_block` proves the
+//!     queue admits one entry per burn block index, and that two refunds for
+//!     two distinct burns coexist.
+//!   * `icc_007_pending_refund_round_trips_through_cbor` round-trips a state
+//!     containing a refund through ciborium, asserting the new field
+//!     deserializes into post-Wave-4 snapshots.
+//!   * `icc_007_legacy_snapshot_without_pending_refunds_decodes_with_empty_map`
+//!     asserts pre-Wave-4 snapshots (no `pending_refunds` field) decode
+//!     successfully via `#[serde(default)]`, leaving the queue empty.
+//!   * `icc_007_retry_count_saturates_at_max` mirrors the abandon-after-N-retries
+//!     contract that the live retry loop enforces.
+
+use candid::Principal;
+use std::collections::BTreeMap;
+
+use rumi_protocol_backend::state::{PendingRefund, State};
+use rumi_protocol_backend::InitArg;
+
+const MAX_PENDING_RETRIES: u8 = 5;
+
+fn user_a() -> Principal { Principal::from_slice(&[1]) }
+fn user_b() -> Principal { Principal::from_slice(&[2]) }
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::anonymous(),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+fn refund(user: Principal, amount_e8s: u64, op_nonce: u128) -> PendingRefund {
+    PendingRefund { user, amount_e8s, retry_count: 0, op_nonce }
+}
+
+#[test]
+fn icc_007_state_holds_pending_refund_keyed_by_burn_block() {
+    let mut state = fresh_state();
+    assert!(state.pending_refunds.is_empty(), "fresh state has no pending refunds");
+
+    state.pending_refunds.insert(1001, refund(user_a(), 100_000_000, 11));
+    state.pending_refunds.insert(1002, refund(user_b(), 50_000_000, 12));
+
+    assert_eq!(state.pending_refunds.len(), 2);
+    let a = state.pending_refunds.get(&1001).expect("entry for burn 1001");
+    assert_eq!(a.user, user_a());
+    assert_eq!(a.amount_e8s, 100_000_000);
+    assert_eq!(a.op_nonce, 11);
+
+    // Inserting a second refund with the same key overwrites: by construction
+    // every burn block index is unique, so this is the right semantics.
+    state.pending_refunds.insert(1001, refund(user_a(), 100_000_000, 99));
+    assert_eq!(state.pending_refunds.get(&1001).unwrap().op_nonce, 99);
+}
+
+#[test]
+fn icc_007_pending_refund_round_trips_through_cbor() {
+    let mut state = fresh_state();
+    state.pending_refunds.insert(2001, refund(user_a(), 250_000_000, 77));
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&state, &mut buf).expect("encode state");
+    let restored: State =
+        ciborium::de::from_reader(buf.as_slice()).expect("decode state");
+
+    assert_eq!(restored.pending_refunds.len(), 1);
+    let entry = restored.pending_refunds.get(&2001).expect("refund survives round-trip");
+    assert_eq!(entry.user, user_a());
+    assert_eq!(entry.amount_e8s, 250_000_000);
+    assert_eq!(entry.op_nonce, 77);
+    assert_eq!(entry.retry_count, 0);
+}
+
+/// Pre-Wave-4 snapshots have no `pending_refunds` field. `#[serde(default)]`
+/// must fill it with an empty map so existing canister state decodes cleanly.
+#[test]
+fn icc_007_legacy_snapshot_without_pending_refunds_decodes_with_empty_map() {
+    // Build a snapshot that encodes only a subset of State fields, then
+    // verify ciborium fills the missing `pending_refunds` from Default.
+    #[derive(serde::Serialize)]
+    struct LegacyMinimalState {
+        pending_redemption_transfer: BTreeMap<u64, rumi_protocol_backend::state::PendingMarginTransfer>,
+    }
+
+    let snapshot = LegacyMinimalState {
+        pending_redemption_transfer: BTreeMap::new(),
+    };
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&snapshot, &mut buf).expect("encode legacy minimal state");
+    let restored: State = ciborium::de::from_reader(buf.as_slice())
+        .expect("decode legacy snapshot via #[serde(default)]");
+
+    assert!(
+        restored.pending_refunds.is_empty(),
+        "legacy snapshot must decode with an empty pending_refunds queue"
+    );
+}
+
+/// The live retry loop calls `retry_count.saturating_add(1)` and abandons at
+/// `>= MAX_PENDING_RETRIES`. This test pins that arithmetic so a future change
+/// to PendingRefund's retry semantics is caught.
+#[test]
+fn icc_007_retry_count_saturates_at_max() {
+    let mut entry = refund(user_a(), 100_000_000, 1);
+    for _ in 0..(MAX_PENDING_RETRIES as u32 + 3) {
+        entry.retry_count = entry.retry_count.saturating_add(1);
+    }
+    assert!(entry.retry_count >= MAX_PENDING_RETRIES);
+    assert!(entry.retry_count < u8::MAX, "retry_count should not wrap before u8::MAX");
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_liq_001_pending_margin_race.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_liq_001_pending_margin_race.rs
@@ -1,0 +1,372 @@
+//! LIQ-001 regression fence: concurrent partial liquidations on the same vault.
+//!
+//! Audit report: `audit-reports/2026-04-22-28e9896/verification-results.md` § LIQ-001.
+//!
+//! # What the bug was
+//!
+//! `pending_margin_transfers` was `BTreeMap<VaultId, PendingMarginTransfer>`,
+//! one slot per vault. The partial-liquidation path
+//! (`vault::liquidate_vault_partial`) does an inter-canister `await` on
+//! `transfer_icusd_from` *before* it inserts the pending entry. Two callers
+//! racing the same vault could both clear the await, then run their
+//! `mutate_state` blocks back to back: liquidator B's `insert(vault_id, ...)`
+//! overwrites liquidator A's. A's icUSD was taken by the backend, A's vault
+//! debit ran, but A's pending margin entry is gone, so A never receives
+//! collateral.
+//!
+//! # How this file tests it
+//!
+//! The bug is purely a keying bug: the same `vault_id` could only hold one
+//! pending entry. The Wave-4 fix re-keys the map to
+//! `(VaultId, Principal)`. We cover the fix at three layers:
+//!
+//!   * `liq_001_two_liquidators_same_vault_keep_separate_pending_entries`:
+//!     direct state-level proof. Insert two pending entries for the same
+//!     `vault_id` from two different `Principal`s. Assert both survive.
+//!     Under the legacy keying this would be a single entry; under the new
+//!     keying we have two.
+//!
+//!   * `liq_001_settling_one_liquidator_does_not_remove_others_entry`:
+//!     mirrors the cleanup that `event::record_margin_transfer` does after
+//!     seeding two entries. Asserts the matching entry is removed and the
+//!     other liquidator's entry is untouched.
+//!
+//!   * `liq_001_legacy_snapshot_format_round_trips_via_custom_deserializer`:
+//!     serializes a state object with the legacy single-slot key shape
+//!     (`BTreeMap<u64, PendingMarginTransfer>`) and asserts the Wave-4
+//!     deserializer accepts it transparently and re-keys each entry by the
+//!     `owner` field on the value. Old mainnet snapshots (where there is at
+//!     most one entry per vault) restore cleanly into the new key space.
+
+use candid::Principal;
+use std::collections::BTreeMap;
+
+use rumi_protocol_backend::numeric::ICP;
+use rumi_protocol_backend::state::{PendingMarginTransfer, State};
+use rumi_protocol_backend::InitArg;
+
+// ──────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────
+
+fn liquidator_a() -> Principal {
+    Principal::from_slice(&[1])
+}
+fn liquidator_b() -> Principal {
+    Principal::from_slice(&[2])
+}
+fn vault_owner() -> Principal {
+    Principal::from_slice(&[3])
+}
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::anonymous(),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+fn pending(owner: Principal, margin_e8s: u64, op_nonce: u128) -> PendingMarginTransfer {
+    PendingMarginTransfer {
+        owner,
+        margin: ICP::new(margin_e8s),
+        collateral_type: Principal::anonymous(),
+        retry_count: 0,
+        op_nonce,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// LIQ-001: pending entries are now per (vault_id, owner)
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn liq_001_two_liquidators_same_vault_keep_separate_pending_entries() {
+    let mut state = fresh_state();
+    let vault_id: u64 = 42;
+
+    // Liquidator A takes a 1 ICP slice
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_a()),
+        pending(liquidator_a(), 100_000_000, 1),
+    );
+
+    // Liquidator B races A and takes a 0.5 ICP slice on the same vault.
+    // Pre-fix this insert would overwrite A's entry; post-fix it's a separate key.
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_b()),
+        pending(liquidator_b(), 50_000_000, 2),
+    );
+
+    assert_eq!(
+        state.pending_margin_transfers.len(),
+        2,
+        "Both liquidators must keep their pending margin entries on the same vault"
+    );
+
+    let a_entry = state
+        .pending_margin_transfers
+        .get(&(vault_id, liquidator_a()))
+        .expect("A's pending entry must exist");
+    let b_entry = state
+        .pending_margin_transfers
+        .get(&(vault_id, liquidator_b()))
+        .expect("B's pending entry must exist");
+
+    assert_eq!(a_entry.owner, liquidator_a());
+    assert_eq!(a_entry.margin.0, 100_000_000);
+    assert_eq!(b_entry.owner, liquidator_b());
+    assert_eq!(b_entry.margin.0, 50_000_000);
+}
+
+#[test]
+fn liq_001_excess_transfers_also_keyed_per_principal() {
+    // Excess transfers are normally vault-owner-only, but the rekey makes the map
+    // schematically uniform with margin transfers. Verify two distinct excess
+    // entries can coexist for the same vault when keyed by (vault_id, owner).
+    let mut state = fresh_state();
+    let vault_id: u64 = 7;
+
+    state.pending_excess_transfers.insert(
+        (vault_id, vault_owner()),
+        pending(vault_owner(), 80_000_000, 10),
+    );
+    // Hypothetical second excess entry from a different principal, used here
+    // purely to assert the keying admits coexistence; real liquidation flow only
+    // produces one excess per vault, but the type contract must allow more.
+    state.pending_excess_transfers.insert(
+        (vault_id, liquidator_a()),
+        pending(liquidator_a(), 5_000_000, 11),
+    );
+
+    assert_eq!(state.pending_excess_transfers.len(), 2);
+    assert!(state.pending_excess_transfers.contains_key(&(vault_id, vault_owner())));
+    assert!(state.pending_excess_transfers.contains_key(&(vault_id, liquidator_a())));
+}
+
+#[test]
+fn liq_001_settling_one_liquidator_does_not_remove_others_entry() {
+    // Mirror the cleanup that `event::record_margin_transfer` does, dropping
+    // one (vault_id, owner) entry and verifying it does not collaterally
+    // remove the other liquidator's pending entry on the same vault.
+    //
+    // We can't call `record_margin_transfer` directly here because it reads
+    // `ic_cdk::api::time()` to stamp the event, which traps outside a canister.
+    // The keying behavior we want to prove is the map removal itself; the
+    // event-record side effect is exercised by `pocket_ic_tests`.
+    let mut state = fresh_state();
+    let vault_id: u64 = 99;
+
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_a()),
+        pending(liquidator_a(), 100_000_000, 1),
+    );
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_b()),
+        pending(liquidator_b(), 50_000_000, 2),
+    );
+
+    // Liquidator A's transfer settles first. The live code does this remove
+    // inside `record_margin_transfer` (event.rs).
+    state
+        .pending_margin_transfers
+        .remove(&(vault_id, liquidator_a()));
+
+    assert!(
+        !state
+            .pending_margin_transfers
+            .contains_key(&(vault_id, liquidator_a())),
+        "A's pending entry must be cleared after their transfer settles"
+    );
+    assert!(
+        state
+            .pending_margin_transfers
+            .contains_key(&(vault_id, liquidator_b())),
+        "B's pending entry must NOT be cleared by A's settlement (pre-fix this would have wiped both)"
+    );
+    assert_eq!(state.pending_margin_transfers.len(), 1);
+}
+
+#[test]
+fn liq_001_replay_of_legacy_margin_transfer_event_drops_all_matching_entries() {
+    // The `Event::MarginTransfer` event predates Wave-4 and doesn't carry the
+    // owner principal. On event replay, the handler retains entries whose
+    // vault_id != the event's vault_id (i.e. drops every matching key).
+    //
+    // For pre-Wave-4 snapshots there is at most one entry per vault, so this
+    // is identical to the legacy single-slot remove. We assert the post-fix
+    // behavior here so a future change to the replay path is caught.
+    let mut state = fresh_state();
+    let vault_id: u64 = 33;
+    let other_vault: u64 = 34;
+
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_a()),
+        pending(liquidator_a(), 100_000_000, 1),
+    );
+    state.pending_margin_transfers.insert(
+        (vault_id, liquidator_b()),
+        pending(liquidator_b(), 50_000_000, 2),
+    );
+    state.pending_margin_transfers.insert(
+        (other_vault, liquidator_a()),
+        pending(liquidator_a(), 75_000_000, 3),
+    );
+
+    // Replay's removal: drop every entry whose vault_id matches.
+    state
+        .pending_margin_transfers
+        .retain(|(vid, _), _| *vid != vault_id);
+
+    assert!(
+        state
+            .pending_margin_transfers
+            .contains_key(&(other_vault, liquidator_a())),
+        "Entries on other vaults must survive replay of MarginTransfer for vault {}",
+        vault_id
+    );
+    assert_eq!(state.pending_margin_transfers.len(), 1);
+}
+
+// ──────────────────────────────────────────────────────────────
+// Migration: old `BTreeMap<u64, _>` snapshots round-trip through the
+// custom deserializer and land as `(vault_id, owner)` keys.
+// ──────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct LegacyPendingMaps {
+    // Field names match the live `State` struct so a CBOR snapshot serialized
+    // from this stand-in is bit-identical to a pre-Wave-4 snapshot for these
+    // two fields.
+    pending_margin_transfers: BTreeMap<u64, PendingMarginTransfer>,
+    pending_excess_transfers: BTreeMap<u64, PendingMarginTransfer>,
+}
+
+#[derive(serde::Deserialize)]
+struct ProbeState {
+    #[serde(default, deserialize_with = "deserialize_via_state_helper")]
+    pending_margin_transfers: BTreeMap<(u64, Principal), PendingMarginTransfer>,
+    #[serde(default, deserialize_with = "deserialize_via_state_helper")]
+    pending_excess_transfers: BTreeMap<(u64, Principal), PendingMarginTransfer>,
+}
+
+// Mirror of the production `state::deserialize_pending_keyed`. Uses a
+// MapAccess-driven Visitor that distinguishes legacy `u64` keys from new
+// `(u64, Principal)` keys per-entry. ciborium handles the small per-key
+// untagged enum cleanly even though it can't dispatch the whole-map variant.
+fn deserialize_via_state_helper<'de, D>(
+    d: D,
+) -> Result<BTreeMap<(u64, Principal), PendingMarginTransfer>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use std::fmt;
+
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum EitherKey {
+        New((u64, Principal)),
+        Legacy(u64),
+    }
+
+    struct V;
+    impl<'de> serde::de::Visitor<'de> for V {
+        type Value = BTreeMap<(u64, Principal), PendingMarginTransfer>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a pending-transfer map")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut out = BTreeMap::new();
+            while let Some(key) = map.next_key::<EitherKey>()? {
+                let value: PendingMarginTransfer = map.next_value()?;
+                let final_key = match key {
+                    EitherKey::New(t) => t,
+                    EitherKey::Legacy(vault_id) => (vault_id, value.owner),
+                };
+                out.insert(final_key, value);
+            }
+            Ok(out)
+        }
+    }
+
+    d.deserialize_map(V)
+}
+
+#[test]
+fn liq_001_legacy_snapshot_format_round_trips_via_custom_deserializer() {
+    // Build a snapshot in the pre-Wave-4 shape: u64 keys, one entry per vault.
+    let mut legacy_margin: BTreeMap<u64, PendingMarginTransfer> = BTreeMap::new();
+    legacy_margin.insert(11, pending(liquidator_a(), 100_000_000, 5));
+    legacy_margin.insert(22, pending(liquidator_b(), 50_000_000, 6));
+
+    let mut legacy_excess: BTreeMap<u64, PendingMarginTransfer> = BTreeMap::new();
+    legacy_excess.insert(33, pending(vault_owner(), 80_000_000, 7));
+
+    let snapshot = LegacyPendingMaps {
+        pending_margin_transfers: legacy_margin,
+        pending_excess_transfers: legacy_excess,
+    };
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&snapshot, &mut buf).expect("encode legacy snapshot");
+
+    // Deserialize with the (test-side mirror of the) Wave-4 deserializer.
+    let probe: ProbeState =
+        ciborium::de::from_reader(buf.as_slice()).expect("decode legacy snapshot via new deserializer");
+
+    // Margin: each legacy entry must have been re-keyed by its `owner` field.
+    assert_eq!(probe.pending_margin_transfers.len(), 2);
+    assert!(probe
+        .pending_margin_transfers
+        .contains_key(&(11, liquidator_a())));
+    assert!(probe
+        .pending_margin_transfers
+        .contains_key(&(22, liquidator_b())));
+
+    // Excess: same migration semantics.
+    assert_eq!(probe.pending_excess_transfers.len(), 1);
+    assert!(probe
+        .pending_excess_transfers
+        .contains_key(&(33, vault_owner())));
+}
+
+#[test]
+fn liq_001_new_snapshot_format_round_trips_unchanged() {
+    // Sanity: the new format must round-trip through itself. Catches accidents
+    // where the deserializer's `untagged` enum picks the wrong variant.
+    let mut state = fresh_state();
+    state.pending_margin_transfers.insert(
+        (5, liquidator_a()),
+        pending(liquidator_a(), 100_000_000, 1),
+    );
+    state.pending_margin_transfers.insert(
+        (5, liquidator_b()),
+        pending(liquidator_b(), 50_000_000, 2),
+    );
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&state, &mut buf).expect("encode new state");
+
+    let restored: State =
+        ciborium::de::from_reader(buf.as_slice()).expect("decode new state");
+
+    assert_eq!(restored.pending_margin_transfers.len(), 2);
+    assert!(restored
+        .pending_margin_transfers
+        .contains_key(&(5, liquidator_a())));
+    assert!(restored
+        .pending_margin_transfers
+        .contains_key(&(5, liquidator_b())));
+}


### PR DESCRIPTION
## Summary

Wave 4 of the [2026-04-22-28e9896 audit remediation](audit-reports/2026-04-22-28e9896/remediation-plan.md). Backend-canister-only.

- **LIQ-001**: `pending_margin_transfers` and `pending_excess_transfers` rekeyed from `BTreeMap<VaultId, _>` to `BTreeMap<(VaultId, Principal), _>`. Concurrent liquidators on the same vault no longer overwrite each other. Custom MapAccess Visitor accepts legacy snapshots and re-keys per entry using the value's `owner`.
- **ICC-002**: `stability_pool_liquidate_with_reserves` refunds the pulled 3USD back to the SP via `transfer_idempotent` when the second-stage call fails. CRITICAL log on refund-of-refund failure.
- **ICC-005**: `drop_pending` helper unifies skip + abandon paths across all three retry loops in `process_pending_transfer`. The underlying ambiguity is resolved by LIQ-001's tuple keying.
- **ICC-007**: `pending_refunds: BTreeMap<u64, PendingRefund>` durable queue for `redeem_reserves` double-failures. `process_pending_transfer` drains it via `transfer_icusd_with_nonce`. `op_nonce` minted once and reused across retries.

ICC-001 (BadFee in excess + redemption loops) shipped as part of Wave 3; verified live and skipped here.

Migration: legacy snapshots decode transparently. New `pending_refunds` field uses `#[serde(default)]`. The custom Visitor handles both `BTreeMap<u64, _>` and `BTreeMap<(u64, Principal), _>` for the rekeyed maps.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p rumi_protocol_backend --lib`: 81/82 (one pre-existing failure flagged in plan as not-a-regression)
- [x] `audit_pocs_liq_001_pending_margin_race`: 6/6
- [x] `audit_pocs_icrc_idempotent`: 5/5 (Wave-3 regression fence)
- [x] `audit_pocs_icc_007_durable_refund`: 4/4
- [x] `stability_pool::audit_pocs_sp_001_double_deduction`: 4/4
- [x] `stability_pool::audit_pocs_auth_001_anon_caller`: 1/1
- [ ] Mainnet smoke: open + close a small vault after upgrade; confirm `pending_*` maps clear and `pending_refunds` stays empty under happy path

ICC-002 and ICC-007 dedicated end-to-end PocketIC tests are not in this PR; they need real-ledger failure injection on the second await and are scoped to a follow-up. The audit_pocs in this PR cover the state-shape and serialization invariants those code paths depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)