### PR TITLE
feat(backend): add bot CR tolerance for scan→claim TOCTOU

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -268,6 +268,7 @@ type Event = variant {
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
+  set_bot_cr_tolerance_bps : record { bps : nat64 };
   set_reserve_redemptions_enabled : record { enabled : bool };
   set_min_icusd_amount : record { amount : text };
   set_borrowing_fee_curve : record { markers : text };
@@ -569,6 +570,7 @@ type ProtocolConfig = record {
   ckusdc_ledger_principal : opt principal;
   recovery_mode_threshold : float64;
   bot_allowed_collateral_types : vec principal;
+  bot_cr_tolerance_bps : nat64;
   liquidation_bot_principal : opt principal;
   reserve_redemption_fee : float64;
   liquidation_protocol_share : float64;
@@ -802,6 +804,7 @@ service : (ProtocolArg) -> {
   get_all_vaults : () -> (vec CandidVault) query;
   get_borrowing_fee : () -> (float64) query;
   get_bot_allowed_collateral_types : () -> (vec principal) query;
+  get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
@@ -891,6 +894,7 @@ service : (ProtocolArg) -> {
   set_borrowing_fee : (float64) -> (Result);
   set_borrowing_fee_curve : (opt text) -> (Result);
   set_bot_allowed_collateral_types : (vec principal) -> (Result);
+  set_bot_cr_tolerance_bps : (nat64) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -358,6 +358,11 @@ pub enum Event {
         collateral_types: Vec<Principal>,
     },
 
+    #[serde(rename = "set_bot_cr_tolerance_bps")]
+    SetBotCrToleranceBps {
+        bps: u64,
+    },
+
     #[serde(rename = "set_liquidation_bonus")]
     SetLiquidationBonus {
         rate: String,
@@ -796,6 +801,7 @@ impl Event {
             Event::SetLiquidationBotPrincipal { .. } => false,
             Event::SetBotBudget { .. } => false,
             Event::SetBotAllowedCollateralTypes { .. } => false,
+            Event::SetBotCrToleranceBps { .. } => false,
             Event::SetLiquidationBonus { .. } => false,
             Event::SetBorrowingFee { .. } => false,
             Event::SetRedemptionFeeFloor { .. } => false,
@@ -936,6 +942,7 @@ impl Event {
             Event::SetLiquidationBotPrincipal { .. } => Some("SetLiquidationBotPrincipal"),
             Event::SetBotBudget { .. } => Some("SetBotBudget"),
             Event::SetBotAllowedCollateralTypes { .. } => Some("SetBotAllowedCollateralTypes"),
+            Event::SetBotCrToleranceBps { .. } => Some("SetBotCrToleranceBps"),
             Event::SetLiquidationBonus { .. } => Some("SetLiquidationBonus"),
             Event::SetBorrowingFee { .. } => Some("SetBorrowingFee"),
             Event::SetRedemptionFeeFloor { .. } => Some("SetRedemptionFeeFloor"),
@@ -1440,6 +1447,9 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             },
             Event::SetBotAllowedCollateralTypes { collateral_types } => {
                 state.bot_allowed_collateral_types = collateral_types.iter().copied().collect();
+            },
+            Event::SetBotCrToleranceBps { bps } => {
+                state.bot_cr_tolerance_bps = bps;
             },
             Event::SetLiquidationBonus { rate } => {
                 if let Ok(dec) = rate.parse::<Decimal>() {
@@ -2374,6 +2384,11 @@ pub fn record_set_bot_budget(state: &mut State, total_e8s: u64, start_timestamp:
 pub fn record_set_bot_allowed_collateral_types(state: &mut State, collateral_types: Vec<Principal>) {
     record_event(&Event::SetBotAllowedCollateralTypes { collateral_types: collateral_types.clone() });
     state.bot_allowed_collateral_types = collateral_types.into_iter().collect();
+}
+
+pub fn record_set_bot_cr_tolerance_bps(state: &mut State, bps: u64) {
+    record_event(&Event::SetBotCrToleranceBps { bps });
+    state.bot_cr_tolerance_bps = bps;
 }
 
 pub fn record_set_liquidation_bonus(state: &mut State, rate: Ratio) {

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -68,6 +68,22 @@ pub const DEFAULT_CHECK_VAULTS_ALERT_BAND_BPS: u64 = 1000;
 /// `set_check_vaults_full_sweep_every_n_ticks`.
 pub const DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS: u64 = 12;
 
+/// Default tolerance (in basis points) added to the per-collateral
+/// `min_liquidation_ratio` when the liquidation bot calls
+/// `bot_claim_liquidation`. Closes the TOCTOU window between the
+/// `scan_unhealthy_vaults` flag (CR < min_ratio) and the bot's
+/// follow-up claim, where an XRC tick between those two moments can
+/// nudge the recomputed CR back above the strict threshold.
+/// 200 bps (2%) covers the typical price moves in a single 30s bot
+/// tick. Tunable via `set_bot_cr_tolerance_bps`.
+pub const DEFAULT_BOT_CR_TOLERANCE_BPS: u64 = 200;
+
+/// Hard cap on the bot CR tolerance an admin may configure. 500 bps
+/// (5%) — beyond this the bot starts liquidating vaults that have
+/// substantially recovered between scan and claim, which is closer to
+/// "near-threshold liquidation" than "race-window absorption".
+pub const MAX_BOT_CR_TOLERANCE_BPS: u64 = 500;
+
 /// Stable token types accepted for vault repayment (1:1 with icUSD)
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StableTokenType {
@@ -477,6 +493,7 @@ pub struct ProtocolConfig {
     pub bot_budget_total_e8s: u64,
     pub bot_budget_remaining_e8s: u64,
     pub bot_allowed_collateral_types: Vec<Principal>,
+    pub bot_cr_tolerance_bps: u64,
 
     // -- Per-collateral configs (all collateral types) --
     pub collateral_configs: Vec<(Principal, state::CollateralConfig)>,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -783,6 +783,7 @@ fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {
         bot_budget_total_e8s: s.bot_budget_total_e8s,
         bot_budget_remaining_e8s: s.bot_budget_remaining_e8s,
         bot_allowed_collateral_types: s.bot_allowed_collateral_types.iter().cloned().collect(),
+        bot_cr_tolerance_bps: s.bot_cr_tolerance_bps,
 
         collateral_configs: s.collateral_configs.iter()
             .map(|(ct, config)| {
@@ -2309,6 +2310,44 @@ fn get_bot_allowed_collateral_types() -> Vec<Principal> {
     read_state(|s| s.bot_allowed_collateral_types.iter().copied().collect())
 }
 
+/// Tolerance (in basis points) added to per-collateral
+/// `min_liquidation_ratio` when the bot calls `bot_claim_liquidation`.
+/// Closes the scan→claim TOCTOU window. See `set_bot_cr_tolerance_bps`.
+#[candid_method(update)]
+#[update]
+async fn set_bot_cr_tolerance_bps(bps: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set the bot CR tolerance".to_string(),
+        ));
+    }
+    let max = rumi_protocol_backend::MAX_BOT_CR_TOLERANCE_BPS;
+    if bps > max {
+        return Err(ProtocolError::GenericError(format!(
+            "Bot CR tolerance {} bps exceeds maximum {} bps",
+            bps, max
+        )));
+    }
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_bot_cr_tolerance_bps(s, bps);
+    });
+    log!(
+        INFO,
+        "[set_bot_cr_tolerance_bps] Bot CR tolerance set to: {} bps ({:.2}% above min_liquidation_ratio)",
+        bps,
+        (bps as f64) / 100.0
+    );
+    Ok(())
+}
+
+#[candid_method(query)]
+#[query]
+fn get_bot_cr_tolerance_bps() -> u64 {
+    read_state(|s| s.bot_cr_tolerance_bps)
+}
+
 /// Bot calls this to CLAIM a vault for liquidation (phase 1 of 2).
 /// Transfers collateral to the bot and locks the vault (`bot_processing = true`).
 /// Vault debt and collateral amounts are NOT modified yet.
@@ -2361,15 +2400,44 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
         let collateral_price_usd = UsdIcp::from(price);
         let ratio = rumi_protocol_backend::compute_collateral_ratio(vault, collateral_price_usd, s);
         let min_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
+        // Apply scan→claim TOCTOU tolerance. The scan in `check_vaults`
+        // flagged this vault as below `min_ratio`; an XRC tick between
+        // that scan and this call can recompute CR slightly above
+        // `min_ratio`. Allowing up to `min_ratio + tolerance` here
+        // closes the race without widening the strict threshold the
+        // manual liquidation paths enforce. The `actual > 0` guard
+        // below catches the Recovery-mode case where `min_ratio +
+        // tolerance` exceeds the partial-cap target CR.
+        let bot_max_ratio = s.get_bot_claim_max_ratio_for(&vault.collateral_type);
 
-        if ratio >= min_ratio {
+        if ratio >= bot_max_ratio {
             return Err(ProtocolError::GenericError(format!(
-                "Vault #{} is not liquidatable (CR {:.2}% >= {:.2}%)",
-                vault_id, ratio.to_f64() * 100.0, min_ratio.to_f64() * 100.0
+                "Vault #{} is not liquidatable (CR {:.2}% >= {:.2}%, base {:.2}% + tolerance {} bps)",
+                vault_id,
+                ratio.to_f64() * 100.0,
+                bot_max_ratio.to_f64() * 100.0,
+                min_ratio.to_f64() * 100.0,
+                s.bot_cr_tolerance_bps
             )));
         }
 
         let actual = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
+
+        // Defense-in-depth: with the tolerance applied, `ratio` may sit
+        // above the partial-cap target CR (`borrow_threshold_ratio`),
+        // in which case `compute_partial_liquidation_cap` returns 0.
+        // Reject explicitly rather than claiming a 0-debt liquidation,
+        // which would deduct nothing from the budget and seize 0
+        // collateral — pointless work that would still write a noisy
+        // BotClaim record.
+        if actual.to_u64() == 0 {
+            return Err(ProtocolError::GenericError(format!(
+                "Vault #{} has no liquidatable debt at current CR {:.2}% (target CR {:.2}%)",
+                vault_id,
+                ratio.to_f64() * 100.0,
+                s.get_min_collateral_ratio_for(&vault.collateral_type).to_f64() * 100.0
+            )));
+        }
 
         if s.bot_budget_remaining_e8s < actual.to_u64() {
             return Err(ProtocolError::GenericError(format!(

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1174,6 +1174,13 @@ pub struct State {
     /// upgrade so the cadence is monotone across deploys.
     #[serde(default)]
     pub ticks_since_full_sweep: u64,
+
+    /// Tolerance (in basis points) added to per-collateral
+    /// `min_liquidation_ratio` when the liquidation bot calls
+    /// `bot_claim_liquidation`. See `DEFAULT_BOT_CR_TOLERANCE_BPS` for
+    /// the rationale. Tunable via `set_bot_cr_tolerance_bps`.
+    #[serde(default = "default_bot_cr_tolerance_bps")]
+    pub bot_cr_tolerance_bps: u64,
 }
 
 fn default_check_vaults_alert_band_bps() -> u64 {
@@ -1182,6 +1189,10 @@ fn default_check_vaults_alert_band_bps() -> u64 {
 
 fn default_check_vaults_full_sweep_every_n_ticks() -> u64 {
     crate::DEFAULT_CHECK_VAULTS_FULL_SWEEP_EVERY_N_TICKS
+}
+
+fn default_bot_cr_tolerance_bps() -> u64 {
+    crate::DEFAULT_BOT_CR_TOLERANCE_BPS
 }
 
 /// Wave-9c DOS-005: result of `State::scan_unhealthy_vaults`. The
@@ -1371,6 +1382,7 @@ impl Default for State {
             check_vaults_full_sweep_every_n_ticks:
                 default_check_vaults_full_sweep_every_n_ticks(),
             ticks_since_full_sweep: 0,
+            bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
         }
     }
 }
@@ -1588,6 +1600,7 @@ impl From<InitArg> for State {
             check_vaults_full_sweep_every_n_ticks:
                 default_check_vaults_full_sweep_every_n_ticks(),
             ticks_since_full_sweep: 0,
+            bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
         }
     }
 }
@@ -3009,6 +3022,25 @@ impl State {
     /// 0 or 1 reverts to pre-Wave-9c behavior (full sweep every tick).
     pub fn set_check_vaults_full_sweep_every_n_ticks(&mut self, n: u64) {
         self.check_vaults_full_sweep_every_n_ticks = n;
+    }
+
+    /// Admin setter for the bot CR tolerance (in basis points). The
+    /// caller in `main.rs` is responsible for clamping to
+    /// `MAX_BOT_CR_TOLERANCE_BPS`.
+    pub fn set_bot_cr_tolerance_bps(&mut self, bps: u64) {
+        self.bot_cr_tolerance_bps = bps;
+    }
+
+    /// Effective bot claim threshold = `min_liquidation_ratio + tolerance`.
+    /// Used by `bot_claim_liquidation` to absorb the scan→claim
+    /// TOCTOU window without widening the strict threshold the manual
+    /// liquidation paths still enforce.
+    pub fn get_bot_claim_max_ratio_for(&self, ct: &CollateralType) -> Ratio {
+        let base = self.get_min_liquidation_ratio_for(ct);
+        let tolerance = Ratio::from(
+            Decimal::from(self.bot_cr_tolerance_bps) / Decimal::from(10_000u64),
+        );
+        base + tolerance
     }
 
     /// Wave-9c DOS-005: walk `vault_cr_index` and return the unhealthy
@@ -5738,5 +5770,60 @@ mod tests {
         } else {
             panic!("expected CBOR map");
         }
+    }
+
+    // ─── Bot CR tolerance ───
+
+    #[test]
+    fn test_bot_cr_tolerance_default_is_two_percent() {
+        let state = test_state();
+        assert_eq!(state.bot_cr_tolerance_bps, crate::DEFAULT_BOT_CR_TOLERANCE_BPS);
+        assert_eq!(crate::DEFAULT_BOT_CR_TOLERANCE_BPS, 200);
+    }
+
+    #[test]
+    fn test_bot_claim_max_ratio_adds_tolerance_to_min_liq() {
+        let mut state = test_state();
+        let icp = state.icp_collateral_type();
+
+        // Default tolerance (200 bps) → 133% + 2% = 135%.
+        let max = state.get_bot_claim_max_ratio_for(&icp);
+        let expected = state.get_min_liquidation_ratio_for(&icp)
+            + Ratio::from(dec!(0.02));
+        assert_eq!(max, expected);
+
+        // 0 bps → no slack; bot threshold collapses to the strict
+        // min_liquidation_ratio (revert path).
+        state.set_bot_cr_tolerance_bps(0);
+        let max_zero = state.get_bot_claim_max_ratio_for(&icp);
+        assert_eq!(max_zero, state.get_min_liquidation_ratio_for(&icp));
+
+        // 500 bps (the configured admin cap) → 133% + 5% = 138%.
+        state.set_bot_cr_tolerance_bps(500);
+        let max_500 = state.get_bot_claim_max_ratio_for(&icp);
+        let expected_500 = state.get_min_liquidation_ratio_for(&icp)
+            + Ratio::from(dec!(0.05));
+        assert_eq!(max_500, expected_500);
+    }
+
+    #[test]
+    fn test_bot_claim_max_ratio_tracks_recovery_mode_threshold() {
+        // In Recovery mode `min_liquidation_ratio` becomes
+        // `borrow_threshold_ratio` (typically 150% for ICP). Tolerance
+        // is additive on whichever base mode dictates.
+        let mut state = test_state();
+        let icp = state.icp_collateral_type();
+        state.mode = crate::Mode::Recovery;
+
+        let max = state.get_bot_claim_max_ratio_for(&icp);
+        let base = state.get_min_liquidation_ratio_for(&icp);
+        let tolerance = Ratio::from(
+            Decimal::from(state.bot_cr_tolerance_bps) / Decimal::from(10_000u64),
+        );
+        assert_eq!(max, base + tolerance);
+
+        // Sanity: in Recovery the base is at or above the borrow threshold.
+        let borrow_threshold = state.get_min_collateral_ratio_for(&icp);
+        assert!(base >= borrow_threshold);
     }
 }


### PR DESCRIPTION
## Summary

- Closes the scan→claim TOCTOU race that has been silently rejecting borderline bot liquidations (e.g. vault #83 / [event 97333](https://app.rumiprotocol.com/explorer/e/event/97333), where the bot saw CR 134.67% 30s after the scan flagged it below 133%, and the SP picked it up via the cascade timeout).
- Adds `bot_cr_tolerance_bps` (default 200 = 2%) added to the per-collateral `min_liquidation_ratio` only inside `bot_claim_liquidation`. Manual liquidation paths still enforce the strict threshold. Admin can tune via `set_bot_cr_tolerance_bps` (capped at 500 bps).
- Adds an explicit `actual == 0` guard in `bot_claim_liquidation` so a Recovery-mode CR above the partial-cap target rejects cleanly instead of claiming a 0-debt liquidation.

## Why

The bot has 101 records with `total_debt_covered_e8s = 0` — every recent attempt has either hit `"No price available"`, a DEX outage, or `"CR >= 133%"`. The CR-rejection class is the easy one to fix: scan and claim use the same `compute_collateral_ratio` against the same `config.last_price`, but they observe it at different moments. A 2% tolerance covers the typical price moves in a single 30s bot tick.

## Test plan

- [x] `cargo test --lib -p rumi_protocol_backend` — 86 passed (3 new: `test_bot_cr_tolerance_default_is_two_percent`, `test_bot_claim_max_ratio_adds_tolerance_to_min_liq`, `test_bot_claim_max_ratio_tracks_recovery_mode_threshold`)
- [ ] Pre-deploy hook runs unit + integration tests before mainnet deploy
- [ ] After deploy: confirm `get_bot_cr_tolerance_bps` returns 200 on mainnet
- [ ] After deploy: monitor next bot rejection in logs — error message should now include `tolerance: 200 bps` and the effective threshold (135% for ICP)

## Files

- `src/rumi_protocol_backend/src/lib.rs` — defaults + ProtocolConfig surface
- `src/rumi_protocol_backend/src/state.rs` — field, setter, `get_bot_claim_max_ratio_for` helper, 3 unit tests
- `src/rumi_protocol_backend/src/event.rs` — `SetBotCrToleranceBps` variant + replay arm + recorder
- `src/rumi_protocol_backend/src/main.rs` — claim-time CR check, `actual == 0` guard, admin setter, getter
- `src/rumi_protocol_backend/rumi_protocol_backend.did` — Event variant, ProtocolConfig, setter, getter

🤖 Generated with [Claude Code](https://claude.com/claude-code)