### PR TITLE
fix(backend,3pool): post-Wave-14 audit bug fixes

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -428,6 +428,22 @@ type Event = variant {
     token_type : StableTokenType;
   };
   set_recovery_cr_multiplier : record { multiplier : text };
+  stability_pool_call_failed : record {
+    vault_ids : vec nat64;
+    reject_code : int32;
+    reject_message : text;
+    timestamp : nat64;
+  };
+  oracle_circuit_breaker : record {
+    consecutive_failures : nat64;
+    timestamp : nat64;
+  };
+  oracle_source_count_insufficient : record {
+    collateral_type : principal;
+    num_sources : nat32;
+    min_required : nat32;
+    timestamp : nat64;
+  };
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
@@ -803,6 +819,7 @@ service : (ProtocolArg) -> {
     ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_fees : (nat64) -> (Fees) query;
+  get_fees_for_collateral : (principal, nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
   get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;
@@ -876,6 +893,8 @@ service : (ProtocolArg) -> {
   set_bot_allowed_collateral_types : (vec principal) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
+  set_check_vaults_alert_band_bps : (nat64) -> (Result);
+  set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
   set_collateral_borrow_threshold : (principal, float64) -> (Result);
   set_collateral_borrowing_fee : (principal, float64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -552,7 +552,26 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'token_type' : StableTokenType,
     }
   } |
-  { 'set_recovery_cr_multiplier' : { 'multiplier' : string } };
+  { 'set_recovery_cr_multiplier' : { 'multiplier' : string } } |
+  { 'stability_pool_call_failed' : {
+      'vault_ids' : Array<bigint>,
+      'reject_code' : number,
+      'reject_message' : string,
+      'timestamp' : bigint,
+    }
+  } |
+  { 'oracle_circuit_breaker' : {
+      'consecutive_failures' : bigint,
+      'timestamp' : bigint,
+    }
+  } |
+  { 'oracle_source_count_insufficient' : {
+      'collateral_type' : Principal,
+      'num_sources' : number,
+      'min_required' : number,
+      'timestamp' : bigint,
+    }
+  };
 export interface EventTimeRange { 'start_ns' : bigint, 'end_ns' : bigint }
 export type EventTypeFilter = { 'BreakerTripped' : null } |
   { 'StabilityPoolDeposit' : null } |
@@ -970,6 +989,7 @@ export interface _SERVICE {
     GetEventsFilteredResponse
   >,
   'get_fees' : ActorMethod<[bigint], Fees>,
+  'get_fees_for_collateral' : ActorMethod<[Principal, bigint], Fees>,
   'get_global_icusd_mint_cap' : ActorMethod<[], bigint>,
   'get_icpswap_routing_enabled' : ActorMethod<[], boolean>,
   'get_interest_pool_share' : ActorMethod<[], number>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -614,6 +614,22 @@ export const idlFactory = ({ IDL }) => {
       'token_type' : StableTokenType,
     }),
     'set_recovery_cr_multiplier' : IDL.Record({ 'multiplier' : IDL.Text }),
+    'stability_pool_call_failed' : IDL.Record({
+      'vault_ids' : IDL.Vec(IDL.Nat64),
+      'reject_code' : IDL.Int32,
+      'reject_message' : IDL.Text,
+      'timestamp' : IDL.Nat64,
+    }),
+    'oracle_circuit_breaker' : IDL.Record({
+      'consecutive_failures' : IDL.Nat64,
+      'timestamp' : IDL.Nat64,
+    }),
+    'oracle_source_count_insufficient' : IDL.Record({
+      'collateral_type' : IDL.Principal,
+      'num_sources' : IDL.Nat32,
+      'min_required' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+    }),
   });
   const EventsByPrincipalPagedResponse = IDL.Record({
     'scan_end' : IDL.Nat64,
@@ -961,6 +977,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_fees' : IDL.Func([IDL.Nat64], [Fees], ['query']),
+    'get_fees_for_collateral' : IDL.Func([IDL.Principal, IDL.Nat64], [Fees], ['query']),
     'get_global_icusd_mint_cap' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_icpswap_routing_enabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_interest_pool_share' : IDL.Func([], [IDL.Float64], ['query']),

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -306,14 +306,19 @@ pub async fn swap(i: u8, j: u8, dx: u128, min_dy: u128) -> Result<u128, ThreePoo
         return Err(ThreePoolError::PoolPaused);
     }
 
+    // 2. Acquire the pool lock BEFORE reading balances so a concurrent
+    //    caller cannot price against stale pre-swap state. Released on
+    //    Drop (Ok, Err, or trap). Audit fence B-01.
+    let _pool_guard = pool_guard::PoolGuard::new()?;
+
     let i_idx = i as usize;
     let j_idx = j as usize;
 
-    // 2. Compute current A and precision_muls
+    // 3. Compute current A and precision_muls
     let amp = get_current_a();
     let precision_muls = get_precision_muls();
 
-    // 3. Read current state
+    // 4. Read current state
     let (balances, fee_curve, admin_fee_bps, token_i_ledger, token_j_ledger, token_j_symbol) =
         read_state(|s| {
             (
@@ -326,21 +331,16 @@ pub async fn swap(i: u8, j: u8, dx: u128, min_dy: u128) -> Result<u128, ThreePoo
             )
         });
 
-    // 4. Calculate swap output using the dynamic fee curve
+    // 5. Calculate swap output using the dynamic fee curve
     let outcome =
         calc_swap_output(i_idx, j_idx, dx, &balances, &precision_muls, amp, &fee_curve, admin_fee_bps)?;
     let output = outcome.output_native;
     let fee = outcome.fee_native;
 
-    // 5. Slippage check
+    // 6. Slippage check
     if output < min_dy {
         return Err(ThreePoolError::SlippageExceeded);
     }
-
-    // 6. Acquire the pool lock BEFORE the first await so a concurrent caller
-    //    cannot price against the same pre-balances. Released on Drop, which
-    //    runs on Ok, Err, or trap. Audit fence B-01.
-    let _pool_guard = pool_guard::PoolGuard::new()?;
 
     // 7. Transfer input token from user to pool
     let caller = ic_cdk::api::caller();
@@ -424,16 +424,21 @@ pub async fn add_liquidity(amounts: Vec<u128>, min_lp: u128) -> Result<u128, Thr
     }
     let amounts_arr: [u128; 3] = [amounts[0], amounts[1], amounts[2]];
 
-    // 3. Compute A and precision_muls
+    // 3. Acquire the pool lock BEFORE reading balances so a concurrent
+    //    caller cannot compute LP amounts against stale state. Released
+    //    on Drop (Ok, Err, or trap). Audit fence B-01.
+    let _pool_guard = pool_guard::PoolGuard::new()?;
+
+    // 4. Compute A and precision_muls
     let amp = get_current_a();
     let precision_muls = get_precision_muls();
 
-    // 4. Read current state
+    // 5. Read current state
     let (old_balances, lp_total_supply, fee_curve) = read_state(|s| {
         (s.balances, s.lp_total_supply, s.config.fee_curve.unwrap_or_default())
     });
 
-    // 5. Calculate LP tokens to mint (dynamic fee curve)
+    // 6. Calculate LP tokens to mint (dynamic fee curve)
     let liq_outcome = calc_add_liquidity(
         &amounts_arr,
         &old_balances,
@@ -444,14 +449,10 @@ pub async fn add_liquidity(amounts: Vec<u128>, min_lp: u128) -> Result<u128, Thr
     )?;
     let lp_minted = liq_outcome.lp_minted;
 
-    // 6. Slippage check
+    // 7. Slippage check
     if lp_minted < min_lp {
         return Err(ThreePoolError::SlippageExceeded);
     }
-
-    // 7. Acquire the pool lock BEFORE the first await. Released on Drop.
-    //    Audit fence B-01.
-    let _pool_guard = pool_guard::PoolGuard::new()?;
 
     // 8. Transfer each non-zero amount from user to pool
     let caller = ic_cdk::api::caller();

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -428,6 +428,22 @@ type Event = variant {
     token_type : StableTokenType;
   };
   set_recovery_cr_multiplier : record { multiplier : text };
+  stability_pool_call_failed : record {
+    vault_ids : vec nat64;
+    reject_code : int32;
+    reject_message : text;
+    timestamp : nat64;
+  };
+  oracle_circuit_breaker : record {
+    consecutive_failures : nat64;
+    timestamp : nat64;
+  };
+  oracle_source_count_insufficient : record {
+    collateral_type : principal;
+    num_sources : nat32;
+    min_required : nat32;
+    timestamp : nat64;
+  };
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
@@ -803,6 +819,7 @@ service : (ProtocolArg) -> {
     ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
   get_fees : (nat64) -> (Fees) query;
+  get_fees_for_collateral : (principal, nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
   get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -797,9 +797,21 @@ fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {
 #[candid_method(query)]
 #[query]
 fn get_fees(redeemed_amount: u64) -> Fees {
+    read_state(|s| {
+        let icp_ct = s.icp_collateral_type();
+        Fees {
+            borrowing_fee: s.get_borrowing_fee().to_f64(),
+            redemption_fee: s.get_redemption_fee_for(&icp_ct, redeemed_amount.into()).to_f64(),
+        }
+    })
+}
+
+#[candid_method(query)]
+#[query]
+fn get_fees_for_collateral(collateral_type: Principal, redeemed_amount: u64) -> Fees {
     read_state(|s| Fees {
         borrowing_fee: s.get_borrowing_fee().to_f64(),
-        redemption_fee: s.get_redemption_fee(redeemed_amount.into()).to_f64(),
+        redemption_fee: s.get_redemption_fee_for(&collateral_type, redeemed_amount.into()).to_f64(),
     })
 }
 
@@ -1300,9 +1312,8 @@ async fn redeem_collateral(collateral_type: Principal, icusd_amount: u64) -> Res
 #[query]
 fn get_redemption_rate() -> f64 {
     read_state(|s| {
-        s.get_redemption_fee(
-            ICUSD::from(100_000_000),
-        ).to_f64()
+        let icp_ct = s.icp_collateral_type();
+        s.get_redemption_fee_for(&icp_ct, ICUSD::from(100_000_000)).to_f64()
     })
 }
 

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -210,9 +210,9 @@ pub async fn fetch_icp_rate() {
                         min_required: floor,
                         timestamp: ic_cdk::api::time(),
                     });
-                    // Skip the price-update branch but keep the rest of the
-                    // tick (cached price stays valid; CDP-01 counter NOT
-                    // touched because the XRC call itself succeeded).
+                    // Skip the price-update branch. `xrc_call_succeeded`
+                    // stays false so the CDP-01 counter treats this as a
+                    // failure (sustained thin-aggregation should trip ReadOnly).
                 } else {
 
                 let rate = Decimal::from_u64(exchange_rate_result.rate).unwrap()
@@ -254,7 +254,10 @@ pub async fn fetch_icp_rate() {
                                 "[FetchPrice] CONFIRMED sub-$0.01 ICP rate {rate}, switching to ReadOnly at timestamp: {}",
                                 exchange_rate_result.timestamp
                             );
-                            mutate_state(|s| s.mode = Mode::ReadOnly);
+                            mutate_state(|s| {
+                            s.mode = Mode::ReadOnly;
+                            s.mode_triggered_by_oracle = false;
+                        });
                         }
                         log!(
                             TRACE_XRC,

--- a/src/rumi_protocol_backend/tests/audit_pocs_cdp_01_oracle_circuit_breaker.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_cdp_01_oracle_circuit_breaker.rs
@@ -146,6 +146,39 @@ fn cdp_01_operator_set_readonly_does_not_auto_clear() {
 }
 
 #[test]
+fn cdp_01_sub_penny_latch_survives_dirty_oracle_flag() {
+    let mut state = fresh_state();
+
+    // Scenario: circuit breaker trips, then a sub-$0.01 price is confirmed.
+    // The sub-$0.01 latch is a price-safety measure that must NOT be cleared
+    // by `note_xrc_success`. But if the circuit breaker left
+    // `mode_triggered_by_oracle = true` and the sub-$0.01 latch didn't
+    // clear it, `note_xrc_success` would incorrectly lift the latch.
+
+    // 1. Trip circuit breaker (sets mode_triggered_by_oracle = true).
+    for _ in 0..MAX_CONSECUTIVE_XRC_FAILURES {
+        note_xrc_failure(&mut state);
+    }
+    assert_eq!(state.mode, Mode::ReadOnly);
+    assert!(state.mode_triggered_by_oracle);
+
+    // 2. Simulate the sub-$0.01 price latch (xrc.rs line ~257).
+    //    After the fix, this also clears mode_triggered_by_oracle.
+    state.mode = Mode::ReadOnly;
+    state.mode_triggered_by_oracle = false;
+
+    // 3. A valid price arrives. note_xrc_success must NOT clear ReadOnly
+    //    because mode_triggered_by_oracle is false (price-driven latch).
+    note_xrc_success(&mut state);
+
+    assert_eq!(
+        state.mode,
+        Mode::ReadOnly,
+        "sub-$0.01 ReadOnly latch must survive note_xrc_success",
+    );
+}
+
+#[test]
 fn cdp_01_failure_after_recovery_starts_counter_fresh() {
     let mut state = fresh_state();
 


### PR DESCRIPTION
## Summary

Post-Wave-14 audit review found 4 bugs and 2 hygiene issues in code touched during the Wave 14a/b/c audit waves:

- **Stale redemption fee display (Medium):** `get_fees()` and `get_redemption_rate()` read the global `current_base_rate` (frozen at 0 since CDP-03 moved to per-collateral fees). Frontend redeem page and explorer showed wrong fee. Fixed to use `get_redemption_fee_for()`. Added `get_fees_for_collateral()` endpoint.
- **Dirty oracle flag (Medium):** If the circuit breaker tripped then a sub-$0.01 price was confirmed, `note_xrc_success()` could clear the price-driven ReadOnly latch via a stale `mode_triggered_by_oracle` flag. Fixed by clearing the flag in the sub-$0.01 latch.
- **PoolGuard TOCTOU (Medium-High):** `swap()` and `add_liquidity()` acquired the PoolGuard after computing output from pool state, allowing concurrent callers to price against stale balances. Moved guard before `read_state`.
- **Missing .did variants (Low):** Three Wave-14a event types (`stability_pool_call_failed`, `oracle_circuit_breaker`, `oracle_source_count_insufficient`) missing from Candid + TS declarations. Added.
- **Stale comment (Low):** Source-floor rejection comment incorrectly said "CDP-01 counter NOT touched." Fixed.

## Test plan

- [x] 366 unit tests pass (`cargo test --lib`)
- [x] 8 audit-fence tests pass (including new `cdp_01_sub_penny_latch_survives_dirty_oracle_flag`)
- [x] 58 integration tests pass (`pocket_ic_tests`, `pocket_ic_3usd`, `integration_test`, `pocket_ic_analytics`)
- [ ] Deploy backend + 3pool to mainnet after merge
- [ ] Verify `get_fees` returns dynamic fee on live canister
- [ ] Verify 3pool swap still works after guard reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)