### PR TITLE
fix(backend): circuit breaker ReadOnly survives TCR recalculation

### DIFF
--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3112,6 +3112,17 @@ impl State {
             return;
         }
 
+        // Wave-14 CDP-01: if the oracle circuit breaker tripped ReadOnly,
+        // TCR recalculation must not override it. Only note_xrc_success
+        // (a fresh valid price) can clear oracle-triggered ReadOnly.
+        // Exception: TCR < 100% still forces ReadOnly for safety.
+        if self.mode_triggered_by_oracle {
+            if new_total_collateral_ratio < Ratio::from(dec!(1.0)) {
+                self.mode = Mode::ReadOnly;
+            }
+            return;
+        }
+
         if new_total_collateral_ratio < dynamic_threshold {
             self.mode = Mode::Recovery;
         } else {

--- a/src/rumi_protocol_backend/tests/audit_pocs_cdp_01_oracle_circuit_breaker.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_cdp_01_oracle_circuit_breaker.rs
@@ -20,11 +20,13 @@
 use candid::Principal;
 
 use rumi_protocol_backend::event::Event;
+use rumi_protocol_backend::numeric::UsdIcp;
 use rumi_protocol_backend::state::{Mode, State};
 use rumi_protocol_backend::xrc::{
     note_xrc_failure_at, note_xrc_success, MAX_CONSECUTIVE_XRC_FAILURES,
 };
 use rumi_protocol_backend::InitArg;
+use rust_decimal_macros::dec;
 
 const TEST_NOW_NS: u64 = 1_700_000_000_000_000_000;
 
@@ -192,4 +194,32 @@ fn cdp_01_failure_after_recovery_starts_counter_fresh() {
 
     assert_eq!(state.consecutive_xrc_failures, 2);
     assert_eq!(state.mode, Mode::GeneralAvailability);
+}
+
+#[test]
+fn cdp_01_circuit_breaker_survives_tcr_recalculation() {
+    let mut state = fresh_state();
+
+    // Trip the circuit breaker.
+    for _ in 0..MAX_CONSECUTIVE_XRC_FAILURES {
+        note_xrc_failure(&mut state);
+    }
+    assert_eq!(state.mode, Mode::ReadOnly);
+    assert!(state.mode_triggered_by_oracle);
+
+    // Simulate the TCR recalculation that runs right after the circuit
+    // breaker in fetch_icp_rate. A healthy cached price would normally
+    // flip mode back to GA, but the circuit breaker must take precedence.
+    let healthy_price = UsdIcp::from(dec!(10.0));
+    state.update_total_collateral_ratio_and_mode(healthy_price);
+
+    assert_eq!(
+        state.mode,
+        Mode::ReadOnly,
+        "circuit breaker ReadOnly must survive update_total_collateral_ratio_and_mode",
+    );
+    assert!(
+        state.mode_triggered_by_oracle,
+        "oracle flag must persist through TCR recalculation",
+    );
 }


### PR DESCRIPTION
## Summary

- **Bug:** After the CDP-01 circuit breaker tripped ReadOnly (3 consecutive XRC failures), `update_total_collateral_ratio_and_mode` immediately overrode it back to GeneralAvailability if the stale cached price still showed a healthy TCR. The circuit breaker was effectively a no-op.
- **Fix:** Added a guard clause in `update_total_collateral_ratio_and_mode` that skips mode transitions when `mode_triggered_by_oracle` is true. Only `note_xrc_success` (a fresh valid XRC fetch) can clear oracle-triggered ReadOnly. TCR < 100% still forces ReadOnly as a safety floor.

## Test plan

- [x] New test `cdp_01_circuit_breaker_survives_tcr_recalculation` (RED then GREEN)
- [x] All 9 circuit breaker audit-fence tests pass
- [x] 366 unit tests pass
- [x] 58 integration tests pass
- [ ] Deploy backend to mainnet after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)