### PR TITLE
fix(explorer): remove SP APY diagnostic, bug no longer reproducing

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -56,12 +56,6 @@
     const split = protocolStatus.interestSplit ?? [];
     const poolShare = (split.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
     const perC = protocolStatus.perCollateralInterest;
-    // Diagnostic log: fires once after data loads to trace which guard causes null.
-    console.debug('[SPLens liveSpApy]', {
-      splitLen: split.length, poolShare,
-      perCLen: perC?.length,
-      eligibleLen: poolStatus?.eligible_icusd_per_collateral?.length,
-    });
     if (!perC || perC.length === 0 || poolShare === 0) return null;
 
     const eligibleMap = new Map<string, number>(


### PR DESCRIPTION
## Summary

- Round-2 task 2.3 ([5517200](https://github.com/RumiLabsXYZ/rumi-protocol-v2/commit/5517200)) added a diagnostic `console.debug` to the StabilityPoolLens `liveSpApy` derivation so a future browser observer could see which guard caused the null fallback.
- Verified on mainnet 2026-04-28: lens displays **6.29% live**, the live formula is computing correctly, and dfx confirms all upstream backend inputs are healthy. The bug doesn't reproduce.
- Removing the now-redundant `console.debug` (fires every page load with healthy data, hidden in default Chrome devtools, the bundled `Object` payload doesn't expand across MCP tooling). Kept the two `console.warn` fallbacks for real fetch failures since those are still the right regression signal.

## Verification

```
SP APY  6.29%  live   <- displayed on /explorer?lens=stability
```

Backend data (via `dfx canister --network ic call rumi_protocol_backend get_protocol_status`):
- `interest_split`: 3 entries, stability_pool = 2200 bps (poolShare = 0.22)
- `per_collateral_interest`: 7 entries, all with non-zero `total_debt_e8s` and `weighted_interest_rate`
- `eligible_icusd_per_collateral` (from SP): 7 entries, each ~$540 icUSD-equivalent

The product of these values through the live formula yields ~6.29%, matching what the lens displays.

## What if it regresses?

The `console.warn` fallbacks added by 5517200 stay:
- `[StabilityPoolLens] poolStatus unavailable` if `fetchStabilityPoolStatus()` rejects or returns null
- `[StabilityPoolLens] protocolStatus failed` if `QueryOperations.getProtocolStatus()` rejects

If a future regression surfaces a null `liveSpApy` again, those warnings would identify a fetch-level failure. For data-shape failures (the original suspected cause), the next investigator can re-add the diagnostic with primitives instead of an object.

## Test plan

- [x] `npx svelte-check` reports 32 errors (baseline).
- [x] Mainnet `/explorer?lens=stability` shows "live" subtext on SP APY card with a non-fallback value.
- [x] Console has no `[StabilityPoolLens]` warnings on a fresh page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)