### PR TITLE
fix(analytics): seed decimals on post_upgrade + backfill missed margin events

### DIFF
--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -1,20 +1,20 @@
 type AddressValuePoint = record {
   ts_ns : nat64;
-  value_usd_e8s : nat64;
   breakdown : vec AddressValueSourceBreakdown;
+  value_usd_e8s : nat64;
 };
 type AddressValueSeriesQuery = record {
   "principal" : principal;
-  window_ns : opt nat64;
   resolution_ns : opt nat64;
+  window_ns : opt nat64;
 };
 type AddressValueSeriesResponse = record {
   "principal" : principal;
-  window_ns : nat64;
   resolution_ns : nat64;
   generated_at_ns : nat64;
-  points : vec AddressValuePoint;
   approximate_sources : vec text;
+  window_ns : nat64;
+  points : vec AddressValuePoint;
 };
 type AddressValueSourceBreakdown = record {
   source : text;
@@ -36,6 +36,14 @@ type ApyResponse = record {
   lp_apy_pct : opt float64;
   window_days : nat32;
   sp_apy_pct : opt float64;
+};
+type BackfillProgress = record {
+  cursor_after : nat64;
+  from : nat64;
+  scanned : nat64;
+  complete : bool;
+  emitted : nat64;
+  total_events : nat64;
 };
 type BalanceTrackerStats = record {
   token : principal;
@@ -156,20 +164,20 @@ type FastPriceSnapshot = record {
   timestamp_ns : nat64;
   prices : vec record { principal; float64; text };
 };
+type FeeBreakdownQuery = record { window_ns : opt nat64 };
+type FeeBreakdownResponse = record {
+  redemption_count : nat32;
+  borrow_count : nat32;
+  redemption_fees_icusd_e8s : nat64;
+  borrow_fees_icusd_e8s : nat64;
+  start_ns : nat64;
+  swap_count : nat32;
+  swap_fees_icusd_e8s : nat64;
+  end_ns : nat64;
+};
 type FeeCurveSeriesResponse = record {
   rows : vec HourlyFeeCurveSnapshot;
   next_from_ts : opt nat64;
-};
-type FeeBreakdownQuery = record { window_ns : opt nat64 };
-type FeeBreakdownResponse = record {
-  borrow_fees_icusd_e8s : nat64;
-  redemption_fees_icusd_e8s : nat64;
-  swap_fees_icusd_e8s : nat64;
-  borrow_count : nat32;
-  redemption_count : nat32;
-  swap_count : nat32;
-  start_ns : nat64;
-  end_ns : nat64;
 };
 type FeeSeriesResponse = record {
   rows : vec DailyFeeRollup;
@@ -277,6 +285,8 @@ type RangeQuery = record {
   limit : opt nat32;
 };
 type ResetErrorCountersArgs = record { sources : opt vec text };
+type Result = variant { Ok : BackfillProgress; Err : text };
+type Result_1 = variant { Ok; Err : text };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
@@ -387,6 +397,7 @@ type VolatilityResponse = record {
   annualized_vol_pct : float64;
 };
 service : (InitArgs) -> {
+  admin_backfill_add_margin_events : (nat64) -> (Result);
   get_address_value_series : (AddressValueSeriesQuery) -> (
       AddressValueSeriesResponse,
     ) query;
@@ -397,8 +408,10 @@ service : (InitArgs) -> {
   get_apys : (ApyQuery) -> (ApyResponse) query;
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
+  get_fee_breakdown_window : (FeeBreakdownQuery) -> (
+      FeeBreakdownResponse,
+    ) query;
   get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
-  get_fee_breakdown_window : (FeeBreakdownQuery) -> (FeeBreakdownResponse) query;
   get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
   get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;
@@ -407,6 +420,7 @@ service : (InitArgs) -> {
   get_pool_routes : (PoolRoutesQuery) -> (PoolRoutesResponse) query;
   get_price_series : (RangeQuery) -> (PriceSeriesResponse) query;
   get_protocol_summary : () -> (ProtocolSummary) query;
+  get_sp_depositor_principals : () -> (vec principal) query;
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
@@ -415,7 +429,6 @@ service : (InitArgs) -> {
       TopCounterpartiesResponse,
     ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
-  get_sp_depositor_principals : () -> (vec principal) query;
   get_top_sp_depositors : (TopSpDepositorsQuery) -> (
       TopSpDepositorsResponse,
     ) query;
@@ -426,6 +439,6 @@ service : (InitArgs) -> {
   get_volatility : (VolatilityQuery) -> (VolatilityResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   ping : () -> (text) query;
-  reset_error_counters : (ResetErrorCountersArgs) -> (variant { Ok; Err : text });
+  reset_error_counters : (ResetErrorCountersArgs) -> (Result_1);
   start_backfill : (principal) -> (text);
 }

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -288,6 +288,73 @@ fn start_backfill(token: Principal) -> String {
     }
 }
 
+/// One-shot backfill for AddMarginToVault → CollateralDeposited. The original
+/// analytics tailer dropped AddMarginToVault on the floor, so vaults that were
+/// topped up after open had their on-chain collateral diverge from what the
+/// timeline reconstructed — the user-facing symptom was vault_equity clamping
+/// to 0 (collateral under-counted, debt full-counted, underwater saturation).
+///
+/// This walks `get_events` from `add_margin_backfill_cursor` (or 0) up to
+/// `min(start + batch_size, get_event_count)` and pushes a CollateralDeposited
+/// analytics row for every AddMarginToVault it finds. The cursor advances
+/// past every event it inspects (admin or otherwise), so the same row never
+/// emits twice across calls. Caller re-invokes until the response shows
+/// `complete = true`.
+#[ic_cdk_macros::update]
+async fn admin_backfill_add_margin_events(batch_size: u64) -> Result<types::BackfillProgress, String> {
+    let admin = state::read_state(|s| s.admin);
+    let caller = ic_cdk::caller();
+    if caller != admin {
+        return Err(format!("unauthorized: caller {} is not admin", caller));
+    }
+    let backend = state::read_state(|s| s.sources.backend);
+    let cursor = state::read_state(|s| s.add_margin_backfill_cursor.unwrap_or(0));
+    let count = sources::backend::get_event_count(backend).await?;
+    if cursor >= count {
+        return Ok(types::BackfillProgress {
+            from: cursor,
+            scanned: 0,
+            emitted: 0,
+            cursor_after: cursor,
+            total_events: count,
+            complete: true,
+        });
+    }
+    let want = batch_size.clamp(1, 5_000).min(count - cursor);
+    let events = sources::backend::get_events(backend, cursor, want).await?;
+    let mut emitted = 0u64;
+    for (i, event) in events.iter().enumerate() {
+        let event_id = cursor + i as u64;
+        if let sources::backend::BackendEvent::AddMarginToVault {
+            vault_id, margin_added, caller: actor, timestamp, ..
+        } = event {
+            storage::events::evt_vaults::push(storage::events::AnalyticsVaultEvent {
+                timestamp_ns: timestamp.unwrap_or(0),
+                source_event_id: event_id,
+                vault_id: *vault_id,
+                owner: actor.unwrap_or(candid::Principal::anonymous()),
+                event_kind: storage::events::VaultEventKind::CollateralDeposited,
+                collateral_type: candid::Principal::anonymous(),
+                amount: *margin_added,
+                fee_amount: None,
+            });
+            emitted += 1;
+        }
+    }
+    let cursor_after = cursor + events.len() as u64;
+    state::mutate_state(|s| {
+        s.add_margin_backfill_cursor = Some(cursor_after);
+    });
+    Ok(types::BackfillProgress {
+        from: cursor,
+        scanned: events.len() as u64,
+        emitted,
+        cursor_after,
+        total_events: count,
+        complete: cursor_after >= count,
+    })
+}
+
 #[ic_cdk_macros::update]
 fn reset_error_counters(args: types::ResetErrorCountersArgs) -> Result<(), String> {
     let admin = state::read_state(|s| s.admin);

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -137,6 +137,14 @@ pub struct SlimState {
     /// the first successful fast-collector run after upgrade.
     #[serde(default)]
     pub collateral_decimals: Option<std::collections::HashMap<Principal, u8>>,
+    /// Highest backend event id processed by the AddMarginToVault one-shot
+    /// backfill. The original tailer dropped those events on the floor, so a
+    /// post-fix upgrade needs to walk the historical log to surface them as
+    /// CollateralDeposited analytics rows. `Some(n)` means events 0..n have
+    /// been swept; resume from `n` on the next admin call. `None` means the
+    /// backfill has not run yet on this canister.
+    #[serde(default)]
+    pub add_margin_backfill_cursor: Option<u64>,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -179,6 +187,7 @@ impl Default for SlimState {
             backfill_active_3usd: None,
             last_pull_cycle_ns: None,
             collateral_decimals: None,
+            add_margin_backfill_cursor: None,
         }
     }
 }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -11,18 +11,21 @@ pub enum SetupContext {
 }
 
 pub fn setup_timers(ctx: SetupContext) {
-    // Fire daily + fast snapshots immediately on init only. On post_upgrade
-    // the pre-existing rows already cover the recent period, so re-firing
-    // would create duplicate snapshots for the same day. Intervals reset on
-    // upgrade and resume normally without an immediate fire.
+    // Fire the daily snapshot only on Init — on post_upgrade the pre-existing
+    // row already covers today, so re-firing would create duplicate daily
+    // snapshots. Fast snapshot, however, also seeds heap-only state that's
+    // wiped by upgrade (collateral_decimals map), so we always fire it
+    // immediately. An extra fast row at upgrade time is cheap (5-min log
+    // cadence) and avoids a 5-minute window where pricing falls back to
+    // 8-decimal defaults — the bug that motivated PR #141.
     if ctx == SetupContext::Init {
         ic_cdk_timers::set_timer(Duration::from_secs(0), || {
             ic_cdk::spawn(daily_snapshot());
         });
-        ic_cdk_timers::set_timer(Duration::from_secs(0), || {
-            ic_cdk::spawn(fast_snapshot());
-        });
     }
+    ic_cdk_timers::set_timer(Duration::from_secs(0), || {
+        ic_cdk::spawn(fast_snapshot());
+    });
 
     ic_cdk_timers::set_timer_interval(Duration::from_secs(60), || {
         ic_cdk::spawn(pull_cycle());

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -402,6 +402,18 @@ pub struct ResetErrorCountersArgs {
     pub sources: Option<Vec<String>>,
 }
 
+/// Progress report for `admin_backfill_add_margin_events`. The caller drives
+/// the loop: keep calling until `complete = true`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct BackfillProgress {
+    pub from: u64,
+    pub scanned: u64,
+    pub emitted: u64,
+    pub cursor_after: u64,
+    pub total_events: u64,
+    pub complete: bool,
+}
+
 // --- Fee breakdown window (Task 3.1) ---
 
 #[derive(CandidType, Deserialize, Clone, Debug)]


### PR DESCRIPTION
## Summary
- Fire `fast_snapshot()` on post_upgrade (not just Init). Without this, `collateral_decimals` is `None` for ~5 min after every upgrade and `price_vault_equity_at` falls back to the hardcoded 8 — i.e. the ckETH inflation bug PR #141 fixed comes back briefly on every redeploy.
- Add `admin_backfill_add_margin_events`, a one-shot resumable admin endpoint that walks the backend event log and emits `CollateralDeposited` rows for any historical `AddMarginToVault` event. The original tailer dropped these on the floor; PR #141 added the new variant but the cursor was already past every historical top-up, so vaults that had been topped up since open showed only the open-time amount and clamped equity to 0.

## Why
After deploying PR #141 to mainnet, the test address (`zegjz-jpi6k-…`) showed `vault_equity = 0` instead of the expected ~$2k. Two reasons: the decimals map was empty in the 5-min post-upgrade window, and historical `AddMarginToVault` events were missing from the timeline so debt outweighed under-counted collateral.

## Test plan
- [x] `cargo test -p rumi_analytics --lib` — 105 passed
- [x] Wasm build clean
- [x] Mainnet deploy succeeded, backfill ran (67,807 events scanned, ~90 historical top-ups emitted)
- [x] Test address chart now shows `vault_equity = $2,376.19` (vs $22.7B pre-fix), within the documented approximation drift of the live allocation card's $1,976

## Notes
- `admin_backfill_add_margin_events` is admin-gated and idempotent across calls (cursor in stable state). After running on mainnet today the cursor sits at the log tail, so re-running is a no-op.
- Adds `add_margin_backfill_cursor: Option<u64>` to `SlimState` (backwards-compat default `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)