### PR TITLE
chore(xrc): refresh stale freshness-threshold doc comment

### DIFF
--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -11,8 +11,9 @@ use std::time::Duration;
 
 /// How often to passively fetch ICP price from XRC (background polling).
 /// Each XRC call costs ~1B cycles. At 60s = ~$58/month, at 300s = ~$12/month.
-/// Price-sensitive operations will fetch on-demand if the cached price is >30s old,
-/// so this is just a lazy background refresh for display/query purposes.
+/// Price-sensitive operations will fetch on-demand if the cached price is older
+/// than `PRICE_FRESHNESS_THRESHOLD_NANOS` (60s as of Wave-5 F-004), so this
+/// timer is just a lazy background refresh for display/query purposes.
 pub const FETCHING_ICP_RATE_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Maximum age (in nanoseconds) of a cached price before a price-sensitive


### PR DESCRIPTION
## Summary

Tiny doc-only follow-up to Wave-5 ([#110](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/110)). The polling-interval docstring on `FETCHING_ICP_RATE_INTERVAL` still said "if the cached price is >30s old" after the threshold was bumped to 60s. Replaced the magic number with a reference to the named constant so the doc tracks source of truth.

## Test plan
- [x] No code change, only a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)