### PR TITLE
fix(analytics): add post-Wave-14 BackendEvent variants for Candid decode

### DIFF
--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -328,6 +328,40 @@ pub enum BackendEvent {
     SetCollateralInterestRate {},
     #[serde(rename = "set_collateral_redemption_tier")]
     SetCollateralRedemptionTier {},
+    // --- Variants added by audit waves 8e/9/10/12/14 ---
+    // Without these, candid decode fails for the entire get_events batch
+    // whenever any post-2026-04-29 event is in range. Empty structs work
+    // because candid skips extra record fields. Cycle drain root cause —
+    // see investigation 2026-05-09.
+    #[serde(rename = "deficit_accrued")]
+    DeficitAccrued {},
+    #[serde(rename = "deficit_repaid")]
+    DeficitRepaid {},
+    #[serde(rename = "breaker_tripped")]
+    BreakerTripped {},
+    #[serde(rename = "breaker_cleared")]
+    BreakerCleared {},
+    #[serde(rename = "set_breaker_window_ns")]
+    SetBreakerWindowNs {},
+    #[serde(rename = "set_breaker_window_debt_ceiling_e8s")]
+    SetBreakerWindowDebtCeilingE8s {},
+    #[serde(rename = "set_deficit_readonly_threshold_e8s")]
+    SetDeficitReadonlyThresholdE8s {},
+    #[serde(rename = "set_deficit_repayment_fraction")]
+    SetDeficitRepaymentFraction {},
+    #[serde(rename = "bot_claim_reconciliation_needed")]
+    BotClaimReconciliationNeeded {},
+    #[serde(rename = "oracle_circuit_breaker")]
+    OracleCircuitBreaker {},
+    #[serde(rename = "oracle_source_count_insufficient")]
+    OracleSourceCountInsufficient {},
+    #[serde(rename = "stability_pool_call_failed")]
+    StabilityPoolCallFailed {},
+    // PR #174 (deployed 2026-05-09). Without this variant, candid decode
+    // fails for any get_events batch containing a SetBotCrToleranceBps row,
+    // breaking analytics ingestion entirely.
+    #[serde(rename = "set_bot_cr_tolerance_bps")]
+    SetBotCrToleranceBps {},
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -432,6 +466,21 @@ impl BackendEvent {
             SetCollateralDebtCeiling {} => Some("SetCollateralDebtCeiling"),
             SetCollateralInterestRate {} => Some("SetCollateralInterestRate"),
             SetCollateralRedemptionTier {} => Some("SetCollateralRedemptionTier"),
+            // Audit-wave variants added 2026-05-09 to fix decode failures.
+            // Admin/diagnostic labels grouped under existing breakdown buckets.
+            DeficitAccrued {} => None,
+            DeficitRepaid {} => None,
+            BreakerTripped {} => Some("BreakerTripped"),
+            BreakerCleared {} => Some("BreakerCleared"),
+            SetBreakerWindowNs {} => Some("SetBreakerWindowNs"),
+            SetBreakerWindowDebtCeilingE8s {} => Some("SetBreakerWindowDebtCeilingE8s"),
+            SetDeficitReadonlyThresholdE8s {} => Some("SetDeficitReadonlyThresholdE8s"),
+            SetDeficitRepaymentFraction {} => Some("SetDeficitRepaymentFraction"),
+            BotClaimReconciliationNeeded {} => Some("BotClaimReconciliationNeeded"),
+            OracleCircuitBreaker {} => Some("OracleCircuitBreaker"),
+            OracleSourceCountInsufficient {} => Some("OracleSourceCountInsufficient"),
+            StabilityPoolCallFailed {} => Some("StabilityPoolCallFailed"),
+            SetBotCrToleranceBps {} => Some("SetBotCrToleranceBps"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds 13 missing variants to `rumi_analytics::sources::backend::BackendEvent` so Candid can decode every event the backend now emits.
- Fixes the silent ingestion stall that left `error_counters.backend = 10,798` and the `backend_events` cursor frozen at 98,026.

## Context
The deployed analytics canister was failing every 30-second pull cycle with `failed to decode canister response as BackendEvent: Fail to decode argument 0`. Each missing variant causes Candid to reject the entire `Vec<BackendEvent>` batch, so analytics' backend cursor was stuck and no new events were ingested.

Missing variants:
- 11 audit-wave variants: `deficit_accrued`, `deficit_repaid`, `breaker_tripped`, `breaker_cleared`, `set_breaker_window_ns`, `set_breaker_window_debt_ceiling_e8s`, `set_deficit_readonly_threshold_e8s`, `set_deficit_repayment_fraction`, `bot_claim_reconciliation_needed`, `oracle_circuit_breaker`, `oracle_source_count_insufficient`, `stability_pool_call_failed`
- 1 PR #174 variant: `set_bot_cr_tolerance_bps` (deployed 2026-05-09)

Empty struct variants are sufficient since analytics doesn't process these admin events; Candid skips extra record fields. Each new variant is also wired into `admin_label()` so the live admin event breakdown surfaces them by name.

## Deploy
Already deployed to mainnet:
- Pre-deploy hash: `0x848a209bd574...`
- Post-deploy hash: `0xc4cecc423cf4...`
- Wasm: 628 KB gzipped, installed via `dfx canister install --mode upgrade`

## Verification
After upgrade:
- `last_error: null` on every cursor (was Candid decode error)
- `cursor_position` advanced 98,026 → 98,650 within ~2 minutes (catch-up working)
- `error_counters.backend` frozen at 10,798 (no new errors accumulating)

## Test plan
- [x] `cargo test -p rumi_analytics --lib` (108 passed)
- [x] Deploy to mainnet via `dfx canister install --mode upgrade`
- [x] Verify `error_counters.backend` stops climbing after deploy
- [x] Verify `backend_events` cursor advances past 98,026

🤖 Generated with [Claude Code](https://claude.com/claude-code)