### PR TITLE
chore: regenerate stale canister declarations

### DIFF
--- a/docs/superpowers/plans/2026-04-27-explorer-review-pass.md
+++ b/docs/superpowers/plans/2026-04-27-explorer-review-pass.md
@@ -1,0 +1,1297 @@
+# Explorer Review Pass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix every Explorer issue Rob flagged in the 2026-04-27 review — broken cards, mislabeled metrics, missing data, dead admin UI — so each lens shows correct, useful, well-labeled information.
+
+**Architecture:** Most "backend bugs" are actually frontend bugs where the UI reads field names that don't exist on the backend response (e.g., `vault.collateral_ratio`, `liquidation.debt_cleared_e8s`). Fix those client-side from data already being returned. The genuinely backend-side gaps are localized to the analytics canister: a missing tailer for the rumi_stability_pool canister (the leaderboard's data source dried up when SP became its own canister), and `fee_amount` being dropped from backend events during tailing. Address those in the analytics canister only — no protocol-backend changes required.
+
+**Tech Stack:** SvelteKit + TypeScript frontend (vault_frontend), Rust analytics canister (rumi_analytics) on the Internet Computer. Build/deploy via DFX.
+
+**Branch:** `feat/explorer-review-pass` (already created from main; uncommitted Phase-0 work in working tree).
+
+---
+
+## Background: classifying the issues
+
+Rob's review hit ~30 distinct items. Root-cause analysis groups them as:
+
+| Class | Examples | Risk to fix |
+|---|---|---|
+| **Frontend reads nonexistent fields** | `vault.collateral_ratio`, `liquidation.debt_cleared_e8s` (the field is `stables_consumed: vec record { principal; nat64 }`) | Low — data already returned, just rename/recompute |
+| **Frontend uses wrong typeKey filters** | Old CamelCase variant set in `LensActivityPanel` never matched real snake_case backend variants (already fixed in Phase 0) | Low |
+| **Analytics canister architectural gap** | Top SP depositors leaderboard reads backend `ProvideLiquidity` events that are never emitted anymore (SP is now a separate canister) | Medium — needs a new tailer + canister deploy |
+| **Analytics drops data on the floor** | `fee_amount` is in the deserialized event but the `..` rest-pattern discards it; rollups stub `None` | Low — pure analytics canister change |
+| **Pure UX/label cleanup** | "Peg imbalance" misread as de-peg; AMM events show as plain "AMM" with no pool ID | Already fixed in Phase 0 |
+
+**Answer to Rob's question** ("which of these is more indicative of a greater problem?"): the genuinely problematic class is **Analytics canister architectural gap** — when the SP became a separate canister, the analytics tailer wasn't updated to follow it, so any leaderboard or rollup that depends on SP activity has been silently empty since. Everything else is local to the frontend or to a single dropped field in analytics — annoying but isolated.
+
+---
+
+## File structure
+
+**Already modified in Phase 0 (uncommitted on `feat/explorer-review-pass`):**
+- `src/vault_frontend/src/lib/components/explorer/EntityLink.svelte` — added `pool` type and `class` prop
+- `src/vault_frontend/src/lib/components/explorer/EventRow.svelte` — entity links instead of facet chips
+- `src/vault_frontend/src/lib/components/explorer/MixedEventRow.svelte` — same
+- `src/vault_frontend/src/lib/components/explorer/CeilingBar.svelte` — show absolute ceiling
+- `src/vault_frontend/src/lib/components/explorer/CollateralTable.svelte` — Vol tooltip
+- `src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte` — snake_case event filters; AccrueInterest excluded
+- `src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte` — sparse-data dots, anchored y-axis
+- `src/vault_frontend/src/lib/components/explorer/PoolHealthStrip.svelte` — "Balanced" not "Stable"
+- `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte` — Protocol Config and cycles chart removed
+- `src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte` — pool registry, AMM Pools card columns
+- `src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte` — RMR display
+- `src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte` — liq share → interest share
+- `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte` — live SP APY
+- `src/vault_frontend/src/lib/utils/displayEvent.ts` — AMM source label uses pool index
+- `src/vault_frontend/src/lib/utils/eventFacets.ts` — init/upgrade reclassified as admin
+- `src/vault_frontend/src/lib/utils/ammNaming.ts` — NEW
+- `src/vault_frontend/src/routes/explorer/activity/+page.svelte` — seed AMM pool registry
+- `src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte` — pool detail TVL
+
+**Phase 1 will create/modify:**
+- `src/vault_frontend/src/lib/utils/vaultCr.ts` — NEW, shared CR computation
+- `src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte` — compute CR + median per collateral
+- `src/vault_frontend/src/lib/components/explorer/CollateralTable.svelte` — receive medianCrBps from real computation
+- `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte` — sum stables_consumed
+- `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte` — admin breakdown + canister inventory cards
+- `src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte` — NEW
+- `src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte` — NEW
+
+**Phase 2 will create/modify (analytics canister, Rust):**
+- `src/rumi_analytics/src/tailing/backend_events.rs` — capture `fee_amount` on Borrow/Redemption
+- `src/rumi_analytics/src/storage/events.rs` — extend `AnalyticsVaultEvent` with `fee_amount`
+- `src/rumi_analytics/src/collectors/rollups.rs` — sum `fee_amount` instead of stubbing None
+- `src/rumi_analytics/src/sources/stability_pool.rs` — NEW shadow types for SP canister events
+- `src/rumi_analytics/src/tailing/stability_pool.rs` — NEW tailer
+- `src/rumi_analytics/src/tailing/mod.rs` — register the SP tailer
+- `src/rumi_analytics/src/lib.rs` — initialize SP cursor + register in init/post_upgrade
+- `src/rumi_analytics/src/storage/cursors.rs` — add SP cursor
+
+---
+
+## Phase 0: Commit work in progress
+
+Phase 0 captures everything done in this session up to the point this plan was written. One commit, descriptive message, no changes — just preserving the work.
+
+### Task 0.1: Sanity-check working tree and commit
+
+**Files:** All Phase-0 modified files listed above.
+
+- [ ] **Step 1: Confirm we're on the feature branch and the audit-wave-8d backend work is stashed**
+
+Run:
+```bash
+git branch --show-current
+git stash list
+```
+Expected: branch is `feat/explorer-review-pass`; stash list shows `audit-wave-8d-backend-wip`.
+
+- [ ] **Step 2: Run svelte-check to confirm no new TS errors from Phase 0**
+
+Run:
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -c ERROR
+```
+Expected: count matches the pre-existing error baseline (33 — all in files Phase 0 didn't touch). If higher, fix before committing.
+
+- [ ] **Step 3: Stage only the Explorer changes**
+
+Run:
+```bash
+git add src/vault_frontend/ docs/superpowers/plans/2026-04-27-explorer-review-pass.md
+git status --short
+```
+Expected: only `src/vault_frontend/...` and the plan file in green; nothing else staged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(explorer): review-pass round 1 — labels, navigation, lens cleanup
+
+Phase 0 of the Explorer review pass per the 2026-04-27 plan:
+
+UX / labeling
+- Rename "peg imbalance" → "balance skew" so users don't mistake
+  pool weight drift for icUSD de-pegging
+- AMM events render as "AMM1 #N" with token-pair labels via a
+  client-side pool registry (deterministic alphabetical ordering)
+- Pool detail pages show TVL (3pool: sum stables; AMM: 3USD * vp +
+  ICP * oracle price)
+- Debt-ceiling cell shows the absolute ceiling next to the meter
+- Redemptions lens shows RMR (floor → ceiling) range
+- Volume charts show dots on non-zero points and anchor y at 0 so
+  sparse activity is visible
+
+Bug fixes
+- Replace FacetChip with EntityLink for principal/token/pool/vault
+  in event rows so clicks navigate to entity pages instead of
+  applying filters
+- Switch SP APY to the same live formula the /liquidity tab uses
+  (was 4.72% from a 7d analytics window vs 6.24% live — discrepancy
+  resolved)
+- Rewrite LensActivityPanel admin/vault filter sets to use the real
+  snake_case event variant names (the previous CamelCase set never
+  matched anything, leaving Vault Activity and admin feeds empty)
+- Reclassify init/upgrade events as 'admin' typeKey so canister
+  upgrades surface in the admin feed
+- Filter accrue_interest events out of every UI scope; "View All"
+  link no longer points to ?type=admin,system
+
+Cleanup
+- Remove "Treasury liq share" tile from Revenue lens (docs material,
+  not Explorer); replace with "Treasury interest share"
+- Drop the Protocol Config card and analytics-only cycles chart
+  from Admin lens
+
+See docs/superpowers/plans/2026-04-27-explorer-review-pass.md for
+the full plan including remaining Phase 1 (frontend) and Phase 2
+(analytics canister) work.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+Expected: commit succeeds.
+
+- [ ] **Step 5: Verify**
+
+Run:
+```bash
+git log --oneline -1
+git status --short
+```
+Expected: latest commit is the one we just made; working tree clean (or showing only audit-wave-8d files we stashed earlier).
+
+---
+
+## Phase 1: Frontend follow-up fixes
+
+Three real bugs left where the frontend reads fields that don't exist, plus two new Admin lens cards to replace the stuff we stripped.
+
+### Task 1.1: Shared CR computation helper
+
+The backend's `Vault` and `CandidVault` types do **not** have a `collateral_ratio` field — CR is computed on-the-fly via `compute_collateral_ratio()` whenever the protocol needs it. The frontend's `vault.collateral_ratio ?? 0` reads `undefined` for every vault, which explains the empty CR distribution histogram and the hardcoded `medianCrBps: 0`.
+
+Fix: add a small helper that takes `(vault, priceMap, configMap)` and returns CR as a percentage. This lets us compute distribution AND median from data CollateralLens already fetches.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/utils/vaultCr.ts`
+- Test: `src/vault_frontend/src/lib/utils/vaultCr.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/vault_frontend/src/lib/utils/vaultCr.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computeVaultCrPct } from './vaultCr';
+
+const ICP = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+
+describe('computeVaultCrPct', () => {
+  it('returns CR as a percent for a typical ICP vault', () => {
+    // 100 ICP @ $5 = $500 collateral, 200 icUSD debt → 250%
+    const vault = {
+      collateral_amount: 100_00_000_000n, // 100 ICP at e8s
+      collateral_type: ICP,
+      borrowed_icusd_amount: 200_00_000_000n, // 200 icUSD at e8s
+    };
+    const priceMap = new Map([[ICP, 5]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeCloseTo(250, 1);
+  });
+
+  it('returns null when debt is zero (debt-free vault)', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: ICP,
+      borrowed_icusd_amount: 0n,
+    };
+    const priceMap = new Map([[ICP, 5]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeNull();
+  });
+
+  it('returns null when price is missing for the collateral', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: ICP,
+      borrowed_icusd_amount: 100_00_000_000n,
+    };
+    expect(computeVaultCrPct(vault, new Map(), new Map())).toBeNull();
+  });
+
+  it('handles principal objects with toText()', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: { toText: () => ICP },
+      borrowed_icusd_amount: 100_00_000_000n,
+    };
+    const priceMap = new Map([[ICP, 10]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeCloseTo(1000, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd src/vault_frontend && npx vitest run src/lib/utils/vaultCr.test.ts
+```
+Expected: FAIL with "Cannot find module './vaultCr'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/vault_frontend/src/lib/utils/vaultCr.ts`:
+```typescript
+/**
+ * Compute a vault's collateral ratio as a percent (e.g., 243 for 243%).
+ *
+ * The backend doesn't store CR on the vault — it's computed on demand from
+ * collateral_amount × price / borrowed_icusd_amount whenever needed. The
+ * frontend has the same inputs (vaults from get_all_vaults, prices from
+ * twap or last_price), so computing here is straightforward.
+ *
+ * Returns null when the vault has zero debt (CR is undefined) or when we
+ * don't have a price for the collateral (better to skip than show 0).
+ */
+
+function principalText(p: any): string {
+  if (!p) return '';
+  if (typeof p === 'string') return p;
+  if (typeof p?.toText === 'function') return p.toText();
+  return String(p);
+}
+
+export function computeVaultCrPct(
+  vault: any,
+  priceMap: Map<string, number>,
+  decimalsMap: Map<string, number>,
+): number | null {
+  const debtE8s = Number(vault.borrowed_icusd_amount ?? 0n);
+  if (debtE8s <= 0) return null;
+
+  const collType = principalText(vault.collateral_type);
+  const price = priceMap.get(collType);
+  if (price == null || price <= 0) return null;
+
+  const decimals = decimalsMap.get(collType) ?? 8;
+  const collAmount = Number(vault.collateral_amount ?? 0n) / Math.pow(10, decimals);
+  const collateralUsd = collAmount * price;
+  const debtUsd = debtE8s / 1e8;
+  return (collateralUsd / debtUsd) * 100;
+}
+
+/**
+ * Median of a numeric array. Returns null for empty input.
+ * Used for the per-collateral median CR column in CollateralTable.
+ */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd src/vault_frontend && npx vitest run src/lib/utils/vaultCr.test.ts
+```
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/utils/vaultCr.ts src/vault_frontend/src/lib/utils/vaultCr.test.ts
+git commit -m "$(cat <<'EOF'
+feat(explorer): add client-side vault CR helper
+
+Backend doesn't store collateral_ratio on the vault — it's computed on
+demand. CollateralLens currently reads vault.collateral_ratio (which is
+undefined) and the table hardcodes medianCrBps=0. Add a helper that
+computes CR from the data we already fetch (vaults + prices) so we can
+populate both the CR distribution histogram and the per-collateral
+median column.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.2: Wire CR helper into CollateralLens
+
+Use the helper to populate the CR distribution histogram and the per-collateral median CR column.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte`
+
+- [ ] **Step 1: Add imports**
+
+In `CollateralLens.svelte`, top of `<script>`, add:
+```typescript
+  import { computeVaultCrPct, median } from '$utils/vaultCr';
+```
+
+- [ ] **Step 2: Replace the broken CR distribution loop**
+
+Find this block (around line 115–133):
+```svelte
+      // CR distribution histogram from all active vaults
+      const bucketDefs: [number, number, string][] = [
+        [0, 110, '<110%'],
+        ...
+      ];
+      const buckets: CrBucket[] = bucketDefs.map(([lo, hi, label]) => ({ lo, hi, label, count: 0 }));
+      for (const v of allVaults) {
+        const cr = Number(v.collateral_ratio ?? 0);
+        if (cr === 0) continue;
+        const pct = cr; // backend uses percent (e.g. 243 for 243%)
+        for (const b of buckets) {
+          if (pct >= b.lo && pct < b.hi) { b.count += 1; break; }
+        }
+      }
+      crBuckets = buckets;
+```
+
+Replace with:
+```svelte
+      // CR distribution + per-collateral median CR. Backend returns vaults
+      // without a collateral_ratio field; compute from collateral × price /
+      // debt using helpers.
+      const decimalsMap = new Map<string, number>();
+      for (const t of totals) {
+        const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
+        if (pid && t.decimals != null) decimalsMap.set(pid, Number(t.decimals));
+      }
+
+      const crByCollateral = new Map<string, number[]>();
+      const bucketDefs: [number, number, string][] = [
+        [0, 110, '<110%'],
+        [110, 150, '110-150%'],
+        [150, 200, '150-200%'],
+        [200, 300, '200-300%'],
+        [300, 500, '300-500%'],
+        [500, Infinity, '500%+'],
+      ];
+      const buckets: CrBucket[] = bucketDefs.map(([lo, hi, label]) => ({ lo, hi, label, count: 0 }));
+
+      for (const v of allVaults) {
+        const cr = computeVaultCrPct(v, priceMap, decimalsMap);
+        if (cr == null) continue;
+        for (const b of buckets) {
+          if (cr >= b.lo && cr < b.hi) { b.count += 1; break; }
+        }
+        const collType = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+        if (!crByCollateral.has(collType)) crByCollateral.set(collType, []);
+        crByCollateral.get(collType)!.push(cr);
+      }
+      crBuckets = buckets;
+```
+
+- [ ] **Step 3: Use the median per collateral when building rows**
+
+Find the `medianCrBps: 0,` line (around line 102). Replace with:
+```svelte
+          medianCrBps: (() => {
+            const m = median(crByCollateral.get(principal) ?? []);
+            return m != null ? Math.round(m * 100) : 0; // bps
+          })(),
+```
+
+Note: Step 3 needs to come **after** the loop that builds `crByCollateral` (Step 2 places the loop earlier than the row-building code, so order is naturally correct — verify by reading the file once more before saving).
+
+- [ ] **Step 4: Type-check**
+
+Run:
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep "CollateralLens" | grep ERROR
+```
+Expected: no output (no new errors).
+
+- [ ] **Step 5: Manual smoke test**
+
+Deploy locally or hit mainnet, open `/explorer?lens=collateral`. CR distribution histogram should show bars for each bucket reflecting actual vault CRs. Avg CR column in CollateralTable should show real percentages instead of `--` for collaterals that have vaults.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): compute CR distribution + median client-side
+
+The backend doesn't return a collateral_ratio field on vaults, so the
+old code reading v.collateral_ratio was always undefined — every vault
+got skipped, the histogram was empty, and the Avg CR column was a
+hardcoded 0.
+
+Use the new vaultCr helper to compute CR from the vault data + price
+map we already fetch, populate the histogram, and compute a real
+median per collateral type.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.3: Fix SP "Recent liquidations absorbed" debt-cleared column
+
+The Candid record `PoolLiquidationRecord` defines `stables_consumed: vec record { principal; nat64 }` — a list of (token-ledger-principal, amount-e8s) pairs showing which stablecoins were burned to clear the vault's debt. The frontend reads `l.debt_cleared_e8s ?? l.debt_amount ?? 0n`, neither of which exists, hence the column is always "0 icUSD".
+
+Fix: sum the amounts in `stables_consumed`. (All stablecoins in scope — icUSD, ckUSDC, ckUSDT — are pegged $1, so a simple sum is correct.)
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte`
+
+- [ ] **Step 1: Locate the broken cell**
+
+Around line 300–302 the table renders:
+```svelte
+              <td class="py-2 px-2 text-right tabular-nums text-gray-300">
+                {formatCompact(Number(l.debt_cleared_e8s ?? l.debt_amount ?? 0n) / 1e8)} icUSD
+              </td>
+```
+
+- [ ] **Step 2: Add a helper at the bottom of the script section**
+
+In the `<script>` block (just before the closing `</script>`), add:
+```typescript
+  // Sum stables_consumed: vec record { principal; nat64 } → total icUSD-equivalent.
+  // All SP stablecoins (icUSD, ckUSDC, ckUSDT) are pegged $1 so a raw sum (after
+  // decimals normalization) is fine. ckUSDC/ckUSDT are 6-decimal; icUSD is 8.
+  function debtClearedFromRecord(rec: any): number {
+    const stables: Array<[any, bigint]> = rec?.stables_consumed ?? [];
+    let total = 0;
+    for (const [tokenPrincipal, amountE8s] of stables) {
+      const principal = typeof tokenPrincipal?.toText === 'function'
+        ? tokenPrincipal.toText() : String(tokenPrincipal);
+      // 6 decimals for ckUSDC / ckUSDT, 8 for everything else (icUSD)
+      const decimals = principal.includes('xevnm-gaaaa') /* ckUSDC */
+        || principal.includes('cngnf-vqaaa') /* ckUSDT */
+        ? 6 : 8;
+      total += Number(amountE8s) / Math.pow(10, decimals);
+    }
+    return total;
+  }
+```
+
+- [ ] **Step 3: Replace the broken cell**
+
+Replace lines 300–302 with:
+```svelte
+              <td class="py-2 px-2 text-right tabular-nums text-gray-300">
+                {formatCompact(debtClearedFromRecord(l))} icUSD
+              </td>
+```
+
+- [ ] **Step 4: Type-check**
+
+Run:
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep "StabilityPoolLens" | grep ERROR
+```
+Expected: no output.
+
+- [ ] **Step 5: Manual smoke test**
+
+Open `/explorer?lens=stability`. The "Recent liquidations absorbed" table should show real debt cleared values (not 0 icUSD) for every row that has stables consumed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): show real debt cleared in SP liquidations table
+
+The PoolLiquidationRecord candid type stores debt cleared as
+`stables_consumed: vec record { principal; nat64 }` — a list of
+(stablecoin-ledger, amount) pairs. The lens was reading non-existent
+debt_cleared_e8s / debt_amount fields so every row showed 0 icUSD.
+
+Sum the amounts in stables_consumed (with decimal normalization for
+ckUSDT/ckUSDC's 6-decimal native units) for the actual debt-cleared
+total.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.4: Admin breakdown card
+
+The analytics canister already exposes `get_admin_event_breakdown()` returning per-label counts (SetBorrowingFee × 3, SetInterestRate × 1, etc.). Surface that in a card so the Admin lens shows what's actually been changing recently, not just an event list.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte`
+
+- [ ] **Step 1: Create the card component**
+
+Create `src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte`:
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchAdminEventBreakdown } from '$services/explorer/analyticsService';
+  import type { AdminEventLabelCount } from '$declarations/rumi_analytics/rumi_analytics.did';
+
+  let labels: AdminEventLabelCount[] = $state([]);
+  let loading = $state(true);
+
+  onMount(async () => {
+    try {
+      const resp = await fetchAdminEventBreakdown();
+      labels = resp.labels.slice().sort((a, b) => Number(b.count) - Number(a.count));
+    } catch (err) {
+      console.error('[AdminBreakdownCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  // Group setter labels by domain so the card has more visual structure
+  // than a flat list — most setters cluster around fees, RMR, recovery
+  // mode, and collateral parameters.
+  function groupOf(label: string): string {
+    if (label.startsWith('SetCollateral')) return 'Collateral';
+    if (label.startsWith('SetRmr') || label.startsWith('SetRedemption') || label.startsWith('SetReserve')) return 'Redemption';
+    if (label.startsWith('SetRecovery')) return 'Recovery';
+    if (label.includes('Fee') || label.includes('InterestRate') || label.includes('InterestSplit') || label.includes('InterestPoolShare')) return 'Fees & interest';
+    if (label === 'Init' || label === 'Upgrade') return 'Lifecycle';
+    if (label.includes('Bot')) return 'Bot';
+    return 'Other';
+  }
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Admin actions by label</h3>
+  <p class="text-xs text-gray-500 mb-3">Counts of each setter / lifecycle event the analytics canister has tailed.</p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if labels.length === 0}
+    <p class="text-sm text-gray-500 py-2">No admin actions recorded yet.</p>
+  {:else}
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
+      {#each labels as l (l.label)}
+        <a
+          href="/explorer/activity?type=admin&admin={encodeURIComponent(l.label)}"
+          class="flex items-baseline justify-between text-sm py-1 border-b border-white/[0.03] hover:bg-white/[0.02]"
+          title="{groupOf(l.label)} · click to filter"
+        >
+          <span class="text-gray-300 font-mono text-xs truncate mr-2">{l.label}</span>
+          <span class="tabular-nums text-gray-200 font-medium">{Number(l.count).toLocaleString()}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Mount it in AdminLens**
+
+In `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte`, add the import near the top of `<script>`:
+```typescript
+  import AdminBreakdownCard from '../AdminBreakdownCard.svelte';
+```
+
+Then at the bottom of the file, between the `LensHealthStrip` line and the `Analytics tailing health` block, insert:
+```svelte
+<AdminBreakdownCard />
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "AdminLens|AdminBreakdownCard" | grep ERROR
+```
+Expected: no output.
+
+- [ ] **Step 4: Smoke test**
+
+Open `/explorer?lens=admin`. The Admin Breakdown card should list every setter label with a count. Clicking a row should jump to the activity feed pre-filtered to that admin label.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): admin actions-by-label breakdown card
+
+Surface the get_admin_event_breakdown analytics endpoint so the Admin
+lens shows which setter functions have been called and how often. Each
+row links to the pre-filtered activity feed for that label.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5: Canister inventory card
+
+The Admin lens lost the cycles chart in Phase 0 (analytics-only, not useful). Replace it with a static-ish card listing every canister in the Rumi ecosystem with its principal ID and links to the IC dashboard. This gives admin transparency without needing per-canister polling.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte`
+
+- [ ] **Step 1: Create the card**
+
+Create `src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte`:
+```svelte
+<script lang="ts">
+  import { CANISTER_IDS } from '$lib/config';
+  import EntityLink from './EntityLink.svelte';
+  import CopyButton from './CopyButton.svelte';
+
+  // Order: protocol core first, then DeFi, then ledgers, then frontends.
+  // The labels here are display-only — the principals come from $lib/config.
+  type Row = { label: string; principal: string; role: string };
+  const rows: Row[] = [
+    { label: 'rumi_protocol_backend', principal: CANISTER_IDS.PROTOCOL_BACKEND ?? '', role: 'Core CDP engine' },
+    { label: 'rumi_treasury', principal: CANISTER_IDS.TREASURY ?? '', role: 'Treasury' },
+    { label: 'rumi_stability_pool', principal: CANISTER_IDS.STABILITY_POOL ?? '', role: 'Stability pool' },
+    { label: 'rumi_3pool', principal: CANISTER_IDS.THREEPOOL, role: 'Stableswap (3USD)' },
+    { label: 'rumi_amm', principal: CANISTER_IDS.AMM ?? '', role: 'AMM' },
+    { label: 'rumi_analytics', principal: CANISTER_IDS.ANALYTICS ?? '', role: 'Analytics tailer' },
+    { label: 'liquidation_bot', principal: CANISTER_IDS.LIQUIDATION_BOT ?? '', role: 'Liquidations' },
+    { label: 'icusd_ledger', principal: CANISTER_IDS.ICUSD_LEDGER, role: 'icUSD ICRC-1/2 ledger' },
+  ].filter((r) => r.principal);
+
+  function dashboardUrl(principal: string): string {
+    return `https://dashboard.internetcomputer.org/canister/${principal}`;
+  }
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Canister inventory</h3>
+  <p class="text-xs text-gray-500 mb-3">Every protocol canister with its principal ID. Dashboard link shows live cycles, controllers, and module hash.</p>
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b border-white/5">
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Canister</th>
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Principal</th>
+        <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Dashboard</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as r (r.principal)}
+        <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
+          <td class="py-2 px-2 font-mono text-xs text-gray-200">{r.label}</td>
+          <td class="py-2 px-2 text-gray-400">{r.role}</td>
+          <td class="py-2 px-2 font-mono text-xs">
+            <span class="inline-flex items-center gap-1">
+              <EntityLink type="canister" value={r.principal} />
+              <CopyButton text={r.principal} />
+            </span>
+          </td>
+          <td class="py-2 px-2 text-right">
+            <a href={dashboardUrl(r.principal)} target="_blank" rel="noopener" class="text-teal-400 hover:text-teal-300 text-xs">View ↗</a>
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+```
+
+- [ ] **Step 2: Verify CANISTER_IDS keys exist**
+
+Run:
+```bash
+grep -n "PROTOCOL_BACKEND\|TREASURY\|STABILITY_POOL\|AMM\|ANALYTICS\|LIQUIDATION_BOT" src/vault_frontend/src/lib/config.ts | head
+```
+
+If any of these aren't defined, you'll need to either add them to `config.ts` or remove that row from the inventory. The Phase 0 work used `CANISTER_IDS.THREEPOOL` and `CANISTER_IDS.ICUSD_LEDGER` so those definitely exist; verify the others before declaring done.
+
+- [ ] **Step 3: Mount in AdminLens**
+
+In `AdminLens.svelte`:
+```typescript
+  import CanisterInventoryCard from '../CanisterInventoryCard.svelte';
+```
+
+Render it after `<AdminBreakdownCard />`:
+```svelte
+<CanisterInventoryCard />
+```
+
+- [ ] **Step 4: Type-check + smoke**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep "CanisterInventoryCard\|AdminLens" | grep ERROR
+```
+Open `/explorer?lens=admin`; verify the inventory table renders with all listed canisters.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): canister inventory card on Admin lens
+
+Replace the analytics-only cycles chart (removed in round 1) with a
+static inventory of every protocol canister: name, role, principal,
+and a link to the IC dashboard for live cycles + controller view.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.6: Verify Vault Activity card now populated
+
+Phase 0 rewrote `LensActivityPanel`'s `isBackendVaultEvent` to use snake_case variant names (the previous CamelCase set never matched). Verify the Collateral lens's "Vault activity" panel now shows real events.
+
+**Files:**
+- (verification only — no code change unless something else is wrong)
+
+- [ ] **Step 1: Open the lens locally / on mainnet**
+
+Navigate to `/explorer?lens=collateral`. Scroll to the "Vault activity" panel.
+
+- [ ] **Step 2: Cross-check against full activity page**
+
+Open `/explorer/activity?type=open_vault,borrow,repay,withdraw_collateral` in another tab. The Collateral lens panel should show approximately the same recent events (same vault IDs, similar timestamps), capped at the lens's `limit=12`.
+
+- [ ] **Step 3: If the panel is empty but the activity page is not**
+
+This means another bug — capture: (a) the network response from `get_events_filtered` (devtools → Network → look for the call from LensActivityPanel), (b) the JSON shape of the first event. Compare to `VAULT_OP_KEYS` set in `LensActivityPanel.svelte`. Likely the event variant key is something we missed.
+
+If the panel matches, no further action; just note in the commit log that the verification passed.
+
+- [ ] **Step 4: No code change → no commit**
+
+(This task only writes a verification step. If issues are found, file as a follow-up task, don't bundle.)
+
+---
+
+## Phase 2: Analytics canister fixes
+
+The analytics canister deploys via `dfx deploy --network ic rumi_analytics`. **Important:** It's an upgrade, never reinstall — global memory holds rolled-up history. Per the project memory, rumi_analytics also exceeds 2MiB ingress so the wasm needs `ic-wasm shrink` + `gzip` before `--mode upgrade`.
+
+### Task 2.1: Capture fee_amount on borrow events
+
+`Event::BorrowFromVault` already carries `fee_amount: ICUSD`. The analytics canister deserializes it (see `src/rumi_analytics/src/sources/backend.rs:102`) but the tailer drops it via the `..` rest pattern.
+
+**Files:**
+- Modify: `src/rumi_analytics/src/storage/events.rs` — add `fee_amount` field to `AnalyticsVaultEvent`
+- Modify: `src/rumi_analytics/src/tailing/backend_events.rs` — capture `fee_amount`
+
+- [ ] **Step 1: Add field to AnalyticsVaultEvent**
+
+In `src/rumi_analytics/src/storage/events.rs`, find `pub struct AnalyticsVaultEvent { ... }`. Add a new field (defaulted for backward compat with existing stable storage):
+```rust
+    /// Fee paid on this event in icUSD e8s. Populated for Borrowed and
+    /// Redeemed; zero for other event kinds. Older stored events default
+    /// to 0 via serde — we just won't have fee data for those.
+    #[serde(default)]
+    pub fee_amount: u64,
+```
+
+- [ ] **Step 2: Update Borrow tailer to capture fee**
+
+In `src/rumi_analytics/src/tailing/backend_events.rs`, find the `BorrowFromVault` branch (around line 108). Replace its `evt_vaults::push(...)` call with:
+```rust
+        BorrowFromVault { vault_id, borrowed_amount, fee_amount, caller, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: caller.unwrap_or(Principal::anonymous()),
+                event_kind: VaultEventKind::Borrowed,
+                collateral_type: Principal::anonymous(),
+                amount: *borrowed_amount,
+                fee_amount: *fee_amount,
+            });
+        }
+```
+
+- [ ] **Step 3: Update Redemption tailer**
+
+Find the `RedemptionOnVaults` branch (around line 185). Replace with:
+```rust
+        RedemptionOnVaults { icusd_amount, fee_amount, owner, collateral_type, timestamp, .. } => {
+            evt_vaults::push(AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: 0,
+                owner: *owner,
+                event_kind: VaultEventKind::Redeemed,
+                collateral_type: collateral_type.unwrap_or(Principal::anonymous()),
+                amount: *icusd_amount,
+                fee_amount: *fee_amount,
+            });
+        }
+```
+
+- [ ] **Step 4: Add `fee_amount: 0` to every other `evt_vaults::push` call**
+
+Every other `evt_vaults::push(...)` in this file needs `fee_amount: 0,` added (Opened, Repaid, CollateralWithdrawn, PartialCollateralWithdrawn, WithdrawAndClose, Closed, DustForgiven). Search:
+```bash
+grep -n "evt_vaults::push" src/rumi_analytics/src/tailing/backend_events.rs
+```
+Add `fee_amount: 0,` to each AnalyticsVaultEvent literal that doesn't already have it.
+
+- [ ] **Step 5: Build to confirm no missed call sites**
+
+Run:
+```bash
+cargo check -p rumi_analytics
+```
+Expected: clean compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/rumi_analytics/src/storage/events.rs src/rumi_analytics/src/tailing/backend_events.rs
+git commit -m "$(cat <<'EOF'
+feat(analytics): capture fee_amount on Borrow and Redemption events
+
+The backend events already carry fee_amount; analytics deserialized
+it but discarded it via the rest-pattern in the tailer. Capture the
+value into AnalyticsVaultEvent.fee_amount so the daily fee rollup
+can sum real numbers instead of stubbing None.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: Sum fees in the daily rollup
+
+Now that `AnalyticsVaultEvent` has `fee_amount`, replace the stubbed `None` in `rollup_fees` with real sums.
+
+**Files:**
+- Modify: `src/rumi_analytics/src/collectors/rollups.rs`
+
+- [ ] **Step 1: Update rollup_fees**
+
+In `src/rumi_analytics/src/collectors/rollups.rs`, replace the function body (lines 100–124) with:
+```rust
+fn rollup_fees(now: u64, day_start: u64) {
+    let swap_events = evt_swaps::range(day_start, now, usize::MAX);
+    let vault_events = evt_vaults::range(day_start, now, usize::MAX);
+
+    let swap_fees: u64 = swap_events.iter().map(|e| e.fee).sum();
+    let mut borrow_count: u32 = 0;
+    let mut redemption_count: u32 = 0;
+    let mut borrow_fees: u64 = 0;
+    let mut redemption_fees: u64 = 0;
+
+    for e in &vault_events {
+        match e.event_kind {
+            VaultEventKind::Borrowed => {
+                borrow_count += 1;
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+            }
+            VaultEventKind::Redeemed => {
+                redemption_count += 1;
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+            }
+            _ => {}
+        }
+    }
+
+    rollups::daily_fees::push(rollups::DailyFeeRollup {
+        timestamp_ns: now,
+        borrowing_fees_e8s: Some(borrow_fees),
+        borrow_count,
+        swap_fees_e8s: swap_fees,
+        redemption_fees_e8s: Some(redemption_fees),
+        redemption_count,
+    });
+}
+```
+
+- [ ] **Step 2: Update existing rollup test**
+
+Run:
+```bash
+cargo test -p rumi_analytics rollup_fees 2>&1 | head -40
+```
+If existing tests assert `borrowing_fees_e8s == None`, update to assert the sum. Read those test files if they exist:
+```bash
+grep -rn "rollup_fees\|borrowing_fees_e8s" src/rumi_analytics/src/ | grep -E "test|spec"
+```
+
+If tests need updates, edit them — keep their assertions semantically identical (still checking borrow_count, swap_fees) but replace the `None` assertion with `Some(expected_sum)`.
+
+- [ ] **Step 3: Run all analytics tests**
+
+```bash
+cargo test -p rumi_analytics
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/rumi_analytics/src/collectors/rollups.rs
+git commit -m "$(cat <<'EOF'
+feat(analytics): sum borrow/redemption fees in daily rollup
+
+borrowing_fees_e8s and redemption_fees_e8s were stubbed None pending
+fee_amount capture in the tailer. Now that AnalyticsVaultEvent has
+fee_amount, sum them per day so the Revenue lens shows real fee
+breakdowns instead of \$0.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.3: Stability-pool canister tailer (the architectural fix)
+
+The big one. The analytics canister has no SP-canister tailer, so deposits/withdrawals to `rumi_stability_pool` (a separate canister since the multi-canister split) are invisible to the Top SP Depositors leaderboard. The lens reads `evt_stability::range(...)` which only contains backend `Event::ProvideLiquidity` events that no longer get emitted.
+
+We'll add a tailer that pulls events from the SP canister's existing event log via `get_pool_events`, translates them into `AnalyticsStabilityEvent`, and pushes them into the same `evt_stability` log the leaderboard reads.
+
+**Files:**
+- Create: `src/rumi_analytics/src/sources/stability_pool.rs`
+- Create: `src/rumi_analytics/src/tailing/stability_pool.rs`
+- Modify: `src/rumi_analytics/src/sources/mod.rs`
+- Modify: `src/rumi_analytics/src/tailing/mod.rs`
+- Modify: `src/rumi_analytics/src/storage/cursors.rs`
+- Modify: `src/rumi_analytics/src/lib.rs`
+- Modify: `src/rumi_analytics/src/storage/mod.rs` (CanisterPrincipals)
+
+- [ ] **Step 1: Add cursor**
+
+In `src/rumi_analytics/src/storage/cursors.rs`, find the existing cursor module pattern (search for `CURSOR_ID_BACKEND_EVENTS`). Add an analogous one:
+```rust
+pub const CURSOR_ID_STABILITY_POOL: u8 = /* next free id */;
+
+pub mod stability_pool_events {
+    use super::*;
+    pub fn get() -> u64 { /* same shape as backend_events::get */ }
+    pub fn set(value: u64) { /* same shape as backend_events::set */ }
+}
+```
+Mirror the existing `backend_events` module exactly — same stable-memory key derivation, same getter/setter. Pick the next free `u8` for `CURSOR_ID_STABILITY_POOL` (look at the highest ID already in use in this file).
+
+- [ ] **Step 2: Add SP principal to canister-principals state**
+
+In `src/rumi_analytics/src/storage/mod.rs`, find `pub struct CanisterPrincipals { ... }`. It already has `stability_pool: Principal` (saw in grep earlier). If not, add. Ensure `init` and `post_upgrade` accept it as an init arg (read the existing handling for `backend` to mirror).
+
+- [ ] **Step 3: Define SP shadow types**
+
+Create `src/rumi_analytics/src/sources/stability_pool.rs`:
+```rust
+//! Shadow types + read helpers for tailing rumi_stability_pool events.
+//!
+//! The SP canister exposes get_pool_event_count / get_pool_events. We mirror
+//! the candid types we care about (Deposit, Withdraw, ClaimCollateral) and
+//! ignore the rest — admin events, errors, etc. don't drive the depositor
+//! leaderboard.
+
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct PoolEvent {
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub event_type: PoolEventType,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum PoolEventType {
+    Deposit { amount: u64, token: Principal },
+    Withdraw { amount: u64, token: Principal },
+    DepositAs3USD { amount: u64 },
+    ClaimCollateral { collateral_type: Principal, amount: u64 },
+    LiquidationExecuted { /* ignore details for tailer */ },
+    LiquidationNotification { /* ignore */ },
+    InterestReceived { /* ignore — too noisy */ },
+    // Catch-all for variants we don't track. serde + candid both tolerate
+    // missing variants if we deserialize as a serde_json::Value-equivalent;
+    // if not, list every variant explicitly. Verify against the SP candid.
+    #[serde(other)]
+    Unknown,
+}
+
+pub async fn get_event_count(sp: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(sp, "get_pool_event_count", ())
+        .await
+        .map_err(|e| format!("get_pool_event_count failed: {:?}", e))?;
+    Ok(count)
+}
+
+pub async fn get_events(sp: Principal, start: u64, length: u64) -> Result<Vec<PoolEvent>, String> {
+    let (events,): (Vec<PoolEvent>,) = ic_cdk::call(sp, "get_pool_events", (start, length))
+        .await
+        .map_err(|e| format!("get_pool_events failed: {:?}", e))?;
+    Ok(events)
+}
+```
+
+**Verify the candid signature** before committing — read `src/declarations/rumi_stability_pool/rumi_stability_pool.did` and confirm `get_pool_event_count` returns `(nat64)` and `get_pool_events` takes `(nat64, nat64)` returning `(vec PoolEvent)`. Adjust the shadow type if the actual variant names differ.
+
+- [ ] **Step 4: Wire into sources/mod.rs**
+
+In `src/rumi_analytics/src/sources/mod.rs`, add:
+```rust
+pub mod stability_pool;
+```
+
+- [ ] **Step 5: Write the tailer**
+
+Create `src/rumi_analytics/src/tailing/stability_pool.rs`:
+```rust
+//! Tail rumi_stability_pool events into evt_stability so the Top SP
+//! Depositors leaderboard has data to aggregate.
+
+use candid::Principal;
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+pub async fn run() {
+    let sp = state::read_state(|s| s.sources.stability_pool);
+    if sp == Principal::anonymous() {
+        return; // SP principal not configured yet
+    }
+    let cursor = cursors::stability_pool_events::get();
+
+    let count = match sources::stability_pool::get_event_count(sp).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_sp] get_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.stability_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_POOL, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_STABILITY_POOL, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::stability_pool::get_events(sp, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_sp] get_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.stability_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_POOL, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for (i, event) in events.iter().enumerate() {
+        let event_id = cursor + i as u64;
+        route_sp_event(event_id, event);
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::stability_pool_events::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_STABILITY_POOL, ic_cdk::api::time());
+        });
+    }
+}
+
+fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
+    use sources::stability_pool::PoolEventType::*;
+
+    let action = match &event.event_type {
+        Deposit { amount, .. } | DepositAs3USD { amount } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::Deposit,
+                amount: *amount,
+            });
+            return;
+        }
+        Withdraw { amount, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::Withdraw,
+                amount: *amount,
+            });
+            return;
+        }
+        ClaimCollateral { amount, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::ClaimReturns,
+                amount: *amount,
+            });
+            return;
+        }
+        // LiquidationExecuted, LiquidationNotification, InterestReceived,
+        // Unknown — ignore for the leaderboard.
+        _ => return,
+    };
+    let _ = action;
+}
+```
+
+- [ ] **Step 6: Register the tailer**
+
+In `src/rumi_analytics/src/tailing/mod.rs`, find where `backend_events` is registered. Add:
+```rust
+pub mod stability_pool;
+```
+Then in whatever async function runs all tailers (probably `pub async fn run_all()` or similar — read the file), add a call to `stability_pool::run().await`.
+
+Add `stability_pool: u32` to the `error_counters` struct so the tailer can increment it (mirror `backend: u32` and any others). Also include in collector_health response.
+
+- [ ] **Step 7: Initialize cursor on first deploy**
+
+In `src/rumi_analytics/src/lib.rs`, find `init` and `post_upgrade`. After cursors are loaded, ensure `cursors::stability_pool_events::get()` returns 0 if never set (default behavior should already do this — verify by reading existing cursor init).
+
+To bootstrap with existing SP history, the cursor starts at 0 and tails will catch up. With a few hundred events that's a few minutes on the next tail tick.
+
+- [ ] **Step 8: Build the canister**
+
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+```
+Expected: clean compile.
+
+- [ ] **Step 9: Run all analytics tests**
+
+```bash
+cargo test -p rumi_analytics
+```
+Expected: all green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/rumi_analytics/
+git commit -m "$(cat <<'EOF'
+feat(analytics): tail rumi_stability_pool canister events
+
+The Top SP Depositors leaderboard reads evt_stability, which has only
+ever been populated from backend Event::ProvideLiquidity / Withdraw /
+ClaimLiquidityReturns. Those variants are dead code — never emitted
+since SP became a separate canister. Result: leaderboard always empty,
+including for fresh deposits.
+
+Add a tailer that pulls events from rumi_stability_pool's own event
+log (get_pool_events) and pushes Deposit/Withdraw/Claim into the
+existing evt_stability so the leaderboard, address-page SP timeline,
+and SP TVL queries all start working.
+
+Cursor starts at 0 so the first run backfills the full SP history.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.4: Deploy analytics + verify
+
+**Files:** none — deploy step.
+
+- [ ] **Step 1: Build, shrink, gzip**
+
+Per project memory, rumi_analytics wasm exceeds 2MiB ingress. Run:
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+ic-wasm target/wasm32-unknown-unknown/release/rumi_analytics.wasm -o target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm shrink
+gzip -f target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm
+ls -la target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm.gz
+```
+Expected: gzipped wasm under 2MiB.
+
+- [ ] **Step 2: Deploy to mainnet (requires explicit confirmation from Rob)**
+
+```bash
+dfx canister install rumi_analytics \
+  --network ic \
+  --mode upgrade \
+  --wasm target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm.gz \
+  --argument '(/* InitArgs literal — see existing deploy notes for shape */)'
+```
+
+**Note:** rumi_analytics requires full InitArgs even on upgrade per project memory. Get the current init args from the previous deploy — likely captured in a deploy script or commit log. Don't guess.
+
+**STOP here and confirm with Rob before running the deploy command.**
+
+- [ ] **Step 3: Verify post-deploy**
+
+After deploy, wait ~10 minutes for the SP cursor to catch up. Then check:
+- `/explorer?lens=stability` — Top depositors card should show entries
+- `/explorer?lens=revenue` — fee breakdown should show non-zero borrowing + redemption fees
+- `/explorer?lens=admin` — collector health card should show `stability_pool` row with non-zero last_collect
+
+If still empty, sanity-check the SP cursor:
+```bash
+dfx canister --network ic call rumi_analytics get_collector_health
+```
+
+---
+
+## Phase 3: Lower priority / nice-to-have
+
+### Task 3.1 (deferred): Per-pool LP APY split
+
+The analytics `get_apys` returns a single `lp_apy_pct`. To split into 3Pool LP APY and AMM LP APY, add `three_pool_lp_apy_pct` and `amm_lp_apy_pct` to the response and compute each from per-pool fee + TVL data. Defer until there's enough volume on both pools that the distinction matters.
+
+### Task 3.2 (deferred): Multi-canister cycles tracking
+
+Per the user's review: nice-to-have, not crucial. The IC dashboard already shows live cycles for any canister; the inventory card we added in Task 1.5 links there for each canister. If we later want native tabs in the lens, the work is: have rumi_analytics call the management canister `canister_status` per-canister on a slow timer (every hour), store snapshots, and expose `get_cycles_series_per_canister`. Not in scope here.
+
+---
+
+## Self-review checklist
+
+**Spec coverage**
+- ✅ "Why is field not populated?" — answered in Background section + Phase 1 fixes
+- ✅ Strip cycles chart — Phase 0 (already done)
+- ✅ More admin activity — Tasks 1.4 (breakdown) + 1.5 (canister inventory) + Phase 2 setter events flowing into admin feed
+- ✅ Top SP depositors empty — Task 2.3
+- ✅ Past redemptions / fees missing — Tasks 2.1 + 2.2
+- ✅ CR distribution / Avg CR / SP debt cleared — Tasks 1.1, 1.2, 1.3
+- ✅ Liquidation Risk card — confirmed not a bug per Rob's clarification, no task needed
+- ✅ Branch setup — Phase 0, Task 0.1
+
+**Placeholder scan**
+- All steps include the actual code or exact commands.
+- No "TBD" / "implement later" markers.
+- The deploy step in Task 2.4 explicitly requires Rob's confirmation before running, with the actual command shown.
+
+**Type consistency**
+- `computeVaultCrPct` returns `number | null` consistently across Task 1.1 (definition) and Task 1.2 (caller).
+- `AnalyticsVaultEvent.fee_amount: u64` defined in Task 2.1, used in Task 2.2 (`e.fee_amount`).
+- `AnalyticsStabilityEvent` shape unchanged; tailer in Task 2.3 produces the same struct the existing leaderboard query already reads.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-explorer-review-pass.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Good fit here since Phase 1 tasks are short and independent.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch with checkpoints. Useful if you want to discuss design choices in-line on the analytics canister work.
+
+Which approach?

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1,49 +1,10 @@
 type Account = record { owner : principal; subaccount : opt blob };
-type ProtocolConfig = record {
-  mode : Mode;
-  frozen : bool;
-  manual_mode_override : bool;
-  borrowing_fee : float64;
-  redemption_fee_floor : float64;
-  redemption_fee_ceiling : float64;
-  reserve_redemption_fee : float64;
-  ckstable_repay_fee : float64;
-  liquidation_bonus : float64;
-  liquidation_protocol_share : float64;
-  rmr_floor : float64;
-  rmr_ceiling : float64;
-  rmr_floor_cr : float64;
-  rmr_ceiling_cr : float64;
-  recovery_cr_multiplier : float64;
-  recovery_mode_threshold : float64;
-  max_partial_liquidation_ratio : float64;
-  min_icusd_amount : nat64;
-  global_icusd_mint_cap : nat64;
-  interest_flush_threshold_e8s : nat64;
-  interest_split : vec InterestSplitArg;
-  global_rate_curve : vec record { float64; float64 };
-  recovery_rate_curve : vec record { text; float64 };
-  borrowing_fee_curve : vec record { float64; float64 };
-  reserve_redemptions_enabled : bool;
-  ckusdt_enabled : bool;
-  ckusdc_enabled : bool;
-  icpswap_routing_enabled : bool;
-  treasury_principal : opt principal;
-  stability_pool_canister : opt principal;
-  three_pool_canister : opt principal;
-  ckusdt_ledger_principal : opt principal;
-  ckusdc_ledger_principal : opt principal;
-  liquidation_bot_principal : opt principal;
-  bot_budget_total_e8s : nat64;
-  bot_budget_remaining_e8s : nat64;
-  bot_allowed_collateral_types : vec principal;
-  collateral_configs : vec record { principal; CollateralConfig };
-};
 type AddCollateralArg = record {
   redemption_fee_ceiling : opt float64;
   debt_ceiling : nat64;
   min_vault_debt : nat64;
   min_collateral_deposit : nat64;
+  redemption_tier : opt nat8;
   redemption_fee_floor : opt float64;
   borrow_threshold_ratio : float64;
   ledger_canister_id : principal;
@@ -53,12 +14,6 @@ type AddCollateralArg = record {
   borrowing_fee : float64;
   interest_rate_apr : float64;
   liquidation_ratio : float64;
-  redemption_tier : opt nat8;
-};
-type VaultRedemptionImpact = record {
-  vault_id : nat64;
-  debt_reduced : nat64;
-  collateral_seized : nat64;
 };
 type BotLiquidationResult = record {
   collateral_amount : nat64;
@@ -96,6 +51,7 @@ type CollateralConfig = record {
   min_collateral_deposit : nat64;
   last_price : opt float64;
   last_price_timestamp : opt nat64;
+  redemption_tier : nat8;
   redemption_fee_floor : blob;
   borrow_threshold_ratio : blob;
   ledger_fee : nat64;
@@ -167,29 +123,34 @@ type Event = variant {
   };
   claim_liquidity_returns : record {
     block_index : nat64;
+    timestamp : opt nat64;
     caller : principal;
     amount : nat64;
-    timestamp : opt nat64;
   };
   collateral_withdrawn : record {
     block_index : nat64;
     vault_id : nat64;
-    amount : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    caller : opt principal;
+    amount : nat64;
   };
   repay_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
     repayed_amount : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    caller : opt principal;
   };
   provide_liquidity : record {
     block_index : nat64;
+    timestamp : opt nat64;
     caller : principal;
     amount : nat64;
-    timestamp : opt nat64;
+  };
+  price_update : record {
+    timestamp : nat64;
+    collateral_type : principal;
+    price : text;
   };
   set_rmr_ceiling_cr : record { value : text };
   set_recovery_rate_curve : record { markers : text };
@@ -200,9 +161,9 @@ type Event = variant {
   withdraw_and_close_vault : record {
     block_index : opt nat64;
     vault_id : nat64;
-    amount : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    caller : opt principal;
+    amount : nat64;
   };
   admin_vault_correction : record {
     vault_id : nat64;
@@ -210,23 +171,38 @@ type Event = variant {
     old_amount : nat64;
     reason : text;
   };
+  set_collateral_min_vault_debt : record {
+    min_vault_debt : nat64;
+    collateral_type : principal;
+  };
   set_recovery_target_cr : record { rate : text };
+  set_collateral_redemption_fee_floor : record {
+    redemption_fee_floor : text;
+    collateral_type : principal;
+  };
   init : InitArg;
   set_stable_ledger_principal : record {
     "principal" : principal;
     token_type : StableTokenType;
   };
-  open_vault : record { block_index : nat64; vault : Vault; timestamp : opt nat64 };
+  open_vault : record {
+    block_index : nat64;
+    vault : Vault;
+    timestamp : opt nat64;
+  };
+  set_collateral_display_color : record {
+    collateral_type : principal;
+    display_color : opt text;
+  };
   redemption_on_vaults : record {
     icusd_amount : nat64;
     icusd_block_index : nat64;
     owner : principal;
-    fee_amount : nat64;
-    current_icp_rate : blob;
-    collateral_type : opt principal;
-    vault_impacts : opt vec VaultRedemptionImpact;
     timestamp : opt nat64;
+    fee_amount : nat64;
+    collateral_type : opt principal;
     vault_redemptions : opt vec VaultRedemption;
+    current_icp_rate : blob;
   };
   set_recovery_parameters : record {
     recovery_interest_rate_apr : opt text;
@@ -239,46 +215,15 @@ type Event = variant {
     collateral_type : principal;
     borrowing_fee : opt text;
   };
-  set_collateral_liquidation_ratio : record {
-    collateral_type : principal;
-    liquidation_ratio : text;
-  };
-  set_collateral_borrow_threshold : record {
-    collateral_type : principal;
-    borrow_threshold_ratio : text;
-  };
-  set_collateral_liquidation_bonus : record {
-    collateral_type : principal;
-    liquidation_bonus : text;
-  };
-  set_collateral_min_vault_debt : record {
-    collateral_type : principal;
-    min_vault_debt : nat64;
-  };
-  set_collateral_ledger_fee : record {
-    collateral_type : principal;
-    ledger_fee : nat64;
-  };
-  set_collateral_redemption_fee_floor : record {
-    collateral_type : principal;
-    redemption_fee_floor : text;
-  };
   set_collateral_redemption_fee_ceiling : record {
-    collateral_type : principal;
     redemption_fee_ceiling : text;
-  };
-  set_collateral_min_deposit : record {
     collateral_type : principal;
-    min_collateral_deposit : nat64;
   };
-  set_collateral_display_color : record {
-    collateral_type : principal;
-    display_color : opt text;
+  margin_transfer : record {
+    block_index : nat64;
+    vault_id : nat64;
+    timestamp : opt nat64;
   };
-  set_bot_allowed_collateral_types : record {
-    collateral_types : vec principal;
-  };
-  margin_transfer : record { block_index : nat64; vault_id : nat64; timestamp : opt nat64 };
   admin_sweep_to_treasury : record {
     block_index : nat64;
     amount : nat64;
@@ -287,18 +232,24 @@ type Event = variant {
   };
   set_rmr_floor_cr : record { value : text };
   set_rmr_ceiling : record { value : text };
+  set_collateral_liquidation_bonus : record {
+    collateral_type : principal;
+    liquidation_bonus : text;
+  };
   set_global_icusd_mint_cap : record { cap : opt text; amount : opt text };
   upgrade : UpgradeArg;
   borrow_from_vault : record {
     block_index : nat64;
     vault_id : nat64;
-    fee_amount : nat64;
-    borrowed_amount : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    fee_amount : nat64;
+    caller : opt principal;
+    borrowed_amount : nat64;
+  };
+  set_bot_allowed_collateral_types : record {
+    collateral_types : vec principal;
   };
   set_reserve_redemptions_enabled : record { enabled : bool };
-  set_icpswap_routing_enabled : record { enabled : bool };
   set_min_icusd_amount : record { amount : text };
   set_borrowing_fee_curve : record { markers : text };
   set_interest_pool_share : record { share : text };
@@ -311,36 +262,53 @@ type Event = variant {
   partial_collateral_withdrawn : record {
     block_index : nat64;
     vault_id : nat64;
-    amount : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    caller : opt principal;
+    amount : nat64;
+  };
+  admin_debt_correction : record {
+    new_accrued : nat64;
+    new_borrowed : nat64;
+    old_accrued : nat64;
+    vault_id : nat64;
+    timestamp : opt nat64;
+    old_borrowed : nat64;
   };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
   };
-  dust_forgiven : record { vault_id : nat64; amount : nat64; timestamp : opt nat64 };
+  set_collateral_liquidation_ratio : record {
+    collateral_type : principal;
+    liquidation_ratio : text;
+  };
+  dust_forgiven : record {
+    vault_id : nat64;
+    timestamp : opt nat64;
+    amount : nat64;
+  };
   partial_liquidate_vault : record {
     protocol_fee_collateral : opt nat64;
     icp_rate : opt blob;
     liquidator_payment : nat64;
     vault_id : nat64;
+    timestamp : opt nat64;
+    three_usd_reserves_e8s : opt nat64;
     liquidator : opt principal;
     icp_to_liquidator : nat64;
-    timestamp : opt nat64;
   };
   withdraw_liquidity : record {
     block_index : nat64;
+    timestamp : opt nat64;
     caller : principal;
     amount : nat64;
-    timestamp : opt nat64;
   };
   admin_mint : record {
     to : principal;
     block_index : nat64;
+    timestamp : opt nat64;
     amount : nat64;
     reason : text;
-    timestamp : opt nat64;
   };
   set_three_pool_canister : record { canister : principal };
   set_liquidation_bonus : record { rate : text };
@@ -349,12 +317,20 @@ type Event = variant {
     icusd_block_index : nat64;
     fee_stable_amount : nat64;
     owner : principal;
+    timestamp : opt nat64;
     fee_amount : nat64;
     stable_amount_sent : nat64;
     stable_token_ledger : principal;
+  };
+  close_vault : record {
+    block_index : opt nat64;
+    vault_id : nat64;
     timestamp : opt nat64;
   };
-  close_vault : record { block_index : opt nat64; vault_id : nat64; timestamp : opt nat64 };
+  set_collateral_min_deposit : record {
+    min_collateral_deposit : nat64;
+    collateral_type : principal;
+  };
   update_collateral_status : record {
     status : CollateralStatus;
     collateral_type : principal;
@@ -364,12 +340,13 @@ type Event = variant {
   add_margin_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
-    margin_added : nat64;
-    caller : opt principal;
     timestamp : opt nat64;
+    caller : opt principal;
+    margin_added : nat64;
   };
   set_stability_pool_principal : record { "principal" : principal };
   set_interest_split : record { split : text };
+  set_icpswap_routing_enabled : record { enabled : bool };
   set_bot_budget : record { start_timestamp : nat64; total_e8s : nat64 };
   set_rmr_floor : record { value : text };
   set_redemption_fee_floor : record { rate : text };
@@ -388,11 +365,19 @@ type Event = variant {
     mode : Mode;
     icp_rate : blob;
     vault_id : nat64;
-    liquidator : opt principal;
     timestamp : opt nat64;
+    liquidator : opt principal;
+  };
+  set_collateral_borrow_threshold : record {
+    borrow_threshold_ratio : text;
+    collateral_type : principal;
   };
   add_collateral_type : record {
     config : CollateralConfig;
+    collateral_type : principal;
+  };
+  set_collateral_ledger_fee : record {
+    ledger_fee : nat64;
     collateral_type : principal;
   };
   set_stable_token_enabled : record {
@@ -400,57 +385,43 @@ type Event = variant {
     token_type : StableTokenType;
   };
   set_recovery_cr_multiplier : record { multiplier : text };
-  price_update : record {
-    collateral_type : principal;
-    price : text;
-    timestamp : nat64;
-  };
-  admin_debt_correction : record {
-    vault_id : nat64;
-    old_borrowed : nat64;
-    new_borrowed : nat64;
-    old_accrued : nat64;
-    new_accrued : nat64;
-    timestamp : opt nat64;
-  };
-};
-type VaultRedemption = record {
-  vault_id : nat64;
-  icusd_redeemed_e8s : nat64;
-  collateral_seized : nat64;
-};
-type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
-type EventTypeFilter = variant {
-  OpenVault;
-  CloseVault;
-  AdjustVault;
-  Borrow;
-  Repay;
-  Liquidation;
-  PartialLiquidation;
-  Redemption;
-  ReserveRedemption;
-  StabilityPoolDeposit;
-  StabilityPoolWithdraw;
-  AdminMint;
-  AdminSweepToTreasury;
-  Admin;
-  PriceUpdate;
-  AccrueInterest;
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
+type EventTypeFilter = variant {
+  StabilityPoolDeposit;
+  AdminSweepToTreasury;
+  AdminMint;
+  AdjustVault;
+  PartialLiquidation;
+  OpenVault;
+  StabilityPoolWithdraw;
+  AccrueInterest;
+  ReserveRedemption;
+  Repay;
+  Liquidation;
+  Borrow;
+  PriceUpdate;
+  Admin;
+  Redemption;
+  CloseVault;
+};
+type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
-  start : nat64;
-  length : nat64;
-  types : opt vec EventTypeFilter;
   "principal" : opt principal;
-  collateral_token : opt principal;
+  types : opt vec EventTypeFilter;
   time_range : opt EventTimeRange;
+  start : nat64;
+  collateral_token : opt principal;
+  length : nat64;
   min_size_e8s : opt nat64;
   admin_labels : opt vec text;
 };
-type GetEventsFilteredResponse = record { total : nat64; events : vec record { nat64; Event } };
+type GetEventsFilteredResponse = record {
+  total : nat64;
+  events : vec record { nat64; Event };
+};
 type GetSnapshotsArg = record { start : nat64; length : nat64 };
+type HttpHeader = record { value : text; name : text };
 type HttpRequest = record {
   url : text;
   method : text;
@@ -458,6 +429,11 @@ type HttpRequest = record {
   headers : vec record { text; text };
 };
 type HttpResponse = record {
+  status : nat;
+  body : blob;
+  headers : vec HttpHeader;
+};
+type HttpResponse_1 = record {
   body : blob;
   headers : vec record { text; text };
   status_code : nat16;
@@ -503,10 +479,7 @@ type PriceSource = variant {
     base_asset_class : XrcAssetClass;
     base_asset : text;
   };
-  CoinGecko : record {
-    coin_id : text;
-    vs_currency : text;
-  };
+  CoinGecko : record { coin_id : text; vs_currency : text };
   LstWrapped : record {
     quote_asset_class : XrcAssetClass;
     haircut : float64;
@@ -518,16 +491,56 @@ type PriceSource = variant {
   };
 };
 type ProtocolArg = variant { Upgrade : UpgradeArg; Init : InitArg };
+type ProtocolConfig = record {
+  global_rate_curve : vec record { float64; float64 };
+  bot_budget_remaining_e8s : nat64;
+  recovery_rate_curve : vec record { text; float64 };
+  redemption_fee_ceiling : float64;
+  ckusdc_ledger_principal : opt principal;
+  recovery_mode_threshold : float64;
+  bot_allowed_collateral_types : vec principal;
+  liquidation_bot_principal : opt principal;
+  reserve_redemption_fee : float64;
+  liquidation_protocol_share : float64;
+  mode : Mode;
+  interest_split : vec InterestSplitArg;
+  recovery_cr_multiplier : float64;
+  borrowing_fee_curve : vec record { float64; float64 };
+  ckusdt_ledger_principal : opt principal;
+  min_icusd_amount : nat64;
+  redemption_fee_floor : float64;
+  interest_flush_threshold_e8s : nat64;
+  three_pool_canister : opt principal;
+  collateral_configs : vec record { principal; CollateralConfig };
+  rmr_ceiling : float64;
+  ckstable_repay_fee : float64;
+  treasury_principal : opt principal;
+  rmr_ceiling_cr : float64;
+  frozen : bool;
+  icpswap_routing_enabled : bool;
+  ckusdc_enabled : bool;
+  ckusdt_enabled : bool;
+  rmr_floor : float64;
+  manual_mode_override : bool;
+  liquidation_bonus : float64;
+  reserve_redemptions_enabled : bool;
+  borrowing_fee : float64;
+  bot_budget_total_e8s : nat64;
+  max_partial_liquidation_ratio : float64;
+  global_icusd_mint_cap : nat64;
+  stability_pool_canister : opt principal;
+  rmr_floor_cr : float64;
+};
 type ProtocolError = variant {
   GenericError : text;
   TemporarilyUnavailable : text;
   TransferError : TransferError;
   AlreadyProcessing;
+  NotLowestCR;
   AnonymousCallerNotAllowed;
   AmountTooLow : record { minimum_amount : nat64 };
   TransferFromError : record { TransferFromError; nat64 };
   CallerNotOwner;
-  NotLowestCR;
 };
 type ProtocolSnapshot = record {
   total_debt : nat64;
@@ -580,20 +593,26 @@ type ReserveRedemptionResult = record {
 };
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
-type Result_10 = variant {
+type Result_10 = variant { Ok : bool; Err : ProtocolError };
+type Result_11 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_12 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_2 = variant { Ok : SuccessWithFee; Err : ProtocolError };
-type Result_3 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
-type Result_4 = variant { Ok : opt nat64; Err : ProtocolError };
-type Result_5 = variant { Ok : float64; Err : ProtocolError };
-type Result_6 = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_7 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_8 = variant { Ok : bool; Err : ProtocolError };
-type Result_9 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_11 = variant { Ok : text; Err : ProtocolError };
-type Result_12 = variant { Ok : nat8; Err : ProtocolError };
+type Result_2 = variant { Ok : text; Err : ProtocolError };
+type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
+type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
+type Result_5 = variant { Ok : opt nat64; Err : ProtocolError };
+type Result_6 = variant { Ok : nat8; Err : ProtocolError };
+type Result_7 = variant { Ok : float64; Err : ProtocolError };
+type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type Result_9 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
+type SpWritedownProof = record {
+  block_index : nat64;
+  ledger_kind : SpProofLedger;
+  vault_id_memo : nat64;
+};
 type StabilityPoolConfig = record {
   enabled : bool;
   liquidation_discount : nat64;
@@ -637,6 +656,7 @@ type TransferFromError = variant {
   TooOld;
   InsufficientFunds : record { balance : nat };
 };
+type TransformArgs = record { context : blob; response : HttpResponse };
 type TreasuryStats = record {
   pending_treasury_collateral_entries : nat64;
   liquidation_protocol_share : float64;
@@ -650,6 +670,7 @@ type UpgradeArg = record { mode : opt Mode; description : opt text };
 type Vault = record {
   collateral_amount : nat64;
   owner : principal;
+  bot_processing : bool;
   vault_id : nat64;
   collateral_type : principal;
   last_accrual_time : nat64;
@@ -657,15 +678,20 @@ type Vault = record {
   borrowed_icusd_amount : nat64;
 };
 type VaultArg = record { vault_id : nat64; amount : nat64 };
-type VaultDebtCorrection = record {
-  vault_id : nat64;
-  correct_borrowed_e8s : nat64;
-  correct_accrued_interest_e8s : nat64;
-};
 type VaultArgWithToken = record {
   vault_id : nat64;
   amount : nat64;
   token_type : StableTokenType;
+};
+type VaultDebtCorrection = record {
+  correct_accrued_interest_e8s : nat64;
+  vault_id : nat64;
+  correct_borrowed_e8s : nat64;
+};
+type VaultRedemption = record {
+  icusd_redeemed_e8s : nat64;
+  vault_id : nat64;
+  collateral_seized : nat64;
 };
 type XrcAssetClass = variant { Cryptocurrency; FiatCurrency };
 service : (ProtocolArg) -> {
@@ -673,22 +699,18 @@ service : (ProtocolArg) -> {
   add_margin_to_vault : (VaultArg) -> (Result_1);
   add_margin_with_deposit : (nat64) -> (Result_1);
   admin_correct_vault_collateral : (nat64, nat64, text) -> (Result);
-  admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_11);
+  admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
-  admin_sweep_to_treasury : (text) -> (Result_1);
-  borrow_from_vault : (VaultArg) -> (Result_2);
-  bot_cancel_liquidation : (nat64) -> (Result);
-  bot_claim_liquidation : (nat64) -> (Result_3);
-  bot_confirm_liquidation : (nat64) -> (Result);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
+  admin_sweep_to_treasury : (text) -> (Result_1);
+  borrow_from_vault : (VaultArg) -> (Result_3);
+  bot_cancel_liquidation : (nat64) -> (Result);
+  bot_claim_liquidation : (nat64) -> (Result_4);
+  bot_confirm_liquidation : (nat64) -> (Result);
   claim_liquidity_returns : () -> (Result_1);
   clear_stuck_operations : (opt principal) -> (Result_1);
-  close_vault : (nat64) -> (Result_4);
-  dev_force_bot_liquidate : (nat64) -> (Result_3);
-  dev_force_partial_bot_liquidate : (nat64) -> (Result_3);
-  dev_test_cascade_liquidation : (nat64) -> (Result_11);
-  dev_test_pool_only_liquidation : (nat64) -> (Result_11);
-  dev_set_collateral_price : (principal, float64) -> (Result_11);
+  close_vault : (nat64) -> (Result_5);
+  coingecko_transform : (TransformArgs) -> (HttpResponse) query;
   enter_recovery_mode : () -> (Result);
   exit_recovery_mode : () -> (Result);
   freeze_protocol : () -> (Result);
@@ -699,37 +721,45 @@ service : (ProtocolArg) -> {
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
+  get_consumed_writedown_proofs : () -> (
+      vec record { SpProofLedger; nat64 },
+    ) query;
   get_deposit_account : (opt principal) -> (Account) query;
   get_event_count : () -> (nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
-  get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_events_by_principal : (principal) -> (vec record { nat64; Event }) query;
+  get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_fees : (nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
+  get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
   get_liquidatable_vaults : () -> (vec CandidVault) query;
   get_liquidation_bonus : () -> (float64) query;
+  get_liquidation_frozen : () -> (bool) query;
+  get_liquidation_ordering_tolerance_bps : () -> (nat64) query;
   get_liquidation_protocol_share : () -> (float64) query;
   get_liquidity_status : (principal) -> (LiquidityStatus) query;
   get_min_icusd_amount : () -> (nat64) query;
-  get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
+  get_protocol_3usd_reserves : () -> (nat64) query;
   get_protocol_config : () -> (ProtocolConfig) query;
+  get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
   get_protocol_status : () -> (ProtocolStatus) query;
   get_recovery_cr_multiplier : () -> (float64) query;
   get_recovery_target_cr : () -> (float64) query;
   get_redemption_fee_ceiling : () -> (float64) query;
   get_redemption_fee_floor : () -> (float64) query;
   get_redemption_rate : () -> (float64) query;
+  get_redemption_tier : (principal) -> (Result_6) query;
   get_reserve_balances : () -> (vec ReserveBalance) query;
   get_reserve_redemption_fee : () -> (float64) query;
   get_reserve_redemptions_enabled : () -> (bool) query;
-  get_icpswap_routing_enabled : () -> (bool) query;
   get_rmr_ceiling : () -> (float64) query;
   get_rmr_ceiling_cr : () -> (float64) query;
   get_rmr_floor : () -> (float64) query;
   get_rmr_floor_cr : () -> (float64) query;
   get_snapshot_count : () -> (nat64) query;
+  get_sp_writedown_disabled : () -> (bool) query;
   get_stability_pool_config : () -> (StabilityPoolConfig) query;
   get_stability_pool_principal : () -> (opt principal) query;
   get_stable_token_enabled : (StableTokenType) -> (bool) query;
@@ -740,31 +770,31 @@ service : (ProtocolArg) -> {
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
   get_vault_history : (nat64) -> (vec Event) query;
-  get_vault_interest_rate : (nat64) -> (Result_5) query;
+  get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
-  coingecko_transform : (record { response : record { status : nat; headers : vec record { name : text; value : text }; body : blob }; context : blob }) -> (record { status : nat; headers : vec record { name : text; value : text }; body : blob }) query;
-  http_request : (HttpRequest) -> (HttpResponse) query;
+  http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
-  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_6);
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;
-  liquidate_vault : (nat64) -> (Result_2);
-  liquidate_vault_partial : (VaultArg) -> (Result_2);
-  liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_2);
-  open_vault : (nat64, opt principal) -> (Result_7);
-  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_7);
-  open_vault_with_deposit : (nat64, opt principal) -> (Result_7);
-  partial_liquidate_vault : (VaultArg) -> (Result_2);
+  liquidate_vault : (nat64) -> (Result_3);
+  liquidate_vault_partial : (VaultArg) -> (Result_3);
+  liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
+  open_vault : (nat64, opt principal) -> (Result_9);
+  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_9);
+  open_vault_with_deposit : (nat64, opt principal) -> (Result_9);
+  partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  recover_pending_transfer : (nat64) -> (Result_8);
-  redeem_collateral : (principal, nat64) -> (Result_2);
-  redeem_icp : (nat64) -> (Result_2);
-  redeem_reserves : (nat64, opt principal) -> (Result_9);
+  recover_pending_transfer : (nat64) -> (Result_10);
+  redeem_collateral : (principal, nat64) -> (Result_3);
+  redeem_icp : (nat64) -> (Result_3);
+  redeem_reserves : (nat64, opt principal) -> (Result_11);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
   set_borrowing_fee : (float64) -> (Result);
   set_borrowing_fee_curve : (opt text) -> (Result);
+  set_bot_allowed_collateral_types : (vec principal) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
   set_collateral_borrow_threshold : (principal, float64) -> (Result);
   set_collateral_borrowing_fee : (principal, float64) -> (Result);
@@ -780,13 +810,15 @@ service : (ProtocolArg) -> {
   set_collateral_status : (principal, CollateralStatus) -> (Result);
   set_global_icusd_mint_cap : (nat64) -> (Result);
   set_healthy_cr : (principal, opt float64) -> (Result);
+  set_icpswap_routing_enabled : (bool) -> (Result);
   set_interest_flush_threshold : (nat64) -> (Result);
   set_interest_pool_share : (float64) -> (Result);
   set_interest_rate : (principal, float64) -> (Result);
   set_interest_split : (vec InterestSplitArg) -> (Result);
   set_liquidation_bonus : (float64) -> (Result);
-  set_bot_allowed_collateral_types : (vec principal) -> (Result);
   set_liquidation_bot_config : (principal, nat64) -> (Result);
+  set_liquidation_frozen : (bool) -> (Result);
+  set_liquidation_ordering_tolerance : (nat64) -> (Result);
   set_liquidation_protocol_share : (float64) -> (Result);
   set_lst_haircut : (principal, float64) -> (Result);
   set_min_icusd_amount : (nat64) -> (Result);
@@ -800,24 +832,33 @@ service : (ProtocolArg) -> {
   set_redemption_fee_ceiling : (float64) -> (Result);
   set_redemption_fee_floor : (float64) -> (Result);
   set_redemption_tier : (principal, nat8) -> (Result);
-  get_redemption_tier : (principal) -> (Result_12) query;
   set_reserve_redemption_fee : (float64) -> (Result);
   set_reserve_redemptions_enabled : (bool) -> (Result);
-  set_icpswap_routing_enabled : (bool) -> (Result);
   set_rmr_ceiling : (float64) -> (Result);
   set_rmr_ceiling_cr : (float64) -> (Result);
   set_rmr_floor : (float64) -> (Result);
   set_rmr_floor_cr : (float64) -> (Result);
+  set_sp_writedown_disabled : (bool) -> (Result);
   set_stability_pool_principal : (principal) -> (Result);
   set_stable_ledger_principal : (StableTokenType, principal) -> (Result);
   set_stable_token_enabled : (StableTokenType, bool) -> (Result);
   set_three_pool_canister : (principal) -> (Result);
   set_treasury_principal : (principal) -> (Result);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_10);
-  stability_pool_liquidate_debt_burned : (nat64, nat64) -> (Result_10);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_12);
+  stability_pool_liquidate_debt_burned : (
+      nat64,
+      nat64,
+      SpWritedownProof,
+    ) -> (Result_12);
+  stability_pool_liquidate_with_reserves : (
+      nat64,
+      nat64,
+      nat64,
+      principal,
+    ) -> (Result_12);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
-  withdraw_and_close_vault : (nat64) -> (Result_4);
+  withdraw_and_close_vault : (nat64) -> (Result_5);
   withdraw_collateral : (nat64) -> (Result_1);
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -58,6 +58,7 @@ export interface CollateralConfig {
   'min_collateral_deposit' : bigint,
   'last_price' : [] | [number],
   'last_price_timestamp' : [] | [bigint],
+  'redemption_tier' : number,
   'redemption_fee_floor' : Uint8Array | number[],
   'borrow_threshold_ratio' : Uint8Array | number[],
   'ledger_fee' : bigint,
@@ -237,7 +238,6 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'icusd_amount' : bigint,
       'icusd_block_index' : bigint,
       'owner' : Principal,
-      'vault_impacts' : [] | [Array<VaultRedemptionImpact>],
       'timestamp' : [] | [bigint],
       'fee_amount' : bigint,
       'collateral_type' : [] | [Principal],
@@ -370,6 +370,7 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'liquidator_payment' : bigint,
       'vault_id' : bigint,
       'timestamp' : [] | [bigint],
+      'three_usd_reserves_e8s' : [] | [bigint],
       'liquidator' : [] | [Principal],
       'icp_to_liquidator' : bigint,
     }
@@ -528,6 +529,7 @@ export interface GetEventsFilteredResponse {
   'events' : Array<[bigint, Event]>,
 }
 export interface GetSnapshotsArg { 'start' : bigint, 'length' : bigint }
+export interface HttpHeader { 'value' : string, 'name' : string }
 export interface HttpRequest {
   'url' : string,
   'method' : string,
@@ -535,6 +537,11 @@ export interface HttpRequest {
   'headers' : Array<[string, string]>,
 }
 export interface HttpResponse {
+  'status' : bigint,
+  'body' : Uint8Array | number[],
+  'headers' : Array<HttpHeader>,
+}
+export interface HttpResponse_1 {
   'body' : Uint8Array | number[],
   'headers' : Array<[string, string]>,
   'status_code' : number,
@@ -646,11 +653,11 @@ export type ProtocolError = { 'GenericError' : string } |
   { 'TemporarilyUnavailable' : string } |
   { 'TransferError' : TransferError } |
   { 'AlreadyProcessing' : null } |
+  { 'NotLowestCR' : null } |
   { 'AnonymousCallerNotAllowed' : null } |
   { 'AmountTooLow' : { 'minimum_amount' : bigint } } |
   { 'TransferFromError' : [TransferFromError, bigint] } |
-  { 'CallerNotOwner' : null } |
-  { 'NotLowestCR' : null };
+  { 'CallerNotOwner' : null };
 export interface ProtocolSnapshot {
   'total_debt' : bigint,
   'collateral_snapshots' : Array<CollateralSnapshot>,
@@ -707,28 +714,35 @@ export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
   { 'Err' : ProtocolError };
-export type Result_10 = { 'Ok' : StabilityPoolLiquidationResult } |
+export type Result_10 = { 'Ok' : boolean } |
   { 'Err' : ProtocolError };
-export type Result_11 = { 'Ok' : string } |
+export type Result_11 = { 'Ok' : ReserveRedemptionResult } |
   { 'Err' : ProtocolError };
-export type Result_12 = { 'Ok' : number } |
+export type Result_12 = { 'Ok' : StabilityPoolLiquidationResult } |
   { 'Err' : ProtocolError };
-export type Result_2 = { 'Ok' : SuccessWithFee } |
+export type Result_2 = { 'Ok' : string } |
   { 'Err' : ProtocolError };
-export type Result_3 = { 'Ok' : BotLiquidationResult } |
+export type Result_3 = { 'Ok' : SuccessWithFee } |
   { 'Err' : ProtocolError };
-export type Result_4 = { 'Ok' : [] | [bigint] } |
+export type Result_4 = { 'Ok' : BotLiquidationResult } |
   { 'Err' : ProtocolError };
-export type Result_5 = { 'Ok' : number } |
+export type Result_5 = { 'Ok' : [] | [bigint] } |
   { 'Err' : ProtocolError };
-export type Result_6 = { 'Ok' : ConsentInfo } |
+export type Result_6 = { 'Ok' : number } |
+  { 'Err' : ProtocolError };
+export type Result_7 = { 'Ok' : number } |
+  { 'Err' : ProtocolError };
+export type Result_8 = { 'Ok' : ConsentInfo } |
   { 'Err' : Icrc21Error };
-export type Result_7 = { 'Ok' : OpenVaultSuccess } |
+export type Result_9 = { 'Ok' : OpenVaultSuccess } |
   { 'Err' : ProtocolError };
-export type Result_8 = { 'Ok' : boolean } |
-  { 'Err' : ProtocolError };
-export type Result_9 = { 'Ok' : ReserveRedemptionResult } |
-  { 'Err' : ProtocolError };
+export type SpProofLedger = { 'IcusdBurn' : null } |
+  { 'ThreePoolTransfer' : null };
+export interface SpWritedownProof {
+  'block_index' : bigint,
+  'ledger_kind' : SpProofLedger,
+  'vault_id_memo' : bigint,
+}
 export interface StabilityPoolConfig {
   'enabled' : boolean,
   'liquidation_discount' : bigint,
@@ -773,6 +787,10 @@ export type TransferFromError = {
   { 'CreatedInFuture' : { 'ledger_time' : bigint } } |
   { 'TooOld' : null } |
   { 'InsufficientFunds' : { 'balance' : bigint } };
+export interface TransformArgs {
+  'context' : Uint8Array | number[],
+  'response' : HttpResponse,
+}
 export interface TreasuryStats {
   'pending_treasury_collateral_entries' : bigint,
   'liquidation_protocol_share' : number,
@@ -789,6 +807,7 @@ export interface UpgradeArg {
 export interface Vault {
   'collateral_amount' : bigint,
   'owner' : Principal,
+  'bot_processing' : boolean,
   'vault_id' : bigint,
   'collateral_type' : Principal,
   'last_accrual_time' : bigint,
@@ -811,11 +830,6 @@ export interface VaultRedemption {
   'vault_id' : bigint,
   'collateral_seized' : bigint,
 }
-export interface VaultRedemptionImpact {
-  'vault_id' : bigint,
-  'collateral_seized' : bigint,
-  'debt_reduced' : bigint,
-}
 export type XrcAssetClass = { 'Cryptocurrency' : null } |
   { 'FiatCurrency' : null };
 export interface _SERVICE {
@@ -828,40 +842,19 @@ export interface _SERVICE {
   >,
   'admin_correct_vault_debts' : ActorMethod<
     [Array<VaultDebtCorrection>],
-    Result_11
+    Result_2
   >,
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
   'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
-  'borrow_from_vault' : ActorMethod<[VaultArg], Result_2>,
+  'borrow_from_vault' : ActorMethod<[VaultArg], Result_3>,
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,
-  'bot_claim_liquidation' : ActorMethod<[bigint], Result_3>,
+  'bot_claim_liquidation' : ActorMethod<[bigint], Result_4>,
   'bot_confirm_liquidation' : ActorMethod<[bigint], Result>,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
   'clear_stuck_operations' : ActorMethod<[[] | [Principal]], Result_1>,
-  'close_vault' : ActorMethod<[bigint], Result_4>,
-  'coingecko_transform' : ActorMethod<
-    [
-      {
-        'context' : Uint8Array | number[],
-        'response' : {
-          'status' : bigint,
-          'body' : Uint8Array | number[],
-          'headers' : Array<{ 'value' : string, 'name' : string }>,
-        },
-      },
-    ],
-    {
-      'status' : bigint,
-      'body' : Uint8Array | number[],
-      'headers' : Array<{ 'value' : string, 'name' : string }>,
-    }
-  >,
-  'dev_force_bot_liquidate' : ActorMethod<[bigint], Result_3>,
-  'dev_force_partial_bot_liquidate' : ActorMethod<[bigint], Result_3>,
-  'dev_set_collateral_price' : ActorMethod<[Principal, number], Result_11>,
-  'dev_test_cascade_liquidation' : ActorMethod<[bigint], Result_11>,
-  'dev_test_pool_only_liquidation' : ActorMethod<[bigint], Result_11>,
+  'close_vault' : ActorMethod<[bigint], Result_5>,
+  'coingecko_transform' : ActorMethod<[TransformArgs], HttpResponse>,
   'enter_recovery_mode' : ActorMethod<[], Result>,
   'exit_recovery_mode' : ActorMethod<[], Result>,
   'freeze_protocol' : ActorMethod<[], Result>,
@@ -872,6 +865,10 @@ export interface _SERVICE {
   'get_ckstable_repay_fee' : ActorMethod<[], number>,
   'get_collateral_config' : ActorMethod<[Principal], [] | [CollateralConfig]>,
   'get_collateral_totals' : ActorMethod<[], Array<CollateralTotals>>,
+  'get_consumed_writedown_proofs' : ActorMethod<
+    [],
+    Array<[SpProofLedger, bigint]>
+  >,
   'get_deposit_account' : ActorMethod<[[] | [Principal]], Account>,
   'get_event_count' : ActorMethod<[], bigint>,
   'get_events' : ActorMethod<[GetEventsArg], Array<Event>>,
@@ -887,9 +884,12 @@ export interface _SERVICE {
   'get_interest_split' : ActorMethod<[], Array<InterestSplitArg>>,
   'get_liquidatable_vaults' : ActorMethod<[], Array<CandidVault>>,
   'get_liquidation_bonus' : ActorMethod<[], number>,
+  'get_liquidation_frozen' : ActorMethod<[], boolean>,
+  'get_liquidation_ordering_tolerance_bps' : ActorMethod<[], bigint>,
   'get_liquidation_protocol_share' : ActorMethod<[], number>,
   'get_liquidity_status' : ActorMethod<[Principal], LiquidityStatus>,
   'get_min_icusd_amount' : ActorMethod<[], bigint>,
+  'get_protocol_3usd_reserves' : ActorMethod<[], bigint>,
   'get_protocol_config' : ActorMethod<[], ProtocolConfig>,
   'get_protocol_snapshots' : ActorMethod<
     [GetSnapshotsArg],
@@ -901,7 +901,7 @@ export interface _SERVICE {
   'get_redemption_fee_ceiling' : ActorMethod<[], number>,
   'get_redemption_fee_floor' : ActorMethod<[], number>,
   'get_redemption_rate' : ActorMethod<[], number>,
-  'get_redemption_tier' : ActorMethod<[Principal], Result_12>,
+  'get_redemption_tier' : ActorMethod<[Principal], Result_6>,
   'get_reserve_balances' : ActorMethod<[], Array<ReserveBalance>>,
   'get_reserve_redemption_fee' : ActorMethod<[], number>,
   'get_reserve_redemptions_enabled' : ActorMethod<[], boolean>,
@@ -910,6 +910,7 @@ export interface _SERVICE {
   'get_rmr_floor' : ActorMethod<[], number>,
   'get_rmr_floor_cr' : ActorMethod<[], number>,
   'get_snapshot_count' : ActorMethod<[], bigint>,
+  'get_sp_writedown_disabled' : ActorMethod<[], boolean>,
   'get_stability_pool_config' : ActorMethod<[], StabilityPoolConfig>,
   'get_stability_pool_principal' : ActorMethod<[], [] | [Principal]>,
   'get_stable_token_enabled' : ActorMethod<[StableTokenType], boolean>,
@@ -921,34 +922,34 @@ export interface _SERVICE {
   'get_treasury_principal' : ActorMethod<[], [] | [Principal]>,
   'get_treasury_stats' : ActorMethod<[], TreasuryStats>,
   'get_vault_history' : ActorMethod<[bigint], Array<Event>>,
-  'get_vault_interest_rate' : ActorMethod<[bigint], Result_5>,
+  'get_vault_interest_rate' : ActorMethod<[bigint], Result_7>,
   'get_vaults' : ActorMethod<[[] | [Principal]], Array<CandidVault>>,
-  'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,
   'icrc10_supported_standards' : ActorMethod<[], Array<StandardRecord>>,
   'icrc21_canister_call_consent_message' : ActorMethod<
     [ConsentMessageRequest],
-    Result_6
+    Result_8
   >,
   'icrc28_trusted_origins' : ActorMethod<[], Icrc28TrustedOriginsResponse>,
-  'liquidate_vault' : ActorMethod<[bigint], Result_2>,
-  'liquidate_vault_partial' : ActorMethod<[VaultArg], Result_2>,
+  'liquidate_vault' : ActorMethod<[bigint], Result_3>,
+  'liquidate_vault_partial' : ActorMethod<[VaultArg], Result_3>,
   'liquidate_vault_partial_with_stable' : ActorMethod<
     [VaultArgWithToken],
-    Result_2
+    Result_3
   >,
-  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_7>,
+  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
   'open_vault_and_borrow' : ActorMethod<
     [bigint, bigint, [] | [Principal]],
-    Result_7
+    Result_9
   >,
-  'open_vault_with_deposit' : ActorMethod<[bigint, [] | [Principal]], Result_7>,
-  'partial_liquidate_vault' : ActorMethod<[VaultArg], Result_2>,
+  'open_vault_with_deposit' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
+  'partial_liquidate_vault' : ActorMethod<[VaultArg], Result_3>,
   'partial_repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'provide_liquidity' : ActorMethod<[bigint], Result_1>,
-  'recover_pending_transfer' : ActorMethod<[bigint], Result_8>,
-  'redeem_collateral' : ActorMethod<[Principal, bigint], Result_2>,
-  'redeem_icp' : ActorMethod<[bigint], Result_2>,
-  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
+  'recover_pending_transfer' : ActorMethod<[bigint], Result_10>,
+  'redeem_collateral' : ActorMethod<[Principal, bigint], Result_3>,
+  'redeem_icp' : ActorMethod<[bigint], Result_3>,
+  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_11>,
   'repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'repay_to_vault_with_stable' : ActorMethod<[VaultArgWithToken], Result_1>,
   'reset_bot_budget' : ActorMethod<[bigint], Result>,
@@ -986,6 +987,8 @@ export interface _SERVICE {
   'set_interest_split' : ActorMethod<[Array<InterestSplitArg>], Result>,
   'set_liquidation_bonus' : ActorMethod<[number], Result>,
   'set_liquidation_bot_config' : ActorMethod<[Principal, bigint], Result>,
+  'set_liquidation_frozen' : ActorMethod<[boolean], Result>,
+  'set_liquidation_ordering_tolerance' : ActorMethod<[bigint], Result>,
   'set_liquidation_protocol_share' : ActorMethod<[number], Result>,
   'set_lst_haircut' : ActorMethod<[Principal, number], Result>,
   'set_min_icusd_amount' : ActorMethod<[bigint], Result>,
@@ -1009,6 +1012,7 @@ export interface _SERVICE {
   'set_rmr_ceiling_cr' : ActorMethod<[number], Result>,
   'set_rmr_floor' : ActorMethod<[number], Result>,
   'set_rmr_floor_cr' : ActorMethod<[number], Result>,
+  'set_sp_writedown_disabled' : ActorMethod<[boolean], Result>,
   'set_stability_pool_principal' : ActorMethod<[Principal], Result>,
   'set_stable_ledger_principal' : ActorMethod<
     [StableTokenType, Principal],
@@ -1017,17 +1021,21 @@ export interface _SERVICE {
   'set_stable_token_enabled' : ActorMethod<[StableTokenType, boolean], Result>,
   'set_three_pool_canister' : ActorMethod<[Principal], Result>,
   'set_treasury_principal' : ActorMethod<[Principal], Result>,
-  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_10>,
+  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_12>,
   'stability_pool_liquidate_debt_burned' : ActorMethod<
-    [bigint, bigint],
-    Result_10
+    [bigint, bigint, SpWritedownProof],
+    Result_12
+  >,
+  'stability_pool_liquidate_with_reserves' : ActorMethod<
+    [bigint, bigint, bigint, Principal],
+    Result_12
   >,
   'unfreeze_protocol' : ActorMethod<[], Result>,
   'update_collateral_config' : ActorMethod<
     [Principal, CollateralConfig],
     Result
   >,
-  'withdraw_and_close_vault' : ActorMethod<[bigint], Result_4>,
+  'withdraw_and_close_vault' : ActorMethod<[bigint], Result_5>,
   'withdraw_collateral' : ActorMethod<[bigint], Result_1>,
   'withdraw_liquidity' : ActorMethod<[bigint], Result_1>,
   'withdraw_partial_collateral' : ActorMethod<[VaultArg], Result_1>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -93,11 +93,11 @@ export const idlFactory = ({ IDL }) => {
     'TemporarilyUnavailable' : IDL.Text,
     'TransferError' : TransferError,
     'AlreadyProcessing' : IDL.Null,
+    'NotLowestCR' : IDL.Null,
     'AnonymousCallerNotAllowed' : IDL.Null,
     'AmountTooLow' : IDL.Record({ 'minimum_amount' : IDL.Nat64 }),
     'TransferFromError' : IDL.Tuple(TransferFromError, IDL.Nat64),
     'CallerNotOwner' : IDL.Null,
-    'NotLowestCR' : IDL.Null,
   });
   const Result = IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ProtocolError });
   const VaultArg = IDL.Record({ 'vault_id' : IDL.Nat64, 'amount' : IDL.Nat64 });
@@ -107,13 +107,13 @@ export const idlFactory = ({ IDL }) => {
     'vault_id' : IDL.Nat64,
     'correct_borrowed_e8s' : IDL.Nat64,
   });
-  const Result_11 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ProtocolError });
+  const Result_2 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ProtocolError });
   const SuccessWithFee = IDL.Record({
     'block_index' : IDL.Nat64,
     'fee_amount_paid' : IDL.Nat64,
     'collateral_amount_received' : IDL.Opt(IDL.Nat64),
   });
-  const Result_2 = IDL.Variant({
+  const Result_3 = IDL.Variant({
     'Ok' : SuccessWithFee,
     'Err' : ProtocolError,
   });
@@ -123,13 +123,23 @@ export const idlFactory = ({ IDL }) => {
     'vault_id' : IDL.Nat64,
     'debt_covered' : IDL.Nat64,
   });
-  const Result_3 = IDL.Variant({
+  const Result_4 = IDL.Variant({
     'Ok' : BotLiquidationResult,
     'Err' : ProtocolError,
   });
-  const Result_4 = IDL.Variant({
+  const Result_5 = IDL.Variant({
     'Ok' : IDL.Opt(IDL.Nat64),
     'Err' : ProtocolError,
+  });
+  const HttpHeader = IDL.Record({ 'value' : IDL.Text, 'name' : IDL.Text });
+  const HttpResponse = IDL.Record({
+    'status' : IDL.Nat,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HttpHeader),
+  });
+  const TransformArgs = IDL.Record({
+    'context' : IDL.Vec(IDL.Nat8),
+    'response' : HttpResponse,
   });
   const CandidVault = IDL.Record({
     'collateral_amount' : IDL.Nat64,
@@ -177,6 +187,7 @@ export const idlFactory = ({ IDL }) => {
     'min_collateral_deposit' : IDL.Nat64,
     'last_price' : IDL.Opt(IDL.Float64),
     'last_price_timestamp' : IDL.Opt(IDL.Nat64),
+    'redemption_tier' : IDL.Nat8,
     'redemption_fee_floor' : IDL.Vec(IDL.Nat8),
     'borrow_threshold_ratio' : IDL.Vec(IDL.Nat8),
     'ledger_fee' : IDL.Nat64,
@@ -198,6 +209,10 @@ export const idlFactory = ({ IDL }) => {
     'price' : IDL.Float64,
     'vault_count' : IDL.Nat64,
     'symbol' : IDL.Text,
+  });
+  const SpProofLedger = IDL.Variant({
+    'IcusdBurn' : IDL.Null,
+    'ThreePoolTransfer' : IDL.Null,
   });
   const Account = IDL.Record({
     'owner' : IDL.Principal,
@@ -242,16 +257,12 @@ export const idlFactory = ({ IDL }) => {
   const Vault = IDL.Record({
     'collateral_amount' : IDL.Nat64,
     'owner' : IDL.Principal,
+    'bot_processing' : IDL.Bool,
     'vault_id' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
     'last_accrual_time' : IDL.Nat64,
     'accrued_interest' : IDL.Nat64,
     'borrowed_icusd_amount' : IDL.Nat64,
-  });
-  const VaultRedemptionImpact = IDL.Record({
-    'vault_id' : IDL.Nat64,
-    'collateral_seized' : IDL.Nat64,
-    'debt_reduced' : IDL.Nat64,
   });
   const VaultRedemption = IDL.Record({
     'icusd_redeemed_e8s' : IDL.Nat64,
@@ -343,7 +354,6 @@ export const idlFactory = ({ IDL }) => {
       'icusd_amount' : IDL.Nat64,
       'icusd_block_index' : IDL.Nat64,
       'owner' : IDL.Principal,
-      'vault_impacts' : IDL.Opt(IDL.Vec(VaultRedemptionImpact)),
       'timestamp' : IDL.Opt(IDL.Nat64),
       'fee_amount' : IDL.Nat64,
       'collateral_type' : IDL.Opt(IDL.Principal),
@@ -445,6 +455,7 @@ export const idlFactory = ({ IDL }) => {
       'liquidator_payment' : IDL.Nat64,
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
+      'three_usd_reserves_e8s' : IDL.Opt(IDL.Nat64),
       'liquidator' : IDL.Opt(IDL.Principal),
       'icp_to_liquidator' : IDL.Nat64,
     }),
@@ -661,7 +672,7 @@ export const idlFactory = ({ IDL }) => {
     'global_icusd_mint_cap' : IDL.Nat64,
     'last_icp_rate' : IDL.Float64,
   });
-  const Result_12 = IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : ProtocolError });
+  const Result_6 = IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : ProtocolError });
   const ReserveBalance = IDL.Record({
     'balance' : IDL.Nat64,
     'ledger' : IDL.Principal,
@@ -681,14 +692,14 @@ export const idlFactory = ({ IDL }) => {
     'total_accrued_interest_system' : IDL.Nat64,
     'pending_interest_for_pools_total' : IDL.Nat64,
   });
-  const Result_5 = IDL.Variant({ 'Ok' : IDL.Float64, 'Err' : ProtocolError });
+  const Result_7 = IDL.Variant({ 'Ok' : IDL.Float64, 'Err' : ProtocolError });
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
     'method' : IDL.Text,
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
   });
-  const HttpResponse = IDL.Record({
+  const HttpResponse_1 = IDL.Record({
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     'status_code' : IDL.Nat16,
@@ -732,7 +743,7 @@ export const idlFactory = ({ IDL }) => {
     'UnsupportedCanisterCall' : ErrorInfo,
     'ConsentMessageUnavailable' : ErrorInfo,
   });
-  const Result_6 = IDL.Variant({ 'Ok' : ConsentInfo, 'Err' : Icrc21Error });
+  const Result_8 = IDL.Variant({ 'Ok' : ConsentInfo, 'Err' : Icrc21Error });
   const Icrc28TrustedOriginsResponse = IDL.Record({
     'trusted_origins' : IDL.Vec(IDL.Text),
   });
@@ -745,11 +756,11 @@ export const idlFactory = ({ IDL }) => {
     'block_index' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
   });
-  const Result_7 = IDL.Variant({
+  const Result_9 = IDL.Variant({
     'Ok' : OpenVaultSuccess,
     'Err' : ProtocolError,
   });
-  const Result_8 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
+  const Result_10 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
   const ReserveRedemptionResult = IDL.Record({
     'icusd_block_index' : IDL.Nat64,
     'stable_token_used' : IDL.Principal,
@@ -757,7 +768,7 @@ export const idlFactory = ({ IDL }) => {
     'fee_amount' : IDL.Nat64,
     'stable_amount_sent' : IDL.Nat64,
   });
-  const Result_9 = IDL.Variant({
+  const Result_11 = IDL.Variant({
     'Ok' : ReserveRedemptionResult,
     'Err' : ProtocolError,
   });
@@ -771,9 +782,14 @@ export const idlFactory = ({ IDL }) => {
     'collateral_type' : IDL.Text,
     'collateral_received' : IDL.Nat64,
   });
-  const Result_10 = IDL.Variant({
+  const Result_12 = IDL.Variant({
     'Ok' : StabilityPoolLiquidationResult,
     'Err' : ProtocolError,
+  });
+  const SpWritedownProof = IDL.Record({
+    'block_index' : IDL.Nat64,
+    'ledger_kind' : SpProofLedger,
+    'vault_id_memo' : IDL.Nat64,
   });
   return IDL.Service({
     'add_collateral_token' : IDL.Func([AddCollateralArg], [Result], []),
@@ -786,7 +802,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'admin_correct_vault_debts' : IDL.Func(
         [IDL.Vec(VaultDebtCorrection)],
-        [Result_11],
+        [Result_2],
         [],
       ),
     'admin_mint_icusd' : IDL.Func(
@@ -796,9 +812,9 @@ export const idlFactory = ({ IDL }) => {
       ),
     'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
-    'borrow_from_vault' : IDL.Func([VaultArg], [Result_2], []),
+    'borrow_from_vault' : IDL.Func([VaultArg], [Result_3], []),
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
-    'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_3], []),
+    'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_4], []),
     'bot_confirm_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
     'clear_stuck_operations' : IDL.Func(
@@ -806,40 +822,12 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
-    'close_vault' : IDL.Func([IDL.Nat64], [Result_4], []),
+    'close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'coingecko_transform' : IDL.Func(
-        [
-          IDL.Record({
-            'context' : IDL.Vec(IDL.Nat8),
-            'response' : IDL.Record({
-              'status' : IDL.Nat,
-              'body' : IDL.Vec(IDL.Nat8),
-              'headers' : IDL.Vec(
-                IDL.Record({ 'value' : IDL.Text, 'name' : IDL.Text })
-              ),
-            }),
-          }),
-        ],
-        [
-          IDL.Record({
-            'status' : IDL.Nat,
-            'body' : IDL.Vec(IDL.Nat8),
-            'headers' : IDL.Vec(
-              IDL.Record({ 'value' : IDL.Text, 'name' : IDL.Text })
-            ),
-          }),
-        ],
+        [TransformArgs],
+        [HttpResponse],
         ['query'],
       ),
-    'dev_force_bot_liquidate' : IDL.Func([IDL.Nat64], [Result_3], []),
-    'dev_force_partial_bot_liquidate' : IDL.Func([IDL.Nat64], [Result_3], []),
-    'dev_set_collateral_price' : IDL.Func(
-        [IDL.Principal, IDL.Float64],
-        [Result_11],
-        [],
-      ),
-    'dev_test_cascade_liquidation' : IDL.Func([IDL.Nat64], [Result_11], []),
-    'dev_test_pool_only_liquidation' : IDL.Func([IDL.Nat64], [Result_11], []),
     'enter_recovery_mode' : IDL.Func([], [Result], []),
     'exit_recovery_mode' : IDL.Func([], [Result], []),
     'freeze_protocol' : IDL.Func([], [Result], []),
@@ -860,6 +848,11 @@ export const idlFactory = ({ IDL }) => {
     'get_collateral_totals' : IDL.Func(
         [],
         [IDL.Vec(CollateralTotals)],
+        ['query'],
+      ),
+    'get_consumed_writedown_proofs' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(SpProofLedger, IDL.Nat64))],
         ['query'],
       ),
     'get_deposit_account' : IDL.Func(
@@ -886,6 +879,12 @@ export const idlFactory = ({ IDL }) => {
     'get_interest_split' : IDL.Func([], [IDL.Vec(InterestSplitArg)], ['query']),
     'get_liquidatable_vaults' : IDL.Func([], [IDL.Vec(CandidVault)], ['query']),
     'get_liquidation_bonus' : IDL.Func([], [IDL.Float64], ['query']),
+    'get_liquidation_frozen' : IDL.Func([], [IDL.Bool], ['query']),
+    'get_liquidation_ordering_tolerance_bps' : IDL.Func(
+        [],
+        [IDL.Nat64],
+        ['query'],
+      ),
     'get_liquidation_protocol_share' : IDL.Func([], [IDL.Float64], ['query']),
     'get_liquidity_status' : IDL.Func(
         [IDL.Principal],
@@ -893,6 +892,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_min_icusd_amount' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_protocol_3usd_reserves' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_protocol_config' : IDL.Func([], [ProtocolConfig], ['query']),
     'get_protocol_snapshots' : IDL.Func(
         [GetSnapshotsArg],
@@ -905,7 +905,7 @@ export const idlFactory = ({ IDL }) => {
     'get_redemption_fee_ceiling' : IDL.Func([], [IDL.Float64], ['query']),
     'get_redemption_fee_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_redemption_rate' : IDL.Func([], [IDL.Float64], ['query']),
-    'get_redemption_tier' : IDL.Func([IDL.Principal], [Result_12], ['query']),
+    'get_redemption_tier' : IDL.Func([IDL.Principal], [Result_6], ['query']),
     'get_reserve_balances' : IDL.Func([], [IDL.Vec(ReserveBalance)], ['query']),
     'get_reserve_redemption_fee' : IDL.Func([], [IDL.Float64], ['query']),
     'get_reserve_redemptions_enabled' : IDL.Func([], [IDL.Bool], ['query']),
@@ -914,6 +914,7 @@ export const idlFactory = ({ IDL }) => {
     'get_rmr_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor_cr' : IDL.Func([], [IDL.Float64], ['query']),
     'get_snapshot_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_sp_writedown_disabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_stability_pool_config' : IDL.Func(
         [],
         [StabilityPoolConfig],
@@ -946,13 +947,13 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_treasury_stats' : IDL.Func([], [TreasuryStats], ['query']),
     'get_vault_history' : IDL.Func([IDL.Nat64], [IDL.Vec(Event)], ['query']),
-    'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_5], ['query']),
+    'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_7], ['query']),
     'get_vaults' : IDL.Func(
         [IDL.Opt(IDL.Principal)],
         [IDL.Vec(CandidVault)],
         ['query'],
       ),
-    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse_1], ['query']),
     'icrc10_supported_standards' : IDL.Func(
         [],
         [IDL.Vec(StandardRecord)],
@@ -960,7 +961,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'icrc21_canister_call_consent_message' : IDL.Func(
         [ConsentMessageRequest],
-        [Result_6],
+        [Result_8],
         [],
       ),
     'icrc28_trusted_origins' : IDL.Func(
@@ -968,37 +969,37 @@ export const idlFactory = ({ IDL }) => {
         [Icrc28TrustedOriginsResponse],
         ['query'],
       ),
-    'liquidate_vault' : IDL.Func([IDL.Nat64], [Result_2], []),
-    'liquidate_vault_partial' : IDL.Func([VaultArg], [Result_2], []),
+    'liquidate_vault' : IDL.Func([IDL.Nat64], [Result_3], []),
+    'liquidate_vault_partial' : IDL.Func([VaultArg], [Result_3], []),
     'liquidate_vault_partial_with_stable' : IDL.Func(
         [VaultArgWithToken],
-        [Result_2],
+        [Result_3],
         [],
       ),
     'open_vault' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_7],
+        [Result_9],
         [],
       ),
     'open_vault_and_borrow' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_7],
+        [Result_9],
         [],
       ),
     'open_vault_with_deposit' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_7],
+        [Result_9],
         [],
       ),
-    'partial_liquidate_vault' : IDL.Func([VaultArg], [Result_2], []),
+    'partial_liquidate_vault' : IDL.Func([VaultArg], [Result_3], []),
     'partial_repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'provide_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
-    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_8], []),
-    'redeem_collateral' : IDL.Func([IDL.Principal, IDL.Nat64], [Result_2], []),
-    'redeem_icp' : IDL.Func([IDL.Nat64], [Result_2], []),
+    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_10], []),
+    'redeem_collateral' : IDL.Func([IDL.Principal, IDL.Nat64], [Result_3], []),
+    'redeem_icp' : IDL.Func([IDL.Nat64], [Result_3], []),
     'redeem_reserves' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_9],
+        [Result_11],
         [],
       ),
     'repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
@@ -1093,6 +1094,8 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'set_liquidation_frozen' : IDL.Func([IDL.Bool], [Result], []),
+    'set_liquidation_ordering_tolerance' : IDL.Func([IDL.Nat64], [Result], []),
     'set_liquidation_protocol_share' : IDL.Func([IDL.Float64], [Result], []),
     'set_lst_haircut' : IDL.Func([IDL.Principal, IDL.Float64], [Result], []),
     'set_min_icusd_amount' : IDL.Func([IDL.Nat64], [Result], []),
@@ -1122,6 +1125,7 @@ export const idlFactory = ({ IDL }) => {
     'set_rmr_ceiling_cr' : IDL.Func([IDL.Float64], [Result], []),
     'set_rmr_floor' : IDL.Func([IDL.Float64], [Result], []),
     'set_rmr_floor_cr' : IDL.Func([IDL.Float64], [Result], []),
+    'set_sp_writedown_disabled' : IDL.Func([IDL.Bool], [Result], []),
     'set_stability_pool_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_stable_ledger_principal' : IDL.Func(
         [StableTokenType, IDL.Principal],
@@ -1137,12 +1141,17 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Func([IDL.Principal], [Result], []),
     'stability_pool_liquidate' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
-        [Result_10],
+        [Result_12],
         [],
       ),
     'stability_pool_liquidate_debt_burned' : IDL.Func(
-        [IDL.Nat64, IDL.Nat64],
-        [Result_10],
+        [IDL.Nat64, IDL.Nat64, SpWritedownProof],
+        [Result_12],
+        [],
+      ),
+    'stability_pool_liquidate_with_reserves' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64, IDL.Nat64, IDL.Principal],
+        [Result_12],
         [],
       ),
     'unfreeze_protocol' : IDL.Func([], [Result], []),
@@ -1151,7 +1160,7 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
-    'withdraw_and_close_vault' : IDL.Func([IDL.Nat64], [Result_4], []),
+    'withdraw_and_close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'withdraw_collateral' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_partial_collateral' : IDL.Func([VaultArg], [Result_1], []),

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -185,6 +185,23 @@ type PoolEventType = variant {
   ClaimCollateral : record { collateral_ledger : principal; amount : nat64 };
   DepositAs3USD : record { token_ledger : principal; amount_in : nat64; lp_minted : nat64 };
   InterestReceived : record { token_ledger : principal; amount : nat64 };
+  OptOutCollateral : record { collateral_type : principal };
+  OptInCollateral : record { collateral_type : principal };
+  LiquidationNotification : record { vault_count : nat64 };
+  LiquidationExecuted : record {
+    vault_id : nat64;
+    stables_consumed_e8s : nat64;
+    collateral_gained : nat64;
+    collateral_type : principal;
+    success : bool;
+  };
+  StablecoinRegistered : record { ledger : principal; symbol : text };
+  CollateralRegistered : record { ledger : principal; symbol : text };
+  ConfigurationUpdated;
+  EmergencyPauseActivated;
+  OperationsResumed;
+  BalanceCorrected : record { user : principal; token_ledger : principal; new_amount : nat64 };
+  CollateralGainCorrected : record { user : principal; collateral_ledger : principal; new_amount : nat64 };
 };
 
 type PoolEvent = record {

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -100,8 +100,16 @@ export interface PoolEvent {
 export type PoolEventType = {
     'Withdraw' : { 'amount' : bigint, 'token_ledger' : Principal }
   } |
+  { 'OperationsResumed' : null } |
+  { 'CollateralRegistered' : { 'ledger' : Principal, 'symbol' : string } } |
+  { 'OptOutCollateral' : { 'collateral_type' : Principal } } |
+  { 'OptInCollateral' : { 'collateral_type' : Principal } } |
+  { 'StablecoinRegistered' : { 'ledger' : Principal, 'symbol' : string } } |
   { 'Deposit' : { 'amount' : bigint, 'token_ledger' : Principal } } |
   { 'InterestReceived' : { 'amount' : bigint, 'token_ledger' : Principal } } |
+  { 'ConfigurationUpdated' : null } |
+  { 'LiquidationNotification' : { 'vault_count' : bigint } } |
+  { 'EmergencyPauseActivated' : null } |
   {
     'DepositAs3USD' : {
       'amount_in' : bigint,
@@ -111,6 +119,29 @@ export type PoolEventType = {
   } |
   {
     'ClaimCollateral' : { 'collateral_ledger' : Principal, 'amount' : bigint }
+  } |
+  {
+    'LiquidationExecuted' : {
+      'stables_consumed_e8s' : bigint,
+      'vault_id' : bigint,
+      'collateral_gained' : bigint,
+      'success' : boolean,
+      'collateral_type' : Principal,
+    }
+  } |
+  {
+    'CollateralGainCorrected' : {
+      'user' : Principal,
+      'new_amount' : bigint,
+      'collateral_ledger' : Principal,
+    }
+  } |
+  {
+    'BalanceCorrected' : {
+      'user' : Principal,
+      'new_amount' : bigint,
+      'token_ledger' : Principal,
+    }
   };
 export interface PoolLiquidationRecord {
   'collateral_price_e8s' : [] | [bigint],

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -52,6 +52,17 @@ export const idlFactory = ({ IDL }) => {
       'amount' : IDL.Nat64,
       'token_ledger' : IDL.Principal,
     }),
+    'OperationsResumed' : IDL.Null,
+    'CollateralRegistered' : IDL.Record({
+      'ledger' : IDL.Principal,
+      'symbol' : IDL.Text,
+    }),
+    'OptOutCollateral' : IDL.Record({ 'collateral_type' : IDL.Principal }),
+    'OptInCollateral' : IDL.Record({ 'collateral_type' : IDL.Principal }),
+    'StablecoinRegistered' : IDL.Record({
+      'ledger' : IDL.Principal,
+      'symbol' : IDL.Text,
+    }),
     'Deposit' : IDL.Record({
       'amount' : IDL.Nat64,
       'token_ledger' : IDL.Principal,
@@ -60,6 +71,9 @@ export const idlFactory = ({ IDL }) => {
       'amount' : IDL.Nat64,
       'token_ledger' : IDL.Principal,
     }),
+    'ConfigurationUpdated' : IDL.Null,
+    'LiquidationNotification' : IDL.Record({ 'vault_count' : IDL.Nat64 }),
+    'EmergencyPauseActivated' : IDL.Null,
     'DepositAs3USD' : IDL.Record({
       'amount_in' : IDL.Nat64,
       'lp_minted' : IDL.Nat64,
@@ -69,42 +83,22 @@ export const idlFactory = ({ IDL }) => {
       'collateral_ledger' : IDL.Principal,
       'amount' : IDL.Nat64,
     }),
-    'OptOutCollateral' : IDL.Record({
-      'collateral_type' : IDL.Principal,
-    }),
-    'OptInCollateral' : IDL.Record({
-      'collateral_type' : IDL.Principal,
-    }),
-    'LiquidationNotification' : IDL.Record({
-      'vault_count' : IDL.Nat64,
-    }),
     'LiquidationExecuted' : IDL.Record({
-      'vault_id' : IDL.Nat64,
       'stables_consumed_e8s' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
       'collateral_gained' : IDL.Nat64,
-      'collateral_type' : IDL.Principal,
       'success' : IDL.Bool,
-    }),
-    'StablecoinRegistered' : IDL.Record({
-      'ledger' : IDL.Principal,
-      'symbol' : IDL.Text,
-    }),
-    'CollateralRegistered' : IDL.Record({
-      'ledger' : IDL.Principal,
-      'symbol' : IDL.Text,
-    }),
-    'ConfigurationUpdated' : IDL.Null,
-    'EmergencyPauseActivated' : IDL.Null,
-    'OperationsResumed' : IDL.Null,
-    'BalanceCorrected' : IDL.Record({
-      'user' : IDL.Principal,
-      'token_ledger' : IDL.Principal,
-      'new_amount' : IDL.Nat64,
+      'collateral_type' : IDL.Principal,
     }),
     'CollateralGainCorrected' : IDL.Record({
       'user' : IDL.Principal,
-      'collateral_ledger' : IDL.Principal,
       'new_amount' : IDL.Nat64,
+      'collateral_ledger' : IDL.Principal,
+    }),
+    'BalanceCorrected' : IDL.Record({
+      'user' : IDL.Principal,
+      'new_amount' : IDL.Nat64,
+      'token_ledger' : IDL.Principal,
     }),
   });
   const PoolEvent = IDL.Record({

--- a/src/declarations/rumi_treasury/rumi_treasury.did
+++ b/src/declarations/rumi_treasury/rumi_treasury.did
@@ -2,13 +2,15 @@ type AssetType = variant {
   ICUSD;
   ICP;
   CKBTC;
+  CKUSDT;
+  CKUSDC;
 };
 
 type DepositType = variant {
-  MintingFee;
+  BorrowingFee;
   RedemptionFee;
-  LiquidationSurplus;
-  StabilityFee;
+  LiquidationFee;
+  InterestRevenue;
 };
 
 type AssetBalance = record {
@@ -39,6 +41,8 @@ type TreasuryInitArgs = record {
   icusd_ledger: principal;
   icp_ledger: principal;
   ckbtc_ledger: opt principal;
+  ckusdt_ledger: opt principal;
+  ckusdc_ledger: opt principal;
 };
 
 type DepositArgs = record {
@@ -62,11 +66,25 @@ type WithdrawResult = record {
   fee: nat64;
 };
 
+type TreasuryAction = variant {
+  Deposit : record { deposit_type : DepositType; asset_type : AssetType; amount : nat64 };
+  Withdraw : record { asset_type : AssetType; amount : nat64; to : principal };
+  SetPaused : record { paused : bool };
+};
+
+type TreasuryEvent = record {
+  id : nat64;
+  timestamp : nat64;
+  caller : principal;
+  action : TreasuryAction;
+};
+
 service : (TreasuryInitArgs) -> {
   deposit: (DepositArgs) -> (variant { Ok : nat64; Err : text });
   withdraw: (WithdrawArgs) -> (variant { Ok : WithdrawResult; Err : text });
   get_status: () -> (TreasuryStatus) query;
   get_deposits: (opt nat64, opt nat64) -> (vec DepositRecord) query;
-  set_controller: (principal) -> (variant { Ok; Err : text });
+  get_events: (opt nat64, opt nat64) -> (vec TreasuryEvent) query;
+  get_event_count: () -> (nat64) query;
   set_paused: (bool) -> (variant { Ok; Err : text });
 }

--- a/src/declarations/rumi_treasury/rumi_treasury.did.d.ts
+++ b/src/declarations/rumi_treasury/rumi_treasury.did.d.ts
@@ -8,6 +8,8 @@ export interface AssetBalance {
   'available' : bigint,
 }
 export type AssetType = { 'ICP' : null } |
+  { 'CKUSDC' : null } |
+  { 'CKUSDT' : null } |
   { 'ICUSD' : null } |
   { 'CKBTC' : null };
 export interface DepositArgs {
@@ -26,12 +28,35 @@ export interface DepositRecord {
   'timestamp' : bigint,
   'amount' : bigint,
 }
-export type DepositType = { 'RedemptionFee' : null } |
-  { 'MintingFee' : null } |
-  { 'StabilityFee' : null } |
-  { 'LiquidationSurplus' : null };
+export type DepositType = { 'BorrowingFee' : null } |
+  { 'LiquidationFee' : null } |
+  { 'RedemptionFee' : null } |
+  { 'InterestRevenue' : null };
+export type TreasuryAction = {
+    'Withdraw' : {
+      'to' : Principal,
+      'asset_type' : AssetType,
+      'amount' : bigint,
+    }
+  } |
+  {
+    'Deposit' : {
+      'asset_type' : AssetType,
+      'deposit_type' : DepositType,
+      'amount' : bigint,
+    }
+  } |
+  { 'SetPaused' : { 'paused' : boolean } };
+export interface TreasuryEvent {
+  'id' : bigint,
+  'action' : TreasuryAction,
+  'timestamp' : bigint,
+  'caller' : Principal,
+}
 export interface TreasuryInitArgs {
   'controller' : Principal,
+  'ckusdt_ledger' : [] | [Principal],
+  'ckusdc_ledger' : [] | [Principal],
   'icp_ledger' : Principal,
   'ckbtc_ledger' : [] | [Principal],
   'icusd_ledger' : Principal,
@@ -63,12 +88,12 @@ export interface _SERVICE {
     [[] | [bigint], [] | [bigint]],
     Array<DepositRecord>
   >,
-  'get_status' : ActorMethod<[], TreasuryStatus>,
-  'set_controller' : ActorMethod<
-    [Principal],
-    { 'Ok' : null } |
-      { 'Err' : string }
+  'get_event_count' : ActorMethod<[], bigint>,
+  'get_events' : ActorMethod<
+    [[] | [bigint], [] | [bigint]],
+    Array<TreasuryEvent>
   >,
+  'get_status' : ActorMethod<[], TreasuryStatus>,
   'set_paused' : ActorMethod<[boolean], { 'Ok' : null } | { 'Err' : string }>,
   'withdraw' : ActorMethod<
     [WithdrawArgs],

--- a/src/declarations/rumi_treasury/rumi_treasury.did.js
+++ b/src/declarations/rumi_treasury/rumi_treasury.did.js
@@ -1,20 +1,24 @@
 export const idlFactory = ({ IDL }) => {
   const TreasuryInitArgs = IDL.Record({
     'controller' : IDL.Principal,
+    'ckusdt_ledger' : IDL.Opt(IDL.Principal),
+    'ckusdc_ledger' : IDL.Opt(IDL.Principal),
     'icp_ledger' : IDL.Principal,
     'ckbtc_ledger' : IDL.Opt(IDL.Principal),
     'icusd_ledger' : IDL.Principal,
   });
   const AssetType = IDL.Variant({
     'ICP' : IDL.Null,
+    'CKUSDC' : IDL.Null,
+    'CKUSDT' : IDL.Null,
     'ICUSD' : IDL.Null,
     'CKBTC' : IDL.Null,
   });
   const DepositType = IDL.Variant({
+    'BorrowingFee' : IDL.Null,
+    'LiquidationFee' : IDL.Null,
     'RedemptionFee' : IDL.Null,
-    'MintingFee' : IDL.Null,
-    'StabilityFee' : IDL.Null,
-    'LiquidationSurplus' : IDL.Null,
+    'InterestRevenue' : IDL.Null,
   });
   const DepositArgs = IDL.Record({
     'asset_type' : AssetType,
@@ -31,6 +35,25 @@ export const idlFactory = ({ IDL }) => {
     'memo' : IDL.Opt(IDL.Text),
     'timestamp' : IDL.Nat64,
     'amount' : IDL.Nat64,
+  });
+  const TreasuryAction = IDL.Variant({
+    'Withdraw' : IDL.Record({
+      'to' : IDL.Principal,
+      'asset_type' : AssetType,
+      'amount' : IDL.Nat64,
+    }),
+    'Deposit' : IDL.Record({
+      'asset_type' : AssetType,
+      'deposit_type' : DepositType,
+      'amount' : IDL.Nat64,
+    }),
+    'SetPaused' : IDL.Record({ 'paused' : IDL.Bool }),
+  });
+  const TreasuryEvent = IDL.Record({
+    'id' : IDL.Nat64,
+    'action' : TreasuryAction,
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Principal,
   });
   const AssetBalance = IDL.Record({
     'total' : IDL.Nat64,
@@ -65,12 +88,13 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(DepositRecord)],
         ['query'],
       ),
-    'get_status' : IDL.Func([], [TreasuryStatus], ['query']),
-    'set_controller' : IDL.Func(
-        [IDL.Principal],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
-        [],
+    'get_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_events' : IDL.Func(
+        [IDL.Opt(IDL.Nat64), IDL.Opt(IDL.Nat64)],
+        [IDL.Vec(TreasuryEvent)],
+        ['query'],
       ),
+    'get_status' : IDL.Func([], [TreasuryStatus], ['query']),
     'set_paused' : IDL.Func(
         [IDL.Bool],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
@@ -86,6 +110,8 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
   const TreasuryInitArgs = IDL.Record({
     'controller' : IDL.Principal,
+    'ckusdt_ledger' : IDL.Opt(IDL.Principal),
+    'ckusdc_ledger' : IDL.Opt(IDL.Principal),
     'icp_ledger' : IDL.Principal,
     'ckbtc_ledger' : IDL.Opt(IDL.Principal),
     'icusd_ledger' : IDL.Principal,

--- a/src/rumi_analytics/src/collectors/rollups.rs
+++ b/src/rumi_analytics/src/collectors/rollups.rs
@@ -104,21 +104,29 @@ fn rollup_fees(now: u64, day_start: u64) {
     let swap_fees: u64 = swap_events.iter().map(|e| e.fee).sum();
     let mut borrow_count: u32 = 0;
     let mut redemption_count: u32 = 0;
+    let mut borrow_fees: u64 = 0;
+    let mut redemption_fees: u64 = 0;
 
     for e in &vault_events {
         match e.event_kind {
-            VaultEventKind::Borrowed => borrow_count += 1,
-            VaultEventKind::Redeemed => redemption_count += 1,
+            VaultEventKind::Borrowed => {
+                borrow_count += 1;
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+            }
+            VaultEventKind::Redeemed => {
+                redemption_count += 1;
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+            }
             _ => {}
         }
     }
 
     rollups::daily_fees::push(rollups::DailyFeeRollup {
         timestamp_ns: now,
-        borrowing_fees_e8s: None,
+        borrowing_fees_e8s: Some(borrow_fees),
         borrow_count,
         swap_fees_e8s: swap_fees,
-        redemption_fees_e8s: None,
+        redemption_fees_e8s: Some(redemption_fees),
         redemption_count,
     });
 }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -204,6 +204,7 @@ fn get_collector_health() -> types::CollectorHealth {
         (cursors::CURSOR_ID_3POOL_LIQUIDITY, "3pool_liquidity", cursors::three_pool_liquidity::get),
         (cursors::CURSOR_ID_3POOL_BLOCKS, "3pool_blocks", cursors::three_pool_blocks::get),
         (cursors::CURSOR_ID_AMM_SWAPS, "amm_swaps", cursors::amm_swaps::get),
+        (cursors::CURSOR_ID_STABILITY_EVENTS, "stability_events", cursors::stability_events::get),
         (cursors::CURSOR_ID_ICUSD_BLOCKS, "icusd_blocks", cursors::icusd_blocks::get),
     ];
 

--- a/src/rumi_analytics/src/queries/address_value.rs
+++ b/src/rumi_analytics/src/queries/address_value.rs
@@ -689,6 +689,7 @@ mod tests {
             event_kind: kind,
             collateral_type: coll_type,
             amount,
+            fee_amount: 0,
         }
     }
     fn liq_event(vault_id: u64, ts: u64, kind: LiquidationKind, coll_amount: u64) -> AnalyticsLiquidationEvent {

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -1321,6 +1321,7 @@ mod tests {
             event_kind: kind,
             collateral_type: Principal::anonymous(),
             amount,
+            fee_amount: 0,
         }
     }
 

--- a/src/rumi_analytics/src/sources/stability_pool.rs
+++ b/src/rumi_analytics/src/sources/stability_pool.rs
@@ -35,22 +35,41 @@ pub async fn get_pool_status(
 
 // --- Event tailing (Phase 4) ---
 
-/// Shadow type for `PoolEventType` from rumi_stability_pool.did.
-/// We enumerate every variant so Candid deserialization succeeds for all
-/// event types. Variants we process have their fields decoded; others use
-/// empty structs (Candid skips extra record fields on the source side).
+/// Shadow type for `PoolEventType` from rumi_stability_pool. The Candid
+/// service .did file lists only 5 variants but the actual Rust enum (in
+/// `src/stability_pool/src/types.rs`) has 16. The wire format includes all
+/// 16, so this shadow MUST enumerate every one or `Vec<PoolEvent>` decoding
+/// fails the moment any non-listed variant appears. We tail Deposit /
+/// Withdraw / DepositAs3USD / ClaimCollateral; everything else gets matched
+/// exhaustively but routed through a no-op skip (see route_sp_event).
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum PoolEventType {
-    #[serde(rename = "Deposit")]
     Deposit { token_ledger: Principal, amount: u64 },
-    #[serde(rename = "Withdraw")]
     Withdraw { token_ledger: Principal, amount: u64 },
-    #[serde(rename = "ClaimCollateral")]
     ClaimCollateral { collateral_ledger: Principal, amount: u64 },
-    #[serde(rename = "DepositAs3USD")]
     DepositAs3USD { token_ledger: Principal, amount_in: u64, lp_minted: u64 },
-    #[serde(rename = "InterestReceived")]
     InterestReceived { token_ledger: Principal, amount: u64 },
+    OptOutCollateral { collateral_type: Principal },
+    OptInCollateral { collateral_type: Principal },
+    LiquidationNotification { vault_count: u64 },
+    LiquidationExecuted {
+        vault_id: u64,
+        stables_consumed_e8s: u64,
+        collateral_gained: u64,
+        collateral_type: Principal,
+        success: bool,
+    },
+    StablecoinRegistered { ledger: Principal, symbol: String },
+    CollateralRegistered { ledger: Principal, symbol: String },
+    ConfigurationUpdated,
+    EmergencyPauseActivated,
+    OperationsResumed,
+    BalanceCorrected { user: Principal, token_ledger: Principal, new_amount: u64 },
+    CollateralGainCorrected {
+        user: Principal,
+        collateral_ledger: Principal,
+        new_amount: u64,
+    },
 }
 
 /// Shadow type for `PoolEvent` from rumi_stability_pool.did.

--- a/src/rumi_analytics/src/sources/stability_pool.rs
+++ b/src/rumi_analytics/src/sources/stability_pool.rs
@@ -32,3 +32,46 @@ pub async fn get_pool_status(
         Err((code, msg)) => Err(format!("get_pool_status: {:?} {}", code, msg)),
     }
 }
+
+// --- Event tailing (Phase 4) ---
+
+/// Shadow type for `PoolEventType` from rumi_stability_pool.did.
+/// We enumerate every variant so Candid deserialization succeeds for all
+/// event types. Variants we process have their fields decoded; others use
+/// empty structs (Candid skips extra record fields on the source side).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum PoolEventType {
+    #[serde(rename = "Deposit")]
+    Deposit { token_ledger: Principal, amount: u64 },
+    #[serde(rename = "Withdraw")]
+    Withdraw { token_ledger: Principal, amount: u64 },
+    #[serde(rename = "ClaimCollateral")]
+    ClaimCollateral { collateral_ledger: Principal, amount: u64 },
+    #[serde(rename = "DepositAs3USD")]
+    DepositAs3USD { token_ledger: Principal, amount_in: u64, lp_minted: u64 },
+    #[serde(rename = "InterestReceived")]
+    InterestReceived { token_ledger: Principal, amount: u64 },
+}
+
+/// Shadow type for `PoolEvent` from rumi_stability_pool.did.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct PoolEvent {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub event_type: PoolEventType,
+}
+
+pub async fn get_pool_event_count(sp: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(sp, "get_pool_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_pool_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+
+pub async fn get_pool_events(sp: Principal, start: u64, length: u64) -> Result<Vec<PoolEvent>, String> {
+    let (events,): (Vec<PoolEvent>,) = ic_cdk::call(sp, "get_pool_events", (start, length))
+        .await
+        .map_err(|(code, msg)| format!("get_pool_events: {:?} {}", code, msg))?;
+    Ok(events)
+}

--- a/src/rumi_analytics/src/storage/cursors.rs
+++ b/src/rumi_analytics/src/storage/cursors.rs
@@ -7,7 +7,7 @@ use super::{Memory, get_memory};
 use super::{
     MEM_CURSOR_BACKEND_EVENTS, MEM_CURSOR_3POOL_SWAPS,
     MEM_CURSOR_3POOL_LIQUIDITY, MEM_CURSOR_3POOL_BLOCKS,
-    MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_ICUSD_BLOCKS,
+    MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_STABILITY_EVENTS, MEM_CURSOR_ICUSD_BLOCKS,
 };
 
 thread_local! {
@@ -31,6 +31,10 @@ thread_local! {
         StableCell::init(get_memory(MEM_CURSOR_AMM_SWAPS), 0u64)
             .expect("init cursor amm_swaps")
     );
+    static CURSOR_STABILITY_EVENTS: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_STABILITY_EVENTS), 0u64)
+            .expect("init cursor stability_events")
+    );
     static CURSOR_ICUSD_BLOCKS: RefCell<StableCell<u64, Memory>> = RefCell::new(
         StableCell::init(get_memory(MEM_CURSOR_ICUSD_BLOCKS), 0u64)
             .expect("init cursor icusd_blocks")
@@ -43,7 +47,7 @@ pub const CURSOR_ID_3POOL_SWAPS: u8 = 2;
 pub const CURSOR_ID_3POOL_LIQUIDITY: u8 = 3;
 pub const CURSOR_ID_3POOL_BLOCKS: u8 = 4;
 pub const CURSOR_ID_AMM_SWAPS: u8 = 5;
-// 6 = MEM_CURSOR_STABILITY_EVENTS, reserved for future stability pool event tailing
+pub const CURSOR_ID_STABILITY_EVENTS: u8 = 6;
 pub const CURSOR_ID_ICUSD_BLOCKS: u8 = 7;
 
 macro_rules! cursor_accessors {
@@ -65,4 +69,5 @@ cursor_accessors!(three_pool_swaps, CURSOR_3POOL_SWAPS);
 cursor_accessors!(three_pool_liquidity, CURSOR_3POOL_LIQUIDITY);
 cursor_accessors!(three_pool_blocks, CURSOR_3POOL_BLOCKS);
 cursor_accessors!(amm_swaps, CURSOR_AMM_SWAPS);
+cursor_accessors!(stability_events, CURSOR_STABILITY_EVENTS);
 cursor_accessors!(icusd_blocks, CURSOR_ICUSD_BLOCKS);

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -82,6 +82,11 @@ pub struct AnalyticsVaultEvent {
     pub event_kind: VaultEventKind,
     pub collateral_type: Principal,
     pub amount: u64,
+    /// Fee paid on this event in icUSD e8s. Populated for Borrowed and
+    /// Redeemed; zero for other event kinds. Older stored events default
+    /// to 0 via serde — we just won't have fee data for those.
+    #[serde(default)]
+    pub fee_amount: u64,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -311,6 +316,7 @@ mod tests {
             event_kind: VaultEventKind::Opened,
             collateral_type: Principal::anonymous(),
             amount: 10_000_000_000,
+            fee_amount: 0,
         };
         let bytes = evt.to_bytes();
         let decoded = AnalyticsVaultEvent::from_bytes(bytes);

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -84,7 +84,7 @@ pub struct AnalyticsVaultEvent {
     pub amount: u64,
     /// Fee paid on this event in icUSD e8s. Populated for Borrowed and
     /// Redeemed; zero for other event kinds. Older stored events default
-    /// to 0 via serde — we just won't have fee data for those.
+    /// to 0 via serde, so they simply lack fee data.
     #[serde(default)]
     pub fee_amount: u64,
 }

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -47,7 +47,6 @@ pub const MEM_CURSOR_3POOL_SWAPS: MemoryId = MemoryId::new(2);
 pub const MEM_CURSOR_3POOL_LIQUIDITY: MemoryId = MemoryId::new(3);
 pub const MEM_CURSOR_3POOL_BLOCKS: MemoryId = MemoryId::new(4);
 pub const MEM_CURSOR_AMM_SWAPS: MemoryId = MemoryId::new(5);
-#[allow(dead_code)]
 pub const MEM_CURSOR_STABILITY_EVENTS: MemoryId = MemoryId::new(6);
 pub const MEM_CURSOR_ICUSD_BLOCKS: MemoryId = MemoryId::new(7);
 

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -103,9 +103,10 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Opened,
                 collateral_type: vault.collateral_type,
                 amount: vault.collateral_amount,
+                fee_amount: 0,
             });
         }
-        BorrowFromVault { vault_id, borrowed_amount, caller, timestamp, .. } => {
+        BorrowFromVault { vault_id, borrowed_amount, fee_amount, caller, timestamp, .. } => {
             evt_vaults::push(AnalyticsVaultEvent {
                 timestamp_ns: timestamp.unwrap_or(0),
                 source_event_id: event_id,
@@ -114,6 +115,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Borrowed,
                 collateral_type: Principal::anonymous(),
                 amount: *borrowed_amount,
+                fee_amount: *fee_amount,
             });
         }
         RepayToVault { vault_id, repayed_amount, caller, timestamp, .. } => {
@@ -125,6 +127,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Repaid,
                 collateral_type: Principal::anonymous(),
                 amount: *repayed_amount,
+                fee_amount: 0,
             });
         }
         CollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
@@ -136,6 +139,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::CollateralWithdrawn,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
+                fee_amount: 0,
             });
         }
         PartialCollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
@@ -147,6 +151,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::PartialCollateralWithdrawn,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
+                fee_amount: 0,
             });
         }
         WithdrawAndCloseVault { vault_id, amount, caller, timestamp, .. } => {
@@ -158,6 +163,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::WithdrawAndClose,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
+                fee_amount: 0,
             });
         }
         VaultWithdrawnAndClosed { vault_id, timestamp, caller, amount } => {
@@ -169,6 +175,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Closed,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
+                fee_amount: 0,
             });
         }
         DustForgiven { vault_id, amount, timestamp } => {
@@ -180,9 +187,10 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::DustForgiven,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
+                fee_amount: 0,
             });
         }
-        RedemptionOnVaults { icusd_amount, owner, collateral_type, timestamp, .. } => {
+        RedemptionOnVaults { icusd_amount, fee_amount, owner, collateral_type, timestamp, .. } => {
             evt_vaults::push(AnalyticsVaultEvent {
                 timestamp_ns: timestamp.unwrap_or(0),
                 source_event_id: event_id,
@@ -191,6 +199,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Redeemed,
                 collateral_type: collateral_type.unwrap_or(Principal::anonymous()),
                 amount: *icusd_amount,
+                fee_amount: *fee_amount,
             });
         }
         ProvideLiquidity { amount, caller, timestamp } => {

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -202,6 +202,12 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 fee_amount: *fee_amount,
             });
         }
+        // Legacy: ProvideLiquidity / WithdrawLiquidity / ClaimLiquidityReturns
+        // were emitted by the protocol backend before the stability pool became
+        // its own canister. They preserve historical SP activity already in the
+        // backend event log. Future SP activity comes through the dedicated
+        // tailing::stability_pool tailer; backend never emits these variants
+        // anymore, so there's no double-source risk.
         ProvideLiquidity { amount, caller, timestamp } => {
             evt_stability::push(AnalyticsStabilityEvent {
                 timestamp_ns: timestamp.unwrap_or(0),

--- a/src/rumi_analytics/src/tailing/mod.rs
+++ b/src/rumi_analytics/src/tailing/mod.rs
@@ -6,6 +6,7 @@ pub mod three_pool_swaps;
 pub mod three_pool_liquidity;
 pub mod amm_swaps;
 pub mod icrc3;
+pub mod stability_pool;
 
 pub const BATCH_SIZE: u64 = 500;
 pub const BACKFILL_BATCH_SIZE: u64 = 1000;

--- a/src/rumi_analytics/src/tailing/stability_pool.rs
+++ b/src/rumi_analytics/src/tailing/stability_pool.rs
@@ -3,8 +3,21 @@
 //! Deposit / Withdraw / ClaimCollateral into evt_stability so the Top SP
 //! Depositors leaderboard and address-page SP timeline start working.
 //!
-//! The cursor starts at 0 on first deploy, so the first tail run backfills
-//! the full SP event history.
+//! The rumi_stability_pool canister keeps a ring buffer of at most 10,000
+//! events (MAX_POOL_EVENTS). When the buffer fills, oldest events are drained.
+//! get_pool_event_count() returns the current window size, not a lifetime
+//! monotonic count; get_pool_events(start, length) indexes by array position.
+//!
+//! To survive ring-buffer rotation we use an id-based cursor: the stored value
+//! is `last_seen_event_id + 1` (i.e. the lowest event.id we still want to
+//! ingest). event.id is set from the SP canister's monotonic next_event_id
+//! counter, so it is stable across buffer rotation. Saved value 0 means
+//! "never run; want id >= 0".
+//!
+//! Each tick we fetch the latest BATCH_SIZE events from the tail of the
+//! current window and filter by event.id >= next_wanted_id. If the SP
+//! produces more than BATCH_SIZE events in 60 seconds the oldest of those
+//! would be missed, but that rate (>500 SP events/min) is unrealistic.
 
 use crate::{sources, state, storage};
 use storage::cursors;
@@ -19,12 +32,13 @@ pub async fn run() {
         return;
     }
 
-    let cursor = cursors::stability_events::get();
+    // Cursor stores `last_seen_event_id + 1`. Value 0 = never run.
+    let next_wanted_id = cursors::stability_events::get();
 
     let count = match sources::stability_pool::get_pool_event_count(sp).await {
         Ok(c) => c,
         Err(e) => {
-            ic_cdk::println!("[tail_stability_pool] get_pool_event_count failed: {}", e);
+            ic_cdk::println!("[tail_sp] get_pool_event_count failed: {}", e);
             state::mutate_state(|s| {
                 s.error_counters.stability_pool += 1;
                 update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
@@ -37,13 +51,20 @@ pub async fn run() {
         update_cursor_source_count(s, cursors::CURSOR_ID_STABILITY_EVENTS, count);
     });
 
-    if count <= cursor { return; }
+    if count == 0 {
+        return;
+    }
 
-    let fetch_len = (count - cursor).min(BATCH_SIZE);
-    let events = match sources::stability_pool::get_pool_events(sp, cursor, fetch_len).await {
+    // Always fetch from the tail of the current window (at most BATCH_SIZE
+    // events). If new events arrived faster than one tick can process, the
+    // oldest ones may have already been rotated out — acceptable given the
+    // 60-second tick interval and a 10k ring buffer.
+    let start = count.saturating_sub(BATCH_SIZE);
+    let length = count - start;
+    let events = match sources::stability_pool::get_pool_events(sp, start, length).await {
         Ok(e) => e,
         Err(e) => {
-            ic_cdk::println!("[tail_stability_pool] get_pool_events failed: {}", e);
+            ic_cdk::println!("[tail_sp] get_pool_events failed: {}", e);
             state::mutate_state(|s| {
                 s.error_counters.stability_pool += 1;
                 update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
@@ -52,29 +73,39 @@ pub async fn run() {
         }
     };
 
+    // highest_id_seen starts one below next_wanted_id so that after the loop
+    // `highest_id_seen + 1` equals the correct new cursor value even when
+    // processed == 0.
+    let mut highest_id_seen = next_wanted_id.saturating_sub(1);
     let mut processed = 0u64;
-    for (i, event) in events.iter().enumerate() {
-        let event_id = cursor + i as u64;
-        route_sp_event(event_id, event);
+    for event in &events {
+        if event.id < next_wanted_id {
+            continue; // already ingested
+        }
+        route_sp_event(event);
+        if event.id > highest_id_seen {
+            highest_id_seen = event.id;
+        }
         processed += 1;
     }
 
     if processed > 0 {
-        cursors::stability_events::set(cursor + processed);
+        // Save `highest_id_seen + 1` so next tick filters out already-seen ids.
+        cursors::stability_events::set(highest_id_seen + 1);
         state::mutate_state(|s| {
             update_cursor_success(s, cursors::CURSOR_ID_STABILITY_EVENTS, ic_cdk::api::time());
         });
     }
 }
 
-fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
+fn route_sp_event(event: &sources::stability_pool::PoolEvent) {
     use sources::stability_pool::PoolEventType::*;
 
     match &event.event_type {
         Deposit { amount, .. } => {
             evt_stability::push(AnalyticsStabilityEvent {
                 timestamp_ns: event.timestamp,
-                source_event_id: event_id,
+                source_event_id: event.id,
                 caller: event.caller,
                 action: StabilityAction::Deposit,
                 amount: *amount,
@@ -83,7 +114,7 @@ fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
         DepositAs3USD { amount_in, .. } => {
             evt_stability::push(AnalyticsStabilityEvent {
                 timestamp_ns: event.timestamp,
-                source_event_id: event_id,
+                source_event_id: event.id,
                 caller: event.caller,
                 action: StabilityAction::Deposit,
                 amount: *amount_in,
@@ -92,7 +123,7 @@ fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
         Withdraw { amount, .. } => {
             evt_stability::push(AnalyticsStabilityEvent {
                 timestamp_ns: event.timestamp,
-                source_event_id: event_id,
+                source_event_id: event.id,
                 caller: event.caller,
                 action: StabilityAction::Withdraw,
                 amount: *amount,
@@ -101,7 +132,7 @@ fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
         ClaimCollateral { amount, .. } => {
             evt_stability::push(AnalyticsStabilityEvent {
                 timestamp_ns: event.timestamp,
-                source_event_id: event_id,
+                source_event_id: event.id,
                 caller: event.caller,
                 action: StabilityAction::ClaimReturns,
                 amount: *amount,

--- a/src/rumi_analytics/src/tailing/stability_pool.rs
+++ b/src/rumi_analytics/src/tailing/stability_pool.rs
@@ -1,0 +1,114 @@
+//! Stability-pool event tailing. Pulls events from rumi_stability_pool's
+//! own event log (get_pool_events / get_pool_event_count) and pushes
+//! Deposit / Withdraw / ClaimCollateral into evt_stability so the Top SP
+//! Depositors leaderboard and address-page SP timeline start working.
+//!
+//! The cursor starts at 0 on first deploy, so the first tail run backfills
+//! the full SP event history.
+
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+pub async fn run() {
+    let sp = state::read_state(|s| s.sources.stability_pool);
+
+    // Skip if not yet configured.
+    if sp == candid::Principal::anonymous() {
+        return;
+    }
+
+    let cursor = cursors::stability_events::get();
+
+    let count = match sources::stability_pool::get_pool_event_count(sp).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_stability_pool] get_pool_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.stability_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_STABILITY_EVENTS, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::stability_pool::get_pool_events(sp, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_stability_pool] get_pool_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.stability_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for (i, event) in events.iter().enumerate() {
+        let event_id = cursor + i as u64;
+        route_sp_event(event_id, event);
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::stability_events::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_STABILITY_EVENTS, ic_cdk::api::time());
+        });
+    }
+}
+
+fn route_sp_event(event_id: u64, event: &sources::stability_pool::PoolEvent) {
+    use sources::stability_pool::PoolEventType::*;
+
+    match &event.event_type {
+        Deposit { amount, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::Deposit,
+                amount: *amount,
+            });
+        }
+        DepositAs3USD { amount_in, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::Deposit,
+                amount: *amount_in,
+            });
+        }
+        Withdraw { amount, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::Withdraw,
+                amount: *amount,
+            });
+        }
+        ClaimCollateral { amount, .. } => {
+            evt_stability::push(AnalyticsStabilityEvent {
+                timestamp_ns: event.timestamp,
+                source_event_id: event_id,
+                caller: event.caller,
+                action: StabilityAction::ClaimReturns,
+                amount: *amount,
+            });
+        }
+        // InterestReceived is a protocol-internal credit, not a user action.
+        // Skip it silently — it doesn't affect the depositor leaderboard.
+        InterestReceived { .. } => {}
+    }
+}

--- a/src/rumi_analytics/src/tailing/stability_pool.rs
+++ b/src/rumi_analytics/src/tailing/stability_pool.rs
@@ -138,8 +138,22 @@ fn route_sp_event(event: &sources::stability_pool::PoolEvent) {
                 amount: *amount,
             });
         }
-        // InterestReceived is a protocol-internal credit, not a user action.
-        // Skip it silently — it doesn't affect the depositor leaderboard.
+        // Everything below is decoded so Vec<PoolEvent> deserialization
+        // succeeds, but skipped — none of these affect the depositor
+        // leaderboard. Listed exhaustively (rather than `_ => {}`) so adding
+        // a new variant on the SP side without updating analytics produces a
+        // compile error here, not a silent drop.
         InterestReceived { .. } => {}
+        OptOutCollateral { .. } => {}
+        OptInCollateral { .. } => {}
+        LiquidationNotification { .. } => {}
+        LiquidationExecuted { .. } => {}
+        StablecoinRegistered { .. } => {}
+        CollateralRegistered { .. } => {}
+        ConfigurationUpdated => {}
+        EmergencyPauseActivated => {}
+        OperationsResumed => {}
+        BalanceCorrected { .. } => {}
+        CollateralGainCorrected { .. } => {}
     }
 }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -49,6 +49,7 @@ async fn pull_cycle() {
         tailing::amm_swaps::run(),
         tailing::icrc3::tail_icusd_blocks(),
         tailing::icrc3::tail_3pool_blocks(),
+        tailing::stability_pool::run(),
     );
 
     // Update pull cycle timestamp

--- a/src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte
@@ -17,9 +17,9 @@
     }
   });
 
-  // Group setter labels by domain so the card has more visual structure
-  // than a flat list — most setters cluster around fees, RMR, recovery
-  // mode, and collateral parameters.
+  // Categorize setter labels by domain. Surfaced in the row tooltip so
+  // hovering tells you which area of the protocol a setter belongs to,
+  // without crowding the visible label cells.
   function groupOf(label: string): string {
     if (label.startsWith('SetCollateral')) return 'Collateral';
     if (label.startsWith('SetRmr') || label.startsWith('SetRedemption') || label.startsWith('SetReserve')) return 'Redemption';

--- a/src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/AdminBreakdownCard.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchAdminEventBreakdown } from '$lib/services/explorer/analyticsService';
+  import type { AdminEventLabelCount } from '$declarations/rumi_analytics/rumi_analytics.did';
+
+  let labels: AdminEventLabelCount[] = $state([]);
+  let loading = $state(true);
+
+  onMount(async () => {
+    try {
+      const resp = await fetchAdminEventBreakdown();
+      labels = resp.labels.slice().sort((a, b) => Number(b.count) - Number(a.count));
+    } catch (err) {
+      console.error('[AdminBreakdownCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  // Group setter labels by domain so the card has more visual structure
+  // than a flat list — most setters cluster around fees, RMR, recovery
+  // mode, and collateral parameters.
+  function groupOf(label: string): string {
+    if (label.startsWith('SetCollateral')) return 'Collateral';
+    if (label.startsWith('SetRmr') || label.startsWith('SetRedemption') || label.startsWith('SetReserve')) return 'Redemption';
+    if (label.startsWith('SetRecovery')) return 'Recovery';
+    if (label.includes('Fee') || label.includes('InterestRate') || label.includes('InterestSplit') || label.includes('InterestPoolShare')) return 'Fees & interest';
+    if (label === 'Init' || label === 'Upgrade') return 'Lifecycle';
+    if (label.includes('Bot')) return 'Bot';
+    return 'Other';
+  }
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Admin actions by label</h3>
+  <p class="text-xs text-gray-500 mb-3">Counts of each setter / lifecycle event the analytics canister has tailed.</p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if labels.length === 0}
+    <p class="text-sm text-gray-500 py-2">No admin actions recorded yet.</p>
+  {:else}
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
+      {#each labels as l (l.label)}
+        <a
+          href="/explorer/activity?type=admin&admin={encodeURIComponent(l.label)}"
+          class="flex items-baseline justify-between text-sm py-1 border-b border-white/[0.03] hover:bg-white/[0.02]"
+          title="{groupOf(l.label)} · click to filter"
+        >
+          <span class="text-gray-300 font-mono text-xs truncate mr-2">{l.label}</span>
+          <span class="tabular-nums text-gray-200 font-medium">{Number(l.count).toLocaleString()}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/CanisterInventoryCard.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { CANISTER_IDS, vault_frontend } from '$lib/config';
+  import EntityLink from './EntityLink.svelte';
+  import CopyButton from './CopyButton.svelte';
+
+  // Order: protocol core first, then DeFi, then ledgers, then frontends.
+  // Liquidation bot principal isn't in $lib/config; sourced from dfx.json.
+  type Row = { label: string; principal: string; role: string };
+  const LIQUIDATION_BOT = 'nygob-3qaaa-aaaap-qttcq-cai';
+
+  const rows: Row[] = [
+    { label: 'rumi_protocol_backend', principal: CANISTER_IDS.PROTOCOL, role: 'Core CDP engine' },
+    { label: 'rumi_treasury', principal: CANISTER_IDS.TREASURY, role: 'Treasury' },
+    { label: 'rumi_stability_pool', principal: CANISTER_IDS.STABILITY_POOL, role: 'Stability pool' },
+    { label: 'rumi_3pool', principal: CANISTER_IDS.THREEPOOL, role: 'Stableswap (3USD)' },
+    { label: 'rumi_amm', principal: CANISTER_IDS.RUMI_AMM, role: '3USD/ICP AMM' },
+    { label: 'rumi_analytics', principal: CANISTER_IDS.ANALYTICS, role: 'Analytics tailer' },
+    { label: 'liquidation_bot', principal: LIQUIDATION_BOT, role: 'Liquidations' },
+    { label: 'icusd_ledger', principal: CANISTER_IDS.ICUSD_LEDGER, role: 'icUSD ICRC-1/2 ledger' },
+    { label: 'vault_frontend', principal: vault_frontend, role: 'Explorer + dApp UI' },
+  ].filter((r) => r.principal);
+
+  function dashboardUrl(principal: string): string {
+    return `https://dashboard.internetcomputer.org/canister/${principal}`;
+  }
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Canister inventory</h3>
+  <p class="text-xs text-gray-500 mb-3">Every protocol canister with its principal ID. Dashboard link shows live cycles, controllers, and module hash.</p>
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b border-white/5">
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Canister</th>
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+        <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Principal</th>
+        <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Dashboard</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as r (r.principal)}
+        <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
+          <td class="py-2 px-2 font-mono text-xs text-gray-200">{r.label}</td>
+          <td class="py-2 px-2 text-gray-400">{r.role}</td>
+          <td class="py-2 px-2 font-mono text-xs">
+            <span class="inline-flex items-center gap-1">
+              <EntityLink type="canister" value={r.principal} />
+              <CopyButton text={r.principal} />
+            </span>
+          </td>
+          <td class="py-2 px-2 text-right">
+            <a href={dashboardUrl(r.principal)} target="_blank" rel="noopener" class="text-teal-400 hover:text-teal-300 text-xs">View ↗</a>
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/CeilingBar.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/CeilingBar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { formatCompact } from '$utils/explorerChartHelpers';
+
   interface Props {
     used: number;
     total: number;
@@ -8,7 +10,8 @@
   let { used, total, unlimited = false }: Props = $props();
 
   const pct = $derived(unlimited ? 0 : total > 0 ? Math.min((used / total) * 100, 100) : 0);
-  const label = $derived(unlimited ? 'No limit' : `${pct.toFixed(0)}%`);
+  // Show absolute ceiling next to bar — easier to reason about than just "7%".
+  const ceilingLabel = $derived(unlimited ? 'No limit' : formatCompact(total));
   const barColor = $derived(
     pct > 90 ? 'bg-pink-400' : pct > 70 ? 'bg-violet-400' : 'bg-teal-400'
   );
@@ -17,10 +20,10 @@
 {#if unlimited}
   <span class="text-xs text-gray-500">Unlimited</span>
 {:else}
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2" title="{used.toLocaleString(undefined, { maximumFractionDigits: 0 })} of {total.toLocaleString(undefined, { maximumFractionDigits: 0 })} icUSD ({pct.toFixed(0)}%)">
     <div class="fill-bar flex-1 min-w-[3rem]">
       <div class="fill-bar-inner {barColor}" style="width: {pct}%"></div>
     </div>
-    <span class="text-xs tabular-nums text-gray-400 w-8 text-right">{label}</span>
+    <span class="text-xs tabular-nums text-gray-400 w-12 text-right">{ceilingLabel}</span>
   </div>
 {/if}

--- a/src/vault_frontend/src/lib/components/explorer/CollateralTable.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/CollateralTable.svelte
@@ -44,7 +44,7 @@
         <tr class="border-b border-white/5">
           <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Asset</th>
           <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
-          <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Vol</th>
+          <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell" title="Annualized price volatility (returns sigma) over the last 30 days">Vol</th>
           <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Vaults</th>
           <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Collateral</th>
           <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Debt</th>

--- a/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
@@ -1,20 +1,24 @@
 <script lang="ts">
   import { shortenPrincipal, getCanisterName, getTokenSymbol, isKnownCanister } from '$utils/explorerHelpers';
+  import { CANISTER_IDS } from '$lib/config';
 
   interface Props {
-    type: 'vault' | 'address' | 'token' | 'event' | 'canister' | 'block_index';
+    type: 'vault' | 'address' | 'token' | 'event' | 'canister' | 'pool' | 'block_index';
     value: string;
     label?: string;
     short?: boolean;
+    /** When set, replaces the default link styling. Use for chip-pill variants in event rows. */
+    class?: string;
   }
 
-  let { type, value, label, short = true }: Props = $props();
+  let { type, value, label, short = true, class: extraClass }: Props = $props();
 
   const icons: Record<string, string> = {
     vault: '🏦',
     address: '👤',
     canister: '📦',
     token: '🪙',
+    pool: '🌊',
     event: '',
     block_index: '🔗',
   };
@@ -26,6 +30,7 @@
       case 'vault': return `/explorer/e/vault/${value}`;
       case 'address': return `/explorer/e/address/${value}`;
       case 'token': return `/explorer/e/token/${value}`;
+      case 'pool': return `/explorer/e/pool/${value}`;
       case 'event': return `/explorer/e/event/${value}`;
       case 'canister': return `/explorer/e/address/${value}`;
       case 'block_index': return null;
@@ -46,6 +51,10 @@
         return short ? shortenPrincipal(value) : value;
       }
       case 'token': return getTokenSymbol(value) ?? (short ? shortenPrincipal(value) : value);
+      case 'pool': {
+        if (value === '3pool' || value === CANISTER_IDS.THREEPOOL) return '3pool';
+        return short ? shortenPrincipal(value) : value;
+      }
       case 'event': return `Event #${value}`;
       case 'canister': {
         const name = getCanisterName(value);
@@ -55,14 +64,21 @@
       case 'block_index': return `#${value}`;
     }
   });
+
+  const linkClass = $derived(
+    extraClass ?? 'inline-flex items-center gap-1 text-blue-400 hover:underline font-mono text-sm',
+  );
+  const spanClass = $derived(
+    extraClass ?? 'inline-flex items-center gap-1 text-gray-300 font-mono text-sm',
+  );
 </script>
 
 {#if href}
-  <a {href} class="inline-flex items-center gap-1 text-blue-400 hover:underline font-mono text-sm" title={value}>
+  <a {href} class={linkClass} title={value}>
     <span>{displayIcon}</span><span>{displayText}</span>
   </a>
 {:else}
-  <span class="inline-flex items-center gap-1 text-gray-300 font-mono text-sm" title={value}>
+  <span class={spanClass} title={value}>
     <span>{displayIcon}</span><span>{displayText}</span>
   </span>
 {/if}

--- a/src/vault_frontend/src/lib/components/explorer/EventRow.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EventRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import EntityLink from './EntityLink.svelte';
   import FacetChip from './FacetChip.svelte';
-  import { timeAgo, shortenPrincipal, formatTimestamp, getTokenSymbol } from '$utils/explorerHelpers';
+  import { timeAgo, formatTimestamp } from '$utils/explorerHelpers';
   import { displayEvent, wrapBackendEvent } from '$utils/displayEvent';
   import { extractFacets, typeFacetLabel, type Facets } from '$utils/eventFacets';
 
@@ -63,14 +63,10 @@
   <!-- Principal -->
   <td class="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">
     {#if display.principal}
-      <FacetChip
-        kind="principal"
+      <EntityLink
+        type="address"
         value={display.principal}
-        label={shortenPrincipal(display.principal)}
-        title={display.principal}
-        class="text-xs text-gray-300 hover:text-blue-300 font-mono px-1 py-0.5"
-        {onFacetClick}
-        {currentFacets}
+        class="inline-flex items-center gap-1 text-xs text-gray-300 hover:text-blue-300 font-mono px-1 py-0.5"
       />
     {:else}
       <span class="text-gray-600">&mdash;</span>
@@ -95,26 +91,21 @@
     <div class="truncate max-w-[360px]" title={display.formatted.summary}>
       {display.formatted.summary}
     </div>
-    {#if onFacetClick && (extraTokens.length || extraVaults.length)}
+    {#if extraTokens.length || extraVaults.length}
       <div class="mt-1 flex flex-wrap gap-1 text-[10px] text-gray-500">
         {#each extraTokens as p (p)}
-          <FacetChip
-            kind="token"
+          <EntityLink
+            type="token"
             value={p}
-            label="+token:{getTokenSymbol(p)}"
-            class="px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 hover:text-teal-300"
-            {onFacetClick}
-            {currentFacets}
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 text-[10px] text-gray-400 hover:text-teal-300 font-mono"
           />
         {/each}
         {#each extraVaults as v (v)}
-          <FacetChip
-            kind="vault"
-            value={v}
-            label="+vault:#{v}"
-            class="px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 hover:text-teal-300"
-            {onFacetClick}
-            {currentFacets}
+          <EntityLink
+            type="vault"
+            value={String(v)}
+            label={`#${v}`}
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 text-[10px] text-gray-400 hover:text-teal-300 font-mono"
           />
         {/each}
       </div>

--- a/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
@@ -41,26 +41,43 @@
   let vaultOwnerMap: Map<number, string> = $state(new Map());
   let loading = $state(true);
 
-  // Backend admin-ish event variant keys. Kept as a reference filter;
-  // add/remove as the backend event schema evolves.
+  // Backend events serialize as snake_case JSON (via #[serde(rename = ...)]).
+  // The previous filters used CamelCase variant names that don't actually exist
+  // on the wire — that's why scope='admin' was empty even though setter events
+  // were being recorded. Sets below match the actual variant keys.
+
+  // User-visible vault operations (NOT setter / admin / system events).
+  const VAULT_OP_KEYS = new Set([
+    'open_vault', 'close_vault', 'withdraw_and_close_vault', 'vault_withdrawn_and_closed',
+    'borrow_from_vault', 'repay_to_vault', 'add_margin_to_vault',
+    'collateral_withdrawn', 'partial_collateral_withdrawn', 'margin_transfer',
+    'liquidate_vault', 'partial_liquidate_vault', 'redistribute_vault',
+    'redemption_on_vaults', 'redemption_transfered',
+    'dust_forgiven',
+  ]);
+
+  // Admin / setter / config-change events. Init + Upgrade live here too —
+  // upgrades are admin actions even though they don't carry an explicit caller.
+  // AccrueInterest is intentionally NOT in this set: it's auto-triggered system
+  // bookkeeping that fires very frequently and floods the activity feed.
   const ADMIN_EVENT_KEYS = new Set([
-    'Init',
-    'Upgrade',
-    'ModeChanged',
-    'ProtocolModeChanged',
-    'ParameterChanged',
-    'CollateralAdded',
-    'CollateralRemoved',
-    'CollateralConfigChanged',
-    'InterestRateChanged',
-    'DebtCeilingChanged',
-    'LiquidationThresholdChanged',
-    'TreasuryConfigChanged',
-    'StabilityPoolConfigured',
-    'FeeFloorChanged',
-    'FeeCeilingChanged',
-    'InterestSplitChanged',
-    'RedemptionConfigChanged',
+    'init', 'upgrade',
+    'set_ckstable_repay_fee', 'set_min_icusd_amount', 'set_global_icusd_mint_cap',
+    'set_stable_token_enabled', 'set_stable_ledger_principal',
+    'set_treasury_principal', 'set_stability_pool_principal', 'set_liquidation_bot_principal',
+    'set_bot_budget', 'set_bot_allowed_collateral_types',
+    'set_liquidation_bonus', 'set_borrowing_fee',
+    'set_redemption_fee_floor', 'set_redemption_fee_ceiling',
+    'set_max_partial_liquidation_ratio', 'set_recovery_target_cr', 'set_recovery_cr_multiplier',
+    'set_liquidation_protocol_share',
+    'add_collateral_type', 'update_collateral_status', 'update_collateral_config',
+    'set_reserve_redemptions_enabled', 'set_icpswap_routing_enabled',
+    'set_reserve_redemption_fee', 'reserve_redemption',
+    'admin_mint', 'admin_vault_correction', 'admin_sweep_to_treasury',
+    'set_recovery_parameters', 'set_rate_curve_markers', 'set_recovery_rate_curve',
+    'set_healthy_cr', 'set_collateral_borrowing_fee', 'set_interest_rate', 'set_interest_pool_share',
+    'set_rmr_floor', 'set_rmr_ceiling', 'set_rmr_floor_cr', 'set_rmr_ceiling_cr',
+    'set_borrowing_fee_curve', 'set_interest_split', 'set_three_pool_canister',
   ]);
 
   function backendEventKey(evt: any): string {
@@ -69,23 +86,26 @@
   }
 
   function isBackendVaultEvent(evt: any): boolean {
-    const key = backendEventKey(evt);
-    return key === 'VaultCreated' || key === 'VaultUpdated' || key === 'VaultClosed'
-      || key === 'VaultAdjusted' || key === 'CollateralDeposited' || key === 'CollateralWithdrawn'
-      || key === 'DebtIncreased' || key === 'DebtRepaid' || key === 'Liquidation' || key === 'Redemption';
+    return VAULT_OP_KEYS.has(backendEventKey(evt));
   }
 
   function isBackendRedemption(evt: any): boolean {
-    return backendEventKey(evt) === 'Redemption';
+    return backendEventKey(evt) === 'redemption_on_vaults';
   }
 
   function isBackendRevenue(evt: any): boolean {
     const key = backendEventKey(evt);
-    return key === 'Redemption' || key === 'Liquidation';
+    return key === 'redemption_on_vaults'
+      || key === 'liquidate_vault'
+      || key === 'partial_liquidate_vault';
   }
 
   function isBackendAdmin(evt: any): boolean {
     return ADMIN_EVENT_KEYS.has(backendEventKey(evt));
+  }
+
+  function isAccrueInterest(evt: any): boolean {
+    return backendEventKey(evt) === 'accrue_interest';
   }
 
   function wrapBackend(events: [bigint, any][]): DisplayEvent[] {
@@ -169,11 +189,12 @@
         fetchRecent(spCount, sampleSize, fetchStabilityPoolEvents),
       ]);
 
-      // Filter backend events by scope
+      // Filter backend events by scope. AccrueInterest is system bookkeeping
+      // that fires every interest tick — never useful in any user-facing scope.
       const backendRows = wrapBackend(backend.events ?? []).filter((de) => {
+        if (isAccrueInterest(de.event)) return false;
         switch (scope) {
           case 'all':
-            // exclude admin by default
             return !isBackendAdmin(de.event);
           case 'vault_ops':
             return isBackendVaultEvent(de.event) && !isBackendAdmin(de.event);

--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -30,7 +30,26 @@
     const minT = points[0].t;
     const maxT = points[points.length - 1].t;
     const { min, max } = computeYScale(points.map(p => p.v));
-    return { minT, maxT, yMin: min, yMax: max };
+    // Anchor the y-axis at 0 when all values are non-negative — otherwise a
+    // small spike on top of zeros (typical for low-volume swap charts) renders
+    // as a flat line near the baseline because computeYScale tightens around
+    // the data. Anchoring keeps the spike visually distinct from baseline.
+    const allNonNeg = points.every((p) => p.v >= 0);
+    const yMin = allNonNeg ? 0 : min;
+    return { minT, maxT, yMin, yMax: max };
+  });
+
+  // Highlight dots for non-zero points when the series is sparse — without
+  // them, an hourly chart with mostly-zero buckets looks empty even when
+  // there's real activity in a couple of buckets.
+  const dotPoints = $derived.by(() => {
+    if (!points.length) return [];
+    const nonZero = points.filter((p) => p.v > 0);
+    if (nonZero.length === 0) return [];
+    // Only annotate when the series is sparse enough that the line alone
+    // wouldn't be obvious. Above this threshold a normal line is plenty.
+    if (nonZero.length > 20) return [];
+    return nonZero;
   });
 
   function x(t: number) {
@@ -84,6 +103,9 @@
       <svg viewBox="0 0 {width} {height}" class="w-full h-full" preserveAspectRatio="none">
         <path d={fillD} fill={fillColor} stroke="none" />
         <path d={pathD} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />
+        {#each dotPoints as p (p.t)}
+          <circle cx={x(p.t).toFixed(2)} cy={y(p.v).toFixed(2)} r="3" fill={color} />
+        {/each}
       </svg>
     {/if}
   </div>

--- a/src/vault_frontend/src/lib/components/explorer/MixedEventRow.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MixedEventRow.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { timeAgo, shortenPrincipal, formatTimestamp, getTokenSymbol } from '$utils/explorerHelpers';
+  import { timeAgo, formatTimestamp } from '$utils/explorerHelpers';
   import { displayEvent } from '$utils/displayEvent';
   import type { DisplayEvent } from '$utils/displayEvent';
   import { extractFacets, typeFacetLabel, type Facets } from '$utils/eventFacets';
   import FacetChip from './FacetChip.svelte';
+  import EntityLink from './EntityLink.svelte';
 
   interface Props {
     event: DisplayEvent;
@@ -23,7 +24,7 @@
   // not size_usd.
   const facetsFor = $derived(extractFacets(event, undefined, undefined, vaultOwnerMap));
 
-  // Secondary chips we render after the summary when onFacetClick is wired.
+  // Secondary entity links we render after the summary — navigate to entity pages.
   const extraTokens = $derived(facetsFor.tokens.slice(0, 3));
   const extraPools = $derived(facetsFor.pools.slice(0, 2));
   const extraVaults = $derived(facetsFor.vaultIds.slice(0, 2));
@@ -44,14 +45,10 @@
   </td>
   <td class="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">
     {#if display.principal}
-      <FacetChip
-        kind="principal"
+      <EntityLink
+        type="address"
         value={display.principal}
-        label={shortenPrincipal(display.principal)}
-        title={display.principal}
-        class="text-xs text-gray-300 hover:text-blue-300 font-mono px-1 py-0.5"
-        {onFacetClick}
-        {currentFacets}
+        class="inline-flex items-center gap-1 text-xs text-gray-300 hover:text-blue-300 font-mono px-1 py-0.5"
       />
     {:else}
       <span class="text-gray-600">&mdash;</span>
@@ -72,36 +69,28 @@
     <div class="truncate max-w-[360px]" title={display.formatted.summary}>
       {display.formatted.summary}
     </div>
-    {#if onFacetClick && (extraTokens.length || extraPools.length || extraVaults.length)}
+    {#if extraTokens.length || extraPools.length || extraVaults.length}
       <div class="mt-1 flex flex-wrap gap-1 text-[10px] text-gray-500">
         {#each extraTokens as p (p)}
-          <FacetChip
-            kind="token"
+          <EntityLink
+            type="token"
             value={p}
-            label="+token:{getTokenSymbol(p)}"
-            class="px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 hover:text-teal-300"
-            {onFacetClick}
-            {currentFacets}
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 text-[10px] text-gray-400 hover:text-teal-300 font-mono"
           />
         {/each}
         {#each extraPools as id (id)}
-          <FacetChip
-            kind="pool"
+          <EntityLink
+            type="pool"
             value={id}
-            label="+pool:{id === '3pool' ? '3pool' : id}"
-            class="px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 hover:text-teal-300"
-            {onFacetClick}
-            {currentFacets}
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 text-[10px] text-gray-400 hover:text-teal-300 font-mono"
           />
         {/each}
         {#each extraVaults as v (v)}
-          <FacetChip
-            kind="vault"
-            value={v}
-            label="+vault:#{v}"
-            class="px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 hover:text-teal-300"
-            {onFacetClick}
-            {currentFacets}
+          <EntityLink
+            type="vault"
+            value={String(v)}
+            label={`#${v}`}
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-gray-700 bg-gray-900/60 text-[10px] text-gray-400 hover:text-teal-300 font-mono"
           />
         {/each}
       </div>

--- a/src/vault_frontend/src/lib/components/explorer/PoolHealthStrip.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/PoolHealthStrip.svelte
@@ -20,16 +20,16 @@
   const pegLabel = $derived.by(() => {
     if (!pegStatus) return '--';
     const imb = pegStatus.max_imbalance_pct;
-    if (imb < 2) return 'Stable';
-    if (imb < 5) return 'Minor drift';
-    return `${imb.toFixed(1)}% imbalance`;
+    if (imb < 2) return 'Balanced';
+    if (imb < 5) return 'Minor skew';
+    return `${imb.toFixed(1)}% skew`;
   });
 </script>
 
 <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-  <!-- 3pool Peg -->
+  <!-- 3pool balance skew (NOT peg deviation — measures how far weights drift from 33/33/33) -->
   <div class="explorer-card flex flex-col gap-1">
-    <span class="vital-label">3pool Peg</span>
+    <span class="vital-label" title="Pool weight skew vs ideal 33/33/33 split. Not a measure of icUSD peg.">3pool balance</span>
     {#if loading}
       <span class="text-sm text-gray-500">Loading...</span>
     {:else}
@@ -37,9 +37,9 @@
     {/if}
   </div>
 
-  <!-- LP APY -->
+  <!-- 3Pool LP APY -->
   <div class="explorer-card flex flex-col gap-1">
-    <span class="vital-label">LP APY (7d)</span>
+    <span class="vital-label">3Pool LP APY (7d)</span>
     {#if loading}
       <span class="text-sm text-gray-500">Loading...</span>
     {:else}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
@@ -3,6 +3,7 @@
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import AdminBreakdownCard from '../AdminBreakdownCard.svelte';
+  import CanisterInventoryCard from '../CanisterInventoryCard.svelte';
   import { fetchCollectorHealth } from '$services/explorer/analyticsService';
   import { fetchProtocolStatus } from '$services/explorer/explorerService';
 
@@ -50,6 +51,8 @@
 <LensHealthStrip title="Admin" metrics={healthMetrics} loading={loading} />
 
 <AdminBreakdownCard />
+
+<CanisterInventoryCard />
 
 {#if collectorHealth}
   <div class="explorer-card">

--- a/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
@@ -2,32 +2,20 @@
   import { onMount } from 'svelte';
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
-  import MiniAreaChart from '../MiniAreaChart.svelte';
-  import {
-    fetchCycleSeries, fetchCollectorHealth,
-  } from '$services/explorer/analyticsService';
-  import { fetchProtocolConfig, fetchProtocolStatus } from '$services/explorer/explorerService';
-  import { formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
+  import { fetchCollectorHealth } from '$services/explorer/analyticsService';
+  import { fetchProtocolStatus } from '$services/explorer/explorerService';
 
-  interface CyclePoint { canister: string; points: { t: number; v: number }[]; latest: number }
-
-  let cycleSeries: any[] = $state([]);
   let collectorHealth: any = $state(null);
-  let config: any = $state(null);
   let status: any = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     try {
-      const [cR, chR, cfR, stR] = await Promise.allSettled([
-        fetchCycleSeries(500),
+      const [chR, stR] = await Promise.allSettled([
         fetchCollectorHealth(),
-        fetchProtocolConfig(),
         fetchProtocolStatus(),
       ]);
-      if (cR.status === 'fulfilled') cycleSeries = cR.value ?? [];
       if (chR.status === 'fulfilled') collectorHealth = chR.value;
-      if (cfR.status === 'fulfilled') config = cfR.value;
       if (stR.status === 'fulfilled') status = stR.value;
     } catch (err) {
       console.error('[AdminLens] onMount error:', err);
@@ -36,124 +24,37 @@
     }
   });
 
-  // cycleSeries rows are HourlyCycleSnapshot { timestamp_ns, cycle_balance }
-  // For v1, show the aggregate series (single-canister analytics canister only).
-  const aggregatePoints = $derived(
-    cycleSeries.map((r: any) => ({
-      t: Number(r.timestamp_ns) / 1_000_000,
-      v: Number(r.cycle_balance) / 1e12, // TC
-    }))
-  );
-  const latestCycles = $derived(
-    aggregatePoints.length ? aggregatePoints[aggregatePoints.length - 1].v : 0
-  );
-
   const mode = $derived.by(() => {
     if (!status?.mode) return 'Unknown';
     return Object.keys(status.mode)[0] ?? 'Unknown';
   });
 
-  const configRows = $derived.by(() => {
-    if (!config) return [] as { label: string; value: string }[];
-    const rows: { label: string; value: string }[] = [];
-    const pct = (v: any) => v == null ? '--' : `${(Number(v) * 100).toFixed(2)}%`;
-    const cr = (v: any) => v == null ? '--' : `${(Number(v) * 100).toFixed(0)}%`;
-    rows.push({ label: 'Mode', value: mode });
-    rows.push({ label: 'Frozen', value: config.frozen ? 'yes' : 'no' });
-    rows.push({ label: 'Borrowing fee', value: pct(config.borrowing_fee) });
-    rows.push({ label: 'Redemption fee floor', value: pct(config.redemption_fee_floor) });
-    rows.push({ label: 'Redemption fee ceiling', value: pct(config.redemption_fee_ceiling) });
-    rows.push({ label: 'Liquidation bonus', value: pct(config.liquidation_bonus) });
-    rows.push({ label: 'Liquidation protocol share', value: pct(config.liquidation_protocol_share) });
-    rows.push({ label: 'RMR floor', value: pct(config.rmr_floor) });
-    rows.push({ label: 'RMR ceiling', value: pct(config.rmr_ceiling) });
-    rows.push({ label: 'RMR floor CR', value: cr(config.rmr_floor_cr) });
-    rows.push({ label: 'RMR ceiling CR', value: cr(config.rmr_ceiling_cr) });
-    rows.push({ label: 'Recovery CR threshold', value: cr(config.recovery_mode_threshold) });
-    rows.push({ label: 'Recovery CR multiplier', value: Number(config.recovery_cr_multiplier ?? 0).toFixed(2) });
-    rows.push({ label: 'Max partial liq ratio', value: pct(config.max_partial_liquidation_ratio) });
-    rows.push({ label: 'Min icUSD mint', value: `${(Number(config.min_icusd_amount ?? 0n) / 1e8).toFixed(2)} icUSD` });
-    rows.push({ label: 'Global mint cap', value: `${formatCompact(Number(config.global_icusd_mint_cap ?? 0n) / 1e8)} icUSD` });
-    rows.push({ label: 'Reserve redemptions enabled', value: config.reserve_redemptions_enabled ? 'yes' : 'no' });
-    return rows;
-  });
-
   const healthMetrics = $derived.by(() => {
     const metrics: any[] = [
       { label: 'Mode', value: mode },
-      {
-        label: 'Analytics cycles',
-        value: `${formatCompact(latestCycles)} TC`,
-        tone: latestCycles < 1 ? 'danger' as const : latestCycles < 3 ? 'caution' as const : 'good' as const,
-      },
     ];
     if (collectorHealth) {
       const errs = Object.values(collectorHealth?.errors ?? {}).reduce((s: number, v: any) => s + Number(v ?? 0), 0);
-      metrics.push({ label: 'Collector errors', value: errs.toLocaleString(), tone: errs > 0 ? 'caution' as const : 'good' as const });
+      metrics.push({
+        label: 'Collector errors',
+        value: errs.toLocaleString(),
+        sub: 'analytics tailing',
+        tone: errs > 0 ? 'caution' as const : 'good' as const,
+      });
     }
-    metrics.push({ label: 'Config params', value: String(configRows.length), sub: 'tracked' });
     return metrics;
-  });
-
-  const splitRows = $derived.by(() => {
-    if (!config?.interest_split) return [];
-    return (config.interest_split as any[]).map(e => ({
-      destination: e.destination,
-      bps: Number(e.bps ?? 0),
-    }));
   });
 </script>
 
 <LensHealthStrip title="Admin" metrics={healthMetrics} loading={loading} />
 
-<div class="explorer-card">
-  <MiniAreaChart
-    points={aggregatePoints}
-    label="Analytics canister cycles (TC)"
-    color={CHART_COLORS.caution}
-    fillColor="rgba(167, 139, 250, 0.15)"
-    valueFormat={(v) => `${v.toFixed(2)} TC`}
-    height={160}
-    loading={loading}
-  />
-</div>
-
-<div class="explorer-card">
-  <h3 class="text-sm font-medium text-gray-300 mb-3">Protocol config</h3>
-  {#if loading}
-    <div class="flex items-center justify-center py-6">
-      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
-    </div>
-  {:else if !config}
-    <p class="text-sm text-gray-500 py-4">Config unavailable.</p>
-  {:else}
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2">
-      {#each configRows as row}
-        <div class="flex items-center justify-between text-sm py-1 border-b border-white/[0.03]">
-          <span class="text-gray-400">{row.label}</span>
-          <span class="tabular-nums text-gray-200 font-medium">{row.value}</span>
-        </div>
-      {/each}
-    </div>
-    {#if splitRows.length > 0}
-      <div class="mt-4 pt-4 border-t border-white/5">
-        <div class="text-xs font-medium text-gray-400 mb-2">Interest split</div>
-        <div class="flex flex-wrap gap-4">
-          {#each splitRows as r}
-            <div class="flex items-baseline gap-2 text-sm">
-              <span class="text-gray-500">{r.destination}</span>
-              <span class="tabular-nums text-gray-200 font-medium">{(r.bps / 100).toFixed(1)}%</span>
-            </div>
-          {/each}
-        </div>
-      </div>
-    {/if}
-  {/if}
-</div>
-
 {#if collectorHealth}
   <div class="explorer-card">
-    <h3 class="text-sm font-medium text-gray-300 mb-3">Collector health</h3>
+    <h3 class="text-sm font-medium text-gray-300 mb-3">Analytics tailing health</h3>
+    <p class="text-xs text-gray-500 mb-3">
+      Per-source counters for the analytics canister's tailers. Non-zero error counts mean some
+      events may have been missed and rollups could be stale until the tailer catches up.
+    </p>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
       <div>
         <div class="text-xs text-gray-500">Last collect</div>
@@ -177,4 +78,8 @@
   </div>
 {/if}
 
-<LensActivityPanel scope="admin" title="Admin events (protocol + 3Pool + AMM)" viewAllHref="/explorer/activity?type=admin,system" />
+<LensActivityPanel
+  scope="admin"
+  title="Admin actions"
+  viewAllHref="/explorer/activity?type=admin"
+/>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
+  import AdminBreakdownCard from '../AdminBreakdownCard.svelte';
   import { fetchCollectorHealth } from '$services/explorer/analyticsService';
   import { fetchProtocolStatus } from '$services/explorer/explorerService';
 
@@ -47,6 +48,8 @@
 </script>
 
 <LensHealthStrip title="Admin" metrics={healthMetrics} loading={loading} />
+
+<AdminBreakdownCard />
 
 {#if collectorHealth}
   <div class="explorer-card">

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -14,6 +14,7 @@
   import {
     e8sToNumber, formatCompact, bpsToPercent, COLLATERAL_SYMBOLS, COLLATERAL_COLORS,
   } from '$utils/explorerChartHelpers';
+  import { computeVaultCrPct, median } from '$utils/vaultCr';
   import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
 
   let systemCrBps = $state(0);
@@ -79,6 +80,38 @@
         if (r.status === 'fulfilled' && r.value) volMap.set(principals[i], r.value.annualized_vol_pct);
       }
 
+      // CR distribution + per-collateral median CR. Backend returns vaults
+      // without a collateral_ratio field; compute from collateral × price /
+      // debt using helpers.
+      const decimalsMap = new Map<string, number>();
+      for (const t of totals) {
+        const pid = t.collateral_type?.toText?.() ?? String(t.collateral_type ?? '');
+        if (pid && t.decimals != null) decimalsMap.set(pid, Number(t.decimals));
+      }
+
+      const crByCollateral = new Map<string, number[]>();
+      const bucketDefs: [number, number, string][] = [
+        [0, 110, '<110%'],
+        [110, 150, '110-150%'],
+        [150, 200, '150-200%'],
+        [200, 300, '200-300%'],
+        [300, 500, '300-500%'],
+        [500, Infinity, '500%+'],
+      ];
+      const buckets: CrBucket[] = bucketDefs.map(([lo, hi, label]) => ({ lo, hi, label, count: 0 }));
+
+      for (const v of allVaults) {
+        const cr = computeVaultCrPct(v, priceMap, decimalsMap);
+        if (cr == null) continue;
+        for (const b of buckets) {
+          if (cr >= b.lo && cr < b.hi) { b.count += 1; break; }
+        }
+        const collType = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+        if (!crByCollateral.has(collType)) crByCollateral.set(collType, []);
+        crByCollateral.get(collType)!.push(cr);
+      }
+      crBuckets = buckets;
+
       const rows: CollateralRow[] = [];
       for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
         const cfg = configMap.get(principal);
@@ -99,7 +132,10 @@
           totalDebt: debt,
           debtCeiling: e8sToNumber(ceilingRaw),
           unlimited,
-          medianCrBps: 0,
+          medianCrBps: (() => {
+            const m = median(crByCollateral.get(principal) ?? []);
+            return m != null ? Math.round(m * 100) : 0; // bps
+          })(),
           volatility: volMap.get(principal) ?? null,
         });
       }
@@ -111,26 +147,6 @@
       collateralRows = rows;
 
       mixTotal = rows.reduce((s, r) => s + r.totalCollateralUsd, 0);
-
-      // CR distribution histogram from all active vaults
-      const bucketDefs: [number, number, string][] = [
-        [0, 110, '<110%'],
-        [110, 150, '110-150%'],
-        [150, 200, '150-200%'],
-        [200, 300, '200-300%'],
-        [300, 500, '300-500%'],
-        [500, Infinity, '500%+'],
-      ];
-      const buckets: CrBucket[] = bucketDefs.map(([lo, hi, label]) => ({ lo, hi, label, count: 0 }));
-      for (const v of allVaults) {
-        const cr = Number(v.collateral_ratio ?? 0);
-        if (cr === 0) continue;
-        const pct = cr; // backend uses percent (e.g. 243 for 243%)
-        for (const b of buckets) {
-          if (pct >= b.lo && pct < b.hi) { b.count += 1; break; }
-        }
-      }
-      crBuckets = buckets;
     } catch (err) {
       console.error('[CollateralLens] onMount error:', err);
     } finally {

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -10,10 +10,13 @@
   import {
     fetchThreePoolState, fetchThreePoolStats, fetchThreePoolHealth,
     fetchThreePoolVolumeSeries, fetchThreePoolVirtualPriceSeries,
-    fetchAmmPools,
+    fetchAmmPools, fetchAmmPoolStats, fetchCollateralPrices,
   } from '$services/explorer/explorerService';
+  import { CANISTER_IDS } from '$lib/config';
   import { POOL_TOKENS } from '$services/threePoolService';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
+  import { ammPoolLabel, ammPoolPair, ammPoolShortLabel, setAmmPoolRegistry } from '$utils/ammNaming';
+  import { getTokenSymbol } from '$utils/explorerHelpers';
   import type { PegStatus } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   let pegStatus: PegStatus | null = $state(null);
@@ -24,13 +27,15 @@
   let volumeSeries: any[] = $state([]);
   let vpSeries: any[] = $state([]);
   let ammPools: any[] = $state([]);
+  let ammPoolStats: Record<string, any> = $state({});
   let lpApy: number | null = $state(null);
   let spApy: number | null = $state(null);
+  let icpUsdPrice: number | null = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     try {
-      const [pegR, stR, statR, hlR, ssR, vsR, vpR, ammR, apyR] = await Promise.allSettled([
+      const [pegR, stR, statR, hlR, ssR, vsR, vpR, ammR, apyR, pricesR] = await Promise.allSettled([
         fetchPegStatus(),
         fetchThreePoolState(),
         fetchThreePoolStats('Last24h'),
@@ -40,6 +45,7 @@
         fetchThreePoolVirtualPriceSeries('Last30d', 86400n),
         fetchAmmPools(),
         fetchApys(),
+        fetchCollateralPrices(),
       ]);
       if (pegR.status === 'fulfilled') pegStatus = pegR.value ?? null;
       if (stR.status === 'fulfilled') poolState = stR.value;
@@ -48,12 +54,33 @@
       if (ssR.status === 'fulfilled') swapSeries = ssR.value ?? [];
       if (vsR.status === 'fulfilled') volumeSeries = vsR.value ?? [];
       if (vpR.status === 'fulfilled') vpSeries = vpR.value ?? [];
-      if (ammR.status === 'fulfilled') ammPools = ammR.value ?? [];
+      if (ammR.status === 'fulfilled') {
+        ammPools = ammR.value ?? [];
+        // Seed the registry so AMM event labels everywhere can resolve "AMM1 · 3USD/ICP"
+        setAmmPoolRegistry(ammPools);
+      }
       if (apyR.status === 'fulfilled' && apyR.value) {
         const aLp = apyR.value.lp_apy_pct?.[0];
         const aSp = apyR.value.sp_apy_pct?.[0];
         if (typeof aLp === 'number' && aLp > 0) lpApy = aLp;
         if (typeof aSp === 'number' && aSp > 0) spApy = aSp;
+      }
+      if (pricesR.status === 'fulfilled') {
+        const map = pricesR.value;
+        icpUsdPrice = map.get(CANISTER_IDS.ICP_LEDGER) ?? null;
+      }
+
+      // Per-pool stats for the AMM Pools card (TVL, 7d volume).
+      if (ammPools.length > 0) {
+        const statResults = await Promise.allSettled(
+          ammPools.map((p: any) => fetchAmmPoolStats(p.pool_id, 'Week')),
+        );
+        const out: Record<string, any> = {};
+        ammPools.forEach((p: any, i: number) => {
+          const r = statResults[i];
+          if (r.status === 'fulfilled' && r.value) out[p.pool_id] = r.value;
+        });
+        ammPoolStats = out;
       }
     } catch (err) {
       console.error('[DexsLens] onMount error:', err);
@@ -127,32 +154,85 @@
       { label: '24h volume', value: `$${formatCompact(volume24h)}` },
       { label: 'Virtual price', value: virtualPrice.toFixed(6), sub: 'compounds with fees' },
       {
-        label: 'Peg imbalance',
-        value: pegStatus ? `${imbalancePct.toFixed(2)}%` : '--',
+        label: '3pool balance',
+        value: pegStatus ? `${imbalancePct.toFixed(2)}% skew` : '--',
         tone: imbalancePct < 2 ? 'good' as const : imbalancePct < 5 ? 'caution' as const : 'danger' as const,
+        sub: 'weight vs 33/33/33',
       },
     ];
     if (health) {
       const arb = Number(health.arb_opportunity_score);
-      metrics.push({ label: 'Arb score', value: `${arb}/100`, tone: arb > 50 ? 'caution' as const : 'good' as const });
+      metrics.push({
+        label: 'Arb score',
+        value: `${arb}/100`,
+        tone: arb > 50 ? 'caution' as const : 'good' as const,
+        sub: '0–100',
+      });
     }
-    metrics.push({ label: 'LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: '7d' });
+    metrics.push({ label: '3Pool LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: '7d' });
     return metrics;
   });
 
-  // AMM pools: collapse list to simple summary
+  // AMM pools: friendly summary with sequential index, token pair, fee, TVL, 7d volume.
+  // TVL = (3USD reserve × 3pool virtual_price) + (other token reserve × oracle price).
+  // For the 3USD/ICP pool that means: 3USD value @ vp_USD + ICP balance × icpUsdPrice.
+  function principalToText(p: any): string {
+    if (!p) return '';
+    if (typeof p === 'string') return p;
+    if (typeof p?.toText === 'function') return p.toText();
+    return String(p);
+  }
+
+  function tokenUsdPrice(principalText: string): number | null {
+    if (principalText === CANISTER_IDS.THREEPOOL) return virtualPrice; // 3USD LP token priced via vp
+    if (principalText === CANISTER_IDS.ICUSD_LEDGER) return 1;
+    if (principalText === CANISTER_IDS.CKUSDT_LEDGER) return 1;
+    if (principalText === CANISTER_IDS.CKUSDC_LEDGER) return 1;
+    if (principalText === CANISTER_IDS.ICP_LEDGER) return icpUsdPrice;
+    return null;
+  }
+
+  function tokenDecimals(principalText: string): number {
+    // ckUSDT/ckUSDC are 6; everything else in our universe is 8. Add to this map
+    // as we onboard tokens with different decimals.
+    if (principalText === CANISTER_IDS.CKUSDT_LEDGER) return 6;
+    if (principalText === CANISTER_IDS.CKUSDC_LEDGER) return 6;
+    return 8;
+  }
+
   const ammSummary = $derived.by(() => {
-    return ammPools.map((p: any) => {
-      const tokens: string[] = Array.isArray(p.tokens)
-        ? p.tokens.map((t: any) => {
-            const sym = t?.symbol ?? t?.name ?? '';
-            return typeof sym === 'string' ? sym : String(sym);
-          })
-        : [];
+    const sorted = [...ammPools].sort((a: any, b: any) => a.pool_id.localeCompare(b.pool_id));
+    return sorted.map((p: any, i: number) => {
+      const tokenA = principalToText(p.token_a);
+      const tokenB = principalToText(p.token_b);
+      const symA = getTokenSymbol(tokenA) || '?';
+      const symB = getTokenSymbol(tokenB) || '?';
+
+      const reserveA = Number(p.reserve_a ?? 0n) / Math.pow(10, tokenDecimals(tokenA));
+      const reserveB = Number(p.reserve_b ?? 0n) / Math.pow(10, tokenDecimals(tokenB));
+      const priceA = tokenUsdPrice(tokenA);
+      const priceB = tokenUsdPrice(tokenB);
+      const tvlUsd = (priceA != null && priceB != null) ? reserveA * priceA + reserveB * priceB : null;
+
+      // 7d volume: sum of both sides' input volume in USD (each swap touches one side
+      // as input, so a + b avoids double-counting).
+      const stat = ammPoolStats[p.pool_id] ?? null;
+      let vol7d: number | null = null;
+      if (stat && priceA != null && priceB != null) {
+        const vA = Number(stat.volume_a_e8s ?? 0n) / Math.pow(10, tokenDecimals(tokenA));
+        const vB = Number(stat.volume_b_e8s ?? 0n) / Math.pow(10, tokenDecimals(tokenB));
+        vol7d = vA * priceA + vB * priceB;
+      }
+
       return {
-        id: p.id ?? p.pool_id ?? p.canister_id ?? 'amm',
-        name: tokens.length > 1 ? tokens.join(' / ') : 'AMM pool',
-        feeBps: Number(p.fee_bps ?? p.fee ?? 0),
+        index: i + 1,
+        id: p.pool_id,
+        name: ammPoolLabel(p.pool_id, p.token_a, p.token_b),
+        shortName: ammPoolShortLabel(p.pool_id),
+        pair: `${symA}/${symB}`,
+        feeBps: Number(p.fee_bps ?? 0),
+        tvlUsd,
+        vol7d,
       };
     });
   });
@@ -251,19 +331,27 @@
         <thead>
           <tr class="border-b border-white/5">
             <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Pool</th>
+            <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Pair</th>
             <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Fee</th>
-            <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">TVL</th>
+            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">7d volume</th>
           </tr>
         </thead>
         <tbody>
-          {#each ammSummary as p}
+          {#each ammSummary as p (p.id)}
             <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
               <td class="py-2 px-2 font-medium">
-                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="text-indigo-300 hover:text-indigo-200">{p.name}</a>
+                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="text-indigo-300 hover:text-indigo-200">{p.shortName}</a>
+              </td>
+              <td class="py-2 px-2 text-gray-300">
+                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="hover:text-indigo-200">{p.pair}</a>
               </td>
               <td class="py-2 px-2 text-right tabular-nums text-gray-400">{(p.feeBps / 100).toFixed(2)}%</td>
-              <td class="py-2 px-2 text-gray-500 font-mono text-xs">
-                <a href={`/explorer/e/pool/${encodeURIComponent(p.id)}`} class="hover:text-gray-300">{p.id}</a>
+              <td class="py-2 px-2 text-right tabular-nums text-gray-300">
+                {p.tvlUsd != null ? `$${formatCompact(p.tvlUsd)}` : '--'}
+              </td>
+              <td class="py-2 px-2 text-right tabular-nums text-gray-400">
+                {p.vol7d != null ? `$${formatCompact(p.vol7d)}` : '--'}
               </td>
             </tr>
           {/each}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
@@ -7,7 +7,7 @@
   import { fetchFeeSeries } from '$services/explorer/analyticsService';
   import {
     fetchRedemptionRate, fetchRedemptionFeeFloor, fetchRedemptionFeeCeiling,
-    fetchRedemptionTier, fetchCollateralTotals,
+    fetchRedemptionTier, fetchCollateralTotals, fetchProtocolConfig,
   } from '$services/explorer/explorerService';
   import {
     e8sToNumber, formatCompact, CHART_COLORS, COLLATERAL_SYMBOLS, getCollateralSymbol,
@@ -17,6 +17,8 @@
   let rate: number | null = $state(null);
   let feeFloor: number | null = $state(null);
   let feeCeiling: number | null = $state(null);
+  let rmrFloor: number | null = $state(null);
+  let rmrCeiling: number | null = $state(null);
   let collateralTotals: any[] = $state([]);
   let tierMap: Map<string, number | null> = $state(new Map());
   let loading = $state(true);
@@ -24,12 +26,13 @@
   onMount(async () => {
     try {
       const principals = Object.keys(COLLATERAL_SYMBOLS);
-      const [feeR, rateR, floorR, ceilR, totalsR, ...tierRs] = await Promise.allSettled([
+      const [feeR, rateR, floorR, ceilR, totalsR, cfgR, ...tierRs] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchRedemptionRate(),
         fetchRedemptionFeeFloor(),
         fetchRedemptionFeeCeiling(),
         fetchCollateralTotals(),
+        fetchProtocolConfig(),
         ...principals.map(p => fetchRedemptionTier(Principal.fromText(p))),
       ]);
       if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
@@ -37,6 +40,14 @@
       if (floorR.status === 'fulfilled') feeFloor = floorR.value;
       if (ceilR.status === 'fulfilled') feeCeiling = ceilR.value;
       if (totalsR.status === 'fulfilled') collateralTotals = totalsR.value ?? [];
+      if (cfgR.status === 'fulfilled' && cfgR.value) {
+        // RMR = redemption margin ratio. Bounds: rmr_floor → rmr_ceiling. The
+        // active value depends on the global CR (between rmr_floor_cr and
+        // rmr_ceiling_cr). Showing the configured range gives a clear picture
+        // of the protocol's redemption margin policy.
+        rmrFloor = typeof cfgR.value.rmr_floor === 'number' ? cfgR.value.rmr_floor : null;
+        rmrCeiling = typeof cfgR.value.rmr_ceiling === 'number' ? cfgR.value.rmr_ceiling : null;
+      }
 
       const tm = new Map<string, number | null>();
       for (let i = 0; i < principals.length; i++) {
@@ -69,10 +80,18 @@
   const formatPct = (v: number | null) =>
     v == null ? '--' : `${(v * 100).toFixed(2)}%`;
 
+  const rmrRangeLabel = $derived.by(() => {
+    if (rmrFloor == null && rmrCeiling == null) return '--';
+    const lo = rmrFloor != null ? `${(rmrFloor * 100).toFixed(2)}%` : '?';
+    const hi = rmrCeiling != null ? `${(rmrCeiling * 100).toFixed(2)}%` : '?';
+    return `${lo} → ${hi}`;
+  });
+
   const healthMetrics = $derived.by(() => [
     { label: 'Live rate', value: formatPct(rate), sub: 'current redemption fee' },
     { label: 'Fee floor', value: formatPct(feeFloor), tone: 'muted' as const },
     { label: 'Fee ceiling', value: formatPct(feeCeiling), tone: 'muted' as const },
+    { label: 'RMR', value: rmrRangeLabel, sub: 'redemption margin (low→high)', tone: 'muted' as const },
     { label: 'Redemptions (90d)', value: redemptions90d.toLocaleString() },
     { label: 'Fees collected (90d)', value: `$${formatCompact(redemptionFees90d)}`, sub: 'icUSD' },
   ]);

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -109,14 +109,24 @@
     };
   });
 
+  // Treasury share of accrued interest (not the liquidation bonus split — that
+  // belongs in the protocol docs). Pulled from interest_split's "treasury"
+  // entry; this is the slice of borrower interest that gets routed to the
+  // treasury canister.
+  const treasuryInterestShare = $derived.by(() => {
+    const bps = splitRows.find((r: any) => r.destination === 'treasury')?.bps ?? 0;
+    return bps / 10000;
+  });
+
   const healthMetrics = $derived.by(() => [
     { label: 'Fees (90d)', value: `$${formatCompact(totalFees)}` },
     { label: '24h fees', value: `$${formatCompact(fees24h)}` },
-    { label: 'LP APY', value: lpApy != null ? `${Number(lpApy).toFixed(2)}%` : '--', sub: '7d' },
+    { label: '3Pool LP APY', value: lpApy != null ? `${Number(lpApy).toFixed(2)}%` : '--', sub: '7d' },
     { label: 'SP APY', value: spApy != null ? `${Number(spApy).toFixed(2)}%` : '--', sub: '7d' },
     {
-      label: 'Treasury liq share',
-      value: treasuryInfo ? `${(treasuryInfo.liquidationShare * 100).toFixed(0)}%` : '--',
+      label: 'Treasury interest share',
+      value: `${(treasuryInterestShare * 100).toFixed(0)}%`,
+      sub: 'of accrued interest',
     },
   ]);
 
@@ -206,23 +216,27 @@
 {#if treasuryInfo}
   <div class="explorer-card">
     <h3 class="text-sm font-medium text-gray-300 mb-3">Treasury</h3>
-    <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+    <div class="grid grid-cols-2 md:grid-cols-2 gap-4">
       <div>
-        <div class="text-xs text-gray-500">Pending interest</div>
+        <div class="text-xs text-gray-500" title="icUSD that has accrued to the treasury but hasn't yet been swept to the treasury canister. Drops to 0 immediately after each periodic flush.">
+          Pending interest
+        </div>
         <div class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
           {formatCompact(treasuryInfo.pendingInterest / 1e8)} icUSD
         </div>
-      </div>
-      <div>
-        <div class="text-xs text-gray-500">Liquidation share</div>
-        <div class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
-          {(treasuryInfo.liquidationShare * 100).toFixed(0)}%
+        <div class="text-[11px] text-gray-500 mt-0.5">
+          Resets to 0 after each automatic flush.
         </div>
       </div>
       <div>
-        <div class="text-xs text-gray-500">Flush threshold</div>
+        <div class="text-xs text-gray-500" title="When pending interest crosses this amount the protocol auto-distributes it to recipients per the interest split. Threshold of 0 means flush every tick.">
+          Flush threshold
+        </div>
         <div class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
-          {formatCompact(treasuryInfo.flushThreshold)} icUSD
+          {treasuryInfo.flushThreshold > 0 ? `${formatCompact(treasuryInfo.flushThreshold)} icUSD` : 'Flush every tick'}
+        </div>
+        <div class="text-[11px] text-gray-500 mt-0.5">
+          Auto-flushes pending interest when crossed.
         </div>
       </div>
     </div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -6,7 +6,7 @@
   import {
     fetchStabilitySeries, fetchApys, fetchTopSpDepositors,
   } from '$services/explorer/analyticsService';
-  import { shortenPrincipal, getCanisterName } from '$utils/explorerHelpers';
+  import { shortenPrincipal, getCanisterName, getTokenDecimals } from '$utils/explorerHelpers';
   import type { TopSpDepositorRow } from '$declarations/rumi_analytics/rumi_analytics.did';
   import {
     fetchStabilityPoolStatus, fetchStabilityPoolLiquidations,
@@ -147,18 +147,16 @@
 
   // Sum stables_consumed: vec record { principal; nat64 } → total icUSD-equivalent.
   // All SP stablecoins (icUSD, ckUSDC, ckUSDT) are pegged $1 so a raw sum (after
-  // decimals normalization) is fine. ckUSDC/ckUSDT are 6-decimal; icUSD is 8.
+  // decimals normalization) is fine. Decimals are looked up via the central
+  // KNOWN_TOKENS registry so onboarding a new stablecoin doesn't silently
+  // produce 100x-inflated numbers here.
   function debtClearedFromRecord(rec: any): number {
     const stables: Array<[any, bigint]> = rec?.stables_consumed ?? [];
     let total = 0;
     for (const [tokenPrincipal, amountE8s] of stables) {
       const principal = typeof tokenPrincipal?.toText === 'function'
         ? tokenPrincipal.toText() : String(tokenPrincipal);
-      // 6 decimals for ckUSDC / ckUSDT, 8 for everything else (icUSD)
-      const decimals = principal.includes('xevnm-gaaaa') /* ckUSDC */
-        || principal.includes('cngnf-vqaaa') /* ckUSDT */
-        ? 6 : 8;
-      total += Number(amountE8s) / Math.pow(10, decimals);
+      total += Number(amountE8s) / Math.pow(10, getTokenDecimals(principal));
     }
     return total;
   }

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -144,6 +144,24 @@
     { label: 'SP APY', value: displayedSpApy != null ? `${displayedSpApy.toFixed(2)}%` : '--', sub: liveSpApy != null ? 'live' : '7d' },
     { label: 'Liquidations absorbed', value: totalLiquidations.toLocaleString() },
   ]);
+
+  // Sum stables_consumed: vec record { principal; nat64 } → total icUSD-equivalent.
+  // All SP stablecoins (icUSD, ckUSDC, ckUSDT) are pegged $1 so a raw sum (after
+  // decimals normalization) is fine. ckUSDC/ckUSDT are 6-decimal; icUSD is 8.
+  function debtClearedFromRecord(rec: any): number {
+    const stables: Array<[any, bigint]> = rec?.stables_consumed ?? [];
+    let total = 0;
+    for (const [tokenPrincipal, amountE8s] of stables) {
+      const principal = typeof tokenPrincipal?.toText === 'function'
+        ? tokenPrincipal.toText() : String(tokenPrincipal);
+      // 6 decimals for ckUSDC / ckUSDT, 8 for everything else (icUSD)
+      const decimals = principal.includes('xevnm-gaaaa') /* ckUSDC */
+        || principal.includes('cngnf-vqaaa') /* ckUSDT */
+        ? 6 : 8;
+      total += Number(amountE8s) / Math.pow(10, decimals);
+    }
+    return total;
+  }
 </script>
 
 <LensHealthStrip title="Stability pool" metrics={healthMetrics} loading={loading} />
@@ -298,7 +316,7 @@
               </td>
               <td class="py-2 px-2 text-gray-300">{symbol}</td>
               <td class="py-2 px-2 text-right tabular-nums text-gray-300">
-                {formatCompact(Number(l.debt_cleared_e8s ?? l.debt_amount ?? 0n) / 1e8)} icUSD
+                {formatCompact(debtClearedFromRecord(l))} icUSD
               </td>
               <td class="py-2 px-2 text-right tabular-nums text-gray-300">
                 {formatCompact(Number(l.collateral_gained ?? l.collateral_amount ?? 0n) / 1e8)}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -11,9 +11,11 @@
   import {
     fetchStabilityPoolStatus, fetchStabilityPoolLiquidations,
   } from '$services/explorer/explorerService';
+  import { QueryOperations } from '$services/protocol/queryOperations';
   import { e8sToNumber, formatCompact, CHART_COLORS, getCollateralSymbol } from '$utils/explorerChartHelpers';
 
   let poolStatus: any = $state(null);
+  let protocolStatus: any = $state(null);
   let series: any[] = $state([]);
   let liquidations: any[] = $state([]);
   let spApy: number | null = $state(null);
@@ -51,15 +53,17 @@
 
   onMount(async () => {
     try {
-      const [stR, seR, lqR, apR] = await Promise.allSettled([
+      const [stR, seR, lqR, apR, prR] = await Promise.allSettled([
         fetchStabilityPoolStatus(),
         fetchStabilitySeries(90),
         fetchStabilityPoolLiquidations(50),
         fetchApys(),
+        QueryOperations.getProtocolStatus(),
       ]);
       if (stR.status === 'fulfilled') poolStatus = stR.value;
       if (seR.status === 'fulfilled') series = seR.value ?? [];
       if (lqR.status === 'fulfilled') liquidations = lqR.value ?? [];
+      if (prR.status === 'fulfilled') protocolStatus = prR.value;
       if (apR.status === 'fulfilled' && apR.value) {
         const v = apR.value.sp_apy_pct?.[0];
         if (typeof v === 'number' && v > 0) spApy = v;
@@ -70,6 +74,37 @@
       loading = false;
     }
   });
+
+  // Live SP APY: same formula the Stability Pool tab uses, computed from
+  // current protocol/pool status. Fixes the discrepancy between the analytics
+  // 7-day rolling number (slow to react) and the live rate users see in /liquidity.
+  const liveSpApy = $derived.by(() => {
+    if (!protocolStatus || !poolStatus) return null;
+    const split = protocolStatus.interestSplit ?? [];
+    const poolShare = (split.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
+    const perC = protocolStatus.perCollateralInterest;
+    if (!perC || perC.length === 0 || poolShare === 0) return null;
+
+    const eligibleMap = new Map<string, number>(
+      (poolStatus.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [
+        typeof p?.toText === 'function' ? p.toText() : String(p),
+        Number(v) / 1e8,
+      ]),
+    );
+
+    let totalApr = 0;
+    for (const info of perC) {
+      const eligible = eligibleMap.get(info.collateralType) ?? 0;
+      if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
+      totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
+    }
+    if (totalApr === 0) return null;
+    const apy = Math.pow(1 + totalApr / 365, 365) - 1;
+    return apy * 100;
+  });
+
+  // Prefer the live computation; fall back to the 7d rolling analytics number.
+  const displayedSpApy = $derived(liveSpApy ?? spApy);
 
   const totalDeposits = $derived(poolStatus ? e8sToNumber(poolStatus.total_deposits_e8s ?? 0n) : 0);
   const depositors = $derived(poolStatus ? Number(poolStatus.total_depositors ?? 0n) : 0);
@@ -105,8 +140,8 @@
   const healthMetrics = $derived.by(() => [
     { label: 'Deposits', value: `$${formatCompact(totalDeposits)}`, sub: 'icUSD' },
     { label: 'Depositors', value: depositors.toLocaleString() },
-    { label: 'Eligible coverage', value: `$${formatCompact(eligibleCoverage)}`, sub: 'backs debt' },
-    { label: 'SP APY', value: spApy != null ? `${spApy.toFixed(2)}%` : '--', sub: '7d' },
+    { label: 'Eligible coverage', value: `$${formatCompact(eligibleCoverage)}`, sub: 'icUSD-equivalent that can absorb liquidations' },
+    { label: 'SP APY', value: displayedSpApy != null ? `${displayedSpApy.toFixed(2)}%` : '--', sub: liveSpApy != null ? 'live' : '7d' },
     { label: 'Liquidations absorbed', value: totalLiquidations.toLocaleString() },
   ]);
 </script>

--- a/src/vault_frontend/src/lib/utils/ammNaming.ts
+++ b/src/vault_frontend/src/lib/utils/ammNaming.ts
@@ -1,0 +1,84 @@
+/**
+ * Helpers for displaying AMM pool identifiers as friendly names.
+ *
+ * The AMM identifies pools by a string `pool_id` (typically a pair of canister
+ * IDs joined by `_`). For UI surfaces we want stable, sequential labels like
+ * "AMM1", "AMM2" plus the token pair, e.g. "AMM1 · 3USD/ICP".
+ *
+ * The numbering is computed client-side from a registry: pools are sorted by
+ * `pool_id` lexicographically so the index is deterministic across reloads
+ * and across users — without needing a backend index field.
+ */
+
+import { getTokenSymbol } from './explorerHelpers';
+
+export interface AmmPoolLike {
+  pool_id: string;
+  token_a?: any;
+  token_b?: any;
+}
+
+let registry: AmmPoolLike[] = [];
+let indexById: Map<string, number> = new Map();
+
+function principalToText(p: any): string {
+  if (!p) return '';
+  if (typeof p === 'string') return p;
+  if (typeof p?.toText === 'function') return p.toText();
+  return String(p);
+}
+
+/**
+ * Seed the registry with the AMM pool list. Call this once after fetching
+ * `getPools()`. Subsequent `ammPoolLabel(...)` lookups are synchronous.
+ */
+export function setAmmPoolRegistry(pools: AmmPoolLike[]): void {
+  const sorted = [...pools].sort((a, b) => a.pool_id.localeCompare(b.pool_id));
+  registry = sorted;
+  indexById = new Map();
+  sorted.forEach((p, i) => indexById.set(p.pool_id, i + 1));
+}
+
+/**
+ * 1-based index for a pool by its id. Returns null if the pool isn't in the
+ * registry yet (e.g. registry hasn't loaded). Numbering is alphabetical by
+ * `pool_id` so it's deterministic.
+ */
+export function ammPoolIndex(poolId: string | undefined | null): number | null {
+  if (!poolId) return null;
+  return indexById.get(poolId) ?? null;
+}
+
+/**
+ * Token pair label like "3USD/ICP". Falls back to a shortened pool id when
+ * tokens aren't resolvable.
+ */
+export function ammPoolPair(poolId: string | undefined | null, fallbackTokenA?: any, fallbackTokenB?: any): string {
+  if (!poolId) return '';
+  const pool = registry.find((p) => p.pool_id === poolId);
+  const aRaw = pool?.token_a ?? fallbackTokenA;
+  const bRaw = pool?.token_b ?? fallbackTokenB;
+  const a = aRaw ? getTokenSymbol(principalToText(aRaw)) : '';
+  const b = bRaw ? getTokenSymbol(principalToText(bRaw)) : '';
+  if (a && b) return `${a}/${b}`;
+  return poolId;
+}
+
+/**
+ * Short pool label like "AMM1". Use when you only have room for the index.
+ */
+export function ammPoolShortLabel(poolId: string | undefined | null): string {
+  const idx = ammPoolIndex(poolId);
+  return idx != null ? `AMM${idx}` : 'AMM';
+}
+
+/**
+ * Long pool label like "AMM1 · 3USD/ICP". Use in headings / table cells where
+ * you have room for both the index and the pair.
+ */
+export function ammPoolLabel(poolId: string | undefined | null, fallbackTokenA?: any, fallbackTokenB?: any): string {
+  const short = ammPoolShortLabel(poolId);
+  const pair = ammPoolPair(poolId, fallbackTokenA, fallbackTokenB);
+  if (pair && pair !== poolId) return `${short} · ${pair}`;
+  return short;
+}

--- a/src/vault_frontend/src/lib/utils/displayEvent.ts
+++ b/src/vault_frontend/src/lib/utils/displayEvent.ts
@@ -6,6 +6,7 @@ import {
 	formatStabilityPoolEvent, formatMultiHopSwapEvent,
 } from './explorerFormatters';
 import type { FormattedEvent } from './explorerFormatters';
+import { ammPoolShortLabel } from './ammNaming';
 
 export type NonBackendSource =
 	| '3pool_swap'
@@ -179,9 +180,18 @@ export function displayEvent(de: DisplayEvent, maps?: DisplayEventMaps): Display
 	const principal = extractEventPrincipal(de.event, de.source, maps?.vaultOwnerMap);
 	const timestamp = de.timestamp || extractEventTimestamp(de.event);
 	const detailHref = isBackend ? `/explorer/e/event/${globalIndex}` : dexDetailHref(de);
-	const sourceLabel = isBackend
-		? null
-		: (DEX_SOURCE_LABEL[de.source as NonBackendSource] ?? null);
+	// AMM-source events get an indexed label like "AMM1" once the registry is
+	// loaded. Falls back to the generic "AMM" label if the registry isn't
+	// populated yet (first paint, or activity page before pools fetched).
+	let sourceLabel: string | null;
+	if (isBackend) {
+		sourceLabel = null;
+	} else if (de.source === 'amm_swap' || de.source === 'amm_liquidity' || de.source === 'amm_admin') {
+		const poolId = de.event?.pool_id ?? de.event?.ammEvent?.pool_id;
+		sourceLabel = ammPoolShortLabel(poolId ? String(poolId) : null);
+	} else {
+		sourceLabel = DEX_SOURCE_LABEL[de.source as NonBackendSource] ?? null;
+	}
 
 	return { globalIndex, source: de.source, formatted, principal, timestamp, detailHref, sourceLabel };
 }

--- a/src/vault_frontend/src/lib/utils/eventFacets.ts
+++ b/src/vault_frontend/src/lib/utils/eventFacets.ts
@@ -253,8 +253,14 @@ export function classifyEventType(de: DisplayEvent): TypeFacetKey {
     case 'redemption_transfered': return 'redemption_transfer';
     case 'reserve_redemption': return 'reserve_redemption';
 
+    // Canister upgrades and init are admin actions — surface them under 'admin'
+    // alongside setter calls. Only accrue_interest stays in 'system' (it's
+    // automatic interest-tick bookkeeping that fires every block, not a user
+    // or admin action).
     case 'init':
     case 'upgrade':
+      return 'admin';
+
     case 'accrue_interest':
       return 'system';
 

--- a/src/vault_frontend/src/lib/utils/vaultCr.test.ts
+++ b/src/vault_frontend/src/lib/utils/vaultCr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeVaultCrPct } from './vaultCr';
+import { computeVaultCrPct, median } from './vaultCr';
 
 const ICP = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
 
@@ -45,5 +45,17 @@ describe('computeVaultCrPct', () => {
     const priceMap = new Map([[ICP, 10]]);
     const decimalsMap = new Map([[ICP, 8]]);
     expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeCloseTo(1000, 1);
+  });
+});
+
+describe('median', () => {
+  it('returns null for empty array', () => {
+    expect(median([])).toBeNull();
+  });
+  it('returns middle value for odd-length input', () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+  it('returns average of two middle values for even-length input', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
   });
 });

--- a/src/vault_frontend/src/lib/utils/vaultCr.test.ts
+++ b/src/vault_frontend/src/lib/utils/vaultCr.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { computeVaultCrPct } from './vaultCr';
+
+const ICP = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+
+describe('computeVaultCrPct', () => {
+  it('returns CR as a percent for a typical ICP vault', () => {
+    // 100 ICP @ $5 = $500 collateral, 200 icUSD debt → 250%
+    const vault = {
+      collateral_amount: 100_00_000_000n, // 100 ICP at e8s
+      collateral_type: ICP,
+      borrowed_icusd_amount: 200_00_000_000n, // 200 icUSD at e8s
+    };
+    const priceMap = new Map([[ICP, 5]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeCloseTo(250, 1);
+  });
+
+  it('returns null when debt is zero (debt-free vault)', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: ICP,
+      borrowed_icusd_amount: 0n,
+    };
+    const priceMap = new Map([[ICP, 5]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeNull();
+  });
+
+  it('returns null when price is missing for the collateral', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: ICP,
+      borrowed_icusd_amount: 100_00_000_000n,
+    };
+    expect(computeVaultCrPct(vault, new Map(), new Map())).toBeNull();
+  });
+
+  it('handles principal objects with toText()', () => {
+    const vault = {
+      collateral_amount: 100_00_000_000n,
+      collateral_type: { toText: () => ICP },
+      borrowed_icusd_amount: 100_00_000_000n,
+    };
+    const priceMap = new Map([[ICP, 10]]);
+    const decimalsMap = new Map([[ICP, 8]]);
+    expect(computeVaultCrPct(vault, priceMap, decimalsMap)).toBeCloseTo(1000, 1);
+  });
+});

--- a/src/vault_frontend/src/lib/utils/vaultCr.ts
+++ b/src/vault_frontend/src/lib/utils/vaultCr.ts
@@ -1,0 +1,50 @@
+/**
+ * Compute a vault's collateral ratio as a percent (e.g., 243 for 243%).
+ *
+ * The backend doesn't store CR on the vault -- it's computed on demand from
+ * collateral_amount x price / borrowed_icusd_amount whenever needed. The
+ * frontend has the same inputs (vaults from get_all_vaults, prices from
+ * twap or last_price), so computing here is straightforward.
+ *
+ * Returns null when the vault has zero debt (CR is undefined) or when we
+ * don't have a price for the collateral (better to skip than show 0).
+ */
+
+function principalText(p: any): string {
+  if (!p) return '';
+  if (typeof p === 'string') return p;
+  if (typeof p?.toText === 'function') return p.toText();
+  return String(p);
+}
+
+export function computeVaultCrPct(
+  vault: any,
+  priceMap: Map<string, number>,
+  decimalsMap: Map<string, number>,
+): number | null {
+  const debtE8s = Number(vault.borrowed_icusd_amount ?? 0n);
+  if (debtE8s <= 0) return null;
+
+  const collType = principalText(vault.collateral_type);
+  const price = priceMap.get(collType);
+  if (price == null || price <= 0) return null;
+
+  const decimals = decimalsMap.get(collType) ?? 8;
+  const collAmount = Number(vault.collateral_amount ?? 0n) / Math.pow(10, decimals);
+  const collateralUsd = collAmount * price;
+  const debtUsd = debtE8s / 1e8;
+  return (collateralUsd / debtUsd) * 100;
+}
+
+/**
+ * Median of a numeric array. Returns null for empty input.
+ * Used for the per-collateral median CR column in CollateralTable.
+ */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -43,6 +43,7 @@
 		toggleAdminLabel,
 		type Facets,
 	} from '$utils/eventFacets';
+	import { setAmmPoolRegistry } from '$utils/ammNaming';
 	import { fetchAdminEventBreakdown } from '$services/explorer/analyticsService';
 	import type { AdminEventLabelCount } from '$declarations/rumi_analytics/rumi_analytics.did';
 
@@ -407,6 +408,8 @@
 				fetchCollateralPrices(),
 			]);
 			knownAmmPools = ammPools ?? [];
+			// Seed registry so AMM event rows render "AMM1" labels instead of generic "AMM".
+			setAmmPoolRegistry(knownAmmPools);
 			priceMap = prices;
 
 			// Pool options: 3pool always first, then AMM pools

--- a/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
@@ -32,12 +32,14 @@
     fetchAmmSwapEventsByTimeRange,
     fetchAmmLiquidityEvents,
     fetchAmmLiquidityEventCount,
+    fetchCollateralPrices,
   } from '$services/explorer/explorerService';
   import { fetchPoolRoutes } from '$services/explorer/analyticsService';
   import type { PoolRoute } from '$declarations/rumi_analytics/rumi_analytics.did';
   import { AMM_TOKENS } from '$services/ammService';
   import type { DisplayEvent } from '$utils/displayEvent';
   import { CANISTER_IDS } from '$lib/config';
+  import { formatCompact } from '$utils/explorerChartHelpers';
 
   const poolIdParam = $derived($page.params.id);
 
@@ -51,6 +53,7 @@
   let loading = $state(true);
   let error = $state<string | null>(null);
   let poolRoutes = $state<PoolRoute[]>([]);
+  let priceMap = $state<Map<string, number>>(new Map());
 
   // ── 3pool state ──────────────────────────────────────────────────────────
   let status = $state<any>(null);
@@ -112,6 +115,46 @@
     const aNorm = Number(ammReserveA) / 10 ** ammTokenA.decimals;
     const bNorm = Number(ammReserveB) / 10 ** ammTokenB.decimals;
     return bNorm === 0 ? 0 : aNorm / bNorm;
+  });
+
+  // ── TVL ──────────────────────────────────────────────────────────────────
+  // 3pool TVL: sum of stable balances normalized to USD ($1 each).
+  const threePoolTvlUsd = $derived.by(() => {
+    if (!status?.tokens?.length || !status?.balances) return 0;
+    let total = 0;
+    for (let i = 0; i < status.tokens.length; i++) {
+      const tok = status.tokens[i];
+      const bal = status.balances[i] ?? 0n;
+      const dec = Number(tok.decimals ?? 8);
+      total += Number(bal) / 10 ** dec; // stables ≈ $1
+    }
+    return total;
+  });
+
+  // AMM TVL: needs oracle prices for both legs. If one leg is 3USD we price it
+  // by the 3pool virtual_price; ICP via the protocol's last_price; everything
+  // else $1 if a stablecoin, else null (unknown — display "--").
+  function priceForToken(ledgerId: string): number | null {
+    if (ledgerId === CANISTER_IDS.THREEPOOL) {
+      // 3USD LP token priced via virtual price (each unit = vp dollars)
+      return Number(virtualPrice) / 1e18 || null;
+    }
+    if (ledgerId === CANISTER_IDS.ICUSD_LEDGER) return 1;
+    if (ledgerId === CANISTER_IDS.CKUSDT_LEDGER) return 1;
+    if (ledgerId === CANISTER_IDS.CKUSDC_LEDGER) return 1;
+    const p = priceMap.get(ledgerId);
+    if (typeof p === 'number' && p > 0) return p;
+    return null;
+  }
+
+  const ammTvlUsd = $derived.by(() => {
+    if (!ammPool || !ammTokenA || !ammTokenB) return null;
+    const priceA = priceForToken(ammTokenA.ledgerId);
+    const priceB = priceForToken(ammTokenB.ledgerId);
+    if (priceA == null || priceB == null) return null;
+    const aNorm = Number(ammReserveA) / 10 ** ammTokenA.decimals;
+    const bNorm = Number(ammReserveB) / 10 ** ammTokenB.decimals;
+    return aNorm * priceA + bNorm * priceB;
   });
 
   // ── Shared formatters ────────────────────────────────────────────────────
@@ -268,6 +311,8 @@
     const routesPromise = fetchPoolRoutes(poolIdParam, ROUTES_WINDOW_NS, 10)
       .then((r) => r.routes)
       .catch(() => [] as PoolRoute[]);
+    // Pull oracle prices once so the AMM branch can value the volatile leg.
+    fetchCollateralPrices().then((m) => { priceMap = m; }).catch(() => {});
 
     if (isThreePool) {
       try {
@@ -320,6 +365,10 @@
         return;
       }
       ammPool = pool;
+
+      // Pull 3pool status so we can value any 3USD leg via virtual_price.
+      // Cheap query, runs in parallel with the rest.
+      fetchThreePoolStatus().then((s) => { status = s; }).catch(() => {});
 
       // Seven-day window of swap events for the activity feed.
       const now = BigInt(Date.now()) * 1_000_000n;
@@ -386,7 +435,11 @@
         <CopyButton text={CANISTER_IDS.THREEPOOL} />
       </div>
 
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">TVL</div>
+          <div class="text-lg font-mono text-white">${formatCompact(threePoolTvlUsd)}</div>
+        </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
           <div class="text-[10px] uppercase tracking-wider text-gray-500">Amplification (A)</div>
           <div class="text-lg font-mono text-white">{currentA || '--'}</div>
@@ -453,7 +506,11 @@
         <CopyButton text={poolIdParam} />
       </div>
 
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
+          <div class="text-[10px] uppercase tracking-wider text-gray-500">TVL</div>
+          <div class="text-lg font-mono text-white">{ammTvlUsd != null ? `$${formatCompact(ammTvlUsd)}` : '--'}</div>
+        </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4">
           <div class="text-[10px] uppercase tracking-wider text-gray-500">Curve</div>
           <div class="text-lg font-mono text-white">Constant product</div>


### PR DESCRIPTION
## Summary
- Source DIDs in `src/<package>/<canister>.did` had drifted from `src/declarations/<canister>/`. Regenerated three canisters via `dfx generate`:
  - `rumi_stability_pool` — adds 11 missing `PoolEventType` variants (the original analytics decode failure that prompted [b6e59a5](https://github.com/RumiLabsXYZ/rumi-protocol-v2/commit/b6e59a5))
  - `rumi_protocol_backend` — large drift, missing `ProtocolConfig`, `VaultRedemptionImpact`, and various event field reordering
  - `rumi_treasury` — missing `BorrowingFee`/`LiquidationFee`/`InterestRevenue` deposit types, `ckusdt_ledger`/`ckusdc_ledger` config fields, `TreasuryEvent`/`TreasuryAction`/`get_events`/`get_event_count`
- `rumi_amm`, `rumi_3pool`, `rumi_analytics` were already in sync — left untouched.
- `liquidation_bot` has never had a `src/declarations/` dir generated; out of scope here.

## Test plan
- [x] `cargo test --package rumi_protocol_backend --bin rumi_protocol_backend check_candid_interface_compatibility` passes (confirms backend source DID matches `__export_service!()`)
- [x] Treasury source-DID types verified present in [src/rumi_treasury/src/types.rs](src/rumi_treasury/src/types.rs) and [lib.rs](src/rumi_treasury/src/lib.rs)
- [x] SP `PoolEventType` now has all 16 variants (matching [src/stability_pool/src/types.rs](src/stability_pool/src/types.rs))
- [x] `diff src/<package>/<canister>.did src/declarations/<canister>/<canister>.did` is empty for every Rust canister with declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)