### PR TITLE
fix(api): paginate unbounded queries (audit Wave 9a — DOS-001/-003/-004/-008)

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -452,6 +452,12 @@ type EventTypeFilter = variant {
   Redemption;
   CloseVault;
 };
+type EventsByPrincipalPagedResponse = record {
+  scan_end : nat64;
+  exhausted : bool;
+  events : vec record { nat64; Event };
+  total_events : nat64;
+};
 type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
@@ -749,6 +755,10 @@ type VaultRedemption = record {
   vault_id : nat64;
   collateral_seized : nat64;
 };
+type VaultsPageResponse = record {
+  vaults : vec CandidVault;
+  next_start_id : opt nat64;
+};
 type XrcAssetClass = variant { Cryptocurrency; FiatCurrency };
 service : (ProtocolArg) -> {
   add_collateral_token : (AddCollateralArg) -> (Result);
@@ -786,6 +796,9 @@ service : (ProtocolArg) -> {
   get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
   get_events_by_principal : (principal) -> (vec record { nat64; Event }) query;
+  get_events_by_principal_paged : (principal, nat64, nat64) -> (
+      EventsByPrincipalPagedResponse,
+    ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_fees : (nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
@@ -793,6 +806,7 @@ service : (ProtocolArg) -> {
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
   get_liquidatable_vaults : () -> (vec CandidVault) query;
+  get_liquidatable_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_liquidation_bonus : () -> (float64) query;
   get_liquidation_frozen : () -> (bool) query;
   get_liquidation_ordering_tolerance_bps : () -> (nat64) query;
@@ -827,9 +841,14 @@ service : (ProtocolArg) -> {
   get_three_pool_canister : () -> (opt principal) query;
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
+  get_vault_count : () -> (nat64) query;
   get_vault_history : (nat64) -> (vec record { nat64; Event }) query;
+  get_vault_history_paged : (nat64, nat64, nat64) -> (
+      GetEventsFilteredResponse,
+    ) query;
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
+  get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
   icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -574,6 +574,12 @@ export type EventTypeFilter = { 'BreakerTripped' : null } |
   { 'DeficitRepaid' : null } |
   { 'Redemption' : null } |
   { 'CloseVault' : null };
+export interface EventsByPrincipalPagedResponse {
+  'scan_end' : bigint,
+  'exhausted' : boolean,
+  'events' : Array<[bigint, Event]>,
+  'total_events' : bigint,
+}
 export type FeeSource = { 'BorrowingFee' : null } |
   { 'RedemptionFee' : null };
 export interface Fees { 'redemption_fee' : number, 'borrowing_fee' : number }
@@ -901,6 +907,10 @@ export interface VaultRedemption {
   'vault_id' : bigint,
   'collateral_seized' : bigint,
 }
+export interface VaultsPageResponse {
+  'vaults' : Array<CandidVault>,
+  'next_start_id' : [] | [bigint],
+}
 export type XrcAssetClass = { 'Cryptocurrency' : null } |
   { 'FiatCurrency' : null };
 export interface _SERVICE {
@@ -949,6 +959,10 @@ export interface _SERVICE {
   >,
   'get_events' : ActorMethod<[GetEventsArg], Array<Event>>,
   'get_events_by_principal' : ActorMethod<[Principal], Array<[bigint, Event]>>,
+  'get_events_by_principal_paged' : ActorMethod<
+    [Principal, bigint, bigint],
+    EventsByPrincipalPagedResponse
+  >,
   'get_events_filtered' : ActorMethod<
     [GetEventsArg],
     GetEventsFilteredResponse
@@ -959,6 +973,10 @@ export interface _SERVICE {
   'get_interest_pool_share' : ActorMethod<[], number>,
   'get_interest_split' : ActorMethod<[], Array<InterestSplitArg>>,
   'get_liquidatable_vaults' : ActorMethod<[], Array<CandidVault>>,
+  'get_liquidatable_vaults_page' : ActorMethod<
+    [bigint, bigint],
+    VaultsPageResponse
+  >,
   'get_liquidation_bonus' : ActorMethod<[], number>,
   'get_liquidation_frozen' : ActorMethod<[], boolean>,
   'get_liquidation_ordering_tolerance_bps' : ActorMethod<[], bigint>,
@@ -997,9 +1015,15 @@ export interface _SERVICE {
   'get_three_pool_canister' : ActorMethod<[], [] | [Principal]>,
   'get_treasury_principal' : ActorMethod<[], [] | [Principal]>,
   'get_treasury_stats' : ActorMethod<[], TreasuryStats>,
+  'get_vault_count' : ActorMethod<[], bigint>,
   'get_vault_history' : ActorMethod<[bigint], Array<[bigint, Event]>>,
+  'get_vault_history_paged' : ActorMethod<
+    [bigint, bigint, bigint],
+    GetEventsFilteredResponse
+  >,
   'get_vault_interest_rate' : ActorMethod<[bigint], Result_7>,
   'get_vaults' : ActorMethod<[[] | [Principal]], Array<CandidVault>>,
+  'get_vaults_page' : ActorMethod<[bigint, bigint], VaultsPageResponse>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,
   'icrc10_supported_standards' : ActorMethod<[], Array<StandardRecord>>,
   'icrc21_canister_call_consent_message' : ActorMethod<

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -615,6 +615,12 @@ export const idlFactory = ({ IDL }) => {
     }),
     'set_recovery_cr_multiplier' : IDL.Record({ 'multiplier' : IDL.Text }),
   });
+  const EventsByPrincipalPagedResponse = IDL.Record({
+    'scan_end' : IDL.Nat64,
+    'exhausted' : IDL.Bool,
+    'events' : IDL.Vec(IDL.Tuple(IDL.Nat64, Event)),
+    'total_events' : IDL.Nat64,
+  });
   const GetEventsFilteredResponse = IDL.Record({
     'total' : IDL.Nat64,
     'events' : IDL.Vec(IDL.Tuple(IDL.Nat64, Event)),
@@ -626,6 +632,10 @@ export const idlFactory = ({ IDL }) => {
   const InterestSplitArg = IDL.Record({
     'bps' : IDL.Nat64,
     'destination' : IDL.Text,
+  });
+  const VaultsPageResponse = IDL.Record({
+    'vaults' : IDL.Vec(CandidVault),
+    'next_start_id' : IDL.Opt(IDL.Nat64),
   });
   const LiquidityStatus = IDL.Record({
     'liquidity_provided' : IDL.Nat64,
@@ -938,6 +948,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Tuple(IDL.Nat64, Event))],
         ['query'],
       ),
+    'get_events_by_principal_paged' : IDL.Func(
+        [IDL.Principal, IDL.Nat64, IDL.Nat64],
+        [EventsByPrincipalPagedResponse],
+        ['query'],
+      ),
     'get_events_filtered' : IDL.Func(
         [GetEventsArg],
         [GetEventsFilteredResponse],
@@ -949,6 +964,11 @@ export const idlFactory = ({ IDL }) => {
     'get_interest_pool_share' : IDL.Func([], [IDL.Float64], ['query']),
     'get_interest_split' : IDL.Func([], [IDL.Vec(InterestSplitArg)], ['query']),
     'get_liquidatable_vaults' : IDL.Func([], [IDL.Vec(CandidVault)], ['query']),
+    'get_liquidatable_vaults_page' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [VaultsPageResponse],
+        ['query'],
+      ),
     'get_liquidation_bonus' : IDL.Func([], [IDL.Float64], ['query']),
     'get_liquidation_frozen' : IDL.Func([], [IDL.Bool], ['query']),
     'get_liquidation_ordering_tolerance_bps' : IDL.Func(
@@ -1017,15 +1037,26 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_treasury_stats' : IDL.Func([], [TreasuryStats], ['query']),
+    'get_vault_count' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_vault_history' : IDL.Func(
         [IDL.Nat64],
         [IDL.Vec(IDL.Tuple(IDL.Nat64, Event))],
+        ['query'],
+      ),
+    'get_vault_history_paged' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64, IDL.Nat64],
+        [GetEventsFilteredResponse],
         ['query'],
       ),
     'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_7], ['query']),
     'get_vaults' : IDL.Func(
         [IDL.Opt(IDL.Principal)],
         [IDL.Vec(CandidVault)],
+        ['query'],
+      ),
+    'get_vaults_page' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [VaultsPageResponse],
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse_1], ['query']),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -452,6 +452,12 @@ type EventTypeFilter = variant {
   Redemption;
   CloseVault;
 };
+type EventsByPrincipalPagedResponse = record {
+  scan_end : nat64;
+  exhausted : bool;
+  events : vec record { nat64; Event };
+  total_events : nat64;
+};
 type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
 type GetEventsArg = record {
@@ -749,6 +755,10 @@ type VaultRedemption = record {
   vault_id : nat64;
   collateral_seized : nat64;
 };
+type VaultsPageResponse = record {
+  vaults : vec CandidVault;
+  next_start_id : opt nat64;
+};
 type XrcAssetClass = variant { Cryptocurrency; FiatCurrency };
 service : (ProtocolArg) -> {
   add_collateral_token : (AddCollateralArg) -> (Result);
@@ -786,6 +796,9 @@ service : (ProtocolArg) -> {
   get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
   get_events_by_principal : (principal) -> (vec record { nat64; Event }) query;
+  get_events_by_principal_paged : (principal, nat64, nat64) -> (
+      EventsByPrincipalPagedResponse,
+    ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_fees : (nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
@@ -793,6 +806,7 @@ service : (ProtocolArg) -> {
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
   get_liquidatable_vaults : () -> (vec CandidVault) query;
+  get_liquidatable_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_liquidation_bonus : () -> (float64) query;
   get_liquidation_frozen : () -> (bool) query;
   get_liquidation_ordering_tolerance_bps : () -> (nat64) query;
@@ -827,9 +841,14 @@ service : (ProtocolArg) -> {
   get_three_pool_canister : () -> (opt principal) query;
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
+  get_vault_count : () -> (nat64) query;
   get_vault_history : (nat64) -> (vec record { nat64; Event }) query;
+  get_vault_history_paged : (nat64, nat64, nat64) -> (
+      GetEventsFilteredResponse,
+    ) query;
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
+  get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
   icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -301,6 +301,72 @@ pub struct GetEventsFilteredResponse {
     pub events: Vec<(u64, crate::event::Event)>,
 }
 
+/// Output cap on `get_vault_history` (DOS-001 legacy entry point) and
+/// page-size cap on `get_vault_history_paged`. Bounds the per-call
+/// reply size; for full historical access callers page via
+/// `get_vault_history_paged`. Audit Wave 9a (DOS-001).
+pub const MAX_VAULT_HISTORY: usize = 200;
+
+/// Output cap on `get_events_by_principal` (DOS-003 legacy entry point):
+/// the function returns the most recent matches in a bounded ring
+/// buffer of this size. Audit Wave 9a (DOS-003).
+pub const MAX_EVENTS_BY_PRINCIPAL_LEGACY: usize = 500;
+
+/// Per-call scan-window cap on `get_events_by_principal_paged`. A
+/// caller cannot scan more than this many event-log entries in a
+/// single call — pages chain to cover larger ranges. Audit Wave 9a
+/// (DOS-003).
+pub const MAX_EVENTS_BY_PRINCIPAL_SCAN: u64 = 5_000;
+
+/// Output cap on `get_events_by_principal_paged`: matches found in the
+/// scan window beyond this count truncate (the caller resumes from
+/// `scan_end`). Audit Wave 9a (DOS-003).
+pub const MAX_EVENTS_BY_PRINCIPAL_OUTPUT: usize = 500;
+
+/// Output cap on `get_all_vaults`, `get_vaults(None)`, and
+/// `get_liquidatable_vaults` legacy entry points. Bounds the per-call
+/// reply size; for full enumeration callers use the `*_page` paged
+/// variants. Audit Wave 9a (DOS-004).
+pub const MAX_VAULTS_LEGACY_PAGE: usize = 500;
+
+/// Page-size cap on `get_vaults_page` and
+/// `get_liquidatable_vaults_page`. Audit Wave 9a (DOS-004).
+pub const MAX_VAULTS_PAGE_LIMIT: u64 = 500;
+
+/// Paginated response for `get_vault_history_paged`. `events` is the
+/// page of matches in newest-first order within the requested window.
+/// `total` is the total matched-event count for this vault so the
+/// caller can render accurate page indicators. Audit Wave 9a (DOS-001).
+#[derive(candid::CandidType, Clone)]
+pub struct VaultHistoryPagedResponse {
+    pub total: u64,
+    pub events: Vec<(u64, crate::event::Event)>,
+}
+
+/// Paginated response for `get_events_by_principal_paged`. Cursor-based
+/// pagination over the global event log: caller passes `scan_start` and
+/// the response reports `scan_end` (resume offset for the next call)
+/// plus an `exhausted` flag once the scan has reached `total_events`.
+/// `events` are the matches found in the scanned window, in scan order.
+/// Audit Wave 9a (DOS-003).
+#[derive(candid::CandidType, Clone)]
+pub struct EventsByPrincipalPagedResponse {
+    pub events: Vec<(u64, crate::event::Event)>,
+    pub scan_end: u64,
+    pub exhausted: bool,
+    pub total_events: u64,
+}
+
+/// Paginated response for `get_vaults_page` / `get_liquidatable_vaults_page`.
+/// `vaults` is the page slice ordered by ascending `vault_id` starting at
+/// `start_id`. `next_start_id` is `Some(id)` to continue paging, `None`
+/// when the end of the map is reached. Audit Wave 9a (DOS-004).
+#[derive(candid::CandidType, candid::Deserialize, Debug)]
+pub struct VaultsPageResponse {
+    pub vaults: Vec<crate::vault::CandidVault>,
+    pub next_start_id: Option<u64>,
+}
+
 #[derive(CandidType, Deserialize, Debug)]
 pub struct LiquidityStatus {
     pub liquidity_provided: u64,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -13,6 +13,9 @@ use rumi_protocol_backend::{
     VaultArgWithToken, StableTokenType, InterestSplitArg,
     GetSnapshotsArg, ProtocolSnapshot, CollateralSnapshot,
     GetEventsFilteredResponse, StabilityPoolLiquidationResult,
+    VaultHistoryPagedResponse, EventsByPrincipalPagedResponse, VaultsPageResponse,
+    MAX_VAULT_HISTORY, MAX_EVENTS_BY_PRINCIPAL_LEGACY, MAX_EVENTS_BY_PRINCIPAL_SCAN,
+    MAX_EVENTS_BY_PRINCIPAL_OUTPUT, MAX_VAULTS_LEGACY_PAGE, MAX_VAULTS_PAGE_LIMIT,
 };
 use rumi_protocol_backend::logs::DEBUG;
 use rumi_protocol_backend::state::mutate_state;
@@ -692,6 +695,17 @@ fn get_fees(redeemed_amount: u64) -> Fees {
     })
 }
 
+/// Legacy entry point for the explorer's per-vault timeline. Kept for
+/// backwards-compat with cached frontend bundles, but now bounded:
+/// returns at most `MAX_VAULT_HISTORY` matches. When a vault has more
+/// than that many events, the newest matches are returned in chronological
+/// order (the frontend reverses for newest-first display). For full
+/// historical access, use `get_vault_history_paged`.
+///
+/// Audit Wave 9a (DOS-001): the previous unbounded scan walked every
+/// stable-log entry and decoded each one for `is_vault_related`. The
+/// per-call cost scaled linearly with total event-log size; this cap
+/// bounds the response to the most relevant slice.
 #[candid_method(query)]
 #[query]
 fn get_vault_history(vault_id: u64) -> Vec<(u64, Event)> {
@@ -699,16 +713,63 @@ fn get_vault_history(vault_id: u64) -> Vec<(u64, Event)> {
         ic_cdk::trap("update call rejected");
     }
 
-    // Iteration order matches the StableLog index, so enumerate() yields the
-    // global event-log index alongside each event. The explorer surfaces these
-    // ids on per-vault activity rows.
-    let mut vault_events: Vec<(u64, Event)> = vec![];
+    // Forward scan with a bounded ring buffer keeps the response size
+    // O(MAX_VAULT_HISTORY) regardless of total log length. Order in
+    // the buffer is chronological (oldest of the latest 200 first),
+    // matching the previous semantic — the frontend already reverses
+    // for newest-first display.
+    let mut buf: std::collections::VecDeque<(u64, Event)> =
+        std::collections::VecDeque::with_capacity(MAX_VAULT_HISTORY);
     for (idx, event) in events().enumerate() {
         if event.is_vault_related(&vault_id) {
-            vault_events.push((idx as u64, event));
+            if buf.len() == MAX_VAULT_HISTORY {
+                buf.pop_front();
+            }
+            buf.push_back((idx as u64, event));
         }
     }
-    vault_events
+    buf.into_iter().collect()
+}
+
+/// Paginated per-vault timeline. `start` indexes into matches sorted
+/// newest-first; `length` is the page size (capped at
+/// `MAX_VAULT_HISTORY_PAGE`). `total` is the total matched-event count
+/// for this vault so the caller can render accurate page indicators.
+///
+/// Audit Wave 9a (DOS-001): bounds response size and gives the
+/// explorer paged access to a vault's full history without forcing a
+/// single round-trip.
+#[candid_method(query)]
+#[query]
+fn get_vault_history_paged(vault_id: u64, start: u64, length: u64) -> VaultHistoryPagedResponse {
+    if ic_cdk::api::data_certificate().is_none() {
+        ic_cdk::trap("update call rejected");
+    }
+
+    let length = length.min(MAX_VAULT_HISTORY as u64);
+
+    let all_matches: Vec<(u64, Event)> = events()
+        .enumerate()
+        .filter(|(_, e)| e.is_vault_related(&vault_id))
+        .map(|(i, e)| (i as u64, e))
+        .collect();
+    let total = all_matches.len() as u64;
+
+    let events_page: Vec<(u64, Event)> = if start >= total {
+        Vec::new()
+    } else {
+        all_matches
+            .into_iter()
+            .rev()
+            .skip(start as usize)
+            .take(length as usize)
+            .collect()
+    };
+
+    VaultHistoryPagedResponse {
+        total,
+        events: events_page,
+    }
 }
 
 #[candid_method(query)]
@@ -901,24 +962,89 @@ fn write_filtered_events_cache(key: u64, now: u64, resp: &GetEventsFilteredRespo
     });
 }
 
-/// Return all events involving a given principal (as owner, caller, or liquidator).
+/// Legacy entry point for the explorer's per-principal activity feed.
+/// Returns up to `MAX_RESULTS` matches in newest-first order. The
+/// previous implementation materialised every match before slicing;
+/// we now use a bounded ring buffer so memory is O(MAX_RESULTS)
+/// regardless of total log length.
+///
+/// Audit Wave 9a (DOS-003): bounds response size and intermediate
+/// memory. The full-log scan complexity is unchanged — for callers
+/// that need to walk a very large log without paying that O(N) cost
+/// per call, use `get_events_by_principal_paged` to scan a bounded
+/// window per call.
 #[candid_method(query)]
 #[query]
 fn get_events_by_principal(principal: Principal) -> Vec<(u64, Event)> {
     if ic_cdk::api::data_certificate().is_none() {
         ic_cdk::trap("update call rejected");
     }
-    const MAX_RESULTS: usize = 500;
 
-    events()
-        .enumerate()
-        .filter(|(_, e)| !e.is_accrue_interest() && e.involves_principal(&principal))
-        .map(|(i, e)| (i as u64, e))
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .take(MAX_RESULTS)
-        .collect()
+    let mut buf: std::collections::VecDeque<(u64, Event)> =
+        std::collections::VecDeque::with_capacity(MAX_EVENTS_BY_PRINCIPAL_LEGACY);
+    for (idx, event) in events().enumerate() {
+        if !event.is_accrue_interest() && event.involves_principal(&principal) {
+            if buf.len() == MAX_EVENTS_BY_PRINCIPAL_LEGACY {
+                buf.pop_front();
+            }
+            buf.push_back((idx as u64, event));
+        }
+    }
+    // Newest-first matches the legacy `.rev().take(MAX_RESULTS)` ordering.
+    buf.into_iter().rev().collect()
+}
+
+/// Cursor-paginated principal activity feed. Caller passes
+/// `scan_start` (event-log index to begin scanning at, inclusive) and
+/// `scan_length` (number of log entries to walk in this call, capped
+/// at `MAX_SCAN_LENGTH`). The response reports the matches found in
+/// that window, the `scan_end` index where the next call should
+/// resume, and an `exhausted` flag set true once the scan reaches
+/// the current end of the event log.
+///
+/// Audit Wave 9a (DOS-003): bounds the per-call scan window so a
+/// caller paging through a very large log can never trigger an
+/// unbounded query — the scan stays under the cycle budget for any
+/// log size. Output is also capped at `MAX_OUTPUT_PER_CALL` matches
+/// to bound the response payload.
+#[candid_method(query)]
+#[query]
+fn get_events_by_principal_paged(
+    principal: Principal,
+    scan_start: u64,
+    scan_length: u64,
+) -> EventsByPrincipalPagedResponse {
+    if ic_cdk::api::data_certificate().is_none() {
+        ic_cdk::trap("update call rejected");
+    }
+
+    let total_events = rumi_protocol_backend::storage::count_events();
+    let scan_length = scan_length.min(MAX_EVENTS_BY_PRINCIPAL_SCAN);
+    let scan_end = scan_start.saturating_add(scan_length).min(total_events);
+
+    let mut events_page: Vec<(u64, Event)> = Vec::new();
+    if scan_start < total_events && scan_length > 0 {
+        for (offset, event) in events()
+            .skip(scan_start as usize)
+            .take(scan_length as usize)
+            .enumerate()
+        {
+            if !event.is_accrue_interest() && event.involves_principal(&principal) {
+                let idx = scan_start.saturating_add(offset as u64);
+                events_page.push((idx, event));
+                if events_page.len() == MAX_EVENTS_BY_PRINCIPAL_OUTPUT {
+                    break;
+                }
+            }
+        }
+    }
+
+    EventsByPrincipalPagedResponse {
+        events: events_page,
+        scan_end,
+        exhausted: scan_end >= total_events,
+        total_events,
+    }
 }
 
 #[candid_method(query)]
@@ -961,6 +1087,17 @@ fn get_liquidity_status(owner: Principal) -> LiquidityStatus {
     })
 }
 
+/// Vault lookup. With `target = Some(principal)` returns every vault
+/// owned by that principal (naturally bounded — typical principals own
+/// 1-2 vaults; the per-principal index walks at most a few entries).
+/// With `target = None` returns the first `MAX_VAULTS_LEGACY_PAGE`
+/// vaults by ascending `vault_id`. For full enumeration use
+/// `get_vaults_page` with cursoring.
+///
+/// Audit Wave 9a (DOS-004): the previous `target = None` branch cloned
+/// every vault and Candid-encoded the full set — at 10k+ vaults that
+/// pushed reply sizes into the megabyte range. The cap bounds the
+/// legacy reply; new callers paginate.
 #[candid_method(query)]
 #[query]
 fn get_vaults(target: Option<Principal>) -> Vec<CandidVault> {
@@ -978,11 +1115,46 @@ fn get_vaults(target: Option<Principal>) -> Vec<CandidVault> {
         None => read_state(|s| {
             s.vault_id_to_vaults
                 .values()
+                .take(MAX_VAULTS_LEGACY_PAGE)
                 .cloned()
                 .map(CandidVault::from)
                 .collect::<Vec<CandidVault>>()
         }),
     }
+}
+
+/// Paginated vault enumeration. Returns vaults with `vault_id >= start_id`
+/// up to `limit` entries (capped at `MAX_VAULTS_PAGE_LIMIT`), ordered
+/// ascending by `vault_id`. `next_start_id` is `Some(id)` when more
+/// vaults remain past this page, `None` when the end of the map is
+/// reached.
+///
+/// Audit Wave 9a (DOS-004): replaces unbounded `get_all_vaults` /
+/// `get_vaults(None)` reads with a cursor-based page so single-call
+/// reply size and instructions stay bounded at any TVL.
+#[candid_method(query)]
+#[query]
+fn get_vaults_page(start_id: u64, limit: u64) -> VaultsPageResponse {
+    let limit = limit.min(MAX_VAULTS_PAGE_LIMIT) as usize;
+
+    read_state(|s| {
+        let mut iter = s.vault_id_to_vaults.range(start_id..);
+        let mut vaults = Vec::with_capacity(limit);
+        for (_, vault) in iter.by_ref().take(limit) {
+            vaults.push(CandidVault::from(vault.clone()));
+        }
+        let next_start_id = iter.next().map(|(id, _)| *id);
+        VaultsPageResponse { vaults, next_start_id }
+    })
+}
+
+/// Total vault count (open + closed). Used by the explorer to size
+/// pagination controls without fetching the full vault list. Audit
+/// Wave 9a (DOS-004) companion to `get_vaults_page`.
+#[candid_method(query)]
+#[query]
+fn get_vault_count() -> u64 {
+    read_state(|s| s.vault_id_to_vaults.len() as u64)
 }
 
 // Vault related operations
@@ -1504,10 +1676,18 @@ async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Protoc
     check_postcondition(rumi_protocol_backend::vault::partial_liquidate_vault(arg).await)
 }
 
-// Add the new get liquidatable vaults endpoint
+/// Legacy entry point used by the layout's at-risk banner and the
+/// liquidator hot path. Returns the first `MAX_LIQUIDATABLE_LEGACY_PAGE`
+/// liquidatable vaults by ascending `vault_id`. New callers should
+/// use `get_liquidatable_vaults_page` for full enumeration.
+///
+/// Audit Wave 9a (DOS-004): bounds reply size and per-call instructions
+/// when a price drop pushes many vaults underwater simultaneously.
 #[candid_method(query)]
 #[query]
 fn get_liquidatable_vaults() -> Vec<CandidVault> {
+    // Wave 9a (DOS-004) shares `MAX_VAULTS_LEGACY_PAGE` with the other
+    // vault enumeration legacy entry points; the cap is the same.
     read_state(|s| {
         // Dummy rate for compute_collateral_ratio parameter (it uses per-collateral price internally)
         let dummy_rate = s.last_icp_rate.unwrap_or(UsdIcp::from(dec!(0.0)));
@@ -1522,18 +1702,62 @@ fn get_liquidatable_vaults() -> Vec<CandidVault> {
                 }
                 ratio < s.get_min_liquidation_ratio_for(&vault.collateral_type)
             })
+            .take(MAX_VAULTS_LEGACY_PAGE)
             .cloned()
             .map(CandidVault::from)
             .collect::<Vec<CandidVault>>()
     })
 }
 
+/// Paginated enumeration of currently-liquidatable vaults, ordered
+/// ascending by `vault_id` starting at `start_id`. `limit` is capped
+/// at `MAX_VAULTS_PAGE_LIMIT` (the same cap as `get_vaults_page`).
+/// `next_start_id` carries the cursor for the next page, or `None`
+/// once the scan has reached the end of the vault map.
+///
+/// Audit Wave 9a (DOS-004): pairs with `get_vaults_page` to give the
+/// liquidations UI bounded-cost paging at any TVL.
+#[candid_method(query)]
+#[query]
+fn get_liquidatable_vaults_page(start_id: u64, limit: u64) -> VaultsPageResponse {
+    let limit = limit.min(MAX_VAULTS_PAGE_LIMIT) as usize;
+
+    read_state(|s| {
+        let dummy_rate = s.last_icp_rate.unwrap_or(UsdIcp::from(dec!(0.0)));
+
+        let mut vaults = Vec::with_capacity(limit);
+        let mut next_start_id: Option<u64> = None;
+        for (id, vault) in s.vault_id_to_vaults.range(start_id..) {
+            let ratio = rumi_protocol_backend::compute_collateral_ratio(vault, dummy_rate, s);
+            if ratio == Ratio::from(Decimal::ZERO) {
+                continue;
+            }
+            if ratio < s.get_min_liquidation_ratio_for(&vault.collateral_type) {
+                if vaults.len() == limit {
+                    next_start_id = Some(*id);
+                    break;
+                }
+                vaults.push(CandidVault::from(vault.clone()));
+            }
+        }
+        VaultsPageResponse { vaults, next_start_id }
+    })
+}
+
+/// Legacy bulk vault enumeration. Returns the first
+/// `MAX_VAULTS_LEGACY_PAGE` vaults by ascending `vault_id`. New
+/// callers should use `get_vaults_page` for full enumeration.
+///
+/// Audit Wave 9a (DOS-004): the unbounded clone+encode path scaled
+/// linearly with `vault_id_to_vaults.len()` — the cap keeps a single
+/// call inside the cycle budget at any TVL.
 #[candid_method(query)]
 #[query]
 fn get_all_vaults() -> Vec<CandidVault> {
     read_state(|s| {
         s.vault_id_to_vaults
             .values()
+            .take(MAX_VAULTS_LEGACY_PAGE)
             .cloned()
             .map(CandidVault::from)
             .collect::<Vec<CandidVault>>()

--- a/src/rumi_protocol_backend/tests/audit_pocs_dos_pagination.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_dos_pagination.rs
@@ -1,0 +1,705 @@
+//! Wave-9a DoS hardening: paginated public queries (DOS-001, DOS-003,
+//! DOS-004).
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/findings.json` findings
+//!     DOS-001 (`get_vault_history`), DOS-003 (`get_events_by_principal`),
+//!     DOS-004 (`get_all_vaults` / `get_vaults(None)` /
+//!     `get_liquidatable_vaults`).
+//!   * Wave plan: `audit-reports/2026-04-22-28e9896/remediation-plan.md`
+//!     §"Wave 9 — DoS hardening", "Quick wins" subsection.
+//!
+//! # What the bugs were
+//!
+//! Each of the three legacy entry points walked an unbounded data
+//! structure in a single query:
+//!
+//!   * `get_vault_history(vault_id)` decoded every event in the stable
+//!     log to evaluate `is_vault_related`. As history grows
+//!     (`AccrueInterest` / `PriceUpdate` events fire on every tick) a
+//!     single call walks the full log; per-call cost scales linearly
+//!     with total log length.
+//!   * `get_events_by_principal(principal)` materialised every match
+//!     into a `Vec<(u64, Event)>` before truncating to MAX_RESULTS=500.
+//!     The `.collect()` step was unbounded in both scan and intermediate
+//!     allocation.
+//!   * `get_all_vaults()`, `get_vaults(None)`, and
+//!     `get_liquidatable_vaults()` cloned and Candid-encoded every vault
+//!     in `vault_id_to_vaults`. At 10k+ vaults the reply would push past
+//!     the 3 MB soft reply ceiling.
+//!
+//! # How this file tests the fix
+//!
+//! This file fences four behaviours:
+//!
+//!   * **Cap-value fence** — assert each public cap constant has its
+//!     audit-pinned value. The implementation references the same
+//!     constants, so a regression that lowers the cap (or raises it
+//!     past the audit budget) trips the fence.
+//!
+//!   * **Paged response shape** — the new `*Paged` / `*Page` response
+//!     types carry the cursor + total fields the explorer needs to
+//!     render accurate page indicators.
+//!
+//!   * **DOS-004 cursor round-trip** (PocketIC) — open ten vaults,
+//!     walk `get_vaults_page` at limit=3, assert (a) no page exceeds
+//!     the requested limit, (b) `next_start_id` advances strictly
+//!     forward, (c) the assembled stream covers every open vault
+//!     exactly once with no gaps or duplicates, (d) the final page's
+//!     `next_start_id` is `None`.
+//!
+//!   * **DOS-001 paged accuracy fence** (PocketIC) — open one vault and
+//!     drive ~30 vault-related events on it. Assert (a)
+//!     `get_vault_history(id)` returns every match (well under
+//!     MAX_VAULT_HISTORY), (b) `get_vault_history_paged(id, 0, 200)`
+//!     returns the same set with `total` matching, (c) the paged
+//!     events are ordered newest-first.
+//!
+//! Exhaustive cap-firing fences (response strictly truncated to the
+//! cap when total > cap) are documented to require >500 vaults / >200
+//! events / >500 principal events. The cap-value constant fences plus
+//! the implementation's `take(MAX_*)` / `length.min(MAX_*)` calls
+//! together pin the cap behavior; the cursor round-trip fence pins
+//! that paging is functionally correct without a single-call DoS.
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::{Duration, SystemTime};
+
+use rumi_protocol_backend::{
+    ProtocolError, MAX_EVENTS_BY_PRINCIPAL_LEGACY, MAX_EVENTS_BY_PRINCIPAL_OUTPUT,
+    MAX_EVENTS_BY_PRINCIPAL_SCAN, MAX_VAULTS_LEGACY_PAGE, MAX_VAULTS_PAGE_LIMIT,
+    MAX_VAULT_HISTORY,
+};
+
+// ─── Constants fences ───
+
+/// DOS-001: `get_vault_history` legacy entry point + page-size cap on
+/// `get_vault_history_paged`.
+#[test]
+fn dos_001_max_vault_history_pinned_at_200() {
+    assert_eq!(MAX_VAULT_HISTORY, 200,
+        "Wave-9a DOS-001: per-vault history cap must be 200 entries (audit budget). \
+         Lowering risks legacy callers losing recent activity; raising restores DoS surface.");
+}
+
+/// DOS-003: `get_events_by_principal` legacy + paged caps.
+#[test]
+fn dos_003_events_by_principal_caps_pinned() {
+    assert_eq!(MAX_EVENTS_BY_PRINCIPAL_LEGACY, 500,
+        "Wave-9a DOS-003: legacy ring-buffer output cap must be 500.");
+    assert_eq!(MAX_EVENTS_BY_PRINCIPAL_SCAN, 5_000,
+        "Wave-9a DOS-003: per-call scan-window cap must be 5_000 — bounds the \
+         instructions any single paged call can spend walking the event log.");
+    assert_eq!(MAX_EVENTS_BY_PRINCIPAL_OUTPUT, 500,
+        "Wave-9a DOS-003: paged output cap must be 500 — matches the legacy cap so \
+         a caller sees the same per-call payload boundary.");
+}
+
+/// DOS-004: legacy `get_all_vaults` / `get_vaults(None)` /
+/// `get_liquidatable_vaults` and the matching `*_page` variants.
+#[test]
+fn dos_004_vaults_page_caps_pinned() {
+    assert_eq!(MAX_VAULTS_LEGACY_PAGE, 500,
+        "Wave-9a DOS-004: legacy bulk-vault entry points must cap at 500 vaults — \
+         keeps a single Candid encode under the IC reply-size soft ceiling.");
+    assert_eq!(MAX_VAULTS_PAGE_LIMIT, 500,
+        "Wave-9a DOS-004: paged vaults entry points must cap `limit` at 500.");
+}
+
+// ─── ICRC-1 candid mirrors (lifted from existing audit POC fixtures) ───
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct FeatureFlags {
+    icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct MetadataValue {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+    #[serde(rename = "Nat")]
+    nat: Option<Nat>,
+    #[serde(rename = "Int")]
+    int: Option<i64>,
+    #[serde(rename = "Blob")]
+    blob: Option<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct InitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum LedgerArg {
+    #[serde(rename = "Init")]
+    Init(InitArgs),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ApproveArgs {
+    from_subaccount: Option<[u8; 32]>,
+    spender: Account,
+    amount: Nat,
+    expected_allowance: Option<Nat>,
+    expires_at: Option<u64>,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ApproveError {
+    BadFee { expected_fee: Nat },
+    InsufficientFunds { balance: Nat },
+    AllowanceChanged { current_allowance: Nat },
+    Expired { ledger_time: u64 },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+// ─── Backend init / vault types ───
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArgVariant {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct VaultArg {
+    vault_id: u64,
+    amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct OpenVaultSuccess {
+    vault_id: u64,
+    block_index: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct CandidVault {
+    collateral_amount: u64,
+    owner: Principal,
+    vault_id: u64,
+    collateral_type: Principal,
+    accrued_interest: u64,
+    icp_margin_amount: u64,
+    borrowed_icusd_amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct VaultsPageResponse {
+    vaults: Vec<CandidVault>,
+    next_start_id: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct VaultHistoryPagedResponse {
+    total: u64,
+    /// `Event` is decoded as `IDLValue` here — we only need the index
+    /// shape for these fences, not the full variant decoding.
+    events: Vec<(u64, candid::Reserved)>,
+}
+
+// ─── Wasm fixtures ───
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn protocol_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn xrc_wasm() -> Vec<u8> {
+    include_bytes!("../../xrc_demo/xrc/xrc.wasm").to_vec()
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+struct MockXRC {
+    rates: Vec<(String, u64)>,
+}
+
+fn prepare_mock_xrc() -> Vec<u8> {
+    let mock = MockXRC {
+        rates: vec![("ICP/USD".to_string(), 1_000_000_000)], // $10.00 e8s
+    };
+    encode_one(mock).expect("encode mock XRC init")
+}
+
+// ─── Helpers ───
+
+fn account(owner: Principal) -> Account {
+    Account { owner, subaccount: None }
+}
+
+fn deploy_icrc1_ledger(
+    pic: &PocketIc,
+    minting_account: Account,
+    transfer_fee: u64,
+    initial_balances: Vec<(Account, Nat)>,
+    name: &str,
+    symbol: &str,
+    controller: Principal,
+) -> Principal {
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = InitArgs {
+        minting_account,
+        fee_collector_account: None,
+        transfer_fee: Nat::from(transfer_fee),
+        decimals: Some(8),
+        max_memo_length: Some(64),
+        token_name: name.into(),
+        token_symbol: symbol.into(),
+        metadata: vec![],
+        initial_balances,
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: controller,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).expect("encode ledger init"),
+        None,
+    );
+    ledger_id
+}
+
+fn icrc2_approve_call(
+    pic: &PocketIc,
+    ledger: Principal,
+    sender: Principal,
+    spender: Principal,
+    amount: u128,
+) {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: account(spender),
+        amount: Nat::from(amount),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    let result = pic
+        .update_call(ledger, sender, "icrc2_approve", encode_one(args).unwrap())
+        .expect("icrc2_approve call failed");
+    let parsed: Result<Nat, ApproveError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode icrc2_approve"),
+        WasmResult::Reject(m) => panic!("icrc2_approve rejected: {}", m),
+    };
+    parsed.expect("approve returned error");
+}
+
+// ─── Fixture ───
+
+struct Fixture {
+    pic: PocketIc,
+    protocol_id: Principal,
+    icp_ledger: Principal,
+    test_user: Principal,
+}
+
+/// Stand up the protocol with a mock XRC at $10/ICP, mint a fat ICP
+/// balance to `test_user`, and pre-approve the protocol for that
+/// allowance. Borrowing fee + interest curves are zeroed so opens are
+/// exact and don't drift the test math.
+fn setup_fixture(initial_icp_e8s: u128) -> Fixture {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+
+    let test_user = Principal::self_authenticating(b"dos_pagination_test_user");
+    let developer = Principal::self_authenticating(b"dos_pagination_developer");
+
+    let protocol_id = pic.create_canister();
+    pic.add_cycles(protocol_id, 2_000_000_000_000);
+    pic.set_controllers(protocol_id, None, vec![Principal::anonymous(), developer])
+        .expect("set_controllers failed");
+
+    let icp_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        10_000,
+        vec![(account(test_user), Nat::from(initial_icp_e8s))],
+        "Internet Computer Protocol",
+        "ICP",
+        developer,
+    );
+
+    let icusd_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        0,
+        vec![],
+        "icUSD",
+        "icUSD",
+        developer,
+    );
+
+    let xrc_id = pic.create_canister();
+    pic.add_cycles(xrc_id, 1_000_000_000_000);
+    pic.install_canister(xrc_id, xrc_wasm(), prepare_mock_xrc(), None);
+
+    pic.set_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1_711_324_800));
+
+    let init = ProtocolArgVariant::Init(ProtocolInitArg {
+        fee_e8s: 10_000,
+        icp_ledger_principal: icp_ledger,
+        xrc_principal: xrc_id,
+        icusd_ledger_principal: icusd_ledger,
+        developer_principal: developer,
+    });
+    pic.install_canister(
+        protocol_id,
+        protocol_wasm(),
+        encode_args((init,)).expect("encode protocol init"),
+        None,
+    );
+
+    pic.advance_time(Duration::from_secs(1));
+    for _ in 0..10 {
+        pic.tick();
+    }
+
+    // Zero out fee/interest curves so the test math stays exact.
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_borrowing_fee_curve",
+            encode_args((None::<String>,)).unwrap(),
+        )
+        .expect("set_borrowing_fee_curve");
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_rate_curve_markers",
+            encode_args((None::<Principal>, vec![(1.5f64, 1.0f64), (3.0f64, 1.0f64)])).unwrap(),
+        )
+        .expect("set_rate_curve_markers");
+    let _ = pic
+        .update_call(
+            protocol_id,
+            developer,
+            "set_borrowing_fee",
+            encode_args((0.0f64,)).unwrap(),
+        )
+        .expect("set_borrowing_fee");
+
+    // Approve once with the full balance so subsequent open_vaults can
+    // pull collateral without a fresh approve per call.
+    icrc2_approve_call(&pic, icp_ledger, test_user, protocol_id, initial_icp_e8s);
+
+    Fixture { pic, protocol_id, icp_ledger, test_user }
+}
+
+fn open_collateral_only_vault(f: &Fixture, collateral_e8s: u64) -> u64 {
+    let result = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.test_user,
+            "open_vault",
+            encode_args((collateral_e8s, None::<Principal>)).unwrap(),
+        )
+        .expect("open_vault failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<OpenVaultSuccess, ProtocolError> =
+                decode_one(&bytes).expect("decode open_vault");
+            r.expect("open_vault returned error").vault_id
+        }
+        WasmResult::Reject(msg) => panic!("open_vault rejected: {}", msg),
+    }
+}
+
+fn add_margin(f: &Fixture, vault_id: u64, amount_e8s: u64) {
+    let result = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.test_user,
+            "add_margin_to_vault",
+            encode_args((VaultArg { vault_id, amount: amount_e8s },)).unwrap(),
+        )
+        .expect("add_margin call failed");
+    if let WasmResult::Reject(m) = result {
+        panic!("add_margin rejected: {}", m);
+    }
+}
+
+fn query_get_vaults_page(f: &Fixture, start_id: u64, limit: u64) -> VaultsPageResponse {
+    let result = f
+        .pic
+        .query_call(
+            f.protocol_id,
+            Principal::anonymous(),
+            "get_vaults_page",
+            encode_args((start_id, limit)).unwrap(),
+        )
+        .expect("get_vaults_page query failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_vaults_page"),
+        WasmResult::Reject(m) => panic!("get_vaults_page rejected: {}", m),
+    }
+}
+
+fn query_get_vault_count(f: &Fixture) -> u64 {
+    let result = f
+        .pic
+        .query_call(
+            f.protocol_id,
+            Principal::anonymous(),
+            "get_vault_count",
+            encode_args(()).unwrap(),
+        )
+        .expect("get_vault_count query failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_vault_count"),
+        WasmResult::Reject(m) => panic!("get_vault_count rejected: {}", m),
+    }
+}
+
+fn query_get_vault_history(f: &Fixture, vault_id: u64) -> Vec<(u64, candid::Reserved)> {
+    let result = f
+        .pic
+        .query_call(
+            f.protocol_id,
+            f.test_user,
+            "get_vault_history",
+            encode_args((vault_id,)).unwrap(),
+        )
+        .expect("get_vault_history query failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_vault_history"),
+        WasmResult::Reject(m) => panic!("get_vault_history rejected: {}", m),
+    }
+}
+
+fn query_get_vault_history_paged(
+    f: &Fixture,
+    vault_id: u64,
+    start: u64,
+    length: u64,
+) -> VaultHistoryPagedResponse {
+    let result = f
+        .pic
+        .query_call(
+            f.protocol_id,
+            f.test_user,
+            "get_vault_history_paged",
+            encode_args((vault_id, start, length)).unwrap(),
+        )
+        .expect("get_vault_history_paged query failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode get_vault_history_paged"),
+        WasmResult::Reject(m) => panic!("get_vault_history_paged rejected: {}", m),
+    }
+}
+
+// ─── PocketIC fences ───
+
+/// Wave-9a DOS-004 cursor round-trip: open ten small vaults, walk
+/// `get_vaults_page` at limit=3, assert (a) no page exceeds the
+/// requested limit, (b) `next_start_id` advances strictly forward,
+/// (c) the assembled stream covers every open vault exactly once,
+/// (d) the final page's `next_start_id` is `None`.
+#[test]
+fn dos_004_get_vaults_page_cursor_round_trip() {
+    // 10 vaults * 1.0 ICP each + 100 ICP slack for fees.
+    let f = setup_fixture(20_000_000_000u128);
+
+    let mut opened_ids: Vec<u64> = Vec::with_capacity(10);
+    for _ in 0..10 {
+        let id = open_collateral_only_vault(&f, 100_000_000); // 1 ICP
+        opened_ids.push(id);
+    }
+    opened_ids.sort();
+
+    assert_eq!(query_get_vault_count(&f), 10);
+
+    // Walk pages of 3 starting at id 0.
+    let mut walked: Vec<u64> = Vec::new();
+    let mut cursor: u64 = 0;
+    let mut prev_cursor: Option<u64> = None;
+    let mut call_count: u32 = 0;
+    loop {
+        let resp = query_get_vaults_page(&f, cursor, 3);
+        assert!(
+            resp.vaults.len() <= 3,
+            "Wave-9a DOS-004: response must not exceed requested limit (got {}, asked 3)",
+            resp.vaults.len(),
+        );
+        for v in &resp.vaults {
+            walked.push(v.vault_id);
+        }
+        call_count += 1;
+        match resp.next_start_id {
+            Some(next) => {
+                if let Some(prev) = prev_cursor {
+                    assert!(
+                        next > prev,
+                        "next_start_id must advance strictly forward: prev={}, next={}",
+                        prev, next,
+                    );
+                }
+                prev_cursor = Some(next);
+                cursor = next;
+            }
+            None => break,
+        }
+        // Defensive guard against an infinite loop if next_start_id ever
+        // failed to advance — limit at 10x the page count needed.
+        assert!(call_count < 20, "cursor walk failed to terminate");
+    }
+
+    walked.sort();
+    assert_eq!(walked, opened_ids,
+        "cursor walk must yield every opened vault exactly once with no gaps or duplicates");
+    assert_eq!(call_count, 4,
+        "10 vaults at limit=3 should take ceil(10/3) + final-empty-or-3rd-with-no-next = 4 calls");
+}
+
+/// Wave-9a DOS-004 absolute cap firing fence: a caller can pass
+/// `limit = u64::MAX` and the canister must clamp the page to
+/// `MAX_VAULTS_PAGE_LIMIT` BEFORE reading the BTreeMap range. With ten
+/// vaults the natural total bounds the response below the cap, so
+/// this fence proves the clamp doesn't crash on huge inputs and
+/// returns the natural total — pre-fix code would also have done
+/// this, but pre-fix code with > 500 vaults would have walked past
+/// the cap. The cap fence at the constant level (above) plus this
+/// "huge limit doesn't crash" fence together pin the contract.
+#[test]
+fn dos_004_get_vaults_page_handles_unbounded_limit() {
+    let f = setup_fixture(20_000_000_000u128);
+
+    for _ in 0..10 {
+        open_collateral_only_vault(&f, 100_000_000);
+    }
+
+    let resp = query_get_vaults_page(&f, 0, u64::MAX);
+    assert_eq!(
+        resp.vaults.len(),
+        10,
+        "with 10 vaults total, response must contain all 10 (clamping limit must not \
+         drop entries below the natural total)",
+    );
+    assert!(resp.next_start_id.is_none(),
+        "10 vaults < cap: there should be no continuation cursor");
+    // Also a lower bound check on the cap: response.len <= MAX_VAULTS_PAGE_LIMIT.
+    assert!(
+        (resp.vaults.len() as u64) <= MAX_VAULTS_PAGE_LIMIT,
+        "Wave-9a DOS-004: response.len must always be <= MAX_VAULTS_PAGE_LIMIT",
+    );
+}
+
+/// Wave-9a DOS-001 paged accuracy fence: open one vault and drive ~30
+/// vault-related events on it via `add_margin_to_vault` (each
+/// generates `MarginTransfer` + `CollateralDeposited`). Assert (a)
+/// `get_vault_history(id)` returns every match (well under
+/// `MAX_VAULT_HISTORY`), (b) `get_vault_history_paged(id, 0, 200)`
+/// returns the same set with `total` matching, (c) the paged events
+/// are ordered newest-first (highest event index first).
+#[test]
+fn dos_001_get_vault_history_paged_matches_legacy() {
+    // 1 vault opened + 30 add_margin * 0.1 ICP + slack for fees.
+    let f = setup_fixture(50_000_000_000u128);
+
+    let vault_id = open_collateral_only_vault(&f, 1_000_000_000); // 10 ICP
+
+    for _ in 0..30 {
+        add_margin(&f, vault_id, 10_000_000); // 0.1 ICP each
+    }
+
+    let legacy = query_get_vault_history(&f, vault_id);
+    assert!(
+        legacy.len() <= MAX_VAULT_HISTORY,
+        "Wave-9a DOS-001: legacy entry point must respect MAX_VAULT_HISTORY ({}) — got {}",
+        MAX_VAULT_HISTORY, legacy.len(),
+    );
+    assert!(
+        legacy.len() >= 31,
+        "expected at least one OpenVault + 30 add_margin events (got {})",
+        legacy.len(),
+    );
+
+    let paged = query_get_vault_history_paged(&f, vault_id, 0, 200);
+    assert_eq!(
+        paged.total as usize,
+        legacy.len(),
+        "paged `total` must equal the legacy match count (both reflect every event \
+         touching this vault)",
+    );
+    assert_eq!(
+        paged.events.len() as usize,
+        legacy.len().min(200),
+        "first page must contain min(total, length) events",
+    );
+
+    // Newest-first ordering: paged event indices descend.
+    let indices: Vec<u64> = paged.events.iter().map(|(idx, _)| *idx).collect();
+    assert!(
+        indices.windows(2).all(|w| w[0] > w[1]),
+        "Wave-9a DOS-001: paged events must be newest-first (descending event-log index); \
+         got indices: {:?}",
+        indices,
+    );
+}

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -239,17 +239,34 @@ pub fn get_liquidation_history(limit: Option<u64>) -> Vec<PoolLiquidationRecord>
     })
 }
 
+/// Server-side cap on `length` for `get_pool_events`. Audit Wave 9a
+/// (DOS-008): without this cap a caller could pass `length = u64::MAX`
+/// and force the canister to slice up to the full pool-event log on a
+/// single query — the same cycle-DoS pattern fixed for the backend's
+/// `get_events`.
+pub const MAX_POOL_EVENTS_PAGE: u64 = 500;
+
+/// Pure paging helper for `get_pool_events`. Clamps `length` to
+/// `MAX_POOL_EVENTS_PAGE` before slicing so a single call's reply size
+/// is bounded regardless of caller input. Extracted from the `#[query]`
+/// wrapper so the audit fence can exercise the clamp without spinning
+/// up a canister fixture.
+pub fn pool_events_page(events: &[PoolEvent], start: u64, length: u64) -> Vec<PoolEvent> {
+    let length = length.min(MAX_POOL_EVENTS_PAGE);
+    let total = events.len() as u64;
+    if start >= total {
+        return Vec::new();
+    }
+    let end = (start + length).min(total) as usize;
+    events[start as usize..end].to_vec()
+}
+
+/// Paginated pool-event log. `length` is server-side clamped via
+/// `pool_events_page` so a caller cannot request the entire log in a
+/// single call, regardless of input. Audit Wave 9a (DOS-008).
 #[query]
 pub fn get_pool_events(start: u64, length: u64) -> Vec<PoolEvent> {
-    read_state(|s| {
-        let events = s.pool_events();
-        let total = events.len() as u64;
-        if start >= total {
-            return vec![];
-        }
-        let end = (start + length).min(total) as usize;
-        events[start as usize..end].to_vec()
-    })
+    read_state(|s| pool_events_page(s.pool_events(), start, length))
 }
 
 #[query]

--- a/src/stability_pool/tests/audit_pocs_dos_008_pool_events_clamp.rs
+++ b/src/stability_pool/tests/audit_pocs_dos_008_pool_events_clamp.rs
@@ -1,0 +1,177 @@
+//! Wave-9a DOS-008: stability-pool `get_pool_events` must clamp the
+//! caller-supplied `length` argument before slicing the pool-event log,
+//! so a single query call's reply size and per-call slice cost stay
+//! bounded regardless of caller input.
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/findings.json` finding DOS-008
+//!     ("get_pool_events on stability pool accepts unbounded length
+//!     argument").
+//!
+//! # What the bug was
+//!
+//! Pre-fix `get_pool_events(start, length)` did
+//!
+//!   ```text
+//!   let end = (start + length).min(total) as usize;
+//!   events[start as usize..end].to_vec()
+//!   ```
+//!
+//! with no upper cap on `length`. A caller could pass
+//! `length = u64::MAX` and force the canister to slice up to the full
+//! pool-event log into a single reply, paying the per-element cycle and
+//! reply-size cost in one shot. As the SP's `pool_events` log grows over
+//! time (capped at `MAX_POOL_EVENTS` ~ 10k internally), the slice would
+//! eventually approach the IC's 2 MB reply limit and consume hundreds of
+//! millions of instructions on a single query.
+//!
+//! # How this file tests the fix
+//!
+//! The slicing logic was extracted from the `#[query]` wrapper into the
+//! pure `pool_events_page(events, start, length)` helper so it can be
+//! driven directly without standing up a canister fixture. Two
+//! behavioural fences plus one numeric fence:
+//!
+//!   * `dos_008_get_pool_events_clamps_unbounded_length_arg` — the
+//!     load-bearing audit fence. Build a 600-event log; call
+//!     `pool_events_page(events, 0, u64::MAX)`. Assert the reply length
+//!     is exactly `MAX_POOL_EVENTS_PAGE` (500) — i.e., the clamp ran.
+//!     Pre-fix code would have returned 600 events (the full log).
+//!
+//!   * `dos_008_pool_events_page_respects_natural_total_under_cap` —
+//!     regression fence. Build a 50-event log (well under the cap);
+//!     ask for `length = 1000`. The natural `total` should win, so the
+//!     reply is 50 events. Without this case the previous fence cannot
+//!     distinguish "clamp fired" from "log was empty".
+//!
+//!   * `dos_008_pool_events_page_cursor_round_trip` — page-correctness
+//!     fence. Walk a 1100-event log in three calls of 500 + 500 + 100
+//!     and assert (a) the IDs reassemble in order with no gaps or
+//!     duplicates, (b) each call's reply is bounded by
+//!     `MAX_POOL_EVENTS_PAGE`, (c) the third call sees only the
+//!     remainder of the log.
+
+use candid::Principal;
+
+use stability_pool::types::{PoolEvent, PoolEventType};
+use stability_pool::{pool_events_page, MAX_POOL_EVENTS_PAGE};
+
+/// Build a synthetic pool-event log of the requested length. Each event
+/// gets a unique `id` so the cursor-round-trip fence can verify slice
+/// boundaries by inspecting reassembled ids.
+fn synth_events(n: u64) -> Vec<PoolEvent> {
+    (0..n)
+        .map(|i| PoolEvent {
+            id: i,
+            timestamp: i,
+            caller: Principal::anonymous(),
+            event_type: PoolEventType::OptInCollateral {
+                collateral_type: Principal::anonymous(),
+            },
+        })
+        .collect()
+}
+
+#[test]
+fn dos_008_get_pool_events_clamps_unbounded_length_arg() {
+    // 600-event log so the post-clamp reply (500) is strictly smaller
+    // than the pre-fix unbounded reply would have been (600). If the
+    // clamp regresses, the reply will exceed MAX_POOL_EVENTS_PAGE.
+    let events = synth_events(600);
+
+    let page = pool_events_page(&events, 0, u64::MAX);
+
+    assert_eq!(
+        page.len() as u64,
+        MAX_POOL_EVENTS_PAGE,
+        "DOS-008: caller-supplied length must be clamped to MAX_POOL_EVENTS_PAGE \
+         before slicing — got reply of {} events for a {}-event log with length=u64::MAX",
+        page.len(),
+        events.len(),
+    );
+    // Cap is the lower of (length, total). Confirm the slice boundary
+    // matches: ids 0..MAX_POOL_EVENTS_PAGE.
+    assert_eq!(page.first().map(|e| e.id), Some(0));
+    assert_eq!(
+        page.last().map(|e| e.id),
+        Some(MAX_POOL_EVENTS_PAGE - 1),
+        "first page must end at id=MAX_POOL_EVENTS_PAGE-1, not before",
+    );
+}
+
+#[test]
+fn dos_008_pool_events_page_respects_natural_total_under_cap() {
+    // Regression fence: when total < MAX_POOL_EVENTS_PAGE the natural
+    // `total` should still bound the reply. This rules out a "broken
+    // clamp returns MAX_POOL_EVENTS_PAGE elements regardless" failure
+    // mode where the implementation hard-pads the response.
+    let events = synth_events(50);
+
+    let page = pool_events_page(&events, 0, 1_000);
+
+    assert_eq!(
+        page.len(),
+        50,
+        "natural total < cap: reply must be the full log, not pad to cap",
+    );
+    assert_eq!(page.first().map(|e| e.id), Some(0));
+    assert_eq!(page.last().map(|e| e.id), Some(49));
+}
+
+#[test]
+fn dos_008_pool_events_page_cursor_round_trip() {
+    // 1100-event log: walk it in three calls and assert the cap fires
+    // on each call until the tail is reached. Concretely: the first two
+    // calls should each return MAX_POOL_EVENTS_PAGE (500) events, the
+    // third should return the remainder (100) and an empty fourth call
+    // should mean the cursor reached the end.
+    const TOTAL: u64 = 1_100;
+    let events = synth_events(TOTAL);
+
+    let mut cursor: u64 = 0;
+    let mut collected: Vec<u64> = Vec::with_capacity(TOTAL as usize);
+    let mut call_count: u32 = 0;
+    while cursor < TOTAL {
+        let page = pool_events_page(&events, cursor, u64::MAX);
+        assert!(
+            page.len() as u64 <= MAX_POOL_EVENTS_PAGE,
+            "DOS-008: every call's reply must be bounded by MAX_POOL_EVENTS_PAGE; \
+             cursor={} got {} events",
+            cursor,
+            page.len(),
+        );
+        // No empty page allowed mid-walk — that would loop forever.
+        assert!(
+            !page.is_empty(),
+            "non-empty log mid-walk must return at least one event \
+             (cursor={}, total={})",
+            cursor,
+            TOTAL,
+        );
+        for ev in &page {
+            collected.push(ev.id);
+        }
+        cursor += page.len() as u64;
+        call_count += 1;
+    }
+
+    assert_eq!(
+        call_count, 3,
+        "1100-event log at 500-per-call ceiling should take exactly 3 calls",
+    );
+    assert_eq!(
+        collected.len() as u64,
+        TOTAL,
+        "cursor walk must collect every event (no gaps, no duplicates)",
+    );
+    // ids reassemble in order: this catches off-by-one on the boundary
+    // between calls (skipping the seam event, or returning it twice).
+    assert!(
+        collected.iter().enumerate().all(|(i, id)| *id == i as u64),
+        "cursor walk must yield ids 0..TOTAL in order without gaps or duplicates",
+    );
+
+    // Past the end: an extra call with cursor == TOTAL should be empty.
+    let past_end = pool_events_page(&events, TOTAL, u64::MAX);
+    assert!(past_end.is_empty(), "calling past total must return empty page");
+}

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -475,14 +475,33 @@ export async function fetchCollateralPrices(): Promise<Map<string, number>> {
 
 // ── Vaults ───────────────────────────────────────────────────────────────────
 
+/**
+ * Page size for cursored vault enumeration. Backend caps each page at 500
+ * (Wave-9a DOS-004 hard limit on `get_vaults_page` / `get_liquidatable_vaults_page`).
+ */
+const VAULT_PAGE_SIZE = 500n;
+/**
+ * Defensive cap on chained pages — at 500 per page that's 50,000 vaults,
+ * comfortably above any realistic TVL. Stops a misbehaving cursor (one that
+ * fails to advance) from looping forever.
+ */
+const VAULT_PAGE_MAX_PAGES = 100;
+
 export async function fetchAllVaults(): Promise<any[]> {
 	const key = 'vaults:all';
 	const cached = getCached<any[]>(key, TTL.VAULTS);
 	if (cached) return cached;
 
 	try {
-		const result = await publicActor.get_all_vaults();
-		return setCache(key, result);
+		const all: any[] = [];
+		let startId = 0n;
+		for (let page = 0; page < VAULT_PAGE_MAX_PAGES; page += 1) {
+			const resp = await publicActor.get_vaults_page(startId, VAULT_PAGE_SIZE);
+			all.push(...resp.vaults);
+			if (resp.next_start_id.length === 0) break;
+			startId = resp.next_start_id[0];
+		}
+		return setCache(key, all);
 	} catch (err) {
 		console.error('[explorerService] fetchAllVaults failed:', err);
 		return [];
@@ -760,14 +779,42 @@ export async function fetchProtocolFeeTotalsFromBackend(
 	return setCache(key, out);
 }
 
+/**
+ * Per-call scan window for the cursored principal-events helper. Backend
+ * caps `scan_length` at 5,000 (Wave-9a DOS-003); we ask for the ceiling so a
+ * typical-size protocol's full log is reachable in a small number of calls.
+ */
+const PRINCIPAL_EVENTS_SCAN_LENGTH = 5_000n;
+/**
+ * Defensive ceiling on chained scan windows. At 5k events per window that's
+ * 500k events of coverage — well above the current log size — but still bounds
+ * a buggy `scan_end` from spinning forever.
+ */
+const PRINCIPAL_EVENTS_MAX_PAGES = 100;
+
 export async function fetchEventsByPrincipal(principal: Principal): Promise<[bigint, any][]> {
 	const key = `events:principal:${principal.toText()}`;
 	const cached = getCached<[bigint, any][]>(key, TTL.EVENTS);
 	if (cached) return cached;
 
 	try {
-		const result = await publicActor.get_events_by_principal(principal);
-		return setCache(key, result);
+		const all: [bigint, any][] = [];
+		let scanStart = 0n;
+		for (let page = 0; page < PRINCIPAL_EVENTS_MAX_PAGES; page += 1) {
+			const resp = await publicActor.get_events_by_principal_paged(
+				principal,
+				scanStart,
+				PRINCIPAL_EVENTS_SCAN_LENGTH,
+			);
+			for (const entry of resp.events) {
+				all.push([entry[0], entry[1]]);
+			}
+			if (resp.exhausted) break;
+			// Defensive: if the cursor doesn't advance, stop rather than loop.
+			if (resp.scan_end <= scanStart) break;
+			scanStart = resp.scan_end;
+		}
+		return setCache(key, all);
 	} catch (err) {
 		console.error('[explorerService] fetchEventsByPrincipal failed:', err);
 		return [];
@@ -787,8 +834,15 @@ export async function fetchLiquidatableVaults(): Promise<any[]> {
 	if (cached) return cached;
 
 	try {
-		const result = await publicActor.get_liquidatable_vaults();
-		return setCache(key, result);
+		const all: any[] = [];
+		let startId = 0n;
+		for (let page = 0; page < VAULT_PAGE_MAX_PAGES; page += 1) {
+			const resp = await publicActor.get_liquidatable_vaults_page(startId, VAULT_PAGE_SIZE);
+			all.push(...resp.vaults);
+			if (resp.next_start_id.length === 0) break;
+			startId = resp.next_start_id[0];
+		}
+		return setCache(key, all);
 	} catch (err) {
 		console.error('[explorerService] fetchLiquidatableVaults failed:', err);
 		return [];

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -2224,10 +2224,37 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
            lowerMsg.includes('tried to close unknown vault');
   }
 
+    /**
+     * Page size for the cursor-based vault enumeration helpers below. The
+     * backend caps each page at 500 (Wave-9a DOS-004); we ask for that ceiling
+     * so a typical-size protocol comes back in a single call. Pages are
+     * stitched into one array so existing call sites still see the full set.
+     */
+    static readonly VAULT_PAGE_SIZE = 500n;
+
+    /**
+     * Defensive ceiling on the number of paginated calls we'll chain in
+     * `getLiquidatableVaults` / `getAllVaults`. At 500 vaults per page this
+     * caps a single fetch at 50,000 vaults — well above any realistic TVL,
+     * but it stops a buggy `next_start_id` (e.g. cursor that fails to advance)
+     * from spinning forever.
+     */
+    static readonly VAULT_PAGE_MAX_PAGES = 100;
+
     static async getLiquidatableVaults(): Promise<CandidVault[]> {
       try {
-        const vaults = await ApiClient.getPublicData<CandidVault[]>('get_liquidatable_vaults');
-        return vaults;
+        const all: CandidVault[] = [];
+        let startId = 0n;
+        for (let page = 0; page < ApiClient.VAULT_PAGE_MAX_PAGES; page += 1) {
+          const resp = await ApiClient.getPublicData<{
+            vaults: CandidVault[];
+            next_start_id: [] | [bigint];
+          }>('get_liquidatable_vaults_page', startId, ApiClient.VAULT_PAGE_SIZE);
+          all.push(...resp.vaults);
+          if (resp.next_start_id.length === 0) break;
+          startId = resp.next_start_id[0];
+        }
+        return all;
       } catch (err) {
         console.error('Failed to get liquidatable vaults:', err);
         return [];
@@ -2236,8 +2263,18 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
 
     static async getAllVaults(): Promise<CandidVault[]> {
       try {
-        const vaults = await ApiClient.getPublicData<CandidVault[]>('get_all_vaults');
-        return vaults;
+        const all: CandidVault[] = [];
+        let startId = 0n;
+        for (let page = 0; page < ApiClient.VAULT_PAGE_MAX_PAGES; page += 1) {
+          const resp = await ApiClient.getPublicData<{
+            vaults: CandidVault[];
+            next_start_id: [] | [bigint];
+          }>('get_vaults_page', startId, ApiClient.VAULT_PAGE_SIZE);
+          all.push(...resp.vaults);
+          if (resp.next_start_id.length === 0) break;
+          startId = resp.next_start_id[0];
+        }
+        return all;
       } catch (err) {
         console.error('Failed to get all vaults:', err);
         return [];

--- a/src/vault_frontend/src/lib/stores/explorerStore.ts
+++ b/src/vault_frontend/src/lib/stores/explorerStore.ts
@@ -116,12 +116,25 @@ export async function fetchSnapshots() {
 	}
 }
 
+// Backend Wave-9a DOS-004: legacy `get_all_vaults` is now capped at 500 vaults
+// per call. Use the paged variant and stitch pages so the explorer continues
+// to see the full vault map at any TVL.
+const VAULT_PAGE_SIZE = 500n;
+const VAULT_PAGE_MAX_PAGES = 100;
+
 export async function fetchAllVaults() {
 	allVaultsLoading.set(true);
 	try {
-		const vaults = await publicActor.get_all_vaults();
-		allVaults.set(vaults);
-		return vaults;
+		const all: any[] = [];
+		let startId = 0n;
+		for (let page = 0; page < VAULT_PAGE_MAX_PAGES; page += 1) {
+			const resp = await publicActor.get_vaults_page(startId, VAULT_PAGE_SIZE);
+			all.push(...resp.vaults);
+			if (resp.next_start_id.length === 0) break;
+			startId = resp.next_start_id[0];
+		}
+		allVaults.set(all);
+		return all;
 	} catch (e) {
 		console.error('Failed to fetch all vaults:', e);
 		return [];
@@ -151,15 +164,33 @@ export async function fetchVaultsByOwner(principal: any) {
 	}
 }
 
+// Backend Wave-9a DOS-003: legacy `get_events_by_principal` still returns the
+// last 500 matches in newest-first order, but the underlying full-log scan
+// remains O(N) per call. Use the paged variant and chain bounded scan windows
+// so an explorer caller paying for full coverage stays under the per-call
+// cycle budget regardless of log size.
+const PRINCIPAL_EVENTS_SCAN_LENGTH = 5_000n;
+const PRINCIPAL_EVENTS_MAX_PAGES = 100;
+
 export async function fetchEventsByPrincipal(principalText: string) {
 	try {
 		const principal = Principal.fromText(principalText);
-		const result = await publicActor.get_events_by_principal(principal);
-		// result is Vec<(u64, Event)>
-		return result.map((tuple: any) => ({
-			event: tuple[1] ?? tuple,
-			globalIndex: Number(tuple[0] ?? 0)
-		}));
+		const matches: { event: any; globalIndex: number }[] = [];
+		let scanStart = 0n;
+		for (let page = 0; page < PRINCIPAL_EVENTS_MAX_PAGES; page += 1) {
+			const resp = await publicActor.get_events_by_principal_paged(
+				principal,
+				scanStart,
+				PRINCIPAL_EVENTS_SCAN_LENGTH,
+			);
+			for (const entry of resp.events) {
+				matches.push({ event: entry[1], globalIndex: Number(entry[0]) });
+			}
+			if (resp.exhausted) break;
+			if (resp.scan_end <= scanStart) break;
+			scanStart = resp.scan_end;
+		}
+		return matches;
 	} catch (e) {
 		console.error('Failed to fetch events by principal:', e);
 		return [];


### PR DESCRIPTION
## Summary
First sub-wave of the deferred Wave 9 from the 2026-04-22 audit (DoS hardening "quick wins"). Closes DOS-001, DOS-003, DOS-004, DOS-008. The unbounded public queries that walked the full event log / vault map / pool-event log on every call are now server-side capped, and cursor-based paged variants give the explorer bounded-cost full enumeration at any TVL.

### Backend (rumi_protocol_backend)
- `get_vault_history(vault_id)` — uses a bounded ring buffer of size 200; returns the latest matches in chronological order (frontend's existing `.reverse()` still gives newest-first display).
- `get_vault_history_paged(vault_id, start, length)` — newest-first paged variant, capped at 200/page, with `total` for accurate UI pagination.
- `get_events_by_principal(principal)` — bounded ring buffer of size 500 instead of `.collect::<Vec<_>>()` materialising every match before slicing. Output unchanged.
- `get_events_by_principal_paged(principal, scan_start, scan_length)` — cursor-based; per-call scan window capped at 5,000 entries, output capped at 500, with `scan_end` / `exhausted` / `total_events`.
- `get_all_vaults` / `get_vaults(None)` / `get_liquidatable_vaults` capped at the first 500 vaults.
- `get_vaults_page(start_id, limit)`, `get_liquidatable_vaults_page(start_id, limit)`, `get_vault_count()` — paged enumeration with `next_start_id` cursor.

All cap constants live in `lib.rs` as `pub const` so test fences pin their values directly.

### Stability pool (rumi_stability_pool)
- `get_pool_events(start, length)` clamps `length` to 500 before slicing. The slicing logic is extracted into `pool_events_page` (pure helper) so the audit POC can fence the clamp at the unit-test level without spinning up a canister.

### Frontend (vault_frontend)
- `ApiClient.getAllVaults` / `getLiquidatableVaults` stitch the new paged endpoints transparently so existing callers keep their "full set" semantic with bounded per-call cost (defensive 100-page ceiling against a misbehaving cursor).
- `explorerStore.fetchAllVaults` / `fetchEventsByPrincipal` and `explorerService.fetchAllVaults` / `fetchLiquidatableVaults` / `fetchEventsByPrincipal` switched to the paged variants directly.
- Frontend type-check error count unchanged from main (33 pre-existing errors in unrelated files; none in files I touched).

### Tests
- **`audit_pocs_dos_008_pool_events_clamp.rs`** (SP): unit fences for `pool_events_page` — clamp on `length=u64::MAX`, natural-total respected when total < cap, full cursor round-trip across a 1,100-event log. Red-fence verified during dev (disabling the clamp turns the cap test red).
- **`audit_pocs_dos_pagination.rs`** (backend): cap-value constant fences (`MAX_VAULT_HISTORY=200`, `MAX_EVENTS_BY_PRINCIPAL_LEGACY=500`, `MAX_EVENTS_BY_PRINCIPAL_SCAN=5000`, `MAX_EVENTS_BY_PRINCIPAL_OUTPUT=500`, `MAX_VAULTS_LEGACY_PAGE=500`, `MAX_VAULTS_PAGE_LIMIT=500`) plus PocketIC cursor round-trip on `get_vaults_page` (10 vaults at limit=3, asserts no gaps/dups, strict cursor advance, terminal `next_start_id=None`), unbounded-limit fence (`limit=u64::MAX` with 10 vaults — natural total wins), and `get_vault_history_paged` accuracy vs. legacy on a vault with ~30 events including newest-first ordering check.

Existing audit POCs (RED-001/002/003, INT-001/002/003/004/006, LIQ-002/003/004/005-pic/008, BOT-001/001b/002, ICRC-idempotent, UPG-001/006) still pass on this branch.

## Test plan
- [x] `cargo test --bin rumi_protocol_backend check_candid_interface_compatibility` → ok (.did matches source)
- [x] `cargo test -p stability_pool` → all green (36 + 1 + 3 + 4 + 4 + 1 + 7 = 56 tests, 0 failures)
- [x] `cargo test -p stability_pool --test audit_pocs_dos_008_pool_events_clamp` → 3/3 ok
- [x] `cargo test -p rumi_protocol_backend --test audit_pocs_dos_pagination` → 6/6 ok in 10.59s
- [x] `cargo test -p rumi_protocol_backend --test pocket_ic_tests` → 27 passed; 0 failed; 2 ignored in 75.33s
- [x] `cargo test -p rumi_protocol_backend --test audit_pocs_red_002_redemption_deficit --test audit_pocs_red_003_readonly_redemption --test audit_pocs_int_002_concurrent_accrual --test audit_pocs_int_006_treasury_drain_concurrent --test audit_pocs_dos_pagination` → all green (6 + 4 + 4 + 5 + 3 = 22)
- [x] Frontend `svelte-check` error count = 33 on this branch, same 33 pre-existing on main (no new errors in files I touched)
- [x] Backed by red-green TDD verification on the SP DOS-008 clamp during development (clamp disabled → cap test fails; restored → green)

Pre-existing failures unchanged by this PR: `tests/tests.rs` (stale `bot_processing` field references), `audit_pocs_liq_005_deficit_account.rs` state-level subtests (need canister-context for `record_event`), `rumi_3pool::icrc3_hash_cache` (needs `--features test_endpoints` build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)