### PR TITLE
fix: Oisy _arr false-negative resilience for all write paths

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
@@ -9,6 +9,7 @@
   } from '../../services/threePoolService';
   import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { formatStableTokenDisplay } from '../../utils/format';
+  import { isOisyLandedSentinel } from '../../services/protocol/oisyResilience';
 
   function poolLedgerRef(index: number) {
     const t = POOL_TOKENS[index];
@@ -36,6 +37,7 @@
   let addLoading = false;
   let addQuoting = false;
   let addError = '';
+  let addNotice = '';
   let addLpEstimate: bigint | null = null;
   let addSlippageBps = 50;
   let showAddSlippage = false;
@@ -47,6 +49,7 @@
   let removeLoading = false;
   let removeQuoting = false;
   let removeError = '';
+  let removeNotice = '';
   let removeEstimates: bigint[] | null = null;
   let removeSingleEstimate: bigint | null = null;
   let removeSingleIndex = 0;
@@ -245,9 +248,14 @@
     try {
       addLoading = true;
       addError = '';
+      addNotice = '';
       const minLp = addLpEstimate * BigInt(10000 - addSlippageBps) / 10000n;
-      await threePoolService.addLiquidity(amounts, minLp);
-      dispatch('success', { action: 'add_liquidity' });
+      const addResult = await threePoolService.addLiquidity(amounts, minLp);
+      const oisyResilient = isOisyLandedSentinel(addResult);
+      if (oisyResilient) {
+        addNotice = 'Mint confirmed on-chain. (Wallet returned an error but the operation succeeded.)';
+      }
+      dispatch('success', { action: 'add_liquidity', oisyResilient });
       addAmounts = ['', '', ''];
       addLpEstimate = null;
       loadLpBalance();
@@ -274,20 +282,26 @@
     try {
       removeLoading = true;
       removeError = '';
+      removeNotice = '';
 
+      let removeResult: unknown;
       if (removeMode === 'proportional') {
         if (!removeEstimates) { removeError = 'Waiting for quote'; return; }
         const minAmounts = removeEstimates.map(a =>
           a * BigInt(10000 - removeSlippageBps) / 10000n
         );
-        await threePoolService.removeLiquidity(lpRaw, minAmounts);
+        removeResult = await threePoolService.removeLiquidity(lpRaw, minAmounts);
       } else {
         if (removeSingleEstimate === null) { removeError = 'Waiting for quote'; return; }
         const minAmount = removeSingleEstimate * BigInt(10000 - removeSlippageBps) / 10000n;
-        await threePoolService.removeOneCoin(lpRaw, removeSingleIndex, minAmount);
+        removeResult = await threePoolService.removeOneCoin(lpRaw, removeSingleIndex, minAmount);
       }
 
-      dispatch('success', { action: 'remove_liquidity' });
+      const oisyResilient = isOisyLandedSentinel(removeResult);
+      if (oisyResilient) {
+        removeNotice = 'Redeem confirmed on-chain. (Wallet returned an error but the operation succeeded.)';
+      }
+      dispatch('success', { action: 'remove_liquidity', oisyResilient });
       removeLpAmount = '';
       removeEstimates = null;
       removeSingleEstimate = null;
@@ -428,6 +442,9 @@
         </svg>
         {addError}
       </div>
+    {/if}
+    {#if addNotice}
+      <div class="notice-bar">{addNotice}</div>
     {/if}
 
   {:else}
@@ -579,6 +596,9 @@
         </svg>
         {removeError}
       </div>
+    {/if}
+    {#if removeNotice}
+      <div class="notice-bar">{removeNotice}</div>
     {/if}
   {/if}
 </div>
@@ -1074,6 +1094,17 @@
     border: 1px solid rgba(224, 107, 159, 0.2);
     border-radius: 0.375rem;
     color: var(--rumi-danger);
+    font-size: 0.8125rem;
+  }
+
+  /* ── Notice bar (Oisy resilient success / informational) ── */
+  .notice-bar {
+    margin-top: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    background: rgba(94, 234, 212, 0.08);
+    border: 1px solid rgba(94, 234, 212, 0.25);
+    border-radius: 0.375rem;
+    color: var(--rumi-safe, #5eead4);
     font-size: 0.8125rem;
   }
 </style>

--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -5,6 +5,12 @@
   import { resolveRoute, executeRoute, preWarmOisySigner, preWarmOisyFees, type SwapRoute } from '../../services/swapRouter';
   import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { CANISTER_IDS } from '../../config';
+  import {
+    callWithOisyFalseNegativeGuard,
+    isOisyLandedSentinel,
+  } from '../../services/protocol/oisyResilience';
+  import { TokenService } from '../../services/tokenService';
+  import { get } from 'svelte/store';
 
   function ammTokenRef(token: AmmToken) {
     return { ledgerId: token.ledgerId, decimals: token.decimals, symbol: token.symbol };
@@ -18,6 +24,7 @@
   let loading = false;
   let quoting = false;
   let error = '';
+  let notice = '';
   let currentRoute: SwapRoute | null = null;
   let midMarketRate: number | null = null;
   let slippageBps = 50;
@@ -203,6 +210,7 @@
     try {
       loading = true;
       error = '';
+      notice = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
 
       // Pre-flight balance check using the cached live fee. The reactive
@@ -217,8 +225,35 @@
         return;
       }
 
-      await executeRoute(currentRoute, fromToken, toToken, amountRaw, slippageBps);
-      dispatch('success', { action: 'swap' });
+      // Oisy false-negative resilience: capture pre-swap destination
+      // balance so we can verify the swap landed on-chain even if
+      // Oisy returns its `_arr` error in the JSON-RPC response.
+      const walletState = get(walletStore);
+      const beforeToBalance = walletState.principal
+        ? await TokenService.getTokenBalance(toToken.ledgerId, walletState.principal).catch(() => null)
+        : null;
+
+      const swapResult = await callWithOisyFalseNegativeGuard(
+        () => executeRoute(currentRoute!, fromToken, toToken, amountRaw, slippageBps),
+        async () => {
+          if (beforeToBalance === null || !walletState.principal) return false;
+          const after = await TokenService.getTokenBalance(
+            toToken.ledgerId, walletState.principal
+          ).catch(() => null);
+          if (after === null) return false;
+          // Destination balance should grow by at least 50% of the
+          // route's quoted output (slippage + ledger fees can shave it).
+          const minDelta = (currentRoute!.estimatedOutput * 50n) / 100n;
+          return after - beforeToBalance >= minDelta;
+        },
+        `swap ${fromToken.symbol} -> ${toToken.symbol} amount=${amountRaw}`
+      );
+      const oisyResilient = isOisyLandedSentinel(swapResult);
+      dispatch('success', { action: 'swap', oisyResilient });
+      if (oisyResilient) {
+        error = '';
+        notice = 'Swap confirmed on-chain. (Wallet returned an error but the operation succeeded.)';
+      }
       amount = '';
       currentRoute = null;
     } catch (err: any) {
@@ -419,6 +454,9 @@
         </svg>
         {error}
       </div>
+    {/if}
+    {#if notice}
+      <div class="notice-bar">{notice}</div>
     {/if}
   {/if}
 </div>
@@ -836,6 +874,17 @@
     border: 1px solid rgba(224, 107, 159, 0.2);
     border-radius: 0.375rem;
     color: var(--rumi-danger);
+    font-size: 0.8125rem;
+  }
+
+  /* ── Notice (Oisy resilient success / informational) ── */
+  .notice-bar {
+    margin-top: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    background: rgba(94, 234, 212, 0.08);
+    border: 1px solid rgba(94, 234, 212, 0.25);
+    border-radius: 0.375rem;
+    color: var(--rumi-safe, #5eead4);
     font-size: 0.8125rem;
   }
 </style>

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -563,7 +563,10 @@
       }
       const result = await protocolService.addMarginToVault(vault.vaultId, amount, vaultCollateralType);
       if (result.success) {
-        toastStore.success(`Added ${amount} ${collateralSymbol}`, 8000); addCollateralAmount = '';
+        const msg = result.oisyResilient
+          ? `Added ${amount} ${collateralSymbol} (wallet glitch ignored — operation confirmed on-chain).`
+          : `Added ${amount} ${collateralSymbol}`;
+        toastStore.success(msg, 8000); addCollateralAmount = '';
         await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
@@ -587,7 +590,10 @@
     try {
       const result = await protocolService.withdrawPartialCollateral(vault.vaultId, amount, collateralDecimals);
       if (result.success) {
-        toastStore.success(`Withdrew ${amount} ${collateralSymbol}`, 8000); withdrawAmount = '';
+        const msg = result.oisyResilient
+          ? `Withdrew ${amount} ${collateralSymbol} (wallet glitch ignored — operation confirmed on-chain).`
+          : `Withdrew ${amount} ${collateralSymbol}`;
+        toastStore.success(msg, 8000); withdrawAmount = '';
         await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
@@ -605,7 +611,10 @@
     try {
       const result = await protocolService.borrowFromVault(vault.vaultId, amount);
       if (result.success) {
-        toastStore.success(`Borrowed ${amount} icUSD`, 8000); borrowAmount = '';
+        const msg = result.oisyResilient
+          ? `Borrowed ${amount} icUSD (wallet glitch ignored — operation confirmed on-chain).`
+          : `Borrowed ${amount} icUSD`;
+        toastStore.success(msg, 8000); borrowAmount = '';
         await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
@@ -626,7 +635,10 @@
         result = await protocolManager.repayToVaultWithStable(vault.vaultId, amount, repayTokenType);
       }
       if (result.success) {
-        toastStore.success(`Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType}`, 8000); repayAmount = '';
+        const msg = result.oisyResilient
+          ? `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType} (wallet glitch ignored — operation confirmed on-chain).`
+          : `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType}`;
+        toastStore.success(msg, 8000); repayAmount = '';
         await new Promise(r => setTimeout(r, 1000));
         await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
@@ -647,7 +659,10 @@
     try {
       const result = await protocolService.withdrawCollateralAndCloseVault(vault.vaultId);
       if (result.success) {
-        toastStore.success('Vault closed. Collateral returned.', 8000);
+        const msg = result.oisyResilient
+          ? 'Vault closed. Collateral returned. (Wallet glitch ignored — confirmed on-chain.)'
+          : 'Vault closed. Collateral returned.';
+        toastStore.success(msg, 8000);
         await vaultStore.refreshVaults(); dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -37,6 +37,7 @@ import {
   callWithOisyFalseNegativeGuard,
   isOisyLandedSentinel,
 } from './oisyResilience';
+import { TokenService } from '../tokenService';
 
 
 
@@ -1902,6 +1903,21 @@ static async repayToVaultWithStable(
           ? [Principal.fromText(preferredToken)]
           : [];
 
+        // Pre-redeem icUSD balance for the Oisy false-negative
+        // verifier: redeem burns icUSD from the caller.
+        const walletState = get(walletStore);
+        const beforeIcusd = walletState.principal
+          ? await TokenService.getTokenBalance(CONFIG.currentIcusdLedgerId, walletState.principal).catch(() => null)
+          : null;
+        const verifyRedeemLanded = async () => {
+          if (beforeIcusd === null || !walletState.principal) return false;
+          const after = await TokenService.getTokenBalance(
+            CONFIG.currentIcusdLedgerId, walletState.principal
+          ).catch(() => null);
+          if (after === null) return false;
+          return beforeIcusd - after >= (icusdE8s * 95n) / 100n;
+        };
+
         // ─── Oisy ICRC-112 batched path ───
         // Always batch approve+redeem — skipping the allowance check eliminates an
         // async canister query that burns the browser user gesture context.
@@ -1925,8 +1941,25 @@ static async repayToVaultWithStable(
           signerAgent.batch();
           const redeemPromise = actor.redeem_reserves(icusdE8s, preferredOpt);
 
-          await signerAgent.execute();
-          const [approveResult, result] = await Promise.all([approvePromise, redeemPromise]);
+          const batchResult = await callWithOisyFalseNegativeGuard(
+            async () => {
+              await signerAgent.execute();
+              return Promise.all([approvePromise, redeemPromise]);
+            },
+            verifyRedeemLanded,
+            `Oisy batched approve+redeem_reserves ${icusdAmount} icUSD`
+          );
+
+          if (isOisyLandedSentinel(batchResult)) {
+            return {
+              success: true,
+              blockIndex: undefined,
+              feePaid: undefined,
+              oisyResilient: true,
+            };
+          }
+
+          const [approveResult, result] = batchResult;
 
           if (approveResult && 'Err' in approveResult) {
             return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
@@ -1962,7 +1995,20 @@ static async repayToVaultWithStable(
         }
 
         const actor = await ApiClient.getAuthenticatedActor();
-        const result = await actor.redeem_reserves(icusdE8s, preferredOpt);
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.redeem_reserves(icusdE8s, preferredOpt),
+          verifyRedeemLanded,
+          `redeem_reserves ${icusdAmount} icUSD`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            blockIndex: undefined,
+            feePaid: undefined,
+            oisyResilient: true,
+          };
+        }
 
         if ('Ok' in result) {
           const r = result.Ok;
@@ -2013,17 +2059,46 @@ static async repayToVaultWithStable(
     static async redeemIcp(icusdAmount: number): Promise<VaultOperationResult> {
       try {
         console.log(`Redeeming ${icusdAmount} icUSD for ICP`);
-        
+
         if (icusdAmount * E8S < MIN_ICUSD_AMOUNT) {
           return {
             success: false,
             error: `Amount too low, minimum is ${MIN_ICUSD_AMOUNT / E8S} icUSD`
           };
         }
-        
+
         const actor = await ApiClient.getAuthenticatedActor();
-        const result = await actor.redeem_icp(BigInt(Math.floor(icusdAmount * E8S)));
-        
+        const amountE8s = BigInt(Math.floor(icusdAmount * E8S));
+
+        // Pre-redeem icUSD balance for the Oisy false-negative
+        // verifier: redeem burns icUSD from the caller's balance.
+        const walletState = get(walletStore);
+        const beforeIcusd = walletState.principal
+          ? await TokenService.getTokenBalance(CONFIG.currentIcusdLedgerId, walletState.principal).catch(() => null)
+          : null;
+
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.redeem_icp(amountE8s),
+          async () => {
+            if (beforeIcusd === null || !walletState.principal) return false;
+            const after = await TokenService.getTokenBalance(
+              CONFIG.currentIcusdLedgerId, walletState.principal
+            ).catch(() => null);
+            if (after === null) return false;
+            return beforeIcusd - after >= (amountE8s * 95n) / 100n;
+          },
+          `redeem_icp ${icusdAmount} icUSD`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            blockIndex: undefined,
+            feePaid: undefined,
+            oisyResilient: true,
+          };
+        }
+
         if ('Ok' in result) {
           return {
             success: true,
@@ -2063,7 +2138,36 @@ static async repayToVaultWithStable(
 
         const actor = await ApiClient.getAuthenticatedActor();
         const collateralPrincipal = Principal.fromText(collateralTypePrincipal);
-        const result = await actor.redeem_collateral(collateralPrincipal, BigInt(Math.floor(icusdAmount * E8S)));
+        const amountE8s = BigInt(Math.floor(icusdAmount * E8S));
+
+        // Pre-redeem icUSD balance for the Oisy false-negative
+        // verifier: redeem burns icUSD from the caller.
+        const walletState = get(walletStore);
+        const beforeIcusd = walletState.principal
+          ? await TokenService.getTokenBalance(CONFIG.currentIcusdLedgerId, walletState.principal).catch(() => null)
+          : null;
+
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.redeem_collateral(collateralPrincipal, amountE8s),
+          async () => {
+            if (beforeIcusd === null || !walletState.principal) return false;
+            const after = await TokenService.getTokenBalance(
+              CONFIG.currentIcusdLedgerId, walletState.principal
+            ).catch(() => null);
+            if (after === null) return false;
+            return beforeIcusd - after >= (amountE8s * 95n) / 100n;
+          },
+          `redeem_collateral ${icusdAmount} icUSD -> ${collateralTypePrincipal}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            blockIndex: undefined,
+            feePaid: undefined,
+            oisyResilient: true,
+          };
+        }
 
         if ('Ok' in result) {
           return {
@@ -2173,6 +2277,32 @@ static async repayToVaultWithStable(
     }
 
     /**
+     * Cache-bypassing snapshot of the connected user's protocol-side
+     * liquidity-pool position (the on-canister stability pool view).
+     * Returns null on any failure.
+     */
+    static async fetchLiquidityStatusSnapshot(): Promise<
+      | {
+          liquidityProvided: bigint;
+          availableReward: bigint;
+        }
+      | null
+    > {
+      try {
+        const walletState = get(walletStore);
+        if (!walletState.principal) return null;
+        const status = await publicActor.get_liquidity_status(walletState.principal);
+        return {
+          liquidityProvided: BigInt(status.liquidity_provided),
+          availableReward: BigInt(status.available_liquidity_reward),
+        };
+      } catch (err) {
+        console.warn('fetchLiquidityStatusSnapshot failed:', err);
+        return null;
+      }
+    }
+
+    /**
      * Find a vault that is in the user's current set but was NOT in
      * `beforeIds`. Used by the open_vault verifier to confirm a new
      * vault landed. Returns null if no new vault is visible yet (or
@@ -2226,30 +2356,52 @@ static async repayToVaultWithStable(
       static async provideLiquidity(amount: number): Promise<VaultOperationResult> {
         try {
           console.log(`Providing ${amount} ICP as liquidity`);
-          
+
           if (amount <= 0) {
             return {
               success: false,
               error: 'Amount must be greater than 0'
             };
           }
-          
+
           // Convert amount to e8s
           const amountE8s = BigInt(Math.floor(amount * E8S));
-          
+
           if (USE_MOCK_DATA) {
             // Simulate processing delay
             await new Promise(resolve => setTimeout(resolve, 1500));
-            
+
             return {
               success: true,
               blockIndex: Math.floor(Math.random() * 1000) + 1
             };
           }
-          
+
           const actor = await ApiClient.getAuthenticatedActor();
-          const result = await actor.provide_liquidity(amountE8s);
-          
+
+          // Pre-provide liquidity snapshot for the Oisy false-negative
+          // verifier. provide_liquidity grows liquidity_provided.
+          const before = await ApiClient.fetchLiquidityStatusSnapshot();
+
+          const result = await callWithOisyFalseNegativeGuard(
+            () => actor.provide_liquidity(amountE8s),
+            async () => {
+              if (!before) return false;
+              const after = await ApiClient.fetchLiquidityStatusSnapshot();
+              if (!after) return false;
+              return after.liquidityProvided - before.liquidityProvided >= (amountE8s * 95n) / 100n;
+            },
+            `provide_liquidity ${amount} ICP`
+          );
+
+          if (isOisyLandedSentinel(result)) {
+            return {
+              success: true,
+              blockIndex: undefined,
+              oisyResilient: true,
+            };
+          }
+
           if (result && typeof result === 'object' && 'Ok' in result) {
             return {
               success: true,
@@ -2274,37 +2426,60 @@ static async repayToVaultWithStable(
           };
         }
       }
-    
+
       /**
        * Withdraw liquidity from the protocol
        */
       static async withdrawLiquidity(amount: number): Promise<VaultOperationResult> {
         try {
           console.log(`Withdrawing ${amount} ICP from liquidity pool`);
-          
+
           if (amount <= 0) {
             return {
               success: false,
               error: 'Amount must be greater than 0'
             };
           }
-          
+
           // Convert amount to e8s
           const amountE8s = BigInt(Math.floor(amount * E8S));
-          
+
           if (USE_MOCK_DATA) {
             // Simulate processing delay
             await new Promise(resolve => setTimeout(resolve, 1500));
-            
+
             return {
               success: true,
               blockIndex: Math.floor(Math.random() * 1000) + 1
             };
           }
-          
+
           const actor = await ApiClient.getAuthenticatedActor();
-          const result = await actor.withdraw_liquidity(amountE8s);
-          
+
+          // Pre-withdraw snapshot. withdraw_liquidity reduces
+          // liquidity_provided by `amount` (or all of it).
+          const before = await ApiClient.fetchLiquidityStatusSnapshot();
+
+          const result = await callWithOisyFalseNegativeGuard(
+            () => actor.withdraw_liquidity(amountE8s),
+            async () => {
+              if (!before) return false;
+              const after = await ApiClient.fetchLiquidityStatusSnapshot();
+              if (!after) return false;
+              const drop = before.liquidityProvided - after.liquidityProvided;
+              return drop >= (amountE8s * 95n) / 100n || after.liquidityProvided === 0n;
+            },
+            `withdraw_liquidity ${amount} ICP`
+          );
+
+          if (isOisyLandedSentinel(result)) {
+            return {
+              success: true,
+              blockIndex: undefined,
+              oisyResilient: true,
+            };
+          }
+
           if ('Ok' in result) {
             return {
               success: true,
@@ -2324,27 +2499,49 @@ static async repayToVaultWithStable(
           };
         }
       }
-    
+
       /**
        * Claim liquidity returns
        */
       static async claimLiquidityReturns(): Promise<VaultOperationResult> {
         try {
           console.log('Claiming liquidity returns');
-          
+
           if (USE_MOCK_DATA) {
             // Simulate processing delay
             await new Promise(resolve => setTimeout(resolve, 1500));
-            
+
             return {
               success: true,
               blockIndex: Math.floor(Math.random() * 1000) + 1
             };
           }
-          
+
           const actor = await ApiClient.getAuthenticatedActor();
-          const result = await actor.claim_liquidity_returns();
-          
+
+          // Pre-claim snapshot. claim_liquidity_returns drops
+          // available_liquidity_reward to 0.
+          const before = await ApiClient.fetchLiquidityStatusSnapshot();
+
+          const result = await callWithOisyFalseNegativeGuard(
+            () => actor.claim_liquidity_returns(),
+            async () => {
+              if (!before || before.availableReward === 0n) return false;
+              const after = await ApiClient.fetchLiquidityStatusSnapshot();
+              if (!after) return false;
+              return after.availableReward < before.availableReward;
+            },
+            `claim_liquidity_returns`
+          );
+
+          if (isOisyLandedSentinel(result)) {
+            return {
+              success: true,
+              blockIndex: undefined,
+              oisyResilient: true,
+            };
+          }
+
           if ('Ok' in result) {
             return {
               success: true,

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -33,6 +33,10 @@ import type {
 import { protocolService } from '../protocol';
 import { RequestDeduplicator } from '../RequestDeduplicator';
 import { collateralStore } from '$lib/stores/collateralStore';
+import {
+  callWithOisyFalseNegativeGuard,
+  isOisyLandedSentinel,
+} from './oisyResilience';
 
 
 
@@ -442,6 +446,20 @@ private static async refreshVaultData(): Promise<void> {
               ? []  // ICP is the default, no need to pass
               : [Principal.fromText(ctPrincipal)];
 
+            // Pre-open vault-id snapshot for the Oisy false-negative
+            // verifier: if open_vault lands but Oisy mangles the
+            // response, we still find the new vault by diffing IDs.
+            const beforeIds = await ApiClient.snapshotUserVaultIds();
+            const verifyOpenLanded = async () => {
+              if (!beforeIds) return false;
+              const newVault = await ApiClient.findNewlyOpenedVault(beforeIds);
+              if (!newVault) return false;
+              // Sanity check: collateral on the new vault is at least
+              // 95% of what we requested. Below that and something
+              // really odd happened.
+              return newVault.collateralAmount >= (amountRaw * 95n) / 100n;
+            };
+
             // ─── Oisy ICRC-112 batched path ───
             // Batches approve + open_vault into a single signer popup via ICRC-112.
             // The SignerAgent natively handles icrc2_approve consent (Tier 1) so
@@ -476,9 +494,27 @@ private static async refreshVaultData(): Promise<void> {
               const vaultPromise = actor.open_vault(amountRaw, collateralTypeOpt);
 
               // Fire both as a single ICRC-112 batch request → one Oisy popup
-              await signerAgent.execute();
+              const batchResult = await callWithOisyFalseNegativeGuard(
+                async () => {
+                  await signerAgent.execute();
+                  return Promise.all([approvePromise, vaultPromise]);
+                },
+                verifyOpenLanded,
+                `Oisy batched approve+open_vault ${collateralAmount} ${symbol}`
+              );
 
-              const [approveResult, result] = await Promise.all([approvePromise, vaultPromise]);
+              if (isOisyLandedSentinel(batchResult)) {
+                // Look up the newly-opened vault to populate vaultId for the UI.
+                const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
+                return {
+                  success: true,
+                  vaultId: found?.vaultId,
+                  blockIndex: undefined,
+                  oisyResilient: true,
+                };
+              }
+
+              const [approveResult, result] = batchResult;
 
               // Check approve result
               if (approveResult && 'Err' in approveResult) {
@@ -537,10 +573,24 @@ private static async refreshVaultData(): Promise<void> {
             });
 
             // Race between the actual operation and the timeout
-            const result = await Promise.race([
-              actor.open_vault(amountRaw, collateralTypeOpt),
-              timeoutPromise
-            ]);
+            const result = await callWithOisyFalseNegativeGuard(
+              () => Promise.race([
+                actor.open_vault(amountRaw, collateralTypeOpt),
+                timeoutPromise
+              ]),
+              verifyOpenLanded,
+              `open_vault ${collateralAmount} ${symbol}`
+            );
+
+            if (isOisyLandedSentinel(result)) {
+              const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
+              return {
+                success: true,
+                vaultId: found?.vaultId,
+                blockIndex: undefined,
+                oisyResilient: true,
+              };
+            }
 
             if ('Ok' in result) {
               return {
@@ -662,6 +712,18 @@ static async openVaultAndBorrow(
           ? []
           : [Principal.fromText(ctPrincipal)];
 
+        // Pre-open-and-borrow snapshot for the Oisy false-negative
+        // verifier. open_vault_and_borrow creates a new vault AND
+        // borrows in one canister call; we treat "new vault appeared
+        // with the right collateral" as proof the call landed.
+        const beforeIds = await ApiClient.snapshotUserVaultIds();
+        const verifyOpenAndBorrowLanded = async () => {
+          if (!beforeIds) return false;
+          const newVault = await ApiClient.findNewlyOpenedVault(beforeIds);
+          if (!newVault) return false;
+          return newVault.collateralAmount >= (amountRaw * 95n) / 100n;
+        };
+
         // ─── Oisy ICRC-112 batched path ───
         const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
 
@@ -693,9 +755,26 @@ static async openVaultAndBorrow(
           const vaultPromise = actor.open_vault_and_borrow(amountRaw, borrowRaw, collateralTypeOpt);
 
           // Fire both as a single ICRC-112 batch request → one Oisy popup
-          await signerAgent.execute();
+          const batchResult = await callWithOisyFalseNegativeGuard(
+            async () => {
+              await signerAgent.execute();
+              return Promise.all([approvePromise, vaultPromise]);
+            },
+            verifyOpenAndBorrowLanded,
+            `Oisy batched approve+open_vault_and_borrow ${collateralAmount} ${symbol}`
+          );
 
-          const [approveResult, result] = await Promise.all([approvePromise, vaultPromise]);
+          if (isOisyLandedSentinel(batchResult)) {
+            const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
+            return {
+              success: true,
+              vaultId: found?.vaultId,
+              blockIndex: undefined,
+              oisyResilient: true,
+            };
+          }
+
+          const [approveResult, result] = batchResult;
 
           if (approveResult && 'Err' in approveResult) {
             return { success: false, error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}` };
@@ -732,10 +811,24 @@ static async openVaultAndBorrow(
           setTimeout(() => reject(new Error("Wallet signature request timed out")), 60000);
         });
 
-        const result = await Promise.race([
-          actor.open_vault_and_borrow(amountRaw, borrowRaw, collateralTypeOpt),
-          timeoutPromise
-        ]);
+        const result = await callWithOisyFalseNegativeGuard(
+          () => Promise.race([
+            actor.open_vault_and_borrow(amountRaw, borrowRaw, collateralTypeOpt),
+            timeoutPromise
+          ]),
+          verifyOpenAndBorrowLanded,
+          `open_vault_and_borrow ${collateralAmount} ${symbol}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
+          return {
+            success: true,
+            vaultId: found?.vaultId,
+            blockIndex: undefined,
+            oisyResilient: true,
+          };
+        }
 
         if ('Ok' in result) {
           return {
@@ -799,15 +892,45 @@ static async borrowFromVault(vaultId: number, icusdAmount: number): Promise<Vaul
       
       // Simulate processing delay
       await new Promise(resolve => setTimeout(resolve, 1200));
-      
+
       const actor = await ApiClient.getAuthenticatedActor();
       const vaultArg = {
         vault_id: BigInt(vaultId),
         amount: BigInt(Math.floor(icusdAmount * E8S))
       };
-      
-      const result = await actor.borrow_from_vault(vaultArg);
-      
+
+      // Snapshot pre-borrow state for the Oisy false-negative verifier.
+      // We compare RAW e8s (not the rounded human float on VaultDTO) so a
+      // 0.1 icUSD borrow can't be hidden by display rounding.
+      const before = await ApiClient.getRawBorrowedE8s(vaultId);
+      const expectedDeltaE8s = vaultArg.amount;
+
+      const result = await callWithOisyFalseNegativeGuard(
+        () => actor.borrow_from_vault(vaultArg),
+        async () => {
+          if (before === null) return false;
+          // Allow up to 1 minute for canister state to be observable
+          // post-call (interest accrual + cert propagation). 95% of the
+          // borrow amount lower bound tolerates the rounding from
+          // BigInt(Math.floor(amount * E8S)) on tiny amounts.
+          const after = await ApiClient.getRawBorrowedE8s(vaultId);
+          if (after === null) return false;
+          const delta = after - before;
+          return delta >= (expectedDeltaE8s * 95n) / 100n;
+        },
+        `borrow ${icusdAmount} icUSD from vault #${vaultId}`
+      );
+
+      if (isOisyLandedSentinel(result)) {
+        return {
+          success: true,
+          vaultId,
+          blockIndex: undefined,
+          feePaid: undefined,
+          oisyResilient: true,
+        };
+      }
+
       if ('Ok' in result) {
         return {
           success: true,
@@ -882,6 +1005,10 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
 
       const actor = await ApiClient.getAuthenticatedActor();
 
+      // Snapshot pre-add collateral for the Oisy false-negative verifier.
+      // We read RAW token units so we can compare with BigInt arithmetic.
+      const beforeCollateral = await ApiClient.getRawCollateralAmount(vaultId);
+
       // ─── Oisy ICRC-112 batched path ───
       // Batches approve + add_margin into a single signer popup via ICRC-112.
       const marginSignerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
@@ -914,10 +1041,33 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
           amount: amountRaw
         });
 
-        // Fire both as a single ICRC-112 batch request → one Oisy popup
-        await marginSignerAgent.execute();
+        // Fire both as a single ICRC-112 batch request → one Oisy popup.
+        // The Oisy `_arr` false-negative can surface from any of these
+        // awaits, so wrap the whole batched-execute in the resilience guard.
+        const batchResult = await callWithOisyFalseNegativeGuard(
+          async () => {
+            await marginSignerAgent.execute();
+            return Promise.all([approvePromise, marginPromise]);
+          },
+          async () => {
+            if (beforeCollateral === null) return false;
+            const after = await ApiClient.getRawCollateralAmount(vaultId);
+            if (after === null) return false;
+            return after - beforeCollateral >= (amountRaw * 95n) / 100n;
+          },
+          `Oisy batched approve+add_margin ${collateralAmount} ${symbol} to vault #${vaultId}`
+        );
 
-        const [approveResult, marginResult] = await Promise.all([approvePromise, marginPromise]);
+        if (isOisyLandedSentinel(batchResult)) {
+          return {
+            success: true,
+            vaultId,
+            blockIndex: undefined,
+            oisyResilient: true,
+          };
+        }
+
+        const [approveResult, marginResult] = batchResult;
 
         if (approveResult && 'Err' in approveResult) {
           return {
@@ -1027,8 +1177,26 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
         amount: vaultArg.amount.toString()
       });
 
-      const result = await actor.add_margin_to_vault(vaultArg);
-      
+      const result = await callWithOisyFalseNegativeGuard(
+        () => actor.add_margin_to_vault(vaultArg),
+        async () => {
+          if (beforeCollateral === null) return false;
+          const after = await ApiClient.getRawCollateralAmount(vaultId);
+          if (after === null) return false;
+          return after - beforeCollateral >= (amountRaw * 95n) / 100n;
+        },
+        `add_margin ${collateralAmount} ${symbol} to vault #${vaultId}`
+      );
+
+      if (isOisyLandedSentinel(result)) {
+        return {
+          success: true,
+          vaultId,
+          blockIndex: undefined,
+          oisyResilient: true,
+        };
+      }
+
       if ('Ok' in result) {
         return {
           success: true,
@@ -1085,6 +1253,24 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
         amount: amountE8s
       };
 
+      // Snapshot pre-repay borrowed amount for the Oisy false-negative
+      // verifier. Repay reduces borrowed by `amount`; interest accrual
+      // (timer-driven, slow) can offset the reduction slightly so we
+      // accept any directional decrease >= 50% of expected as a landed
+      // op. Anything smaller would be too noisy.
+      const beforeBorrowed = await ApiClient.getRawBorrowedE8s(vaultId);
+
+      const verifyRepayLanded = async () => {
+        if (beforeBorrowed === null) return false;
+        const after = await ApiClient.getRawBorrowedE8s(vaultId);
+        if (after === null) return false;
+        // Borrowed went down by at least half the requested amount.
+        // (Interest accrual since the snapshot can shrink the visible
+        // delta; full debt close can put `after` at 0.)
+        const drop = beforeBorrowed - after;
+        return drop >= (amountE8s * 50n) / 100n || after === 0n;
+      };
+
       // ─── Oisy ICRC-112 batched path ───
       // Always batch approve+repay — skipping the allowance check eliminates an
       // async canister query that burns the browser user gesture context. The approve
@@ -1108,8 +1294,20 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
         signerAgent.batch();
         const repayPromise = actor.repay_to_vault(vaultArg);
 
-        await signerAgent.execute();
-        const [approveResult, result] = await Promise.all([approvePromise, repayPromise]);
+        const batchResult = await callWithOisyFalseNegativeGuard(
+          async () => {
+            await signerAgent.execute();
+            return Promise.all([approvePromise, repayPromise]);
+          },
+          verifyRepayLanded,
+          `Oisy batched approve+repay ${icusdAmount} icUSD to vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(batchResult)) {
+          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+        }
+
+        const [approveResult, result] = batchResult;
 
         if (approveResult && 'Err' in approveResult) {
           return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
@@ -1122,7 +1320,15 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
       }
 
       // ─── Standard path (non-Oisy) ───
-      const result = await actor.repay_to_vault(vaultArg);
+      const result = await callWithOisyFalseNegativeGuard(
+        () => actor.repay_to_vault(vaultArg),
+        verifyRepayLanded,
+        `repay ${icusdAmount} icUSD to vault #${vaultId}`
+      );
+
+      if (isOisyLandedSentinel(result)) {
+        return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+      }
 
       if ('Ok' in result) {
         return {
@@ -1185,6 +1391,16 @@ static async repayToVaultWithStable(
         token_type
       };
 
+      // Pre-repay snapshot — same shape as repayToVault.
+      const beforeBorrowed = await ApiClient.getRawBorrowedE8s(vaultId);
+      const verifyRepayLanded = async () => {
+        if (beforeBorrowed === null) return false;
+        const after = await ApiClient.getRawBorrowedE8s(vaultId);
+        if (after === null) return false;
+        const drop = beforeBorrowed - after;
+        return drop >= (amountE8s * 50n) / 100n || after === 0n;
+      };
+
       // ─── Oisy ICRC-112 batched path ───
       // Always batch approve+repay — skipping the allowance check eliminates an
       // async canister query that burns the browser user gesture context.
@@ -1208,8 +1424,20 @@ static async repayToVaultWithStable(
         signerAgent.batch();
         const repayPromise = actor.repay_to_vault_with_stable(vaultArgWithToken);
 
-        await signerAgent.execute();
-        const [approveResult, result] = await Promise.all([approvePromise, repayPromise]);
+        const batchResult = await callWithOisyFalseNegativeGuard(
+          async () => {
+            await signerAgent.execute();
+            return Promise.all([approvePromise, repayPromise]);
+          },
+          verifyRepayLanded,
+          `Oisy batched approve+repay ${amount} ${tokenType} to vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(batchResult)) {
+          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+        }
+
+        const [approveResult, result] = batchResult;
 
         if (approveResult && 'Err' in approveResult) {
           return { success: false, error: `${tokenType} approval failed: ${JSON.stringify(approveResult.Err)}` };
@@ -1222,7 +1450,15 @@ static async repayToVaultWithStable(
       }
 
       // ─── Standard path (non-Oisy, or Oisy with sufficient allowance) ───
-      const result = await actor.repay_to_vault_with_stable(vaultArgWithToken);
+      const result = await callWithOisyFalseNegativeGuard(
+        () => actor.repay_to_vault_with_stable(vaultArgWithToken),
+        verifyRepayLanded,
+        `repay ${amount} ${tokenType} to vault #${vaultId}`
+      );
+
+      if (isOisyLandedSentinel(result)) {
+        return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+      }
 
       if ('Ok' in result) {
         return {
@@ -1281,8 +1517,31 @@ static async repayToVaultWithStable(
         }
   
         // Execute close operation
-        const result = await actor.close_vault(BigInt(vaultId));
-        
+        // close_vault deletes the vault from canister state when it has
+        // no collateral and no debt. Verifier: vault no longer present.
+        type CloseVaultResult = { Ok: [] | [bigint] } | { Err: ProtocolError };
+        const result = await callWithOisyFalseNegativeGuard<CloseVaultResult>(
+          () => actor.close_vault(BigInt(vaultId)) as Promise<CloseVaultResult>,
+          async () => {
+            const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+            // Either snapshot says vault is gone, or both collateral
+            // and borrowed are now zero (canister may keep a husk).
+            if (!snap) return false;
+            if (!snap.exists) return true;
+            return snap.collateralAmount === 0n && snap.borrowedIcusd === 0n;
+          },
+          `close_vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            vaultId,
+            message: `Successfully closed vault #${vaultId}`,
+            oisyResilient: true,
+          };
+        }
+
         if ('Ok' in result) {
           return {
             success: true,
@@ -1290,7 +1549,7 @@ static async repayToVaultWithStable(
             message: `Successfully closed vault #${vaultId}`
           };
         }
-        
+
         const errorMsg = ApiClient.formatProtocolError(result.Err);
         return {
           success: false,
@@ -1457,16 +1716,42 @@ static async repayToVaultWithStable(
       
       try {
         console.log(`Withdrawing collateral from vault #${vaultId}`);
-        
+
         // Get the authenticated actor
         const actor = await ApiClient.getAuthenticatedActor();
-        
-        // Call withdraw_collateral
-        const result = await actor.withdraw_collateral(BigInt(vaultId));
-        
+
+        // Snapshot for the Oisy false-negative verifier. Full withdraw
+        // takes collateral to zero (and may auto-close the vault).
+        const beforeCollateral = await ApiClient.getRawCollateralAmount(vaultId);
+
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.withdraw_collateral(BigInt(vaultId)),
+          async () => {
+            // Either vault is gone (auto-closed) or collateral dropped
+            // by at least 95% of the pre-call value.
+            const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+            if (!snap) return false;
+            if (!snap.exists) return true;
+            if (beforeCollateral === null) return false;
+            const drop = beforeCollateral - snap.collateralAmount;
+            return drop >= (beforeCollateral * 95n) / 100n;
+          },
+          `withdraw_collateral from vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            blockIndex: undefined,
+            vaultId,
+            message: `Successfully withdrew collateral from vault #${vaultId}. If the vault had no debt, it may have been automatically closed.`,
+            oisyResilient: true,
+          };
+        }
+
         if ('Ok' in result) {
           const blockIndex = Number(result.Ok);
-          
+
           // IMPORTANT: Add a note about the vault possibly being auto-closed
           return {
             success: true,
@@ -1504,12 +1789,35 @@ static async repayToVaultWithStable(
         // Min amount validated by backend (per-collateral min_collateral_deposit)
 
         const actor = await ApiClient.getAuthenticatedActor();
+        const expectedDelta = BigInt(Math.floor(icpAmount * factor));
         const vaultArg = {
           vault_id: BigInt(vaultId),
-          amount: BigInt(Math.floor(icpAmount * factor))
+          amount: expectedDelta
         };
 
-        const result = await actor.withdraw_partial_collateral(vaultArg);
+        // Snapshot for the Oisy false-negative verifier.
+        const beforeCollateral = await ApiClient.getRawCollateralAmount(vaultId);
+
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.withdraw_partial_collateral(vaultArg),
+          async () => {
+            if (beforeCollateral === null) return false;
+            const after = await ApiClient.getRawCollateralAmount(vaultId);
+            if (after === null) return false;
+            const drop = beforeCollateral - after;
+            return drop >= (expectedDelta * 95n) / 100n;
+          },
+          `withdraw_partial_collateral ${icpAmount} from vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            vaultId,
+            blockIndex: undefined,
+            oisyResilient: true,
+          };
+        }
 
         if ('Ok' in result) {
           return {
@@ -1788,6 +2096,104 @@ static async repayToVaultWithStable(
         return vaults.find(v => v.vaultId === vaultId) || null;
       } catch (err) {
         console.error('Error getting vault by ID:', err);
+        return null;
+      }
+    }
+
+    /**
+     * Cache-bypassing snapshot of a vault's RAW (e8s / token-decimals) state.
+     * Used by the Oisy false-negative verifier — needs precise BigInts, not
+     * the float-rounded values on VaultDTO.
+     *
+     * Returns null if the wallet isn't connected or the canister query fails.
+     * Returns `{ exists: false }` if the user has vaults but vaultId isn't
+     * among them (e.g. closed vault, or open_vault that never landed).
+     */
+    static async fetchVaultRawSnapshot(vaultId: number): Promise<
+      | { exists: true; collateralAmount: bigint; borrowedIcusd: bigint; icpMargin: bigint }
+      | { exists: false }
+      | null
+    > {
+      try {
+        const walletState = get(walletStore);
+        if (!walletState.principal) return null;
+
+        const canisterVaults = await publicActor.get_vaults([walletState.principal]);
+        const v = canisterVaults.find(cv => Number(cv.vault_id) === vaultId);
+        if (!v) return { exists: false };
+        return {
+          exists: true,
+          collateralAmount: BigInt(v.collateral_amount),
+          borrowedIcusd: BigInt(v.borrowed_icusd_amount),
+          icpMargin: BigInt(v.icp_margin_amount),
+        };
+      } catch (err) {
+        console.warn(`fetchVaultRawSnapshot(${vaultId}) failed:`, err);
+        return null;
+      }
+    }
+
+    /**
+     * Convenience wrapper around fetchVaultRawSnapshot returning just
+     * borrowed_icusd_amount in raw e8s. Returns null on any failure or
+     * when the vault doesn't exist.
+     */
+    static async getRawBorrowedE8s(vaultId: number): Promise<bigint | null> {
+      const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+      if (!snap || !snap.exists) return null;
+      return snap.borrowedIcusd;
+    }
+
+    /**
+     * Convenience wrapper around fetchVaultRawSnapshot returning just
+     * collateral_amount in raw token units (per collateral decimals).
+     * Returns null on any failure or when the vault doesn't exist.
+     */
+    static async getRawCollateralAmount(vaultId: number): Promise<bigint | null> {
+      const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+      if (!snap || !snap.exists) return null;
+      return snap.collateralAmount;
+    }
+
+    /**
+     * Snapshot the set of vault IDs the connected user owns right now.
+     * Used by the open_vault Oisy false-negative verifier (which then
+     * looks for a NEW id post-call). Returns null on any failure.
+     */
+    static async snapshotUserVaultIds(): Promise<Set<number> | null> {
+      try {
+        const walletState = get(walletStore);
+        if (!walletState.principal) return null;
+        const canisterVaults = await publicActor.get_vaults([walletState.principal]);
+        return new Set(canisterVaults.map(v => Number(v.vault_id)));
+      } catch (err) {
+        console.warn('snapshotUserVaultIds failed:', err);
+        return null;
+      }
+    }
+
+    /**
+     * Find a vault that is in the user's current set but was NOT in
+     * `beforeIds`. Used by the open_vault verifier to confirm a new
+     * vault landed. Returns null if no new vault is visible yet (or
+     * on any query failure).
+     */
+    static async findNewlyOpenedVault(
+      beforeIds: Set<number>
+    ): Promise<{ vaultId: number; collateralAmount: bigint } | null> {
+      try {
+        const walletState = get(walletStore);
+        if (!walletState.principal) return null;
+        const canisterVaults = await publicActor.get_vaults([walletState.principal]);
+        for (const v of canisterVaults) {
+          const id = Number(v.vault_id);
+          if (!beforeIds.has(id)) {
+            return { vaultId: id, collateralAmount: BigInt(v.collateral_amount) };
+          }
+        }
+        return null;
+      } catch (err) {
+        console.warn('findNewlyOpenedVault failed:', err);
         return null;
       }
     }
@@ -2164,12 +2570,36 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
       try {
         // Call the unified backend method
         const actor = await ApiClient.getAuthenticatedActor();
-        const result = await actor.withdraw_and_close_vault(BigInt(vaultId));
-        
+
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.withdraw_and_close_vault(BigInt(vaultId)),
+          async () => {
+            // After withdraw_and_close, the vault is gone. The
+            // canister may keep a husk with zeroed fields, so accept
+            // either form as proof.
+            const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+            if (!snap) return false;
+            if (!snap.exists) return true;
+            return snap.collateralAmount === 0n && snap.borrowedIcusd === 0n;
+          },
+          `withdraw_and_close_vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            vaultId,
+            blockIndex: undefined,
+            message: `Successfully withdrew collateral and closed vault #${vaultId}`,
+            vaultClosed: true,
+            oisyResilient: true,
+          };
+        }
+
         if ('Ok' in result) {
           // If we got a block index back, there was an ICP transfer
           const blockIndex = result.Ok.length > 0 ? Number(result.Ok[0]) : undefined;
-          
+
           return {
             success: true,
             vaultId,

--- a/src/vault_frontend/src/lib/services/protocol/oisyResilience.spec.ts
+++ b/src/vault_frontend/src/lib/services/protocol/oisyResilience.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isOisyArrFalseNegative,
+  isOisyLandedSentinel,
+  callWithOisyFalseNegativeGuard,
+  OISY_LANDED,
+} from './oisyResilience';
+
+describe('isOisyArrFalseNegative', () => {
+  it('matches the actual Oisy error message captured from production', () => {
+    // The literal payload Oisy returned in JSON-RPC error responses on 2026-05-05
+    const err = new Error("Cannot read properties of undefined (reading '_arr')");
+    expect(isOisyArrFalseNegative(err)).toBe(true);
+  });
+
+  it('matches even when the pattern is wrapped in a longer message', () => {
+    const err = new Error(
+      "Po: Cannot read properties of undefined (reading '_arr') at Va (chunks/x.js:1)"
+    );
+    expect(isOisyArrFalseNegative(err)).toBe(true);
+  });
+
+  it('matches plain object errors with a string .message field', () => {
+    expect(
+      isOisyArrFalseNegative({ message: "Cannot read properties of undefined (reading '_arr')" })
+    ).toBe(true);
+  });
+
+  it('does NOT match unrelated errors mentioning undefined or _arr separately', () => {
+    expect(isOisyArrFalseNegative(new Error('something is undefined'))).toBe(false);
+    expect(isOisyArrFalseNegative(new Error('property _arr is missing'))).toBe(false);
+    expect(isOisyArrFalseNegative(new Error('Cannot read properties of null'))).toBe(false);
+  });
+
+  it('safely handles null, undefined, and non-error values', () => {
+    expect(isOisyArrFalseNegative(null)).toBe(false);
+    expect(isOisyArrFalseNegative(undefined)).toBe(false);
+    expect(isOisyArrFalseNegative('arbitrary string')).toBe(false);
+    expect(isOisyArrFalseNegative(42)).toBe(false);
+  });
+});
+
+describe('isOisyLandedSentinel', () => {
+  it('recognises the OISY_LANDED constant', () => {
+    expect(isOisyLandedSentinel(OISY_LANDED)).toBe(true);
+  });
+
+  it('rejects unrelated objects', () => {
+    expect(isOisyLandedSentinel({ Ok: { vault_id: 1n } })).toBe(false);
+    expect(isOisyLandedSentinel({ __oisyLanded: false })).toBe(false);
+    expect(isOisyLandedSentinel(null)).toBe(false);
+    expect(isOisyLandedSentinel(undefined)).toBe(false);
+  });
+});
+
+describe('callWithOisyFalseNegativeGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns the call result unchanged when the call succeeds', async () => {
+    const call = vi.fn().mockResolvedValue({ Ok: { block_index: 42n } });
+    const verify = vi.fn();
+
+    const result = await callWithOisyFalseNegativeGuard(call, verify, 'test op');
+
+    expect(result).toEqual({ Ok: { block_index: 42n } });
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-Oisy errors without consulting the verifier', async () => {
+    const err = new Error('network down');
+    const call = vi.fn().mockRejectedValue(err);
+    const verify = vi.fn();
+
+    await expect(callWithOisyFalseNegativeGuard(call, verify, 'test op')).rejects.toBe(err);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it('returns OISY_LANDED when the call hits the _arr pattern AND verifier confirms success', async () => {
+    const oisyErr = new Error("Cannot read properties of undefined (reading '_arr')");
+    const call = vi.fn().mockRejectedValue(oisyErr);
+    const verify = vi.fn().mockResolvedValue(true);
+
+    const result = await callWithOisyFalseNegativeGuard(call, verify, 'borrow 1 icUSD');
+
+    expect(isOisyLandedSentinel(result)).toBe(true);
+    expect(verify).toHaveBeenCalledOnce();
+  });
+
+  it('re-throws the original error when verifier returns false', async () => {
+    const oisyErr = new Error("Cannot read properties of undefined (reading '_arr')");
+    const call = vi.fn().mockRejectedValue(oisyErr);
+    const verify = vi.fn().mockResolvedValue(false);
+
+    await expect(callWithOisyFalseNegativeGuard(call, verify, 'borrow 1 icUSD')).rejects.toBe(
+      oisyErr
+    );
+  });
+
+  it('re-throws the ORIGINAL error (not the verifier error) when verifier itself throws', async () => {
+    const oisyErr = new Error("Cannot read properties of undefined (reading '_arr')");
+    const verifyErr = new Error('IC fetch failed');
+    const call = vi.fn().mockRejectedValue(oisyErr);
+    const verify = vi.fn().mockRejectedValue(verifyErr);
+
+    await expect(callWithOisyFalseNegativeGuard(call, verify, 'borrow 1 icUSD')).rejects.toBe(
+      oisyErr
+    );
+  });
+});

--- a/src/vault_frontend/src/lib/services/protocol/oisyResilience.ts
+++ b/src/vault_frontend/src/lib/services/protocol/oisyResilience.ts
@@ -1,0 +1,137 @@
+/**
+ * Oisy false-negative resilience.
+ *
+ * Background
+ * ----------
+ * Oisy's signer popup (ICRC-49 `icrc49_call_canister` flow) sometimes returns a
+ * JSON-RPC error response of the form:
+ *
+ *   { code: 4000, message: "Cannot read properties of undefined (reading '_arr')" }
+ *
+ * even though the canister call itself was signed and submitted successfully.
+ * The on-chain state advances; only the response Oisy hands back to the calling
+ * page is malformed. This shows up in the slide-computer-signer client as a
+ * `Po` error with that message, surfaced to UI handlers via `err.message`.
+ *
+ * Reproduction (verified 2026-05-05): borrow_from_vault from vault_frontend
+ * with Oisy as the active wallet — call lands, frontend toast shows the
+ * `_arr` error, refresh shows new borrowed balance.
+ *
+ * Mitigation
+ * ----------
+ * Wrap any write call that might be subject to this false-negative in
+ * `callWithOisyFalseNegativeGuard`. If the call rejects with the known Oisy
+ * pattern, run a verifier that checks on-chain state. If the verifier
+ * confirms the operation landed, return the OISY_LANDED sentinel; otherwise
+ * re-throw the original error.
+ *
+ * The verifier is operation-specific (e.g. "borrowed amount on vault N
+ * increased") because canister state has no generic "did this op land"
+ * signal. Each call site supplies its own verifier.
+ *
+ * This guard is a defensive workaround. Once Oisy ships a fix, the helper
+ * becomes a no-op for that error pattern but stays in the codebase as
+ * cheap insurance against future signer-side glitches.
+ */
+
+/**
+ * Sentinel value returned by `callWithOisyFalseNegativeGuard` when the
+ * underlying call rejected with the Oisy `_arr` pattern AND on-chain
+ * verification confirmed the operation actually succeeded.
+ *
+ * Call sites detect this with `isOisyLandedSentinel(result)` and translate
+ * it into a success response (typically without a block index, since the
+ * normal response carrying that info was lost).
+ */
+export const OISY_LANDED = Object.freeze({ __oisyLanded: true as const });
+export type OisyLandedSentinel = typeof OISY_LANDED;
+
+/**
+ * Substring of the Oisy error message we treat as a false-negative
+ * candidate. Kept narrow on purpose so we never accidentally swallow
+ * unrelated errors that happen to contain the word "undefined".
+ */
+const OISY_ARR_PATTERN = "Cannot read properties of undefined (reading '_arr')";
+
+/**
+ * Returns true if `err` looks like the Oisy `_arr` false-negative.
+ *
+ * The slide-computer-signer wraps the JSON-RPC error in a `Po` error and
+ * exposes the raw message via `err.message`, so a substring match on
+ * `.message` is sufficient. We also check `.toString()` as a belt-and-
+ * suspenders fallback for cases where the message has been re-thrown or
+ * concatenated.
+ */
+export function isOisyArrFalseNegative(err: unknown): boolean {
+  if (!err) return false;
+  const msg =
+    (err instanceof Error && err.message) ||
+    (typeof err === 'object' && err !== null && 'message' in err && typeof (err as { message: unknown }).message === 'string'
+      ? (err as { message: string }).message
+      : '') ||
+    String(err);
+  return msg.includes(OISY_ARR_PATTERN);
+}
+
+/**
+ * Returns true if `value` is the OISY_LANDED sentinel returned by
+ * `callWithOisyFalseNegativeGuard`.
+ */
+export function isOisyLandedSentinel(value: unknown): value is OisyLandedSentinel {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { __oisyLanded?: unknown }).__oisyLanded === true
+  );
+}
+
+/**
+ * Run `call`, catching the known Oisy `_arr` false-negative.
+ *
+ * If `call` rejects with the Oisy pattern, run `verify` to check whether
+ * the operation landed on-chain anyway. If `verify` returns true, resolve
+ * with `OISY_LANDED`. Otherwise (or if `verify` itself throws) re-throw
+ * the original error.
+ *
+ * Other errors propagate untouched.
+ *
+ * @param call    The write operation that might be subject to the Oisy false-negative.
+ * @param verify  Returns true if on-chain state shows the operation succeeded.
+ * @param opLabel Short human-readable label for logging (e.g. "borrow 1 icUSD from vault #51").
+ */
+export async function callWithOisyFalseNegativeGuard<T>(
+  call: () => Promise<T>,
+  verify: () => Promise<boolean>,
+  opLabel: string
+): Promise<T | OisyLandedSentinel> {
+  try {
+    return await call();
+  } catch (err) {
+    if (!isOisyArrFalseNegative(err)) {
+      throw err;
+    }
+
+    let landed = false;
+    try {
+      landed = await verify();
+    } catch (verifyErr) {
+      // Verifier failure must NEVER mask the original signer error. Log and
+      // re-throw the original so the user sees real failure rather than a
+      // silent recovery that might be wrong.
+      console.error(
+        `[Oisy resilience] ${opLabel}: verifier threw, re-throwing original signer error`,
+        verifyErr
+      );
+      throw err;
+    }
+
+    if (!landed) {
+      throw err;
+    }
+
+    console.warn(
+      `[Oisy resilience] ${opLabel}: signer reported _arr error but on-chain verification confirms the operation landed. Treating as success.`
+    );
+    return OISY_LANDED;
+  }
+}

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -12,6 +12,7 @@ import { IcpswapProvider } from './providers/icpswapProvider';
 import { ProviderRegistry } from './providers/providerRegistry';
 import { fetchLedgerFee, getCachedLedgerFee } from './ledgerFeeService';
 import type { ProviderQuote } from './providers/types';
+import { isOisyLandedSentinel, type OisyLandedSentinel } from './protocol/oisyResilience';
 
 // ──────────────────────────────────────────────────────────────
 // Provider registry for the 3USD <-> ICP hop.
@@ -356,7 +357,7 @@ export async function executeRoute(
   to: AmmToken,
   amountIn: bigint,
   slippageBps: number,
-): Promise<bigint> {
+): Promise<bigint | OisyLandedSentinel> {
   const minOutput = route.estimatedOutput * BigInt(10000 - slippageBps) / 10000n;
 
   // Kill-switch guard: a route quoted while ICPswap routing was enabled must
@@ -430,7 +431,11 @@ export async function executeRoute(
       amounts[from.threePoolIndex] = amountIn;
       const threeUsdEstimate = await threePoolService.calcAddLiquidity(amounts);
       const threeUsdMinOutput = threeUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
-      const threeUsdReceived = await threePoolService.addLiquidity(amounts, threeUsdMinOutput);
+      const hop1Result = await threePoolService.addLiquidity(amounts, threeUsdMinOutput);
+      // Non-Oisy path: sentinel is unreachable (Oisy case exits above), but
+      // guard the type for safety.
+      if (isOisyLandedSentinel(hop1Result)) return hop1Result;
+      const threeUsdReceived = hop1Result;
 
       // Hop 2: 3USD -> ICP via winning provider. Re-quote with actual received
       // amount so the slippage budget reflects what we really have.

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -7,6 +7,11 @@ import { CANISTER_IDS, CONFIG } from '../config';
 import { isOisyWallet } from './protocol/walletOperations';
 import { getOisySignerAgent, createOisyActor } from './oisySigner';
 import { fetchLedgerFee } from './ledgerFeeService';
+import {
+  callWithOisyFalseNegativeGuard,
+  type OisyLandedSentinel,
+} from './protocol/oisyResilience';
+import { TokenService } from './tokenService';
 
 // ──────────────────────────────────────────────────────────────
 // Types — mirrors the Candid interface
@@ -464,7 +469,7 @@ class ThreePoolService {
     }
   }
 
-  async addLiquidity(amounts: bigint[], minLp: bigint): Promise<bigint> {
+  async addLiquidity(amounts: bigint[], minLp: bigint): Promise<bigint | OisyLandedSentinel> {
     const wallet = get(walletStore);
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
@@ -475,6 +480,17 @@ class ThreePoolService {
     const approveAmounts: bigint[] = await Promise.all(
       amounts.map((amt, k) => amt > 0n ? approvalAmount(amt, POOL_TOKENS[k]) : Promise.resolve(0n)),
     );
+
+    // Pre-mint LP balance for the Oisy false-negative verifier.
+    const beforeLp = await this.safeGetLpBalance(wallet.principal);
+    const verifyAddLanded = async () => {
+      if (beforeLp === null) return false;
+      const after = await this.safeGetLpBalance(wallet.principal);
+      if (after === null) return false;
+      // LP minted: balance grew by at least 95% of `minLp` (which is
+      // already the slippage-protected lower bound).
+      return after - beforeLp >= (minLp * 95n) / 100n;
+    };
 
     if (oisyDetected && wallet.principal) {
       // ─── Oisy ICRC-112 batched path ───
@@ -500,18 +516,22 @@ class ThreePoolService {
       signerAgent.batch();
       const addPromise = poolActor.add_liquidity(amounts, minLp);
 
-      await signerAgent.execute();
-      const results = await Promise.all([...approvePromises, addPromise]);
-
-      // Check approve results
-      for (let i = 0; i < approvePromises.length; i++) {
-        const r = results[i];
-        if (r && 'Err' in r) throw new Error(`Approval failed: ${JSON.stringify(r.Err)}`);
-      }
-
-      const addResult = results[results.length - 1] as { Ok: bigint } | { Err: any };
-      if ('Err' in addResult) throw new Error(this.formatError(addResult.Err));
-      return addResult.Ok;
+      const guarded = await callWithOisyFalseNegativeGuard(
+        async () => {
+          await signerAgent.execute();
+          const results = await Promise.all([...approvePromises, addPromise]);
+          for (let i = 0; i < approvePromises.length; i++) {
+            const r = results[i];
+            if (r && 'Err' in r) throw new Error(`Approval failed: ${JSON.stringify(r.Err)}`);
+          }
+          const addResult = results[results.length - 1] as { Ok: bigint } | { Err: any };
+          if ('Err' in addResult) throw new Error(this.formatError(addResult.Err));
+          return addResult.Ok;
+        },
+        verifyAddLanded,
+        `Oisy batched 3pool add_liquidity`
+      );
+      return guarded;
     } else {
       // ─── Non-Oisy path: sequential approvals ───
       for (let k = 0; k < 3; k++) {
@@ -531,30 +551,89 @@ class ThreePoolService {
       }
 
       const poolActor = await walletStore.getActor(THREEPOOL_CANISTER_ID, canisterIDLs.three_pool) as any;
-      const result = await poolActor.add_liquidity(amounts, minLp) as { Ok: bigint } | { Err: any };
-      if ('Err' in result) throw new Error(this.formatError(result.Err));
-      return result.Ok;
+      const result = await callWithOisyFalseNegativeGuard(
+        async () => {
+          const r = await poolActor.add_liquidity(amounts, minLp) as { Ok: bigint } | { Err: any };
+          if ('Err' in r) throw new Error(this.formatError(r.Err));
+          return r.Ok;
+        },
+        verifyAddLanded,
+        `3pool add_liquidity`
+      );
+      return result;
     }
   }
 
-  async removeLiquidity(lpBurn: bigint, minAmounts: bigint[]): Promise<bigint[]> {
-    const wallet = get(walletStore);
-    if (!wallet.isConnected) throw new Error('Wallet not connected');
-
-    const poolActor = await walletStore.getActor(THREEPOOL_CANISTER_ID, canisterIDLs.three_pool) as any;
-    const result = await poolActor.remove_liquidity(lpBurn, minAmounts) as { Ok: bigint[] } | { Err: any };
-    if ('Err' in result) throw new Error(this.formatError(result.Err));
-    return result.Ok;
+  /**
+   * Read the user's current LP (3USD) balance via the pool's ICRC-1
+   * `icrc1_balance_of` for the Oisy false-negative verifier.
+   * Returns null on any failure (caller treats null as "can't verify").
+   */
+  private async safeGetLpBalance(principal: Principal | null | undefined): Promise<bigint | null> {
+    if (!principal) return null;
+    try {
+      return await TokenService.getTokenBalance(THREEPOOL_CANISTER_ID, principal);
+    } catch (err) {
+      console.warn('threePoolService.safeGetLpBalance failed:', err);
+      return null;
+    }
   }
 
-  async removeOneCoin(lpBurn: bigint, coinIndex: number, minAmount: bigint): Promise<bigint> {
+  async removeLiquidity(
+    lpBurn: bigint,
+    minAmounts: bigint[]
+  ): Promise<bigint[] | OisyLandedSentinel> {
     const wallet = get(walletStore);
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
+    const beforeLp = await this.safeGetLpBalance(wallet.principal);
+
     const poolActor = await walletStore.getActor(THREEPOOL_CANISTER_ID, canisterIDLs.three_pool) as any;
-    const result = await poolActor.remove_one_coin(lpBurn, coinIndex, minAmount) as { Ok: bigint } | { Err: any };
-    if ('Err' in result) throw new Error(this.formatError(result.Err));
-    return result.Ok;
+    const result = await callWithOisyFalseNegativeGuard(
+      async () => {
+        const r = await poolActor.remove_liquidity(lpBurn, minAmounts) as { Ok: bigint[] } | { Err: any };
+        if ('Err' in r) throw new Error(this.formatError(r.Err));
+        return r.Ok;
+      },
+      async () => {
+        if (beforeLp === null) return false;
+        const after = await this.safeGetLpBalance(wallet.principal);
+        if (after === null) return false;
+        // LP burned: balance dropped by at least 95% of the requested
+        // burn amount (or the user is now empty).
+        return beforeLp - after >= (lpBurn * 95n) / 100n || after === 0n;
+      },
+      `3pool remove_liquidity ${lpBurn} LP`
+    );
+    return result;
+  }
+
+  async removeOneCoin(
+    lpBurn: bigint,
+    coinIndex: number,
+    minAmount: bigint
+  ): Promise<bigint | OisyLandedSentinel> {
+    const wallet = get(walletStore);
+    if (!wallet.isConnected) throw new Error('Wallet not connected');
+
+    const beforeLp = await this.safeGetLpBalance(wallet.principal);
+
+    const poolActor = await walletStore.getActor(THREEPOOL_CANISTER_ID, canisterIDLs.three_pool) as any;
+    const result = await callWithOisyFalseNegativeGuard(
+      async () => {
+        const r = await poolActor.remove_one_coin(lpBurn, coinIndex, minAmount) as { Ok: bigint } | { Err: any };
+        if ('Err' in r) throw new Error(this.formatError(r.Err));
+        return r.Ok;
+      },
+      async () => {
+        if (beforeLp === null) return false;
+        const after = await this.safeGetLpBalance(wallet.principal);
+        if (after === null) return false;
+        return beforeLp - after >= (lpBurn * 95n) / 100n || after === 0n;
+      },
+      `3pool remove_one_coin ${lpBurn} LP -> token ${coinIndex}`
+    );
+    return result;
   }
 
   // ── Error formatting ──

--- a/src/vault_frontend/src/lib/services/types.ts
+++ b/src/vault_frontend/src/lib/services/types.ts
@@ -24,6 +24,14 @@ export interface VaultOperationResult {
   blockIndex?: number;
   feePaid?: number;
   message?: string;
+  /**
+   * True when the underlying signer (Oisy) returned a false-negative `_arr`
+   * error but on-chain verification confirmed the operation actually landed.
+   * Callers can surface a softer toast ("Submitted, refresh to confirm").
+   * `blockIndex` and `feePaid` are unavailable in this case because the
+   * normal response carrying them was never delivered.
+   */
+  oisyResilient?: boolean;
 }
 
 export interface VaultHistoryEvent {

--- a/src/vault_frontend/src/routes/+page.svelte
+++ b/src/vault_frontend/src/routes/+page.svelte
@@ -204,7 +204,10 @@
       const result = await protocolService.openVaultAndBorrow(collateralAmount, icusdAmount, selectedCollateralPrincipal);
 
       if (result.success) {
-        successMessage = `Successfully created vault #${result.vaultId} and borrowed ${icusdAmount} icUSD!`;
+        const vaultLabel = result.vaultId !== undefined ? `vault #${result.vaultId}` : 'vault';
+        successMessage = result.oisyResilient
+          ? `Submitted: created ${vaultLabel} and borrowed ${icusdAmount} icUSD. (Wallet glitch ignored — confirmed on-chain.)`
+          : `Successfully created ${vaultLabel} and borrowed ${icusdAmount} icUSD!`;
         if ($principal) await appDataStore.refreshAll($principal);
         collateralAmount = 1; icusdAmount = 5;
       } else { errorMessage = result.error || 'Failed to create vault'; }

--- a/src/vault_frontend/src/routes/liquidity/+page.svelte
+++ b/src/vault_frontend/src/routes/liquidity/+page.svelte
@@ -100,7 +100,9 @@
       const result = await protocolService.provideLiquidity(provideAmount);
       
       if (result.success) {
-        successMessage = `Successfully provided ${formatNumber(provideAmount)} ICP to the liquidity pool`;
+        successMessage = result.oisyResilient
+          ? `Confirmed on-chain: provided ${formatNumber(provideAmount)} ICP. (Wallet glitch ignored.)`
+          : `Successfully provided ${formatNumber(provideAmount)} ICP to the liquidity pool`;
         provideAmount = 0;
         // Refresh data
         await fetchData();
@@ -128,7 +130,9 @@
       const result = await protocolService.withdrawLiquidity(withdrawAmount);
       
       if (result.success) {
-        successMessage = `Successfully withdrew ${formatNumber(withdrawAmount)} ICP from the liquidity pool`;
+        successMessage = result.oisyResilient
+          ? `Confirmed on-chain: withdrew ${formatNumber(withdrawAmount)} ICP. (Wallet glitch ignored.)`
+          : `Successfully withdrew ${formatNumber(withdrawAmount)} ICP from the liquidity pool`;
         withdrawAmount = 0;
         // Refresh data
         await fetchData();
@@ -156,7 +160,9 @@
       const result = await protocolService.claimLiquidityReturns();
       
       if (result.success) {
-        successMessage = `Successfully claimed ${formatStableTx(liquidityStatus.availableLiquidityReward)} icUSD rewards`;
+        successMessage = result.oisyResilient
+          ? `Claim confirmed on-chain. (Wallet glitch ignored — refresh to see updated balance.)`
+          : `Successfully claimed ${formatStableTx(liquidityStatus.availableLiquidityReward)} icUSD rewards`;
         // Refresh data
         await fetchData();
       } else {

--- a/src/vault_frontend/src/routes/redeem/+page.svelte
+++ b/src/vault_frontend/src/routes/redeem/+page.svelte
@@ -277,16 +277,20 @@
         // Use the unified reserve redemption endpoint (reserves first, vault spillover automatic)
         const result = await protocolService.redeemReserves(icusdAmount, preferredTokenPrincipal);
         if (result.success) {
-          const stableReceived = (result.stableAmountSent || 0) / 1e6;
-          let msg = `Redeemed ${formatStableTx(stableReceived, 6)} stablecoins`;
-          if (result.vaultSpillover && result.vaultSpillover > 0) {
-            const spilloverIcusd = result.vaultSpillover / 1e8;
-            msg += ` + ${formatStableTx(spilloverIcusd)} icUSD redeemed from vaults (ICP)`;
+          if (result.oisyResilient) {
+            successMessage = `Redeem confirmed on-chain for ${formatStableTx(icusdAmount)} icUSD. (Wallet returned an error but the operation succeeded.)`;
+          } else {
+            const stableReceived = (result.stableAmountSent || 0) / 1e6;
+            let msg = `Redeemed ${formatStableTx(stableReceived, 6)} stablecoins`;
+            if (result.vaultSpillover && result.vaultSpillover > 0) {
+              const spilloverIcusd = result.vaultSpillover / 1e8;
+              msg += ` + ${formatStableTx(spilloverIcusd)} icUSD redeemed from vaults (ICP)`;
+            }
+            if (result.feePaid) {
+              msg += ` (fee: ${formatStableTx(result.feePaid)} icUSD)`;
+            }
+            successMessage = msg;
           }
-          if (result.feePaid) {
-            msg += ` (fee: ${formatStableTx(result.feePaid)} icUSD)`;
-          }
-          successMessage = msg;
           icusdAmount = 0;
           await wallet.refreshBalance();
           fetchData();
@@ -303,9 +307,13 @@
         // No reserves available — fall back to direct ICP vault redemption
         const result = await protocolService.redeemIcp(icusdAmount);
         if (result.success) {
-          const icpEstimate = icusdAmount > 0 && icpPrice > 0
-            ? (icusdAmount - icusdAmount * vaultRedemptionFee) / icpPrice : 0;
-          successMessage = `Redeemed ~${formatNumber(icpEstimate)} ICP for ${formatStableTx(icusdAmount)} icUSD`;
+          if (result.oisyResilient) {
+            successMessage = `Redeem confirmed on-chain for ${formatStableTx(icusdAmount)} icUSD. (Wallet returned an error but the operation succeeded.)`;
+          } else {
+            const icpEstimate = icusdAmount > 0 && icpPrice > 0
+              ? (icusdAmount - icusdAmount * vaultRedemptionFee) / icpPrice : 0;
+            successMessage = `Redeemed ~${formatNumber(icpEstimate)} ICP for ${formatStableTx(icusdAmount)} icUSD`;
+          }
           icusdAmount = 0;
           await wallet.refreshBalance();
         } else {


### PR DESCRIPTION
## Summary
- Oisy signer returns a JSON-RPC error (`Cannot read properties of undefined (reading '_arr')`) on every write op even though the on-chain call succeeds. This is an Oisy-side bug in their post-call response building.
- Adds a defensive `callWithOisyFalseNegativeGuard` pattern: on that specific error, verify on-chain state via anonymous query; if the operation landed, surface success with a soft notice instead of a red error toast.
- Covers **all** user-facing write paths: vault ops, 3pool mint/redeem, swap router, stability pool, and redemptions.
- 12 unit tests for the core helper; 78/78 test suite passes; svelte-check clean (no new errors).

## Test plan
- [x] Unit tests pass (78/78)
- [x] svelte-check produces no new type errors
- [x] npm run build succeeds
- [ ] Manual smoke test on mainnet with Oisy wallet after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)