### PR TITLE
fix(liq): SP 3USD writedown verifier tolerates 3pool subaccount drop

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -702,6 +702,7 @@ service : (ProtocolArg) -> {
   admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
+  admin_retry_sp_liquidation : (vec nat64) -> (variant { Ok : nat64; Err : ProtocolError });
   admin_sweep_to_treasury : (text) -> (Result_1);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -846,6 +846,11 @@ export interface _SERVICE {
   >,
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
   'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
+  'admin_retry_sp_liquidation' : ActorMethod<
+    [BigUint64Array | bigint[]],
+    { 'Ok' : bigint } |
+      { 'Err' : ProtocolError }
+  >,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
   'borrow_from_vault' : ActorMethod<[VaultArg], Result_3>,
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -811,6 +811,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
+    'admin_retry_sp_liquidation' : IDL.Func(
+        [IDL.Vec(IDL.Nat64)],
+        [IDL.Variant({ 'Ok' : IDL.Nat64, 'Err' : ProtocolError })],
+        [],
+      ),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
     'borrow_from_vault' : IDL.Func([VaultArg], [Result_3], []),
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -702,6 +702,7 @@ service : (ProtocolArg) -> {
   admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
+  admin_retry_sp_liquidation : (vec nat64) -> (variant { Ok : nat64; Err : ProtocolError });
   admin_sweep_to_treasury : (text) -> (Result_1);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/src/icrc3_proof.rs
+++ b/src/rumi_protocol_backend/src/icrc3_proof.rs
@@ -267,12 +267,29 @@ pub fn validate_block(
                 .to
                 .as_ref()
                 .ok_or_else(|| "transfer block missing 'to' field".to_string())?;
-            if to.owner != expected.reserves_account.owner
-                || to.subaccount != expected.reserves_account.subaccount
-            {
+            // The 3pool ledger's ICRC-3 block log records `to: Principal` only,
+            // dropping the subaccount (see `Icrc3Transaction::Transfer` in
+            // `rumi_3pool/src/types.rs` and `account_to_value` in
+            // `rumi_3pool/src/icrc3.rs`). The actual ICRC-2 transfer still
+            // credits the correct (owner, subaccount) pair on-ledger, but the
+            // block has no subaccount to compare against. Verify the owner
+            // matches and accept either `None` or the expected subaccount —
+            // the security invariant ("transfer ended up at the protocol
+            // canister's principal") still holds, since the destination is
+            // hardcoded in `transfer_3usd_to_reserves` and the SP cannot
+            // redirect it.
+            if to.owner != expected.reserves_account.owner {
                 return Err(format!(
                     "block 'to' does not equal expected reserves account (owner {} sub {:?})",
                     expected.reserves_account.owner, expected.reserves_account.subaccount
+                ));
+            }
+            if to.subaccount.is_some()
+                && to.subaccount != expected.reserves_account.subaccount
+            {
+                return Err(format!(
+                    "block 'to' subaccount {:?} does not equal expected {:?}",
+                    to.subaccount, expected.reserves_account.subaccount
                 ));
             }
             // Memo is NOT checked on the 3pool transfer path — see fn doc.

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2481,6 +2481,32 @@ fn get_bot_stats() -> BotStatsResponse {
 ///   so vault debt stays as-is. Just unlocks vault and restores budget.
 /// - `apply_debt_reduction = true`: ConfirmFailed case. ckUSDC DID reach the backend,
 ///   so also write down the vault's debt and collateral (same as what confirm would do).
+/// Admin escape hatch: remove a vault from `sp_attempted_vaults` so the next
+/// `check_vaults` cycle re-routes it to the stability pool for another shot.
+/// Used after fixing a bug that caused the SP's first attempt to fail
+/// without consuming any stables (e.g. the 3pool ICRC-3 subaccount drop fix
+/// that landed alongside this endpoint). The set is normally one-shot per
+/// vault to prevent endless retry loops, so clearing must be deliberate.
+#[candid_method(update)]
+#[update]
+fn admin_retry_sp_liquidation(vault_ids: Vec<u64>) -> Result<u64, ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_dev = read_state(|s| s.developer_principal == caller);
+    if !is_dev {
+        return Err(ProtocolError::GenericError("Unauthorized: developer only".to_string()));
+    }
+    let cleared = mutate_state(|s| {
+        let mut n = 0u64;
+        for vid in &vault_ids {
+            if s.sp_attempted_vaults.remove(vid) {
+                n += 1;
+            }
+        }
+        n
+    });
+    Ok(cleared)
+}
+
 #[candid_method(update)]
 #[update]
 fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Result<(), ProtocolError> {


### PR DESCRIPTION
## Root cause

Vault 161 hit manual liquidation queue after the bot timed out and the SP attempted but failed (SP event #134). Backend rejected the SP's 3USD writedown proof:

> SP writedown proof verification failed: block 'to' does not equal expected reserves account (owner tfesu-vyaaa-aaaap-qrd7q-cai sub Some([36, 39, 28, 23, ...]))

The rumi_3pool ledger's ICRC-3 block log records transfers as `to: Principal` (just the owner), not `to: Account` — see `Icrc3Transaction::Transfer` in `rumi_3pool/src/types.rs` and `account_to_value` in `rumi_3pool/src/icrc3.rs` which encodes only the owner. The on-ledger ICRC-2 transfer still credits the correct (owner, subaccount), so funds end up in the protocol's reserves subaccount as intended; **only the block log loses the subaccount info**. The proof verifier reads the block, sees `to.subaccount = None` while expecting `Some(SHA256("protocol_3usd_reserves"))`, and rejects.

This blocks **every** 3USD-funded SP liquidation.

## Hotfix (this PR)

In `validate_block` for the `ThreePoolTransfer` path:

- Require `to.owner` matches expected.
- Accept `to.subaccount` that is either `None` (the buggy 3pool encoding) or matches the expected subaccount.

Security invariant — "transfer ended up at the protocol canister's principal" — still holds: `transfer_3usd_to_reserves` hardcodes the destination so the SP cannot redirect funds elsewhere.

Also adds `admin_retry_sp_liquidation(vec<nat64>) -> nat64` (dev-principal-gated) so vault 161 (and any future vaults stuck after a known-bug SP attempt) can be cleared from `sp_attempted_vaults` and re-routed to the SP on the next `check_vaults` cycle.

## Long-term fix (follow-up)

Make rumi_3pool record `Account` in its ICRC-3 block log instead of just `Principal`. That's a 3pool upgrade with stable-memory implications (the `Icrc3Transaction` enum changes shape). Once 3pool stores subaccounts correctly, the `to.subaccount.is_some() && to.subaccount != expected` branch is the only one that fires and the relaxed `None` clause becomes dead code.

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend` — clean.
- [ ] Pre-deploy hook runs unit + integration tests on backend changes.
- [ ] After deploy: `dfx canister --network ic call rumi_protocol_backend admin_retry_sp_liquidation '(vec { 161 : nat64 })' --identity rumi_identity` returns `(variant { Ok = 1 : nat64 })`.
- [ ] Within ~5 min: `check_vaults` re-attempts SP for vault 161, this time the proof verifier accepts the block and the liquidation succeeds.
- [ ] Verify on the explorer: vault 161 closed (or partially liquidated), SP event log shows a `LiquidationExecuted { success = true }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)