### PR TITLE
feat(explorer): review pass round 2 (analytics queries + lens reworks + bug fixes)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-explorer-review-pass-round-2-brief.md
+++ b/docs/superpowers/plans/2026-04-27-explorer-review-pass-round-2-brief.md
@@ -1,0 +1,180 @@
+# Explorer Review Pass — Round 2 Brief
+
+> Hand this prompt to a fresh session. It picks up from `feat/explorer-review-pass` after the round-1 work shipped. The new session should investigate root causes (use the **systematic-debugging** skill for the data bugs), make design decisions explicitly with Rob (the items marked **DECISION**), and execute as a planned set of tasks.
+
+---
+
+## State of play
+
+- Branch: **`feat/explorer-review-pass`** (16 commits ahead of `main`, **not yet pushed**)
+- Two mainnet deploys done by the round-1 session:
+  - **rumi_analytics** (`dtlu2-uqaaa-aaaap-qugcq-cai`) — SP tailer live, ingesting from `evt_stability` cursor 126; fee_amount captured in tailer + summed in daily rollup; all 16 SP `PoolEventType` variants matched.
+  - **vault_frontend** (`tcfua-yaaaa-aaaap-qrd7q-cai`) — all round-1 frontend changes live.
+- The original plan: `docs/superpowers/plans/2026-04-27-explorer-review-pass.md`. All Phase 0/1/2 tasks completed.
+
+**Important wrinkle:** The analytics canister's daily fee rollup writes one row per day. Round-1 added `Some(borrow_fees) / Some(redemption_fees)` to the rollup, but the historical rows pre-deploy still have `borrowing_fees_e8s = null` / `redemption_fees_e8s = null`. The next daily tick (after the deploy) will produce the first rollup with real fee sums. Until then, the Revenue lens shows the historical-only data, which is what Rob is reporting as "nothing changed." Confirm the timer state before assuming a bug — `dfx canister --network ic call rumi_analytics get_collector_health` and look at `last_pull_cycle_ns`. The daily fee rollup runs separately from `pull_cycle` though — track down its trigger schedule.
+
+---
+
+## Round-1 leftovers + new observations
+
+Grouped by lens. Most items are bugs (root-cause-first). A few are design decisions Rob explicitly wants to weigh in on.
+
+### A. Activity feed (cross-lens)
+
+- **A1.** AMM event badge currently shows truncated token identifiers (e.g. `+pool:fohh4-...cai_ryjl3-...cai`). **Rename to `🌊 3USD/ICP`** — wave emoji to match the 3pool style, token-pair label, no AMM1 prefix in the chip itself. The "AMM1" label can stay as the source-prefix on the row's leading cell. Source label is in `src/vault_frontend/src/lib/utils/displayEvent.ts` (`DEX_SOURCE_LABEL` + the AMM-source override added in round 1) and the chip render is in `MixedEventRow.svelte` / `EventRow.svelte`.
+
+### B. Collateral lens
+
+- **B1. CR distribution histogram bars are tiny slivers.** Round-1 fixed the empty-data bug (vault.collateral_ratio doesn't exist; helper computes CR client-side). But the rendering is still broken — bars are unreadably small. Investigate: probably the bar height calc in `CollateralLens.svelte` (the `pct = (b.count / maxBucket) * 100` line and the `style="height: {pct}%"` div). Could also be a CSS height issue — the parent `<div class="flex items-end gap-2 h-40">` may be losing its height. Use systematic-debugging.
+
+- **B2. Liquidation Risk card is empty.** Rob clarified what he wants here: vaults that are **below minimum CR but above the liquidation threshold** — the warning zone where no more borrowing is possible (this is what triggers the warning icon on each vault). Currently the lens calls `fetchLiquidatableVaults()` which returns vaults at-or-below the liquidation threshold, so it's almost always empty.
+
+  Implementation: take all vaults, compute CR client-side via the round-1 helper, filter to those where `cr < min_cr_for_borrowing && cr >= liquidation_ratio`. The thresholds come from `fetchCollateralConfigs` (each has `borrow_threshold_ratio` and `liquidation_ratio`). Display in the existing `LiquidationRiskTable` component.
+
+### C. Stability Pool lens
+
+This section needs a **rework**, not just bug fixes. Rob's vision:
+
+- **C1. Top depositors → "Current depositors" snapshot.** Drop the time-window logic. Show every principal currently holding any SP balance, ordered by total USD value descending. **Don't normalize 3USD into icUSD** — show per-token columns: icUSD, 3USD, ckUSDT, ckUSDC, etc. Each column shows that user's balance in that token (or empty if zero).
+
+- **C2. The pool says 4 depositors but only 1 shows in the leaderboard.** This is a real data bug — the analytics endpoint is missing depositors. Trace through:
+  1. `dfx canister --network ic call rumi_analytics get_top_sp_depositors '(record { window_ns = null; limit = opt 50 })'` — does it return all 4?
+  2. If not, look at `compute_top_sp_depositors` in `src/rumi_analytics/src/queries/live.rs:749` — the `window_stats.into_iter().filter(|(_, (dep, _))| *dep > 0)` line drops anyone whose deposit total in the window is 0, which means depositors who haven't deposited recently are filtered out even if they still have a balance.
+  3. With C1's redesign (snapshot, not flow), this filter logic gets thrown out anyway — read directly from `evt_stability` and reduce per-principal: `+amount on Deposit, -amount on Withdraw`. Net positive = active depositor.
+
+  Also note: the SP canister itself probably exposes a balances query (`get_pool_status` returns `total_depositors` and there's likely a per-user query too — check `src/declarations/rumi_stability_pool/rumi_stability_pool.did`). It might be cleaner to query the SP canister directly for current balances rather than reconstructing from events.
+
+- **C3. Rob's principal shows balance=0 despite having ~$500 in 3USD + a couple icUSD.** Same root cause as C2 likely. Reproducer: his principal is in `~/.config/dfx/identity/rumi_identity/` — `dfx identity get-principal` returns it. Cross-check: `dfx canister --network ic call rumi_stability_pool get_user_position '(principal "<his>")'` (or whatever the SP canister's per-user query is named — find it in the .did) should show real balances.
+
+- **C4. Replace "Collateral in pool" card with "Per-collateral opt-in coverage."**
+
+  Rob's spec: for each supported collateral type, show:
+  - Collateral symbol (ICP, BOB, EXE, ckBTC, ckETH, ckXAUT, nICP)
+  - **% of depositors who haven't opted out** of that collateral (i.e., would absorb a liquidation in it)
+  - **Total $ available** for liquidating that collateral (sum of stable balances across opted-in depositors)
+
+  Example: `ICP 100% $1,000` (all 4 depositors are in for ICP, $1k total backing) / `BOB 50% $500` (half opted out).
+
+  Data source: SP events include `OptOutCollateral { collateral_type }` and `OptInCollateral { collateral_type }` (round-1 already added these to the analytics shadow type but doesn't aggregate them — see `src/rumi_analytics/src/sources/stability_pool.rs`). The "total $ available" cross-references each opted-in depositor's stable balance.
+
+  This is a reasonably big new analytics endpoint. May need a fresh query in `src/rumi_analytics/src/queries/live.rs` (e.g., `get_sp_coverage_per_collateral`) plus frontend consumption.
+
+### D. Redemptions lens
+
+- **D1. Replace RMR range tile with a single "current RMR" tile.** Round-1 showed "RMR floor → ceiling" (96% → 100%) which Rob says is meaningless to readers. Show the **active RMR** value (which depends on current global CR vs `rmr_floor_cr` / `rmr_ceiling_cr`). Add an info-bubble tooltip explaining: what RMR is, how it moves, and ideally a small inline curve preview or a link to the docs curve.
+
+  Find the active-RMR computation in the backend: `src/rumi_protocol_backend/src/state.rs` — search for `rmr_floor_cr`, `rmr_ceiling_cr`, the linear interpolation logic. There may already be a `get_current_rmr()` query exposed in the candid. If not, the frontend can compute it from the protocol status (`total_collateral_ratio`) plus the four RMR config fields.
+
+- **D2. "Recent redemption activity" panel at the bottom is empty even though "View All" shows redemptions.** This is a `LensActivityPanel` bug — the lens-level filter is too strict OR the lens is sourcing from a different feed than View All.
+
+  Look at `LensActivityPanel.svelte` with `scope="redemptions"`. The `isBackendRedemption` filter (rewritten in round 1 to use snake_case) checks for `redemption_on_vaults`. But maybe the limit is too small (default 12) and there are no redemptions in the most recent N events. Try widening the fetch window — for redemptions specifically, "recent" should mean "the latest redemption event regardless of age," not "in the last N events overall." Either bump the fetch size for this scope or change the source to `fetchEventsByPrincipal` / a redemption-specific endpoint.
+
+### E. Revenue lens
+
+**Rob notes none of his original observations were addressed visually. Most of these are real bugs — go through each.**
+
+- **E1. "Fees (90d) = $1" but "24h fees = $5" — contradiction.** The 90d total can't be less than the 24h total. Bug in either:
+  - The 90d sum (probably summing only `swap_fees_e8s` from rollups, ignoring borrow + redemption — but those are also $0/null in the historical rollups, so it should at least equal 24h)
+  - The 24h estimate (`fees24h` derived in `RevenueLens.svelte` includes `estimatedDailyBorrow` from live protocol state — that's a forward-looking estimate, not actual realized fees)
+
+  The contradiction is real. Track down the math in `RevenueLens.svelte`:
+  ```typescript
+  const totalBorrow = $derived(feeRows.reduce(...));
+  const totalRedemption = $derived(...);
+  const totalSwap = $derived(...);
+  const totalFees = $derived(totalBorrow + totalRedemption + totalSwap);
+  const estimatedDailyBorrow = $derived(/* from protocol status */);
+  const fees24h = $derived(swapFees24h + estimatedDailyBorrow);
+  ```
+  `totalFees` (90d) is realized fees from rollups; `fees24h` is partly estimated. They use different units / methodologies. Either make them consistent or label them clearly so the contradiction goes away. Possibly: replace `fees24h` with the most recent rollup row's actual fees instead of an estimate.
+
+- **E2. 3Pool LP APY = null.** The analytics `compute_lp_apy` returns null when the TVL snapshot rows have `None` reserves. Find why TVL snapshots are empty — look at `src/rumi_analytics/src/collectors/tvl.rs` and `compute_lp_apy` in `queries/live.rs`. Possibly the 3pool snapshot collector isn't running, or the reserve fields aren't being populated correctly.
+
+- **E3. SP APY says 4.72% — Rob believes wrong.** Round-1 added a live SP APY computation matching the /liquidity tab. If the lens still shows 4.72%, the live formula returned null and we fell back to the 7d analytics number. Check `liveSpApy` in `StabilityPoolLens.svelte` — it uses `protocolStatus.interestSplit` and `protocolStatus.perCollateralInterest`. If either is empty/missing, falls back. Investigate why those would be empty post-deploy.
+
+- **E4. Fee breakdown: $0 borrow, $0 redemption, $1 swap — root cause + plan.** Background: round-1's analytics changes (capture fee_amount + sum it) only affect rollups written AFTER the deploy. Historical daily rollups have `borrowing_fees_e8s = null`, `redemption_fees_e8s = null`. Three options:
+  1. **Wait** for the daily rollup to fire and write a real-fee row. The Revenue card will show `$X` for "today" but the 90d total will still mostly be null.
+  2. **Backfill historical rollups** by re-scanning `evt_vaults` for the past 90 days. Add a one-shot backfill endpoint in rumi_analytics.
+  3. **Frontend computes 90d totals on the fly** by reading `evt_vaults` directly (analytics already exposes vault events) and summing `fee_amount` per day. Bypass the rollup entirely for this metric.
+
+  **DECISION:** which approach. I'd lean toward option 2 (backfill) because rollups are the canonical source. Option 3 makes the frontend compute a lot of data on every page load.
+
+- **E5. Treasury card rework.** Currently shows "Pending interest = 0 / Flush threshold = 0." Rob's right — flush threshold of 0 means pending always immediately flushes, so this is permanently uninformative.
+
+  Replace with a **Treasury holdings** card: actual token balances held by the rumi_treasury canister (`tlg74-oiaaa-aaaap-qrd6a-cai`). Query `icrc1_balance_of` on each ledger (icUSD, ckUSDT, ckUSDC, ICP, etc.) using the treasury canister as the account owner. Show one row per token with symbol + balance + USD-equivalent.
+
+  This is "look up balances on the ledgers using the treasury principal as account" — straightforward but new code. Probably belongs in `src/vault_frontend/src/lib/services/explorer/explorerService.ts` as `fetchTreasuryHoldings()`.
+
+### F. DEXs lens
+
+- **F1. Arb score** needs a tooltip explaining what it is. (Look at `src/rumi_analytics/src/queries/live.rs` for the formula. Probably some price-deviation × pool-imbalance metric. Translate the formula into plain English for the tooltip.)
+
+- **F2. 3pool LP APY null** — same root cause as E2. Fix once, both lenses show it.
+
+- **F3. 3pool swap volume chart shows just a single dot at "$70."** Round-1 added dots for non-zero points to make sparse data visible. With only one non-zero point in the entire 7-day hourly series, the result is a single dot — technically correct but looks broken. Better: when only 1 non-zero point exists, fall back to a centered "indicator" or extend the dot rendering to be more obvious (e.g., a vertical line marker + the value). Or change the source data: pull a longer window so there's more chance of multiple points.
+
+- **F4. 3pool virtual price chart y-axis scale.** Currently looks like a flat line because the y-range covers the full positive number space. The virtual price moves slowly (e.g. 1.063 → 1.064) and a chart from 0 means the slope is invisible. **Tighten the y-axis** to a small padding around the actual data range (e.g. `[min × 0.999, max × 1.001]`). The `MiniAreaChart` round-1 changed for the volume case anchored y at 0 for "all non-negative" — that's the wrong behavior here. Add a prop like `yAxisMode: 'zero-anchored' | 'data-fit'` or detect the case (small variance relative to absolute value) and use data-fit automatically.
+
+- **F5. AMM Pools card pair label.** Says `3USD LP/ICP` — should be just `3USD/ICP`. The "LP" suffix comes from `getTokenSymbol()` for the THREEPOOL principal — check `KNOWN_TOKENS` in `src/vault_frontend/src/lib/utils/explorerHelpers.ts`. If the registered symbol is "3USD LP" change it to "3USD" (since 3USD IS the LP token, the LP suffix is redundant). Or, in the AMM Pools card specifically, strip a trailing " LP" from the rendered pair.
+
+- **F6. Remove redundant bottom-row cards.** Below the AMM Pools card there are three small cards (3pool balance / 3pool LP APY / Stability pool APY) duplicating the top-strip metrics. The third one isn't even relevant to the DEXs lens. Strip the entire row out — rendered by `<PoolHealthStrip />` in `DexsLens.svelte`. Just delete that line.
+
+### G. Admin lens
+
+- **G1. Top "health strip" card is sparse.** Currently shows `Mode` and `Collector errors`. Either:
+  1. Justify it with more useful stats (canister cycles for ALL canisters, latest setter timestamp, etc.) and keep it
+  2. Merge it into the Admin Breakdown card
+  3. Drop it entirely
+
+  **DECISION:** which. The 12-errors fix below interacts with this — if we keep the card, the collector errors number is more meaningful once it's accurate.
+
+- **G2. Explain "Collector errors."** Add a tooltip / sub-text on the metric. It's the count of failed inter-canister calls from the analytics canister's tailers (e.g., when the SP canister returns an unexpected response shape and decode fails). Sub-source breakdown is already in the "Analytics tailing health" card below — link the two visually if they stay separate.
+
+- **G3. The 12 leftover `error_counters.stability_pool` errors.** Background: round-1's first deploy of the SP tailer failed at runtime (the SP candid is stale and missing 11 PoolEventType variants — this was the deploy bug) and incremented the counter 12 times before the fix landed. Now the counter sits at 12 forever — accurate that they happened, but misleading because they're from a fixed bug.
+
+  **DECISION:** four options:
+  1. **Add a `reset_error_counters` admin endpoint** (gated by the admin principal) on rumi_analytics. One-shot use for cases like this. Slight scope creep.
+  2. **Reset in `post_upgrade`** — make the next analytics upgrade zero out specific source counters. Avoids new endpoint but requires a migration commit.
+  3. **Frontend "since cursor X" display** — store a baseline counter at deploy time, only show errors-since-baseline. Doesn't actually fix the data.
+  4. **Document and accept** — the counter is technically accurate. Add a small "(historical)" annotation explaining post-deploy errors are leftover from a known fix.
+
+  My lean: option 1 (admin endpoint) — useful primitive to have for operational reasons beyond this incident.
+
+---
+
+## Suggested execution order
+
+1. **Triage + brainstorm with Rob.** Before coding, walk through the DECISION items and the design changes (C1/C4/E5/G1/G3) to lock in the approach.
+2. **Use writing-plans to convert the agreed decisions into a Round-2 plan.**
+3. **Use subagent-driven-development for execution** — each lens is roughly independent.
+4. **Investigate the data bugs with systematic-debugging** before fixing them. Don't guess. Especially:
+   - C2 (depositor count mismatch)
+   - C3 (Rob's balance = 0)
+   - E1 (fee total contradiction)
+   - E2 / F2 (LP APY null root cause — probably a TVL collector issue)
+   - E3 (live SP APY null fallback)
+
+5. **Push the branch + open a PR** when round 2 is complete (round 1 hasn't been pushed yet — the round-2 work goes on the same branch).
+
+---
+
+## Quick reference
+
+| Item | File |
+|---|---|
+| Round-1 plan | `docs/superpowers/plans/2026-04-27-explorer-review-pass.md` |
+| AMM source label override | `src/vault_frontend/src/lib/utils/displayEvent.ts` |
+| Pool registry helper | `src/vault_frontend/src/lib/utils/ammNaming.ts` |
+| Vault CR helper | `src/vault_frontend/src/lib/utils/vaultCr.ts` |
+| Lens activity filter (snake_case rewrite) | `src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte` |
+| Mini chart with sparse-data dots | `src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte` |
+| Analytics SP shadow types (16 variants) | `src/rumi_analytics/src/sources/stability_pool.rs` |
+| Analytics SP tailer (id-based cursor) | `src/rumi_analytics/src/tailing/stability_pool.rs` |
+| Analytics fee rollup (sums after round 1) | `src/rumi_analytics/src/collectors/rollups.rs` |
+| SP candid (stale; flagged separately) | `src/declarations/rumi_stability_pool/rumi_stability_pool.did` |
+| SP Rust types (16 variants) | `src/stability_pool/src/types.rs` |
+| Treasury principal | `tlg74-oiaaa-aaaap-qrd6a-cai` |
+| rumi_analytics principal | `dtlu2-uqaaa-aaaap-qugcq-cai` |
+
+Branch: `feat/explorer-review-pass` (16 commits). Do not rebase or squash — Rob prefers regular merge commits per project memory.

--- a/docs/superpowers/plans/2026-04-28-explorer-review-pass-round-2.md
+++ b/docs/superpowers/plans/2026-04-28-explorer-review-pass-round-2.md
@@ -1,0 +1,2064 @@
+# Explorer Review Pass — Round 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. For each task whose root cause is unknown (D2, E2/F2, E3), use superpowers:systematic-debugging before writing code.
+
+**Goal:** Resolve every leftover and new issue from Rob's round-2 Explorer review — broken bars/labels, dead cards, contradictory fee numbers, missing depositors, sparse Admin lens — by combining frontend lens cleanups with four targeted analytics canister additions, on top of the round-1 work already on `feat/explorer-review-pass`.
+
+**Architecture:** The vast majority of items are frontend (label, layout, chart axis, fetch path). The genuine backend additions are localized to `rumi_analytics`: a new `get_fee_breakdown_window` query that aggregates fees from the raw `evt_vaults` / `evt_swaps` event logs (so the round-1 fee data flows immediately without touching the append-only daily-fees rollup history); a new `get_sp_depositor_principals` query that returns distinct principals from `evt_stability` (the C-family rework then asks the SP canister for authoritative balances per principal); and a new admin-gated `reset_error_counters` endpoint that lets us zero out the 12 leftover stability_pool counter increments from round-1's first deploy. No protocol-backend changes; no SP canister changes; no rollup migrations; no history deletion.
+
+**Tech Stack:** SvelteKit + TypeScript (vault_frontend), Rust analytics canister (rumi_analytics) on the Internet Computer. Build/deploy via DFX; rumi_analytics wasm needs `ic-wasm shrink` + `gzip` before install per project memory.
+
+**Branch:** `feat/explorer-review-pass` (16 commits, do not push until round 2 lands on top).
+
+---
+
+## Background
+
+Round 1 shipped to mainnet. Both `rumi_analytics` (`dtlu2-uqaaa-aaaap-qugcq-cai`) and `vault_frontend` (`tcfua-yaaaa-aaaap-qrd7q-cai`) are live with the round-1 fixes. The brief at `docs/superpowers/plans/2026-04-27-explorer-review-pass-round-2-brief.md` enumerates all leftover items by lens. The four DECISION items the user weighed in on:
+
+- **E4 (historical fee backfill):** The `daily_fees` log is `StableLog` (append-only, no random writes — confirmed in `src/rumi_analytics/src/storage/rollups.rs:108`). Backfilling historical rows would require either a storage migration or wiping the log. We agreed: never delete history. Instead, add a server-side `get_fee_breakdown_window(window_ns)` query that aggregates from `evt_vaults` + `evt_swaps` directly. Daily rollups continue accumulating untouched and remain canonical for daily series; the new query gives correct totals for any window immediately.
+- **E5 (Treasury holdings card):** Frontend-direct via `icrc1_balance_of` per ledger using the treasury principal (`tlg74-oiaaa-aaaap-qrd6a-cai`) as account owner. Free, fast, current-by-construction. New `fetchTreasuryHoldings()` in `explorerService.ts`.
+- **G1 (sparse Admin top card):** Keep + flesh out. Add Last admin action timestamp + Admin actions 24h count alongside Mode and Collector errors. Mode is too important to merge or drop. Don't add cycles back (round 1 dropped the cycles chart for a reason).
+- **G3 (12 leftover stability_pool errors):** Add admin-gated `reset_error_counters(opt vec text)` endpoint to rumi_analytics. The admin-check pattern already exists at `src/rumi_analytics/src/lib.rs:262-265`. Pass a list of source names to selectively zero out counters; pass null to reset all.
+
+For the C-family rework, the SP canister exposes `get_user_position : (opt principal) -> (opt UserStabilityPosition)` (verified in `src/declarations/rumi_stability_pool/rumi_stability_pool.did:245`). `UserStabilityPosition` carries everything we need: `stablecoin_balances`, `collateral_gains`, `opted_out_collateral`, `total_usd_value_e8s`. There's no `list_all_depositors` query, so the analytics canister will return distinct principals from event history; the frontend then asks SP per-principal for authoritative balances.
+
+---
+
+## File structure
+
+**Frontend new files:**
+- `src/vault_frontend/src/lib/components/explorer/SpCurrentDepositorsCard.svelte` — C1 snapshot
+- `src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte` — C4 per-collateral opt-in coverage
+- `src/vault_frontend/src/lib/components/explorer/TreasuryHoldingsCard.svelte` — E5
+
+**Frontend modified files:**
+- `src/vault_frontend/src/lib/utils/displayEvent.ts` — A1 chip label
+- `src/vault_frontend/src/lib/utils/explorerHelpers.ts` — F5 KNOWN_TOKENS label
+- `src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte` — F3 single-dot fallback, F4 y-axis mode prop
+- `src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte` — D2 redemption fetch widening
+- `src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte` — B1, B2
+- `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte` — replace top depositors and collateral-in-pool with new cards (C1, C4)
+- `src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte` — D1 single current RMR tile
+- `src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte` — E1+E4 unified breakdown call, E5 mount, E3 verify post-fix
+- `src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte` — F1 tooltip, F5 label fix, F6 row removal, E2/F2 (consumes fix from analytics)
+- `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte` — G1 strip, G2 collector errors tooltip
+- `src/vault_frontend/src/lib/services/explorer/analyticsService.ts` — fetchFeeBreakdownWindow, fetchSpDepositorPrincipals, resetErrorCounters
+- `src/vault_frontend/src/lib/services/explorer/explorerService.ts` — fetchTreasuryHoldings, fetchCurrentSpDepositors
+
+**Analytics canister modified files:**
+- `src/rumi_analytics/src/queries/live.rs` — get_fee_breakdown_window, get_sp_depositor_principals
+- `src/rumi_analytics/src/lib.rs` — register new queries + reset_error_counters update
+- `src/rumi_analytics/src/types.rs` — FeeBreakdownQuery, FeeBreakdownResponse, ResetErrorCountersArgs
+- `src/rumi_analytics/rumi_analytics.did` — declare new endpoints
+- (Investigation only) `src/rumi_analytics/src/collectors/tvl.rs` and / or `queries/live.rs` for E2/F2 root cause
+
+---
+
+## Phase 1: Frontend cleanups (no backend dep)
+
+### Task 1.1: A1 — AMM event chip label
+
+The activity feed shows `+pool:fohh4-...cai_ryjl3-...cai` for AMM events. Replace with `🌊 3USD/ICP` so it matches the 3pool style.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/utils/displayEvent.ts`
+
+- [ ] **Step 1: Read the file to find the AMM source override added in round 1**
+
+```bash
+grep -n "AMM\|ammNaming\|pool:" src/vault_frontend/src/lib/utils/displayEvent.ts | head -20
+```
+
+Identify the function or constant that produces the AMM-event chip text.
+
+- [ ] **Step 2: Replace the truncated-principal chip with a static token-pair label**
+
+Use `getPoolPair()` from `$utils/ammNaming` (already imported / available) to get the friendly label. Replace the chip-text producer:
+
+```typescript
+// Old (round 1):
+//   chip = `+pool:${truncatePrincipal(poolPrincipalA)}_${truncatePrincipal(poolPrincipalB)}`;
+// New:
+import { getPoolPair } from './ammNaming';
+const pair = getPoolPair(poolPrincipal); // returns e.g. "3USD/ICP"
+chip = `🌊 ${pair}`;
+```
+
+If `getPoolPair` doesn't yet expose this signature, extend it (it already has the registry seeded in `routes/explorer/activity/+page.svelte`). Look for the AMM index → token-pair mapping and surface a function that takes the pool principal directly.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "displayEvent|ammNaming" | grep ERROR
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Smoke test**
+
+Open `/explorer/activity` on local or mainnet. AMM rows should show `🌊 3USD/ICP` (or whatever the pair is) in the chip.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/utils/displayEvent.ts src/vault_frontend/src/lib/utils/ammNaming.ts
+git commit -m "$(cat <<'EOF'
+fix(explorer): readable AMM chip label (token pair, not truncated principals)
+
+Activity feed showed "+pool:fohh4-...cai_ryjl3-...cai" for AMM events.
+Use the existing pool registry to render "🌊 3USD/ICP" instead — wave
+emoji matches the 3pool style, token pair is the actual content people
+care about.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.2: F5 — fix "3USD LP/ICP" label to "3USD/ICP"
+
+The AMM Pools card pair label says `3USD LP/ICP`. The `LP` suffix is redundant because 3USD itself IS the LP token.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/utils/explorerHelpers.ts`
+
+- [ ] **Step 1: Find the symbol entry in KNOWN_TOKENS**
+
+```bash
+grep -n "3USD LP\|3USD\|THREEPOOL\|fohh4-yyaaa" src/vault_frontend/src/lib/utils/explorerHelpers.ts | head
+```
+
+- [ ] **Step 2: Change the symbol from `3USD LP` to `3USD`**
+
+In `KNOWN_TOKENS`, change the entry for the THREEPOOL principal (`fohh4-yyaaa-aaaap-qtkpa-cai`):
+
+```typescript
+[CANISTER_IDS.THREEPOOL, { symbol: '3USD', decimals: 8 }],
+```
+
+(Verify the pre-existing key shape — could be `{ symbol, decimals, name }` or similar — match it exactly.)
+
+- [ ] **Step 3: Verify other consumers of getTokenSymbol still produce sensible labels**
+
+```bash
+grep -rn "getTokenSymbol\|3USD LP" src/vault_frontend/src/lib/ | head -20
+```
+
+If anything specifically expects `3USD LP` (e.g. a row label intentionally distinguishing the LP from the underlying), keep that local override. Otherwise let the registry change propagate.
+
+- [ ] **Step 4: Smoke test**
+
+Open `/explorer?lens=dexs`. The AMM Pools row should now read `3USD/ICP`, not `3USD LP/ICP`. Cross-check `/explorer/activity` and `/explorer/e/pool/<principal>` — wherever the symbol surfaces.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/utils/explorerHelpers.ts
+git commit -m "$(cat <<'EOF'
+fix(explorer): drop redundant "LP" suffix from 3USD token label
+
+3USD is the 3pool LP token, so labelling it "3USD LP" produces awkward
+pair labels like "3USD LP/ICP". Strip the suffix in KNOWN_TOKENS.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.3: F4 — MiniAreaChart y-axis mode prop
+
+Round 1 anchored the y-axis at zero so sparse volume series stay readable. That's wrong for the 3pool virtual price chart, where values cluster at 1.063–1.064 and a chart from zero looks like a flat line. Add a `yAxisMode` prop with two modes.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte`
+
+- [ ] **Step 1: Read the existing y-axis logic**
+
+```bash
+grep -n "min\|max\|y0\|y1\|yMin\|yMax\|range\|domain" src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte | head -30
+```
+
+Identify where round 1 forced y-anchoring at 0 (likely a `Math.min(0, ...)` or a hardcoded `yMin = 0`).
+
+- [ ] **Step 2: Add prop + branching**
+
+Add to the component's props:
+
+```typescript
+export let yAxisMode: 'zero-anchored' | 'data-fit' = 'zero-anchored';
+```
+
+Replace the y-min/max derivation:
+
+```typescript
+$: dataMin = Math.min(...values);
+$: dataMax = Math.max(...values);
+$: yMin = yAxisMode === 'zero-anchored' ? Math.min(0, dataMin) : dataMin * 0.999;
+$: yMax = yAxisMode === 'zero-anchored' ? Math.max(0, dataMax) : dataMax * 1.001;
+```
+
+(The exact path expression depends on how `yMin`/`yMax` flow into the SVG. Match the existing variable names; don't introduce new ones.)
+
+- [ ] **Step 3: Pass `yAxisMode="data-fit"` from the virtual price chart caller**
+
+```bash
+grep -rn "MiniAreaChart" src/vault_frontend/src/lib/components/explorer/ | grep -i "virtual\|vp\|three_pool"
+```
+
+For the virtual-price chart instance (look in `DexsLens.svelte` or wherever virtual price is rendered), pass `yAxisMode="data-fit"`.
+
+- [ ] **Step 4: Smoke test**
+
+`/explorer?lens=dexs`. Virtual price chart should now show a slope (zooming the y-axis to a tight range around 1.063–1.064). Volume charts should still anchor at 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): add data-fit y-axis mode to MiniAreaChart
+
+Round 1's zero-anchored axis is right for volume but wrong for the
+virtual price chart, where values barely move from 1.06. The slope was
+invisible. Add a yAxisMode prop with 'zero-anchored' (default, for
+non-negative volumes) and 'data-fit' (for slowly-changing quantities)
+and use 'data-fit' for the virtual price chart.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.4: F3 — single-dot fallback in MiniAreaChart
+
+When the entire 7-day series has only one non-zero point, the chart shows a single isolated dot that looks broken. Add a more obvious indicator for that case.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte`
+
+- [ ] **Step 1: Detect the single-non-zero case**
+
+In the script section, derive:
+
+```typescript
+$: nonZeroCount = values.filter((v) => v > 0).length;
+$: isSingleEvent = nonZeroCount === 1;
+```
+
+- [ ] **Step 2: Render a vertical marker line at the single non-zero index**
+
+In the SVG markup, when `isSingleEvent`, draw a vertical line + larger dot + a small annotation showing the value:
+
+```svelte
+{#if isSingleEvent}
+  {@const i = values.findIndex((v) => v > 0)}
+  {@const x = (i / (values.length - 1)) * width}
+  {@const v = values[i]}
+  <line x1={x} y1={0} x2={x} y2={height} stroke="rgb(45 212 191 / 0.4)" stroke-dasharray="2 2" />
+  <circle cx={x} cy={height - ((v - yMin) / (yMax - yMin)) * height} r="3.5" fill="rgb(45 212 191)" />
+{:else}
+  <!-- existing path/dots rendering -->
+{/if}
+```
+
+(Adjust to match the existing variable names — the actual `width`, `height`, `yMin`, `yMax` names already in scope.)
+
+- [ ] **Step 3: Smoke test**
+
+`/explorer?lens=dexs`. The 3pool swap volume chart with a single $70 point should now render a dashed vertical guide at that timestamp plus a clearer dot, instead of a lonely dot at 70 floating mid-chart.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): single-event chart fallback shows a vertical marker
+
+When a 7d hourly series has just one non-zero point, the bare dot looks
+broken. Render a dashed vertical guide + a larger dot at the event index
+so the data point is unmistakable.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.5: F1 — Arb score tooltip
+
+The DEXs lens shows an "Arb score" with no explanation. Add a tooltip translating the formula to plain English.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte`
+
+- [ ] **Step 1: Find the formula in the analytics canister**
+
+```bash
+grep -rn "arb_score\|arbitrage" src/rumi_analytics/src/queries/live.rs | head -10
+```
+
+Read the math; translate to one sentence — typically something like "price deviation between pools weighted by pool depth" or "max profit available to a one-trade arbitrageur."
+
+- [ ] **Step 2: Add the tooltip to the Arb score cell**
+
+In `DexsLens.svelte`, find the Arb score cell:
+
+```bash
+grep -n "Arb score\|arb_score" src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+```
+
+Add a `title` attribute or an info-bubble icon:
+
+```svelte
+<span class="inline-flex items-center gap-1">
+  Arb score
+  <span
+    class="text-gray-500 cursor-help text-xs"
+    title="Estimated arbitrage opportunity between this pool and others. Higher = more price drift relative to depth. 0 means pools are aligned."
+  >ⓘ</span>
+</span>
+```
+
+(Replace the placeholder description with the real formula translation found in Step 1.)
+
+- [ ] **Step 3: Smoke test**
+
+`/explorer?lens=dexs`. Hovering "Arb score" should show the tooltip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+git commit -m "$(cat <<'EOF'
+docs(explorer): explain Arb score with a tooltip
+
+The DEXs lens showed a numeric Arb score with no context. Add an info
+bubble that translates the analytics formula to plain English.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.6: F6 — remove redundant DEXs bottom row
+
+Three small cards at the bottom of the DEXs lens duplicate the top strip. The third (Stability Pool APY) doesn't belong on the DEXs lens at all.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte`
+
+- [ ] **Step 1: Find the offending row**
+
+```bash
+grep -n "PoolHealthStrip\|3pool balance\|3pool LP APY\|Stability pool APY" src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+```
+
+- [ ] **Step 2: Delete the `<PoolHealthStrip />` line and any unused import**
+
+If `PoolHealthStrip` is only used here, remove the import too. Don't delete the component file — it's still used in the StabilityPool / Overview lenses.
+
+- [ ] **Step 3: Smoke test**
+
+`/explorer?lens=dexs`. The bottom row of three cards is gone; the top metrics (3pool balance, 3pool LP APY) still appear in the lens header.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): drop duplicate metric strip from DEXs lens
+
+The bottom-row cards duplicated the top-strip metrics, and one (SP APY)
+isn't even relevant to DEXs. Remove the row.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.7: D1 — single current RMR tile
+
+Replace the `RMR floor → ceiling` (96% → 100%) range tile with a tile showing the active RMR plus an info tooltip.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte`
+
+- [ ] **Step 1: Find the active-RMR derivation**
+
+The active RMR depends on global CR vs `rmr_floor_cr` / `rmr_ceiling_cr`. Look for an existing query exposing it:
+
+```bash
+grep -rn "get_current_rmr\|active_rmr\|currentRmr" src/rumi_protocol_backend/src/ src/declarations/rumi_protocol_backend/ | head -10
+```
+
+If the backend already exposes a current-RMR query, call it. If not, compute it client-side from `protocolStatus.totalCollateralRatio` (or whatever it's named in the .did) and the four RMR config fields:
+
+```typescript
+function activeRmrPct(totalCr: number, floorCr: number, ceilingCr: number, floor: number, ceiling: number): number {
+  if (totalCr >= ceilingCr) return ceiling;
+  if (totalCr <= floorCr) return floor;
+  const t = (totalCr - floorCr) / (ceilingCr - floorCr);
+  return floor + t * (ceiling - floor);
+}
+```
+
+(Confirm the linear interpolation matches the backend's `compute_rmr_for_global_cr` semantics — read `src/rumi_protocol_backend/src/state.rs` and grep for `rmr_floor_cr`.)
+
+- [ ] **Step 2: Replace the range tile**
+
+Find the floor → ceiling tile in `RedemptionsLens.svelte`:
+
+```bash
+grep -n "RMR\|rmr_floor\|rmr_ceiling" src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+```
+
+Replace with a single-value tile:
+
+```svelte
+<div class="explorer-tile">
+  <div class="text-xs text-gray-500 mb-1 inline-flex items-center gap-1">
+    Current RMR
+    <span class="cursor-help" title="Redemption Multiplier Ratio: the % of icUSD a redeemer receives in collateral. Slides linearly from {floor}% (when global CR is at or below {floorCr}%) to {ceiling}% (when global CR is at or above {ceilingCr}%). Higher = more collateral returned per icUSD redeemed.">ⓘ</span>
+  </div>
+  <div class="text-2xl font-semibold text-gray-100 tabular-nums">{activeRmr.toFixed(2)}%</div>
+  <div class="text-xs text-gray-500 mt-1">at global CR {totalCrPct.toFixed(1)}%</div>
+</div>
+```
+
+- [ ] **Step 3: Smoke test**
+
+`/explorer?lens=redemptions`. Tile shows a single "Current RMR" with the active value, contextual sub-text, and a hover tooltip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): single current RMR tile with curve tooltip
+
+The "RMR floor → ceiling" range tile read as meaningless to non-CDP
+users. Replace with the active RMR value (interpolated from current
+global CR), sub-text showing what CR drove it, and an info bubble that
+explains the floor/ceiling mechanism.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.8: B1 — fix CR distribution histogram bar rendering
+
+Round 1 fixed the empty-data bug (CR is computed client-side via the helper). Bars are still tiny slivers. Investigate height calc + parent container.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte`
+
+- [ ] **Step 1: Use systematic-debugging — read the histogram render block**
+
+```bash
+grep -n "crBuckets\|h-40\|maxBucket\|height:" src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte | head -20
+```
+
+Read the affected block. Hypothesise: either the `pct = (b.count / maxBucket) * 100` produces tiny percentages (because one bucket dominates), the parent `.flex .items-end .h-40` has lost its height through tailwind class collision, or each bar has a min-height issue. Confirm with browser devtools after deploy or local: inspect the bar div's computed height and the parent's computed height.
+
+- [ ] **Step 2: Apply the fix**
+
+Most likely: the parent loses height because the lens layout puts the histogram in a flex child that doesn't grant explicit height. Two complementary fixes:
+
+(a) Add a min-height to the bar so non-zero values render visibly:
+
+```svelte
+<div
+  class="flex-1 bg-teal-400/40 hover:bg-teal-400/60 rounded-t transition-colors"
+  style="height: {Math.max(pct, 2)}%"  
+  title={`${b.label}: ${b.count} vault${b.count === 1 ? '' : 's'}`}
+></div>
+```
+
+(b) Ensure the histogram container has explicit height:
+
+```svelte
+<div class="flex items-end gap-2 h-40 min-h-[10rem]">
+  ...
+</div>
+```
+
+- [ ] **Step 3: Smoke test**
+
+`/explorer?lens=collateral`. Histogram bars should be clearly visible. Hovering shows the count tooltip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): readable CR histogram bars
+
+Round 1 fixed the empty-data bug by computing CR client-side, but bars
+were still tiny slivers — both the dominant-bucket scaling and the
+parent flex height contributed. Force a 2% minimum bar height for any
+non-zero bucket and pin the container height explicitly.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.9: B2 — Liquidation Risk warning-zone vaults
+
+The Liquidation Risk card is empty because `fetchLiquidatableVaults()` returns vaults at-or-below liquidation threshold. Rob wants the warning zone instead: vaults below min CR for borrowing but above the liquidation threshold.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte`
+
+- [ ] **Step 1: Read existing data fetches in the lens**
+
+```bash
+grep -n "fetchLiquidatableVaults\|fetchAllVaults\|fetchCollateralConfigs\|liquidationRisk\|borrow_threshold" src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte | head -20
+```
+
+Confirm `allVaults`, `priceMap`, and `fetchCollateralConfigs` outputs are already in scope (they were after round 1's CR helper wire-up).
+
+- [ ] **Step 2: Replace `fetchLiquidatableVaults` consumer with client-side filter**
+
+After the round-1 CR computation loop, add a separate filter for warning-zone vaults:
+
+```typescript
+import { computeVaultCrPct } from '$utils/vaultCr';
+
+// configs: from fetchCollateralConfigs() — each has borrow_threshold_ratio (min CR for borrow) and liquidation_ratio
+const warningZone = [];
+for (const v of allVaults) {
+  const cr = computeVaultCrPct(v, priceMap, decimalsMap);
+  if (cr == null) continue;
+  const collType = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+  const cfg = configMap.get(collType);
+  if (!cfg) continue;
+  const minCrPct = Number(cfg.borrow_threshold_ratio) / 100; // ratio is e.g. 13000 bps for 130%
+  const liqCrPct = Number(cfg.liquidation_ratio) / 100;
+  if (cr < minCrPct && cr >= liqCrPct) {
+    warningZone.push({ ...v, _cr: cr });
+  }
+}
+```
+
+(Verify the units of `borrow_threshold_ratio` and `liquidation_ratio` in the protocol-backend candid — could be bps, percent × 100, or already a ratio. Don't guess; read `src/declarations/rumi_protocol_backend/rumi_protocol_backend.did`.)
+
+- [ ] **Step 3: Pass `warningZone` to `LiquidationRiskTable` instead of `liquidatableVaults`**
+
+```svelte
+<LiquidationRiskTable vaults={warningZone} />
+```
+
+- [ ] **Step 4: Update `LiquidationRiskTable` if its prop name or shape needs changing**
+
+```bash
+grep -n "export let\|interface" src/vault_frontend/src/lib/components/explorer/LiquidationRiskTable.svelte | head
+```
+
+Make sure the table renders cleanly with the new shape. If it expected a specific field that doesn't exist (e.g. `debt_amount`), wire to the equivalent field on `Vault` or compute it.
+
+- [ ] **Step 5: Smoke test**
+
+`/explorer?lens=collateral`. The Liquidation Risk card should now show vaults in the warning zone (below min CR but above liquidation), if any exist. Confirm by cross-checking against any vault the UI currently flags with a warning icon.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte src/vault_frontend/src/lib/components/explorer/LiquidationRiskTable.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): Liquidation Risk shows warning-zone vaults
+
+fetchLiquidatableVaults returns vaults at-or-below the liquidation
+threshold — almost always empty in normal operation. Rob's intent for
+this card is the warning zone: vaults below min CR for borrowing but
+above the liquidation threshold (the same set that triggers the
+warning icon on each vault).
+
+Compute client-side from allVaults + priceMap + collateralConfigs,
+filter to that band, and pass to LiquidationRiskTable.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2: Investigate + fix data bugs (use systematic-debugging)
+
+### Task 2.1: D2 — recent redemption activity panel empty
+
+The lens-level redemption panel is empty even though `/explorer/activity` shows redemptions. Possible causes per the brief: filter mismatch, fetch limit too small, wrong source.
+
+**Files:**
+- Investigate: `src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte`
+- Possibly modify the same file
+
+- [ ] **Step 1: Use superpowers:systematic-debugging — verify the symptom**
+
+Open `/explorer?lens=redemptions` on mainnet and `/explorer/activity?type=redemption_on_vaults` in another tab. Confirm the lens panel is empty while the activity feed shows redemption rows.
+
+- [ ] **Step 2: Read the panel's filter logic**
+
+```bash
+grep -n "isBackendRedemption\|scope\s*===\s*['\"]redemptions\|redemption_on_vaults" src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte | head
+```
+
+Read the filter logic for `scope="redemptions"`. Three failure modes to check:
+1. Filter expects a key that doesn't match the event variant (should be `redemption_on_vaults` snake_case after round 1)
+2. Default `limit=12` is too small — most-recent 12 events don't include any redemptions
+3. The fetch endpoint differs from what `/explorer/activity` uses
+
+- [ ] **Step 3: Form a hypothesis and verify with the network response**
+
+Hit the lens locally, open devtools → Network → find the `get_events_filtered` (or whatever) call. Inspect the response payload. If the filter matches but no redemption events are in the response, the limit is the issue. If redemption events are present but the panel filter rejects them, the filter is the issue.
+
+- [ ] **Step 4: Apply the fix**
+
+Most likely fix is widening the fetch for the `redemptions` scope specifically. In `LensActivityPanel.svelte`, where `scope === 'redemptions'`, either bump the fetch limit (e.g. 50) or call a redemption-specific fetch:
+
+```typescript
+const fetchLimit = scope === 'redemptions' ? 50 : 12;
+const events = await fetchEventsFiltered({ types: TYPE_KEYS_FOR[scope], limit: fetchLimit });
+```
+
+Or if the issue is type mismatch, fix the filter set:
+
+```typescript
+const TYPE_KEYS_REDEMPTIONS = ['redemption_on_vaults'];
+```
+
+(Verify against the actual variant name in `src/rumi_analytics/src/storage/events.rs` — should be `Redeemed` in `VaultEventKind` and surfaced as `redeemed` or `redemption_on_vaults` in the activity-feed payload depending on serialization.)
+
+- [ ] **Step 5: Smoke test**
+
+`/explorer?lens=redemptions`. The Recent redemption activity panel should now show the most recent redemption events, matching what the activity feed page shows.
+
+- [ ] **Step 6: Commit (write the commit body around the actual root cause found in Step 3)**
+
+Template — fill in the diagnosis sentence:
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): populate redemption activity panel on lens
+
+[One sentence: what was actually broken — type-key mismatch / fetch
+limit too narrow / wrong source endpoint — based on Step 3 finding.]
+
+[One sentence: how the fix in Step 4 corrects it.]
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: E2 / F2 — 3Pool LP APY null root cause
+
+Both lenses show a null LP APY. Round 1 introduced the live-APY computation; if it's null, fall back to analytics; if analytics is null, the chain breaks. Investigate `compute_lp_apy` and the TVL collector.
+
+**Files:**
+- Investigate: `src/rumi_analytics/src/queries/live.rs`, `src/rumi_analytics/src/collectors/tvl.rs`
+- Modify: whichever of those is producing the None
+
+- [ ] **Step 1: systematic-debugging — verify the symptom on-canister**
+
+```bash
+dfx canister --network ic call rumi_analytics get_apys
+```
+
+Inspect the response. Confirm `lp_apy_pct = null` (or `opt {}`).
+
+- [ ] **Step 2: Read `compute_lp_apy`**
+
+```bash
+grep -n "compute_lp_apy\|lp_apy_pct" src/rumi_analytics/src/queries/live.rs | head
+```
+
+Read the function. Identify what input is None — likely the TVL snapshot reserve fields.
+
+- [ ] **Step 3: Read the TVL collector**
+
+```bash
+grep -n "three_pool\|reserves\|TvlSnapshot\|push_tvl" src/rumi_analytics/src/collectors/tvl.rs
+```
+
+Three possible failure modes:
+1. The collector isn't running (timer not registered)
+2. The collector runs but errors out (`error_counters.three_pool > 0`)
+3. The collector runs but writes None reserves
+
+Check the live state:
+
+```bash
+dfx canister --network ic call rumi_analytics get_collector_health
+```
+
+Look at `last_collect_ns`, `errors.three_pool`, `source_counts.three_pool`.
+
+- [ ] **Step 4: Form a hypothesis and apply a targeted fix**
+
+Likely root causes (verify before fixing):
+- Reserve fields renamed in the 3pool candid; the collector's shadow type is stale → fix shadow type
+- Reserve fields wrapped in `opt` upstream → collector unwraps wrong → adjust
+- The fee/volume fields used in APY math have wrong units → fix units
+
+Make the targeted change. Don't speculatively rewrite — fix only the field that's None.
+
+- [ ] **Step 5: Build + test**
+
+```bash
+cargo test -p rumi_analytics
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+```
+
+- [ ] **Step 6: Commit (write the commit body around the actual root cause found in Step 3-4)**
+
+Template:
+
+```bash
+git add src/rumi_analytics/
+git commit -m "$(cat <<'EOF'
+fix(analytics): 3pool LP APY no longer null
+
+[One sentence: which input was None — empty reserves / wrong field
+name / collector erroring — and where the gap was.]
+
+[One sentence: the targeted fix in Step 4.]
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Defer deploy until Phase 7 — bundle with the other analytics changes.)
+
+### Task 2.3: E3 — SP APY 4.72% root cause
+
+The lens still shows the analytics 7d fallback (4.72%) instead of the live 6.24%. Round 1's `liveSpApy` derivation depends on `protocolStatus.interestSplit` and `protocolStatus.perCollateralInterest`; one of those is presumably empty.
+
+**Files:**
+- Investigate: `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte`
+- Possibly modify: same file or `protocolStatus` consumer
+
+- [ ] **Step 1: systematic-debugging — instrument the derivation**
+
+In `StabilityPoolLens.svelte`, temporarily log the inputs:
+
+```typescript
+const liveSpApy = $derived.by(() => {
+  if (!protocolStatus) return null;
+  const split = protocolStatus.interestSplit ?? [];
+  const perC = protocolStatus.perCollateralInterest;
+  console.log('[SP APY debug]', { split, perC, totalDebt: protocolStatus.totalDebt });
+  // ...existing logic
+});
+```
+
+Open `/explorer?lens=stability` and read the console.
+
+- [ ] **Step 2: Identify which input is empty**
+
+If `interestSplit` is `[]` or `perCollateralInterest` is `undefined`, the live formula returns null and we fall back. Check the candid mapping:
+
+```bash
+grep -n "interest_split\|per_collateral_interest" src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+grep -n "interestSplit\|perCollateralInterest" src/vault_frontend/src/lib/services/explorer/explorerService.ts
+```
+
+The candid uses snake_case; the frontend may be reading the wrong field name. Or the backend is returning an empty vec.
+
+- [ ] **Step 3: Apply the fix**
+
+If it's a frontend mapping bug, fix the field access. If the backend is returning empty, that's a deeper issue — log the protocol status raw response and verify.
+
+- [ ] **Step 4: Smoke test**
+
+`/explorer?lens=stability`. SP APY should now show the live value (~6.24% per Rob's expectation), matching the /liquidity tab.
+
+- [ ] **Step 5: Remove debug logging + commit (write commit body around the actual finding from Step 2)**
+
+Template:
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): SP APY uses live formula instead of 7d fallback
+
+[One sentence: which input — interestSplit / perCollateralInterest /
+totalDebt — was empty or wrong-cased, and why that caused the live
+derivation to return null.]
+
+[One sentence: the targeted fix.]
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3: Analytics canister additions
+
+### Task 3.1: E4 — `get_fee_breakdown_window` query
+
+Add a server-side aggregation that reads `evt_vaults` + `evt_swaps` directly. Frontend uses this for both the 90d total and the 24h total — same methodology, no contradiction (E1 piggybacks on this).
+
+**Files:**
+- Modify: `src/rumi_analytics/src/types.rs`
+- Modify: `src/rumi_analytics/src/queries/live.rs`
+- Modify: `src/rumi_analytics/src/lib.rs`
+- Modify: `src/rumi_analytics/rumi_analytics.did`
+
+- [ ] **Step 1: Add the query types**
+
+In `src/rumi_analytics/src/types.rs`, append:
+
+```rust
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct FeeBreakdownQuery {
+    pub window_ns: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct FeeBreakdownResponse {
+    pub borrow_fees_icusd_e8s: u64,
+    pub redemption_fees_icusd_e8s: u64,
+    pub swap_fees_icusd_e8s: u64,
+    pub borrow_count: u32,
+    pub redemption_count: u32,
+    pub swap_count: u32,
+    pub start_ns: u64,
+    pub end_ns: u64,
+}
+```
+
+- [ ] **Step 2: Implement the query**
+
+In `src/rumi_analytics/src/queries/live.rs`, add:
+
+```rust
+use crate::storage::events::{evt_vaults, evt_swaps, VaultEventKind};
+use crate::types::{FeeBreakdownQuery, FeeBreakdownResponse};
+
+pub fn get_fee_breakdown_window(query: FeeBreakdownQuery) -> FeeBreakdownResponse {
+    let now = ic_cdk::api::time();
+    let start = match query.window_ns {
+        Some(window) => now.saturating_sub(window),
+        None => 0,
+    };
+
+    let vault_events = evt_vaults::range(start, now, usize::MAX);
+    let swap_events = evt_swaps::range(start, now, usize::MAX);
+
+    let mut borrow_fees: u64 = 0;
+    let mut redemption_fees: u64 = 0;
+    let mut borrow_count: u32 = 0;
+    let mut redemption_count: u32 = 0;
+    for e in &vault_events {
+        match e.event_kind {
+            VaultEventKind::Borrowed => {
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+                borrow_count += 1;
+            }
+            VaultEventKind::Redeemed => {
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+                redemption_count += 1;
+            }
+            _ => {}
+        }
+    }
+
+    let swap_fees: u64 = swap_events.iter().map(|e| e.fee).sum();
+    let swap_count = swap_events.len() as u32;
+
+    FeeBreakdownResponse {
+        borrow_fees_icusd_e8s: borrow_fees,
+        redemption_fees_icusd_e8s: redemption_fees,
+        swap_fees_icusd_e8s: swap_fees,
+        borrow_count,
+        redemption_count,
+        swap_count,
+        start_ns: start,
+        end_ns: now,
+    }
+}
+```
+
+- [ ] **Step 3: Register the query in lib.rs**
+
+In `src/rumi_analytics/src/lib.rs`, near the other `#[query]` declarations:
+
+```rust
+#[query]
+fn get_fee_breakdown_window(query: types::FeeBreakdownQuery) -> types::FeeBreakdownResponse {
+    queries::live::get_fee_breakdown_window(query)
+}
+```
+
+- [ ] **Step 4: Add to the .did file**
+
+In `src/rumi_analytics/rumi_analytics.did`, declare:
+
+```candid
+type FeeBreakdownQuery = record {
+  window_ns : opt nat64;
+};
+
+type FeeBreakdownResponse = record {
+  borrow_fees_icusd_e8s : nat64;
+  redemption_fees_icusd_e8s : nat64;
+  swap_fees_icusd_e8s : nat64;
+  borrow_count : nat32;
+  redemption_count : nat32;
+  swap_count : nat32;
+  start_ns : nat64;
+  end_ns : nat64;
+};
+
+// In the service block:
+get_fee_breakdown_window : (FeeBreakdownQuery) -> (FeeBreakdownResponse) query;
+```
+
+- [ ] **Step 5: Build to confirm**
+
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+```
+
+Expected: clean compile.
+
+- [ ] **Step 6: Add a unit test**
+
+In `src/rumi_analytics/src/queries/live.rs` or the appropriate test module:
+
+```rust
+#[test]
+fn fee_breakdown_window_zero_for_empty_logs() {
+    // Note: this test asserts the math works on empty inputs.
+    // Production data tests live in pocket_ic.
+    let q = FeeBreakdownQuery { window_ns: Some(86_400_000_000_000) };
+    let r = get_fee_breakdown_window(q);
+    assert_eq!(r.borrow_fees_icusd_e8s, 0);
+    assert_eq!(r.swap_count, 0);
+}
+```
+
+```bash
+cargo test -p rumi_analytics fee_breakdown_window
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_analytics/src/types.rs src/rumi_analytics/src/queries/live.rs src/rumi_analytics/src/lib.rs src/rumi_analytics/rumi_analytics.did
+git commit -m "$(cat <<'EOF'
+feat(analytics): get_fee_breakdown_window query
+
+Aggregates fees from evt_vaults and evt_swaps for any time window.
+Used by the Revenue lens for both the 90d total and the 24h total
+so the two metrics share methodology — fixes the contradiction where
+24h fees > 90d fees due to one being live-estimated and the other
+read from null-stubbed historical rollups.
+
+Reads raw event logs rather than rollups, so it works correctly even
+for windows that overlap pre-deploy days when borrowing_fees_e8s was
+None. The daily_fees rollup remains canonical for daily series; this
+query supplements with on-demand window aggregation.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.2: C2 — `get_sp_depositor_principals` query
+
+Returns distinct principals from `evt_stability` so the frontend can ask SP per-principal for authoritative balances.
+
+**Files:**
+- Modify: `src/rumi_analytics/src/queries/live.rs`
+- Modify: `src/rumi_analytics/src/lib.rs`
+- Modify: `src/rumi_analytics/rumi_analytics.did`
+
+- [ ] **Step 1: Implement the query**
+
+In `src/rumi_analytics/src/queries/live.rs`:
+
+```rust
+use std::collections::HashSet;
+use candid::Principal;
+use crate::storage::events::evt_stability;
+
+pub fn get_sp_depositor_principals() -> Vec<Principal> {
+    let events = evt_stability::range(0, u64::MAX, usize::MAX);
+    let mut set: HashSet<Principal> = HashSet::new();
+    for e in events {
+        set.insert(e.caller);
+    }
+    set.into_iter().collect()
+}
+```
+
+- [ ] **Step 2: Register in lib.rs**
+
+```rust
+#[query]
+fn get_sp_depositor_principals() -> Vec<Principal> {
+    queries::live::get_sp_depositor_principals()
+}
+```
+
+- [ ] **Step 3: Add to .did**
+
+```candid
+get_sp_depositor_principals : () -> (vec principal) query;
+```
+
+- [ ] **Step 4: Build + test**
+
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/src/queries/live.rs src/rumi_analytics/src/lib.rs src/rumi_analytics/rumi_analytics.did
+git commit -m "$(cat <<'EOF'
+feat(analytics): get_sp_depositor_principals query
+
+Returns the distinct set of principals that have ever appeared in an
+evt_stability event. The frontend uses this list to fan out per-user
+SP queries (get_user_position) and reconstruct the current depositor
+snapshot — replaces the round-1 leaderboard query that filtered out
+anyone whose deposit total in the recent window was 0, even if their
+balance was still > 0.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.3: G3 — `reset_error_counters` admin endpoint
+
+Admin-gated update endpoint to zero specific or all source error counters.
+
+**Files:**
+- Modify: `src/rumi_analytics/src/types.rs`
+- Modify: `src/rumi_analytics/src/lib.rs`
+- Modify: `src/rumi_analytics/rumi_analytics.did`
+
+- [ ] **Step 1: Add args type**
+
+In `types.rs`:
+
+```rust
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ResetErrorCountersArgs {
+    /// null = reset all sources; else only the listed source names.
+    /// Valid names: "backend", "stability_pool", "three_pool", "icusd_ledger".
+    pub sources: Option<Vec<String>>,
+}
+```
+
+- [ ] **Step 2: Add the endpoint in lib.rs**
+
+```rust
+#[update]
+fn reset_error_counters(args: types::ResetErrorCountersArgs) -> Result<(), String> {
+    let admin = state::read_state(|s| s.admin);
+    let caller = ic_cdk::caller();
+    if caller != admin {
+        return Err(format!("unauthorized: caller {} is not admin", caller));
+    }
+    state::mutate_state(|s| {
+        let reset_all = args.sources.is_none();
+        let sources = args.sources.unwrap_or_default();
+        let touch = |name: &str| reset_all || sources.iter().any(|s| s == name);
+        if touch("backend") { s.error_counters.backend = 0; }
+        if touch("stability_pool") { s.error_counters.stability_pool = 0; }
+        if touch("three_pool") { s.error_counters.three_pool = 0; }
+        if touch("icusd_ledger") { s.error_counters.icusd_ledger = 0; }
+    });
+    Ok(())
+}
+```
+
+(Verify the exact field names in `ErrorCounters` first:
+
+```bash
+grep -n "pub struct ErrorCounters\|pub backend\|pub stability_pool\|pub three_pool\|pub icusd_ledger" src/rumi_analytics/src/storage/mod.rs
+```
+
+If a field name differs, adjust.)
+
+- [ ] **Step 3: Add to .did**
+
+```candid
+type ResetErrorCountersArgs = record {
+  sources : opt vec text;
+};
+
+reset_error_counters : (ResetErrorCountersArgs) -> (variant { Ok; Err : text });
+```
+
+- [ ] **Step 4: Build + test**
+
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+cargo test -p rumi_analytics
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_analytics/src/types.rs src/rumi_analytics/src/lib.rs src/rumi_analytics/rumi_analytics.did
+git commit -m "$(cat <<'EOF'
+feat(analytics): admin-gated reset_error_counters endpoint
+
+Operational primitive for zeroing error counters after a known fix
+ships. Pass null to reset all, or a list like vec {"stability_pool"}
+to selectively reset specific sources. Caller must equal the admin
+principal stored in state.
+
+Used in the round-2 deploy to clear the 12 leftover stability_pool
+counter increments from round 1's first deploy (which failed at
+runtime because the SP candid was missing 11 PoolEventType variants —
+fix shipped in round-1 commit b6e59a5).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4: Stability Pool lens rework (depends on Phase 3 deploy)
+
+### Task 4.1: Service: `fetchCurrentSpDepositors`
+
+Combines the new analytics principal-list query with per-principal SP `get_user_position` calls in parallel.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/services/explorer/analyticsService.ts`
+- Modify: `src/vault_frontend/src/lib/services/explorer/explorerService.ts`
+
+- [ ] **Step 1: Add `fetchSpDepositorPrincipals` to analyticsService**
+
+```typescript
+export async function fetchSpDepositorPrincipals(): Promise<Principal[]> {
+  const actor = getAnalyticsActor();
+  return await actor.get_sp_depositor_principals();
+}
+```
+
+- [ ] **Step 2: Add `fetchCurrentSpDepositors` to explorerService**
+
+```typescript
+import { fetchSpDepositorPrincipals } from './analyticsService';
+import { getStabilityPoolActor } from '$lib/canisters/stabilityPool';
+import type { UserStabilityPosition } from '$declarations/rumi_stability_pool/rumi_stability_pool.did';
+
+export type CurrentSpDepositor = {
+  principal: Principal;
+  position: UserStabilityPosition;
+};
+
+export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> {
+  const principals = await fetchSpDepositorPrincipals();
+  const sp = getStabilityPoolActor();
+  const positions = await Promise.all(
+    principals.map((p) => sp.get_user_position([p]).catch(() => [])),
+  );
+  return positions
+    .map((maybe, i) => {
+      const pos = Array.isArray(maybe) ? maybe[0] : maybe;
+      return pos ? { principal: principals[i], position: pos as UserStabilityPosition } : null;
+    })
+    .filter((row): row is CurrentSpDepositor => row !== null && Number(row.position.total_usd_value_e8s) > 0)
+    .sort((a, b) => Number(b.position.total_usd_value_e8s - a.position.total_usd_value_e8s));
+}
+```
+
+(Verify the SP actor accessor — likely already exists; if not, add a small wrapper that builds an `Actor.createActor` against the SP canister.)
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "explorerService|analyticsService" | grep ERROR
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/services/explorer/analyticsService.ts src/vault_frontend/src/lib/services/explorer/explorerService.ts
+git commit -m "$(cat <<'EOF'
+feat(explorer): fetchCurrentSpDepositors service
+
+Combines the new analytics get_sp_depositor_principals (distinct
+principals from evt_stability) with parallel SP get_user_position
+calls. Returns active depositors only (total_usd_value_e8s > 0)
+sorted by USD value descending. The SP canister is the source of
+truth for current balances; analytics just supplies the principal
+set to fan out over.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4.2: C1 — Current Depositors snapshot card
+
+Replace the time-windowed Top Depositors leaderboard with a snapshot table that shows every active depositor with per-token columns (icUSD, 3USD, ckUSDT, ckUSDC). No 3USD-into-icUSD normalization.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/explorer/SpCurrentDepositorsCard.svelte`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte`
+
+- [ ] **Step 1: Create the card component**
+
+`SpCurrentDepositorsCard.svelte`:
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchCurrentSpDepositors, type CurrentSpDepositor } from '$services/explorer/explorerService';
+  import { getTokenSymbol, getTokenDecimals } from '$utils/explorerHelpers';
+  import EntityLink from './EntityLink.svelte';
+
+  let depositors: CurrentSpDepositor[] = $state([]);
+  let loading = $state(true);
+  let error: string | null = $state(null);
+
+  // Distinct token principals across all depositors → column headers
+  const tokens = $derived.by(() => {
+    const set = new Set<string>();
+    for (const d of depositors) {
+      for (const [token] of d.position.stablecoin_balances) {
+        set.add(token.toText());
+      }
+    }
+    return Array.from(set);
+  });
+
+  function balanceOf(d: CurrentSpDepositor, token: string): bigint {
+    for (const [t, amt] of d.position.stablecoin_balances) {
+      if (t.toText() === token) return amt;
+    }
+    return 0n;
+  }
+
+  function fmt(amt: bigint, token: string): string {
+    const decimals = getTokenDecimals(token) ?? 8;
+    if (amt === 0n) return '';
+    const v = Number(amt) / Math.pow(10, decimals);
+    return v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+
+  onMount(async () => {
+    try {
+      depositors = await fetchCurrentSpDepositors();
+    } catch (err: any) {
+      console.error('[SpCurrentDepositorsCard] load failed:', err);
+      error = err?.message ?? String(err);
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Current depositors</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    Every principal currently holding a non-zero SP balance. Per-token columns; sort by total USD value.
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if error}
+    <p class="text-sm text-red-400 py-2">Failed to load: {error}</p>
+  {:else if depositors.length === 0}
+    <p class="text-sm text-gray-500 py-2">No active depositors.</p>
+  {:else}
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-white/5">
+          <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Depositor</th>
+          {#each tokens as t (t)}
+            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">{getTokenSymbol(t)}</th>
+          {/each}
+          <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Total USD</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each depositors as d (d.principal.toText())}
+          <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
+            <td class="py-2 px-2 font-mono text-xs">
+              <EntityLink type="principal" value={d.principal.toText()} />
+            </td>
+            {#each tokens as t (t)}
+              <td class="py-2 px-2 text-right tabular-nums text-gray-300">{fmt(balanceOf(d, t), t)}</td>
+            {/each}
+            <td class="py-2 px-2 text-right tabular-nums text-gray-100 font-medium">
+              ${(Number(d.position.total_usd_value_e8s) / 1e8).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Mount in StabilityPoolLens**
+
+```bash
+grep -n "TopDepositorsCard\|fetchTopSpDepositors\|leaderboard\|top depositors" src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte | head
+```
+
+Replace the Top Depositors render block with `<SpCurrentDepositorsCard />`. Remove now-unused imports + state if they were only for the old leaderboard.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "SpCurrentDepositorsCard|StabilityPoolLens" | grep ERROR
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Smoke test (post-deploy)**
+
+After the analytics deploy in Phase 7, open `/explorer?lens=stability`. The new "Current depositors" card should show every active depositor with per-token columns. Specifically: Rob's principal should appear with a non-zero icUSD + 3USD balance (verifies C3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/SpCurrentDepositorsCard.svelte src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): SP current depositors snapshot card
+
+Drop the time-windowed Top Depositors leaderboard (which filtered out
+anyone with no recent deposit activity even if their balance was
+non-zero) and replace with a snapshot of every principal currently
+holding an SP position. Per-token columns (icUSD, 3USD, ckUSDT,
+ckUSDC, ...) sourced from the SP canister's get_user_position — no
+3USD→icUSD normalization. Sorted by total USD value descending.
+
+Fixes the 4-vs-1 depositor mismatch (C2) and Rob-shows-zero (C3) at
+the source: SP balances are authoritative, analytics events just
+supply the principal set.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4.3: C4 — Per-collateral opt-in coverage card
+
+For each supported collateral, show what % of depositors are opted in and the total stable backing they provide.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte`
+
+- [ ] **Step 1: Create the card component**
+
+`SpCoverageCard.svelte`:
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchCurrentSpDepositors, type CurrentSpDepositor } from '$services/explorer/explorerService';
+  import { fetchCollateralConfigs } from '$services/explorer/explorerService';
+  import { getTokenSymbol } from '$utils/explorerHelpers';
+
+  let depositors: CurrentSpDepositor[] = $state([]);
+  let collaterals: string[] = $state([]); // principal text
+  let loading = $state(true);
+
+  function isOptedIn(d: CurrentSpDepositor, collType: string): boolean {
+    return !d.position.opted_out_collateral.some((p) => p.toText() === collType);
+  }
+
+  function totalStableUsd(d: CurrentSpDepositor): number {
+    // total_usd_value_e8s already sums stables; treat 1e8 as $1
+    return Number(d.position.total_usd_value_e8s) / 1e8;
+  }
+
+  const rows = $derived.by(() => {
+    return collaterals.map((c) => {
+      const optedIn = depositors.filter((d) => isOptedIn(d, c));
+      const pct = depositors.length > 0 ? (optedIn.length / depositors.length) * 100 : 0;
+      const usd = optedIn.reduce((s, d) => s + totalStableUsd(d), 0);
+      return { collateral: c, pct, usd, count: optedIn.length, total: depositors.length };
+    });
+  });
+
+  onMount(async () => {
+    try {
+      const [d, configs] = await Promise.all([
+        fetchCurrentSpDepositors(),
+        fetchCollateralConfigs(),
+      ]);
+      depositors = d;
+      collaterals = configs.map((c) => c.collateral_type?.toText?.() ?? String(c.collateral_type));
+    } catch (err) {
+      console.error('[SpCoverageCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Per-collateral opt-in coverage</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    For each supported collateral, the share of SP depositors who haven't opted out and the total stable backing they provide.
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if rows.length === 0}
+    <p class="text-sm text-gray-500 py-2">No collaterals configured.</p>
+  {:else}
+    <div class="space-y-2">
+      {#each rows as r (r.collateral)}
+        <div class="flex items-baseline justify-between text-sm">
+          <span class="text-gray-200 font-medium w-16">{getTokenSymbol(r.collateral)}</span>
+          <span class="tabular-nums text-gray-400">{r.count}/{r.total} opted in ({r.pct.toFixed(0)}%)</span>
+          <span class="tabular-nums text-gray-100 font-medium">
+            ${r.usd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Mount in StabilityPoolLens**
+
+Find the "Collateral in pool" card render in `StabilityPoolLens.svelte` and replace it with `<SpCoverageCard />`. Remove old fetch state if unused.
+
+- [ ] **Step 3: Type-check + smoke**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "SpCoverageCard|StabilityPoolLens" | grep ERROR
+```
+
+`/explorer?lens=stability` after deploy: card shows e.g. "ICP 100% $1,000 / BOB 50% $500".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): per-collateral opt-in coverage card
+
+Replaces the unstructured "Collateral in pool" card. For each supported
+collateral, shows the % of SP depositors who are still opted in (would
+absorb a liquidation in that collateral) and the total stable backing
+they supply. Computed client-side from current SP positions (which
+include opted_out_collateral) — no analytics changes needed.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5: Revenue lens rework
+
+### Task 5.1: E1 + E4 — wire fee breakdown query for both 24h and 90d
+
+Same methodology, no contradiction. Replace both the live-estimated 24h fees and the rollup-summed 90d fees with two calls to `get_fee_breakdown_window`.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/services/explorer/analyticsService.ts`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte`
+
+- [ ] **Step 1: Add the service wrapper**
+
+```typescript
+export type FeeBreakdown = {
+  borrowIcusd: number;
+  redemptionIcusd: number;
+  swapIcusd: number;
+  borrowCount: number;
+  redemptionCount: number;
+  swapCount: number;
+  startNs: bigint;
+  endNs: bigint;
+};
+
+const NS_PER_DAY = 86_400n * 1_000_000_000n;
+
+export async function fetchFeeBreakdownWindow(windowDays: number | null): Promise<FeeBreakdown> {
+  const actor = getAnalyticsActor();
+  const window_ns: [] | [bigint] = windowDays == null ? [] : [BigInt(windowDays) * NS_PER_DAY];
+  const r = await actor.get_fee_breakdown_window({ window_ns });
+  return {
+    borrowIcusd: Number(r.borrow_fees_icusd_e8s) / 1e8,
+    redemptionIcusd: Number(r.redemption_fees_icusd_e8s) / 1e8,
+    swapIcusd: Number(r.swap_fees_icusd_e8s) / 1e8,
+    borrowCount: Number(r.borrow_count),
+    redemptionCount: Number(r.redemption_count),
+    swapCount: Number(r.swap_count),
+    startNs: r.start_ns,
+    endNs: r.end_ns,
+  };
+}
+```
+
+- [ ] **Step 2: Replace fee derivations in RevenueLens**
+
+```bash
+grep -n "fees24h\|totalFees\|totalBorrow\|totalRedemption\|totalSwap\|estimatedDailyBorrow" src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte | head
+```
+
+Replace the `feeRows`-based 90d derivation and the `estimatedDailyBorrow`-based 24h derivation with two calls:
+
+```typescript
+let fees24h: FeeBreakdown | null = $state(null);
+let fees90d: FeeBreakdown | null = $state(null);
+
+onMount(async () => {
+  // ...existing fetches
+  const [r24, r90] = await Promise.all([
+    fetchFeeBreakdownWindow(1),
+    fetchFeeBreakdownWindow(90),
+  ]);
+  fees24h = r24;
+  fees90d = r90;
+});
+
+const totalBorrow = $derived(fees90d?.borrowIcusd ?? 0);
+const totalRedemption = $derived(fees90d?.redemptionIcusd ?? 0);
+const totalSwap = $derived(fees90d?.swapIcusd ?? 0);
+const totalFees = $derived(totalBorrow + totalRedemption + totalSwap);
+const fees24hTotal = $derived((fees24h?.borrowIcusd ?? 0) + (fees24h?.redemptionIcusd ?? 0) + (fees24h?.swapIcusd ?? 0));
+```
+
+Remove the now-dead `feeRows.reduce(...)` aggregations and the `estimatedDailyBorrow` derivation. Keep the daily-rollup chart as-is — that still uses the rollup data for the time-series view, which is the rollup's actual purpose.
+
+- [ ] **Step 3: Type-check + smoke**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep "RevenueLens" | grep ERROR
+```
+
+Open `/explorer?lens=revenue` after the analytics deploy. The 24h fees and 90d fees should be consistent (90d ≥ 24h). Borrow + redemption fees should show real numbers, not $0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/services/explorer/analyticsService.ts src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+git commit -m "$(cat <<'EOF'
+fix(explorer): unified fee breakdown for both 24h and 90d cards
+
+Replace the live-estimated 24h fees + rollup-summed 90d fees (which
+contradicted each other because one was forward-looking and the other
+read null-stubbed historical rollups) with two calls to the new
+get_fee_breakdown_window query. Both totals now share methodology and
+read directly from evt_vaults + evt_swaps.
+
+90d total now reflects real borrow + redemption fees from the entire
+window, not just post-round-1 days.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 5.2: E5 — Treasury holdings card
+
+Frontend-direct ledger queries via `icrc1_balance_of` using the treasury principal as account owner.
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/explorer/TreasuryHoldingsCard.svelte`
+- Modify: `src/vault_frontend/src/lib/services/explorer/explorerService.ts`
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte`
+
+- [ ] **Step 1: Add `fetchTreasuryHoldings` to explorerService**
+
+```typescript
+import { Principal } from '@dfinity/principal';
+import { CANISTER_IDS } from '$lib/config';
+
+const TREASURY_PRINCIPAL = Principal.fromText('tlg74-oiaaa-aaaap-qrd6a-cai');
+
+export type TreasuryHolding = {
+  symbol: string;
+  ledger: string;
+  balanceE8s: bigint;
+  decimals: number;
+  usd: number;
+};
+
+const TRACKED_LEDGERS: Array<{ symbol: string; principal: string; decimals: number; usdEachE8s: number }> = [
+  { symbol: 'icUSD', principal: CANISTER_IDS.ICUSD_LEDGER, decimals: 8, usdEachE8s: 1 },
+  { symbol: 'ckUSDT', principal: 'cngnf-vqaaa-aaaar-qag4q-cai', decimals: 6, usdEachE8s: 1 },
+  { symbol: 'ckUSDC', principal: 'xevnm-gaaaa-aaaar-qafnq-cai', decimals: 6, usdEachE8s: 1 },
+  { symbol: 'ICP', principal: 'ryjl3-tyaaa-aaaaa-aaaba-cai', decimals: 8, usdEachE8s: -1 /* live price */ },
+];
+
+export async function fetchTreasuryHoldings(icpPriceUsd: number): Promise<TreasuryHolding[]> {
+  const balances = await Promise.all(
+    TRACKED_LEDGERS.map(async (l) => {
+      try {
+        const actor = getIcrc1Actor(l.principal); // small wrapper
+        const balance = await actor.icrc1_balance_of({ owner: TREASURY_PRINCIPAL, subaccount: [] });
+        const v = Number(balance) / Math.pow(10, l.decimals);
+        const usd = l.usdEachE8s === -1 ? v * icpPriceUsd : v * l.usdEachE8s;
+        return { symbol: l.symbol, ledger: l.principal, balanceE8s: balance, decimals: l.decimals, usd };
+      } catch (err) {
+        console.error(`[fetchTreasuryHoldings] ${l.symbol} failed:`, err);
+        return { symbol: l.symbol, ledger: l.principal, balanceE8s: 0n, decimals: l.decimals, usd: 0 };
+      }
+    }),
+  );
+  return balances.filter((b) => b.balanceE8s > 0n);
+}
+```
+
+(If `getIcrc1Actor(principal)` doesn't yet exist, write a small inline wrapper using `Actor.createActor` with the standard ICRC-1 interface idl. There may already be one — grep first.)
+
+- [ ] **Step 2: Create the card**
+
+`TreasuryHoldingsCard.svelte`:
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchTreasuryHoldings, type TreasuryHolding, fetchProtocolStatus } from '$services/explorer/explorerService';
+
+  let holdings: TreasuryHolding[] = $state([]);
+  let loading = $state(true);
+
+  onMount(async () => {
+    try {
+      const status = await fetchProtocolStatus();
+      const icpPrice = Number(status?.last_icp_rate ?? status?.icpPriceE8s ?? 0n) / 1e8;
+      holdings = await fetchTreasuryHoldings(icpPrice);
+    } catch (err) {
+      console.error('[TreasuryHoldingsCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  const totalUsd = $derived(holdings.reduce((s, h) => s + h.usd, 0));
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Treasury holdings</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    Live token balances of the rumi_treasury canister.
+    <code class="text-gray-600">tlg74-oiaaa-aaaap-qrd6a-cai</code>
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if holdings.length === 0}
+    <p class="text-sm text-gray-500 py-2">No tracked balances.</p>
+  {:else}
+    <table class="w-full text-sm">
+      <tbody>
+        {#each holdings as h (h.ledger)}
+          <tr class="border-b border-white/[0.03]">
+            <td class="py-1.5 px-2 text-gray-200">{h.symbol}</td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-300">
+              {(Number(h.balanceE8s) / Math.pow(10, h.decimals)).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-100 font-medium">
+              ${h.usd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+          </tr>
+        {/each}
+        <tr class="border-t border-white/10">
+          <td class="py-1.5 px-2 text-xs text-gray-500 uppercase">Total</td>
+          <td></td>
+          <td class="py-1.5 px-2 text-right tabular-nums text-teal-300 font-semibold">
+            ${totalUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  {/if}
+</div>
+```
+
+- [ ] **Step 3: Mount in RevenueLens**
+
+Find the existing Treasury card (the "Pending interest = 0 / Flush threshold = 0" tile or block) and replace it with `<TreasuryHoldingsCard />`.
+
+- [ ] **Step 4: Type-check + smoke**
+
+```bash
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -E "TreasuryHoldingsCard|RevenueLens|explorerService" | grep ERROR
+```
+
+`/explorer?lens=revenue` after deploy: card shows real balances per token in the treasury, plus total USD.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/TreasuryHoldingsCard.svelte src/vault_frontend/src/lib/services/explorer/explorerService.ts src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): treasury holdings card replaces pending-interest tile
+
+The old card showed Pending interest = 0 / Flush threshold = 0 — a
+permanently uninformative metric since the flush threshold is 0.
+Replace with actual treasury holdings: query icrc1_balance_of on each
+tracked ledger using the rumi_treasury principal as the account owner.
+Free, fast, current-by-construction; no analytics changes needed.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6: Admin lens enhancements
+
+### Task 6.1: G1 — flesh out the Admin health strip
+
+Add Last admin action timestamp + Admin actions 24h count alongside existing Mode + Collector errors.
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte`
+
+- [ ] **Step 1: Fetch the latest admin event + 24h count**
+
+The activity feed already supports filtering by admin type. Add to `onMount`:
+
+```typescript
+import { fetchEventsFiltered } from '$services/explorer/analyticsService';
+
+let lastAdmin: any = $state(null);
+let adminCount24h = $state(0);
+
+onMount(async () => {
+  const [chR, stR, latestAdminR, count24hR] = await Promise.allSettled([
+    fetchCollectorHealth(),
+    fetchProtocolStatus(),
+    fetchEventsFiltered({ types: ['admin'], limit: 1 }),
+    fetchEventsFiltered({ types: ['admin'], sinceNs: BigInt(Date.now() - 86_400_000) * 1_000_000n }),
+  ]);
+  // ...existing assignments
+  if (latestAdminR.status === 'fulfilled') lastAdmin = latestAdminR.value?.[0] ?? null;
+  if (count24hR.status === 'fulfilled') adminCount24h = count24hR.value?.length ?? 0;
+});
+```
+
+(Verify `fetchEventsFiltered` accepts the `sinceNs` / `limit` params — it likely already does given the round-1 work; if the param name differs, match it.)
+
+- [ ] **Step 2: Add metrics**
+
+Extend `healthMetrics`:
+
+```typescript
+const lastAdminRel = $derived.by(() => {
+  if (!lastAdmin?.timestamp_ns) return '--';
+  const ms = Number(lastAdmin.timestamp_ns) / 1_000_000;
+  const ago = Date.now() - ms;
+  if (ago < 60_000) return 'just now';
+  if (ago < 3_600_000) return `${Math.floor(ago / 60_000)}m ago`;
+  if (ago < 86_400_000) return `${Math.floor(ago / 3_600_000)}h ago`;
+  return `${Math.floor(ago / 86_400_000)}d ago`;
+});
+
+const healthMetrics = $derived.by(() => {
+  const metrics: any[] = [
+    { label: 'Mode', value: mode },
+  ];
+  if (collectorHealth) {
+    const errs = Object.values(collectorHealth?.errors ?? {}).reduce((s: number, v: any) => s + Number(v ?? 0), 0);
+    metrics.push({
+      label: 'Collector errors',
+      value: errs.toLocaleString(),
+      sub: 'analytics tailing',
+      tone: errs > 0 ? 'caution' as const : 'good' as const,
+      tooltip: 'Failed inter-canister calls from the analytics tailers (e.g. unexpected response shape, decode failure). Per-source breakdown below.',
+    });
+  }
+  metrics.push({ label: 'Last admin action', value: lastAdminRel });
+  metrics.push({ label: 'Admin actions 24h', value: adminCount24h.toLocaleString() });
+  return metrics;
+});
+```
+
+- [ ] **Step 3: Render `tooltip` in `LensHealthStrip` if not already supported**
+
+```bash
+grep -n "tooltip\|title\|export let metrics" src/vault_frontend/src/lib/components/explorer/LensHealthStrip.svelte | head
+```
+
+If tooltips aren't yet rendered, add a small `title={m.tooltip}` to the metric label render. (Keep G2 minimal — just hover text on the label.)
+
+- [ ] **Step 4: Smoke test + commit**
+
+`/explorer?lens=admin`: strip shows four metrics now, with tooltip on Collector errors.
+
+```bash
+git add src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte src/vault_frontend/src/lib/components/explorer/LensHealthStrip.svelte
+git commit -m "$(cat <<'EOF'
+feat(explorer): flesh out Admin health strip
+
+Add Last admin action (relative time) and Admin actions 24h alongside
+the existing Mode and Collector errors. Mode stays first since it's
+the most important at-a-glance health indicator (Normal vs Recovery
+vs Frozen). Tooltip on Collector errors explains what the count means
+(failed inter-canister calls from analytics tailers).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 7: Analytics deploy + verify
+
+### Task 7.1: Build, shrink, gzip
+
+**Files:** none — deploy step.
+
+- [ ] **Step 1: Build**
+
+```bash
+cargo build -p rumi_analytics --target wasm32-unknown-unknown --release
+```
+
+- [ ] **Step 2: Shrink**
+
+```bash
+ic-wasm target/wasm32-unknown-unknown/release/rumi_analytics.wasm -o target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm shrink
+```
+
+- [ ] **Step 3: Gzip**
+
+```bash
+gzip -fk target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm
+ls -la target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm.gz
+```
+
+Expected: file exists, under 2MiB.
+
+### Task 7.2: Deploy to mainnet (requires Rob's confirmation)
+
+**Files:** none — deploy step.
+
+- [ ] **Step 1: Get the InitArgs candid literal from a previous deploy**
+
+Look at the previous deploy command (likely captured in shell history, the round-1 commit message, or a deploy script):
+
+```bash
+git log --all --oneline --grep="analytics" --grep="deploy" | head
+grep -rn "InitArgs\|admin = principal" .claude/ 2>/dev/null | head
+```
+
+If you can't find a captured literal, ask Rob — don't guess.
+
+- [ ] **Step 2: Confirm with Rob before deploying**
+
+Show the planned command + InitArgs to Rob in the chat. Wait for explicit confirmation.
+
+- [ ] **Step 3: Deploy**
+
+```bash
+dfx canister install rumi_analytics \
+  --network ic \
+  --mode upgrade \
+  --wasm target/wasm32-unknown-unknown/release/rumi_analytics.shrunk.wasm.gz \
+  --argument '<InitArgs literal from Step 1>'
+```
+
+- [ ] **Step 4: Wait + verify the new endpoints respond**
+
+```bash
+sleep 15
+dfx canister --network ic call rumi_analytics get_fee_breakdown_window '(record { window_ns = opt 7_776_000_000_000_000 })'  # 90 days
+dfx canister --network ic call rumi_analytics get_sp_depositor_principals
+dfx canister --network ic call rumi_analytics get_collector_health
+```
+
+Expected: all three return without error. The fee breakdown should show real borrow + redemption + swap fees. The principal list should include at least 4 entries (matching the SP `total_depositors`).
+
+### Task 7.3: Reset stability_pool error counter via the new endpoint
+
+**Files:** none — operational step.
+
+- [ ] **Step 1: Identify the admin principal**
+
+```bash
+dfx identity get-principal --identity rumi_identity
+```
+
+(Or whichever identity owns the analytics canister — should match the principal stored in `state.admin`.)
+
+- [ ] **Step 2: Reset the stability_pool counter**
+
+```bash
+dfx canister --network ic call rumi_analytics reset_error_counters '(record { sources = opt vec { "stability_pool" } })' --identity rumi_identity
+```
+
+Expected: `(variant { Ok })`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+dfx canister --network ic call rumi_analytics get_collector_health
+```
+
+`error_counters.stability_pool` should now read 0.
+
+- [ ] **Step 4: Smoke test the Admin lens**
+
+`/explorer?lens=admin`. Collector errors should now show 0 (or just the actual ongoing count if any have occurred since).
+
+### Task 7.4: Smoke test all lenses
+
+**Files:** none — verification step.
+
+- [ ] **Step 1: Walk every lens**
+
+`/explorer` → Overview, Collateral, Stability, Redemptions, Revenue, DEXs, Admin. For each, check:
+
+- No console errors
+- All cards render data (not loading spinners stuck)
+- Cross-reference the round-2 brief items: A1 chip label, B1 histogram, B2 warning zone, C1 snapshot, C4 coverage, D1 RMR tile, D2 redemption panel, E1 fees consistent, E2/F2 LP APY non-null, E3 SP APY ≈ 6.24%, E4 fee breakdown non-zero, E5 treasury card, F1 tooltip, F3 single-event chart, F4 virtual price slope, F5 3USD pair, F6 row removed, G1 strip metrics, G3 zero errors
+
+- [ ] **Step 2: Take updated screenshots if anything looks off**
+
+Replace the explorer-lens-* PNGs at the repo root with updated captures so the next reviewer has fresh references.
+
+---
+
+## Phase 8: Push branch + open PR
+
+### Task 8.1: Final review
+
+**Files:** none.
+
+- [ ] **Step 1: Walk the diff**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cargo test -p rumi_analytics
+cd src/vault_frontend && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | grep -c ERROR
+```
+
+Expected: tests pass; svelte-check error count matches the round-1 baseline (33 pre-existing errors in unrelated files).
+
+### Task 8.2: Push + open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/explorer-review-pass
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat(explorer): review pass (rounds 1+2)" --body "$(cat <<'EOF'
+## Summary
+
+Two rounds of Explorer review, landing together on `feat/explorer-review-pass`. Round 1 fixed labels, navigation, and the analytics-canister architectural gap (SP tailer + fee_amount capture + daily fee rollup sums). Round 2 fixes the remaining bugs Rob flagged on review and reworks several lenses per his vision.
+
+### Round 2 highlights
+- **Stability lens rework:** Top Depositors → Current Depositors snapshot (per-token columns), new Per-collateral opt-in coverage card; SP balances now read authoritatively from the SP canister via a new `get_sp_depositor_principals` analytics query
+- **Revenue lens:** new `get_fee_breakdown_window` analytics query reads fees directly from `evt_vaults` + `evt_swaps` so the 24h and 90d cards share methodology and historical pre-deploy fees show up immediately
+- **Treasury holdings card** (live `icrc1_balance_of` per ledger) replaces the uninformative pending-interest tile
+- **Admin lens:** strip flesh-out (Last admin action, 24h count, tooltip on Collector errors); new `reset_error_counters` admin endpoint clears the 12 leftover stability_pool errors from round-1's first deploy
+- **Collateral lens:** CR histogram bars actually render now; Liquidation Risk shows warning-zone vaults (below min CR but above liquidation threshold)
+- **Redemptions lens:** single Current RMR tile with curve tooltip; recent activity panel populated
+- **DEXs lens:** virtual-price chart uses data-fit y-axis to show actual slope; redundant bottom-row strip removed; "3USD LP/ICP" → "3USD/ICP"; Arb score tooltip
+- **Activity feed:** AMM events render as "🌊 3USD/ICP" instead of truncated principals
+
+## Test plan
+- [ ] svelte-check error count matches round-1 baseline (33 pre-existing)
+- [ ] cargo test -p rumi_analytics green
+- [ ] Each lens loads without console errors on mainnet
+- [ ] SP depositor count on the lens matches `get_pool_status.total_depositors`
+- [ ] Rob's principal appears with non-zero icUSD + 3USD balance in the new SP snapshot
+- [ ] 90d fees ≥ 24h fees (no contradiction)
+- [ ] Treasury card sums match `icrc1_balance_of` calls run independently
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage** — every item from the round-2 brief mapped to a task:
+
+| Brief item | Task |
+|---|---|
+| A1 AMM chip | 1.1 |
+| B1 CR histogram | 1.8 |
+| B2 Liquidation Risk | 1.9 |
+| C1 Current Depositors | 4.2 (deps 3.2, 4.1) |
+| C2 4-vs-1 mismatch | 3.2 + 4.2 |
+| C3 Rob's balance 0 | 4.2 (same root as C2) |
+| C4 Per-collateral coverage | 4.3 |
+| D1 Current RMR tile | 1.7 |
+| D2 Redemption panel | 2.1 |
+| E1 Fee contradiction | 5.1 (subsumed by E4 unification) |
+| E2 3pool LP APY null | 2.2 |
+| E3 SP APY 4.72% | 2.3 |
+| E4 Fee breakdown | 3.1 + 5.1 |
+| E5 Treasury card | 5.2 |
+| F1 Arb score tooltip | 1.5 |
+| F2 LP APY null | 2.2 (same as E2) |
+| F3 Single-dot fallback | 1.4 |
+| F4 Virtual price y-axis | 1.3 |
+| F5 3USD pair label | 1.2 |
+| F6 Bottom row removal | 1.6 |
+| G1 Admin strip | 6.1 |
+| G2 Collector errors tooltip | 6.1 (combined) |
+| G3 Reset error counters | 3.3 + 7.3 |
+
+**Placeholder scan**
+
+- Investigation tasks (2.1, 2.2, 2.3) include placeholders like `<root cause from Step N>` in commit messages — these are deliberate; the executing subagent fills them in once root cause is identified.
+- All implementation steps have actual code or exact commands.
+- Deploy step (7.2) explicitly requires Rob's confirmation.
+
+**Type consistency**
+
+- `FeeBreakdown` (frontend), `FeeBreakdownResponse` (canister), `FeeBreakdownQuery` (canister) are defined once and used consistently.
+- `CurrentSpDepositor` shape is defined in 4.1 and consumed in 4.2 and 4.3.
+- `ResetErrorCountersArgs.sources` is `Option<Vec<String>>` in Rust / `opt vec text` in candid / `string[] | undefined` in TS.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-28-explorer-review-pass-round-2.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks. Phases 1, 2, 4, 5, 6 are mostly independent; Phase 3 (analytics) feeds into Phases 4-6. Phase 7 deploy is the integration point.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans. Useful if Rob wants to discuss findings on the data-bug investigations (D2, E2/F2, E3) inline.
+
+Which approach?

--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -160,6 +160,17 @@ type FeeCurveSeriesResponse = record {
   rows : vec HourlyFeeCurveSnapshot;
   next_from_ts : opt nat64;
 };
+type FeeBreakdownQuery = record { window_ns : opt nat64 };
+type FeeBreakdownResponse = record {
+  borrow_fees_icusd_e8s : nat64;
+  redemption_fees_icusd_e8s : nat64;
+  swap_fees_icusd_e8s : nat64;
+  borrow_count : nat32;
+  redemption_count : nat32;
+  swap_count : nat32;
+  start_ns : nat64;
+  end_ns : nat64;
+};
 type FeeSeriesResponse = record {
   rows : vec DailyFeeRollup;
   next_from_ts : opt nat64;
@@ -265,6 +276,7 @@ type RangeQuery = record {
   offset : opt nat64;
   limit : opt nat32;
 };
+type ResetErrorCountersArgs = record { sources : opt vec text };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
@@ -386,6 +398,7 @@ service : (InitArgs) -> {
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
   get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
+  get_fee_breakdown_window : (FeeBreakdownQuery) -> (FeeBreakdownResponse) query;
   get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
   get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;
@@ -402,6 +415,7 @@ service : (InitArgs) -> {
       TopCounterpartiesResponse,
     ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
+  get_sp_depositor_principals : () -> (vec principal) query;
   get_top_sp_depositors : (TopSpDepositorsQuery) -> (
       TopSpDepositorsResponse,
     ) query;
@@ -412,5 +426,6 @@ service : (InitArgs) -> {
   get_volatility : (VolatilityQuery) -> (VolatilityResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   ping : () -> (text) query;
+  reset_error_counters : (ResetErrorCountersArgs) -> (variant { Ok; Err : text });
   start_backfill : (principal) -> (text);
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -160,6 +160,17 @@ export interface FastPriceSnapshot {
   'timestamp_ns' : bigint,
   'prices' : Array<[Principal, number, string]>,
 }
+export interface FeeBreakdownQuery { 'window_ns' : [] | [bigint] }
+export interface FeeBreakdownResponse {
+  'redemption_count' : number,
+  'borrow_count' : number,
+  'redemption_fees_icusd_e8s' : bigint,
+  'borrow_fees_icusd_e8s' : bigint,
+  'start_ns' : bigint,
+  'swap_count' : number,
+  'swap_fees_icusd_e8s' : bigint,
+  'end_ns' : bigint,
+}
 export interface FeeCurveSeriesResponse {
   'rows' : Array<HourlyFeeCurveSnapshot>,
   'next_from_ts' : [] | [bigint],
@@ -272,6 +283,7 @@ export interface RangeQuery {
   'offset' : [] | [bigint],
   'limit' : [] | [number],
 }
+export interface ResetErrorCountersArgs { 'sources' : [] | [Array<string>] }
 export interface StabilitySeriesResponse {
   'rows' : Array<DailyStabilityRow>,
   'next_from_ts' : [] | [bigint],
@@ -403,6 +415,10 @@ export interface _SERVICE {
   'get_apys' : ActorMethod<[ApyQuery], ApyResponse>,
   'get_collector_health' : ActorMethod<[], CollectorHealth>,
   'get_cycle_series' : ActorMethod<[RangeQuery], CycleSeriesResponse>,
+  'get_fee_breakdown_window' : ActorMethod<
+    [FeeBreakdownQuery],
+    FeeBreakdownResponse
+  >,
   'get_fee_curve_series' : ActorMethod<[RangeQuery], FeeCurveSeriesResponse>,
   'get_fee_series' : ActorMethod<[RangeQuery], FeeSeriesResponse>,
   'get_holder_series' : ActorMethod<
@@ -418,6 +434,7 @@ export interface _SERVICE {
   'get_pool_routes' : ActorMethod<[PoolRoutesQuery], PoolRoutesResponse>,
   'get_price_series' : ActorMethod<[RangeQuery], PriceSeriesResponse>,
   'get_protocol_summary' : ActorMethod<[], ProtocolSummary>,
+  'get_sp_depositor_principals' : ActorMethod<[], Array<Principal>>,
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_swap_series' : ActorMethod<[RangeQuery], SwapSeriesResponse>,
   'get_three_pool_series' : ActorMethod<[RangeQuery], ThreePoolSeriesResponse>,
@@ -441,6 +458,11 @@ export interface _SERVICE {
   'get_volatility' : ActorMethod<[VolatilityQuery], VolatilityResponse>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'ping' : ActorMethod<[], string>,
+  'reset_error_counters' : ActorMethod<
+    [ResetErrorCountersArgs],
+    { 'Ok' : null } |
+      { 'Err' : string }
+  >,
   'start_backfill' : ActorMethod<[Principal], string>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -88,6 +88,17 @@ export const idlFactory = ({ IDL }) => {
     'rows' : IDL.Vec(HourlyCycleSnapshot),
     'next_from_ts' : IDL.Opt(IDL.Nat64),
   });
+  const FeeBreakdownQuery = IDL.Record({ 'window_ns' : IDL.Opt(IDL.Nat64) });
+  const FeeBreakdownResponse = IDL.Record({
+    'redemption_count' : IDL.Nat32,
+    'borrow_count' : IDL.Nat32,
+    'redemption_fees_icusd_e8s' : IDL.Nat64,
+    'borrow_fees_icusd_e8s' : IDL.Nat64,
+    'start_ns' : IDL.Nat64,
+    'swap_count' : IDL.Nat32,
+    'swap_fees_icusd_e8s' : IDL.Nat64,
+    'end_ns' : IDL.Nat64,
+  });
   const HourlyFeeCurveSnapshot = IDL.Record({
     'collateral_stats' : IDL.Vec(
       IDL.Tuple(IDL.Principal, IDL.Nat64, IDL.Nat64, IDL.Float64)
@@ -391,6 +402,9 @@ export const idlFactory = ({ IDL }) => {
     'headers' : IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     'status_code' : IDL.Nat16,
   });
+  const ResetErrorCountersArgs = IDL.Record({
+    'sources' : IDL.Opt(IDL.Vec(IDL.Text)),
+  });
   return IDL.Service({
     'get_address_value_series' : IDL.Func(
         [AddressValueSeriesQuery],
@@ -408,6 +422,11 @@ export const idlFactory = ({ IDL }) => {
     'get_cycle_series' : IDL.Func(
         [RangeQuery],
         [CycleSeriesResponse],
+        ['query'],
+      ),
+    'get_fee_breakdown_window' : IDL.Func(
+        [FeeBreakdownQuery],
+        [FeeBreakdownResponse],
         ['query'],
       ),
     'get_fee_curve_series' : IDL.Func(
@@ -439,6 +458,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_protocol_summary' : IDL.Func([], [ProtocolSummary], ['query']),
+    'get_sp_depositor_principals' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Principal)],
+        ['query'],
+      ),
     'get_stability_series' : IDL.Func(
         [RangeQuery],
         [StabilitySeriesResponse],
@@ -489,6 +513,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'ping' : IDL.Func([], [IDL.Text], ['query']),
+    'reset_error_counters' : IDL.Func(
+        [ResetErrorCountersArgs],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
+        [],
+      ),
     'start_backfill' : IDL.Func([IDL.Principal], [IDL.Text], []),
   });
 };

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -414,6 +414,7 @@ service : (InitArgs) -> {
       TopCounterpartiesResponse,
     ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
+  get_sp_depositor_principals : () -> (vec principal) query;
   get_top_sp_depositors : (TopSpDepositorsQuery) -> (
       TopSpDepositorsResponse,
     ) query;

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -276,6 +276,7 @@ type RangeQuery = record {
   offset : opt nat64;
   limit : opt nat32;
 };
+type ResetErrorCountersArgs = record { sources : opt vec text };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
@@ -425,5 +426,6 @@ service : (InitArgs) -> {
   get_volatility : (VolatilityQuery) -> (VolatilityResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   ping : () -> (text) query;
+  reset_error_counters : (ResetErrorCountersArgs) -> (variant { Ok; Err : text });
   start_backfill : (principal) -> (text);
 }

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -160,6 +160,17 @@ type FeeCurveSeriesResponse = record {
   rows : vec HourlyFeeCurveSnapshot;
   next_from_ts : opt nat64;
 };
+type FeeBreakdownQuery = record { window_ns : opt nat64 };
+type FeeBreakdownResponse = record {
+  borrow_fees_icusd_e8s : nat64;
+  redemption_fees_icusd_e8s : nat64;
+  swap_fees_icusd_e8s : nat64;
+  borrow_count : nat32;
+  redemption_count : nat32;
+  swap_count : nat32;
+  start_ns : nat64;
+  end_ns : nat64;
+};
 type FeeSeriesResponse = record {
   rows : vec DailyFeeRollup;
   next_from_ts : opt nat64;
@@ -386,6 +397,7 @@ service : (InitArgs) -> {
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
   get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
+  get_fee_breakdown_window : (FeeBreakdownQuery) -> (FeeBreakdownResponse) query;
   get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
   get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;

--- a/src/rumi_analytics/src/collectors/rollups.rs
+++ b/src/rumi_analytics/src/collectors/rollups.rs
@@ -111,11 +111,11 @@ fn rollup_fees(now: u64, day_start: u64) {
         match e.event_kind {
             VaultEventKind::Borrowed => {
                 borrow_count += 1;
-                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount.unwrap_or(0));
             }
             VaultEventKind::Redeemed => {
                 redemption_count += 1;
-                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount.unwrap_or(0));
             }
             _ => {}
         }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -185,6 +185,11 @@ fn get_fee_breakdown_window(query: types::FeeBreakdownQuery) -> types::FeeBreakd
 }
 
 #[ic_cdk_macros::query]
+fn get_sp_depositor_principals() -> Vec<Principal> {
+    queries::live::get_sp_depositor_principals()
+}
+
+#[ic_cdk_macros::query]
 fn get_token_flow(query: types::TokenFlowQuery) -> types::TokenFlowResponse {
     queries::flow::get_token_flow(query)
 }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -288,4 +288,24 @@ fn start_backfill(token: Principal) -> String {
     }
 }
 
+#[ic_cdk_macros::update]
+fn reset_error_counters(args: types::ResetErrorCountersArgs) -> Result<(), String> {
+    let admin = state::read_state(|s| s.admin);
+    let caller = ic_cdk::caller();
+    if caller != admin {
+        return Err(format!("unauthorized: caller {} is not admin", caller));
+    }
+    state::mutate_state(|s| {
+        let reset_all = args.sources.is_none();
+        let sources = args.sources.unwrap_or_default();
+        let touch = |name: &str| reset_all || sources.iter().any(|src| src == name);
+        if touch("backend") { s.error_counters.backend = 0; }
+        if touch("stability_pool") { s.error_counters.stability_pool = 0; }
+        if touch("three_pool") { s.error_counters.three_pool = 0; }
+        if touch("icusd_ledger") { s.error_counters.icusd_ledger = 0; }
+        if touch("amm") { s.error_counters.amm = 0; }
+    });
+    Ok(())
+}
+
 ic_cdk::export_candid!();

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -180,6 +180,11 @@ fn get_trade_activity(query: types::TradeActivityQuery) -> types::TradeActivityR
 }
 
 #[ic_cdk_macros::query]
+fn get_fee_breakdown_window(query: types::FeeBreakdownQuery) -> types::FeeBreakdownResponse {
+    queries::live::get_fee_breakdown_window(query)
+}
+
+#[ic_cdk_macros::query]
 fn get_token_flow(query: types::TokenFlowQuery) -> types::TokenFlowResponse {
     queries::flow::get_token_flow(query)
 }

--- a/src/rumi_analytics/src/queries/address_value.rs
+++ b/src/rumi_analytics/src/queries/address_value.rs
@@ -689,7 +689,7 @@ mod tests {
             event_kind: kind,
             collateral_type: coll_type,
             amount,
-            fee_amount: 0,
+            fee_amount: None,
         }
     }
     fn liq_event(vault_id: u64, ts: u64, kind: LiquidationKind, coll_amount: u64) -> AnalyticsLiquidationEvent {

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -943,11 +943,11 @@ pub fn compute_vault_fee_totals(
     for e in vault_events {
         match e.event_kind {
             storage::events::VaultEventKind::Borrowed => {
-                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount.unwrap_or(0));
                 borrow_count += 1;
             }
             storage::events::VaultEventKind::Redeemed => {
-                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount.unwrap_or(0));
                 redemption_count += 1;
             }
             _ => {}
@@ -1384,7 +1384,7 @@ mod tests {
             event_kind: kind,
             collateral_type: Principal::anonymous(),
             amount,
-            fee_amount: 0,
+            fee_amount: None,
         }
     }
 
@@ -1706,7 +1706,7 @@ mod tests {
             event_kind: kind,
             collateral_type: Principal::anonymous(),
             amount: 1_000_000,
-            fee_amount,
+            fee_amount: Some(fee_amount),
         }
     }
 

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -904,6 +904,69 @@ pub fn get_protocol_summary() -> types::ProtocolSummary {
     }
 }
 
+// ─── Fee Breakdown Window (Task 3.1) ───
+
+pub fn get_fee_breakdown_window(query: types::FeeBreakdownQuery) -> types::FeeBreakdownResponse {
+    let now = ic_cdk::api::time();
+    let start = match query.window_ns {
+        Some(window) => now.saturating_sub(window),
+        None => 0,
+    };
+
+    let vault_events = storage::events::evt_vaults::range(start, now, usize::MAX);
+    let swap_events = storage::events::evt_swaps::range(start, now, usize::MAX);
+
+    let (borrow_fees, redemption_fees, borrow_count, redemption_count) =
+        compute_vault_fee_totals(&vault_events);
+    let swap_fees: u64 = swap_events.iter().map(|e| e.fee).sum();
+    let swap_count = swap_events.len() as u32;
+
+    types::FeeBreakdownResponse {
+        borrow_fees_icusd_e8s: borrow_fees,
+        redemption_fees_icusd_e8s: redemption_fees,
+        swap_fees_icusd_e8s: swap_fees,
+        borrow_count,
+        redemption_count,
+        swap_count,
+        start_ns: start,
+        end_ns: now,
+    }
+}
+
+pub fn compute_vault_fee_totals(
+    vault_events: &[storage::events::AnalyticsVaultEvent],
+) -> (u64, u64, u32, u32) {
+    let mut borrow_fees: u64 = 0;
+    let mut redemption_fees: u64 = 0;
+    let mut borrow_count: u32 = 0;
+    let mut redemption_count: u32 = 0;
+    for e in vault_events {
+        match e.event_kind {
+            storage::events::VaultEventKind::Borrowed => {
+                borrow_fees = borrow_fees.saturating_add(e.fee_amount);
+                borrow_count += 1;
+            }
+            storage::events::VaultEventKind::Redeemed => {
+                redemption_fees = redemption_fees.saturating_add(e.fee_amount);
+                redemption_count += 1;
+            }
+            _ => {}
+        }
+    }
+    (borrow_fees, redemption_fees, borrow_count, redemption_count)
+}
+
+// ─── SP Depositor Principals (Task 3.2) ───
+
+pub fn get_sp_depositor_principals() -> Vec<Principal> {
+    let events = storage::events::evt_stability::range(0, u64::MAX, usize::MAX);
+    let mut set: HashSet<Principal> = HashSet::new();
+    for e in events {
+        set.insert(e.caller);
+    }
+    set.into_iter().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1627,5 +1690,60 @@ mod tests {
         let other_total = by_p.iter().find(|(p, _)| *p == other).map(|(_, b)| *b).unwrap();
         assert_eq!(owner_total, 175);
         assert_eq!(other_total, 10);
+    }
+
+    // ─── Task 3.1: fee breakdown compute helper ───
+
+    fn make_fee_vault_event(
+        kind: storage::events::VaultEventKind,
+        fee_amount: u64,
+    ) -> storage::events::AnalyticsVaultEvent {
+        storage::events::AnalyticsVaultEvent {
+            timestamp_ns: 1_000_000,
+            source_event_id: 0,
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            event_kind: kind,
+            collateral_type: Principal::anonymous(),
+            amount: 1_000_000,
+            fee_amount,
+        }
+    }
+
+    #[test]
+    fn fee_breakdown_empty_inputs_all_zeros() {
+        let (bf, rf, bc, rc) = compute_vault_fee_totals(&[]);
+        assert_eq!(bf, 0);
+        assert_eq!(rf, 0);
+        assert_eq!(bc, 0);
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn fee_breakdown_borrow_and_redeem_counts_and_sums() {
+        use storage::events::VaultEventKind;
+        let events = vec![
+            make_fee_vault_event(VaultEventKind::Borrowed, 500_000),
+            make_fee_vault_event(VaultEventKind::Borrowed, 300_000),
+            make_fee_vault_event(VaultEventKind::Redeemed, 100_000),
+            make_fee_vault_event(VaultEventKind::Repaid, 0),  // should be ignored
+        ];
+        let (bf, rf, bc, rc) = compute_vault_fee_totals(&events);
+        assert_eq!(bf, 800_000);
+        assert_eq!(rf, 100_000);
+        assert_eq!(bc, 2);
+        assert_eq!(rc, 1);
+    }
+
+    #[test]
+    fn fee_breakdown_saturating_add_on_large_fees() {
+        use storage::events::VaultEventKind;
+        let events = vec![
+            make_fee_vault_event(VaultEventKind::Borrowed, u64::MAX),
+            make_fee_vault_event(VaultEventKind::Borrowed, 1),
+        ];
+        let (bf, _, bc, _) = compute_vault_fee_totals(&events);
+        assert_eq!(bf, u64::MAX); // saturating, not overflow
+        assert_eq!(bc, 2);
     }
 }

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -82,11 +82,13 @@ pub struct AnalyticsVaultEvent {
     pub event_kind: VaultEventKind,
     pub collateral_type: Principal,
     pub amount: u64,
-    /// Fee paid on this event in icUSD e8s. Populated for Borrowed and
-    /// Redeemed; zero for other event kinds. Older stored events default
-    /// to 0 via serde, so they simply lack fee data.
+    /// Fee paid on this event in icUSD e8s. Populated as `Some(fee)` for
+    /// Borrowed and Redeemed; `None` for other event kinds and for events
+    /// stored before round 1 introduced this field. Optional so candid
+    /// subtyping accepts decoding pre-round-1 stable storage entries that
+    /// lack the field entirely.
     #[serde(default)]
-    pub fee_amount: u64,
+    pub fee_amount: Option<u64>,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -316,12 +318,47 @@ mod tests {
             event_kind: VaultEventKind::Opened,
             collateral_type: Principal::anonymous(),
             amount: 10_000_000_000,
-            fee_amount: 0,
+            fee_amount: None,
         };
         let bytes = evt.to_bytes();
         let decoded = AnalyticsVaultEvent::from_bytes(bytes);
         assert_eq!(decoded.vault_id, 1);
         assert!(matches!(decoded.event_kind, VaultEventKind::Opened));
+        assert_eq!(decoded.fee_amount, None);
+    }
+
+    /// Pre-round-1 events were encoded by an `AnalyticsVaultEvent` whose
+    /// struct lacked `fee_amount` entirely. The first round-2 deploy traps
+    /// when `fee_amount` is required (`u64`) because candid subtyping
+    /// rejects "field missing" against a non-optional schema. This test
+    /// pins down the fix: a legacy-shaped struct round-trips into the
+    /// current one with `fee_amount = None`.
+    #[test]
+    fn vault_event_decodes_pre_round1_legacy_shape() {
+        #[derive(candid::CandidType, serde::Deserialize)]
+        struct LegacyVaultEvent {
+            timestamp_ns: u64,
+            source_event_id: u64,
+            vault_id: u64,
+            owner: Principal,
+            event_kind: VaultEventKind,
+            collateral_type: Principal,
+            amount: u64,
+        }
+        let legacy = LegacyVaultEvent {
+            timestamp_ns: 3_000_000,
+            source_event_id: 5,
+            vault_id: 42,
+            owner: Principal::anonymous(),
+            event_kind: VaultEventKind::Borrowed,
+            collateral_type: Principal::anonymous(),
+            amount: 1_000_000_000,
+        };
+        let bytes = candid::Encode!(&legacy).expect("encode legacy");
+        let decoded = AnalyticsVaultEvent::from_bytes(std::borrow::Cow::Owned(bytes));
+        assert_eq!(decoded.vault_id, 42);
+        assert!(matches!(decoded.event_kind, VaultEventKind::Borrowed));
+        assert_eq!(decoded.fee_amount, None);
     }
 
     #[test]

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -103,7 +103,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Opened,
                 collateral_type: vault.collateral_type,
                 amount: vault.collateral_amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         BorrowFromVault { vault_id, borrowed_amount, fee_amount, caller, timestamp, .. } => {
@@ -115,7 +115,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Borrowed,
                 collateral_type: Principal::anonymous(),
                 amount: *borrowed_amount,
-                fee_amount: *fee_amount,
+                fee_amount: Some(*fee_amount),
             });
         }
         RepayToVault { vault_id, repayed_amount, caller, timestamp, .. } => {
@@ -127,7 +127,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Repaid,
                 collateral_type: Principal::anonymous(),
                 amount: *repayed_amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         CollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
@@ -139,7 +139,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::CollateralWithdrawn,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         PartialCollateralWithdrawn { vault_id, amount, caller, timestamp, .. } => {
@@ -151,7 +151,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::PartialCollateralWithdrawn,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         WithdrawAndCloseVault { vault_id, amount, caller, timestamp, .. } => {
@@ -163,7 +163,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::WithdrawAndClose,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         VaultWithdrawnAndClosed { vault_id, timestamp, caller, amount } => {
@@ -175,7 +175,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Closed,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         DustForgiven { vault_id, amount, timestamp } => {
@@ -187,7 +187,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::DustForgiven,
                 collateral_type: Principal::anonymous(),
                 amount: *amount,
-                fee_amount: 0,
+                fee_amount: None,
             });
         }
         RedemptionOnVaults { icusd_amount, fee_amount, owner, collateral_type, timestamp, .. } => {
@@ -199,7 +199,7 @@ fn route_backend_event(event_id: u64, event: &sources::backend::BackendEvent) {
                 event_kind: VaultEventKind::Redeemed,
                 collateral_type: collateral_type.unwrap_or(Principal::anonymous()),
                 amount: *icusd_amount,
-                fee_amount: *fee_amount,
+                fee_amount: Some(*fee_amount),
             });
         }
         // Legacy: ProvideLiquidity / WithdrawLiquidity / ClaimLiquidityReturns

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -393,6 +393,15 @@ pub struct PoolRoutesResponse {
     pub routes: Vec<PoolRoute>,
 }
 
+// --- Admin reset error counters (Task 3.3) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ResetErrorCountersArgs {
+    /// null = reset all sources; else only the listed source names.
+    /// Valid names: "backend", "stability_pool", "three_pool", "icusd_ledger", "amm".
+    pub sources: Option<Vec<String>>,
+}
+
 // --- Fee breakdown window (Task 3.1) ---
 
 #[derive(CandidType, Deserialize, Clone, Debug)]

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -393,6 +393,25 @@ pub struct PoolRoutesResponse {
     pub routes: Vec<PoolRoute>,
 }
 
+// --- Fee breakdown window (Task 3.1) ---
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct FeeBreakdownQuery {
+    pub window_ns: Option<u64>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct FeeBreakdownResponse {
+    pub borrow_fees_icusd_e8s: u64,
+    pub redemption_fees_icusd_e8s: u64,
+    pub swap_fees_icusd_e8s: u64,
+    pub borrow_count: u32,
+    pub redemption_count: u32,
+    pub swap_count: u32,
+    pub start_ns: u64,
+    pub end_ns: u64,
+}
+
 // --- Address value series (portfolio value over time, stacked by source) ---
 
 #[derive(CandidType, Deserialize, Clone, Debug)]

--- a/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
@@ -10,6 +10,7 @@
     fetch3PoolLiquidityEvents, fetch3PoolLiquidityEventCount,
     fetch3PoolAdminEvents, fetch3PoolAdminEventCount,
     fetchStabilityPoolEvents, fetchStabilityPoolEventCount,
+    type BackendEventFilters,
   } from '$services/explorer/explorerService';
   import { extractEventTimestamp } from '$utils/displayEvent';
   import type { DisplayEvent } from '$utils/displayEvent';
@@ -144,8 +145,13 @@
     try {
       // Fetch backend events + vault maps. Always include unless scope is purely DEX/SP/admin.
       const needsBackend = scope === 'all' || scope === 'vault_ops' || scope === 'redemptions' || scope === 'revenue' || scope === 'admin';
+      // For the redemptions scope, use a server-side type filter so we find
+      // redemption events across the full log rather than hoping they appear
+      // in the most recent 72 entries. Other scopes keep the unfiltered tail
+      // (vault_ops, revenue, admin, all mix event kinds so filtering is harder).
+      const redemptionFilters: BackendEventFilters = { types: ['Redemption'] };
       const backendPromise = needsBackend
-        ? fetchEvents(0n, BigInt(limit * 6)).catch(() => ({ total: 0n, events: [] }))
+        ? fetchEvents(0n, scope === 'redemptions' ? 50n : BigInt(limit * 6), scope === 'redemptions' ? redemptionFilters : undefined).catch(() => ({ total: 0n, events: [] }))
         : Promise.resolve({ total: 0n, events: [] });
 
       const vaultsPromise = fetchAllVaults().catch(() => []);

--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -10,6 +10,12 @@
     label?: string;
     valueFormat?: (v: number) => string;
     loading?: boolean;
+    // 'zero-anchored': y-axis always includes 0 (good for volumes, counts).
+    // 'data-fit': y-axis tightly wraps the data range (good for slowly-moving
+    // quantities like virtual price, where all values cluster near 1.06).
+    // Assumes positive values; data-fit padding multipliers behave unexpectedly
+    // for negative inputs.
+    yAxisMode?: 'zero-anchored' | 'data-fit';
   }
   let {
     points,
@@ -20,6 +26,7 @@
     label,
     valueFormat,
     loading = false,
+    yAxisMode = 'zero-anchored',
   }: Props = $props();
 
   const padX = 8;
@@ -30,13 +37,23 @@
     const minT = points[0].t;
     const maxT = points[points.length - 1].t;
     const { min, max } = computeYScale(points.map(p => p.v));
-    // Anchor the y-axis at 0 when all values are non-negative — otherwise a
-    // small spike on top of zeros (typical for low-volume swap charts) renders
-    // as a flat line near the baseline because computeYScale tightens around
-    // the data. Anchoring keeps the spike visually distinct from baseline.
-    const allNonNeg = points.every((p) => p.v >= 0);
-    const yMin = allNonNeg ? 0 : min;
-    return { minT, maxT, yMin, yMax: max };
+    let yMin: number;
+    let yMax: number;
+    if (yAxisMode === 'data-fit') {
+      // Tightly wrap the data range with a small margin so the slope is visible
+      // even when values cluster (e.g. virtual price 1.063–1.064).
+      yMin = min * 0.999;
+      yMax = max * 1.001;
+    } else {
+      // Anchor the y-axis at 0 when all values are non-negative — otherwise a
+      // small spike on top of zeros (typical for low-volume swap charts) renders
+      // as a flat line near the baseline because computeYScale tightens around
+      // the data. Anchoring keeps the spike visually distinct from baseline.
+      const allNonNeg = points.every((p) => p.v >= 0);
+      yMin = allNonNeg ? 0 : min;
+      yMax = max;
+    }
+    return { minT, maxT, yMin, yMax };
   });
 
   // Highlight dots for non-zero points when the series is sparse — without

--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -56,6 +56,14 @@
     return { minT, maxT, yMin, yMax };
   });
 
+  // When the entire series has exactly one non-zero point the bare dot looks
+  // broken. Detect that case so the template can render a more obvious
+  // vertical-marker fallback instead.
+  const nonZeroCount = $derived(points.filter((p) => p.v > 0).length);
+  // Guard points.length > 1 to avoid NaN when there is only one element
+  // (i / (length - 1) would be 0/0).
+  const isSingleEvent = $derived(nonZeroCount === 1 && points.length > 1);
+
   // Highlight dots for non-zero points when the series is sparse — without
   // them, an hourly chart with mostly-zero buckets looks empty even when
   // there's real activity in a couple of buckets.
@@ -118,11 +126,19 @@
       </div>
     {:else}
       <svg viewBox="0 0 {width} {height}" class="w-full h-full" preserveAspectRatio="none">
-        <path d={fillD} fill={fillColor} stroke="none" />
-        <path d={pathD} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />
-        {#each dotPoints as p (p.t)}
-          <circle cx={x(p.t).toFixed(2)} cy={y(p.v).toFixed(2)} r="3" fill={color} />
-        {/each}
+        {#if isSingleEvent}
+          {@const si = points.findIndex((p) => p.v > 0)}
+          {@const sx = x(points[si].t)}
+          {@const sv = points[si].v}
+          <line x1={sx} y1={0} x2={sx} y2={height} stroke="rgb(45 212 191 / 0.4)" stroke-dasharray="2 2" />
+          <circle cx={sx} cy={y(sv)} r="3.5" fill="rgb(45 212 191)" />
+        {:else}
+          <path d={fillD} fill={fillColor} stroke="none" />
+          <path d={pathD} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />
+          {#each dotPoints as p (p.t)}
+            <circle cx={x(p.t).toFixed(2)} cy={y(p.v).toFixed(2)} r="3" fill={color} />
+          {/each}
+        {/if}
       </svg>
     {/if}
   </div>

--- a/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchCurrentSpDepositors, fetchCollateralConfigs, type CurrentSpDepositor } from '$services/explorer/explorerService';
+  import { getTokenSymbol } from '$utils/explorerHelpers';
+
+  let depositors: CurrentSpDepositor[] = $state([]);
+  let collaterals: string[] = $state([]); // principal text
+  let loading = $state(true);
+
+  function isOptedIn(d: CurrentSpDepositor, collType: string): boolean {
+    return !d.position.opted_out_collateral.some((p) => p.toText() === collType);
+  }
+
+  function totalStableUsd(d: CurrentSpDepositor): number {
+    return Number(d.position.total_usd_value_e8s) / 1e8;
+  }
+
+  const rows = $derived.by(() => {
+    return collaterals.map((c) => {
+      const optedIn = depositors.filter((d) => isOptedIn(d, c));
+      const pct = depositors.length > 0 ? (optedIn.length / depositors.length) * 100 : 0;
+      const usd = optedIn.reduce((s, d) => s + totalStableUsd(d), 0);
+      return { collateral: c, pct, usd, count: optedIn.length, total: depositors.length };
+    });
+  });
+
+  onMount(async () => {
+    try {
+      const [d, configs] = await Promise.all([
+        fetchCurrentSpDepositors(),
+        fetchCollateralConfigs(),
+      ]);
+      depositors = d;
+      // CollateralConfig uses ledger_canister_id as the collateral identifier.
+      collaterals = configs
+        .map((c: any) => c.ledger_canister_id?.toText?.() ?? '')
+        .filter((id: string) => id.length > 0);
+    } catch (err) {
+      console.error('[SpCoverageCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Per-collateral opt-in coverage</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    For each supported collateral, the share of SP depositors who haven't opted out and the total stable backing they provide.
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if rows.length === 0}
+    <p class="text-sm text-gray-500 py-2">No collaterals configured.</p>
+  {:else}
+    <div class="space-y-2">
+      {#each rows as r (r.collateral)}
+        <div class="flex items-baseline justify-between text-sm gap-4">
+          <span class="text-gray-200 font-medium w-20 shrink-0">{getTokenSymbol(r.collateral)}</span>
+          <span class="tabular-nums text-gray-400 flex-1">{r.count}/{r.total} opted in ({r.pct.toFixed(0)}%)</span>
+          <span class="tabular-nums text-gray-100 font-medium">
+            ${r.usd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/SpCurrentDepositorsCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/SpCurrentDepositorsCard.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchCurrentSpDepositors, type CurrentSpDepositor } from '$services/explorer/explorerService';
+  import { getTokenSymbol, getTokenDecimals } from '$utils/explorerHelpers';
+  import EntityLink from './EntityLink.svelte';
+
+  let depositors: CurrentSpDepositor[] = $state([]);
+  let loading = $state(true);
+  let error: string | null = $state(null);
+
+  // Distinct token principals across all depositors → column headers
+  const tokens = $derived.by(() => {
+    const set = new Set<string>();
+    for (const d of depositors) {
+      for (const [token] of d.position.stablecoin_balances) {
+        set.add(token.toText());
+      }
+    }
+    return Array.from(set);
+  });
+
+  function balanceOf(d: CurrentSpDepositor, token: string): bigint {
+    for (const [t, amt] of d.position.stablecoin_balances) {
+      if (t.toText() === token) return amt;
+    }
+    return 0n;
+  }
+
+  function fmt(amt: bigint, token: string): string {
+    if (amt === 0n) return '';
+    const decimals = getTokenDecimals(token);
+    const v = Number(amt) / Math.pow(10, decimals);
+    return v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+
+  onMount(async () => {
+    try {
+      depositors = await fetchCurrentSpDepositors();
+    } catch (err: any) {
+      console.error('[SpCurrentDepositorsCard] load failed:', err);
+      error = err?.message ?? String(err);
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Current depositors</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    Every principal currently holding a non-zero SP balance. Per-token columns; sorted by total USD value.
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if error}
+    <p class="text-sm text-red-400 py-2">Failed to load: {error}</p>
+  {:else if depositors.length === 0}
+    <p class="text-sm text-gray-500 py-2">No active depositors.</p>
+  {:else}
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-white/5">
+            <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Depositor</th>
+            {#each tokens as t (t)}
+              <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">{getTokenSymbol(t)}</th>
+            {/each}
+            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Total USD</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each depositors as d (d.principal.toText())}
+            <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
+              <td class="py-2 px-2 font-mono text-xs">
+                <EntityLink type="address" value={d.principal.toText()} />
+              </td>
+              {#each tokens as t (t)}
+                <td class="py-2 px-2 text-right tabular-nums text-gray-300">{fmt(balanceOf(d, t), t)}</td>
+              {/each}
+              <td class="py-2 px-2 text-right tabular-nums text-gray-100 font-medium">
+                ${(Number(d.position.total_usd_value_e8s) / 1e8).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/TreasuryHoldingsCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/TreasuryHoldingsCard.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { ProtocolService } from '$services/protocol';
+  import { fetchTreasuryHoldings, type TreasuryHolding } from '$services/explorer/explorerService';
+
+  let holdings = $state<TreasuryHolding[]>([]);
+  let loading = $state(true);
+
+  onMount(async () => {
+    try {
+      const status = await ProtocolService.getProtocolStatus();
+      const icpPrice: number = (status?.lastIcpRate ?? 0) as number;
+      holdings = await fetchTreasuryHoldings(icpPrice);
+    } catch (err) {
+      console.error('[TreasuryHoldingsCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  const totalUsd = $derived(holdings.reduce((s, h) => s + h.usd, 0));
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Treasury holdings</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    Live token balances of the rumi_treasury canister
+    (<code class="text-gray-600">tlg74-oiaaa-aaaap-qrd6a-cai</code>).
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if holdings.length === 0}
+    <p class="text-sm text-gray-500 py-2">No tracked balances.</p>
+  {:else}
+    <table class="w-full text-sm">
+      <tbody>
+        {#each holdings as h (h.ledger)}
+          <tr class="border-b border-white/[0.03]">
+            <td class="py-1.5 px-2 text-gray-200">{h.symbol}</td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-300">
+              {(Number(h.balanceE8s) / Math.pow(10, h.decimals)).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-100 font-medium">
+              ${h.usd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+          </tr>
+        {/each}
+        <tr class="border-t border-white/10">
+          <td class="py-1.5 px-2 text-xs text-gray-500 uppercase">Total</td>
+          <td></td>
+          <td class="py-1.5 px-2 text-right tabular-nums text-teal-300 font-semibold">
+            ${totalUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
@@ -4,11 +4,14 @@
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import AdminBreakdownCard from '../AdminBreakdownCard.svelte';
   import CanisterInventoryCard from '../CanisterInventoryCard.svelte';
-  import { fetchCollectorHealth } from '$services/explorer/analyticsService';
-  import { fetchProtocolStatus } from '$services/explorer/explorerService';
+  import { fetchCollectorHealth, fetchAdminEventBreakdown } from '$services/explorer/analyticsService';
+  import { fetchProtocolStatus, fetchEvents } from '$services/explorer/explorerService';
+  import { extractEventTimestamp } from '$utils/displayEvent';
 
   let collectorHealth: any = $state(null);
   let status: any = $state(null);
+  let lastAdminEvent: any = $state(null);
+  let adminCount24h = $state(0);
   let loading = $state(true);
 
   onMount(async () => {
@@ -24,11 +27,40 @@
     } finally {
       loading = false;
     }
+
+    // Latest admin event (page=0 returns most recent first)
+    try {
+      const result = await fetchEvents(0n, 1n, { types: ['Admin'] });
+      lastAdminEvent = result.events?.[0]?.[1] ?? null;
+    } catch (err) {
+      console.warn('[AdminLens] latest admin fetch failed:', err);
+    }
+
+    // 24h admin count: ask analytics for a 24h windowed breakdown and sum labels
+    try {
+      const windowNs = BigInt(86_400) * 1_000_000_000n;
+      const breakdown = await fetchAdminEventBreakdown(windowNs);
+      adminCount24h = breakdown.labels.reduce((s, l) => s + Number(l.count), 0);
+    } catch (err) {
+      console.warn('[AdminLens] 24h admin count fetch failed:', err);
+    }
   });
 
   const mode = $derived.by(() => {
     if (!status?.mode) return 'Unknown';
     return Object.keys(status.mode)[0] ?? 'Unknown';
+  });
+
+  const lastAdminRel = $derived.by(() => {
+    if (!lastAdminEvent) return '--';
+    const tsNs = extractEventTimestamp(lastAdminEvent);
+    if (!tsNs) return '--';
+    const ms = tsNs / 1_000_000;
+    const ago = Date.now() - ms;
+    if (ago < 60_000) return 'just now';
+    if (ago < 3_600_000) return `${Math.floor(ago / 60_000)}m ago`;
+    if (ago < 86_400_000) return `${Math.floor(ago / 3_600_000)}h ago`;
+    return `${Math.floor(ago / 86_400_000)}d ago`;
   });
 
   const healthMetrics = $derived.by(() => {
@@ -40,10 +72,12 @@
       metrics.push({
         label: 'Collector errors',
         value: errs.toLocaleString(),
-        sub: 'analytics tailing',
+        sub: 'failed inter-canister calls from analytics tailers (unexpected response shape, decode failure). Per-source breakdown below.',
         tone: errs > 0 ? 'caution' as const : 'good' as const,
       });
     }
+    metrics.push({ label: 'Last admin action', value: lastAdminRel });
+    metrics.push({ label: 'Admin actions 24h', value: adminCount24h.toLocaleString() });
     return metrics;
   });
 </script>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -230,15 +230,17 @@
     {:else if allVaults.length === 0}
       <p class="text-sm text-gray-500 py-4">No active vaults.</p>
     {:else}
-      <div class="flex items-end gap-2 h-40 border-b border-white/5 mt-4">
+      <div class="flex items-end gap-2 h-40 min-h-[10rem] border-b border-white/5 mt-4">
         {#each crBuckets as b}
           {@const pct = (b.count / maxBucket) * 100}
+          {@const barPct = b.count > 0 ? Math.max(pct, 2) : 0}
           {@const tone = b.lo < 150 ? '#f472b6' : b.lo < 200 ? '#a78bfa' : '#2DD4BF'}
-          <div class="flex-1 flex flex-col items-center justify-end">
+          <div class="flex-1 flex flex-col items-center justify-end h-full">
             <span class="text-[11px] font-medium text-gray-400 mb-1">{b.count}</span>
             <div
               class="w-full rounded-t"
-              style="height: {pct}%; min-height: {b.count > 0 ? '2px' : '0'}; background: {tone}; opacity: 0.75;"
+              style="height: {barPct}%; background: {tone}; opacity: 0.75;"
+              title="{b.label}: {b.count} vault{b.count === 1 ? '' : 's'}"
             ></div>
           </div>
         {/each}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -9,12 +9,13 @@
     fetchProtocolSummary, fetchTwap, fetchVolatility, fetchLiquidationSeries,
   } from '$services/explorer/analyticsService';
   import {
-    fetchCollateralConfigs, fetchCollateralTotals, fetchAllVaults, fetchLiquidatableVaults,
+    fetchCollateralConfigs, fetchCollateralTotals, fetchAllVaults,
   } from '$services/explorer/explorerService';
   import {
     e8sToNumber, formatCompact, bpsToPercent, COLLATERAL_SYMBOLS, COLLATERAL_COLORS,
   } from '$utils/explorerChartHelpers';
   import { computeVaultCrPct, median } from '$utils/vaultCr';
+  import { decodeRustDecimal } from '$utils/decimalUtils';
   import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
 
   let systemCrBps = $state(0);
@@ -33,14 +34,13 @@
     try {
       const principals = Object.keys(COLLATERAL_SYMBOLS);
       const [
-        summaryR, twapR, configsR, totalsR, allVaultsR, liqVaultsR, liqSeriesR, ...volResults
+        summaryR, twapR, configsR, totalsR, allVaultsR, liqSeriesR, ...volResults
       ] = await Promise.allSettled([
         fetchProtocolSummary(),
         fetchTwap(),
         fetchCollateralConfigs(),
         fetchCollateralTotals(),
         fetchAllVaults(),
-        fetchLiquidatableVaults(),
         fetchLiquidationSeries(7),
         ...principals.map(p => fetchVolatility(Principal.fromText(p))),
       ]);
@@ -51,7 +51,6 @@
       const configs = configsR.status === 'fulfilled' ? configsR.value ?? [] : [];
       const totals = totalsR.status === 'fulfilled' ? totalsR.value ?? [] : [];
       allVaults = allVaultsR.status === 'fulfilled' ? allVaultsR.value ?? [] : [];
-      atRiskVaults = liqVaultsR.status === 'fulfilled' ? liqVaultsR.value ?? [] : [];
 
       const liqSeries = liqSeriesR.status === 'fulfilled' ? liqSeriesR.value ?? [] : [];
       liq7dCount = liqSeries.reduce((s: number, d: any) => s + Number(d.liquidation_count ?? 0), 0);
@@ -111,6 +110,42 @@
         crByCollateral.get(collType)!.push(cr);
       }
       crBuckets = buckets;
+
+      // Warning zone: vaults below min borrow CR but above liquidation threshold.
+      // These are the same vaults that trigger the warning icon on the vault page.
+      // borrow_threshold_ratio and liquidation_ratio are 16-byte Rust Decimal blobs;
+      // decodeRustDecimal returns an absolute ratio (e.g. 1.3 for 130%).
+      // computeVaultCrPct returns CR as a percentage (e.g. 130 for 130%).
+      const warningZone: any[] = [];
+      for (const v of allVaults) {
+        const cr = computeVaultCrPct(v, priceMap, decimalsMap);
+        if (cr == null) continue;
+        const collType = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+        const cfg = configMap.get(collType);
+        if (!cfg) continue;
+        const borrowThresholdRatio = cfg.borrow_threshold_ratio
+          ? decodeRustDecimal(cfg.borrow_threshold_ratio) * 100
+          : null;
+        const liquidationRatio = cfg.liquidation_ratio
+          ? decodeRustDecimal(cfg.liquidation_ratio) * 100
+          : null;
+        if (borrowThresholdRatio == null || liquidationRatio == null) continue;
+        if (cr < borrowThresholdRatio && cr >= liquidationRatio) {
+          warningZone.push({
+            vault_id: Number(v.vault_id),
+            owner: v.owner?.toText?.() ?? String(v.owner ?? ''),
+            collateral_type: v.collateral_type,
+            collateral_ratio: cr,
+            liquidation_ratio: liquidationRatio,
+            borrowed_icusd_amount: Number(v.borrowed_icusd_amount ?? 0),
+            collateral_amount: Number(v.collateral_amount ?? 0),
+            collateral_decimals: decimalsMap.get(collType) ?? 8,
+          });
+        }
+      }
+      // Sort by CR ascending so the most-at-risk vaults appear first.
+      warningZone.sort((a, b) => a.collateral_ratio - b.collateral_ratio);
+      atRiskVaults = warningZone;
 
       const rows: CollateralRow[] = [];
       for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -319,6 +319,7 @@
       fillColor="rgba(52, 211, 153, 0.15)"
       valueFormat={(v) => v.toFixed(6)}
       loading={loading}
+      yAxisMode="data-fit"
     />
   </div>
 </div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -61,8 +61,8 @@
       if (apyR.status === 'fulfilled' && apyR.value) {
         const aLp = apyR.value.lp_apy_pct?.[0];
         const aSp = apyR.value.sp_apy_pct?.[0];
-        if (typeof aLp === 'number' && aLp > 0) lpApy = aLp;
-        if (typeof aSp === 'number' && aSp > 0) spApy = aSp;
+        if (typeof aLp === 'number') lpApy = aLp;
+        if (typeof aSp === 'number') spApy = aSp;
       }
       if (pricesR.status === 'fulfilled') {
         const map = pricesR.value;

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -166,7 +166,7 @@
         label: 'Arb score',
         value: `${arb}/100`,
         tone: arb > 50 ? 'caution' as const : 'good' as const,
-        sub: '0–100',
+        sub: 'pool imbalance % of saturation; higher = more profit available to a rebalancing trader',
       });
     }
     metrics.push({ label: '3Pool LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: '7d' });

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -3,7 +3,6 @@
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
-  import PoolHealthStrip from '../PoolHealthStrip.svelte';
   import {
     fetchSwapSeries, fetchThreePoolSeries, fetchPegStatus, fetchApys,
   } from '$services/explorer/analyticsService';
@@ -361,7 +360,5 @@
     </div>
   </div>
 {/if}
-
-<PoolHealthStrip {pegStatus} {lpApy} {spApy} loading={loading} />
 
 <LensActivityPanel scope="dexs" title="DEX activity" viewAllHref="/explorer/activity?type=dex" />

--- a/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
@@ -82,12 +82,12 @@
     if (apyR.status === 'fulfilled' && apyR.value) {
       const aLp = apyR.value.lp_apy_pct?.[0];
       const aSp = apyR.value.sp_apy_pct?.[0];
-      if (typeof aLp === 'number' && aLp > 0) lpApy = aLp;
-      if (typeof aSp === 'number' && aSp > 0) spApy = aSp;
+      if (typeof aLp === 'number') lpApy = aLp;
+      if (typeof aSp === 'number') spApy = aSp;
     }
 
-    // Fallback APY compute when analytics is empty.
-    if (!lpApy || !spApy) {
+    // Fallback APY compute when analytics has no data (null means no rows).
+    if (lpApy === null || spApy === null) {
       try {
         const [psR, poolR, spR] = await Promise.allSettled([
           ProtocolService.getProtocolStatus(),
@@ -98,7 +98,7 @@
         const pool = poolR.status === 'fulfilled' ? poolR.value : null;
         const sp = spR.status === 'fulfilled' ? spR.value : null;
 
-        if (!lpApy && ps && pool) {
+        if (lpApy === null && ps && pool) {
           let poolTvlE8s = 0;
           for (let i = 0; i < pool.balances.length; i++) {
             const token = POOL_TOKENS[i];
@@ -110,7 +110,7 @@
           const computed = calculateTheoreticalApy(threePoolBps, ps.perCollateralInterest, poolTvlE8s / 1e8);
           if (computed != null) lpApy = computed * 100;
         }
-        if (!spApy && ps && sp) {
+        if (spApy === null && ps && sp) {
           const poolShare = (ps.interestSplit?.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
           const perC = ps.perCollateralInterest;
           if (poolShare > 0 && perC?.length > 0) {

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
@@ -7,7 +7,7 @@
   import { fetchFeeSeries } from '$services/explorer/analyticsService';
   import {
     fetchRedemptionRate, fetchRedemptionFeeFloor, fetchRedemptionFeeCeiling,
-    fetchRedemptionTier, fetchCollateralTotals, fetchProtocolConfig,
+    fetchRedemptionTier, fetchCollateralTotals, fetchProtocolConfig, fetchProtocolStatus,
   } from '$services/explorer/explorerService';
   import {
     e8sToNumber, formatCompact, CHART_COLORS, COLLATERAL_SYMBOLS, getCollateralSymbol,
@@ -19,6 +19,9 @@
   let feeCeiling: number | null = $state(null);
   let rmrFloor: number | null = $state(null);
   let rmrCeiling: number | null = $state(null);
+  let rmrFloorCr: number | null = $state(null);
+  let rmrCeilingCr: number | null = $state(null);
+  let totalCollateralRatio: number | null = $state(null);
   let collateralTotals: any[] = $state([]);
   let tierMap: Map<string, number | null> = $state(new Map());
   let loading = $state(true);
@@ -26,13 +29,14 @@
   onMount(async () => {
     try {
       const principals = Object.keys(COLLATERAL_SYMBOLS);
-      const [feeR, rateR, floorR, ceilR, totalsR, cfgR, ...tierRs] = await Promise.allSettled([
+      const [feeR, rateR, floorR, ceilR, totalsR, cfgR, statusR, ...tierRs] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchRedemptionRate(),
         fetchRedemptionFeeFloor(),
         fetchRedemptionFeeCeiling(),
         fetchCollateralTotals(),
         fetchProtocolConfig(),
+        fetchProtocolStatus(),
         ...principals.map(p => fetchRedemptionTier(Principal.fromText(p))),
       ]);
       if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
@@ -41,12 +45,15 @@
       if (ceilR.status === 'fulfilled') feeCeiling = ceilR.value;
       if (totalsR.status === 'fulfilled') collateralTotals = totalsR.value ?? [];
       if (cfgR.status === 'fulfilled' && cfgR.value) {
-        // RMR = redemption margin ratio. Bounds: rmr_floor → rmr_ceiling. The
-        // active value depends on the global CR (between rmr_floor_cr and
-        // rmr_ceiling_cr). Showing the configured range gives a clear picture
-        // of the protocol's redemption margin policy.
         rmrFloor = typeof cfgR.value.rmr_floor === 'number' ? cfgR.value.rmr_floor : null;
         rmrCeiling = typeof cfgR.value.rmr_ceiling === 'number' ? cfgR.value.rmr_ceiling : null;
+        rmrFloorCr = typeof cfgR.value.rmr_floor_cr === 'number' ? cfgR.value.rmr_floor_cr : null;
+        rmrCeilingCr = typeof cfgR.value.rmr_ceiling_cr === 'number' ? cfgR.value.rmr_ceiling_cr : null;
+      }
+      if (statusR.status === 'fulfilled' && statusR.value) {
+        totalCollateralRatio = typeof statusR.value.total_collateral_ratio === 'number'
+          ? statusR.value.total_collateral_ratio
+          : null;
       }
 
       const tm = new Map<string, number | null>();
@@ -80,18 +87,44 @@
   const formatPct = (v: number | null) =>
     v == null ? '--' : `${(v * 100).toFixed(2)}%`;
 
-  const rmrRangeLabel = $derived.by(() => {
-    if (rmrFloor == null && rmrCeiling == null) return '--';
-    const lo = rmrFloor != null ? `${(rmrFloor * 100).toFixed(2)}%` : '?';
-    const hi = rmrCeiling != null ? `${(rmrCeiling * 100).toFixed(2)}%` : '?';
-    return `${lo} → ${hi}`;
+  // Active RMR: linear interpolation matching backend get_redemption_margin_ratio().
+  // tcr (total_collateral_ratio) is an absolute ratio (e.g. 2.5 = 250% CR).
+  // rmrFloorCr / rmrCeilingCr are also absolute ratios (e.g. 2.25 / 1.50).
+  // rmrFloor / rmrCeiling are decimal fractions (e.g. 0.96 / 1.0).
+  const activeRmr = $derived.by((): number | null => {
+    if (rmrFloor == null || rmrCeiling == null || rmrFloorCr == null || rmrCeilingCr == null) return null;
+    const tcr = totalCollateralRatio;
+    if (tcr == null) return null;
+    if (tcr <= rmrCeilingCr) return rmrCeiling;
+    if (tcr >= rmrFloorCr) return rmrFloor;
+    const range = rmrFloorCr - rmrCeilingCr;
+    const position = tcr - rmrCeilingCr;
+    const spread = rmrCeiling - rmrFloor;
+    return rmrCeiling - (position / range) * spread;
+  });
+
+  const activeRmrLabel = $derived.by(() => {
+    if (activeRmr == null) return '--';
+    return `${(activeRmr * 100).toFixed(2)}%`;
+  });
+
+  // Sub-text for the RMR tile: show what CR drove it and the configured range.
+  const activeRmrSub = $derived.by(() => {
+    const crPct = totalCollateralRatio != null ? `at ${(totalCollateralRatio * 100).toFixed(0)}% CR` : '';
+    if (rmrFloor == null || rmrCeiling == null || rmrFloorCr == null || rmrCeilingCr == null) return crPct || undefined;
+    const floorPct = `${(rmrFloor * 100).toFixed(0)}%`;
+    const ceilPct = `${(rmrCeiling * 100).toFixed(0)}%`;
+    const floorCrPct = `${(rmrFloorCr * 100).toFixed(0)}%`;
+    const ceilCrPct = `${(rmrCeilingCr * 100).toFixed(0)}%`;
+    const range = `${floorPct} (CR ${floorCrPct}) to ${ceilPct} (CR ${ceilCrPct})`;
+    return crPct ? `${crPct}; slides ${range}` : `slides ${range}`;
   });
 
   const healthMetrics = $derived.by(() => [
     { label: 'Live rate', value: formatPct(rate), sub: 'current redemption fee' },
     { label: 'Fee floor', value: formatPct(feeFloor), tone: 'muted' as const },
     { label: 'Fee ceiling', value: formatPct(feeCeiling), tone: 'muted' as const },
-    { label: 'RMR', value: rmrRangeLabel, sub: 'redemption margin (low→high)', tone: 'muted' as const },
+    { label: 'Current RMR', value: activeRmrLabel, sub: activeRmrSub },
     { label: 'Redemptions (90d)', value: redemptions90d.toLocaleString() },
     { label: 'Fees collected (90d)', value: `$${formatCompact(redemptionFees90d)}`, sub: 'icUSD' },
   ]);

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -70,15 +70,16 @@
     return swapFees24h + estimatedDailyBorrow;
   });
 
-  // Analytics returns 0 when the window has no data; treat that as "--"
-  // rather than confidently displaying 0.00%.
+  // Backend returns None (null in Candid) when there is genuinely no data.
+  // It returns Some(0.0) when the window has data but zero fees. Display
+  // 0.00% for a confirmed zero rather than hiding it as "--".
   const lpApy = $derived.by(() => {
     const v = apys?.lp_apy_pct?.[0];
-    return typeof v === 'number' && v > 0 ? v : null;
+    return typeof v === 'number' ? v : null;
   });
   const spApy = $derived.by(() => {
     const v = apys?.sp_apy_pct?.[0];
-    return typeof v === 'number' && v > 0 ? v : null;
+    return typeof v === 'number' ? v : null;
   });
 
   const feePoints = $derived(

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -3,11 +3,12 @@
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
+  import TreasuryHoldingsCard from '../TreasuryHoldingsCard.svelte';
   import {
     fetchFeeSeries, fetchApys, fetchFeeBreakdownWindow, type FeeBreakdown,
   } from '$services/explorer/analyticsService';
   import {
-    fetchTreasuryStats, fetchInterestSplit,
+    fetchInterestSplit,
   } from '$services/explorer/explorerService';
   import { ProtocolService } from '$services/protocol';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
@@ -16,19 +17,17 @@
   let apys: any = $state(null);
   let fees24hData = $state<FeeBreakdown | null>(null);
   let fees90dData = $state<FeeBreakdown | null>(null);
-  let treasury: any = $state(null);
   let interestSplit: any[] = $state([]);
   let protocolStatus: any = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     try {
-      const [feeR, apR, f24R, f90R, trsR, spR, psR] = await Promise.allSettled([
+      const [feeR, apR, f24R, f90R, spR, psR] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchApys(),
         fetchFeeBreakdownWindow(1),
         fetchFeeBreakdownWindow(90),
-        fetchTreasuryStats(),
         fetchInterestSplit(),
         ProtocolService.getProtocolStatus(),
       ]);
@@ -36,7 +35,6 @@
       if (apR.status === 'fulfilled') apys = apR.value;
       if (f24R.status === 'fulfilled') fees24hData = f24R.value;
       if (f90R.status === 'fulfilled') fees90dData = f90R.value;
-      if (trsR.status === 'fulfilled') treasury = trsR.value;
       if (spR.status === 'fulfilled') interestSplit = spR.value ?? [];
       if (psR.status === 'fulfilled') protocolStatus = psR.value;
     } catch (err) {
@@ -83,16 +81,6 @@
       destination: e.destination ?? String(e.destination ?? ''),
       bps: Number(e.bps ?? 0),
     })).filter((r: any) => r.bps > 0);
-  });
-
-  const treasuryInfo = $derived.by(() => {
-    if (!treasury) return null;
-    return {
-      pendingInterest: Number(treasury.pending_treasury_interest ?? 0n),
-      liquidationShare: Number(treasury.liquidation_protocol_share ?? 0),
-      flushThreshold: e8sToNumber(treasury.interest_flush_threshold_e8s ?? 0n),
-      principal: treasury.treasury_principal?.[0]?.toText?.() ?? treasury.treasury_principal?.[0] ?? null,
-    };
   });
 
   // Treasury share of accrued interest (not the liquidation bonus split — that
@@ -199,40 +187,7 @@
   </div>
 </div>
 
-{#if treasuryInfo}
-  <div class="explorer-card">
-    <h3 class="text-sm font-medium text-gray-300 mb-3">Treasury</h3>
-    <div class="grid grid-cols-2 md:grid-cols-2 gap-4">
-      <div>
-        <div class="text-xs text-gray-500" title="icUSD that has accrued to the treasury but hasn't yet been swept to the treasury canister. Drops to 0 immediately after each periodic flush.">
-          Pending interest
-        </div>
-        <div class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
-          {formatCompact(treasuryInfo.pendingInterest / 1e8)} icUSD
-        </div>
-        <div class="text-[11px] text-gray-500 mt-0.5">
-          Resets to 0 after each automatic flush.
-        </div>
-      </div>
-      <div>
-        <div class="text-xs text-gray-500" title="When pending interest crosses this amount the protocol auto-distributes it to recipients per the interest split. Threshold of 0 means flush every tick.">
-          Flush threshold
-        </div>
-        <div class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
-          {treasuryInfo.flushThreshold > 0 ? `${formatCompact(treasuryInfo.flushThreshold)} icUSD` : 'Flush every tick'}
-        </div>
-        <div class="text-[11px] text-gray-500 mt-0.5">
-          Auto-flushes pending interest when crossed.
-        </div>
-      </div>
-    </div>
-    {#if treasuryInfo.principal}
-      <div class="mt-3 text-xs text-gray-500">
-        Treasury canister: <span class="font-mono text-gray-400">{treasuryInfo.principal}</span>
-      </div>
-    {/if}
-  </div>
-{/if}
+<TreasuryHoldingsCard />
 
 <!-- Revenue-bearing = redemptions + liquidations + swaps (everything the protocol charges a fee on). -->
 <LensActivityPanel

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -4,7 +4,7 @@
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
   import {
-    fetchFeeSeries, fetchApys, fetchTradeActivity,
+    fetchFeeSeries, fetchApys, fetchFeeBreakdownWindow, type FeeBreakdown,
   } from '$services/explorer/analyticsService';
   import {
     fetchTreasuryStats, fetchInterestSplit,
@@ -14,7 +14,8 @@
 
   let feeRows: any[] = $state([]);
   let apys: any = $state(null);
-  let tradeActivity: any = $state(null);
+  let fees24hData = $state<FeeBreakdown | null>(null);
+  let fees90dData = $state<FeeBreakdown | null>(null);
   let treasury: any = $state(null);
   let interestSplit: any[] = $state([]);
   let protocolStatus: any = $state(null);
@@ -22,17 +23,19 @@
 
   onMount(async () => {
     try {
-      const [feeR, apR, trR, trsR, spR, psR] = await Promise.allSettled([
+      const [feeR, apR, f24R, f90R, trsR, spR, psR] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchApys(),
-        fetchTradeActivity(),
+        fetchFeeBreakdownWindow(1),
+        fetchFeeBreakdownWindow(90),
         fetchTreasuryStats(),
         fetchInterestSplit(),
         ProtocolService.getProtocolStatus(),
       ]);
       if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
       if (apR.status === 'fulfilled') apys = apR.value;
-      if (trR.status === 'fulfilled') tradeActivity = trR.value;
+      if (f24R.status === 'fulfilled') fees24hData = f24R.value;
+      if (f90R.status === 'fulfilled') fees90dData = f90R.value;
       if (trsR.status === 'fulfilled') treasury = trsR.value;
       if (spR.status === 'fulfilled') interestSplit = spR.value ?? [];
       if (psR.status === 'fulfilled') protocolStatus = psR.value;
@@ -43,32 +46,14 @@
     }
   });
 
-  const totalBorrow = $derived(
-    feeRows.reduce((s: number, d: any) => s + e8sToNumber(d.borrowing_fees_e8s?.[0] ?? d.borrowing_fees_e8s ?? 0n), 0)
-  );
-  const totalRedemption = $derived(
-    feeRows.reduce((s: number, d: any) => s + e8sToNumber(d.redemption_fees_e8s?.[0] ?? d.redemption_fees_e8s ?? 0n), 0)
-  );
-  const totalSwap = $derived(
-    feeRows.reduce((s: number, d: any) => s + e8sToNumber(d.swap_fees_e8s ?? 0n), 0)
-  );
+  const totalBorrow = $derived(fees90dData?.borrowIcusd ?? 0);
+  const totalRedemption = $derived(fees90dData?.redemptionIcusd ?? 0);
+  const totalSwap = $derived(fees90dData?.swapIcusd ?? 0);
   const totalFees = $derived(totalBorrow + totalRedemption + totalSwap);
 
-  const estimatedDailyBorrow = $derived.by(() => {
-    if (!protocolStatus?.perCollateralInterest) return 0;
-    const treasuryBps = protocolStatus.interestSplit?.find((e: any) => e.destination === 'treasury')?.bps ?? 0;
-    const treasuryShare = treasuryBps / 10000;
-    let dailyInterest = 0;
-    for (const info of protocolStatus.perCollateralInterest) {
-      dailyInterest += info.weightedInterestRate * info.totalDebtE8s;
-    }
-    return dailyInterest * treasuryShare;
-  });
-
-  const fees24h = $derived.by(() => {
-    const swapFees24h = tradeActivity ? e8sToNumber(tradeActivity.total_fees_e8s) : 0;
-    return swapFees24h + estimatedDailyBorrow;
-  });
+  const fees24h = $derived(
+    (fees24hData?.borrowIcusd ?? 0) + (fees24hData?.redemptionIcusd ?? 0) + (fees24hData?.swapIcusd ?? 0)
+  );
 
   // Backend returns None (null in Candid) when there is genuinely no data.
   // It returns Some(0.0) when the window has data but zero fees. Display

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -3,11 +3,11 @@
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
+  import SpCurrentDepositorsCard from '../SpCurrentDepositorsCard.svelte';
   import {
-    fetchStabilitySeries, fetchApys, fetchTopSpDepositors,
+    fetchStabilitySeries, fetchApys,
   } from '$services/explorer/analyticsService';
-  import { shortenPrincipal, getCanisterName, getTokenDecimals } from '$utils/explorerHelpers';
-  import type { TopSpDepositorRow } from '$declarations/rumi_analytics/rumi_analytics.did';
+  import { getTokenDecimals } from '$utils/explorerHelpers';
   import {
     fetchStabilityPoolStatus, fetchStabilityPoolLiquidations,
   } from '$services/explorer/explorerService';
@@ -20,36 +20,6 @@
   let liquidations: any[] = $state([]);
   let spApy: number | null = $state(null);
   let loading = $state(true);
-
-  // Top depositors leaderboard (analytics-backed).
-  type DepWindow = '7d' | '30d' | '90d' | 'all';
-  let depWindow: DepWindow = $state('30d');
-  let depositors_top: TopSpDepositorRow[] = $state([]);
-  let depLoading = $state(false);
-
-  const DEP_WINDOW_NS: Record<DepWindow, bigint> = {
-    '7d': 7n * 86_400n * 1_000_000_000n,
-    '30d': 30n * 86_400n * 1_000_000_000n,
-    '90d': 90n * 86_400n * 1_000_000_000n,
-    all: (1n << 63n) - 1n,
-  };
-
-  async function loadTopDepositors(win: DepWindow) {
-    depLoading = true;
-    try {
-      const resp = await fetchTopSpDepositors(DEP_WINDOW_NS[win], 20);
-      depositors_top = resp.rows;
-    } catch (err) {
-      console.error('[StabilityPoolLens] loadTopDepositors failed:', err);
-      depositors_top = [];
-    } finally {
-      depLoading = false;
-    }
-  }
-
-  $effect(() => {
-    loadTopDepositors(depWindow);
-  });
 
   onMount(async () => {
     try {
@@ -211,82 +181,7 @@
   </div>
 {/if}
 
-<div class="explorer-card">
-  <div class="flex items-center justify-between gap-3 flex-wrap mb-3">
-    <div>
-      <h3 class="text-sm font-medium text-gray-300">Top depositors</h3>
-      <p class="text-xs text-gray-500">Ranked by total deposit volume in the window</p>
-    </div>
-    <div class="inline-flex rounded-lg border border-gray-700/70 overflow-hidden text-[11px]">
-      {#each ['7d', '30d', '90d', 'all'] as const as w (w)}
-        <button
-          type="button"
-          class="px-2.5 py-1 border-r border-gray-700/70 last:border-r-0 transition-colors"
-          class:bg-teal-500={depWindow === w}
-          class:text-white={depWindow === w}
-          class:text-gray-400={depWindow !== w}
-          class:hover:text-gray-200={depWindow !== w}
-          onclick={() => (depWindow = w)}
-        >
-          {w.toUpperCase()}
-        </button>
-      {/each}
-    </div>
-  </div>
-  {#if depLoading && depositors_top.length === 0}
-    <div class="flex items-center justify-center py-6">
-      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
-    </div>
-  {:else if depositors_top.length === 0}
-    <p class="text-sm text-gray-500 py-4">No deposit activity in this window.</p>
-  {:else}
-    <div class="overflow-x-auto">
-      <table class="w-full text-sm">
-        <thead>
-          <tr class="border-b border-white/5">
-            <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
-            <th class="text-left py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Principal</th>
-            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Deposited (window)</th>
-            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Current balance</th>
-            <th class="text-right py-2 px-2 text-xs font-medium text-gray-500 uppercase tracking-wider">Net (window)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each depositors_top as row, i (row.principal.toText())}
-            {@const pid = row.principal.toText()}
-            {@const label = getCanisterName(pid) ?? shortenPrincipal(pid)}
-            <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]">
-              <td class="py-2 px-2 text-gray-500 tabular-nums">{i + 1}</td>
-              <td class="py-2 px-2">
-                <a
-                  href="/explorer/e/address/{pid}"
-                  class="text-teal-400 hover:text-teal-300 font-mono"
-                  title={pid}
-                >
-                  {label}
-                </a>
-              </td>
-              <td class="py-2 px-2 text-right tabular-nums text-gray-300">
-                {formatCompact(e8sToNumber(row.total_deposited_e8s))} icUSD
-              </td>
-              <td class="py-2 px-2 text-right tabular-nums text-gray-300">
-                {formatCompact(e8sToNumber(row.current_balance_e8s))}
-              </td>
-              <td
-                class="py-2 px-2 text-right tabular-nums"
-                class:text-emerald-400={row.net_position_e8s > 0n}
-                class:text-rose-400={row.net_position_e8s < 0n}
-                class:text-gray-400={row.net_position_e8s === 0n}
-              >
-                {row.net_position_e8s < 0n ? '-' : ''}{formatCompact(Math.abs(Number(row.net_position_e8s)) / 1e8)}
-              </td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
-  {/if}
-</div>
+<SpCurrentDepositorsCard />
 
 <div class="explorer-card">
   <h3 class="text-sm font-medium text-gray-300 mb-3">Recent liquidations absorbed</h3>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -60,13 +60,15 @@
         fetchApys(),
         QueryOperations.getProtocolStatus(),
       ]);
-      if (stR.status === 'fulfilled') poolStatus = stR.value;
+      if (stR.status === 'fulfilled' && stR.value) poolStatus = stR.value;
+      else console.warn('[StabilityPoolLens] poolStatus unavailable:', stR.status === 'rejected' ? stR.reason : 'null response');
       if (seR.status === 'fulfilled') series = seR.value ?? [];
       if (lqR.status === 'fulfilled') liquidations = lqR.value ?? [];
       if (prR.status === 'fulfilled') protocolStatus = prR.value;
+      else console.warn('[StabilityPoolLens] protocolStatus failed:', prR.reason);
       if (apR.status === 'fulfilled' && apR.value) {
         const v = apR.value.sp_apy_pct?.[0];
-        if (typeof v === 'number' && v > 0) spApy = v;
+        if (typeof v === 'number') spApy = v;
       }
     } catch (err) {
       console.error('[StabilityPoolLens] onMount error:', err);
@@ -83,6 +85,12 @@
     const split = protocolStatus.interestSplit ?? [];
     const poolShare = (split.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
     const perC = protocolStatus.perCollateralInterest;
+    // Diagnostic log: fires once after data loads to trace which guard causes null.
+    console.debug('[SPLens liveSpApy]', {
+      splitLen: split.length, poolShare,
+      perCLen: perC?.length,
+      eligibleLen: poolStatus?.eligible_icusd_per_collateral?.length,
+    });
     if (!perC || perC.length === 0 || poolShare === 0) return null;
 
     const eligibleMap = new Map<string, number>(

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -4,6 +4,7 @@
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
   import SpCurrentDepositorsCard from '../SpCurrentDepositorsCard.svelte';
+  import SpCoverageCard from '../SpCoverageCard.svelte';
   import {
     fetchStabilitySeries, fetchApys,
   } from '$services/explorer/analyticsService';
@@ -101,20 +102,6 @@
     series.map((r: any) => ({ t: Number(r.timestamp_ns) / 1_000_000, v: Number(r.total_liquidations_executed ?? 0n) }))
   );
 
-  const collateralGains = $derived.by(() => {
-    // PoolStatus.collateral_gains is the aggregate collateral in the pool,
-    // each entry a (collateral principal, raw amount) pair.
-    const perCol = poolStatus?.collateral_gains ?? [];
-    return perCol.map(([p, v]: [any, any]) => {
-      const pid = typeof p === 'object' && p.toText ? p.toText() : String(p);
-      return {
-        principal: pid,
-        symbol: getCollateralSymbol(pid),
-        amount: Number(v),
-      };
-    });
-  });
-
   const healthMetrics = $derived.by(() => [
     { label: 'Deposits', value: `$${formatCompact(totalDeposits)}`, sub: 'icUSD' },
     { label: 'Depositors', value: depositors.toLocaleString() },
@@ -165,21 +152,7 @@
   </div>
 </div>
 
-{#if collateralGains.length > 0}
-  <div class="explorer-card">
-    <h3 class="text-sm font-medium text-gray-300 mb-3">Collateral in pool</h3>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-      {#each collateralGains as g}
-        <div class="flex flex-col">
-          <span class="text-xs text-gray-500">{g.symbol}</span>
-          <span class="text-base font-semibold tabular-nums text-gray-200 mt-0.5">
-            {formatCompact(g.amount / 1e8)}
-          </span>
-        </div>
-      {/each}
-    </div>
-  </div>
-{/if}
+<SpCoverageCard />
 
 <SpCurrentDepositorsCard />
 

--- a/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
@@ -624,6 +624,28 @@ export async function fetchPoolRoutes(
 	}
 }
 
+// ── SP depositor principals ────────────────────────────────────────────────
+
+/**
+ * Returns the distinct set of principals that have ever deposited into the
+ * Stability Pool (sourced from evt_stability records). Use this as the fan-out
+ * set for per-principal SP position queries; the SP canister is the source of
+ * truth for current balances.
+ */
+export async function fetchSpDepositorPrincipals(): Promise<Principal[]> {
+	const key = 'analytics:sp_depositor_principals';
+	const cached = getCached<Principal[]>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	try {
+		const result = await getActor().get_sp_depositor_principals();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[analyticsService] fetchSpDepositorPrincipals failed:', err);
+		return [];
+	}
+}
+
 // ── Address value series (portfolio value over time) ───────────────────────
 
 const EMPTY_ADDRESS_VALUE_SERIES = (principal: Principal): AddressValueSeriesResponse => ({

--- a/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/analyticsService.ts
@@ -35,6 +35,7 @@ import type {
 	TokenFlowResponse,
 	PoolRoutesResponse,
 	AddressValueSeriesResponse,
+	FeeBreakdownResponse,
 } from '$declarations/rumi_analytics/rumi_analytics.did';
 
 // ── TTL constants (ms) ───────────────────────────────────────────────────────
@@ -686,4 +687,44 @@ export async function fetchAddressValueSeries(
 		console.error('[analyticsService] fetchAddressValueSeries failed:', err);
 		return EMPTY_ADDRESS_VALUE_SERIES(principal);
 	}
+}
+
+// ── Fee breakdown window ─────────────────────────────────────────────────────
+
+const NS_PER_DAY = 86_400n * 1_000_000_000n;
+
+export type FeeBreakdown = {
+	borrowIcusd: number;
+	redemptionIcusd: number;
+	swapIcusd: number;
+	borrowCount: number;
+	redemptionCount: number;
+	swapCount: number;
+	startNs: bigint;
+	endNs: bigint;
+};
+
+/**
+ * Fetch fee totals for a given trailing window via get_fee_breakdown_window.
+ * windowDays=null means "all time" (no window constraint).
+ * Both 24h and 90d cards use this so they share methodology.
+ */
+export async function fetchFeeBreakdownWindow(windowDays: number | null): Promise<FeeBreakdown> {
+	const key = `analytics:fee_breakdown:${windowDays ?? 'all'}`;
+	const cached = getCached<FeeBreakdown>(key, TTL.AGGREGATE);
+	if (cached) return cached;
+
+	const window_ns: [] | [bigint] = windowDays == null ? [] : [BigInt(windowDays) * NS_PER_DAY];
+	const r: FeeBreakdownResponse = await getActor().get_fee_breakdown_window({ window_ns });
+	const result: FeeBreakdown = {
+		borrowIcusd: Number(r.borrow_fees_icusd_e8s) / 1e8,
+		redemptionIcusd: Number(r.redemption_fees_icusd_e8s) / 1e8,
+		swapIcusd: Number(r.swap_fees_icusd_e8s) / 1e8,
+		borrowCount: Number(r.borrow_count),
+		redemptionCount: Number(r.redemption_count),
+		swapCount: Number(r.swap_count),
+		startNs: r.start_ns,
+		endNs: r.end_ns,
+	};
+	return setCache(key, result);
 }

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -16,6 +16,9 @@ import type { AmmStatsWindow } from '$services/ammService';
 import { CANISTER_IDS, CONFIG } from '$lib/config';
 import type { _SERVICE as IcusdLedgerService } from '$declarations/icusd_ledger/icusd_ledger.did';
 import type { _SERVICE as IcusdIndexService } from '$declarations/icusd_index/icusd_index.did';
+import type { UserStabilityPosition } from '$declarations/rumi_stability_pool/rumi_stability_pool.did';
+import { idlFactory as stabilityPoolIDL } from '$declarations/rumi_stability_pool/rumi_stability_pool.did.js';
+import { fetchSpDepositorPrincipals } from './analyticsService';
 
 // ── TTL constants (ms) ───────────────────────────────────────────────────────
 
@@ -779,6 +782,66 @@ export async function fetchStabilityPoolEventCount(): Promise<bigint> {
 	} catch (err) {
 		console.error('[explorerService] fetchStabilityPoolEventCount failed:', err);
 		return 0n;
+	}
+}
+
+// ── Current SP depositors (SP canister as source of truth) ─────────────────
+
+export type CurrentSpDepositor = {
+	principal: Principal;
+	position: UserStabilityPosition;
+};
+
+let _spActor: any = null;
+
+function getStabilityPoolActor() {
+	if (_spActor) return _spActor;
+	const agent = new HttpAgent({ host: CONFIG.host ?? 'https://icp-api.io' });
+	if (CONFIG.isLocal) agent.fetchRootKey().catch(() => {});
+	_spActor = Actor.createActor(stabilityPoolIDL as any, {
+		agent,
+		canisterId: CANISTER_IDS.STABILITY_POOL,
+	});
+	return _spActor;
+}
+
+/**
+ * Returns every principal currently holding a non-zero SP balance, sorted by
+ * total USD value descending. The analytics canister supplies the set of
+ * principals to fan out over; the SP canister is the source of truth for
+ * current positions.
+ */
+export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> {
+	const key = 'pool:stability:current_depositors';
+	const cached = getCached<CurrentSpDepositor[]>(key, TTL.POOL);
+	if (cached) return cached;
+
+	try {
+		const principals = await fetchSpDepositorPrincipals();
+		const sp = getStabilityPoolActor();
+		const positions = await Promise.all(
+			principals.map(async (p) => {
+				try {
+					return await sp.get_user_position([p]);
+				} catch (err) {
+					console.warn('[fetchCurrentSpDepositors] get_user_position failed for', p.toText(), err);
+					return [];
+				}
+			}),
+		);
+		const out: CurrentSpDepositor[] = [];
+		for (let i = 0; i < principals.length; i++) {
+			const maybe = positions[i];
+			const pos = Array.isArray(maybe) ? maybe[0] : maybe;
+			if (pos && Number(pos.total_usd_value_e8s) > 0) {
+				out.push({ principal: principals[i], position: pos as UserStabilityPosition });
+			}
+		}
+		out.sort((a, b) => Number(b.position.total_usd_value_e8s) - Number(a.position.total_usd_value_e8s));
+		return setCache(key, out);
+	} catch (err) {
+		console.error('[explorerService] fetchCurrentSpDepositors failed:', err);
+		return [];
 	}
 }
 

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -1759,3 +1759,57 @@ export async function fetchThreeUsdHolders(): Promise<{ holders: TokenHolder[]; 
 		return { holders: [], totalSupply: 0n, txCount: 0n };
 	}
 }
+
+// ── Treasury holdings ────────────────────────────────────────────────────────
+
+export type TreasuryHolding = {
+	symbol: string;
+	ledger: string;
+	balanceE8s: bigint;
+	decimals: number;
+	usd: number;
+};
+
+/** Ledgers we track for the treasury holdings card. */
+const TREASURY_TRACKED_LEDGERS: Array<{
+	symbol: string;
+	principal: string;
+	decimals: number;
+	/** usdEachE8s === -1 means use live ICP price */
+	usdEachE8s: number;
+}> = [
+	{ symbol: 'icUSD', principal: CANISTER_IDS.ICUSD_LEDGER, decimals: 8, usdEachE8s: 1 },
+	{ symbol: 'ckUSDT', principal: CANISTER_IDS.CKUSDT_LEDGER, decimals: 6, usdEachE8s: 1 },
+	{ symbol: 'ckUSDC', principal: CANISTER_IDS.CKUSDC_LEDGER, decimals: 6, usdEachE8s: 1 },
+	{ symbol: 'ICP', principal: CANISTER_IDS.ICP_LEDGER, decimals: 8, usdEachE8s: -1 },
+];
+
+const TREASURY_PRINCIPAL = Principal.fromText(CANISTER_IDS.TREASURY);
+
+/**
+ * Query `icrc1_balance_of` on each tracked ledger using the rumi_treasury
+ * principal as the account owner. Returns only tokens with a non-zero balance.
+ * icpPriceUsd should be the live USD price of ICP (e.g. from protocolStatus.lastIcpRate).
+ */
+export async function fetchTreasuryHoldings(icpPriceUsd: number): Promise<TreasuryHolding[]> {
+	const key = `treasury:holdings:${Math.floor(icpPriceUsd)}`;
+	const cached = getCached<TreasuryHolding[]>(key, TTL.TREASURY);
+	if (cached) return cached;
+
+	const balances = await Promise.all(
+		TREASURY_TRACKED_LEDGERS.map(async (l) => {
+			try {
+				const balanceE8s = await fetchIcrc1BalanceOf(l.principal, TREASURY_PRINCIPAL);
+				const amount = Number(balanceE8s) / Math.pow(10, l.decimals);
+				const usd = l.usdEachE8s === -1 ? amount * icpPriceUsd : amount * l.usdEachE8s;
+				return { symbol: l.symbol, ledger: l.principal, balanceE8s, decimals: l.decimals, usd };
+			} catch (err) {
+				console.error(`[explorerService] fetchTreasuryHoldings ${l.symbol} failed:`, err);
+				return { symbol: l.symbol, ledger: l.principal, balanceE8s: 0n, decimals: l.decimals, usd: 0 };
+			}
+		}),
+	);
+
+	const result = balances.filter((b) => b.balanceE8s > 0n);
+	return setCache(key, result);
+}

--- a/src/vault_frontend/src/lib/utils/displayEvent.ts
+++ b/src/vault_frontend/src/lib/utils/displayEvent.ts
@@ -6,7 +6,7 @@ import {
 	formatStabilityPoolEvent, formatMultiHopSwapEvent,
 } from './explorerFormatters';
 import type { FormattedEvent } from './explorerFormatters';
-import { ammPoolShortLabel } from './ammNaming';
+import { ammPoolPair } from './ammNaming';
 
 export type NonBackendSource =
 	| '3pool_swap'
@@ -180,15 +180,16 @@ export function displayEvent(de: DisplayEvent, maps?: DisplayEventMaps): Display
 	const principal = extractEventPrincipal(de.event, de.source, maps?.vaultOwnerMap);
 	const timestamp = de.timestamp || extractEventTimestamp(de.event);
 	const detailHref = isBackend ? `/explorer/e/event/${globalIndex}` : dexDetailHref(de);
-	// AMM-source events get an indexed label like "AMM1" once the registry is
-	// loaded. Falls back to the generic "AMM" label if the registry isn't
+	// AMM-source events get a friendly label like "🌊 3USD/ICP" once the registry
+	// is loaded. Falls back to the generic "AMM" label if the registry isn't
 	// populated yet (first paint, or activity page before pools fetched).
 	let sourceLabel: string | null;
 	if (isBackend) {
 		sourceLabel = null;
 	} else if (de.source === 'amm_swap' || de.source === 'amm_liquidity' || de.source === 'amm_admin') {
 		const poolId = de.event?.pool_id ?? de.event?.ammEvent?.pool_id;
-		sourceLabel = ammPoolShortLabel(poolId ? String(poolId) : null);
+		const pair = ammPoolPair(poolId ? String(poolId) : null);
+		sourceLabel = pair ? `🌊 ${pair}` : 'AMM';
 	} else {
 		sourceLabel = DEX_SOURCE_LABEL[de.source as NonBackendSource] ?? null;
 	}

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -417,7 +417,7 @@ export function formatStabilityPoolEvent(evt: any): FormattedEvent {
     const amtIn = formatE8s(data.amount_in, dec);
     const lpMinted = formatE8s(data.lp_minted, 8);
     typeName = 'Deposit as 3USD';
-    summary = `Deposited ${amtIn} ${sym} → ${lpMinted} 3USD LP`;
+    summary = `Deposited ${amtIn} ${sym} → ${lpMinted} 3USD`;
     fields.push({ label: 'Amount In', value: `${amtIn} ${sym}`, type: 'amount' });
     fields.push({ label: 'LP Minted', value: `${lpMinted} 3USD`, type: 'amount' });
   } else if (key === 'InterestReceived') {
@@ -516,12 +516,12 @@ export function formatMultiHopSwapEvent(merged: {
 
   if (direction === 'stable_to_icp') {
     fields.push({ label: 'Deposited', value: `${stablecoinAmount} ${stablecoinSymbol}`, type: 'amount' });
-    fields.push({ label: '3Pool Output', value: `${threeUsdAmount} 3USD LP`, type: 'amount' });
+    fields.push({ label: '3Pool Output', value: `${threeUsdAmount} 3USD`, type: 'amount' });
     fields.push({ label: 'AMM Output', value: `${finalAmount} ${finalSymbol}`, type: 'amount' });
     fields.push({ label: 'Route', value: `${stablecoinSymbol} → 3Pool → AMM → ${finalSymbol}`, type: 'text' });
   } else {
     fields.push({ label: 'Swapped In', value: `${finalAmount} ${finalSymbol}`, type: 'amount' });
-    fields.push({ label: 'AMM Output', value: `${threeUsdAmount} 3USD LP`, type: 'amount' });
+    fields.push({ label: 'AMM Output', value: `${threeUsdAmount} 3USD`, type: 'amount' });
     fields.push({ label: 'Redeemed', value: `${stablecoinAmount} ${stablecoinSymbol}`, type: 'amount' });
     fields.push({ label: 'Route', value: `${finalSymbol} → AMM → 3Pool → ${stablecoinSymbol}`, type: 'text' });
   }

--- a/src/vault_frontend/src/lib/utils/explorerHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerHelpers.ts
@@ -105,7 +105,7 @@ export const KNOWN_TOKENS: Record<string, TokenInfo> = {
   [CANISTER_IDS.ICUSD_LEDGER]: { symbol: 'icUSD', name: 'icUSD Stablecoin', decimals: 8 },
   [CANISTER_IDS.CKUSDT_LEDGER]: { symbol: 'ckUSDT', name: 'Chain-Key USDT', decimals: 6 },
   [CANISTER_IDS.CKUSDC_LEDGER]: { symbol: 'ckUSDC', name: 'Chain-Key USDC', decimals: 6 },
-  [CANISTER_IDS.THREEPOOL]: { symbol: '3USD LP', name: 'Rumi 3Pool LP Token', decimals: 8 },
+  [CANISTER_IDS.THREEPOOL]: { symbol: '3USD', name: 'Rumi 3Pool LP Token', decimals: 8 },
   // Collateral tokens
   'mxzaz-hqaaa-aaaar-qaada-cai': { symbol: 'ckBTC', name: 'Chain-Key Bitcoin', decimals: 8 },
   'ss2fx-dyaaa-aaaar-qacoq-cai': { symbol: 'ckETH', name: 'Chain-Key Ethereum', decimals: 18 },


### PR DESCRIPTION
## Summary

Round 2 of the Explorer review pass. Round 1 already merged to main; this PR adds 23 commits on top: 3 new analytics endpoints, 9 frontend lens cleanups, 3 data-bug fixes, full Stability Pool + Revenue lens reworks, and Admin lens enhancements.

The new analytics endpoints are already live on mainnet (deployed during this work). Frontend changes deploy with the next vault_frontend release.

### New analytics endpoints (live on `dtlu2-uqaaa-aaaap-qugcq-cai`)
- **`get_fee_breakdown_window`** — server-side fee aggregation reading `evt_vaults` + `evt_swaps` directly. Used by Revenue lens for both 24h and 90d cards (same methodology, no contradiction).
- **`get_sp_depositor_principals`** — distinct principals from `evt_stability`. Frontend fans out per-principal `get_user_position` calls to the SP canister for authoritative balances.
- **`reset_error_counters`** — admin-gated zero-out of source error counters. Used to clear the 12 leftover `stability_pool` increments from round 1's first deploy.

### Backwards-compat fix (analytics)
Round 1 added `fee_amount: u64` to `AnalyticsVaultEvent` with `#[serde(default)]`, expecting that to handle pre-round-1 stable storage entries lacking the field. But `Storable` uses Candid encoding (not serde), and Candid subtyping rejects "field missing" against a non-optional `nat64` schema. The bug was latent until `get_fee_breakdown_window`'s 90-day window forced reads of the oldest events, exposing a `CanisterError` trap on the first deploy. Hotfixed in `bd372fc`: `fee_amount: u64` → `Option<u64>` so the candid type is `opt nat64`, accepting both old and new payloads. Adds a regression test (`vault_event_decodes_pre_round1_legacy_shape`) to catch future schema-extension regressions.

### Frontend lens reworks
- **Stability Pool lens:** Top Depositors leaderboard → Current Depositors snapshot (per-token columns: icUSD, 3USD, ckUSDT, ckUSDC). Fixes the 4-vs-1 depositor mismatch (C2) and the "Rob shows zero" bug (C3) at the source. New Per-collateral opt-in coverage card showing % opted in and total stable backing per collateral.
- **Revenue lens:** Big-number fee cards now use `get_fee_breakdown_window` for both 24h and 90d (consistent methodology). Treasury card replaced uninformative "Pending interest = 0 / Flush threshold = 0" tile with live `icrc1_balance_of` of treasury principal across icUSD / ckUSDT / ckUSDC / ICP.
- **Admin lens:** Health strip fleshed out with Last admin action (relative time) and Admin actions 24h count. Mode kept first as the at-a-glance protocol indicator. Collector errors metric now has explanatory sub-text.
- **Collateral lens:** CR histogram bars actually render (height calc + container fix). Liquidation Risk card shows warning-zone vaults (below min-CR-for-borrow but above liquidation threshold) instead of the always-empty at-or-below-liquidation set.
- **Redemptions lens:** Single Current RMR tile with curve explanation in sub-text. Recent redemption activity panel now populated (was empty due to client-side filter on tail-fetched events; switched to server-side `types: ['Redemption']` filter).
- **DEXs lens:** Virtual price chart uses `data-fit` y-axis to actually show slope (was flat-looking due to zero-anchoring). Single-event volume series renders a vertical marker fallback instead of a lonely dot. Removed redundant bottom-row strip. Renamed "3USD LP" → "3USD" in token registry. Added Arb score sub-text explanation.
- **Activity feed:** AMM events render as "🌊 3USD/ICP" instead of truncated principals.

### Data-bug investigations (root cause first)
- **D2 (redemption panel empty):** Lens was tail-fetching unfiltered then JS-filtering — redemptions are sparse so the tail rarely contained any. Fix: server-side `types: ['Redemption']` filter for the redemptions scope.
- **E2/F2 (3pool LP APY null):** Backend correctly returns `Some(0.0)` for confirmed zero-fee windows (no swaps in 19 days). Frontend's `> 0` guard was treating that as null and hiding it. Fixed across Revenue, DEXs, Overview, and (bundled with E3) Stability Pool lenses.
- **E3 (SP APY 4.72% fallback):** Mainnet `get_protocol_status` returns healthy `interest_split` + `per_collateral_interest`; with those values the live formula computes ~6.34%. Without browser-console access the implementer couldn't pinpoint which silent-failure path fires at runtime. Added `console.warn` on previously silent rejections + `console.debug` of `liveSpApy` inputs to diagnose post-deploy. Tightened poolStatus null-guard. Fixed the `> 0` guard pattern.

### Operational
- Reset `error_counters.stability_pool` from 12 → 0 after analytics deploy via the new endpoint.

## Test plan

- [x] svelte-check: 32 errors (1 below round-1 baseline of 33; round-2 fixed a stale TS error in passing). All remaining errors in unrelated files.
- [x] cargo test -p rumi_analytics --lib: 97 passed (96 baseline + new `vault_event_decodes_pre_round1_legacy_shape` regression test).
- [x] cargo test --test pocket_ic_analytics: 24 passed (run during Phase 3).
- [x] Mainnet smoke: `get_fee_breakdown_window '(record { window_ns = opt 7_776_000_000_000_000 })'` returns 180 borrows / 4 redemptions / 92 swaps / $1.30 swap fees over 90d.
- [x] Mainnet smoke: `get_sp_depositor_principals` returns the active depositor list.
- [x] Mainnet smoke: `reset_error_counters '(record { sources = opt vec { "stability_pool" } })'` returns Ok; subsequent `get_collector_health` shows `stability_pool = 0`.
- [ ] After frontend deploy: walk every lens (Overview, Collateral, Stability, Redemptions, Revenue, DEXs, Admin) and verify all the visible items in this PR. Console-debug the SP APY null path if E3 still falls back.

## Follow-ups (out of scope)

- Revenue + admin scopes on `LensActivityPanel` have the same tail-fetch weakness as D2 had. Apply server-side type filters to those scopes too.
- `error_counters.backend = 10,220` on the analytics canister — pre-existing, not from round-2 work. Worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)