### PR TITLE
chore(stability_pool): mirror new ThreePoolError variant

### DIFF
--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -455,7 +455,27 @@ pub async fn deposit_as_3usd(
 
     let lp_minted = match lp_result {
         Ok((Ok(lp),)) => lp,
-        _ => {
+        Ok((Err(e),)) => {
+            log!(
+                INFO,
+                "deposit_as_3usd: 3pool add_liquidity returned error {:?}; refunding {}",
+                e,
+                amount
+            );
+            refund_user(caller, token_ledger, amount).await;
+            return Err(StabilityPoolError::InterCanisterCallFailed {
+                target: "3pool".to_string(),
+                method: "add_liquidity".to_string(),
+            });
+        }
+        Err((code, msg)) => {
+            log!(
+                INFO,
+                "deposit_as_3usd: 3pool add_liquidity call failed: {:?} {}; refunding {}",
+                code,
+                msg,
+                amount
+            );
             refund_user(caller, token_ledger, amount).await;
             return Err(StabilityPoolError::InterCanisterCallFailed {
                 target: "3pool".to_string(),

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -392,6 +392,10 @@ pub enum ThreePoolErrorRemote {
     InsufficientPoolBalance { token: String, required: u128, available: u128 },
     InsufficientLpBalance { required: u128, available: u128 },
     BurnFailed { token: String, reason: String },
+    /// Audit fence B-01 (Wave 14a): rumi_3pool returns this when another
+    /// concurrent operation holds the pool lock. The SP `add_liquidity`
+    /// path will refund the user and surface a transient call failure.
+    PoolLocked,
 }
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to PR [#157](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/157). The 3pool now exposes a new `PoolLocked` error variant. The stability_pool maintains its own deserialization mirror (`ThreePoolErrorRemote`) and would otherwise fall through the Candid catch-all when this variant is returned.

- Adds `PoolLocked` to `ThreePoolErrorRemote`.
- Splits the single catch-all in `deposit_as_3usd` into `Ok((Err(_),))` and `Err((code, msg))` branches with structured logging so operators can see exactly why a refund happened.
- User-visible behavior unchanged: refund + `InterCanisterCallFailed`.

## Test plan

- [x] `cargo test --lib -p stability_pool` (36 / 36 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)