### PR TITLE
feat(swap): Oisy batched execution for direct ICPswap 3USD<->ICP

### DIFF
--- a/src/vault_frontend/src/lib/services/swapRouter.spec.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.spec.ts
@@ -44,6 +44,8 @@ vi.mock('./providers/rumiAmmProvider', () => ({
 
 vi.mock('./providers/icpswapProvider', () => ({
   IcpswapProvider: vi.fn(() => mocks.icpswapMock),
+  // Used by the Oisy batched executor for the deposit/withdraw fee field.
+  icrc1Fee: vi.fn(() => 10n),
 }));
 
 // Neutralise ammService — the provider mocks bypass it, but getAmmPoolId
@@ -74,7 +76,9 @@ vi.mock('./protocol/walletOperations', () => ({
   isOisyWallet: mocks.isOisyWalletMock,
 }));
 
-// Keep oisySigner and pnp importable without side effects.
+// Keep oisySigner and pnp importable without side effects. The Oisy ICPswap
+// direct dispatch test below overrides these with concrete fakes via
+// vi.mocked(...).mockResolvedValueOnce(...).
 vi.mock('./oisySigner', () => ({
   getOisySignerAgent: vi.fn(),
   createOisyActor: vi.fn(),
@@ -82,7 +86,13 @@ vi.mock('./oisySigner', () => ({
 vi.mock('./pnp', () => ({ canisterIDLs: {} }));
 vi.mock('../stores/wallet', () => ({
   walletStore: {
-    subscribe: () => () => {},
+    // svelte/store's `get()` calls subscribe(set) and reads back synchronously,
+    // so we must invoke `set` with a value. Oisy branches need a truthy
+    // principal to clear the "Wallet not connected" guard.
+    subscribe: (set: (v: any) => void) => {
+      set({ principal: { toText: () => 'aaaaa-aa' } });
+      return () => {};
+    },
     // Non-Oisy ICPswap branches call walletStore.getActor to build an
     // authenticated actor and (separately) to run icrc2_approve. Return
     // a stub that satisfies both call sites; tests that care about the
@@ -291,9 +301,39 @@ describe('swapRouter — provider registry integration', () => {
     });
   });
 
-  describe('Oisy transitional guard', () => {
-    it('rejects Oisy executions when ICPswap wins', async () => {
+  // ──────────────────────────────────────────────────────────────
+  // Oisy ICPswap direct dispatch (3USD <-> ICP, single-hop ICPswap winner).
+  // Verifies the `amm_swap` case routes through the batched executor when
+  // Oisy is the wallet, and through provider.swap otherwise.
+  // ──────────────────────────────────────────────────────────────
+
+  describe('Oisy ICPswap direct dispatch (amm_swap)', () => {
+    it('dispatches through the batched executor instead of provider.swap when ICPswap wins', async () => {
       isOisyWalletMock.mockReturnValue(true);
+
+      // Wire up Oisy fakes: signer agent collects batched promises and
+      // returns control once execute() resolves. Actors must respond with
+      // shapes the executor unpacks (Ok/ok per call site).
+      const fakeSigner = {
+        batch: vi.fn(),
+        execute: vi.fn().mockResolvedValue(undefined),
+      };
+      const fakeFromLedger = {
+        icrc2_approve: vi.fn().mockResolvedValue({ Ok: 1n }),
+      };
+      const fakePool = {
+        depositFrom: vi.fn().mockResolvedValue({ ok: 0n }),
+        swap: vi.fn().mockResolvedValue({ ok: 0n }),
+        withdraw: vi.fn().mockResolvedValue({ ok: 1_499n }),
+      };
+      const oisySigner = await import('./oisySigner');
+      vi.mocked(oisySigner.getOisySignerAgent).mockResolvedValue(fakeSigner as any);
+      vi.mocked(oisySigner.createOisyActor).mockImplementation(((canisterId: string) => {
+        // Pool ID from icpswapQuote() fixture above
+        if (canisterId === 'mu2zw-6iaaa-aaaar-qb56q-cai') return fakePool;
+        return fakeFromLedger;
+      }) as any);
+
       const route: SwapRoute = {
         type: 'amm_swap',
         pathDisplay: 'x',
@@ -302,8 +342,37 @@ describe('swapRouter — provider registry integration', () => {
         feeDisplay: '0.30%',
         providerQuote: icpswapQuote(1_500n),
       };
-      await expect(executeRoute(route, threeUsd, icp, 100n, 50))
-        .rejects.toThrow(/not yet supported \(Task 10\)/);
+
+      const out = await executeRoute(route, threeUsd, icp, 100n, 50);
+
+      // Provider.swap path was bypassed
+      expect(icpswapMock.swap).not.toHaveBeenCalled();
+      // Oisy batched flow ran end to end
+      expect(fakeSigner.execute).toHaveBeenCalledTimes(1);
+      expect(fakeFromLedger.icrc2_approve).toHaveBeenCalledTimes(1);
+      expect(fakePool.depositFrom).toHaveBeenCalledTimes(1);
+      expect(fakePool.swap).toHaveBeenCalledTimes(1);
+      expect(fakePool.withdraw).toHaveBeenCalledTimes(1);
+      // Returns the `ok` value from the final withdraw call
+      expect(out).toBe(1_499n);
+    });
+
+    it('still uses provider.swap when Oisy wins with Rumi AMM (Rumi handles signer internally)', async () => {
+      isOisyWalletMock.mockReturnValue(true);
+      rumiAmmMock.swap.mockResolvedValue({ amountOut: 990n });
+
+      const route: SwapRoute = {
+        type: 'amm_swap',
+        pathDisplay: 'x',
+        hops: 1,
+        estimatedOutput: 1_000n,
+        feeDisplay: '0.30%',
+        providerQuote: rumiQuote(1_000n),
+      };
+
+      const out = await executeRoute(route, threeUsd, icp, 100n, 50);
+      expect(rumiAmmMock.swap).toHaveBeenCalledTimes(1);
+      expect(out).toBe(990n);
     });
   });
 

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -115,8 +115,7 @@ export interface SwapRoute {
   /**
    * Cached Rumi AMM pool ID. Populated when the 3USD/ICP hop resolves to
    * Rumi AMM so the Oisy batched executor can reuse it without an extra
-   * canister query. Removed in Task 10 once Oisy dispatches through the
-   * provider registry.
+   * canister query.
    */
   poolId?: string;
   /**
@@ -126,8 +125,7 @@ export interface SwapRoute {
   providerQuote?: ProviderQuote;
   /**
    * Winning provider quote for the 3USD/ICP leg of a two-hop route
-   * (Cases 5/6: stable <-> ICP). Task 10 uses this to dispatch via the
-   * provider registry; Task 9 only populates it.
+   * (Cases 5/6: stable <-> ICP).
    */
   hopProviderQuote?: ProviderQuote;
 }
@@ -231,7 +229,7 @@ export async function resolveRoute(
       feeDisplay: quote.feeDisplay,
       providerQuote: quote,
       // Keep poolId populated when Rumi AMM wins so the Oisy helper can
-      // reuse it without an extra canister query. Task 10 removes this.
+      // reuse it without an extra canister query.
       poolId: quote.provider === 'rumi_amm' ? (quote.meta.poolId as string) : undefined,
     };
   }
@@ -390,9 +388,18 @@ export async function executeRoute(
     }
 
     case 'amm_swap': {
-      assertOisyProviderSupported(route);
       const quote = route.providerQuote;
       if (!quote) throw new Error('amm_swap route missing providerQuote');
+
+      // Oisy + ICPswap needs the batched executor: ICPswap's deposit -> swap
+      // -> withdraw flow has to land in one signer popup. Rumi AMM works with
+      // Oisy through the standard provider.swap path because ammService.swap
+      // already routes through the signer agent. Plain II also uses
+      // provider.swap for both providers.
+      if (isOisyWallet() && isIcpswapProvider(quote.provider)) {
+        return await executeIcpswapDirectOisy(route, from, to, amountIn, slippageBps);
+      }
+
       const provider = threeUsdIcpRegistry().get(quote.provider);
 
       // RumiAmmProvider handles approval internally via ammService.swap.
@@ -538,26 +545,6 @@ async function approveIcpswapPool(
 
   // Small delay for ledger sync (matches threePoolService.swap non-Oisy path).
   await new Promise(r => setTimeout(r, 2000));
-}
-
-/**
- * Transitional guard: direct Case 4 (3USD <-> ICP) Oisy executions only know
- * how to route through Rumi AMM. Two-hop cases (stable_to_icp / icp_to_stable)
- * now dispatch ICPswap and Rumi AMM natively via the Oisy helpers below.
- * Rejects Oisy + ICPswap combos for `amm_swap` until that path is added.
- * Case 4 was deferred because users with only icUSD/ICP can fall back to
- * Internet Identity or route through the 2-hop path; the 3USD-direct case
- * is rarer and lower-impact.
- */
-function assertOisyProviderSupported(route: SwapRoute): void {
-  if (!isOisyWallet()) return;
-  const winner = route.providerQuote?.provider ?? route.hopProviderQuote?.provider;
-  if (winner && winner !== 'rumi_amm') {
-    throw new Error(
-      `Oisy batched execution for ${winner} is not yet supported (Task 10). ` +
-      `Please use Internet Identity for this swap, or switch to a smaller amount that routes through Rumi AMM.`,
-    );
-  }
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -937,7 +924,9 @@ async function executeIcpToStableOisyIcpswap(
 }
 
 /**
- * icUSD <-> ICP direct via ICPswap (Oisy batched):
+ * Direct ICPswap pool swap (Oisy batched). Used by both `icusd_icp_direct`
+ * (icUSD <-> ICP) and `amm_swap` (3USD <-> ICP) when ICPswap wins the quote.
+ *
  * 1. Approve input token -> ICPswap pool
  * 2. ICPswap.depositFrom (pulls input via ICRC-2)
  * 3. ICPswap.swap
@@ -958,7 +947,7 @@ async function executeIcpswapDirectOisy(
   if (!wallet.principal) throw new Error('Wallet not connected');
 
   const q = route.providerQuote;
-  if (!q) throw new Error('icusd_icp_direct Oisy route missing providerQuote');
+  if (!q) throw new Error('ICPswap direct Oisy route missing providerQuote');
 
   const icpswapPoolId = q.meta.poolCanisterId as string | undefined;
   const zeroForOne = q.meta.zeroForOne;


### PR DESCRIPTION
## Summary

Finishes Task 10 from the ICPswap routing integration: when an Oisy user swaps 3USD <-> ICP at a size where ICPswap beats Rumi AMM, the trade now goes through instead of throwing "Oisy batched execution for icpswap_3usd_icp is not yet supported (Task 10)".

The existing `executeIcpswapDirectOisy` helper (used for icUSD/ICP direct) is already provider-agnostic — it drives the approve → depositFrom → swap → withdraw batch off `route.providerQuote`. So the change is just: dispatch through it from the `amm_swap` case when `isOisyWallet() && isIcpswapProvider(quote.provider)`. Rumi AMM still goes through `provider.swap` because `ammService.swap` already supports Oisy.

The transitional guard `assertOisyProviderSupported` is removed. Comments referencing "Task 10" are cleaned up.

## What I changed

- `swapRouter.ts`: branch `amm_swap` on Oisy + ICPswap to call `executeIcpswapDirectOisy`. Remove `assertOisyProviderSupported`. Update doc comment on `executeIcpswapDirectOisy` to reflect dual use.
- `swapRouter.spec.ts`: replace the "rejects Oisy executions when ICPswap wins" test with two new tests verifying (1) Oisy + ICPswap dispatches through the batched executor (provider.swap not called, signer.execute called), (2) Oisy + Rumi AMM still uses provider.swap. Add `icrc1Fee` export to the icpswapProvider mock; update walletStore mock to expose a principal so Oisy code paths don't crash on `get(walletStore)`.

## Test plan

- [x] `npx vitest run src/lib/services/swapRouter.spec.ts` — 12/12 pass
- [x] Full frontend suite: `npx vitest run` — 50/50 pass
- [x] `svelte-check` error count unchanged from main (32 pre-existing)
- [ ] Manual: Oisy swap 7 3USD → ICP after deploy (currently triggers the error in this PR's screenshot)
- [ ] Manual: Oisy swap small 3USD → ICP (Rumi AMM winner, regression check on the unchanged path)
- [ ] Manual: II swap 3USD → ICP (regression check on non-Oisy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)