### PR TITLE
chore(tests): bump expected cursor count to 7 (SP tailer added)

### DIFF
--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -722,8 +722,11 @@ fn collector_health_reports_cursor_positions() {
 
     let health = get_collector_health(&env);
 
-    // Should have 6 cursors
-    assert_eq!(health.cursors.len(), 6, "expected 6 cursors");
+    // Should have 7 cursors. The original 6 (icusd_blocks, threeusd_blocks,
+    // backend_events, 3pool_liquidity_events, amm_swap_events, ThreeUsd icrc3)
+    // plus the stability_pool_events tailer added by commit 2ce0771
+    // ("feat(analytics): tail rumi_stability_pool canister events").
+    assert_eq!(health.cursors.len(), 7, "expected 7 cursors");
 
     // last_pull_cycle_ns should be non-zero after a pull cycle
     assert!(health.last_pull_cycle_ns > 0, "last_pull_cycle_ns should be set");


### PR DESCRIPTION
## Summary

`collector_health_reports_cursor_positions` was asserting `cursors.len() == 6` against the analytics canister's collector health report. Commit [2ce0771](https://github.com/RumiLabsXYZ/rumi-protocol-v2/commit/2ce0771) ("feat(analytics): tail rumi_stability_pool canister events") added a 7th collector (`stability_pool_events`) without updating this assertion, so the test has been failing on main since then and blocking the pre-deploy hook.

This PR bumps the assertion to 7 with a comment listing all collectors so the next addition has a clear list to update.

## Test plan

- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p rumi_analytics --test pocket_ic_analytics collector_health_reports_cursor_positions` (1 passed)
- [x] Pre-deploy hook unblocked for the next backend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)