### PR TITLE
feat: icUSD-only SP interest + AMM1 activation + 30/15/50/5 split

### DIFF
--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -169,18 +169,26 @@ impl StabilityPoolState {
         *self.total_stablecoin_balances.entry(token_ledger).or_insert(0) += amount;
     }
 
-    /// Distribute interest revenue pro-rata to all depositors of a given stablecoin.
+    /// Distribute icUSD interest revenue to eligible icUSD-holding depositors.
     /// Called by the backend after minting interest to the pool canister.
     ///
-    /// Interest is distributed pro-rata based on each depositor's **total USD
-    /// value** across all stablecoins (icUSD, 3USD, ckUSDT, etc.), not just
-    /// their balance of the token being distributed. This ensures all depositors
-    /// earn interest proportional to their total deposit, regardless of which
-    /// stablecoin(s) they deposited.
+    /// Interest is distributed pro-rata based on each depositor's **icUSD balance
+    /// only** (computed via `DepositPosition::icusd_value`). Depositors who hold
+    /// only 3USD, ckUSDC, or ckUSDT do not earn from this stream (they still
+    /// absorb liquidations pro-rata via the separate `compute_token_draw` path,
+    /// but the protocol's borrowing-interest yield goes to icUSD holders only).
     ///
     /// When `collateral_type` is provided, depositors who have opted out of that
-    /// collateral are excluded from the distribution — they should not earn
-    /// interest from vaults backed by collateral they've opted out of.
+    /// collateral are excluded from the distribution (they should not earn
+    /// interest from vaults backed by collateral they've opted out of).
+    ///
+    /// If no eligible depositors hold icUSD when this is called, the function
+    /// logs a warning and returns without crediting anyone. The minted icUSD
+    /// remains in the SP canister's ICRC-1 balance, untracked by
+    /// `total_stablecoin_balances`. This is a known operator-visible edge case:
+    /// the icUSD will be picked up on the next distribution that has eligible
+    /// depositors, or will need manual reconciliation if the no-icUSD-depositors
+    /// state persists.
     pub fn distribute_interest_revenue(&mut self, token_ledger: Principal, amount: u64, collateral_type: Option<Principal>) {
         if amount == 0 {
             return;
@@ -211,7 +219,17 @@ impl StabilityPoolState {
 
         let eligible_total: u64 = holders.iter().map(|(_, b)| *b).sum();
         if eligible_total == 0 {
-            return; // No eligible depositors — nothing to distribute
+            // No icUSD depositors. The minted icUSD remains in the SP canister's
+            // ICRC-1 balance, untracked in total_stablecoin_balances. Surface for
+            // operator visibility: a persistent occurrence indicates the SP has
+            // drifted away from icUSD-only and may need manual reconciliation.
+            log!(
+                INFO,
+                "WARN distribute_interest_revenue: {} of token {} received but no eligible icUSD depositors; amount remains in SP canister",
+                amount,
+                token_ledger
+            );
+            return;
         }
 
         let mut distributed: u64 = 0;
@@ -1813,6 +1831,76 @@ mod tests {
             "icUSD depositor should receive the full 10 icUSD interest");
         assert_eq!(bob_icusd, 0,
             "3USD depositor should receive no icUSD interest");
+    }
+
+    #[test]
+    fn test_distribute_interest_mixed_position() {
+        // Tests the most common real-world scenario: a depositor with both icUSD
+        // and 3USD. Only the icUSD slice should count toward their interest share.
+        //
+        // Setup:
+        //   - user_a: 100 icUSD only
+        //   - user_b: 100 icUSD + 100 3USD (mixed position)
+        // Distribute: 20 icUSD interest, no collateral_type filter
+        // Expected (pro-rata on icUSD-only): each gets 10 icUSD
+        //   - user_a: 100 → 110
+        //   - user_b's icUSD: 100 → 110 (user_b's 3USD unchanged at 100)
+        let mut state = test_state_with_3usd();
+
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), three_usd_ledger(), 100_00000000);
+
+        state.distribute_interest_revenue(icusd_ledger(), 20_00000000, None);
+
+        let alice_icusd = state.deposits.get(&user_a()).unwrap()
+            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let bob_icusd = state.deposits.get(&user_b()).unwrap()
+            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let bob_three_usd = state.deposits.get(&user_b()).unwrap()
+            .stablecoin_balances.get(&three_usd_ledger()).copied().unwrap_or(0);
+
+        assert_eq!(alice_icusd, 110_00000000,
+            "user_a (100 icUSD) earns 10 icUSD on equal-icUSD share");
+        assert_eq!(bob_icusd, 110_00000000,
+            "user_b's icUSD slice (100) earns 10 icUSD (same as user_a)");
+        assert_eq!(bob_three_usd, 100_00000000,
+            "user_b's 3USD balance is not credited and not touched");
+    }
+
+    #[test]
+    fn test_distribute_interest_no_icusd_depositors() {
+        // When the pool has depositors but none hold icUSD, the function should
+        // return without crediting anyone or advancing aggregates. The icUSD
+        // amount remains in the SP canister's ICRC-1 balance (orphaned for
+        // operator visibility; see function docstring).
+        let mut state = test_state_with_3usd();
+
+        // Both depositors hold only 3USD — no icUSD anywhere
+        add_deposit_direct(&mut state, user_a(), three_usd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), three_usd_ledger(), 100_00000000);
+
+        let total_received_before = state.total_interest_received_e8s.unwrap_or(0);
+        let stable_balance_before = state.total_stablecoin_balances
+            .get(&icusd_ledger()).copied().unwrap_or(0);
+
+        state.distribute_interest_revenue(icusd_ledger(), 10_00000000, None);
+
+        // Aggregates unchanged
+        assert_eq!(state.total_interest_received_e8s.unwrap_or(0), total_received_before,
+            "total_interest_received_e8s should not advance when no icUSD depositors");
+        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0),
+            stable_balance_before,
+            "total_stablecoin_balances[icusd] should not advance");
+
+        // Neither depositor's balances changed
+        for user in [user_a(), user_b()] {
+            let pos = state.deposits.get(&user).unwrap();
+            assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 0,
+                "depositor without icUSD should not be credited");
+            assert_eq!(pos.stablecoin_balances.get(&three_usd_ledger()).copied().unwrap_or(0),
+                100_00000000, "3USD balance unchanged");
+        }
     }
 
     // ─── Test: Rounding dust doesn't drift aggregate totals ───

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -190,15 +190,13 @@ impl StabilityPoolState {
             .map(|c| c.decimals)
             .unwrap_or(8);
 
-        let vps = self.virtual_prices().clone();
-
-        // Collect eligible (principal, total_usd_value_e8s) pairs — use total
-        // deposit value across ALL stablecoins for share calculation.
-        // Exclude depositors who opted out of the collateral type.
+        // Only icUSD-denominated balances earn the interest stream.
+        // 3USD, ckUSDC, ckUSDT depositors still participate in liquidations
+        // pro-rata but no longer earn the interest distribution.
         let holders: Vec<(Principal, u64)> = self.deposits.iter()
             .filter_map(|(p, pos)| {
-                let total_value = pos.total_usd_value(&self.stablecoin_registry, &vps);
-                if total_value == 0 {
+                let icusd_value = pos.icusd_value(&self.stablecoin_registry);
+                if icusd_value == 0 {
                     return None;
                 }
                 // If we know the collateral source, skip opted-out depositors
@@ -207,7 +205,7 @@ impl StabilityPoolState {
                         return None;
                     }
                 }
-                Some((*p, total_value))
+                Some((*p, icusd_value))
             })
             .collect();
 
@@ -1742,7 +1740,9 @@ mod tests {
 
     #[test]
     fn test_distribute_interest_cross_stablecoin() {
-        // A ckUSDT-only depositor should earn interest proportional to their total value
+        // Under the icUSD-only interest rule, a ckUSDT-only depositor earns
+        // no interest. They still participate in liquidations pro-rata
+        // (separate code path) but are excluded from the interest stream.
         let mut state = test_state(); // Already has ckUSDT registered (6 decimals, priority 2)
 
         // A deposits 50 icUSD, B deposits 50 ckUSDT (both worth $50)
@@ -1754,38 +1754,65 @@ mod tests {
 
         let a = state.deposits.get(&user_a()).unwrap();
         let b = state.deposits.get(&user_b()).unwrap();
-        // Both have equal $50 deposits, so each gets 5 icUSD
-        assert_eq!(a.stablecoin_balances[&icusd_ledger()], 55_00000000, "A: 50 + 5 icUSD");
-        assert_eq!(b.stablecoin_balances[&icusd_ledger()], 5_00000000, "B: 0 + 5 icUSD (newly created)");
+        let a_interest = a.stablecoin_balances[&icusd_ledger()] - 50_00000000;
+        let b_interest = b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        // icUSD-only rule: A (the icUSD depositor) gets the full 10 icUSD,
+        // B (the ckUSDT depositor) gets nothing.
+        assert_eq!(a_interest, 10_00000000, "icUSD depositor should receive the full 10 icUSD interest");
+        assert_eq!(b_interest, 0, "ckUSDT depositor should earn no interest under icUSD-only rule");
         assert_eq!(b.stablecoin_balances[&ckusdt_ledger()], 50_000_000, "B: ckUSDT unchanged");
         assert_eq!(state.total_stablecoin_balances[&icusd_ledger()], 60_00000000);
     }
 
     #[test]
     fn test_distribute_interest_3usd_lp_depositor() {
-        // 3USD LP depositor should earn interest based on virtual-price-adjusted value
+        // Under the icUSD-only interest rule, a 3USD LP depositor earns
+        // no interest. They still participate in liquidations pro-rata
+        // (separate code path) but are excluded from the interest stream.
         let mut state = test_state_with_3usd();
 
         // A deposits 100 icUSD ($100), B deposits 100 3USD (worth ~$104.92 at vp=1.0492)
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
         add_deposit_direct(&mut state, user_b(), three_usd_ledger(), 100_00000000);
 
-        // Total value: A=$100 + B=~$104.92 = ~$204.92
         // Distribute 20 icUSD interest
         state.distribute_interest_revenue(icusd_ledger(), 20_00000000, None);
 
         let a = state.deposits.get(&user_a()).unwrap();
         let b = state.deposits.get(&user_b()).unwrap();
-        // A's share: 20 * 100_00000000 / 204_92000000 ≈ 9.76 icUSD
-        // B's share: 20 * 104_92000000 / 204_92000000 ≈ 10.24 icUSD
         let a_interest = a.stablecoin_balances[&icusd_ledger()] - 100_00000000;
         let b_interest = b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
-        // Total interest must equal 20 icUSD
-        assert_eq!(a_interest + b_interest, 20_00000000, "All interest accounted for");
-        // B (3USD depositor) should have earned interest
-        assert!(b_interest > 0, "3USD depositor must earn interest");
-        // B should get slightly more than A since 3USD is worth more at vp > 1.0
-        assert!(b_interest > a_interest, "3USD depositor earns more due to higher value");
+        // icUSD-only rule: A (the icUSD depositor) takes the entire 20 icUSD,
+        // B (the 3USD LP depositor) gets nothing.
+        assert_eq!(a_interest, 20_00000000, "icUSD depositor should receive the full 20 icUSD interest");
+        assert_eq!(b_interest, 0, "3USD depositor should earn no interest under icUSD-only rule");
+        assert_eq!(b.stablecoin_balances[&three_usd_ledger()], 100_00000000, "B: 3USD position unchanged");
+    }
+
+    #[test]
+    fn test_distribute_interest_icusd_only() {
+        // Two depositors, both opted in for ICP collateral interest:
+        //   - user_a: 100 icUSD
+        //   - user_b: 100 3USD (LP token, virtual_price = 1.0492)
+        // Interest of 10 icUSD is distributed.
+        // Expected (under icUSD-only rule): user_a gets 10 icUSD, user_b gets 0.
+        let mut state = test_state_with_3usd();
+
+        // Deposit 100 icUSD for user_a, 100 3USD for user_b (both opted in for ICP by default)
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), three_usd_ledger(), 100_00000000);
+
+        state.distribute_interest_revenue(icusd_ledger(), 10_00000000, Some(icp_ledger()));
+
+        let alice_icusd = state.deposits.get(&user_a()).unwrap()
+            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let bob_icusd = state.deposits.get(&user_b()).unwrap()
+            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+
+        assert_eq!(alice_icusd, 100_00000000 + 10_00000000,
+            "icUSD depositor should receive the full 10 icUSD interest");
+        assert_eq!(bob_icusd, 0,
+            "3USD depositor should receive no icUSD interest");
     }
 
     // ─── Test: Rounding dust doesn't drift aggregate totals ───

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -103,6 +103,24 @@ impl DepositPosition {
         }).sum()
     }
 
+    /// icUSD-only stablecoin value in e8s.
+    /// Identifies the icUSD ledger by symbol from the registry. Returns 0 if
+    /// no icUSD ledger is registered or the depositor holds no icUSD.
+    /// icUSD is 8 decimals, so the raw balance is the e8s value directly.
+    pub fn icusd_value(
+        &self,
+        stablecoin_registry: &BTreeMap<Principal, StablecoinConfig>,
+    ) -> u64 {
+        let icusd_ledger = stablecoin_registry.iter()
+            .find(|(_, c)| c.symbol == "icUSD")
+            .map(|(id, _)| *id);
+
+        match icusd_ledger {
+            Some(ledger) => self.stablecoin_balances.get(&ledger).copied().unwrap_or(0),
+            None => 0,
+        }
+    }
+
     /// Whether this user is opted in for a given collateral type.
     pub fn is_opted_in(&self, collateral_type: &Principal) -> bool {
         !self.opted_out_collateral.contains(collateral_type)
@@ -492,4 +510,71 @@ pub struct RedeemAndBurnResult {
     pub token_amount_burned: u128,
     pub lp_amount_burned: u128,
     pub burn_block_index: u64,
+}
+
+#[cfg(test)]
+mod icusd_value_tests {
+    use super::*;
+    use candid::Principal;
+    use std::collections::BTreeMap;
+
+    fn config(ledger: Principal, symbol: &str, decimals: u8, priority: u8, is_lp: bool) -> StablecoinConfig {
+        StablecoinConfig {
+            ledger_id: ledger,
+            symbol: symbol.to_string(),
+            decimals,
+            priority,
+            is_active: true,
+            transfer_fee: None,
+            is_lp_token: if is_lp { Some(true) } else { None },
+            underlying_pool: None,
+        }
+    }
+
+    #[test]
+    fn icusd_value_returns_only_icusd_balance() {
+        let icusd = Principal::from_text("t6bor-paaaa-aaaap-qrd5q-cai").unwrap();
+        let ckusdc = Principal::from_text("xevnm-gaaaa-aaaar-qafnq-cai").unwrap();
+        let three_usd = Principal::from_text("fohh4-yyaaa-aaaap-qtkpa-cai").unwrap();
+
+        let mut registry = BTreeMap::new();
+        registry.insert(icusd, config(icusd, "icUSD", 8, 1, false));
+        registry.insert(ckusdc, config(ckusdc, "ckUSDC", 6, 1, false));
+        registry.insert(three_usd, config(three_usd, "3USD", 8, 1, true));
+
+        let mut pos = DepositPosition::new(0);
+        pos.stablecoin_balances.insert(icusd, 100_00_000_000); // 100 icUSD (e8s)
+        pos.stablecoin_balances.insert(ckusdc, 200_000_000);   // 200 ckUSDC (e6s)
+        pos.stablecoin_balances.insert(three_usd, 50_00_000_000); // 50 3USD (e8s)
+
+        let v = pos.icusd_value(&registry);
+        assert_eq!(v, 100_00_000_000, "should return only the icUSD balance in e8s");
+    }
+
+    #[test]
+    fn icusd_value_zero_when_no_icusd_balance() {
+        let icusd = Principal::from_text("t6bor-paaaa-aaaap-qrd5q-cai").unwrap();
+        let ckusdc = Principal::from_text("xevnm-gaaaa-aaaar-qafnq-cai").unwrap();
+
+        let mut registry = BTreeMap::new();
+        registry.insert(icusd, config(icusd, "icUSD", 8, 1, false));
+        registry.insert(ckusdc, config(ckusdc, "ckUSDC", 6, 1, false));
+
+        let mut pos = DepositPosition::new(0);
+        pos.stablecoin_balances.insert(ckusdc, 500_000_000);
+
+        assert_eq!(pos.icusd_value(&registry), 0);
+    }
+
+    #[test]
+    fn icusd_value_zero_when_registry_has_no_icusd() {
+        let icusd = Principal::from_text("t6bor-paaaa-aaaap-qrd5q-cai").unwrap();
+        let registry: BTreeMap<Principal, StablecoinConfig> = BTreeMap::new();
+
+        let mut pos = DepositPosition::new(0);
+        pos.stablecoin_balances.insert(icusd, 100_00_000_000);
+
+        assert_eq!(pos.icusd_value(&registry), 0,
+            "registry without icUSD config means we can't identify which ledger is icUSD");
+    }
 }

--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -137,9 +137,9 @@
         {#if showApyTooltip}
           <div class="apy-tooltip">
             <div class="apy-tooltip-caret"></div>
-            <p><strong>Interest APY</strong> applies to <strong>icUSD</strong> deposits. icUSD depositors earn a share of all borrowing interest paid by vault owners.</p>
+            <p><strong>Interest APY</strong> applies to <strong>icUSD</strong> deposits only. icUSD depositors earn a share of all borrowing interest paid by vault owners.</p>
             <div class="apy-tooltip-divider"></div>
-            <p><strong>ckUSDC</strong>, <strong>ckUSDT</strong>, and <strong>3USD</strong> deposits don't earn interest directly, but are used <em>first</em> for liquidations, giving priority access to discounted collateral. <strong>3USD</strong> LP tokens also earn yield from swap fees and interest donations in the 3pool.</p>
+            <p><strong>ckUSDC</strong>, <strong>ckUSDT</strong>, and <strong>3USD</strong> deposits don't earn interest, but still absorb liquidations pro-rata alongside icUSD — every depositor receives discounted collateral on the same terms when liquidations fire. <strong>3USD</strong> LP tokens also earn yield from swap fees and interest donations in the 3pool.</p>
           </div>
         {/if}
       </div>

--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -139,7 +139,8 @@
             <div class="apy-tooltip-caret"></div>
             <p><strong>Interest APY</strong> applies to <strong>icUSD</strong> deposits only. icUSD depositors earn a share of all borrowing interest paid by vault owners.</p>
             <div class="apy-tooltip-divider"></div>
-            <p><strong>ckUSDC</strong>, <strong>ckUSDT</strong>, and <strong>3USD</strong> deposits don't earn interest, but still absorb liquidations pro-rata alongside icUSD — every depositor receives discounted collateral on the same terms when liquidations fire. <strong>3USD</strong> LP tokens also earn yield from swap fees and interest donations in the 3pool.</p>
+            <p><strong>ckUSDC</strong> and <strong>ckUSDT</strong> deposits don't earn interest, but get <em>first</em> priority in liquidations — they're consumed before icUSD and 3USD, giving them earliest access to discounted collateral.</p>
+            <p><strong>3USD</strong> deposits sit at the same priority as icUSD for liquidations. They don't earn interest in the pool, but 3USD LP tokens earn yield from swap fees and interest donations in the 3pool itself.</p>
           </div>
         {/if}
       </div>


### PR DESCRIPTION
## Summary

Three coordinated changes shipping as one design pivot, deployed to mainnet 2026-05-18:

- **SP interest distribution is icUSD-only.** `distribute_interest_revenue` now computes pro-rata shares against `DepositPosition::icusd_value` instead of `total_usd_value`. 3USD/ckUSDC/ckUSDT depositors no longer earn the protocol interest stream. They still absorb liquidations pro-rata per their priority tier.
- **AMM1 activated as the fourth interest destination** (completes the other session's pending Step 5 of the AMM1 earnings runbook). AMM1 wasm + `set_amm1_canister` were already in place from that session; this PR's deploy adds the missing piece.
- **New interest split: 30% 3pool / 15% AMM1 / 50% SP / 5% Treasury** (was 75/22/3 with no AMM1).

Liquidation priorities are UNCHANGED — ckUSDC/ckUSDT at priority=2 (consumed first), icUSD/3USD at priority=1 (consumed second). Initial design considered equalizing; reversed after discussion (current tiered structure is what's intended).

Frontend tooltip rewritten to describe the actual behavior: tiered liquidation priority + icUSD-only interest.

## Mainnet state (already deployed)

| Canister | Pre-deploy | Post-deploy |
|----------|------------|-------------|
| `rumi_stability_pool` | `0x46eacfe7...` | `0x2fcc5fee...` |
| `rumi_protocol_backend` | `0x51bbdc58...` | unchanged (admin call only) |
| `vault_frontend` | asset upgrade | asset state updated |

Admin call: `set_interest_split` → 3000/1500/5000/500 bps.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` — 396 passed, 1 ignored, 0 failed
- [x] SP lib: 42 passed (3 new in `icusd_value_tests`, 2 new in `state.rs`, 37 existing)
- [x] Mainnet deploy + verification: SP module hash changed, depositors intact (5), priorities preserved, interest split flipped successfully
- [x] Frontend deployed; tooltip text live on app.rumiprotocol.com
- [ ] T+1hr check: first AMM1 donation arrives on next harvest tick
- [ ] T+1day check: TVL snapshot
- [ ] T+1week check: re-tune decision

## Known open item

`distribute_interest_revenue` silently leaves orphan icUSD in the SP canister's ICRC-1 balance when called with no eligible icUSD depositors. Log warning fires for operator visibility. Tests lock in this behavior; thorough fix (treasury fallback or deficit-account routing) is a follow-up.

## Commits

- `f5d6fff` feat(stability_pool): add icusd_value helper on DepositPosition
- `7f440cb` feat(stability_pool): icUSD-only interest distribution
- `d410d96` fix(stability_pool): address Task 2 review feedback
- `79ef9df` fix(frontend): tooltip matches new SP behavior (pro-rata wording, then corrected by 10ef01c)
- `10ef01c` fix(frontend): tooltip describes tiered liquidation priority

Forum announcement draft local-only at `docs/announcements/2026-05-18-sp-icusd-only-interest-amm1-activation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)