### PR TITLE
fix(vault_frontend): query icrc1_fee() instead of hardcoding ledger fees (audit ICRC-005 frontend half)

### DIFF
--- a/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
@@ -6,6 +6,7 @@
   import { formatStableTokenDisplay, formatStableTokenTx } from '../../utils/format';
   import type { PoolStatus, StablecoinConfig, UserPosition } from '../../services/stabilityPoolService';
   import { CANISTER_IDS } from '../../config';
+  import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
 
   export let poolStatus: PoolStatus | null = null;
   export let userPosition: UserPosition | null = null;
@@ -80,27 +81,32 @@
     showDropdown = false;
   }
 
-  // Ledger transfer fee per token (approve + transfer_from both charge a fee).
-  //
-  // TODO(audit ICRC-005): Replace this hardcoded table with a live
-  // `icrc1_fee()` query against `token.ledger`, cached per-ledger with a
-  // ~10-minute TTL. The backend now refreshes its own cache when transfers
-  // come back BadFee (`management::transfer_idempotent`). The frontend
-  // should mirror that — query the ledger directly so a fee bump on chain
-  // doesn't make `getLedgerFee` silently undercharge or overcharge until
-  // we ship a frontend update.
-  function getLedgerFee(token: StablecoinConfig): bigint {
-    // 3USD LP token (8 decimals) = 0.001 = 100_000 e8s (same as icUSD)
-    // icUSD (8 decimals) = 0.001 = 100_000 e8s
-    // ckUSDC / ckUSDT (6 decimals) = 0.01 = 10_000
-    return token.decimals === 8 ? 100_000n : 10_000n;
+  // Audit ICRC-005: per-ledger ICRC-1 fee is queried live (cached for the
+  // session in ledgerFeeService). `setMax` and validation read from the
+  // sync cache; `handleSubmit` does an `await fetchLedgerFee(...)` so the
+  // pre-flight check uses the freshest value before the actual approve.
+
+  function ledgerRefFor(token: StablecoinConfig) {
+    return {
+      ledgerId: token.ledger_id.toText(),
+      decimals: token.decimals,
+      symbol: token.symbol,
+    };
+  }
+
+  // Warm the fee cache for every active stablecoin once `poolStatus` resolves
+  // so `setMax` and validation reads from `getCachedLedgerFee` see live values.
+  $: if (activeStablecoins.length > 0) {
+    for (const token of activeStablecoins) {
+      void fetchLedgerFee(ledgerRefFor(token));
+    }
   }
 
   function setMax() {
     if (!selectedToken) return;
     if (activeTab === 'deposit') {
       // Depositing costs 2 ledger fees: one for icrc2_approve, one for icrc2_transfer_from
-      const totalFees = getLedgerFee(selectedToken) * 2n;
+      const totalFees = getCachedLedgerFee(ledgerRefFor(selectedToken)) * 2n;
       const adjusted = walletBalance > totalFees ? walletBalance - totalFees : 0n;
       amount = formatStableTokenTx(adjusted, selectedToken.decimals);
     } else {
@@ -126,8 +132,10 @@
           error = `Minimum deposit is 1 ${selectedToken.symbol}`;
           return;
         }
-        // User needs amount + 2 fees (approve + transfer_from)
-        const totalFees = getLedgerFee(selectedToken) * 2n;
+        // User needs amount + 2 fees (approve + transfer_from). Refresh the
+        // live fee here so the pre-flight check uses the freshest value.
+        const liveFee = await fetchLedgerFee(ledgerRefFor(selectedToken));
+        const totalFees = liveFee * 2n;
         if (rawAmount + totalFees > walletBalance) {
           error = 'Insufficient balance (amount + fees)';
           return;

--- a/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
   import { walletStore } from '../../stores/wallet';
-  import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount, getLedgerFee, approvalAmount } from '../../services/ammService';
+  import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount } from '../../services/ammService';
   import type { PoolInfo } from '../../services/ammService';
   import { CANISTER_IDS } from '../../config';
   import { ProtocolService } from '../../services/protocol';

--- a/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
@@ -6,9 +6,20 @@
     POOL_TOKENS,
     parseTokenAmount,
     formatTokenAmount,
-    getLedgerFee,
   } from '../../services/threePoolService';
+  import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { formatStableTokenDisplay } from '../../utils/format';
+
+  function poolLedgerRef(index: number) {
+    const t = POOL_TOKENS[index];
+    return { ledgerId: t.ledgerId, decimals: t.decimals, symbol: t.symbol };
+  }
+
+  // Warm the per-ledger fee cache once on mount so reactive `setAddMax` /
+  // validation reads from `getCachedLedgerFee` see live values. Audit ICRC-005.
+  for (let _idx = 0; _idx < POOL_TOKENS.length; _idx++) {
+    void fetchLedgerFee(poolLedgerRef(_idx));
+  }
 
   const dispatch = createEventDispatcher();
 
@@ -95,7 +106,7 @@
     const val = parseFloat(a);
     if (!val || val <= 0) return false;
     const raw = parseTokenAmount(a, POOL_TOKENS[i].decimals);
-    const fees = getLedgerFee(POOL_TOKENS[i].decimals) * 2n;
+    const fees = getCachedLedgerFee(poolLedgerRef(i)) * 2n;
     return raw + fees > getBalance(i);
   });
 
@@ -189,7 +200,7 @@
   // ── Max buttons ──
   function setAddMax(index: number) {
     const balance = getBalance(index);
-    const totalFees = getLedgerFee(POOL_TOKENS[index].decimals) * 2n;
+    const totalFees = getCachedLedgerFee(poolLedgerRef(index)) * 2n;
     const adjusted = balance > totalFees ? balance - totalFees : 0n;
     const divisor = Math.pow(10, POOL_TOKENS[index].decimals);
     addAmounts[index] = (Number(adjusted) / divisor).toFixed(POOL_TOKENS[index].decimals);
@@ -222,7 +233,8 @@
     for (let k = 0; k < 3; k++) {
       if (amounts[k] > 0n) {
         const balance = getBalance(k);
-        const fees = getLedgerFee(POOL_TOKENS[k].decimals) * 2n;
+        const liveFee = await fetchLedgerFee(poolLedgerRef(k));
+        const fees = liveFee * 2n;
         if (amounts[k] + fees > balance) {
           addError = `Insufficient ${POOL_TOKENS[k].symbol} balance`;
           return;
@@ -343,7 +355,7 @@
             const val = parseFloat(addAmounts[i]);
             if (!val || val <= 0) return false;
             const raw = parseTokenAmount(addAmounts[i], token.decimals);
-            const fees = getLedgerFee(token.decimals) * 2n;
+            const fees = getCachedLedgerFee(poolLedgerRef(i)) * 2n;
             return raw + fees > getBalance(i);
           })()}
         />

--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { walletStore } from '../../stores/wallet';
-  import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount, getLedgerFee, type AmmToken } from '../../services/ammService';
+  import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount, type AmmToken } from '../../services/ammService';
   import { resolveRoute, executeRoute, preWarmOisySigner, type SwapRoute } from '../../services/swapRouter';
+  import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { CANISTER_IDS } from '../../config';
+
+  function ammTokenRef(token: AmmToken) {
+    return { ledgerId: token.ledgerId, decimals: token.decimals, symbol: token.symbol };
+  }
 
   const dispatch = createEventDispatcher();
 
@@ -35,6 +40,10 @@
   })();
 
   $: walletBalanceFormatted = formatTokenAmount(walletBalance, fromToken.decimals);
+
+  // Warm the live ledger-fee cache for the selected `from` token so MAX and
+  // validation use the freshest value. Audit ICRC-005 (frontend half).
+  $: void fetchLedgerFee(ammTokenRef(fromToken));
 
   // Formatted output
   $: outputFormatted = currentRoute
@@ -163,7 +172,7 @@
   }
 
   function setMax() {
-    const totalFees = getLedgerFee(fromToken) * 2n;
+    const totalFees = getCachedLedgerFee(ammTokenRef(fromToken)) * 2n;
     const adjusted = walletBalance > totalFees ? walletBalance - totalFees : 0n;
     const divisor = Math.pow(10, fromToken.decimals);
     amount = (Number(adjusted) / divisor).toFixed(fromToken.decimals);
@@ -194,7 +203,9 @@
       error = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
 
-      const totalFees = getLedgerFee(fromToken) * 2n;
+      // Refresh live fee for the pre-flight check before executing the route.
+      const liveFee = await fetchLedgerFee(ammTokenRef(fromToken));
+      const totalFees = liveFee * 2n;
       if (amountRaw + totalFees > walletBalance) {
         error = 'Insufficient balance (amount + fees)';
         return;

--- a/src/vault_frontend/src/lib/services/ammService.ts
+++ b/src/vault_frontend/src/lib/services/ammService.ts
@@ -6,6 +6,7 @@ import { get } from 'svelte/store';
 import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
+import { fetchLedgerFee } from './ledgerFeeService';
 
 // ──────────────────────────────────────────────────────────────
 // Types — mirrors the AMM Candid interface
@@ -102,15 +103,19 @@ export const AMM_TOKENS: AmmToken[] = [
   },
 ];
 
-/** Ledger transfer fee per token. */
-export function getLedgerFee(token: AmmToken): bigint {
-  if (token.symbol === 'ICP') return 10_000n;
-  return token.decimals === 8 ? 100_000n : 10_000n;
+/** Live ledger transfer fee for an AMM token (audit ICRC-005). */
+export function tokenFee(token: AmmToken): Promise<bigint> {
+  return fetchLedgerFee({
+    ledgerId: token.ledgerId,
+    decimals: token.decimals,
+    symbol: token.symbol,
+  });
 }
 
-/** Compute approval amount: transfer amount + ledger fee. */
-export function approvalAmount(amount: bigint, token: AmmToken): bigint {
-  return amount + getLedgerFee(token);
+/** Compute approval amount: transfer amount + the live ledger fee. */
+export async function approvalAmount(amount: bigint, token: AmmToken): Promise<bigint> {
+  const fee = await tokenFee(token);
+  return amount + fee;
 }
 
 export function parseTokenAmount(amount: string, decimals: number): bigint {
@@ -311,6 +316,7 @@ class AmmService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     const oisyDetected = isOisyWallet();
+    const approveAmt = await approvalAmount(amountIn, inputToken);
 
     if (oisyDetected && wallet.principal) {
       const signerAgent = await getOisySignerAgent(wallet.principal);
@@ -319,7 +325,7 @@ class AmmService {
 
       signerAgent.batch();
       const approvePromise = ledgerActor.icrc2_approve({
-        amount: approvalAmount(amountIn, inputToken),
+        amount: approveAmt,
         spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: [],
@@ -339,7 +345,7 @@ class AmmService {
     } else {
       const ledgerActor = await walletStore.getActor(inputToken.ledgerId, CONFIG.icusd_ledgerIDL) as any;
       const approveResult = await ledgerActor.icrc2_approve({
-        amount: approvalAmount(amountIn, inputToken),
+        amount: approveAmt,
         spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: [],
@@ -371,6 +377,11 @@ class AmmService {
 
     const oisyDetected = isOisyWallet();
 
+    // Pre-compute approval amounts so the batched signer flow doesn't need
+    // to await mid-batch.
+    const approveA = amountA > 0n ? await approvalAmount(amountA, tokenA) : 0n;
+    const approveB = amountB > 0n ? await approvalAmount(amountB, tokenB) : 0n;
+
     if (oisyDetected && wallet.principal) {
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const approvePromises: Promise<any>[] = [];
@@ -379,7 +390,7 @@ class AmmService {
         const ledgerA = createOisyActor(tokenA.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
         signerAgent.batch();
         approvePromises.push(ledgerA.icrc2_approve({
-          amount: approvalAmount(amountA, tokenA),
+          amount: approveA,
           spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
@@ -390,7 +401,7 @@ class AmmService {
         const ledgerB = createOisyActor(tokenB.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
         signerAgent.batch();
         approvePromises.push(ledgerB.icrc2_approve({
-          amount: approvalAmount(amountB, tokenB),
+          amount: approveB,
           spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
@@ -418,7 +429,7 @@ class AmmService {
       if (amountA > 0n) {
         const ledgerA = await walletStore.getActor(tokenA.ledgerId, CONFIG.icusd_ledgerIDL) as any;
         const r = await ledgerA.icrc2_approve({
-          amount: approvalAmount(amountA, tokenA), spender,
+          amount: approveA, spender,
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
         });
@@ -429,7 +440,7 @@ class AmmService {
       if (amountB > 0n) {
         const ledgerB = await walletStore.getActor(tokenB.ledgerId, CONFIG.icusd_ledgerIDL) as any;
         const r = await ledgerB.icrc2_approve({
-          amount: approvalAmount(amountB, tokenB), spender,
+          amount: approveB, spender,
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
         });

--- a/src/vault_frontend/src/lib/services/ledgerFeeService.spec.ts
+++ b/src/vault_frontend/src/lib/services/ledgerFeeService.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ──────────────────────────────────────────────────────────────
+// Hoisted mocks for @dfinity/agent so we can swap icrc1_fee()
+// behaviour per-test without rebuilding the module under test.
+// ──────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  icrc1Fee: vi.fn(),
+  fetchRootKey: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@dfinity/agent', async () => {
+  const actual = await vi.importActual<typeof import('@dfinity/agent')>('@dfinity/agent');
+  return {
+    ...actual,
+    Actor: {
+      ...actual.Actor,
+      createActor: vi.fn(() => ({ icrc1_fee: mocks.icrc1Fee })),
+    },
+    HttpAgent: vi.fn(() => ({
+      fetchRootKey: mocks.fetchRootKey,
+    })),
+    AnonymousIdentity: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('../config', () => ({
+  CONFIG: { host: 'https://icp0.io', isLocal: false },
+}));
+
+vi.mock('../idls/ledger.idl.js', () => ({
+  ICRC1_IDL: {},
+}));
+
+import { fetchLedgerFee, getCachedLedgerFee, _clearLedgerFeeCache } from './ledgerFeeService';
+
+describe('ledgerFeeService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearLedgerFeeCache();
+  });
+
+  it('returns the live icrc1_fee on first call', async () => {
+    mocks.icrc1Fee.mockResolvedValueOnce(20_000n);
+    const fee = await fetchLedgerFee({ ledgerId: 'aaaaa-aa', decimals: 8 });
+    expect(fee).toBe(20_000n);
+    expect(mocks.icrc1Fee).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the fee — second call within TTL does not re-query', async () => {
+    mocks.icrc1Fee.mockResolvedValue(15_000n);
+    await fetchLedgerFee({ ledgerId: 'bbbbb-bb', decimals: 6 });
+    await fetchLedgerFee({ ledgerId: 'bbbbb-bb', decimals: 6 });
+    expect(mocks.icrc1Fee).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back on query error, warns to console, and returns the 8-decimal fallback', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.icrc1Fee.mockRejectedValueOnce(new Error('network'));
+    const fee = await fetchLedgerFee({ ledgerId: 'ccccc-cc', decimals: 8 });
+    expect(fee).toBe(100_000n);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to ICP fee (10_000) when symbol is ICP and the query fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.icrc1Fee.mockRejectedValueOnce(new Error('network'));
+    const fee = await fetchLedgerFee({ ledgerId: 'icp-led', symbol: 'ICP', decimals: 8 });
+    expect(fee).toBe(10_000n);
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to the 6-decimal value (10_000) when query fails for a stablecoin', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.icrc1Fee.mockRejectedValueOnce(new Error('offline'));
+    const fee = await fetchLedgerFee({ ledgerId: 'ckusdt-led', decimals: 6 });
+    expect(fee).toBe(10_000n);
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT cache fallback results so a later success can overwrite', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.icrc1Fee.mockRejectedValueOnce(new Error('first call fails'));
+    mocks.icrc1Fee.mockResolvedValueOnce(42_000n);
+
+    const first = await fetchLedgerFee({ ledgerId: 'eeeee-ee', decimals: 8 });
+    expect(first).toBe(100_000n); // fallback
+
+    const second = await fetchLedgerFee({ ledgerId: 'eeeee-ee', decimals: 8 });
+    expect(second).toBe(42_000n); // live value, NOT the fallback
+    expect(mocks.icrc1Fee).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it('getCachedLedgerFee returns cached value if present', async () => {
+    mocks.icrc1Fee.mockResolvedValueOnce(25_000n);
+    await fetchLedgerFee({ ledgerId: 'ddddd-dd', decimals: 6 });
+    expect(getCachedLedgerFee({ ledgerId: 'ddddd-dd', decimals: 6 })).toBe(25_000n);
+  });
+
+  it('getCachedLedgerFee returns the 8-decimal fallback when nothing is cached', () => {
+    expect(getCachedLedgerFee({ ledgerId: 'never-seen', decimals: 8 })).toBe(100_000n);
+  });
+
+  it('getCachedLedgerFee returns the ICP fallback when symbol is ICP and nothing is cached', () => {
+    expect(getCachedLedgerFee({ ledgerId: 'icp-cold', symbol: 'ICP', decimals: 8 })).toBe(10_000n);
+  });
+});

--- a/src/vault_frontend/src/lib/services/ledgerFeeService.ts
+++ b/src/vault_frontend/src/lib/services/ledgerFeeService.ts
@@ -1,0 +1,122 @@
+/**
+ * Live ICRC-1 ledger transfer fee lookup with per-session caching.
+ *
+ * Audit ICRC-005 (frontend half): the previous design hardcoded fees in
+ * `getLedgerFee()` switches across the codebase, which silently drifted
+ * out of sync any time a ledger bumped its fee on chain. This service
+ * queries `icrc1_fee()` directly and caches per-ledger for the session,
+ * so a fee bump propagates without a frontend redeploy.
+ *
+ * `fetchLedgerFee` is async + cached. `getCachedLedgerFee` is the sync
+ * accessor for batched signer flows that can't await mid-batch — pair it
+ * with an upstream `await fetchLedgerFee(...)` to ensure the cache is
+ * warm before the batch runs.
+ *
+ * Failure mode: on query error the helper logs a warning and falls back
+ * to a value derived from the token's decimals/symbol. Failures are NOT
+ * cached, so the next call re-tries. If the fallback diverges from the
+ * actual on-chain fee, the ICRC-1 ledger will surface BadFee on transfer
+ * — the user sees the error there rather than this code silently
+ * undercharging or overcharging.
+ */
+
+import { Actor, HttpAgent, AnonymousIdentity } from '@dfinity/agent';
+import { CONFIG } from '../config';
+import { ICRC1_IDL } from '../idls/ledger.idl.js';
+
+const TTL_MS = 5 * 60 * 1000; // 5-minute cache window
+
+const FALLBACK_FEE_BY_DECIMALS: Record<number, bigint> = {
+  6: 10_000n,   // ckUSDC, ckUSDT
+  8: 100_000n,  // icUSD, 3USD
+};
+
+const ICP_FALLBACK_FEE = 10_000n;
+
+const DEFAULT_FALLBACK_FEE = 10_000n;
+
+interface CacheEntry {
+  fee: bigint;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+let _anonAgent: HttpAgent | null = null;
+
+export interface LedgerFeeRef {
+  /** ICRC-1 ledger canister ID (text form). */
+  ledgerId: string;
+  /** Token decimals — used for fallback selection if the live query fails. */
+  decimals?: number;
+  /** Token symbol — used for fallback selection (ICP gets a different default than 8-decimal stables). */
+  symbol?: string;
+}
+
+async function getAnonAgent(): Promise<HttpAgent> {
+  if (!_anonAgent) {
+    _anonAgent = new HttpAgent({
+      host: CONFIG.host,
+      identity: new AnonymousIdentity(),
+    });
+    if (CONFIG.isLocal) {
+      await _anonAgent.fetchRootKey();
+    }
+  }
+  return _anonAgent;
+}
+
+function fallbackFee(ref: LedgerFeeRef): bigint {
+  if (ref.symbol === 'ICP') return ICP_FALLBACK_FEE;
+  if (ref.decimals !== undefined) {
+    const f = FALLBACK_FEE_BY_DECIMALS[ref.decimals];
+    if (f !== undefined) return f;
+  }
+  return DEFAULT_FALLBACK_FEE;
+}
+
+/**
+ * Query the ICRC-1 transfer fee for a ledger, returning a cached value when fresh.
+ * On error, logs a warning and returns a fallback derived from the token metadata.
+ * Failures are NOT cached — the next call retries.
+ */
+export async function fetchLedgerFee(ref: LedgerFeeRef): Promise<bigint> {
+  const cached = cache.get(ref.ledgerId);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < TTL_MS) {
+    return cached.fee;
+  }
+
+  try {
+    const agent = await getAnonAgent();
+    const actor = Actor.createActor(ICRC1_IDL as any, {
+      agent,
+      canisterId: ref.ledgerId,
+    });
+    const fee = (await (actor as any).icrc1_fee()) as bigint;
+    cache.set(ref.ledgerId, { fee, fetchedAt: now });
+    return fee;
+  } catch (err) {
+    console.warn(
+      `[ledgerFeeService] icrc1_fee query failed for ${ref.ledgerId}; using fallback. ` +
+        'The displayed transfer fee may be stale until the ledger responds again.',
+      err,
+    );
+    return fallbackFee(ref);
+  }
+}
+
+/**
+ * Synchronous accessor — returns the cached fee if present, else the fallback.
+ * Use only after `fetchLedgerFee` has been awaited at least once for this ledger,
+ * or in code paths where falling back to the hardcoded default is acceptable.
+ */
+export function getCachedLedgerFee(ref: LedgerFeeRef): bigint {
+  const cached = cache.get(ref.ledgerId);
+  if (cached) return cached.fee;
+  return fallbackFee(ref);
+}
+
+/** Test hook. Resets the cache so tests are deterministic. */
+export function _clearLedgerFeeCache(): void {
+  cache.clear();
+}

--- a/src/vault_frontend/src/lib/services/providers/icpswapProvider.spec.ts
+++ b/src/vault_frontend/src/lib/services/providers/icpswapProvider.spec.ts
@@ -23,6 +23,19 @@ vi.mock('../../stores/wallet', () => ({
   },
 }));
 
+// Audit ICRC-005 (frontend half): IcpswapProvider.swap now reads ledger
+// fees through ledgerFeeService instead of a hardcoded switch. Stub it so
+// the existing depositFrom/withdraw fee assertions still resolve to the
+// same values per ledger.
+vi.mock('../ledgerFeeService', () => ({
+  fetchLedgerFee: vi.fn(({ ledgerId }: { ledgerId: string }) => {
+    if (ledgerId === 't6bor-paaaa-aaaap-qrd5q-cai') return Promise.resolve(100_000n); // icUSD
+    if (ledgerId === 'ryjl3-tyaaa-aaaaa-aaaba-cai') return Promise.resolve(10_000n);  // ICP
+    return Promise.resolve(10_000n); // default
+  }),
+  getCachedLedgerFee: vi.fn(() => 10_000n),
+}));
+
 import { Actor } from '@dfinity/agent';
 import { IcpswapProvider } from './icpswapProvider';
 import type { AmmToken } from '../ammService';

--- a/src/vault_frontend/src/lib/services/providers/icpswapProvider.ts
+++ b/src/vault_frontend/src/lib/services/providers/icpswapProvider.ts
@@ -1,27 +1,32 @@
 import { Actor, HttpAgent } from '@dfinity/agent';
 import type { _SERVICE as IcpswapPool } from '$declarations/icpswap_pool/icpswap_pool.did';
 import { idlFactory as icpswapPoolIDL } from '$declarations/icpswap_pool/icpswap_pool.did.js';
-import { CONFIG, CANISTER_IDS } from '../../config';
+import { CONFIG } from '../../config';
 import { walletStore } from '../../stores/wallet';
 import { canisterIDLs } from '../pnp';
 import type { AmmToken } from '../ammService';
+import { fetchLedgerFee, getCachedLedgerFee } from '../ledgerFeeService';
 import type { SwapProvider, ProviderQuote, ProviderSwapResult, ProviderId } from './types';
 
 /**
- * Returns the exact ICRC-1 transfer fee for a known ledger.
- * ICPswap pool's depositFrom/withdraw expect this value in the `fee` field
- * to match the pool's internal fee cache.
+ * Returns the live ICRC-1 transfer fee for a ledger (audit ICRC-005).
+ *
+ * Async: queries `icrc1_fee()` on the ledger and caches the result for the
+ * session. ICPswap pool's depositFrom/withdraw require this value in the
+ * `fee` field to match the pool's internal cache.
  */
-export function icrc1Fee(ledgerId: string): bigint {
-  switch (ledgerId) {
-    case CANISTER_IDS.ICP_LEDGER:   return 10_000n;     // 0.0001 ICP
-    case CANISTER_IDS.ICUSD_LEDGER: return 100_000n;    // 0.001 icUSD
-    case CANISTER_IDS.THREEPOOL:    return 0n;           // 3USD has zero fee
-    case CANISTER_IDS.CKUSDT_LEDGER: return 10_000n;    // ckUSDT
-    case CANISTER_IDS.CKUSDC_LEDGER: return 10_000n;    // ckUSDC
-    default:
-      throw new Error(`Unknown ledger fee for ${ledgerId}; add it to icrc1Fee()`);
-  }
+export function icrc1Fee(ledgerId: string): Promise<bigint> {
+  return fetchLedgerFee({ ledgerId });
+}
+
+/**
+ * Synchronous accessor — returns the cached fee if present, else a fallback.
+ * Use only when `fetchLedgerFee(...)` has already been awaited for the same
+ * ledger upstream (e.g., inside Oisy batched signer flows where the cache
+ * is pre-warmed before the batch begins).
+ */
+export function icrc1FeeSync(ledgerId: string): bigint {
+  return getCachedLedgerFee({ ledgerId });
 }
 
 export interface IcpswapProviderConfig {
@@ -97,7 +102,7 @@ export class IcpswapProvider implements SwapProvider {
     const depositResult = await pool.depositFrom({
       token: tokenIn.ledgerId,
       amount: amountIn,
-      fee: icrc1Fee(tokenIn.ledgerId),
+      fee: await icrc1Fee(tokenIn.ledgerId),
     });
     this.unwrapResult(depositResult, 'depositFrom');
 
@@ -121,7 +126,7 @@ export class IcpswapProvider implements SwapProvider {
       const withdrawResult = await pool.withdraw({
         token: tokenOut.ledgerId,
         amount: swapOut,
-        fee: icrc1Fee(tokenOut.ledgerId),
+        fee: await icrc1Fee(tokenOut.ledgerId),
       });
       withdrawn = this.unwrapResult(withdrawResult, 'withdraw');
     } catch (err) {

--- a/src/vault_frontend/src/lib/services/swapRouter.spec.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.spec.ts
@@ -44,8 +44,15 @@ vi.mock('./providers/rumiAmmProvider', () => ({
 
 vi.mock('./providers/icpswapProvider', () => ({
   IcpswapProvider: vi.fn(() => mocks.icpswapMock),
-  // Used by the Oisy batched executor for the deposit/withdraw fee field.
-  icrc1Fee: vi.fn(() => 10n),
+}));
+
+// Audit ICRC-005 (frontend half): the Oisy batched executor now pulls fees
+// from the live ledger via ledgerFeeService instead of hardcoded constants.
+// Mock it so tests don't hit a real agent.
+vi.mock('./ledgerFeeService', () => ({
+  fetchLedgerFee: vi.fn().mockResolvedValue(10n),
+  getCachedLedgerFee: vi.fn(() => 10n),
+  _clearLedgerFeeCache: vi.fn(),
 }));
 
 // Neutralise ammService — the provider mocks bypass it, but getAmmPoolId
@@ -59,6 +66,11 @@ vi.mock('./ammService', async () => {
       getQuote: vi.fn(),
       swap: vi.fn(),
     },
+    // approvalAmount and tokenFee are async since the live-fee migration —
+    // override with deterministic stubs so swapRouter's pre-batch awaits
+    // don't reach the network.
+    tokenFee: vi.fn().mockResolvedValue(10n),
+    approvalAmount: vi.fn(async (amount: bigint) => amount + 10n),
   };
 });
 

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -1,6 +1,6 @@
 import { Principal } from '@dfinity/principal';
 import { threePoolService, POOL_TOKENS } from './threePoolService';
-import { ammService, AMM_TOKENS, approvalAmount, getLedgerFee, type AmmToken } from './ammService';
+import { ammService, AMM_TOKENS, approvalAmount, tokenFee, type AmmToken } from './ammService';
 import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
@@ -8,8 +8,9 @@ import { canisterIDLs } from './pnp';
 import { walletStore } from '../stores/wallet';
 import { get } from 'svelte/store';
 import { RumiAmmProvider } from './providers/rumiAmmProvider';
-import { IcpswapProvider, icrc1Fee } from './providers/icpswapProvider';
+import { IcpswapProvider } from './providers/icpswapProvider';
 import { ProviderRegistry } from './providers/providerRegistry';
+import { fetchLedgerFee } from './ledgerFeeService';
 import type { ProviderQuote } from './providers/types';
 
 // ──────────────────────────────────────────────────────────────
@@ -528,12 +529,13 @@ async function approveIcpswapPool(
   amountIn: bigint,
   poolCanisterId: string,
 ): Promise<void> {
+  const approveAmt = await approvalAmount(amountIn, fromToken);
   const ledgerActor = await walletStore.getActor(
     fromToken.ledgerId, CONFIG.icusd_ledgerIDL
   ) as any;
 
   const approveResult = await ledgerActor.icrc2_approve({
-    amount: approvalAmount(amountIn, fromToken),
+    amount: approveAmt,
     spender: { owner: Principal.fromText(poolCanisterId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -613,6 +615,9 @@ async function executeStableToIcpOisy(
   const amounts: [bigint, bigint, bigint] = [0n, 0n, 0n];
   amounts[from.threePoolIndex] = amountIn;
 
+  // Pre-fetch live ICRC-1 fee before entering the signer batch (no awaits allowed mid-batch).
+  const fromFee = await tokenFee(from);
+
   // Signer agent was pre-warmed during quote phase — cached, no popup
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
@@ -623,7 +628,7 @@ async function executeStableToIcpOisy(
   // Step 1: Approve stablecoin → 3pool
   signerAgent.batch();
   const p1 = stableLedger.icrc2_approve({
-    amount: amountIn + getLedgerFee(from) * 2n,
+    amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -690,6 +695,9 @@ async function executeIcpToStableOisy(
   const threeUsdMinOutput = threeUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
   const stableMinOutput = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
+  // Pre-fetch live ICRC-1 fee before entering the signer batch.
+  const icpFee = await tokenFee(icpToken);
+
   // Signer agent was pre-warmed during quote phase — cached, no popup
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
@@ -700,7 +708,7 @@ async function executeIcpToStableOisy(
   // Step 1: Approve ICP → AMM
   signerAgent.batch();
   const p1 = icpLedger.icrc2_approve({
-    amount: amountIn + getLedgerFee(icpToken) * 2n,
+    amount: amountIn + icpFee * 2n,
     spender: { owner: Principal.fromText(AMM_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -765,6 +773,14 @@ async function executeStableToIcpOisyIcpswap(
   const amounts: [bigint, bigint, bigint] = [0n, 0n, 0n];
   amounts[from.threePoolIndex] = amountIn;
 
+  // Pre-fetch every live ICRC-1 fee the batched signer flow needs before
+  // entering `signerAgent.batch()` (no awaits allowed mid-batch).
+  const [fromFee, threeUsdFee, icpFee] = await Promise.all([
+    tokenFee(from),
+    fetchLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' }),
+    fetchLedgerFee({ ledgerId: CANISTER_IDS.ICP_LEDGER, decimals: 8, symbol: 'ICP' }),
+  ]);
+
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const stableLedger = createOisyActor(fromPoolToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
@@ -774,7 +790,7 @@ async function executeStableToIcpOisyIcpswap(
   // Step 1: approve stablecoin → 3pool
   signerAgent.batch();
   const p1 = stableLedger.icrc2_approve({
-    amount: amountIn + getLedgerFee(from) * 2n,
+    amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -799,7 +815,7 @@ async function executeStableToIcpOisyIcpswap(
   const p4 = icpswapPool.depositFrom({
     token: CANISTER_IDS.THREEPOOL,
     amount: threeUsdEstimate,
-    fee: icrc1Fee(CANISTER_IDS.THREEPOOL),
+    fee: threeUsdFee,
   });
 
   // Step 5: ICPswap swap (uses pre-committed 3USD amount; slippage via amountOutMinimum)
@@ -816,7 +832,7 @@ async function executeStableToIcpOisyIcpswap(
   const p6 = icpswapPool.withdraw({
     token: CANISTER_IDS.ICP_LEDGER,
     amount: icpMinOutput,
-    fee: icrc1Fee(CANISTER_IDS.ICP_LEDGER),
+    fee: icpFee,
   });
 
   await signerAgent.execute();
@@ -867,6 +883,12 @@ async function executeIcpToStableOisyIcpswap(
   const threeUsdMinFromSwap = threeUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
   const stableMinOutput = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
+  // Pre-fetch every live ICRC-1 fee the batched signer flow needs.
+  const [icpFee, threeUsdFee] = await Promise.all([
+    tokenFee(icpToken),
+    fetchLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' }),
+  ]);
+
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const icpLedger = createOisyActor(ICP_LEDGER_ID, CONFIG.icusd_ledgerIDL, signerAgent);
@@ -876,7 +898,7 @@ async function executeIcpToStableOisyIcpswap(
   // Step 1: approve ICP → ICPswap pool
   signerAgent.batch();
   const p1 = icpLedger.icrc2_approve({
-    amount: amountIn + getLedgerFee(icpToken) * 2n,
+    amount: amountIn + icpFee * 2n,
     spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -887,7 +909,7 @@ async function executeIcpToStableOisyIcpswap(
   const p2 = icpswapPool.depositFrom({
     token: ICP_LEDGER_ID,
     amount: amountIn,
-    fee: icrc1Fee(ICP_LEDGER_ID),
+    fee: icpFee,
   });
 
   // Step 3: ICPswap swap ICP → 3USD
@@ -903,7 +925,7 @@ async function executeIcpToStableOisyIcpswap(
   const p4 = icpswapPool.withdraw({
     token: CANISTER_IDS.THREEPOOL,
     amount: threeUsdMinFromSwap,
-    fee: icrc1Fee(CANISTER_IDS.THREEPOOL),
+    fee: threeUsdFee,
   });
 
   // Step 5: 3pool remove_one_coin (3USD → target stablecoin)
@@ -960,6 +982,12 @@ async function executeIcpswapDirectOisy(
 
   const minOut = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
+  // Pre-fetch every live ICRC-1 fee the batched signer flow needs.
+  const [fromFee, toFee] = await Promise.all([
+    tokenFee(from),
+    tokenFee(to),
+  ]);
+
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const fromLedger = createOisyActor(from.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
@@ -968,7 +996,7 @@ async function executeIcpswapDirectOisy(
   // Step 1: approve input -> ICPswap pool
   signerAgent.batch();
   const p1 = fromLedger.icrc2_approve({
-    amount: amountIn + getLedgerFee(from) * 2n,
+    amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
@@ -979,7 +1007,7 @@ async function executeIcpswapDirectOisy(
   const p2 = icpswapPool.depositFrom({
     token: from.ledgerId,
     amount: amountIn,
-    fee: icrc1Fee(from.ledgerId),
+    fee: fromFee,
   });
 
   // Step 3: ICPswap swap
@@ -995,7 +1023,7 @@ async function executeIcpswapDirectOisy(
   const p4 = icpswapPool.withdraw({
     token: to.ledgerId,
     amount: minOut,
-    fee: icrc1Fee(to.ledgerId),
+    fee: toFee,
   });
 
   await signerAgent.execute();

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -6,6 +6,7 @@ import { get } from 'svelte/store';
 import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
+import { fetchLedgerFee } from './ledgerFeeService';
 
 // ──────────────────────────────────────────────────────────────
 // Types — mirrors the Candid interface
@@ -92,16 +93,19 @@ export function formatTokenAmount(amount: bigint, decimals: number): string {
   return trimmed;
 }
 
-/** Ledger transfer fee per token (approve + transfer_from both charge a fee). */
-export function getLedgerFee(decimals: number): bigint {
-  // icUSD (8 decimals) = 0.001 = 100_000 e8s
-  // ckUSDC / ckUSDT (6 decimals) = 0.01 = 10_000
-  return decimals === 8 ? 100_000n : 10_000n;
+/** Live ICRC-1 fee for a 3pool token (audit ICRC-005). */
+export function poolTokenFee(token: SwapToken): Promise<bigint> {
+  return fetchLedgerFee({
+    ledgerId: token.ledgerId,
+    decimals: token.decimals,
+    symbol: token.symbol,
+  });
 }
 
-/** Compute approval amount: transfer amount + ledger fee (for transfer_from). */
-function approvalAmount(amount: bigint, decimals: number): bigint {
-  return amount + getLedgerFee(decimals);
+/** Compute approval amount: transfer amount + live ledger fee (for transfer_from). */
+async function approvalAmount(amount: bigint, token: SwapToken): Promise<bigint> {
+  const fee = await poolTokenFee(token);
+  return amount + fee;
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -393,6 +397,7 @@ class ThreePoolService {
 
     const fromToken = POOL_TOKENS[fromIndex];
     const oisyDetected = isOisyWallet();
+    const approveAmt = await approvalAmount(dxRaw, fromToken);
 
     if (oisyDetected && wallet.principal) {
       // ─── Oisy ICRC-112 batched path ───
@@ -408,7 +413,7 @@ class ThreePoolService {
       // Sequence 0: approve
       signerAgent.batch();
       const approvePromise = ledgerActor.icrc2_approve({
-        amount: approvalAmount(dxRaw, fromToken.decimals),
+        amount: approveAmt,
         spender: { owner: Principal.fromText(THREEPOOL_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: []
@@ -435,7 +440,7 @@ class ThreePoolService {
       ) as any;
 
       const approveResult = await ledgerActor.icrc2_approve({
-        amount: approvalAmount(dxRaw, fromToken.decimals),
+        amount: approveAmt,
         spender: { owner: Principal.fromText(THREEPOOL_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: []
@@ -466,6 +471,11 @@ class ThreePoolService {
     const oisyDetected = isOisyWallet();
     const spender = { owner: Principal.fromText(THREEPOOL_CANISTER_ID), subaccount: [] };
 
+    // Pre-compute approval amounts so we don't need to await mid-batch.
+    const approveAmounts: bigint[] = await Promise.all(
+      amounts.map((amt, k) => amt > 0n ? approvalAmount(amt, POOL_TOKENS[k]) : Promise.resolve(0n)),
+    );
+
     if (oisyDetected && wallet.principal) {
       // ─── Oisy ICRC-112 batched path ───
       const signerAgent = await getOisySignerAgent(wallet.principal);
@@ -478,7 +488,7 @@ class ThreePoolService {
           const ledgerActor = createOisyActor(token.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
           signerAgent.batch();
           approvePromises.push(ledgerActor.icrc2_approve({
-            amount: approvalAmount(amounts[k], POOL_TOKENS[k].decimals),
+            amount: approveAmounts[k],
             spender, expires_at: [], expected_allowance: [], memo: [], fee: [],
             from_subaccount: [], created_at_time: []
           }));
@@ -509,7 +519,7 @@ class ThreePoolService {
           const token = POOL_TOKENS[k];
           const ledgerActor = await walletStore.getActor(token.ledgerId, CONFIG.icusd_ledgerIDL) as any;
           const approveResult = await ledgerActor.icrc2_approve({
-            amount: approvalAmount(amounts[k], POOL_TOKENS[k].decimals),
+            amount: approveAmounts[k],
             spender, expires_at: [], expected_allowance: [], memo: [], fee: [],
             from_subaccount: [], created_at_time: []
           });

--- a/src/vault_frontend/src/lib/services/transferService.ts
+++ b/src/vault_frontend/src/lib/services/transferService.ts
@@ -144,17 +144,13 @@ export async function transferICRC1(
 }
 
 /**
- * Query a ledger's ICRC-1 fee (returns raw smallest-unit bigint)
+ * Query a ledger's ICRC-1 fee (returns raw smallest-unit bigint).
+ * Delegates to the shared `ledgerFeeService` so cache + fallback behaviour
+ * stays consistent across the app (audit ICRC-005, frontend half).
  */
 export async function queryICRC1Fee(ledgerCanisterId: string): Promise<bigint> {
-  try {
-    const { TokenService } = await import('./tokenService');
-    const actor = await TokenService.createAnonymousActor(ledgerCanisterId, ICRC1_IDL);
-    return await (actor as any).icrc1_fee();
-  } catch (err) {
-    console.warn('Failed to query fee for', ledgerCanisterId, err);
-    return 10_000n; // fallback
-  }
+  const { fetchLedgerFee } = await import('./ledgerFeeService');
+  return fetchLedgerFee({ ledgerId: ledgerCanisterId });
 }
 
 /** Transfer ICP (convenience wrapper) */


### PR DESCRIPTION
## Summary

Closes the deferred frontend half of audit **ICRC-005**. Adds [`ledgerFeeService.ts`](src/vault_frontend/src/lib/services/ledgerFeeService.ts) with a per-session, per-ledger cache of live `icrc1_fee()` query results, then migrates every hardcoded fee table and switch across the frontend to read from the service instead.

The on-chain half landed earlier (Wave 3 — `transfer_idempotent` + per-ledger fee cache + BadFee branch refresh). With this PR the audit cycle is fully closed except for the SNS-coupled AUTH bundle.

## What changed

- **New service**: [`src/vault_frontend/src/lib/services/ledgerFeeService.ts`](src/vault_frontend/src/lib/services/ledgerFeeService.ts) exposes `fetchLedgerFee` (async, cached, with fallback) and `getCachedLedgerFee` (sync accessor for batched signer flows).
- **9 unit tests** in [`ledgerFeeService.spec.ts`](src/vault_frontend/src/lib/services/ledgerFeeService.spec.ts) covering cache hit/miss, TTL, error fallback, ICP-vs-stable fallback, and ensuring failures are not cached.
- **Removed every hardcoded `getLedgerFee()` switch**:
  - `DepositInterface.svelte:92` (the explicit TODO)
  - `ammService.ts:106` (replaced with async `tokenFee` + `approvalAmount`)
  - `threePoolService.ts:96` (replaced with async `poolTokenFee`)
  - `icpswapProvider.ts:15` (now async, delegates to the service)
- **All callers migrated**: `swapRouter.ts` Oisy batched executors pre-fetch all needed fees before entering `signerAgent.batch()`; `SwapInterface`, `LiquidityInterface`, `AmmLiquidityPanel` use the new helpers; `transferService.queryICRC1Fee` delegates.

## Test plan

- [x] `npm run test` — 66/66 unit tests pass (including the new 9-test `ledgerFeeService` suite)
- [x] `npm run check` — 32 errors / 48 warnings, identical to pre-change baseline (no regressions; all errors are pre-existing in untouched files)
- [x] `npm run build` — clean asset bundle (`✓ built in 7.58s`)
- [ ] After merge + asset deploy, verify in browser that the deposit/swap/liquidity flows display the live ledger fee correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)