### PR TITLE
fix(explorer+analytics+backend): closed-vault rendering, AMM LP, indexed vault history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,12 @@ audit-reports/
 # Local design/spec/planning notes (whitepaper and existing tracked docs in this folder
 # stay tracked; this only blocks new untracked additions from being committed)
 docs/
+
+# Superpowers local brainstorm/cache
+.superpowers/
+
+# Loose screenshots at repo root (Claude Preview / browser captures during debugging).
+# Tracked screenshots under docs/screenshots/ are unaffected because they're already
+# in git history.
+/explorer-*.png
+/pr*-*.png

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ pocket-ic
 technical-analysis/
 xrc_demo/
 .playwright-mcp/
+
+# Security: audit reports stay local (repo is PUBLIC)
+audit-reports/
+
+# Local design/spec/planning notes (whitepaper and existing tracked docs in this folder
+# stay tracked; this only blocks new untracked additions from being committed)
+docs/

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -158,6 +158,11 @@ type Event = variant {
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
   set_max_partial_liquidation_ratio : record { rate : text };
+  breaker_tripped : record {
+    total_e8s : nat64;
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   withdraw_and_close_vault : record {
     block_index : opt nat64;
     vault_id : nat64;
@@ -246,6 +251,10 @@ type Event = variant {
     caller : opt principal;
     borrowed_amount : nat64;
   };
+  set_breaker_window_debt_ceiling_e8s : record {
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
@@ -287,6 +296,7 @@ type Event = variant {
     timestamp : opt nat64;
     amount : nat64;
   };
+  set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
     protocol_fee_collateral : opt nat64;
     icp_rate : opt blob;
@@ -331,12 +341,21 @@ type Event = variant {
     min_collateral_deposit : nat64;
     collateral_type : principal;
   };
+  breaker_cleared : record { remaining_total_e8s : nat64; timestamp : nat64 };
   update_collateral_status : record {
     status : CollateralStatus;
     collateral_type : principal;
   };
   set_healthy_cr : record { healthy_cr : opt text; collateral_type : text };
+  set_deficit_repayment_fraction : record {
+    fraction : blob;
+    timestamp : nat64;
+  };
   set_redemption_fee_ceiling : record { rate : text };
+  set_deficit_readonly_threshold_e8s : record {
+    threshold_e8s : nat64;
+    timestamp : nat64;
+  };
   add_margin_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
@@ -355,12 +374,25 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  deficit_repaid : record {
+    remaining_deficit : nat64;
+    source : FeeSource;
+    timestamp : nat64;
+    anchor_block_index : opt nat64;
+    amount : nat64;
+  };
   redemption_transfered : record {
     icusd_block_index : nat64;
     icp_block_index : nat64;
     timestamp : opt nat64;
   };
   set_liquidation_bot_principal : record { "principal" : principal };
+  deficit_accrued : record {
+    new_deficit : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    amount : nat64;
+  };
   liquidate_vault : record {
     mode : Mode;
     icp_rate : blob;
@@ -388,6 +420,7 @@ type Event = variant {
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
+  BreakerTripped;
   StabilityPoolDeposit;
   AdminSweepToTreasury;
   AdminMint;
@@ -398,13 +431,16 @@ type EventTypeFilter = variant {
   AccrueInterest;
   ReserveRedemption;
   Repay;
+  DeficitAccrued;
   Liquidation;
   Borrow;
   PriceUpdate;
   Admin;
+  DeficitRepaid;
   Redemption;
   CloseVault;
 };
+type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
   "principal" : opt principal;
@@ -552,6 +588,7 @@ type ProtocolSnapshot = record {
 type ProtocolStatus = record {
   last_icp_timestamp : nat64;
   borrowing_fee_curve_resolved : vec record { float64; float64 };
+  deficit_readonly_threshold_e8s : nat64;
   recovery_mode_threshold : float64;
   per_collateral_interest : vec CollateralInterestInfo;
   reserve_redemption_fee : float64;
@@ -562,25 +599,24 @@ type ProtocolStatus = record {
   total_icusd_borrowed : nat64;
   min_icusd_amount : nat64;
   total_collateral_ratio : float64;
+  deficit_repayment_fraction : float64;
   ckstable_repay_fee : float64;
+  windowed_liquidation_total_e8s : nat64;
   total_icp_margin : nat64;
   recovery_target_cr : float64;
   frozen : bool;
   weighted_average_interest_rate : float64;
+  liquidation_breaker_tripped : bool;
+  protocol_deficit_icusd : nat64;
+  breaker_window_ns : nat64;
   manual_mode_override : bool;
   liquidation_bonus : float64;
   per_collateral_rate_curves : vec PerCollateralRateCurve;
   reserve_redemptions_enabled : bool;
-  global_icusd_mint_cap : nat64;
-  last_icp_rate : float64;
-  protocol_deficit_icusd : nat64;
   total_deficit_repaid_icusd : nat64;
-  deficit_repayment_fraction : float64;
-  deficit_readonly_threshold_e8s : nat64;
-  breaker_window_ns : nat64;
+  global_icusd_mint_cap : nat64;
   breaker_window_debt_ceiling_e8s : nat64;
-  windowed_liquidation_total_e8s : nat64;
-  liquidation_breaker_tripped : bool;
+  last_icp_rate : float64;
 };
 type RateCurve = record {
   method : InterpolationMethod;
@@ -778,7 +814,7 @@ service : (ProtocolArg) -> {
   get_three_pool_canister : () -> (opt principal) query;
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
-  get_vault_history : (nat64) -> (vec Event) query;
+  get_vault_history : (nat64) -> (vec record { nat64; Event }) query;
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   http_request : (HttpRequest) -> (HttpResponse_1) query;
@@ -858,17 +894,12 @@ service : (ProtocolArg) -> {
   set_three_pool_canister : (principal) -> (Result);
   set_treasury_principal : (principal) -> (Result);
   stability_pool_liquidate : (nat64, nat64) -> (Result_12);
-  stability_pool_liquidate_debt_burned : (
-      nat64,
-      nat64,
-      SpWritedownProof,
-    ) -> (Result_12);
-  stability_pool_liquidate_with_reserves : (
-      nat64,
-      nat64,
-      nat64,
-      principal,
-    ) -> (Result_12);
+  stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
+      Result_12,
+    );
+  stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
+      Result_12,
+    );
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
@@ -876,4 +907,3 @@ service : (ProtocolArg) -> {
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);
 }
-

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -771,6 +771,7 @@ service : (ProtocolArg) -> {
     ) query;
   get_deposit_account : (opt principal) -> (Account) query;
   get_event_count : () -> (nat64) query;
+  get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
   get_events_by_principal : (principal) -> (vec record { nat64; Event }) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -184,6 +184,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'accrue_interest' : { 'timestamp' : bigint } } |
   { 'set_max_partial_liquidation_ratio' : { 'rate' : string } } |
   {
+    'breaker_tripped' : {
+      'total_e8s' : bigint,
+      'timestamp' : bigint,
+      'ceiling_e8s' : bigint,
+    }
+  } |
+  {
     'withdraw_and_close_vault' : {
       'block_index' : [] | [bigint],
       'vault_id' : bigint,
@@ -307,6 +314,12 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'set_breaker_window_debt_ceiling_e8s' : {
+      'timestamp' : bigint,
+      'ceiling_e8s' : bigint,
+    }
+  } |
+  {
     'set_bot_allowed_collateral_types' : {
       'collateral_types' : Array<Principal>,
     }
@@ -363,6 +376,7 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'amount' : bigint,
     }
   } |
+  { 'set_breaker_window_ns' : { 'window_ns' : bigint, 'timestamp' : bigint } } |
   {
     'partial_liquidate_vault' : {
       'protocol_fee_collateral' : [] | [bigint],
@@ -420,6 +434,9 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'breaker_cleared' : { 'remaining_total_e8s' : bigint, 'timestamp' : bigint }
+  } |
+  {
     'update_collateral_status' : {
       'status' : CollateralStatus,
       'collateral_type' : Principal,
@@ -431,7 +448,19 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'collateral_type' : string,
     }
   } |
+  {
+    'set_deficit_repayment_fraction' : {
+      'fraction' : Uint8Array | number[],
+      'timestamp' : bigint,
+    }
+  } |
   { 'set_redemption_fee_ceiling' : { 'rate' : string } } |
+  {
+    'set_deficit_readonly_threshold_e8s' : {
+      'threshold_e8s' : bigint,
+      'timestamp' : bigint,
+    }
+  } |
   {
     'add_margin_to_vault' : {
       'block_index' : bigint,
@@ -455,6 +484,15 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   } |
   { 'set_reserve_redemption_fee' : { 'fee' : string } } |
   {
+    'deficit_repaid' : {
+      'remaining_deficit' : bigint,
+      'source' : FeeSource,
+      'timestamp' : bigint,
+      'anchor_block_index' : [] | [bigint],
+      'amount' : bigint,
+    }
+  } |
+  {
     'redemption_transfered' : {
       'icusd_block_index' : bigint,
       'icp_block_index' : bigint,
@@ -462,6 +500,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   { 'set_liquidation_bot_principal' : { 'principal' : Principal } } |
+  {
+    'deficit_accrued' : {
+      'new_deficit' : bigint,
+      'vault_id' : bigint,
+      'timestamp' : bigint,
+      'amount' : bigint,
+    }
+  } |
   {
     'liquidate_vault' : {
       'mode' : Mode,
@@ -497,7 +543,8 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   } |
   { 'set_recovery_cr_multiplier' : { 'multiplier' : string } };
 export interface EventTimeRange { 'start_ns' : bigint, 'end_ns' : bigint }
-export type EventTypeFilter = { 'StabilityPoolDeposit' : null } |
+export type EventTypeFilter = { 'BreakerTripped' : null } |
+  { 'StabilityPoolDeposit' : null } |
   { 'AdminSweepToTreasury' : null } |
   { 'AdminMint' : null } |
   { 'AdjustVault' : null } |
@@ -507,12 +554,16 @@ export type EventTypeFilter = { 'StabilityPoolDeposit' : null } |
   { 'AccrueInterest' : null } |
   { 'ReserveRedemption' : null } |
   { 'Repay' : null } |
+  { 'DeficitAccrued' : null } |
   { 'Liquidation' : null } |
   { 'Borrow' : null } |
   { 'PriceUpdate' : null } |
   { 'Admin' : null } |
+  { 'DeficitRepaid' : null } |
   { 'Redemption' : null } |
   { 'CloseVault' : null };
+export type FeeSource = { 'BorrowingFee' : null } |
+  { 'RedemptionFee' : null };
 export interface Fees { 'redemption_fee' : number, 'borrowing_fee' : number }
 export interface GetEventsArg {
   'principal' : [] | [Principal],
@@ -930,7 +981,7 @@ export interface _SERVICE {
   'get_three_pool_canister' : ActorMethod<[], [] | [Principal]>,
   'get_treasury_principal' : ActorMethod<[], [] | [Principal]>,
   'get_treasury_stats' : ActorMethod<[], TreasuryStats>,
-  'get_vault_history' : ActorMethod<[bigint], Array<Event>>,
+  'get_vault_history' : ActorMethod<[bigint], Array<[bigint, Event]>>,
   'get_vault_interest_rate' : ActorMethod<[bigint], Result_7>,
   'get_vaults' : ActorMethod<[[] | [Principal]], Array<CandidVault>>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -931,6 +931,10 @@ export interface _SERVICE {
   >,
   'get_deposit_account' : ActorMethod<[[] | [Principal]], Account>,
   'get_event_count' : ActorMethod<[], bigint>,
+  'get_event_timestamps' : ActorMethod<
+    [bigint, bigint],
+    BigUint64Array | bigint[]
+  >,
   'get_events' : ActorMethod<[GetEventsArg], Array<Event>>,
   'get_events_by_principal' : ActorMethod<[Principal], Array<[bigint, Event]>>,
   'get_events_filtered' : ActorMethod<

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -915,6 +915,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_event_timestamps' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(IDL.Nat64)],
+        ['query'],
+      ),
     'get_events' : IDL.Func([GetEventsArg], [IDL.Vec(Event)], ['query']),
     'get_events_by_principal' : IDL.Func(
         [IDL.Principal],

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -219,6 +219,7 @@ export const idlFactory = ({ IDL }) => {
     'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const EventTypeFilter = IDL.Variant({
+    'BreakerTripped' : IDL.Null,
     'StabilityPoolDeposit' : IDL.Null,
     'AdminSweepToTreasury' : IDL.Null,
     'AdminMint' : IDL.Null,
@@ -229,10 +230,12 @@ export const idlFactory = ({ IDL }) => {
     'AccrueInterest' : IDL.Null,
     'ReserveRedemption' : IDL.Null,
     'Repay' : IDL.Null,
+    'DeficitAccrued' : IDL.Null,
     'Liquidation' : IDL.Null,
     'Borrow' : IDL.Null,
     'PriceUpdate' : IDL.Null,
     'Admin' : IDL.Null,
+    'DeficitRepaid' : IDL.Null,
     'Redemption' : IDL.Null,
     'CloseVault' : IDL.Null,
   });
@@ -268,6 +271,10 @@ export const idlFactory = ({ IDL }) => {
     'icusd_redeemed_e8s' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
     'collateral_seized' : IDL.Nat64,
+  });
+  const FeeSource = IDL.Variant({
+    'BorrowingFee' : IDL.Null,
+    'RedemptionFee' : IDL.Null,
   });
   const Event = IDL.Variant({
     'set_borrowing_fee' : IDL.Record({ 'rate' : IDL.Text }),
@@ -314,6 +321,11 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Record({ 'principal' : IDL.Principal }),
     'accrue_interest' : IDL.Record({ 'timestamp' : IDL.Nat64 }),
     'set_max_partial_liquidation_ratio' : IDL.Record({ 'rate' : IDL.Text }),
+    'breaker_tripped' : IDL.Record({
+      'total_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+      'ceiling_e8s' : IDL.Nat64,
+    }),
     'withdraw_and_close_vault' : IDL.Record({
       'block_index' : IDL.Opt(IDL.Nat64),
       'vault_id' : IDL.Nat64,
@@ -405,6 +417,10 @@ export const idlFactory = ({ IDL }) => {
       'caller' : IDL.Opt(IDL.Principal),
       'borrowed_amount' : IDL.Nat64,
     }),
+    'set_breaker_window_debt_ceiling_e8s' : IDL.Record({
+      'timestamp' : IDL.Nat64,
+      'ceiling_e8s' : IDL.Nat64,
+    }),
     'set_bot_allowed_collateral_types' : IDL.Record({
       'collateral_types' : IDL.Vec(IDL.Principal),
     }),
@@ -448,6 +464,10 @@ export const idlFactory = ({ IDL }) => {
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
       'amount' : IDL.Nat64,
+    }),
+    'set_breaker_window_ns' : IDL.Record({
+      'window_ns' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
     }),
     'partial_liquidate_vault' : IDL.Record({
       'protocol_fee_collateral' : IDL.Opt(IDL.Nat64),
@@ -493,6 +513,10 @@ export const idlFactory = ({ IDL }) => {
       'min_collateral_deposit' : IDL.Nat64,
       'collateral_type' : IDL.Principal,
     }),
+    'breaker_cleared' : IDL.Record({
+      'remaining_total_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+    }),
     'update_collateral_status' : IDL.Record({
       'status' : CollateralStatus,
       'collateral_type' : IDL.Principal,
@@ -501,7 +525,15 @@ export const idlFactory = ({ IDL }) => {
       'healthy_cr' : IDL.Opt(IDL.Text),
       'collateral_type' : IDL.Text,
     }),
+    'set_deficit_repayment_fraction' : IDL.Record({
+      'fraction' : IDL.Vec(IDL.Nat8),
+      'timestamp' : IDL.Nat64,
+    }),
     'set_redemption_fee_ceiling' : IDL.Record({ 'rate' : IDL.Text }),
+    'set_deficit_readonly_threshold_e8s' : IDL.Record({
+      'threshold_e8s' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+    }),
     'add_margin_to_vault' : IDL.Record({
       'block_index' : IDL.Nat64,
       'vault_id' : IDL.Nat64,
@@ -525,6 +557,13 @@ export const idlFactory = ({ IDL }) => {
       'interest_rate_apr' : IDL.Text,
     }),
     'set_reserve_redemption_fee' : IDL.Record({ 'fee' : IDL.Text }),
+    'deficit_repaid' : IDL.Record({
+      'remaining_deficit' : IDL.Nat64,
+      'source' : FeeSource,
+      'timestamp' : IDL.Nat64,
+      'anchor_block_index' : IDL.Opt(IDL.Nat64),
+      'amount' : IDL.Nat64,
+    }),
     'redemption_transfered' : IDL.Record({
       'icusd_block_index' : IDL.Nat64,
       'icp_block_index' : IDL.Nat64,
@@ -532,6 +571,12 @@ export const idlFactory = ({ IDL }) => {
     }),
     'set_liquidation_bot_principal' : IDL.Record({
       'principal' : IDL.Principal,
+    }),
+    'deficit_accrued' : IDL.Record({
+      'new_deficit' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+      'amount' : IDL.Nat64,
     }),
     'liquidate_vault' : IDL.Record({
       'mode' : Mode,
@@ -955,7 +1000,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_treasury_stats' : IDL.Func([], [TreasuryStats], ['query']),
-    'get_vault_history' : IDL.Func([IDL.Nat64], [IDL.Vec(Event)], ['query']),
+    'get_vault_history' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Vec(IDL.Tuple(IDL.Nat64, Event))],
+        ['query'],
+      ),
     'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_7], ['query']),
     'get_vaults' : IDL.Func(
         [IDL.Opt(IDL.Principal)],

--- a/src/rumi_analytics/src/collectors/fast.rs
+++ b/src/rumi_analytics/src/collectors/fast.rs
@@ -3,13 +3,14 @@
 use crate::{sources, state, storage};
 
 pub async fn run() -> Result<(), String> {
-    let (backend_id, three_pool_id) = state::read_state(|s| {
-        (s.sources.backend, s.sources.three_pool)
+    let (backend_id, three_pool_id, amm_id) = state::read_state(|s| {
+        (s.sources.backend, s.sources.three_pool, s.sources.amm)
     });
 
-    let (prices_res, pool_res) = futures::join!(
+    let (prices_res, pool_res, amm_pools_res) = futures::join!(
         sources::backend::get_collateral_totals(backend_id),
         sources::three_pool::get_pool_status(three_pool_id),
+        sources::amm::get_pools(amm_id),
     );
 
     let now = ic_cdk::api::time();
@@ -53,6 +54,28 @@ pub async fn run() -> Result<(), String> {
         Err(e) => {
             ic_cdk::println!("[fast] get_pool_status error: {}", e);
             state::mutate_state(|s| s.error_counters.three_pool += 1);
+        }
+    }
+
+    match amm_pools_res {
+        Ok(pools) => {
+            use num_traits::ToPrimitive;
+            let snaps: Vec<storage::AmmPoolSnapshot> = pools
+                .into_iter()
+                .map(|p| storage::AmmPoolSnapshot {
+                    pool_id: p.pool_id,
+                    token_a: p.token_a,
+                    token_b: p.token_b,
+                    reserve_a: p.reserve_a.0.to_u128().unwrap_or(0),
+                    reserve_b: p.reserve_b.0.to_u128().unwrap_or(0),
+                    total_lp_shares: p.total_lp_shares.0.to_u128().unwrap_or(0),
+                })
+                .collect();
+            state::mutate_state(|s| s.amm_pools = Some(snaps));
+        }
+        Err(e) => {
+            ic_cdk::println!("[fast] amm get_pools error: {}", e);
+            state::mutate_state(|s| s.error_counters.amm += 1);
         }
     }
 

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -204,6 +204,15 @@ fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types::Add
     queries::address_value::get_address_value_series(query)
 }
 
+/// Debug helper — exposes the AMM pool snapshot the address-value query reads
+/// from. Lets us check whether the chart's mismatch with the live allocation
+/// card is caused by stale reserves vs. mispriced reserves vs. a token-side
+/// mix-up. Cheap query, no aggregation, safe to keep behind no flag.
+#[ic_cdk_macros::query]
+fn debug_amm_pool_snapshot() -> Vec<storage::AmmPoolSnapshot> {
+    state::read_state(|s| s.amm_pools.clone().unwrap_or_default())
+}
+
 #[ic_cdk_macros::query]
 fn get_collector_health() -> types::CollectorHealth {
     use storage::cursors;
@@ -214,6 +223,7 @@ fn get_collector_health() -> types::CollectorHealth {
         (cursors::CURSOR_ID_3POOL_LIQUIDITY, "3pool_liquidity", cursors::three_pool_liquidity::get),
         (cursors::CURSOR_ID_3POOL_BLOCKS, "3pool_blocks", cursors::three_pool_blocks::get),
         (cursors::CURSOR_ID_AMM_SWAPS, "amm_swaps", cursors::amm_swaps::get),
+        (cursors::CURSOR_ID_AMM_LIQUIDITY, "amm_liquidity", cursors::amm_liquidity::get),
         (cursors::CURSOR_ID_STABILITY_EVENTS, "stability_events", cursors::stability_events::get),
         (cursors::CURSOR_ID_ICUSD_BLOCKS, "icusd_blocks", cursors::icusd_blocks::get),
     ];

--- a/src/rumi_analytics/src/queries/address_value.rs
+++ b/src/rumi_analytics/src/queries/address_value.rs
@@ -66,7 +66,16 @@ pub const SRC_THREEUSD: &str = "threeusd";
 /// `VaultPositionState` for the approximations that make this a flagged
 /// `approximate_sources` entry.
 pub const SRC_VAULT_EQUITY: &str = "vault_equity";
+/// Per-(principal, pool) LP shares × USD value of the pool's reserves.
+/// Approximate: historical points use the LATEST pool composition (we don't
+/// snapshot AMM reserves to a stable log) — drift bounded by rebalances
+/// since the user's LP position was opened.
+pub const SRC_AMM_LP: &str = "amm_lp";
 pub const SRC_SP_DEPOSIT: &str = "sp_deposit";
+/// Retained as a constant so historical breakdowns and tests that still
+/// reference the legacy source string compile; no longer pushed into live
+/// breakdowns (3USD = 3pool LP, see compute_address_value_series).
+#[allow(dead_code)]
 pub const SRC_3POOL_LP: &str = "three_pool_lp";
 
 thread_local! {
@@ -131,14 +140,16 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
     let liq_evs = storage::events::evt_liquidations::range(0, now, MAX_EVENT_LOAD);
     let sp_evs = storage::events::evt_stability::range(0, now, MAX_EVENT_LOAD);
     let liquidity_evs = storage::events::evt_liquidity::range(0, now, MAX_EVENT_LOAD);
+    let amm_liq_evs = storage::events::evt_amm_liquidity::range(0, now, MAX_EVENT_LOAD);
     let price_snaps = storage::fast::fast_prices::range(0, now, MAX_EVENT_LOAD);
     let three_pool_snaps = storage::fast::fast_3pool::range(0, now, MAX_EVENT_LOAD);
 
-    let (icusd_ledger, three_pool, collateral_decimals) = state::read_state(|s| {
+    let (icusd_ledger, three_pool, collateral_decimals, amm_pools) = state::read_state(|s| {
         (
             s.sources.icusd_ledger,
             s.sources.three_pool,
             s.collateral_decimals.clone().unwrap_or_default(),
+            s.amm_pools.clone().unwrap_or_default(),
         )
     });
     let icusd_balance = storage::balance_tracker::all_balances(storage::balance_tracker::Token::IcUsd)
@@ -167,6 +178,7 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
         &liq_evs,
         &sp_evs,
         &liquidity_evs,
+        &amm_liq_evs,
         &price_snaps,
         &three_pool_snaps,
         icusd_balance,
@@ -176,6 +188,7 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
         icusd_ledger,
         three_pool,
         &collateral_decimals,
+        &amm_pools,
     );
 
     let approximate_sources = vec![
@@ -187,10 +200,12 @@ pub fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types:
         // emits AccrueInterest with no per-vault breakdown). See
         // VaultPositionState docs for the precise drift bounds.
         SRC_VAULT_EQUITY.to_string(),
-        // AMM LP is absent from the output entirely in v1; no source string
-        // surfaces here because the breakdown never contains an "amm_lp"
-        // entry. Documented in the module header so the UI can set
-        // expectations without reading the backend.
+        // AMM LP is approximated: historical points are valued with the
+        // CURRENT pool composition (we cache the latest reserves in heap
+        // and don't snapshot them to a stable log). Drift is bounded by
+        // pool rebalancing since the position was opened; for stable-stable
+        // pools it's negligible, for volatile pools it can be material.
+        SRC_AMM_LP.to_string(),
     ];
 
     let resp = types::AddressValueSeriesResponse {
@@ -245,6 +260,7 @@ pub fn compute_address_value_series(
     liquidation_events: &[storage::events::AnalyticsLiquidationEvent],
     stability_events: &[storage::events::AnalyticsStabilityEvent],
     liquidity_3pool_events: &[storage::events::AnalyticsLiquidityEvent],
+    amm_liquidity_events: &[storage::events::AnalyticsAmmLiquidityEvent],
     price_snaps: &[storage::fast::FastPriceSnapshot],
     three_pool_snaps: &[storage::fast::Fast3PoolSnapshot],
     icusd_current_balance_e8s: u64,
@@ -254,6 +270,7 @@ pub fn compute_address_value_series(
     icusd_ledger: Principal,
     three_pool: Principal,
     collateral_decimals: &HashMap<Principal, u8>,
+    amm_pools: &[storage::AmmPoolSnapshot],
 ) -> Vec<types::AddressValuePoint> {
     let timestamps = sample_timestamps(from_ns, to_ns, resolution_ns);
 
@@ -262,7 +279,13 @@ pub fn compute_address_value_series(
     // at the largest ts <= sample_ts.
     let vault_timeline = build_vault_position_timeline(principal, vault_events, liquidation_events);
     let sp_timeline = build_sp_deposit_timeline(principal, stability_events);
-    let three_pool_lp_timeline = build_three_pool_lp_timeline(principal, liquidity_3pool_events);
+    let amm_lp_timeline = build_amm_lp_timeline(principal, amm_liquidity_events);
+    // Note: build_three_pool_lp_timeline is still exposed for tests + future
+    // historical 3USD-balance reconstruction work, but the live breakdown
+    // path no longer uses it (3USD ledger balance now stands in for 3pool LP
+    // exposure to avoid double-counting AMM-locked 3USD).
+    let _ = liquidity_3pool_events;
+    let _ = three_pool_snaps;
 
     let mut points = Vec::with_capacity(timestamps.len());
     for ts in timestamps {
@@ -327,22 +350,36 @@ pub fn compute_address_value_series(
             total = total.saturating_add(sp_balance);
         }
 
-        // 3pool LP balance × historical virtual price.
-        let lp_amount = lookup_timeline_scalar_at(&three_pool_lp_timeline, ts);
-        if lp_amount > 0 {
-            let vp = virtual_price_at(ts, three_pool_snaps);
-            let lp_value = apply_virtual_price(lp_amount, vp);
-            if lp_value > 0 {
-                breakdown.push(types::AddressValueSourceBreakdown {
-                    source: SRC_3POOL_LP.to_string(),
-                    value_usd_e8s: lp_value,
-                });
-                total = total.saturating_add(lp_value);
-            }
-        }
+        // 3pool LP exposure is intentionally NOT a separate source: 3USD IS
+        // the rumi_3pool LP token, so a user's 3pool position equals their
+        // 3USD ledger balance — already counted under SRC_THREEUSD above. The
+        // earlier `three_pool_lp` line tracked cumulative add/remove events
+        // and double-counted any 3USD that had been transferred elsewhere
+        // (e.g. deposited as AMM liquidity), inflating portfolio totals. The
+        // AMM-locked portion is now represented inside SRC_AMM_LP via pool
+        // reserves, which is also where the user's true 3pool exposure
+        // surfaces when they're an LP rather than holding 3USD directly.
 
-        let _ = icusd_ledger;
-        let _ = three_pool;
+        // AMM LP positions across all pools the principal has touched.
+        // Approximation: the latest pool composition is applied at every
+        // sample ts since reserves aren't snapshotted to a stable log.
+        let amm_lp_state = amm_lp_lookup_at(&amm_lp_timeline, ts);
+        let amm_lp_value = price_amm_lp_state(
+            &amm_lp_state,
+            ts,
+            amm_pools,
+            price_snaps,
+            collateral_decimals,
+            icusd_ledger,
+            three_pool,
+        );
+        if amm_lp_value > 0 {
+            breakdown.push(types::AddressValueSourceBreakdown {
+                source: SRC_AMM_LP.to_string(),
+                value_usd_e8s: amm_lp_value,
+            });
+            total = total.saturating_add(amm_lp_value);
+        }
 
         points.push(types::AddressValuePoint {
             ts_ns: ts,
@@ -606,6 +643,7 @@ pub fn build_sp_deposit_timeline(
 
 /// 3pool LP holdings reconstructed from Add / Remove / RemoveOneCoin events.
 /// Donate events don't mint LP tokens, so they're skipped.
+#[allow(dead_code)]
 pub fn build_three_pool_lp_timeline(
     principal: Principal,
     liquidity_events: &[storage::events::AnalyticsLiquidityEvent],
@@ -646,6 +684,118 @@ pub fn lookup_timeline_scalar_at(timeline: &[(u64, u64)], ts: u64) -> u64 {
     last
 }
 
+/// Per-pool LP shares held by a principal at one timeline event.
+pub type AmmLpState = HashMap<String, u64>;
+
+/// Reconstruct LP-share holdings per pool over time from AddLiquidity /
+/// RemoveLiquidity events. Each timeline entry carries a full state snapshot
+/// so pricing at a sample ts is one map lookup per pool.
+pub fn build_amm_lp_timeline(
+    principal: Principal,
+    events: &[storage::events::AnalyticsAmmLiquidityEvent],
+) -> Vec<(u64, AmmLpState)> {
+    use storage::events::LiquidityAction;
+    let mut running: AmmLpState = HashMap::new();
+    let mut timeline: Vec<(u64, AmmLpState)> = Vec::new();
+    for e in events {
+        if e.caller != principal {
+            continue;
+        }
+        let entry = running.entry(e.pool_id.clone()).or_insert(0);
+        let before = *entry;
+        match e.action {
+            LiquidityAction::Add => *entry = entry.saturating_add(e.lp_shares),
+            LiquidityAction::Remove | LiquidityAction::RemoveOneCoin => {
+                *entry = entry.saturating_sub(e.lp_shares)
+            }
+            LiquidityAction::Donate => {}
+        }
+        if *entry != before {
+            timeline.push((e.timestamp_ns, running.clone()));
+        }
+    }
+    timeline
+}
+
+/// Latest LP-state at or before `ts`. Empty map if the timeline doesn't cover
+/// the timestamp.
+pub fn amm_lp_lookup_at(timeline: &[(u64, AmmLpState)], ts: u64) -> AmmLpState {
+    let mut last: Option<&AmmLpState> = None;
+    for (event_ts, state) in timeline {
+        if *event_ts > ts {
+            break;
+        }
+        last = Some(state);
+    }
+    last.cloned().unwrap_or_default()
+}
+
+/// Convert a raw token amount into USD e8s using the given decimals.
+fn raw_to_usd_e8s(raw: u128, price_usd: f64, decimals: u8) -> u128 {
+    if raw == 0 || price_usd <= 0.0 {
+        return 0;
+    }
+    let price_e8s = (price_usd * 1e8) as u128;
+    let scaled = raw.saturating_mul(price_e8s);
+    let divisor = 10u128.pow(decimals as u32);
+    if divisor == 0 { return 0; }
+    scaled / divisor
+}
+
+/// Sum the user's USD value across every AMM pool they hold LP in.
+///
+/// Per-pool valuation: `(lp_shares / total_lp_shares) × (reserve_a × price_a +
+/// reserve_b × price_b)`. Stablecoins (icUSD, 3USD-LP) are pinned to $1
+/// because the spot-price log doesn't carry them. Any pool whose composition
+/// can't be priced (missing snapshot or both legs unpriced) contributes 0.
+#[allow(clippy::too_many_arguments)]
+pub fn price_amm_lp_state(
+    state: &AmmLpState,
+    ts: u64,
+    pools: &[storage::AmmPoolSnapshot],
+    price_snaps: &[storage::fast::FastPriceSnapshot],
+    decimals_map: &HashMap<Principal, u8>,
+    icusd_ledger: Principal,
+    three_pool: Principal,
+) -> u64 {
+    if state.is_empty() {
+        return 0;
+    }
+    let mut total_e8s: u128 = 0;
+    for (pool_id, lp_shares) in state {
+        if *lp_shares == 0 { continue; }
+        let pool = match pools.iter().find(|p| &p.pool_id == pool_id) {
+            Some(p) => p,
+            None => continue,
+        };
+        if pool.total_lp_shares == 0 { continue; }
+
+        // Per-leg USD value of the full pool reserves.
+        let leg_usd = |token: Principal, reserve: u128| -> u128 {
+            let dec = decimals_map.get(&token).copied().unwrap_or(8);
+            let price = if token == icusd_ledger || token == three_pool {
+                1.0
+            } else {
+                match price_usd_at(token, ts, price_snaps) {
+                    Some(p) => p,
+                    None => return 0,
+                }
+            };
+            raw_to_usd_e8s(reserve, price, dec)
+        };
+        let pool_usd = leg_usd(pool.token_a, pool.reserve_a)
+            .saturating_add(leg_usd(pool.token_b, pool.reserve_b));
+        if pool_usd == 0 { continue; }
+
+        // user_share = lp_shares / total_lp_shares; user_usd = pool_usd × share.
+        let user_usd = pool_usd
+            .saturating_mul(*lp_shares as u128)
+            / pool.total_lp_shares;
+        total_e8s = total_e8s.saturating_add(user_usd);
+    }
+    total_e8s.min(u64::MAX as u128) as u64
+}
+
 // ─── Pricing helpers ───────────────────────────────────────────────────────
 
 /// Latest USD price for `token` recorded at or before `ts`. Returns `None`
@@ -673,6 +823,7 @@ pub fn price_usd_at(
 /// multiplier on the LP share value. Defaults to 1.0 when no snapshot covers
 /// the range (bootstrap period, or principal's first activity predates any
 /// recorded Fast3PoolSnapshot).
+#[allow(dead_code)]
 pub fn virtual_price_at(
     ts: u64,
     snapshots: &[storage::fast::Fast3PoolSnapshot],
@@ -692,6 +843,7 @@ pub fn virtual_price_at(
 
 /// Apply an 18-decimal-ish virtual price multiplier to an 8-decimal LP amount.
 /// Result is clamped into u64 to avoid overflow surprises on degenerate inputs.
+#[allow(dead_code)]
 pub fn apply_virtual_price(lp_amount_e8s: u64, virtual_price: f64) -> u64 {
     if lp_amount_e8s == 0 || virtual_price <= 0.0 {
         return 0;
@@ -1129,6 +1281,80 @@ mod tests {
         assert_eq!(v2, 10_000_000_000);
     }
 
+    // ─── AMM LP timeline + pricing ───────────────────────────────────────
+
+    fn amm_evt(
+        ts: u64,
+        caller: Principal,
+        pool: &str,
+        action: storage::events::LiquidityAction,
+        lp: u64,
+    ) -> storage::events::AnalyticsAmmLiquidityEvent {
+        storage::events::AnalyticsAmmLiquidityEvent {
+            timestamp_ns: ts,
+            source_event_id: 0,
+            caller,
+            pool_id: pool.to_string(),
+            action,
+            lp_shares: lp,
+        }
+    }
+
+    #[test]
+    fn amm_lp_timeline_runs_per_pool_balances() {
+        let me = p(1);
+        let events = vec![
+            amm_evt(100, me, "pool_a", storage::events::LiquidityAction::Add, 1_000),
+            amm_evt(200, me, "pool_b", storage::events::LiquidityAction::Add, 500),
+            amm_evt(300, me, "pool_a", storage::events::LiquidityAction::Remove, 200),
+            // Other principal — should not contribute to my timeline.
+            amm_evt(400, p(2), "pool_a", storage::events::LiquidityAction::Add, 9_999),
+        ];
+        let timeline = build_amm_lp_timeline(me, &events);
+        assert_eq!(timeline.len(), 3);
+        assert_eq!(timeline[0].1.get("pool_a").copied(), Some(1_000));
+        assert_eq!(timeline[1].1.get("pool_a").copied(), Some(1_000));
+        assert_eq!(timeline[1].1.get("pool_b").copied(), Some(500));
+        assert_eq!(timeline[2].1.get("pool_a").copied(), Some(800));
+        assert_eq!(timeline[2].1.get("pool_b").copied(), Some(500));
+    }
+
+    #[test]
+    fn amm_lp_pricing_uses_user_share_of_pool_reserves() {
+        let me = p(1);
+        let icp = icp_ledger();
+        let icusd = icusd_ledger();
+        // Pool: 100 ICP @ $5 + 500 icUSD @ $1 = $1000 of reserves, 1000 LP shares total.
+        let pools = vec![storage::AmmPoolSnapshot {
+            pool_id: "icp_icusd".to_string(),
+            token_a: icp,
+            token_b: icusd,
+            reserve_a: 100 * 1_0000_0000,
+            reserve_b: 500 * 1_0000_0000,
+            total_lp_shares: 1_000,
+        }];
+        let snaps = vec![price_snap(100, vec![(icp, 5.0)])];
+        let decimals: HashMap<Principal, u8> = HashMap::from([(icp, 8), (icusd, 8)]);
+        let mut state: AmmLpState = HashMap::new();
+        state.insert("icp_icusd".to_string(), 250); // 25 % of pool
+
+        let v = price_amm_lp_state(&state, 200, &pools, &snaps, &decimals, icusd, three_pool());
+        // 25 % of $1000 = $250 → 25_000_000_000 e8s.
+        assert_eq!(v, 25_000_000_000);
+    }
+
+    #[test]
+    fn amm_lp_pricing_skips_pool_with_no_snapshot() {
+        let me = p(1);
+        let _ = me;
+        let pools: Vec<storage::AmmPoolSnapshot> = vec![]; // pool snapshot missing
+        let mut state: AmmLpState = HashMap::new();
+        state.insert("ghost_pool".to_string(), 100);
+
+        let v = price_amm_lp_state(&state, 200, &pools, &[], &HashMap::new(), icusd_ledger(), three_pool());
+        assert_eq!(v, 0);
+    }
+
     // ─── Series composition ─────────────────────────────────────────────
 
     #[test]
@@ -1139,6 +1365,7 @@ mod tests {
             me,
             0, 400, 100,
             &[], &[], &[], &[],
+            &[], // amm_liquidity_events
             &[],
             &[],
             100_000_000_000u64, // $100 in e8s
@@ -1146,6 +1373,7 @@ mod tests {
             0, None,
             icusd_ledger(), three_pool(),
             &HashMap::new(),
+            &[],
         );
         // Points at t=0, 100, 200, 300, 400.
         assert_eq!(points.len(), 5);
@@ -1183,11 +1411,13 @@ mod tests {
             me,
             0, 400, 100,
             &vault_evs, &[], &sp_evs, &lp_evs,
+            &[], // amm_liquidity_events
             &prices, &tp_snaps,
             0, None,
             0, None,
             icusd_ledger(), three_pool(),
             &HashMap::from([(icp_ledger(), 8)]),
+            &[],
         );
         // t=0: nothing yet.
         assert_eq!(points[0].value_usd_e8s, 0);
@@ -1200,12 +1430,12 @@ mod tests {
         let t200 = &points[2];
         assert_eq!(t200.breakdown.len(), 2);
         assert_eq!(t200.value_usd_e8s, 5_000_000_000 + 50_00_000_000);
-        // t=300: vault + SP + LP. LP = 20e8 * 1.02 ≈ 20.4e8.
+        // t=300: vault + SP only. The legacy three_pool_lp source was dropped
+        // because 3USD = 3pool LP and is already counted via SRC_THREEUSD,
+        // and it double-counted any 3USD redeployed into AMM liquidity.
         let t300 = &points[3];
-        assert_eq!(t300.breakdown.len(), 3);
-        let lp_src = t300.breakdown.iter().find(|b| b.source == SRC_3POOL_LP).unwrap();
-        // 20_00_000_000 * 1.02 = 20_40_000_000.
-        assert!((lp_src.value_usd_e8s as i64 - 20_40_000_000).abs() <= 1);
+        assert_eq!(t300.breakdown.len(), 2);
+        assert!(t300.breakdown.iter().all(|b| b.source != SRC_3POOL_LP));
     }
 
     #[test]
@@ -1225,10 +1455,12 @@ mod tests {
             me,
             0, 400, 100,
             &vault_evs, &[], &[], &[],
+            &[], // amm_liquidity_events
             &prices, &[],
             0, None, 0, None,
             icusd_ledger(), three_pool(),
             &HashMap::from([(icp_ledger(), 8)]),
+            &[],
         );
         assert_eq!(points.len(), 5);
         assert_eq!(points[1].value_usd_e8s, 5_000_000_000);  // $50 @ t=100
@@ -1244,10 +1476,12 @@ mod tests {
             me,
             0, 200, 100,
             &[], &[], &[], &[],
+            &[], // amm_liquidity_events
             &[], &[],
             0, None, 0, None,
             icusd_ledger(), three_pool(),
             &HashMap::new(),
+            &[],
         );
         for p in &points {
             assert_eq!(p.value_usd_e8s, 0);

--- a/src/rumi_analytics/src/sources/amm.rs
+++ b/src/rumi_analytics/src/sources/amm.rs
@@ -34,3 +34,63 @@ pub async fn get_amm_swap_event_count(amm: Principal) -> Result<u64, String> {
         .map_err(|(code, msg)| format!("get_amm_swap_event_count: {:?} {}", code, msg))?;
     Ok(count)
 }
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum AmmLiquidityAction {
+    AddLiquidity,
+    RemoveLiquidity,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct AmmLiquidityEvent {
+    pub id: u64,
+    pub caller: Principal,
+    pub pool_id: String,
+    pub action: AmmLiquidityAction,
+    pub token_a: Principal,
+    pub amount_a: Nat,
+    pub token_b: Principal,
+    pub amount_b: Nat,
+    pub lp_shares: Nat,
+    pub timestamp: u64,
+}
+
+pub async fn get_amm_liquidity_events(
+    amm: Principal,
+    start: u64,
+    length: u64,
+) -> Result<Vec<AmmLiquidityEvent>, String> {
+    let (events,): (Vec<AmmLiquidityEvent>,) =
+        ic_cdk::call(amm, "get_amm_liquidity_events", (start, length))
+            .await
+            .map_err(|(code, msg)| format!("get_amm_liquidity_events: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_amm_liquidity_event_count(amm: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(amm, "get_amm_liquidity_event_count", ())
+        .await
+        .map_err(|(code, msg)| format!("get_amm_liquidity_event_count: {:?} {}", code, msg))?;
+    Ok(count)
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct AmmPoolInfo {
+    pub pool_id: String,
+    pub token_a: Principal,
+    pub token_b: Principal,
+    pub reserve_a: Nat,
+    pub reserve_b: Nat,
+    pub total_lp_shares: Nat,
+    // Other fields (fee_bps, protocol_fee_bps, curve, paused) ignored —
+    // pricing only needs reserves + supply. Optional means decoding skips
+    // them; absence here doesn't break a candid extractor that orders
+    // record fields.
+}
+
+pub async fn get_pools(amm: Principal) -> Result<Vec<AmmPoolInfo>, String> {
+    let (pools,): (Vec<AmmPoolInfo>,) = ic_cdk::call(amm, "get_pools", ())
+        .await
+        .map_err(|(code, msg)| format!("get_pools: {:?} {}", code, msg))?;
+    Ok(pools)
+}

--- a/src/rumi_analytics/src/storage/cursors.rs
+++ b/src/rumi_analytics/src/storage/cursors.rs
@@ -8,6 +8,7 @@ use super::{
     MEM_CURSOR_BACKEND_EVENTS, MEM_CURSOR_3POOL_SWAPS,
     MEM_CURSOR_3POOL_LIQUIDITY, MEM_CURSOR_3POOL_BLOCKS,
     MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_STABILITY_EVENTS, MEM_CURSOR_ICUSD_BLOCKS,
+    MEM_CURSOR_AMM_LIQUIDITY,
 };
 
 thread_local! {
@@ -39,6 +40,10 @@ thread_local! {
         StableCell::init(get_memory(MEM_CURSOR_ICUSD_BLOCKS), 0u64)
             .expect("init cursor icusd_blocks")
     );
+    static CURSOR_AMM_LIQUIDITY: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_AMM_LIQUIDITY), 0u64)
+            .expect("init cursor amm_liquidity")
+    );
 }
 
 /// Cursor identifiers matching MemoryIds. Used as keys in SlimState metadata maps.
@@ -49,6 +54,7 @@ pub const CURSOR_ID_3POOL_BLOCKS: u8 = 4;
 pub const CURSOR_ID_AMM_SWAPS: u8 = 5;
 pub const CURSOR_ID_STABILITY_EVENTS: u8 = 6;
 pub const CURSOR_ID_ICUSD_BLOCKS: u8 = 7;
+pub const CURSOR_ID_AMM_LIQUIDITY: u8 = 8;
 
 macro_rules! cursor_accessors {
     ($mod_name:ident, $cell:ident) => {
@@ -71,3 +77,4 @@ cursor_accessors!(three_pool_blocks, CURSOR_3POOL_BLOCKS);
 cursor_accessors!(amm_swaps, CURSOR_AMM_SWAPS);
 cursor_accessors!(stability_events, CURSOR_STABILITY_EVENTS);
 cursor_accessors!(icusd_blocks, CURSOR_ICUSD_BLOCKS);
+cursor_accessors!(amm_liquidity, CURSOR_AMM_LIQUIDITY);

--- a/src/rumi_analytics/src/storage/events.rs
+++ b/src/rumi_analytics/src/storage/events.rs
@@ -13,6 +13,7 @@ use super::{
     MEM_EVT_VAULTS_IDX, MEM_EVT_VAULTS_DATA,
     MEM_EVT_STABILITY_IDX, MEM_EVT_STABILITY_DATA,
     MEM_EVT_ADMIN_IDX, MEM_EVT_ADMIN_DATA,
+    MEM_EVT_AMM_LIQUIDITY_IDX, MEM_EVT_AMM_LIQUIDITY_DATA,
 };
 
 // --- Enum types ---
@@ -141,6 +142,18 @@ pub struct AnalyticsAdminEvent {
     pub label: String,
 }
 
+/// AMM Add/RemoveLiquidity event mirror, used to reconstruct per-(principal,
+/// pool_id) LP-share timelines for portfolio valuation.
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsAmmLiquidityEvent {
+    pub timestamp_ns: u64,
+    pub source_event_id: u64,
+    pub caller: Principal,
+    pub pool_id: String,
+    pub action: LiquidityAction,
+    pub lp_shares: u64,
+}
+
 // --- Storable impls ---
 
 macro_rules! storable_candid {
@@ -163,6 +176,7 @@ storable_candid!(AnalyticsSwapEvent);
 storable_candid!(AnalyticsLiquidityEvent);
 storable_candid!(AnalyticsStabilityEvent);
 storable_candid!(AnalyticsAdminEvent);
+storable_candid!(AnalyticsAmmLiquidityEvent);
 
 // --- StableLog instances ---
 
@@ -213,6 +227,14 @@ thread_local! {
                 get_memory(MEM_EVT_ADMIN_IDX),
                 get_memory(MEM_EVT_ADMIN_DATA),
             ).expect("init EVT_ADMIN log")
+        });
+
+    static EVT_AMM_LIQUIDITY_LOG: RefCell<ic_stable_structures::StableLog<AnalyticsAmmLiquidityEvent, Memory, Memory>> =
+        RefCell::new({
+            ic_stable_structures::StableLog::init(
+                get_memory(MEM_EVT_AMM_LIQUIDITY_IDX),
+                get_memory(MEM_EVT_AMM_LIQUIDITY_DATA),
+            ).expect("init EVT_AMM_LIQUIDITY log")
         });
 }
 
@@ -269,6 +291,7 @@ evt_accessors!(evt_liquidity, EVT_LIQUIDITY_LOG, AnalyticsLiquidityEvent);
 evt_accessors!(evt_vaults, EVT_VAULTS_LOG, AnalyticsVaultEvent);
 evt_accessors!(evt_stability, EVT_STABILITY_LOG, AnalyticsStabilityEvent);
 evt_accessors!(evt_admin, EVT_ADMIN_LOG, AnalyticsAdminEvent);
+evt_accessors!(evt_amm_liquidity, EVT_AMM_LIQUIDITY_LOG, AnalyticsAmmLiquidityEvent);
 
 // --- Tests ---
 

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -100,6 +100,11 @@ pub const MEM_BAL_3USD: MemoryId = MemoryId::new(57);
 pub const MEM_FIRSTSEEN_ICUSD: MemoryId = MemoryId::new(58);
 pub const MEM_FIRSTSEEN_3USD: MemoryId = MemoryId::new(59);
 
+// AMM liquidity event mirror + cursor (added 2026-04-30 with vault_equity work).
+pub const MEM_EVT_AMM_LIQUIDITY_IDX: MemoryId = MemoryId::new(60);
+pub const MEM_EVT_AMM_LIQUIDITY_DATA: MemoryId = MemoryId::new(61);
+pub const MEM_CURSOR_AMM_LIQUIDITY: MemoryId = MemoryId::new(62);
+
 // --- SlimState ---
 // Bounded residual heap state. Written to MemoryId 0 via StableCell. Holds
 // only small fixed-size values; never any unbounded collections.
@@ -145,6 +150,27 @@ pub struct SlimState {
     /// backfill has not run yet on this canister.
     #[serde(default)]
     pub add_margin_backfill_cursor: Option<u64>,
+    /// Latest AMM pool composition (reserves + LP supply + token pair),
+    /// refreshed every fast-collector cycle. Used by `address_value` to
+    /// price each LP position as `(lp_shares / total_lp_shares) ×
+    /// (reserve_a × price_a + reserve_b × price_b)`. Heap-only because
+    /// queries can't make inter-canister calls — the cache is wiped on
+    /// upgrade and re-populated on the first fast tick (which the post_
+    /// upgrade hook fires immediately, see timers.rs). `None` until the
+    /// first successful AMM `get_pools` after upgrade.
+    #[serde(default)]
+    pub amm_pools: Option<Vec<AmmPoolSnapshot>>,
+}
+
+/// Snapshot of one AMM pool's composition for portfolio LP valuation.
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct AmmPoolSnapshot {
+    pub pool_id: String,
+    pub token_a: Principal,
+    pub token_b: Principal,
+    pub reserve_a: u128,
+    pub reserve_b: u128,
+    pub total_lp_shares: u128,
 }
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
@@ -188,6 +214,7 @@ impl Default for SlimState {
             last_pull_cycle_ns: None,
             collateral_decimals: None,
             add_margin_backfill_cursor: None,
+            amm_pools: None,
         }
     }
 }

--- a/src/rumi_analytics/src/tailing/amm_liquidity.rs
+++ b/src/rumi_analytics/src/tailing/amm_liquidity.rs
@@ -1,0 +1,77 @@
+//! AMM liquidity event tailing. Mirrors AddLiquidity / RemoveLiquidity events
+//! into evt_amm_liquidity so the address-value query can reconstruct per-
+//! principal LP-share timelines without making inter-canister calls.
+
+use crate::{sources, state, storage};
+use storage::cursors;
+use storage::events::*;
+use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
+
+fn nat_to_u64(n: &candid::Nat) -> u64 {
+    use num_traits::ToPrimitive;
+    n.0.to_u64().unwrap_or(u64::MAX)
+}
+
+fn convert_action(action: &sources::amm::AmmLiquidityAction) -> LiquidityAction {
+    use sources::amm::AmmLiquidityAction::*;
+    match action {
+        AddLiquidity => LiquidityAction::Add,
+        RemoveLiquidity => LiquidityAction::Remove,
+    }
+}
+
+pub async fn run() {
+    let amm = state::read_state(|s| s.sources.amm);
+    let cursor = cursors::amm_liquidity::get();
+
+    let count = match sources::amm::get_amm_liquidity_event_count(amm).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_amm_liq] get_amm_liquidity_event_count failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.amm += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_AMM_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_AMM_LIQUIDITY, count);
+    });
+
+    if count <= cursor { return; }
+
+    let fetch_len = (count - cursor).min(BATCH_SIZE);
+    let events = match sources::amm::get_amm_liquidity_events(amm, cursor, fetch_len).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_amm_liq] get_amm_liquidity_events failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.amm += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_AMM_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+
+    let mut processed = 0u64;
+    for evt in &events {
+        evt_amm_liquidity::push(AnalyticsAmmLiquidityEvent {
+            timestamp_ns: evt.timestamp,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            pool_id: evt.pool_id.clone(),
+            action: convert_action(&evt.action),
+            lp_shares: nat_to_u64(&evt.lp_shares),
+        });
+        processed += 1;
+    }
+
+    if processed > 0 {
+        cursors::amm_liquidity::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_AMM_LIQUIDITY, ic_cdk::api::time());
+        });
+    }
+}

--- a/src/rumi_analytics/src/tailing/mod.rs
+++ b/src/rumi_analytics/src/tailing/mod.rs
@@ -5,6 +5,7 @@ pub mod backend_events;
 pub mod three_pool_swaps;
 pub mod three_pool_liquidity;
 pub mod amm_swaps;
+pub mod amm_liquidity;
 pub mod icrc3;
 pub mod stability_pool;
 

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -50,6 +50,7 @@ async fn pull_cycle() {
         tailing::three_pool_swaps::run(),
         tailing::three_pool_liquidity::run(),
         tailing::amm_swaps::run(),
+        tailing::amm_liquidity::run(),
         tailing::icrc3::tail_icusd_blocks(),
         tailing::icrc3::tail_3pool_blocks(),
         tailing::stability_pool::run(),

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -448,7 +448,9 @@ pub struct AddressValueSeriesQuery {
 #[derive(CandidType, Clone, Debug, PartialEq)]
 pub struct AddressValueSourceBreakdown {
     /// Short identifier for the source, e.g. "icusd", "threeusd",
-    /// "vault_collateral", "sp_deposit", "three_pool_lp".
+    /// "vault_equity", "sp_deposit", "amm_lp". (The legacy "three_pool_lp"
+    /// source is no longer emitted; 3USD = rumi_3pool LP, so 3pool exposure
+    /// is captured by "threeusd" plus "amm_lp" for AMM-locked 3USD.)
     pub source: String,
     pub value_usd_e8s: u64,
 }

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -158,6 +158,11 @@ type Event = variant {
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
   set_max_partial_liquidation_ratio : record { rate : text };
+  breaker_tripped : record {
+    total_e8s : nat64;
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   withdraw_and_close_vault : record {
     block_index : opt nat64;
     vault_id : nat64;
@@ -246,6 +251,10 @@ type Event = variant {
     caller : opt principal;
     borrowed_amount : nat64;
   };
+  set_breaker_window_debt_ceiling_e8s : record {
+    timestamp : nat64;
+    ceiling_e8s : nat64;
+  };
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
@@ -287,6 +296,7 @@ type Event = variant {
     timestamp : opt nat64;
     amount : nat64;
   };
+  set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
     protocol_fee_collateral : opt nat64;
     icp_rate : opt blob;
@@ -331,12 +341,21 @@ type Event = variant {
     min_collateral_deposit : nat64;
     collateral_type : principal;
   };
+  breaker_cleared : record { remaining_total_e8s : nat64; timestamp : nat64 };
   update_collateral_status : record {
     status : CollateralStatus;
     collateral_type : principal;
   };
   set_healthy_cr : record { healthy_cr : opt text; collateral_type : text };
+  set_deficit_repayment_fraction : record {
+    fraction : blob;
+    timestamp : nat64;
+  };
   set_redemption_fee_ceiling : record { rate : text };
+  set_deficit_readonly_threshold_e8s : record {
+    threshold_e8s : nat64;
+    timestamp : nat64;
+  };
   add_margin_to_vault : record {
     block_index : nat64;
     vault_id : nat64;
@@ -355,12 +374,25 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  deficit_repaid : record {
+    remaining_deficit : nat64;
+    source : FeeSource;
+    timestamp : nat64;
+    anchor_block_index : opt nat64;
+    amount : nat64;
+  };
   redemption_transfered : record {
     icusd_block_index : nat64;
     icp_block_index : nat64;
     timestamp : opt nat64;
   };
   set_liquidation_bot_principal : record { "principal" : principal };
+  deficit_accrued : record {
+    new_deficit : nat64;
+    vault_id : nat64;
+    timestamp : nat64;
+    amount : nat64;
+  };
   liquidate_vault : record {
     mode : Mode;
     icp_rate : blob;
@@ -388,6 +420,7 @@ type Event = variant {
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
+  BreakerTripped;
   StabilityPoolDeposit;
   AdminSweepToTreasury;
   AdminMint;
@@ -398,13 +431,16 @@ type EventTypeFilter = variant {
   AccrueInterest;
   ReserveRedemption;
   Repay;
+  DeficitAccrued;
   Liquidation;
   Borrow;
   PriceUpdate;
   Admin;
+  DeficitRepaid;
   Redemption;
   CloseVault;
 };
+type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
   "principal" : opt principal;
@@ -552,6 +588,7 @@ type ProtocolSnapshot = record {
 type ProtocolStatus = record {
   last_icp_timestamp : nat64;
   borrowing_fee_curve_resolved : vec record { float64; float64 };
+  deficit_readonly_threshold_e8s : nat64;
   recovery_mode_threshold : float64;
   per_collateral_interest : vec CollateralInterestInfo;
   reserve_redemption_fee : float64;
@@ -562,25 +599,24 @@ type ProtocolStatus = record {
   total_icusd_borrowed : nat64;
   min_icusd_amount : nat64;
   total_collateral_ratio : float64;
+  deficit_repayment_fraction : float64;
   ckstable_repay_fee : float64;
+  windowed_liquidation_total_e8s : nat64;
   total_icp_margin : nat64;
   recovery_target_cr : float64;
   frozen : bool;
   weighted_average_interest_rate : float64;
+  liquidation_breaker_tripped : bool;
+  protocol_deficit_icusd : nat64;
+  breaker_window_ns : nat64;
   manual_mode_override : bool;
   liquidation_bonus : float64;
   per_collateral_rate_curves : vec PerCollateralRateCurve;
   reserve_redemptions_enabled : bool;
-  global_icusd_mint_cap : nat64;
-  last_icp_rate : float64;
-  protocol_deficit_icusd : nat64;
   total_deficit_repaid_icusd : nat64;
-  deficit_repayment_fraction : float64;
-  deficit_readonly_threshold_e8s : nat64;
-  breaker_window_ns : nat64;
+  global_icusd_mint_cap : nat64;
   breaker_window_debt_ceiling_e8s : nat64;
-  windowed_liquidation_total_e8s : nat64;
-  liquidation_breaker_tripped : bool;
+  last_icp_rate : float64;
 };
 type RateCurve = record {
   method : InterpolationMethod;
@@ -778,7 +814,7 @@ service : (ProtocolArg) -> {
   get_three_pool_canister : () -> (opt principal) query;
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
-  get_vault_history : (nat64) -> (vec Event) query;
+  get_vault_history : (nat64) -> (vec record { nat64; Event }) query;
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   http_request : (HttpRequest) -> (HttpResponse_1) query;
@@ -858,17 +894,12 @@ service : (ProtocolArg) -> {
   set_three_pool_canister : (principal) -> (Result);
   set_treasury_principal : (principal) -> (Result);
   stability_pool_liquidate : (nat64, nat64) -> (Result_12);
-  stability_pool_liquidate_debt_burned : (
-      nat64,
-      nat64,
-      SpWritedownProof,
-    ) -> (Result_12);
-  stability_pool_liquidate_with_reserves : (
-      nat64,
-      nat64,
-      nat64,
-      principal,
-    ) -> (Result_12);
+  stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
+      Result_12,
+    );
+  stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
+      Result_12,
+    );
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
@@ -876,4 +907,3 @@ service : (ProtocolArg) -> {
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);
 }
-

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -771,6 +771,7 @@ service : (ProtocolArg) -> {
     ) query;
   get_deposit_account : (opt principal) -> (Account) query;
   get_event_count : () -> (nat64) query;
+  get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
   get_events_by_principal : (principal) -> (vec record { nat64; Event }) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -694,15 +694,18 @@ fn get_fees(redeemed_amount: u64) -> Fees {
 
 #[candid_method(query)]
 #[query]
-fn get_vault_history(vault_id: u64) -> Vec<Event> {
+fn get_vault_history(vault_id: u64) -> Vec<(u64, Event)> {
     if ic_cdk::api::data_certificate().is_none() {
         ic_cdk::trap("update call rejected");
     }
 
-    let mut vault_events: Vec<Event> = vec![];
-    for event in events() {
+    // Iteration order matches the StableLog index, so enumerate() yields the
+    // global event-log index alongside each event. The explorer surfaces these
+    // ids on per-vault activity rows.
+    let mut vault_events: Vec<(u64, Event)> = vec![];
+    for (idx, event) in events().enumerate() {
         if event.is_vault_related(&vault_id) {
-            vault_events.push(event);
+            vault_events.push((idx as u64, event));
         }
     }
     vault_events
@@ -5088,14 +5091,21 @@ fn check_candid_interface_compatibility() {
 
     let new_interface = __export_service();
 
-    // check the public interface against the actual one
-    let old_interface =
-        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("rumi_protocol_backend.did");
+    // Allow regenerating the .did from the live source: `RUMI_REGEN_DID=1
+    // cargo test ... check_candid_interface_compatibility`. Skips the equality
+    // assertion and writes the canonical interface back to the file instead.
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let did_path = manifest_dir.join("rumi_protocol_backend.did");
+    if std::env::var("RUMI_REGEN_DID").is_ok() {
+        std::fs::write(&did_path, &new_interface).expect("failed to write .did");
+        eprintln!("Regenerated {}", did_path.display());
+        return;
+    }
 
     check_service_compatible(
         "actual Rumi Protocol candid interface",
         CandidSource::Text(&new_interface),
         "declared candid interface in rumi_protocol_backend.did file",
-        CandidSource::File(old_interface.as_path()),
+        CandidSource::File(did_path.as_path()),
     );
 }

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -728,6 +728,27 @@ fn get_event_count() -> u64 {
     rumi_protocol_backend::storage::count_events()
 }
 
+/// Recording-time timestamp for `length` consecutive events starting at
+/// `start`. Slots past the end of the side log come back as `0`; the
+/// frontend uses these to fill in a real time on admin/upgrade rows whose
+/// event payloads have no inline `timestamp` field. Pre-existing events
+/// (recorded before this side log shipped) also surface as `0`.
+///
+/// Cap is high enough (80k) to cover the entire current event log in a
+/// single round-trip — at 8 bytes per nat64 that's a 640 KB response,
+/// well under the 2 MB IC reply limit. Without that headroom the
+/// frontend's mixed-feed admin scope (which spans tens of thousands of
+/// indices) misses every event past the first 2k of the requested range.
+#[candid_method(query)]
+#[query]
+fn get_event_timestamps(start: u64, length: u64) -> Vec<u64> {
+    if ic_cdk::api::data_certificate().is_none() {
+        ic_cdk::trap("update call rejected");
+    }
+    const MAX: u64 = 80_000;
+    rumi_protocol_backend::storage::get_event_timestamps(start, length.min(MAX))
+}
+
 /// Server-side filtered event query, paginated newest-first.
 /// `start` is the page number (0-indexed) into the *filtered* result set;
 /// `length` is page size (capped at `MAX_PAGE_SIZE`).

--- a/src/rumi_protocol_backend/src/storage.rs
+++ b/src/rumi_protocol_backend/src/storage.rs
@@ -11,10 +11,23 @@ const LOG_DATA_MEMORY_ID: MemoryId = MemoryId::new(1);
 const SNAPSHOT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(2);
 const SNAPSHOT_DATA_MEMORY_ID: MemoryId = MemoryId::new(3);
 const STATE_MEMORY_ID: MemoryId = MemoryId::new(4);
+// Index-aligned timestamp side log. Most pre-existing event variants
+// (Upgrade, every set_*, admin_mint, admin_*) lack an explicit
+// `timestamp` field, so the explorer renders them with no time
+// indicator. We can't change those variant shapes without breaking the
+// stored CBOR, but we CAN write a timestamp at the same index in a
+// parallel log on every `record_event`. The frontend reads
+// `get_event_timestamps` and falls back to that when an event has no
+// inline timestamp. Pre-existing rows surface as 0 (the timestamp log
+// is empty before this change ships) — those stay timestampless,
+// which matches today's behaviour.
+const EVENT_TS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(5);
+const EVENT_TS_DATA_MEMORY_ID: MemoryId = MemoryId::new(6);
 
 type VMem = VirtualMemory<DefaultMemoryImpl>;
 type EventLog = StableLog<Vec<u8>, VMem, VMem>;
 type SnapshotLog = StableLog<Vec<u8>, VMem, VMem>;
+type TimestampLog = StableLog<u64, VMem, VMem>;
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
@@ -40,6 +53,20 @@ thread_local! {
                       m.borrow().get(SNAPSHOT_INDEX_MEMORY_ID),
                       m.borrow().get(SNAPSHOT_DATA_MEMORY_ID)
                   ).expect("failed to initialize snapshot log")
+              )
+        );
+
+    /// Index-aligned `ic_cdk::api::time()` side log: position N here is the
+    /// recording-time timestamp for `EVENTS[N]`. Empty for events recorded
+    /// before this log shipped — those return 0 and the explorer keeps
+    /// rendering "—" for them.
+    static EVENT_TIMESTAMPS: RefCell<TimestampLog> = MEMORY_MANAGER
+        .with(|m|
+              RefCell::new(
+                  StableLog::init(
+                      m.borrow().get(EVENT_TS_INDEX_MEMORY_ID),
+                      m.borrow().get(EVENT_TS_DATA_MEMORY_ID)
+                  ).expect("failed to initialize event timestamp log")
               )
         );
 }
@@ -99,15 +126,71 @@ pub fn count_events() -> u64 {
     EVENTS.with(|events| events.borrow().len())
 }
 
-/// Records a new minter event.
+/// Records a new minter event. Also stamps the recording-time timestamp into
+/// the parallel `EVENT_TIMESTAMPS` log so explorer surfaces can render a real
+/// time even for variants whose payload has no `timestamp` field (Upgrade,
+/// every set_*, admin_*). The two logs always grow in lock-step from this
+/// point forward — index N in EVENTS aligns with index N in EVENT_TIMESTAMPS.
 pub fn record_event(event: &Event) {
     let bytes = encode_event(event);
+    let now = ic_cdk::api::time();
     EVENTS.with(|events| {
         events
             .borrow()
             .append(&bytes)
             .expect("failed to append an entry to the event log")
     });
+    EVENT_TIMESTAMPS.with(|ts| {
+        ts.borrow()
+            .append(&now)
+            .expect("failed to append to the event timestamp log");
+    });
+}
+
+/// Returns the recording-time timestamp for the event at the given **event-log
+/// index**, or `None` for events that pre-date the side log (returned as 0 by
+/// `get_event_timestamps` to keep the response shape index-aligned).
+///
+/// Index alignment: EVENT_TIMESTAMPS starts empty in the deploy that ships
+/// this side log, but the EVENTS log already has thousands of entries. The
+/// first push to EVENT_TIMESTAMPS therefore sits at side-log index 0 even
+/// though the corresponding event is at EVENTS index `count_events_at_first_push`.
+/// We reconstruct the offset on every read as `events_len - timestamps_len`,
+/// which is invariant once we always push to both logs together.
+pub fn get_event_timestamp(index: u64) -> Option<u64> {
+    let events_len = count_events();
+    EVENT_TIMESTAMPS.with(|ts| {
+        let log = ts.borrow();
+        let ts_len = log.len();
+        let offset = events_len.saturating_sub(ts_len);
+        if index < offset {
+            return None;
+        }
+        log.get(index - offset)
+    })
+}
+
+/// Returns up to `length` consecutive timestamps starting at the given
+/// **event-log index**. Slots before the side log's coverage window or past
+/// the end of EVENTS come back as 0 so the caller can use the returned vec as
+/// a direct index-aligned overlay over an event slice.
+pub fn get_event_timestamps(start: u64, length: u64) -> Vec<u64> {
+    let events_len = count_events();
+    EVENT_TIMESTAMPS.with(|ts| {
+        let log = ts.borrow();
+        let ts_len = log.len();
+        let offset = events_len.saturating_sub(ts_len);
+        let mut out = Vec::with_capacity(length as usize);
+        for i in 0..length {
+            let idx = start.saturating_add(i);
+            if idx < offset || idx >= events_len {
+                out.push(0);
+                continue;
+            }
+            out.push(log.get(idx - offset).unwrap_or(0));
+        }
+        out
+    })
 }
 
 // ── State Serialization (pre/post upgrade) ────────────────────────────────

--- a/src/vault_frontend/src/lib/components/explorer/ActiveFilterChips.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/ActiveFilterChips.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { shortenPrincipal, getTokenSymbol } from '$utils/explorerHelpers';
   import { typeFacetLabel, hasAnyFacet, type Facets } from '$utils/eventFacets';
+  import { ammPoolLabel } from '$utils/ammNaming';
+  import { CANISTER_IDS } from '$lib/config';
 
   interface Props {
     facets: Facets;
@@ -10,6 +12,21 @@
   }
 
   let { facets, onChange, onClear, onSaveView }: Props = $props();
+
+  // Friendly label for a pool facet value: "Rumi 3Pool" for the literal
+  // 3pool token and "AMM1 · 3USD/ICP" for AMM pools (resolved through the
+  // shared registry that DexsLens seeds at load time). Falls back to a
+  // shortened principal pair for anything still unknown.
+  function poolChipLabel(id: string): string {
+    if (id === '3pool' || id === CANISTER_IDS.THREEPOOL) return 'Rumi 3Pool';
+    const friendly = ammPoolLabel(id);
+    if (friendly && friendly !== 'AMM' && friendly !== id) return friendly;
+    // Last-resort: split principal pair on `_` and shorten each side
+    if (id.includes('_')) {
+      return id.split('_').map(shortenPrincipal).join(' / ');
+    }
+    return shortenPrincipal(id);
+  }
 
   const anyActive = $derived(hasAnyFacet(facets));
 
@@ -73,8 +90,8 @@
     {/each}
 
     {#each facets.pools as id (id)}
-      <span class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full bg-cyan-500/15 text-cyan-300 border border-cyan-500/30">
-        <span>pool:{id}</span>
+      <span class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full bg-cyan-500/15 text-cyan-300 border border-cyan-500/30" title={`pool:${id}`}>
+        <span>pool:{poolChipLabel(id)}</span>
         <button type="button" aria-label="Remove pool" class="text-cyan-200 hover:text-white" onclick={() => removePool(id)}>×</button>
       </span>
     {/each}

--- a/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/EntityLink.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { shortenPrincipal, getCanisterName, getTokenSymbol, isKnownCanister } from '$utils/explorerHelpers';
+  import { ammPoolShortLabel } from '$utils/ammNaming';
   import { CANISTER_IDS } from '$lib/config';
 
   interface Props {
@@ -53,6 +54,11 @@
       case 'token': return getTokenSymbol(value) ?? (short ? shortenPrincipal(value) : value);
       case 'pool': {
         if (value === '3pool' || value === CANISTER_IDS.THREEPOOL) return '3pool';
+        // AMM pool ids are joined principals like `pA_pB`. Resolve via the
+        // pool registry for "AMM1"-style labels; fall back to the shortened
+        // principal pair if the registry hasn't loaded yet.
+        const ammLabel = ammPoolShortLabel(value);
+        if (ammLabel && ammLabel !== 'AMM') return ammLabel;
         return short ? shortenPrincipal(value) : value;
       }
       case 'event': return `Event #${value}`;

--- a/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
@@ -3,11 +3,11 @@
   import MixedEventsTable from './MixedEventsTable.svelte';
   import {
     fetchEvents, fetchAllVaults,
-    fetchSwapEvents, fetchSwapEventCount,
+    fetchThreePoolSwapEventsCombined,
+    fetch3PoolLiquidityEventsCombined,
     fetchAmmSwapEvents, fetchAmmSwapEventCount,
     fetchAmmLiquidityEvents, fetchAmmLiquidityEventCount,
     fetchAmmAdminEvents, fetchAmmAdminEventCount,
-    fetch3PoolLiquidityEvents, fetch3PoolLiquidityEventCount,
     fetch3PoolAdminEvents, fetch3PoolAdminEventCount,
     fetchStabilityPoolEvents, fetchStabilityPoolEventCount,
     type BackendEventFilters,
@@ -198,18 +198,18 @@
       const needsDexs = scope === 'all' || scope === 'revenue' || scope === 'dexs' || scope === 'admin';
       const needsSp = scope === 'all' || scope === 'stability_pool';
 
-      const swapCountP = needsDexs ? fetchSwapEventCount().catch(() => 0n) : Promise.resolve(0n);
+      // 3pool swap & liquidity reads pull combined v1+v2 streams below;
+      // there's no count endpoint that covers both logs.
       const ammSwapCountP = needsDexs ? fetchAmmSwapEventCount().catch(() => 0n) : Promise.resolve(0n);
       const ammLiqCountP = needsDexs ? fetchAmmLiquidityEventCount().catch(() => 0n) : Promise.resolve(0n);
       const ammAdminCountP = scope === 'all' || scope === 'admin'
         ? fetchAmmAdminEventCount().catch(() => 0n) : Promise.resolve(0n);
-      const threeLiqCountP = needsDexs ? fetch3PoolLiquidityEventCount().catch(() => 0n) : Promise.resolve(0n);
       const threeAdminCountP = scope === 'all' || scope === 'admin'
         ? fetch3PoolAdminEventCount().catch(() => 0n) : Promise.resolve(0n);
       const spCountP = needsSp ? fetchStabilityPoolEventCount().catch(() => 0n) : Promise.resolve(0n);
 
-      const [backend, vaults, swapCount, ammSwapCount, ammLiqCount, ammAdminCount, threeLiqCount, threeAdminCount, spCount] = await Promise.all([
-        backendPromise, vaultsPromise, swapCountP, ammSwapCountP, ammLiqCountP, ammAdminCountP, threeLiqCountP, threeAdminCountP, spCountP,
+      const [backend, vaults, ammSwapCount, ammLiqCount, ammAdminCount, threeAdminCount, spCount] = await Promise.all([
+        backendPromise, vaultsPromise, ammSwapCountP, ammLiqCountP, ammAdminCountP, threeAdminCountP, spCountP,
       ]);
 
       // Populate vault maps
@@ -223,13 +223,16 @@
       vaultCollateralMap = collMap;
       vaultOwnerMap = ownerMap;
 
-      // Pull recent event batches from each source
+      // Pull recent event batches from each source. 3pool swap and liquidity
+      // come from combined v1+v2 readers so frozen pre-migration entries
+      // appear alongside live writes — otherwise the lens panel silently
+      // drops 49 swap + 18 liquidity historical events from the stream.
       const [swaps, ammSwaps, ammLiq, ammAdmin, threeLiq, threeAdmin, sp] = await Promise.all([
-        fetchRecent(swapCount, sampleSize, fetchSwapEvents),
+        needsDexs ? fetchThreePoolSwapEventsCombined(sampleSize).catch(() => []) : Promise.resolve([]),
         fetchRecent(ammSwapCount, sampleSize, fetchAmmSwapEvents),
         fetchRecent(ammLiqCount, sampleSize, fetchAmmLiquidityEvents),
         fetchRecent(ammAdminCount, sampleSize, fetchAmmAdminEvents),
-        threeLiqCount === 0n ? Promise.resolve([]) : fetch3PoolLiquidityEvents(sampleSize < threeLiqCount ? sampleSize : threeLiqCount, 0n).catch(() => []),
+        needsDexs ? fetch3PoolLiquidityEventsCombined().catch(() => []) : Promise.resolve([]),
         fetchRecent(threeAdminCount, sampleSize, fetch3PoolAdminEvents),
         fetchRecent(spCount, sampleSize, fetchStabilityPoolEvents),
       ]);

--- a/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/LensActivityPanel.svelte
@@ -74,11 +74,22 @@
     'add_collateral_type', 'update_collateral_status', 'update_collateral_config',
     'set_reserve_redemptions_enabled', 'set_icpswap_routing_enabled',
     'set_reserve_redemption_fee', 'reserve_redemption',
-    'admin_mint', 'admin_vault_correction', 'admin_sweep_to_treasury',
+    'admin_mint', 'admin_vault_correction', 'admin_debt_correction', 'admin_sweep_to_treasury',
     'set_recovery_parameters', 'set_rate_curve_markers', 'set_recovery_rate_curve',
     'set_healthy_cr', 'set_collateral_borrowing_fee', 'set_interest_rate', 'set_interest_pool_share',
     'set_rmr_floor', 'set_rmr_ceiling', 'set_rmr_floor_cr', 'set_rmr_ceiling_cr',
     'set_borrowing_fee_curve', 'set_interest_split', 'set_three_pool_canister',
+    // Per-collateral setters that previously fell through and never made it
+    // into the admin-scoped feed.
+    'set_collateral_borrow_threshold', 'set_collateral_display_color',
+    'set_collateral_ledger_fee', 'set_collateral_liquidation_bonus',
+    'set_collateral_liquidation_ratio', 'set_collateral_min_deposit',
+    'set_collateral_min_vault_debt',
+    'set_collateral_redemption_fee_ceiling', 'set_collateral_redemption_fee_floor',
+    // Wave-10 LIQ-008 mass-liquidation breaker tunables.
+    'set_breaker_window_ns', 'set_breaker_window_debt_ceiling_e8s',
+    // Wave-8e LIQ-005 deficit-routing tunables.
+    'set_deficit_readonly_threshold_e8s', 'set_deficit_repayment_fraction',
   ]);
 
   function backendEventKey(evt: any): string {

--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -16,6 +16,13 @@
     // Assumes positive values; data-fit padding multipliers behave unexpectedly
     // for negative inputs.
     yAxisMode?: 'zero-anchored' | 'data-fit';
+    /**
+     * Override the headline number rendered in the card title. Use for
+     * "daily activity" charts where each bucket is independent (count/fees per
+     * day) and the rightmost bucket alone is misleading — you'd rather show
+     * the sum across the visible window.
+     */
+    headlineValue?: number;
   }
   let {
     points,
@@ -27,6 +34,7 @@
     valueFormat,
     loading = false,
     yAxisMode = 'zero-anchored',
+    headlineValue,
   }: Props = $props();
 
   const padX = 8;
@@ -104,6 +112,7 @@
   });
 
   const latest = $derived(points.length ? points[points.length - 1].v : 0);
+  const headline = $derived(headlineValue ?? latest);
 </script>
 
 <div class="space-y-2">
@@ -112,7 +121,7 @@
       <span class="text-xs font-medium text-gray-400">{label}</span>
       {#if !loading && points.length}
         <span class="text-sm font-semibold tabular-nums" style="color: {color};">
-          {valueFormat ? valueFormat(latest) : latest.toLocaleString()}
+          {valueFormat ? valueFormat(headline) : headline.toLocaleString()}
         </span>
       {/if}
     </div>

--- a/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MiniAreaChart.svelte
@@ -151,7 +151,7 @@
         {:else}
           <path d={fillD} fill={fillColor} stroke="none" />
           <path d={pathD} fill="none" stroke={color} stroke-width="1.5" stroke-linejoin="round" />
-          {#each dotPoints as p (p.t)}
+          {#each dotPoints as p, i (`${p.t}-${i}`)}
             <circle cx={x(p.t).toFixed(2)} cy={y(p.v).toFixed(2)} r="3" fill={color} />
           {/each}
         {/if}

--- a/src/vault_frontend/src/lib/components/explorer/MixedEventRow.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/MixedEventRow.svelte
@@ -28,12 +28,48 @@
   const extraTokens = $derived(facetsFor.tokens.slice(0, 3));
   const extraPools = $derived(facetsFor.pools.slice(0, 2));
   const extraVaults = $derived(facetsFor.vaultIds.slice(0, 2));
+
+  // Each non-backend source has its own ID counter on the canister, so
+  // "AMM1 #6" (liquidity) sorting after "AMM1 #44" (swap) reads as out of
+  // order even when the timestamps are correct. Append a per-type tag to
+  // the cell so the disambiguation is visible at a glance.
+  const subtypeTag = $derived.by(() => {
+    switch (display.source) {
+      case '3pool_swap':
+      case 'amm_swap':
+      case 'multi_hop_swap':
+        return 'swap';
+      case '3pool_liquidity':
+      case 'amm_liquidity':
+        return 'liq';
+      case '3pool_admin':
+      case 'amm_admin':
+        return 'admin';
+      default:
+        return null;
+    }
+  });
+
+  // 3pool swap reads merge v1 (pre-migration, frozen) and v2 (live) entries.
+  // The combined fetcher offsets v1 ids into a non-overlapping band so
+  // timestamps stay sortable, but the visible id should be the canister's
+  // original v1 id with a "v1·" prefix so the historical context is clear.
+  const isLegacyV1 = $derived(event.event?.__legacyV1 === true);
+  const displayedId = $derived(
+    isLegacyV1 && event.event?.legacy_id != null
+      ? `v1·#${event.event.legacy_id}`
+      : `#${display.globalIndex}`,
+  );
 </script>
 
 <tr class="border-b border-gray-700/50 hover:bg-gray-800/30 transition-colors group">
   <td class="px-4 py-3">
-    <a href={display.detailHref} class="text-xs text-blue-400 hover:text-blue-300 font-mono" title="{display.sourceLabel} Event #{display.globalIndex}">
-      {display.sourceLabel} #{display.globalIndex}
+    <a href={display.detailHref} class="text-xs text-blue-400 hover:text-blue-300 font-mono whitespace-nowrap" title="{display.sourceLabel} {subtypeTag ?? ''} Event {displayedId}">
+      {display.sourceLabel}
+      {#if subtypeTag}
+        <span class="text-gray-500">{subtypeTag}</span>
+      {/if}
+      {displayedId}
     </a>
   </td>
   <td class="px-4 py-3 text-xs text-gray-500 whitespace-nowrap">

--- a/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
@@ -2,6 +2,15 @@
   import { onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import { fetchAddressValueSeries } from '$services/explorer/analyticsService';
+  import {
+    fetchAmmPools,
+    fetchAmmLpBalance,
+    fetchCollateralPrices,
+    fetchVaultsByOwner,
+    fetchCollateralConfigs,
+  } from '$services/explorer/explorerService';
+  import { CANISTER_IDS } from '$lib/config';
+  import { getTokenDecimals } from '$utils/explorerHelpers';
   import type {
     AddressValuePoint,
     AddressValueSeriesResponse,
@@ -58,6 +67,26 @@
   let loading = $state(true);
   let errorMessage = $state<string | null>(null);
 
+  // Multiplier we apply to the analytics' `amm_lp` series so the rightmost
+  // chart point matches the live AMM LP value (computed from on-chain pool
+  // reserves + the user's actual lp_balance). The analytics canister
+  // reconstructs the user's per-pool LP shares by replaying AddLiquidity /
+  // RemoveLiquidity events from 0 — but pool *bootstrap* shares (the LP
+  // tokens minted when the pool was first created) are NOT in the event
+  // log, so any user who seeded a pool ends up with an undercount. Scaling
+  // the whole series uniformly is the cheapest fix that keeps the chart
+  // shape but pins the latest point to the truth surfaced by the live
+  // allocation card.
+  let liveAmmLpScale = $state<number>(1);
+
+  // Same idea for vault equity. The analytics timeline subtracts only
+  // borrowed_principal from collateral and ignores accrued_interest because
+  // backend `AccrueInterest` events don't carry per-vault breakdowns. That
+  // makes the chart's vault_equity strictly higher than the truth that the
+  // live allocation card surfaces. Scale all timeline points so the latest
+  // matches the live (collateral_usd − borrowed − accrued_interest) total.
+  let liveVaultEquityScale = $state<number>(1);
+
   async function loadSeries(target: string, range: RangeSpec) {
     let principalObj: Principal;
     try {
@@ -78,6 +107,93 @@
       response = null;
     } finally {
       loading = false;
+    }
+
+    // Compute the live AMM LP USD value and divide by what the analytics
+    // canister reported at the rightmost point. The ratio scales the whole
+    // amm_lp band so the chart's final value matches reality. Failures here
+    // silently fall back to scale=1 — better to render the analytics value
+    // unchanged than to show nothing.
+    try {
+      const principalObjLive = Principal.fromText(target);
+      const [pools, prices] = await Promise.all([
+        fetchAmmPools().catch(() => []),
+        fetchCollateralPrices().catch(() => new Map<string, number>()),
+      ]);
+      let liveTotalUsd = 0;
+      await Promise.all(
+        (pools as any[]).map(async (pool) => {
+          const poolId = String(pool.pool_id ?? '');
+          if (!poolId) return;
+          const balance = await fetchAmmLpBalance(poolId, principalObjLive).catch(() => 0n);
+          if (balance === 0n) return;
+          const totalShares = BigInt(pool.total_lp_shares ?? 0);
+          if (totalShares === 0n) return;
+          const tokenA = pool.token_a?.toText?.() ?? String(pool.token_a ?? '');
+          const tokenB = pool.token_b?.toText?.() ?? String(pool.token_b ?? '');
+          const decA = getTokenDecimals(tokenA);
+          const decB = getTokenDecimals(tokenB);
+          // 3USD pinned to $1 (matches analytics' price_amm_lp_state).
+          const priceA = prices.get(tokenA) ?? (tokenA === CANISTER_IDS.THREEPOOL ? 1 : 0);
+          const priceB = prices.get(tokenB) ?? (tokenB === CANISTER_IDS.THREEPOOL ? 1 : 0);
+          const shareRatio = Number(balance) / Number(totalShares);
+          const valueA = (Number(BigInt(pool.reserve_a ?? 0)) / 10 ** decA) * shareRatio * priceA;
+          const valueB = (Number(BigInt(pool.reserve_b ?? 0)) / 10 ** decB) * shareRatio * priceB;
+          liveTotalUsd += valueA + valueB;
+        }),
+      );
+      const seriesLatest = response?.points?.[response.points.length - 1];
+      const seriesAmmLp = seriesLatest
+        ? Number(
+            seriesLatest.breakdown.find((b) => b.source === 'amm_lp')?.value_usd_e8s ?? 0n,
+          ) / 1e8
+        : 0;
+      if (seriesAmmLp > 0 && liveTotalUsd > 0) {
+        liveAmmLpScale = liveTotalUsd / seriesAmmLp;
+      } else {
+        liveAmmLpScale = 1;
+      }
+    } catch (err) {
+      console.error('[PortfolioValueChart] live AMM LP correction failed:', err);
+      liveAmmLpScale = 1;
+    }
+
+    // Vault equity correction. Mirror the address page's allocation-card math:
+    // (collateral_amount × price) − (borrowed_icusd + accrued_interest).
+    try {
+      const principalObjLive = Principal.fromText(target);
+      const [vaults, prices, configs] = await Promise.all([
+        fetchVaultsByOwner(principalObjLive).catch(() => []),
+        fetchCollateralPrices().catch(() => new Map<string, number>()),
+        fetchCollateralConfigs().catch(() => []),
+      ]);
+      let liveEquityUsd = 0;
+      for (const v of vaults as any[]) {
+        const ct = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+        if (!ct) continue;
+        const cfg = (configs as any[]).find((c: any) => {
+          const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id ?? '');
+          return pid === ct;
+        });
+        const dec = cfg?.decimals != null ? Number(cfg.decimals) : getTokenDecimals(ct);
+        const collUsd = (Number(BigInt(v.collateral_amount ?? 0)) / 10 ** dec) * (prices.get(ct) ?? 0);
+        const debtUsd = Number(BigInt(v.borrowed_icusd_amount ?? 0) + BigInt(v.accrued_interest ?? 0)) / 1e8;
+        liveEquityUsd += Math.max(0, collUsd - debtUsd);
+      }
+      const seriesLatest = response?.points?.[response.points.length - 1];
+      const seriesEquity = seriesLatest
+        ? Number(
+            seriesLatest.breakdown.find((b) => b.source === 'vault_equity')?.value_usd_e8s ?? 0n,
+          ) / 1e8
+        : 0;
+      if (seriesEquity > 0 && liveEquityUsd >= 0) {
+        liveVaultEquityScale = liveEquityUsd / seriesEquity;
+      } else {
+        liveVaultEquityScale = 1;
+      }
+    } catch (err) {
+      console.error('[PortfolioValueChart] live vault equity correction failed:', err);
+      liveVaultEquityScale = 1;
     }
   }
 
@@ -134,15 +250,30 @@
 
   const hasAnyValue = $derived(points.some((p) => Number(p.value_usd_e8s) > 0));
 
-  /** Value per source at each point, 8-decimal → USD float. */
+  /** Value per source at each point, 8-decimal → USD float. AMM LP and vault
+   * equity get live-correction multipliers so the rightmost chart point
+   * matches the live allocation card (see liveAmmLpScale / liveVaultEquityScale). */
   function sourceValueUsd(pt: AddressValuePoint, sourceKey: string): number {
     for (const b of pt.breakdown) {
-      if (b.source === sourceKey) return Number(b.value_usd_e8s) / 1e8;
+      if (b.source === sourceKey) {
+        const raw = Number(b.value_usd_e8s) / 1e8;
+        if (sourceKey === 'amm_lp') return raw * liveAmmLpScale;
+        if (sourceKey === 'vault_equity') return raw * liveVaultEquityScale;
+        return raw;
+      }
     }
     return 0;
   }
 
-  const totalsUsd = $derived(points.map((p) => Number(p.value_usd_e8s) / 1e8));
+  /**
+   * Re-derive the per-point total because each AMM LP value is scaled by the
+   * live-correction factor — the analytics-reported `value_usd_e8s` doesn't
+   * include that scaling. Without this, the rightmost stack would visually
+   * overshoot the headline total label.
+   */
+  const totalsUsd = $derived(
+    points.map((p) => SOURCE_STYLES.reduce((sum, style) => sum + sourceValueUsd(p, style.key), 0)),
+  );
   const maxTotalUsd = $derived(totalsUsd.reduce((a, b) => Math.max(a, b), 0));
 
   /**

--- a/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
@@ -107,9 +107,13 @@
 
   const SOURCE_STYLES: readonly SourceStyle[] = [
     { key: 'vault_equity',     label: 'Vault equity',     color: '#d176e8', fill: 'rgba(209, 118, 232, 0.22)' },
-    { key: 'three_pool_lp',    label: '3pool LP',         color: '#fbbf24', fill: 'rgba(251, 191, 36, 0.22)' },
+    { key: 'amm_lp',           label: 'AMM LP',           color: '#f87171', fill: 'rgba(248, 113, 113, 0.22)' },
     { key: 'sp_deposit',       label: 'Stability pool',   color: '#34d399', fill: 'rgba(52, 211, 153, 0.22)' },
     { key: 'icusd',            label: 'icUSD',            color: '#2DD4BF', fill: 'rgba(45, 212, 191, 0.22)' },
+    // 3USD ledger balance also represents the user's 3pool LP exposure
+    // (3USD = rumi_3pool LP token). The separate `three_pool_lp` source was
+    // removed analytics-side because it double-counted 3USD redeployed as
+    // AMM liquidity (which now surfaces under `amm_lp` via pool reserves).
     { key: 'threeusd',         label: '3USD',             color: '#818cf8', fill: 'rgba(129, 140, 248, 0.22)' },
   ] as const;
 
@@ -118,6 +122,8 @@
     threeusd: '3USD ledger balance shown as current value (approximation).',
     vault_equity:
       'Vault equity = collateral USD − icUSD debt. Debt excludes accrued interest and per-vault redemption seizure (timeline approximation).',
+    amm_lp:
+      'AMM LP positions priced with the latest pool composition at every historical point (reserves are not snapshotted; drift bounded by pool rebalancing since open).',
   };
 
   // ── Derived series ─────────────────────────────────────────────────────

--- a/src/vault_frontend/src/lib/components/explorer/TvlChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/TvlChart.svelte
@@ -4,10 +4,16 @@
     filterByTimeRange, computeYScale,
     CHART_COLORS, TIME_RANGES, type TimeRange
   } from '$utils/explorerChartHelpers';
-  import type { DailyTvlRow } from '$declarations/rumi_analytics/rumi_analytics.did';
+  import type { DailyVaultSnapshotRow } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   interface Props {
-    data: DailyTvlRow[];
+    /**
+     * Vault series rows. Used because they expose `total_collateral_usd_e8s`
+     * (sum across every collateral type, priced via the per-row snapshot)
+     * and `total_debt_e8s`. The legacy `DailyTvlRow` only carried
+     * `total_icp_collateral_e8s` — ICP-only and in raw ICP units, not USD.
+     */
+    data: DailyVaultSnapshotRow[];
     loading?: boolean;
   }
   let { data, loading = false }: Props = $props();
@@ -21,11 +27,24 @@
 
   const filtered = $derived(filterByTimeRange(data, selectedRange));
 
+  // Drop snapshot rows where `total_collateral_usd_e8s` saturated to u64::MAX —
+  // a known pre-PR-#142 bug that left at least one row stamped with the
+  // sentinel value (~$184B in USD when divided by e8s). Without this filter
+  // the y-axis blows up and crushes every legitimate sample to baseline.
+  const SATURATED_U64 = 18_446_744_073_709_551_615n;
+  const cleaned = $derived(
+    filtered.filter((row) => BigInt(row.total_collateral_usd_e8s) !== SATURATED_U64),
+  );
+
   const points = $derived(
-    filtered.map(row => ({
+    cleaned.map(row => ({
       x: Number(row.timestamp_ns),
-      collateral: e8sToNumber(row.total_icp_collateral_e8s),
-      debt: e8sToNumber(row.total_icusd_supply_e8s),
+      // total_collateral_usd_e8s already sums every collateral type (ICP, BOB,
+      // ckBTC, ckETH, nICP, …) priced in USD at the snapshot's spot rate, so
+      // the line shows the protocol's true collateral footprint instead of the
+      // ICP-only raw-units approximation.
+      collateral: e8sToNumber(row.total_collateral_usd_e8s),
+      debt: e8sToNumber(row.total_debt_e8s),
     }))
   );
 
@@ -141,7 +160,7 @@
     <div class="flex items-center gap-4 mt-2 ml-[60px]">
       <div class="flex items-center gap-1.5">
         <div class="w-3 h-0.5 rounded" style="background: {CHART_COLORS.teal}"></div>
-        <span class="text-xs text-gray-500">Collateral (ICP)</span>
+        <span class="text-xs text-gray-500">Collateral (USD)</span>
       </div>
       <div class="flex items-center gap-1.5">
         <div class="w-3 h-0.5 rounded border-b border-dashed" style="border-color: {CHART_COLORS.purple}"></div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -126,8 +126,15 @@
     return total;
   });
 
-  const volumePoints = $derived(
-    volumeSeries.map((p: any) => {
+  // The 3pool's `get_volume_series` only emits buckets that contain swaps.
+  // For a 7d/hourly chart over a low-volume pool that yields just a handful
+  // of points; the line then draws straight between distant non-zero hours
+  // and looks like a perfect linear trend instead of a sparse spike chart.
+  // Pad in explicit zero-value buckets across the full window so the chart
+  // shows what actually happened: brief activity surrounded by zeros.
+  const volumePoints = $derived.by(() => {
+    if (!volumeSeries.length) return [] as { t: number; v: number }[];
+    const valued = volumeSeries.map((p: any) => {
       let total = 0;
       for (let i = 0; i < p.volume_per_token.length; i++) {
         const tok = POOL_TOKENS[i];
@@ -135,8 +142,24 @@
         total += Number(p.volume_per_token[i]) / Math.pow(10, tok.decimals);
       }
       return { t: Number(p.timestamp) * 1000, v: total };
-    })
-  );
+    });
+    valued.sort((a, b) => a.t - b.t);
+    const BUCKET_MS = 3_600_000; // matches the 3600s bucketSecs above
+    const WINDOW_MS = 7 * 24 * 3_600_000;
+    const nowMs = Date.now();
+    const startMs = Math.floor((nowMs - WINDOW_MS) / BUCKET_MS) * BUCKET_MS;
+    const endMs = Math.floor(nowMs / BUCKET_MS) * BUCKET_MS;
+    const valueAt = new Map<number, number>();
+    for (const p of valued) {
+      const bucket = Math.floor(p.t / BUCKET_MS) * BUCKET_MS;
+      valueAt.set(bucket, (valueAt.get(bucket) ?? 0) + p.v);
+    }
+    const out: { t: number; v: number }[] = [];
+    for (let t = startMs; t <= endMs; t += BUCKET_MS) {
+      out.push({ t, v: valueAt.get(t) ?? 0 });
+    }
+    return out;
+  });
 
   const vpPoints = $derived(
     vpSeries.map((p: any) => ({

--- a/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/DexsLens.svelte
@@ -141,7 +141,8 @@
         if (!tok) continue;
         total += Number(p.volume_per_token[i]) / Math.pow(10, tok.decimals);
       }
-      return { t: Number(p.timestamp) * 1000, v: total };
+      // p.timestamp is in nanoseconds; the chart works in ms.
+      return { t: Number(p.timestamp) / 1_000_000, v: total };
     });
     valued.sort((a, b) => a.t - b.t);
     const BUCKET_MS = 3_600_000; // matches the 3600s bucketSecs above
@@ -330,6 +331,7 @@
       color={CHART_COLORS.teal}
       fillColor={CHART_COLORS.tealDim}
       valueFormat={(v) => `$${formatCompact(v)}`}
+      headlineValue={volumePoints.reduce((s, p) => s + p.v, 0)}
       loading={loading}
     />
   </div>
@@ -343,6 +345,7 @@
       color={CHART_COLORS.purple}
       fillColor={CHART_COLORS.purpleDim}
       valueFormat={(v) => `$${formatCompact(v)}`}
+      headlineValue={swapSeriesPoints.reduce((s, p) => s + p.v, 0)}
       loading={loading}
     />
   </div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
@@ -8,7 +8,7 @@
   import TvlChart from '../TvlChart.svelte';
   import TokenFlowSankey from '../TokenFlowSankey.svelte';
   import {
-    fetchProtocolSummary, fetchTvlSeries, fetchVaultSeries,
+    fetchProtocolSummary, fetchVaultSeries,
     fetchFeeSeries, fetchPegStatus, fetchApys, fetchTokenFlow,
   } from '$services/explorer/analyticsService';
   import { ProtocolService } from '$services/protocol';
@@ -16,12 +16,10 @@
   import { stabilityPoolService } from '$services/stabilityPoolService';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
   import { liveSpApyPct, liveLpApyPct } from '$utils/liveApy';
-  import type { ProtocolSummary, DailyTvlRow, PegStatus, TokenFlowEdge } from '$declarations/rumi_analytics/rumi_analytics.did';
+  import type { ProtocolSummary, PegStatus, TokenFlowEdge } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   let summary: ProtocolSummary | null = $state(null);
   let summaryLoading = $state(true);
-  let tvlData: DailyTvlRow[] = $state([]);
-  let tvlLoading = $state(true);
   let vaultRows: any[] = $state([]);
   let feeRows: any[] = $state([]);
   let seriesLoading = $state(true);
@@ -62,9 +60,8 @@
   });
 
   onMount(async () => {
-    const [sumR, tvlR, vaultR, feeR, pegR, apyR] = await Promise.allSettled([
+    const [sumR, vaultR, feeR, pegR, apyR] = await Promise.allSettled([
       fetchProtocolSummary(),
-      fetchTvlSeries(365),
       fetchVaultSeries(90),
       fetchFeeSeries(90),
       fetchPegStatus(),
@@ -73,9 +70,6 @@
 
     if (sumR.status === 'fulfilled' && sumR.value) summary = sumR.value;
     summaryLoading = false;
-
-    if (tvlR.status === 'fulfilled') tvlData = tvlR.value ?? [];
-    tvlLoading = false;
 
     if (vaultR.status === 'fulfilled') vaultRows = vaultR.value ?? [];
     if (feeR.status === 'fulfilled') feeRows = feeR.value ?? [];
@@ -178,7 +172,7 @@
   <div class="flex items-center justify-between mb-3">
     <h3 class="text-sm font-medium text-gray-300">Total Value Locked</h3>
   </div>
-  <TvlChart data={tvlData} loading={tvlLoading} />
+  <TvlChart data={vaultRows} loading={seriesLoading} />
 </div>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -189,6 +183,7 @@
       color={CHART_COLORS.teal}
       fillColor={CHART_COLORS.tealDim}
       valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+      yAxisMode="data-fit"
       loading={seriesLoading}
     />
   </div>
@@ -199,6 +194,7 @@
       color={CHART_COLORS.purple}
       fillColor={CHART_COLORS.purpleDim}
       valueFormat={(v) => `$${formatCompact(v)}`}
+      yAxisMode="data-fit"
       loading={seriesLoading}
     />
   </div>
@@ -211,6 +207,7 @@
     color={CHART_COLORS.action}
     fillColor="rgba(52, 211, 153, 0.15)"
     valueFormat={(v) => `$${formatCompact(v)}`}
+    headlineValue={feePoints.reduce((s, p) => s + p.v, 0)}
     height={160}
     loading={seriesLoading}
   />

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
@@ -35,6 +35,12 @@
   // were tailed before fee_amount was tracked and decode as None.
   let live90dRedemptionCount: number | null = $state(null);
   let live90dRedemptionFeesIcusd: number | null = $state(null);
+  // Daily-bucketed live redemption activity (count + fees) over the same 90d
+  // window. Populated alongside the headline numbers so the two chart cards
+  // ("Daily redemption count" / "Daily redemption fees") show real activity
+  // instead of the all-zeros rollup output.
+  let liveDailyCountPoints: { t: number; v: number }[] | null = $state(null);
+  let liveDailyFeePoints: { t: number; v: number }[] | null = $state(null);
 
   onMount(async () => {
     try {
@@ -91,8 +97,18 @@
 
     (async () => {
       try {
-        const cutoffNs = BigInt(Date.now() - 90 * 24 * 60 * 60 * 1000) * 1_000_000n;
-        let total = 0n;
+        const nowMs = Date.now();
+        const cutoffMs = nowMs - 90 * 24 * 60 * 60 * 1000;
+        const cutoffNs = BigInt(cutoffMs) * 1_000_000n;
+        const DAY_MS = 86_400_000;
+        // Bucket day-keyed sums so the chart can render daily granularity even
+        // when the rollup table is all zeros (historic redemptions in the
+        // analytics canister have fee_amount=None so the daily rollup misses
+        // them; backend event log is authoritative).
+        const dayBucket = (tsMs: number) => Math.floor(tsMs / DAY_MS) * DAY_MS;
+        const countByDay = new Map<number, number>();
+        const feeByDay = new Map<number, number>();
+        let totalFee = 0n;
         const PAGE = 200n;
         let page = 0n;
         // get_events_filtered returns newest-first; stop once we cross the 90d boundary.
@@ -123,12 +139,31 @@
               break;
             }
             const fee = inner.fee_amount;
-            if (fee != null) total += BigInt(fee);
+            if (fee != null) totalFee += BigInt(fee);
+            const tsMs = ts != null ? Number(BigInt(ts) / 1_000_000n) : nowMs;
+            const bucket = dayBucket(tsMs);
+            countByDay.set(bucket, (countByDay.get(bucket) ?? 0) + 1);
+            if (fee != null) {
+              feeByDay.set(bucket, (feeByDay.get(bucket) ?? 0) + Number(fee) / 1e8);
+            }
           }
           if (crossed || tuples.length < Number(PAGE)) break;
           page += 1n;
         }
-        live90dRedemptionFeesIcusd = Number(total) / 1e8;
+        live90dRedemptionFeesIcusd = Number(totalFee) / 1e8;
+
+        // Pad zero-buckets across the full 90d window so the chart renders a
+        // proper daily bar series instead of just the active days.
+        const startBucket = dayBucket(cutoffMs);
+        const endBucket = dayBucket(nowMs);
+        const cPts: { t: number; v: number }[] = [];
+        const fPts: { t: number; v: number }[] = [];
+        for (let t = startBucket; t <= endBucket; t += DAY_MS) {
+          cPts.push({ t, v: countByDay.get(t) ?? 0 });
+          fPts.push({ t, v: feeByDay.get(t) ?? 0 });
+        }
+        liveDailyCountPoints = cPts;
+        liveDailyFeePoints = fPts;
       } catch (err) {
         console.error('[RedemptionsLens] backend redemption fee scan failed:', err);
       }
@@ -144,14 +179,20 @@
   );
   const redemptions90d = $derived(live90dRedemptionCount ?? rollupRedemptions90d);
   const redemptionFees90d = $derived(live90dRedemptionFeesIcusd ?? rollupRedemptionFees90d);
+  // Use live-scan daily buckets when they've resolved (real activity); fall
+  // back to the rollup-derived points only as a placeholder until then. The
+  // rollup table is all-zeros for redemptions today (see headline-numbers
+  // comment above) so the live points are usually authoritative.
   const redemptionCountPoints = $derived(
-    feeRows.map((r: any) => ({ t: Number(r.timestamp_ns) / 1_000_000, v: Number(r.redemption_count ?? 0) }))
+    liveDailyCountPoints
+      ?? feeRows.map((r: any) => ({ t: Number(r.timestamp_ns) / 1_000_000, v: Number(r.redemption_count ?? 0) }))
   );
   const redemptionFeePoints = $derived(
-    feeRows.map((r: any) => ({
-      t: Number(r.timestamp_ns) / 1_000_000,
-      v: e8sToNumber(r.redemption_fees_e8s?.[0] ?? r.redemption_fees_e8s ?? 0n),
-    }))
+    liveDailyFeePoints
+      ?? feeRows.map((r: any) => ({
+        t: Number(r.timestamp_ns) / 1_000_000,
+        v: e8sToNumber(r.redemption_fees_e8s?.[0] ?? r.redemption_fees_e8s ?? 0n),
+      }))
   );
 
   const formatPct = (v: number | null) =>
@@ -243,6 +284,7 @@
       color={CHART_COLORS.teal}
       fillColor={CHART_COLORS.tealDim}
       valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+      headlineValue={redemptions90d}
       loading={loading}
     />
   </div>
@@ -253,6 +295,7 @@
       color={CHART_COLORS.purple}
       fillColor={CHART_COLORS.purpleDim}
       valueFormat={(v) => `$${formatCompact(v)}`}
+      headlineValue={redemptionFees90d}
       loading={loading}
     />
   </div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RedemptionsLens.svelte
@@ -4,11 +4,12 @@
   import LensHealthStrip from '../LensHealthStrip.svelte';
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
-  import { fetchFeeSeries } from '$services/explorer/analyticsService';
+  import { fetchFeeSeries, fetchFeeBreakdownWindow } from '$services/explorer/analyticsService';
   import {
     fetchRedemptionRate, fetchRedemptionFeeFloor, fetchRedemptionFeeCeiling,
     fetchRedemptionTier, fetchCollateralTotals, fetchProtocolConfig, fetchProtocolStatus,
   } from '$services/explorer/explorerService';
+  import { publicActor } from '$lib/services/protocol/apiClient';
   import {
     e8sToNumber, formatCompact, CHART_COLORS, COLLATERAL_SYMBOLS, getCollateralSymbol,
   } from '$utils/explorerChartHelpers';
@@ -25,6 +26,15 @@
   let collateralTotals: any[] = $state([]);
   let tierMap: Map<string, number | null> = $state(new Map());
   let loading = $state(true);
+  // Live 90-day count + fee totals computed from the source-of-truth event
+  // logs (analytics for count, backend event log for fees) instead of from
+  // the daily rollup series. Rollups only see the trailing 24h at scrape time
+  // and don't backfill, so historical redemption events that pre-date a
+  // collector deploy never get a non-zero rollup row. The backend event log
+  // is authoritative for fees because some early AnalyticsVaultEvent rows
+  // were tailed before fee_amount was tracked and decode as None.
+  let live90dRedemptionCount: number | null = $state(null);
+  let live90dRedemptionFeesIcusd: number | null = $state(null);
 
   onMount(async () => {
     try {
@@ -68,12 +78,72 @@
     } finally {
       loading = false;
     }
+
+    // Live 90d redemption totals — fire after the main load so the UI is not
+    // blocked. Count comes from the analytics live query (cheap, single
+    // round-trip). Fees come from the backend event log filtered to
+    // Redemption type, summed client-side, because the AnalyticsVaultEvent
+    // rows for historical redemptions stored fee_amount=None and the rollup
+    // path therefore reports $0 even when there were real fees collected.
+    fetchFeeBreakdownWindow(90)
+      .then((b) => { live90dRedemptionCount = b.redemptionCount; })
+      .catch((err) => console.error('[RedemptionsLens] fee breakdown failed:', err));
+
+    (async () => {
+      try {
+        const cutoffNs = BigInt(Date.now() - 90 * 24 * 60 * 60 * 1000) * 1_000_000n;
+        let total = 0n;
+        const PAGE = 200n;
+        let page = 0n;
+        // get_events_filtered returns newest-first; stop once we cross the 90d boundary.
+        while (true) {
+          const resp = await publicActor.get_events_filtered({
+            start: page,
+            length: PAGE,
+            types: [[{ Redemption: null }]],
+            principal: [],
+            collateral_token: [],
+            time_range: [],
+            min_size_e8s: [],
+            admin_labels: [],
+          });
+          // events: Array<[bigint, Event]>
+          const tuples = (resp as any)?.events ?? [];
+          if (tuples.length === 0) break;
+          let crossed = false;
+          for (const pair of tuples) {
+            const evt = Array.isArray(pair) ? pair[1] : (pair?.event ?? pair);
+            const et = (evt as any)?.event_type ?? evt;
+            const inner = et?.redemption_on_vaults;
+            if (!inner) continue;
+            const tsArr = inner.timestamp;
+            const ts = Array.isArray(tsArr) ? tsArr[0] : tsArr;
+            if (ts != null && BigInt(ts) < cutoffNs) {
+              crossed = true;
+              break;
+            }
+            const fee = inner.fee_amount;
+            if (fee != null) total += BigInt(fee);
+          }
+          if (crossed || tuples.length < Number(PAGE)) break;
+          page += 1n;
+        }
+        live90dRedemptionFeesIcusd = Number(total) / 1e8;
+      } catch (err) {
+        console.error('[RedemptionsLens] backend redemption fee scan failed:', err);
+      }
+    })();
   });
 
-  const redemptions90d = $derived(feeRows.reduce((s, d: any) => s + Number(d.redemption_count ?? 0), 0));
-  const redemptionFees90d = $derived(
+  // Prefer the live total when it has resolved; fall back to the rollup sum
+  // until the live query lands so the card never shows a stale 0 longer than
+  // necessary.
+  const rollupRedemptions90d = $derived(feeRows.reduce((s, d: any) => s + Number(d.redemption_count ?? 0), 0));
+  const rollupRedemptionFees90d = $derived(
     feeRows.reduce((s, d: any) => s + e8sToNumber(d.redemption_fees_e8s?.[0] ?? d.redemption_fees_e8s ?? 0n), 0)
   );
+  const redemptions90d = $derived(live90dRedemptionCount ?? rollupRedemptions90d);
+  const redemptionFees90d = $derived(live90dRedemptionFeesIcusd ?? rollupRedemptionFees90d);
   const redemptionCountPoints = $derived(
     feeRows.map((r: any) => ({ t: Number(r.timestamp_ns) / 1_000_000, v: Number(r.redemption_count ?? 0) }))
   );

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -159,6 +159,7 @@
     color={CHART_COLORS.action}
     fillColor="rgba(52, 211, 153, 0.15)"
     valueFormat={(v) => `$${formatCompact(v)}`}
+    headlineValue={feePoints.reduce((s, p) => s + p.v, 0)}
     height={180}
     loading={loading}
   />

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -119,6 +119,7 @@
       color={CHART_COLORS.teal}
       fillColor={CHART_COLORS.tealDim}
       valueFormat={(v) => `$${formatCompact(v)}`}
+      yAxisMode="data-fit"
       loading={loading}
     />
   </div>
@@ -129,6 +130,7 @@
       color={CHART_COLORS.danger}
       fillColor="rgba(224, 107, 159, 0.15)"
       valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+      yAxisMode="data-fit"
       loading={loading}
     />
   </div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/StabilityPoolLens.svelte
@@ -60,11 +60,21 @@
   const totalDeposits = $derived(poolStatus ? e8sToNumber(poolStatus.total_deposits_e8s ?? 0n) : 0);
   const depositors = $derived(poolStatus ? Number(poolStatus.total_depositors ?? 0n) : 0);
   const totalLiquidations = $derived(poolStatus ? Number(poolStatus.total_liquidations_executed ?? 0n) : 0);
+  // `eligible_icusd_per_collateral` reports, FOR EACH collateral type, the
+  // share of the pool opted-in to absorb that specific collateral. With all
+  // depositors opted in to every collateral (the default), each entry equals
+  // the total pool — so summing across collaterals N-counts the same dollars
+  // and inflates the headline. Take the minimum (worst-case coverage across
+  // collaterals) — matches what users expect when reading the label.
   const eligibleCoverage = $derived.by(() => {
-    if (!poolStatus?.eligible_icusd_per_collateral) return 0;
-    let sum = 0;
-    for (const [, v] of poolStatus.eligible_icusd_per_collateral) sum += Number(v);
-    return sum / 1e8;
+    const rows = poolStatus?.eligible_icusd_per_collateral;
+    if (!rows || rows.length === 0) return 0;
+    let min = Infinity;
+    for (const [, v] of rows) {
+      const n = Number(v);
+      if (n < min) min = n;
+    }
+    return Number.isFinite(min) ? min / 1e8 : 0;
   });
 
   const depositSeries = $derived(

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -330,16 +330,79 @@ export async function fetchThreePoolTopSwappers(
 	}
 }
 
-export async function fetchThreePoolSwapEventsV2(start: bigint, length: bigint): Promise<any[]> {
-	const key = `pool:3pool:swapEventsV2:${start}:${length}`;
+/**
+ * Fetch 3Pool v2 swap events newest-first.
+ * `limit` = max events, `offset` = skip this many most-recent. Matches the canister's v2 contract.
+ * Callers that want "all events newest-first" should pass (totalCount, 0n).
+ *
+ * NOTE: this only returns events written after the v1→v2 dynamic-fee migration.
+ * For full history including pre-migration swaps, use {@link fetchThreePoolSwapEventsCombined}.
+ */
+export async function fetchThreePoolSwapEventsV2(limit: bigint, offset: bigint = 0n): Promise<any[]> {
+	const key = `pool:3pool:swapEventsV2:${limit}:${offset}`;
 	const cached = getCached<any[]>(key, TTL.EVENTS);
 	if (cached) return cached;
 
 	try {
-		const result = await threePoolService.getSwapEventsV2(start, length);
+		const result = await threePoolService.getSwapEventsV2(limit, offset);
 		return setCache(key, result);
 	} catch (err) {
 		console.error('[explorerService] fetchThreePoolSwapEventsV2 failed:', err);
+		return [];
+	}
+}
+
+/**
+ * Combined newest-first stream of 3Pool swap events across BOTH the v2 log
+ * (live writes since the dynamic-fee migration) and the v1 log (frozen
+ * historical entries that never got copied into v2). v1 events are tagged
+ * with `__legacyV1: true` and exposed under synthetic IDs offset by
+ * `LEGACY_V1_OFFSET` so they don't collide with v2 IDs in the URL/display.
+ *
+ * `maxV2` caps the v2 batch (live activity is bounded so this rarely binds).
+ * v1 is always fully read because the log is frozen at 49 events.
+ */
+const LEGACY_V1_OFFSET = 1_000_000n;
+
+export async function fetchThreePoolSwapEventsCombined(maxV2: bigint = 1_000n): Promise<any[]> {
+	const key = `pool:3pool:swapEventsCombined:${maxV2}`;
+	const cached = getCached<any[]>(key, TTL.EVENTS);
+	if (cached) return cached;
+
+	try {
+		const [v2Events, v1Count] = await Promise.all([
+			threePoolService.getSwapEventsV2(maxV2, 0n),
+			threePoolService.getSwapEventCount().catch(() => 0n),
+		]);
+
+		const v1RawEvents = Number(v1Count) > 0
+			? await threePoolService.getSwapEvents(0n, v1Count).catch(() => [])
+			: [];
+
+		// Annotate v1 events: surface the original v1 id under `legacy_id`,
+		// shift the synthetic id into a non-overlapping band, and add the
+		// fields formatters/facet code expect from a v2-shaped event so the
+		// rest of the pipeline (badges, dynamic-fee labels) doesn't NPE.
+		const v1Tagged = v1RawEvents.map((e: any) => ({
+			...e,
+			__legacyV1: true,
+			legacy_id: e.id,
+			id: BigInt(e.id ?? 0) + LEGACY_V1_OFFSET,
+			fee_bps: 30, // pre-migration static fee was 30 bps
+			migrated: false,
+			is_rebalancing: false,
+			imbalance_before: 0n,
+			imbalance_after: 0n,
+			pool_balances_after: [],
+			virtual_price_after: 0n,
+		}));
+
+		const combined = [...v2Events, ...v1Tagged];
+		// Newest-first across the union so consumers don't need to re-sort.
+		combined.sort((a: any, b: any) => Number(BigInt(b.timestamp ?? 0n) - BigInt(a.timestamp ?? 0n)));
+		return setCache(key, combined);
+	} catch (err) {
+		console.error('[explorerService] fetchThreePoolSwapEventsCombined failed:', err);
 		return [];
 	}
 }
@@ -971,6 +1034,12 @@ export async function fetchThreePoolStatus(): Promise<any | null> {
 	}
 }
 
+/**
+ * @deprecated swap_v1 is frozen at the migration cutoff — live writes only
+ * land in swap_v2. Use {@link fetchThreePoolSwapEventsV2} for any code that
+ * needs to surface recent swap activity. This wrapper stays for migration
+ * tooling; do not call it from the activity feed or pool pages.
+ */
 export async function fetchSwapEvents(start: bigint, length: bigint): Promise<any[]> {
 	const key = `pool:3pool:swaps:${start}:${length}`;
 	const cached = getCached<any[]>(key, TTL.POOL);
@@ -985,6 +1054,11 @@ export async function fetchSwapEvents(start: bigint, length: bigint): Promise<an
 	}
 }
 
+/**
+ * @deprecated Returns the swap_v1 count, frozen at migration. Not the live
+ * total. Don't use to gate paging or visibility. See
+ * {@link fetchThreePoolSwapEventsV2} for current event reads.
+ */
 export async function fetchSwapEventCount(): Promise<bigint> {
 	const key = 'pool:3pool:swapcount';
 	const cached = getCached<bigint>(key, TTL.POOL);
@@ -1253,6 +1327,9 @@ export async function fetchAmmSwapEventsByTimeRange(
  * Fetch 3Pool v2 liquidity events newest-first.
  * `limit` = max events, `offset` = skip this many most-recent. Matches the canister's v2 contract.
  * Callers that want "all events newest-first" should pass (totalCount, 0n).
+ *
+ * NOTE: this only returns events written after the v1→v2 dynamic-fee migration.
+ * For full history including pre-migration entries, use {@link fetch3PoolLiquidityEventsCombined}.
  */
 export async function fetch3PoolLiquidityEvents(limit: bigint, offset: bigint): Promise<any[]> {
 	const key = `pool:3pool:liquidity:${limit}:${offset}`;
@@ -1279,6 +1356,61 @@ export async function fetch3PoolLiquidityEventCount(): Promise<bigint> {
 	} catch (err) {
 		console.error('[explorerService] fetch3PoolLiquidityEventCount failed:', err);
 		return 0n;
+	}
+}
+
+/**
+ * Combined newest-first stream of 3Pool liquidity events across both the v2
+ * log (live writes, dynamic-fee schema) and the v1 log (frozen historical
+ * entries that never got copied into v2). v1 entries are tagged with
+ * `__legacyV1: true` and exposed under synthetic IDs offset by
+ * LEGACY_V1_OFFSET so they don't collide with v2 IDs in the URL/display.
+ *
+ * Same pattern as {@link fetchThreePoolSwapEventsCombined} — see that doc.
+ */
+export async function fetch3PoolLiquidityEventsCombined(): Promise<any[]> {
+	const key = 'pool:3pool:liquidity:combined';
+	const cached = getCached<any[]>(key, TTL.POOL);
+	if (cached) return cached;
+
+	try {
+		const [v2Count, v1Count] = await Promise.all([
+			threePoolService.getLiquidityEventCount().catch(() => 0n),
+			threePoolService.getLiquidityEventCountV1().catch(() => 0n),
+		]);
+
+		const [v2Events, v1RawEvents] = await Promise.all([
+			Number(v2Count) > 0
+				? threePoolService.getLiquidityEvents(v2Count, 0n).catch(() => [])
+				: Promise.resolve([] as any[]),
+			Number(v1Count) > 0
+				? threePoolService.getLiquidityEventsV1(0n, v1Count).catch(() => [])
+				: Promise.resolve([] as any[]),
+		]);
+
+		// Annotate v1 entries with the v2-shaped fields formatters/facets
+		// expect, plus the bookkeeping that lets the UI render "v1·#N" and
+		// route URLs deterministically.
+		const v1Tagged = v1RawEvents.map((e: any) => ({
+			...e,
+			__legacyV1: true,
+			legacy_id: e.id,
+			id: BigInt(e.id ?? 0) + LEGACY_V1_OFFSET,
+			migrated: false,
+			is_rebalancing: false,
+			imbalance_before: 0n,
+			imbalance_after: 0n,
+			pool_balances_after: [],
+			virtual_price_after: 0n,
+			fee_bps: e.fee != null ? [] : [],
+		}));
+
+		const combined = [...v2Events, ...v1Tagged];
+		combined.sort((a: any, b: any) => Number(BigInt(b.timestamp ?? 0n) - BigInt(a.timestamp ?? 0n)));
+		return setCache(key, combined);
+	} catch (err) {
+		console.error('[explorerService] fetch3PoolLiquidityEventsCombined failed:', err);
+		return [];
 	}
 }
 
@@ -1344,7 +1476,12 @@ export async function fetchDexEvent(source: DexEventSource, id: number): Promise
 /** Return the total count of events for a non-backend source. Used to gate "Next" navigation. */
 export async function fetchDexEventCount(source: DexEventSource): Promise<bigint> {
 	switch (source) {
-		case '3pool_swap':       return fetchSwapEventCount();
+		case '3pool_swap': {
+			// No v2 count endpoint — return v1+v2 combined length so the
+			// historical (frozen v1) entries are reflected in the count.
+			const events = await fetchThreePoolSwapEventsCombined();
+			return BigInt(events.length);
+		}
 		case 'amm_swap':         return fetchAmmSwapEventCount();
 		case 'amm_liquidity':    return fetchAmmLiquidityEventCount();
 		case 'amm_admin':        return fetchAmmAdminEventCount();
@@ -1359,8 +1496,14 @@ export async function fetchDexEventCount(source: DexEventSource): Promise<bigint
 export async function fetchAllDexEvents(source: DexEventSource): Promise<any[]> {
 	switch (source) {
 		case '3pool_swap': {
-			const count = await fetchSwapEventCount();
-			return Number(count) > 0 ? fetchSwapEvents(0n, count) : [];
+			// Combine v2 (live) and v1 (frozen historical) so the explorer
+			// surfaces the full swap history, not just post-migration entries.
+			return fetchThreePoolSwapEventsCombined();
+		}
+		case '3pool_liquidity': {
+			// Same v1+v2 split as swaps — pre-migration liquidity entries
+			// would otherwise be invisible in the activity feed.
+			return fetch3PoolLiquidityEventsCombined();
 		}
 		case 'amm_swap': {
 			const count = await fetchAmmSwapEventCount();
@@ -1373,10 +1516,6 @@ export async function fetchAllDexEvents(source: DexEventSource): Promise<any[]> 
 		case 'amm_admin': {
 			const count = await fetchAmmAdminEventCount();
 			return Number(count) > 0 ? fetchAmmAdminEvents(0n, count) : [];
-		}
-		case '3pool_liquidity': {
-			const count = await fetch3PoolLiquidityEventCount();
-			return Number(count) > 0 ? fetch3PoolLiquidityEvents(count, 0n) : [];
 		}
 		case '3pool_admin': {
 			const count = await fetch3PoolAdminEventCount();

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -476,14 +476,29 @@ export async function fetchVaultsByOwner(principal: Principal): Promise<any[]> {
 	}
 }
 
-export async function fetchVaultHistory(vaultId: bigint): Promise<any[]> {
+/**
+ * Per-vault event history. The backend now returns `(global_index, event)`
+ * tuples; we expose them as `{ index, event }` so callers can render the
+ * canonical Event #N link on every row without a second query against the
+ * global event log.
+ */
+export interface VaultHistoryEntry {
+	index: bigint;
+	event: any;
+}
+
+export async function fetchVaultHistory(vaultId: bigint): Promise<VaultHistoryEntry[]> {
 	const key = `vaults:history:${vaultId}`;
-	const cached = getCached<any[]>(key, TTL.EVENTS);
+	const cached = getCached<VaultHistoryEntry[]>(key, TTL.EVENTS);
 	if (cached) return cached;
 
 	try {
 		const result = await publicActor.get_vault_history(vaultId);
-		return setCache(key, result);
+		const entries: VaultHistoryEntry[] = (result as any[]).map((pair: any) => ({
+			index: BigInt(pair[0]),
+			event: pair[1],
+		}));
+		return setCache(key, entries);
 	} catch (err) {
 		console.error('[explorerService] fetchVaultHistory failed:', err);
 		return [];

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -596,7 +596,40 @@ export async function fetchEvents(
 		arg.admin_labels = filters?.admin_labels?.length ? [filters.admin_labels] : [];
 
 		const result = await publicActor.get_events_filtered(arg);
-		const data = { total: result.total, events: result.events ?? [] };
+		const rawEvents: [bigint, any][] = result.events ?? [];
+		let events: [bigint, any][] = rawEvents;
+
+		// Overlay recording-time timestamps from the side log so admin/upgrade
+		// rows (whose payloads have no inline `timestamp` field) get a real
+		// time. The candid-decoded event payloads are sometimes non-extensible,
+		// so we rebuild the [idx, evt] pairs with shallow clones that carry
+		// the side-log timestamp on a `__ts_ns` field. Older indices (before
+		// the side log shipped) come back as 0 and we leave those alone so
+		// the renderer keeps showing "—".
+		if (rawEvents.length > 0) {
+			let minIdx = rawEvents[0][0];
+			let maxIdx = rawEvents[0][0];
+			for (const [idx] of rawEvents) {
+				if (idx < minIdx) minIdx = idx;
+				if (idx > maxIdx) maxIdx = idx;
+			}
+			const span = Number(maxIdx - minIdx) + 1;
+			try {
+				const tsArr = (await publicActor.get_event_timestamps(minIdx, BigInt(span))) as bigint[];
+				events = rawEvents.map(([idx, evt]) => {
+					const offset = Number(idx - minIdx);
+					const ts = tsArr[offset];
+					if (ts && ts !== 0n && evt && typeof evt === 'object') {
+						return [idx, { ...evt, __ts_ns: ts }];
+					}
+					return [idx, evt];
+				});
+			} catch (err) {
+				console.error('[explorerService] get_event_timestamps overlay failed:', err);
+			}
+		}
+
+		const data = { total: result.total, events };
 		return setCache(key, data);
 	} catch (err) {
 		console.error('[explorerService] fetchEvents failed:', err);

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -1538,9 +1538,11 @@ static async repayToVaultWithStable(
      */
     static async getVaultHistory(vaultId: number): Promise<any[]> {
       try {
-        // Use anonymous actor for read-only queries — avoids Oisy signer popups
+        // Use anonymous actor for read-only queries — avoids Oisy signer popups.
+        // Backend returns `(global_index, event)` tuples; legacy callers want a
+        // flat event list, so drop the index here.
         const history = await publicActor.get_vault_history(BigInt(vaultId));
-        return history.map((event: any) => event);
+        return (history as any[]).map((pair: any) => pair[1]);
       } catch (err) {
         console.error('Error getting vault history:', err);
         return [];

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -293,6 +293,19 @@ class ThreePoolService {
     return await actor.get_liquidity_event_count_v2() as bigint;
   }
 
+  // v1 liquidity log: frozen at the dynamic-fee migration but still holds
+  // pre-migration history (oldest-first by index). Use the explorer-side
+  // combined fetcher rather than this method directly when surfacing events.
+  async getLiquidityEventsV1(start: bigint, length: bigint): Promise<any[]> {
+    const actor = await this.getQueryActor();
+    return await actor.get_liquidity_events(start, length) as any[];
+  }
+
+  async getLiquidityEventCountV1(): Promise<bigint> {
+    const actor = await this.getQueryActor();
+    return await actor.get_liquidity_event_count() as bigint;
+  }
+
   async getAdminEvents(start: bigint, length: bigint): Promise<any[]> {
     const actor = await this.getQueryActor();
     return await actor.get_admin_events(start, length) as any[];
@@ -365,9 +378,11 @@ class ThreePoolService {
     return await actor.get_top_swappers({ [window]: null } as any, n) as Array<[Principal, bigint, bigint]>;
   }
 
-  async getSwapEventsV2(start: bigint, length: bigint): Promise<any[]> {
+  // v2 swap endpoint is newest-first: offset skips the N most-recent events, limit takes the next batch.
+  // Mirrors get_liquidity_events_v2 above. The canister returns events[0] = newest in window.
+  async getSwapEventsV2(limit: bigint, offset: bigint = 0n): Promise<any[]> {
     const actor = await this.getQueryActor();
-    return await actor.get_swap_events_v2(start, length) as any[];
+    return await actor.get_swap_events_v2(limit, offset) as any[];
   }
 
   // ── Mutations ──

--- a/src/vault_frontend/src/lib/stores/explorerStore.ts
+++ b/src/vault_frontend/src/lib/stores/explorerStore.ts
@@ -199,19 +199,31 @@ export async function fetchPoolEvents() {
 			console.error('Failed to fetch SP liquidations:', e);
 		}
 
-		// 3Pool: swap events
+		// 3Pool: swap events. swap_v1 is frozen at migration but still holds
+		// most of the historical activity, so read both logs and merge.
 		try {
-			const swapCount = await threePoolService.getSwapEventCount();
-			if (swapCount > 0n) {
-				const fetchCount = 200n;
-				const start = swapCount > fetchCount ? swapCount - fetchCount : 0n;
-				const swapEvents = await threePoolService.getSwapEvents(start, fetchCount);
-				for (const evt of swapEvents) {
+			const [v2Events, v1Count] = await Promise.all([
+				threePoolService.getSwapEventsV2(200n, 0n),
+				threePoolService.getSwapEventCount().catch(() => 0n),
+			]);
+			for (const evt of v2Events) {
+				results.push({
+					source: '3pool_swap',
+					timestamp: evt.timestamp,
+					event: evt,
+					globalIndex: Number(evt.id),
+				});
+			}
+			if (Number(v1Count) > 0) {
+				const v1Events = await threePoolService.getSwapEvents(0n, v1Count);
+				for (const evt of v1Events) {
 					results.push({
 						source: '3pool_swap',
 						timestamp: evt.timestamp,
 						event: evt,
-						globalIndex: Number(evt.id),
+						// Offset legacy IDs into a non-overlapping band so the
+						// pool-events store key stays unique across v1+v2.
+						globalIndex: Number(evt.id) + 1_000_000,
 					});
 				}
 			}

--- a/src/vault_frontend/src/lib/stores/explorerStore.ts
+++ b/src/vault_frontend/src/lib/stores/explorerStore.ts
@@ -132,7 +132,10 @@ export async function fetchAllVaults() {
 
 export async function fetchVaultHistory(vaultId: number) {
 	try {
-		return await publicActor.get_vault_history(BigInt(vaultId));
+		// Backend returns `(global_index, event)` tuples; this legacy entry point
+		// returns the flat event list for back-compat with non-explorer surfaces.
+		const result = await publicActor.get_vault_history(BigInt(vaultId));
+		return (result as any[]).map((pair: any) => pair[1]);
 	} catch (e) {
 		console.error(`Failed to fetch history for vault #${vaultId}:`, e);
 		return [];

--- a/src/vault_frontend/src/lib/utils/displayEvent.ts
+++ b/src/vault_frontend/src/lib/utils/displayEvent.ts
@@ -47,10 +47,23 @@ export function extractEventTimestamp(event: any): number {
 	if (event?.timestamp != null) return Number(event.timestamp);
 	const eventType = event?.event_type ?? event;
 	if (!eventType) return 0;
-	const key = Object.keys(eventType)[0];
-	if (!key) return 0;
+	// Skip our `__ts_ns` overlay key when picking the variant tag — the
+	// shallow clone fetchEvents creates places it alongside the variant key.
+	const key = Object.keys(eventType).filter(k => k !== '__ts_ns')[0];
+	if (!key) {
+		return event?.__ts_ns != null ? Number(event.__ts_ns) : 0;
+	}
 	const data = eventType[key];
-	if (data?.timestamp != null) return Number(data.timestamp);
+	if (data?.timestamp != null) {
+		// Backend events use `opt nat64` for timestamps which the JS bindings
+		// surface as either the bare value or a [value]/[]-wrapped option.
+		const t = Array.isArray(data.timestamp) ? data.timestamp[0] : data.timestamp;
+		if (t != null) return Number(t);
+	}
+	// Fallback to the parallel EVENT_TIMESTAMPS side log (see fetchEvents):
+	// admin / upgrade / set_* variants don't carry an inline timestamp, so
+	// the explorer uses the recording-time timestamp from the side log.
+	if (event?.__ts_ns != null) return Number(event.__ts_ns);
 	return 0;
 }
 

--- a/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
@@ -137,3 +137,67 @@ export function computeYScale(values: number[]): { min: number; max: number; tic
   const ticks = Array.from({ length: 5 }, (_, i) => min + step * i);
   return { min, max, ticks };
 }
+
+/**
+ * Pad a sparse "flow" series (volume, fees, counts per bucket) to the full
+ * window by inserting zero buckets where the source has no data. Without
+ * this, a single non-zero bucket renders as a straight line between two
+ * disconnected points instead of a clear spike against a zero baseline.
+ *
+ * `points` timestamps must be in milliseconds. Returns ms-keyed buckets.
+ */
+export function padZeroBuckets(
+  points: { t: number; v: number }[],
+  windowMs: number,
+  bucketMs: number,
+): { t: number; v: number }[] {
+  const valueAt = new Map<number, number>();
+  for (const p of points) {
+    const bucket = Math.floor(p.t / bucketMs) * bucketMs;
+    valueAt.set(bucket, (valueAt.get(bucket) ?? 0) + p.v);
+  }
+  const nowMs = Date.now();
+  const startMs = Math.floor((nowMs - windowMs) / bucketMs) * bucketMs;
+  const endMs = Math.floor(nowMs / bucketMs) * bucketMs;
+  const out: { t: number; v: number }[] = [];
+  for (let t = startMs; t <= endMs; t += bucketMs) {
+    out.push({ t, v: valueAt.get(t) ?? 0 });
+  }
+  return out;
+}
+
+/**
+ * Pad a sparse snapshot series (balances, prices, virtual price) to the full
+ * window by forward-filling the most recent known value into each bucket.
+ * Buckets before the first observed value use `defaultValue` (which can be
+ * the current live value, so a bare 1-point series still shows the level).
+ *
+ * `points` timestamps must be in milliseconds.
+ */
+export function padForwardFill(
+  points: { t: number; v: number }[],
+  windowMs: number,
+  bucketMs: number,
+  defaultValue: number,
+): { t: number; v: number }[] {
+  const sorted = [...points].sort((a, b) => a.t - b.t);
+  const valueAt = new Map<number, number>();
+  for (const p of sorted) {
+    const bucket = Math.floor(p.t / bucketMs) * bucketMs;
+    valueAt.set(bucket, p.v);
+  }
+  const nowMs = Date.now();
+  const startMs = Math.floor((nowMs - windowMs) / bucketMs) * bucketMs;
+  const endMs = Math.floor(nowMs / bucketMs) * bucketMs;
+  // Seed forward-fill with the most recent known value before the window.
+  let lastValue = defaultValue;
+  for (const p of sorted) {
+    if (p.t < startMs) lastValue = p.v;
+  }
+  const out: { t: number; v: number }[] = [];
+  for (let t = startMs; t <= endMs; t += bucketMs) {
+    if (valueAt.has(t)) lastValue = valueAt.get(t) as number;
+    out.push({ t, v: lastValue });
+  }
+  return out;
+}

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -874,9 +874,12 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
     case 'withdraw_and_close_vault':
     case 'vault_withdrawn_and_closed':
     case 'VaultWithdrawnAndClosed': {
-      const sym = tokenSymbol(d.collateral_type ?? 'unknown');
+      const collType = vaultCollateral(d.vault_id);
+      const sym = tokenSymbol(collType);
+      const dec = tokenDecimals(collType);
       fields.push(vaultField(d.vault_id));
-      if (d.amount !== undefined) fields.push(amountField('Collateral Returned', d.amount, 8, sym || 'ICP'));
+      if (collType !== 'unknown') fields.push(tokenField(collType));
+      if (d.amount !== undefined) fields.push(amountField('Collateral Returned', d.amount, dec, sym));
       pushIfPresent(fields, addressField('Caller', d.caller));
       if (d.block_index !== undefined) fields.push(blockIndexField('Block Index', optValue(d.block_index)));
       const eventTs = optValue<any>(d.timestamp) ?? ts;

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -1164,13 +1164,56 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
       const amt = fmtE8s(d.icusd_amount);
       fields.push(amountField('icUSD Redeemed', d.icusd_amount));
       fields.push(amountField('Fee', d.fee_amount));
-      if (d.current_icp_rate !== undefined) {
-        fields.push(textField('ICP Rate', `$${Number(d.current_icp_rate).toFixed(4)}`));
-      }
+      // current_icp_rate is a candid blob (UsdIcp serialized), not a number —
+      // skip the field rather than render "$NaN" until it has a proper decoder.
       if (d.icusd_block_index !== undefined) fields.push(blockIndexField('icUSD Block Index', d.icusd_block_index));
       if (ts) fields.push(timestampField(ts));
+
+      // Per-vault breakdown: surface every vault touched by this redemption
+      // with the amount drained and the collateral seized. The same vault
+      // can appear multiple times when the redemption is iterative — collapse
+      // those into one row per vault so the list stays scannable.
+      //
+      // Labels must be unique because the event detail render uses
+      // `(field.label)` as the keyed-each key — duplicate labels would crash
+      // the page. Embed the vault id directly in the label.
+      if (vaultRedemptions && vaultRedemptions.length > 0) {
+        const ctPrincipalText = optPrincipalToText(d.collateral_type);
+        const collSym = ctPrincipalText ? getTokenSymbol(ctPrincipalText) : '';
+        const byVault = new Map<number, { redeemed: bigint; seized: bigint }>();
+        for (const vr of vaultRedemptions) {
+          const vid = Number(vr.vault_id);
+          const entry = byVault.get(vid) ?? { redeemed: 0n, seized: 0n };
+          entry.redeemed += BigInt(vr.icusd_redeemed_e8s ?? 0);
+          entry.seized += BigInt(vr.collateral_seized ?? 0);
+          byVault.set(vid, entry);
+        }
+        // Sort by largest redemption first so the most-impacted vaults lead.
+        const ordered = [...byVault.entries()].sort(
+          (a, b) => Number(b[1].redeemed - a[1].redeemed),
+        );
+        for (const [vid, agg] of ordered) {
+          const redeemedDisplay = fmtE8s(agg.redeemed);
+          const seizedDisplay = ctPrincipalText
+            ? formatTokenAmount(agg.seized, ctPrincipalText)
+            : (Number(agg.seized) / 1e8).toFixed(4);
+          // Single row per vault, label disambiguated by vault id, value
+          // shows the drain amounts. Linking through `linkTarget` so the
+          // detail page renders a clickable vault chip.
+          fields.push({
+            label: `Vault #${vid}`,
+            value: `${redeemedDisplay} icUSD → ${seizedDisplay}${collSym ? ` ${collSym}` : ''}`,
+            type: 'vault',
+            linkTarget: String(vid),
+          });
+        }
+      }
+
+      const summary = vaultRedemptions && vaultRedemptions.length > 0
+        ? `Redeemed ${amt} icUSD across ${new Set(vaultRedemptions.map((vr: any) => Number(vr.vault_id))).size} vault${new Set(vaultRedemptions.map((vr: any) => Number(vr.vault_id))).size === 1 ? '' : 's'} (fee: ${fee} icUSD)`
+        : `Redeemed ${amt} icUSD (fee: ${fee} icUSD)`;
       return {
-        summary: `Redeemed ${amt} icUSD (fee: ${fee} icUSD)`,
+        summary,
         typeName, category, badgeColor, fields,
       };
     }

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -28,6 +28,7 @@ export type FieldType =
   | 'timestamp'
   | 'json'
   | 'canister'
+  | 'pool'
   | 'block_index'
   | 'ratio';
 
@@ -153,7 +154,7 @@ export function formatAmmSwapEvent(event: any): FormattedEvent {
   const fields: EventField[] = [
     { label: 'Token In', value: `${amountIn} ${tokenInSym}`, type: 'amount' },
     { label: 'Token Out', value: `${amountOut} ${tokenOutSym}`, type: 'amount' },
-    { label: 'Pool', value: String(poolId), type: 'text' },
+    { label: 'Pool', value: String(poolId), type: 'pool', linkTarget: String(poolId) },
   ];
 
   if (tokenInPrincipal) fields.push({ label: 'Token In Ledger', value: shortenPrincipal(tokenInPrincipal), type: 'token', linkTarget: tokenInPrincipal });
@@ -195,7 +196,7 @@ export function formatAmmLiquidityEvent(event: any): FormattedEvent {
     { label: 'Token A', value: `${amtA} ${tokenA}`, type: 'amount' },
     { label: 'Token B', value: `${amtB} ${tokenB}`, type: 'amount' },
     { label: 'LP Shares', value: lpShares, type: 'amount' },
-    { label: 'Pool', value: String(poolId), type: 'text' },
+    { label: 'Pool', value: String(poolId), type: 'pool', linkTarget: String(poolId) },
   ];
 
   if (tokenAPrincipal) fields.push({ label: 'Token A Ledger', value: shortenPrincipal(tokenAPrincipal), type: 'token', linkTarget: tokenAPrincipal });

--- a/src/vault_frontend/src/routes/explorer/+layout.svelte
+++ b/src/vault_frontend/src/routes/explorer/+layout.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
+  import { onMount } from 'svelte';
   import SearchBar from '$lib/components/explorer/SearchBar.svelte';
   import {
     isVaultId, isEventIndex, parseEventIndex, isPrincipal, resolveTokenAlias
   } from '$lib/utils/explorerHelpers';
+  import { setAmmPoolRegistry } from '$utils/ammNaming';
+  import { fetchAmmPools } from '$services/explorer/explorerService';
   import type { Snippet } from 'svelte';
+
+  // Seed the AMM pool registry once on layout mount so that every explorer
+  // sub-page (event detail, vault detail, address detail, etc.) can resolve
+  // AMM pool ids to "AMMn"-style labels — not just the lenses that fetch
+  // pools themselves. Failures are silent: pages will fall back to the
+  // shortened-principal pair until the registry catches up.
+  onMount(async () => {
+    try {
+      const pools = await fetchAmmPools();
+      if (Array.isArray(pools) && pools.length > 0) setAmmPoolRegistry(pools);
+    } catch (err) {
+      console.error('[explorer layout] AMM registry seed failed:', err);
+    }
+  });
 
   let { children }: { children: Snippet } = $props();
 

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -10,11 +10,11 @@
 	import ErrorState from '$components/explorer/ErrorState.svelte';
 	import {
 		fetchEvents,
-		fetchSwapEvents, fetchSwapEventCount,
+		fetchThreePoolSwapEventsCombined,
+		fetch3PoolLiquidityEventsCombined,
 		fetchAmmSwapEvents, fetchAmmSwapEventCount,
 		fetchAmmLiquidityEvents, fetchAmmLiquidityEventCount,
 		fetchAmmAdminEvents, fetchAmmAdminEventCount,
-		fetch3PoolLiquidityEvents, fetch3PoolLiquidityEventCount,
 		fetch3PoolAdminEvents, fetch3PoolAdminEventCount,
 		fetchStabilityPoolEvents, fetchStabilityPoolEventCount,
 		fetch3PoolSwapEventsByPrincipal,
@@ -43,7 +43,7 @@
 		toggleAdminLabel,
 		type Facets,
 	} from '$utils/eventFacets';
-	import { setAmmPoolRegistry } from '$utils/ammNaming';
+	import { setAmmPoolRegistry, ammPoolLabel } from '$utils/ammNaming';
 	import { fetchAdminEventBreakdown } from '$services/explorer/analyticsService';
 	import type { AdminEventLabelCount } from '$declarations/rumi_analytics/rumi_analytics.did';
 
@@ -416,16 +416,17 @@
 			const poolSet = new Set<string>();
 			for (const p of knownAmmPools) poolSet.add(p.pool_id);
 			poolSet.add('3pool');
+			// Build friendly labels for the pool dropdown — use the shared AMM
+			// registry so each pool reads as "AMM1 · 3USD/ICP" instead of leaking
+			// the canister principal pair into the chip / dropdown UI.
 			poolOptions = [...poolSet]
 				.map((id) => {
 					if (id === '3pool') return { id, label: 'Rumi 3Pool' };
 					const pool = knownAmmPools.find((p: any) => p.pool_id === id);
 					if (pool) {
-						const a = getTokenSymbol(pool.token_a?.toText?.() ?? '');
-						const b = getTokenSymbol(pool.token_b?.toText?.() ?? '');
-						return { id, label: `AMM · ${a}/${b} (${id})` };
+						return { id, label: ammPoolLabel(id, pool.token_a, pool.token_b) };
 					}
-					return { id, label: id };
+					return { id, label: ammPoolLabel(id) };
 				})
 				.sort((a, b) => a.label.localeCompare(b.label));
 
@@ -493,16 +494,14 @@
 		}
 
 		// time-only or tail: full fetch + client-side post-filter handles
-		// time narrowing. (3pool has a swap_by_time_range endpoint but no
-		// liquidity equivalent — keeping the dispatch symmetric.)
-		const [swapCount, liqCount, adminCount] = await Promise.all([
-			fetchSwapEventCount(),
-			fetch3PoolLiquidityEventCount(),
-			fetch3PoolAdminEventCount(),
-		]);
+		// time narrowing. Swaps and liquidity both come from combined v1+v2
+		// readers so frozen pre-migration history is visible alongside live
+		// writes. (3pool has a swap_by_time_range endpoint but no liquidity
+		// equivalent — keeping the dispatch symmetric.)
+		const adminCount = await fetch3PoolAdminEventCount();
 		const [swaps, liquidity, admin] = await Promise.all([
-			Number(swapCount) > 0 ? fetchSwapEvents(0n, swapCount) : Promise.resolve([]),
-			Number(liqCount) > 0 ? fetch3PoolLiquidityEvents(liqCount, 0n) : Promise.resolve([]),
+			fetchThreePoolSwapEventsCombined(),
+			fetch3PoolLiquidityEventsCombined(),
 			Number(adminCount) > 0 ? fetch3PoolAdminEvents(0n, adminCount) : Promise.resolve([]),
 		]);
 		return { swaps, liquidity, admin };

--- a/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import EntityShell from '$components/explorer/entity/EntityShell.svelte';
   import CRDial from '$components/explorer/entity/CRDial.svelte';
@@ -714,7 +713,13 @@
     }
   }
 
-  onMount(loadAddress);
+  // SvelteKit reuses this component when navigating between sibling
+  // /e/address/[principal] routes; an onMount-only load would leave the page
+  // stuck on the prior principal's data.
+  $effect(() => {
+    void principalStr;
+    loadAddress();
+  });
 
   const pageTitle = $derived(
     knownCanister && canisterName ? canisterName : shortenPrincipal(principalStr),

--- a/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import EntityShell from '$components/explorer/entity/EntityShell.svelte';
   import EntityLink from '$components/explorer/EntityLink.svelte';
@@ -11,7 +10,7 @@
   import { formatTimestamp, shortenPrincipal, getCanisterName } from '$utils/explorerHelpers';
   import {
     fetchAllVaults, fetchEventCount, fetchEvents, fetchDexEvent, fetchDexEventCount,
-    fetchAllDexEvents,
+    fetchAllDexEvents, fetchVaultHistory,
   } from '$services/explorer/explorerService';
   import type { DexEventSource } from '$services/explorer/explorerService';
   import {
@@ -96,6 +95,63 @@
     };
   });
 
+  /**
+   * Pull every vault_id this backend event touches. Most variants carry a
+   * top-level `vault_id`; redemption_on_vaults carries a `vault_redemptions`
+   * array of `{ vault_id, ... }` records.
+   */
+  function extractVaultIds(rawEvent: any): number[] {
+    const out = new Set<number>();
+    const t = rawEvent?.event_type ?? rawEvent;
+    const key = t ? Object.keys(t)[0] : null;
+    if (!key) return [];
+    const data = t[key];
+    if (data?.vault_id != null) out.add(Number(data.vault_id));
+    const vault = data?.vault;
+    if (vault?.vault_id != null) out.add(Number(vault.vault_id));
+    const redemptions = Array.isArray(data?.vault_redemptions)
+      ? (data.vault_redemptions[0] ?? data.vault_redemptions)
+      : null;
+    if (Array.isArray(redemptions)) {
+      for (const r of redemptions) {
+        if (r?.vault_id != null) out.add(Number(r.vault_id));
+      }
+    }
+    return [...out];
+  }
+
+  /**
+   * For each vault_id referenced by the event but missing from the active-vault
+   * map (i.e. the vault has been closed), fetch its history and seed the map
+   * from the open_vault entry. Lets formatters resolve token symbols/decimals
+   * for closed vaults.
+   */
+  async function seedClosedVaultCollateral(rawEvent: any, map: Map<number, string>) {
+    const ids = extractVaultIds(rawEvent).filter((id) => !map.has(id));
+    if (!ids.length) return;
+    await Promise.all(
+      ids.map(async (id) => {
+        try {
+          const hist = await fetchVaultHistory(BigInt(id));
+          for (const entry of hist) {
+            const evt = entry?.event;
+            const et = evt?.event_type ?? evt;
+            const k = Object.keys(et)[0];
+            if (k !== 'open_vault') continue;
+            const v = et[k]?.vault;
+            if (v && Number(v.vault_id) === id) {
+              const ct = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+              if (ct) map.set(id, ct);
+              break;
+            }
+          }
+        } catch (err) {
+          console.error('[event] seedClosedVaultCollateral failed for', id, err);
+        }
+      }),
+    );
+  }
+
   async function loadEvent() {
     loading = true;
     error = null;
@@ -123,6 +179,12 @@
 
         if (results.length > 0) {
           event = results[0];
+          // Closed vaults are absent from get_all_vaults, so the map is missing
+          // their collateral type and the formatter falls back to "unknown".
+          // Seed any vault_id this event references but the live map didn't
+          // have, by reading the open_vault entry from that vault's history.
+          await seedClosedVaultCollateral(event, map);
+          vaultCollateralMap = new Map(map);
         } else {
           error = `Event #${parsed.id} not found.`;
         }
@@ -191,7 +253,13 @@
     }
   }
 
-  onMount(loadEvent);
+  // SvelteKit reuses this component across sibling /e/event/[id] navigations,
+  // so onMount alone would only fire on the first visit and leave the page
+  // stuck on the prior event.
+  $effect(() => {
+    void rawId;
+    loadEvent();
+  });
 
   const timestampNs = $derived(display?.timestamp ?? 0);
   const blockIndex = $derived.by(() => {

--- a/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/event/[id]/+page.svelte
@@ -325,6 +325,8 @@
                   </span>
                 {:else if field.type === 'token' && field.linkTarget}
                   <EntityLink type="token" value={field.linkTarget} />
+                {:else if field.type === 'pool' && field.linkTarget}
+                  <EntityLink type="pool" value={field.linkTarget} />
                 {:else if field.type === 'event' && field.linkTarget}
                   <EntityLink type="event" value={field.linkTarget} />
                 {:else if field.type === 'amount'}

--- a/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
   import EntityShell from '$components/explorer/entity/EntityShell.svelte';
   import EntityLink from '$components/explorer/EntityLink.svelte';
   import CopyButton from '$components/explorer/CopyButton.svelte';
@@ -408,7 +407,13 @@
     }
   }
 
-  onMount(loadPool);
+  // Re-run on pool id change so navigating between sibling /e/pool/[id]
+  // routes (which reuse this component) refetches instead of sticking on the
+  // prior pool's data.
+  $effect(() => {
+    void poolIdParam;
+    loadPool();
+  });
 </script>
 
 <svelte:head>

--- a/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/pool/[id]/+page.svelte
@@ -13,10 +13,10 @@
     fetchThreePoolHealth,
     fetchThreePoolTopLps,
     fetchThreePoolTopSwappers,
-    fetchThreePoolSwapEventsV2,
+    fetchThreePoolSwapEventsCombined,
+    fetch3PoolLiquidityEventsCombined,
     fetch3PoolLiquidityEvents,
     fetch3PoolLiquidityEventCount,
-    fetchSwapEventCount,
     fetchThreePoolVolumeSeries,
     fetchThreePoolBalanceSeries,
     fetchThreePoolFeeSeries,
@@ -38,7 +38,8 @@
   import { AMM_TOKENS } from '$services/ammService';
   import type { DisplayEvent } from '$utils/displayEvent';
   import { CANISTER_IDS } from '$lib/config';
-  import { formatCompact } from '$utils/explorerChartHelpers';
+  import { formatCompact, padZeroBuckets, padForwardFill } from '$utils/explorerChartHelpers';
+  import { POOL_TOKENS } from '$services/threePoolService';
 
   const poolIdParam = $derived($page.params.id);
 
@@ -182,30 +183,70 @@
   }
 
   // ── 3pool series points ──────────────────────────────────────────────────
-  const volPoints = $derived(
-    volSeries.map((p: any) => ({
-      t: Number(p.timestamp),
-      v: (p.volume_per_token as bigint[]).reduce((a, b) => a + Number(b) / 1e18, 0),
-    })),
-  );
+  // Canister timestamps are nanoseconds; chart helpers expect ms. The
+  // canister also only emits buckets that contain swaps — pad the full 7d
+  // hourly window so sparse activity reads as spikes against a baseline
+  // instead of a straight line between two distant points.
+  const VOL_BUCKET_MS = 3_600_000;          // 3600s on the canister side
+  const VOL_WINDOW_MS = 7 * 24 * 3_600_000;
 
-  const vpPoints = $derived(
-    vpSeries.map((p: any) => ({ t: Number(p.timestamp), v: Number(p.virtual_price) / 1e18 })),
-  );
+  const volPoints = $derived.by(() => {
+    if (!volSeries.length) return [] as { t: number; v: number }[];
+    const raw = volSeries.map((p: any) => {
+      // volume_per_token[i] is sum of amount_in for token index i, in raw
+      // token units. Stables are ~$1 so summing normalized values yields
+      // a USD figure. The previous /1e18 was wrong: stables use 6/8 dec.
+      let total = 0;
+      const arr = p.volume_per_token as bigint[];
+      for (let i = 0; i < arr.length; i++) {
+        const tok = POOL_TOKENS[i];
+        if (!tok) continue;
+        total += Number(arr[i]) / 10 ** tok.decimals;
+      }
+      return { t: Number(p.timestamp) / 1_000_000, v: total };
+    });
+    return padZeroBuckets(raw, VOL_WINDOW_MS, VOL_BUCKET_MS);
+  });
 
-  const feePoints = $derived(
-    feeSeries.map((p: any) => ({ t: Number(p.timestamp), v: Number(p.avg_fee_bps) / 100 })),
-  );
+  // Virtual price is monotonic-ish around 1.0; data-fit Y axis on the
+  // chart side keeps the slope visible. Forward-fill so a stale snapshot
+  // window still draws as a continuous level instead of a 1-segment line.
+  const vpPoints = $derived.by(() => {
+    if (!vpSeries.length) return [] as { t: number; v: number }[];
+    const raw = vpSeries.map((p: any) => ({
+      t: Number(p.timestamp) / 1_000_000,
+      v: Number(p.virtual_price) / 1e18,
+    }));
+    const liveVp = Number(virtualPrice) / 1e18 || raw[raw.length - 1]?.v || 1;
+    return padForwardFill(raw, VOL_WINDOW_MS, VOL_BUCKET_MS, liveVp);
+  });
+
+  const feePoints = $derived.by(() => {
+    if (!feeSeries.length) return [] as { t: number; v: number }[];
+    const raw = feeSeries.map((p: any) => ({
+      t: Number(p.timestamp) / 1_000_000,
+      v: Number(p.avg_fee_bps) / 100,
+    }));
+    return padZeroBuckets(raw, VOL_WINDOW_MS, VOL_BUCKET_MS);
+  });
 
   const balancePointsByToken = $derived.by(() => {
-    if (!balSeries.length || !tokens.length) return [] as Array<{ symbol: string; points: { t: number; v: number }[] }>;
-    return tokens.map((tok: any, i: number) => ({
-      symbol: tok.symbol,
-      points: balSeries.map((p: any) => ({
-        t: Number(p.timestamp),
+    if (!tokens.length) return [] as Array<{ symbol: string; points: { t: number; v: number }[] }>;
+    return tokens.map((tok: any, i: number) => {
+      const liveBalance = Number(balances[i] ?? 0n) / 10 ** Number(tok.decimals);
+      const raw = balSeries.map((p: any) => ({
+        t: Number(p.timestamp) / 1_000_000,
         v: Number((p.balances as bigint[])[i] ?? 0n) / 10 ** Number(tok.decimals),
-      })),
-    }));
+      }));
+      // Forward-fill so balance reads as a level across the window (the
+      // canister only emits balance points on swap events, which can be
+      // sparse). Default fills with the current live balance when no
+      // historical samples land before the window start.
+      return {
+        symbol: tok.symbol,
+        points: padForwardFill(raw, VOL_WINDOW_MS, VOL_BUCKET_MS, liveBalance),
+      };
+    });
   });
 
   // ── AMM series points ────────────────────────────────────────────────────
@@ -223,30 +264,41 @@
     }));
   });
 
+  // AMM series share the 7d / hourly window used elsewhere on this page.
+  const ammVolPointsPadded = $derived.by(() => {
+    if (!ammTokenA || !ammTokenB) return [] as { t: number; v: number }[];
+    return padZeroBuckets(ammVolPoints, VOL_WINDOW_MS, VOL_BUCKET_MS);
+  });
+
   const ammBalancePointsA = $derived.by(() => {
-    if (!ammBalSeries.length || !ammTokenA) return [];
-    return ammBalSeries.map((p: any) => ({
+    if (!ammTokenA) return [] as { t: number; v: number }[];
+    const liveA = Number(ammReserveA) / 10 ** ammTokenA.decimals;
+    const raw = ammBalSeries.map((p: any) => ({
       t: Number(p.ts_ns) / 1_000_000,
       v: Number(p.reserve_a_e8s) / 10 ** ammTokenA.decimals,
     }));
+    return padForwardFill(raw, VOL_WINDOW_MS, VOL_BUCKET_MS, liveA);
   });
 
   const ammBalancePointsB = $derived.by(() => {
-    if (!ammBalSeries.length || !ammTokenB) return [];
-    return ammBalSeries.map((p: any) => ({
+    if (!ammTokenB) return [] as { t: number; v: number }[];
+    const liveB = Number(ammReserveB) / 10 ** ammTokenB.decimals;
+    const raw = ammBalSeries.map((p: any) => ({
       t: Number(p.ts_ns) / 1_000_000,
       v: Number(p.reserve_b_e8s) / 10 ** ammTokenB.decimals,
     }));
+    return padForwardFill(raw, VOL_WINDOW_MS, VOL_BUCKET_MS, liveB);
   });
 
   const ammFeePoints = $derived.by(() => {
-    if (!ammFeeSeries.length || !ammTokenA || !ammTokenB) return [];
-    return ammFeeSeries.map((p: any) => ({
+    if (!ammTokenA || !ammTokenB) return [] as { t: number; v: number }[];
+    const raw = ammFeeSeries.map((p: any) => ({
       t: Number(p.ts_ns) / 1_000_000,
       v:
         Number(p.fees_a_e8s) / 10 ** ammTokenA.decimals +
         Number(p.fees_b_e8s) / 10 ** ammTokenB.decimals,
     }));
+    return padZeroBuckets(raw, VOL_WINDOW_MS, VOL_BUCKET_MS);
   });
 
   // ── Merged event feeds ───────────────────────────────────────────────────
@@ -315,19 +367,18 @@
 
     if (isThreePool) {
       try {
-        const swapCount = await fetchSwapEventCount().catch(() => 0n);
-        const liqCount = await fetch3PoolLiquidityEventCount().catch(() => 0n);
-
+        // Combined v1+v2 swap and liquidity history; the activity slice
+        // picks the top 40 after merging. Without v1 the panel only shows
+        // ~5 post-migration swaps + 23 post-migration liq events and the
+        // historical context (49 swap + 18 liq) is gone.
         const [s, st, h, lps, swappers, sev, lev, vol, bal, fees, vp, routes] = await Promise.all([
           fetchThreePoolStatus(),
           fetchThreePoolStatsWindow('Last7d'),
           fetchThreePoolHealth(),
           fetchThreePoolTopLps(10n),
           fetchThreePoolTopSwappers('Last7d', 10n),
-          swapCount > 0n
-            ? fetchThreePoolSwapEventsV2(swapCount > 50n ? swapCount - 50n : 0n, swapCount > 50n ? 50n : swapCount)
-            : Promise.resolve([]),
-          liqCount > 0n ? fetch3PoolLiquidityEvents(liqCount > 30n ? 30n : liqCount, 0n) : Promise.resolve([]),
+          fetchThreePoolSwapEventsCombined(),
+          fetch3PoolLiquidityEventsCombined(),
           fetchThreePoolVolumeSeries('Last7d', 3600n),
           fetchThreePoolBalanceSeries('Last7d', 3600n),
           fetchThreePoolFeeSeries('Last7d', 3600n),
@@ -369,7 +420,12 @@
       // Cheap query, runs in parallel with the rest.
       fetchThreePoolStatus().then((s) => { status = s; }).catch(() => {});
 
-      // Seven-day window of swap events for the activity feed.
+      // Seven-day window of swap events for the activity feed. The AMM
+      // time-range endpoint iterates oldest-first and `take`s the first N
+      // matches, so the limit needs to comfortably exceed the expected
+      // weekly volume — otherwise high-volume pools would silently drop
+      // the most recent swaps. 1000 is generous at current activity levels
+      // (~10/wk) and well within the canister response budget.
       const now = BigInt(Date.now()) * 1_000_000n;
       const sevenDaysNs = 7n * 24n * 3_600n * 1_000_000_000n;
       const liqCount = await fetchAmmLiquidityEventCount().catch(() => 0n);
@@ -379,11 +435,10 @@
           fetchAmmPoolStats(poolIdParam, 'Week'),
           fetchAmmTopLps(poolIdParam, 10),
           fetchAmmTopSwappers(poolIdParam, 'Week', 10),
-          fetchAmmSwapEventsByTimeRange(poolIdParam, now - sevenDaysNs, now, 100n),
-          // Liquidity events aren't per-pool yet in the old endpoint; filter client-side.
-          liqCount > 0n
-            ? fetchAmmLiquidityEvents(liqCount > 200n ? liqCount - 200n : 0n, liqCount > 200n ? 200n : liqCount)
-            : Promise.resolve([]),
+          fetchAmmSwapEventsByTimeRange(poolIdParam, now - sevenDaysNs, now, 1000n),
+          // Liquidity events aren't per-pool in the old endpoint; pull the
+          // entire log so client-side filter sees every event for this pool.
+          liqCount > 0n ? fetchAmmLiquidityEvents(0n, liqCount) : Promise.resolve([]),
           fetchAmmVolumeSeries(poolIdParam, 'Week', 60),
           fetchAmmBalanceSeries(poolIdParam, 'Week', 60),
           fetchAmmFeeSeries(poolIdParam, 'Week', 60),
@@ -767,6 +822,7 @@
             color="#a78bfa"
             fillColor="rgba(167, 139, 250, 0.12)"
             valueFormat={(v) => `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
+            headlineValue={volPoints.reduce((s, p) => s + p.v, 0)}
           />
         </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
@@ -776,6 +832,7 @@
             color="#34d399"
             fillColor="rgba(52, 211, 153, 0.12)"
             valueFormat={(v) => v.toFixed(6)}
+            yAxisMode="data-fit"
           />
         </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
@@ -795,6 +852,7 @@
               color="#60a5fa"
               fillColor="rgba(96, 165, 250, 0.12)"
               valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+              yAxisMode="data-fit"
             />
           </div>
         {/each}
@@ -803,11 +861,12 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
           <MiniAreaChart
-            points={ammVolPoints}
+            points={ammVolPointsPadded}
             label={`Swap volume (7d, ${ammTokenA.symbol}+${ammTokenB.symbol} combined)`}
             color="#a78bfa"
             fillColor="rgba(167, 139, 250, 0.12)"
             valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            headlineValue={ammVolPointsPadded.reduce((s, p) => s + p.v, 0)}
           />
         </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
@@ -817,6 +876,7 @@
             color="#fbbf24"
             fillColor="rgba(251, 191, 36, 0.12)"
             valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+            headlineValue={ammFeePoints.reduce((s, p) => s + p.v, 0)}
           />
         </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
@@ -826,6 +886,7 @@
             color={ammTokenA.color}
             fillColor={`${ammTokenA.color}22`}
             valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            yAxisMode="data-fit"
           />
         </div>
         <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-5">
@@ -835,6 +896,7 @@
             color={ammTokenB.color}
             fillColor={`${ammTokenB.color}22`}
             valueFormat={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            yAxisMode="data-fit"
           />
         </div>
         {#if ammStats}

--- a/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
@@ -15,7 +15,7 @@
     fetchAmmSwapEventCount,
     fetchAmmLiquidityEvents,
     fetchAmmLiquidityEventCount,
-    fetchThreePoolSwapEventsV2,
+    fetchThreePoolSwapEventsCombined,
     fetchThreePoolState,
     fetchStabilityPoolEvents,
     fetchStabilityPoolEventCount,
@@ -591,7 +591,7 @@
         eventLength > 0n
           ? fetchEvents(eventStart, eventLength).catch(() => ({ total: 0n, events: [] as [bigint, any][] }))
           : Promise.resolve({ total: 0n, events: [] as [bigint, any][] }),
-        fetchThreePoolSwapEventsV2(0n, THREE_POOL_SWAP_PULL).catch(() => []),
+        fetchThreePoolSwapEventsCombined(THREE_POOL_SWAP_PULL).catch(() => []),
         ammSwapLen > 0n ? fetchAmmSwapEvents(ammSwapStart, ammSwapLen).catch(() => []) : Promise.resolve([]),
         ammLiqLen > 0n ? fetchAmmLiquidityEvents(ammLiqStart, ammLiqLen).catch(() => []) : Promise.resolve([]),
         spLen > 0n ? fetchStabilityPoolEvents(spStart, spLen).catch(() => []) : Promise.resolve([]),

--- a/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import EntityShell from '$components/explorer/entity/EntityShell.svelte';
   import MixedEventsTable from '$components/explorer/MixedEventsTable.svelte';
@@ -627,7 +626,12 @@
     }
   }
 
-  onMount(loadToken);
+  // Re-run on token change so sibling /e/token/[id] navigations refetch
+  // rather than reusing this component with stale state.
+  $effect(() => {
+    void tokenPrincipal;
+    loadToken();
+  });
 </script>
 
 <EntityShell

--- a/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import EntityShell from '$components/explorer/entity/EntityShell.svelte';
   import CRDial from '$components/explorer/entity/CRDial.svelte';
@@ -14,6 +13,7 @@
   import {
     fetchVault, fetchVaultInterestRate, fetchCollateralConfigs,
     fetchCollateralPrices, fetchVaultHistory, fetchVaultsByOwner,
+    type VaultHistoryEntry,
   } from '$services/explorer/explorerService';
   import { fetchPriceSeries } from '$services/explorer/analyticsService';
   import {
@@ -27,7 +27,7 @@
   let interestRate = $state<number | null>(null);
   let collateralConfigs = $state<any[]>([]);
   let collateralPrices = $state<Map<string, number>>(new Map());
-  let history = $state<any[]>([]);
+  let history = $state<VaultHistoryEntry[]>([]);
   let ownerVaults = $state<any[]>([]);
   let priceSeries = $state<{ timestamp_ns: bigint; prices: Array<[any, number]> }[]>([]);
 
@@ -101,7 +101,7 @@
 
   const creationTimestamp = $derived.by(() => {
     if (!history.length) return null;
-    const first = history[0];
+    const first = history[0]?.event;
     const eventType = first?.event_type ?? first;
     const key = Object.keys(eventType)[0];
     const data = key ? eventType[key] : null;
@@ -115,7 +115,7 @@
 
   const lastActivityTimestamp = $derived.by(() => {
     if (!history.length) return null;
-    const last = history[history.length - 1];
+    const last = history[history.length - 1]?.event;
     const eventType = last?.event_type ?? last;
     const key = Object.keys(eventType)[0];
     const data = key ? eventType[key] : null;
@@ -129,7 +129,8 @@
   /** Extract every principal referenced by history events (excluding owner). */
   const touchedBy = $derived.by(() => {
     const seen = new Map<string, Set<string>>();
-    for (const evt of history) {
+    for (const entry of history) {
+      const evt = entry?.event;
       const eventType = evt?.event_type ?? evt;
       const key = Object.keys(eventType)[0];
       if (!key) continue;
@@ -222,7 +223,8 @@
     let debtE8s = 0n;
     const points: TimelinePoint[] = [];
 
-    for (const evt of history) {
+    for (const entry of history) {
+      const evt = entry?.event;
       const eventType = evt?.event_type ?? evt;
       const key = Object.keys(eventType)[0];
       if (!key) continue;
@@ -316,20 +318,33 @@
    * identity (owner, collateral_type) and replays events to derive final
    * collateral + debt (which for a closed vault end at zero).
    */
-  function synthesizeVaultFromHistory(id: number, h: any[]): any | null {
+  function synthesizeVaultFromHistory(id: number, h: VaultHistoryEntry[]): any | null {
     if (!h.length) return null;
-    const first = h[0];
-    const firstType = first?.event_type ?? first;
-    const firstKey = Object.keys(firstType)[0];
-    if (firstKey !== 'open_vault') return null;
-    const firstData = firstType[firstKey];
-    const openVault = firstData?.vault;
+    // History can contain owner-keyed events that pre-date this vault (e.g. a
+    // redemption_on_vaults that the same principal performed against other
+    // vaults), so scan forward for the open_vault entry rather than assuming
+    // it sits at index 0.
+    let openIdx = -1;
+    let openVault: any = null;
+    for (let i = 0; i < h.length; i++) {
+      const evt = h[i]?.event;
+      const et = evt?.event_type ?? evt;
+      const key = Object.keys(et)[0];
+      if (key !== 'open_vault') continue;
+      const v = et[key]?.vault;
+      if (v && Number(v.vault_id) === id) {
+        openIdx = i;
+        openVault = v;
+        break;
+      }
+    }
     if (!openVault) return null;
 
     let coll = BigInt(openVault.collateral_amount ?? 0);
     let debt = BigInt(openVault.borrowed_icusd_amount ?? 0);
-    for (let i = 1; i < h.length; i++) {
-      const et = h[i]?.event_type ?? h[i];
+    for (let i = openIdx + 1; i < h.length; i++) {
+      const evt = h[i]?.event;
+      const et = evt?.event_type ?? evt;
       const key = Object.keys(et)[0];
       const d = et[key];
       switch (key) {
@@ -392,8 +407,17 @@
     loadingCore = true;
     loadingHistory = true;
     loadError = null;
-    const id = BigInt(vaultId);
+    // Reset prior-vault state so navigating between /vault/X and /vault/Y
+    // doesn't briefly render Y with X's data while the new fetches resolve.
+    vault = null;
+    history = [];
+    ownerVaults = [];
     try {
+      if (!Number.isFinite(vaultId)) {
+        loadError = `Invalid vault id: "${$page.params.id}"`;
+        return;
+      }
+      const id = BigInt(vaultId);
       const [v, r, configs, prices, h, pseries] = await Promise.all([
         fetchVault(id).catch(() => null),
         fetchVaultInterestRate(id).catch(() => null),
@@ -432,7 +456,13 @@
     }
   }
 
-  onMount(loadVault);
+  // Re-run on every vaultId change. SvelteKit reuses the component when
+  // navigating between sibling /e/vault/[id] routes, so onMount() alone would
+  // only fire on the first visit and leave the page stuck on the prior vault.
+  $effect(() => {
+    void vaultId;
+    loadVault();
+  });
 
   const statusLabel = $derived(isClosed ? 'Closed' : 'Active');
 </script>
@@ -577,8 +607,8 @@
             </tr>
           </thead>
           <tbody>
-            {#each sortedHistory as evt, i (i)}
-              <EventRow event={evt} index={null} vaultCollateralMap={vaultCollateralMap} />
+            {#each sortedHistory as entry (entry.index)}
+              <EventRow event={entry.event} index={Number(entry.index)} vaultCollateralMap={vaultCollateralMap} />
             {/each}
           </tbody>
         </table>

--- a/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/vault/[id]/+page.svelte
@@ -303,7 +303,17 @@
       const debtHuman = Number(debtE8s) / 1e8;
       const p = priceAt(t);
       const crAt = debtHuman > 0 && p > 0 ? (collHuman * p) / debtHuman : Infinity;
-      points.push({ t, cr: crAt, collateral: collHuman, debt: debtHuman, price: p });
+      // Multiple backend events frequently share the same nanosecond timestamp
+      // (e.g. open_vault + borrow_from_vault recorded in the same transaction).
+      // Fold consecutive same-t entries into a single point so charts that
+      // key by timestamp don't blow up with duplicate keys, and so the dot
+      // overlay doesn't paint two circles on top of each other.
+      const last = points.length > 0 ? points[points.length - 1] : null;
+      if (last && last.t === t) {
+        points[points.length - 1] = { t, cr: crAt, collateral: collHuman, debt: debtHuman, price: p };
+      } else {
+        points.push({ t, cr: crAt, collateral: collHuman, debt: debtHuman, price: p });
+      }
     }
 
     return points;


### PR DESCRIPTION
## Summary

Three layers of fixes that surfaced while looking at the explorer's handling of closed Vault #148.

### Backend (`64c4ecc`)
- `get_vault_history(vault_id)` now returns `(global_index, Event)` tuples so per-vault activity rows can render real Event #N links without a second pass over the global event log.
- Catches up the candid `.did` with Wave-8e (`DeficitAccrued`, `DeficitRepaid`) and Wave-10 (`BreakerTripped` + 3 admin variants) `EventTypeFilter` entries plus 4 missing `Event` variants. Adds a `RUMI_REGEN_DID=1` toggle on the compat test for future drift.

### Analytics (`559a3d9`)
- Wires the AMM-liquidity tailer so AMM LP positions surface under the `amm_lp` source on the address-value chart.
- **Drops the `three_pool_lp` source.** 3USD *is* the rumi_3pool LP token, so emitting both `three_pool_lp` (cumulative LP-mint events) and `threeusd` (current ledger balance × \$1) double-counted any 3USD that had been redeployed into AMM liquidity. After this change, 3pool exposure is captured by `threeusd` (in-wallet) plus `amm_lp` (locked-as-AMM-collateral).

### Explorer / frontend (`3a01ba1`)
- Closed-vault detail pages now render full historical state. `synthesizeVaultFromHistory` previously bailed when the first history entry wasn't `open_vault`; in practice owner-keyed events (e.g. `redemption_on_vaults` on unrelated vaults) leak in front. Now scans for the matching `open_vault` and replays from there.
- `withdraw_and_close_vault` event row no longer renders "unknown" — uses the `vaultCollateral(d.vault_id)` lookup the other vault events already use, and the event detail page seeds the map from per-vault history when referencing a closed vault.
- Vault / event / pool / token / address pages re-fetch on param change. They were using `onMount(loadX)` only, but SvelteKit reuses the component across sibling `[id]` routes, so subsequent navigations rendered prior data (or stuck on the first-load spinner if `BigInt(NaN)` had thrown). Now `$effect(() => { void <param>; loadX(); })`.
- Vault activity rows show real Event #N IDs (consumes the new backend tuple shape).

## Verification
- `cargo test -p rumi_protocol_backend --lib` → 83 pass
- `cargo test -p rumi_analytics --lib` → 108 pass
- `check_candid_interface_compatibility` passes
- Both canisters build clean to `wasm32-unknown-unknown` (release)
- `npm run build` in `vault_frontend` produces a clean `dist/`
- `svelte-check` adds zero errors over baseline

## Deploy ordering
1. `rumi_protocol_backend` (signature change in `get_vault_history`)
2. `rumi_analytics` (needs `ic-wasm shrink` + `gzip`; full `InitArgs` even on upgrade)
3. `vault_frontend` (consumes both)

## Test plan
- [ ] Vault #148 (closed) detail page renders full history with synthesized state.
- [ ] Event #67841 (Withdraw & Close) shows "BOB" instead of "unknown".
- [ ] Vault page activity rows show clickable Event #N links.
- [ ] Navigating between sibling `/explorer/e/vault/<id>` URLs refetches.
- [ ] Address page chart `three_pool_lp` line is gone; `amm_lp` populates for principals with AMM positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)