### PR TITLE
fix(xrc): never persist fetch/timer lock flags across upgrades

### DIFF
--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -710,7 +710,16 @@ pub struct State {
     pub principal_guard_timestamps: BTreeMap<Principal, u64>, // Add timestamps for guards
     pub operation_states: BTreeMap<Principal, OperationState>, // Track operation states
     pub operation_names: BTreeMap<Principal, String>, // Track operation names
+    /// Transient runtime lock for `TimerLogicGuard`. Cleared on guard `Drop`.
+    /// `serde(default, skip_serializing)`: NEVER persisted across upgrades —
+    /// otherwise an upgrade caught with the lock held would leave it stuck `true`
+    /// on the restored state, since the in-flight future is killed by the upgrade
+    /// before its `Drop` runs.
+    #[serde(default, skip_serializing)]
     pub is_timer_running: bool,
+    /// Transient runtime lock for `FetchXrcGuard`. Same upgrade-safety rationale
+    /// as `is_timer_running` — see that field's doc comment.
+    #[serde(default, skip_serializing)]
     pub is_fetching_rate: bool,
 
     /// When true, automatic mode transitions (from price updates) are suppressed.


### PR DESCRIPTION
## Summary
- **Live mainnet bug:** `last_icp_timestamp` on `rumi_protocol_backend` has been frozen for ~18.7h. Every borrow / repay / liquidation / redemption fails with "Last known ICP price too old".
- **Root cause:** `is_fetching_rate` and `is_timer_running` are transient in-memory locks (`FetchXrcGuard` / `TimerLogicGuard`) cleared on `Drop`, but they were being serialized into the upgrade snapshot. A recent upgrade caught `fetch_icp_rate()` paused at an XRC `await`; the upgrade killed the future before `Drop` ran, the lock got persisted as `true`, and every subsequent fetch exits at the guard check.
- **Fix:** add `#[serde(default, skip_serializing)]` to both fields so they default to `false` on every restore. Same pattern already used for the trove CR index in this file.

## Test plan
- [x] `cargo check -p rumi_protocol_backend --target wasm32-unknown-unknown` clean
- [ ] Pre-deploy hook runs unit + integration tests on mainnet upgrade
- [ ] Verify post-deploy: `last_icp_timestamp` advances within 5 min (next timer tick) or immediately on first authenticated user call
- [ ] Verify post-deploy: opening a new vault with ICP succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)