### PR TITLE
fix(audit): Wave-11 BOT-001 — auto-cancel collateral-return verification

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -158,6 +158,11 @@ type Event = variant {
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
   set_max_partial_liquidation_ratio : record { rate : text };
+  breaker_tripped : record {
+    total_e8s : nat64;
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   withdraw_and_close_vault : record {
     block_index : opt nat64;
     vault_id : nat64;
@@ -176,6 +181,12 @@ type Event = variant {
     collateral_type : principal;
   };
   set_recovery_target_cr : record { rate : text };
+  bot_claim_reconciliation_needed : record {
+    required_balance : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    observed_balance : nat64;
+  };
   set_collateral_redemption_fee_floor : record {
     redemption_fee_floor : text;
     collateral_type : principal;
@@ -246,6 +257,10 @@ type Event = variant {
     caller : opt principal;
     borrowed_amount : nat64;
   };
+  set_breaker_window_debt_ceiling_e8s : record {
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
@@ -287,6 +302,7 @@ type Event = variant {
     timestamp : opt nat64;
     amount : nat64;
   };
+  set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
     protocol_fee_collateral : opt nat64;
     icp_rate : opt blob;
@@ -331,12 +347,21 @@ type Event = variant {
     min_collateral_deposit : nat64;
     collateral_type : principal;
   };
+  breaker_cleared : record { remaining_total_e8s : nat64; timestamp : nat64 };
   update_collateral_status : record {
     status : CollateralStatus;
     collateral_type : principal;
   };
   set_healthy_cr : record { healthy_cr : opt text; collateral_type : text };
+  set_deficit_repayment_fraction : record {
+    fraction : blob;
+    timestamp : nat64;
+  };
   set_redemption_fee_ceiling : record { rate : text };
+  set_deficit_readonly_threshold_e8s : record {
+    threshold_e8s : nat64;
+    timestamp : nat64;
+  };
   add_margin_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
@@ -355,12 +380,25 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  deficit_repaid : record {
+    remaining_deficit : nat64;
+    source : FeeSource;
+    timestamp : nat64;
+    anchor_block_index : opt nat64;
+    amount : nat64;
+  };
   redemption_transfered : record {
     icusd_block_index : nat64;
     icp_block_index : nat64;
     timestamp : opt nat64;
   };
   set_liquidation_bot_principal : record { "principal" : principal };
+  deficit_accrued : record {
+    new_deficit : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    amount : nat64;
+  };
   liquidate_vault : record {
     mode : Mode;
     icp_rate : blob;
@@ -388,9 +426,11 @@ type Event = variant {
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
+  BreakerTripped;
   StabilityPoolDeposit;
   AdminSweepToTreasury;
   AdminMint;
+  BotClaimReconciliationNeeded;
   AdjustVault;
   PartialLiquidation;
   OpenVault;
@@ -398,13 +438,16 @@ type EventTypeFilter = variant {
   AccrueInterest;
   ReserveRedemption;
   Repay;
+  DeficitAccrued;
   Liquidation;
   Borrow;
   PriceUpdate;
   Admin;
+  DeficitRepaid;
   Redemption;
   CloseVault;
 };
+type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
   "principal" : opt principal;
@@ -552,6 +595,7 @@ type ProtocolSnapshot = record {
 type ProtocolStatus = record {
   last_icp_timestamp : nat64;
   borrowing_fee_curve_resolved : vec record { float64; float64 };
+  deficit_readonly_threshold_e8s : nat64;
   recovery_mode_threshold : float64;
   per_collateral_interest : vec CollateralInterestInfo;
   reserve_redemption_fee : float64;
@@ -562,25 +606,24 @@ type ProtocolStatus = record {
   total_icusd_borrowed : nat64;
   min_icusd_amount : nat64;
   total_collateral_ratio : float64;
+  deficit_repayment_fraction : float64;
   ckstable_repay_fee : float64;
+  windowed_liquidation_total_e8s : nat64;
   total_icp_margin : nat64;
   recovery_target_cr : float64;
   frozen : bool;
   weighted_average_interest_rate : float64;
+  liquidation_breaker_tripped : bool;
+  protocol_deficit_icusd : nat64;
+  breaker_window_ns : nat64;
   manual_mode_override : bool;
   liquidation_bonus : float64;
   per_collateral_rate_curves : vec PerCollateralRateCurve;
   reserve_redemptions_enabled : bool;
-  global_icusd_mint_cap : nat64;
-  last_icp_rate : float64;
-  protocol_deficit_icusd : nat64;
   total_deficit_repaid_icusd : nat64;
-  deficit_repayment_fraction : float64;
-  deficit_readonly_threshold_e8s : nat64;
-  breaker_window_ns : nat64;
+  global_icusd_mint_cap : nat64;
   breaker_window_debt_ceiling_e8s : nat64;
-  windowed_liquidation_total_e8s : nat64;
-  liquidation_breaker_tripped : bool;
+  last_icp_rate : float64;
 };
 type RateCurve = record {
   method : InterpolationMethod;
@@ -858,17 +901,12 @@ service : (ProtocolArg) -> {
   set_three_pool_canister : (principal) -> (Result);
   set_treasury_principal : (principal) -> (Result);
   stability_pool_liquidate : (nat64, nat64) -> (Result_12);
-  stability_pool_liquidate_debt_burned : (
-      nat64,
-      nat64,
-      SpWritedownProof,
-    ) -> (Result_12);
-  stability_pool_liquidate_with_reserves : (
-      nat64,
-      nat64,
-      nat64,
-      principal,
-    ) -> (Result_12);
+  stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
+      Result_12,
+    );
+  stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
+      Result_12,
+    );
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -184,6 +184,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'accrue_interest' : { 'timestamp' : bigint } } |
   { 'set_max_partial_liquidation_ratio' : { 'rate' : string } } |
   {
+    'breaker_tripped' : {
+      'total_e8s' : bigint,
+      'timestamp' : bigint,
+      'ceiling_e8s' : bigint,
+    }
+  } |
+  {
     'withdraw_and_close_vault' : {
       'block_index' : [] | [bigint],
       'vault_id' : bigint,
@@ -207,6 +214,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   { 'set_recovery_target_cr' : { 'rate' : string } } |
+  {
+    'bot_claim_reconciliation_needed' : {
+      'required_balance' : bigint,
+      'vault_id' : bigint,
+      'timestamp' : bigint,
+      'observed_balance' : bigint,
+    }
+  } |
   {
     'set_collateral_redemption_fee_floor' : {
       'redemption_fee_floor' : string,
@@ -307,6 +322,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'set_breaker_window_debt_ceiling_e8s' : {
+      'timestamp' : bigint,
+      'ceiling_e8s' : bigint,
+    }
+  } |
+  {
     'set_bot_allowed_collateral_types' : {
       'collateral_types' : Array<Principal>,
     }
@@ -363,6 +384,7 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'amount' : bigint,
     }
   } |
+  { 'set_breaker_window_ns' : { 'window_ns' : bigint, 'timestamp' : bigint } } |
   {
     'partial_liquidate_vault' : {
       'protocol_fee_collateral' : [] | [bigint],
@@ -420,6 +442,9 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'breaker_cleared' : { 'remaining_total_e8s' : bigint, 'timestamp' : bigint }
+  } |
+  {
     'update_collateral_status' : {
       'status' : CollateralStatus,
       'collateral_type' : Principal,
@@ -431,7 +456,19 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'collateral_type' : string,
     }
   } |
+  {
+    'set_deficit_repayment_fraction' : {
+      'fraction' : Uint8Array | number[],
+      'timestamp' : bigint,
+    }
+  } |
   { 'set_redemption_fee_ceiling' : { 'rate' : string } } |
+  {
+    'set_deficit_readonly_threshold_e8s' : {
+      'threshold_e8s' : bigint,
+      'timestamp' : bigint,
+    }
+  } |
   {
     'add_margin_to_vault' : {
       'block_index' : bigint,
@@ -455,6 +492,15 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   } |
   { 'set_reserve_redemption_fee' : { 'fee' : string } } |
   {
+    'deficit_repaid' : {
+      'remaining_deficit' : bigint,
+      'source' : FeeSource,
+      'timestamp' : bigint,
+      'anchor_block_index' : [] | [bigint],
+      'amount' : bigint,
+    }
+  } |
+  {
     'redemption_transfered' : {
       'icusd_block_index' : bigint,
       'icp_block_index' : bigint,
@@ -462,6 +508,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   { 'set_liquidation_bot_principal' : { 'principal' : Principal } } |
+  {
+    'deficit_accrued' : {
+      'new_deficit' : bigint,
+      'vault_id' : bigint,
+      'timestamp' : bigint,
+      'amount' : bigint,
+    }
+  } |
   {
     'liquidate_vault' : {
       'mode' : Mode,
@@ -497,9 +551,11 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   } |
   { 'set_recovery_cr_multiplier' : { 'multiplier' : string } };
 export interface EventTimeRange { 'start_ns' : bigint, 'end_ns' : bigint }
-export type EventTypeFilter = { 'StabilityPoolDeposit' : null } |
+export type EventTypeFilter = { 'BreakerTripped' : null } |
+  { 'StabilityPoolDeposit' : null } |
   { 'AdminSweepToTreasury' : null } |
   { 'AdminMint' : null } |
+  { 'BotClaimReconciliationNeeded' : null } |
   { 'AdjustVault' : null } |
   { 'PartialLiquidation' : null } |
   { 'OpenVault' : null } |
@@ -507,12 +563,16 @@ export type EventTypeFilter = { 'StabilityPoolDeposit' : null } |
   { 'AccrueInterest' : null } |
   { 'ReserveRedemption' : null } |
   { 'Repay' : null } |
+  { 'DeficitAccrued' : null } |
   { 'Liquidation' : null } |
   { 'Borrow' : null } |
   { 'PriceUpdate' : null } |
   { 'Admin' : null } |
+  { 'DeficitRepaid' : null } |
   { 'Redemption' : null } |
   { 'CloseVault' : null };
+export type FeeSource = { 'BorrowingFee' : null } |
+  { 'RedemptionFee' : null };
 export interface Fees { 'redemption_fee' : number, 'borrowing_fee' : number }
 export interface GetEventsArg {
   'principal' : [] | [Principal],

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -219,9 +219,11 @@ export const idlFactory = ({ IDL }) => {
     'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const EventTypeFilter = IDL.Variant({
+    'BreakerTripped' : IDL.Null,
     'StabilityPoolDeposit' : IDL.Null,
     'AdminSweepToTreasury' : IDL.Null,
     'AdminMint' : IDL.Null,
+    'BotClaimReconciliationNeeded' : IDL.Null,
     'AdjustVault' : IDL.Null,
     'PartialLiquidation' : IDL.Null,
     'OpenVault' : IDL.Null,
@@ -229,10 +231,12 @@ export const idlFactory = ({ IDL }) => {
     'AccrueInterest' : IDL.Null,
     'ReserveRedemption' : IDL.Null,
     'Repay' : IDL.Null,
+    'DeficitAccrued' : IDL.Null,
     'Liquidation' : IDL.Null,
     'Borrow' : IDL.Null,
     'PriceUpdate' : IDL.Null,
     'Admin' : IDL.Null,
+    'DeficitRepaid' : IDL.Null,
     'Redemption' : IDL.Null,
     'CloseVault' : IDL.Null,
   });
@@ -268,6 +272,10 @@ export const idlFactory = ({ IDL }) => {
     'icusd_redeemed_e8s' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
     'collateral_seized' : IDL.Nat64,
+  });
+  const FeeSource = IDL.Variant({
+    'BorrowingFee' : IDL.Null,
+    'RedemptionFee' : IDL.Null,
   });
   const Event = IDL.Variant({
     'set_borrowing_fee' : IDL.Record({ 'rate' : IDL.Text }),
@@ -314,6 +322,11 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Record({ 'principal' : IDL.Principal }),
     'accrue_interest' : IDL.Record({ 'timestamp' : IDL.Nat64 }),
     'set_max_partial_liquidation_ratio' : IDL.Record({ 'rate' : IDL.Text }),
+    'breaker_tripped' : IDL.Record({
+      'total_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+      'ceiling_e8s' : IDL.Nat64,
+    }),
     'withdraw_and_close_vault' : IDL.Record({
       'block_index' : IDL.Opt(IDL.Nat64),
       'vault_id' : IDL.Nat64,
@@ -332,6 +345,12 @@ export const idlFactory = ({ IDL }) => {
       'collateral_type' : IDL.Principal,
     }),
     'set_recovery_target_cr' : IDL.Record({ 'rate' : IDL.Text }),
+    'bot_claim_reconciliation_needed' : IDL.Record({
+      'required_balance' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+      'observed_balance' : IDL.Nat64,
+    }),
     'set_collateral_redemption_fee_floor' : IDL.Record({
       'redemption_fee_floor' : IDL.Text,
       'collateral_type' : IDL.Principal,
@@ -405,6 +424,10 @@ export const idlFactory = ({ IDL }) => {
       'caller' : IDL.Opt(IDL.Principal),
       'borrowed_amount' : IDL.Nat64,
     }),
+    'set_breaker_window_debt_ceiling_e8s' : IDL.Record({
+      'timestamp' : IDL.Nat64,
+      'ceiling_e8s' : IDL.Nat64,
+    }),
     'set_bot_allowed_collateral_types' : IDL.Record({
       'collateral_types' : IDL.Vec(IDL.Principal),
     }),
@@ -448,6 +471,10 @@ export const idlFactory = ({ IDL }) => {
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
       'amount' : IDL.Nat64,
+    }),
+    'set_breaker_window_ns' : IDL.Record({
+      'window_ns' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
     }),
     'partial_liquidate_vault' : IDL.Record({
       'protocol_fee_collateral' : IDL.Opt(IDL.Nat64),
@@ -493,6 +520,10 @@ export const idlFactory = ({ IDL }) => {
       'min_collateral_deposit' : IDL.Nat64,
       'collateral_type' : IDL.Principal,
     }),
+    'breaker_cleared' : IDL.Record({
+      'remaining_total_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+    }),
     'update_collateral_status' : IDL.Record({
       'status' : CollateralStatus,
       'collateral_type' : IDL.Principal,
@@ -501,7 +532,15 @@ export const idlFactory = ({ IDL }) => {
       'healthy_cr' : IDL.Opt(IDL.Text),
       'collateral_type' : IDL.Text,
     }),
+    'set_deficit_repayment_fraction' : IDL.Record({
+      'fraction' : IDL.Vec(IDL.Nat8),
+      'timestamp' : IDL.Nat64,
+    }),
     'set_redemption_fee_ceiling' : IDL.Record({ 'rate' : IDL.Text }),
+    'set_deficit_readonly_threshold_e8s' : IDL.Record({
+      'threshold_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+    }),
     'add_margin_to_vault' : IDL.Record({
       'block_index' : IDL.Nat64,
       'vault_id' : IDL.Nat64,
@@ -525,6 +564,13 @@ export const idlFactory = ({ IDL }) => {
       'interest_rate_apr' : IDL.Text,
     }),
     'set_reserve_redemption_fee' : IDL.Record({ 'fee' : IDL.Text }),
+    'deficit_repaid' : IDL.Record({
+      'remaining_deficit' : IDL.Nat64,
+      'source' : FeeSource,
+      'timestamp' : IDL.Nat64,
+      'anchor_block_index' : IDL.Opt(IDL.Nat64),
+      'amount' : IDL.Nat64,
+    }),
     'redemption_transfered' : IDL.Record({
       'icusd_block_index' : IDL.Nat64,
       'icp_block_index' : IDL.Nat64,
@@ -532,6 +578,12 @@ export const idlFactory = ({ IDL }) => {
     }),
     'set_liquidation_bot_principal' : IDL.Record({
       'principal' : IDL.Principal,
+    }),
+    'deficit_accrued' : IDL.Record({
+      'new_deficit' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+      'amount' : IDL.Nat64,
     }),
     'liquidate_vault' : IDL.Record({
       'mode' : Mode,

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -158,6 +158,11 @@ type Event = variant {
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
   set_max_partial_liquidation_ratio : record { rate : text };
+  breaker_tripped : record {
+    total_e8s : nat64;
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   withdraw_and_close_vault : record {
     block_index : opt nat64;
     vault_id : nat64;
@@ -176,6 +181,12 @@ type Event = variant {
     collateral_type : principal;
   };
   set_recovery_target_cr : record { rate : text };
+  bot_claim_reconciliation_needed : record {
+    required_balance : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    observed_balance : nat64;
+  };
   set_collateral_redemption_fee_floor : record {
     redemption_fee_floor : text;
     collateral_type : principal;
@@ -246,6 +257,10 @@ type Event = variant {
     caller : opt principal;
     borrowed_amount : nat64;
   };
+  set_breaker_window_debt_ceiling_e8s : record {
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
@@ -287,6 +302,7 @@ type Event = variant {
     timestamp : opt nat64;
     amount : nat64;
   };
+  set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
     protocol_fee_collateral : opt nat64;
     icp_rate : opt blob;
@@ -331,12 +347,21 @@ type Event = variant {
     min_collateral_deposit : nat64;
     collateral_type : principal;
   };
+  breaker_cleared : record { remaining_total_e8s : nat64; timestamp : nat64 };
   update_collateral_status : record {
     status : CollateralStatus;
     collateral_type : principal;
   };
   set_healthy_cr : record { healthy_cr : opt text; collateral_type : text };
+  set_deficit_repayment_fraction : record {
+    fraction : blob;
+    timestamp : nat64;
+  };
   set_redemption_fee_ceiling : record { rate : text };
+  set_deficit_readonly_threshold_e8s : record {
+    threshold_e8s : nat64;
+    timestamp : nat64;
+  };
   add_margin_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
@@ -355,12 +380,25 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  deficit_repaid : record {
+    remaining_deficit : nat64;
+    source : FeeSource;
+    timestamp : nat64;
+    anchor_block_index : opt nat64;
+    amount : nat64;
+  };
   redemption_transfered : record {
     icusd_block_index : nat64;
     icp_block_index : nat64;
     timestamp : opt nat64;
   };
   set_liquidation_bot_principal : record { "principal" : principal };
+  deficit_accrued : record {
+    new_deficit : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    amount : nat64;
+  };
   liquidate_vault : record {
     mode : Mode;
     icp_rate : blob;
@@ -388,9 +426,11 @@ type Event = variant {
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
+  BreakerTripped;
   StabilityPoolDeposit;
   AdminSweepToTreasury;
   AdminMint;
+  BotClaimReconciliationNeeded;
   AdjustVault;
   PartialLiquidation;
   OpenVault;
@@ -398,13 +438,16 @@ type EventTypeFilter = variant {
   AccrueInterest;
   ReserveRedemption;
   Repay;
+  DeficitAccrued;
   Liquidation;
   Borrow;
   PriceUpdate;
   Admin;
+  DeficitRepaid;
   Redemption;
   CloseVault;
 };
+type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
   "principal" : opt principal;
@@ -552,6 +595,7 @@ type ProtocolSnapshot = record {
 type ProtocolStatus = record {
   last_icp_timestamp : nat64;
   borrowing_fee_curve_resolved : vec record { float64; float64 };
+  deficit_readonly_threshold_e8s : nat64;
   recovery_mode_threshold : float64;
   per_collateral_interest : vec CollateralInterestInfo;
   reserve_redemption_fee : float64;
@@ -562,25 +606,24 @@ type ProtocolStatus = record {
   total_icusd_borrowed : nat64;
   min_icusd_amount : nat64;
   total_collateral_ratio : float64;
+  deficit_repayment_fraction : float64;
   ckstable_repay_fee : float64;
+  windowed_liquidation_total_e8s : nat64;
   total_icp_margin : nat64;
   recovery_target_cr : float64;
   frozen : bool;
   weighted_average_interest_rate : float64;
+  liquidation_breaker_tripped : bool;
+  protocol_deficit_icusd : nat64;
+  breaker_window_ns : nat64;
   manual_mode_override : bool;
   liquidation_bonus : float64;
   per_collateral_rate_curves : vec PerCollateralRateCurve;
   reserve_redemptions_enabled : bool;
-  global_icusd_mint_cap : nat64;
-  last_icp_rate : float64;
-  protocol_deficit_icusd : nat64;
   total_deficit_repaid_icusd : nat64;
-  deficit_repayment_fraction : float64;
-  deficit_readonly_threshold_e8s : nat64;
-  breaker_window_ns : nat64;
+  global_icusd_mint_cap : nat64;
   breaker_window_debt_ceiling_e8s : nat64;
-  windowed_liquidation_total_e8s : nat64;
-  liquidation_breaker_tripped : bool;
+  last_icp_rate : float64;
 };
 type RateCurve = record {
   method : InterpolationMethod;
@@ -858,17 +901,12 @@ service : (ProtocolArg) -> {
   set_three_pool_canister : (principal) -> (Result);
   set_treasury_principal : (principal) -> (Result);
   stability_pool_liquidate : (nat64, nat64) -> (Result_12);
-  stability_pool_liquidate_debt_burned : (
-      nat64,
-      nat64,
-      SpWritedownProof,
-    ) -> (Result_12);
-  stability_pool_liquidate_with_reserves : (
-      nat64,
-      nat64,
-      nat64,
-      principal,
-    ) -> (Result_12);
+  stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
+      Result_12,
+    );
+  stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
+      Result_12,
+    );
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -668,6 +668,22 @@ pub enum Event {
         ceiling_e8s: u64,
         timestamp: u64,
     },
+
+    /// Wave-11 BOT-001: `check_vaults` detected an expired `bot_claims` entry
+    /// whose collateral was not returned (`icrc1_balance_of` < required).
+    /// The auto-cancel was skipped to keep the protocol from clearing the
+    /// claim while the bot still holds the collateral. Admin must reconcile
+    /// manually via `bot_cancel_liquidation` once the collateral is back, or
+    /// via an admin sweep if the bot is genuinely stuck. Re-emitted on every
+    /// `check_vaults` tick the gate fires; the explorer can group by
+    /// `vault_id` to dedupe.
+    #[serde(rename = "bot_claim_reconciliation_needed")]
+    BotClaimReconciliationNeeded {
+        vault_id: u64,
+        observed_balance: u64,
+        required_balance: u64,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -764,6 +780,8 @@ impl Event {
             Event::BreakerCleared { .. } => false,
             Event::SetBreakerWindowNs { .. } => false,
             Event::SetBreakerWindowDebtCeilingE8s { .. } => false,
+            // Wave-11 BOT-001
+            Event::BotClaimReconciliationNeeded { vault_id, .. } => vault_id == filter_vault_id,
         }
     }
 
@@ -809,6 +827,11 @@ impl Event {
             // Wave-10 LIQ-008: BreakerTripped is auto-emitted; BreakerCleared
             // and the two Set* tunables collapse to Admin via the catch-all.
             Event::BreakerTripped { .. } => EventTypeFilter::BreakerTripped,
+            // Wave-11 BOT-001: dedicated filter so operators can query stuck
+            // claims directly without scanning the Admin bucket.
+            Event::BotClaimReconciliationNeeded { .. } => {
+                EventTypeFilter::BotClaimReconciliationNeeded
+            }
             _ => EventTypeFilter::Admin,
         }
     }
@@ -922,6 +945,8 @@ impl Event {
             Event::BreakerCleared { timestamp, .. } => Some(*timestamp),
             Event::SetBreakerWindowNs { timestamp, .. } => Some(*timestamp),
             Event::SetBreakerWindowDebtCeilingE8s { timestamp, .. } => Some(*timestamp),
+            // Wave-11 BOT-001
+            Event::BotClaimReconciliationNeeded { timestamp, .. } => Some(*timestamp),
             _ => None,
         }
     }
@@ -1669,6 +1694,12 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             Event::SetBreakerWindowDebtCeilingE8s { ceiling_e8s, .. } => {
                 state.breaker_window_debt_ceiling_e8s = ceiling_e8s;
             },
+            // Wave-11 BOT-001: informational. The audit trail records that
+            // `check_vaults` skipped an auto-cancel because the bot had not
+            // returned the collateral; no replay-side state mutation is needed
+            // because the underlying `BotClaim` and `vault.bot_processing`
+            // were intentionally left untouched.
+            Event::BotClaimReconciliationNeeded { .. } => {},
         }
     }
     state.next_available_vault_id = vault_id;
@@ -1877,6 +1908,26 @@ pub fn record_set_breaker_window_debt_ceiling_e8s(state: &mut State, ceiling_e8s
     state.breaker_window_debt_ceiling_e8s = ceiling_e8s;
     record_event(&Event::SetBreakerWindowDebtCeilingE8s {
         ceiling_e8s,
+        timestamp: now(),
+    });
+}
+
+/// Wave-11 BOT-001: records that `check_vaults` skipped an auto-cancel of an
+/// expired `bot_claims` entry because the bot had not returned the collateral.
+/// The `BotClaim` is intentionally left in place so admin can reconcile via
+/// `bot_cancel_liquidation` once the collateral is back; this recorder makes
+/// no state mutation. `_state` is taken for consistency with the rest of the
+/// recorder API.
+pub fn record_bot_claim_reconciliation_needed(
+    _state: &mut State,
+    vault_id: u64,
+    observed_balance: u64,
+    required_balance: u64,
+) {
+    record_event(&Event::BotClaimReconciliationNeeded {
+        vault_id,
+        observed_balance,
+        required_balance,
         timestamp: now(),
     });
 }

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -10,6 +10,7 @@ use crate::state::{mutate_state, read_state, Mode};
 use crate::vault::Vault;
 use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
+use num_traits::ToPrimitive;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -246,6 +247,11 @@ pub enum EventTypeFilter {
     /// Distinct from the admin tunables (which collapse to `Admin`) so
     /// operators can audit every breaker firing in isolation.
     BreakerTripped,
+    /// Wave-11 BOT-001: a `check_vaults` auto-cancel was skipped because the
+    /// bot did not return the collateral within the 10-minute window. Distinct
+    /// filter so operators can directly query "stuck claims awaiting
+    /// reconciliation" without scanning the noisier admin bucket.
+    BotClaimReconciliationNeeded,
 }
 
 /// Inclusive nanosecond timestamp window for the time facet.
@@ -490,9 +496,23 @@ pub struct LiquidatableVaultInfo {
     pub collateral_price_e8s: u64,
 }
 
-pub fn check_vaults() {
+pub async fn check_vaults() {
     // Auto-cancel bot claims that have been pending too long (10 minutes).
     // This prevents vaults from being permanently locked if the bot crashes.
+    //
+    // Wave-11 BOT-001: gate the auto-cancel on the protocol's collateral
+    // balance having returned to (>=) `claim.collateral_amount - ledger_fee`.
+    // Without this, a CLAIM → SWAP-ok → TRANSFER-fail → admin-AFK-10min
+    // sequence would clear the claim while the bot still holds the
+    // collateral, leaving the vault permanently underwater. Mirrors the
+    // subaccount + fee derivation used by `bot_cancel_liquidation`. On a
+    // shortfall we leave the claim in place and emit
+    // `BotClaimReconciliationNeeded` so admin can reconcile manually.
+    //
+    // The guard re-emits the event on every tick the gate fires (no
+    // per-claim "already emitted" flag, since a state-shape change is
+    // out of scope for this wave). The explorer can group by `vault_id`
+    // to dedupe; operator action is unchanged regardless of count.
     const BOT_CLAIM_TIMEOUT_NS: u64 = 600_000_000_000; // 10 minutes
     let now = ic_cdk::api::time();
 
@@ -503,11 +523,82 @@ pub fn check_vaults() {
             .collect()
     });
 
+    let backend_id = ic_cdk::id();
     for (vault_id, claim) in &expired_claims {
-        log!(INFO, "[check_vaults] Auto-cancelling stuck bot claim for vault #{} (claimed {}s ago)",
-            vault_id, (now - claim.claimed_at) / 1_000_000_000);
+        let required = read_state(|s| {
+            let fee = s
+                .get_collateral_config(&claim.collateral_type)
+                .map(|c| c.ledger_fee)
+                .unwrap_or(0);
+            claim.collateral_amount.saturating_sub(fee)
+        });
+
+        let balance_result: Result<(candid::Nat,), _> = ic_cdk::call(
+            claim.collateral_type,
+            "icrc1_balance_of",
+            (icrc_ledger_types::icrc1::account::Account {
+                owner: backend_id,
+                subaccount: None,
+            },),
+        )
+        .await;
+
+        let observed = match balance_result {
+            Ok((bal,)) => bal.0.to_u64().unwrap_or(0),
+            Err((code, msg)) => {
+                log!(
+                    INFO,
+                    "[BOT-001] auto-cancel balance query failed for vault #{}: {:?} {}; deferring this tick",
+                    vault_id,
+                    code,
+                    msg
+                );
+                continue;
+            }
+        };
+
+        if observed < required {
+            log!(
+                INFO,
+                "[BOT-001] auto-cancel skipped for vault #{}: balance {} < required {} (collateral_amount {})",
+                vault_id,
+                observed,
+                required,
+                claim.collateral_amount
+            );
+            mutate_state(|s| {
+                // TOCTOU re-check: between collecting expired_claims and
+                // awaiting the balance query, the bot may have called
+                // `bot_cancel_liquidation` itself and cleared the claim.
+                // Avoid emitting a misleading reconciliation event for a
+                // vault that no longer needs reconciliation.
+                if !s.bot_claims.contains_key(vault_id) {
+                    return;
+                }
+                crate::event::record_bot_claim_reconciliation_needed(
+                    s, *vault_id, observed, required,
+                );
+            });
+            continue;
+        }
+
+        log!(
+            INFO,
+            "[check_vaults] Auto-cancelling stuck bot claim for vault #{} (claimed {}s ago, balance {} >= required {})",
+            vault_id,
+            (now - claim.claimed_at) / 1_000_000_000,
+            observed,
+            required
+        );
 
         mutate_state(|s| {
+            // TOCTOU re-check: skip the budget restore if the claim was
+            // already cleared during the await window (e.g., bot raced us
+            // by calling `bot_cancel_liquidation`). Without this guard the
+            // budget would be double-credited.
+            if !s.bot_claims.contains_key(vault_id) {
+                return;
+            }
             if let Some(vault) = s.vault_id_to_vaults.get_mut(vault_id) {
                 vault.bot_processing = false;
             }

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -114,7 +114,7 @@ pub async fn fetch_icp_rate() {
         mutate_state(|s| s.harvest_accrued_interest());
     }
     if read_state(|s| s.mode != crate::Mode::ReadOnly) {
-        crate::check_vaults();
+        crate::check_vaults().await;
     }
 
     // Drain any pending treasury interest/collateral accumulated from sync liquidations

--- a/src/rumi_protocol_backend/tests/audit_pocs_bot_001_auto_cancel_balance.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_bot_001_auto_cancel_balance.rs
@@ -1,0 +1,112 @@
+//! Wave-11 BOT-001: auto-cancel collateral-return verification — Layer 1 unit tests.
+//!
+//! Layer 1 covers the pure-data shape of the new `BotClaimReconciliationNeeded`
+//! event variant: CBOR round-trip, type-filter classification, vault-id
+//! matching, principal involvement, timestamp surfacing, and
+//! `EventTypeFilter::BotClaimReconciliationNeeded` round-trip.
+//!
+//! The auto-cancel guard itself sits inside `check_vaults` and requires a
+//! canister context (icrc1_balance_of inter-canister call). That path is
+//! fenced in `audit_pocs_bot_001_auto_cancel_balance_pic.rs`.
+
+use candid::Principal;
+use rumi_protocol_backend::event::Event;
+use rumi_protocol_backend::EventTypeFilter;
+
+const TS: u64 = 1_700_000_000_000_000_000;
+const VAULT_ID: u64 = 42;
+const OBSERVED: u64 = 1_000_000;
+const REQUIRED: u64 = 99_990_000;
+
+fn sample_event() -> Event {
+    Event::BotClaimReconciliationNeeded {
+        vault_id: VAULT_ID,
+        observed_balance: OBSERVED,
+        required_balance: REQUIRED,
+        timestamp: TS,
+    }
+}
+
+#[test]
+fn bot_001_event_round_trips_cbor() {
+    let event = sample_event();
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&event, &mut bytes).expect("encode");
+    let decoded: Event = ciborium::de::from_reader(bytes.as_slice()).expect("decode");
+
+    match decoded {
+        Event::BotClaimReconciliationNeeded {
+            vault_id,
+            observed_balance,
+            required_balance,
+            timestamp,
+        } => {
+            assert_eq!(vault_id, VAULT_ID);
+            assert_eq!(observed_balance, OBSERVED);
+            assert_eq!(required_balance, REQUIRED);
+            assert_eq!(timestamp, TS);
+        }
+        other => panic!("expected BotClaimReconciliationNeeded, got {:?}", other),
+    }
+}
+
+#[test]
+fn bot_001_event_classifies_to_dedicated_filter() {
+    assert_eq!(
+        sample_event().type_filter(),
+        EventTypeFilter::BotClaimReconciliationNeeded
+    );
+}
+
+#[test]
+fn bot_001_event_is_vault_related_for_matching_vault() {
+    let event = sample_event();
+    assert!(event.is_vault_related(&VAULT_ID));
+    assert!(!event.is_vault_related(&(VAULT_ID + 1)));
+    assert!(!event.is_vault_related(&0));
+}
+
+#[test]
+fn bot_001_event_does_not_involve_principal() {
+    let event = sample_event();
+    let principal = Principal::from_slice(&[1, 2, 3, 4]);
+    assert!(!event.involves_principal(&principal));
+    assert!(!event.involves_principal(&Principal::anonymous()));
+}
+
+#[test]
+fn bot_001_event_surfaces_timestamp() {
+    assert_eq!(sample_event().timestamp_ns(), Some(TS));
+}
+
+#[test]
+fn bot_001_event_admin_label_is_none() {
+    // BotClaimReconciliationNeeded has its own dedicated `EventTypeFilter`,
+    // so it must NOT be classified as Admin and therefore admin_label is None.
+    assert!(sample_event().admin_label().is_none());
+}
+
+#[test]
+fn bot_001_event_type_filter_round_trips_cbor() {
+    let filter = EventTypeFilter::BotClaimReconciliationNeeded;
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&filter, &mut bytes).expect("encode");
+    let decoded: EventTypeFilter = ciborium::de::from_reader(bytes.as_slice()).expect("decode");
+    assert_eq!(decoded, EventTypeFilter::BotClaimReconciliationNeeded);
+}
+
+#[test]
+fn bot_001_event_size_e8s_usd_is_none() {
+    // BOT-001 is informational (no monetary magnitude). The size facet must
+    // treat it as "passes" by returning None.
+    assert_eq!(sample_event().size_e8s_usd(1_000_000_000), None);
+}
+
+#[test]
+fn bot_001_event_no_collateral_token() {
+    // The event carries vault_id, not collateral_type. The collateral_token
+    // helper should resolve to None unless the caller's vault_lookup map has
+    // an entry. With an empty map: None.
+    let lookup = std::collections::HashMap::new();
+    assert_eq!(sample_event().collateral_token(&lookup), None);
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_bot_001_auto_cancel_balance_pic.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_bot_001_auto_cancel_balance_pic.rs
@@ -1,0 +1,844 @@
+//! Wave-11 BOT-001: auto-cancel collateral-return verification — Layer 3 PocketIC fence.
+//!
+//! Layer 1 (`audit_pocs_bot_001_auto_cancel_balance.rs`) covers the pure data
+//! shape of the new `BotClaimReconciliationNeeded` event variant. Layer 3
+//! exercises the canister-boundary path that Layer 1 cannot:
+//!
+//!   * `check_vaults` actually queries `icrc1_balance_of` on the collateral
+//!     ledger when an expired `bot_claims` entry is detected;
+//!   * a balance shortfall (the bot retained the collateral) leaves the
+//!     claim in place, leaves `bot_budget_remaining_e8s` unchanged, and
+//!     emits `BotClaimReconciliationNeeded`;
+//!   * a sufficient balance (the bot returned the collateral) clears the
+//!     claim and restores the budget — preserving the pre-Wave-11 happy
+//!     path so we don't regress the original "bot crashed" auto-cancel.
+//!
+//! The "icrc1_balance_of returns an error" branch is exercised in code
+//! review only; reliably injecting a ledger-side error from PocketIC would
+//! require a custom mock ledger that can't transact, which would also
+//! prevent the bot's collateral transfer in setup. The Layer-1 fence
+//! confirms the variant + dispatch are correct.
+//!
+//! Fixture is lifted from `audit_pocs_liq_008_circuit_breaker_pic.rs`. The
+//! breaker is left at its default-disabled state since the BOT-001 path
+//! sits *above* the breaker gate in `check_vaults`.
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::{Duration, SystemTime};
+
+use rumi_protocol_backend::event::Event;
+use rumi_protocol_backend::ProtocolError;
+use rumi_protocol_backend::EventTypeFilter;
+
+// ─── Local mirrors of ICRC-1 Candid types ───
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct FeatureFlags {
+    icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct MetadataValue {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+    #[serde(rename = "Nat")]
+    nat: Option<Nat>,
+    #[serde(rename = "Int")]
+    int: Option<i64>,
+    #[serde(rename = "Blob")]
+    blob: Option<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct InitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum LedgerArg {
+    #[serde(rename = "Init")]
+    Init(InitArgs),
+    #[serde(rename = "Upgrade")]
+    Upgrade(Option<()>),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ApproveArgs {
+    from_subaccount: Option<[u8; 32]>,
+    spender: Account,
+    amount: Nat,
+    expected_allowance: Option<Nat>,
+    expires_at: Option<u64>,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ApproveError {
+    BadFee { expected_fee: Nat },
+    InsufficientFunds { balance: Nat },
+    AllowanceChanged { current_allowance: Nat },
+    Expired { ledger_time: u64 },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct TransferArg {
+    from_subaccount: Option<[u8; 32]>,
+    to: Account,
+    amount: Nat,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum TransferError {
+    BadFee { expected_fee: Nat },
+    BadBurn { min_burn_amount: Nat },
+    InsufficientFunds { balance: Nat },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+// ─── Backend init / vault types ───
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArgVariant {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct VaultArg {
+    vault_id: u64,
+    amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct OpenVaultSuccess {
+    vault_id: u64,
+    block_index: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SuccessWithFee {
+    block_index: u64,
+    fee_amount_paid: u64,
+    collateral_amount_received: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct BotLiquidationResult {
+    vault_id: u64,
+    collateral_amount: u64,
+    debt_covered: u64,
+    collateral_price_e8s: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct BotStatsResponse {
+    liquidation_bot_principal: Option<Principal>,
+    budget_total_e8s: u64,
+    budget_remaining_e8s: u64,
+    budget_start_timestamp: u64,
+    total_debt_covered_e8s: u64,
+}
+
+// Subset of the real GetEventsArg / GetEventsFilteredResponse — only the
+// fields this fence needs. Field-keyed Candid records let us subset safely.
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+struct GetEventsArg {
+    start: u64,
+    length: u64,
+    types: Option<Vec<EventTypeFilter>>,
+    principal: Option<Principal>,
+    collateral_token: Option<Principal>,
+    time_range: Option<EventTimeRange>,
+    min_size_e8s: Option<u64>,
+    admin_labels: Option<Vec<String>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct EventTimeRange {
+    start_ns: u64,
+    end_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct GetEventsFilteredResponse {
+    total: u64,
+    events: Vec<(u64, Event)>,
+}
+
+// ─── WASM fixtures ───
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn protocol_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn xrc_wasm() -> Vec<u8> {
+    include_bytes!("../../xrc_demo/xrc/xrc.wasm").to_vec()
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+struct MockXRC {
+    rates: Vec<(String, u64)>,
+}
+
+fn prepare_mock_xrc() -> Vec<u8> {
+    let mock = MockXRC {
+        rates: vec![("ICP/USD".to_string(), 1_000_000_000)], // $10.00 (e8s)
+    };
+    encode_one(mock).expect("encode mock XRC init")
+}
+
+// ─── Helpers ───
+
+fn account(owner: Principal) -> Account {
+    Account {
+        owner,
+        subaccount: None,
+    }
+}
+
+fn deploy_icrc1_ledger(
+    pic: &PocketIc,
+    minting_account: Account,
+    transfer_fee: u64,
+    initial_balances: Vec<(Account, Nat)>,
+    name: &str,
+    symbol: &str,
+    controller: Principal,
+) -> Principal {
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = InitArgs {
+        minting_account,
+        fee_collector_account: None,
+        transfer_fee: Nat::from(transfer_fee),
+        decimals: Some(8),
+        max_memo_length: Some(64),
+        token_name: name.into(),
+        token_symbol: symbol.into(),
+        metadata: vec![],
+        initial_balances,
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: controller,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).expect("encode ledger init"),
+        None,
+    );
+    ledger_id
+}
+
+fn icrc2_approve_call(
+    pic: &PocketIc,
+    ledger: Principal,
+    sender: Principal,
+    spender: Principal,
+    amount: u128,
+) {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: account(spender),
+        amount: Nat::from(amount),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    let result = pic
+        .update_call(ledger, sender, "icrc2_approve", encode_one(args).unwrap())
+        .expect("icrc2_approve call failed");
+    let parsed: Result<Nat, ApproveError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode icrc2_approve"),
+        WasmResult::Reject(m) => panic!("icrc2_approve rejected: {}", m),
+    };
+    parsed.expect("approve returned error");
+}
+
+fn icrc1_transfer_call(
+    pic: &PocketIc,
+    ledger: Principal,
+    sender: Principal,
+    to: Principal,
+    amount: u128,
+) {
+    let args = TransferArg {
+        from_subaccount: None,
+        to: account(to),
+        amount: Nat::from(amount),
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    let result = pic
+        .update_call(ledger, sender, "icrc1_transfer", encode_one(args).unwrap())
+        .expect("icrc1_transfer call failed");
+    let parsed: Result<Nat, TransferError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode icrc1_transfer"),
+        WasmResult::Reject(m) => panic!("icrc1_transfer rejected: {}", m),
+    };
+    parsed.expect("transfer returned error");
+}
+
+fn icrc1_balance_of_call(pic: &PocketIc, ledger: Principal, owner: Principal) -> u64 {
+    let result = pic
+        .query_call(
+            ledger,
+            Principal::anonymous(),
+            "icrc1_balance_of",
+            encode_one(account(owner)).unwrap(),
+        )
+        .expect("icrc1_balance_of call failed");
+    let parsed: Nat = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode balance"),
+        WasmResult::Reject(m) => panic!("balance rejected: {}", m),
+    };
+    use num_traits::ToPrimitive;
+    parsed.0.to_u64().unwrap_or(0)
+}
+
+fn xrc_set_rate(
+    pic: &PocketIc,
+    xrc: Principal,
+    sender: Principal,
+    base: &str,
+    quote: &str,
+    rate_e8s: u64,
+) {
+    let result = pic
+        .update_call(
+            xrc,
+            sender,
+            "set_exchange_rate",
+            encode_args((base.to_string(), quote.to_string(), rate_e8s)).unwrap(),
+        )
+        .expect("set_exchange_rate call failed");
+    match result {
+        WasmResult::Reply(_) => {}
+        WasmResult::Reject(m) => panic!("set_exchange_rate rejected: {}", m),
+    }
+}
+
+fn get_bot_stats(pic: &PocketIc, protocol_id: Principal) -> BotStatsResponse {
+    let result = pic
+        .query_call(
+            protocol_id,
+            Principal::anonymous(),
+            "get_bot_stats",
+            encode_args(()).unwrap(),
+        )
+        .expect("get_bot_stats call failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_bot_stats"),
+        WasmResult::Reject(m) => panic!("get_bot_stats rejected: {}", m),
+    }
+}
+
+fn get_bot_001_events(pic: &PocketIc, protocol_id: Principal) -> Vec<Event> {
+    let args = GetEventsArg {
+        start: 0,
+        length: 200,
+        types: Some(vec![EventTypeFilter::BotClaimReconciliationNeeded]),
+        ..Default::default()
+    };
+    // `get_events_filtered` is `#[query]` and traps on update calls. Hit it
+    // as a query so the data-certificate guard in main.rs doesn't reject.
+    let result = pic
+        .query_call(
+            protocol_id,
+            Principal::anonymous(),
+            "get_events_filtered",
+            encode_one(args).unwrap(),
+        )
+        .expect("get_events_filtered call failed");
+    let parsed: GetEventsFilteredResponse = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_events_filtered"),
+        WasmResult::Reject(m) => panic!("get_events_filtered rejected: {}", m),
+    };
+    parsed.events.into_iter().map(|(_, e)| e).collect()
+}
+
+fn set_liquidation_bot_config_admin(
+    fixture: &Fixture,
+    bot_principal: Principal,
+    monthly_budget_e8s: u64,
+) {
+    let result = fixture
+        .pic
+        .update_call(
+            fixture.protocol_id,
+            fixture.developer,
+            "set_liquidation_bot_config",
+            encode_args((bot_principal, monthly_budget_e8s)).unwrap(),
+        )
+        .expect("set_liquidation_bot_config call failed");
+    let parsed: Result<(), ProtocolError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode set_liquidation_bot_config"),
+        WasmResult::Reject(m) => panic!("set_liquidation_bot_config rejected: {}", m),
+    };
+    parsed.expect("set_liquidation_bot_config returned error");
+}
+
+fn bot_claim_call(
+    fixture: &Fixture,
+    bot: Principal,
+    vault_id: u64,
+) -> Result<BotLiquidationResult, ProtocolError> {
+    let result = fixture
+        .pic
+        .update_call(
+            fixture.protocol_id,
+            bot,
+            "bot_claim_liquidation",
+            encode_args((vault_id,)).unwrap(),
+        )
+        .expect("bot_claim_liquidation call failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode bot_claim_liquidation"),
+        WasmResult::Reject(m) => panic!("bot_claim_liquidation rejected: {}", m),
+    }
+}
+
+// ─── Fixture ───
+
+struct Fixture {
+    pic: PocketIc,
+    protocol_id: Principal,
+    icp_ledger: Principal,
+    #[allow(dead_code)]
+    icusd_ledger: Principal,
+    xrc_id: Principal,
+    developer: Principal,
+    #[allow(dead_code)]
+    test_user: Principal,
+    /// Pre-opened vault id with 50 ICP collateral and 100 icUSD borrowed.
+    /// At $10/ICP starting price → CR = 500%. Drop ICP to $0.10 to push
+    /// well below the 110% liquidation threshold.
+    vault_id: u64,
+}
+
+fn setup_fixture() -> Fixture {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+
+    let test_user = Principal::self_authenticating(b"bot_001_pic_user");
+    let developer = Principal::self_authenticating(b"bot_001_pic_developer");
+    let treasury = Principal::self_authenticating(b"bot_001_pic_treasury");
+    // Wave-11 BOT-001: the ICP ledger MUST use a minting account that is
+    // NOT the protocol. The LIQ-008 fixture uses `protocol_id` as the
+    // minting account for convenience, but that turns every protocol →
+    // bot transfer into a mint (and bot → protocol return into a burn) —
+    // which makes `icrc1_balance_of(protocol_id)` always 0 and breaks
+    // the BOT-001 gate's premise. A separate minter lets the protocol
+    // hold a real balance that the gate can observe.
+    let icp_minter = Principal::self_authenticating(b"bot_001_pic_icp_minter");
+
+    let protocol_id = pic.create_canister();
+    pic.add_cycles(protocol_id, 2_000_000_000_000);
+    pic.set_controllers(protocol_id, None, vec![Principal::anonymous(), developer])
+        .expect("set_controllers failed");
+
+    let icp_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(icp_minter),
+        10_000,
+        vec![(account(test_user), Nat::from(1_000_000_000_000u64))],
+        "Internet Computer Protocol",
+        "ICP",
+        developer,
+    );
+
+    // icUSD ledger keeps protocol as minter — that's how icUSD actually
+    // works (the protocol mints/burns icUSD on borrow/repay). Only the
+    // collateral ledger needs a separate minter.
+    let icusd_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        0,
+        vec![],
+        "icUSD",
+        "icUSD",
+        developer,
+    );
+
+    let xrc_id = pic.create_canister();
+    pic.add_cycles(xrc_id, 1_000_000_000_000);
+    pic.install_canister(xrc_id, xrc_wasm(), prepare_mock_xrc(), None);
+
+    pic.set_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1_711_324_800));
+
+    let init = ProtocolArgVariant::Init(ProtocolInitArg {
+        fee_e8s: 10_000,
+        icp_ledger_principal: icp_ledger,
+        xrc_principal: xrc_id,
+        icusd_ledger_principal: icusd_ledger,
+        developer_principal: developer,
+    });
+    pic.install_canister(
+        protocol_id,
+        protocol_wasm(),
+        encode_args((init,)).expect("encode protocol init"),
+        None,
+    );
+
+    pic.advance_time(Duration::from_secs(1));
+    for _ in 0..10 {
+        pic.tick();
+    }
+
+    // Quiet down rate / fee curves so the vault math stays predictable across
+    // ticks. Same boilerplate as the LIQ-008 fixture.
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_borrowing_fee_curve",
+            encode_args((None::<String>,)).unwrap(),
+        )
+        .expect("set_borrowing_fee_curve");
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_rate_curve_markers",
+            encode_args((None::<Principal>, vec![(1.5f64, 1.0f64), (3.0f64, 1.0f64)])).unwrap(),
+        )
+        .expect("set_rate_curve_markers");
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_borrowing_fee",
+            encode_args((0.0f64,)).unwrap(),
+        )
+        .expect("set_borrowing_fee");
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_interest_rate",
+            encode_args((icp_ledger, 0.0f64)).unwrap(),
+        )
+        .expect("set_interest_rate");
+
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_treasury_principal",
+            encode_args((treasury,)).unwrap(),
+        )
+        .expect("set_treasury_principal");
+
+    icrc2_approve_call(&pic, icp_ledger, test_user, protocol_id, 50_000_000_000u128);
+    let open_result = pic
+        .update_call(
+            protocol_id,
+            test_user,
+            "open_vault",
+            encode_args((5_000_000_000u64, None::<Principal>)).unwrap(),
+        )
+        .expect("open_vault failed");
+    let vault_id = match open_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<OpenVaultSuccess, ProtocolError> =
+                decode_one(&bytes).expect("decode open_vault");
+            r.expect("open_vault returned error").vault_id
+        }
+        WasmResult::Reject(msg) => panic!("open_vault rejected: {}", msg),
+    };
+
+    let borrow_arg = VaultArg {
+        vault_id,
+        amount: 10_000_000_000u64, // 100 icUSD borrowed
+    };
+    let borrow_result = pic
+        .update_call(
+            protocol_id,
+            test_user,
+            "borrow_from_vault",
+            encode_args((borrow_arg,)).unwrap(),
+        )
+        .expect("borrow_from_vault failed");
+    match borrow_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<SuccessWithFee, ProtocolError> =
+                decode_one(&bytes).expect("decode borrow");
+            r.expect("borrow_from_vault returned error");
+        }
+        WasmResult::Reject(msg) => panic!("borrow rejected: {}", msg),
+    }
+
+    Fixture {
+        pic,
+        protocol_id,
+        icp_ledger,
+        icusd_ledger,
+        xrc_id,
+        developer,
+        test_user,
+        vault_id,
+    }
+}
+
+/// Drop ICP price and tick until the protocol's cached price reflects it.
+/// Drops outside the 70%-143% sanity band (e.g. $10 → $0.10) need three
+/// consecutive matching XRC samples before `check_price_sanity_band`
+/// confirms — each XRC interval is 300s, so we advance 310s and tick four
+/// times to land safely past the third confirmation.
+fn drop_icp_price(fixture: &Fixture, new_price_e8s: u64) {
+    xrc_set_rate(
+        &fixture.pic,
+        fixture.xrc_id,
+        fixture.developer,
+        "ICP",
+        "USD",
+        new_price_e8s,
+    );
+    for _ in 0..4 {
+        fixture.pic.advance_time(Duration::from_secs(310));
+        for _ in 0..15 {
+            fixture.pic.tick();
+        }
+    }
+}
+
+/// Make `vault_id` underwater AND configure the bot, then have the bot
+/// claim the vault. After this call, the bot principal holds the
+/// collateral and the protocol has a live `bot_claims` entry. Returns
+/// `(pre_claim_budget, claim)` so callers can compare against the
+/// post-claim budget without races against the bot-config write.
+fn seed_bot_claim(fixture: &Fixture) -> (u64, BotLiquidationResult) {
+    // Bot = developer for fixture simplicity. Budget large enough for
+    // the full 100 icUSD claim ($10k).
+    set_liquidation_bot_config_admin(fixture, fixture.developer, 1_000_000_000_000u64);
+
+    // Drop to $2.50/ICP. Vault: 50 ICP × $2.50 / $100 debt = 125% CR
+    // (< 133% liq threshold → liquidatable) yet TCR also = 125% (> 100%
+    // → no ReadOnly auto-latch, so `check_vaults` keeps running and the
+    // BOT-001 gate has a chance to fire on the next tick).
+    drop_icp_price(fixture, 250_000_000);
+
+    let pre_claim_budget = get_bot_stats(&fixture.pic, fixture.protocol_id).budget_remaining_e8s;
+
+    let claim = bot_claim_call(fixture, fixture.developer, fixture.vault_id)
+        .expect("bot_claim_liquidation must succeed against underwater vault");
+
+    (pre_claim_budget, claim)
+}
+
+/// Advance time + tick enough for the XRC interval to fire and
+/// `check_vaults` (and its BOT-001 gate) to run. The bot-claim timeout is
+/// 600s; we advance 700s so the claim qualifies as expired by the time
+/// the next XRC tick runs.
+fn fast_forward_past_bot_timeout(fixture: &Fixture) {
+    fixture.pic.advance_time(Duration::from_secs(700));
+    for _ in 0..15 {
+        fixture.pic.tick();
+    }
+}
+
+// ─── Tests ───
+
+/// BOT-001 PIC #1: when the bot did NOT return the collateral, the
+/// auto-cancel must skip — keeping `bot_claims`, `vault.bot_processing`,
+/// and `bot_budget_remaining_e8s` intact — and emit a
+/// `BotClaimReconciliationNeeded` event so admin can reconcile.
+#[test]
+fn bot_001_pic_auto_cancel_skipped_when_balance_below_required() {
+    let f = setup_fixture();
+
+    let (pre_claim_budget, claim) = seed_bot_claim(&f);
+
+    // Sanity: the budget was deducted by the claim.
+    let post_claim_budget = get_bot_stats(&f.pic, f.protocol_id).budget_remaining_e8s;
+    assert!(
+        post_claim_budget < pre_claim_budget,
+        "bot_claim_liquidation must deduct from budget (before {} after {})",
+        pre_claim_budget,
+        post_claim_budget
+    );
+
+    // Sanity: the bot now actually holds the collateral (so the BOT-001
+    // gate has something to detect).
+    let bot_balance = icrc1_balance_of_call(&f.pic, f.icp_ledger, f.developer);
+    assert!(
+        bot_balance >= claim.collateral_amount.saturating_sub(10_000),
+        "bot must hold the seized collateral; got {} expected ~{}",
+        bot_balance,
+        claim.collateral_amount
+    );
+
+    // Sanity: no BOT-001 events yet.
+    assert!(
+        get_bot_001_events(&f.pic, f.protocol_id).is_empty(),
+        "no BotClaimReconciliationNeeded events expected before timeout"
+    );
+
+    // Advance past the 10-min auto-cancel timeout and trigger
+    // `check_vaults` via XRC tick. Critically, the bot did NOT return the
+    // collateral, so the BOT-001 gate must fire.
+    fast_forward_past_bot_timeout(&f);
+
+    // The auto-cancel must NOT have fired: budget unchanged from
+    // post-claim baseline (no restore), claim still present.
+    let final_budget = get_bot_stats(&f.pic, f.protocol_id).budget_remaining_e8s;
+    assert_eq!(
+        final_budget, post_claim_budget,
+        "BOT-001 gate must prevent budget restore when collateral wasn't returned (saw budget {} vs expected {})",
+        final_budget, post_claim_budget
+    );
+
+    // A `BotClaimReconciliationNeeded` event must exist for this vault.
+    let events = get_bot_001_events(&f.pic, f.protocol_id);
+    assert!(
+        !events.is_empty(),
+        "BOT-001 gate must emit BotClaimReconciliationNeeded when shortfall detected"
+    );
+    let matched = events.iter().any(|e| match e {
+        Event::BotClaimReconciliationNeeded {
+            vault_id,
+            observed_balance,
+            required_balance,
+            ..
+        } => *vault_id == f.vault_id && observed_balance < required_balance,
+        _ => false,
+    });
+    assert!(
+        matched,
+        "expected a BotClaimReconciliationNeeded event for vault #{} with observed < required, saw {:?}",
+        f.vault_id, events
+    );
+}
+
+/// BOT-001 PIC #2: when the bot DID return the collateral, the
+/// auto-cancel proceeds — clearing the claim, restoring the budget, and
+/// NOT emitting `BotClaimReconciliationNeeded`. This preserves the
+/// pre-Wave-11 happy path so we don't regress the "bot crashed but
+/// returned funds" recovery.
+#[test]
+fn bot_001_pic_auto_cancel_proceeds_when_balance_sufficient() {
+    let f = setup_fixture();
+
+    let (pre_claim_budget, claim) = seed_bot_claim(&f);
+
+    let post_claim_budget = get_bot_stats(&f.pic, f.protocol_id).budget_remaining_e8s;
+    assert!(
+        post_claim_budget < pre_claim_budget,
+        "bot_claim_liquidation must deduct from budget"
+    );
+
+    // Bot returns the collateral to the protocol's main account, paying
+    // the ICP transfer fee. The BOT-001 gate compares against
+    // `claim.collateral_amount - ledger_fee`, so transferring exactly
+    // that amount is the threshold case where the gate must NOT fire.
+    let icp_fee: u64 = 10_000;
+    let return_amount = claim.collateral_amount.saturating_sub(icp_fee);
+    icrc1_transfer_call(
+        &f.pic,
+        f.icp_ledger,
+        f.developer,
+        f.protocol_id,
+        return_amount as u128,
+    );
+
+    // Sanity: the protocol's main account must now hold AT LEAST the
+    // required collateral so the BOT-001 gate has something to detect on
+    // the next `check_vaults` tick. If this assertion fires, the rest of
+    // the test is moot — the bot return didn't actually credit the
+    // protocol.
+    let protocol_balance = icrc1_balance_of_call(&f.pic, f.icp_ledger, f.protocol_id);
+    let required = claim.collateral_amount.saturating_sub(icp_fee);
+    assert!(
+        protocol_balance >= required,
+        "protocol balance {} must cover required {} after bot return",
+        protocol_balance,
+        required
+    );
+
+    fast_forward_past_bot_timeout(&f);
+
+    // Auto-cancel must have fired: budget restored, no BOT-001 event.
+    let final_budget = get_bot_stats(&f.pic, f.protocol_id).budget_remaining_e8s;
+    assert_eq!(
+        final_budget, pre_claim_budget,
+        "auto-cancel must restore budget when collateral was returned (saw {} expected pre-claim baseline {})",
+        final_budget, pre_claim_budget
+    );
+
+    let events = get_bot_001_events(&f.pic, f.protocol_id);
+    assert!(
+        events.is_empty(),
+        "no BotClaimReconciliationNeeded events expected on the happy path; got {:?}",
+        events
+    );
+}


### PR DESCRIPTION
## Summary
- Gates the 10-min `bot_claims` auto-cancel in `check_vaults` on `icrc1_balance_of` returning at least `claim.collateral_amount - ledger_fee`. Skips the cancel and emits `BotClaimReconciliationNeeded` when the bot still holds the collateral, so admin can reconcile manually.
- Adds the `BotClaimReconciliationNeeded` event + dedicated `EventTypeFilter` so operators can directly query stuck claims (mirrors how Wave-10 split out `BreakerTripped`).
- `check_vaults` becomes async to host the inter-canister balance query; only caller is `xrc::fetch_icp_rate` which is already async.
- TOCTOU re-check on the mutate, since the bot may race us by calling `bot_cancel_liquidation` itself during the await window — without the re-check, `bot_budget_remaining_e8s` would be double-credited.

## Background
Closes BOT-001 from the 2026-04-22-28e9896 audit. Pre-Wave-11, a `CLAIM → SWAP-ok → TRANSFER-fail → admin-AFK-10min` sequence would clear the claim while the bot still held the collateral, leaving the vault permanently underwater. The explicit `bot_cancel_liquidation` endpoint queries `icrc1_balance_of` today but only logs the result — it does NOT gate on it. Wave-11 brings the unattended auto-cancel to a stricter standard than the explicit endpoint.

## Discoveries
- `bot_cancel_liquidation` does NOT actually gate on the balance check today; it only logs the result. Out of scope for Wave-11 (the explicit endpoint is admin/bot-driven, not unattended), but flagging here as a follow-up for consideration.
- The canonical `src/rumi_protocol_backend/rumi_protocol_backend.did` was stale on `main`: missing Wave-8e (`DeficitAccrued`, `DeficitRepaid`, `Set*`) and Wave-10 (`BreakerTripped`, `BreakerCleared`, `Set*`) variants. The `check_candid_interface_compatibility` test was failing on `main` too. Wave-11's regen sweeps up both prior waves' missing entries.

## Tests
Three layers, matching Wave-8e / Wave-10 pattern:

- **Layer 1** (`audit_pocs_bot_001_auto_cancel_balance.rs`, 9 tests): CBOR round-trip of the variant, classification to dedicated filter, vault-id matching, principal involvement (false), timestamp surfacing, admin-label semantics, size/collateral-token semantics, EventTypeFilter CBOR round-trip.
- **Layer 3** (`audit_pocs_bot_001_auto_cancel_balance_pic.rs`, 2 tests): end-to-end through `check_vaults` + the XRC tick. One asserts the gate fires (claim retained, budget unchanged, event emitted) when the bot hasn't returned. The other asserts the gate passes (claim cleared, budget restored, no event) when the bot has returned. Fixture uses a separate ICP minter so the protocol holds a real balance the gate can observe — without that, every transfer is a mint/burn and the balance is always 0.
- **Layer 1 + LIQ-005 + LIQ-008 PIC + `pocket_ic_tests` regression**: 83 / 9 / 4 / 5 / 27 passed, no regressions.

The `icrc1_balance_of` error branch is exercised in code review only (reliably injecting a ledger-side error from PocketIC requires a non-transacting mock that also blocks the bot's collateral transfer in setup).

## Test plan
- [x] Layer 1 fence (9 passed)
- [x] Layer 3 PocketIC fence — both branches (2 passed)
- [x] Backend `--lib` regression (83 passed, 1 ignored)
- [x] LIQ-008 PIC regression (5 passed)
- [x] LIQ-005 PIC regression (4 passed)
- [x] `pocket_ic_tests` regression (27 passed, 2 ignored)
- [x] `check_candid_interface_compatibility` passes
- [ ] Mainnet deploy + post-deploy hash recorded
- [ ] 24h bake watch on `[BOT-001]` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)