### PR TITLE
fix(explorer): single-event chart shows baseline + value flag

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -130,8 +130,22 @@
           {@const si = points.findIndex((p) => p.v > 0)}
           {@const sx = x(points[si].t)}
           {@const sv = points[si].v}
-          <line x1={sx} y1={0} x2={sx} y2={height} stroke="rgb(45 212 191 / 0.4)" stroke-dasharray="2 2" />
-          <circle cx={sx} cy={y(sv)} r="3.5" fill="rgb(45 212 191)" />
+          {@const sy = y(sv)}
+          {@const baselineY = height - padY}
+          <!-- Render the same baseline (y=0) the multi-point path would draw, so
+               the chart has visual presence instead of looking empty. -->
+          <line x1={padX} y1={baselineY} x2={width - padX} y2={baselineY}
+                stroke={color} stroke-width="1.5" stroke-opacity="0.5" />
+          <!-- Vertical guide from baseline to the spike, plus a flag for the
+               value so a single non-zero bucket reads at a glance. -->
+          <line x1={sx} y1={baselineY} x2={sx} y2={sy}
+                stroke={color} stroke-width="1.5" stroke-dasharray="3 3" />
+          <circle cx={sx} cy={sy} r="4" fill={color} />
+          <text x={sx} y={Math.max(12, sy - 8)} text-anchor="middle"
+                font-size="11" font-family="ui-monospace, SFMono-Regular, monospace"
+                fill={color} style="paint-order: stroke; stroke: rgba(0,0,0,0.6); stroke-width: 3;">
+            {valueFormat ? valueFormat(sv) : sv.toLocaleString()}
+          </text>
         {:else}
           <path d={fillD} fill={fillColor} stroke="none" />
           <path d={pathD} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />


### PR DESCRIPTION
## Summary

Round-3 issue F. The 3pool swap volume (7d / hourly) chart had ~167 zero buckets and 1 non-zero — the prior single-event render dropped the path entirely and drew just a faint dashed vertical at 0.4 opacity, so the chart looked broken (a lone dot floating in empty space).

Now renders so the case clearly conveys "one event at \$X":
- Solid baseline at y=0 across full width (matches what a multi-point path would draw)
- Vertical guide from baseline to the spike, dashed + full color
- Filled marker at the data point
- Value flag above the marker (dark stroke for legibility)

`valueFormat` is reused so the flag inherits the card's currency / unit formatting (\$70, 1.06, etc.). Standard multi-point path is unchanged.

## Test plan

- [x] `npx svelte-check`: 32 errors (baseline maintained).
- [ ] After deploy: `/explorer?lens=dexs` "3Pool swap volume (7d / hourly)" card renders the single non-zero point with a baseline, vertical guide, dot, and value label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)