### PR TITLE
fix(xrc): clear transient locks in post_upgrade (recover stuck state)

### DIFF
--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -482,6 +482,17 @@ fn post_upgrade(arg: ProtocolArg) {
         end - start
     );
 
+    // Defense-in-depth: clear transient runtime locks unconditionally on every
+    // upgrade. The matching State fields now use `serde(skip_serializing)` so
+    // future upgrades won't re-introduce a stuck lock, but snapshots written by
+    // the OLD code (before that change shipped) can still carry `true`. Locks
+    // guard in-flight async futures that the upgrade has already killed, so
+    // resetting them here is always correct.
+    mutate_state(|s| {
+        s.is_fetching_rate = false;
+        s.is_timer_running = false;
+    });
+
     setup_timers();
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #123. That PR added `serde(skip_serializing)` to the lock flags so future snapshots won't persist them — but `skip_serializing` only affects writes. Snapshots written by the OLD code already contain `is_fetching_rate: true`, and the new code deserializes that value, so the protocol stayed broken after the first deploy (verified: \`last_icp_timestamp\` still frozen at the same nanos as before #123 shipped).

This PR clears both transient locks unconditionally in `post_upgrade`. They guard in-flight async futures that the upgrade has already killed, so resetting them is always correct.

## Test plan
- [x] `cargo check -p rumi_protocol_backend --target wasm32-unknown-unknown` clean
- [ ] Post-deploy: \`last_icp_timestamp\` advances within 5 min
- [ ] Post-deploy: opening a new vault with ICP succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)