### PR TITLE
fix(explorer): Revenue fee totals from backend event log (no analytics deploy)

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -9,6 +9,7 @@
   } from '$services/explorer/analyticsService';
   import {
     fetchInterestSplit, fetchStabilityPoolStatus, fetchThreePoolStatus,
+    fetchProtocolFeeTotalsFromBackend,
   } from '$services/explorer/explorerService';
   import { ProtocolService } from '$services/protocol';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
@@ -18,15 +19,25 @@
   let apys: any = $state(null);
   let fees24hData = $state<FeeBreakdown | null>(null);
   let fees90dData = $state<FeeBreakdown | null>(null);
+  let backendFees24h = $state<{ borrowIcusd: number; redemptionIcusd: number } | null>(null);
+  let backendFees90d = $state<{ borrowIcusd: number; redemptionIcusd: number } | null>(null);
   let interestSplit: any[] = $state([]);
   let protocolStatus: any = $state(null);
   let poolStatus: any = $state(null);
   let threePoolStatus: any = $state(null);
   let loading = $state(true);
 
+  const MS_PER_DAY = 86_400_000;
+
   onMount(async () => {
     try {
-      const [feeR, apR, f24R, f90R, spR, psR, poolR, tpR] = await Promise.allSettled([
+      // Borrow / redemption fees come from the backend event log directly.
+      // The analytics rollup (`fetchFeeBreakdownWindow`) reads `evt_vaults`
+      // whose historical rows have `fee_amount = None` (round-1 added the
+      // capture; pre-round-1 entries are stuck at null), which is why the
+      // 90d totals previously showed only swap fees. Swap fees stay on
+      // analytics (`evt_swaps` was always populated correctly).
+      const [feeR, apR, f24R, f90R, spR, psR, poolR, tpR, b24R, b90R] = await Promise.allSettled([
         fetchFeeSeries(90),
         fetchApys(),
         fetchFeeBreakdownWindow(1),
@@ -35,6 +46,8 @@
         ProtocolService.getProtocolStatus(),
         fetchStabilityPoolStatus(),
         fetchThreePoolStatus(),
+        fetchProtocolFeeTotalsFromBackend(MS_PER_DAY),
+        fetchProtocolFeeTotalsFromBackend(90 * MS_PER_DAY),
       ]);
       if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
       if (apR.status === 'fulfilled') apys = apR.value;
@@ -44,6 +57,8 @@
       if (psR.status === 'fulfilled') protocolStatus = psR.value;
       if (poolR.status === 'fulfilled') poolStatus = poolR.value;
       if (tpR.status === 'fulfilled') threePoolStatus = tpR.value;
+      if (b24R.status === 'fulfilled') backendFees24h = b24R.value;
+      if (b90R.status === 'fulfilled') backendFees90d = b90R.value;
     } catch (err) {
       console.error('[RevenueLens] onMount error:', err);
     } finally {
@@ -51,13 +66,17 @@
     }
   });
 
-  const totalBorrow = $derived(fees90dData?.borrowIcusd ?? 0);
-  const totalRedemption = $derived(fees90dData?.redemptionIcusd ?? 0);
+  // Borrow / redemption: backend event log (authoritative). Swap: analytics
+  // (`evt_swaps` was always populated correctly by the 3pool / AMM tailers).
+  const totalBorrow = $derived(backendFees90d?.borrowIcusd ?? fees90dData?.borrowIcusd ?? 0);
+  const totalRedemption = $derived(backendFees90d?.redemptionIcusd ?? fees90dData?.redemptionIcusd ?? 0);
   const totalSwap = $derived(fees90dData?.swapIcusd ?? 0);
   const totalFees = $derived(totalBorrow + totalRedemption + totalSwap);
 
   const fees24h = $derived(
-    (fees24hData?.borrowIcusd ?? 0) + (fees24hData?.redemptionIcusd ?? 0) + (fees24hData?.swapIcusd ?? 0)
+    (backendFees24h?.borrowIcusd ?? fees24hData?.borrowIcusd ?? 0)
+      + (backendFees24h?.redemptionIcusd ?? fees24hData?.redemptionIcusd ?? 0)
+      + (fees24hData?.swapIcusd ?? 0)
   );
 
   // Live formulas first; analytics 7d rolling as the fallback (the rolling

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -589,6 +589,66 @@ export async function fetchEvents(
 	}
 }
 
+/**
+ * Authoritative fee totals for a trailing window, sourced directly from the
+ * backend event log. The analytics canister's `get_fee_breakdown_window`
+ * derives borrow / redemption fees from `evt_vaults`, but historical entries
+ * there were ingested before the analytics tailer captured `fee_amount` (the
+ * column was added in round-1; rows ingested before that have `None`). This
+ * function paginates the backend's filtered event log, which has authoritative
+ * `fee_amount` on every Borrow / Redemption variant, and sums them.
+ *
+ * Returns icUSD values (e8s normalized). Capped at MAX_PAGES * 200 events,
+ * which covers any realistic 90d window for this protocol.
+ */
+export async function fetchProtocolFeeTotalsFromBackend(
+	windowMs: number,
+): Promise<{ borrowIcusd: number; redemptionIcusd: number; borrowCount: number; redemptionCount: number }> {
+	const key = `events:fee_totals:${windowMs}`;
+	const cached = getCached<{ borrowIcusd: number; redemptionIcusd: number; borrowCount: number; redemptionCount: number }>(key, TTL.EVENTS);
+	if (cached) return cached;
+
+	const nowNs = BigInt(Date.now()) * 1_000_000n;
+	const startNs = nowNs - BigInt(windowMs) * 1_000_000n;
+	const PAGE_SIZE = 200n;
+	const MAX_PAGES = 25; // 5,000-event ceiling; ~30x current 90d count
+
+	let borrowFeesE8s = 0n;
+	let redemptionFeesE8s = 0n;
+	let borrowCount = 0;
+	let redemptionCount = 0;
+	let offset = 0n;
+
+	for (let p = 0; p < MAX_PAGES; p++) {
+		const result = await fetchEvents(offset, PAGE_SIZE, {
+			types: ['Borrow', 'Redemption'],
+			time_range: { start_ns: startNs, end_ns: nowNs },
+		});
+		if (result.events.length === 0) break;
+		for (const [, evt] of result.events) {
+			const variantKey = Object.keys(evt ?? {})[0];
+			const data = evt?.[variantKey] ?? {};
+			if (variantKey === 'borrow_from_vault') {
+				borrowFeesE8s += BigInt(data.fee_amount ?? 0);
+				borrowCount += 1;
+			} else if (variantKey === 'redemption_on_vaults') {
+				redemptionFeesE8s += BigInt(data.fee_amount ?? 0);
+				redemptionCount += 1;
+			}
+		}
+		offset += BigInt(result.events.length);
+		if (offset >= result.total) break;
+	}
+
+	const out = {
+		borrowIcusd: Number(borrowFeesE8s) / 1e8,
+		redemptionIcusd: Number(redemptionFeesE8s) / 1e8,
+		borrowCount,
+		redemptionCount,
+	};
+	return setCache(key, out);
+}
+
 export async function fetchEventsByPrincipal(principal: Principal): Promise<[bigint, any][]> {
 	const key = `events:principal:${principal.toText()}`;
 	const cached = getCached<[bigint, any][]>(key, TTL.EVENTS);


### PR DESCRIPTION
## Summary

Round-2 task E4 fix. The Revenue lens showed **\$1 fees (90d)** with \$0 borrowing / \$0 redemption because the analytics rollup (`get_fee_breakdown_window`) reads from `evt_vaults`, whose historical rows have `fee_amount = None`. Round-1 added the fee-amount capture, but every Borrow / Redemption event ingested before round-1 is stuck at null.

**Fix**: pull borrow + redemption totals from the backend's event log directly via `get_events_filtered`. The protocol_backend stores `fee_amount` on every Borrow / Redemption variant — this is the source of truth. New helper `fetchProtocolFeeTotalsFromBackend(windowMs)` paginates the filtered log (types `['Borrow', 'Redemption']`, time_range trailing window) and sums `fee_amount`. Capped at 5,000 events as a safety ceiling.

Swap fees stay on analytics (`evt_swaps` was always populated correctly).

## Why not backfill the analytics rollup?

The round-2 brief originally leaned toward option 2 (backfill historical rollups). `evt_vaults` is a `StableLog` (append-only) backed by ic-stable-structures, so backfilling means rewriting to a new log instance and migrating — substantial churn for a metric that the backend can answer directly. Frontend on-the-fly is contained, the data cost is minimal (180 events for the 90d window on current mainnet state), and the analytics layer is unchanged.

## Test plan

- [x] `npx svelte-check`: 32 errors (baseline maintained).
- [x] Mainnet sanity (`dfx canister --network ic call rumi_protocol_backend get_event_count` → ~65k; types-filtered Borrow / Redemption query in 90d returns the actual fee totals).
- [ ] After deploy: `/explorer?lens=revenue` "Fees (90d)" card shows the real total (not just \~\$1), Borrowing and Redemption rows in the breakdown bar populate proportionally, "24h fees" reflects realized borrow + redemption activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)