### PR TITLE
feat(sp): list_depositor_principals query + frontend uses it directly

### DIFF
--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -266,4 +266,5 @@ service : (StabilityPoolInitArgs) -> {
   get_suspended_tokens : () -> (vec record { principal; nat32 }) query;
   get_pool_events : (nat64, nat64) -> (vec PoolEvent) query;
   get_pool_event_count : () -> (nat64) query;
+  list_depositor_principals : () -> (vec principal) query;
 };

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -304,6 +304,7 @@ export interface _SERVICE {
     [Icrc21ConsentMessageRequest],
     Icrc21ConsentMessageResponse
   >,
+  'list_depositor_principals' : ActorMethod<[], Array<Principal>>,
   /**
    * ── Liquidation ──
    */

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -303,6 +303,11 @@ export const idlFactory = ({ IDL }) => {
         [Icrc21ConsentMessageResponse],
         [],
       ),
+    'list_depositor_principals' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Principal)],
+        ['query'],
+      ),
     'notify_liquidatable_vaults' : IDL.Func(
         [IDL.Vec(LiquidatableVaultInfo)],
         [IDL.Vec(LiquidationResult)],

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -257,6 +257,17 @@ pub fn get_pool_event_count() -> u64 {
     read_state(|s| s.pool_event_count())
 }
 
+/// Enumerate every principal currently holding a deposit. The frontend's
+/// "Current depositors" card needs this because the analytics shadow log
+/// (`evt_stability`) misses depositors whose Deposit events predate the
+/// analytics tailer (or were dropped while the tailer was decoding broken
+/// shadow types). Pool's `deposits` map is the source of truth — its keys
+/// equal `total_depositors` from `get_pool_status`.
+#[query]
+pub fn list_depositor_principals() -> Vec<Principal> {
+    read_state(|s| s.deposits.keys().copied().collect())
+}
+
 #[query]
 pub fn check_pool_capacity(collateral_type: Principal, debt_amount_e8s: u64) -> bool {
     read_state(|s| s.effective_pool_for_collateral(&collateral_type) >= debt_amount_e8s)

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -266,4 +266,5 @@ service : (StabilityPoolInitArgs) -> {
   get_suspended_tokens : () -> (vec record { principal; nat32 }) query;
   get_pool_events : (nat64, nat64) -> (vec PoolEvent) query;
   get_pool_event_count : () -> (nat64) query;
+  list_depositor_principals : () -> (vec principal) query;
 };

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -18,7 +18,6 @@ import type { _SERVICE as IcusdLedgerService } from '$declarations/icusd_ledger/
 import type { _SERVICE as IcusdIndexService } from '$declarations/icusd_index/icusd_index.did';
 import type { UserStabilityPosition } from '$declarations/rumi_stability_pool/rumi_stability_pool.did';
 import { idlFactory as stabilityPoolIDL } from '$declarations/rumi_stability_pool/rumi_stability_pool.did.js';
-import { fetchSpDepositorPrincipals } from './analyticsService';
 
 // ── TTL constants (ms) ───────────────────────────────────────────────────────
 
@@ -807,9 +806,12 @@ function getStabilityPoolActor() {
 
 /**
  * Returns every principal currently holding a non-zero SP balance, sorted by
- * total USD value descending. The analytics canister supplies the set of
- * principals to fan out over; the SP canister is the source of truth for
- * current positions.
+ * total USD value descending. The SP canister is the source of truth for both
+ * the depositor set and each user's position — using `list_depositor_principals`
+ * (added in this PR) instead of the analytics shadow log fixes the case where
+ * old depositors are missing from `evt_stability` because their Deposit events
+ * predate the analytics tailer or were dropped while the shadow types were
+ * stale.
  */
 export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> {
 	const key = 'pool:stability:current_depositors';
@@ -817,8 +819,8 @@ export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> 
 	if (cached) return cached;
 
 	try {
-		const principals = await fetchSpDepositorPrincipals();
 		const sp = getStabilityPoolActor();
+		const principals: Principal[] = await sp.list_depositor_principals();
 		const positions = await Promise.all(
 			principals.map(async (p) => {
 				try {


### PR DESCRIPTION
## Summary

Round-2 task C2 fix. The explorer's "Current depositors" card was showing only 1 of 4 depositors because it sourced its principal list from the analytics shadow log (`evt_stability` via `get_sp_depositor_principals`). Depositors whose Deposit event predates the analytics tailer or were dropped while the shadow types were stale never made it into evt_stability, even though their balance still exists in the SP's `deposits` map.

- **SP canister**: new `list_depositor_principals : () -> (vec principal) query`, backed by `state.deposits.keys()`. Pool's deposits map is the source of truth — its size equals `total_depositors` from `get_pool_status`.
- **Frontend**: `fetchCurrentSpDepositors` now calls the SP canister directly. Drops the analytics indirection that was the source of the gap.

## Deploy order

⚠️ **SP canister must deploy first**, then vault_frontend. The frontend call to `list_depositor_principals` will fail until the SP canister is upgraded.

SP upgrade requires `--argument` per project memory. Pre-deploy hook (.claude/hooks/pre-deploy-test.sh) will run unit + integration tests since the change touches `.rs` files.

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown --release -p stability_pool` — clean.
- [x] `dfx generate rumi_stability_pool` — declarations regenerated, new method shows in `.did.d.ts`.
- [x] `npx svelte-check` — 32 errors (baseline maintained).
- [ ] After SP deploy: `dfx canister --network ic call rumi_stability_pool list_depositor_principals '()'` returns 4 principals (matches `get_pool_status.total_depositors`).
- [ ] After frontend deploy: `/explorer?lens=stability` "Current depositors" card shows all 4 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)