### PR TITLE
fix(analytics): split system CR (aggregate) from median vault CR

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -267,6 +267,7 @@ type ProtocolSummary = record {
   total_vault_count : nat32;
   total_collateral_usd_e8s : nat64;
   system_cr_bps : nat32;
+  median_cr_bps : nat32;
   swap_count_24h : nat32;
   volume_24h_e8s : nat64;
 };

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -274,6 +274,7 @@ export interface ProtocolSummary {
   'total_vault_count' : number,
   'total_collateral_usd_e8s' : bigint,
   'system_cr_bps' : number,
+  'median_cr_bps' : number,
   'swap_count_24h' : number,
   'volume_24h_e8s' : bigint,
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -221,6 +221,7 @@ export const idlFactory = ({ IDL }) => {
     'total_vault_count' : IDL.Nat32,
     'total_collateral_usd_e8s' : IDL.Nat64,
     'system_cr_bps' : IDL.Nat32,
+    'median_cr_bps' : IDL.Nat32,
     'swap_count_24h' : IDL.Nat32,
     'volume_24h_e8s' : IDL.Nat64,
   });

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -275,6 +275,7 @@ type ProtocolSummary = record {
   total_vault_count : nat32;
   total_collateral_usd_e8s : nat64;
   system_cr_bps : nat32;
+  median_cr_bps : nat32;
   swap_count_24h : nat32;
   volume_24h_e8s : nat64;
 };

--- a/src/rumi_analytics/src/http/metrics.rs
+++ b/src/rumi_analytics/src/http/metrics.rs
@@ -61,9 +61,22 @@ pub fn render() -> String {
             );
             gauge(
                 &mut out,
-                "rumi_system_cr_bps",
-                "System-wide median collateral ratio in basis points",
+                "rumi_median_cr_bps",
+                "Median vault collateral ratio in basis points",
                 row.median_cr_bps as f64,
+            );
+            let system_cr_bps = if row.total_debt_e8s > 0 {
+                ((row.total_collateral_usd_e8s as u128).saturating_mul(10_000)
+                    / row.total_debt_e8s as u128)
+                    .min(u32::MAX as u128) as u32
+            } else {
+                0
+            };
+            gauge(
+                &mut out,
+                "rumi_system_cr_bps",
+                "Aggregate system collateral ratio (total collateral / total debt) in basis points",
+                system_cr_bps as f64,
             );
         }
     }

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -858,12 +858,21 @@ pub fn get_protocol_summary() -> types::ProtocolSummary {
 
     // Latest vault snapshot for TVL/CR/vault count.
     let vault_n = storage::daily_vaults::len();
-    let (tvl, debt, cr, vaults) = if vault_n > 0 {
+    let (tvl, debt, median_cr, vaults) = if vault_n > 0 {
         storage::daily_vaults::get(vault_n - 1)
             .map(|v| (v.total_collateral_usd_e8s, v.total_debt_e8s, v.median_cr_bps, v.total_vault_count))
             .unwrap_or((0, 0, 0, 0))
     } else {
         (0, 0, 0, 0)
+    };
+    // True system CR = aggregate collateral value / aggregate debt, in bps.
+    // The daily_vaults row stores median_cr separately; surface both so callers
+    // can distinguish "where does the typical vault sit" from "how healthy is
+    // the protocol overall."
+    let system_cr_bps = if debt > 0 {
+        ((tvl as u128).saturating_mul(10_000) / debt as u128).min(u32::MAX as u128) as u32
+    } else {
+        0
     };
 
     // Circulating supply from cache.
@@ -892,7 +901,8 @@ pub fn get_protocol_summary() -> types::ProtocolSummary {
         timestamp_ns: now,
         total_collateral_usd_e8s: tvl,
         total_debt_e8s: debt,
-        system_cr_bps: cr,
+        system_cr_bps,
+        median_cr_bps: median_cr,
         total_vault_count: vaults,
         circulating_supply_icusd_e8s: supply,
         volume_24h_e8s: activity.total_volume_e8s,

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -215,6 +215,7 @@ pub struct ProtocolSummary {
     pub total_collateral_usd_e8s: u64,
     pub total_debt_e8s: u64,
     pub system_cr_bps: u32,
+    pub median_cr_bps: u32,
     pub total_vault_count: u32,
     pub circulating_supply_icusd_e8s: Option<u128>,
     pub volume_24h_e8s: u64,

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -1076,6 +1076,7 @@ struct TestProtocolSummary {
     total_collateral_usd_e8s: u64,
     total_debt_e8s: u64,
     system_cr_bps: u32,
+    median_cr_bps: u32,
     total_vault_count: u32,
     volume_24h_e8s: u64,
     swap_count_24h: u32,

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -18,7 +18,7 @@
   import { decodeRustDecimal } from '$utils/decimalUtils';
   import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
 
-  let systemCrBps = $state(0);
+  let medianCrBps = $state(0);
   let loading = $state(true);
   let collateralRows: CollateralRow[] = $state([]);
   let atRiskVaults: any[] = $state([]);
@@ -46,7 +46,7 @@
       ]);
 
       const summary = summaryR.status === 'fulfilled' ? summaryR.value : null;
-      systemCrBps = summary?.system_cr_bps ? Number(summary.system_cr_bps) : 0;
+      medianCrBps = summary?.median_cr_bps ? Number(summary.median_cr_bps) : 0;
 
       const configs = configsR.status === 'fulfilled' ? configsR.value ?? [] : [];
       const totals = totalsR.status === 'fulfilled' ? totalsR.value ?? [] : [];
@@ -189,10 +189,10 @@
     }
   });
 
-  const systemCrTone = $derived.by(() => {
-    if (systemCrBps === 0) return 'muted' as const;
-    if (systemCrBps < 15000) return 'danger' as const;
-    if (systemCrBps < 20000) return 'caution' as const;
+  const medianCrTone = $derived.by(() => {
+    if (medianCrBps === 0) return 'muted' as const;
+    if (medianCrBps < 15000) return 'danger' as const;
+    if (medianCrBps < 20000) return 'caution' as const;
     return 'good' as const;
   });
 
@@ -202,7 +202,7 @@
   });
 
   const healthMetrics = $derived.by(() => [
-    { label: 'Aggregate CR', value: systemCrBps > 0 ? bpsToPercent(systemCrBps) : '--', tone: systemCrTone },
+    { label: 'Median Vault CR', value: medianCrBps > 0 ? bpsToPercent(medianCrBps) : '--', tone: medianCrTone },
     { label: 'At-risk vaults', value: String(atRiskVaults.length), tone: atRiskVaults.length > 0 ? 'caution' as const : 'good' as const },
     { label: 'Liquidated (7d)', value: String(liq7dCount), sub: liq7dCount > 0 ? 'events' : 'none' },
     { label: 'Global liq threshold', value: '110%', sub: 'min CR' },


### PR DESCRIPTION
## Summary
- `get_protocol_summary` was assigning `daily_vaults.median_cr_bps` to `ProtocolSummary.system_cr_bps`, so Explorer's "System CR" / "Aggregate CR" cards showed the median (~204%) instead of the true aggregate (~180%).
- `system_cr_bps` now = `total_collateral / total_debt` in bps (matches backend's `total_collateral_ratio`). New `median_cr_bps` field surfaces median separately.
- Prometheus now emits both `rumi_system_cr_bps` (true aggregate) and `rumi_median_cr_bps`.
- Frontend: Overview "System CR" reads corrected aggregate. Collateral page tile renamed "Aggregate CR" → "Median Vault CR" and reads `median_cr_bps`.

## On-chain verification (post-deploy)
- `system_cr_bps = 18_103` → **181.03%** ✓ (matches backend `total_collateral_ratio = 1.799`)
- `median_cr_bps = 20_368` → **203.68%** ✓

## Deploy
- `rumi_analytics` deployed to mainnet (shrunk + gzipped, identity `rumi_identity`)
- `vault_frontend` deployed to mainnet

## Test plan
- [x] `cargo check -p rumi_analytics` clean
- [x] Verified both fields return correct values on mainnet
- [ ] Spot-check Explorer Overview shows ~180% System CR
- [ ] Spot-check Collateral page shows "Median Vault CR" ~204%

🤖 Generated with [Claude Code](https://claude.com/claude-code)