### PR TITLE
fix(explorer): formatCompact preserves small non-zero values + clearer DEXs label

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -155,7 +155,10 @@
   const healthMetrics = $derived.by(() => {
     const metrics = [
       { label: '3pool TVL', value: `$${formatCompact(threePoolTvl)}` },
-      { label: '24h volume', value: `$${formatCompact(volume24h)}` },
+      // Specifically 3pool's 24h swap volume — AMM swaps are tracked
+      // separately on the AMM Pools card. The unqualified "24h volume"
+      // label was confusing when AMM had volume but 3pool didn't.
+      { label: '3pool 24h volume', value: `$${formatCompact(volume24h)}` },
       { label: 'Virtual price', value: virtualPrice.toFixed(6), sub: 'compounds with fees' },
       {
         label: '3pool balance',

--- a/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
@@ -3,12 +3,30 @@
  * Formatters, scales, and color constants for SVG charts.
  */
 
-/** Format a large number with K/M/B suffixes. */
+/** Format a number with K/M/B suffixes for large magnitudes and appropriate
+ *  decimals for small magnitudes. The previous version always used 0
+ *  decimals below the K threshold, which rendered values like $0.02 as
+ *  "$0" — actively misleading on cards like Revenue's "24h fees" where
+ *  there ARE non-zero fees, just small ones.
+ *
+ *  Bands:
+ *  - 0 → "0"
+ *  - (0, 0.01) → 4 decimals ("0.0023")
+ *  - [0.01, 1) → 2 decimals ("0.02", "0.50")
+ *  - [1, 1000) → 0 decimals ("12", "999")
+ *  - [1K, 1M) → "1.2K"
+ *  - [1M, 1B) → "1.2M"
+ *  - [1B, ∞) → "1.2B"
+ */
 export function formatCompact(value: number): string {
-  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
-  return value.toFixed(0);
+  if (value === 0) return '0';
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  if (abs >= 1) return value.toFixed(0);
+  if (abs >= 0.01) return value.toFixed(2);
+  return value.toFixed(4);
 }
 
 /** Format basis points as percentage string. */


### PR DESCRIPTION
## Two display bugs that surfaced when reviewing 24h cards

**1. \`formatCompact\` rounded small non-zero values to \`0\`**

Revenue lens "24h fees" rendered as \`\$0\` even when there were fees:

```
borrow_fees_icusd_e8s = 300_000     → \$0.003
swap_fees_icusd_e8s   = 1_757_081   → \$0.0176
total                              → \~\$0.02
formatCompact(0.02)                → "0"  ← bug
```

The previous \`formatCompact\` used \`value.toFixed(0)\` for anything below the K threshold, dropping all decimals. Added bands so small non-zero values keep enough precision to read.

| input | before | after |
|---|---|---|
| 0      | "0"   | "0" |
| 0.0023 | "0"   | "0.0023" |
| 0.02   | "0"   | "0.02" |
| 0.5    | "0"   | "0.50" |
| 12     | "12"  | "12" |
| 1234   | "1.2K"| "1.2K" |

**2. DEXs lens "24h volume" was actually 3pool-only**

The card sources from \`get_pool_stats('Last24h')\` on the 3pool canister and ignores AMM activity. When AMM has volume in the last 24h but 3pool has zero, the unlabeled "\$0" looked like a bug next to Overview's "\$6 24h Volume". Renamed to "3pool 24h volume" to match the data source. AMM activity continues to show on the AMM Pools card.

## Test plan

- [x] svelte-check 32 errors (baseline maintained).
- [ ] After deploy: Revenue lens "24h fees" shows ~\$0.02 instead of \$0.
- [ ] After deploy: DEXs lens shows "3pool 24h volume \$0" (clearer that it's 3pool-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)