### PR TITLE
fix(liquidation_bot): correct ckUSDC fee default, add claim retry, add swap test harness

### DIFF
--- a/src/liquidation_bot/liquidation_bot.did
+++ b/src/liquidation_bot/liquidation_bot.did
@@ -79,6 +79,13 @@ type BotAdminEvent = record {
   action : BotAdminAction;
 };
 
+type SwapResult = record {
+  ckusdc_received_e6 : nat64;
+  effective_price_e8s : nat64;
+};
+
+type TestSwapResult = variant { Ok : SwapResult; Err : text };
+
 service : (BotInitArgs) -> {
   // Core
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> ();
@@ -103,4 +110,10 @@ service : (BotInitArgs) -> {
   admin_approve_pool : () -> ();
   admin_sweep_ckusdc : (principal, opt nat64) -> ();
   admin_retry_stuck_claim : (nat64) -> ();
+  // Returns (icp_fee_e8s, ckusdc_fee_e6) freshly read from each ledger and
+  // also writes them back into BotConfig so future swaps use the live values.
+  admin_refresh_fees : () -> (nat64, nat64);
+  // Runs the live swap path (ICP -> ckUSDC) using `amount_e8s` from the bot's
+  // ICP balance. ckUSDC stays in the bot; retrieve via `admin_sweep_ckusdc`.
+  admin_test_swap : (nat64) -> (TestSwapResult);
 };

--- a/src/liquidation_bot/src/lib.rs
+++ b/src/liquidation_bot/src/lib.rs
@@ -148,7 +148,8 @@ fn inspect_message() {
     match method.as_str() {
         // Admin/auth methods: reject anonymous to save cycles on Candid decoding
         "set_config" | "admin_resolve_pool_ordering" | "admin_approve_pool"
-        | "admin_sweep_ckusdc" | "admin_retry_stuck_claim" => {
+        | "admin_sweep_ckusdc" | "admin_retry_stuck_claim"
+        | "admin_refresh_fees" | "admin_test_swap" => {
             if ic_cdk::api::caller() != Principal::anonymous() {
                 ic_cdk::api::call::accept_message();
             }
@@ -357,7 +358,13 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
         Err((code, msg)) => ic_cdk::trap(&format!("Balance query failed: {:?} {}", code, msg)),
     };
 
-    let fee = state::read_state(|s| s.config.as_ref().expect("Config not set").ckusdc_fee_e6.unwrap_or(10));
+    let fee = state::read_state(|s| {
+        s.config
+            .as_ref()
+            .expect("Config not set")
+            .ckusdc_fee_e6
+            .unwrap_or(10_000)
+    });
     let send_amount = balance.saturating_sub(fee);
 
     let transfer_args = icrc_ledger_types::icrc1::transfer::TransferArg {
@@ -388,6 +395,75 @@ async fn admin_sweep_ckusdc(target: Principal, record_id: Option<u64>) {
         Ok((Err(e),)) => ic_cdk::trap(&format!("Sweep transfer failed: {:?}", e)),
         Err((code, msg)) => ic_cdk::trap(&format!("Sweep call failed: {:?} {}", code, msg)),
     }
+}
+
+/// Refresh the cached ICRC-1 transfer fees from each ledger and store them on
+/// the in-memory BotConfig. This exists because ICPSwap's `depositFromAndSwap`
+/// requires the caller to pass the exact `tokenInFee` / `tokenOutFee` values
+/// the pool has cached; a stale `BotConfig.ckusdc_fee_e6` is what caused every
+/// swap to fail with "Wrong fee cache (expected: 10000, received: 10)".
+/// Returns the resolved (icp_fee_e8s, ckusdc_fee_e6) pair.
+#[update]
+async fn admin_refresh_fees() -> (u64, u64) {
+    require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .unwrap_or_else(|_| ic_cdk::trap("Another operation is in progress"));
+    let (icp_ledger, ckusdc_ledger) = state::read_state(|s| {
+        let c = s.config.as_ref().expect("Config not set");
+        (c.icp_ledger, c.ckusdc_ledger)
+    });
+
+    let icp_fee = swap::fetch_ledger_fee(icp_ledger)
+        .await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Failed to fetch ICP fee: {}", e)));
+    let ckusdc_fee = swap::fetch_ledger_fee(ckusdc_ledger)
+        .await
+        .unwrap_or_else(|e| ic_cdk::trap(&format!("Failed to fetch ckUSDC fee: {}", e)));
+
+    state::mutate_state(|s| {
+        if let Some(ref mut config) = s.config {
+            config.icp_fee_e8s = Some(icp_fee);
+            config.ckusdc_fee_e6 = Some(ckusdc_fee);
+        }
+    });
+
+    log!(
+        INFO,
+        "Refreshed ledger fees: ICP={} e8s, ckUSDC={} e6",
+        icp_fee,
+        ckusdc_fee
+    );
+
+    (icp_fee, ckusdc_fee)
+}
+
+/// Run the live swap path (quote -> apply slippage -> `depositFromAndSwap`)
+/// against the configured ICPSwap pool using `amount_e8s` of ICP from the
+/// bot's own balance. Admin-only. Designed for end-to-end verification of the
+/// swap leg without waiting for an organic liquidation.
+///
+/// The resulting ckUSDC stays in the bot canister; retrieve via
+/// `admin_sweep_ckusdc`.
+#[update]
+async fn admin_test_swap(amount_e8s: u64) -> Result<swap::SwapResult, String> {
+    require_admin();
+    let _guard = ProcessingGuard::acquire()
+        .map_err(|_| "Another operation is in progress".to_string())?;
+    let config = state::read_state(|s| s.config.clone())
+        .ok_or_else(|| "Config not set".to_string())?;
+
+    log!(INFO, "admin_test_swap: attempting to swap {} ICP e8s", amount_e8s);
+    let result = swap::swap_icp_for_ckusdc(&config, amount_e8s).await;
+    match &result {
+        Ok(r) => log!(
+            INFO,
+            "admin_test_swap succeeded: received {} ckUSDC e6 at effective price {} e8s",
+            r.ckusdc_received_e6,
+            r.effective_price_e8s
+        ),
+        Err(e) => log!(INFO, "admin_test_swap failed: {}", e),
+    }
+    result
 }
 
 /// Retry confirm for a stuck claim.

--- a/src/liquidation_bot/src/process.rs
+++ b/src/liquidation_bot/src/process.rs
@@ -8,6 +8,32 @@ use crate::swap;
 const CONFIRM_ATTEMPTS: u8 = 5;
 const CANCEL_ATTEMPTS: u8 = 3;
 
+/// Max number of times the bot will re-attempt `bot_claim_liquidation` for a
+/// single vault before giving up and letting the cascade escalate to the SP.
+/// Each retry costs ~30s of bot processing time. Three is enough to ride out
+/// the scan→claim oracle TOCTOU window in most cases without burning the full
+/// 300s cascade-timeout budget on a single uncooperative vault.
+pub const CLAIM_RETRY_LIMIT: u8 = 3;
+
+/// Decision tree for what to do after `bot_claim_liquidation` returns Err.
+/// `current_count` is the number of attempts already made (0 = first try just
+/// failed). Returns `GiveUp` when the limit has been reached, otherwise
+/// `Retry` with the incremented count to persist.
+#[derive(Debug, PartialEq)]
+pub(crate) enum ClaimRetryAction {
+    Retry { new_count: u8 },
+    GiveUp,
+}
+
+pub(crate) fn next_claim_retry_action(current_count: u8, max: u8) -> ClaimRetryAction {
+    let attempted = current_count.saturating_add(1);
+    if attempted >= max {
+        ClaimRetryAction::GiveUp
+    } else {
+        ClaimRetryAction::Retry { new_count: attempted }
+    }
+}
+
 /// Outcome of the swap-failure cleanup path. Pure data, produced by
 /// `decide_swap_failure_outcome` and consumed by `process_pending` to write
 /// the LiquidationRecord and emit the STUCK log line if applicable.
@@ -128,24 +154,74 @@ pub async fn process_pending() {
         }
     };
 
-    log!(crate::INFO, "Processing vault #{}", vault.vault_id);
+    let prior_retry_count = state::read_state(|s| {
+        s.claim_retry_counts.get(&vault.vault_id).copied().unwrap_or(0)
+    });
+    log!(
+        crate::INFO,
+        "Processing vault #{} (attempt {}/{})",
+        vault.vault_id,
+        prior_retry_count + 1,
+        CLAIM_RETRY_LIMIT
+    );
     let record_id = history::next_id();
     let timestamp = ic_cdk::api::time();
 
     // -- Phase 1: CLAIM --
     let liq_result = call_bot_claim_liquidation(&config, vault.vault_id).await;
     let (collateral_amount, debt_covered, collateral_price) = match liq_result {
-        Ok(r) => (r.collateral_amount, r.debt_covered, r.collateral_price_e8s),
+        Ok(r) => {
+            state::mutate_state(|s| {
+                s.claim_retry_counts.remove(&vault.vault_id);
+            });
+            (r.collateral_amount, r.debt_covered, r.collateral_price_e8s)
+        }
         Err(e) => {
-            log!(crate::INFO, "Claim failed for vault #{}: {}", vault.vault_id, e);
+            let action = next_claim_retry_action(prior_retry_count, CLAIM_RETRY_LIMIT);
+            let (status, message) = match &action {
+                ClaimRetryAction::Retry { new_count } => (
+                    LiquidationStatus::ClaimFailed,
+                    format!(
+                        "Attempt {}/{}: {}",
+                        new_count, CLAIM_RETRY_LIMIT, e
+                    ),
+                ),
+                ClaimRetryAction::GiveUp => (
+                    LiquidationStatus::ClaimFailed,
+                    format!(
+                        "Final attempt {}/{} (giving up; cascade will escalate to SP): {}",
+                        CLAIM_RETRY_LIMIT, CLAIM_RETRY_LIMIT, e
+                    ),
+                ),
+            };
+            log!(crate::INFO, "Claim failed for vault #{}: {}", vault.vault_id, message);
             write_record(LiquidationRecordV1 {
                 id: record_id, vault_id: vault.vault_id, timestamp,
-                status: LiquidationStatus::ClaimFailed,
+                status,
                 collateral_claimed_e8s: 0, debt_to_cover_e8s: 0, icp_swapped_e8s: 0,
                 ckusdc_received_e6: 0, ckusdc_transferred_e6: 0, icp_to_treasury_e8s: 0,
                 oracle_price_e8s: 0, effective_price_e8s: 0, slippage_bps: 0,
-                error_message: Some(e), confirm_retry_count: 0,
+                error_message: Some(message), confirm_retry_count: 0,
             });
+            match action {
+                ClaimRetryAction::Retry { new_count } => {
+                    let vault_id = vault.vault_id;
+                    state::mutate_state(|s| {
+                        s.claim_retry_counts.insert(vault_id, new_count);
+                        // Re-queue at the front of the Vec so other pending
+                        // vaults pop first (LIFO); skip if a concurrent
+                        // `notify_liquidatable_vaults` already re-added us.
+                        if !s.pending_vaults.iter().any(|v| v.vault_id == vault_id) {
+                            s.pending_vaults.insert(0, vault);
+                        }
+                    });
+                }
+                ClaimRetryAction::GiveUp => {
+                    state::mutate_state(|s| {
+                        s.claim_retry_counts.remove(&vault.vault_id);
+                    });
+                }
+            }
             return;
         }
     };
@@ -426,6 +502,37 @@ mod tests {
         assert!(log.contains("STUCK"));
         assert!(log.contains("vault #7"));
         assert!(log.contains("3 attempts"));
+    }
+
+    #[test]
+    fn claim_retry_first_failure_schedules_retry() {
+        // First failure (count=0) on a 3-attempt limit must reschedule, not drop.
+        let action = next_claim_retry_action(0, 3);
+        assert_eq!(action, ClaimRetryAction::Retry { new_count: 1 });
+    }
+
+    #[test]
+    fn claim_retry_penultimate_failure_still_retries() {
+        // Second failure (count=1) leaves one more shot before the limit.
+        let action = next_claim_retry_action(1, 3);
+        assert_eq!(action, ClaimRetryAction::Retry { new_count: 2 });
+    }
+
+    #[test]
+    fn claim_retry_final_failure_gives_up() {
+        // Third failure (count=2) hits the limit, so the bot must stop trying
+        // and let the 300s cascade escalate to the stability pool.
+        let action = next_claim_retry_action(2, 3);
+        assert_eq!(action, ClaimRetryAction::GiveUp);
+    }
+
+    #[test]
+    fn claim_retry_handles_counter_overflow_safely() {
+        // Defensive: if state somehow got a u8::MAX counter (e.g. legacy data
+        // corruption), saturating_add prevents wraparound to 0, and the
+        // attempted >= max check still pushes us into GiveUp.
+        let action = next_claim_retry_action(u8::MAX, 3);
+        assert_eq!(action, ClaimRetryAction::GiveUp);
     }
 
     #[test]

--- a/src/liquidation_bot/src/state.rs
+++ b/src/liquidation_bot/src/state.rs
@@ -2,6 +2,7 @@ use candid::{CandidType, Deserialize, Principal};
 use ic_stable_structures::writer::Writer;
 use serde::Serialize;
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 
 use crate::memory;
 
@@ -116,6 +117,13 @@ pub struct BotState {
     pub admin_events: Vec<BotAdminEvent>,
     #[serde(default)]
     pub migrated_to_stable_structures: bool,
+    /// Per-vault claim-attempt counter. Incremented on each `ClaimFailed`
+    /// returned by `bot_claim_liquidation`, cleared on success or after the
+    /// retry ceiling is hit. Lives in heap state only (not persisted across
+    /// upgrades), because the cascade re-notifies surviving liquidatable
+    /// vaults on its next tick anyway.
+    #[serde(default)]
+    pub claim_retry_counts: BTreeMap<u64, u8>,
 }
 
 thread_local! {

--- a/src/liquidation_bot/src/swap.rs
+++ b/src/liquidation_bot/src/swap.rs
@@ -1,14 +1,36 @@
-use candid::{Nat, Principal};
+use candid::{CandidType, Nat, Principal};
 use ic_canister_log::log;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
+use serde::Deserialize;
 
 use crate::icpswap;
 use crate::state::BotConfig;
 
+/// Belt-and-suspenders default when `BotConfig.*_fee` is unset. The real fee
+/// for ICP and ckUSDC is 10_000 in their respective base units (e8s for ICP
+/// and e6 for ckUSDC, since ckUSDC has 6 decimals and a fee of $0.01).
+/// Previously this default was 10 for ckUSDC, which is what blew up every
+/// ICPSwap swap with "Wrong fee cache (expected: 10000, received: 10)".
+const FALLBACK_LEDGER_FEE: u64 = 10_000;
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
 pub struct SwapResult {
     pub ckusdc_received_e6: u64,
     pub effective_price_e8s: u64,
+}
+
+/// Fetch a token ledger's current ICRC-1 transfer fee.
+pub async fn fetch_ledger_fee(ledger: Principal) -> Result<u64, String> {
+    let result: Result<(Nat,), _> = ic_cdk::call(ledger, "icrc1_fee", ()).await;
+    match result {
+        Ok((n,)) => n
+            .0
+            .to_string()
+            .parse::<u64>()
+            .map_err(|_| format!("icrc1_fee returned non-u64 value from {}", ledger)),
+        Err((code, msg)) => Err(format!("icrc1_fee call failed ({:?}): {}", code, msg)),
+    }
 }
 
 /// One-time infinite ICRC-2 approve. Amount = u128::MAX, no expiry.
@@ -96,8 +118,8 @@ pub async fn swap_icp_for_ckusdc(
         min_output
     );
 
-    let icp_fee = config.icp_fee_e8s.unwrap_or(10_000);
-    let ckusdc_fee = config.ckusdc_fee_e6.unwrap_or(10);
+    let icp_fee = config.icp_fee_e8s.unwrap_or(FALLBACK_LEDGER_FEE);
+    let ckusdc_fee = config.ckusdc_fee_e6.unwrap_or(FALLBACK_LEDGER_FEE);
 
     let received = icpswap::deposit_and_swap(
         config.icpswap_pool,
@@ -141,7 +163,7 @@ pub async fn return_collateral_to_backend(
     amount_e8s: u64,
     collateral_ledger: Principal,
 ) -> Result<(), String> {
-    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let fee = config.icp_fee_e8s.unwrap_or(FALLBACK_LEDGER_FEE);
     let send_amount = amount_e8s.saturating_sub(fee);
     if send_amount == 0 {
         return Err("Collateral amount too small to cover transfer fee".to_string());
@@ -187,7 +209,7 @@ pub async fn transfer_ckusdc_to_backend(
     config: &BotConfig,
     amount_e6: u64,
 ) -> Result<u64, String> {
-    let fee = config.ckusdc_fee_e6.unwrap_or(10);
+    let fee = config.ckusdc_fee_e6.unwrap_or(FALLBACK_LEDGER_FEE);
     let send_amount = amount_e6.saturating_sub(fee);
     if send_amount == 0 {
         return Err("ckUSDC amount too small to cover transfer fee".to_string());
@@ -231,7 +253,7 @@ pub async fn transfer_icp_to_treasury(
     config: &BotConfig,
     amount_e8s: u64,
 ) -> Result<(), String> {
-    let fee = config.icp_fee_e8s.unwrap_or(10_000);
+    let fee = config.icp_fee_e8s.unwrap_or(FALLBACK_LEDGER_FEE);
     let send_amount = amount_e8s.saturating_sub(fee);
     if send_amount == 0 {
         return Ok(());


### PR DESCRIPTION
## Why

The liquidation bot has completed **0 liquidations** across 101 attempts on mainnet. Today's overnight liquidations all fell through to the stability pool. Investigation surfaced two distinct failure modes:

1. **`SwapFailed` (5 of 12 recent attempts)** — ICPSwap rejecting every swap with `Wrong fee cache (expected: 10000, received: 10)`. Root cause: `swap.rs:100` had `config.ckusdc_fee_e6.unwrap_or(10)` — looks like a typo, real fee is `10_000` for both ICP and ckUSDC ledgers.

2. **`ClaimFailed` (7 of 12 recent attempts)** — the scan→claim TOCTOU on oracle price. Backend selects a vault when `CR < 133%`, then ~12 seconds later when the bot calls `bot_claim_liquidation`, an XRC tick has updated the cached price and CR is now above the bot's 200 bps tolerance ceiling. Bot gets one shot per vault, falls through, SP catches.

## What

### 1. Fee defaults corrected (swap.rs, lib.rs)

Replaced `unwrap_or(10)` with a named `FALLBACK_LEDGER_FEE = 10_000` constant used at every fee fallback site (swap, return-to-backend, transfer-ckusdc, transfer-icp-to-treasury, admin_sweep_ckusdc).

### 2. Bot-side claim retry (process.rs, state.rs)

Added `CLAIM_RETRY_LIMIT = 3` and a pure `next_claim_retry_action(count, max)` helper with unit tests. `process_pending` now re-queues a vault that fails the CR-tolerance check, up to 3 attempts ~30s apart. Each retry stays well inside the 300s cascade timeout so the SP can still escalate on a persistently uncooperative vault.

State change: new `claim_retry_counts: BTreeMap<u64, u8>` on `BotState` with `#[serde(default)]`. Heap-only — resets on upgrade because the cascade re-notifies surviving liquidatable vaults on its next tick.

### 3. Admin test harness (lib.rs, .did)

- `admin_refresh_fees() -> (nat64, nat64)`: calls `icrc1_fee` on both ledgers, writes the results back into `BotConfig`, returns `(icp_fee, ckusdc_fee)`.
- `admin_test_swap(amount_e8s) -> Result<SwapResult, text>`: runs the same swap path a liquidation would (quote → slippage → `depositFromAndSwap`) using ICP from the bot's own balance. The resulting ckUSDC stays in the bot; retrieve via `admin_sweep_ckusdc`. Designed for end-to-end verification of the swap leg without waiting for an organic liquidation.

## Tests

9 lib unit tests pass, including 4 new ones for the retry decision (`next_claim_retry_action`):

- First failure (count=0) schedules retry
- Penultimate failure (count=1) still retries
- Final failure (count=2) gives up
- u8::MAX counter is handled safely via `saturating_add`

Legacy state deserialization test still passes (confirms `claim_retry_counts` defaults cleanly on old state blobs).

## Deploy plan (post-merge)

1. Upgrade the bot canister (`dfx deploy liquidation_bot --network ic --identity rumi_identity` with dummy `BotInitArgs` upgrade argument).
2. Admin calls `admin_refresh_fees` to populate live ledger fee values into config (belt-and-suspenders over the constant default).
3. Admin sends a small amount of ICP to the bot's principal, then calls `admin_test_swap(amount_e8s)` to verify the ICPSwap path end-to-end.
4. Watch the next organic liquidation get caught by the bot.

## Test plan

- [x] Unit tests pass (`cargo test --package liquidation_bot --lib`)
- [x] Workspace build clean (`cargo build --workspace`)
- [ ] After deploy: `admin_refresh_fees` returns `(10_000, 10_000)`
- [ ] After deploy: `admin_test_swap` with 0.5 ICP completes successfully
- [ ] Within 24h: bot completes its first organic liquidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)