### PR TITLE
fix(analytics): tail 3pool v2 swap + liquidity logs

### DIFF
--- a/src/rumi_analytics/src/sources/three_pool.rs
+++ b/src/rumi_analytics/src/sources/three_pool.rs
@@ -148,3 +148,110 @@ pub async fn get_liquidity_event_count(three_pool: Principal) -> Result<u64, Str
         .map_err(|(code, msg)| format!("get_liquidity_event_count: {:?} {}", code, msg))?;
     Ok(count)
 }
+
+// --- v2 event tailing ---
+//
+// rumi_3pool exposes a parallel set of v2 endpoints for swaps and liquidity
+// events written under the dynamic-fee schema. v1 is frozen at the migration
+// cutoff, v2 is the live log. The frontend `fetchThreePoolSwapEventsCombined`
+// merges both — analytics needs the v2 tail too or its evt_swaps mirror
+// silently misses every swap since the migration. See
+// `tailing/three_pool_swaps_v2.rs` for the consumer.
+//
+// v2 endpoint quirks worth noting in case future readers wonder:
+//
+// 1. Pagination semantics differ from v1. v1 is `(start, length)` returning
+//    oldest-first; v2 is `(limit, offset)` returning *newest-first*, with
+//    `offset` measured from the newest event. The tailer paginates from the
+//    oldest unseen entry by computing `offset = total - cursor - batch`.
+// 2. There is no `get_swap_event_count_v2` deployed on rumi_3pool today —
+//    only `get_liquidity_event_count_v2`. The swap tailer derives its total
+//    from the newest event's `id` field (ids are sequential from 0, so
+//    `total = newest.id + 1`). When/if a count endpoint lands on rumi_3pool
+//    we can switch to it without changing tailer behavior.
+// 3. v2 events carry a `migrated` flag set on the v1 entries that were
+//    backfilled into v2 at migration time. The tailer skips `migrated == true`
+//    entries since their v1 originals are already mirrored via the v1 tailer.
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolSwapEventV2 {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub token_in: u8,
+    pub token_out: u8,
+    pub amount_in: u128,
+    pub amount_out: u128,
+    pub fee: u128,
+    #[allow(dead_code)]
+    pub fee_bps: u16,
+    #[allow(dead_code)]
+    pub imbalance_before: u64,
+    #[allow(dead_code)]
+    pub imbalance_after: u64,
+    #[allow(dead_code)]
+    pub is_rebalancing: bool,
+    #[allow(dead_code)]
+    pub pool_balances_after: [u128; 3],
+    #[allow(dead_code)]
+    pub virtual_price_after: u128,
+    #[serde(default)]
+    pub migrated: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct ThreePoolLiquidityEventV2 {
+    pub id: u64,
+    pub timestamp: u64,
+    pub caller: Principal,
+    pub action: ThreePoolLiquidityAction,
+    pub amounts: [u128; 3],
+    pub lp_amount: u128,
+    pub coin_index: Option<u8>,
+    pub fee: Option<u128>,
+    #[allow(dead_code)]
+    pub fee_bps: Option<u16>,
+    #[allow(dead_code)]
+    pub imbalance_before: u64,
+    #[allow(dead_code)]
+    pub imbalance_after: u64,
+    #[allow(dead_code)]
+    pub is_rebalancing: bool,
+    #[allow(dead_code)]
+    pub pool_balances_after: [u128; 3],
+    #[allow(dead_code)]
+    pub virtual_price_after: u128,
+    #[serde(default)]
+    pub migrated: bool,
+}
+
+pub async fn get_swap_events_v2(
+    three_pool: Principal,
+    limit: u64,
+    offset: u64,
+) -> Result<Vec<ThreePoolSwapEventV2>, String> {
+    let (events,): (Vec<ThreePoolSwapEventV2>,) =
+        ic_cdk::call(three_pool, "get_swap_events_v2", (limit, offset))
+            .await
+            .map_err(|(code, msg)| format!("get_swap_events_v2: {:?} {}", code, msg))?;
+    Ok(events)
+}
+
+pub async fn get_liquidity_event_count_v2(three_pool: Principal) -> Result<u64, String> {
+    let (count,): (u64,) = ic_cdk::call(three_pool, "get_liquidity_event_count_v2", ())
+        .await
+        .map_err(|(code, msg)| format!("get_liquidity_event_count_v2: {:?} {}", code, msg))?;
+    Ok(count)
+}
+
+pub async fn get_liquidity_events_v2(
+    three_pool: Principal,
+    limit: u64,
+    offset: u64,
+) -> Result<Vec<ThreePoolLiquidityEventV2>, String> {
+    let (events,): (Vec<ThreePoolLiquidityEventV2>,) =
+        ic_cdk::call(three_pool, "get_liquidity_events_v2", (limit, offset))
+            .await
+            .map_err(|(code, msg)| format!("get_liquidity_events_v2: {:?} {}", code, msg))?;
+    Ok(events)
+}

--- a/src/rumi_analytics/src/storage/cursors.rs
+++ b/src/rumi_analytics/src/storage/cursors.rs
@@ -9,6 +9,7 @@ use super::{
     MEM_CURSOR_3POOL_LIQUIDITY, MEM_CURSOR_3POOL_BLOCKS,
     MEM_CURSOR_AMM_SWAPS, MEM_CURSOR_STABILITY_EVENTS, MEM_CURSOR_ICUSD_BLOCKS,
     MEM_CURSOR_AMM_LIQUIDITY,
+    MEM_CURSOR_3POOL_SWAPS_V2, MEM_CURSOR_3POOL_LIQUIDITY_V2,
 };
 
 thread_local! {
@@ -44,6 +45,14 @@ thread_local! {
         StableCell::init(get_memory(MEM_CURSOR_AMM_LIQUIDITY), 0u64)
             .expect("init cursor amm_liquidity")
     );
+    static CURSOR_3POOL_SWAPS_V2: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_SWAPS_V2), 0u64)
+            .expect("init cursor 3pool_swaps_v2")
+    );
+    static CURSOR_3POOL_LIQUIDITY_V2: RefCell<StableCell<u64, Memory>> = RefCell::new(
+        StableCell::init(get_memory(MEM_CURSOR_3POOL_LIQUIDITY_V2), 0u64)
+            .expect("init cursor 3pool_liquidity_v2")
+    );
 }
 
 /// Cursor identifiers matching MemoryIds. Used as keys in SlimState metadata maps.
@@ -78,3 +87,5 @@ cursor_accessors!(amm_swaps, CURSOR_AMM_SWAPS);
 cursor_accessors!(stability_events, CURSOR_STABILITY_EVENTS);
 cursor_accessors!(icusd_blocks, CURSOR_ICUSD_BLOCKS);
 cursor_accessors!(amm_liquidity, CURSOR_AMM_LIQUIDITY);
+cursor_accessors!(three_pool_swaps_v2, CURSOR_3POOL_SWAPS_V2);
+cursor_accessors!(three_pool_liquidity_v2, CURSOR_3POOL_LIQUIDITY_V2);

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -26,7 +26,8 @@ pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 // Slot reservation map (must match docs/plans/2026-04-07-rumi-analytics-design.md):
 //   0       SlimState (StableCell)
 //   1-7     cursor cells (StableCell<u64>) - one per source stream
-//   8-9     reserved
+//   8       3pool v2 swap cursor (added 2026-05-02 with v2-tailing fix)
+//   9       3pool v2 liquidity cursor (added 2026-05-02 with v2-tailing fix)
 //   10-25   daily snapshot logs (paired idx/data, StableLog)
 //   26-29   reserved
 //   30-33   fast (5min) snapshot logs
@@ -49,6 +50,11 @@ pub const MEM_CURSOR_3POOL_BLOCKS: MemoryId = MemoryId::new(4);
 pub const MEM_CURSOR_AMM_SWAPS: MemoryId = MemoryId::new(5);
 pub const MEM_CURSOR_STABILITY_EVENTS: MemoryId = MemoryId::new(6);
 pub const MEM_CURSOR_ICUSD_BLOCKS: MemoryId = MemoryId::new(7);
+// v2 cursors live alongside v1 cursors so the v1 logs (frozen at the
+// dynamic-fee migration cutoff) and the v2 logs (live writes) are tailed
+// independently — each maintains its own next-index-to-fetch.
+pub const MEM_CURSOR_3POOL_SWAPS_V2: MemoryId = MemoryId::new(8);
+pub const MEM_CURSOR_3POOL_LIQUIDITY_V2: MemoryId = MemoryId::new(9);
 
 // Daily snapshot logs
 pub const MEM_DAILY_TVL_IDX: MemoryId = MemoryId::new(10);

--- a/src/rumi_analytics/src/tailing/three_pool_liquidity.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_liquidity.rs
@@ -21,6 +21,11 @@ fn convert_action(action: &sources::three_pool::ThreePoolLiquidityAction) -> Liq
 }
 
 pub async fn run() {
+    tail_v1().await;
+    tail_v2().await;
+}
+
+async fn tail_v1() {
     let three_pool = state::read_state(|s| s.sources.three_pool);
     let cursor = cursors::three_pool_liquidity::get();
 
@@ -72,6 +77,91 @@ pub async fn run() {
 
     if processed > 0 {
         cursors::three_pool_liquidity::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, ic_cdk::api::time());
+        });
+    }
+}
+
+fn u128_to_u64(v: u128) -> u64 {
+    v.min(u64::MAX as u128) as u64
+}
+
+/// Tail v2 liquidity events. Has a real `get_liquidity_event_count_v2`
+/// endpoint (unlike the v2 swap log) so we can paginate without a probe.
+async fn tail_v2() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let cursor = cursors::three_pool_liquidity_v2::get();
+
+    let total = match sources::three_pool::get_liquidity_event_count_v2(three_pool).await {
+        Ok(c) => c,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_liq_v2] get_liquidity_event_count_v2 failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, total);
+    });
+
+    if total <= cursor { return; }
+
+    // v2 returns newest-first within (limit, offset); offset past the newer
+    // unseen tail and reverse so we push in id order.
+    let unseen = total - cursor;
+    let fetch_len = unseen.min(BATCH_SIZE);
+    let offset = unseen - fetch_len;
+    let mut events = match sources::three_pool::get_liquidity_events_v2(three_pool, fetch_len, offset).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_liq_v2] get_liquidity_events_v2 failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, e);
+            });
+            return;
+        }
+    };
+    events.reverse();
+
+    // Drift guard — see the matching comment in `tail_v2` for swaps.
+    if let Some(first) = events.first() {
+        if first.id != cursor {
+            ic_cdk::println!(
+                "[tail_3pool_liq_v2] id drift: expected first id={}, got {} (count={}). Will retry.",
+                cursor, first.id, total
+            );
+            return;
+        }
+    }
+
+    let mut advanced = 0u64;
+    for evt in &events {
+        // Advance the cursor on migrated entries too — they were already
+        // mirrored via tail_v1, and skipping them must not pin the cursor.
+        advanced += 1;
+        if evt.migrated {
+            continue;
+        }
+        evt_liquidity::push(AnalyticsLiquidityEvent {
+            timestamp_ns: evt.timestamp,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            action: convert_action(&evt.action),
+            amounts: evt.amounts.iter().map(|&n| u128_to_u64(n)).collect(),
+            lp_amount: u128_to_u64(evt.lp_amount),
+            coin_index: evt.coin_index,
+            fee: evt.fee.map(u128_to_u64),
+        });
+    }
+
+    if advanced > 0 {
+        cursors::three_pool_liquidity_v2::set(cursor + advanced);
         state::mutate_state(|s| {
             update_cursor_success(s, cursors::CURSOR_ID_3POOL_LIQUIDITY, ic_cdk::api::time());
         });

--- a/src/rumi_analytics/src/tailing/three_pool_swaps.rs
+++ b/src/rumi_analytics/src/tailing/three_pool_swaps.rs
@@ -39,6 +39,11 @@ fn normalize_to_e8s(raw: u64, token_idx: u8) -> u64 {
 }
 
 pub async fn run() {
+    tail_v1().await;
+    tail_v2().await;
+}
+
+async fn tail_v1() {
     let three_pool = state::read_state(|s| s.sources.three_pool);
     let cursor = cursors::three_pool_swaps::get();
 
@@ -98,6 +103,116 @@ pub async fn run() {
 
     if processed > 0 {
         cursors::three_pool_swaps::set(cursor + processed);
+        state::mutate_state(|s| {
+            update_cursor_success(s, cursors::CURSOR_ID_3POOL_SWAPS, ic_cdk::api::time());
+        });
+    }
+}
+
+/// Normalize a u128 amount to e8s (8-decimal) using its 3pool token slot.
+/// v2 events carry amounts as `u128` rather than `Nat`, so we widen the
+/// internal `u64` representation through u128 arithmetic before clamping.
+fn normalize_u128_to_e8s(raw: u128, token_idx: u8) -> u64 {
+    let decimals = THREE_POOL_DECIMALS.get(token_idx as usize).copied().unwrap_or(8);
+    let normalized: u128 = if decimals >= 8 {
+        raw / 10u128.pow((decimals - 8) as u32)
+    } else {
+        raw.saturating_mul(10u128.pow((8 - decimals) as u32))
+    };
+    normalized.min(u64::MAX as u128) as u64
+}
+
+/// Tail v2 swap events. Mirrors `tail_v1` but reads from the v2 log via
+/// `get_swap_events_v2`, which paginates newest-first and exposes no count
+/// endpoint. We derive the total from the newest event's `id` field. Skips
+/// `migrated == true` entries since their v1 originals are already in
+/// `evt_swaps` via `tail_v1`.
+async fn tail_v2() {
+    let three_pool = state::read_state(|s| s.sources.three_pool);
+    let cursor = cursors::three_pool_swaps_v2::get();
+
+    // Probe newest to derive total. Empty log → total = 0.
+    let probe = match sources::three_pool::get_swap_events_v2(three_pool, 1, 0).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_swaps_v2] probe failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_SWAPS, e);
+            });
+            return;
+        }
+    };
+    let total: u64 = probe.first().map(|e| e.id + 1).unwrap_or(0);
+
+    state::mutate_state(|s| {
+        update_cursor_source_count(s, cursors::CURSOR_ID_3POOL_SWAPS, total);
+    });
+
+    if total <= cursor { return; }
+
+    // Fetch the oldest BATCH_SIZE unseen entries. v2 returns newest-first
+    // within (limit, offset), so we offset past the newer entries we'll pick
+    // up on later ticks and reverse the slice locally to push in id order.
+    let unseen = total - cursor;
+    let fetch_len = unseen.min(BATCH_SIZE);
+    let offset = unseen - fetch_len;
+    let mut events = match sources::three_pool::get_swap_events_v2(three_pool, fetch_len, offset).await {
+        Ok(e) => e,
+        Err(e) => {
+            ic_cdk::println!("[tail_3pool_swaps_v2] get_swap_events_v2 failed: {}", e);
+            state::mutate_state(|s| {
+                s.error_counters.three_pool += 1;
+                update_cursor_error(s, cursors::CURSOR_ID_3POOL_SWAPS, e);
+            });
+            return;
+        }
+    };
+    events.reverse();
+
+    // Sanity check: under offset/limit arithmetic the oldest fetched event
+    // must have id == cursor. If it doesn't, the source grew between our
+    // probe and our fetch (or returned an unexpected slice). Bail without
+    // advancing — next tick re-probes and retries.
+    if let Some(first) = events.first() {
+        if first.id != cursor {
+            ic_cdk::println!(
+                "[tail_3pool_swaps_v2] id drift: expected first id={}, got {} (probe total={}). Will retry.",
+                cursor, first.id, total
+            );
+            return;
+        }
+    }
+
+    let mut advanced = 0u64;
+    for evt in &events {
+        // Always advance the cursor — even for migrated entries we skip — so
+        // a v2 log dominated by migrated rows doesn't pin the cursor.
+        advanced += 1;
+        if evt.migrated {
+            continue;
+        }
+        let (Some(token_in), Some(token_out)) =
+            (token_principal(evt.token_in), token_principal(evt.token_out))
+        else {
+            ic_cdk::println!("[tail_3pool_swaps_v2] skipping event with out-of-range token index: in={} out={}", evt.token_in, evt.token_out);
+            continue;
+        };
+        evt_swaps::push(AnalyticsSwapEvent {
+            timestamp_ns: evt.timestamp,
+            source: SwapSource::ThreePool,
+            source_event_id: evt.id,
+            caller: evt.caller,
+            token_in,
+            token_out,
+            amount_in: normalize_u128_to_e8s(evt.amount_in, evt.token_in),
+            amount_out: normalize_u128_to_e8s(evt.amount_out, evt.token_out),
+            fee: normalize_u128_to_e8s(evt.fee, evt.token_out),
+        });
+    }
+
+    if advanced > 0 {
+        cursors::three_pool_swaps_v2::set(cursor + advanced);
         state::mutate_state(|s| {
             update_cursor_success(s, cursors::CURSOR_ID_3POOL_SWAPS, ic_cdk::api::time());
         });


### PR DESCRIPTION
## Summary

- The v1→v2 dynamic-fee migration on rumi_3pool froze v1 and routed live writes to v2. Analytics only ever tailed v1, so every 3pool swap and liquidity event since the migration was missing from \`evt_swaps\` / \`evt_liquidity\`.
- This adds v2 tailing into the existing 3pool tailers — v1 stays as-is (frozen, 49 events), v2 paginates newest-first via \`(limit, offset)\`, filters \`migrated\`, and has an id-drift guard that bails on cursor advancement if the source grew between probe and fetch.
- Visible effect post-deploy: Token-flow Sankey, daily swap/fee rollups, and every aggregate that reads the event mirror start showing real data once the next pull-cycle tick (~60s) backfills.

## Why it happened

The frontend's \`fetchThreePoolSwapEventsCombined\` already merges v1+v2, but the analytics canister was never taught about v2. Confirmed by querying \`get_token_flow\` for 7d on mainnet — it returned only ICP↔3USD AMM edges; all v2 3pool activity was invisible.

## Notes

- rumi_3pool exposes \`get_liquidity_event_count_v2\` but not \`get_swap_event_count_v2\` — the swap tailer derives total from the newest event's \`id\` (probe-and-derive). When/if a count endpoint lands we can swap to it without behavior changes.
- Cursor cells use the previously-reserved memory IDs 8 and 9 — no new memory layout reservations needed.
- No timer or schedule changes — v1 and v2 share the same source slot (CURSOR_ID_3POOL_SWAPS / CURSOR_ID_3POOL_LIQUIDITY), so the staggering math doesn't move.

## Test plan

- [ ] \`cargo test -p rumi_analytics --lib\` — 108 passed locally
- [ ] \`cargo build -p rumi_analytics --target wasm32-unknown-unknown --release\` — clean
- [ ] After mainnet deploy: query \`get_token_flow\` with the 7d window, confirm 3pool edges (icUSD/ckUSDT/ckUSDC pairs) appear alongside the AMM ICP↔3USD edges
- [ ] After mainnet deploy: hit \`/api/health\`, confirm \`evt_swaps\` row count rises by the v2 backlog and \`error_counters.three_pool\` stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)