### PR TITLE
fix(explorer): round-3 frontend cleanups (AMM1, Liquidation Risk crash, live APY, Admin polish)

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/LensHealthStrip.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LensHealthStrip.svelte
@@ -39,7 +39,11 @@
             {m.value}
           </span>
           {#if m.sub}
-            <span class="text-[11px] text-gray-500 mt-0.5">{m.sub}</span>
+            <!-- Cap sub width so a long descriptor (e.g. the Admin lens
+                 "Collector errors" explanation) wraps within the metric
+                 column instead of expanding the column and squeezing
+                 siblings out of the row. -->
+            <span class="text-[11px] text-gray-500 mt-0.5 max-w-[14rem] leading-snug">{m.sub}</span>
           {/if}
         </div>
       {/each}

--- a/src/vault_frontend/src/lib/components/explorer/LiquidationRiskTable.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LiquidationRiskTable.svelte
@@ -68,13 +68,13 @@
           {#each vaults as vault}
             <tr class="border-b border-gray-700/30 hover:bg-gray-700/20 transition-colors">
               <td class="px-4 py-2.5">
-                <EntityLink type="vault" id={vault.vault_id} />
+                <EntityLink type="vault" value={String(vault.vault_id)} />
               </td>
               <td class="px-2 py-2.5 text-center">
                 <CRDial cr={vault.collateral_ratio / 100} liquidationCR={vault.liquidation_ratio / 100} size="sm" />
               </td>
               <td class="px-4 py-2.5">
-                <EntityLink type="address" id={vault.owner} />
+                <EntityLink type="address" value={vault.owner} />
               </td>
               <td class="px-4 py-2.5 text-gray-300 text-xs">
                 {collateralSymbol(vault.collateral_type)}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/AdminLens.svelte
@@ -5,12 +5,11 @@
   import AdminBreakdownCard from '../AdminBreakdownCard.svelte';
   import CanisterInventoryCard from '../CanisterInventoryCard.svelte';
   import { fetchCollectorHealth, fetchAdminEventBreakdown } from '$services/explorer/analyticsService';
-  import { fetchProtocolStatus, fetchEvents } from '$services/explorer/explorerService';
-  import { extractEventTimestamp } from '$utils/displayEvent';
+  import { fetchProtocolStatus } from '$services/explorer/explorerService';
 
   let collectorHealth: any = $state(null);
   let status: any = $state(null);
-  let lastAdminEvent: any = $state(null);
+  let lastAdminTsNs: number = $state(0);
   let adminCount24h = $state(0);
   let loading = $state(true);
 
@@ -28,21 +27,31 @@
       loading = false;
     }
 
-    // Latest admin event (page=0 returns most recent first)
-    try {
-      const result = await fetchEvents(0n, 1n, { types: ['Admin'] });
-      lastAdminEvent = result.events?.[0]?.[1] ?? null;
-    } catch (err) {
-      console.warn('[AdminLens] latest admin fetch failed:', err);
-    }
-
-    // 24h admin count: ask analytics for a 24h windowed breakdown and sum labels
+    // The backend's admin/setter Event variants do NOT carry a timestamp field
+    // (most are empty structs like `SetBorrowingFee {}`), so deriving the
+    // "Last admin action" relative time from a `fetchEvents` lookup yields no
+    // usable timestamp. The analytics shadow log (evt_admin) stamps each entry
+    // with the tail-time as an upper-bound timestamp, and the analytics
+    // breakdown response exposes that as `last_at_ns` per label. Use a 24h
+    // breakdown for the count, then a wider (default 30d) window to find the
+    // most recent admin timestamp across all labels.
     try {
       const windowNs = BigInt(86_400) * 1_000_000_000n;
       const breakdown = await fetchAdminEventBreakdown(windowNs);
       adminCount24h = breakdown.labels.reduce((s, l) => s + Number(l.count), 0);
     } catch (err) {
       console.warn('[AdminLens] 24h admin count fetch failed:', err);
+    }
+    try {
+      const breakdown30d = await fetchAdminEventBreakdown();
+      let maxTs = 0;
+      for (const l of breakdown30d.labels) {
+        const t = l.last_at_ns?.[0];
+        if (t != null && Number(t) > maxTs) maxTs = Number(t);
+      }
+      lastAdminTsNs = maxTs;
+    } catch (err) {
+      console.warn('[AdminLens] last admin timestamp fetch failed:', err);
     }
   });
 
@@ -52,10 +61,8 @@
   });
 
   const lastAdminRel = $derived.by(() => {
-    if (!lastAdminEvent) return '--';
-    const tsNs = extractEventTimestamp(lastAdminEvent);
-    if (!tsNs) return '--';
-    const ms = tsNs / 1_000_000;
+    if (!lastAdminTsNs) return '--';
+    const ms = lastAdminTsNs / 1_000_000;
     const ago = Date.now() - ms;
     if (ago < 60_000) return 'just now';
     if (ago < 3_600_000) return `${Math.floor(ago / 60_000)}m ago`;
@@ -72,7 +79,7 @@
       metrics.push({
         label: 'Collector errors',
         value: errs.toLocaleString(),
-        sub: 'failed inter-canister calls from analytics tailers (unexpected response shape, decode failure). Per-source breakdown below.',
+        sub: 'failed tailer calls (see breakdown below)',
         tone: errs > 0 ? 'caution' as const : 'good' as const,
       });
     }

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -13,9 +13,11 @@
   } from '$services/explorer/explorerService';
   import { CANISTER_IDS } from '$lib/config';
   import { POOL_TOKENS } from '$services/threePoolService';
+  import { ProtocolService } from '$services/protocol';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
   import { ammPoolLabel, ammPoolPair, ammPoolShortLabel, setAmmPoolRegistry } from '$utils/ammNaming';
   import { getTokenSymbol } from '$utils/explorerHelpers';
+  import { liveLpApyPct } from '$utils/liveApy';
   import type { PegStatus } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   let pegStatus: PegStatus | null = $state(null);
@@ -27,14 +29,14 @@
   let vpSeries: any[] = $state([]);
   let ammPools: any[] = $state([]);
   let ammPoolStats: Record<string, any> = $state({});
-  let lpApy: number | null = $state(null);
-  let spApy: number | null = $state(null);
+  let analyticsLpApy: number | null = $state(null);
+  let liveLp: number | null = $state(null);
   let icpUsdPrice: number | null = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     try {
-      const [pegR, stR, statR, hlR, ssR, vsR, vpR, ammR, apyR, pricesR] = await Promise.allSettled([
+      const [pegR, stR, statR, hlR, ssR, vsR, vpR, ammR, apyR, pricesR, psR] = await Promise.allSettled([
         fetchPegStatus(),
         fetchThreePoolState(),
         fetchThreePoolStats('Last24h'),
@@ -45,6 +47,7 @@
         fetchAmmPools(),
         fetchApys(),
         fetchCollateralPrices(),
+        ProtocolService.getProtocolStatus(),
       ]);
       if (pegR.status === 'fulfilled') pegStatus = pegR.value ?? null;
       if (stR.status === 'fulfilled') poolState = stR.value;
@@ -60,13 +63,15 @@
       }
       if (apyR.status === 'fulfilled' && apyR.value) {
         const aLp = apyR.value.lp_apy_pct?.[0];
-        const aSp = apyR.value.sp_apy_pct?.[0];
-        if (typeof aLp === 'number') lpApy = aLp;
-        if (typeof aSp === 'number') spApy = aSp;
+        if (typeof aLp === 'number') analyticsLpApy = aLp;
       }
       if (pricesR.status === 'fulfilled') {
         const map = pricesR.value;
         icpUsdPrice = map.get(CANISTER_IDS.ICP_LEDGER) ?? null;
+      }
+      // Live LP APY computed once protocol status + pool state are in.
+      if (psR.status === 'fulfilled' && stR.status === 'fulfilled') {
+        liveLp = liveLpApyPct(psR.value, stR.value?.balances);
       }
 
       // Per-pool stats for the AMM Pools card (TVL, 7d volume).
@@ -168,7 +173,12 @@
         sub: 'pool imbalance % of saturation; higher = more profit available to a rebalancing trader',
       });
     }
-    metrics.push({ label: '3Pool LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: '7d' });
+    const lpApy = liveLp ?? analyticsLpApy;
+    metrics.push({
+      label: '3Pool LP APY',
+      value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--',
+      sub: liveLp != null ? 'live' : '7d',
+    });
     return metrics;
   });
 

--- a/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
@@ -12,9 +12,10 @@
     fetchFeeSeries, fetchPegStatus, fetchApys, fetchTokenFlow,
   } from '$services/explorer/analyticsService';
   import { ProtocolService } from '$services/protocol';
-  import { threePoolService, POOL_TOKENS, calculateTheoreticalApy } from '$services/threePoolService';
+  import { threePoolService } from '$services/threePoolService';
   import { stabilityPoolService } from '$services/stabilityPoolService';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
+  import { liveSpApyPct, liveLpApyPct } from '$utils/liveApy';
   import type { ProtocolSummary, DailyTvlRow, PegStatus, TokenFlowEdge } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   let summary: ProtocolSummary | null = $state(null);
@@ -25,8 +26,10 @@
   let feeRows: any[] = $state([]);
   let seriesLoading = $state(true);
   let pegStatus: PegStatus | null = $state(null);
-  let lpApy: number | null = $state(null);
-  let spApy: number | null = $state(null);
+  let analyticsLpApy: number | null = $state(null);
+  let analyticsSpApy: number | null = $state(null);
+  let liveLp: number | null = $state(null);
+  let liveSp: number | null = $state(null);
   let poolsLoading = $state(true);
 
   type FlowWindowKey = '24h' | '7d' | '30d';
@@ -82,59 +85,36 @@
     if (apyR.status === 'fulfilled' && apyR.value) {
       const aLp = apyR.value.lp_apy_pct?.[0];
       const aSp = apyR.value.sp_apy_pct?.[0];
-      if (typeof aLp === 'number') lpApy = aLp;
-      if (typeof aSp === 'number') spApy = aSp;
+      if (typeof aLp === 'number') analyticsLpApy = aLp;
+      if (typeof aSp === 'number') analyticsSpApy = aSp;
     }
 
-    // Fallback APY compute when analytics has no data (null means no rows).
-    if (lpApy === null || spApy === null) {
-      try {
-        const [psR, poolR, spR] = await Promise.allSettled([
-          ProtocolService.getProtocolStatus(),
-          threePoolService.getPoolStatus(),
-          stabilityPoolService.getPoolStatus(),
-        ]);
-        const ps = psR.status === 'fulfilled' ? psR.value : null;
-        const pool = poolR.status === 'fulfilled' ? poolR.value : null;
-        const sp = spR.status === 'fulfilled' ? spR.value : null;
-
-        if (lpApy === null && ps && pool) {
-          let poolTvlE8s = 0;
-          for (let i = 0; i < pool.balances.length; i++) {
-            const token = POOL_TOKENS[i];
-            if (token) {
-              poolTvlE8s += token.decimals === 8 ? Number(pool.balances[i]) : Number(pool.balances[i]) * 100;
-            }
-          }
-          const threePoolBps = ps.interestSplit?.find((e: any) => e.destination === 'three_pool')?.bps ?? 5000;
-          const computed = calculateTheoreticalApy(threePoolBps, ps.perCollateralInterest, poolTvlE8s / 1e8);
-          if (computed != null) lpApy = computed * 100;
-        }
-        if (spApy === null && ps && sp) {
-          const poolShare = (ps.interestSplit?.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
-          const perC = ps.perCollateralInterest;
-          if (poolShare > 0 && perC?.length > 0) {
-            const eligibleMap = new Map<string, number>(
-              (sp.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [
-                typeof p === 'object' && typeof p.toText === 'function' ? p.toText() : String(p),
-                Number(v) / 1e8,
-              ])
-            );
-            let totalApr = 0;
-            for (const info of perC) {
-              const eligible = eligibleMap.get(info.collateralType) ?? 0;
-              if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-              totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
-            }
-            if (totalApr > 0) spApy = (Math.pow(1 + totalApr / 365, 365) - 1) * 100;
-          }
-        }
-      } catch (err) {
-        console.error('[OverviewLens] apy fallback error:', err);
-      }
+    // Always compute the live values too. The analytics 7d numbers can sit at
+    // zero when the rolling window has no realized fee activity, even though
+    // LPs/SP depositors are still earning from interest_split. Live derives
+    // from current protocol + pool state and reflects what a depositor would
+    // earn right now. Falls back to analytics if any input is missing.
+    try {
+      const [psR, poolR, spR] = await Promise.allSettled([
+        ProtocolService.getProtocolStatus(),
+        threePoolService.getPoolStatus(),
+        stabilityPoolService.getPoolStatus(),
+      ]);
+      const ps = psR.status === 'fulfilled' ? psR.value : null;
+      const pool = poolR.status === 'fulfilled' ? poolR.value : null;
+      const sp = spR.status === 'fulfilled' ? spR.value : null;
+      liveLp = liveLpApyPct(ps, pool?.balances);
+      liveSp = liveSpApyPct(ps, sp);
+    } catch (err) {
+      console.error('[OverviewLens] live APY compute error:', err);
     }
     poolsLoading = false;
   });
+
+  const lpApy = $derived(liveLp ?? analyticsLpApy);
+  const spApy = $derived(liveSp ?? analyticsSpApy);
+  const lpApySub = $derived(liveLp != null ? 'live' : '7d');
+  const spApySub = $derived(liveSp != null ? 'live' : '7d');
 
   const pegPct = $derived.by(() => {
     if (!pegStatus) return '--';
@@ -162,8 +142,8 @@
       { label: '24h Volume', value: `$${formatCompact(volume24h)}` },
       { label: '24h Swaps', value: Number(summary.swap_count_24h).toLocaleString() },
       { label: 'Peg', value: pegPct, tone: pegTone },
-      { label: 'LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: '7d' },
-      { label: 'SP APY', value: spApy != null ? `${spApy.toFixed(2)}%` : '--', sub: '7d' },
+      { label: 'LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: lpApySub },
+      { label: 'SP APY', value: spApy != null ? `${spApy.toFixed(2)}%` : '--', sub: spApySub },
     ];
   });
 

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -8,10 +8,11 @@
     fetchFeeSeries, fetchApys, fetchFeeBreakdownWindow, type FeeBreakdown,
   } from '$services/explorer/analyticsService';
   import {
-    fetchInterestSplit,
+    fetchInterestSplit, fetchStabilityPoolStatus, fetchThreePoolStatus,
   } from '$services/explorer/explorerService';
   import { ProtocolService } from '$services/protocol';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
+  import { liveSpApyPct, liveLpApyPct } from '$utils/liveApy';
 
   let feeRows: any[] = $state([]);
   let apys: any = $state(null);
@@ -19,17 +20,21 @@
   let fees90dData = $state<FeeBreakdown | null>(null);
   let interestSplit: any[] = $state([]);
   let protocolStatus: any = $state(null);
+  let poolStatus: any = $state(null);
+  let threePoolStatus: any = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     try {
-      const [feeR, apR, f24R, f90R, spR, psR] = await Promise.allSettled([
+      const [feeR, apR, f24R, f90R, spR, psR, poolR, tpR] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchApys(),
         fetchFeeBreakdownWindow(1),
         fetchFeeBreakdownWindow(90),
         fetchInterestSplit(),
         ProtocolService.getProtocolStatus(),
+        fetchStabilityPoolStatus(),
+        fetchThreePoolStatus(),
       ]);
       if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
       if (apR.status === 'fulfilled') apys = apR.value;
@@ -37,6 +42,8 @@
       if (f90R.status === 'fulfilled') fees90dData = f90R.value;
       if (spR.status === 'fulfilled') interestSplit = spR.value ?? [];
       if (psR.status === 'fulfilled') protocolStatus = psR.value;
+      if (poolR.status === 'fulfilled') poolStatus = poolR.value;
+      if (tpR.status === 'fulfilled') threePoolStatus = tpR.value;
     } catch (err) {
       console.error('[RevenueLens] onMount error:', err);
     } finally {
@@ -53,17 +60,23 @@
     (fees24hData?.borrowIcusd ?? 0) + (fees24hData?.redemptionIcusd ?? 0) + (fees24hData?.swapIcusd ?? 0)
   );
 
-  // Backend returns None (null in Candid) when there is genuinely no data.
-  // It returns Some(0.0) when the window has data but zero fees. Display
-  // 0.00% for a confirmed zero rather than hiding it as "--".
-  const lpApy = $derived.by(() => {
+  // Live formulas first; analytics 7d rolling as the fallback (the rolling
+  // number can sit at zero when the window happens to have no realized fee
+  // activity, even though LPs/depositors are still earning from interest_split).
+  const analyticsLpApy = $derived.by(() => {
     const v = apys?.lp_apy_pct?.[0];
     return typeof v === 'number' ? v : null;
   });
-  const spApy = $derived.by(() => {
+  const analyticsSpApy = $derived.by(() => {
     const v = apys?.sp_apy_pct?.[0];
     return typeof v === 'number' ? v : null;
   });
+  const liveLp = $derived(liveLpApyPct(protocolStatus, threePoolStatus?.balances));
+  const liveSp = $derived(liveSpApyPct(protocolStatus, poolStatus));
+  const lpApy = $derived(liveLp ?? analyticsLpApy);
+  const spApy = $derived(liveSp ?? analyticsSpApy);
+  const lpApySub = $derived(liveLp != null ? 'live' : '7d');
+  const spApySub = $derived(liveSp != null ? 'live' : '7d');
 
   const feePoints = $derived(
     feeRows.map((r: any) => {
@@ -95,8 +108,8 @@
   const healthMetrics = $derived.by(() => [
     { label: 'Fees (90d)', value: `$${formatCompact(totalFees)}` },
     { label: '24h fees', value: `$${formatCompact(fees24h)}` },
-    { label: '3Pool LP APY', value: lpApy != null ? `${Number(lpApy).toFixed(2)}%` : '--', sub: '7d' },
-    { label: 'SP APY', value: spApy != null ? `${Number(spApy).toFixed(2)}%` : '--', sub: '7d' },
+    { label: '3Pool LP APY', value: lpApy != null ? `${Number(lpApy).toFixed(2)}%` : '--', sub: lpApySub },
+    { label: 'SP APY', value: spApy != null ? `${Number(spApy).toFixed(2)}%` : '--', sub: spApySub },
     {
       label: 'Treasury interest share',
       value: `${(treasuryInterestShare * 100).toFixed(0)}%`,

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -14,6 +14,7 @@
   } from '$services/explorer/explorerService';
   import { QueryOperations } from '$services/protocol/queryOperations';
   import { e8sToNumber, formatCompact, CHART_COLORS, getCollateralSymbol } from '$utils/explorerChartHelpers';
+  import { liveSpApyPct } from '$utils/liveApy';
 
   let poolStatus: any = $state(null);
   let protocolStatus: any = $state(null);
@@ -48,33 +49,10 @@
     }
   });
 
-  // Live SP APY: same formula the Stability Pool tab uses, computed from
-  // current protocol/pool status. Fixes the discrepancy between the analytics
-  // 7-day rolling number (slow to react) and the live rate users see in /liquidity.
-  const liveSpApy = $derived.by(() => {
-    if (!protocolStatus || !poolStatus) return null;
-    const split = protocolStatus.interestSplit ?? [];
-    const poolShare = (split.find((e: any) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
-    const perC = protocolStatus.perCollateralInterest;
-    if (!perC || perC.length === 0 || poolShare === 0) return null;
-
-    const eligibleMap = new Map<string, number>(
-      (poolStatus.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [
-        typeof p?.toText === 'function' ? p.toText() : String(p),
-        Number(v) / 1e8,
-      ]),
-    );
-
-    let totalApr = 0;
-    for (const info of perC) {
-      const eligible = eligibleMap.get(info.collateralType) ?? 0;
-      if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-      totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
-    }
-    if (totalApr === 0) return null;
-    const apy = Math.pow(1 + totalApr / 365, 365) - 1;
-    return apy * 100;
-  });
+  // Live SP APY: shared formula in $utils/liveApy. The analytics 7d rolling
+  // number lags reality and can sit at zero when the window has no realized
+  // fee activity, so prefer the live value with analytics as fallback.
+  const liveSpApy = $derived(liveSpApyPct(protocolStatus, poolStatus));
 
   // Prefer the live computation; fall back to the 7d rolling analytics number.
   const displayedSpApy = $derived(liveSpApy ?? spApy);

--- a/src/vault_frontend/src/lib/utils/displayEvent.ts
+++ b/src/vault_frontend/src/lib/utils/displayEvent.ts
@@ -6,7 +6,7 @@ import {
 	formatStabilityPoolEvent, formatMultiHopSwapEvent,
 } from './explorerFormatters';
 import type { FormattedEvent } from './explorerFormatters';
-import { ammPoolPair } from './ammNaming';
+import { ammPoolShortLabel } from './ammNaming';
 
 export type NonBackendSource =
 	| '3pool_swap'
@@ -187,9 +187,13 @@ export function displayEvent(de: DisplayEvent, maps?: DisplayEventMaps): Display
 	if (isBackend) {
 		sourceLabel = null;
 	} else if (de.source === 'amm_swap' || de.source === 'amm_liquidity' || de.source === 'amm_admin') {
+		// Leading-cell label is the source-prefix ("AMM1"), per the round-2 brief.
+		// `ammPoolPair` falls back to the raw underscore-joined principal pair
+		// when the registry hasn't loaded the pool, which spilled into the cell
+		// as `🌊 fohh4-...cai_ryjl3-...cai`. `ammPoolShortLabel` is the
+		// registry-indexed name ("AMM1") with a clean "AMM" fallback.
 		const poolId = de.event?.pool_id ?? de.event?.ammEvent?.pool_id;
-		const pair = ammPoolPair(poolId ? String(poolId) : null);
-		sourceLabel = pair ? `🌊 ${pair}` : 'AMM';
+		sourceLabel = ammPoolShortLabel(poolId ? String(poolId) : null);
 	} else {
 		sourceLabel = DEX_SOURCE_LABEL[de.source as NonBackendSource] ?? null;
 	}

--- a/src/vault_frontend/src/lib/utils/liveApy.ts
+++ b/src/vault_frontend/src/lib/utils/liveApy.ts
@@ -1,0 +1,118 @@
+/**
+ * Live APY math for the explorer lenses. The analytics canister exposes a 7-day
+ * rolling APY (`get_apys`) that's stale when conditions change recently or when
+ * a window has zero swap volume (then it's 0% even though LP holders are still
+ * earning from interest-split). These helpers compute the *current* APY from
+ * protocol + pool state so the lenses display what a depositor would actually
+ * earn right now. Use the analytics value as a fallback only.
+ *
+ * Formula reference: see `calculateTheoreticalApy` in `threePoolService.ts`
+ * (LP side) and `liveSpApy` in `StabilityPoolLens.svelte` (SP side). This file
+ * unifies both so every lens stays in sync.
+ */
+
+interface ProtocolStatusLike {
+  interestSplit?: { destination: string; bps: number }[];
+  perCollateralInterest?: {
+    collateralType: string;
+    totalDebtE8s: number;
+    weightedInterestRate: number;
+  }[];
+}
+
+interface PoolStatusLike {
+  eligible_icusd_per_collateral?: Array<[any, bigint]>;
+}
+
+function principalText(p: any): string {
+  if (typeof p === 'string') return p;
+  if (typeof p?.toText === 'function') return p.toText();
+  return String(p);
+}
+
+/**
+ * Live SP APY as a percentage (e.g. 6.29 for 6.29%). Mirrors the formula
+ * in the /liquidity tab. Returns null if any input is missing.
+ *
+ * Note: `protocolStatus.perCollateralInterest[i].totalDebtE8s` is already
+ * normalized to icUSD (the upstream `QueryOperations.getProtocolStatus` divides
+ * by 1e8). The eligible map here also normalizes the bigint e8s to icUSD, so
+ * the ratio is in matching units.
+ */
+export function liveSpApyPct(
+  protocolStatus: ProtocolStatusLike | null | undefined,
+  poolStatus: PoolStatusLike | null | undefined,
+): number | null {
+  if (!protocolStatus || !poolStatus) return null;
+
+  const split = protocolStatus.interestSplit ?? [];
+  const poolShare =
+    (split.find((e) => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
+  const perC = protocolStatus.perCollateralInterest;
+  if (!perC || perC.length === 0 || poolShare === 0) return null;
+
+  const eligibleMap = new Map<string, number>(
+    (poolStatus.eligible_icusd_per_collateral ?? []).map(([p, v]) => [
+      principalText(p),
+      Number(v) / 1e8,
+    ]),
+  );
+
+  let totalApr = 0;
+  for (const info of perC) {
+    const eligible = eligibleMap.get(info.collateralType) ?? 0;
+    if (
+      eligible === 0 ||
+      info.totalDebtE8s === 0 ||
+      info.weightedInterestRate === 0
+    ) {
+      continue;
+    }
+    totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
+  }
+  if (totalApr === 0) return null;
+  return (Math.pow(1 + totalApr / 365, 365) - 1) * 100;
+}
+
+/**
+ * Live 3pool LP APY as a percentage (e.g. 4.50 for 4.50%). Mirrors the
+ * `calculateTheoreticalApy` math but takes raw 3pool balances and the protocol
+ * `interest_split` directly so a single call site doesn't need to plumb both
+ * shapes. Returns null if inputs are missing.
+ *
+ * `threePoolBalances` is the raw `pool.balances` vec keyed by token index
+ * (0=icUSD/8d, 1=ckUSDT/6d, 2=ckUSDC/6d). Decimals are normalized so the TVL
+ * sum is in icUSD-equivalent.
+ */
+export function liveLpApyPct(
+  protocolStatus: ProtocolStatusLike | null | undefined,
+  threePoolBalances: bigint[] | undefined | null,
+): number | null {
+  if (!protocolStatus) return null;
+  if (!threePoolBalances || threePoolBalances.length === 0) return null;
+
+  const split = protocolStatus.interestSplit ?? [];
+  const threePoolBps =
+    split.find((e) => e.destination === 'three_pool')?.bps ?? 0;
+  const perC = protocolStatus.perCollateralInterest;
+  if (!perC || perC.length === 0 || threePoolBps === 0) return null;
+
+  // 3pool token order: [icUSD (8d), ckUSDT (6d), ckUSDC (6d)]
+  const decimalsByIdx = [8, 6, 6];
+  let poolTvlIcusd = 0;
+  for (let i = 0; i < threePoolBalances.length; i++) {
+    const dec = decimalsByIdx[i] ?? 8;
+    poolTvlIcusd += Number(threePoolBalances[i]) / 10 ** dec;
+  }
+  if (poolTvlIcusd <= 0) return null;
+
+  const threePoolShare = threePoolBps / 10000;
+  let totalApr = 0;
+  for (const info of perC) {
+    if (info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
+    totalApr +=
+      (info.weightedInterestRate * threePoolShare * info.totalDebtE8s) / poolTvlIcusd;
+  }
+  if (totalApr === 0) return null;
+  return (Math.pow(1 + totalApr / 365, 365) - 1) * 100;
+}


### PR DESCRIPTION
## Summary

Bundle of round-3 explorer issues, all frontend-only.

1. **AMM activity rows: leading cell now shows `AMM1`** (was the long underscore-joined principal pair `fohh4-...cai_ryjl3-...cai`). `ammPoolPair` falls back to the raw `pool_id` when the registry hasn't loaded the pool, and that string was bleeding into the cell.
2. **Liquidation Risk card crash fixed.** `LiquidationRiskTable` passed `id={...}` to `EntityLink` which only reads `value`; the resulting `shortenPrincipal(undefined)` threw and broke the lens render mid-paint, leaving the card on "Loading..." even though `loading=false` and `15 at risk` had already populated.
3. **Live LP / SP APY across all lenses.** Extracted the two formulas into `$utils/liveApy.ts` (`liveSpApyPct`, `liveLpApyPct`) and switched every lens to prefer the live value over the analytics 7d rolling number. The 7d number can sit at zero when there's no realized fee activity in the window even though LPs / SP depositors are still earning from interest_split. The "live" / "7d" sub-text reflects which one is showing.
4. **Admin "Last admin action" no longer "--".** Setter event variants don't carry a timestamp on the backend, so `fetchEvents` returns no usable timestamp. Use `max(last_at_ns)` from a 30d analytics admin breakdown (the analytics shadow stamps every admin entry at tail-time).
5. **Admin "Collector errors" description** shortened to fit, plus a `max-w-[14rem]` cap on the LensHealthStrip sub element so any long descriptor wraps within its column.

## Direct answer to "which SP APY is right?"

The **Stability Pool page (~6.29% live) is correct** for "what would I earn right now". The 4.29% on Revenue / Overview / DEXs was the analytics 7d rolling realized number, which lags reality and zeros out when the window has no realized fees. After this PR every lens shows the live formula with the analytics value as fallback only.

## Out of scope (separate PRs needed)

- **Revenue $1 fees (90d) / no borrowing fees**: historical daily rollups have null fee fields. Needs an analytics rollup backfill (round-2 plan E4 option 2) or a frontend on-the-fly compute reading evt_vaults directly. Larger change, separate PR.
- **SP depositors card shows 1 of 4**: `evt_stability` only has events from 1 caller because the other 3 deposited before SP event logging started (or while the analytics tailer was broken). Needs an enumeration endpoint on the SP canister to list current depositor principals. Backend change, separate PR.
- **3pool swap volume single-dot chart**: cosmetic; deferred.

## Test plan

- [x] `npx svelte-check`: 32 errors (baseline maintained).
- [ ] After deploy: `/explorer/activity` AMM swap rows show "AMM1 #N" leading cell, not the long principal pair.
- [ ] After deploy: `/explorer?lens=collateral` Liquidation Risk card populates with the at-risk vault rows (no longer stuck on "Loading...").
- [ ] After deploy: `/explorer?lens=overview`, `/explorer?lens=revenue`, `/explorer?lens=dexs` all show LP APY / SP APY with `live` sub-text matching the Stability Pool page.
- [ ] After deploy: `/explorer?lens=admin` shows a relative time for "Last admin action" and the "Collector errors" descriptor fits in its column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)