### PR TITLE
fix(analytics): skip immediate snapshot fire on post_upgrade

### DIFF
--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -40,7 +40,7 @@ fn init(args: InitArgs) {
     };
     storage::set_slim(s);
     state::hydrate_from_slim();
-    timers::setup_timers();
+    timers::setup_timers(timers::SetupContext::Init);
 }
 
 #[ic_cdk_macros::pre_upgrade]
@@ -51,7 +51,7 @@ fn pre_upgrade() {
 #[ic_cdk_macros::post_upgrade]
 fn post_upgrade() {
     state::hydrate_from_slim();
-    timers::setup_timers();
+    timers::setup_timers(timers::SetupContext::PostUpgrade);
 }
 
 #[ic_cdk_macros::query]

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -4,15 +4,25 @@
 use std::time::Duration;
 use crate::{collectors, sources, state, tailing};
 
-pub fn setup_timers() {
-    // Fire daily + fast snapshots immediately on init/upgrade (set_timer_interval
-    // waits for the full interval before the first tick).
-    ic_cdk_timers::set_timer(Duration::from_secs(0), || {
-        ic_cdk::spawn(daily_snapshot());
-    });
-    ic_cdk_timers::set_timer(Duration::from_secs(0), || {
-        ic_cdk::spawn(fast_snapshot());
-    });
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SetupContext {
+    Init,
+    PostUpgrade,
+}
+
+pub fn setup_timers(ctx: SetupContext) {
+    // Fire daily + fast snapshots immediately on init only. On post_upgrade
+    // the pre-existing rows already cover the recent period, so re-firing
+    // would create duplicate snapshots for the same day. Intervals reset on
+    // upgrade and resume normally without an immediate fire.
+    if ctx == SetupContext::Init {
+        ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+            ic_cdk::spawn(daily_snapshot());
+        });
+        ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+            ic_cdk::spawn(fast_snapshot());
+        });
+    }
 
     ic_cdk_timers::set_timer_interval(Duration::from_secs(60), || {
         ic_cdk::spawn(pull_cycle());

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -651,15 +651,7 @@ fn stability_snapshot_skipped_when_source_unavailable() {
     assert!(resp.rows.is_empty(), "no stability row when source canister unavailable");
 }
 
-// Pre-existing failure on main: assertion `vault log lost rows on upgrade`
-// (left: 2, right: 3) -- a row goes missing across the analytics canister
-// upgrade. Verified pre-existing at commit b1c2a7a; not introduced by
-// Wave-6 (upgrade-safety changes are limited to stability_pool and rumi_amm,
-// neither of which feeds rumi_analytics directly). Marked #[ignore] so the
-// pre-deploy hook can proceed; tracked as a real bug for separate
-// investigation (likely a missing pre_upgrade snapshot for the vault log).
 #[test]
-#[ignore = "pre-existing bug on main: vault log row lost across analytics upgrade"]
 fn upgrade_preserves_supply_cache_and_tvl_log() {
     let env = setup();
     env.pic.advance_time(std::time::Duration::from_secs(86_400 + 65));


### PR DESCRIPTION
## Summary
- `setup_timers()` was scheduling `t=0` one-shot daily/fast snapshot timers on both `init` and `post_upgrade`. After an upgrade, the post_upgrade one-shot fired a fresh `daily_snapshot` that pushed duplicate rows for the same day.
- Differentiate `setup_timers` via a `SetupContext` enum: fire `t=0` snapshots only on `Init`. On `PostUpgrade`, the pre-existing rows already cover the recent period, and intervals resume normally.
- Removes the `#[ignore]` from `upgrade_preserves_supply_cache_and_tvl_log` (added during Wave-6 audit cleanup).

## Why the test was failing
Re-reading the assertion: `assert_eq!(before_vault_rows, after_vault_rows)` with `left: 2, right: 3` means the vault log **gained** a row after upgrade, not lost one. The error message "vault log lost rows on upgrade" was misleading.

After post_upgrade returned, the t=0 daily_snapshot fired and called `collectors::vaults::run()` + `collectors::tvl::run()` concurrently. The vault collector finished its 2 backend calls faster than the TVL collector (which also waits on stability_pool + 3pool calls that fail slowly because the test fixture uses anonymous principals). By the time the test queried, vault had 3 rows but TVL still had 2.

## Test plan
- [x] `upgrade_preserves_supply_cache_and_tvl_log` passes (no longer ignored)
- [x] All 25 PocketIC integration tests pass (including `upgrade_preserves_phase4_state`, `upgrade_preserves_phase5_state`, `live_queries_survive_upgrade`)
- [x] All 93 rumi_analytics unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)