### PR TITLE
fix(analytics): pre-list set_amm1_canister BackendEvent variant

### DIFF
--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -362,6 +362,14 @@ pub enum BackendEvent {
     // breaking analytics ingestion entirely.
     #[serde(rename = "set_bot_cr_tolerance_bps")]
     SetBotCrToleranceBps {},
+    // Backend commit 18dd5f1 (2026-05-09) added the `set_amm1_canister`
+    // admin endpoint. Pre-listing the event variant here so analytics
+    // continues decoding cleanly the first time an admin wires the AMM1
+    // canister principal into the backend — without this, the entire
+    // `Vec<BackendEvent>` decode of any batch containing one of these
+    // rows would fail and halt ingestion.
+    #[serde(rename = "set_amm1_canister")]
+    SetAmm1Canister {},
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -481,6 +489,7 @@ impl BackendEvent {
             OracleSourceCountInsufficient {} => Some("OracleSourceCountInsufficient"),
             StabilityPoolCallFailed {} => Some("StabilityPoolCallFailed"),
             SetBotCrToleranceBps {} => Some("SetBotCrToleranceBps"),
+            SetAmm1Canister {} => Some("SetAmm1Canister"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Backend commit `18dd5f1` (2026-05-09) added the `set_amm1_canister` admin endpoint, which emits a corresponding `Event::SetAmm1Canister` row in `get_events` when called. That backend wasm is staged for deploy alongside the nICP price fix (#177 already merged), but the analytics canister's `BackendEvent` enum doesn't yet know about the variant.
- Same class of silent ingestion-halt that PR #176 fixed for the audit-wave variants and `set_bot_cr_tolerance_bps`: a missing variant causes the entire `Vec<BackendEvent>` decode to fail for any batch containing one of these rows. Analytics intentionally avoids `#[serde(other)]` (per the comment in `backend.rs`) because it doesn't work reliably with the candid crate's deserializer.
- This PR adds `SetAmm1Canister {}` as an empty struct (we don't process its contents) plus the matching `admin_label` arm so the exhaustive match still compiles.

## Deploy order
Deploy this analytics wasm BEFORE the backend that ships `set_amm1_canister`, so ingestion stays clean through the first time an admin wires AMM1 into the backend.

## Test plan
- [x] `cargo build --lib -p rumi_analytics` clean
- [x] `cargo build --target wasm32-unknown-unknown --release -p rumi_analytics` clean (deployable)
- [x] `cargo test --lib -p rumi_analytics` — 108 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)