### PR TITLE
fix(api): shard check_vaults to at-risk band (audit Wave 9c — DOS-005)

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -876,6 +876,8 @@ service : (ProtocolArg) -> {
   set_bot_allowed_collateral_types : (vec principal) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
+  set_check_vaults_alert_band_bps : (nat64) -> (Result);
+  set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
   set_collateral_borrow_threshold : (principal, float64) -> (Result);
   set_collateral_borrowing_fee : (principal, float64) -> (Result);

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -55,6 +55,19 @@ pub const MINIMUM_COLLATERAL_RATIO: Ratio = Ratio::new(dec!(1.33));  // 133%
 /// Default protocol share of liquidator's bonus profit (3%).
 pub const DEFAULT_LIQUIDATION_PROTOCOL_SHARE: Ratio = Ratio::new(dec!(0.03));
 
+/// Wave-9c DOS-005: default alert band (in basis points) above each
+/// collateral's `min_liquidation_ratio` within which `check_vaults`
+/// walks the sorted-troves index. 1000 bps = 10% headroom. Tuned via
+/// `set_check_vaults_alert_band_bps`.
+pub const DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS: u64 = 1000;
+
+/// Wave-9c DOS-005: default cadence (in 5-minute XRC ticks) for the
+/// safety-belt full sweep that walks every vault regardless of CR
+/// band. 12 = once per hour. 0 or 1 means full sweep every tick
+/// (effectively reverts to pre-Wave-9c behavior). Tuned via
+/// `set_check_vaults_full_sweep_every_n_ticks`.
+pub const DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS: u64 = 12;
+
 /// Stable token types accepted for vault repayment (1:1 with icUSD)
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StableTokenType {
@@ -724,30 +737,26 @@ pub async fn check_vaults() {
     // unchanged; the order is now sorted by CR ascending. This matches the
     // server-side band-gate behavior — the bot/pool see the same vault the
     // band gate would accept first.
-    let (unhealthy_vaults, _healthy_vaults) = read_state(|s| {
-        let mut unhealthy_vaults: Vec<Vault> = vec![];
-        let mut healthy_vaults: Vec<Vault> = vec![];
-        for (_cr_key, bucket) in s.vault_cr_index.iter() {
-            for vid in bucket {
-                let vault = match s.vault_id_to_vaults.get(vid) {
-                    Some(v) => v,
-                    None => continue, // index drift — ignore
-                };
-                if vault.bot_processing {
-                    // Skip — bot is actively processing this vault
-                    continue;
-                }
-                if compute_collateral_ratio(vault, dummy_rate, s)
-                    < s.get_min_liquidation_ratio_for(&vault.collateral_type)
-                {
-                    unhealthy_vaults.push(vault.clone());
-                } else {
-                    healthy_vaults.push(vault.clone())
-                }
-            }
-        }
-        (unhealthy_vaults, healthy_vaults)
-    });
+    //
+    // Wave-9c DOS-005: bound the walk to the at-risk band on most ticks.
+    // `advance_check_vaults_tick` returns true on the Nth tick (default
+    // every 12 = once per hour at the 5-min cadence), making that tick a
+    // full sweep. This is the safety belt for cross-collateral CR-key
+    // drift: a vault whose key is stale-above-threshold is missed by
+    // band-only ticks but caught by the next full sweep. Tunable via
+    // `set_check_vaults_alert_band_bps` and
+    // `set_check_vaults_full_sweep_every_n_ticks`.
+    let do_full_sweep = mutate_state(|s| s.advance_check_vaults_tick());
+    let scan = read_state(|s| s.scan_unhealthy_vaults(dummy_rate, do_full_sweep));
+    log!(
+        INFO,
+        "[check_vaults] {} tick: visited {} vault(s), threshold_key={}, found {} unhealthy",
+        if scan.was_full_sweep { "full-sweep" } else { "band-only" },
+        scan.vaults_visited,
+        scan.threshold_key,
+        scan.unhealthy_vaults.len(),
+    );
+    let unhealthy_vaults = scan.unhealthy_vaults;
 
     // Log unhealthy vaults but don't liquidate them
     if !unhealthy_vaults.is_empty() {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -3650,6 +3650,64 @@ async fn set_breaker_window_debt_ceiling_e8s(new_ceiling: u64) -> Result<(), Pro
     Ok(())
 }
 
+/// Wave-9c DOS-005: tune the alert-band width (in bps) used by
+/// `check_vaults` to bound the sorted-troves walk on band-only ticks.
+/// Default 1000 bps (10% headroom above the worst per-collateral
+/// `min_liquidation_ratio`). 0 disables the band (only vaults strictly
+/// below the worst floor are visited). Wider values trade cycle savings
+/// for safety margin against cross-collateral CR-key drift.
+#[candid_method(update)]
+#[update]
+async fn set_check_vaults_alert_band_bps(new_band_bps: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set check_vaults alert band".to_string(),
+        ));
+    }
+    mutate_state(|s| s.set_check_vaults_alert_band_bps(new_band_bps));
+    log!(
+        INFO,
+        "[set_check_vaults_alert_band_bps] Alert band set to: {} bps ({:.2}% headroom)",
+        new_band_bps,
+        (new_band_bps as f64) / 100.0
+    );
+    Ok(())
+}
+
+/// Wave-9c DOS-005: tune the cadence of the safety-belt full sweep that
+/// walks every vault in `vault_cr_index` regardless of CR band.
+/// Default 12 (one full sweep per hour at the 5-minute XRC cadence).
+/// 0 or 1 forces full sweep every tick (revert path that mirrors
+/// pre-Wave-9c behavior).
+#[candid_method(update)]
+#[update]
+async fn set_check_vaults_full_sweep_every_n_ticks(
+    new_n: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set check_vaults full-sweep cadence"
+                .to_string(),
+        ));
+    }
+    mutate_state(|s| s.set_check_vaults_full_sweep_every_n_ticks(new_n));
+    log!(
+        INFO,
+        "[set_check_vaults_full_sweep_every_n_ticks] Cadence set to: {} ticks ({})",
+        new_n,
+        if new_n <= 1 {
+            "full sweep every tick (Wave-9c effectively disabled)"
+        } else {
+            "Wave-9c band sharding active"
+        }
+    );
+    Ok(())
+}
+
 /// Wave-10 LIQ-008: clear the breaker latch so `check_vaults` resumes
 /// auto-publishing on the next tick. Admin-only. Emits `BreakerCleared`
 /// with the windowed total at clear time so the audit trail captures

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -14,6 +14,7 @@ use std::cell::RefCell;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::ops::Bound;
 use crate::guard::OperationState;
 
 // Like assert_eq, but returns an error instead of panicking.
@@ -1072,6 +1073,70 @@ pub struct State {
     /// with the nanosecond timestamp at which they were computed.
     #[serde(default)]
     pub treasury_stats_snapshot: Option<(u64, TreasuryStatsSnapshot)>,
+
+    // ─── Wave-9c DOS-005: shard `check_vaults` to the at-risk band ───
+    //
+    // `check_vaults` runs every 5-minute XRC tick. Pre-Wave-9c it walked
+    // every entry of `vault_cr_index` to identify liquidatable vaults.
+    // Wave-9c bounds that walk to the at-risk band (vaults whose CR-key
+    // is below `max(min_liq_ratio across collaterals) +
+    // alert_band_bps / 10000`). Every Nth tick is a "full sweep" that
+    // walks the entire index as a safety belt for cross-collateral
+    // CR-key drift (the index is not re-keyed on price update).
+    //
+    // `serde(default)`: pre-Wave-9c snapshots decode each field via the
+    // matching `default_*` fn (or 0 for the counter), so the post-
+    // upgrade behavior matches the audit-spec defaults without a
+    // snapshot-format migration.
+
+    /// Wave-9c DOS-005: alert band (in bps) above the worst per-
+    /// collateral `min_liquidation_ratio` within which `check_vaults`
+    /// walks the sorted-troves index on band-only ticks. Default
+    /// `DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS` (1000 bps = 10% headroom).
+    /// Tunable via `set_check_vaults_alert_band_bps`.
+    #[serde(default = "default_check_vaults_alert_band_bps")]
+    pub check_vaults_alert_band_bps: u64,
+
+    /// Wave-9c DOS-005: cadence (in ticks) of the safety-belt full
+    /// sweep. The Nth `check_vaults` tick walks every vault in
+    /// `vault_cr_index` instead of just the at-risk band. Default
+    /// `DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS` (12 = one full
+    /// sweep per hour at the 5-minute XRC cadence). 0 or 1 forces
+    /// full sweep every tick (revert path). Tunable via
+    /// `set_check_vaults_full_sweep_every_n_ticks`.
+    #[serde(default = "default_check_vaults_full_sweep_every_n_ticks")]
+    pub check_vaults_full_sweep_every_n_ticks: u64,
+
+    /// Wave-9c DOS-005: incremented on every band-only tick. When it
+    /// reaches `check_vaults_full_sweep_every_n_ticks`, the next tick
+    /// performs a full sweep and the counter resets to 0. Survives
+    /// upgrade so the cadence is monotone across deploys.
+    #[serde(default)]
+    pub ticks_since_full_sweep: u64,
+}
+
+fn default_check_vaults_alert_band_bps() -> u64 {
+    crate::DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS
+}
+
+fn default_check_vaults_full_sweep_every_n_ticks() -> u64 {
+    crate::DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS
+}
+
+/// Wave-9c DOS-005: result of `State::scan_unhealthy_vaults`. The
+/// caller (production: `lib.rs::check_vaults`; tests: the audit POC)
+/// uses `unhealthy_vaults` as the input to bot/SP routing and reads
+/// `vaults_visited` / `was_full_sweep` for instrumentation.
+///
+/// `vaults_visited` counts every vault entry in iterated buckets,
+/// including those skipped due to `bot_processing` — that read still
+/// burns cycles, so the counter reflects the actual cycle cost paid.
+#[derive(Clone, Debug)]
+pub struct UnhealthyVaultScan {
+    pub unhealthy_vaults: Vec<Vault>,
+    pub vaults_visited: u64,
+    pub was_full_sweep: bool,
+    pub threshold_key: u64,
 }
 
 /// Wave-9b DOS-006: heavy aggregates served from cache for
@@ -1234,6 +1299,11 @@ impl Default for State {
             // Wave-9b DOS-006/-007
             protocol_status_snapshot: None,
             treasury_stats_snapshot: None,
+            // Wave-9c DOS-005
+            check_vaults_alert_band_bps: default_check_vaults_alert_band_bps(),
+            check_vaults_full_sweep_every_n_ticks:
+                default_check_vaults_full_sweep_every_n_ticks(),
+            ticks_since_full_sweep: 0,
         }
     }
 }
@@ -1440,6 +1510,11 @@ impl From<InitArg> for State {
             // Wave-9b DOS-006/-007
             protocol_status_snapshot: None,
             treasury_stats_snapshot: None,
+            // Wave-9c DOS-005
+            check_vaults_alert_band_bps: default_check_vaults_alert_band_bps(),
+            check_vaults_full_sweep_every_n_ticks:
+                default_check_vaults_full_sweep_every_n_ticks(),
+            ticks_since_full_sweep: 0,
         }
     }
 }
@@ -2776,6 +2851,136 @@ impl State {
     /// can widen to effectively-disable the gate during emergencies.
     pub fn set_liquidation_ordering_tolerance(&mut self, tolerance: Ratio) {
         self.liquidation_ordering_tolerance = tolerance;
+    }
+
+    // ---- Wave-9c DOS-005: shard `check_vaults` to the at-risk band -----
+
+    /// Wave-9c DOS-005: resolve the `vault_cr_index` upper-bound key for
+    /// the at-risk-band walk. Vaults whose CR-key is strictly less than
+    /// the returned value are visited on band-only ticks; vaults at or
+    /// above are skipped.
+    ///
+    /// Threshold = `max(min_liquidation_ratio across active collaterals)
+    ///            + alert_band_bps / 10000`.
+    ///
+    /// Using the maximum across collaterals is intentional: the index is
+    /// keyed on raw CR (not on per-collateral CR-relative-to-floor), so
+    /// a single threshold has to cover the worst floor. ICP at
+    /// liquidation_ratio 1.33 is currently the worst; a future
+    /// collateral with a higher floor (e.g., 1.5) would automatically
+    /// widen the band. The trade is a few extra iterations on band ticks
+    /// for vaults below the worst floor but above their own — those
+    /// vaults are filtered by the per-vault CR check inside the scan.
+    ///
+    /// In Recovery mode `get_min_liquidation_ratio_for` returns
+    /// `borrow_threshold_ratio` (a higher floor), so the threshold
+    /// widens automatically — Recovery mode liquidates more vaults, so
+    /// the band-walk must visit more.
+    pub fn check_vaults_alert_threshold_key(&self) -> u64 {
+        let band_decimal =
+            Decimal::from(self.check_vaults_alert_band_bps) / Decimal::from(10_000u64);
+        let max_min_liq: Decimal = self
+            .collateral_configs
+            .values()
+            .map(|c| match self.mode {
+                Mode::Recovery => c.borrow_threshold_ratio.0,
+                _ => c.liquidation_ratio.0,
+            })
+            .max()
+            .unwrap_or_else(|| MINIMUM_COLLATERAL_RATIO.0);
+        let threshold = Ratio::from(max_min_liq + band_decimal);
+        Self::cr_index_key(threshold)
+    }
+
+    /// Wave-9c DOS-005: tick the band-vs-full-sweep cadence counter.
+    /// Returns true when the caller should perform a full sweep.
+    ///
+    /// Behavior:
+    ///   * `check_vaults_full_sweep_every_n_ticks <= 1`: every tick is
+    ///     a full sweep (revert path / pre-Wave-9c behavior). Counter
+    ///     stays at 0.
+    ///   * `n >= 2`: counter increments. When it reaches `n`, the
+    ///     caller performs a full sweep and the counter resets to 0.
+    ///     This makes ticks 1..(n-1) band-only and tick n the sweep.
+    pub fn advance_check_vaults_tick(&mut self) -> bool {
+        let n = self.check_vaults_full_sweep_every_n_ticks;
+        if n <= 1 {
+            self.ticks_since_full_sweep = 0;
+            return true;
+        }
+        self.ticks_since_full_sweep = self.ticks_since_full_sweep.saturating_add(1);
+        if self.ticks_since_full_sweep >= n {
+            self.ticks_since_full_sweep = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wave-9c DOS-005: admin setter for the alert-band width.
+    pub fn set_check_vaults_alert_band_bps(&mut self, band_bps: u64) {
+        self.check_vaults_alert_band_bps = band_bps;
+    }
+
+    /// Wave-9c DOS-005: admin setter for the full-sweep cadence.
+    /// 0 or 1 reverts to pre-Wave-9c behavior (full sweep every tick).
+    pub fn set_check_vaults_full_sweep_every_n_ticks(&mut self, n: u64) {
+        self.check_vaults_full_sweep_every_n_ticks = n;
+    }
+
+    /// Wave-9c DOS-005: walk `vault_cr_index` and return the unhealthy
+    /// vault list plus instrumentation metadata. The walk is bounded by
+    /// the at-risk threshold when `do_full_sweep == false`, and walks
+    /// the entire index otherwise.
+    ///
+    /// Per-vault classification mirrors the pre-Wave-9c logic in
+    /// `lib.rs::check_vaults`: skip `bot_processing` vaults
+    /// (already claimed) and push the remainder into the `unhealthy`
+    /// vec when `compute_collateral_ratio < min_liquidation_ratio`.
+    /// Healthy vaults inside the band are visited but discarded.
+    ///
+    /// `vaults_visited` increments for every vault entry in iterated
+    /// buckets, including those skipped due to `bot_processing` — that
+    /// read still costs cycles, so the counter reflects actual cost
+    /// paid (useful for production telemetry and the DOS-005 fence).
+    pub fn scan_unhealthy_vaults(&self, rate: UsdIcp, do_full_sweep: bool) -> UnhealthyVaultScan {
+        let threshold_key = self.check_vaults_alert_threshold_key();
+        let upper_bound = if do_full_sweep {
+            Bound::Unbounded
+        } else {
+            Bound::Excluded(threshold_key)
+        };
+
+        let mut unhealthy_vaults: Vec<Vault> = Vec::new();
+        let mut visited: u64 = 0;
+
+        for (_cr_key, bucket) in self
+            .vault_cr_index
+            .range::<u64, _>((Bound::Unbounded, upper_bound))
+        {
+            for vid in bucket {
+                let vault = match self.vault_id_to_vaults.get(vid) {
+                    Some(v) => v,
+                    None => continue, // index drift — ignore
+                };
+                visited += 1;
+                if vault.bot_processing {
+                    continue;
+                }
+                if compute_collateral_ratio(vault, rate, self)
+                    < self.get_min_liquidation_ratio_for(&vault.collateral_type)
+                {
+                    unhealthy_vaults.push(vault.clone());
+                }
+            }
+        }
+
+        UnhealthyVaultScan {
+            unhealthy_vaults,
+            vaults_visited: visited,
+            was_full_sweep: do_full_sweep,
+            threshold_key,
+        }
     }
 
     /// Sync a global fee-setting event to the ICP CollateralConfig (for backward compat during replay)

--- a/src/rumi_protocol_backend/tests/audit_pocs_dos_005_check_vaults_shard.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_dos_005_check_vaults_shard.rs
@@ -1,0 +1,560 @@
+//! Wave-9c DoS hardening: shard `check_vaults` to the at-risk CR band
+//! (DOS-005).
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/findings.json` finding DOS-005
+//!     (`check_vaults() and accrue_all_vault_interest() iterate all vaults
+//!     on every XRC tick`).
+//!   * Wave plan: `audit-reports/2026-04-22-28e9896/remediation-plan.md`
+//!     §"Wave 9 — DoS hardening".
+//!
+//! # What the gap is
+//!
+//! `check_vaults()` runs every 5 minutes on the XRC price tick and
+//! currently walks every entry in `vault_cr_index` to identify
+//! liquidatable vaults. At current TVL this is fine; at scale the cost
+//! grows linearly with vault count and dominates the backend's cycle
+//! budget — most vaults walked are deeply healthy and re-checking them
+//! is wasted work.
+//!
+//! # How this file pins the fix
+//!
+//! Wave-9c reuses the LIQ-002 sorted-troves index (`vault_cr_index`)
+//! to walk only vaults whose CR is at or below
+//! `max(min_liquidation_ratio across collaterals) +
+//! check_vaults_alert_band_bps / 10000`. Vaults far above the band are
+//! skipped on band-only ticks. Every Nth tick (default 12 = once per
+//! hour at the 5-minute XRC cadence) walks the full index as a safety
+//! belt for cross-collateral CR-key drift.
+//!
+//! Layered fences (mirrors the LIQ-002 file structure):
+//!
+//!  1. **Constant fences** — defaults pinned at audit-spec values.
+//!  2. **Threshold-key resolution** — `check_vaults_alert_threshold_key`
+//!     uses the worst (max) `min_liq_ratio` across active collaterals,
+//!     not a single hard-coded constant. Multi-collateral protocols
+//!     would silently miss vaults if we keyed off the wrong floor.
+//!  3. **Tick advance** — `advance_check_vaults_tick` returns the
+//!     band-vs-full-sweep decision and rolls `ticks_since_full_sweep`.
+//!     Pinned for K=0, K=1, K=3, K=12 cadences.
+//!  4. **Scan correctness** — `scan_unhealthy_vaults` returns a vec of
+//!     unhealthy vaults plus the visited count and full-sweep flag.
+//!     The unhealthy vec must equal what a full sweep would have
+//!     produced for any vault inside the band; the visited count fences
+//!     the "cycle savings" contract on band-only ticks.
+//!  5. **Drift safety belt** — without the periodic full sweep, a
+//!     vault whose CR-key is stale-above-threshold (cross-collateral
+//!     drift) would be missed. The full sweep finds it within K ticks.
+//!  6. **Admin tunables** — both setters change behavior on the next
+//!     tick. Setting `full_sweep_every_n_ticks = 1` reverts to
+//!     pre-Wave-9c behavior (full sweep every tick).
+//!  7. **Upgrade hygiene** — pre-Wave-9c snapshots decode with the
+//!     three new fields populated from `serde(default)`. State::default
+//!     and `From<InitArg>` agree on the defaults.
+
+use candid::Principal;
+use rust_decimal_macros::dec;
+
+use rumi_protocol_backend::numeric::{Ratio, UsdIcp, ICUSD};
+use rumi_protocol_backend::state::{State, UnhealthyVaultScan};
+use rumi_protocol_backend::vault::Vault;
+use rumi_protocol_backend::{
+    InitArg, DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS,
+    DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS,
+};
+
+fn icp_ledger() -> Principal {
+    Principal::from_slice(&[10])
+}
+
+fn fresh_state_with_price(price: f64) -> State {
+    let mut state = State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: icp_ledger(),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    let icp = state.icp_collateral_type();
+    if let Some(config) = state.collateral_configs.get_mut(&icp) {
+        config.last_price = Some(price);
+    }
+    state
+}
+
+fn make_vault(vault_id: u64, collateral_e8s: u64, borrowed_icusd_e8s: u64) -> Vault {
+    Vault {
+        owner: Principal::anonymous(),
+        vault_id,
+        collateral_amount: collateral_e8s,
+        borrowed_icusd_amount: ICUSD::new(borrowed_icusd_e8s),
+        collateral_type: icp_ledger(),
+        last_accrual_time: 0,
+        accrued_interest: ICUSD::new(0),
+        bot_processing: false,
+    }
+}
+
+fn open_and_reindex(state: &mut State, vault: Vault) {
+    let vid = vault.vault_id;
+    state.open_vault(vault);
+    state.reindex_vault_cr(vid);
+}
+
+fn dummy_rate() -> UsdIcp {
+    UsdIcp::from(dec!(1.0))
+}
+
+// ============================================================================
+// Layer 1 — constant fences
+// ============================================================================
+
+#[test]
+fn dos_005_default_alert_band_pinned_at_1000_bps() {
+    assert_eq!(
+        DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS, 1000,
+        "Wave-9c DOS-005: default alert band must be 1000 bps (10% headroom). \
+         Lowering risks missing vaults that drift toward liquidation between \
+         re-keys; raising widens the band and burns extra cycles per tick."
+    );
+}
+
+#[test]
+fn dos_005_default_full_sweep_cadence_pinned_at_12_ticks() {
+    assert_eq!(
+        DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS, 12,
+        "Wave-9c DOS-005: default full-sweep cadence must be 12 ticks \
+         (one full sweep per hour at the 5-minute XRC tick cadence). \
+         Lowering bounds the worst-case missed-vault window but reduces \
+         cycle savings; raising extends the missed window beyond an hour."
+    );
+}
+
+#[test]
+fn dos_005_default_state_initializes_band_and_cadence() {
+    let state = fresh_state_with_price(10.0);
+    assert_eq!(
+        state.check_vaults_alert_band_bps, DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS,
+        "fresh state must initialize alert band to default"
+    );
+    assert_eq!(
+        state.check_vaults_full_sweep_every_n_ticks,
+        DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS,
+        "fresh state must initialize full-sweep cadence to default"
+    );
+    assert_eq!(
+        state.ticks_since_full_sweep, 0,
+        "fresh state must start at tick 0 (next tick is tick 1, not full sweep)"
+    );
+}
+
+// ============================================================================
+// Layer 2 — threshold-key resolution
+// ============================================================================
+
+#[test]
+fn dos_005_threshold_uses_max_min_liq_ratio_plus_band() {
+    // ICP default: liquidation_ratio = 1.33, borrow_threshold = 1.5.
+    // Default band = 1000 bps = 0.10. In Normal mode, threshold should be
+    // 1.33 + 0.10 = 1.43 → key = 14_300.
+    let state = fresh_state_with_price(10.0);
+    assert_eq!(state.check_vaults_alert_threshold_key(), 14_300);
+}
+
+#[test]
+fn dos_005_threshold_widens_in_recovery_mode() {
+    // Recovery mode: get_min_liquidation_ratio_for returns
+    // borrow_threshold_ratio (1.5) instead of liquidation_ratio (1.33).
+    // Threshold = 1.5 + 0.10 = 1.60 → key = 16_000.
+    let mut state = fresh_state_with_price(10.0);
+    state.mode = rumi_protocol_backend::state::Mode::Recovery;
+    assert_eq!(state.check_vaults_alert_threshold_key(), 16_000);
+}
+
+#[test]
+fn dos_005_threshold_widens_when_admin_widens_band() {
+    let mut state = fresh_state_with_price(10.0);
+    // Default 1000 bps → threshold 14_300.
+    assert_eq!(state.check_vaults_alert_threshold_key(), 14_300);
+    // Widen to 5000 bps (50%) → threshold 1.33 + 0.50 = 1.83 → key 18_300.
+    state.set_check_vaults_alert_band_bps(5000);
+    assert_eq!(state.check_vaults_alert_threshold_key(), 18_300);
+}
+
+// ============================================================================
+// Layer 3 — tick advance / full-sweep cadence
+// ============================================================================
+
+#[test]
+fn dos_005_advance_tick_with_default_k_runs_band_for_first_11_ticks() {
+    let mut state = fresh_state_with_price(10.0);
+    // Default K=12: ticks 1..=11 are band-only; tick 12 is full sweep.
+    for tick in 1..=11u64 {
+        let do_full = state.advance_check_vaults_tick();
+        assert!(
+            !do_full,
+            "tick {} of 12 should be band-only (K=12, default cadence)",
+            tick
+        );
+    }
+    let do_full = state.advance_check_vaults_tick();
+    assert!(do_full, "tick 12 of 12 should be the full sweep");
+    // After full sweep, counter resets — next 11 ticks are band again.
+    for tick in 1..=11u64 {
+        let do_full = state.advance_check_vaults_tick();
+        assert!(
+            !do_full,
+            "tick {} after full sweep should be band-only",
+            tick
+        );
+    }
+    assert!(
+        state.advance_check_vaults_tick(),
+        "12 ticks past full sweep must trigger another full sweep"
+    );
+}
+
+#[test]
+fn dos_005_advance_tick_with_k_3_runs_band_band_full() {
+    let mut state = fresh_state_with_price(10.0);
+    state.set_check_vaults_full_sweep_every_n_ticks(3);
+    assert!(!state.advance_check_vaults_tick(), "K=3 tick 1: band only");
+    assert!(!state.advance_check_vaults_tick(), "K=3 tick 2: band only");
+    assert!(state.advance_check_vaults_tick(), "K=3 tick 3: full sweep");
+    assert!(!state.advance_check_vaults_tick(), "K=3 tick 4: band only");
+    assert!(!state.advance_check_vaults_tick(), "K=3 tick 5: band only");
+    assert!(state.advance_check_vaults_tick(), "K=3 tick 6: full sweep");
+}
+
+#[test]
+fn dos_005_k_zero_means_always_full_sweep() {
+    // K=0 disables the optimization (every tick is full sweep =
+    // pre-Wave-9c behavior). This is the safe revert path if production
+    // reveals an issue.
+    let mut state = fresh_state_with_price(10.0);
+    state.set_check_vaults_full_sweep_every_n_ticks(0);
+    for _ in 0..5 {
+        assert!(
+            state.advance_check_vaults_tick(),
+            "K=0 must full-sweep every tick"
+        );
+    }
+}
+
+#[test]
+fn dos_005_k_one_means_always_full_sweep() {
+    let mut state = fresh_state_with_price(10.0);
+    state.set_check_vaults_full_sweep_every_n_ticks(1);
+    for _ in 0..5 {
+        assert!(
+            state.advance_check_vaults_tick(),
+            "K=1 must full-sweep every tick"
+        );
+    }
+}
+
+// ============================================================================
+// Layer 4 — scan correctness (the core contract)
+// ============================================================================
+
+#[test]
+fn dos_005_band_only_tick_skips_above_threshold_vaults() {
+    // 50 vaults total: half safely above the band (CR 5.0), half at risk
+    // (CR 1.40, just inside the 1.43 default threshold). On a band-only
+    // tick, the scanner must visit only the 25 at-risk vaults, not the
+    // other 25.
+    let mut state = fresh_state_with_price(10.0);
+
+    // 25 at-risk vaults: 1 ICP at $10, debt ~ 7.143 icUSD → CR ~ 1.40
+    for i in 1..=25u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 714_000_000));
+    }
+    // 25 safely-above vaults: 1 ICP at $10, debt = 2 icUSD → CR = 5.0
+    for i in 26..=50u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 200_000_000));
+    }
+
+    let scan: UnhealthyVaultScan = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert!(!scan.was_full_sweep);
+    assert_eq!(
+        scan.vaults_visited, 25,
+        "band-only tick must visit only the 25 at-risk vaults; got {}",
+        scan.vaults_visited
+    );
+}
+
+#[test]
+fn dos_005_full_sweep_tick_visits_every_vault() {
+    // Same setup; full-sweep tick must visit all 50.
+    let mut state = fresh_state_with_price(10.0);
+    for i in 1..=25u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 714_000_000));
+    }
+    for i in 26..=50u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 200_000_000));
+    }
+
+    let scan = state.scan_unhealthy_vaults(dummy_rate(), true);
+    assert!(scan.was_full_sweep);
+    assert_eq!(scan.vaults_visited, 50);
+}
+
+#[test]
+fn dos_005_band_only_tick_finds_underwater_vaults_at_index_bottom() {
+    // 1 deeply underwater vault (CR 1.10), 5 safe vaults (CR 5.0).
+    // Even on a band-only tick, the underwater vault must surface in the
+    // unhealthy list — it's at the bottom of the index, well within band.
+    let mut state = fresh_state_with_price(10.0);
+    open_and_reindex(&mut state, make_vault(1, 100_000_000, 909_090_909)); // CR ~1.10
+    for i in 2..=6u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 200_000_000)); // CR 5.0
+    }
+
+    let scan = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        scan.unhealthy_vaults.len(),
+        1,
+        "underwater vault must be found on first band tick"
+    );
+    assert_eq!(scan.unhealthy_vaults[0].vault_id, 1);
+}
+
+#[test]
+fn dos_005_band_visit_count_grows_after_user_activity_pushes_vaults_into_band() {
+    // Vaults at CR 1.6 (above default 1.43 threshold). Band tick visits 0.
+    // After three vaults borrow more icUSD (re-keying their CR into the
+    // band), the next band tick visits exactly those three. Pins the
+    // contract that the band reflects current re-keyed state.
+    let mut state = fresh_state_with_price(10.0);
+    for i in 1..=5u64 {
+        open_and_reindex(&mut state, make_vault(i, 100_000_000, 625_000_000)); // CR 1.6
+    }
+
+    let scan_before = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        scan_before.vaults_visited, 0,
+        "tick before borrow: all vaults above band"
+    );
+
+    // Three vaults borrow more, dropping CR from 1.6 to ~1.25.
+    // Existing debt 6.25 icUSD; borrow another 1.75 icUSD → debt 8 icUSD →
+    // CR = 10 / 8 = 1.25 (below 1.33 liquidation_ratio: now liquidatable).
+    for vid in 1..=3u64 {
+        state.borrow_from_vault(vid, ICUSD::new(175_000_000));
+        state.reindex_vault_cr(vid);
+    }
+
+    let scan_after = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        scan_after.vaults_visited, 3,
+        "tick after borrow: 3 vaults pulled into band"
+    );
+    assert_eq!(
+        scan_after.unhealthy_vaults.len(),
+        3,
+        "all three are now below liquidation_ratio"
+    );
+}
+
+#[test]
+fn dos_005_band_only_and_full_sweep_agree_on_unhealthy_set_for_in_band_vaults() {
+    // The band-only tick must produce the same unhealthy set as a full
+    // sweep, *for vaults whose CR-key is inside the band*. This is the
+    // "no false negatives within the band" guarantee.
+    let mut state = fresh_state_with_price(10.0);
+    open_and_reindex(&mut state, make_vault(1, 100_000_000, 909_090_909)); // CR 1.10 (underwater)
+    open_and_reindex(&mut state, make_vault(2, 100_000_000, 800_000_000)); // CR 1.25 (underwater)
+    open_and_reindex(&mut state, make_vault(3, 100_000_000, 714_000_000)); // CR ~1.40 (in-band, healthy)
+    open_and_reindex(&mut state, make_vault(4, 100_000_000, 200_000_000)); // CR 5.0 (above)
+
+    let band = state.scan_unhealthy_vaults(dummy_rate(), false);
+    let full = state.scan_unhealthy_vaults(dummy_rate(), true);
+
+    let mut band_ids: Vec<u64> = band.unhealthy_vaults.iter().map(|v| v.vault_id).collect();
+    let mut full_ids: Vec<u64> = full.unhealthy_vaults.iter().map(|v| v.vault_id).collect();
+    band_ids.sort();
+    full_ids.sort();
+    assert_eq!(
+        band_ids, full_ids,
+        "band tick and full sweep must agree on the unhealthy set when no \
+         vault drifts above the band threshold"
+    );
+}
+
+// ============================================================================
+// Layer 5 — drift safety belt
+// ============================================================================
+
+#[test]
+fn dos_005_full_sweep_catches_stale_keyed_drifted_vault_band_misses() {
+    // Cross-collateral drift scenario: a vault was healthy when last
+    // re-keyed (key well above threshold), but its current CR (recomputed
+    // from the cached price) is now underwater. The band tick misses it
+    // (key is above threshold); the safety-belt full sweep catches it.
+    //
+    // This pins the contract that the periodic full sweep is the
+    // mitigation for stale-key drift, not just an optimization knob.
+    let mut state = fresh_state_with_price(10.0);
+    // Vault opened at CR 1.6 (key 16_000) — above default 14_300 threshold.
+    open_and_reindex(&mut state, make_vault(1, 100_000_000, 625_000_000));
+
+    // Price drops to $7. Real CR = $7 / $6.25 = 1.12 (deeply underwater),
+    // but `vault_cr_index` key stays at 16_000 because the price-update
+    // path does NOT re-key (per LIQ-002 SAFETY contract).
+    let icp = state.icp_collateral_type();
+    if let Some(config) = state.collateral_configs.get_mut(&icp) {
+        config.last_price = Some(7.0);
+    }
+
+    // Band tick misses the now-underwater vault (its key 16_000 is above
+    // the 14_300 threshold).
+    let band = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        band.unhealthy_vaults.len(),
+        0,
+        "band tick misses stale-keyed drifted vault (this is the documented limitation)"
+    );
+
+    // Full sweep walks every key, including 16_000, and finds the drifted
+    // vault by recomputing CR with the current cached price.
+    let full = state.scan_unhealthy_vaults(dummy_rate(), true);
+    assert_eq!(
+        full.unhealthy_vaults.len(),
+        1,
+        "full sweep catches drifted vault via real-time CR recompute"
+    );
+    assert_eq!(full.unhealthy_vaults[0].vault_id, 1);
+}
+
+// ============================================================================
+// Layer 6 — admin tunables
+// ============================================================================
+
+#[test]
+fn dos_005_admin_widening_band_visits_more_vaults_next_tick() {
+    let mut state = fresh_state_with_price(10.0);
+    // Vault at CR 1.6 — outside default 1000 bps band.
+    open_and_reindex(&mut state, make_vault(1, 100_000_000, 625_000_000));
+
+    let scan_before = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(scan_before.vaults_visited, 0);
+
+    // Widen to 5000 bps (50%) → threshold 1.83 → key 18_300. Now vault 1
+    // (key 16_000) is inside the band.
+    state.set_check_vaults_alert_band_bps(5000);
+    let scan_after = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        scan_after.vaults_visited, 1,
+        "widened band visits the previously-out-of-band vault"
+    );
+}
+
+#[test]
+fn dos_005_admin_lowering_full_sweep_cadence_speeds_up_drift_recovery() {
+    let mut state = fresh_state_with_price(10.0);
+    // K=2: every other tick is full sweep.
+    state.set_check_vaults_full_sweep_every_n_ticks(2);
+    assert!(!state.advance_check_vaults_tick());
+    assert!(state.advance_check_vaults_tick());
+    assert!(!state.advance_check_vaults_tick());
+    assert!(state.advance_check_vaults_tick());
+}
+
+// ============================================================================
+// Layer 7 — upgrade hygiene (serde defaults)
+// ============================================================================
+
+#[test]
+fn dos_005_state_default_initializes_new_fields() {
+    // The `Default` impl on State is used as the serde fallback for
+    // missing fields in pre-Wave-9c CBOR snapshots. Each new field must
+    // resolve to the audited default.
+    let s = State::default();
+    assert_eq!(s.check_vaults_alert_band_bps, DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS);
+    assert_eq!(
+        s.check_vaults_full_sweep_every_n_ticks,
+        DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS
+    );
+    assert_eq!(s.ticks_since_full_sweep, 0);
+}
+
+#[test]
+fn dos_005_simulated_pre_upgrade_snapshot_decodes_to_defaults() {
+    // Simulate a pre-Wave-9c snapshot: the three new fields default via
+    // their `serde(default)` annotation. We can't easily round-trip CBOR
+    // here without mocking storage, but we can fence the contract by
+    // checking that `State::default()` (which IS the serde fallback)
+    // produces the same values as a fresh `From<InitArg>`.
+    let from_init = fresh_state_with_price(10.0);
+    let from_default = State::default();
+    assert_eq!(
+        from_init.check_vaults_alert_band_bps,
+        from_default.check_vaults_alert_band_bps,
+        "Default impl must agree with From<InitArg> on alert band"
+    );
+    assert_eq!(
+        from_init.check_vaults_full_sweep_every_n_ticks,
+        from_default.check_vaults_full_sweep_every_n_ticks,
+        "Default impl must agree with From<InitArg> on full-sweep cadence"
+    );
+}
+
+// ============================================================================
+// Layer 8 — interaction with bot_processing flag
+// ============================================================================
+
+#[test]
+fn dos_005_bot_processing_vaults_skipped_in_unhealthy_list_but_still_counted_visited() {
+    // The pre-Wave-9c logic skipped `bot_processing` vaults via `continue`
+    // before classifying. Wave-9c preserves that behavior — bot-claimed
+    // vaults are not double-published — but the visit counter still
+    // increments because the cycle cost was paid (we read the vault to
+    // check the flag).
+    let mut state = fresh_state_with_price(10.0);
+    open_and_reindex(&mut state, make_vault(1, 100_000_000, 909_090_909)); // CR 1.10 unhealthy
+    open_and_reindex(&mut state, make_vault(2, 100_000_000, 800_000_000)); // CR 1.25 unhealthy
+    if let Some(v) = state.vault_id_to_vaults.get_mut(&2) {
+        v.bot_processing = true;
+    }
+
+    let scan = state.scan_unhealthy_vaults(dummy_rate(), false);
+    assert_eq!(
+        scan.unhealthy_vaults.len(),
+        1,
+        "bot_processing vault not republished"
+    );
+    assert_eq!(scan.unhealthy_vaults[0].vault_id, 1);
+    assert_eq!(
+        scan.vaults_visited, 2,
+        "both vaults visited (bot_processing flag read counts as a visit)"
+    );
+}
+
+// ============================================================================
+// Layer 9 — Ratio-based fence using public API
+// ============================================================================
+
+#[test]
+fn dos_005_ratio_helper_round_trips_band_setter() {
+    let mut state = fresh_state_with_price(10.0);
+    // 0 bps = no headroom; threshold is exactly the worst min_liq_ratio.
+    state.set_check_vaults_alert_band_bps(0);
+    assert_eq!(state.check_vaults_alert_threshold_key(), 13_300);
+    // 10000 bps (100%) → threshold 1.33 + 1.0 = 2.33 → key 23_300.
+    state.set_check_vaults_alert_band_bps(10_000);
+    assert_eq!(state.check_vaults_alert_threshold_key(), 23_300);
+    // Sanity: setter is idempotent (no Ratio drift).
+    state.set_check_vaults_alert_band_bps(1000);
+    assert_eq!(state.check_vaults_alert_threshold_key(), 14_300);
+}
+
+// Helper: keep the unused-import warning at bay if Ratio isn't used in the
+// final assertion list above.
+#[allow(dead_code)]
+fn _ratio_anchor() -> Ratio {
+    Ratio::new(dec!(1.0))
+}


### PR DESCRIPTION
## Summary
- Bound `check_vaults`'s per-tick walk to the at-risk CR band via the Wave-8b sorted-troves index, so safe vaults stop costing cycles every 5-minute XRC tick.
- Periodic full sweep (default every 12 ticks = once per hour) as a safety belt for cross-collateral CR-key drift.
- Both knobs admin-tunable; the cadence knob doubles as the revert path.

## Design call: at-risk band vs even-shard

This PR ships **Option B** (CR-band, default 1000 bps headroom). **Option A** (`vault_id mod N`, advance shard each tick) is a one-line swap if production reveals issues. Tunable via `set_check_vaults_alert_band_bps` and `set_check_vaults_full_sweep_every_n_ticks` admin endpoints.

### Tradeoff matrix

|                                           | Option A (vault_id mod N)                                 | Option B (at-risk band, **shipped**)                       |
| ----------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
| Cycle cost / tick (normal market)         | Constant: ~`N_total / N` vaults walked                    | Near-zero: only the at-risk band                           |
| Cycle cost / tick (price stress)          | Constant: same as normal                                  | Spikes proportional to band breach (work happens where it matters) |
| Worst-case latency to liquidate cold vault | Up to `N * tick = 60 min` (with N=12)                     | Up to `K * tick = 60 min` for stale-keyed drift; immediate for in-band |
| Cross-collateral CR-key drift             | Not affected (visits everyone in turn)                    | **Documented limitation** — vaults whose key is stale-above-threshold are missed by band ticks; full sweep catches them within K ticks |
| Observability                             | "Which shard is this tick" — boring, predictable          | `vaults_visited` and `threshold_key` per tick — variable but informative |
| Revert path                                | Set N=1 (full sweep every tick)                           | Set `full_sweep_every_n_ticks=1` (full sweep every tick)   |
| Per-collateral correctness                | Same: per-vault CR check inside the loop is the gate      | Same                                                       |

**Why B is the default:** at small TVL the band is almost always empty, so the cycle savings are large. The drift risk is bounded by K (the safety-belt full sweep) and the operator can widen the band or shorten K if production reveals edge cases. The pattern reuses LIQ-002's existing index — no new bookkeeping.

**When you'd want A instead:** if cycle cost stability matters more than savings (e.g., a billing model that prefers predictable spend), or if cross-collateral drift makes the band unreliable in practice.

## What changed

* **State** (3 new fields, all `serde(default)`): `check_vaults_alert_band_bps`, `check_vaults_full_sweep_every_n_ticks`, `ticks_since_full_sweep`. Pre-Wave-9c CBOR snapshots decode to the audited defaults (1000 bps, 12 ticks, 0).
* **State helpers**:
  * `check_vaults_alert_threshold_key()` — resolves the `vault_cr_index` upper-bound key from `max(min_liq_ratio across active collaterals) + band_bps / 10000`. Recovery mode automatically widens the threshold (uses `borrow_threshold_ratio` instead of `liquidation_ratio`).
  * `advance_check_vaults_tick()` — returns the band-vs-full-sweep decision and rolls the counter. K=0 or K=1 forces full sweep every tick (revert path).
  * `scan_unhealthy_vaults(rate, do_full_sweep) -> UnhealthyVaultScan` — bounded walk + per-vault classification, returns `(unhealthy_vaults, vaults_visited, was_full_sweep, threshold_key)` for instrumentation.
  * `set_check_vaults_alert_band_bps`, `set_check_vaults_full_sweep_every_n_ticks` — admin setters.
* **`lib.rs::check_vaults`** — replaces the unbounded `vault_cr_index.iter()` walk with `advance_check_vaults_tick()` + `scan_unhealthy_vaults()`. Logs `band-only` / `full-sweep` and `visited / threshold_key / unhealthy` per tick.
* **`main.rs`** — two new admin endpoints gated to the developer principal, mirroring the Wave-10 breaker setter pattern.
* **`.did`** — declares the two new admin endpoints.

The only path that changed inside `check_vaults` is the underwater-vault-discovery walk. The bot-claim auto-cancel section at the top runs unconditionally as before; the breaker check, bot/SP routing, and `bot_pending_vaults` / `sp_attempted_vaults` retention logic all stay intact.

## Tests

`src/rumi_protocol_backend/tests/audit_pocs_dos_005_check_vaults_shard.rs` — 22 state-level tests, no PocketIC required.

```
running 22 tests
test dos_005_default_alert_band_pinned_at_1000_bps ... ok
test dos_005_default_full_sweep_cadence_pinned_at_12_ticks ... ok
test dos_005_default_state_initializes_band_and_cadence ... ok
test dos_005_threshold_uses_max_min_liq_ratio_plus_band ... ok
test dos_005_threshold_widens_in_recovery_mode ... ok
test dos_005_threshold_widens_when_admin_widens_band ... ok
test dos_005_advance_tick_with_default_k_runs_band_for_first_11_ticks ... ok
test dos_005_advance_tick_with_k_3_runs_band_band_full ... ok
test dos_005_k_zero_means_always_full_sweep ... ok
test dos_005_k_one_means_always_full_sweep ... ok
test dos_005_band_only_tick_skips_above_threshold_vaults ... ok
test dos_005_full_sweep_tick_visits_every_vault ... ok
test dos_005_band_only_tick_finds_underwater_vaults_at_index_bottom ... ok
test dos_005_band_visit_count_grows_after_user_activity_pushes_vaults_into_band ... ok
test dos_005_band_only_and_full_sweep_agree_on_unhealthy_set_for_in_band_vaults ... ok
test dos_005_full_sweep_catches_stale_keyed_drifted_vault_band_misses ... ok
test dos_005_admin_widening_band_visits_more_vaults_next_tick ... ok
test dos_005_admin_lowering_full_sweep_cadence_speeds_up_drift_recovery ... ok
test dos_005_state_default_initializes_new_fields ... ok
test dos_005_simulated_pre_upgrade_snapshot_decodes_to_defaults ... ok
test dos_005_bot_processing_vaults_skipped_in_unhealthy_list_but_still_counted_visited ... ok
test dos_005_ratio_helper_round_trips_band_setter ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

**TDD red-green proof:** bypassing the band logic (`upper_bound = Bound::Unbounded` regardless of `do_full_sweep`) makes `band_only_tick_skips_above_threshold_vaults` fail with `got 50, expected 25`. The fence is real.

## Verification

* `cargo test --workspace --lib`: **365 passed, 1 ignored** (matches Wave 9b deploy baseline).
* `cargo test --package rumi_protocol_backend --lib`: **83 passed, 1 ignored**.
* `cargo test --test audit_pocs_dos_005_check_vaults_shard`: **22 passed**.
* All other audit_pocs files (BOT-001/001b/002, ICRC-idempotent, INT-001/002/003/004/006, LIQ-002/003/004/007/008, RED-001/002/003, DOS-pagination, DOS-006/007): **green**, including LIQ-008 circuit-breaker tests (which depend on the same `check_vaults` path).
* `cargo test --test pocket_ic_tests`: **42 passed, 3 ignored**.
* **Pre-existing-on-main breakage NOT introduced by this PR:** `audit_pocs_liq_005_deficit_account` 5 non-PIC subtests (need canister context for `ic_cdk::api::time()`) — confirmed by stashing the PR and running on main HEAD with the same failure count. Documented in the Wave 9b deploy memory.

## Test plan
- [x] `cargo test --workspace --lib` green
- [x] `cargo test --test audit_pocs_dos_005_check_vaults_shard` green (22/22)
- [x] All prior audit_pocs green (excluding pre-existing LIQ-005 non-PIC failures)
- [x] `cargo test --test pocket_ic_tests` green
- [x] TDD red verified: bypassing the band makes a strong test fail
- [ ] After PR merges to main, deploy to mainnet:
  ```bash
  dfx deploy rumi_protocol_backend --network ic --argument \
    '(variant { Upgrade = record { mode = null; description = opt
      "Wave 9c (audit DOS-005): shard check_vaults to at-risk CR band via Wave-8b sorted-troves index, with periodic full sweep" } })'
  ```
- [ ] Capture post-deploy module hash; pre-deploy baseline hash: `0xa717a340ccd226e9cf9c0756c06600c25f56f0c586974b75a507cf8e54268a06`
- [ ] 24h bake before Wave 9d

🤖 Generated with [Claude Code](https://claude.com/claude-code)