### PR TITLE
fix(analytics,xrc): stagger pull cycle + XRC timer lifecycle (audit Wave 9d — DOS-010, -011)

### DIFF
--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -12,6 +12,7 @@ mod queries;
 mod timers;
 mod tailing;
 mod types;
+pub mod pull_schedule;
 
 use crate::storage::{SlimState, SourceCanisterIds};
 

--- a/src/rumi_analytics/src/pull_schedule.rs
+++ b/src/rumi_analytics/src/pull_schedule.rs
@@ -1,0 +1,130 @@
+//! Wave-9d DoS hardening (DOS-010): per-source pull schedule.
+//!
+//! Pre-Wave-9d the pull cycle ran every 60s and fired all 9 sources
+//! through `futures::join!`, producing a synchronized burst of inter-
+//! canister calls every minute. Wave-9d replaces that with a per-source
+//! `next_pull_at_ns` schedule walked by a fast 5s tick. Each source
+//! still fires every 60s — they just no longer all fire together.
+//!
+//! All logic in this module is pure (no `ic_cdk::api::time()`, no
+//! state mutation) so it is unit-testable from
+//! `tests/audit_pocs_dos_010_stagger.rs`.
+//!
+//! See `audit-reports/2026-04-22-28e9896/findings.json` finding DOS-010
+//! and `audit-reports/2026-04-22-28e9896/remediation-plan.md`
+//! §"Wave 9 — DoS hardening".
+
+use std::collections::HashMap;
+
+use crate::storage::cursors;
+
+const SEC_NANOS: u64 = 1_000_000_000;
+
+/// How often the schedule walker fires. 5s gives a max latency of one
+/// tick between a source becoming due and being pulled — well below the
+/// 60s pacing contract.
+pub const PULL_CYCLE_TICK_SECS: u64 = 5;
+
+/// How often each source fires. 60s preserves the pre-Wave-9d analytics
+/// freshness contract surfaced via `last_pull_cycle_ns` and the per-
+/// cursor `last_success_ns` fields.
+pub const PULL_CYCLE_PERIOD_NS: u64 = 60 * SEC_NANOS;
+
+/// Initial offset between adjacent source slots. 6s × 9 sources = 54s
+/// fits comfortably inside the 60s `PULL_CYCLE_PERIOD_NS` window so
+/// every source fires exactly once per window even on the discretized
+/// 5s tick grid. Keeps every source 1s past the previous tick's slot
+/// (sources land at t=0/6/12/.../48 → ticks 0/10/15/.../50).
+pub const PULL_CYCLE_SOURCE_OFFSET_NS: u64 = 6 * SEC_NANOS;
+
+// Source ids. Tailers reuse their CURSOR_ID so the schedule key matches
+// the cursor metadata key. Source 0 is synthetic (supply cache has no
+// cursor).
+
+pub const SOURCE_ID_SUPPLY_CACHE: u8 = 0;
+pub const SOURCE_ID_BACKEND_EVENTS: u8 = cursors::CURSOR_ID_BACKEND_EVENTS;
+pub const SOURCE_ID_3POOL_SWAPS: u8 = cursors::CURSOR_ID_3POOL_SWAPS;
+pub const SOURCE_ID_3POOL_LIQUIDITY: u8 = cursors::CURSOR_ID_3POOL_LIQUIDITY;
+pub const SOURCE_ID_3POOL_BLOCKS: u8 = cursors::CURSOR_ID_3POOL_BLOCKS;
+pub const SOURCE_ID_AMM_SWAPS: u8 = cursors::CURSOR_ID_AMM_SWAPS;
+pub const SOURCE_ID_STABILITY_EVENTS: u8 = cursors::CURSOR_ID_STABILITY_EVENTS;
+pub const SOURCE_ID_ICUSD_BLOCKS: u8 = cursors::CURSOR_ID_ICUSD_BLOCKS;
+pub const SOURCE_ID_AMM_LIQUIDITY: u8 = cursors::CURSOR_ID_AMM_LIQUIDITY;
+
+/// All source ids in the order they should be seeded with offsets.
+/// Order matters: `seed_initial_schedule` assigns offset = index ×
+/// `PULL_CYCLE_SOURCE_OFFSET_NS`, so reordering this list shifts the
+/// staggering pattern.
+pub const ALL_SOURCE_IDS: &[u8] = &[
+    SOURCE_ID_SUPPLY_CACHE,
+    SOURCE_ID_BACKEND_EVENTS,
+    SOURCE_ID_3POOL_SWAPS,
+    SOURCE_ID_3POOL_LIQUIDITY,
+    SOURCE_ID_3POOL_BLOCKS,
+    SOURCE_ID_AMM_SWAPS,
+    SOURCE_ID_STABILITY_EVENTS,
+    SOURCE_ID_ICUSD_BLOCKS,
+    SOURCE_ID_AMM_LIQUIDITY,
+];
+
+/// Build a fresh schedule with sources spread across the 60s window.
+/// Source at index N gets deadline `now + N * PULL_CYCLE_SOURCE_OFFSET_NS`.
+pub fn seed_initial_schedule(now_ns: u64, sources: &[u8]) -> HashMap<u8, u64> {
+    let mut schedule = HashMap::with_capacity(sources.len());
+    for (idx, &source_id) in sources.iter().enumerate() {
+        let deadline = now_ns.saturating_add((idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS);
+        schedule.insert(source_id, deadline);
+    }
+    schedule
+}
+
+/// Re-seed on `post_upgrade`: copy every entry from `existing` verbatim
+/// (preserving in-flight offsets) and seed any source missing from
+/// `existing` at its index offset relative to `now_ns`. Never overwrites
+/// an existing entry.
+pub fn reseed_preserving(
+    now_ns: u64,
+    existing: &HashMap<u8, u64>,
+    sources: &[u8],
+) -> HashMap<u8, u64> {
+    let mut merged = existing.clone();
+    for (idx, &source_id) in sources.iter().enumerate() {
+        merged.entry(source_id).or_insert_with(|| {
+            now_ns.saturating_add((idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS)
+        });
+    }
+    merged
+}
+
+/// Return source ids whose deadline has passed and that should fire
+/// this tick. Sources missing from `schedule` are treated as due (so a
+/// newly added source fires on its next tick instead of being silently
+/// skipped until the next reseed).
+pub fn compute_due_sources(
+    now_ns: u64,
+    schedule: &HashMap<u8, u64>,
+    sources: &[u8],
+) -> Vec<u8> {
+    sources
+        .iter()
+        .copied()
+        .filter(|id| match schedule.get(id) {
+            Some(deadline) => *deadline <= now_ns,
+            None => true,
+        })
+        .collect()
+}
+
+/// Bump each fired source's deadline by `PULL_CYCLE_PERIOD_NS` from the
+/// tick's `now_ns`. Idempotent if the same source fires twice in a tick
+/// (only the last write wins, but the next deadline is the same).
+pub fn advance_schedule_for_fired(
+    schedule: &mut HashMap<u8, u64>,
+    now_ns: u64,
+    fired: &[u8],
+) {
+    for &source_id in fired {
+        let next = now_ns.saturating_add(PULL_CYCLE_PERIOD_NS);
+        schedule.insert(source_id, next);
+    }
+}

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -160,6 +160,13 @@ pub struct SlimState {
     /// first successful AMM `get_pools` after upgrade.
     #[serde(default)]
     pub amm_pools: Option<Vec<AmmPoolSnapshot>>,
+    /// Wave-9d DOS-010: per-source `next_pull_at_ns` deadlines for the
+    /// staggered pull cycle. Source ids match `pull_schedule::SOURCE_ID_*`
+    /// (tailers reuse their `cursors::CURSOR_ID_*` value). Persisted so
+    /// staggering offsets survive upgrade. `None` on legacy snapshots →
+    /// re-seeded on `post_upgrade`.
+    #[serde(default)]
+    pub source_next_pull_ns: Option<std::collections::HashMap<u8, u64>>,
 }
 
 /// Snapshot of one AMM pool's composition for portfolio LP valuation.
@@ -215,6 +222,7 @@ impl Default for SlimState {
             collateral_decimals: None,
             add_margin_backfill_cursor: None,
             amm_pools: None,
+            source_next_pull_ns: None,
         }
     }
 }

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -1,8 +1,13 @@
 //! Timer wiring. Phase 3 populates the daily tier with three collectors.
 //! Phase 4 adds event tailing and ICRC-3 block tailing to the pull cycle.
+//!
+//! Wave-9d (DOS-010) replaced the 60s `pull_cycle` join-storm with a
+//! per-source schedule walked by a 5s tick. Each source still fires
+//! every 60s; offsets persist across upgrade. See
+//! `pull_schedule.rs` for the pure logic.
 
 use std::time::Duration;
-use crate::{collectors, sources, state, tailing};
+use crate::{collectors, pull_schedule, sources, state, tailing};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SetupContext {
@@ -11,6 +16,17 @@ pub enum SetupContext {
 }
 
 pub fn setup_timers(ctx: SetupContext) {
+    // Wave-9d DOS-010: ensure every source has a `next_pull_at_ns`
+    // entry. On Init the schedule is empty → fresh offsets. On
+    // PostUpgrade existing offsets are preserved, only newly added
+    // sources are seeded.
+    let now = ic_cdk::api::time();
+    state::mutate_state(|s| {
+        let existing = s.source_next_pull_ns.clone().unwrap_or_default();
+        let merged = pull_schedule::reseed_preserving(now, &existing, pull_schedule::ALL_SOURCE_IDS);
+        s.source_next_pull_ns = Some(merged);
+    });
+
     // Fire the daily snapshot only on Init — on post_upgrade the pre-existing
     // row already covers today, so re-firing would create duplicate daily
     // snapshots. Fast snapshot, however, also seeds heap-only state that's
@@ -27,9 +43,14 @@ pub fn setup_timers(ctx: SetupContext) {
         ic_cdk::spawn(fast_snapshot());
     });
 
-    ic_cdk_timers::set_timer_interval(Duration::from_secs(60), || {
-        ic_cdk::spawn(pull_cycle());
-    });
+    // Wave-9d DOS-010: walk the per-source schedule every
+    // PULL_CYCLE_TICK_SECS (5s). Each source still fires every 60s; the
+    // burst of 9 concurrent inter-canister calls is now spread across
+    // the window.
+    ic_cdk_timers::set_timer_interval(
+        Duration::from_secs(pull_schedule::PULL_CYCLE_TICK_SECS),
+        || ic_cdk::spawn(pull_due_sources()),
+    );
     ic_cdk_timers::set_timer_interval(Duration::from_secs(300), || {
         ic_cdk::spawn(fast_snapshot());
     });
@@ -41,25 +62,68 @@ pub fn setup_timers(ctx: SetupContext) {
     });
 }
 
-async fn pull_cycle() {
-    refresh_supply_cache().await;
+/// Wave-9d DOS-010: walk the per-source schedule, fire any sources whose
+/// `next_pull_at_ns` is past, and bump their next deadline by
+/// `PULL_CYCLE_PERIOD_NS`. Typically fires 1 source per tick (sometimes 2
+/// when offsets cluster against the 5s tick grid).
+async fn pull_due_sources() {
+    let now = ic_cdk::api::time();
+    let due: Vec<u8> = state::read_state(|s| {
+        let schedule = s.source_next_pull_ns.clone().unwrap_or_default();
+        pull_schedule::compute_due_sources(now, &schedule, pull_schedule::ALL_SOURCE_IDS)
+    });
 
-    // Event tailing (Phase 4) - all sources are independent, run concurrently.
-    futures::join!(
-        tailing::backend_events::run(),
-        tailing::three_pool_swaps::run(),
-        tailing::three_pool_liquidity::run(),
-        tailing::amm_swaps::run(),
-        tailing::amm_liquidity::run(),
-        tailing::icrc3::tail_icusd_blocks(),
-        tailing::icrc3::tail_3pool_blocks(),
-        tailing::stability_pool::run(),
-    );
+    if due.is_empty() {
+        return;
+    }
 
-    // Update pull cycle timestamp
+    // Advance the schedule BEFORE awaiting any sources so a slow source
+    // doesn't double-fire on the next tick if its deadline is still in
+    // the past when the next tick arrives.
+    state::mutate_state(|s| {
+        let mut schedule = s.source_next_pull_ns.clone().unwrap_or_default();
+        pull_schedule::advance_schedule_for_fired(&mut schedule, now, &due);
+        s.source_next_pull_ns = Some(schedule);
+    });
+
+    // Fire each due source concurrently. Within a single tick that's at
+    // most 1-2 sources (vs 9 in the pre-Wave-9d sync storm). A slow
+    // source here doesn't block sources due on subsequent ticks because
+    // each tick is its own spawn().
+    let futs: Vec<_> = due.iter().map(|&id| run_source(id)).collect();
+    futures::future::join_all(futs).await;
+
+    // Update pull cycle timestamp (analytics freshness contract).
     state::mutate_state(|s| {
         s.last_pull_cycle_ns = Some(ic_cdk::api::time());
     });
+}
+
+/// Dispatch a single source pull by id. Adding a new source means
+/// adding it to `pull_schedule::ALL_SOURCE_IDS` AND adding a branch
+/// here.
+async fn run_source(source_id: u8) {
+    use crate::storage::cursors;
+    match source_id {
+        pull_schedule::SOURCE_ID_SUPPLY_CACHE => refresh_supply_cache().await,
+        cursors::CURSOR_ID_BACKEND_EVENTS => tailing::backend_events::run().await,
+        cursors::CURSOR_ID_3POOL_SWAPS => tailing::three_pool_swaps::run().await,
+        cursors::CURSOR_ID_3POOL_LIQUIDITY => tailing::three_pool_liquidity::run().await,
+        cursors::CURSOR_ID_3POOL_BLOCKS => tailing::icrc3::tail_3pool_blocks().await,
+        cursors::CURSOR_ID_AMM_SWAPS => tailing::amm_swaps::run().await,
+        cursors::CURSOR_ID_STABILITY_EVENTS => tailing::stability_pool::run().await,
+        cursors::CURSOR_ID_ICUSD_BLOCKS => tailing::icrc3::tail_icusd_blocks().await,
+        cursors::CURSOR_ID_AMM_LIQUIDITY => tailing::amm_liquidity::run().await,
+        _ => {
+            // Schedule contains an id not in run_source — drop it
+            // silently to avoid a permanent re-fire loop. Fix by adding
+            // the missing match arm.
+            ic_cdk::println!(
+                "[rumi_analytics] pull_due_sources: unknown source id {}",
+                source_id
+            );
+        }
+    }
 }
 
 async fn refresh_supply_cache() {

--- a/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
+++ b/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
@@ -1,0 +1,439 @@
+//! Wave-9d DoS hardening: stagger `rumi_analytics` pull cycle
+//! (DOS-010).
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/findings.json` finding DOS-010
+//!     (`pull_cycle fires every 60s with N concurrent inter-canister
+//!     calls`).
+//!   * Wave plan: `audit-reports/2026-04-22-28e9896/remediation-plan.md`
+//!     §"Wave 9 — DoS hardening".
+//!
+//! # What the gap is
+//!
+//! Pre-Wave-9d `pull_cycle()` ran every 60s and fired all source pulls
+//! (refresh_supply_cache + 7 event tailers + 1 ICRC-3 tailer = 9 calls)
+//! through `futures::join!` — every minute the canister generated a
+//! synchronized burst of inter-canister calls against the upstream
+//! protocol/3pool/AMM/SP/ledgers. Cycle cost is paid every tick even
+//! when no new data flows through.
+//!
+//! # How this file pins the fix
+//!
+//! Wave-9d switches to a **per-source schedule**: every source has its
+//! own `next_pull_at_ns` deadline, persisted in `SlimState` (so offsets
+//! survive upgrade). A small fast tick (every `PULL_CYCLE_TICK_SECS`
+//! seconds) walks the schedule, fires only sources whose deadline has
+//! passed, and bumps their next deadline by `PULL_CYCLE_PERIOD_NS`.
+//! Initial offsets spread the 9 sources across the 60s window at
+//! `PULL_CYCLE_SOURCE_OFFSET_NS` spacing.
+//!
+//! Layered fences (mirrors the LIQ-002 / DOS-005 file structure):
+//!
+//!  1. **Constant fences** — TICK / PERIOD / OFFSET pinned at audit-spec
+//!     values. Source-id list pinned (changes need a deliberate edit).
+//!  2. **Initial schedule** — `seed_initial_schedule` produces a
+//!     deterministic offset per source so they spread across the 60s
+//!     window instead of all firing at `now`.
+//!  3. **Due-source selection** — `compute_due_sources` returns ONLY
+//!     sources whose `next_pull_at_ns` is in the past. Out-of-band
+//!     timestamp arithmetic (saturating subtraction, clock skew) must
+//!     not include future-due sources in the firing set.
+//!  4. **Schedule advance** — `advance_schedule_for_fired` bumps each
+//!     fired source by exactly `PULL_CYCLE_PERIOD_NS`. Each source must
+//!     fire exactly once per `PULL_CYCLE_PERIOD_NS` window across many
+//!     ticks.
+//!  5. **Upgrade hygiene** — pre-Wave-9d snapshots decode with the new
+//!     `source_next_pull_ns` field populated from `serde(default)`. The
+//!     re-seed on `post_upgrade` must NOT clobber existing offsets when
+//!     the field is already populated.
+//!  6. **Late-added source** — adding a new source to `ALL_SOURCE_IDS`
+//!     after deploy (or on a fresh canister where the schedule has
+//!     drifted) must seed an offset for the new source without
+//!     disturbing the existing ones.
+
+use std::collections::HashMap;
+
+use rumi_analytics::pull_schedule::{
+    self, advance_schedule_for_fired, compute_due_sources, seed_initial_schedule,
+    ALL_SOURCE_IDS, PULL_CYCLE_PERIOD_NS, PULL_CYCLE_SOURCE_OFFSET_NS, PULL_CYCLE_TICK_SECS,
+    SOURCE_ID_AMM_LIQUIDITY, SOURCE_ID_AMM_SWAPS, SOURCE_ID_BACKEND_EVENTS,
+    SOURCE_ID_ICUSD_BLOCKS, SOURCE_ID_STABILITY_EVENTS, SOURCE_ID_SUPPLY_CACHE,
+    SOURCE_ID_3POOL_BLOCKS, SOURCE_ID_3POOL_LIQUIDITY, SOURCE_ID_3POOL_SWAPS,
+};
+
+const SEC_NANOS: u64 = 1_000_000_000;
+
+// ============================================================================
+// Layer 1 — constant fences
+// ============================================================================
+
+#[test]
+fn dos_010_tick_seconds_pinned_at_5() {
+    assert_eq!(
+        PULL_CYCLE_TICK_SECS, 5,
+        "Wave-9d DOS-010: pull-cycle tick must be 5s. Lengthening it \
+         pushes some sources past their nominal 60s cadence; shortening \
+         it wakes the canister more often without spreading work further."
+    );
+}
+
+#[test]
+fn dos_010_period_pinned_at_60s() {
+    assert_eq!(
+        PULL_CYCLE_PERIOD_NS,
+        60 * SEC_NANOS,
+        "Wave-9d DOS-010: each source must fire every 60s (matches the \
+         pre-Wave-9d cadence). Changing this changes the analytics \
+         freshness contract surfaced through `last_pull_cycle_ns`."
+    );
+}
+
+#[test]
+fn dos_010_offset_spreads_sources_across_window() {
+    // 9 sources × 6s offset = 54s spread, fits cleanly inside the 60s
+    // PULL_CYCLE_PERIOD_NS window. Pre-Wave-9d behaviour collapsed all
+    // 9 source pulls into the same instant; 6s spacing puts each on its
+    // own tick when the wall clock advances in 5s steps.
+    assert_eq!(
+        PULL_CYCLE_SOURCE_OFFSET_NS,
+        6 * SEC_NANOS,
+        "Wave-9d DOS-010: source-offset spacing must be 6s. Wider spacing \
+         (e.g., 7s × 9 = 63s) overshoots the 60s window and leaves the \
+         last source firing on alternate cycles relative to the 5s tick grid."
+    );
+}
+
+#[test]
+fn dos_010_source_ids_full_list_pinned() {
+    // Pinning the source-id list ensures any new source forces an
+    // explicit edit here AND in seed_initial_schedule's coverage. This
+    // is the same fence pattern as cursors.rs CURSOR_ID_*.
+    let mut got: Vec<u8> = ALL_SOURCE_IDS.iter().copied().collect();
+    got.sort();
+    let expected: Vec<u8> = vec![
+        SOURCE_ID_SUPPLY_CACHE,    // 0
+        SOURCE_ID_BACKEND_EVENTS,  // 1 (matches CURSOR_ID_BACKEND_EVENTS)
+        SOURCE_ID_3POOL_SWAPS,     // 2
+        SOURCE_ID_3POOL_LIQUIDITY, // 3
+        SOURCE_ID_3POOL_BLOCKS,    // 4
+        SOURCE_ID_AMM_SWAPS,       // 5
+        SOURCE_ID_STABILITY_EVENTS,// 6
+        SOURCE_ID_ICUSD_BLOCKS,    // 7
+        SOURCE_ID_AMM_LIQUIDITY,   // 8
+    ];
+    assert_eq!(got, expected, "ALL_SOURCE_IDS must list every source pull. Adding a new tailer means adding a new id here and a new branch in run_source.");
+}
+
+#[test]
+fn dos_010_supply_cache_id_is_zero() {
+    // Source IDs 1..=8 mirror the CURSOR_ID_* range so the schedule key
+    // for a tailer matches its cursor metadata key. Source 0 is the
+    // synthetic supply-cache id (no cursor exists).
+    assert_eq!(SOURCE_ID_SUPPLY_CACHE, 0);
+}
+
+// ============================================================================
+// Layer 2 — initial schedule (offsets spread across the window)
+// ============================================================================
+
+#[test]
+fn dos_010_seed_initial_schedule_assigns_unique_offsets() {
+    let now: u64 = 1_000_000_000_000;
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    assert_eq!(
+        schedule.len(),
+        ALL_SOURCE_IDS.len(),
+        "every source must receive an initial deadline"
+    );
+    let mut deadlines: Vec<u64> = schedule.values().copied().collect();
+    deadlines.sort();
+    deadlines.dedup();
+    assert_eq!(
+        deadlines.len(),
+        ALL_SOURCE_IDS.len(),
+        "all source deadlines must be unique (no two sources share a slot)"
+    );
+}
+
+#[test]
+fn dos_010_seed_initial_schedule_offsets_are_evenly_spaced() {
+    // Source N gets `now + N * PULL_CYCLE_SOURCE_OFFSET_NS`.
+    // (N is the source's index in ALL_SOURCE_IDS so the spacing stays
+    // even regardless of the actual u8 ids.)
+    let now: u64 = 0;
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    for (idx, source_id) in ALL_SOURCE_IDS.iter().enumerate() {
+        let expected = now + (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS;
+        assert_eq!(
+            schedule.get(source_id).copied(),
+            Some(expected),
+            "source id {} (index {}) must be seeded at offset {}",
+            source_id, idx, expected
+        );
+    }
+}
+
+#[test]
+fn dos_010_seed_initial_schedule_preserves_existing_entries() {
+    // Re-seeding (e.g., on post_upgrade) must NOT overwrite existing
+    // deadlines — that would reset the staggering window every upgrade.
+    let now: u64 = 1_000_000_000_000;
+    let mut existing = HashMap::new();
+    existing.insert(SOURCE_ID_BACKEND_EVENTS, 999_000_000_000);
+    existing.insert(SOURCE_ID_3POOL_SWAPS, 998_000_000_000);
+
+    let merged = pull_schedule::reseed_preserving(now, &existing, ALL_SOURCE_IDS);
+
+    assert_eq!(
+        merged.get(&SOURCE_ID_BACKEND_EVENTS).copied(),
+        Some(999_000_000_000),
+        "existing deadline for backend_events must be preserved"
+    );
+    assert_eq!(
+        merged.get(&SOURCE_ID_3POOL_SWAPS).copied(),
+        Some(998_000_000_000),
+        "existing deadline for 3pool_swaps must be preserved"
+    );
+    // New sources get fresh offsets relative to `now`.
+    let backend_idx = ALL_SOURCE_IDS
+        .iter()
+        .position(|id| *id == SOURCE_ID_BACKEND_EVENTS)
+        .unwrap();
+    assert_ne!(
+        merged.get(&SOURCE_ID_SUPPLY_CACHE).copied(),
+        Some(999_000_000_000),
+        "supply-cache must NOT be backfilled with another source's deadline"
+    );
+    let supply_idx = ALL_SOURCE_IDS
+        .iter()
+        .position(|id| *id == SOURCE_ID_SUPPLY_CACHE)
+        .unwrap();
+    let _ = backend_idx; // silence unused — referenced in trace if assertion fires
+    let expected_supply = now + (supply_idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS;
+    assert_eq!(
+        merged.get(&SOURCE_ID_SUPPLY_CACHE).copied(),
+        Some(expected_supply),
+        "newly added source must be seeded at its index offset"
+    );
+}
+
+// ============================================================================
+// Layer 3 — due-source selection
+// ============================================================================
+
+#[test]
+fn dos_010_compute_due_sources_returns_empty_when_nothing_is_due() {
+    // Schedule is now+offset; at exactly `now` only the source whose
+    // offset == 0 (index 0 = supply cache) is due.
+    let now: u64 = 100 * SEC_NANOS;
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+    assert_eq!(
+        due,
+        vec![SOURCE_ID_SUPPLY_CACHE],
+        "at t=now, only the source seeded at offset 0 (supply cache) is due"
+    );
+}
+
+#[test]
+fn dos_010_compute_due_sources_includes_only_past_deadlines() {
+    let now: u64 = 100 * SEC_NANOS;
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    // Advance to just past source-index-3's offset (3 * 7s = 21s into the cycle).
+    let later = now + 22 * SEC_NANOS;
+    let due = compute_due_sources(later, &schedule, ALL_SOURCE_IDS);
+    // Sources 0..=3 (by index) should be due; their seed-time was 0/7/14/21s past now.
+    assert_eq!(
+        due.len(),
+        4,
+        "at t=now+22s, sources at offsets 0/7/14/21 must all be due (got {} = {:?})",
+        due.len(), due
+    );
+    for &id in &due {
+        let idx = ALL_SOURCE_IDS.iter().position(|&i| i == id).unwrap();
+        assert!(
+            (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS <= 22 * SEC_NANOS,
+            "source id {} (index {}) was reported due but its offset is in the future",
+            id, idx
+        );
+    }
+}
+
+#[test]
+fn dos_010_compute_due_sources_treats_missing_entry_as_due() {
+    // If `next_pull_at_ns` is missing for some source (e.g., new source
+    // added between upgrades and re-seed has not yet run), it MUST be
+    // due. Otherwise a never-seeded source would never fire.
+    let mut schedule = HashMap::new();
+    schedule.insert(SOURCE_ID_SUPPLY_CACHE, u64::MAX); // far future
+    let now: u64 = 100 * SEC_NANOS;
+    let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+    // Only sources NOT in schedule should be due (everything except SOURCE_ID_SUPPLY_CACHE).
+    assert!(
+        !due.contains(&SOURCE_ID_SUPPLY_CACHE),
+        "source with future deadline must not be reported due"
+    );
+    assert_eq!(
+        due.len(),
+        ALL_SOURCE_IDS.len() - 1,
+        "every source except SUPPLY_CACHE has no schedule entry — all should be reported due"
+    );
+}
+
+// ============================================================================
+// Layer 4 — schedule advance / per-source 60s pacing
+// ============================================================================
+
+#[test]
+fn dos_010_advance_schedule_bumps_fired_sources_by_period() {
+    let now: u64 = 100 * SEC_NANOS;
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let original_supply = schedule[&SOURCE_ID_SUPPLY_CACHE];
+    let fired = vec![SOURCE_ID_SUPPLY_CACHE];
+
+    advance_schedule_for_fired(&mut schedule, now, &fired);
+
+    assert_eq!(
+        schedule[&SOURCE_ID_SUPPLY_CACHE],
+        now + PULL_CYCLE_PERIOD_NS,
+        "fired source must have its deadline pushed exactly PULL_CYCLE_PERIOD_NS into the future"
+    );
+    let _ = original_supply; // value irrelevant; checked the new value is `now + period`
+
+    // Non-fired sources must not be touched.
+    for &id in ALL_SOURCE_IDS {
+        if id == SOURCE_ID_SUPPLY_CACHE {
+            continue;
+        }
+        let idx = ALL_SOURCE_IDS.iter().position(|&i| i == id).unwrap();
+        assert_eq!(
+            schedule[&id],
+            now + (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS,
+            "non-fired source {} must keep its original deadline",
+            id
+        );
+    }
+}
+
+#[test]
+fn dos_010_each_source_fires_exactly_once_per_window() {
+    // Walk a 60s window in 5s ticks. With 9 sources × 7s offsets,
+    // each source must fire exactly once across the window.
+    let mut now: u64 = 0;
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let mut fire_counts: HashMap<u8, u32> = HashMap::new();
+
+    // Walk PULL_CYCLE_PERIOD_NS worth of ticks. PULL_CYCLE_PERIOD_NS / TICK_SECS = 60/5 = 12 ticks.
+    let n_ticks = PULL_CYCLE_PERIOD_NS / (PULL_CYCLE_TICK_SECS * SEC_NANOS);
+    for _ in 0..n_ticks {
+        let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+        for &id in &due {
+            *fire_counts.entry(id).or_insert(0) += 1;
+        }
+        advance_schedule_for_fired(&mut schedule, now, &due);
+        now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
+    }
+
+    // Walk one more period. Final tally should be 1 per source per
+    // window, total = 9 fires per 60s.
+    for &id in ALL_SOURCE_IDS {
+        let count = fire_counts.get(&id).copied().unwrap_or(0);
+        assert_eq!(
+            count, 1,
+            "source id {} must fire exactly once per 60s window (got {} fires across {} ticks)",
+            id, count, n_ticks
+        );
+    }
+    // Total fires == number of sources.
+    let total: u32 = fire_counts.values().sum();
+    assert_eq!(
+        total,
+        ALL_SOURCE_IDS.len() as u32,
+        "total fires across one 60s window must equal source count (got {})",
+        total
+    );
+}
+
+#[test]
+fn dos_010_no_sync_storm_at_any_single_tick() {
+    // Walk the schedule for many ticks; assert that at no point are
+    // more than `ceil(N_sources * tick / period) + 1` sources due
+    // simultaneously. Pre-fix all 9 fired together; post-fix at most
+    // 1-2 per tick (drift may cluster a couple together but never all 9).
+    let mut now: u64 = 0;
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let max_per_tick_observed = {
+        let mut m: usize = 0;
+        for _ in 0..200 {
+            let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+            if due.len() > m {
+                m = due.len();
+            }
+            advance_schedule_for_fired(&mut schedule, now, &due);
+            now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
+        }
+        m
+    };
+    // Hard upper bound: 2 per tick (some clustering as the deadlines
+    // drift relative to the 5s tick grid). If this ever exceeds 2,
+    // either the offset shrunk or the tick grew and DOS-010's premise
+    // is undermined.
+    assert!(
+        max_per_tick_observed <= 2,
+        "no single tick must fire more than 2 sources concurrently (got {})",
+        max_per_tick_observed
+    );
+}
+
+// ============================================================================
+// Layer 5 — upgrade hygiene
+// ============================================================================
+
+#[test]
+fn dos_010_reseed_after_upgrade_preserves_in_flight_offsets() {
+    // Simulate: tick a few times, snapshot the schedule, "upgrade" by
+    // re-seeding with the snapshot, assert the schedule is unchanged.
+    let mut now: u64 = 0;
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    for _ in 0..5 {
+        let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+        advance_schedule_for_fired(&mut schedule, now, &due);
+        now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
+    }
+    let snapshot: HashMap<u8, u64> = schedule.clone();
+
+    // Simulate post_upgrade: reseed with the snapshot.
+    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS);
+
+    // Every entry from snapshot must survive verbatim.
+    for (id, deadline) in snapshot.iter() {
+        assert_eq!(
+            merged.get(id).copied(),
+            Some(*deadline),
+            "post-upgrade reseed must preserve in-flight deadline for source {}",
+            id
+        );
+    }
+}
+
+#[test]
+fn dos_010_reseed_after_upgrade_seeds_newly_added_source() {
+    // Pre-upgrade snapshot is missing a source (simulating a new tailer
+    // added in the upgrade). Reseed must add it without disturbing the
+    // existing entries.
+    let now: u64 = 100 * SEC_NANOS;
+    let mut snapshot = HashMap::new();
+    for &id in ALL_SOURCE_IDS.iter().take(ALL_SOURCE_IDS.len() - 1) {
+        snapshot.insert(id, now + 1);
+    }
+    let new_source_id = *ALL_SOURCE_IDS.last().unwrap();
+    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS);
+    assert!(
+        merged.contains_key(&new_source_id),
+        "post-upgrade reseed must seed a new source not present in snapshot"
+    );
+    // Existing entries unchanged.
+    for &id in ALL_SOURCE_IDS.iter().take(ALL_SOURCE_IDS.len() - 1) {
+        assert_eq!(merged[&id], now + 1, "existing source {} disturbed", id);
+    }
+}

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -195,6 +195,10 @@ fn setup_timers() {
 
     // Price timers for all non-ICP collateral types (timers don't survive upgrades,
     // so we re-register them here for any collateral added via add_collateral_token).
+    // Wave-9d DOS-011: register through `xrc::register_collateral_price_timer` so
+    // each closure gates the XRC fetch on `CollateralStatus`. Wound-down collateral
+    // (Frozen / Sunset / Deprecated) keeps the timer alive but skips the ~1B-cycle
+    // XRC call until status flips back to Active or Paused.
     let non_icp_collaterals: Vec<candid::Principal> = read_state(|s| {
         let icp = s.icp_collateral_type();
         s.collateral_configs.keys()
@@ -204,10 +208,7 @@ fn setup_timers() {
     });
     for ledger_id in non_icp_collaterals {
         log!(INFO, "[setup_timers] Registering price timer for collateral {}", ledger_id);
-        ic_cdk_timers::set_timer_interval(
-            rumi_protocol_backend::xrc::FETCHING_ICP_RATE_INTERVAL,
-            move || ic_cdk::spawn(rumi_protocol_backend::management::fetch_collateral_price(ledger_id)),
-        );
+        rumi_protocol_backend::xrc::register_collateral_price_timer(ledger_id);
     }
 
     // clean_stale_operations timer removed — the old implementation dangerously
@@ -4632,14 +4633,16 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
     // Register a price-fetching timer for the new collateral type.
     // ICP has its own dedicated timer in setup_timers(); other collateral
     // types use the generic fetch_collateral_price.
+    // Wave-9d DOS-011: registers via `xrc::register_collateral_price_timer`
+    // so the closure gates on `CollateralStatus`. The timer is permanent
+    // for the canister lifetime; status changes flip the gate at the next
+    // tick with no `clear_timer` / `TimerId` bookkeeping (which would not
+    // survive upgrade anyway).
     let ledger_id = arg.ledger_canister_id;
     let is_icp = read_state(|s| s.icp_collateral_type() == ledger_id);
     if !is_icp {
         log!(INFO, "[add_collateral_token] Registering price timer for collateral {}", ledger_id);
-        ic_cdk_timers::set_timer_interval(
-            rumi_protocol_backend::xrc::FETCHING_ICP_RATE_INTERVAL,
-            move || ic_cdk::spawn(rumi_protocol_backend::management::fetch_collateral_price(ledger_id)),
-        );
+        rumi_protocol_backend::xrc::register_collateral_price_timer(ledger_id);
     }
 
     log!(INFO, "[add_collateral_token] Added collateral type: {} (decimals={})", arg.ledger_canister_id, decimals);

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -1,13 +1,78 @@
 use crate::logs::TRACE_XRC;
-use crate::numeric::UsdIcp;  
-use crate::state::{mutate_state, read_state};
+use crate::numeric::UsdIcp;
+use crate::state::{mutate_state, read_state, CollateralStatus};
 use crate::Decimal;
 use crate::Mode;
+use candid::Principal;
 use ic_canister_log::log;
 use ic_xrc_types::GetExchangeRateResult;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal_macros::dec;
 use std::time::Duration;
+
+/// Wave-9d DOS-011: classifies whether a collateral type's periodic
+/// background XRC price refresh is still useful given its lifecycle
+/// status. Returns true for `Active` and `Paused` (both still allow
+/// price-sensitive operations such as liquidation), false for the soft-
+/// delist statuses (`Frozen`, `Sunset`, `Deprecated`) where every code
+/// path that would consume a fresh price is already blocked or read-
+/// only.
+///
+/// Used by the per-collateral 300s timer closures registered in
+/// `setup_timers()` and `add_collateral_token` so that wound-down
+/// collateral no longer burns ~1B cycles per tick on a useless XRC
+/// call.
+pub fn collateral_needs_periodic_price_refresh(status: CollateralStatus) -> bool {
+    match status {
+        CollateralStatus::Active | CollateralStatus::Paused => true,
+        CollateralStatus::Frozen
+        | CollateralStatus::Sunset
+        | CollateralStatus::Deprecated => false,
+    }
+}
+
+/// Wave-9d DOS-011: pure-state gate used by the per-collateral price
+/// timer closure. Returns true if the closure should call XRC for this
+/// collateral, false to early-return without burning the ~1B cycles of
+/// an XRC fetch. Exposed as a module function so unit tests can pin the
+/// composition (status lookup + classification) without spawning a
+/// canister. Returns false for unknown collateral so a stale closure
+/// (collateral removed entirely from `collateral_configs`) doesn't keep
+/// hitting XRC for a deleted ledger.
+pub fn should_fetch_collateral_price(
+    state: &crate::state::State,
+    ledger_id: &Principal,
+) -> bool {
+    state
+        .get_collateral_status(ledger_id)
+        .map(collateral_needs_periodic_price_refresh)
+        .unwrap_or(false)
+}
+
+/// Wave-9d DOS-011: registers the recurring per-collateral XRC price
+/// timer with the status-check gate baked in. Used by both
+/// `setup_timers()` (re-registering after upgrade) and
+/// `add_collateral_token` (registering for a brand-new collateral).
+///
+/// The timer keeps firing every `FETCHING_ICP_RATE_INTERVAL`
+/// regardless of status — that's free. The gate runs synchronously
+/// INSIDE the closure (before any `ic_cdk::spawn`): if the collateral
+/// is wound down, we early-return before allocating an async task and
+/// before the (~1B cycle) XRC call.
+pub fn register_collateral_price_timer(ledger_id: Principal) {
+    ic_cdk_timers::set_timer_interval(FETCHING_ICP_RATE_INTERVAL, move || {
+        let go = read_state(|s| should_fetch_collateral_price(s, &ledger_id));
+        if !go {
+            log!(
+                TRACE_XRC,
+                "[register_collateral_price_timer] skipping fetch for {} (wound-down or removed)",
+                ledger_id
+            );
+            return;
+        }
+        ic_cdk::spawn(crate::management::fetch_collateral_price(ledger_id));
+    });
+}
 
 /// How often to passively fetch ICP price from XRC (background polling).
 /// Each XRC call costs ~1B cycles. At 60s = ~$58/month, at 300s = ~$12/month.

--- a/src/rumi_protocol_backend/tests/audit_pocs_dos_011_xrc_timer_lifecycle.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_dos_011_xrc_timer_lifecycle.rs
@@ -1,0 +1,260 @@
+//! Wave-9d DoS hardening: XRC timer status check
+//! (DOS-011).
+//!
+//! Audit report:
+//!   * `audit-reports/2026-04-22-28e9896/findings.json` finding DOS-011
+//!     (`Every add_collateral_token registers a new permanent XRC price
+//!     timer`, recommendation: "Inside the timer closure, check
+//!     collateral status and early-return if disabled").
+//!   * Wave plan: `audit-reports/2026-04-22-28e9896/remediation-plan.md`
+//!     §"Wave 9 — DoS hardening".
+//!
+//! # What the gap is
+//!
+//! Pre-Wave-9d every call to `add_collateral_token` registered a
+//! permanent `set_timer_interval` that fires every 300s and burns
+//! ~1B cycles per call to XRC, regardless of whether the collateral is
+//! still actively being used. CollateralStatus has 5 lifecycle states
+//! (Active / Paused / Frozen / Sunset / Deprecated), but only Active
+//! and Paused require ongoing price updates: Frozen, Sunset, and
+//! Deprecated either block all operations or are read-only winding-
+//! down states where a fresh price doesn't change anything.
+//!
+//! # Why the status-check approach (not the cancel-path approach)
+//!
+//! The audit's stated recommendation is "check collateral status and
+//! early-return if disabled". We follow that rather than canceling
+//! timers via `clear_timer`:
+//!  * `TimerId` is a runtime handle that does NOT survive upgrade —
+//!    every `setup_timers()` call re-registers a fresh set of timers.
+//!    Storing TimerId in stable memory would be misleading.
+//!  * After `setup_timers()` the canister has one timer per non-ICP
+//!    collateral, each closure capturing the ledger principal. Adding a
+//!    one-line `read_state` gate at the top of the closure costs ~3
+//!    instructions vs. the ~1B cycles of the XRC call we skip.
+//!  * Reactivation works automatically: when status flips from Sunset
+//!    back to Active (admin call), the very next 300s tick resumes
+//!    fetching with no timer re-registration needed.
+//!  * Same outcome as cancel-path: Frozen/Sunset/Deprecated collateral
+//!    no longer burns cycles on background XRC fetches.
+//!
+//! Layered fences:
+//!
+//!  1. **Pure-function fence** —
+//!     `collateral_needs_periodic_price_refresh(status)` returns true
+//!     only for Active and Paused. Paused still allows liquidations
+//!     (per `CollateralStatus::allows_liquidation`), so we still want
+//!     fresh prices.
+//!  2. **Status-coverage fence** — every variant of CollateralStatus
+//!     must appear in the helper's match (compile fails otherwise).
+//!  3. **Active-state-needs-price** — the helper must return true for
+//!     statuses where any price-sensitive operation can still happen.
+//!  4. **Soft-delist-skips-fetch** — the helper must return false for
+//!     Frozen, Sunset, Deprecated.
+//!  5. **Round-trip on status flip** — flipping status flips the
+//!     helper's answer immediately (no cached / stale answer).
+
+use candid::Principal;
+
+use rumi_protocol_backend::state::{CollateralStatus, State};
+use rumi_protocol_backend::xrc::{
+    collateral_needs_periodic_price_refresh, should_fetch_collateral_price,
+};
+use rumi_protocol_backend::InitArg;
+
+fn icp_ledger() -> Principal {
+    Principal::from_slice(&[10])
+}
+
+fn other_ledger() -> Principal {
+    Principal::from_slice(&[20])
+}
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: icp_ledger(),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+fn set_status(state: &mut State, ct: Principal, status: CollateralStatus) {
+    if let Some(config) = state.collateral_configs.get_mut(&ct) {
+        config.status = status;
+    } else {
+        panic!("collateral type {} not in configs", ct);
+    }
+}
+
+// ============================================================================
+// Layer 1 — pure-function fence
+// ============================================================================
+
+#[test]
+fn dos_011_active_collateral_needs_price() {
+    assert!(
+        collateral_needs_periodic_price_refresh(CollateralStatus::Active),
+        "Active collateral must keep receiving price updates — every \
+         user-facing op (open / borrow / withdraw / liquidate / redeem) \
+         requires a fresh price."
+    );
+}
+
+#[test]
+fn dos_011_paused_collateral_needs_price() {
+    // Paused allows repay + add_collateral + close + liquidation, all
+    // of which are price-sensitive. Skipping price refresh for Paused
+    // would let liquidations run on stale prices.
+    assert!(
+        collateral_needs_periodic_price_refresh(CollateralStatus::Paused),
+        "Paused collateral still allows liquidations and must keep \
+         receiving price updates. Skipping refresh would let \
+         liquidations run on stale data."
+    );
+}
+
+// ============================================================================
+// Layer 2 — soft-delist statuses skip fetch
+// ============================================================================
+
+#[test]
+fn dos_011_frozen_collateral_skips_price() {
+    assert!(
+        !collateral_needs_periodic_price_refresh(CollateralStatus::Frozen),
+        "Frozen collateral blocks every operation (HARD STOP). \
+         Background price fetches are pure cycle waste."
+    );
+}
+
+#[test]
+fn dos_011_sunset_collateral_skips_price() {
+    assert!(
+        !collateral_needs_periodic_price_refresh(CollateralStatus::Sunset),
+        "Sunset collateral allows only repay/withdraw/close — no \
+         price-sensitive operations. Background fetches are unnecessary."
+    );
+}
+
+#[test]
+fn dos_011_deprecated_collateral_skips_price() {
+    assert!(
+        !collateral_needs_periodic_price_refresh(CollateralStatus::Deprecated),
+        "Deprecated collateral is read-only. Nothing on the protocol \
+         touches its price; background fetches burn ~1B cycles per tick \
+         for no behavioural change."
+    );
+}
+
+// ============================================================================
+// Layer 3 — round trip on status flip
+// ============================================================================
+
+#[test]
+fn dos_011_helper_round_trips_on_status_flips() {
+    // Active → Frozen → Active. The helper's answer flips with the
+    // status; there is no cached / hysteretic value to stomach.
+    let active = CollateralStatus::Active;
+    let frozen = CollateralStatus::Frozen;
+    assert!(collateral_needs_periodic_price_refresh(active));
+    assert!(!collateral_needs_periodic_price_refresh(frozen));
+    assert!(collateral_needs_periodic_price_refresh(active));
+}
+
+// ============================================================================
+// Layer 4 — exhaustive coverage of CollateralStatus
+// ============================================================================
+
+// ============================================================================
+// Layer 4 — state-level gate (composes status lookup + classification)
+// ============================================================================
+
+#[test]
+fn dos_011_state_gate_returns_true_for_active_collateral() {
+    let mut state = fresh_state();
+    set_status(&mut state, icp_ledger(), CollateralStatus::Active);
+    assert!(
+        should_fetch_collateral_price(&state, &icp_ledger()),
+        "active collateral must be fetched"
+    );
+}
+
+#[test]
+fn dos_011_state_gate_returns_false_for_sunset_collateral() {
+    let mut state = fresh_state();
+    set_status(&mut state, icp_ledger(), CollateralStatus::Sunset);
+    assert!(
+        !should_fetch_collateral_price(&state, &icp_ledger()),
+        "sunset collateral must be skipped"
+    );
+}
+
+#[test]
+fn dos_011_state_gate_round_trips_on_status_flip_in_state() {
+    // Active → Frozen → Active flip-on-state, mirroring what
+    // `set_collateral_status` does when admin flips a collateral.
+    let mut state = fresh_state();
+    set_status(&mut state, icp_ledger(), CollateralStatus::Active);
+    assert!(should_fetch_collateral_price(&state, &icp_ledger()));
+    set_status(&mut state, icp_ledger(), CollateralStatus::Frozen);
+    assert!(!should_fetch_collateral_price(&state, &icp_ledger()));
+    set_status(&mut state, icp_ledger(), CollateralStatus::Active);
+    assert!(should_fetch_collateral_price(&state, &icp_ledger()));
+}
+
+#[test]
+fn dos_011_state_gate_returns_false_for_unknown_collateral() {
+    // If a closure outlives its collateral entry (e.g., never present
+    // in `collateral_configs`) the gate must skip — otherwise the timer
+    // would pound XRC for a deleted ledger every 300s.
+    let state = fresh_state();
+    assert!(
+        !should_fetch_collateral_price(&state, &other_ledger()),
+        "unknown collateral must be skipped"
+    );
+}
+
+// ============================================================================
+// Layer 5 — exhaustive coverage of CollateralStatus
+// ============================================================================
+
+#[test]
+fn dos_011_every_status_variant_classified() {
+    // If a new CollateralStatus variant is added without updating the
+    // helper, the match in `collateral_needs_periodic_price_refresh`
+    // would compile (any of the existing arms could shadow it). This
+    // test pins the count: 5 variants today, all classified explicitly.
+    let variants = [
+        CollateralStatus::Active,
+        CollateralStatus::Paused,
+        CollateralStatus::Frozen,
+        CollateralStatus::Sunset,
+        CollateralStatus::Deprecated,
+    ];
+    let mut needs = 0usize;
+    let mut skips = 0usize;
+    for s in &variants {
+        if collateral_needs_periodic_price_refresh(*s) {
+            needs += 1;
+        } else {
+            skips += 1;
+        }
+    }
+    assert_eq!(
+        needs, 2,
+        "exactly 2 statuses (Active, Paused) must need periodic price \
+         refresh — got {} needs / {} skips",
+        needs, skips
+    );
+    assert_eq!(
+        skips, 3,
+        "exactly 3 statuses (Frozen, Sunset, Deprecated) must skip the \
+         periodic refresh — got {} needs / {} skips",
+        needs, skips
+    );
+}


### PR DESCRIPTION
## Summary

Wave 9d closes the final two cycle-DoS findings deferred from the
2026-04-22 audit's Wave 9 cluster. Two independent fixes on two
different canisters bundled into one PR (both small).

- **DOS-010** (rumi_analytics): replace the 60s `pull_cycle` join-storm
  with a per-source `next_pull_at_ns` schedule walked by a 5s tick.
  9 sources still fire every 60s — they just no longer all fire in the
  same instant. Schedule persists in `SlimState` so offsets survive
  upgrade.
- **DOS-011** (rumi_protocol_backend): add a synchronous status gate
  inside the per-collateral 300s XRC price-timer closure. Wound-down
  collateral (Frozen / Sunset / Deprecated) early-returns before the
  ~1B-cycle XRC call.

## DOS-010 design — Option A (per-cursor jitter offset)

`SlimState.source_next_pull_ns: Option<HashMap<u8, u64>>` holds each
source's next deadline. The new `pull_due_sources` walker fires every
`PULL_CYCLE_TICK_SECS` (5s) and:

1. reads the schedule, picks sources whose deadline `<= now`
2. advances each fired source's deadline to `now + PULL_CYCLE_PERIOD_NS` (60s)
3. concurrently runs only the due sources (typically 1-2 per tick)

Initial offsets: source at index N gets `now + N * 6s`. Nine sources ×
6s = 54s spread, fits cleanly inside the 60s period on the discretized
5s tick grid. Re-seeding on `post_upgrade` preserves in-flight offsets
and only seeds new sources missing from the snapshot.

Pure logic in `pull_schedule` module so unit tests pin the behaviour
(`seed_initial_schedule`, `compute_due_sources`,
`advance_schedule_for_fired`, `reseed_preserving`) without spawning a
canister. Surface change is additive — a single `#[serde(default)]`
field on `SlimState`. Legacy CBOR snapshots decode with `None` and get
re-seeded by `setup_timers` on upgrade.

## DOS-011 design — status check at timer closure entry (NOT cancel-path)

The auditor's recommendation reads "Inside the timer closure, check
collateral status and early-return if disabled." We follow that rather
than cancelling timers via `clear_timer`:

- `TimerId` does NOT survive upgrade — `setup_timers()` re-registers
  fresh timers every time. Storing TimerId in stable memory would be
  misleading and brittle.
- Soft-delist already exists via `CollateralStatus`: 5 lifecycle states
  where Frozen/Sunset/Deprecated all block or read-only the operations
  that consume a fresh price. The gate is just `matches!(status,
  Active | Paused)`.
- Reactivation works automatically: status flip from Sunset back to
  Active flips the gate at the next 300s tick, no timer
  re-registration needed.
- The check is synchronous and runs BEFORE `ic_cdk::spawn`, so wound-
  down collateral skips the spawn allocation too.

Same outcome as the cancel-path approach (no XRC calls for wound-down
collateral) without any TimerId bookkeeping.

## Surface changes

- `rumi_analytics::pull_schedule` (new pub module): `PULL_CYCLE_TICK_SECS`,
  `PULL_CYCLE_PERIOD_NS`, `PULL_CYCLE_SOURCE_OFFSET_NS`, `ALL_SOURCE_IDS`,
  9 `SOURCE_ID_*` constants, plus `seed_initial_schedule`,
  `reseed_preserving`, `compute_due_sources`, `advance_schedule_for_fired`.
- `SlimState.source_next_pull_ns: Option<HashMap<u8, u64>>` — additive
  with `#[serde(default)]`. Legacy snapshots decode to `None`.
- `rumi_protocol_backend::xrc::collateral_needs_periodic_price_refresh`
  (new pub fn), `should_fetch_collateral_price` (new pub fn),
  `register_collateral_price_timer` (new pub fn). All additive.
- No Candid surface change. No new endpoints. No state migration risk.

## Test plan

New `audit_pocs` per finding (TDD red-green verified empirically):

- [x] `audit_pocs_dos_010_stagger` (rumi_analytics): 16 tests across 5
      layers — constant fences, initial schedule offsets, due-source
      selection edge cases, schedule advance + per-source 60s pacing,
      no-sync-storm bound, post-upgrade re-seed preserves in-flight
      offsets, late-added source.
- [x] `audit_pocs_dos_011_xrc_timer_lifecycle` (rumi_protocol_backend):
      11 tests — pure helper × every CollateralStatus variant, state-
      level gate composition (status lookup + classification), unknown-
      collateral early-return, exhaustive-coverage fence pinning the
      "exactly 2 statuses need refresh" contract.

TDD red-green empirically verified: setting offset to 0 in
`seed_initial_schedule` causes 6 DOS-010 tests to fail including the
"no sync storm" bound (got 9 = pre-Wave-9d). Returning `true` for all
statuses in `collateral_needs_periodic_price_refresh` causes 7 DOS-011
tests to fail including all soft-delist skip tests. Restored
implementations: 16/16 + 11/11 pass.

Full suite (matches Wave 9c baseline):
- `cargo test --workspace --lib`: 365 passed, 1 ignored
- `cargo test -p rumi_protocol_backend --test pocket_ic_tests`: 27 passed, 2 ignored
- `cargo test -p rumi_analytics --test pocket_ic_analytics`: 24 passed, 1 ignored
- All prior audit_pocs (RED-001/002/003, INT-001/002/003/004/006,
  LIQ-001/002/003/004/005/007/008, BOT-001/001b, ICRC-idempotent,
  DOS-pagination, DOS-005, DOS-006/007): green

Pre-existing-on-main breakage NOT introduced by this PR (same as
Wave 9c): `tests/tests.rs` 28 compile errors (stale `bot_processing`
field), `audit_pocs_liq_005_deficit_account` 5 non-PIC subtests need
canister context for `ic_cdk::api::time()`, `rumi_3pool::icrc3_hash_cache`
needs `--features test_endpoints`.

## Bake watch (24h after deploy)

- rumi_analytics inter-canister-call rate per minute should drop from
  9 burst to 1-2 spread across the window. Watch
  `dfx canister --network ic logs dtlu2-uqaaa-aaaap-qugcq-cai` for
  the new "[rumi_analytics] pull_due_sources" trace pattern (one source
  pulled per ~6s slot vs the legacy `pull_cycle` running everything at
  once).
- backend cycles consumption per `add_collateral_token` should no
  longer accumulate permanent ~1B-cycle XRC calls for wound-down
  collateral. The "[register_collateral_price_timer] skipping fetch
  for X (wound-down)" trace fires when status is Frozen/Sunset/
  Deprecated.
- Reactivation path: flipping a collateral from Sunset back to Active
  via `set_collateral_status` should resume XRC fetching at the next
  300s tick with no timer re-registration. No deploy needed.
- Both deploys are independently reversible: `register_collateral_price_timer`
  collapses to the prior inline `set_timer_interval`; `pull_due_sources`
  collapses back to a 60s `pull_cycle` with `futures::join!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)