### PR TITLE
fix(interest): close async-mint races on harvest and treasury drain (audit INT-002 + INT-006)

### DIFF
--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -2289,6 +2289,68 @@ impl State {
         }
     }
 
+    // -------------------------------------------------------------------
+    // Audit INT-002 / INT-006: snapshot-then-decrement pair for the
+    // async-mint paths that drain `pending_interest_for_pools` and
+    // `pending_treasury_interest`. The take helper performs the
+    // pre-await snapshot+zero atomically (so a concurrent harvest landing
+    // during the await accumulates against zero, not against the old
+    // snapshot). The restore helper merges an unminted snapshot back via
+    // saturating_add — preserving any concurrent increment instead of
+    // overwriting it.
+    // -------------------------------------------------------------------
+
+    /// Atomic snapshot+take of a `pending_interest_for_pools` bucket.
+    /// Returns the e8s amount that was held; removes the entry.
+    /// Pair with `restore_pending_interest_for_pool` on async failure.
+    pub fn take_pending_interest_for_pool(&mut self, collateral_type: Principal) -> u64 {
+        self.pending_interest_for_pools
+            .remove(&collateral_type)
+            .unwrap_or(0)
+    }
+
+    /// Restore an unminted snapshot to a `pending_interest_for_pools`
+    /// bucket via saturating_add. Use on the failure arm of an async
+    /// distribute so any concurrent harvest that landed during the await
+    /// is preserved. No-op when `amount_e8s == 0`.
+    pub fn restore_pending_interest_for_pool(
+        &mut self,
+        collateral_type: Principal,
+        amount_e8s: u64,
+    ) {
+        if amount_e8s == 0 {
+            return;
+        }
+        let entry = self
+            .pending_interest_for_pools
+            .entry(collateral_type)
+            .or_insert(0);
+        *entry = entry.saturating_add(amount_e8s);
+    }
+
+    /// Atomic snapshot+take of `pending_treasury_interest`. Returns the
+    /// ICUSD amount that was held; sets the field to zero. Pair with
+    /// `restore_pending_treasury_interest` on async failure.
+    pub fn take_pending_treasury_interest(&mut self) -> ICUSD {
+        let snapshot = self.pending_treasury_interest;
+        self.pending_treasury_interest = ICUSD::new(0);
+        snapshot
+    }
+
+    /// Restore an unminted snapshot to `pending_treasury_interest` via
+    /// saturating_add. Preserves any concurrent credit that landed
+    /// during the await. No-op when `amount.0 == 0`.
+    pub fn restore_pending_treasury_interest(&mut self, amount: ICUSD) {
+        if amount.0 == 0 {
+            return;
+        }
+        let combined = self
+            .pending_treasury_interest
+            .to_u64()
+            .saturating_add(amount.to_u64());
+        self.pending_treasury_interest = ICUSD::new(combined);
+    }
+
     /// Compute the debt-weighted average interest rate across all vaults.
     /// Returns 0 if no vaults have outstanding debt.
     pub fn weighted_average_interest_rate(&self) -> Ratio {

--- a/src/rumi_protocol_backend/src/treasury.rs
+++ b/src/rumi_protocol_backend/src/treasury.rs
@@ -188,34 +188,51 @@ pub async fn notify_treasury_deposit(
 // ---------------------------------------------------------------------------
 
 /// Mint icUSD interest revenue to treasury and record the deposit.
-pub async fn mint_interest_to_treasury(interest_share: ICUSD) {
+///
+/// Returns `Ok(())` when the icUSD mint itself succeeded — the
+/// downstream `notify_treasury_deposit` call is bookkeeping and its
+/// failure does not roll back the mint. Returns `Err(interest_share)`
+/// when the mint did not happen (no treasury configured, or the ledger
+/// call failed); the caller is expected to re-queue this amount via
+/// the snapshot-then-decrement restore path so revenue is not lost.
+pub async fn mint_interest_to_treasury(interest_share: ICUSD) -> Result<(), ICUSD> {
     if interest_share.0 == 0 {
-        return;
+        return Ok(());
     }
     let treasury = read_state(|s| s.treasury_principal);
-    if let Some(tp) = treasury {
-        match management::mint_icusd(interest_share, tp).await {
-            Ok(block_index) => {
-                log!(
-                    INFO,
-                    "[treasury] Minted {} icUSD interest revenue (block {})",
-                    interest_share.to_u64(),
-                    block_index
-                );
-                let _ = notify_treasury_deposit(
-                    tp,
-                    DepositType::InterestRevenue,
-                    AssetType::ICUSD,
-                    interest_share.to_u64(),
-                    block_index,
-                )
-                .await;
-            }
-            Err(e) => log!(
+    let Some(tp) = treasury else {
+        log!(
+            INFO,
+            "[treasury] WARNING: no treasury principal configured; {} icUSD interest unminted",
+            interest_share.to_u64()
+        );
+        return Err(interest_share);
+    };
+    match management::mint_icusd(interest_share, tp).await {
+        Ok(block_index) => {
+            log!(
+                INFO,
+                "[treasury] Minted {} icUSD interest revenue (block {})",
+                interest_share.to_u64(),
+                block_index
+            );
+            let _ = notify_treasury_deposit(
+                tp,
+                DepositType::InterestRevenue,
+                AssetType::ICUSD,
+                interest_share.to_u64(),
+                block_index,
+            )
+            .await;
+            Ok(())
+        }
+        Err(e) => {
+            log!(
                 INFO,
                 "[treasury] WARNING: interest mint failed: {:?}",
                 e
-            ),
+            );
+            Err(interest_share)
         }
     }
 }
@@ -225,58 +242,76 @@ pub async fn mint_interest_to_treasury(interest_share: ICUSD) {
 ///
 /// `collateral_type` identifies which collateral's vault generated this interest.
 /// The pool uses it to exclude depositors who opted out of that collateral.
-pub async fn mint_interest_to_stability_pool(interest_share: ICUSD, collateral_type: Principal) {
+///
+/// Returns `Ok(())` when the icUSD mint succeeded — the post-mint
+/// `receive_interest_revenue` notification is bookkeeping and its
+/// failure does not roll back the mint. Returns `Err(interest_share)`
+/// when the mint did not happen (no pool configured, or the ledger
+/// call failed); the caller re-queues this via the snapshot-then-
+/// decrement restore path.
+pub async fn mint_interest_to_stability_pool(
+    interest_share: ICUSD,
+    collateral_type: Principal,
+) -> Result<(), ICUSD> {
     if interest_share.0 == 0 {
-        return;
+        return Ok(());
     }
     let (stability_pool, icusd_ledger) =
         read_state(|s| (s.stability_pool_canister, s.icusd_ledger_principal));
-    if let Some(pool_principal) = stability_pool {
-        match management::mint_icusd(interest_share, pool_principal).await {
-            Ok(block_index) => {
-                log!(
-                    INFO,
-                    "[treasury] Minted {} icUSD interest to stability pool (block {})",
-                    interest_share.to_u64(),
-                    block_index
-                );
+    let Some(pool_principal) = stability_pool else {
+        log!(
+            INFO,
+            "[treasury] WARNING: no stability pool configured; {} icUSD interest unminted",
+            interest_share.to_u64()
+        );
+        return Err(interest_share);
+    };
+    match management::mint_icusd(interest_share, pool_principal).await {
+        Ok(block_index) => {
+            log!(
+                INFO,
+                "[treasury] Minted {} icUSD interest to stability pool (block {})",
+                interest_share.to_u64(),
+                block_index
+            );
 
-                // Notify pool to distribute interest pro-rata to depositors.
-                // Fire-and-forget: failure is logged but does not block repayment.
-                let amount = interest_share.to_u64();
-                let ct: Option<Principal> = Some(collateral_type);
-                let result: Result<(candid::IDLValue,), _> = ic_cdk::call(
-                    pool_principal,
-                    "receive_interest_revenue",
-                    (icusd_ledger, amount, ct),
-                )
-                .await;
-                match result {
-                    Ok(_) => {
-                        log!(
-                            INFO,
-                            "[treasury] Pool acknowledged interest distribution ({} icUSD, collateral {})",
-                            amount,
-                            collateral_type
-                        );
-                    }
-                    Err(e) => {
-                        log!(
-                            INFO,
-                            "[treasury] WARNING: pool interest notification call failed: {:?}",
-                            e
-                        );
-                    }
+            // Notify pool to distribute interest pro-rata to depositors.
+            // Fire-and-forget: failure is logged but does not block repayment.
+            let amount = interest_share.to_u64();
+            let ct: Option<Principal> = Some(collateral_type);
+            let result: Result<(candid::IDLValue,), _> = ic_cdk::call(
+                pool_principal,
+                "receive_interest_revenue",
+                (icusd_ledger, amount, ct),
+            )
+            .await;
+            match result {
+                Ok(_) => {
+                    log!(
+                        INFO,
+                        "[treasury] Pool acknowledged interest distribution ({} icUSD, collateral {})",
+                        amount,
+                        collateral_type
+                    );
+                }
+                Err(e) => {
+                    log!(
+                        INFO,
+                        "[treasury] WARNING: pool interest notification call failed: {:?}",
+                        e
+                    );
                 }
             }
-            Err(e) => {
-                log!(
-                    INFO,
-                    "[treasury] WARNING: stability pool interest mint failed ({} icUSD): {:?}",
-                    interest_share.to_u64(),
-                    e
-                );
-            }
+            Ok(())
+        }
+        Err(e) => {
+            log!(
+                INFO,
+                "[treasury] WARNING: stability pool interest mint failed ({} icUSD): {:?}",
+                interest_share.to_u64(),
+                e
+            );
+            Err(interest_share)
         }
     }
 }
@@ -292,9 +327,14 @@ pub async fn mint_interest_to_stability_pool(interest_share: ICUSD, collateral_t
 /// then calls `donate(0, amount)` to inject yield into the pool.
 ///
 /// `collateral_type` is needed for stability pool interest routing.
-pub async fn distribute_interest(interest: ICUSD, collateral_type: Principal) {
+///
+/// Returns the total icUSD that failed to mint across all recipients.
+/// The caller (e.g. `flush_pending_interest`) re-queues this via the
+/// snapshot-then-decrement restore path so the failed share is replayed
+/// on the next tick rather than silently lost.
+pub async fn distribute_interest(interest: ICUSD, collateral_type: Principal) -> ICUSD {
     if interest.0 == 0 {
-        return;
+        return ICUSD::new(0);
     }
 
     let (split, three_pool) = read_state(|s| {
@@ -302,6 +342,7 @@ pub async fn distribute_interest(interest: ICUSD, collateral_type: Principal) {
     });
 
     let total_e8s = interest.to_u64();
+    let mut unminted_e8s: u64 = 0;
 
     for recipient in &split {
         let share_e8s = ((total_e8s as u128) * (recipient.bps as u128) / 10_000) as u64;
@@ -312,21 +353,32 @@ pub async fn distribute_interest(interest: ICUSD, collateral_type: Principal) {
 
         match &recipient.destination {
             crate::state::InterestDestination::StabilityPool => {
-                mint_interest_to_stability_pool(share, collateral_type).await;
+                if let Err(unsent) =
+                    mint_interest_to_stability_pool(share, collateral_type).await
+                {
+                    unminted_e8s = unminted_e8s.saturating_add(unsent.to_u64());
+                }
             }
             crate::state::InterestDestination::Treasury => {
-                mint_interest_to_treasury(share).await;
+                if let Err(unsent) = mint_interest_to_treasury(share).await {
+                    unminted_e8s = unminted_e8s.saturating_add(unsent.to_u64());
+                }
             }
             crate::state::InterestDestination::ThreePool => {
                 if let Some(pool_canister) = three_pool {
-                    donate_to_three_pool(pool_canister, share_e8s).await;
+                    if let Err(unsent_e8s) = donate_to_three_pool(pool_canister, share_e8s).await {
+                        unminted_e8s = unminted_e8s.saturating_add(unsent_e8s);
+                    }
                 } else {
                     log!(INFO, "[treasury] WARNING: 3pool interest share ({} icUSD) has no target canister configured, sending to treasury instead", share_e8s);
-                    mint_interest_to_treasury(share).await;
+                    if let Err(unsent) = mint_interest_to_treasury(share).await {
+                        unminted_e8s = unminted_e8s.saturating_add(unsent.to_u64());
+                    }
                 }
             }
         }
     }
+    ICUSD::from(unminted_e8s)
 }
 
 /// Distribute stablecoin-denominated interest revenue.
@@ -359,7 +411,11 @@ pub async fn distribute_stablecoin_interest(
         match &recipient.destination {
             crate::state::InterestDestination::StabilityPool => {
                 let pool_icusd = ICUSD::from(share_e8s);
-                mint_interest_to_stability_pool(pool_icusd, collateral_type).await;
+                // Stablecoin path keeps legacy "log + drop" on mint failure.
+                // No bucket to re-queue against (the funds live in
+                // collateral reserves, not a pending field). Audit
+                // INT-002 covered only the icUSD-denominated path.
+                let _ = mint_interest_to_stability_pool(pool_icusd, collateral_type).await;
             }
             crate::state::InterestDestination::Treasury => {
                 // Transfer stablecoins (not icUSD) to treasury
@@ -389,11 +445,11 @@ pub async fn distribute_stablecoin_interest(
             }
             crate::state::InterestDestination::ThreePool => {
                 if let Some(pool_canister) = three_pool {
-                    donate_to_three_pool(pool_canister, share_e8s).await;
+                    let _ = donate_to_three_pool(pool_canister, share_e8s).await;
                 } else {
                     // Fallback: mint icUSD to treasury (same as distribute_interest)
                     log!(INFO, "[treasury] WARNING: 3pool interest share ({} icUSD) has no target canister, sending to treasury instead", share_e8s);
-                    mint_interest_to_treasury(ICUSD::from(share_e8s)).await;
+                    let _ = mint_interest_to_treasury(ICUSD::from(share_e8s)).await;
                 }
             }
         }
@@ -403,7 +459,13 @@ pub async fn distribute_stablecoin_interest(
 /// Mint icUSD directly to the 3pool canister, then call `receive_donation`
 /// so the pool updates its internal balances.
 /// Non-critical: failures are logged but don't block protocol operations.
-async fn donate_to_three_pool(pool_canister: Principal, amount_e8s: u64) {
+///
+/// Returns `Ok(())` when the icUSD mint succeeded — the subsequent
+/// `receive_donation` notification is bookkeeping and its failure does
+/// not roll back the mint. Returns `Err(amount_e8s)` when the mint
+/// itself failed; the caller re-queues this via the snapshot-then-
+/// decrement restore path.
+async fn donate_to_three_pool(pool_canister: Principal, amount_e8s: u64) -> Result<(), u64> {
     // 1. Mint icUSD directly to the 3pool canister
     let icusd = ICUSD::from(amount_e8s);
     match crate::management::mint_icusd(icusd, pool_canister).await {
@@ -412,7 +474,7 @@ async fn donate_to_three_pool(pool_canister: Principal, amount_e8s: u64) {
         }
         Err(e) => {
             log!(INFO, "[treasury] WARNING: 3pool donation mint failed: {:?}", e);
-            return;
+            return Err(amount_e8s);
         }
     }
 
@@ -431,6 +493,7 @@ async fn donate_to_three_pool(pool_canister: Principal, amount_e8s: u64) {
             log!(INFO, "[treasury] WARNING: 3pool receive_donation call failed: {:?} {}", code, msg);
         }
     }
+    Ok(())
 }
 
 /// Mirror of the 3pool ThreePoolError for the donate response.
@@ -554,57 +617,101 @@ pub async fn send_liquidation_fee_to_treasury(
 /// Flush accumulated interest from periodic harvesting to pools/treasury.
 /// For each collateral bucket that has reached the threshold, calls
 /// `distribute_interest` which handles the N-way split (3pool, stability pool, treasury).
+///
+/// Audit INT-002: uses the snapshot-then-decrement pattern so a mint
+/// failure inside `distribute_interest` re-queues the unminted portion
+/// via `restore_pending_interest_for_pool` (saturating_add). Concurrent
+/// harvest credits that land during the await accumulate against zero
+/// rather than against the old snapshot, so neither side is silently
+/// overwritten.
 pub async fn flush_pending_interest() {
     let (pending, threshold) = read_state(|s| {
         (s.pending_interest_for_pools.clone(), s.interest_flush_threshold_e8s)
     });
 
     for (collateral_type, amount) in pending {
-        if amount >= threshold {
-            log!(INFO, "[treasury] Flushing {} icUSD interest for collateral {}", amount, collateral_type);
-            // Zero out this bucket BEFORE the async call to prevent double-flush
+        if amount < threshold {
+            continue;
+        }
+        log!(
+            INFO,
+            "[treasury] Flushing {} icUSD interest for collateral {}",
+            amount,
+            collateral_type
+        );
+        // Atomic snapshot+take. The actual amount taken may be larger
+        // than the cloned `amount` if a concurrent harvest landed
+        // between the clone and this mutate; we mint what is currently
+        // in the bucket regardless.
+        let snapshot_e8s = crate::state::mutate_state(|s| {
+            s.take_pending_interest_for_pool(collateral_type)
+        });
+        if snapshot_e8s == 0 {
+            continue;
+        }
+        let unminted = distribute_interest(
+            ICUSD::from(snapshot_e8s),
+            collateral_type,
+        )
+        .await;
+        if unminted.0 > 0 {
             crate::state::mutate_state(|s| {
-                s.pending_interest_for_pools.remove(&collateral_type);
+                s.restore_pending_interest_for_pool(collateral_type, unminted.to_u64());
             });
-            distribute_interest(ICUSD::from(amount), collateral_type).await;
+            log!(
+                INFO,
+                "[treasury] CRITICAL: re-queued {} icUSD for collateral {} after partial mint failure (snapshot {})",
+                unminted.to_u64(),
+                collateral_type,
+                snapshot_e8s,
+            );
         }
     }
 }
 
 /// Mint pending treasury interest accumulated from sync liquidations.
 /// Called from the XRC timer tick to drain `pending_treasury_interest`.
+///
+/// Audit INT-006: uses the snapshot-then-decrement pattern so a
+/// concurrent credit landing during the await is preserved on both
+/// arms. The pre-await `take` zeroes the field so any concurrent
+/// increment accumulates against zero; on mint failure the snapshot is
+/// restored via `saturating_add`, merging with whatever landed.
 pub async fn drain_pending_treasury_interest() {
-    let pending = read_state(|s| s.pending_treasury_interest);
-    if pending.0 == 0 {
+    let treasury = read_state(|s| s.treasury_principal);
+    let Some(tp) = treasury else {
+        return;
+    };
+    // Atomic snapshot+zero before the await.
+    let snapshot = crate::state::mutate_state(|s| s.take_pending_treasury_interest());
+    if snapshot.0 == 0 {
         return;
     }
-    let treasury = read_state(|s| s.treasury_principal);
-    if let Some(tp) = treasury {
-        match management::mint_icusd(pending, tp).await {
-            Ok(block_index) => {
-                crate::state::mutate_state(|s| {
-                    s.pending_treasury_interest = ICUSD::new(0);
-                });
-                log!(
-                    INFO,
-                    "[treasury] Drained {} pending interest (block {})",
-                    pending.to_u64(),
-                    block_index
-                );
-                let _ = notify_treasury_deposit(
-                    tp,
-                    DepositType::InterestRevenue,
-                    AssetType::ICUSD,
-                    pending.to_u64(),
-                    block_index,
-                )
-                .await;
-            }
-            Err(e) => log!(
+    match management::mint_icusd(snapshot, tp).await {
+        Ok(block_index) => {
+            log!(
                 INFO,
-                "[treasury] WARNING: pending interest drain failed: {:?}",
+                "[treasury] Drained {} pending interest (block {})",
+                snapshot.to_u64(),
+                block_index
+            );
+            let _ = notify_treasury_deposit(
+                tp,
+                DepositType::InterestRevenue,
+                AssetType::ICUSD,
+                snapshot.to_u64(),
+                block_index,
+            )
+            .await;
+        }
+        Err(e) => {
+            crate::state::mutate_state(|s| s.restore_pending_treasury_interest(snapshot));
+            log!(
+                INFO,
+                "[treasury] CRITICAL: pending interest drain failed, re-queued {} icUSD: {:?}",
+                snapshot.to_u64(),
                 e
-            ),
+            );
         }
     }
 }

--- a/src/rumi_protocol_backend/tests/audit_pocs_int_002_concurrent_accrual.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_int_002_concurrent_accrual.rs
@@ -1,0 +1,168 @@
+//! INT-002 regression fence: the async interest-distribution path must
+//! recover its snapshot on mint failure without losing concurrent
+//! accrual that landed during the await window.
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/raw-pass-results/debt-interest.json`
+//!     finding INT-002.
+//!
+//! # What the bug was
+//!
+//! `treasury::flush_pending_interest` reads `pending_interest_for_pools`,
+//! removes the bucket entry BEFORE awaiting `distribute_interest`, then
+//! relies on the inner mints to succeed. Each inner mint
+//! (`mint_interest_to_treasury`, `mint_interest_to_stability_pool`,
+//! `donate_to_three_pool`) only logs on failure — there was no path back
+//! to the bucket. A single transient mint failure permanently dropped
+//! that tick's interest revenue.
+//!
+//! Naively restoring the original snapshot on failure would also lose
+//! any concurrent harvest that landed in the bucket during the await
+//! window: `BTreeMap::insert` would overwrite the concurrent value
+//! rather than merging it.
+//!
+//! # How this file tests the fix
+//!
+//! The fix introduces a snapshot-then-decrement pair on `State`:
+//!
+//!   * `take_pending_interest_for_pool` — atomic snapshot + remove of a
+//!     collateral bucket. Returns the e8s amount that was held.
+//!   * `restore_pending_interest_for_pool` — saturating_add of an
+//!     unminted amount back into the bucket. Used on the failure arm.
+//!
+//! Both tests construct a populated bucket, call `take_…` to capture
+//! the snapshot (mirroring the `mutate_state` step before the await),
+//! then directly mutate the bucket to simulate a concurrent harvest
+//! landing during the await. The success arm asserts that the bucket
+//! retains only the concurrent harvest (the snapshot was minted). The
+//! failure arm asserts that calling `restore_…` merges the snapshot
+//! back via `saturating_add`, so the bucket holds snapshot + concurrent
+//! and neither side is silently overwritten.
+
+use candid::Principal;
+
+use rumi_protocol_backend::state::State;
+use rumi_protocol_backend::InitArg;
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::from_slice(&[10]),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+const INITIAL_BUCKET_E8S: u64 = 100_000_000;
+const CONCURRENT_HARVEST_E8S: u64 = 50_000_000;
+
+#[test]
+fn int_002_success_arm_preserves_concurrent_accrual() {
+    let mut state = fresh_state();
+    let ct = Principal::from_slice(&[10]);
+
+    state
+        .pending_interest_for_pools
+        .insert(ct, INITIAL_BUCKET_E8S);
+
+    // Step 1: atomic snapshot + zero — the fix's pre-await mutation.
+    let snapshot = state.take_pending_interest_for_pool(ct);
+    assert_eq!(
+        snapshot, INITIAL_BUCKET_E8S,
+        "snapshot must capture the full bucket value before the await"
+    );
+    assert!(
+        !state.pending_interest_for_pools.contains_key(&ct),
+        "bucket must be drained to zero so concurrent harvests accumulate cleanly"
+    );
+
+    // Step 2: simulate a concurrent harvest landing during the await.
+    *state
+        .pending_interest_for_pools
+        .entry(ct)
+        .or_insert(0) += CONCURRENT_HARVEST_E8S;
+
+    // Step 3a: success arm — snapshot was minted, no restore needed.
+    // The bucket holds ONLY the concurrent harvest (the snapshot is gone
+    // because the recipients received it as a real ledger mint).
+    assert_eq!(
+        state.pending_interest_for_pools.get(&ct).copied(),
+        Some(CONCURRENT_HARVEST_E8S),
+        "success arm: bucket retains concurrent harvest only; snapshot was minted out"
+    );
+}
+
+#[test]
+fn int_002_failure_arm_restores_snapshot_and_preserves_concurrent_accrual() {
+    let mut state = fresh_state();
+    let ct = Principal::from_slice(&[10]);
+
+    state
+        .pending_interest_for_pools
+        .insert(ct, INITIAL_BUCKET_E8S);
+
+    // Step 1: atomic snapshot + zero.
+    let snapshot = state.take_pending_interest_for_pool(ct);
+
+    // Step 2: simulate a concurrent harvest landing during the await.
+    *state
+        .pending_interest_for_pools
+        .entry(ct)
+        .or_insert(0) += CONCURRENT_HARVEST_E8S;
+
+    // Step 3b: failure arm — restore the unminted snapshot via the
+    // fix's saturating_add pair.
+    state.restore_pending_interest_for_pool(ct, snapshot);
+
+    // The bucket must now hold BOTH the original snapshot (recovered)
+    // AND the concurrent harvest (preserved). A naive `insert(ct,
+    // snapshot)` would overwrite the concurrent value — that is the
+    // race the fix closes.
+    assert_eq!(
+        state.pending_interest_for_pools.get(&ct).copied(),
+        Some(INITIAL_BUCKET_E8S + CONCURRENT_HARVEST_E8S),
+        "failure restore must merge via saturating_add, not overwrite"
+    );
+}
+
+#[test]
+fn int_002_restore_saturates_at_u64_max() {
+    let mut state = fresh_state();
+    let ct = Principal::from_slice(&[10]);
+
+    // Bucket is already at the u64 ceiling. Restoring any non-zero
+    // snapshot must not panic — saturating_add caps the bucket.
+    state
+        .pending_interest_for_pools
+        .insert(ct, u64::MAX);
+
+    state.restore_pending_interest_for_pool(ct, INITIAL_BUCKET_E8S);
+
+    assert_eq!(
+        state.pending_interest_for_pools.get(&ct).copied(),
+        Some(u64::MAX),
+        "restore must saturate at u64::MAX rather than wrap or panic"
+    );
+}
+
+#[test]
+fn int_002_take_on_empty_bucket_returns_zero() {
+    let mut state = fresh_state();
+    let ct = Principal::from_slice(&[10]);
+
+    let snapshot = state.take_pending_interest_for_pool(ct);
+
+    assert_eq!(
+        snapshot, 0,
+        "take on a missing bucket must return 0, not panic or insert a sentinel"
+    );
+    assert!(
+        !state.pending_interest_for_pools.contains_key(&ct),
+        "take must not create a zero entry as a side effect"
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_int_006_treasury_drain_concurrent.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_int_006_treasury_drain_concurrent.rs
@@ -1,0 +1,164 @@
+//! INT-006 regression fence: the treasury-interest drain must zero its
+//! snapshot atomically with the read and recover via saturating_add on
+//! mint failure, so concurrent increments landing during the await
+//! survive both arms.
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/raw-pass-results/debt-interest.json`
+//!     finding INT-006.
+//!
+//! # What the bug was
+//!
+//! `treasury::drain_pending_treasury_interest` read
+//! `pending_treasury_interest` into a local, awaited
+//! `mint_icusd(pending, treasury)`, then on success unconditionally
+//! assigned `s.pending_treasury_interest = ICUSD::new(0)`. If another
+//! code path credited `pending_treasury_interest` during the await
+//! window, the post-mint zeroing dropped that credit. On failure no
+//! restore ran (concurrent credits survived) — the asymmetry is the
+//! anti-pattern the audit flagged.
+//!
+//! No code path currently writes to `pending_treasury_interest` (the
+//! field is effectively dead today), but if a future change adds a
+//! writer the existing zero-after-await drain would silently lose
+//! revenue. This file pins the contract for that future writer.
+//!
+//! # How this file tests the fix
+//!
+//! The fix introduces a snapshot-then-decrement pair on `State`:
+//!
+//!   * `take_pending_treasury_interest` — atomic snapshot + zero of the
+//!     field. Returns the ICUSD amount that was held.
+//!   * `restore_pending_treasury_interest` — saturating_add of an
+//!     unminted amount back into the field. Used on the failure arm.
+//!
+//! Mirroring the INT-002 fences: each test pre-loads the field, takes
+//! the snapshot (the `mutate_state` step that lands before the await),
+//! then directly mutates the field to simulate a concurrent credit
+//! landing during the await. The success arm asserts the field retains
+//! only the concurrent credit. The failure arm asserts that calling
+//! `restore_…` merges the snapshot back via `saturating_add`.
+
+use candid::Principal;
+
+use rumi_protocol_backend::numeric::ICUSD;
+use rumi_protocol_backend::state::State;
+use rumi_protocol_backend::InitArg;
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::from_slice(&[10]),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+const INITIAL_FIELD_E8S: u64 = 100_000_000;
+const CONCURRENT_CREDIT_E8S: u64 = 50_000_000;
+
+#[test]
+fn int_006_success_arm_preserves_concurrent_credit() {
+    let mut state = fresh_state();
+
+    state.pending_treasury_interest = ICUSD::new(INITIAL_FIELD_E8S);
+
+    // Step 1: atomic snapshot + zero — the fix's pre-await mutation.
+    let snapshot = state.take_pending_treasury_interest();
+    assert_eq!(
+        snapshot.to_u64(),
+        INITIAL_FIELD_E8S,
+        "snapshot must capture the full field value before the await"
+    );
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        0,
+        "field must be drained to zero so concurrent credits accumulate cleanly"
+    );
+
+    // Step 2: simulate a concurrent credit landing during the await.
+    state.pending_treasury_interest =
+        state.pending_treasury_interest + ICUSD::new(CONCURRENT_CREDIT_E8S);
+
+    // Step 3a: success arm — snapshot was minted, no restore needed.
+    // The field holds ONLY the concurrent credit.
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        CONCURRENT_CREDIT_E8S,
+        "success arm: field retains concurrent credit only; snapshot was minted out"
+    );
+}
+
+#[test]
+fn int_006_failure_arm_restores_snapshot_and_preserves_concurrent_credit() {
+    let mut state = fresh_state();
+
+    state.pending_treasury_interest = ICUSD::new(INITIAL_FIELD_E8S);
+
+    // Step 1: atomic snapshot + zero.
+    let snapshot = state.take_pending_treasury_interest();
+
+    // Step 2: simulate a concurrent credit landing during the await.
+    state.pending_treasury_interest =
+        state.pending_treasury_interest + ICUSD::new(CONCURRENT_CREDIT_E8S);
+
+    // Step 3b: failure arm — restore the unminted snapshot via the
+    // fix's saturating_add pair.
+    state.restore_pending_treasury_interest(snapshot);
+
+    // The field must now hold BOTH the original snapshot (recovered)
+    // AND the concurrent credit (preserved). A naive
+    // `pending_treasury_interest = snapshot` would overwrite the
+    // concurrent value — that is the race the fix closes.
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        INITIAL_FIELD_E8S + CONCURRENT_CREDIT_E8S,
+        "failure restore must merge via saturating_add, not overwrite"
+    );
+}
+
+#[test]
+fn int_006_restore_saturates_at_u64_max() {
+    let mut state = fresh_state();
+
+    // Field is already at the u64 ceiling. Restoring any non-zero
+    // snapshot must not panic — saturating_add caps the field.
+    state.pending_treasury_interest = ICUSD::new(u64::MAX);
+
+    state.restore_pending_treasury_interest(ICUSD::new(INITIAL_FIELD_E8S));
+
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        u64::MAX,
+        "restore must saturate at u64::MAX rather than wrap or panic"
+    );
+}
+
+#[test]
+fn int_006_take_on_zero_field_returns_zero() {
+    let mut state = fresh_state();
+
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        0,
+        "fresh state has zero pending treasury interest"
+    );
+
+    let snapshot = state.take_pending_treasury_interest();
+
+    assert_eq!(
+        snapshot.to_u64(),
+        0,
+        "take on a zero field must return 0 cleanly"
+    );
+    assert_eq!(
+        state.pending_treasury_interest.to_u64(),
+        0,
+        "field stays at zero after take of zero"
+    );
+}


### PR DESCRIPTION
## Summary
- Both interest-revenue async-mint paths now use a snapshot-then-decrement pattern: pre-await `mutate_state` takes the bucket atomically, post-await `saturating_add` restores the unminted portion on error so concurrent credits that landed during the await are preserved on both arms.
- Targets the two remaining audit follow-ups (INT-002 + INT-006) that share the same root cause.

## Changes
- `state.rs` — new `take_pending_interest_for_pool` / `restore_pending_interest_for_pool` and `take_pending_treasury_interest` / `restore_pending_treasury_interest` (saturating_add).
- `treasury.rs` — `mint_interest_to_treasury`, `mint_interest_to_stability_pool`, `donate_to_three_pool` now return whether the mint itself succeeded; `distribute_interest` accumulates unminted ICUSD and returns it.
- `treasury.rs` — `flush_pending_interest` re-queues the unminted portion via the new restore helper.
- `treasury.rs` — `drain_pending_treasury_interest` snapshots before the mint and restores on failure.
- `distribute_stablecoin_interest` keeps legacy log+drop semantics (no bucket to re-queue against; out of scope).

## Tests
New state-level audit fences:
- `audit_pocs_int_002_concurrent_accrual` (4 tests) — success arm preserves concurrent harvest, failure arm restores via saturating_add, saturation at u64::MAX, zero-bucket take.
- `audit_pocs_int_006_treasury_drain_concurrent` (4 tests) — same shape against `pending_treasury_interest`.

Both tests fail to compile against current main (helpers absent) and pass after the fix.

## Test plan
- [x] `cargo test --lib` (workspace, all packages) passes.
- [x] `cargo test -p rumi_protocol_backend --test audit_pocs_int_002_concurrent_accrual --test audit_pocs_int_006_treasury_drain_concurrent` passes (4 + 4).
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p rumi_protocol_backend --test pocket_ic_tests` passes (27/27).
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p rumi_3pool --test integration_test` passes (9/9).
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p stability_pool --test pocket_ic_3usd` passes (7/7).
- [x] `POCKET_IC_BIN=./pocket-ic cargo test -p rumi_analytics --test pocket_ic_analytics`: 23 pass, 1 pre-existing failure (`collector_health_reports_cursor_positions`) reproduces on main and is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)