### PR TITLE
fix(backend): audit followup wave 14b (per-collateral fee + timer split)

### DIFF
--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -649,6 +649,29 @@ pub fn record_sp_notification_result_at(
     }
 }
 
+/// Wave-14b CDP-03: write the post-redemption base rate and timestamp to
+/// the per-collateral `CollateralConfig` (NOT the legacy global
+/// `s.current_base_rate` / `s.last_redemption_time`).
+///
+/// Pre-Wave-14b the redemption path wrote to the global fields, which
+/// meant a redemption against ckBTC corrupted the rate that subsequently
+/// priced ICP redemptions, leaking value across collateral types.
+///
+/// Pure-state function. Silently no-ops for unknown collateral types
+/// (the surrounding redemption path already validated the collateral via
+/// `get_collateral_price_decimal`, but defense in depth is cheap).
+pub fn record_per_collateral_redemption_fee(
+    state: &mut state::State,
+    collateral_type: &candid::Principal,
+    base_fee: numeric::Ratio,
+    now_ns: u64,
+) {
+    if let Some(config) = state.collateral_configs.get_mut(collateral_type) {
+        config.current_base_rate = base_fee;
+        config.last_redemption_time = now_ns;
+    }
+}
+
 pub async fn check_vaults() {
     // Auto-cancel bot claims that have been pending too long (10 minutes).
     // This prevents vaults from being permanently locked if the bot crashes.

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -187,11 +187,26 @@ fn setup_timers() {
         });
     }
 
-    // ── Recurring price fetching timers ─────────────────────────────────────
-    // ICP rate fetching timer
+    // ── Wave-14b CDP-12: three independent timers ────────────────────────
+    // Timer A (300s): XRC fetch + price update + CDP-14 source-floor + CDP-01
+    //   consecutive-failure circuit breaker. Pre-Wave-14b this single timer
+    //   chained the interest/check_vaults/treasury work below; a trap in any
+    //   step skipped everything downstream silently.
     ic_cdk_timers::set_timer_interval(rumi_protocol_backend::xrc::FETCHING_ICP_RATE_INTERVAL, || {
         ic_cdk::spawn(rumi_protocol_backend::xrc::fetch_icp_rate())
     });
+    // Timer B (60s): interest accrual + harvest + treasury drains + flush.
+    //   Independent of XRC freshness; runs on cached state. Cheap.
+    ic_cdk_timers::set_timer_interval(
+        rumi_protocol_backend::xrc::INTEREST_AND_TREASURY_TICK_INTERVAL,
+        || ic_cdk::spawn(rumi_protocol_backend::xrc::interest_and_treasury_tick()),
+    );
+    // Timer C (300s): check_vaults + aggregate-snapshot refresh.
+    //   Matches the pre-Wave-14b cadence so liquidation latency is unchanged.
+    ic_cdk_timers::set_timer_interval(
+        rumi_protocol_backend::xrc::VAULT_CHECK_TICK_INTERVAL,
+        || ic_cdk::spawn(rumi_protocol_backend::xrc::vault_check_tick()),
+    );
 
     // Price timers for all non-ICP collateral types (timers don't survive upgrades,
     // so we re-register them here for any collateral added via add_collateral_token).

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -403,9 +403,17 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
 
         mutate_state(|s| {
             let spillover_icusd = ICUSD::from(spillover_e8s);
-            let base_fee = s.get_redemption_fee(spillover_icusd);
-            s.current_base_rate = base_fee;
-            s.last_redemption_time = ic_cdk::api::time();
+            // Wave-14b CDP-03: per-collateral fee path (see redeem_collateral
+            // for full rationale). The spillover redeems against `best_ct`,
+            // so the base rate is read from and written back to that
+            // collateral's config alone.
+            let base_fee = s.get_redemption_fee_for(&best_ct, spillover_icusd);
+            crate::record_per_collateral_redemption_fee(
+                s,
+                &best_ct,
+                base_fee,
+                ic_cdk::api::time(),
+            );
             let vault_fee = spillover_icusd * base_fee;
 
             // Note: RMR was already applied when computing spillover_e8s (line 160).
@@ -489,9 +497,18 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
     match transfer_icusd_from(icusd_amount, caller).await {
         Ok(block_index) => {
             let fee_amount = mutate_state(|s| {
-                let base_fee = s.get_redemption_fee(icusd_amount);
-                s.current_base_rate = base_fee;
-                s.last_redemption_time = ic_cdk::api::time();
+                // Wave-14b CDP-03: price the fee against the per-collateral
+                // base rate, and write the post-redemption rate back to the
+                // per-collateral config (NOT the legacy global fields). A
+                // redemption against one collateral no longer corrupts the
+                // base rate used to price redemptions against any other.
+                let base_fee = s.get_redemption_fee_for(&collateral_type, icusd_amount);
+                crate::record_per_collateral_redemption_fee(
+                    s,
+                    &collateral_type,
+                    base_fee,
+                    ic_cdk::api::time(),
+                );
                 let fee_amount = icusd_amount * base_fee;
 
                 // Apply dynamic Redemption Margin Ratio: redeemers get RMR × face value

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -303,37 +303,63 @@ pub async fn fetch_icp_rate() {
     if let Some(last_icp_rate) = read_state(|s| s.last_icp_rate) {
         mutate_state(|s| s.update_total_collateral_ratio_and_mode(last_icp_rate));
     }
-    // Accrue interest on all vaults before checking vault health.
-    // This ensures liquidation decisions use up-to-date debt balances.
+    // Wave-14b CDP-12: the post-fetch interest / treasury / vault-check work
+    // moved out of this function and into separate, independently scheduled
+    // timers. See `interest_and_treasury_tick` (Timer B) and
+    // `vault_check_tick` (Timer C) below, wired up in `setup_timers`. A trap
+    // anywhere in fetch_icp_rate (Timer A) no longer skips the downstream
+    // bookkeeping silently.
+}
+
+/// Wave-14b CDP-12 Timer B: per-tick maintenance work that does NOT need a
+/// fresh XRC sample. Runs interest accrual + harvest + treasury drains +
+/// flush. Skipped under `Mode::ReadOnly` for the same reason the chained
+/// version was: no new debt is being created, no new fees to drain.
+///
+/// Cheap in cycles: pure in-memory state walks plus three short
+/// inter-canister calls to the icUSD ledger via the treasury module.
+pub async fn interest_and_treasury_tick() {
     if read_state(|s| s.mode != crate::Mode::ReadOnly) {
         let now = ic_cdk::api::time();
         mutate_state(|s| crate::event::record_accrue_interest(s, now));
         // Harvest accrued interest from vaults into pending distribution map.
-        // This zeroes per-vault accrued_interest so interest won't be double-counted
+        // Zeroes per-vault accrued_interest so interest won't double-count
         // if a repayment happens before the next tick.
         mutate_state(|s| s.harvest_accrued_interest());
     }
-    if read_state(|s| s.mode != crate::Mode::ReadOnly) {
-        crate::check_vaults().await;
-    }
 
-    // Drain any pending treasury interest/collateral accumulated from sync liquidations
+    // Drain pending treasury interest/collateral accumulated from sync
+    // liquidations.
     crate::treasury::drain_pending_treasury_interest().await;
     crate::treasury::drain_pending_treasury_collateral().await;
 
-    // Flush accumulated interest to pools/treasury when threshold is reached
+    // Flush accumulated interest to pools/treasury when threshold is reached.
     crate::treasury::flush_pending_interest().await;
+}
 
-    // Wave-9b DOS-006/-007: refresh both aggregate query snapshots.
-    // Runs after `check_vaults` (which already iterates every vault),
-    // `drain_pending_treasury_*`, and `flush_pending_interest` so the
-    // snapshot reflects the post-tick view of totals + accrued
-    // interest. Unconditional — keeping the cache warm even in
-    // ReadOnly mode lets `get_protocol_status` and `get_treasury_stats`
-    // serve from cache while the protocol is paused.
+/// Wave-14b CDP-12 Timer C: vault health sweep + aggregate-snapshot refresh.
+/// Runs `check_vaults` (which dispatches to bot / SP and handles partial
+/// liquidations) and then refreshes the cached query snapshots so
+/// `get_protocol_status` / `get_treasury_stats` serve fresh totals.
+///
+/// `check_vaults` is gated on `mode != ReadOnly`; the snapshot refresh is
+/// unconditional (keeping the cache warm in ReadOnly lets queries continue
+/// to serve from cache while the protocol is paused).
+pub async fn vault_check_tick() {
+    if read_state(|s| s.mode != crate::Mode::ReadOnly) {
+        crate::check_vaults().await;
+    }
     let now = ic_cdk::api::time();
     mutate_state(|s| s.refresh_aggregate_snapshots(now));
 }
+
+/// Wave-14b CDP-12: cadence for the interest / treasury maintenance timer
+/// (Timer B). Cheaper than Timer A's XRC fetch, so 60s is comfortable.
+pub const INTEREST_AND_TREASURY_TICK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Wave-14b CDP-12: cadence for the vault-check timer (Timer C). Matches
+/// the legacy 300s `check_vaults` cadence.
+pub const VAULT_CHECK_TICK_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Ensures the price for the given collateral type is fresh enough for
 /// a price-sensitive operation. ICP uses its own dedicated path; other

--- a/src/rumi_protocol_backend/tests/audit_pocs_cdp_03_per_collateral_fee.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_cdp_03_per_collateral_fee.rs
@@ -1,0 +1,169 @@
+//! CDP-03 regression fence: a redemption against one collateral type must
+//! not corrupt the redemption-fee state (`current_base_rate`,
+//! `last_redemption_time`) used to price redemptions against any other
+//! collateral.
+//!
+//! Pre-fix the redemption code wrote to the GLOBAL `s.current_base_rate`
+//! and `s.last_redemption_time` even though per-collateral fields exist
+//! at `s.collateral_configs.get(&ct).current_base_rate /
+//! .last_redemption_time`. Result: a redemption against ckBTC moved the
+//! global base rate that subsequently priced ICP redemptions, leaking
+//! value across collateral types.
+//!
+//! Audit fence per `.claude/security-docs/2026-05-02-wave-14-avai-parity-plan.md`.
+//!
+//! Layered fences:
+//!  1. The per-collateral helper writes ONLY the targeted collateral's
+//!     fields.
+//!  2. It does NOT touch the global `s.current_base_rate` /
+//!     `s.last_redemption_time` (they remain available as aggregate
+//!     display values but are no longer mutated by the redemption path).
+//!  3. Two redemptions against different collaterals each update only
+//!     their own per-collateral state.
+
+use candid::Principal;
+
+use rumi_protocol_backend::numeric::Ratio;
+use rumi_protocol_backend::record_per_collateral_redemption_fee;
+use rumi_protocol_backend::state::State;
+use rumi_protocol_backend::InitArg;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+const TEST_NOW_NS: u64 = 1_700_000_000_000_000_000;
+
+fn fresh_state_with_two_collaterals() -> (State, Principal, Principal) {
+    let icp = Principal::from_slice(&[10]);
+    let other = Principal::from_text("aaaaa-aa").unwrap();
+    let mut state = State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: icp,
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    let mut config = state
+        .collateral_configs
+        .get(&icp)
+        .expect("ICP config must exist")
+        .clone();
+    config.ledger_canister_id = other;
+    state.collateral_configs.insert(other, config);
+    (state, icp, other)
+}
+
+#[test]
+fn cdp_03_helper_updates_targeted_collateral_only() {
+    let (mut state, icp, other) = fresh_state_with_two_collaterals();
+
+    // Initial per-collateral values are zeros from From<InitArg>.
+    assert_eq!(
+        state.collateral_configs[&icp].current_base_rate,
+        Ratio::from(Decimal::ZERO)
+    );
+    assert_eq!(state.collateral_configs[&icp].last_redemption_time, 0);
+    assert_eq!(
+        state.collateral_configs[&other].current_base_rate,
+        Ratio::from(Decimal::ZERO)
+    );
+    assert_eq!(state.collateral_configs[&other].last_redemption_time, 0);
+
+    // Apply the per-collateral fee record for ICP.
+    let new_rate = Ratio::from(dec!(0.05));
+    record_per_collateral_redemption_fee(&mut state, &icp, new_rate, TEST_NOW_NS);
+
+    // ICP's per-collateral fields advanced.
+    assert_eq!(state.collateral_configs[&icp].current_base_rate, new_rate);
+    assert_eq!(
+        state.collateral_configs[&icp].last_redemption_time,
+        TEST_NOW_NS
+    );
+
+    // The OTHER collateral's per-collateral fields are unchanged.
+    assert_eq!(
+        state.collateral_configs[&other].current_base_rate,
+        Ratio::from(Decimal::ZERO),
+        "redeeming against ICP must NOT touch the other collateral's base rate"
+    );
+    assert_eq!(
+        state.collateral_configs[&other].last_redemption_time, 0,
+        "redeeming against ICP must NOT touch the other collateral's last_redemption_time"
+    );
+}
+
+#[test]
+fn cdp_03_helper_does_not_mutate_global_fields() {
+    let (mut state, icp, _other) = fresh_state_with_two_collaterals();
+
+    // Capture the legacy global fields before the call.
+    let global_rate_before = state.current_base_rate;
+    let global_time_before = state.last_redemption_time;
+
+    record_per_collateral_redemption_fee(&mut state, &icp, Ratio::from(dec!(0.10)), TEST_NOW_NS);
+
+    // Globals must NOT have been touched. They remain available as legacy
+    // aggregate fields but are no longer mutated by the redemption path.
+    assert_eq!(
+        state.current_base_rate, global_rate_before,
+        "legacy global current_base_rate must be untouched by per-collateral redemption fee"
+    );
+    assert_eq!(
+        state.last_redemption_time, global_time_before,
+        "legacy global last_redemption_time must be untouched by per-collateral redemption fee"
+    );
+}
+
+#[test]
+fn cdp_03_two_redemptions_against_different_collaterals_are_isolated() {
+    let (mut state, icp, other) = fresh_state_with_two_collaterals();
+
+    record_per_collateral_redemption_fee(&mut state, &icp, Ratio::from(dec!(0.05)), TEST_NOW_NS);
+    record_per_collateral_redemption_fee(
+        &mut state,
+        &other,
+        Ratio::from(dec!(0.10)),
+        TEST_NOW_NS + 60_000_000_000,
+    );
+
+    // Each collateral has its own values; neither corrupted the other.
+    assert_eq!(
+        state.collateral_configs[&icp].current_base_rate,
+        Ratio::from(dec!(0.05))
+    );
+    assert_eq!(
+        state.collateral_configs[&icp].last_redemption_time,
+        TEST_NOW_NS
+    );
+    assert_eq!(
+        state.collateral_configs[&other].current_base_rate,
+        Ratio::from(dec!(0.10))
+    );
+    assert_eq!(
+        state.collateral_configs[&other].last_redemption_time,
+        TEST_NOW_NS + 60_000_000_000
+    );
+}
+
+#[test]
+fn cdp_03_unknown_collateral_is_a_noop() {
+    let (mut state, _icp, _other) = fresh_state_with_two_collaterals();
+    let global_rate_before = state.current_base_rate;
+
+    let unknown = Principal::from_text("2vxsx-fae").unwrap();
+    record_per_collateral_redemption_fee(
+        &mut state,
+        &unknown,
+        Ratio::from(dec!(0.99)),
+        TEST_NOW_NS,
+    );
+
+    // Helper must silently no-op for unknown collateral types: the
+    // surrounding redemption path already validated the type via
+    // `get_collateral_price_decimal`, but defense in depth is cheap.
+    assert!(state.collateral_configs.get(&unknown).is_none());
+    assert_eq!(state.current_base_rate, global_rate_before);
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_cdp_12_timer_split.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_cdp_12_timer_split.rs
@@ -1,0 +1,80 @@
+//! CDP-12 regression fence: the post-XRC bookkeeping (interest accrual,
+//! treasury drains, vault-health sweep) runs in independently scheduled
+//! timers, not a single chained closure where one trap skips everything
+//! downstream.
+//!
+//! Pre-fix `fetch_icp_rate` (Timer A) chained: XRC fetch → interest
+//! accrual O(V) → drain_pending_treasury_interest →
+//! drain_pending_treasury_collateral → flush_pending_interest →
+//! check_vaults O(V) → spawn bot/SP. A trap anywhere in this chain
+//! skipped all downstream work for the next 5 minutes.
+//!
+//! Audit fence per `.claude/security-docs/2026-05-02-wave-14-avai-parity-plan.md`.
+//!
+//! Layered fences:
+//!  1. `fetch_icp_rate` (Timer A), `interest_and_treasury_tick` (Timer B),
+//!     `vault_check_tick` (Timer C) all exist as separate `pub async fn`
+//!     entry points.
+//!  2. Their cadence constants (`FETCHING_ICP_RATE_INTERVAL`,
+//!     `INTEREST_AND_TREASURY_TICK_INTERVAL`, `VAULT_CHECK_TICK_INTERVAL`)
+//!     are exposed and have sensible defaults.
+//!
+//! IC message-level trap isolation gives us the runtime behavior the plan
+//! calls for: a trap inside Timer B's callback kills only that message,
+//! Timer A and C continue firing on their own intervals. (`catch_unwind`
+//! at the application layer is not a thing on wasm/IC; the runtime
+//! handles it.)
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use rumi_protocol_backend::xrc::{
+    fetch_icp_rate, interest_and_treasury_tick, vault_check_tick,
+    FETCHING_ICP_RATE_INTERVAL, INTEREST_AND_TREASURY_TICK_INTERVAL,
+    VAULT_CHECK_TICK_INTERVAL,
+};
+
+#[test]
+fn cdp_12_three_timer_entry_points_exist_with_unit_return() {
+    // Compilation alone proves the functions exist with the expected
+    // signatures. Boxing into a trait object enforces `pub async fn () -> ()`
+    // (any other return type or arg list would fail to coerce).
+    fn assert_async_unit_fn<F>(_: F)
+    where
+        F: Fn() -> Pin<Box<dyn Future<Output = ()>>>,
+    {
+    }
+
+    // The three entry points the plan calls for. All async + unit return.
+    assert_async_unit_fn(|| Box::pin(fetch_icp_rate()) as _);
+    assert_async_unit_fn(|| Box::pin(interest_and_treasury_tick()) as _);
+    assert_async_unit_fn(|| Box::pin(vault_check_tick()) as _);
+}
+
+#[test]
+fn cdp_12_intervals_have_sensible_defaults() {
+    // Timer A (XRC) keeps the legacy 300s cadence to avoid a 5x cycle
+    // increase that would come from going to the plan-suggested 60s
+    // without an ops review.
+    assert_eq!(
+        FETCHING_ICP_RATE_INTERVAL,
+        Duration::from_secs(300),
+        "Timer A interval must remain 300s to preserve XRC cycle budget",
+    );
+
+    // Timer B (interest + treasury) at 60s per the plan; cheap in cycles.
+    assert_eq!(
+        INTEREST_AND_TREASURY_TICK_INTERVAL,
+        Duration::from_secs(60),
+        "Timer B interval should be 60s for fast interest accrual",
+    );
+
+    // Timer C (check_vaults + aggregate-snapshot refresh) at 300s — same
+    // cadence the chained version had, so liquidation latency is unchanged.
+    assert_eq!(
+        VAULT_CHECK_TICK_INTERVAL,
+        Duration::from_secs(300),
+        "Timer C interval must match the legacy 300s check_vaults cadence",
+    );
+}


### PR DESCRIPTION
## Summary

Sub-wave 14b of the Wave 14 audit follow-up. Two independent backend hardening fixes bundled because they ship together.

### CDP-03: per-collateral redemption fee path
- `redeem_collateral` and the spillover arm of `redeem_reserves` now go through `s.get_redemption_fee_for(&ct, ...)` and write the post-redemption base rate via the new `record_per_collateral_redemption_fee` helper.
- Pre-fix the redemption path wrote to the GLOBAL `s.current_base_rate` and `s.last_redemption_time`, so a redemption against one collateral corrupted the rate that priced redemptions against any other.
- The legacy global fields are NOT removed (kept for aggregate-display callers) but are no longer mutated by the redemption path.

### CDP-12: XRC timer chain split
The 300s XRC tick was a single chained closure: `fetch_icp_rate → interest accrual → harvest → drain_treasury_interest → drain_treasury_collateral → flush_pending_interest → check_vaults → bot/SP spawn → refresh snapshots`. A trap anywhere in the chain skipped everything downstream silently for the next 5 minutes.

Now three independent `set_timer_interval` callbacks:
- **Timer A** (300s, unchanged): `fetch_icp_rate` (XRC fetch + price + CDP-14 + CDP-01).
- **Timer B** (60s, new): `interest_and_treasury_tick` (interest accrual + harvest + treasury drains + flush). Cheap; runs more often without cycle pain.
- **Timer C** (300s, new): `vault_check_tick` (check_vaults + aggregate-snapshot refresh). Matches the legacy cadence so liquidation latency is unchanged.

IC's per-message trap isolation gives the "fail-isolated" runtime behavior the plan calls for; no application-level `catch_unwind` is needed (and isn't really a thing on wasm/IC).

**Cadence note:** the plan suggested 60s for Timer A. I kept it at 300s to avoid a 5x XRC cycle increase that would warrant an ops review. The split itself satisfies CDP-12's isolation goal; cadence tuning can ride a future PR.

## Test plan

- [x] 4 audit-fence tests for CDP-03: `audit_pocs_cdp_03_per_collateral_fee.rs`
- [x] 2 audit-fence tests for CDP-12: `audit_pocs_cdp_12_timer_split.rs`
- [x] `cargo test --lib` (whole workspace): 366 pass
- [x] `cargo test --test pocket_ic_tests --test pocket_ic_3usd --test integration_test --test pocket_ic_analytics`: 82 pass

## Bake plan after merge

- 24h watch on event log for `OracleCircuitBreaker`, `OracleSourceCountInsufficient`, `StabilityPoolCallFailed` (carries forward from PR-a2).
- New: confirm Timer B is firing at ~60s cadence (interest accrual events should appear ~5x more frequently than before).
- New: confirm Timer C is firing at ~300s cadence (check_vaults bot/SP notifications should keep the same rate as before).
- Per-collateral `current_base_rate` should diverge across collaterals after independent redemption activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)