### PR TITLE
fix(redemption): close ReadOnly bypass + route redemption shortfall into deficit account (audit RED-002 + RED-003)

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -108,6 +108,10 @@ type ConsentMessageSpec = record {
   metadata : ConsentMessageMetadata;
   device_spec : opt DeviceSpec;
 };
+type DeficitSource = variant {
+  Liquidation : record { vault_id : nat64 };
+  Redemption : record { redeemer : principal };
+};
 type DeviceSpec = variant {
   GenericDisplay;
   LineDisplay : record { characters_per_line : nat16; lines_per_page : nat16 };
@@ -395,6 +399,7 @@ type Event = variant {
   set_liquidation_bot_principal : record { "principal" : principal };
   deficit_accrued : record {
     new_deficit : nat64;
+    source : opt DeficitSource;
     vault_id : nat64;
     timestamp : nat64;
     amount : nat64;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -119,6 +119,8 @@ export interface ConsentMessageSpec {
   'metadata' : ConsentMessageMetadata,
   'device_spec' : [] | [DeviceSpec],
 }
+export type DeficitSource = { 'Liquidation' : { 'vault_id' : bigint } } |
+  { 'Redemption' : { 'redeemer' : Principal } };
 export type DeviceSpec = { 'GenericDisplay' : null } |
   {
     'LineDisplay' : {
@@ -511,6 +513,7 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   {
     'deficit_accrued' : {
       'new_deficit' : bigint,
+      'source' : [] | [DeficitSource],
       'vault_id' : bigint,
       'timestamp' : bigint,
       'amount' : bigint,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -277,6 +277,10 @@ export const idlFactory = ({ IDL }) => {
     'BorrowingFee' : IDL.Null,
     'RedemptionFee' : IDL.Null,
   });
+  const DeficitSource = IDL.Variant({
+    'Liquidation' : IDL.Record({ 'vault_id' : IDL.Nat64 }),
+    'Redemption' : IDL.Record({ 'redeemer' : IDL.Principal }),
+  });
   const Event = IDL.Variant({
     'set_borrowing_fee' : IDL.Record({ 'rate' : IDL.Text }),
     'VaultWithdrawnAndClosed' : IDL.Record({
@@ -581,6 +585,7 @@ export const idlFactory = ({ IDL }) => {
     }),
     'deficit_accrued' : IDL.Record({
       'new_deficit' : IDL.Nat64,
+      'source' : IDL.Opt(DeficitSource),
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Nat64,
       'amount' : IDL.Nat64,

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -108,6 +108,10 @@ type ConsentMessageSpec = record {
   metadata : ConsentMessageMetadata;
   device_spec : opt DeviceSpec;
 };
+type DeficitSource = variant {
+  Liquidation : record { vault_id : nat64 };
+  Redemption : record { redeemer : principal };
+};
 type DeviceSpec = variant {
   GenericDisplay;
   LineDisplay : record { characters_per_line : nat16; lines_per_page : nat16 };
@@ -395,6 +399,7 @@ type Event = variant {
   set_liquidation_bot_principal : record { "principal" : principal };
   deficit_accrued : record {
     new_deficit : nat64;
+    source : opt DeficitSource;
     vault_id : nat64;
     timestamp : nat64;
     amount : nat64;

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -28,6 +28,25 @@ pub enum FeeSource {
     RedemptionFee,
 }
 
+/// Wave-9 RED-002: identifies which path accrued a shortfall to
+/// `protocol_deficit_icusd`. Persisted on the `DeficitAccrued` event so
+/// the explorer can attribute deficit growth between liquidation and
+/// redemption flows. Pre-Wave-9 events serialize without this field
+/// and decode with `source = None` via `serde(default)`; new events
+/// always populate it.
+///
+/// Liquidation deficits also retain `vault_id` on the parent event for
+/// back-compat with the existing event-log shape; for redemption,
+/// `vault_id` on the parent is set to 0 (the cr-walk touches multiple
+/// vaults, no single id applies) and the redeemer principal lives
+/// inside this enum.
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum DeficitSource {
+    Liquidation { vault_id: u64 },
+    Redemption { redeemer: Principal },
+}
+
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Event {
     #[serde(rename = "open_vault")]
@@ -121,18 +140,29 @@ pub enum Event {
         timestamp: Option<u64>,
     },
 
-    /// Wave-8e LIQ-005: an underwater liquidation netted seized USD <
-    /// debt cleared, accruing the shortfall to `protocol_deficit_icusd`.
-    /// Emitted from every liquidation path (`liquidate_vault`,
-    /// `liquidate_vault_partial`, `liquidate_vault_partial_with_stable`,
-    /// `partial_liquidate_vault`, `liquidate_vault_debt_already_burned`)
-    /// when shortfall > 0.
+    /// Wave-8e LIQ-005 + Wave-9 RED-002: a redemption or liquidation
+    /// netted seized USD < debt cleared, accruing the shortfall to
+    /// `protocol_deficit_icusd`. Emitted from every liquidation path
+    /// (`liquidate_vault`, `liquidate_vault_partial`,
+    /// `liquidate_vault_partial_with_stable`, `partial_liquidate_vault`,
+    /// `liquidate_vault_debt_already_burned`) when shortfall > 0, and
+    /// from `record_redemption_on_vaults` when redeemer claim exceeds
+    /// vault collateral at oracle price.
+    ///
+    /// `vault_id` is the originating vault for liquidation and 0 for
+    /// redemption (the cr-walk touches multiple vaults). The new
+    /// `source` field is the canonical attribution: pre-Wave-9 events
+    /// decode with `source = None` (all pre-Wave-9 deficit rows were
+    /// liquidation by definition); post-Wave-9 events always populate
+    /// it.
     #[serde(rename = "deficit_accrued")]
     DeficitAccrued {
         vault_id: u64,
         amount: ICUSD,
         new_deficit: ICUSD,
         timestamp: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<DeficitSource>,
     },
 
     /// Wave-8e LIQ-005: a fee collection routed `amount` icUSD toward
@@ -1802,18 +1832,29 @@ pub fn record_margin_transfer(state: &mut State, vault_id: u64, owner: Principal
 /// Record a `DeficitAccrued` event and increment `protocol_deficit_icusd`.
 /// Caller is responsible for invoking `state.check_deficit_readonly_latch()`
 /// afterwards if the latch threshold is configured.
+///
+/// Wave-9 RED-002: takes a `DeficitSource` so liquidation and redemption
+/// deficits are distinguishable in the event log. The legacy `vault_id`
+/// field on the event is preserved for back-compat and continues to be
+/// populated for liquidation; redemption deficits set `vault_id = 0` on
+/// the parent event because the cr-walk touches multiple vaults.
 pub fn record_deficit_accrued(
     state: &mut State,
-    vault_id: u64,
+    source: DeficitSource,
     amount: ICUSD,
     timestamp: u64,
 ) {
     state.accrue_deficit_shortfall(amount);
+    let vault_id = match source {
+        DeficitSource::Liquidation { vault_id } => vault_id,
+        DeficitSource::Redemption { .. } => 0,
+    };
     record_event(&Event::DeficitAccrued {
         vault_id,
         amount,
         new_deficit: state.protocol_deficit_icusd,
         timestamp,
+        source: Some(source),
     });
 }
 
@@ -2015,6 +2056,20 @@ pub fn record_redemption_on_vaults(
         .map(UsdIcp::from)
         .unwrap_or(collateral_price); // fallback to parameter if no config price
 
+    // Wave-9 RED-002: snapshot price + decimals before mutation so the
+    // shortfall calc below uses the same oracle figures the water-fill
+    // walked. `redeem_on_vaults` mutates state but doesn't touch
+    // `collateral_configs`, so reading after is also safe — we read
+    // here to keep the data flow explicit.
+    let (price_decimal, decimals) = state.get_collateral_config(&redeem_ct)
+        .map(|c| {
+            let p = c.last_price
+                .and_then(rust_decimal::Decimal::from_f64_retain)
+                .unwrap_or(ct_price.0);
+            (p, c.decimals)
+        })
+        .unwrap_or((ct_price.0, 8));
+
     let vault_redemptions = state.redeem_on_vaults(icusd_amount, ct_price, &redeem_ct);
     record_event(&Event::RedemptionOnVaults {
         owner,
@@ -2024,13 +2079,101 @@ pub fn record_redemption_on_vaults(
         icusd_block_index,
         collateral_type: Some(redeem_ct),
         timestamp: Some(now()),
-        vault_redemptions: if vault_redemptions.is_empty() { None } else { Some(vault_redemptions) },
+        vault_redemptions: if vault_redemptions.is_empty() { None } else { Some(vault_redemptions.clone()) },
     });
+
+    // Wave-9 RED-002: route any redemption-side shortfall into the
+    // Wave-8e deficit account. The pure helper takes an explicit
+    // timestamp so unit tests can exercise the predicate without an
+    // `ic_cdk::api::time()` panic — production callers pass `now()`.
+    let _shortfall = accrue_redemption_shortfall_at(
+        state,
+        owner,
+        icusd_amount,
+        &vault_redemptions,
+        price_decimal,
+        decimals,
+        now(),
+    );
+
     let margin: ICP = icusd_amount / ct_price;
     let op_nonce = state.next_op_nonce();
     state
         .pending_redemption_transfer
         .insert(icusd_block_index, PendingMarginTransfer { owner, margin, collateral_type: redeem_ct, retry_count: 0, op_nonce });
+}
+
+/// Wave-9 RED-002: pure-math predicate for the redemption shortfall.
+/// Returns `target - sum(actual_collateral_seized) * price` clamped at
+/// zero, the metric the audit asked for. Pure (no state mutation, no
+/// event recording, no canister-clock read), so unit tests can drive
+/// it directly off `state.redeem_on_vaults` output.
+///
+/// Two silent-shortfall modes are unified by this metric:
+///
+///   * **Mode 1** — vault debt cap fires (water-fill exhausts available
+///     vaults before consuming the full redemption claim);
+///     `collateral_seized` totals to less than `icusd_amount / price`.
+///   * **Mode 2** — underwater vault (saturating-sub on
+///     `vault.collateral_amount` clips an attempted deduction). The
+///     `VaultRedemption.collateral_seized` field is now authoritative
+///     for the post-saturation actual amount (pre-Wave-9 it was the
+///     *requested* amount and silently over-reported).
+pub fn compute_redemption_shortfall(
+    target_icusd: ICUSD,
+    vault_redemptions: &[VaultRedemption],
+    price_decimal: rust_decimal::Decimal,
+    decimals: u8,
+) -> ICUSD {
+    let total_collateral_seized: u64 =
+        vault_redemptions.iter().map(|v| v.collateral_seized).sum();
+    let value_seized_at_oracle =
+        crate::numeric::collateral_usd_value(total_collateral_seized, price_decimal, decimals);
+    target_icusd.saturating_sub(value_seized_at_oracle)
+}
+
+/// Wave-9 RED-002: predicate + accrual + auto-latch check for redemption
+/// shortfalls. Calls `compute_redemption_shortfall` for the math, then
+/// (if non-zero) routes the shortfall through the same accrual helper
+/// that liquidation paths use (LIQ-005). Mirrors the LIQ-005
+/// liquidation accrual predicate inside `vault.rs::liquidate_vault`.
+///
+/// Pure with respect to the canister clock — callers pass the timestamp
+/// explicitly. Returns the shortfall accrued (zero when the redemption
+/// was solvent at oracle price).
+pub fn accrue_redemption_shortfall_at(
+    state: &mut State,
+    redeemer: Principal,
+    target_icusd: ICUSD,
+    vault_redemptions: &[VaultRedemption],
+    price_decimal: rust_decimal::Decimal,
+    decimals: u8,
+    timestamp: u64,
+) -> ICUSD {
+    let shortfall = compute_redemption_shortfall(
+        target_icusd,
+        vault_redemptions,
+        price_decimal,
+        decimals,
+    );
+    if shortfall.0 > 0 {
+        record_deficit_accrued(
+            state,
+            DeficitSource::Redemption { redeemer },
+            shortfall,
+            timestamp,
+        );
+        if state.check_deficit_readonly_latch() {
+            ic_canister_log::log!(
+                crate::logs::INFO,
+                "[RED-002] deficit threshold {} crossed by redemption (redeemer {}) shortfall {}; auto-latched ReadOnly",
+                state.deficit_readonly_threshold_e8s,
+                redeemer,
+                shortfall.to_u64()
+            );
+        }
+    }
+    shortfall
 }
 
 pub fn record_redemption_transfered(

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -999,6 +999,13 @@ async fn redeem_icp(icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> 
 #[update]
 async fn redeem_collateral(collateral_type: Principal, icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
     validate_call().await?;
+    // Wave-9 RED-003: gate redemption on protocol mode. ReadOnly auto-latches
+    // when total collateral ratio drops below 100% (Wave-1) or when the
+    // deficit account crosses the configured threshold (Wave-8e LIQ-005);
+    // both are insolvency signals where further redemption would deepen the
+    // bad-debt position by extracting collateral from a protocol that
+    // already owes more than it holds.
+    validate_mode()?;
     // Wave-5 RED-001: validate_call only refreshes ICP. For non-ICP collaterals
     // (BOB, EXE, ckBTC, ckETH, ckXAUT, nICP) the redeemer would otherwise pay
     // out at whatever last_price is cached, which could be hours stale if the
@@ -3123,6 +3130,10 @@ fn get_liquidation_ordering_tolerance_bps() -> u64 {
 #[update]
 async fn redeem_reserves(amount: u64, preferred_token: Option<Principal>) -> Result<ReserveRedemptionResult, ProtocolError> {
     validate_call().await?;
+    // Wave-9 RED-003: reserve redemption walks the same vault cr-index as
+    // redeem_collateral on its spillover branch, so the same ReadOnly gate
+    // applies. See main.rs::redeem_collateral for the rationale.
+    validate_mode()?;
     rumi_protocol_backend::vault::redeem_reserves(amount, preferred_token).await
 }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3395,30 +3395,50 @@ impl State {
                 price,
                 decimals,
             );
-            self.deduct_amount_from_vault(collateral_to_deduct, icusd_to_deduct, *vault_id);
+            // Wave-9 RED-002: capture the actual collateral seized (post
+            // saturating-sub). For solvent vaults this equals
+            // `collateral_to_deduct`; for underwater vaults the
+            // saturation clip means the seized amount is less. The
+            // difference (in icUSD-at-oracle) is bad debt routed via
+            // `record_redemption_on_vaults` into the deficit account.
+            let actual_collateral_seized =
+                self.deduct_amount_from_vault(collateral_to_deduct, icusd_to_deduct, *vault_id);
             distributed += actual_share;
 
             results.push(crate::event::VaultRedemption {
                 vault_id: *vault_id,
                 icusd_redeemed_e8s: actual_share as u64,
-                collateral_seized: collateral_to_deduct,
+                collateral_seized: actual_collateral_seized,
             });
         }
     }
 
+    /// Deduct `collateral_to_deduct` collateral and `icusd_amount_to_deduct`
+    /// icUSD-debt from `vault_id`, saturating both subtractions at zero.
+    /// Returns the **actual** collateral deducted (after saturation), which
+    /// equals `collateral_to_deduct` for solvent vaults and
+    /// `vault.collateral_amount` for vaults whose collateral runs short.
+    ///
+    /// Wave-9 RED-002: the actual amount is the load-bearing input to the
+    /// redemption-side deficit accrual — the redeemer was paid out for the
+    /// full claim, but only this much collateral actually came out of the
+    /// vault. The difference is bad debt (now routed via
+    /// `record_deficit_accrued`).
     fn deduct_amount_from_vault(
         &mut self,
         collateral_to_deduct: u64,
         icusd_amount_to_deduct: ICUSD,
         vault_id: VaultId,
-    ) {
-        match self.vault_id_to_vaults.get_mut(&vault_id) {
+    ) -> u64 {
+        let actual_collateral_deducted = match self.vault_id_to_vaults.get_mut(&vault_id) {
             Some(vault) => {
                 // Use saturating arithmetic: during event replay, interest
                 // drift can inflate debt/collateral values, causing the
                 // deduction to exceed the vault's balance.
                 vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(icusd_amount_to_deduct);
+                let pre_collateral = vault.collateral_amount;
                 vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_to_deduct);
+                let actual = pre_collateral.saturating_sub(vault.collateral_amount);
                 // INT-001: redemption can shrink `borrowed_icusd_amount` below
                 // `accrued_interest`, breaking the invariant that drives the
                 // proportional interest-share math in `repay_to_vault`.
@@ -3428,13 +3448,15 @@ impl State {
                 if vault.accrued_interest > vault.borrowed_icusd_amount {
                     vault.accrued_interest = vault.borrowed_icusd_amount;
                 }
+                actual
             }
             None => ic_cdk::trap("cannot deduct from unknown vault"),
-        }
+        };
         // Wave-8b LIQ-002: redemption water-fill mutates each touched vault's
         // debt/collateral; re-key its index entry so the next redemption /
         // liquidation sees the updated CR.
         self.reindex_vault_cr(vault_id);
+        actual_collateral_deducted
     }
 
     pub fn check_semantically_eq(&self, other: &Self) -> Result<(), String> {

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -2245,7 +2245,7 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                vault_id,
+                crate::event::DeficitSource::Liquidation { vault_id },
                 shortfall,
                 ic_cdk::api::time(),
             );
@@ -2542,7 +2542,7 @@ pub async fn liquidate_vault_partial_with_stable(
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                vault_id,
+                crate::event::DeficitSource::Liquidation { vault_id },
                 shortfall,
                 ic_cdk::api::time(),
             );
@@ -2938,7 +2938,7 @@ pub async fn liquidate_vault_debt_already_burned(
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                vault_id,
+                crate::event::DeficitSource::Liquidation { vault_id },
                 shortfall,
                 ic_cdk::api::time(),
             );
@@ -3198,7 +3198,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                vault_id,
+                crate::event::DeficitSource::Liquidation { vault_id },
                 shortfall,
                 ic_cdk::api::time(),
             );
@@ -3659,7 +3659,7 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                arg.vault_id,
+                crate::event::DeficitSource::Liquidation { vault_id: arg.vault_id },
                 shortfall,
                 ic_cdk::api::time(),
             );

--- a/src/rumi_protocol_backend/tests/audit_pocs_liq_005_deficit_account.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_liq_005_deficit_account.rs
@@ -202,7 +202,7 @@ fn liq_005_check_readonly_latch_does_not_fire_below_threshold() {
 
 use rumi_protocol_backend::EventTypeFilter;
 use rumi_protocol_backend::event::{
-    Event, FeeSource, record_deficit_accrued, record_deficit_repaid,
+    DeficitSource, Event, FeeSource, record_deficit_accrued, record_deficit_repaid,
 };
 
 #[test]
@@ -212,6 +212,7 @@ fn liq_005_event_deficit_accrued_round_trip() {
         amount: ICUSD::new(1_500),
         new_deficit: ICUSD::new(1_500),
         timestamp: 1_700_000_000_000_000_000,
+        source: Some(DeficitSource::Liquidation { vault_id: 42 }),
     };
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&e, &mut bytes).expect("encode");
@@ -257,7 +258,12 @@ fn liq_005_event_deficit_repaid_round_trip_redemption_no_anchor() {
 #[test]
 fn liq_005_record_deficit_accrued_emits_event_and_updates_state() {
     let mut s = State::default();
-    record_deficit_accrued(&mut s, /*vault_id=*/ 7, ICUSD::new(900), /*timestamp=*/ 1_000);
+    record_deficit_accrued(
+        &mut s,
+        DeficitSource::Liquidation { vault_id: 7 },
+        ICUSD::new(900),
+        /*timestamp=*/ 1_000,
+    );
     assert_eq!(s.protocol_deficit_icusd, ICUSD::new(900));
 }
 

--- a/src/rumi_protocol_backend/tests/audit_pocs_red_002_redemption_deficit.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_red_002_redemption_deficit.rs
@@ -1,0 +1,366 @@
+//! Wave-9 RED-002: redemption-side bad debt must accrue to the
+//! Wave-8e deficit account.
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/raw-pass-results/redemption-peg.json`
+//!     finding RED-002.
+//!
+//! # What the bug was
+//!
+//! `redeem_collateral` and `redeem_reserves` (vault-spillover branch)
+//! both delegate to `event::record_redemption_on_vaults`, which calls
+//! `state.redeem_on_vaults` to walk the cr-index ascending and deduct
+//! collateral per vault. When a vault's collateral runs short of the
+//! redeemer's claim at oracle price, the
+//! `vault.collateral_amount.saturating_sub(...)` clip silently absorbs
+//! the remainder. Pre-fix, the redeemer was paid from
+//! `pending_redemption_transfer` for the full claim while only the
+//! capped amount was deducted from vaults; the difference was
+//! socialized invisibly.
+//!
+//! Liquidation shortfalls were already routed through
+//! `State::accrue_deficit_shortfall` (Wave-8e LIQ-005). RED-002 extends
+//! that machinery to redemption: the redeemer-claim minus actual
+//! collateral seized at oracle price is now accrued to
+//! `protocol_deficit_icusd` and emitted as `Event::DeficitAccrued` with
+//! the new `DeficitSource::Redemption { redeemer }` source variant.
+//!
+//! # How this file tests the fix
+//!
+//! Unit tests drive the production codepath in two layers:
+//!   * State + math: `state.redeem_on_vaults` returns the per-vault
+//!     breakdown with actual (post-saturation) `collateral_seized`,
+//!     and `event::compute_redemption_shortfall` derives the icUSD
+//!     shortfall from that breakdown. Both are state-side helpers
+//!     used inside `record_redemption_on_vaults` on a live canister.
+//!   * State mutation: `state.accrue_deficit_shortfall` increments
+//!     `protocol_deficit_icusd`. The composed
+//!     `accrue_redemption_shortfall_at` helper additionally records
+//!     a `DeficitAccrued` event with the new `Redemption` source
+//!     variant; the event-recording leg is exercised by the existing
+//!     PocketIC suite (`record_event` reads `ic_cdk::api::time()`
+//!     which panics outside a canister, so we don't drive it here).
+//!
+//! Three behavioural scenarios + one event-shape fence + one structural
+//! fence:
+//!   * Scenario A (TDD red-green) — underwater vault: redeem against a
+//!     vault whose collateral value at oracle price is far below its
+//!     debt. Assert that the shortfall predicate returns the missing
+//!     icUSD AND that `state.accrue_deficit_shortfall` increments
+//!     `protocol_deficit_icusd` by exactly that amount.
+//!   * Scenario B (regression fence) — solvent vault: redeem against a
+//!     healthy vault. Assert that the shortfall predicate returns 0
+//!     (no false-positive accrual).
+//!   * Scenario C (TDD red-green) — `DeficitSource::Redemption` is a
+//!     distinct variant carrying the redeemer principal, AND
+//!     `record_redemption_on_vaults` constructs that variant rather
+//!     than reusing `Liquidation`. Structural fence reads
+//!     `event.rs` directly to pin the wiring.
+//!   * `red_002_deficit_accrued_event_with_liquidation_source_round_trips`
+//!     — pin the extended `Event::DeficitAccrued` CBOR shape (the
+//!     legacy back-compat case is covered by
+//!     `red_002_legacy_deficit_accrued_event_decodes_with_source_none`).
+
+use candid::Principal;
+use rumi_protocol_backend::event::{
+    compute_redemption_shortfall, DeficitSource, Event, VaultRedemption,
+};
+use rumi_protocol_backend::numeric::{ICUSD, UsdIcp};
+use rumi_protocol_backend::state::{CollateralStatus, State};
+use rumi_protocol_backend::vault::Vault;
+use rumi_protocol_backend::InitArg;
+use std::path::PathBuf;
+
+const DEFAULT_DECIMALS: u8 = 8;
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::from_slice(&[10]),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+fn icp_ct(state: &State) -> Principal {
+    state.icp_collateral_type()
+}
+
+fn open_test_vault(state: &mut State, vault_id: u64, debt_e8s: u64, collateral_e8s: u64) {
+    let ct = icp_ct(state);
+    state.open_vault(Vault {
+        owner: Principal::from_slice(&[1]),
+        vault_id,
+        collateral_amount: collateral_e8s,
+        borrowed_icusd_amount: ICUSD::new(debt_e8s),
+        collateral_type: ct,
+        last_accrual_time: 0,
+        accrued_interest: ICUSD::new(0),
+        bot_processing: false,
+    });
+}
+
+fn set_icp_price(state: &mut State, price_usd: f64) {
+    let ct = icp_ct(state);
+    if let Some(c) = state.collateral_configs.get_mut(&ct) {
+        c.last_price = Some(price_usd);
+        c.last_price_timestamp = Some(1);
+        c.status = CollateralStatus::Active;
+    }
+}
+
+fn redeem_then_accrue(
+    state: &mut State,
+    target: ICUSD,
+    price_usd: f64,
+    decimals: u8,
+) -> (Vec<VaultRedemption>, ICUSD) {
+    let ct = icp_ct(state);
+    let ct_price = UsdIcp::from(rust_decimal::Decimal::from_f64_retain(price_usd).unwrap());
+    let vault_redemptions = state.redeem_on_vaults(target, ct_price, &ct);
+    let shortfall = compute_redemption_shortfall(
+        target,
+        &vault_redemptions,
+        rust_decimal::Decimal::from_f64_retain(price_usd).unwrap(),
+        decimals,
+    );
+    // Mirror the production helper's state mutation. The composed
+    // `accrue_redemption_shortfall_at` additionally records a
+    // `DeficitAccrued` event; we skip that here because `record_event`
+    // pulls `ic_cdk::api::time()` which panics outside a canister
+    // context (a pre-existing limitation that already affects the
+    // LIQ-005 audit POCs that touch the event log).
+    if shortfall.0 > 0 {
+        state.accrue_deficit_shortfall(shortfall);
+    }
+    (vault_redemptions, shortfall)
+}
+
+// ─── Behavioural scenarios ───
+
+#[test]
+fn red_002_scenario_a_underwater_vault_accrues_redemption_deficit() {
+    // Setup: 1 vault with 10 icUSD debt and only 1 ICP collateral at
+    // $5/ICP. Collateral value = $5, debt = $10 → CR = 0.5 (severely
+    // underwater). Redeeming the full 10 icUSD against this vault
+    // means the redeemer's claim ($10) exceeds what vault collateral
+    // can cover at oracle price ($5).
+    let mut state = fresh_state();
+    let debt_e8s: u64 = 1_000_000_000; // 10 icUSD
+    let collateral_e8s: u64 = 100_000_000; // 1 ICP
+    open_test_vault(&mut state, 1, debt_e8s, collateral_e8s);
+    set_icp_price(&mut state, 5.0);
+
+    let pre_deficit = state.protocol_deficit_icusd;
+
+    let (breakdown, shortfall) = redeem_then_accrue(
+        &mut state,
+        ICUSD::new(debt_e8s),
+        5.0,
+        DEFAULT_DECIMALS,
+    );
+
+    // Sanity on the per-vault breakdown: collateral_seized is now the
+    // *actual* amount post-saturation, not the requested amount.
+    assert_eq!(breakdown.len(), 1);
+    assert_eq!(breakdown[0].vault_id, 1);
+    assert_eq!(breakdown[0].icusd_redeemed_e8s, debt_e8s);
+    assert_eq!(
+        breakdown[0].collateral_seized, collateral_e8s,
+        "post-fix VaultRedemption.collateral_seized must be the \
+         actual seized amount, not the requested amount"
+    );
+
+    // Predicate: redeemer claim ($10) - actual collateral seized at oracle
+    //         = 10 icUSD - 1 ICP * $5 = 5 icUSD = 500_000_000 e8s.
+    let expected_shortfall = ICUSD::new(500_000_000);
+    assert_eq!(
+        shortfall, expected_shortfall,
+        "compute_redemption_shortfall must return {} e8s for an \
+         underwater redemption (got {})",
+        expected_shortfall.to_u64(),
+        shortfall.to_u64(),
+    );
+
+    // State mutation: protocol_deficit_icusd is incremented by the shortfall.
+    let new_deficit = state.protocol_deficit_icusd - pre_deficit;
+    assert_eq!(
+        new_deficit, expected_shortfall,
+        "underwater redemption must accrue {} e8s to protocol_deficit_icusd \
+         (got {})",
+        expected_shortfall.to_u64(),
+        new_deficit.to_u64(),
+    );
+}
+
+#[test]
+fn red_002_scenario_b_solvent_redemption_no_deficit() {
+    // Setup: 1 solvent vault with 10 icUSD debt and 5 ICP collateral
+    // at $5/ICP. Collateral value = $25, plenty to cover the full
+    // redemption at oracle price. No shortfall expected.
+    let mut state = fresh_state();
+    let debt_e8s: u64 = 1_000_000_000; // 10 icUSD
+    let collateral_e8s: u64 = 500_000_000; // 5 ICP
+    open_test_vault(&mut state, 1, debt_e8s, collateral_e8s);
+    set_icp_price(&mut state, 5.0);
+
+    let pre_deficit = state.protocol_deficit_icusd;
+
+    let (_breakdown, shortfall) = redeem_then_accrue(
+        &mut state,
+        ICUSD::new(debt_e8s),
+        5.0,
+        DEFAULT_DECIMALS,
+    );
+
+    assert_eq!(
+        shortfall,
+        ICUSD::new(0),
+        "solvent redemption must compute zero shortfall (got {} e8s)",
+        shortfall.to_u64(),
+    );
+    let new_deficit = state.protocol_deficit_icusd - pre_deficit;
+    assert_eq!(
+        new_deficit,
+        ICUSD::new(0),
+        "solvent redemption must not accrue any deficit (got {} e8s)",
+        new_deficit.to_u64(),
+    );
+}
+
+#[test]
+fn red_002_scenario_c_event_carries_redemption_source_variant() {
+    // Two-part fence:
+    //   1. `DeficitSource::Redemption` is a distinct variant carrying
+    //      the redeemer principal — exercised at the type level here.
+    //   2. `record_redemption_on_vaults` (event.rs) constructs that
+    //      variant on the deficit-accrual leg, NOT
+    //      `DeficitSource::Liquidation`. Structural fence reads the
+    //      event.rs source directly and asserts the wiring.
+    //
+    // Layered this way because the integrated event-emission path
+    // (`record_event` → `ic_cdk::api::time()`) cannot be exercised in
+    // a unit test environment.
+
+    // Part 1: variant fence.
+    let redeemer = Principal::from_slice(&[42]);
+    let source = DeficitSource::Redemption { redeemer };
+    match source.clone() {
+        DeficitSource::Redemption { redeemer: r } => {
+            assert_eq!(
+                r, redeemer,
+                "DeficitSource::Redemption must carry the redeemer principal so \
+                 explorer can attribute deficit growth back to the user that \
+                 triggered the underwater redemption"
+            );
+        }
+        DeficitSource::Liquidation { .. } => {
+            panic!("clone of Redemption produced Liquidation");
+        }
+    }
+
+    // Part 2: structural wiring fence.
+    let event_rs_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/event.rs");
+    let event_rs = std::fs::read_to_string(&event_rs_path)
+        .unwrap_or_else(|e| panic!("read {}: {}", event_rs_path.display(), e));
+
+    // The fix wires `record_redemption_on_vaults` → the new
+    // `accrue_redemption_shortfall_at` helper, which in turn calls
+    // `record_deficit_accrued` with `DeficitSource::Redemption`.
+    // Pin both call sites textually so refactoring this path can't
+    // silently regress to passing `Liquidation` (or no source at all).
+    let helper_decl_idx = event_rs
+        .find("pub fn accrue_redemption_shortfall_at(")
+        .expect(
+            "event.rs must define `accrue_redemption_shortfall_at` — the pure \
+             helper that drives the Wave-9 RED-002 redemption shortfall accrual",
+        );
+    let helper_body = &event_rs[helper_decl_idx..];
+    assert!(
+        helper_body.contains("DeficitSource::Redemption"),
+        "accrue_redemption_shortfall_at must construct \
+         DeficitSource::Redemption when accruing the redemption-side \
+         shortfall (audit RED-002). Reusing Liquidation would mis-attribute \
+         deficit growth in the explorer."
+    );
+
+    let entry_decl_idx = event_rs
+        .find("pub fn record_redemption_on_vaults(")
+        .expect("event.rs must define `record_redemption_on_vaults`");
+    let entry_to_helper_slice = &event_rs[entry_decl_idx..];
+    assert!(
+        entry_to_helper_slice.contains("accrue_redemption_shortfall_at"),
+        "record_redemption_on_vaults must invoke \
+         accrue_redemption_shortfall_at so every redemption that walks the \
+         vault cr-index has its shortfall (if any) routed into the deficit \
+         account (audit RED-002)."
+    );
+}
+
+// ─── Event-shape round-trip fences ───
+//
+// The standalone `DeficitSource::Redemption` variant carries a
+// `candid::Principal`, whose serde Deserialize impl asserts a Candid
+// context and panics under ciborium ("Not called by Candid"). We
+// therefore round-trip the LIQUIDATION variant only — that's enough
+// to pin the enum's CBOR tagging and, more importantly, the
+// extended `Event::DeficitAccrued` shape carrying the new `source`
+// field. The Redemption variant's wire format is exercised
+// end-to-end by the PocketIC redemption suite.
+
+#[test]
+fn red_002_deficit_accrued_event_with_liquidation_source_round_trips() {
+    let e = Event::DeficitAccrued {
+        vault_id: 7,
+        amount: ICUSD::new(500_000_000),
+        new_deficit: ICUSD::new(500_000_000),
+        timestamp: 1_700_000_000_000_000_000,
+        source: Some(DeficitSource::Liquidation { vault_id: 7 }),
+    };
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&e, &mut bytes).expect("encode");
+    let decoded: Event =
+        ciborium::de::from_reader(bytes.as_slice()).expect("decode");
+    assert_eq!(decoded, e);
+}
+
+#[test]
+fn red_002_legacy_deficit_accrued_event_decodes_with_source_none() {
+    // Pre-Wave-9 events were serialized without the `source` field. We
+    // simulate that by encoding a current event with source = None
+    // (`skip_serializing_if = "Option::is_none"` drops the field on
+    // the wire) and asserting it decodes with `source = None` again.
+    // Round-tripping `None` is exactly the back-compat case: pre-Wave-9
+    // canister event-log entries lack the field on disk, and serde's
+    // `default` annotation backfills `None` on read.
+    let e = Event::DeficitAccrued {
+        vault_id: 1,
+        amount: ICUSD::new(100),
+        new_deficit: ICUSD::new(100),
+        timestamp: 1_700_000_000_000_000_000,
+        source: None,
+    };
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&e, &mut bytes).expect("encode");
+    let decoded: Event = ciborium::de::from_reader(bytes.as_slice()).expect(
+        "legacy DeficitAccrued (no source) must decode under serde(default)",
+    );
+
+    match decoded {
+        Event::DeficitAccrued { source, vault_id, .. } => {
+            assert!(
+                source.is_none(),
+                "legacy DeficitAccrued must decode with source = None; got {:?}",
+                source,
+            );
+            assert_eq!(vault_id, 1);
+        }
+        other => panic!("decoded into wrong variant: {:?}", other),
+    }
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_red_003_readonly_redemption.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_red_003_readonly_redemption.rs
@@ -1,0 +1,116 @@
+//! Wave-9 RED-003: redemption endpoints must respect protocol mode.
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/raw-pass-results/redemption-peg.json`
+//!     finding RED-003.
+//!
+//! # What the bug was
+//!
+//! `validate_mode()` (defined at `src/main.rs::validate_mode`) gates
+//! state-mutating endpoints to `Mode::GeneralAvailability` /
+//! `Mode::Recovery` and rejects when `state.mode == ReadOnly`. It is
+//! called from `borrow_from_vault`, `withdraw_partial_collateral`,
+//! `add_margin`, `open_vault_with_deposit`, and `open_vault_and_borrow`.
+//!
+//! `redeem_collateral` and `redeem_reserves` did NOT call it. ReadOnly
+//! is the auto-latched state when total collateral ratio drops below
+//! 100% (Wave-1 latch) or, post-Wave-8e, when the deficit account
+//! crosses its admin-configured threshold. Allowing redemption while
+//! ReadOnly meant a redeemer could continue extracting collateral from
+//! a protocol that was already insolvent, deepening the bad-debt
+//! position.
+//!
+//! # How this file tests the fix
+//!
+//! The fix is a one-line change at the two redemption entry points in
+//! `src/main.rs`. This file pins:
+//!
+//!   1. The state-side invariant that `Mode::ReadOnly` is a distinct
+//!      variant detectable by the caller.
+//!   2. A structural fence reading `src/main.rs` directly: both
+//!      `redeem_collateral` and `redeem_reserves` MUST contain a
+//!      `validate_mode()?` call after the fix lands. The structural
+//!      fence will FAIL on pre-fix main and PASS post-fix.
+
+use rumi_protocol_backend::state::{Mode, State};
+use std::path::PathBuf;
+
+/// Reads `src/main.rs` from the package root for source-level structural
+/// assertions. `CARGO_MANIFEST_DIR` always points to the package root
+/// (`src/rumi_protocol_backend/`), so resolving `src/main.rs` from there
+/// is robust to test invocation from any working directory.
+fn read_main_rs() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+/// Slice the body of a free `async fn` named `fn_name` from its declaration
+/// up to the next free function declaration (column-0 `async fn ` or `fn `).
+/// `main.rs` declares free functions only at column 0 and never nests them,
+/// so this is sufficient for entry-point bodies.
+fn function_body_slice<'a>(source: &'a str, fn_name: &str) -> &'a str {
+    let header = format!("async fn {}(", fn_name);
+    let start = source
+        .find(&header)
+        .unwrap_or_else(|| panic!("function `{}` not found in main.rs", fn_name));
+    let after_header = start + header.len();
+    let next_async = source[after_header..]
+        .find("\nasync fn ")
+        .map(|i| after_header + i);
+    let next_fn = source[after_header..]
+        .find("\nfn ")
+        .map(|i| after_header + i);
+    let end = match (next_async, next_fn) {
+        (Some(a), Some(f)) => a.min(f),
+        (Some(a), None) => a,
+        (None, Some(f)) => f,
+        (None, None) => source.len(),
+    };
+    &source[start..end]
+}
+
+#[test]
+fn red_003_mode_readonly_is_a_distinct_state_variant() {
+    // Sanity fence: the `ReadOnly` variant exists, is the rejection
+    // state validate_mode checks against, and is distinct from the
+    // two pass-through variants.
+    let mut state = State::default();
+    assert_eq!(state.mode, Mode::GeneralAvailability);
+    assert_ne!(state.mode, Mode::ReadOnly);
+    assert_ne!(state.mode, Mode::Recovery);
+
+    state.mode = Mode::ReadOnly;
+    assert_eq!(state.mode, Mode::ReadOnly);
+
+    state.mode = Mode::Recovery;
+    assert_eq!(state.mode, Mode::Recovery);
+}
+
+#[test]
+fn red_003_main_rs_redeem_collateral_calls_validate_mode() {
+    let main_rs = read_main_rs();
+    let body = function_body_slice(&main_rs, "redeem_collateral");
+    assert!(
+        body.contains("validate_mode()?"),
+        "main.rs::redeem_collateral entry point must call `validate_mode()?` \
+         to gate redemption on protocol mode (audit RED-003). The fix mirrors \
+         the existing pattern at borrow_from_vault, open_vault_with_deposit, \
+         and open_vault_and_borrow.\n\nInspected body:\n{}",
+        body,
+    );
+}
+
+#[test]
+fn red_003_main_rs_redeem_reserves_calls_validate_mode() {
+    let main_rs = read_main_rs();
+    let body = function_body_slice(&main_rs, "redeem_reserves");
+    assert!(
+        body.contains("validate_mode()?"),
+        "main.rs::redeem_reserves entry point must call `validate_mode()?` \
+         to gate reserve redemption on protocol mode (audit RED-003). \
+         Reserve-redemption spillover walks the same vault cr-index as \
+         redeem_collateral, so the same gate applies.\n\nInspected body:\n{}",
+        body,
+    );
+}


### PR DESCRIPTION
## Summary

Closes the two redemption-path findings flagged by the 2026-04-22 audit second-pass verification. Both ride together because they touch the same call paths (`redeem_collateral` and `redeem_reserves`).

- **RED-003** — gate redemption on protocol mode. `validate_mode()` is now called by both redeem entry points in `main.rs`, mirroring the existing gate at `borrow_from_vault` / `open_vault_with_deposit` / `open_vault_and_borrow`. Stops further collateral extraction once the protocol auto-latches into `ReadOnly` (TCR < 100% or Wave-8e deficit threshold crossed) where redemption would deepen the bad-debt position.
- **RED-002** — route the redemption-side shortfall into the Wave-8e deficit account. The cr-walk's saturating-sub on `vault.collateral_amount` (underwater vault) and the per-vault debt cap (vault exhausted before consuming the full claim) were previously absorbed silently. The metric `target - sum(actual_collateral_seized) * price` now accrues to `protocol_deficit_icusd` via the same helper liquidation paths use (LIQ-005). New `DeficitSource::Redemption { redeemer }` event variant attributes the deficit growth back to the redemption path so the explorer can break out source totals.

## Surface change

- New `DeficitSource` enum + optional `source : opt DeficitSource` field on `Event::DeficitAccrued`. Pre-Wave-9 events decode with `source = None` via `serde(default)` — upgrade-safe.
- `State::deduct_amount_from_vault` returns the actual collateral deducted (post-saturation); `VaultRedemption.collateral_seized` becomes authoritative for the *actual* amount instead of the *requested* amount. Underwater rows are now accurate.
- Two new helpers in `event.rs`: `compute_redemption_shortfall` (pure math, unit-testable) and `accrue_redemption_shortfall_at` (math + state mutation + event recording).
- `.did` and TS declarations regenerated for the new field.

Repo is public; commit/PR text describes the fix abstractly. Reference IDs only.

## Test plan

- [x] `cargo test --lib` — 83/83 pass
- [x] `cargo test --test audit_pocs_red_002_redemption_deficit` — 5/5 pass (scenarios A/B/C + event shape + legacy decode)
- [x] `cargo test --test audit_pocs_red_003_readonly_redemption` — 3/3 pass (state-mode fence + 2 structural fences on `main.rs`)
- [x] `POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_tests` — 27/27 pass (2 ignored)
- [x] `POCKET_IC_BIN=./pocket-ic cargo test --test audit_pocs_liq_005_deficit_account_pic` — 4/4 pass (liquidation deficit behavior unchanged)
- [x] `POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_3usd --test integration_test` — 7/7 + 9/9 pass
- [x] `cargo test check_candid_interface_compatibility` — passes (.did matches Rust source)

## Authorization scope

Implement, test, open the PR. Do NOT merge, do NOT deploy until Rob explicitly authorizes both (separate authorizations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)