### PR TITLE
fix(audit): Wave-13 BOT-002 propagate cancel errors on swap-fail path

### DIFF
--- a/src/liquidation_bot/src/process.rs
+++ b/src/liquidation_bot/src/process.rs
@@ -6,6 +6,76 @@ use crate::state::{self, BotConfig};
 use crate::swap;
 
 const CONFIRM_ATTEMPTS: u8 = 5;
+const CANCEL_ATTEMPTS: u8 = 3;
+
+/// Outcome of the swap-failure cleanup path. Pure data, produced by
+/// `decide_swap_failure_outcome` and consumed by `process_pending` to write
+/// the LiquidationRecord and emit the STUCK log line if applicable.
+#[derive(Debug, PartialEq)]
+pub(crate) struct SwapFailureOutcome {
+    pub status: history::LiquidationStatus,
+    pub error_message: String,
+    /// Some(line) when the bot is leaving a claim active that the protocol
+    /// will reconcile (Wave-11 auto-cancel after 10 min, or admin via
+    /// `admin_resolve_stuck_claim`). None when both cleanup steps succeeded.
+    pub stuck_log: Option<String>,
+}
+
+/// Wave 13 (BOT-002): decide which `LiquidationStatus` and `error_message`
+/// to record after a swap failure, given the outcomes of the return-collateral
+/// transfer and the cancel-claim retry loop.
+///
+/// Before Wave 13 the bot ignored both call results with `let _ = ...` and
+/// always wrote `SwapFailed`, even when the protocol's claim was still active
+/// (budget unrestored, vault still flagged). With the Wave-12 BOT-001b balance
+/// gate a failed return guarantees the cancel rejects, so the bot record must
+/// reflect that the claim is stuck pending Wave-11 auto-cancel.
+///
+/// Status mapping reuses existing variants (no `.did` change):
+///   * Both cleanup steps OK     -> SwapFailed (happy cleanup)
+///   * Return failed             -> TransferFailed (bot couldn't return ICP)
+///   * Return OK, cancel stuck   -> ConfirmFailed (protocol-side bookkeeping stuck)
+///
+/// `return_err` takes priority over `cancel_err` defensively: when the return
+/// fails the integration never attempts cancel, so cancel_err should be None,
+/// but the helper still picks deterministically if both are somehow set.
+pub(crate) fn decide_swap_failure_outcome(
+    vault_id: u64,
+    swap_err: &str,
+    return_err: Option<&str>,
+    cancel_err: Option<(u8, &str)>,
+) -> SwapFailureOutcome {
+    if let Some(rerr) = return_err {
+        return SwapFailureOutcome {
+            status: history::LiquidationStatus::TransferFailed,
+            error_message: format!("swap: {} | return: {}", swap_err, rerr),
+            stuck_log: Some(format!(
+                "STUCK: ICP return failed after swap failure for vault #{}; claim still active. Wave-11 auto-cancel will fire in 10 min, or admin can run admin_resolve_stuck_claim.",
+                vault_id
+            )),
+        };
+    }
+
+    if let Some((attempts, cerr)) = cancel_err {
+        return SwapFailureOutcome {
+            status: history::LiquidationStatus::ConfirmFailed,
+            error_message: format!(
+                "swap: {} | cancel after {} retries: {}",
+                swap_err, attempts, cerr
+            ),
+            stuck_log: Some(format!(
+                "STUCK: cancel failed after {} attempts for vault #{}; ICP returned but claim still active. Wave-11 auto-cancel will fire in 10 min.",
+                attempts, vault_id
+            )),
+        };
+    }
+
+    SwapFailureOutcome {
+        status: history::LiquidationStatus::SwapFailed,
+        error_message: swap_err.to_string(),
+        stuck_log: None,
+    }
+}
 
 /// Result returned by the backend's `bot_claim_liquidation` endpoint.
 #[derive(CandidType, Deserialize, Debug)]
@@ -86,18 +156,72 @@ pub async fn process_pending() {
 
     let (ckusdc_received, effective_price) = match swap_result {
         Ok(r) => (r.ckusdc_received_e6, r.effective_price_e8s),
-        Err(e) => {
-            log!(crate::INFO, "Swap failed for vault #{}: {}. Returning ICP.", vault.vault_id, e);
-            let _ = swap::return_collateral_to_backend(&config, collateral_amount, config.icp_ledger).await;
-            let _ = call_bot_cancel_liquidation(&config, vault.vault_id).await;
+        Err(swap_err) => {
+            log!(crate::INFO, "Swap failed for vault #{}: {}. Returning ICP.", vault.vault_id, swap_err);
+
+            // Step 1: return seized ICP to the backend.
+            let return_result = swap::return_collateral_to_backend(
+                &config,
+                collateral_amount,
+                config.icp_ledger,
+            )
+            .await;
+
+            // Step 2: cancel the protocol-side claim, only if the return succeeded.
+            // The Wave-12 BOT-001b balance gate rejects cancel until the protocol's
+            // collateral balance is back to (>=) `claim.collateral_amount - fee`,
+            // so attempting cancel after a failed return is pointless and would
+            // just produce noisy `[BOT-001b] cancel rejected` log lines.
+            let cancel_err = if return_result.is_ok() {
+                let mut last_err = String::new();
+                let mut succeeded = false;
+                let mut attempts: u8 = 0;
+                for attempt in 0..CANCEL_ATTEMPTS {
+                    attempts = attempt + 1;
+                    match call_bot_cancel_liquidation(&config, vault.vault_id).await {
+                        Ok(()) => {
+                            succeeded = true;
+                            break;
+                        }
+                        Err(e) => {
+                            last_err = e;
+                            if attempt + 1 < CANCEL_ATTEMPTS {
+                                log!(
+                                    crate::INFO,
+                                    "Cancel attempt {}/{} failed for vault #{}: {}. Retrying.",
+                                    attempt + 1,
+                                    CANCEL_ATTEMPTS,
+                                    vault.vault_id,
+                                    last_err
+                                );
+                            }
+                        }
+                    }
+                }
+                if succeeded { None } else { Some((attempts, last_err)) }
+            } else {
+                None
+            };
+
+            let outcome = decide_swap_failure_outcome(
+                vault.vault_id,
+                &swap_err,
+                return_result.as_ref().err().map(|s| s.as_str()),
+                cancel_err.as_ref().map(|(n, e)| (*n, e.as_str())),
+            );
+
+            if let Some(line) = &outcome.stuck_log {
+                log!(crate::INFO, "{}", line);
+            }
+
             write_record(LiquidationRecordV1 {
                 id: record_id, vault_id: vault.vault_id, timestamp,
-                status: LiquidationStatus::SwapFailed,
+                status: outcome.status,
                 collateral_claimed_e8s: collateral_amount, debt_to_cover_e8s: debt_covered,
                 icp_swapped_e8s: swap_amount, ckusdc_received_e6: 0, ckusdc_transferred_e6: 0,
                 icp_to_treasury_e8s: 0, oracle_price_e8s: collateral_price,
                 effective_price_e8s: 0, slippage_bps: 0,
-                error_message: Some(e), confirm_retry_count: 0,
+                error_message: Some(outcome.error_message), confirm_retry_count: 0,
             });
             return;
         }
@@ -258,4 +382,65 @@ fn calculate_slippage(effective_price_e8s: u64, oracle_price_e8s: u64) -> i32 {
     }
     let diff = oracle_price_e8s as i64 - effective_price_e8s as i64;
     (diff * 10_000 / oracle_price_e8s as i64) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SWAP_ERR: &str = "Quote returned zero output";
+    const RETURN_ERR: &str = "Transfer error: BadFee";
+    const CANCEL_ERR: &str = "GenericError(\"Cannot cancel claim for vault #7: protocol collateral balance 0 < required 99990000\")";
+
+    #[test]
+    fn swap_failure_clean_cleanup_records_swap_failed() {
+        let outcome = decide_swap_failure_outcome(7, SWAP_ERR, None, None);
+        assert_eq!(outcome.status, LiquidationStatus::SwapFailed);
+        assert_eq!(outcome.error_message, SWAP_ERR);
+        assert!(outcome.stuck_log.is_none(), "happy cleanup must not log STUCK");
+    }
+
+    #[test]
+    fn swap_failure_with_failed_return_records_transfer_failed_and_logs_stuck() {
+        let outcome = decide_swap_failure_outcome(7, SWAP_ERR, Some(RETURN_ERR), None);
+        assert_eq!(outcome.status, LiquidationStatus::TransferFailed);
+        assert!(outcome.error_message.contains("swap: "));
+        assert!(outcome.error_message.contains(SWAP_ERR));
+        assert!(outcome.error_message.contains("return: "));
+        assert!(outcome.error_message.contains(RETURN_ERR));
+        let log = outcome.stuck_log.expect("must surface STUCK log");
+        assert!(log.contains("STUCK"));
+        assert!(log.contains("vault #7"));
+        assert!(log.contains("ICP return failed"));
+    }
+
+    #[test]
+    fn swap_failure_with_stuck_cancel_records_confirm_failed_and_logs_stuck() {
+        let outcome = decide_swap_failure_outcome(7, SWAP_ERR, None, Some((3, CANCEL_ERR)));
+        assert_eq!(outcome.status, LiquidationStatus::ConfirmFailed);
+        assert!(outcome.error_message.contains("swap: "));
+        assert!(outcome.error_message.contains(SWAP_ERR));
+        assert!(outcome.error_message.contains("cancel after 3 retries: "));
+        assert!(outcome.error_message.contains(CANCEL_ERR));
+        let log = outcome.stuck_log.expect("must surface STUCK log");
+        assert!(log.contains("STUCK"));
+        assert!(log.contains("vault #7"));
+        assert!(log.contains("3 attempts"));
+    }
+
+    #[test]
+    fn return_error_takes_priority_over_cancel_error() {
+        // Defensive: integration code should never hand both, but the helper
+        // must still pick deterministically. Return failure dominates because
+        // the cancel never actually happened in that branch.
+        let outcome = decide_swap_failure_outcome(
+            42,
+            SWAP_ERR,
+            Some(RETURN_ERR),
+            Some((3, CANCEL_ERR)),
+        );
+        assert_eq!(outcome.status, LiquidationStatus::TransferFailed);
+        assert!(outcome.error_message.contains("return: "));
+        assert!(!outcome.error_message.contains("cancel after"));
+    }
 }


### PR DESCRIPTION
## Summary

Wave-12 (BOT-001b, [#144](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/144)) added a balance gate to the protocol's `bot_cancel_liquidation` that rejects when the seized collateral has not yet returned. The `liquidation_bot`'s swap-failure cleanup at [`process.rs:90-92` (pre-fix)](https://github.com/RumiLabsXYZ/rumi-protocol-v2/blob/25c0779/src/liquidation_bot/src/process.rs#L90-L92) ignored both the return-collateral and cancel-claim results with `let _ = ...`, so the bot's `LiquidationRecord` always wrote `SwapFailed` even when the protocol claim was still active (budget unrestored, vault still flagged for the 10-min Wave-11 auto-cancel).

Bot-side bookkeeping only. Protocol invariants are unchanged.

## Behavior change

| Cleanup outcome | Before | After |
| --- | --- | --- |
| Return OK, cancel OK | `SwapFailed` | `SwapFailed` (no change) |
| Return failed | `SwapFailed` (record wrong, claim active) | `TransferFailed` + STUCK log; cancel skipped (Wave-12 gate would reject it) |
| Return OK, cancel stuck | `SwapFailed` (record wrong, claim active) | `ConfirmFailed` + STUCK log after 3 retries |

Reuses existing `LiquidationStatus` variants with prefixed `error_message` (`"swap: X | return: Y"` / `"swap: X | cancel after N retries: Y"`):
- Zero `.did` change, zero migration concern (records are Candid-encoded, only the writer reads them).
- `get_stuck_records` already covers both `TransferFailed` and `ConfirmFailed` so admin tooling auto-picks these up.
- Frontend explorer reads the legacy `BotLiquidationEvent.success: bool`, not the typed enum, so no UI impact.

## Design

Cleanup decision logic lives in a pure `decide_swap_failure_outcome(vault_id, swap_err, return_err, cancel_err) -> SwapFailureOutcome` helper. The helper has no IO, takes `Option`s for each cleanup outcome, and returns a `(status, error_message, stuck_log)` triple. The integration in `process_pending` does the IO calls and feeds `Result`s into the helper.

`return_err` takes priority over `cancel_err` defensively: when the return fails the integration never attempts cancel (Wave-12 gate would reject anyway), but the helper still picks deterministically if both are somehow set.

`CANCEL_ATTEMPTS = 3`, modeled on the existing `CONFIRM_ATTEMPTS = 5` retry loop. No exponential backoff (between attempts the awaiting future yields anyway and this isn't latency-sensitive). Errors are flattened to a `String` (the existing `BackendError` decoder already does `{:?}`); the simple "try N times unconditionally" approach matches the existing confirm-retry shape.

## Tests

Layer 1 only, per spec recommendation. Layer 3 PIC would require making `return_collateral_to_backend` fail mid-flow against a real ledger, which is invasive for marginal coverage when the helper is fully exhaustive over its three input combinations.

```
cargo test -p liquidation_bot --lib                                       # 5 passed (1 pre-existing + 4 new helper tests)
cargo build -p liquidation_bot --target wasm32-unknown-unknown --release  # builds clean

# Backend regression at Wave-12 baseline (no protocol change)
cargo test -p rumi_protocol_backend --lib                                 # 83 passed, 1 ignored
POCKET_IC_BIN=./pocket-ic cargo test -p rumi_protocol_backend \
  --test audit_pocs_bot_001b_explicit_cancel_balance_pic                  # 2 passed
POCKET_IC_BIN=./pocket-ic cargo test -p rumi_protocol_backend \
  --test audit_pocs_bot_001_auto_cancel_balance_pic                       # 2 passed
```

## What this does NOT do

- Does NOT touch `rumi_protocol_backend`. Wave-12 gate stays as-is. Protocol module hash should be unchanged after merge.
- Does NOT change the contract between bot and protocol. Same endpoints, same error shapes.
- Does NOT add new admin endpoints. `admin_resolve_stuck_claim` already covers the residual escape hatch.
- Does NOT add SP retry logic (per the standing project rule).

## Test plan

- [x] Layer-1 unit tests pass (4 new + pre-existing state regression test)
- [x] Bot wasm builds clean
- [x] Backend lib tests at Wave-12 baseline (83/1)
- [x] Wave-12 explicit-cancel PIC fence still passes (2/2)
- [x] Wave-11 auto-cancel PIC fence still passes (2/2)
- [x] No `.did` surface change
- [ ] After deploy: 24h bake watch on the bot's `STUCK:` log lines (should be 0 under healthy operation) and the protocol's `[BOT-001b] cancel rejected` lines (should drop to 0 since the bot stops calling cancel after a failed return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)