### PR TITLE
fix(backend): deactivate NotLowestCR band gate on liquidation entry points

### DIFF
--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -596,12 +596,12 @@ pub enum ProtocolError {
     CallerNotOwner,
     AmountTooLow { minimum_amount: u64 },
     GenericError(String),
-    /// Wave-8b LIQ-002: rejected because the requested vault is not within
-    /// `liquidation_ordering_tolerance` of the lowest-CR vault. Liquidators
-    /// must process the worst vault first so the protocol cannot be left
-    /// with deeply-underwater bad debt while easy targets are picked off.
-    /// The caller can either pick a worst-or-near-worst vault, or wait until
-    /// admin widens the tolerance band.
+    /// Wave-8b LIQ-002 band-gate rejection. **Deactivated 2026-05-18 — no
+    /// live code path emits this variant.** Retained in the enum so
+    /// historical on-chain events recorded before the deactivation still
+    /// decode cleanly. See `state::is_within_liquidation_band` and the
+    /// "Layer 2.5 — band gate DEACTIVATION fence" comment in
+    /// `tests/audit_pocs_liq_002_sorted_troves_index.rs` for background.
     NotLowestCR,
 }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -2964,13 +2964,22 @@ impl State {
     }
 
     /// Returns true if `vault_id` is within `liquidation_ordering_tolerance`
-    /// (in CR units) of the bottom of the index — i.e., one of the worst-CR
-    /// vaults. Liquidator endpoints gate on this BEFORE the per-vault CR
-    /// check.
+    /// (in CR units) of the bottom of the index, i.e., one of the worst-CR
+    /// vaults.
     ///
-    /// Returns false for an unindexed `vault_id` (defensive: the caller must
-    /// have just attempted to liquidate a vault that does not exist or that
-    /// was opened during the call but not re-keyed).
+    /// **Deactivated 2026-05-18.** No production code path calls this; the
+    /// band gate it backed (Wave-8b LIQ-002) was removed because its global,
+    /// cross-collateral, liquidatable-unfiltered floor blocked the SP from
+    /// processing legitimate liquidations whenever the index bottom was
+    /// anchored by an unrelated or unliquidatable vault. The function and
+    /// the underlying `vault_cr_index` are preserved so a future
+    /// MEV-resistance pass can re-enable a properly-scoped variant
+    /// (per-collateral index + liquidatable-filtered floor). See the
+    /// "Layer 2.5 — band gate DEACTIVATION fence" comment in
+    /// `tests/audit_pocs_liq_002_sorted_troves_index.rs` for context.
+    ///
+    /// Returns false for an unindexed `vault_id`.
+    #[allow(dead_code)]
     pub fn is_within_liquidation_band(&self, vault_id: u64) -> bool {
         let mut my_key: Option<u64> = None;
         for (key, bucket) in self.vault_cr_index.iter() {

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -2110,13 +2110,13 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_partial_{}", vault_id))?;
 
-    // Wave-8b LIQ-002: reject vaults that are not within the lowest-CR band.
-    // Forces liquidators to process the worst vault first; blocks MEV cherry-
-    // picking that would leave deeply-underwater vaults on the books.
-    if !read_state(|s| s.is_within_liquidation_band(vault_id)) {
-        guard_principal.fail();
-        return Err(ProtocolError::NotLowestCR);
-    }
+    // Wave-8b LIQ-002 band gate deactivated 2026-05-18. The per-vault CR
+    // check below remains the authoritative liquidatability test. See
+    // `tests/audit_pocs_liq_002_sorted_troves_index.rs` ("Layer 2.5 —
+    // band gate DEACTIVATION fence") for background. The helper
+    // `state::is_within_liquidation_band` is preserved as dead code for
+    // future MEV-resistance re-introduction (per-collateral index +
+    // liquidatable-filtered floor).
 
     let liquidation_amount: ICUSD = icusd_amount.into();
 
@@ -2385,11 +2385,8 @@ pub async fn liquidate_vault_partial_with_stable(
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_stable_{}", vault_id))?;
 
-    // Wave-8b LIQ-002: reject vaults that are not within the lowest-CR band.
-    if !read_state(|s| s.is_within_liquidation_band(vault_id)) {
-        guard_principal.fail();
-        return Err(ProtocolError::NotLowestCR);
-    }
+    // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
+    // `liquidate_vault_partial` above for rationale).
 
     // Check if the selected stable token is enabled
     let is_enabled = read_state(|s| match token_type {
@@ -2710,16 +2707,14 @@ pub async fn liquidate_vault_debt_already_burned(
     three_usd_received_e8s: Option<u64>,
     proof: crate::icrc3_proof::SpWritedownProof,
 ) -> Result<StabilityPoolLiquidationResult, ProtocolError> {
-    // Wave-8b LIQ-002 SAFETY: this path is intentionally NOT gated on
-    // `is_within_liquidation_band`. It is the stability-pool-triggered
-    // writedown — the caller is gated on `caller == stability_pool_canister`
-    // by the entry point in `main.rs` (`stability_pool_liquidate_*`), and the
-    // SP has already committed icUSD via the 3pool burn. Adding the band gate
-    // here would mean a worst-CR-vault race could block legitimate SP
-    // writedowns and orphan the burned icUSD with no on-chain accounting.
-    // The CR index is still kept fresh by the post-mutation `reindex_vault_cr`
-    // call at the end of this function so subsequent user-initiated
-    // liquidations see the post-writedown CR.
+    // Wave-8b LIQ-002 band gate is deactivated globally as of 2026-05-18.
+    // This path was never gated to begin with: it is the stability-pool-
+    // triggered writedown, with the caller gated on
+    // `caller == stability_pool_canister` by the entry point in `main.rs`
+    // (`stability_pool_liquidate_*`), and the SP has already committed
+    // icUSD via the 3pool burn. The CR index is still kept fresh by the
+    // post-mutation `reindex_vault_cr` call at the end of this function so
+    // any future re-introduction of the band check sees a current CR.
 
     // Wave-8c LIQ-004 (kill switch): admin-toggleable disable of this path.
     // Independent of `frozen` and `liquidation_frozen`. Use during a
@@ -3013,13 +3008,11 @@ pub async fn liquidate_vault_debt_already_burned(
             }
         }
 
-        // Wave-8b LIQ-002: re-key after partial deduction, or unindex if drained.
-        // SAFETY: this path is the SP-triggered writedown, gated on
-        // caller==stability_pool. It intentionally bypasses the
-        // `is_within_liquidation_band` check (the band gate is a
-        // user-input safety net, not an SP one — the SP has already
-        // committed icUSD via the 3pool burn). The index update still
-        // happens so subsequent user-initiated liquidations see fresh CR.
+        // Wave-8b LIQ-002: re-key after partial deduction, or unindex if
+        // drained. The band gate that originally consumed this index was
+        // deactivated 2026-05-18, but `check_vaults`' at-risk-band sharding
+        // (Wave-9c DOS-005) still relies on accurate CR keys, so the index
+        // must stay current.
         if removed {
             s.unindex_vault_cr(vault_id);
         } else {
@@ -3084,11 +3077,8 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_{}", vault_id))?;
 
-    // Wave-8b LIQ-002: reject vaults that are not within the lowest-CR band.
-    if !read_state(|s| s.is_within_liquidation_band(vault_id)) {
-        guard_principal.fail();
-        return Err(ProtocolError::NotLowestCR);
-    }
+    // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
+    // `liquidate_vault_partial` above for rationale).
 
     // Step 1: Validate vault is liquidatable
     let (vault, collateral_price, config_decimals, collateral_price_usd, mode) = match read_state(|s| {
@@ -3521,11 +3511,8 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("partial_liquidate_vault_{}", arg.vault_id))?;
 
-    // Wave-8b LIQ-002: reject vaults that are not within the lowest-CR band.
-    if !read_state(|s| s.is_within_liquidation_band(arg.vault_id)) {
-        guard_principal.fail();
-        return Err(ProtocolError::NotLowestCR);
-    }
+    // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
+    // `liquidate_vault_partial` above for rationale).
 
     let liquidator_payment: ICUSD = arg.amount.into();
 

--- a/src/rumi_protocol_backend/tests/audit_pocs_liq_002_sorted_troves_index.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_liq_002_sorted_troves_index.rs
@@ -1,10 +1,27 @@
-//! LIQ-002 regression fence: sorted-troves index + liquidation ordering.
+//! LIQ-002 regression fence: sorted-troves index + (formerly) liquidation
+//! ordering gate.
 //!
 //! Audit report:
 //!   * `audit-reports/2026-04-22-28e9896/raw-pass-results/liquidation-mechanics.json`
 //!     finding LIQ-002.
 //!
-//! # What the gap was
+//! # Status as of 2026-05-18
+//!
+//! **The band gate is deactivated.** On 2026-05-17 a series of legitimately-
+//! underwater ICP vaults failed liquidation on mainnet because the global
+//! `is_within_liquidation_band` floor was anchored by an unrelated vault
+//! (likely with a stale or missing collateral price, which keys at 0).
+//! The gate's design (single global CR index across all collateral types,
+//! no filtering for liquidatability) made the failure mode unavoidable
+//! during fast price moves, and Rumi currently has no observable
+//! third-party liquidation MEV for the gate to defend against. The four
+//! `vault.rs` call sites were removed on 2026-05-18; see Layer 2.5 below.
+//!
+//! The index, helper, and admin endpoints are preserved so a future
+//! re-introduction can ship with a properly-scoped implementation
+//! (per-collateral index + liquidatable-filtered floor).
+//!
+//! # What the gap was (historical)
 //!
 //! Pre-Wave-8b, every liquidator endpoint accepted any caller-provided
 //! `vault_id` as long as the vault's CR was below `min_liquidation_ratio`.
@@ -14,35 +31,31 @@
 //! headroom) and skip deeply-underwater vaults, leaving the protocol with
 //! unfinished bad debt while harvesting easy wins.
 //!
-//! # How this file tests the fix
+//! # Test layers in this file
 //!
-//! Three layers, mirroring the structure of the LIQ-007 fence:
-//!
-//!  1. **Pure index unit tests (state-level, no canister context)** — confirm
+//!  1. **Pure index unit tests (state-level, no canister context).** Confirm
 //!     that every mutation that moves a vault's debt or collateral re-keys
 //!     the index, that closes/full-liquidations un-index, and that the
-//!     index size invariant holds after each operation.
+//!     index size invariant holds after each operation. **Still active:**
+//!     `check_vaults`' at-risk-band sharding (Wave-9c DOS-005) still
+//!     depends on the index, so these tests pin a live contract.
 //!
-//!  2. **Ordering enforcement at the state layer** — `is_within_liquidation_band`
+//!  2. **Ordering enforcement at the state layer.** `is_within_liquidation_band`
 //!     returns true for the bottom-of-stack vault, false for mid-stack
-//!     vaults, and respects the admin-tunable tolerance.
+//!     vaults, and respects the admin-tunable tolerance. **Helper is now
+//!     dead code in production; tests are retained as documentation of the
+//!     pre-deactivation contract and as a starting point for any future
+//!     re-introduction.**
 //!
-//!  3. **Scale + migration tests** — open 100 vaults via the state mutators,
-//!     assert the band gate rejects mid-stack and accepts worst-CR; simulate
-//!     the post_upgrade rebuild over 50 vaults to pin the migration contract.
+//!  2.5. **Band gate DEACTIVATION fence (2026-05-18).** Structural test
+//!     asserting that no entry point in `vault.rs` returns
+//!     `ProtocolError::NotLowestCR`. Fails loudly if the gate is
+//!     accidentally re-wired without a redesigned helper.
 //!
-//! # Why no dedicated PocketIC file
-//!
-//! The four liquidator entry points each call
-//! `read_state(|s| s.is_within_liquidation_band(vault_id))` BEFORE any other
-//! work. The wiring is verified by the Rust compiler (the call site exists
-//! in each function) and by the state-level fence (the helper returns
-//! the correct result for all interesting scenarios). A full PocketIC test
-//! would replicate all of that at one or two orders of magnitude higher
-//! cost (per-test setup is multi-second; opening 100 vaults via canister
-//! calls takes minutes). The existing `pocket_ic_tests` suite continues to
-//! exercise single-vault liquidation paths, where the band gate trivially
-//! passes — confirming the gate does not regress the existing flow.
+//!  3. **Scale + migration tests.** Open 100 vaults via the state mutators,
+//!     assert the (deactivated) band helper rejects mid-stack and accepts
+//!     worst-CR; simulate the post_upgrade rebuild over 50 vaults to pin
+//!     the migration contract. Retained for the same reason as Layer 2.
 
 use candid::Principal;
 
@@ -420,6 +433,46 @@ fn liq_002_admin_can_widen_tolerance() {
     state.set_liquidation_ordering_tolerance(Ratio::new(dec!(1.0)));
     assert!(state.is_within_liquidation_band(2));
     assert!(state.is_within_liquidation_band(3));
+}
+
+// ============================================================================
+// Layer 2.5 — band gate DEACTIVATION fence (2026-05-18)
+// ============================================================================
+//
+// Background: on 2026-05-17 a series of legitimately-underwater ICP vaults
+// failed liquidation on mainnet because every entry point gated on
+// `is_within_liquidation_band` and the global bottom-of-index was anchored
+// by an unrelated vault. The gate was originally added (Wave-8b LIQ-002) to
+// prevent MEV cherry-picking, but Rumi currently has no observable
+// third-party liquidation MEV — so the gate's only achievement was blocking
+// the protocol's own SP/bot from working.
+//
+// On 2026-05-18 the four gate call sites in `vault.rs` were removed.
+// `is_within_liquidation_band` and the underlying index stay in place for a
+// future, properly-scoped MEV-resistance re-introduction (per-collateral
+// index + liquidatable-filtered floor). Until then, the helper is reachable
+// from tests but is no longer wired into any liquidation entry point.
+//
+// The structural test below pins that contract.
+
+#[test]
+fn liq_002_band_gate_no_longer_wired_into_liquidation_entry_points() {
+    // After the 2026-05-18 band-gate removal, no entry point in `vault.rs`
+    // may return `ProtocolError::NotLowestCR`. The variant itself stays in
+    // the enum so historical on-chain events still decode, but no live code
+    // path emits it. Treat this test as the regression fence for accidental
+    // re-introduction.
+    let src = include_str!("../src/vault.rs");
+    let occurrences = src.matches("ProtocolError::NotLowestCR").count();
+    assert_eq!(
+        occurrences, 0,
+        "vault.rs must not return ProtocolError::NotLowestCR (band gate \
+         deactivated 2026-05-18). Found {} call site(s). If you are \
+         deliberately re-enabling the band, fix the helper first \
+         (per-collateral index + liquidatable-filtered floor) and delete \
+         this test.",
+        occurrences,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **The 5/17 mainnet incident:** vaults #149, #179, #182, and #183 went underwater during an ICP wick, the bot routed all four to the stability pool, and every liquidation came back `LiquidationExecuted { success: false, stables_consumed: 0 }`. SP logs show the backend rejected each call with `ProtocolError::NotLowestCR`. The fallback alt-stable draws (ckUSDT 0.054 icUSD, ckUSDC 0.01 icUSD, 3USD-LP ~0.04–0.08 icUSD) were all below the 0.1 icUSD backend minimum so nothing absorbed the debt. ICP price recovered and the four vaults are no longer liquidatable, so there was no actual loss.
- **Root cause:** the Wave-8b LIQ-002 band gate (`is_within_liquidation_band`) rejects any vault whose CR-key sits more than 100 bps above the bottom of `vault_cr_index`. The index is global across all collateral types, and the floor includes vaults that can't themselves be liquidated (a vault with missing/stale collateral price keys at 0 by design). When the bottom anchor drifts away from the actually-liquidatable cohort, every legitimate liquidation fails.
- **The fix:** remove the four call sites in `vault.rs`. The per-vault CR check that immediately follows remains the authoritative liquidatability test. The gate was designed to prevent MEV cherry-picking; Rumi has no observable third-party liquidation MEV at this stage, so the gate is currently only blocking the protocol's own SP/bot.
- **What is preserved:** `vault_cr_index` and `reindex_vault_cr` stay live (Wave-9c DOS-005 at-risk-band sharding still uses them). `is_within_liquidation_band`, the admin setter/getter, and the `NotLowestCR` enum variant are kept so historical events still decode and a future, properly-scoped re-introduction (per-collateral index, liquidatable-filtered floor) is a one-PR change.

## Test plan

- [x] `cargo build --release` clean.
- [x] `cargo test --lib` (backend): 92 passed, 0 failed.
- [x] `cargo test --test audit_pocs_liq_002_sorted_troves_index`: 22 passed (includes the new `liq_002_band_gate_no_longer_wired_into_liquidation_entry_points` structural fence).
- [x] All non-`_pic` audit POC suites pass except 5 pre-existing `ic_cdk::api::time()` panics in `audit_pocs_liq_005_deficit_account` (confirmed identical on `main`).
- [x] `cargo test --test pocket_ic_tests`: 27 passed.
- [x] `cargo test -p stability_pool --test pocket_ic_3usd`: 7 passed.
- [x] `cargo test -p rumi_3pool --test integration_test`: 9 passed.
- [x] `cargo test -p rumi_analytics --test pocket_ic_analytics`: 24 passed.
- [ ] Awaiting manual verification post-deploy: next ICP wick triggers `LiquidationExecuted { success: true }` events for legitimately-underwater vaults across the CR spread.

## Deploy notes

- Backend upgrade only. No state migration required. State field `liquidation_ordering_tolerance` is preserved untouched.
- Suggested upgrade description: `"Remove NotLowestCR band gate; liquidations no longer require lowest-CR-first ordering"`.
- Use `--identity rumi_identity` and pre-deploy hook will gate on the test run.

## What this does NOT do

- Does not widen the tolerance as a workaround.
- Does not refactor the SP's alt-stable fallback path (a red herring in the incident).
- Does not touch the bot's separate `bot_cr_tolerance_bps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)