### PR TITLE
fix(swap): preserve Oisy click-handler gesture context

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import { walletStore } from '../../stores/wallet';
   import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount, type AmmToken } from '../../services/ammService';
-  import { resolveRoute, executeRoute, preWarmOisySigner, type SwapRoute } from '../../services/swapRouter';
+  import { resolveRoute, executeRoute, preWarmOisySigner, preWarmOisyFees, type SwapRoute } from '../../services/swapRouter';
   import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { CANISTER_IDS } from '../../config';
 
@@ -116,10 +116,12 @@
       quoting = true;
       error = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
-      // Run quote + signer pre-warm in parallel so both are ready before click
+      // Run quote + signer/fee pre-warm in parallel so the click handler stays
+      // synchronous all the way to signerAgent.execute() (Oisy popup gate).
       const [route] = await Promise.all([
         resolveRoute(fromToken, toToken, amountRaw),
         preWarmOisySigner(),
+        preWarmOisyFees(),
       ]);
       currentRoute = route;
       midMarketRate = await fetchMidMarketRate(currentRoute);
@@ -203,8 +205,12 @@
       error = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
 
-      // Refresh live fee for the pre-flight check before executing the route.
-      const liveFee = await fetchLedgerFee(ammTokenRef(fromToken));
+      // Pre-flight balance check using the cached live fee. The reactive
+      // `void fetchLedgerFee(...)` above and `preWarmOisyFees()` keep this
+      // warm; awaiting here would burn the click-handler gesture window
+      // and trip Oisy's "Signer window should not be opened outside of click
+      // handler" guard. Backend ledgers also enforce the balance check.
+      const liveFee = getCachedLedgerFee(ammTokenRef(fromToken));
       const totalFees = liveFee * 2n;
       if (amountRaw + totalFees > walletBalance) {
         error = 'Insufficient balance (amount + fees)';

--- a/src/vault_frontend/src/lib/services/ammService.ts
+++ b/src/vault_frontend/src/lib/services/ammService.ts
@@ -6,7 +6,7 @@ import { get } from 'svelte/store';
 import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
-import { fetchLedgerFee } from './ledgerFeeService';
+import { fetchLedgerFee, getCachedLedgerFee } from './ledgerFeeService';
 
 // ──────────────────────────────────────────────────────────────
 // Types — mirrors the AMM Candid interface
@@ -106,6 +106,21 @@ export const AMM_TOKENS: AmmToken[] = [
 /** Live ledger transfer fee for an AMM token (audit ICRC-005). */
 export function tokenFee(token: AmmToken): Promise<bigint> {
   return fetchLedgerFee({
+    ledgerId: token.ledgerId,
+    decimals: token.decimals,
+    symbol: token.symbol,
+  });
+}
+
+/**
+ * Synchronous version of `tokenFee`. Returns the cached fee or the hardcoded
+ * fallback. Use inside Oisy signer-batch code paths where a click-handler
+ * gesture window must be preserved (no `await` between click and
+ * `signerAgent.execute()`). Callers MUST ensure the cache is warmed first via
+ * `preWarmOisyFees()` during the quote phase.
+ */
+export function tokenFeeCached(token: AmmToken): bigint {
+  return getCachedLedgerFee({
     ledgerId: token.ledgerId,
     decimals: token.decimals,
     symbol: token.symbol,

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -1,6 +1,6 @@
 import { Principal } from '@dfinity/principal';
 import { threePoolService, POOL_TOKENS } from './threePoolService';
-import { ammService, AMM_TOKENS, approvalAmount, tokenFee, type AmmToken } from './ammService';
+import { ammService, AMM_TOKENS, approvalAmount, tokenFeeCached, type AmmToken } from './ammService';
 import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
@@ -10,7 +10,7 @@ import { get } from 'svelte/store';
 import { RumiAmmProvider } from './providers/rumiAmmProvider';
 import { IcpswapProvider } from './providers/icpswapProvider';
 import { ProviderRegistry } from './providers/providerRegistry';
-import { fetchLedgerFee } from './ledgerFeeService';
+import { fetchLedgerFee, getCachedLedgerFee } from './ledgerFeeService';
 import type { ProviderQuote } from './providers/types';
 
 // ──────────────────────────────────────────────────────────────
@@ -565,6 +565,29 @@ export async function preWarmOisySigner(): Promise<void> {
   await getOisySignerAgent(wallet.principal);
 }
 
+/**
+ * Pre-warm the live ICRC-1 fee cache for every AMM token so the Oisy executors
+ * can read fees synchronously via `tokenFeeCached` / `getCachedLedgerFee`.
+ *
+ * The Oisy executors must not `await` between the user's click and
+ * `signerAgent.execute()` or the browser blocks the popup with a
+ * "Signer window should not be opened outside of click handler" error. By
+ * fetching every relevant fee during the quote phase (5-min cache TTL), the
+ * click-handler path stays fully synchronous.
+ *
+ * No-op for non-Oisy wallets; the standard ICRC-2 paths can `await` freely.
+ */
+export async function preWarmOisyFees(): Promise<void> {
+  if (!isOisyWallet()) return;
+  await Promise.all(
+    AMM_TOKENS.map(t => fetchLedgerFee({
+      ledgerId: t.ledgerId,
+      decimals: t.decimals,
+      symbol: t.symbol,
+    })),
+  );
+}
+
 // ──────────────────────────────────────────────────────────────
 // Oisy-batched multi-hop execution
 //
@@ -615,8 +638,8 @@ async function executeStableToIcpOisy(
   const amounts: [bigint, bigint, bigint] = [0n, 0n, 0n];
   amounts[from.threePoolIndex] = amountIn;
 
-  // Pre-fetch live ICRC-1 fee before entering the signer batch (no awaits allowed mid-batch).
-  const fromFee = await tokenFee(from);
+  // Read live ICRC-1 fee from cache. preWarmOisyFees() warmed it during quote.
+  const fromFee = tokenFeeCached(from);
 
   // Signer agent was pre-warmed during quote phase — cached, no popup
   const signerAgent = await getOisySignerAgent(wallet.principal);
@@ -695,8 +718,8 @@ async function executeIcpToStableOisy(
   const threeUsdMinOutput = threeUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
   const stableMinOutput = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
-  // Pre-fetch live ICRC-1 fee before entering the signer batch.
-  const icpFee = await tokenFee(icpToken);
+  // Read live ICRC-1 fee from cache. preWarmOisyFees() warmed it during quote.
+  const icpFee = tokenFeeCached(icpToken);
 
   // Signer agent was pre-warmed during quote phase — cached, no popup
   const signerAgent = await getOisySignerAgent(wallet.principal);
@@ -773,13 +796,10 @@ async function executeStableToIcpOisyIcpswap(
   const amounts: [bigint, bigint, bigint] = [0n, 0n, 0n];
   amounts[from.threePoolIndex] = amountIn;
 
-  // Pre-fetch every live ICRC-1 fee the batched signer flow needs before
-  // entering `signerAgent.batch()` (no awaits allowed mid-batch).
-  const [fromFee, threeUsdFee, icpFee] = await Promise.all([
-    tokenFee(from),
-    fetchLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' }),
-    fetchLedgerFee({ ledgerId: CANISTER_IDS.ICP_LEDGER, decimals: 8, symbol: 'ICP' }),
-  ]);
+  // Read live ICRC-1 fees from cache. preWarmOisyFees() warmed them during quote.
+  const fromFee = tokenFeeCached(from);
+  const threeUsdFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' });
+  const icpFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.ICP_LEDGER, decimals: 8, symbol: 'ICP' });
 
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
@@ -883,11 +903,9 @@ async function executeIcpToStableOisyIcpswap(
   const threeUsdMinFromSwap = threeUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
   const stableMinOutput = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
-  // Pre-fetch every live ICRC-1 fee the batched signer flow needs.
-  const [icpFee, threeUsdFee] = await Promise.all([
-    tokenFee(icpToken),
-    fetchLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' }),
-  ]);
+  // Read live ICRC-1 fees from cache. preWarmOisyFees() warmed them during quote.
+  const icpFee = tokenFeeCached(icpToken);
+  const threeUsdFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' });
 
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
@@ -982,11 +1000,9 @@ async function executeIcpswapDirectOisy(
 
   const minOut = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
-  // Pre-fetch every live ICRC-1 fee the batched signer flow needs.
-  const [fromFee, toFee] = await Promise.all([
-    tokenFee(from),
-    tokenFee(to),
-  ]);
+  // Read live ICRC-1 fees from cache. preWarmOisyFees() warmed them during quote.
+  const fromFee = tokenFeeCached(from);
+  const toFee = tokenFeeCached(to);
 
   const signerAgent = await getOisySignerAgent(wallet.principal);
 


### PR DESCRIPTION
## Summary
- Fixes the Oisy swap error: **"Signer window should not be opened outside of click handler"**
- Three async fee fetches were sitting between the user's click and `signerAgent.execute()`, burning the browser's user-gesture window before signer-js could open the popup.
- Adds `preWarmOisyFees()` to warm all AMM-token ICRC-1 fees during the quote phase (parallel with the existing `preWarmOisySigner()`), and replaces every in-executor `await tokenFee(...)` / `await fetchLedgerFee(...)` with the sync cached accessors.

## Why this was happening
The Oisy executor block in `swapRouter.ts` explicitly declares "no async canister calls — all values pre-computed during `resolveRoute()`" (comment at the top of the Oisy section). The signer agent is already pre-warmed via `preWarmOisySigner()`. But fee fetches were added later inside the executors and broke that contract:

1. `SwapInterface.svelte:207` — `await fetchLedgerFee(...)` (pre-flight balance check)
2. `swapRouter.ts:887` — `await Promise.all([tokenFee(icpToken), fetchLedgerFee(3USD)])` (live fee re-fetch)
3. `swapRouter.ts:892` — `await getOisySignerAgent(...)` (cached, but still yields)

Even cache hits resolve on a microtask. signer-js measures elapsed time since the click and refuses to open the popup once the gesture window expires.

## What changed
- `swapRouter.ts`: new `preWarmOisyFees()` (no-op for non-Oisy wallets) that hydrates the fee cache for every AMM token. Five Oisy executors switch to sync `tokenFeeCached(...)` / `getCachedLedgerFee(...)`.
- `ammService.ts`: new `tokenFeeCached()` sync helper backed by `getCachedLedgerFee()`.
- `SwapInterface.svelte`: `fetchQuote()` now awaits `preWarmOisyFees()` alongside `preWarmOisySigner()`. The click-handler `await fetchLedgerFee(...)` is replaced with the sync cached read.

Click-handler path for Oisy is now synchronous all the way to `signerAgent.execute()`. The only remaining `await` is `getOisySignerAgent()` which resolves on a microtask (agent already cached from quote phase).

## Safety
- Skipping the live fee fetch in the click handler is safe: the reactive `void fetchLedgerFee(...)` and `preWarmOisyFees()` both keep the cache warm; on a cold cache `getCachedLedgerFee()` returns the hardcoded fallback (per audit ICRC-005). Backend ledgers also enforce the balance + fee check, so the frontend pre-flight is purely UX.
- Non-Oisy wallets are unchanged — they go through the standard ICRC-2 paths that can `await` freely.

## Test plan
- [ ] Connect Oisy → quote ICP → icUSD → click Swap → single signer popup, no error
- [ ] Same for icUSD → ICP, 3USD → ICP, ICP → 3USD via ICPswap, stable → stable
- [ ] Connect Internet Identity → all swap paths still work (non-Oisy unchanged)
- [ ] Force-evict the fee cache (wait >5min) → first quote re-warms it, no popup error on subsequent click
- [ ] Insufficient-balance pre-flight still triggers the "Insufficient balance (amount + fees)" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)