### PR TITLE
fix(3pool): preserve subaccounts in ICRC-3 block log

### DIFF
--- a/src/declarations/icusd_index/icusd_index.did
+++ b/src/declarations/icusd_index/icusd_index.did
@@ -1,0 +1,178 @@
+type Tokens = nat;
+
+type InitArg = record {
+  ledger_id : principal;
+  // The legacy parameter to set a fixed interval in seconds in which to retrieve blocks from the ledger.
+  // If set, the index will set both `min_retrieve_blocks_from_ledger_interval_seconds` and
+  // `max_retrieve_blocks_from_ledger_interval_seconds` to the value of `retrieve_blocks_from_ledger_interval_seconds`.
+  // If either the min or max interval parameters are also set, the index will trap during initialization.
+  retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  // The minimum and maximum intervals in seconds in which to retrieve blocks from the ledger.
+  // When a request to the ledger returns an empty response, the interval is increased (up to the maximum).
+  // In case of a non-empty response, the interval is decreased (down to the minimum). A lower value makes the index more
+  // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+  // A higher values means that it takes longer for new blocks to show up in the index.
+  min_retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  max_retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+};
+
+type UpgradeArg = record {
+  ledger_id : opt principal;
+  // The legacy parameter to set a fixed interval in seconds in which to retrieve blocks from the ledger.
+  // If set, the index will set both `min_retrieve_blocks_from_ledger_interval_seconds` and
+  // `max_retrieve_blocks_from_ledger_interval_seconds` to the value of `retrieve_blocks_from_ledger_interval_seconds`.
+  // If either the min or max interval parameters are also set, the index will trap during post upgrade.
+  retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  // The minimum and maximum intervals in seconds in which to retrieve blocks from the ledger.
+  // When a request to the ledger returns an empty response, the interval is increased (up to the maximum).
+  // In case of a non-empty response, the interval is decreased (down to the minimum). A lower value makes the index more
+  // responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+  // A higher values means that it takes longer for new blocks to show up in the index.
+  min_retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+  max_retrieve_blocks_from_ledger_interval_seconds : opt nat64;
+};
+
+type IndexArg = variant {
+  Init : InitArg;
+  Upgrade : UpgradeArg
+};
+
+type GetBlocksRequest = record {
+  start : nat;
+  length : nat
+};
+
+type Value = variant {
+  Blob : blob;
+  Text : text;
+  Nat : nat;
+  Nat64 : nat64;
+  Int : int;
+  Array : vec Value;
+  Map : Map
+};
+
+type Map = vec record { text; Value };
+
+type Block = Value;
+
+type GetBlocksResponse = record {
+  chain_length : nat64;
+  blocks : vec Block
+};
+
+type BlockIndex = nat;
+
+type SubAccount = blob;
+
+type Account = record { owner : principal; subaccount : opt SubAccount };
+
+type Transaction = record {
+  burn : opt Burn;
+  kind : text;
+  mint : opt Mint;
+  approve : opt Approve;
+  fee_collector : opt FeeCollector;
+  timestamp : nat64;
+  transfer : opt Transfer
+};
+
+type FeeCollector = record {
+  caller : opt principal;
+  fee_collector : opt Account;
+  ts : opt nat64;
+  mthd : opt text
+};
+
+type Approve = record {
+  fee : opt Tokens;
+  from : Account;
+  memo : opt vec nat8;
+  created_at_time : opt nat64;
+  amount : Tokens;
+  expected_allowance : opt Tokens;
+  expires_at : opt nat64;
+  spender : Account
+};
+
+type Burn = record {
+  from : Account;
+  memo : opt vec nat8;
+  created_at_time : opt nat64;
+  amount : Tokens;
+  spender : opt Account;
+  fee : opt nat
+};
+
+type Mint = record {
+  to : Account;
+  memo : opt vec nat8;
+  created_at_time : opt nat64;
+  amount : Tokens;
+  fee : opt nat
+};
+
+type Transfer = record {
+  to : Account;
+  fee : opt Tokens;
+  from : Account;
+  memo : opt vec nat8;
+  created_at_time : opt nat64;
+  amount : Tokens;
+  spender : opt Account
+};
+
+type GetAccountTransactionsArgs = record {
+  account : Account;
+  // The txid of the last transaction seen by the client.
+  // If None then the results will start from the most recent
+  // txid. If set then the results will start from the next
+  // most recent txid after start (start won't be included).
+  start : opt BlockIndex;
+  // Maximum number of transactions to fetch.
+  max_results : nat
+};
+
+type TransactionWithId = record {
+  id : BlockIndex;
+  transaction : Transaction
+};
+
+type GetTransactions = record {
+  balance : Tokens;
+  transactions : vec TransactionWithId;
+  // The txid of the oldest transaction the account has
+  oldest_tx_id : opt BlockIndex
+};
+
+type GetTransactionsErr = record {
+  message : text
+};
+
+type GetTransactionsResult = variant {
+  Ok : GetTransactions;
+  Err : GetTransactionsErr
+};
+
+type ListSubaccountsArgs = record {
+  owner : principal;
+  start : opt SubAccount
+};
+
+type Status = record {
+  num_blocks_synced : BlockIndex
+};
+
+type FeeCollectorRanges = record {
+  ranges : vec record { Account; vec record { BlockIndex; BlockIndex } }
+}
+
+service : (index_arg : opt IndexArg) -> {
+  get_account_transactions : (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
+  get_blocks : (GetBlocksRequest) -> (GetBlocksResponse) query;
+  get_fee_collectors_ranges : () -> (FeeCollectorRanges) query;
+  icrc1_balance_of : (Account) -> (Tokens) query;
+  ledger_id : () -> (principal) query;
+  list_subaccounts : (ListSubaccountsArgs) -> (vec SubAccount) query;
+  status : () -> (Status) query
+}

--- a/src/declarations/icusd_index/icusd_index.did.d.ts
+++ b/src/declarations/icusd_index/icusd_index.did.d.ts
@@ -1,0 +1,165 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+export interface Account {
+  'owner' : Principal,
+  'subaccount' : [] | [SubAccount],
+}
+export interface Approve {
+  'fee' : [] | [Tokens],
+  'from' : Account,
+  'memo' : [] | [Uint8Array | number[]],
+  'created_at_time' : [] | [bigint],
+  'amount' : Tokens,
+  'expected_allowance' : [] | [Tokens],
+  'expires_at' : [] | [bigint],
+  'spender' : Account,
+}
+export type Block = Value;
+export type BlockIndex = bigint;
+export interface Burn {
+  'fee' : [] | [bigint],
+  'from' : Account,
+  'memo' : [] | [Uint8Array | number[]],
+  'created_at_time' : [] | [bigint],
+  'amount' : Tokens,
+  'spender' : [] | [Account],
+}
+export interface FeeCollector {
+  'ts' : [] | [bigint],
+  'mthd' : [] | [string],
+  'fee_collector' : [] | [Account],
+  'caller' : [] | [Principal],
+}
+export interface FeeCollectorRanges {
+  'ranges' : Array<[Account, Array<[BlockIndex, BlockIndex]>]>,
+}
+export interface GetAccountTransactionsArgs {
+  /**
+   * Maximum number of transactions to fetch.
+   */
+  'max_results' : bigint,
+  /**
+   * The txid of the last transaction seen by the client.
+   * If None then the results will start from the most recent
+   * txid. If set then the results will start from the next
+   * most recent txid after start (start won't be included).
+   */
+  'start' : [] | [BlockIndex],
+  'account' : Account,
+}
+export interface GetBlocksRequest { 'start' : bigint, 'length' : bigint }
+export interface GetBlocksResponse {
+  'blocks' : Array<Block>,
+  'chain_length' : bigint,
+}
+export interface GetTransactions {
+  'balance' : Tokens,
+  'transactions' : Array<TransactionWithId>,
+  /**
+   * The txid of the oldest transaction the account has
+   */
+  'oldest_tx_id' : [] | [BlockIndex],
+}
+export interface GetTransactionsErr { 'message' : string }
+export type GetTransactionsResult = { 'Ok' : GetTransactions } |
+  { 'Err' : GetTransactionsErr };
+export type IndexArg = { 'Upgrade' : UpgradeArg } |
+  { 'Init' : InitArg };
+export interface InitArg {
+  'ledger_id' : Principal,
+  /**
+   * The legacy parameter to set a fixed interval in seconds in which to retrieve blocks from the ledger.
+   * If set, the index will set both `min_retrieve_blocks_from_ledger_interval_seconds` and
+   * `max_retrieve_blocks_from_ledger_interval_seconds` to the value of `retrieve_blocks_from_ledger_interval_seconds`.
+   * If either the min or max interval parameters are also set, the index will trap during initialization.
+   */
+  'retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+  /**
+   * The minimum and maximum intervals in seconds in which to retrieve blocks from the ledger.
+   * When a request to the ledger returns an empty response, the interval is increased (up to the maximum).
+   * In case of a non-empty response, the interval is decreased (down to the minimum). A lower value makes the index more
+   * responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+   * A higher values means that it takes longer for new blocks to show up in the index.
+   */
+  'min_retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+  'max_retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+}
+export interface ListSubaccountsArgs {
+  'owner' : Principal,
+  'start' : [] | [SubAccount],
+}
+export type Map = Array<[string, Value]>;
+export interface Mint {
+  'to' : Account,
+  'fee' : [] | [bigint],
+  'memo' : [] | [Uint8Array | number[]],
+  'created_at_time' : [] | [bigint],
+  'amount' : Tokens,
+}
+export interface Status { 'num_blocks_synced' : BlockIndex }
+export type SubAccount = Uint8Array | number[];
+export type Tokens = bigint;
+export interface Transaction {
+  'burn' : [] | [Burn],
+  'kind' : string,
+  'mint' : [] | [Mint],
+  'approve' : [] | [Approve],
+  'fee_collector' : [] | [FeeCollector],
+  'timestamp' : bigint,
+  'transfer' : [] | [Transfer],
+}
+export interface TransactionWithId {
+  'id' : BlockIndex,
+  'transaction' : Transaction,
+}
+export interface Transfer {
+  'to' : Account,
+  'fee' : [] | [Tokens],
+  'from' : Account,
+  'memo' : [] | [Uint8Array | number[]],
+  'created_at_time' : [] | [bigint],
+  'amount' : Tokens,
+  'spender' : [] | [Account],
+}
+export interface UpgradeArg {
+  'ledger_id' : [] | [Principal],
+  /**
+   * The legacy parameter to set a fixed interval in seconds in which to retrieve blocks from the ledger.
+   * If set, the index will set both `min_retrieve_blocks_from_ledger_interval_seconds` and
+   * `max_retrieve_blocks_from_ledger_interval_seconds` to the value of `retrieve_blocks_from_ledger_interval_seconds`.
+   * If either the min or max interval parameters are also set, the index will trap during post upgrade.
+   */
+  'retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+  /**
+   * The minimum and maximum intervals in seconds in which to retrieve blocks from the ledger.
+   * When a request to the ledger returns an empty response, the interval is increased (up to the maximum).
+   * In case of a non-empty response, the interval is decreased (down to the minimum). A lower value makes the index more
+   * responsive in showing new blocks, but increases the consumption of cycles of both the index and ledger canisters.
+   * A higher values means that it takes longer for new blocks to show up in the index.
+   */
+  'min_retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+  'max_retrieve_blocks_from_ledger_interval_seconds' : [] | [bigint],
+}
+export type Value = { 'Int' : bigint } |
+  { 'Map' : Map } |
+  { 'Nat' : bigint } |
+  { 'Nat64' : bigint } |
+  { 'Blob' : Uint8Array | number[] } |
+  { 'Text' : string } |
+  { 'Array' : Array<Value> };
+export interface _SERVICE {
+  'get_account_transactions' : ActorMethod<
+    [GetAccountTransactionsArgs],
+    GetTransactionsResult
+  >,
+  'get_blocks' : ActorMethod<[GetBlocksRequest], GetBlocksResponse>,
+  'get_fee_collectors_ranges' : ActorMethod<[], FeeCollectorRanges>,
+  'icrc1_balance_of' : ActorMethod<[Account], Tokens>,
+  'ledger_id' : ActorMethod<[], Principal>,
+  'list_subaccounts' : ActorMethod<[ListSubaccountsArgs], Array<SubAccount>>,
+  'status' : ActorMethod<[], Status>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/icusd_index/icusd_index.did.js
+++ b/src/declarations/icusd_index/icusd_index.did.js
@@ -1,0 +1,155 @@
+export const idlFactory = ({ IDL }) => {
+  const Value = IDL.Rec();
+  const UpgradeArg = IDL.Record({
+    'ledger_id' : IDL.Opt(IDL.Principal),
+    'retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'min_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'max_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const InitArg = IDL.Record({
+    'ledger_id' : IDL.Principal,
+    'retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'min_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'max_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const IndexArg = IDL.Variant({ 'Upgrade' : UpgradeArg, 'Init' : InitArg });
+  const BlockIndex = IDL.Nat;
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Account = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(SubAccount),
+  });
+  const GetAccountTransactionsArgs = IDL.Record({
+    'max_results' : IDL.Nat,
+    'start' : IDL.Opt(BlockIndex),
+    'account' : Account,
+  });
+  const Tokens = IDL.Nat;
+  const Burn = IDL.Record({
+    'fee' : IDL.Opt(IDL.Nat),
+    'from' : Account,
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'created_at_time' : IDL.Opt(IDL.Nat64),
+    'amount' : Tokens,
+    'spender' : IDL.Opt(Account),
+  });
+  const Mint = IDL.Record({
+    'to' : Account,
+    'fee' : IDL.Opt(IDL.Nat),
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'created_at_time' : IDL.Opt(IDL.Nat64),
+    'amount' : Tokens,
+  });
+  const Approve = IDL.Record({
+    'fee' : IDL.Opt(Tokens),
+    'from' : Account,
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'created_at_time' : IDL.Opt(IDL.Nat64),
+    'amount' : Tokens,
+    'expected_allowance' : IDL.Opt(Tokens),
+    'expires_at' : IDL.Opt(IDL.Nat64),
+    'spender' : Account,
+  });
+  const FeeCollector = IDL.Record({
+    'ts' : IDL.Opt(IDL.Nat64),
+    'mthd' : IDL.Opt(IDL.Text),
+    'fee_collector' : IDL.Opt(Account),
+    'caller' : IDL.Opt(IDL.Principal),
+  });
+  const Transfer = IDL.Record({
+    'to' : Account,
+    'fee' : IDL.Opt(Tokens),
+    'from' : Account,
+    'memo' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'created_at_time' : IDL.Opt(IDL.Nat64),
+    'amount' : Tokens,
+    'spender' : IDL.Opt(Account),
+  });
+  const Transaction = IDL.Record({
+    'burn' : IDL.Opt(Burn),
+    'kind' : IDL.Text,
+    'mint' : IDL.Opt(Mint),
+    'approve' : IDL.Opt(Approve),
+    'fee_collector' : IDL.Opt(FeeCollector),
+    'timestamp' : IDL.Nat64,
+    'transfer' : IDL.Opt(Transfer),
+  });
+  const TransactionWithId = IDL.Record({
+    'id' : BlockIndex,
+    'transaction' : Transaction,
+  });
+  const GetTransactions = IDL.Record({
+    'balance' : Tokens,
+    'transactions' : IDL.Vec(TransactionWithId),
+    'oldest_tx_id' : IDL.Opt(BlockIndex),
+  });
+  const GetTransactionsErr = IDL.Record({ 'message' : IDL.Text });
+  const GetTransactionsResult = IDL.Variant({
+    'Ok' : GetTransactions,
+    'Err' : GetTransactionsErr,
+  });
+  const GetBlocksRequest = IDL.Record({
+    'start' : IDL.Nat,
+    'length' : IDL.Nat,
+  });
+  const Map = IDL.Vec(IDL.Tuple(IDL.Text, Value));
+  Value.fill(
+    IDL.Variant({
+      'Int' : IDL.Int,
+      'Map' : Map,
+      'Nat' : IDL.Nat,
+      'Nat64' : IDL.Nat64,
+      'Blob' : IDL.Vec(IDL.Nat8),
+      'Text' : IDL.Text,
+      'Array' : IDL.Vec(Value),
+    })
+  );
+  const Block = Value;
+  const GetBlocksResponse = IDL.Record({
+    'blocks' : IDL.Vec(Block),
+    'chain_length' : IDL.Nat64,
+  });
+  const FeeCollectorRanges = IDL.Record({
+    'ranges' : IDL.Vec(
+      IDL.Tuple(Account, IDL.Vec(IDL.Tuple(BlockIndex, BlockIndex)))
+    ),
+  });
+  const ListSubaccountsArgs = IDL.Record({
+    'owner' : IDL.Principal,
+    'start' : IDL.Opt(SubAccount),
+  });
+  const Status = IDL.Record({ 'num_blocks_synced' : BlockIndex });
+  return IDL.Service({
+    'get_account_transactions' : IDL.Func(
+        [GetAccountTransactionsArgs],
+        [GetTransactionsResult],
+        ['query'],
+      ),
+    'get_blocks' : IDL.Func([GetBlocksRequest], [GetBlocksResponse], ['query']),
+    'get_fee_collectors_ranges' : IDL.Func([], [FeeCollectorRanges], ['query']),
+    'icrc1_balance_of' : IDL.Func([Account], [Tokens], ['query']),
+    'ledger_id' : IDL.Func([], [IDL.Principal], ['query']),
+    'list_subaccounts' : IDL.Func(
+        [ListSubaccountsArgs],
+        [IDL.Vec(SubAccount)],
+        ['query'],
+      ),
+    'status' : IDL.Func([], [Status], ['query']),
+  });
+};
+export const init = ({ IDL }) => {
+  const UpgradeArg = IDL.Record({
+    'ledger_id' : IDL.Opt(IDL.Principal),
+    'retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'min_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'max_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const InitArg = IDL.Record({
+    'ledger_id' : IDL.Principal,
+    'retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'min_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+    'max_retrieve_blocks_from_ledger_interval_seconds' : IDL.Opt(IDL.Nat64),
+  });
+  const IndexArg = IDL.Variant({ 'Upgrade' : UpgradeArg, 'Init' : InitArg });
+  return [IDL.Opt(IndexArg)];
+};

--- a/src/declarations/icusd_index/index.d.ts
+++ b/src/declarations/icusd_index/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './icusd_index.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const icusd_index: ActorSubclass<_SERVICE>;

--- a/src/declarations/icusd_index/index.js
+++ b/src/declarations/icusd_index/index.js
@@ -1,0 +1,42 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./icusd_index.did.js";
+export { idlFactory } from "./icusd_index.did.js";
+
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_ICUSD_INDEX;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const icusd_index = canisterId ? createActor(canisterId) : undefined;

--- a/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
@@ -459,12 +459,17 @@ export interface _SERVICE {
   >,
   'get_imbalance_stats' : ActorMethod<[StatsWindow], ImbalanceStats>,
   'get_liquidity_event_count' : ActorMethod<[], bigint>,
+  'get_liquidity_event_count_v2' : ActorMethod<[], bigint>,
   'get_liquidity_events' : ActorMethod<[bigint, bigint], Array<LiquidityEvent>>,
   /**
    * Explorer endpoints (E1-E14)
    */
   'get_liquidity_events_by_principal' : ActorMethod<
     [Principal, bigint, bigint],
+    Array<LiquidityEventV2>
+  >,
+  'get_liquidity_events_v2' : ActorMethod<
+    [bigint, bigint],
     Array<LiquidityEventV2>
   >,
   'get_lp_balance' : ActorMethod<[Principal], bigint>,
@@ -483,8 +488,6 @@ export interface _SERVICE {
     Array<SwapEventV2>
   >,
   'get_swap_events_v2' : ActorMethod<[bigint, bigint], Array<SwapEventV2>>,
-  'get_liquidity_events_v2' : ActorMethod<[bigint, bigint], Array<LiquidityEventV2>>,
-  'get_liquidity_event_count_v2' : ActorMethod<[], bigint>,
   'get_top_lps' : ActorMethod<[bigint], Array<[Principal, bigint, number]>>,
   'get_top_swappers' : ActorMethod<
     [StatsWindow, bigint],

--- a/src/declarations/rumi_3pool/rumi_3pool.did.js
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.js
@@ -511,6 +511,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_liquidity_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_liquidity_event_count_v2' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_liquidity_events' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
         [IDL.Vec(LiquidityEvent)],
@@ -518,6 +519,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_liquidity_events_by_principal' : IDL.Func(
         [IDL.Principal, IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidityEventV2)],
+        ['query'],
+      ),
+    'get_liquidity_events_v2' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
         [IDL.Vec(LiquidityEventV2)],
         ['query'],
       ),
@@ -547,12 +553,6 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(SwapEventV2)],
         ['query'],
       ),
-    'get_liquidity_events_v2' : IDL.Func(
-        [IDL.Nat64, IDL.Nat64],
-        [IDL.Vec(LiquidityEventV2)],
-        ['query'],
-      ),
-    'get_liquidity_event_count_v2' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_top_lps' : IDL.Func(
         [IDL.Nat64],
         [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat, IDL.Nat32))],

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -702,7 +702,6 @@ service : (ProtocolArg) -> {
   admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
-  admin_retry_sp_liquidation : (vec nat64) -> (variant { Ok : nat64; Err : ProtocolError });
   admin_sweep_to_treasury : (text) -> (Result_1);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -846,11 +846,6 @@ export interface _SERVICE {
   >,
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
   'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
-  'admin_retry_sp_liquidation' : ActorMethod<
-    [BigUint64Array | bigint[]],
-    { 'Ok' : bigint } |
-      { 'Err' : ProtocolError }
-  >,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
   'borrow_from_vault' : ActorMethod<[VaultArg], Result_3>,
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -811,11 +811,6 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
-    'admin_retry_sp_liquidation' : IDL.Func(
-        [IDL.Vec(IDL.Nat64)],
-        [IDL.Variant({ 'Ok' : IDL.Nat64, 'Err' : ProtocolError })],
-        [],
-      ),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
     'borrow_from_vault' : IDL.Func([VaultArg], [Result_3], []),
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),

--- a/src/rumi_3pool/src/icrc3.rs
+++ b/src/rumi_3pool/src/icrc3.rs
@@ -89,10 +89,17 @@ pub struct SupportedBlockType {
 
 // ─── Helpers: encode blocks as ICRC3Value ───
 
-fn account_to_value(principal: Principal) -> Icrc3Value {
-    Icrc3Value::Array(vec![
-        Icrc3Value::Blob(principal.as_slice().to_vec()),
-    ])
+/// Encode a (principal, optional subaccount) pair as the ICRC-3 standard
+/// `Account` value: `[owner_blob]` if no subaccount, `[owner_blob, sub_blob]`
+/// if a subaccount is present. Blocks written before the subaccount fields
+/// were added to `Icrc3Transaction` always pass `None` here, which preserves
+/// their original `[owner_blob]` encoding (and therefore their hash chain).
+fn account_to_value(principal: Principal, subaccount: Option<&[u8]>) -> Icrc3Value {
+    let mut parts = vec![Icrc3Value::Blob(principal.as_slice().to_vec())];
+    if let Some(sub) = subaccount {
+        parts.push(Icrc3Value::Blob(sub.to_vec()));
+    }
+    Icrc3Value::Array(parts)
 }
 
 /// Encode a block as an ICRC-3 Value with optional parent hash.
@@ -101,43 +108,52 @@ fn account_to_value(principal: Principal) -> Icrc3Value {
 ///   - block hashing (representation-independent hash of this value)
 pub fn encode_block_with_phash(block: &Icrc3Block, phash: Option<&[u8; 32]>) -> Icrc3Value {
     let (btype, tx_map) = match &block.tx {
-        Icrc3Transaction::Mint { to, amount } => (
+        Icrc3Transaction::Mint { to, amount, to_subaccount } => (
             "1mint",
             vec![
                 ("op".to_string(), Icrc3Value::Text("mint".to_string())),
-                ("to".to_string(), account_to_value(*to)),
+                ("to".to_string(), account_to_value(*to, to_subaccount.as_deref())),
                 ("amt".to_string(), Icrc3Value::Nat(Nat::from(*amount))),
             ],
         ),
-        Icrc3Transaction::Burn { from, amount } => (
+        Icrc3Transaction::Burn { from, amount, from_subaccount } => (
             "1burn",
             vec![
                 ("op".to_string(), Icrc3Value::Text("burn".to_string())),
-                ("from".to_string(), account_to_value(*from)),
+                ("from".to_string(), account_to_value(*from, from_subaccount.as_deref())),
                 ("amt".to_string(), Icrc3Value::Nat(Nat::from(*amount))),
             ],
         ),
-        Icrc3Transaction::Transfer { from, to, amount, spender } => {
+        Icrc3Transaction::Transfer {
+            from, to, amount, spender,
+            from_subaccount, to_subaccount, spender_subaccount,
+        } => {
             let mut fields = vec![
                 ("op".to_string(), Icrc3Value::Text("xfer".to_string())),
-                ("from".to_string(), account_to_value(*from)),
-                ("to".to_string(), account_to_value(*to)),
+                ("from".to_string(), account_to_value(*from, from_subaccount.as_deref())),
+                ("to".to_string(), account_to_value(*to, to_subaccount.as_deref())),
                 ("amt".to_string(), Icrc3Value::Nat(Nat::from(*amount))),
             ];
             if let Some(s) = spender {
-                fields.push(("spender".to_string(), account_to_value(*s)));
+                fields.push((
+                    "spender".to_string(),
+                    account_to_value(*s, spender_subaccount.as_deref()),
+                ));
             }
             ("1xfer", fields)
         }
-        Icrc3Transaction::Approve { from, spender, amount, expires_at } => {
+        Icrc3Transaction::Approve {
+            from, spender, amount, expires_at,
+            from_subaccount, spender_subaccount,
+        } => {
             // Cap approve amounts to u64::MAX for index-ng compatibility.
             // The standard index-ng deserializes amounts as u64 and rejects
             // blocks with larger values. Approvals often use u128::MAX.
             let capped = std::cmp::min(*amount, u64::MAX as u128) as u64;
             let mut fields = vec![
                 ("op".to_string(), Icrc3Value::Text("approve".to_string())),
-                ("from".to_string(), account_to_value(*from)),
-                ("spender".to_string(), account_to_value(*spender)),
+                ("from".to_string(), account_to_value(*from, from_subaccount.as_deref())),
+                ("spender".to_string(), account_to_value(*spender, spender_subaccount.as_deref())),
                 ("amt".to_string(), Icrc3Value::Nat(Nat::from(capped))),
             ];
             // index-ng expects "expected_allowance" and "expires_at" (full names, not abbreviated)

--- a/src/rumi_3pool/src/icrc_token.rs
+++ b/src/rumi_3pool/src/icrc_token.rs
@@ -97,8 +97,13 @@ pub fn icrc1_transfer(caller: Principal, args: TransferArg) -> Result<Nat, Trans
     }
 
     // Both from_subaccount and to accept any subaccount — balances are keyed
-    // by owner principal only, so subaccounts are effectively ignored.
+    // by owner principal only, so subaccounts are effectively ignored for
+    // *balance* lookups. The subaccounts ARE preserved into the ICRC-3 block
+    // log so external consumers (e.g. the protocol_backend's SP writedown
+    // proof verifier) see the actual destination Account the caller chose.
     let to_principal = args.to.owner;
+    let from_subaccount = args.from_subaccount.map(|s| s.to_vec());
+    let to_subaccount = args.to.subaccount.map(|s| s.to_vec());
 
     let amount = nat_to_u128(&args.amount).map_err(|_| TransferError::GenericError {
         error_code: Nat::from(2u64),
@@ -139,6 +144,9 @@ pub fn icrc1_transfer(caller: Principal, args: TransferArg) -> Result<Nat, Trans
             to: to_principal,
             amount,
             spender: None,
+            from_subaccount,
+            to_subaccount,
+            spender_subaccount: None,
         });
         Ok(Nat::from(id))
     })
@@ -156,8 +164,12 @@ pub fn icrc2_approve(caller: Principal, args: ApproveArgs) -> Result<Nat, Approv
         }
     }
 
-    // Subaccounts accepted but ignored — balances keyed by principal only.
+    // Subaccounts accepted but ignored for balance/allowance keying — the
+    // 3pool tracks balances per principal only. Block log preserves the
+    // subaccounts the caller chose for ICRC-3 consumers.
     let spender_principal = args.spender.owner;
+    let from_subaccount = args.from_subaccount.map(|s| s.to_vec());
+    let spender_subaccount = args.spender.subaccount.map(|s| s.to_vec());
 
     let amount = nat_to_u128(&args.amount).map_err(|_| ApproveError::GenericError {
         error_code: Nat::from(2u64),
@@ -201,6 +213,8 @@ pub fn icrc2_approve(caller: Principal, args: ApproveArgs) -> Result<Nat, Approv
             spender: spender_principal,
             amount,
             expires_at: args.expires_at,
+            from_subaccount,
+            spender_subaccount,
         });
         Ok(Nat::from(id))
     })
@@ -242,9 +256,13 @@ pub fn icrc2_transfer_from(
         }
     }
 
-    // Subaccounts accepted but ignored — balances keyed by principal only.
+    // Subaccounts accepted but ignored for balance keying — block log
+    // preserves them for ICRC-3 consumers (see icrc1_transfer comment).
     let from_principal = args.from.owner;
     let to_principal = args.to.owner;
+    let from_subaccount = args.from.subaccount.map(|s| s.to_vec());
+    let to_subaccount = args.to.subaccount.map(|s| s.to_vec());
+    let spender_subaccount = args.spender_subaccount.map(|s| s.to_vec());
 
     let amount = nat_to_u128(&args.amount).map_err(|_| TransferFromError::GenericError {
         error_code: Nat::from(2u64),
@@ -302,6 +320,9 @@ pub fn icrc2_transfer_from(
             to: to_principal,
             amount,
             spender: Some(caller),
+            from_subaccount,
+            to_subaccount,
+            spender_subaccount,
         });
         Ok(Nat::from(id))
     })

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -418,7 +418,11 @@ pub async fn add_liquidity(amounts: Vec<u128>, min_lp: u128) -> Result<u128, Thr
         s.lp_total_supply += lp_minted;
         s.is_initialized = true;
         // Log mint block for ICRC-3 index
-        s.log_block(Icrc3Transaction::Mint { to: caller, amount: lp_minted });
+        s.log_block(Icrc3Transaction::Mint {
+            to: caller,
+            amount: lp_minted,
+            to_subaccount: None,
+        });
     });
 
     // Record liquidity event v2 (dynamic-fee schema). v1 writes are stopped —
@@ -506,7 +510,11 @@ pub async fn remove_liquidity(
             s.balances[k] -= amounts[k];
         }
         // Log burn block for ICRC-3 index
-        s.log_block(Icrc3Transaction::Burn { from: caller, amount: lp_burn });
+        s.log_block(Icrc3Transaction::Burn {
+            from: caller,
+            amount: lp_burn,
+            from_subaccount: None,
+        });
     });
 
     // 6. Transfer each non-zero amount to user
@@ -619,7 +627,11 @@ pub async fn remove_one_coin(
         s.balances[idx] -= amount + admin_fee_share;
         s.admin_fees[idx] += admin_fee_share;
         // Log burn block for ICRC-3 index
-        s.log_block(Icrc3Transaction::Burn { from: caller, amount: lp_burn });
+        s.log_block(Icrc3Transaction::Burn {
+            from: caller,
+            amount: lp_burn,
+            from_subaccount: None,
+        });
     });
 
     // 6. Transfer to user
@@ -1838,6 +1850,7 @@ pub async fn authorized_redeem_and_burn(
                 s.log_block(Icrc3Transaction::Burn {
                     from: caller,
                     amount: args.lp_amount,
+                    from_subaccount: None,
                 });
             });
 

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -845,7 +845,7 @@ mod tests {
             blocks: Some(vec![Icrc3Block {
                 id: 0,
                 timestamp: 1,
-                tx: Icrc3Transaction::Mint { to: p, amount: 1 },
+                tx: Icrc3Transaction::Mint { to: p, amount: 1, to_subaccount: None },
             }]),
             last_block_hash: Some([7u8; 32]),
             admin_fees: [4, 5, 6],

--- a/src/rumi_3pool/src/types.rs
+++ b/src/rumi_3pool/src/types.rs
@@ -125,12 +125,57 @@ pub struct Icrc3Block {
 }
 
 /// A transaction recorded in the ICRC-3 block log.
+///
+/// Each role's subaccount is stored alongside the principal so the ICRC-3
+/// block encoding can emit the full `[owner, subaccount]` Account shape
+/// required by external verifiers (e.g. the protocol_backend's SP writedown
+/// proof verification path). Subaccount fields are `Option<Vec<u8>>` and use
+/// `#[serde(default)]` so blocks written before this change still decode
+/// (their subaccount fields are `None`, and the encoder falls back to the
+/// legacy `[owner]`-only encoding for those blocks — preserving the existing
+/// ICRC-3 hash chain).
+///
+/// Note: the 3pool's per-balance bookkeeping is still keyed by `Principal`
+/// only (subaccounts are accepted on the API surface but ignored for balance
+/// lookups — see icrc_token.rs). This change only fixes the *block log* so
+/// it correctly reflects the destination Account that ICRC-3 consumers need
+/// to see.
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
 pub enum Icrc3Transaction {
-    Mint { to: Principal, amount: u128 },
-    Burn { from: Principal, amount: u128 },
-    Transfer { from: Principal, to: Principal, amount: u128, spender: Option<Principal> },
-    Approve { from: Principal, spender: Principal, amount: u128, expires_at: Option<u64> },
+    Mint {
+        to: Principal,
+        amount: u128,
+        #[serde(default)]
+        to_subaccount: Option<Vec<u8>>,
+    },
+    Burn {
+        from: Principal,
+        amount: u128,
+        #[serde(default)]
+        from_subaccount: Option<Vec<u8>>,
+    },
+    Transfer {
+        from: Principal,
+        to: Principal,
+        amount: u128,
+        spender: Option<Principal>,
+        #[serde(default)]
+        from_subaccount: Option<Vec<u8>>,
+        #[serde(default)]
+        to_subaccount: Option<Vec<u8>>,
+        #[serde(default)]
+        spender_subaccount: Option<Vec<u8>>,
+    },
+    Approve {
+        from: Principal,
+        spender: Principal,
+        amount: u128,
+        expires_at: Option<u64>,
+        #[serde(default)]
+        from_subaccount: Option<Vec<u8>>,
+        #[serde(default)]
+        spender_subaccount: Option<Vec<u8>>,
+    },
 }
 
 // ─── Virtual Price Snapshots (for APY calculation) ───

--- a/src/rumi_3pool/tests/drain.rs
+++ b/src/rumi_3pool/tests/drain.rs
@@ -95,7 +95,7 @@ fn dummy_block(id: u64, p: Principal) -> Icrc3Block {
     Icrc3Block {
         id,
         timestamp: id,
-        tx: Icrc3Transaction::Mint { to: p, amount: 1 },
+        tx: Icrc3Transaction::Mint { to: p, amount: 1, to_subaccount: None },
     }
 }
 

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -702,7 +702,6 @@ service : (ProtocolArg) -> {
   admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
-  admin_retry_sp_liquidation : (vec nat64) -> (variant { Ok : nat64; Err : ProtocolError });
   admin_sweep_to_treasury : (text) -> (Result_1);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/src/icrc3_proof.rs
+++ b/src/rumi_protocol_backend/src/icrc3_proof.rs
@@ -267,29 +267,12 @@ pub fn validate_block(
                 .to
                 .as_ref()
                 .ok_or_else(|| "transfer block missing 'to' field".to_string())?;
-            // The 3pool ledger's ICRC-3 block log records `to: Principal` only,
-            // dropping the subaccount (see `Icrc3Transaction::Transfer` in
-            // `rumi_3pool/src/types.rs` and `account_to_value` in
-            // `rumi_3pool/src/icrc3.rs`). The actual ICRC-2 transfer still
-            // credits the correct (owner, subaccount) pair on-ledger, but the
-            // block has no subaccount to compare against. Verify the owner
-            // matches and accept either `None` or the expected subaccount —
-            // the security invariant ("transfer ended up at the protocol
-            // canister's principal") still holds, since the destination is
-            // hardcoded in `transfer_3usd_to_reserves` and the SP cannot
-            // redirect it.
-            if to.owner != expected.reserves_account.owner {
+            if to.owner != expected.reserves_account.owner
+                || to.subaccount != expected.reserves_account.subaccount
+            {
                 return Err(format!(
                     "block 'to' does not equal expected reserves account (owner {} sub {:?})",
                     expected.reserves_account.owner, expected.reserves_account.subaccount
-                ));
-            }
-            if to.subaccount.is_some()
-                && to.subaccount != expected.reserves_account.subaccount
-            {
-                return Err(format!(
-                    "block 'to' subaccount {:?} does not equal expected {:?}",
-                    to.subaccount, expected.reserves_account.subaccount
                 ));
             }
             // Memo is NOT checked on the 3pool transfer path — see fn doc.

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2481,32 +2481,6 @@ fn get_bot_stats() -> BotStatsResponse {
 ///   so vault debt stays as-is. Just unlocks vault and restores budget.
 /// - `apply_debt_reduction = true`: ConfirmFailed case. ckUSDC DID reach the backend,
 ///   so also write down the vault's debt and collateral (same as what confirm would do).
-/// Admin escape hatch: remove a vault from `sp_attempted_vaults` so the next
-/// `check_vaults` cycle re-routes it to the stability pool for another shot.
-/// Used after fixing a bug that caused the SP's first attempt to fail
-/// without consuming any stables (e.g. the 3pool ICRC-3 subaccount drop fix
-/// that landed alongside this endpoint). The set is normally one-shot per
-/// vault to prevent endless retry loops, so clearing must be deliberate.
-#[candid_method(update)]
-#[update]
-fn admin_retry_sp_liquidation(vault_ids: Vec<u64>) -> Result<u64, ProtocolError> {
-    let caller = ic_cdk::caller();
-    let is_dev = read_state(|s| s.developer_principal == caller);
-    if !is_dev {
-        return Err(ProtocolError::GenericError("Unauthorized: developer only".to_string()));
-    }
-    let cleared = mutate_state(|s| {
-        let mut n = 0u64;
-        for vid in &vault_ids {
-            if s.sp_attempted_vaults.remove(vid) {
-                n += 1;
-            }
-        }
-        n
-    });
-    Ok(cleared)
-}
-
 #[candid_method(update)]
 #[update]
 fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Result<(), ProtocolError> {


### PR DESCRIPTION
## Root cause

Vault 161's SP liquidation failed (SP event #134) and every prior 3USD-funded SP liquidation hits the same wall.

The `rumi_3pool` ledger's `Icrc3Transaction` variants store `Principal` only — subaccount info from `from` / `to` / `spender` is discarded before the block is logged. The on-ledger ICRC-2 transfer still credits the correct `(owner, subaccount)` pair (the 3pool balance map is intentionally keyed by `Principal` so subaccounts are "accepted but ignored" for balance lookups), but the ICRC-3 block log records `to: [owner_blob]` with no subaccount.

The protocol_backend's SP writedown proof verifier reads that block, sees `to.subaccount = None`, expects `Some(SHA256("protocol_3usd_reserves"))`, rejects the proof. Every 3USD-funded SP liquidation fails on its first attempt; the vault falls through to manual.

## Fix (rumi_3pool)

`Icrc3Transaction` variants gain `Option<Vec<u8>>` subaccount fields alongside existing principal fields, with `#[serde(default)]`:

```rust
Mint    { to: Principal, amount, to_subaccount: Option<Vec<u8>> }
Burn    { from: Principal, amount, from_subaccount: Option<Vec<u8>> }
Transfer{ from, to, amount, spender, from_subaccount, to_subaccount, spender_subaccount }
Approve { from, spender, amount, expires_at, from_subaccount, spender_subaccount }
```

- **Stable memory back-compat**: existing on-disk blocks decode (missing subaccount fields → `None`).
- **ICRC-3 hash chain back-compat**: encoder emits the legacy `[owner_blob]` shape when subaccount is `None`, so block hashes for pre-fix blocks recompute to the same value. New blocks emit the standard `[owner_blob, subaccount_blob]` shape required by ICRC-3 verifiers.
- Balance and allowance bookkeeping stay keyed by `Principal`. Only the block log learns about subaccounts.

Writers (`icrc_token.rs`, `lib.rs`) populate the subaccount fields from `args.to.subaccount`, `args.from.subaccount`, `args.from_subaccount`, `args.spender_subaccount`, etc.

## Backend cleanup

The verifier relaxation from PR [#133](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/133) is reverted — strict `(owner, subaccount)` equality is restored now that the 3pool emits compliant blocks.

`admin_retry_sp_liquidation` from PR #133 is removed per project policy: **failed SP liquidations stay failed and fall to manual**. We don't retry. Vault 161 sits in manual until its CR rises above the threshold and drops again, at which point the natural unhealthy → healthy → unhealthy lifecycle in `check_vaults` re-routes it through the bot/SP cascade as designed.

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown --release -p rumi_3pool` — clean.
- [x] `cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend` — clean.
- [x] `cargo test -p rumi_3pool --lib` — 93 passed.
- [x] `cargo test -p rumi_protocol_backend --lib` — 83 passed.
- [ ] After 3pool + backend deploy: a fresh 3USD-funded SP liquidation succeeds. Verifier path: SP transfers via `transfer_from` → 3pool block records `to: [owner_blob, sub_blob]` (with subaccount) → backend verifier sees correct `(owner, sub)` → proof accepted → debt written down.
- [ ] Existing pre-fix blocks: `dfx canister --network ic call rumi_3pool icrc3_get_blocks '(vec { record { start = 0:nat; length = 5:nat } })'` returns blocks whose `tx.to` is still `[owner_blob]` (legacy shape preserved, hash chain unbroken).

## Deploy order

1. `rumi_3pool` upgrade (must come first; the backend's verifier expects compliant blocks).
2. `rumi_protocol_backend` upgrade (with the verifier hack reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)