### PR TITLE
fix(backend): prune liquidation routing state on every check_vaults tick

### DIFF
--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -682,6 +682,46 @@ pub fn record_sp_notification_result_at(
     }
 }
 
+/// Prune routing-state entries (`sp_attempted_vaults`, `bot_pending_vaults`)
+/// for vaults that have either recovered above their liquidation floor or
+/// timed out of their bot window.
+///
+/// Designed to be called from `check_vaults` UNCONDITIONALLY on every
+/// tick, including ticks where no vault is currently liquidatable. On a
+/// quiet tick `unhealthy_ids` is empty, so both `retain` predicates
+/// evaluate false for every entry and both collections are flushed.
+///
+/// # Background (2026-05-18 follow-up)
+///
+/// Pre-fix, this cleanup lived INLINE inside `check_vaults` and only ran
+/// inside the `if !unhealthy_vaults.is_empty()` branch. The 2026-05-17
+/// incident exposed the consequence: vaults #149/#179/#182/#183 were
+/// SP-attempted, the now-deactivated `NotLowestCR` band gate rejected
+/// every call, the SP transport still returned `Ok(())` so
+/// `record_sp_notification_result` blacklisted them, and after price
+/// recovery the blacklist did not clear because the cleanup was skipped
+/// on every quiet tick that followed.
+///
+/// `bot_pending_vaults` entries past `bot_timeout_ns` are dropped here
+/// even if the vault is still unhealthy — the routing logic in
+/// `check_vaults` reads absence-from-map as the signal to fall back from
+/// the bot to the stability pool.
+///
+/// Pure-state. No I/O.
+pub fn prune_recovered_routing_state(
+    state: &mut state::State,
+    unhealthy_ids: &std::collections::BTreeSet<u64>,
+    now_ns: u64,
+    bot_timeout_ns: u64,
+) {
+    state
+        .bot_pending_vaults
+        .retain(|vid, ts| unhealthy_ids.contains(vid) && now_ns.saturating_sub(*ts) < bot_timeout_ns);
+    state
+        .sp_attempted_vaults
+        .retain(|vid| unhealthy_ids.contains(vid));
+}
+
 /// Wave-14b CDP-03: write the post-redemption base rate and timestamp to
 /// the per-collateral `CollateralConfig` (NOT the legacy global
 /// `s.current_base_rate` / `s.last_redemption_time`).
@@ -865,6 +905,24 @@ pub async fn check_vaults() {
     );
     let unhealthy_vaults = scan.unhealthy_vaults;
 
+    // 2026-05-18 follow-up: prune routing state unconditionally on every
+    // tick — even quiet ones — so a vault that was SP-attempted during a
+    // prior unhealthy episode and has since recovered does not stay
+    // blacklisted forever. Pre-fix this cleanup was inline INSIDE the
+    // `if !unhealthy_vaults.is_empty()` branch and was skipped on quiet
+    // ticks; the 5/17 incident exposed the consequence (vaults
+    // #149/#179/#182/#183 stuck on the SP blacklist until manual
+    // liquidation). See `prune_recovered_routing_state` doc.
+    let now = ic_cdk::api::time();
+    let bot_timeout_ns: u64 = 300_000_000_000; // 5 min
+    let scan_unhealthy_ids: std::collections::BTreeSet<u64> = unhealthy_vaults
+        .iter()
+        .map(|v| v.vault_id)
+        .collect();
+    mutate_state(|s| {
+        prune_recovered_routing_state(s, &scan_unhealthy_ids, now, bot_timeout_ns);
+    });
+
     // Log unhealthy vaults but don't liquidate them
     if !unhealthy_vaults.is_empty() {
         log!(
@@ -915,10 +973,10 @@ pub async fn check_vaults() {
         // 1. Bot gets first shot at vaults with bot-eligible collateral
         // 2. Stability pool handles: non-bot-eligible immediately + bot-eligible after timeout
         // 3. Manual liquidation is always available as last resort (via get_liquidatable_vaults)
-
-        let now = ic_cdk::api::time();
-        // Bot gets one check_vaults cycle (5 min = 300s) before fallback
-        let bot_timeout_ns: u64 = 300_000_000_000;
+        //
+        // `now` and `bot_timeout_ns` were established above the `if` block
+        // for the unconditional `prune_recovered_routing_state` call;
+        // re-used here for the cascade decisions.
 
         let (bot_allowed, bot_canister, pool_canister) = read_state(|s| {
             (
@@ -972,30 +1030,21 @@ pub async fn check_vaults() {
             }
         }
 
-        // Update tracking state
-        let unhealthy_ids: std::collections::BTreeSet<u64> = vault_notifications
-            .iter()
-            .map(|v| v.vault_id)
-            .collect();
+        // Update tracking state.
+        //
+        // The `prune_recovered_routing_state` call above already retained
+        // only the entries whose vault is still in the scan's
+        // `unhealthy_ids` set. The remaining work here is to insert the
+        // newly-routed bot vaults so the timeout window starts ticking.
+        // The SP-attempted insertion is done inside the spawn's Ok arm via
+        // `record_sp_notification_result` (Wave-14a CDP-10), not here.
         let bot_vault_ids: Vec<u64> = for_bot.iter().map(|v| v.vault_id).collect();
         let pool_vault_ids: Vec<u64> = for_pool.iter().map(|v| v.vault_id).collect();
 
         mutate_state(|s| {
-            // Record newly-sent bot vaults
             for vid in &bot_vault_ids {
                 s.bot_pending_vaults.entry(*vid).or_insert(now);
             }
-            // Keep bot entries that are still unhealthy AND haven't timed out yet.
-            s.bot_pending_vaults
-                .retain(|vid, ts| unhealthy_ids.contains(vid) && now.saturating_sub(*ts) < bot_timeout_ns);
-
-            // Wave-14a CDP-10: SP-attempted insertion is now done INSIDE the
-            // spawn's Ok arm via `record_sp_notification_result`, not here.
-            // The pre-Wave-14a unconditional insert blacklisted vaults whose
-            // SP transport had failed.
-            //
-            // Clear SP tracking for vaults that are now healthy (owner repaid/added collateral)
-            s.sp_attempted_vaults.retain(|vid| unhealthy_ids.contains(vid));
         });
 
         // Push to bot (fire-and-forget with error logging)

--- a/src/rumi_protocol_backend/tests/audit_pocs_routing_state_cleanup.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_routing_state_cleanup.rs
@@ -1,0 +1,205 @@
+//! Routing-state cleanup fence (2026-05-18).
+//!
+//! # The bug
+//!
+//! Pre-2026-05-18, `check_vaults` ran the `sp_attempted_vaults.retain(...)`
+//! and `bot_pending_vaults.retain(...)` cleanup loops INSIDE the
+//! `if !unhealthy_vaults.is_empty()` branch. On any tick where no vault was
+//! currently liquidatable, the cleanup was skipped entirely. The
+//! `unhealthy_ids` set, the only thing those `retain` predicates compare
+//! against, was also only built inside that branch.
+//!
+//! Consequence: a vault that was SP-attempted during one unhealthy episode
+//! and then recovered above its liquidation floor stayed in
+//! `sp_attempted_vaults` until *another* vault happened to become
+//! liquidatable simultaneously. On a small protocol with usually 0-1
+//! liquidatable vaults at a time, that simultaneity is rare, so stale
+//! blacklist entries could persist indefinitely. When the recovered vault
+//! later dropped below its floor again, `check_vaults` line 940 said
+//! "SP already had its shot" and routed it to manual-only, denying it the
+//! bot/pool retry that the design always intended.
+//!
+//! The 2026-05-17 incident exposed this in production: vaults #149, #179,
+//! #182, #183 were SP-attempted, the band gate rejected them (`NotLowestCR`),
+//! the SP transport call still returned `Ok(())` so they got blacklisted,
+//! and after price recovery they stayed blacklisted because no other vault
+//! was simultaneously underwater.
+//!
+//! # The fix
+//!
+//! Extract the cleanup into a pure function
+//! (`prune_recovered_routing_state`) and call it from `check_vaults`
+//! UNCONDITIONALLY on every tick, including ticks where no vault is
+//! currently liquidatable. On a quiet tick, `unhealthy_ids` is empty, so
+//! both `retain` predicates evaluate false for every entry, and both
+//! collections are flushed. This is correct: if no vault is liquidatable,
+//! no vault needs a routing-state entry.
+//!
+//! # What this fence pins
+//!
+//!  1. The pure helper exists with the expected signature.
+//!  2. Empty `unhealthy_ids` flushes both collections in full.
+//!  3. Non-empty `unhealthy_ids` retains only matching entries.
+//!  4. `bot_pending_vaults` entries past `bot_timeout_ns` are dropped even
+//!     when still unhealthy (handoff to SP).
+//!  5. Reproduces the 5/17 incident at helper level: four vaults blacklisted,
+//!     then a quiet tick flushes them.
+//!  6. Idempotent: running the cleanup twice with the same args is the same
+//!     as running it once.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use candid::Principal;
+
+use rumi_protocol_backend::prune_recovered_routing_state;
+use rumi_protocol_backend::state::State;
+use rumi_protocol_backend::InitArg;
+
+const TEST_NOW_NS: u64 = 1_700_000_000_000_000_000;
+const BOT_TIMEOUT_NS: u64 = 300_000_000_000; // 5 min, matches production
+
+fn fresh_state() -> State {
+    State::from(InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: Principal::from_slice(&[10]),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    })
+}
+
+#[test]
+fn prune_empty_unhealthy_flushes_sp_attempted() {
+    // The 5/17 regression scenario at helper level: blacklist has stale
+    // entries from a prior episode, no vault is currently liquidatable, the
+    // cleanup must flush.
+    let mut state = fresh_state();
+    state.sp_attempted_vaults.insert(149);
+    state.sp_attempted_vaults.insert(179);
+    state.sp_attempted_vaults.insert(182);
+    state.sp_attempted_vaults.insert(183);
+
+    let unhealthy: BTreeSet<u64> = BTreeSet::new();
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+
+    assert!(
+        state.sp_attempted_vaults.is_empty(),
+        "quiet tick must flush sp_attempted_vaults; got {:?}",
+        state.sp_attempted_vaults,
+    );
+}
+
+#[test]
+fn prune_empty_unhealthy_flushes_bot_pending() {
+    let mut state = fresh_state();
+    state.bot_pending_vaults.insert(7, TEST_NOW_NS);
+    state.bot_pending_vaults.insert(8, TEST_NOW_NS);
+
+    let unhealthy: BTreeSet<u64> = BTreeSet::new();
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+
+    assert!(
+        state.bot_pending_vaults.is_empty(),
+        "quiet tick must flush bot_pending_vaults; got {:?}",
+        state.bot_pending_vaults,
+    );
+}
+
+#[test]
+fn prune_partial_unhealthy_keeps_only_matching_sp_attempted() {
+    let mut state = fresh_state();
+    state.sp_attempted_vaults.insert(3);
+    state.sp_attempted_vaults.insert(5);
+    state.sp_attempted_vaults.insert(7);
+
+    let mut unhealthy: BTreeSet<u64> = BTreeSet::new();
+    unhealthy.insert(5);
+
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+
+    assert_eq!(
+        state.sp_attempted_vaults,
+        [5u64].into_iter().collect::<BTreeSet<u64>>(),
+        "only vault 5 (still unhealthy) must remain blacklisted",
+    );
+}
+
+#[test]
+fn prune_partial_unhealthy_keeps_only_matching_bot_pending() {
+    let mut state = fresh_state();
+    state.bot_pending_vaults.insert(3, TEST_NOW_NS);
+    state.bot_pending_vaults.insert(5, TEST_NOW_NS);
+    state.bot_pending_vaults.insert(7, TEST_NOW_NS);
+
+    let mut unhealthy: BTreeSet<u64> = BTreeSet::new();
+    unhealthy.insert(5);
+
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+
+    let expected: BTreeMap<u64, u64> = [(5u64, TEST_NOW_NS)].into_iter().collect();
+    assert_eq!(state.bot_pending_vaults, expected);
+}
+
+#[test]
+fn prune_bot_pending_drops_timed_out_even_when_still_unhealthy() {
+    // bot_pending_vaults serves two purposes: (1) track active bot
+    // notifications, (2) hand off to SP after `bot_timeout_ns`. The cleanup
+    // must drop entries whose age >= bot_timeout_ns even if the vault is
+    // still unhealthy — the routing logic relies on absence-from-map to
+    // decide "this one falls to the pool now."
+    let mut state = fresh_state();
+    let stale_ts = TEST_NOW_NS.saturating_sub(BOT_TIMEOUT_NS + 1);
+    let fresh_ts = TEST_NOW_NS.saturating_sub(BOT_TIMEOUT_NS / 2);
+    state.bot_pending_vaults.insert(100, stale_ts);
+    state.bot_pending_vaults.insert(101, fresh_ts);
+
+    let unhealthy: BTreeSet<u64> = [100u64, 101u64].into_iter().collect();
+
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+
+    assert!(
+        !state.bot_pending_vaults.contains_key(&100),
+        "vault 100 (timed out, still unhealthy) must be dropped so SP fallback can fire",
+    );
+    assert!(
+        state.bot_pending_vaults.contains_key(&101),
+        "vault 101 (within window, still unhealthy) must be kept",
+    );
+}
+
+#[test]
+fn prune_is_idempotent() {
+    let mut state = fresh_state();
+    state.sp_attempted_vaults.insert(3);
+    state.sp_attempted_vaults.insert(5);
+    state.bot_pending_vaults.insert(3, TEST_NOW_NS);
+
+    let unhealthy: BTreeSet<u64> = [5u64].into_iter().collect();
+
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+    let after_first = (
+        state.sp_attempted_vaults.clone(),
+        state.bot_pending_vaults.clone(),
+    );
+
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+    let after_second = (
+        state.sp_attempted_vaults.clone(),
+        state.bot_pending_vaults.clone(),
+    );
+
+    assert_eq!(after_first, after_second, "prune must be idempotent");
+}
+
+#[test]
+fn prune_with_no_state_to_clean_is_a_noop() {
+    let mut state = fresh_state();
+    let unhealthy: BTreeSet<u64> = BTreeSet::new();
+    prune_recovered_routing_state(&mut state, &unhealthy, TEST_NOW_NS, BOT_TIMEOUT_NS);
+    assert!(state.sp_attempted_vaults.is_empty());
+    assert!(state.bot_pending_vaults.is_empty());
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #183. The 5/17 incident left vaults #149/#179/#182/#183 stuck in `sp_attempted_vaults`: the band gate (now removed) rejected each one after the SP transport returned `Ok`, so `record_sp_notification_result` blacklisted them, then the cleanup that should have flushed them on recovery never ran because the `retain` lived inside `if !unhealthy_vaults.is_empty()`. On a small protocol where 0-1 vaults are usually underwater at a time, that conditional almost never fires when it needs to.

## The fix

- Extract the cleanup into a pure `prune_recovered_routing_state` helper in `lib.rs`.
- Call it from `check_vaults` UNCONDITIONALLY on every tick, before the routing branch.
- On a quiet tick `unhealthy_ids` is empty, both `retain` predicates evaluate false for every entry, both collections flush. If no vault is liquidatable, no vault needs routing state.

Behavior now matches the intended design:

```
vault CR drops below floor   →   try bot (5 min)
                                  ↓ no liquidation
                                  try pool (one shot)
                                  ↓ no liquidation
                                  fall to manual

vault CR recovers above floor →  blacklist entry clears

vault CR drops below floor again → fresh bot → pool → manual cycle
```

## Self-healing for the 5/17 vaults

No post-upgrade migration. The first `check_vaults` tick after this deploy will see #149/#179/#182/#183 as healthy and flush them from `sp_attempted_vaults` automatically. Next time any of them drops below 133% they'll route through bot → pool normally.

## Test plan

- [x] `cargo build --release`: clean.
- [x] 7/7 new tests in `audit_pocs_routing_state_cleanup.rs` (the 5/17 regression at helper level, partial-unhealthy cases, bot-timeout case, idempotency, no-op).
- [x] 4/4 CDP-10 SP-blacklist fence tests still pass.
- [x] 22/22 LIQ-002 sorted-troves tests still pass.
- [x] 22/22 DOS-005 check-vaults-shard tests still pass.
- [x] 92/92 backend lib unit tests pass.
- [x] 27/27 `pocket_ic_tests` pass.
- [x] 7/7 `pocket_ic_3usd` pass.
- [x] 9/9 `rumi_3pool integration_test` pass.
- [x] 24/24 `pocket_ic_analytics` pass.

## Deploy notes

- Backend upgrade only. No state migration required.
- Suggested upgrade description: `"Prune sp_attempted_vaults and bot_pending_vaults on every check_vaults tick; self-heals 5/17 stale blacklist for #149/#179/#182/#183"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)