### PR TITLE
perf(3pool): cache ICRC-3 hash chain (cuts daily cycle burn ~30x)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-rumi-3pool-icrc3-hash-cache.md
+++ b/docs/superpowers/plans/2026-04-29-rumi-3pool-icrc3-hash-cache.md
@@ -1,0 +1,1562 @@
+# Rumi 3pool ICRC-3 Hash-Chain Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut `rumi_3pool` daily cycle burn from ~0.33 TC to ~0.01 TC by removing the O(N) hash-chain rebuild in `icrc3_get_blocks`, and harden the change with end-to-end correctness + cycle benchmarks so the optimization is provably safe and measurably effective.
+
+**Architecture:** Add a parallel `StableLog<StorableHash, ...>` that mirrors block hashes 1:1 with the existing blocks log. `log_block` writes both atomically inside the same message. `icrc3_get_blocks` reads the parent hash directly from the cache and encodes only the requested range — turning per-call work from O(total_blocks) into O(requested_blocks). A one-shot backfill in `post_upgrade` populates the cache for the existing 1,447 mainnet blocks. Defensive cross-checks (cache length parity + tip hash equality) trap on any inconsistency, leveraging IC `post_upgrade` rollback semantics for atomicity.
+
+**Tech Stack:** Rust, `ic-cdk 0.12.0`, `ic-stable-structures 0.6.7` (`StableLog`, `MemoryManager`), `sha2 0.10`, `candid 0.10.6`, PocketIC 6.0.0 for integration tests.
+
+**Spec:** Conversation context, 2026-04-29. Investigation traced 0.33 TC/day burn to [`src/rumi_3pool/src/icrc3.rs:204-217`](../../../src/rumi_3pool/src/icrc3.rs#L204-L217), where the comment itself acknowledges "This is O(end) per request — acceptable for typical index-ng polling windows; if it becomes a hot path we can cache cumulative hashes alongside the blocks log." It is now the hot path.
+
+---
+
+## Background and Why
+
+The `threeusd_index` canister (DFINITY's standard `ic-icrc1-index-ng-latest.wasm.gz`, [dfx.json:41-46](../../../dfx.json#L41-L46)) polls the 3pool via inter-canister update calls roughly every 7-8 seconds to fetch new ICRC-3 blocks. When an update calls a `#[query]` method cross-canister, the query is executed in **replicated mode** and the *called* canister pays the execution cost.
+
+Today, every such poll causes 3pool to read all N blocks from stable memory, Candid-encode each into an `Icrc3Value`, and SHA-256 hash each — solely to compute the parent hash for the first requested block. With N = 1,447 and growing ~90 blocks/day, this dominates the canister's cycle burn (326B cycles/day of activity vs. 3.5B/day idle storage).
+
+The fix is the one suggested in the existing TODO comment: cache the cumulative block hashes. After this change:
+
+- `log_block` (write path): same instructions plus one 32-byte append. Negligible.
+- `icrc3_get_blocks` (read/poll path): one cache lookup for the parent hash, then encode only the blocks actually being returned (typically 1–10 per poll).
+
+Expected per-call work: **~29M cycles → ~50K cycles**, a ~600× reduction. Daily burn target: **0.33 TC → ~0.01 TC**.
+
+---
+
+## File Structure
+
+**Modified files:**
+
+- `src/rumi_3pool/src/storage.rs` — add `StorableHash` wrapper, two new memory IDs (18, 19), the `BLOCK_HASHES_LOG` thread_local, and a `block_hashes` log API module. Add a new `backfill_hash_chain` function in the `migration` submodule.
+- `src/rumi_3pool/src/state.rs` — modify `log_block` (line 147) so the parent-hash retrieval and the dual write (block + hash) are atomic within the same message.
+- `src/rumi_3pool/src/icrc3.rs` — rewrite `icrc3_get_blocks` (line 186) to use the cached parent hash and encode only the requested range.
+- `src/rumi_3pool/src/lib.rs` — extend `post_upgrade` (line 70) with the backfill call and tip-equality check.
+
+**New files:**
+
+- `src/rumi_3pool/tests/icrc3_hash_cache.rs` — PocketIC test suite covering: equivalence vs. recomputed reference, hash-chain integrity for arbitrary `(start, length)` queries, cycle benchmark before/after, and post_upgrade backfill correctness.
+
+**No changes to:**
+
+- The Candid interface (`src/rumi_3pool/rumi_3pool.did`) — the bytes returned by `icrc3_get_blocks` must be identical pre- and post-fix, so the Candid signature is unchanged.
+- The migration drain path in `storage::migration::drain_legacy_state` — that runs once on the Phase A migration and is already complete on mainnet. The new backfill is additive.
+
+---
+
+## Out of Scope (Explicit, with Reason)
+
+These were considered and deliberately deferred — listed here so future readers don't assume they were missed:
+
+- **ICRC-3 archive canisters.** ICRC-3 supports archive canisters that hold older blocks. We currently return `archived_blocks: vec![]`. At 90 blocks/day we hit 50K blocks in ~18 months, which is the soft threshold where archives meaningfully help. Adding archive support is a multi-canister change with its own deployment surface. **Trigger:** revisit when `blocks::len() > 50_000` or when post_upgrade serialization time exceeds 2s.
+- **Other `iter_all` hot paths.** `state.rs:223` (`swap_events_v2`), `state.rs:228` (`liquidity_events_v2`), and `lib.rs:942` (`get_vp_snapshots`) all do full-log scans. They feed user-facing explorer queries, not auto-polled inter-canister calls, so they aren't burning cycles at scale today. Audit step in Task 11 documents them with a watch threshold.
+- **Stable memory bucket size reduction.** The 18 memory IDs each consume an 8 MiB bucket on first write. Custom `BUCKET_SIZE_IN_PAGES` would shrink this but requires a destructive `MemoryManager` reset. Risk/benefit doesn't justify it: the structural overhead is ~3.5B cycles/day idle, which is dwarfed by the activity burn we're fixing.
+- **Caching the encoded `Icrc3Value` form.** Once we cache the parent hash, encoding work drops to O(requested_range), which is already small (1–10 blocks typically). Caching the encoded form would 3× the storage cost for marginal gain.
+
+---
+
+## Task 1: Add `StorableHash` wrapper
+
+**Files:**
+- Modify: `src/rumi_3pool/src/storage.rs` (after line 227 where `StorableU128` ends)
+
+A new wrapper for `[u8; 32]` so we can use it as a `StableLog` element. Mirrors `StorableU128`'s pattern.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `mod tests` block at the bottom of `storage.rs` (around line 730):
+
+```rust
+    #[test]
+    fn storable_hash_roundtrip() {
+        let original = [0xABu8; 32];
+        let sh = StorableHash(original);
+        let bytes = sh.to_bytes();
+        let back = StorableHash::from_bytes(bytes);
+        assert_eq!(back.0, original);
+    }
+
+    #[test]
+    fn storable_hash_distinct_values() {
+        let a = StorableHash([1u8; 32]);
+        let b = StorableHash([2u8; 32]);
+        assert_ne!(a.to_bytes(), b.to_bytes());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::storable_hash 2>&1 | tail -20
+```
+
+Expected: FAIL with `cannot find type StorableHash in this scope`.
+
+- [ ] **Step 3: Add `StorableHash` definition**
+
+Insert after the `StorableU128` impl ends (line 227) and before the `Unit` definition:
+
+```rust
+/// 32-byte hash stored verbatim. Used for the ICRC-3 cumulative hash-chain
+/// cache so that `icrc3_get_blocks` can fetch a block's parent hash in O(1)
+/// instead of recomputing the chain from block 0.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct StorableHash(pub [u8; 32]);
+
+impl Storable for StorableHash {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.0.to_vec())
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes.as_ref());
+        StorableHash(arr)
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::storable_hash 2>&1 | tail -20
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_3pool/src/storage.rs
+git commit -m "feat(3pool): add StorableHash wrapper for hash-chain cache"
+```
+
+---
+
+## Task 2: Add the block-hashes stable log
+
+**Files:**
+- Modify: `src/rumi_3pool/src/storage.rs`
+
+Allocate two new memory IDs and stand up the `StableLog<StorableHash, ...>` plus a `block_hashes` log API module that mirrors the existing `blocks` API.
+
+- [ ] **Step 1: Update memory-ID layout comment and constants**
+
+In `storage.rs`, find the comment block at lines 15-27 and update the layout map. Replace lines 15-27 with:
+
+```rust
+// Memory ID layout (20 IDs used; 255 available):
+//
+//   0       SlimState cell              — bounded residual heap
+//   1       lp_balances                 — BTreeMap<Principal, u128>
+//   2       lp_allowances               — BTreeMap<(Principal, Principal), LpAllowance>
+//   3       authorized_burn_callers     — BTreeMap<Principal, ()>
+//   4,5     swap_events_v1 log          — preserved forever for auditability
+//   6,7     liquidity_events_v1 log     — preserved forever
+//   8,9     swap_events_v2 log
+//   10,11   liquidity_events_v2 log
+//   12,13   admin_events log
+//   14,15   vp_snapshots log
+//   16,17   icrc3_blocks log
+//   18,19   icrc3_block_hashes log      — cumulative hash chain cache (parallel
+//                                         to blocks log; entry i == hash of block i)
+```
+
+Then add the new memory ID constants. Find line 71 (`const MEM_BLOCKS_DATA: MemoryId = MemoryId::new(17);`) and append two new lines:
+
+```rust
+const MEM_BLOCK_HASHES_INDEX: MemoryId = MemoryId::new(18);
+const MEM_BLOCK_HASHES_DATA: MemoryId = MemoryId::new(19);
+```
+
+- [ ] **Step 2: Add the thread-local stable log**
+
+Find the `BLOCKS_LOG` thread_local at lines 355-362. Append after it (still inside the `thread_local! { ... }` block):
+
+```rust
+    pub(crate) static BLOCK_HASHES_LOG: RefCell<StableLog<StorableHash, Memory, Memory>> =
+        RefCell::new(
+            StableLog::init(
+                MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_INDEX)),
+                MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_DATA)),
+            )
+            .expect("init block_hashes log"),
+        );
+```
+
+- [ ] **Step 3: Add the `block_hashes` log API module**
+
+Find line 513 (`log_api!(blocks, BLOCKS_LOG, Icrc3Block);`) and append:
+
+```rust
+log_api!(block_hashes, BLOCK_HASHES_LOG, StorableHash);
+```
+
+This generates `block_hashes::push`, `block_hashes::len`, `block_hashes::get`, `block_hashes::range`, and `block_hashes::iter_all` automatically.
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+cargo build -p rumi_3pool 2>&1 | tail -20
+```
+
+Expected: build succeeds with no errors. Warnings about unused symbols are acceptable at this point — they go away in Task 3.
+
+- [ ] **Step 5: Add a smoke test for the new log**
+
+Append to the `mod tests` block:
+
+```rust
+    #[test]
+    fn block_hashes_log_initializes_empty() {
+        // Reset memory manager state by using a fresh subprocess for this test
+        // is not necessary — we just verify len() is callable and returns 0
+        // when the log has never been written. The lazy init will allocate one
+        // bucket on first len() call.
+        let initial_len = block_hashes::len();
+        assert_eq!(initial_len, 0);
+    }
+```
+
+Note: this test depends on no other test having pushed entries before it. Run it in isolation.
+
+- [ ] **Step 6: Run the smoke test**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::block_hashes_log_initializes_empty 2>&1 | tail -10
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_3pool/src/storage.rs
+git commit -m "feat(3pool): add icrc3_block_hashes parallel stable log"
+```
+
+---
+
+## Task 3: Modify `log_block` to write the hash-chain entry
+
+**Files:**
+- Modify: `src/rumi_3pool/src/state.rs:147-166`
+
+Atomically push to both logs inside the same canister message so the cache can never get out of sync with blocks.
+
+- [ ] **Step 1: Read the current `log_block` to confirm exact line numbers**
+
+```bash
+grep -n "pub fn log_block" /Users/robertripley/coding/rumi-protocol-v2/src/rumi_3pool/src/state.rs
+```
+
+Expected: `147:    pub fn log_block(&mut self, tx: crate::types::Icrc3Transaction) -> u64 {`
+
+- [ ] **Step 2: Update `log_block` to push the hash to the new log**
+
+Replace the body of `log_block` (lines 147-166) with this version. The only change is the addition of the `crate::storage::block_hashes::push(...)` line and an updated docstring:
+
+```rust
+    /// Log a transaction block, compute its hash, update certified data,
+    /// and return its index.
+    ///
+    /// Block IDs are sequential starting from 0, matching `StableLog` index.
+    /// The hash of each block is also pushed to `storage::block_hashes` so
+    /// `icrc3_get_blocks` can fetch a parent hash in O(1) rather than
+    /// recomputing the chain from block 0.
+    ///
+    /// Both writes happen inside this single message; IC message-level
+    /// atomicity guarantees they cannot diverge.
+    pub fn log_block(&mut self, tx: crate::types::Icrc3Transaction) -> u64 {
+        let id = crate::storage::blocks::len();
+        let block = crate::types::Icrc3Block {
+            id,
+            timestamp: ic_cdk::api::time(),
+            tx,
+        };
+        let prev_hash = self.last_block_hash;
+        let encoded = crate::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
+        let block_hash = crate::certification::hash_value(&encoded);
+        crate::storage::blocks::push(block);
+        crate::storage::block_hashes::push(crate::storage::StorableHash(block_hash));
+        self.last_block_hash = Some(block_hash);
+        crate::certification::set_certified_tip(id, &block_hash);
+        id
+    }
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo build -p rumi_3pool 2>&1 | tail -20
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run the existing 3pool integration test to confirm nothing broke**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test integration_test 2>&1 | tail -30
+```
+
+Expected: existing test still passes. New blocks will now also be in `block_hashes` log.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_3pool/src/state.rs
+git commit -m "feat(3pool): write hash-chain cache alongside every new block"
+```
+
+---
+
+## Task 4: Add a `backfill_hash_chain` migration helper
+
+**Files:**
+- Modify: `src/rumi_3pool/src/storage.rs` (in the `migration` submodule, after line 705)
+
+Idempotent helper that catches the cache up to the blocks log. Used both for the first deploy after this change ships (1,447 existing blocks have no cached hashes) and as a defensive no-op on every subsequent upgrade.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests` in `storage.rs`:
+
+```rust
+    #[test]
+    fn backfill_is_idempotent_when_cache_is_full() {
+        // After Task 3, every push to blocks already pushes to block_hashes.
+        // So if both logs have the same length, backfill should be a no-op.
+        let blocks_before = blocks::len();
+        let hashes_before = block_hashes::len();
+        if blocks_before != hashes_before {
+            // We cannot run this test in isolation if other tests left the logs
+            // in an inconsistent state. Skip rather than fail.
+            return;
+        }
+        crate::storage::migration::backfill_hash_chain();
+        assert_eq!(blocks::len(), blocks_before);
+        assert_eq!(block_hashes::len(), hashes_before);
+    }
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::backfill_is_idempotent 2>&1 | tail -10
+```
+
+Expected: FAIL with `cannot find function backfill_hash_chain`.
+
+- [ ] **Step 3: Add the backfill function**
+
+In `storage.rs`, find the end of the `migration` submodule (around line 705 — the closing `}` after `drain_legacy_state`) and add a new function INSIDE the `migration` module, before its closing brace:
+
+```rust
+    /// Backfill `block_hashes` to match `blocks` length.
+    ///
+    /// After this function returns:
+    ///   - `block_hashes::len() == blocks::len()`
+    ///   - For every `i in 0..blocks::len()`, `block_hashes::get(i)` equals
+    ///     the SHA-256 of the ICRC-3 encoding of `blocks::get(i)` with the
+    ///     correct parent hash.
+    ///
+    /// Idempotent: a no-op when the lengths already match. Safe to call from
+    /// `post_upgrade` on every upgrade (steady-state cost: 2 stable reads).
+    ///
+    /// Trapping inside this function rolls back stable memory atomically per
+    /// IC `post_upgrade` semantics, so partial backfills cannot persist.
+    pub fn backfill_hash_chain() {
+        let blocks_len = crate::storage::blocks::len();
+        let hashes_len = crate::storage::block_hashes::len();
+        if hashes_len >= blocks_len {
+            // Already up to date. (`>` would be a logic bug; we tolerate it
+            // here and let the integrity check in post_upgrade trap on it.)
+            return;
+        }
+
+        // Recompute the chain from block 0 up to (but not including) the
+        // first missing index. We need the parent hash for the first block
+        // we're about to fill, which is the cached hash of (start - 1) if
+        // any cache exists, or computed from scratch if hashes_len == 0.
+        let start = hashes_len;
+        let mut prev_hash: Option<[u8; 32]> = if start == 0 {
+            None
+        } else {
+            Some(
+                crate::storage::block_hashes::get(start - 1)
+                    .expect("cached hash present below hashes_len")
+                    .0,
+            )
+        };
+
+        for i in start..blocks_len {
+            let block = crate::storage::blocks::get(i)
+                .expect("block present below blocks_len");
+            let encoded = crate::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
+            let block_hash = crate::certification::hash_value(&encoded);
+            crate::storage::block_hashes::push(crate::storage::StorableHash(block_hash));
+            prev_hash = Some(block_hash);
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::backfill_is_idempotent 2>&1 | tail -10
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 5: Add a stronger backfill test that exercises the loop**
+
+Append to `mod tests`:
+
+```rust
+    #[test]
+    fn backfill_fills_missing_hashes_correctly() {
+        use crate::types::{Icrc3Block, Icrc3Transaction};
+        use candid::Principal;
+
+        // Push three blocks via the storage API directly (skipping log_block,
+        // which would also write to block_hashes). This simulates the
+        // "existing mainnet state" scenario where blocks exist but the
+        // hash-chain cache is empty.
+        let baseline = blocks::len();
+        let hash_baseline = block_hashes::len();
+        if baseline != hash_baseline {
+            // Cannot guarantee preconditions; skip.
+            return;
+        }
+
+        let p = Principal::anonymous();
+        for i in 0..3u64 {
+            let block = Icrc3Block {
+                id: baseline + i,
+                timestamp: 1_000 + i,
+                tx: Icrc3Transaction::Mint {
+                    to: p,
+                    amount: 100 + i as u128,
+                    to_subaccount: None,
+                },
+            };
+            blocks::push(block);
+        }
+
+        assert_eq!(blocks::len(), baseline + 3);
+        assert_eq!(block_hashes::len(), hash_baseline);
+
+        crate::storage::migration::backfill_hash_chain();
+
+        assert_eq!(block_hashes::len(), baseline + 3);
+
+        // Verify every newly added hash is consistent with its block's
+        // ICRC-3 encoding under the correct parent.
+        let mut prev = if baseline == 0 {
+            None
+        } else {
+            Some(block_hashes::get(baseline - 1).unwrap().0)
+        };
+        for i in baseline..baseline + 3 {
+            let block = blocks::get(i).unwrap();
+            let encoded = crate::icrc3::encode_block_with_phash(&block, prev.as_ref());
+            let expected = crate::certification::hash_value(&encoded);
+            let cached = block_hashes::get(i).unwrap().0;
+            assert_eq!(cached, expected, "hash mismatch at index {i}");
+            prev = Some(cached);
+        }
+    }
+```
+
+- [ ] **Step 6: Run the new test**
+
+```bash
+cargo test -p rumi_3pool --lib storage::tests::backfill_fills_missing_hashes_correctly 2>&1 | tail -20
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rumi_3pool/src/storage.rs
+git commit -m "feat(3pool): add backfill_hash_chain migration helper"
+```
+
+---
+
+## Task 5: Wire backfill + integrity check into `post_upgrade`
+
+**Files:**
+- Modify: `src/rumi_3pool/src/lib.rs:70-142`
+
+The `post_upgrade` already has hash-chain verification (lines 92-104). After this change it must additionally:
+1. Run `backfill_hash_chain()` so the cache is current.
+2. Verify `block_hashes::len() == blocks::len()`.
+3. Verify the last cached hash equals `state.last_block_hash`.
+
+These checks belong AFTER any drain logic (so they run on both first-time-after-A and steady-state paths).
+
+- [ ] **Step 1: Read the current `post_upgrade` body**
+
+```bash
+sed -n '60,145p' /Users/robertripley/coding/rumi-protocol-v2/src/rumi_3pool/src/lib.rs
+```
+
+Confirm structure: there's a match on `storage::migration::read_legacy_blob()` with a `Some(legacy_state) =>` branch (lines 71-119) that does the drain, and a `_ =>` branch (lines 120-130) that's the steady-state path. Both branches converge at line 132.
+
+- [ ] **Step 2: Insert the backfill + verification block**
+
+Find line 139 (the closing of the `if let Some(h) = read_state(...)` block). Right BEFORE the `setup_timers();` call on line 141, insert:
+
+```rust
+    // ── ICRC-3 hash-chain cache: backfill (if needed) and verify ──
+    //
+    // First post_upgrade after this change ships will backfill 1,447 entries.
+    // Every subsequent upgrade hits the early-return inside backfill and the
+    // checks below run cheaply.
+    storage::migration::backfill_hash_chain();
+
+    let blocks_len = storage::blocks::len();
+    let hashes_len = storage::block_hashes::len();
+    if hashes_len != blocks_len {
+        ic_cdk::trap(&format!(
+            "post_upgrade: ICRC-3 hash cache length mismatch. \
+             blocks={blocks_len} hashes={hashes_len}"
+        ));
+    }
+
+    if blocks_len > 0 {
+        let cached_tip = storage::block_hashes::get(blocks_len - 1)
+            .expect("cached tip present when blocks_len > 0")
+            .0;
+        let state_tip = read_state(|s| s.last_block_hash);
+        if Some(cached_tip) != state_tip {
+            ic_cdk::trap(&format!(
+                "post_upgrade: ICRC-3 cached tip != state.last_block_hash. \
+                 cached={:?} state={:?}",
+                cached_tip, state_tip
+            ));
+        }
+    }
+
+    log!(INFO,
+        "Rumi 3pool post-upgrade: hash cache OK. blocks={blocks_len} hashes={hashes_len}");
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo build -p rumi_3pool 2>&1 | tail -20
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run the integration test to verify post_upgrade succeeds**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test integration_test 2>&1 | tail -30
+```
+
+Expected: existing test passes (its post_upgrade path runs the new code on an empty blocks log — backfill is a no-op, lengths both 0, no tip check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_3pool/src/lib.rs
+git commit -m "feat(3pool): backfill + verify hash-chain cache on post_upgrade"
+```
+
+---
+
+## Task 6: Rewrite `icrc3_get_blocks` to use the cache
+
+**Files:**
+- Modify: `src/rumi_3pool/src/icrc3.rs:186-225`
+
+The optimization. After this change, per-call work is O(end - start) instead of O(end). Crucially, the response bytes must be **identical** to the old implementation — Task 7's equivalence test enforces this.
+
+- [ ] **Step 1: Replace the function body**
+
+Replace lines 186-225 with:
+
+```rust
+pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
+    let log_length = crate::storage::blocks::len();
+
+    let mut result_blocks = Vec::new();
+    for arg in &args {
+        let start = nat_to_u64(&arg.start);
+        let length = nat_to_u64(&arg.length);
+
+        if start >= log_length {
+            continue;
+        }
+        let end = std::cmp::min(start.saturating_add(length), log_length);
+        if end <= start {
+            continue;
+        }
+
+        // Parent hash for the first requested block: cached at index
+        // (start - 1), or None if start == 0.
+        let mut prev_hash: Option<[u8; 32]> = if start == 0 {
+            None
+        } else {
+            Some(
+                crate::storage::block_hashes::get(start - 1)
+                    .expect("hash cache must cover all blocks; backfill runs in post_upgrade")
+                    .0,
+            )
+        };
+
+        // Read only the requested range from the blocks log. Encoding +
+        // hashing happens once per returned block, replacing the old
+        // O(end) chain rebuild.
+        let blocks = crate::storage::blocks::range(start, end - start);
+        for block in &blocks {
+            let encoded = encode_block_with_phash(block, prev_hash.as_ref());
+            // Compute the running hash so the next iteration has its parent.
+            // (For the LAST block, prev_hash isn't read again — but computing
+            // it keeps the code symmetric and is cheap.)
+            let block_hash = crate::certification::hash_value(&encoded);
+            result_blocks.push(BlockWithId {
+                id: Nat::from(block.id),
+                block: encoded,
+            });
+            prev_hash = Some(block_hash);
+        }
+    }
+
+    GetBlocksResult {
+        log_length: Nat::from(log_length),
+        blocks: result_blocks,
+        archived_blocks: vec![],
+    }
+}
+```
+
+Note the symmetry: we still compute each returned block's hash because `encode_block_with_phash` for the *next* block needs it as the parent. But we no longer re-derive it for blocks we don't return.
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo build -p rumi_3pool 2>&1 | tail -20
+```
+
+Expected: clean build, no warnings.
+
+- [ ] **Step 3: Run all 3pool unit tests**
+
+```bash
+cargo test -p rumi_3pool --lib 2>&1 | tail -30
+```
+
+Expected: all pass. The optimization should not break any existing logic.
+
+- [ ] **Step 4: Run integration tests**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test integration_test 2>&1 | tail -20
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_3pool/src/icrc3.rs
+git commit -m "perf(3pool): use cached parent hash in icrc3_get_blocks (O(end) -> O(range))"
+```
+
+---
+
+## Task 7: Equivalence integration test (new vs. reference)
+
+**Files:**
+- Create: `src/rumi_3pool/tests/icrc3_hash_cache.rs`
+
+Property test: for every meaningful `(start, length)` window, the new `icrc3_get_blocks` returns the same `Icrc3Value`s and the chain reconstructs to the same tip hash as a from-scratch reference computation. This is the load-bearing safety net — if the optimization changed any byte, the index canister would detect a chain break in production.
+
+- [ ] **Step 1: Create the test file with the harness**
+
+The harness sets up a fresh PocketIC environment with three ICRC-1 ledgers and the 3pool, mirroring `integration_test.rs`. To keep this plan focused, we **factor the harness out of `integration_test.rs`** in Step 2.
+
+For now, create the test file with imports and a single equivalence test:
+
+```rust
+// src/rumi_3pool/tests/icrc3_hash_cache.rs
+//
+// Verifies the ICRC-3 hash-chain cache optimization (Task 6) produces output
+// bit-identical to a from-scratch reference computation, and that the cache
+// stays consistent across upgrades.
+//
+// These tests use the SAME deploy/setup harness as `integration_test.rs`;
+// the shared bits live in `tests/common/mod.rs` (introduced in Step 2).
+
+mod common;
+
+use candid::{decode_one, encode_args, encode_one, Nat, Principal};
+use pocket_ic::WasmResult;
+use rumi_3pool::icrc3::{BlockWithId, GetBlocksArgs, GetBlocksResult, Icrc3Value};
+use rumi_3pool::types::*;
+
+use common::{deploy_pool_with_liquidity_and_swaps, three_pool_canister_id, ThreePoolHarness};
+
+/// Reference implementation: rebuild the entire hash chain from block 0,
+/// returning the ICRC-3 Value form of the requested range. This is what
+/// `icrc3_get_blocks` did pre-optimization.
+fn reference_get_blocks(
+    harness: &ThreePoolHarness,
+    start: u64,
+    length: u64,
+) -> Vec<BlockWithId> {
+    // Fetch every block in [0, start + length) one at a time so the reference
+    // doesn't depend on the optimized endpoint at all. We use a private query
+    // method that returns raw stored blocks.
+    let log_length = harness.icrc3_log_length();
+    let end = std::cmp::min(start.saturating_add(length), log_length);
+    if start >= end {
+        return vec![];
+    }
+
+    let mut prev_hash: Option<[u8; 32]> = None;
+    let mut out = Vec::new();
+    for i in 0..end {
+        let block = harness.get_raw_block(i);
+        let encoded = rumi_3pool::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
+        let block_hash = rumi_3pool::certification::hash_value(&encoded);
+        if i >= start {
+            out.push(BlockWithId {
+                id: Nat::from(i),
+                block: encoded,
+            });
+        }
+        prev_hash = Some(block_hash);
+    }
+    out
+}
+
+#[test]
+fn icrc3_get_blocks_matches_reference_for_all_windows() {
+    let harness = deploy_pool_with_liquidity_and_swaps(50);
+
+    let log_length = harness.icrc3_log_length();
+    assert!(log_length >= 50, "expected at least 50 blocks, got {log_length}");
+
+    let test_windows: Vec<(u64, u64)> = vec![
+        (0, 1),
+        (0, 10),
+        (0, log_length),
+        (log_length - 1, 1),
+        (log_length / 2, 5),
+        (log_length, 10),       // off-the-end → empty
+        (log_length + 1, 5),    // past end → empty
+        (5, 0),                 // zero length → empty
+    ];
+
+    for (start, length) in test_windows {
+        let optimized = harness.icrc3_get_blocks(start, length);
+        let reference = reference_get_blocks(&harness, start, length);
+        assert_eq!(
+            optimized.len(),
+            reference.len(),
+            "length mismatch at (start={start}, length={length})"
+        );
+        for (a, b) in optimized.iter().zip(reference.iter()) {
+            assert_eq!(a.id, b.id, "id mismatch at (start={start})");
+            // Comparing Icrc3Values directly: equal iff representation-identical.
+            assert_eq!(a.block, b.block, "block mismatch at (start={start})");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Extract the shared harness into `tests/common/mod.rs`**
+
+Create `src/rumi_3pool/tests/common/mod.rs`. Move the WASM loaders, ledger init types, and a deploy helper here. Replace the body with:
+
+```rust
+// Shared PocketIC harness for 3pool integration tests.
+//
+// Wraps PocketIC + the three ICRC-1 ledgers + the 3pool canister behind a
+// `ThreePoolHarness` struct so individual tests stay focused on assertions
+// rather than setup boilerplate.
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use icrc_ledger_types::icrc1::account::Account;
+use icrc_ledger_types::icrc2::approve::ApproveArgs;
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use rumi_3pool::icrc3::{BlockWithId, GetBlocksArgs, GetBlocksResult};
+use rumi_3pool::types::*;
+
+#[derive(CandidType, Deserialize)]
+struct FeatureFlags { icrc2: bool }
+
+#[derive(CandidType, Deserialize)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize)]
+enum MetadataValue { Nat(Nat), Int(candid::Int), Text(String), Blob(Vec<u8>) }
+
+#[derive(CandidType, Deserialize)]
+struct LedgerInitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize)]
+enum LedgerArg { Init(LedgerInitArgs) }
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn three_pool_wasm() -> Vec<u8> {
+    include_bytes!("../../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm").to_vec()
+}
+
+pub struct ThreePoolHarness {
+    pub pic: PocketIc,
+    pub admin: Principal,
+    pub user: Principal,
+    pub three_pool: Principal,
+    pub ledgers: [Principal; 3],
+}
+
+impl ThreePoolHarness {
+    pub fn three_pool(&self) -> Principal { self.three_pool }
+
+    pub fn icrc3_get_blocks(&self, start: u64, length: u64) -> Vec<BlockWithId> {
+        let arg = vec![GetBlocksArgs {
+            start: Nat::from(start),
+            length: Nat::from(length),
+        }];
+        let bytes = self.pic
+            .query_call(self.three_pool, Principal::anonymous(), "icrc3_get_blocks",
+                encode_one(arg).unwrap())
+            .expect("icrc3_get_blocks query failed");
+        let WasmResult::Reply(reply) = bytes else { panic!("icrc3_get_blocks rejected") };
+        let result: GetBlocksResult = decode_one(&reply).unwrap();
+        result.blocks
+    }
+
+    pub fn icrc3_log_length(&self) -> u64 {
+        let arg = vec![GetBlocksArgs { start: Nat::from(0u64), length: Nat::from(0u64) }];
+        let bytes = self.pic
+            .query_call(self.three_pool, Principal::anonymous(), "icrc3_get_blocks",
+                encode_one(arg).unwrap())
+            .expect("icrc3_get_blocks query failed");
+        let WasmResult::Reply(reply) = bytes else { panic!("rejected") };
+        let result: GetBlocksResult = decode_one(&reply).unwrap();
+        result.log_length.0.try_into().unwrap()
+    }
+
+    /// Read a single raw block as stored (without phash recomputation).
+    /// Used by the reference impl in `icrc3_hash_cache.rs`. Implemented by
+    /// fetching the single-block range via the optimized endpoint and decoding
+    /// the returned ICRC-3 Value back into an Icrc3Block via a roundtrip helper.
+    ///
+    /// NOTE: this returns the BLOCK as stored, NOT the encoded value. It is
+    /// for the reference computation only.
+    pub fn get_raw_block(&self, id: u64) -> Icrc3Block {
+        // Read via a dedicated test endpoint that bypasses ICRC-3 encoding.
+        // We add this endpoint in Step 3 below.
+        let bytes = self.pic
+            .query_call(self.three_pool, Principal::anonymous(), "test_get_raw_block",
+                encode_one(id).unwrap())
+            .expect("test_get_raw_block query failed");
+        let WasmResult::Reply(reply) = bytes else { panic!("rejected") };
+        decode_one::<Icrc3Block>(&reply).unwrap()
+    }
+}
+
+/// Deploy the pool with bootstrap liquidity, then perform `n_swaps` swaps
+/// and `n_swaps / 5` add/remove liquidity actions to generate ICRC-3 blocks.
+///
+/// Returns a harness with at least `n_swaps + 5` blocks in the ICRC-3 log
+/// (each LP token transfer / mint / burn produces one block).
+pub fn deploy_pool_with_liquidity_and_swaps(n_swaps: u64) -> ThreePoolHarness {
+    // Bootstrap is identical to the harness in integration_test.rs through the
+    // "deploy + bootstrap liquidity" point. After that, perform `n_swaps`
+    // swaps. Implementation detail: copy the existing setup verbatim, refactor
+    // shared bits into helper methods on PocketIcBuilder.
+    //
+    // For brevity here, the helper body follows the same shape as
+    // `test_3pool_deploy_add_liquidity_and_swap` in integration_test.rs.
+    todo!("Copy + adapt the deploy/bootstrap from integration_test.rs::test_3pool_deploy_add_liquidity_and_swap")
+}
+
+pub fn three_pool_canister_id() -> Principal {
+    Principal::anonymous() // placeholder; harness fills this in
+}
+```
+
+That `todo!()` is a deliberate flag — it's filled in during Step 4 below by copying the existing setup logic.
+
+- [ ] **Step 3: Add `test_get_raw_block` endpoint behind a `cfg(test)` gate**
+
+The reference impl needs raw blocks bypassing ICRC-3 encoding. Add to `src/rumi_3pool/src/lib.rs`, near the other `icrc3_*` endpoints (around line 2034):
+
+```rust
+/// Test-only: return a raw `Icrc3Block` by id, bypassing ICRC-3 encoding.
+/// Used by integration tests as the ground truth for hash-chain comparisons.
+#[cfg(any(feature = "test_endpoints", test))]
+#[query]
+pub fn test_get_raw_block(id: u64) -> Option<types::Icrc3Block> {
+    storage::blocks::get(id)
+}
+```
+
+Add a `test_endpoints` feature to `src/rumi_3pool/Cargo.toml`:
+
+```toml
+[features]
+test_endpoints = []
+```
+
+Build the test wasm with that feature for the integration test:
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+```
+
+The default mainnet build does NOT enable `test_endpoints`, so this endpoint never ships to production.
+
+- [ ] **Step 4: Fill in the harness `deploy_pool_with_liquidity_and_swaps`**
+
+Open `src/rumi_3pool/tests/integration_test.rs` and copy the setup logic (lines ~140-340 of the existing test) into `tests/common/mod.rs` as the body of `deploy_pool_with_liquidity_and_swaps`. After bootstrap liquidity is added, perform `n_swaps` swaps in a loop:
+
+```rust
+    for i in 0..n_swaps {
+        let token_in = (i % 3) as u8;
+        let token_out = ((i + 1) % 3) as u8;
+        let amount: u128 = 1_000_000;
+        let swap_args = encode_args((token_in, token_out, amount, 0u128)).unwrap();
+        let _result = pic.update_call(three_pool, user, "swap", swap_args)
+            .expect("swap failed");
+    }
+```
+
+Adjust amounts and the bootstrap-liquidity values to match what the original test deposits. The exact numbers are not load-bearing here — we just need ≥ 50 blocks generated.
+
+- [ ] **Step 5: Update `integration_test.rs` to use the shared harness**
+
+Open `src/rumi_3pool/tests/integration_test.rs`. Replace its inline setup block with a call to `common::deploy_pool_with_liquidity_and_swaps(0)` (zero swaps; the test does its own). Add `mod common;` at the top.
+
+This eliminates the duplication and ensures any harness fixes propagate to both test files.
+
+- [ ] **Step 6: Run the equivalence test**
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints 2>&1 | tail -30
+```
+
+Expected: `icrc3_get_blocks_matches_reference_for_all_windows ... ok`.
+
+- [ ] **Step 7: Run the existing integration test to confirm the harness refactor didn't regress it**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test integration_test 2>&1 | tail -20
+```
+
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/rumi_3pool/tests/icrc3_hash_cache.rs \
+        src/rumi_3pool/tests/common/mod.rs \
+        src/rumi_3pool/tests/integration_test.rs \
+        src/rumi_3pool/src/lib.rs \
+        src/rumi_3pool/Cargo.toml
+git commit -m "test(3pool): equivalence test for icrc3_get_blocks vs reference"
+```
+
+---
+
+## Task 8: Cycle benchmark test (proves the optimization works)
+
+**Files:**
+- Modify: `src/rumi_3pool/tests/icrc3_hash_cache.rs`
+
+Empirical proof. Generate a substantial number of blocks, then measure how many cycles `icrc3_get_blocks` consumes when called as an inter-canister update (i.e., the same execution mode as production polling).
+
+PocketIC 6.0.0 exposes `pic.cycle_balance(canister_id) -> u128`. We:
+1. Snapshot balance.
+2. Call `icrc3_get_blocks` 100 times via inter-canister update from a helper canister (or via direct update — either works, what matters is replicated execution).
+3. Snapshot balance again.
+4. Diff / 100 = cycles per call.
+
+Direct update calls go through ingress and pay ingress cost, but for the relative comparison we just need consistent measurement. Easiest: use update mode from PocketIC, then divide.
+
+- [ ] **Step 1: Add the benchmark test**
+
+Append to `src/rumi_3pool/tests/icrc3_hash_cache.rs`:
+
+```rust
+#[test]
+fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
+    // We measure cycles burned per `icrc3_get_blocks` UPDATE call (replicated
+    // execution, i.e. the production polling path). With 200 blocks vs. 50
+    // blocks, the per-call cost should be approximately constant — the
+    // hallmark of an O(range) algorithm. Without the cache, cost would be
+    // 4× higher at 200 blocks.
+
+    fn cycles_per_call(harness: &ThreePoolHarness, n_calls: u32) -> u128 {
+        let log_length = harness.icrc3_log_length();
+        let last = log_length.saturating_sub(1);
+        let arg = encode_one(vec![GetBlocksArgs {
+            start: Nat::from(last),
+            length: Nat::from(1u64),
+        }]).unwrap();
+
+        let before = harness.pic.cycle_balance(harness.three_pool);
+        for _ in 0..n_calls {
+            let _ = harness.pic
+                .update_call(harness.three_pool, Principal::anonymous(),
+                             "icrc3_get_blocks", arg.clone())
+                .expect("icrc3_get_blocks update failed");
+        }
+        let after = harness.pic.cycle_balance(harness.three_pool);
+        let burned = before.saturating_sub(after);
+        burned / (n_calls as u128)
+    }
+
+    // Build two harnesses with different block counts. (Two separate PocketIC
+    // instances; ~30s combined runtime.)
+    let small = deploy_pool_with_liquidity_and_swaps(50);
+    let large = deploy_pool_with_liquidity_and_swaps(200);
+
+    let small_per_call = cycles_per_call(&small, 50);
+    let large_per_call = cycles_per_call(&large, 50);
+
+    eprintln!("icrc3_get_blocks cycles/call: 50 blocks={small_per_call}, 200 blocks={large_per_call}");
+
+    // With the cache, cost is dominated by the per-update message base + a
+    // single block encode + hash. We expect the ratio < 1.5× even though
+    // log_length grew 4×. Without the cache, ratio would be near 4×.
+    assert!(
+        large_per_call < small_per_call * 3 / 2,
+        "icrc3_get_blocks cycles per call grew super-linearly with log_length: \
+         50 blocks: {small_per_call}, 200 blocks: {large_per_call}. \
+         The hash-chain cache is not effective."
+    );
+
+    // Sanity floor — at minimum the call costs more than a no-op message.
+    assert!(small_per_call > 100_000, "suspiciously low: {small_per_call}");
+}
+```
+
+- [ ] **Step 2: Run the benchmark**
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints \
+    icrc3_get_blocks_cycle_cost_is_constant -- --nocapture 2>&1 | tail -30
+```
+
+Expected: PASS. The eprintln output should show the 200-block call costing roughly the same as the 50-block call (e.g., both around 1-3M cycles). Record the actual numbers in the commit message for posterity.
+
+- [ ] **Step 3: Verify the test fails without the optimization**
+
+This is the most important verification step — confirming the test catches a regression. Temporarily revert `src/rumi_3pool/src/icrc3.rs` to the O(N) version (just the body of `icrc3_get_blocks`), rerun the bench, confirm it FAILS, then re-apply the optimization.
+
+```bash
+git stash push src/rumi_3pool/src/icrc3.rs
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints \
+    icrc3_get_blocks_cycle_cost_is_constant -- --nocapture 2>&1 | tail -30
+git stash pop
+```
+
+Expected during stash: FAIL with the assertion message and a roughly-4× cost ratio. After the pop, re-run to confirm it passes again.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/rumi_3pool/tests/icrc3_hash_cache.rs
+git commit -m "test(3pool): benchmark icrc3_get_blocks shows constant per-call cost"
+```
+
+---
+
+## Task 9: Backfill simulation test
+
+**Files:**
+- Modify: `src/rumi_3pool/tests/icrc3_hash_cache.rs`
+
+Simulate the mainnet upgrade scenario: a canister with N blocks but ZERO entries in the new hash-chain log, then run the upgrade and verify `post_upgrade` populates the cache correctly.
+
+We can't trivially clear the new log on a deployed canister in PocketIC (the hash log starts empty before any block is logged, but after Task 3, every `log_block` writes to it). So we simulate by:
+1. Deploy 3pool wasm.
+2. Generate N blocks.
+3. Deploy a special "stripped" wasm that doesn't write to `block_hashes` — same as the pre-Task-3 behavior. Or alternately:
+4. Use a `cfg`-gated test endpoint to clear the hash log.
+
+The cleanest approach: a `#[cfg(any(feature = "test_endpoints", test))] #[update]` endpoint `test_clear_hash_cache()` that empties the log. Then we generate blocks, clear the cache, upgrade, and assert post_upgrade backfilled correctly.
+
+- [ ] **Step 1: Add the test endpoint**
+
+In `src/rumi_3pool/src/lib.rs`, near `test_get_raw_block` (Task 7 Step 3):
+
+```rust
+/// Test-only: clear the ICRC-3 hash cache. Used by tests to simulate the
+/// pre-Task-3 mainnet state where blocks exist but the cache is empty.
+#[cfg(any(feature = "test_endpoints", test))]
+#[update]
+pub fn test_clear_hash_cache() {
+    storage::BLOCK_HASHES_LOG.with(|l| {
+        let mm = l.borrow();
+        let len = mm.len();
+        // StableLog has no truncate; rebuild it. We expose a private helper
+        // in storage.rs for this in Step 2.
+        drop(mm);
+    });
+    storage::clear_block_hashes_for_test();
+}
+```
+
+- [ ] **Step 2: Add `clear_block_hashes_for_test` in `storage.rs`**
+
+`StableLog` has no truncate API. The cleanest way to "clear" it is to swap in a fresh log over the same memory IDs. But `MemoryManager` will reuse existing buckets. The simplest approach:
+
+```rust
+#[cfg(any(feature = "test_endpoints", test))]
+pub fn clear_block_hashes_for_test() {
+    // Pop all entries by reinitializing the StableLog over its memories.
+    // This zeroes the index header, effectively setting len() to 0.
+    BLOCK_HASHES_LOG.with(|l| {
+        let mut log = l.borrow_mut();
+        // Replace with a fresh log over the same memory IDs. `StableLog::init`
+        // will detect the existing magic and reload. To force-clear, we use
+        // `StableLog::new` which writes a fresh header.
+        let idx_mem = MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_INDEX));
+        let dat_mem = MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_DATA));
+        *log = StableLog::new(idx_mem, dat_mem).expect("re-init block_hashes log");
+    });
+}
+```
+
+If `StableLog::new` doesn't exist in `ic-stable-structures 0.6.7`, fall back to: read all entries, then expose a tracking counter that the helper resets — but `StableLog` doesn't support deletion either. In that case, use a `cfg` flag to gate the cache REUSE entirely, simulating "cache empty" via a runtime override.
+
+Verify the API:
+
+```bash
+grep -rn "fn new\|fn init" ~/.cargo/registry/src/index.crates.io-*/ic-stable-structures-0.6.7/src/log.rs 2>&1 | head -10
+```
+
+If `StableLog::new` is not available, use this alternate Step 2:
+
+```rust
+// Alternate: track an "effective length" override.
+#[cfg(any(feature = "test_endpoints", test))]
+thread_local! {
+    static HASH_CACHE_EFFECTIVE_LEN_OVERRIDE: RefCell<Option<u64>> =
+        const { RefCell::new(None) };
+}
+
+#[cfg(any(feature = "test_endpoints", test))]
+pub fn clear_block_hashes_for_test() {
+    HASH_CACHE_EFFECTIVE_LEN_OVERRIDE.with(|o| *o.borrow_mut() = Some(0));
+}
+```
+
+And modify `block_hashes::len` and `block_hashes::get` accessors to consult the override under the `test_endpoints` feature. (This is messier; prefer `StableLog::new` if available.)
+
+- [ ] **Step 3: Add the backfill simulation test**
+
+Append to `icrc3_hash_cache.rs`:
+
+```rust
+#[test]
+fn post_upgrade_backfills_empty_hash_cache() {
+    let harness = deploy_pool_with_liquidity_and_swaps(30);
+    let log_length = harness.icrc3_log_length();
+    assert!(log_length >= 30);
+
+    // Snapshot the current tip from icrc3_get_tip_certificate (which reads
+    // state.last_block_hash and is unchanged by Task 6).
+    let pre_upgrade_blocks = harness.icrc3_get_blocks(0, log_length);
+    assert_eq!(pre_upgrade_blocks.len(), log_length as usize);
+
+    // Clear the hash cache, simulating pre-Task-3 mainnet state.
+    harness.pic
+        .update_call(harness.three_pool, harness.admin, "test_clear_hash_cache",
+                     encode_one(()).unwrap())
+        .expect("clear failed");
+
+    // Trigger an upgrade (with the same wasm; post_upgrade still runs).
+    let wasm = include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm").to_vec();
+    harness.pic
+        .upgrade_canister(harness.three_pool, wasm, vec![], Some(harness.admin))
+        .expect("upgrade failed");
+
+    // After post_upgrade backfill, the cache should be full and the endpoint
+    // should return identical bytes for every window.
+    let post_upgrade_blocks = harness.icrc3_get_blocks(0, log_length);
+    assert_eq!(post_upgrade_blocks.len(), pre_upgrade_blocks.len());
+    for (a, b) in pre_upgrade_blocks.iter().zip(post_upgrade_blocks.iter()) {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.block, b.block, "block changed across upgrade with backfill");
+    }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints \
+    post_upgrade_backfills_empty_hash_cache 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rumi_3pool/src/lib.rs \
+        src/rumi_3pool/src/storage.rs \
+        src/rumi_3pool/tests/icrc3_hash_cache.rs
+git commit -m "test(3pool): post_upgrade backfills empty hash cache correctly"
+```
+
+---
+
+## Task 10: Trap-on-mismatch tests
+
+**Files:**
+- Modify: `src/rumi_3pool/tests/icrc3_hash_cache.rs`
+
+The integrity checks in Task 5 trap on inconsistency. Verify they actually trigger when the data is corrupt — otherwise we have a placebo defense.
+
+- [ ] **Step 1: Add a corruption test**
+
+This test requires another `cfg`-gated helper that writes a wrong hash into the cache. Add to `lib.rs`:
+
+```rust
+#[cfg(any(feature = "test_endpoints", test))]
+#[update]
+pub fn test_corrupt_hash_cache_tip(bogus_hash: Vec<u8>) {
+    assert_eq!(bogus_hash.len(), 32);
+    let mut h = [0u8; 32];
+    h.copy_from_slice(&bogus_hash);
+    let len = storage::block_hashes::len();
+    if len == 0 { return; }
+    storage::block_hashes::push(storage::StorableHash(h));
+    // Length is now blocks_len + 1, which will trip the parity check on next
+    // upgrade.
+}
+```
+
+Append to `icrc3_hash_cache.rs`:
+
+```rust
+#[test]
+fn post_upgrade_traps_on_hash_cache_length_mismatch() {
+    let harness = deploy_pool_with_liquidity_and_swaps(10);
+
+    // Corrupt the cache by appending an extra hash.
+    let bogus = vec![0xFFu8; 32];
+    harness.pic
+        .update_call(harness.three_pool, harness.admin, "test_corrupt_hash_cache_tip",
+                     encode_one(bogus).unwrap())
+        .expect("corrupt failed");
+
+    // Upgrade should trap because hashes_len > blocks_len.
+    let wasm = include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm").to_vec();
+    let result = harness.pic.upgrade_canister(harness.three_pool, wasm, vec![], Some(harness.admin));
+    assert!(result.is_err(), "expected upgrade to trap on cache mismatch");
+    let err_str = format!("{:?}", result.err().unwrap());
+    assert!(
+        err_str.contains("hash cache length mismatch") || err_str.contains("hash"),
+        "expected trap message about hash cache, got: {err_str}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints \
+    post_upgrade_traps_on_hash_cache_length_mismatch 2>&1 | tail -20
+```
+
+Expected: PASS — the trap fires and the upgrade rolls back.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_3pool/src/lib.rs \
+        src/rumi_3pool/tests/icrc3_hash_cache.rs
+git commit -m "test(3pool): post_upgrade traps on corrupted hash cache"
+```
+
+---
+
+## Task 11: Audit document for remaining iter_all hot paths (optional but recommended)
+
+**Files:**
+- Modify: `src/rumi_3pool/src/state.rs` and `src/rumi_3pool/src/lib.rs` (comment additions only)
+
+The user asked for a forward-thinking solution. We're not implementing further optimizations now (out of scope per the design decisions), but we should leave breadcrumbs so the next person who looks at cycle burn doesn't repeat the diagnostic work.
+
+- [ ] **Step 1: Annotate the remaining `iter_all` call sites**
+
+Add a comment block above each of these lines:
+
+`src/rumi_3pool/src/state.rs:223` — above `pub fn swap_events_v2`:
+
+```rust
+    // PERFORMANCE NOTE: O(N) over all swap events. Used by explorer queries
+    // (`get_top_swappers`, `get_volume_series`). Not currently a hot path
+    // because these are user-driven, not auto-polled. If swap volume grows or
+    // a frontend polls these queries on a short interval, consider:
+    //   1. Adding a windowed cache keyed by `StatsWindow` (heap-only).
+    //   2. Maintaining running aggregates in `state` updated on every swap.
+    // Watch threshold: swap_v2::len() > 50_000 OR per-day query count from
+    // explorer > 1_000 (check threeusd_index logs and replica metrics).
+    /// Snapshot every v2 swap event...
+```
+
+Same pattern at `state.rs:228` (`liquidity_events_v2`) and `lib.rs:942` (`get_vp_snapshots`).
+
+`lib.rs:942` — above `pub fn get_vp_snapshots`:
+
+```rust
+    // PERFORMANCE NOTE: O(N) over all VP snapshots. At 4 snapshots/day this
+    // grows ~1500/year. Watch threshold: vp_snap::len() > 10_000.
+    /// Returns all virtual_price snapshots for APY calculation and historical charts.
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo build -p rumi_3pool 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/rumi_3pool/src/state.rs src/rumi_3pool/src/lib.rs
+git commit -m "docs(3pool): annotate remaining iter_all call sites with watch thresholds"
+```
+
+---
+
+## Task 12: Run the full pre-deploy gauntlet
+
+**Files:** none (verification only)
+
+Before any mainnet deploy, run every test surface that touches the 3pool. The pre-deploy hook in `.claude/hooks/pre-deploy-test.sh` runs unit + integration tests; we run them explicitly here so we can read the output.
+
+- [ ] **Step 1: Run all 3pool unit tests**
+
+```bash
+cargo test -p rumi_3pool --lib 2>&1 | tail -30
+```
+
+Expected: every test passes.
+
+- [ ] **Step 2: Run all 3pool integration tests (default features)**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test integration_test 2>&1 | tail -20
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run the new hash-cache test suite**
+
+```bash
+cargo build -p rumi_3pool --release --target wasm32-unknown-unknown --features test_endpoints
+POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints 2>&1 | tail -30
+```
+
+Expected: all four tests pass (equivalence, benchmark, backfill, trap).
+
+- [ ] **Step 4: Run the broader pocket_ic_3usd suite that exercises the stability pool ↔ 3pool path**
+
+```bash
+POCKET_IC_BIN=$PWD/pocket-ic cargo test --test pocket_ic_3usd 2>&1 | tail -20
+```
+
+Expected: pass. (This catches any unintended interaction with the SP's use of the 3pool.)
+
+- [ ] **Step 5: Run the workspace-wide cargo build to catch any cross-crate breakage**
+
+```bash
+cargo build --release --target wasm32-unknown-unknown 2>&1 | tail -10
+```
+
+Expected: clean build of every canister.
+
+- [ ] **Step 6: Capture cycle baseline before deploy**
+
+```bash
+dfx canister --network ic status rumi_3pool 2>&1 | grep -E "Idle cycles|Memory Size|Balance|Module hash" > /tmp/3pool-pre-deploy.txt
+cat /tmp/3pool-pre-deploy.txt
+```
+
+Save this output — we'll compare against post-deploy numbers in Task 14.
+
+---
+
+## Task 13: Mainnet deploy
+
+**Files:** none (deploy step)
+
+This is a backend canister upgrade. Per [.claude/CLAUDE.md and global memory](../../../.claude/CLAUDE.md), all backend deploys must include a description and use `dfx deploy` (never `install`).
+
+**STOP — REQUIRES USER AUTHORIZATION.** Per memory rule: *"Never merge PRs or deploy without explicit authorization."* The executor MUST pause here, summarize the plan results so far, and explicitly ask the user before running the deploy command.
+
+- [ ] **Step 1: Confirm authorization**
+
+Ask the user: *"Plan complete, all tests green. Ready to deploy rumi_3pool with the hash-cache fix? Pre-deploy hash cache target: 1,447 blocks (or whatever current count is). Backfill is expected to take ~50ms in post_upgrade. Confirm before I run dfx deploy."*
+
+WAIT for explicit approval before proceeding to Step 2.
+
+- [ ] **Step 2: Deploy**
+
+```bash
+dfx deploy --network ic rumi_3pool --argument '(variant { Upgrade = record { description = opt "Cache ICRC-3 cumulative hash chain in parallel StableLog. Cuts icrc3_get_blocks per-call cost from O(N) to O(range). Backfills 1,447 existing blocks on post_upgrade." } })' 2>&1 | tail -30
+```
+
+Note: 3pool's existing post_upgrade may not accept an `Upgrade` variant — check the canister's init args type at `src/rumi_3pool/src/lib.rs` (look near `#[ic_cdk::init]` and `#[ic_cdk::post_upgrade]`). If 3pool uses `()` for post_upgrade args, drop `--argument` from the deploy.
+
+- [ ] **Step 3: Watch the post_upgrade log**
+
+```bash
+dfx canister --network ic logs rumi_3pool 2>&1 | tail -10
+```
+
+Expected to see (in order):
+- "Rumi 3pool pre-upgrade: flushing SlimState to stable cell"
+- "Rumi 3pool post-upgrade: loaded from SlimState. LP supply: ..., holders: ..., blocks: 1447"
+- "Rumi 3pool post-upgrade: hash cache OK. blocks=1447 hashes=1447"
+- "VP snapshot taken"
+
+If the third line is missing, the new code didn't deploy. If it shows mismatched numbers, investigate immediately — but stable memory rolled back atomically per IC spec, so the canister is on the OLD wasm and ICRC-3 is unaffected.
+
+---
+
+## Task 14: Post-deploy verification (24h watch)
+
+**Files:** none (monitoring)
+
+The fix is empirically validated only when CycleOps shows the expected drop. Plan for two verification windows: a 1-hour smoke check and a 24-hour soak.
+
+- [ ] **Step 1: T+0 — verify icrc3_get_blocks still serves correct data**
+
+```bash
+dfx canister --network ic call rumi_3pool icrc3_get_blocks '(vec { record { start = 0 : nat; length = 5 : nat } })' 2>&1 | tail -20
+```
+
+Expected: returns 5 blocks with valid `phash` chain. Compare the output's first block's hash bytes against a snapshot taken pre-deploy (you can save one with the same call before Task 13 for direct diff).
+
+- [ ] **Step 2: T+1h — verify threeusd_index has not stalled**
+
+```bash
+dfx canister --network ic call threeusd_index status 2>&1 | tail -10
+```
+
+Expected: `num_blocks_synced` matches `rumi_3pool::icrc3_get_blocks log_length` (or is within a small lag window). If `num_blocks_synced` is stuck at the pre-deploy value, the index detected a chain break and stopped — investigate immediately. (Highly unlikely given Tasks 7+9, but this is the canary.)
+
+- [ ] **Step 3: T+1h — observe initial cycle burn**
+
+Open the CycleOps dashboard and look at the rumi_3pool burn rate. The 24h average will still include yesterday's pre-fix data. The instant burn rate (last hour) should already show the drop.
+
+- [ ] **Step 4: T+24h — confirm the win**
+
+```bash
+dfx canister --network ic status rumi_3pool 2>&1 | grep -E "Idle cycles|Balance"
+```
+
+Expected idle cycles: roughly unchanged (~3.5B/day; we added one memory bucket). Expected balance: meaningfully higher than the pre-deploy delta, because the canister stopped burning ~320B cycles/day on icrc3_get_blocks. Compare against `/tmp/3pool-pre-deploy.txt` from Task 12.
+
+CycleOps 24h burn target: **0.33 TC → ~0.01 TC** (give or take, depending on residual update activity).
+
+- [ ] **Step 5: Update the global memory**
+
+After confirmation, update `/Users/robertripley/.claude/projects/-Users-robertripley-coding-rumi-protocol-v2/memory/MEMORY.md` to record the win and remove the relevant follow-up entry. Specifically: replace any "icrc3_get_blocks O(N) burn" mention with "fixed in commit XXX (date)".
+
+---
+
+## Self-Review Checklist
+
+Run through this after the plan is complete and before handoff:
+
+**Spec coverage:**
+- ✅ Diagnose cycle burn — established in conversation context.
+- ✅ Cache the cumulative hash chain — Tasks 1, 2.
+- ✅ Atomic dual-write on `log_block` — Task 3.
+- ✅ Idempotent backfill on `post_upgrade` — Task 4, 5.
+- ✅ Integrity checks (length parity + tip equality) — Task 5.
+- ✅ Optimized `icrc3_get_blocks` — Task 6.
+- ✅ Equivalence test against reference impl — Task 7.
+- ✅ Cycle benchmark proving the win — Task 8.
+- ✅ Migration safety test (post_upgrade backfill from empty) — Task 9.
+- ✅ Trap correctness test (corrupted cache) — Task 10.
+- ✅ Forward-thinking: audit other hot paths — Task 11.
+- ✅ Pre-deploy gauntlet — Task 12.
+- ✅ Mainnet deploy with authorization gate — Task 13.
+- ✅ Post-deploy verification + memory update — Task 14.
+
+**Type / API consistency:**
+- `StorableHash([u8; 32])` — defined in Task 1, used in Tasks 2, 3, 4, 9, 10.
+- `block_hashes` log API — generated by `log_api!` macro in Task 2, called as `block_hashes::push`, `len`, `get`, `range` everywhere consistently.
+- `MEM_BLOCK_HASHES_INDEX = 18`, `MEM_BLOCK_HASHES_DATA = 19` — used in Task 2 init AND Task 9 alternate clear path.
+- `clear_block_hashes_for_test` — defined in Task 9 Step 2, called in Task 9 endpoint and tests.
+
+**Placeholder scan:**
+- One acknowledged `todo!()` in Task 7 Step 2 (the harness body) — Step 4 of that task is "Fill in the harness", with explicit instructions on which lines to copy. Not a hidden TODO.
+- Task 9 Step 2 has two alternates depending on `StableLog::new` availability in `ic-stable-structures 0.6.7`; Step 2 explicitly tells the executor to grep for the API and pick the right path.
+- No "implement later" / "TBD" / vague references.
+
+**Risk surface:**
+- ICRC-3 chain integrity is load-bearing for `threeusd_index`. Tasks 7, 9, 10 collectively verify the fix doesn't change a single byte of output, the backfill produces correct hashes, and corruption traps loudly.
+- Stable memory layout grows by 2 IDs (18, 19). New buckets cost ~16 MiB extra storage at one-time-burn ~400M cycles/day idle. Net win still ~320B/day.
+- Deploy gated on user authorization (Task 13 Step 1).
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-04-29-rumi-3pool-icrc3-hash-cache.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration. Best fit here because tasks 1–11 are mostly independent and the agent can carry less context per dispatch.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, with checkpoints at the end of Tasks 6, 10, and 12 for human review.
+
+Which approach?

--- a/src/rumi_3pool/Cargo.toml
+++ b/src/rumi_3pool/Cargo.toml
@@ -28,3 +28,6 @@ num-traits = "0.2"
 assert_matches = "1.3.0"
 pocket-ic = "6.0.0"
 serde_json = "1.0"
+
+[features]
+test_endpoints = []

--- a/src/rumi_3pool/src/icrc3.rs
+++ b/src/rumi_3pool/src/icrc3.rs
@@ -13,7 +13,7 @@ use crate::types::{Icrc3Block, Icrc3Transaction};
 
 /// Generic value type used by ICRC-3 to encode blocks as nested maps.
 /// The index-ng expects this exact Candid structure.
-#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Icrc3Value {
     Blob(Vec<u8>),
     Text(String),
@@ -31,7 +31,7 @@ pub struct GetBlocksArgs {
     pub length: Nat,
 }
 
-#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct BlockWithId {
     pub id: Nat,
     pub block: Icrc3Value,

--- a/src/rumi_3pool/src/icrc3.rs
+++ b/src/rumi_3pool/src/icrc3.rs
@@ -207,7 +207,10 @@ pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
         } else {
             Some(
                 crate::storage::block_hashes::get(start - 1)
-                    .expect("hash cache must cover all blocks; backfill runs in post_upgrade")
+                    .expect(
+                        "hash cache must cover all blocks: the post_upgrade \
+                         backfill + integrity check enforces this invariant"
+                    )
                     .0,
             )
         };

--- a/src/rumi_3pool/src/icrc3.rs
+++ b/src/rumi_3pool/src/icrc3.rs
@@ -194,25 +194,39 @@ pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
         if start >= log_length {
             continue;
         }
-
         let end = std::cmp::min(start.saturating_add(length), log_length);
+        if end <= start {
+            continue;
+        }
 
-        // Rebuild hash chain for the requested range so we can include phash.
-        // We must compute hashes from block 0 up to `end` to get the parent
-        // hash for the first requested block. This is O(end) per request —
-        // acceptable for typical index-ng polling windows; if it becomes a
-        // hot path we can cache cumulative hashes alongside the blocks log.
-        let prefix = crate::storage::blocks::range(0, end);
-        let mut prev_hash: Option<[u8; 32]> = None;
-        for block in &prefix {
+        // Parent hash for the first requested block: cached at index
+        // (start - 1), or None if start == 0. Tasks 4-5 guarantee the
+        // cache covers all blocks via post_upgrade backfill.
+        let mut prev_hash: Option<[u8; 32]> = if start == 0 {
+            None
+        } else {
+            Some(
+                crate::storage::block_hashes::get(start - 1)
+                    .expect("hash cache must cover all blocks; backfill runs in post_upgrade")
+                    .0,
+            )
+        };
+
+        // Read only the requested range from the blocks log. Encoding +
+        // hashing happens once per returned block, replacing the old
+        // O(end) chain rebuild.
+        let blocks = crate::storage::blocks::range(start, end - start);
+        for block in &blocks {
             let encoded = encode_block_with_phash(block, prev_hash.as_ref());
+            // Compute the running hash so the next iteration has its parent.
+            // For the LAST block in this range, prev_hash is not read again,
+            // but computing it keeps the loop body symmetric and the cost is
+            // a single SHA-256 over the encoded value.
             let block_hash = crate::certification::hash_value(&encoded);
-            if block.id >= start {
-                result_blocks.push(BlockWithId {
-                    id: Nat::from(block.id),
-                    block: encoded,
-                });
-            }
+            result_blocks.push(BlockWithId {
+                id: Nat::from(block.id),
+                block: encoded,
+            });
             prev_hash = Some(block_hash);
         }
     }
@@ -220,7 +234,7 @@ pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
     GetBlocksResult {
         log_length: Nat::from(log_length),
         blocks: result_blocks,
-        archived_blocks: vec![], // No archiving
+        archived_blocks: vec![],
     }
 }
 

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -2110,6 +2110,16 @@ pub fn test_get_raw_block(id: u64) -> Option<types::Icrc3Block> {
     storage::blocks::get(id)
 }
 
+/// Test-only: clear the ICRC-3 hash cache. Used by tests to simulate the
+/// pre-Task-3 mainnet state where blocks exist but the cache is empty.
+/// The post_upgrade hook (Task 5) backfills the cache; this endpoint lets
+/// tests force the canister into the pre-backfill state to exercise it.
+#[cfg(any(feature = "test_endpoints", test))]
+#[update]
+pub fn test_clear_hash_cache() {
+    storage::clear_block_hashes_for_test();
+}
+
 #[cfg(test)]
 mod bot_endpoint_tests {
     use super::*;

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -988,6 +988,9 @@ pub fn get_admin_fees() -> Vec<u128> {
     read_state(|s| s.admin_fees.to_vec())
 }
 
+// PERFORMANCE NOTE: O(N) over all VP snapshots. At 4 snapshots/day this
+// grows ~1500/year. Currently called by explorer charts; not a hot path.
+// Watch threshold: vp_snap::len() > 10_000 (i.e. ~7 years of snapshots).
 /// Returns all virtual_price snapshots for APY calculation and historical charts.
 #[query]
 pub fn get_vp_snapshots() -> Vec<VirtualPriceSnapshot> {

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -138,6 +138,39 @@ fn post_upgrade() {
         }
     }
 
+    // ── ICRC-3 hash-chain cache: backfill (if needed) and verify ──
+    //
+    // First post_upgrade after this change ships will backfill all
+    // pre-existing blocks. Every subsequent upgrade hits the early-return
+    // inside backfill and the checks below run cheaply.
+    storage::migration::backfill_hash_chain();
+
+    let blocks_len = storage::blocks::len();
+    let hashes_len = storage::block_hashes::len();
+    if hashes_len != blocks_len {
+        ic_cdk::trap(&format!(
+            "post_upgrade: ICRC-3 hash cache length mismatch. \
+             blocks={blocks_len} hashes={hashes_len}"
+        ));
+    }
+
+    if blocks_len > 0 {
+        let cached_tip = storage::block_hashes::get(blocks_len - 1)
+            .expect("cached tip present when blocks_len > 0")
+            .0;
+        let state_tip = read_state(|s| s.last_block_hash);
+        if Some(cached_tip) != state_tip {
+            ic_cdk::trap(&format!(
+                "post_upgrade: ICRC-3 cached tip != state.last_block_hash. \
+                 cached={:?} state={:?}",
+                cached_tip, state_tip
+            ));
+        }
+    }
+
+    log!(INFO,
+        "Rumi 3pool post-upgrade: hash cache OK. blocks={blocks_len} hashes={hashes_len}");
+
     setup_timers();
 }
 

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -53,6 +53,18 @@ fn pre_upgrade() {
     storage::set_slim(slim);
 }
 
+/// Lower-case hex of a 32-byte hash. Used in trap messages for ICRC-3
+/// hash-chain integrity checks so on-call output matches block-explorer
+/// formatting rather than the default `{:?}` decimal-byte rendering.
+fn hex_lower(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(&mut s, "{:02x}", b);
+    }
+    s
+}
+
 #[post_upgrade]
 fn post_upgrade() {
     // Step 1: BEFORE touching any storage::* thread-local, try to read a
@@ -143,6 +155,7 @@ fn post_upgrade() {
     // First post_upgrade after this change ships will backfill all
     // pre-existing blocks. Every subsequent upgrade hits the early-return
     // inside backfill and the checks below run cheaply.
+    let hashes_before_backfill = storage::block_hashes::len();
     storage::migration::backfill_hash_chain();
 
     let blocks_len = storage::blocks::len();
@@ -162,14 +175,19 @@ fn post_upgrade() {
         if Some(cached_tip) != state_tip {
             ic_cdk::trap(&format!(
                 "post_upgrade: ICRC-3 cached tip != state.last_block_hash. \
-                 cached={:?} state={:?}",
-                cached_tip, state_tip
+                 cached={} state={}",
+                hex_lower(&cached_tip),
+                state_tip.map(|h| hex_lower(&h)).unwrap_or_else(|| "None".to_string()),
             ));
         }
     }
 
-    log!(INFO,
-        "Rumi 3pool post-upgrade: hash cache OK. blocks={blocks_len} hashes={hashes_len}");
+    let backfilled = blocks_len.saturating_sub(hashes_before_backfill);
+    if backfilled > 0 {
+        log!(INFO,
+            "Rumi 3pool post-upgrade: backfilled {backfilled} ICRC-3 hashes. \
+             blocks={blocks_len} hashes={hashes_len}");
+    }
 
     setup_timers();
 }

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -2101,6 +2101,15 @@ pub fn icrc3_supported_block_types() -> Vec<icrc3::SupportedBlockType> {
     icrc3::icrc3_supported_block_types()
 }
 
+/// Test-only: return a raw `Icrc3Block` by id, bypassing ICRC-3 encoding.
+/// Used by the equivalence integration test as the ground truth for
+/// hash-chain comparisons. Never enabled in mainnet builds.
+#[cfg(any(feature = "test_endpoints", test))]
+#[query]
+pub fn test_get_raw_block(id: u64) -> Option<types::Icrc3Block> {
+    storage::blocks::get(id)
+}
+
 #[cfg(test)]
 mod bot_endpoint_tests {
     use super::*;

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -2121,8 +2121,11 @@ pub fn test_clear_hash_cache() {
 }
 
 /// Test-only: append a bogus 32-byte entry to `block_hashes`, making it
-/// strictly longer than `blocks`. The next `post_upgrade` should trap
-/// on the length-mismatch integrity check (Task 5).
+/// strictly longer than `blocks`. The next upgrade will trap. In practice
+/// `backfill_hash_chain` catches the inversion first (defense-in-depth
+/// added in the Task 4 fixup); the post_upgrade parity check (Task 5)
+/// is the secondary catcher for any case where backfill returns without
+/// detecting it.
 #[cfg(any(feature = "test_endpoints", test))]
 #[update]
 pub fn test_corrupt_hash_cache_tip(bogus_hash: Vec<u8>) {

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -2120,6 +2120,18 @@ pub fn test_clear_hash_cache() {
     storage::clear_block_hashes_for_test();
 }
 
+/// Test-only: append a bogus 32-byte entry to `block_hashes`, making it
+/// strictly longer than `blocks`. The next `post_upgrade` should trap
+/// on the length-mismatch integrity check (Task 5).
+#[cfg(any(feature = "test_endpoints", test))]
+#[update]
+pub fn test_corrupt_hash_cache_tip(bogus_hash: Vec<u8>) {
+    assert_eq!(bogus_hash.len(), 32, "bogus hash must be 32 bytes");
+    let mut h = [0u8; 32];
+    h.copy_from_slice(&bogus_hash);
+    storage::push_bogus_hash_for_test(h);
+}
+
 #[cfg(test)]
 mod bot_endpoint_tests {
     use super::*;

--- a/src/rumi_3pool/src/state.rs
+++ b/src/rumi_3pool/src/state.rs
@@ -218,6 +218,14 @@ impl ThreePoolState {
         self.liquidity_events.get_or_insert_with(Vec::new)
     }
 
+    // PERFORMANCE NOTE: O(N) over all swap events. Used by explorer queries
+    // (`get_top_swappers`, `get_volume_series`). Not currently a hot path
+    // because these are user-driven, not auto-polled. If swap volume grows
+    // or a frontend starts polling these on a short interval, consider:
+    //   1. Adding a windowed cache keyed by `StatsWindow` (heap-only).
+    //   2. Maintaining running aggregates in `state` updated on every swap.
+    // Watch threshold: swap_v2::len() > 50_000 OR per-day query count from
+    // explorer > 1_000 (check threeusd_index logs and replica metrics).
     /// Snapshot every v2 swap event currently stored in `storage::swap_v2`.
     ///
     /// Returns a freshly allocated `Vec` — reads go through the stable log,
@@ -229,6 +237,11 @@ impl ThreePoolState {
         crate::storage::swap_v2::iter_all()
     }
 
+    // PERFORMANCE NOTE: O(N) over all liquidity events. Used by explorer
+    // queries that aggregate AddLiquidity / RemoveLiquidity activity.
+    // Same considerations as `swap_events_v2` apply: this becomes a cycle
+    // burner if event volume grows or polling frequency increases.
+    // Watch threshold: liq_v2::len() > 50_000.
     /// Snapshot every v2 liquidity event. See `swap_events_v2` for notes.
     pub fn liquidity_events_v2(&self) -> Vec<LiquidityEventV2> {
         crate::storage::liq_v2::iter_all()

--- a/src/rumi_3pool/src/state.rs
+++ b/src/rumi_3pool/src/state.rs
@@ -142,25 +142,27 @@ impl ThreePoolState {
 
     /// Log a transaction block, compute its hash, update certified data,
     /// and return its index.
-    /// Block IDs are sequential starting from 0, matching Vec position,
-    /// so that ICRC-3 `log_length` == `blocks.len()` and `start` indexing works.
+    ///
+    /// Block IDs are sequential starting from 0, matching `StableLog` index.
+    /// The hash of each block is also pushed to `storage::block_hashes` so
+    /// `icrc3_get_blocks` can fetch a parent hash in O(1) rather than
+    /// recomputing the chain from block 0.
+    ///
+    /// Both writes happen inside this single message; IC message-level
+    /// atomicity guarantees they cannot diverge.
     pub fn log_block(&mut self, tx: crate::types::Icrc3Transaction) -> u64 {
-        // Block IDs are sequential starting from 0; the StableLog index
-        // provides the ordering. After the A6 drain, storage::blocks::len()
-        // equals the legacy heap len, so new IDs continue uninterrupted.
         let id = crate::storage::blocks::len();
         let block = crate::types::Icrc3Block {
             id,
             timestamp: ic_cdk::api::time(),
             tx,
         };
-        // Compute hash: encode block with parent hash, then hash the value.
         let prev_hash = self.last_block_hash;
         let encoded = crate::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
         let block_hash = crate::certification::hash_value(&encoded);
         crate::storage::blocks::push(block);
+        crate::storage::block_hashes::push(crate::storage::StorableHash(block_hash));
         self.last_block_hash = Some(block_hash);
-        // Update IC certified data so index-ng can verify the chain tip
         crate::certification::set_certified_tip(id, &block_hash);
         id
     }

--- a/src/rumi_3pool/src/state.rs
+++ b/src/rumi_3pool/src/state.rs
@@ -149,7 +149,10 @@ impl ThreePoolState {
     /// recomputing the chain from block 0.
     ///
     /// Both writes happen inside this single message; IC message-level
-    /// atomicity guarantees they cannot diverge.
+    /// atomicity guarantees they cannot diverge for blocks logged after
+    /// this code ships. Pre-existing blocks (logged before the cache was
+    /// introduced) are populated by the post_upgrade backfill in
+    /// `storage::migration::backfill_hash_chain`.
     pub fn log_block(&mut self, tx: crate::types::Icrc3Transaction) -> u64 {
         let id = crate::storage::blocks::len();
         let block = crate::types::Icrc3Block {

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -226,6 +226,29 @@ impl Storable for StorableU128 {
     };
 }
 
+/// 32-byte hash stored verbatim. Used for the ICRC-3 cumulative hash-chain
+/// cache so that `icrc3_get_blocks` can fetch a block's parent hash in O(1)
+/// instead of recomputing the chain from block 0.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct StorableHash(pub [u8; 32]);
+
+impl Storable for StorableHash {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.0.to_vec())
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes.as_ref());
+        StorableHash(arr)
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+}
+
 /// Empty marker for set-style BTreeMaps (`BTreeMap<K, ()>` isn't supported
 /// directly because `()` would need a Storable impl we don't control).
 #[derive(Clone, Copy, Debug, Default)]
@@ -918,5 +941,21 @@ mod tests {
         assert!(back.swap_events_v2.is_none());
         assert!(back.blocks.is_none());
         assert_eq!(back.lp_total_supply, 0);
+    }
+
+    #[test]
+    fn storable_hash_roundtrip() {
+        let original = [0xABu8; 32];
+        let sh = StorableHash(original);
+        let bytes = sh.to_bytes();
+        let back = StorableHash::from_bytes(bytes);
+        assert_eq!(back.0, original);
+    }
+
+    #[test]
+    fn storable_hash_distinct_values() {
+        let a = StorableHash([1u8; 32]);
+        let b = StorableHash([2u8; 32]);
+        assert_ne!(a.to_bytes(), b.to_bytes());
     }
 }

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -12,7 +12,7 @@
 //     first time on the new wasm (one-shot drain from the legacy blob) or
 //     subsequent times (load `SlimState` from its cell).
 //
-// Memory ID layout (18 IDs used; 255 available):
+// Memory ID layout (20 IDs used; 255 available):
 //
 //   0       SlimState cell              — bounded residual heap
 //   1       lp_balances                 — BTreeMap<Principal, u128>
@@ -25,6 +25,8 @@
 //   12,13   admin_events log
 //   14,15   vp_snapshots log
 //   16,17   icrc3_blocks log
+//   18,19   icrc3_block_hashes log      — cumulative hash chain cache (parallel
+//                                         to blocks log; entry i == hash of block i)
 //
 // Migration semantics: the first `post_upgrade` after the Phase A deploy runs
 // a one-shot drain (see `storage::migration`). All subsequent upgrades just
@@ -70,6 +72,8 @@ const MEM_VP_SNAP_INDEX: MemoryId = MemoryId::new(14);
 const MEM_VP_SNAP_DATA: MemoryId = MemoryId::new(15);
 const MEM_BLOCKS_INDEX: MemoryId = MemoryId::new(16);
 const MEM_BLOCKS_DATA: MemoryId = MemoryId::new(17);
+const MEM_BLOCK_HASHES_INDEX: MemoryId = MemoryId::new(18);
+const MEM_BLOCK_HASHES_DATA: MemoryId = MemoryId::new(19);
 
 // ─── SlimState ───────────────────────────────────────────────────────────────
 //
@@ -383,6 +387,15 @@ thread_local! {
             )
             .expect("init blocks log"),
         );
+
+    pub(crate) static BLOCK_HASHES_LOG: RefCell<StableLog<StorableHash, Memory, Memory>> =
+        RefCell::new(
+            StableLog::init(
+                MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_INDEX)),
+                MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_DATA)),
+            )
+            .expect("init block_hashes log"),
+        );
 }
 
 // ─── Public API: SlimState cell ──────────────────────────────────────────────
@@ -534,6 +547,7 @@ log_api!(liq_v2, LIQ_V2_LOG, LiquidityEventV2);
 log_api!(admin_ev, ADMIN_EV_LOG, ThreePoolAdminEvent);
 log_api!(vp_snap, VP_SNAP_LOG, VirtualPriceSnapshot);
 log_api!(blocks, BLOCKS_LOG, Icrc3Block);
+log_api!(block_hashes, BLOCK_HASHES_LOG, StorableHash);
 
 // ─── Migration: one-shot drain from the legacy raw-offset-0 blob ─────────────
 
@@ -957,5 +971,14 @@ mod tests {
         let a = StorableHash([1u8; 32]);
         let b = StorableHash([2u8; 32]);
         assert_ne!(a.to_bytes(), b.to_bytes());
+    }
+
+    #[test]
+    fn block_hashes_log_initializes_empty() {
+        // Smoke check: the log API is callable and `len()` returns 0 on a
+        // fresh thread-local. Other tests in this binary may push entries
+        // before this one runs depending on test ordering, so we only
+        // assert non-panic — not strict zero.
+        let _ = block_hashes::len();
     }
 }

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -549,6 +549,26 @@ log_api!(vp_snap, VP_SNAP_LOG, VirtualPriceSnapshot);
 log_api!(blocks, BLOCKS_LOG, Icrc3Block);
 log_api!(block_hashes, BLOCK_HASHES_LOG, StorableHash);
 
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/// Test-only: forcibly clear the `block_hashes` log to length 0.
+///
+/// Used by integration tests to simulate the pre-Task-3 mainnet state
+/// where blocks exist but the hash cache is empty. Reinitializes the
+/// `StableLog` over the same memory IDs, which zeros the index header.
+///
+/// NEVER call this from production code. The post_upgrade backfill
+/// (Task 5) repopulates the cache, but until that runs the canister
+/// would serve broken icrc3_get_blocks responses.
+#[cfg(any(feature = "test_endpoints", test))]
+pub fn clear_block_hashes_for_test() {
+    BLOCK_HASHES_LOG.with(|l| {
+        let idx_mem = MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_INDEX));
+        let dat_mem = MM.with(|m| m.borrow().get(MEM_BLOCK_HASHES_DATA));
+        *l.borrow_mut() = StableLog::new(idx_mem, dat_mem);
+    });
+}
+
 // ─── Migration: one-shot drain from the legacy raw-offset-0 blob ─────────────
 
 pub mod migration {

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -552,8 +552,18 @@ log_api!(block_hashes, BLOCK_HASHES_LOG, StorableHash);
 // ─── Migration: one-shot drain from the legacy raw-offset-0 blob ─────────────
 
 pub mod migration {
-    //! One-shot drain of the legacy pre-Phase-A state layout into the new
-    //! stable structures.
+    //! Post-upgrade migration helpers.
+    //!
+    //! Two functions live here:
+    //!
+    //!   1. `read_legacy_blob` + `drain_legacy_state` are the one-shot
+    //!      Phase A drain that moved heap collections to stable structures.
+    //!      Already shipped on mainnet; subsequent upgrades skip the drain.
+    //!
+    //!   2. `backfill_hash_chain` brings the ICRC-3 `block_hashes` log up
+    //!      to parity with the `blocks` log. Idempotent and called on every
+    //!      upgrade. The first upgrade after the cache shipped fills all
+    //!      pre-existing blocks; subsequent upgrades early-return.
     //!
     //! ## Safety argument
     //!
@@ -755,11 +765,23 @@ pub mod migration {
     /// Trapping inside this function rolls back stable memory atomically per
     /// IC `post_upgrade` semantics, so partial backfills cannot persist.
     pub fn backfill_hash_chain() {
+        // INVARIANT: the hash computation here MUST match
+        // `ThreePoolState::log_block` in state.rs (same encode_block_with_phash
+        // call with the same prev_hash semantics, same hash_value over the
+        // result). If you change the hash representation in either place,
+        // change it in both, or the chain will silently diverge for any
+        // backfilled blocks.
         let blocks_len = crate::storage::blocks::len();
         let hashes_len = crate::storage::block_hashes::len();
-        if hashes_len >= blocks_len {
-            // Already up to date. (`>` would be a logic bug; we tolerate it
-            // here and let the integrity check in post_upgrade trap on it.)
+        if hashes_len > blocks_len {
+            ic_cdk::trap(&format!(
+                "block_hashes ({hashes_len}) exceeds blocks ({blocks_len}): \
+                 hash cache is corrupted. This invariant is also re-checked \
+                 in post_upgrade, but failing fast here makes the failure \
+                 mode local."
+            ));
+        }
+        if hashes_len == blocks_len {
             return;
         }
 
@@ -1031,6 +1053,15 @@ mod tests {
 
     #[test]
     fn backfill_is_idempotent_when_cache_is_full() {
+        // NOTE: This test (and `backfill_fills_missing_hashes_correctly` below)
+        // shares the storage thread_locals with every other test in this binary.
+        // Under `cargo test`'s default parallel execution they may silently
+        // early-out if another test has perturbed the logs first. This is
+        // acceptable here because Task 7's PocketIC integration tests exercise
+        // the full backfill path against a hermetically-isolated canister
+        // instance and provide the load-bearing coverage. These unit tests
+        // are best-effort regression catchers for development iteration.
+        //
         // After Task 3, every push to blocks already pushes to block_hashes.
         // So if both logs have the same length, backfill should be a no-op.
         let blocks_before = blocks::len();

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -740,6 +740,53 @@ pub mod migration {
             }
         }
     }
+
+    /// Backfill `block_hashes` to match `blocks` length.
+    ///
+    /// After this function returns:
+    ///   * `block_hashes::len() == blocks::len()`
+    ///   * For every `i in 0..blocks::len()`, `block_hashes::get(i)` equals
+    ///     the SHA-256 of the ICRC-3 encoding of `blocks::get(i)` with the
+    ///     correct parent hash.
+    ///
+    /// Idempotent: a no-op when the lengths already match. Safe to call from
+    /// `post_upgrade` on every upgrade (steady-state cost: 2 stable reads).
+    ///
+    /// Trapping inside this function rolls back stable memory atomically per
+    /// IC `post_upgrade` semantics, so partial backfills cannot persist.
+    pub fn backfill_hash_chain() {
+        let blocks_len = crate::storage::blocks::len();
+        let hashes_len = crate::storage::block_hashes::len();
+        if hashes_len >= blocks_len {
+            // Already up to date. (`>` would be a logic bug; we tolerate it
+            // here and let the integrity check in post_upgrade trap on it.)
+            return;
+        }
+
+        // Recompute the chain from block 0 up to (but not including) the
+        // first missing index. We need the parent hash for the first block
+        // we are about to fill, which is the cached hash of (start - 1) if
+        // any cache exists, or computed from scratch if hashes_len == 0.
+        let start = hashes_len;
+        let mut prev_hash: Option<[u8; 32]> = if start == 0 {
+            None
+        } else {
+            Some(
+                crate::storage::block_hashes::get(start - 1)
+                    .expect("cached hash present below hashes_len")
+                    .0,
+            )
+        };
+
+        for i in start..blocks_len {
+            let block = crate::storage::blocks::get(i)
+                .expect("block present below blocks_len");
+            let encoded = crate::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
+            let block_hash = crate::certification::hash_value(&encoded);
+            crate::storage::block_hashes::push(crate::storage::StorableHash(block_hash));
+            prev_hash = Some(block_hash);
+        }
+    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -980,5 +1027,74 @@ mod tests {
         // this log, this test may need to be marked #[ignore] or restructured
         // to check len-equals-blocks::len() instead.
         assert_eq!(block_hashes::len(), 0);
+    }
+
+    #[test]
+    fn backfill_is_idempotent_when_cache_is_full() {
+        // After Task 3, every push to blocks already pushes to block_hashes.
+        // So if both logs have the same length, backfill should be a no-op.
+        let blocks_before = blocks::len();
+        let hashes_before = block_hashes::len();
+        if blocks_before != hashes_before {
+            // We cannot run this test in isolation if other tests left the
+            // logs in an inconsistent state. Skip rather than fail.
+            return;
+        }
+        crate::storage::migration::backfill_hash_chain();
+        assert_eq!(blocks::len(), blocks_before);
+        assert_eq!(block_hashes::len(), hashes_before);
+    }
+
+    #[test]
+    fn backfill_fills_missing_hashes_correctly() {
+        use crate::types::{Icrc3Block, Icrc3Transaction};
+        use candid::Principal;
+
+        // Push three blocks via the storage API directly (skipping log_block,
+        // which would also write to block_hashes). This simulates the
+        // "existing mainnet state" scenario where blocks exist but the
+        // hash-chain cache is empty.
+        let baseline = blocks::len();
+        let hash_baseline = block_hashes::len();
+        if baseline != hash_baseline {
+            return;
+        }
+
+        let p = Principal::anonymous();
+        for i in 0..3u64 {
+            let block = Icrc3Block {
+                id: baseline + i,
+                timestamp: 1_000 + i,
+                tx: Icrc3Transaction::Mint {
+                    to: p,
+                    amount: 100 + i as u128,
+                    to_subaccount: None,
+                },
+            };
+            blocks::push(block);
+        }
+
+        assert_eq!(blocks::len(), baseline + 3);
+        assert_eq!(block_hashes::len(), hash_baseline);
+
+        crate::storage::migration::backfill_hash_chain();
+
+        assert_eq!(block_hashes::len(), baseline + 3);
+
+        // Verify every newly added hash is consistent with its block's
+        // ICRC-3 encoding under the correct parent.
+        let mut prev = if baseline == 0 {
+            None
+        } else {
+            Some(block_hashes::get(baseline - 1).unwrap().0)
+        };
+        for i in baseline..baseline + 3 {
+            let block = blocks::get(i).unwrap();
+            let encoded = crate::icrc3::encode_block_with_phash(&block, prev.as_ref());
+            let expected = crate::certification::hash_value(&encoded);
+            let cached = block_hashes::get(i).unwrap().0;
+            assert_eq!(cached, expected, "hash mismatch at index {i}");
+            prev = Some(cached);
+        }
     }
 }

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -569,6 +569,19 @@ pub fn clear_block_hashes_for_test() {
     });
 }
 
+/// Test-only: append a bogus hash entry to `block_hashes`, making
+/// `block_hashes::len() == blocks::len() + 1`. Used by integration tests
+/// to verify the post_upgrade integrity check traps on cache corruption.
+///
+/// NEVER call from production code.
+#[cfg(any(feature = "test_endpoints", test))]
+pub fn push_bogus_hash_for_test(bogus: [u8; 32]) {
+    BLOCK_HASHES_LOG.with(|l| {
+        let mut log = l.borrow_mut();
+        log.append(&StorableHash(bogus)).expect("append bogus hash");
+    });
+}
+
 // ─── Migration: one-shot drain from the legacy raw-offset-0 blob ─────────────
 
 pub mod migration {

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -975,10 +975,10 @@ mod tests {
 
     #[test]
     fn block_hashes_log_initializes_empty() {
-        // Smoke check: the log API is callable and `len()` returns 0 on a
-        // fresh thread-local. Other tests in this binary may push entries
-        // before this one runs depending on test ordering, so we only
-        // assert non-panic — not strict zero.
-        let _ = block_hashes::len();
+        // At this point in the codebase no test mutates the block_hashes log,
+        // so it must be empty. If a future task adds a test that pushes to
+        // this log, this test may need to be marked #[ignore] or restructured
+        // to check len-equals-blocks::len() instead.
+        assert_eq!(block_hashes::len(), 0);
     }
 }

--- a/src/rumi_3pool/tests/common/mod.rs
+++ b/src/rumi_3pool/tests/common/mod.rs
@@ -1,0 +1,360 @@
+// Shared PocketIC harness for 3pool integration tests.
+//
+// Wraps PocketIC + the three ICRC-1 ledgers + the 3pool canister behind a
+// `ThreePoolHarness` struct so individual tests stay focused on assertions
+// rather than setup boilerplate.
+
+#![allow(dead_code)]
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use icrc_ledger_types::icrc1::account::Account;
+use icrc_ledger_types::icrc2::approve::ApproveArgs;
+use pocket_ic::{PocketIcBuilder, WasmResult};
+use rumi_3pool::icrc3::{BlockWithId, GetBlocksArgs, GetBlocksResult};
+use rumi_3pool::types::*;
+
+// ─── Candid types for ICRC-1 ledger initialization ───
+
+#[derive(CandidType, Deserialize)]
+pub struct FeatureFlags {
+    pub icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ArchiveOptions {
+    pub num_blocks_to_archive: u64,
+    pub trigger_threshold: u64,
+    pub controller_id: Principal,
+    pub max_transactions_per_response: Option<u64>,
+    pub max_message_size_bytes: Option<u64>,
+    pub cycles_for_archive_creation: Option<u64>,
+    pub node_max_memory_size_bytes: Option<u64>,
+    pub more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum MetadataValue {
+    Nat(candid::Nat),
+    Int(candid::Int),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct LedgerInitArgs {
+    pub minting_account: Account,
+    pub fee_collector_account: Option<Account>,
+    pub transfer_fee: candid::Nat,
+    pub decimals: Option<u8>,
+    pub max_memo_length: Option<u16>,
+    pub token_name: String,
+    pub token_symbol: String,
+    pub metadata: Vec<(String, MetadataValue)>,
+    pub initial_balances: Vec<(Account, candid::Nat)>,
+    pub feature_flags: Option<FeatureFlags>,
+    pub maximum_number_of_accounts: Option<u64>,
+    pub accounts_overflow_trim_quantity: Option<u64>,
+    pub archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum LedgerArg {
+    Init(LedgerInitArgs),
+}
+
+// ─── WASM loaders ───
+
+pub fn icrc1_ledger_wasm() -> Vec<u8> {
+    // Path: from src/rumi_3pool/tests/common/ back to src/rumi_3pool/ledger/
+    include_bytes!("../../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+pub fn three_pool_wasm() -> Vec<u8> {
+    // Both integration_test.rs and icrc3_hash_cache.rs include the same
+    // WASM file. Build with `--features test_endpoints` if you need the
+    // test_get_raw_block endpoint exposed (icrc3_hash_cache.rs needs it;
+    // integration_test.rs doesn't but the endpoint being present is harmless).
+    include_bytes!("../../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm").to_vec()
+}
+
+// ─── Harness ───
+
+pub struct ThreePoolHarness {
+    pub pic: pocket_ic::PocketIc,
+    pub admin: Principal,
+    pub user: Principal,
+    pub three_pool: Principal,
+    pub ledgers: [Principal; 3],
+}
+
+impl ThreePoolHarness {
+    pub fn icrc3_get_blocks(&self, start: u64, length: u64) -> Vec<BlockWithId> {
+        let arg = vec![GetBlocksArgs {
+            start: Nat::from(start),
+            length: Nat::from(length),
+        }];
+        let bytes = self
+            .pic
+            .query_call(
+                self.three_pool,
+                Principal::anonymous(),
+                "icrc3_get_blocks",
+                encode_one(arg).unwrap(),
+            )
+            .expect("icrc3_get_blocks query failed");
+        let WasmResult::Reply(reply) = bytes else {
+            panic!("icrc3_get_blocks rejected")
+        };
+        let result: GetBlocksResult = decode_one(&reply).unwrap();
+        result.blocks
+    }
+
+    pub fn icrc3_log_length(&self) -> u64 {
+        let arg = vec![GetBlocksArgs {
+            start: Nat::from(0u64),
+            length: Nat::from(0u64),
+        }];
+        let bytes = self
+            .pic
+            .query_call(
+                self.three_pool,
+                Principal::anonymous(),
+                "icrc3_get_blocks",
+                encode_one(arg).unwrap(),
+            )
+            .expect("icrc3_get_blocks query failed");
+        let WasmResult::Reply(reply) = bytes else {
+            panic!("icrc3_get_blocks rejected")
+        };
+        let result: GetBlocksResult = decode_one(&reply).unwrap();
+        result.log_length.0.try_into().unwrap()
+    }
+
+    /// Read a single raw block via the test-only test_get_raw_block endpoint.
+    /// Used by the reference impl in `icrc3_hash_cache.rs` to walk the chain
+    /// from scratch without going through icrc3_get_blocks.
+    pub fn get_raw_block(&self, id: u64) -> Icrc3Block {
+        let bytes = self
+            .pic
+            .query_call(
+                self.three_pool,
+                Principal::anonymous(),
+                "test_get_raw_block",
+                encode_one(id).unwrap(),
+            )
+            .expect("test_get_raw_block query failed");
+        let WasmResult::Reply(reply) = bytes else {
+            panic!("test_get_raw_block rejected")
+        };
+        decode_one::<Option<Icrc3Block>>(&reply)
+            .unwrap()
+            .unwrap_or_else(|| panic!("block {id} missing"))
+    }
+}
+
+struct LedgerSpec {
+    name: &'static str,
+    symbol: &'static str,
+    decimals: u8,
+    initial_balance: u128,
+}
+
+/// Deploy the pool with bootstrap liquidity. Then perform `n_swaps`
+/// alternating swaps to generate additional ICRC-3 blocks.
+///
+/// Returns a harness with at least `n_swaps` + a handful of LP-token mint
+/// blocks in the ICRC-3 log.
+pub fn deploy_pool_with_liquidity_and_swaps(n_swaps: u64) -> ThreePoolHarness {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    let minting_account = Principal::self_authenticating(&[100, 100, 100]);
+    let user = Principal::self_authenticating(&[1, 2, 3, 4]);
+    let admin = Principal::self_authenticating(&[5, 6, 7, 8]);
+
+    let ledger_specs = [
+        LedgerSpec {
+            name: "icUSD",
+            symbol: "icUSD",
+            decimals: 8,
+            initial_balance: 1_000_000_000_000_000, // 10M with 8 decimals
+        },
+        LedgerSpec {
+            name: "ckUSDT",
+            symbol: "ckUSDT",
+            decimals: 6,
+            initial_balance: 10_000_000_000_000, // 10M with 6 decimals
+        },
+        LedgerSpec {
+            name: "ckUSDC",
+            symbol: "ckUSDC",
+            decimals: 6,
+            initial_balance: 10_000_000_000_000, // 10M with 6 decimals
+        },
+    ];
+
+    let mut ledger_ids = Vec::new();
+    for spec in &ledger_specs {
+        let ledger_id = pic.create_canister();
+        pic.add_cycles(ledger_id, 2_000_000_000_000);
+        let init_args = LedgerInitArgs {
+            minting_account: Account {
+                owner: minting_account,
+                subaccount: None,
+            },
+            fee_collector_account: None,
+            transfer_fee: candid::Nat::from(0u64),
+            decimals: Some(spec.decimals),
+            max_memo_length: Some(32),
+            token_name: spec.name.to_string(),
+            token_symbol: spec.symbol.to_string(),
+            metadata: vec![],
+            initial_balances: vec![(
+                Account {
+                    owner: user,
+                    subaccount: None,
+                },
+                candid::Nat::from(spec.initial_balance),
+            )],
+            feature_flags: Some(FeatureFlags { icrc2: true }),
+            maximum_number_of_accounts: None,
+            accounts_overflow_trim_quantity: None,
+            archive_options: ArchiveOptions {
+                num_blocks_to_archive: 2000,
+                trigger_threshold: 1000,
+                controller_id: admin,
+                max_transactions_per_response: None,
+                max_message_size_bytes: None,
+                cycles_for_archive_creation: None,
+                node_max_memory_size_bytes: None,
+                more_controller_ids: None,
+            },
+        };
+        let encoded = encode_args((LedgerArg::Init(init_args),)).unwrap();
+        pic.install_canister(ledger_id, icrc1_ledger_wasm(), encoded, None);
+        ledger_ids.push(ledger_id);
+    }
+
+    let pool_init_args = ThreePoolInitArgs {
+        tokens: [
+            TokenConfig {
+                ledger_id: ledger_ids[0],
+                symbol: "icUSD".to_string(),
+                decimals: 8,
+                precision_mul: 10_000_000_000,
+            },
+            TokenConfig {
+                ledger_id: ledger_ids[1],
+                symbol: "ckUSDT".to_string(),
+                decimals: 6,
+                precision_mul: 1_000_000_000_000,
+            },
+            TokenConfig {
+                ledger_id: ledger_ids[2],
+                symbol: "ckUSDC".to_string(),
+                decimals: 6,
+                precision_mul: 1_000_000_000_000,
+            },
+        ],
+        initial_a: 100,
+        swap_fee_bps: 4,
+        admin_fee_bps: 5000,
+        admin,
+    };
+
+    let pool_id = pic.create_canister();
+    pic.add_cycles(pool_id, 2_000_000_000_000);
+    pic.install_canister(
+        pool_id,
+        three_pool_wasm(),
+        encode_one(pool_init_args).unwrap(),
+        None,
+    );
+
+    // Approve pool on all 3 ledgers.
+    for ledger_id in &ledger_ids {
+        let approve_args = ApproveArgs {
+            from_subaccount: None,
+            spender: Account {
+                owner: pool_id,
+                subaccount: None,
+            },
+            amount: candid::Nat::from(u128::MAX),
+            expected_allowance: None,
+            expires_at: None,
+            fee: None,
+            memo: None,
+            created_at_time: None,
+        };
+        pic.update_call(
+            *ledger_id,
+            user,
+            "icrc2_approve",
+            encode_one(approve_args).unwrap(),
+        )
+        .expect("icrc2_approve failed");
+    }
+
+    // Seed pool with 1M / 1M / 1M.
+    let add_liq_amounts: Vec<u128> = vec![
+        100_000_000_000_000, // 1M icUSD (8 dec)
+        1_000_000_000_000,   // 1M ckUSDT (6 dec)
+        1_000_000_000_000,   // 1M ckUSDC (6 dec)
+    ];
+    let res = pic
+        .update_call(
+            pool_id,
+            user,
+            "add_liquidity",
+            encode_args((add_liq_amounts, 0u128)).unwrap(),
+        )
+        .expect("add_liquidity failed");
+    if let WasmResult::Reply(bytes) = res {
+        let r: Result<candid::Nat, ThreePoolError> = decode_one(&bytes).unwrap();
+        r.expect("add_liquidity err");
+    }
+
+    let harness = ThreePoolHarness {
+        pic,
+        admin,
+        user,
+        three_pool: pool_id,
+        ledgers: [ledger_ids[0], ledger_ids[1], ledger_ids[2]],
+    };
+
+    // Generate n_swaps additional ICRC-3 blocks by transferring 1 unit of LP
+    // token to a dummy recipient for each iteration. LP transfers are logged as
+    // ICRC-3 Transfer blocks. Swaps are NOT logged in the ICRC-3 chain (only
+    // LP token mint/burn/transfer/approve operations are).
+    let dummy_recipient = Principal::self_authenticating(&[99, 88, 77]);
+    for _ in 0..n_swaps {
+        let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
+            from_subaccount: None,
+            to: Account {
+                owner: dummy_recipient,
+                subaccount: None,
+            },
+            fee: None,
+            created_at_time: None,
+            memo: None,
+            amount: candid::Nat::from(1u64),
+        };
+        let res = harness
+            .pic
+            .update_call(
+                harness.three_pool,
+                harness.user,
+                "icrc1_transfer",
+                encode_one(transfer_args).unwrap(),
+            )
+            .expect("icrc1_transfer failed");
+        if let WasmResult::Reply(bytes) = res {
+            let r: Result<
+                candid::Nat,
+                icrc_ledger_types::icrc1::transfer::TransferError,
+            > = decode_one(&bytes).unwrap();
+            r.expect("icrc1_transfer returned err");
+        }
+    }
+
+    harness
+}

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -187,6 +187,44 @@ fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
 }
 
 #[test]
+fn post_upgrade_traps_on_hash_cache_length_mismatch() {
+    let harness = deploy_pool_with_liquidity_and_swaps(10);
+    assert_test_endpoints_built(&harness);
+
+    // Corrupt the cache by appending a bogus 32-byte hash. block_hashes::len()
+    // is now blocks::len() + 1, which both `backfill_hash_chain` and the
+    // post_upgrade integrity check should detect.
+    let bogus = vec![0xFFu8; 32];
+    let _ = harness.pic
+        .update_call(harness.three_pool, harness.admin, "test_corrupt_hash_cache_tip",
+                     candid::encode_one(bogus).unwrap())
+        .expect("test_corrupt_hash_cache_tip failed");
+
+    // Trigger an upgrade. post_upgrade traps; PocketIC reports the trap and
+    // rolls back stable memory atomically per IC spec, leaving the canister
+    // on the prior wasm.
+    let wasm = include_bytes!(
+        "../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm"
+    ).to_vec();
+    let result = harness.pic.upgrade_canister(harness.three_pool, wasm, vec![], None);
+
+    assert!(
+        result.is_err(),
+        "expected upgrade to trap on hash cache corruption, but it succeeded"
+    );
+
+    // Verify the trap message identifies the failure mode. We accept either
+    // the backfill_hash_chain trap ("block_hashes ... exceeds blocks ...")
+    // or the post_upgrade integrity-check trap ("hash cache length mismatch").
+    let err_str = format!("{:?}", result.err().unwrap());
+    let mentions_hash = err_str.contains("hash") || err_str.contains("block_hashes");
+    assert!(
+        mentions_hash,
+        "expected trap message to mention the hash cache, got: {err_str}"
+    );
+}
+
+#[test]
 fn post_upgrade_backfills_empty_hash_cache() {
     let harness = deploy_pool_with_liquidity_and_swaps(30);
     assert_test_endpoints_built(&harness);

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -164,10 +164,12 @@ fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
 
     // With the cache, cost is dominated by the per-update message base
     // plus a single block encode + hash. We expect the ratio to stay
-    // well under 2x even though log_length grew 4x. Without the cache,
-    // ratio would approach 4x.
+    // well under 1.5x even though log_length grew 4x. Without the cache,
+    // ratio would approach 4x. (Measured on the optimized branch: ratio
+    // is ~1.001x, so the 1.5x bound has ample margin against drift while
+    // catching subtler regressions than a looser 2x bound would.)
     assert!(
-        large_per_call < small_per_call * 2,
+        large_per_call * 2 < small_per_call * 3,
         "icrc3_get_blocks cycles per call grew super-linearly with log_length: \
          50 blocks: {small_per_call}, 200 blocks: {large_per_call}. \
          The hash-chain cache is not effective."

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -1,0 +1,106 @@
+// src/rumi_3pool/tests/icrc3_hash_cache.rs
+//
+// Verifies the ICRC-3 hash-chain cache optimization (Task 6) produces output
+// bit-identical to a from-scratch reference computation.
+//
+// The reference impl walks the raw block log from block 0, building the hash
+// chain incrementally without touching block_hashes::get. The optimized path
+// (icrc3_get_blocks) uses the cached tip hash. If any byte differs, this test
+// catches it before threeusd_index detects a chain break in production.
+
+mod common;
+
+use candid::Nat;
+use rumi_3pool::icrc3::{BlockWithId, Icrc3Value};
+
+use common::{deploy_pool_with_liquidity_and_swaps, ThreePoolHarness};
+
+/// Reference implementation: rebuild the entire hash chain from block 0,
+/// returning the ICRC-3 Value form of the requested range. This mirrors the
+/// pre-optimization O(N) logic and deliberately does NOT use block_hashes::get.
+fn reference_get_blocks(
+    harness: &ThreePoolHarness,
+    start: u64,
+    length: u64,
+) -> Vec<BlockWithId> {
+    let log_length = harness.icrc3_log_length();
+    let end = std::cmp::min(start.saturating_add(length), log_length);
+    if start >= end {
+        return vec![];
+    }
+
+    let mut prev_hash: Option<[u8; 32]> = None;
+    let mut out = Vec::new();
+
+    for i in 0..end {
+        let block = harness.get_raw_block(i);
+        let encoded: Icrc3Value =
+            rumi_3pool::icrc3::encode_block_with_phash(&block, prev_hash.as_ref());
+        let block_hash = rumi_3pool::certification::hash_value(&encoded);
+
+        if i >= start {
+            out.push(BlockWithId {
+                id: Nat::from(i),
+                block: encoded,
+            });
+        }
+
+        prev_hash = Some(block_hash);
+    }
+
+    out
+}
+
+#[test]
+fn icrc3_get_blocks_matches_reference_for_all_windows() {
+    // Deploy pool and run 50 swaps to produce a meaningful-length ICRC-3 log.
+    // Each swap emits at least one block, plus add_liquidity emits blocks too.
+    let harness = deploy_pool_with_liquidity_and_swaps(50);
+
+    let log_length = harness.icrc3_log_length();
+    assert!(
+        log_length >= 5,
+        "expected at least 5 blocks, got {log_length}"
+    );
+
+    // Adjust window list based on actual log_length.
+    let test_windows: Vec<(u64, u64)> = vec![
+        (0, 1),
+        (0, 10),
+        (0, log_length),
+        (log_length.saturating_sub(1), 1),
+        (log_length / 2, 5),
+        (log_length, 10),     // off-the-end -> empty
+        (log_length + 1, 5),  // past end -> empty
+        (5, 0),               // zero length -> empty
+    ];
+
+    for (start, length) in test_windows {
+        let optimized = harness.icrc3_get_blocks(start, length);
+        let reference = reference_get_blocks(&harness, start, length);
+
+        assert_eq!(
+            optimized.len(),
+            reference.len(),
+            "block count mismatch at window (start={start}, length={length}): \
+             optimized={}, reference={}",
+            optimized.len(),
+            reference.len(),
+        );
+
+        for (a, b) in optimized.iter().zip(reference.iter()) {
+            assert_eq!(
+                a.id, b.id,
+                "id mismatch at window (start={start}, length={length}): \
+                 optimized id={:?}, reference id={:?}",
+                a.id, b.id,
+            );
+            assert_eq!(
+                a.block, b.block,
+                "block content mismatch at window (start={start}, length={length}) \
+                 for block id={:?}",
+                a.id,
+            );
+        }
+    }
+}

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -15,6 +15,29 @@ use rumi_3pool::icrc3::{BlockWithId, GetBlocksArgs, Icrc3Value};
 
 use common::{deploy_pool_with_liquidity_and_swaps, ThreePoolHarness};
 
+/// Verify that the WASM running in the harness was built with
+/// `--features test_endpoints`. The two test-only endpoints
+/// (`test_get_raw_block`, `test_clear_hash_cache`) are gated behind that
+/// feature; without it, this whole test file is unrunnable.
+///
+/// Probing here gives a clear, actionable error message rather than
+/// letting individual update / query calls panic with PocketIC's
+/// generic "method not found" rejection deep inside an assertion loop.
+fn assert_test_endpoints_built(harness: &ThreePoolHarness) {
+    let probe = harness.pic.query_call(
+        harness.three_pool,
+        candid::Principal::anonymous(),
+        "test_get_raw_block",
+        candid::encode_one(0u64).unwrap(),
+    );
+    assert!(
+        probe.is_ok(),
+        "test-only endpoints missing from WASM. \
+         Rebuild with: cargo build -p rumi_3pool --release \
+         --target wasm32-unknown-unknown --features test_endpoints"
+    );
+}
+
 /// Reference implementation: rebuild the entire hash chain from block 0,
 /// returning the ICRC-3 Value form of the requested range. This mirrors the
 /// pre-optimization O(N) logic and deliberately does NOT use block_hashes::get.
@@ -56,23 +79,7 @@ fn icrc3_get_blocks_matches_reference_for_all_windows() {
     // Deploy pool and run 50 swaps to produce a meaningful-length ICRC-3 log.
     // Each swap emits at least one block, plus add_liquidity emits blocks too.
     let harness = deploy_pool_with_liquidity_and_swaps(50);
-
-    // Probe the test-only endpoint. If this fails, the WASM was almost
-    // certainly built without `--features test_endpoints`. Fail fast with
-    // a clear message rather than letting the assertion loop produce
-    // confusing "method not found" panics inside reference_get_blocks.
-    let probe_result = harness.pic.query_call(
-        harness.three_pool,
-        candid::Principal::anonymous(),
-        "test_get_raw_block",
-        candid::encode_one(0u64).unwrap(),
-    );
-    assert!(
-        probe_result.is_ok(),
-        "test_get_raw_block endpoint missing from WASM. \
-         Rebuild with: cargo build -p rumi_3pool --release \
-         --target wasm32-unknown-unknown --features test_endpoints"
-    );
+    assert_test_endpoints_built(&harness);
 
     let log_length = harness.icrc3_log_length();
     // 1 Mint (initial AddLiquidity) + 50 Transfers (deploy_pool's loop) = 51.
@@ -182,6 +189,7 @@ fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
 #[test]
 fn post_upgrade_backfills_empty_hash_cache() {
     let harness = deploy_pool_with_liquidity_and_swaps(30);
+    assert_test_endpoints_built(&harness);
 
     let log_length = harness.icrc3_log_length();
     assert!(log_length >= 30, "expected at least 30 blocks, got {log_length}");

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -178,3 +178,42 @@ fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
     // Sanity floor: at minimum the call costs more than a no-op message.
     assert!(small_per_call > 100_000, "suspiciously low: {small_per_call}");
 }
+
+#[test]
+fn post_upgrade_backfills_empty_hash_cache() {
+    let harness = deploy_pool_with_liquidity_and_swaps(30);
+
+    let log_length = harness.icrc3_log_length();
+    assert!(log_length >= 30, "expected at least 30 blocks, got {log_length}");
+
+    // Snapshot the current view of all blocks via the live optimized endpoint.
+    // After post_upgrade backfills the cleared cache, the response for the
+    // same query must be byte-identical.
+    let pre_upgrade_blocks = harness.icrc3_get_blocks(0, log_length);
+    assert_eq!(pre_upgrade_blocks.len(), log_length as usize);
+
+    // Clear the hash cache, simulating pre-Task-3 mainnet state.
+    let _ = harness.pic
+        .update_call(harness.three_pool, harness.admin, "test_clear_hash_cache",
+                     candid::encode_one(()).unwrap())
+        .expect("test_clear_hash_cache failed");
+
+    // Upgrade with the same wasm. post_upgrade runs backfill_hash_chain,
+    // which should detect hashes_len < blocks_len and refill all entries.
+    // Sender is None (PocketIC provisional mode allows the upgrade without
+    // a controller check, matching how we installed the canister initially).
+    let wasm = include_bytes!(
+        "../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm"
+    ).to_vec();
+    harness.pic
+        .upgrade_canister(harness.three_pool, wasm, vec![], None)
+        .expect("upgrade failed (post_upgrade likely trapped on integrity check)");
+
+    // After backfill, identical query response.
+    let post_upgrade_blocks = harness.icrc3_get_blocks(0, log_length);
+    assert_eq!(post_upgrade_blocks.len(), pre_upgrade_blocks.len());
+    for (a, b) in pre_upgrade_blocks.iter().zip(post_upgrade_blocks.iter()) {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.block, b.block, "block content changed across upgrade with backfill");
+    }
+}

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -57,11 +57,28 @@ fn icrc3_get_blocks_matches_reference_for_all_windows() {
     // Each swap emits at least one block, plus add_liquidity emits blocks too.
     let harness = deploy_pool_with_liquidity_and_swaps(50);
 
-    let log_length = harness.icrc3_log_length();
-    assert!(
-        log_length >= 5,
-        "expected at least 5 blocks, got {log_length}"
+    // Probe the test-only endpoint. If this fails, the WASM was almost
+    // certainly built without `--features test_endpoints`. Fail fast with
+    // a clear message rather than letting the assertion loop produce
+    // confusing "method not found" panics inside reference_get_blocks.
+    let probe_result = harness.pic.query_call(
+        harness.three_pool,
+        candid::Principal::anonymous(),
+        "test_get_raw_block",
+        candid::encode_one(0u64).unwrap(),
     );
+    assert!(
+        probe_result.is_ok(),
+        "test_get_raw_block endpoint missing from WASM. \
+         Rebuild with: cargo build -p rumi_3pool --release \
+         --target wasm32-unknown-unknown --features test_endpoints"
+    );
+
+    let log_length = harness.icrc3_log_length();
+    // 1 Mint (initial AddLiquidity) + 50 Transfers (deploy_pool's loop) = 51.
+    // Lower than this means LP token operations stopped generating ICRC-3
+    // blocks somewhere -- a regression worth catching here.
+    assert!(log_length >= 51, "expected at least 51 blocks, got {log_length}");
 
     // Adjust window list based on actual log_length.
     let test_windows: Vec<(u64, u64)> = vec![
@@ -69,6 +86,7 @@ fn icrc3_get_blocks_matches_reference_for_all_windows() {
         (0, 10),
         (0, log_length),
         (log_length.saturating_sub(1), 1),
+        (log_length.saturating_sub(1), 2),  // straddle: last valid + one past end
         (log_length / 2, 5),
         (log_length, 10),     // off-the-end -> empty
         (log_length + 1, 5),  // past end -> empty

--- a/src/rumi_3pool/tests/icrc3_hash_cache.rs
+++ b/src/rumi_3pool/tests/icrc3_hash_cache.rs
@@ -10,8 +10,8 @@
 
 mod common;
 
-use candid::Nat;
-use rumi_3pool::icrc3::{BlockWithId, Icrc3Value};
+use candid::{encode_one, Nat};
+use rumi_3pool::icrc3::{BlockWithId, GetBlocksArgs, Icrc3Value};
 
 use common::{deploy_pool_with_liquidity_and_swaps, ThreePoolHarness};
 
@@ -121,4 +121,58 @@ fn icrc3_get_blocks_matches_reference_for_all_windows() {
             );
         }
     }
+}
+
+#[test]
+fn icrc3_get_blocks_cycle_cost_is_constant_in_log_length() {
+    // We measure cycles burned per `icrc3_get_blocks` UPDATE call
+    // (replicated execution, i.e. the production polling path). With
+    // 200 blocks vs 50 blocks, the per-call cost should be approximately
+    // constant -- the hallmark of an O(range) algorithm. Without the
+    // cache, cost would be ~4x higher at 200 blocks.
+
+    fn cycles_per_call(harness: &common::ThreePoolHarness, n_calls: u32) -> u128 {
+        let log_length = harness.icrc3_log_length();
+        let last = log_length.saturating_sub(1);
+        let arg = encode_one(vec![GetBlocksArgs {
+            start: Nat::from(last),
+            length: Nat::from(1u64),
+        }]).unwrap();
+
+        let before = harness.pic.cycle_balance(harness.three_pool);
+        for _ in 0..n_calls {
+            let _ = harness.pic
+                .update_call(harness.three_pool, candid::Principal::anonymous(),
+                             "icrc3_get_blocks", arg.clone())
+                .expect("icrc3_get_blocks update failed");
+        }
+        let after = harness.pic.cycle_balance(harness.three_pool);
+        let burned = before.saturating_sub(after);
+        burned / (n_calls as u128)
+    }
+
+    // Build two harnesses with different block counts.
+    let small = common::deploy_pool_with_liquidity_and_swaps(50);
+    let large = common::deploy_pool_with_liquidity_and_swaps(200);
+
+    let small_per_call = cycles_per_call(&small, 50);
+    let large_per_call = cycles_per_call(&large, 50);
+
+    eprintln!(
+        "icrc3_get_blocks cycles/call: 50 blocks={small_per_call}, 200 blocks={large_per_call}"
+    );
+
+    // With the cache, cost is dominated by the per-update message base
+    // plus a single block encode + hash. We expect the ratio to stay
+    // well under 2x even though log_length grew 4x. Without the cache,
+    // ratio would approach 4x.
+    assert!(
+        large_per_call < small_per_call * 2,
+        "icrc3_get_blocks cycles per call grew super-linearly with log_length: \
+         50 blocks: {small_per_call}, 200 blocks: {large_per_call}. \
+         The hash-chain cache is not effective."
+    );
+
+    // Sanity floor: at minimum the call costs more than a no-op message.
+    assert!(small_per_call > 100_000, "suspiciously low: {small_per_call}");
 }

--- a/src/rumi_3pool/tests/integration_test.rs
+++ b/src/rumi_3pool/tests/integration_test.rs
@@ -1,68 +1,14 @@
-use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Principal};
+mod common;
+
+use candid::{decode_one, encode_args, encode_one, Principal};
+use common::{
+    icrc1_ledger_wasm, three_pool_wasm, ArchiveOptions, FeatureFlags, LedgerArg, LedgerInitArgs,
+};
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
 use pocket_ic::{PocketIcBuilder, WasmResult};
 
 use rumi_3pool::types::*;
-
-// ─── Candid types for ICRC-1 ledger initialization ───
-
-#[derive(CandidType, Deserialize)]
-struct FeatureFlags {
-    icrc2: bool,
-}
-
-#[derive(CandidType, Deserialize)]
-struct ArchiveOptions {
-    num_blocks_to_archive: u64,
-    trigger_threshold: u64,
-    controller_id: Principal,
-    max_transactions_per_response: Option<u64>,
-    max_message_size_bytes: Option<u64>,
-    cycles_for_archive_creation: Option<u64>,
-    node_max_memory_size_bytes: Option<u64>,
-    more_controller_ids: Option<Vec<Principal>>,
-}
-
-#[derive(CandidType, Deserialize)]
-enum MetadataValue {
-    Nat(candid::Nat),
-    Int(candid::Int),
-    Text(String),
-    Blob(Vec<u8>),
-}
-
-#[derive(CandidType, Deserialize)]
-struct LedgerInitArgs {
-    minting_account: Account,
-    fee_collector_account: Option<Account>,
-    transfer_fee: candid::Nat,
-    decimals: Option<u8>,
-    max_memo_length: Option<u16>,
-    token_name: String,
-    token_symbol: String,
-    metadata: Vec<(String, MetadataValue)>,
-    initial_balances: Vec<(Account, candid::Nat)>,
-    feature_flags: Option<FeatureFlags>,
-    maximum_number_of_accounts: Option<u64>,
-    accounts_overflow_trim_quantity: Option<u64>,
-    archive_options: ArchiveOptions,
-}
-
-#[derive(CandidType, Deserialize)]
-enum LedgerArg {
-    Init(LedgerInitArgs),
-}
-
-// ─── WASM loaders ───
-
-fn icrc1_ledger_wasm() -> Vec<u8> {
-    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
-}
-
-fn three_pool_wasm() -> Vec<u8> {
-    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_3pool.wasm").to_vec()
-}
 
 // ─── Integration Test ───
 


### PR DESCRIPTION
## Summary

- Adds a parallel `StableLog<StorableHash>` (memory IDs 18/19) that mirrors `block_hashes[i] == hash(block_i)`. `log_block` writes to both atomically; `icrc3_get_blocks` reads the parent hash directly instead of recomputing the entire chain from block 0 on every call. Per-call work drops from O(blocks_total) to O(requested_range).
- `post_upgrade` runs an idempotent `backfill_hash_chain` then a length-parity + tip-equality integrity check; either layer traps on cache corruption and rolls back atomically.
- Output of `icrc3_get_blocks` is bit-identical to the previous implementation. Empirically verified by a from-scratch reference impl in `tests/icrc3_hash_cache.rs` against 9 query windows.

## Empirical results

PocketIC cycle benchmark (`tests/icrc3_hash_cache.rs::icrc3_get_blocks_cycle_cost_is_constant_in_log_length`):

| log_length | optimized cycles/call | unoptimized cycles/call |
|---|---|---|
| 50 | 7,222,486 | 30,854,354 |
| 200 | 7,231,150 | 102,634,934 |
| ratio (200/50) | **1.001x** | **3.33x** |

The optimized cost is constant in `log_length` (the defining property). The unoptimized cost grows linearly. Test catches the regression — verified by stashing the optimization and confirming the assertion fires.

Mainnet pre-deploy: ~0.33 TC/day burn (CycleOps), 1474 ICRC-3 blocks. Post-deploy expected target: ~0.01 TC/day. The 24h soak will confirm.

## Mainnet deploy

Already deployed 2026-04-29. Module hash:
- pre: `0x20b69ffb8f6c63adb80f21cd011b6a315ccb3fec6b2bab3a47f72c9ce163300f`
- post: `0xf7e39f8dc118c535d732f27b7ada8b034e3bc593150627bd037c789d1411ff58`

`post_upgrade` log line confirmed the backfill: `Rumi 3pool post-upgrade: backfilled 1474 ICRC-3 hashes. blocks=1474 hashes=1474`. `threeusd_index.status` shows `num_blocks_synced = 1474`, in sync with the 3pool's `log_length` — confirms no chain break.

## Test plan

- [x] `cargo test -p rumi_3pool --lib` (98 passed)
- [x] `cargo test -p rumi_3pool --test integration_test` (9 passed)
- [x] `cargo test -p rumi_3pool --test icrc3_hash_cache --features test_endpoints` (4 passed: equivalence, benchmark, backfill simulation, corruption trap)
- [x] `cargo test --test pocket_ic_3usd` (7 passed; cross-canister exercise of the new dual-write path)
- [x] Workspace `--release --target wasm32-unknown-unknown` builds clean
- [x] Mainnet deploy + post_upgrade integrity check passed (1474 hashes backfilled)
- [x] threeusd_index continues indexing post-deploy (chain integrity verified)
- [ ] T+24h CycleOps comparison (target: ~0.33 TC/day → ~0.01 TC/day)

## Out of scope (intentional)

Documented in the plan at `docs/superpowers/plans/2026-04-29-rumi-3pool-icrc3-hash-cache.md`:
- ICRC-3 archive canisters (revisit at >50K blocks; currently 1.5K)
- Bucket size reduction (too risky; gain too small)
- Other `iter_all` hot paths in `swap_events_v2` / `liquidity_events_v2` / `get_vp_snapshots` — annotated with watch thresholds in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)