### PR TITLE
chore(analytics-test): bump cursor count expectation to 8

### DIFF
--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -722,11 +722,14 @@ fn collector_health_reports_cursor_positions() {
 
     let health = get_collector_health(&env);
 
-    // Should have 7 cursors. The original 6 (icusd_blocks, threeusd_blocks,
-    // backend_events, 3pool_liquidity_events, amm_swap_events, ThreeUsd icrc3)
-    // plus the stability_pool_events tailer added by commit 2ce0771
-    // ("feat(analytics): tail rumi_stability_pool canister events").
-    assert_eq!(health.cursors.len(), 7, "expected 7 cursors");
+    // Eight cursors total. The first six covered Phase 4 sources:
+    // backend_events, 3pool_swaps, 3pool_liquidity, 3pool_blocks (icrc3),
+    // amm_swaps, icusd_blocks (icrc3). The 2ce0771 SP-events tailer added
+    // stability_events (cursor #7). Commit 559a3d9 (AMM LP collector wiring,
+    // dropping the double-counted three_pool_lp aggregate) added the
+    // amm_liquidity tailer (cursor #8). When new tailers are added, bump
+    // this count and add a sentence describing the new source.
+    assert_eq!(health.cursors.len(), 8, "expected 8 cursors");
 
     // last_pull_cycle_ns should be non-zero after a pull cycle
     assert!(health.last_pull_cycle_ns > 0, "last_pull_cycle_ns should be set");


### PR DESCRIPTION
## Summary
- The `collector_health_reports_cursor_positions` integration test expected 7 cursors but the analytics canister registers 8 (commit 559a3d9 added the `amm_liquidity` tailer after #122 bumped the expectation to 7).
- Bump the assertion to 8 and rewrite the comment to enumerate every cursor + remind future contributors to keep this in sync.
- Pre-flight cleanup so the pre-deploy hook is green before the Wave 9 (DoS hardening) PRs begin landing.

## Test plan
- [x] `cargo test --test pocket_ic_analytics collector_health_reports_cursor_positions` → passes
- [x] `cargo test --test pocket_ic_analytics` → 24 passed; 0 failed; 1 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)