### PR TITLE
fix(backend): derive nICP price from cached ICP rate, no redundant XRC call

### DIFF
--- a/src/rumi_protocol_backend/src/management.rs
+++ b/src/rumi_protocol_backend/src/management.rs
@@ -393,6 +393,59 @@ struct LstCanisterInfo {
     exchange_rate: u64,
 }
 
+/// Wave-14a follow-up: compute the final price for an `LstWrapped`
+/// collateral from already-fetched inputs. Pure function — does not call
+/// XRC or the LST canister.
+///
+/// Previously, `fetch_collateral_price` issued its own XRC
+/// `get_exchange_rate` call for the LST's `base_asset` (e.g. ICP/USD for
+/// nICP) even though `xrc::fetch_icp_rate` had just cached the same rate.
+/// That duplicated the ~1B-cycle XRC round-trip per LST collateral per
+/// refresh tick and also doubled every CDP-14 source-count rejection
+/// event (one tagged ICP, a paired one tagged nICP). The duplicated call
+/// produced no extra information: the price of nICP is mechanically
+/// derived from the ICP price, WaterNeuron's redemption rate, and the
+/// configured haircut.
+///
+/// Returns `None` if any input would yield a non-positive / non-finite
+/// price:
+///   * `wn_exchange_rate == 0` (LST canister unhealthy or not yet
+///     initialized — refuse to publish a price; cached value stays in
+///     place).
+///   * `haircut < 0` or `haircut >= 1` (misconfiguration).
+///   * `underlying_rate <= 0` (no upstream price available).
+///
+/// `wn_exchange_rate` is the LST canister's `exchange_rate` field, scaled
+/// by E8S. For WaterNeuron's nICP this represents "nICP minted per ICP
+/// staked", so the multiplier `E8S / wn_exchange_rate` converts an
+/// underlying ICP price into the equivalent nICP price (1 nICP redeems
+/// for `1 / multiplier` ICP).
+pub fn compute_lst_wrapped_price(
+    underlying_rate: rust_decimal::Decimal,
+    wn_exchange_rate: u64,
+    haircut: f64,
+) -> Option<rust_decimal::Decimal> {
+    use rust_decimal::prelude::FromPrimitive;
+    use rust_decimal::Decimal;
+
+    if wn_exchange_rate == 0 {
+        return None;
+    }
+    if underlying_rate <= Decimal::ZERO {
+        return None;
+    }
+    let haircut_dec = Decimal::from_f64(haircut)?;
+    if haircut_dec < Decimal::ZERO || haircut_dec >= Decimal::ONE {
+        return None;
+    }
+    let multiplier = Decimal::from(crate::E8S) / Decimal::from(wn_exchange_rate);
+    let adjusted = underlying_rate * multiplier * (Decimal::ONE - haircut_dec);
+    if adjusted <= Decimal::ZERO {
+        return None;
+    }
+    Some(adjusted)
+}
+
 /// Generic price fetch for any collateral type using its PriceSource config.
 /// Routes to XRC, CoinGecko HTTPS outcall, or LstWrapped depending on config.
 pub async fn fetch_collateral_price(collateral_type: Principal) {
@@ -412,6 +465,131 @@ pub async fn fetch_collateral_price(collateral_type: Principal) {
             return;
         }
     };
+
+    // Wave-14a follow-up: LstWrapped derives its price from the cached
+    // underlying-asset rate (currently always ICP/USD, maintained by
+    // Timer A via `xrc::fetch_icp_rate`). No XRC call is issued here —
+    // duplicating that call burned ~1B cycles per refresh per LST
+    // collateral and doubled every source-count rejection event. The
+    // LST canister call (`get_info`) is still required, since the
+    // redemption rate is not cached anywhere else.
+    if let PriceSource::LstWrapped {
+        rate_canister_id,
+        rate_method,
+        haircut,
+        ref base_asset,
+        ..
+    } = price_source
+    {
+        // Today, ICP is the only supported LstWrapped underlying. If a
+        // future config wires up a non-ICP base, route it explicitly here
+        // rather than silently falling through to a stale path.
+        if base_asset != "ICP" {
+            log!(
+                TRACE_XRC,
+                "[fetch_collateral_price] LstWrapped base_asset {:?} for {} not yet supported; skipping",
+                base_asset,
+                collateral_type
+            );
+            return;
+        }
+
+        let cached = read_state(|s| match (s.last_icp_rate, s.last_icp_timestamp) {
+            (Some(rate), Some(ts)) => Some((rate, ts)),
+            _ => None,
+        });
+        let Some((icp_rate, ts_nanos)) = cached else {
+            log!(
+                TRACE_XRC,
+                "[fetch_collateral_price] LstWrapped {}: no cached ICP rate yet (Timer A has not landed); skipping",
+                collateral_type
+            );
+            return;
+        };
+
+        let rate_result: Result<(LstCanisterInfo,), _> =
+            ic_cdk::call(rate_canister_id, rate_method.as_str(), ()).await;
+        let info = match rate_result {
+            Ok((info,)) => info,
+            Err((code, msg)) => {
+                log!(
+                    TRACE_XRC,
+                    "[fetch_collateral_price] LstWrapped rate canister error for {}: {:?} {}",
+                    collateral_type, code, msg
+                );
+                return;
+            }
+        };
+
+        let underlying_decimal = icp_rate.0;
+        let Some(final_rate) =
+            compute_lst_wrapped_price(underlying_decimal, info.exchange_rate, haircut)
+        else {
+            log!(
+                TRACE_XRC,
+                "[fetch_collateral_price] LstWrapped {}: compute returned None (underlying={}, wn_rate={}, haircut={})",
+                collateral_type, underlying_decimal, info.exchange_rate, haircut
+            );
+            return;
+        };
+
+        log!(
+            TRACE_XRC,
+            "[fetch_collateral_price] LstWrapped final: {} (underlying={}, wn_rate={}, haircut={})",
+            final_rate, underlying_decimal, info.exchange_rate, haircut
+        );
+
+        // Honor the same monotonic-timestamp gate as the XRC path: only
+        // publish if the cached underlying timestamp is newer than the
+        // collateral's last stored timestamp. Re-publishing the same
+        // underlying tick would emit a duplicate `price_update` event for
+        // no observable change.
+        let should_update = read_state(|s| {
+            s.get_collateral_config(&collateral_type)
+                .map(|c| match c.last_price_timestamp {
+                    Some(last_ts) => last_ts < ts_nanos,
+                    None => true,
+                })
+                .unwrap_or(false)
+        });
+        if !should_update {
+            return;
+        }
+
+        // Wave-5 LIQ-007: gate the LST-side price through the sanity band
+        // (rejects single outliers; multi-confirmation required to accept).
+        use rust_decimal::prelude::ToPrimitive;
+        let final_rate_f64 = match final_rate.to_f64() {
+            Some(v) if v.is_finite() && v > 0.0 => v,
+            _ => {
+                log!(
+                    TRACE_XRC,
+                    "[fetch_collateral_price] LstWrapped {}: non-positive/non-finite final rate {}; skipping",
+                    collateral_type, final_rate
+                );
+                return;
+            }
+        };
+        let accepted =
+            mutate_state(|s| s.check_price_sanity_band(&collateral_type, final_rate_f64));
+        if !accepted {
+            log!(
+                TRACE_XRC,
+                "[fetch_collateral_price] rejecting outlier LstWrapped rate {} for {}; awaiting confirmation",
+                final_rate_f64, collateral_type
+            );
+            return;
+        }
+
+        mutate_state(|s| {
+            if let Some(config) = s.collateral_configs.get_mut(&collateral_type) {
+                config.last_price = Some(final_rate_f64);
+                config.last_price_timestamp = Some(ts_nanos);
+                crate::event::record_price_update(collateral_type, final_rate, ts_nanos);
+            }
+        });
+        return;
+    }
 
     // CoinGecko variant uses HTTPS outcalls — completely separate path from XRC
     if let PriceSource::CoinGecko { ref coin_id, ref vs_currency } = price_source {
@@ -463,15 +641,17 @@ pub async fn fetch_collateral_price(collateral_type: Principal) {
         return;
     }
 
-    // XRC-based path (Xrc and LstWrapped variants)
+    // XRC-based path (only the `Xrc` variant reaches here now —
+    // `LstWrapped` is handled above without an XRC call, and `CoinGecko`
+    // is handled in its own branch).
     const XRC_CALL_COST_CYCLES: u64 = 1_000_000_000;
     const XRC_MARGIN_SEC: u64 = 60;
 
     let (base_asset, base_asset_class, quote_asset, quote_asset_class) = match &price_source {
-        PriceSource::Xrc { base_asset, base_asset_class, quote_asset, quote_asset_class }
-        | PriceSource::LstWrapped { base_asset, base_asset_class, quote_asset, quote_asset_class, .. } => {
+        PriceSource::Xrc { base_asset, base_asset_class, quote_asset, quote_asset_class } => {
             (base_asset.clone(), base_asset_class.clone(), quote_asset.clone(), quote_asset_class.clone())
         }
+        PriceSource::LstWrapped { .. } => unreachable!(), // handled above
         PriceSource::CoinGecko { .. } => unreachable!(), // handled above
     };
 
@@ -561,44 +741,10 @@ pub async fn fetch_collateral_price(collateral_type: Principal) {
 
     let Some((rate, ts_nanos)) = underlying_rate else { return };
 
-    // For LstWrapped, multiply by the redemption rate and apply haircut
-    let final_rate = match &price_source {
-        PriceSource::Xrc { .. } => rate,
-        PriceSource::LstWrapped { rate_canister_id, rate_method, haircut, .. } => {
-            let rate_result: Result<(LstCanisterInfo,), _> =
-                ic_cdk::call(*rate_canister_id, rate_method.as_str(), ()).await;
-
-            match rate_result {
-                Ok((info,)) => {
-                    if info.exchange_rate == 0 {
-                        log!(TRACE_XRC, "[fetch_collateral_price] LstWrapped exchange_rate is 0, skipping");
-                        return;
-                    }
-                    let multiplier = rust_decimal::Decimal::from(crate::E8S)
-                        / rust_decimal::Decimal::from(info.exchange_rate);
-                    let haircut_dec = rust_decimal::Decimal::from_f64(*haircut)
-                        .unwrap_or(rust_decimal::Decimal::ZERO);
-                    let adjusted = rate * multiplier * (rust_decimal::Decimal::ONE - haircut_dec);
-
-                    log!(
-                        TRACE_XRC,
-                        "[fetch_collateral_price] LstWrapped final: {} (underlying={}, multiplier={}, haircut={})",
-                        adjusted, rate, multiplier, haircut
-                    );
-                    adjusted
-                }
-                Err((code, msg)) => {
-                    log!(
-                        TRACE_XRC,
-                        "[fetch_collateral_price] LstWrapped rate canister error: {:?} {}",
-                        code, msg
-                    );
-                    return;
-                }
-            }
-        }
-        PriceSource::CoinGecko { .. } => unreachable!(),
-    };
+    // Only the plain `Xrc` variant reaches here — `LstWrapped` is handled
+    // above without re-fetching from XRC, and `CoinGecko` has its own
+    // early-return branch.
+    let final_rate = rate;
 
     let should_update = read_state(|s| {
         s.get_collateral_config(&collateral_type)

--- a/src/rumi_protocol_backend/tests/lst_wrapped_price_derives_from_cached_underlying.rs
+++ b/src/rumi_protocol_backend/tests/lst_wrapped_price_derives_from_cached_underlying.rs
@@ -1,0 +1,122 @@
+//! Wave-14a follow-up: `LstWrapped` collateral price must derive from the
+//! cached underlying-asset rate (e.g. ICP/USD from Timer A) rather than
+//! issuing its own redundant XRC call.
+//!
+//! Pre-fix, `management::fetch_collateral_price` made an independent
+//! `get_exchange_rate` call to XRC for the LST's `base_asset` even though
+//! Timer A (`xrc::fetch_icp_rate`) had just cached the very same rate.
+//! On mainnet this duplicated every ICP/USD fetch (~1B cycles per call,
+//! ~6B cycles/day extra) and also doubled every CDP-14 source-count
+//! rejection event (one for ICP collateral, a paired one for nICP).
+//!
+//! The pure helper `management::compute_lst_wrapped_price` enforces the
+//! contract: given an already-fetched underlying rate, the WaterNeuron-
+//! style canister's `exchange_rate`, and the configured haircut, produce
+//! the final nICP/USD price (or `None` if any input would yield a
+//! non-positive or non-finite result).
+
+use rumi_protocol_backend::management::compute_lst_wrapped_price;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal_macros::dec;
+
+/// E8S scale used by WaterNeuron's `exchange_rate` field. Repeating the
+/// constant locally keeps the test independent of backend internals.
+const E8S: u64 = 100_000_000;
+
+#[test]
+fn nicp_price_matches_observed_mainnet_computation() {
+    // Reconstructs the LstWrapped log line observed on mainnet:
+    //   "LstWrapped final: 3.8778636004174468138893800984
+    //    (underlying=3.261682912, multiplier=1.2514894288565178633220861978,
+    //     haircut=0.05)"
+    //
+    // multiplier = E8S / wn_exchange_rate  =>
+    // wn_exchange_rate = E8S / multiplier  ≈ 79_904_804 (truncated)
+    let underlying = dec!(3.261682912);
+    let wn_exchange_rate: u64 = 79_904_804; // ~0.799 ICP per nICP, the mainnet value
+    let haircut = 0.05_f64;
+
+    let got = compute_lst_wrapped_price(underlying, wn_exchange_rate, haircut)
+        .expect("happy-path inputs must produce a price");
+
+    // Compare on `f64` because the underlying multiplier is irrational
+    // in decimal. The conversion must succeed — a None here would mean
+    // the helper produced a non-representable value, which is itself a bug.
+    let got_f64 = got
+        .to_f64()
+        .expect("helper output must be representable as f64");
+    let expected = 3.877863600_f64;
+    assert!(
+        (got_f64 - expected).abs() < 1e-5,
+        "expected ≈{}, got {}",
+        expected,
+        got_f64
+    );
+}
+
+#[test]
+fn zero_wn_exchange_rate_returns_none() {
+    // WaterNeuron unhealthy / not yet initialized: must NOT publish a price.
+    let got = compute_lst_wrapped_price(dec!(3.26), 0, 0.05);
+    assert!(
+        got.is_none(),
+        "exchange_rate of 0 indicates the LST canister is unhealthy; \
+         must return None so the cached price stays in place",
+    );
+}
+
+#[test]
+fn negative_haircut_returns_none() {
+    // A negative haircut would inflate the price above the underlying-derived
+    // value, which only ever makes sense as a misconfiguration. Refuse.
+    let got = compute_lst_wrapped_price(dec!(3.26), 80_000_000, -0.05);
+    assert!(
+        got.is_none(),
+        "negative haircut must be refused as a misconfiguration",
+    );
+}
+
+#[test]
+fn haircut_at_or_above_one_returns_none() {
+    // Haircut of 1.0 or higher collapses the price to zero/negative.
+    assert!(
+        compute_lst_wrapped_price(dec!(3.26), 80_000_000, 1.0).is_none(),
+        "haircut = 1.0 produces zero price; must return None",
+    );
+    assert!(
+        compute_lst_wrapped_price(dec!(3.26), 80_000_000, 1.5).is_none(),
+        "haircut > 1.0 produces negative price; must return None",
+    );
+}
+
+#[test]
+fn zero_or_negative_underlying_returns_none() {
+    // No price means no LST price. A non-positive underlying must not
+    // propagate into a non-positive LST price.
+    assert!(
+        compute_lst_wrapped_price(dec!(0), 80_000_000, 0.05).is_none(),
+        "zero underlying rate must return None",
+    );
+    assert!(
+        compute_lst_wrapped_price(dec!(-1), 80_000_000, 0.05).is_none(),
+        "negative underlying rate must return None",
+    );
+}
+
+#[test]
+fn zero_haircut_just_applies_multiplier() {
+    // multiplier = E8S / E8S = 1.0 → price equals underlying exactly.
+    let got = compute_lst_wrapped_price(dec!(3.26), E8S, 0.0)
+        .expect("zero-haircut, unit-multiplier inputs must succeed");
+    assert_eq!(got, dec!(3.26));
+}
+
+#[test]
+fn pure_helper_does_not_depend_on_state_or_async() {
+    // Documenting the contract: this is a pure helper. The test runs in a
+    // synchronous context with no canister state, no XRC mock, no LST
+    // canister mock. If a future change reintroduces a hidden dependency
+    // (e.g. an inter-canister call inside the helper), this file fails to
+    // compile as an integration test — which is the point of the fence.
+    let _ = compute_lst_wrapped_price(dec!(1), E8S, 0.0);
+}

--- a/src/rumi_protocol_backend/tests/lst_wrapped_price_derives_from_cached_underlying.rs
+++ b/src/rumi_protocol_backend/tests/lst_wrapped_price_derives_from_cached_underlying.rs
@@ -90,6 +90,28 @@ fn haircut_at_or_above_one_returns_none() {
 }
 
 #[test]
+fn nan_or_infinite_haircut_returns_none() {
+    // Pre-fix behavior used `Decimal::from_f64(haircut).unwrap_or(ZERO)`,
+    // which silently treated `NaN` and `Infinity` as a 0% haircut and
+    // published an inflated price. The new helper refuses both. (The
+    // admin endpoint `set_lst_haircut` uses `<` / `>` validation that
+    // returns false for `NaN`, so a NaN haircut COULD be stored in
+    // state; the helper is the last line of defense.)
+    assert!(
+        compute_lst_wrapped_price(dec!(3.26), 80_000_000, f64::NAN).is_none(),
+        "NaN haircut must be refused, not silently treated as zero",
+    );
+    assert!(
+        compute_lst_wrapped_price(dec!(3.26), 80_000_000, f64::INFINITY).is_none(),
+        "+infinity haircut must be refused",
+    );
+    assert!(
+        compute_lst_wrapped_price(dec!(3.26), 80_000_000, f64::NEG_INFINITY).is_none(),
+        "-infinity haircut must be refused",
+    );
+}
+
+#[test]
 fn zero_or_negative_underlying_returns_none() {
     // No price means no LST price. A non-positive underlying must not
     // propagate into a non-positive LST price.


### PR DESCRIPTION
## Summary

- The nICP price refresh in `management::fetch_collateral_price` previously made its own `get_exchange_rate` call to XRC for ICP/USD — the same rate that Timer A (`xrc::fetch_icp_rate`) had just cached. That duplicated ~1B cycles per refresh per LST collateral (~6B cycles/day on mainnet) and doubled every CDP-14 source-count rejection event (one tagged ICP, a paired one tagged nICP from the same thin XRC aggregation).
- The price of nICP is mechanically derived from the ICP price, WaterNeuron's `exchange_rate`, and the configured haircut. The new pure helper `compute_lst_wrapped_price` does that math; the `LstWrapped` branch of `fetch_collateral_price` now reads `state.last_icp_rate` + `state.last_icp_timestamp` (preserved across upgrades in stable memory) and only calls WaterNeuron's `get_info` — no XRC round-trip.
- Side effects of the change: explorer activity feed should show roughly half as many `OracleSourceCountInsufficient` events (no more paired ICP/nICP rejections on the same thin XRC tick), and the ICP and nICP `price_update` events now share the same timestamp by construction.

## Behavioral notes

- `base_asset` is gated to `"ICP"`. A future LST with a non-ICP underlying must be routed through this branch explicitly rather than silently falling through.
- The XRC-path match arm for `LstWrapped` is now `unreachable!()`. Adding a new `PriceSource` variant in the future will fail to compile until handled, which is the intended fence.
- The helper refuses NaN / Infinity / non-positive haircuts and `wn_exchange_rate == 0`. Pre-fix code used `Decimal::from_f64(haircut).unwrap_or(ZERO)` which silently treated NaN as a 0% haircut — strictly worse. A separate follow-up tracks hardening `set_lst_haircut` itself with `is_finite()`.

## Test plan

- [x] `cargo build --lib` clean
- [x] `cargo build --target wasm32-unknown-unknown --release` clean (deployable wasm)
- [x] 86 lib unit tests pass
- [x] 8 new tests in `tests/lst_wrapped_price_derives_from_cached_underlying.rs` cover the mainnet-observed computation + every refusal path
- [x] 39 existing tests across the adjacent oracle/price surface (CDP-01, CDP-14, DOS-011, LIQ-007, RED-001) still pass
- [x] No new clippy warnings introduced
- [ ] Post-deploy: explorer activity feed should show ~50% fewer source-count-insufficient events; backend cycles/day should drop by ~6B

🤖 Generated with [Claude Code](https://claude.com/claude-code)