### PR TITLE
feat(frontend): surface bot liquidation history

### DIFF
--- a/src/declarations/liquidation_bot/index.d.ts
+++ b/src/declarations/liquidation_bot/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './liquidation_bot.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const liquidation_bot: ActorSubclass<_SERVICE>;

--- a/src/declarations/liquidation_bot/index.js
+++ b/src/declarations/liquidation_bot/index.js
@@ -1,0 +1,42 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./liquidation_bot.did.js";
+export { idlFactory } from "./liquidation_bot.did.js";
+
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_LIQUIDATION_BOT;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const liquidation_bot = canisterId ? createActor(canisterId) : undefined;

--- a/src/declarations/liquidation_bot/liquidation_bot.did
+++ b/src/declarations/liquidation_bot/liquidation_bot.did
@@ -1,0 +1,119 @@
+type BotConfig = record {
+  backend_principal : principal;
+  treasury_principal : principal;
+  admin : principal;
+  max_slippage_bps : nat16;
+  icp_ledger : principal;
+  ckusdc_ledger : principal;
+  icpswap_pool : principal;
+  icpswap_zero_for_one : opt bool;
+  icp_fee_e8s : opt nat64;
+  ckusdc_fee_e6 : opt nat64;
+  // Legacy fields (ignored, kept for deserialization compat)
+  three_pool_principal : opt principal;
+  kong_swap_principal : opt principal;
+  ckusdt_ledger : opt principal;
+  icusd_ledger : opt principal;
+};
+
+type BotInitArgs = record {
+  config : BotConfig;
+};
+
+type BotStats = record {
+  total_debt_covered_e8s : nat64;
+  total_ckusdc_deposited_e6 : nat64;
+  total_collateral_received_e8s : nat64;
+  total_collateral_to_treasury_e8s : nat64;
+  events_count : nat64;
+};
+
+type LiquidatableVaultInfo = record {
+  vault_id : nat64;
+  collateral_type : principal;
+  debt_amount : nat64;
+  collateral_amount : nat64;
+  recommended_liquidation_amount : nat64;
+  collateral_price_e8s : nat64;
+};
+
+type LiquidationStatus = variant {
+  Completed;
+  SwapFailed;
+  TransferFailed;
+  ConfirmFailed;
+  ClaimFailed;
+  AdminResolved;
+};
+
+type LiquidationRecordV1 = record {
+  id : nat64;
+  vault_id : nat64;
+  timestamp : nat64;
+  status : LiquidationStatus;
+  collateral_claimed_e8s : nat64;
+  debt_to_cover_e8s : nat64;
+  icp_swapped_e8s : nat64;
+  ckusdc_received_e6 : nat64;
+  ckusdc_transferred_e6 : nat64;
+  icp_to_treasury_e8s : nat64;
+  oracle_price_e8s : nat64;
+  effective_price_e8s : nat64;
+  slippage_bps : int32;
+  error_message : opt text;
+  confirm_retry_count : nat8;
+};
+
+type LiquidationRecordVersioned = variant {
+  V1 : LiquidationRecordV1;
+};
+
+type BotAdminAction = variant {
+  ConfigUpdated;
+  VaultsNotified : record { count : nat64 };
+};
+
+type BotAdminEvent = record {
+  timestamp : nat64;
+  caller : text;
+  action : BotAdminAction;
+};
+
+type SwapResult = record {
+  ckusdc_received_e6 : nat64;
+  effective_price_e8s : nat64;
+};
+
+type TestSwapResult = variant { Ok : SwapResult; Err : text };
+
+service : (BotInitArgs) -> {
+  // Core
+  notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> ();
+  set_config : (BotConfig) -> ();
+
+  // Stats
+  get_bot_stats : () -> (BotStats) query;
+
+  // History
+  get_liquidation : (nat64) -> (opt LiquidationRecordVersioned) query;
+  get_liquidations : (nat64, nat64) -> (vec LiquidationRecordVersioned) query;
+  get_liquidation_count : () -> (nat64) query;
+  get_stuck_liquidations : () -> (vec LiquidationRecordVersioned) query;
+  get_liquidation_events : (nat64, nat64) -> (vec LiquidationRecordVersioned) query;
+
+  // Admin events
+  get_admin_events : (nat64, nat64) -> (vec BotAdminEvent) query;
+  get_admin_event_count : () -> (nat64) query;
+
+  // Admin actions
+  admin_resolve_pool_ordering : () -> ();
+  admin_approve_pool : () -> ();
+  admin_sweep_ckusdc : (principal, opt nat64) -> ();
+  admin_retry_stuck_claim : (nat64) -> ();
+  // Returns (icp_fee_e8s, ckusdc_fee_e6) freshly read from each ledger and
+  // also writes them back into BotConfig so future swaps use the live values.
+  admin_refresh_fees : () -> (nat64, nat64);
+  // Runs the live swap path (ICP -> ckUSDC) using `amount_e8s` from the bot's
+  // ICP balance. ckUSDC stays in the bot; retrieve via `admin_sweep_ckusdc`.
+  admin_test_swap : (nat64) -> (TestSwapResult);
+};

--- a/src/declarations/liquidation_bot/liquidation_bot.did.d.ts
+++ b/src/declarations/liquidation_bot/liquidation_bot.did.d.ts
@@ -1,0 +1,128 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+export type BotAdminAction = { 'VaultsNotified' : { 'count' : bigint } } |
+  { 'ConfigUpdated' : null };
+export interface BotAdminEvent {
+  'action' : BotAdminAction,
+  'timestamp' : bigint,
+  'caller' : string,
+}
+export interface BotConfig {
+  'ckusdt_ledger' : [] | [Principal],
+  'icp_fee_e8s' : [] | [bigint],
+  'admin' : Principal,
+  'backend_principal' : Principal,
+  'icpswap_zero_for_one' : [] | [boolean],
+  'ckusdc_ledger' : Principal,
+  'kong_swap_principal' : [] | [Principal],
+  'icp_ledger' : Principal,
+  'treasury_principal' : Principal,
+  'icpswap_pool' : Principal,
+  'icusd_ledger' : [] | [Principal],
+  'max_slippage_bps' : number,
+  'ckusdc_fee_e6' : [] | [bigint],
+  /**
+   * Legacy fields (ignored, kept for deserialization compat)
+   */
+  'three_pool_principal' : [] | [Principal],
+}
+export interface BotInitArgs { 'config' : BotConfig }
+export interface BotStats {
+  'total_debt_covered_e8s' : bigint,
+  'total_collateral_to_treasury_e8s' : bigint,
+  'total_ckusdc_deposited_e6' : bigint,
+  'events_count' : bigint,
+  'total_collateral_received_e8s' : bigint,
+}
+export interface LiquidatableVaultInfo {
+  'collateral_amount' : bigint,
+  'recommended_liquidation_amount' : bigint,
+  'collateral_price_e8s' : bigint,
+  'debt_amount' : bigint,
+  'vault_id' : bigint,
+  'collateral_type' : Principal,
+}
+export interface LiquidationRecordV1 {
+  'id' : bigint,
+  'status' : LiquidationStatus,
+  'ckusdc_transferred_e6' : bigint,
+  'oracle_price_e8s' : bigint,
+  'ckusdc_received_e6' : bigint,
+  'error_message' : [] | [string],
+  'icp_to_treasury_e8s' : bigint,
+  'collateral_claimed_e8s' : bigint,
+  'vault_id' : bigint,
+  'slippage_bps' : number,
+  'timestamp' : bigint,
+  'confirm_retry_count' : number,
+  'debt_to_cover_e8s' : bigint,
+  'effective_price_e8s' : bigint,
+  'icp_swapped_e8s' : bigint,
+}
+export type LiquidationRecordVersioned = { 'V1' : LiquidationRecordV1 };
+export type LiquidationStatus = { 'ClaimFailed' : null } |
+  { 'SwapFailed' : null } |
+  { 'ConfirmFailed' : null } |
+  { 'AdminResolved' : null } |
+  { 'TransferFailed' : null } |
+  { 'Completed' : null };
+export interface SwapResult {
+  'ckusdc_received_e6' : bigint,
+  'effective_price_e8s' : bigint,
+}
+export type TestSwapResult = { 'Ok' : SwapResult } |
+  { 'Err' : string };
+export interface _SERVICE {
+  'admin_approve_pool' : ActorMethod<[], undefined>,
+  /**
+   * Returns (icp_fee_e8s, ckusdc_fee_e6) freshly read from each ledger and
+   * also writes them back into BotConfig so future swaps use the live values.
+   */
+  'admin_refresh_fees' : ActorMethod<[], [bigint, bigint]>,
+  /**
+   * Admin actions
+   */
+  'admin_resolve_pool_ordering' : ActorMethod<[], undefined>,
+  'admin_retry_stuck_claim' : ActorMethod<[bigint], undefined>,
+  'admin_sweep_ckusdc' : ActorMethod<[Principal, [] | [bigint]], undefined>,
+  /**
+   * Runs the live swap path (ICP -> ckUSDC) using `amount_e8s` from the bot's
+   * ICP balance. ckUSDC stays in the bot; retrieve via `admin_sweep_ckusdc`.
+   */
+  'admin_test_swap' : ActorMethod<[bigint], TestSwapResult>,
+  'get_admin_event_count' : ActorMethod<[], bigint>,
+  /**
+   * Admin events
+   */
+  'get_admin_events' : ActorMethod<[bigint, bigint], Array<BotAdminEvent>>,
+  /**
+   * Stats
+   */
+  'get_bot_stats' : ActorMethod<[], BotStats>,
+  /**
+   * History
+   */
+  'get_liquidation' : ActorMethod<[bigint], [] | [LiquidationRecordVersioned]>,
+  'get_liquidation_count' : ActorMethod<[], bigint>,
+  'get_liquidation_events' : ActorMethod<
+    [bigint, bigint],
+    Array<LiquidationRecordVersioned>
+  >,
+  'get_liquidations' : ActorMethod<
+    [bigint, bigint],
+    Array<LiquidationRecordVersioned>
+  >,
+  'get_stuck_liquidations' : ActorMethod<[], Array<LiquidationRecordVersioned>>,
+  /**
+   * Core
+   */
+  'notify_liquidatable_vaults' : ActorMethod<
+    [Array<LiquidatableVaultInfo>],
+    undefined
+  >,
+  'set_config' : ActorMethod<[BotConfig], undefined>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/liquidation_bot/liquidation_bot.did.js
+++ b/src/declarations/liquidation_bot/liquidation_bot.did.js
@@ -1,0 +1,142 @@
+export const idlFactory = ({ IDL }) => {
+  const BotConfig = IDL.Record({
+    'ckusdt_ledger' : IDL.Opt(IDL.Principal),
+    'icp_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'admin' : IDL.Principal,
+    'backend_principal' : IDL.Principal,
+    'icpswap_zero_for_one' : IDL.Opt(IDL.Bool),
+    'ckusdc_ledger' : IDL.Principal,
+    'kong_swap_principal' : IDL.Opt(IDL.Principal),
+    'icp_ledger' : IDL.Principal,
+    'treasury_principal' : IDL.Principal,
+    'icpswap_pool' : IDL.Principal,
+    'icusd_ledger' : IDL.Opt(IDL.Principal),
+    'max_slippage_bps' : IDL.Nat16,
+    'ckusdc_fee_e6' : IDL.Opt(IDL.Nat64),
+    'three_pool_principal' : IDL.Opt(IDL.Principal),
+  });
+  const BotInitArgs = IDL.Record({ 'config' : BotConfig });
+  const SwapResult = IDL.Record({
+    'ckusdc_received_e6' : IDL.Nat64,
+    'effective_price_e8s' : IDL.Nat64,
+  });
+  const TestSwapResult = IDL.Variant({ 'Ok' : SwapResult, 'Err' : IDL.Text });
+  const BotAdminAction = IDL.Variant({
+    'VaultsNotified' : IDL.Record({ 'count' : IDL.Nat64 }),
+    'ConfigUpdated' : IDL.Null,
+  });
+  const BotAdminEvent = IDL.Record({
+    'action' : BotAdminAction,
+    'timestamp' : IDL.Nat64,
+    'caller' : IDL.Text,
+  });
+  const BotStats = IDL.Record({
+    'total_debt_covered_e8s' : IDL.Nat64,
+    'total_collateral_to_treasury_e8s' : IDL.Nat64,
+    'total_ckusdc_deposited_e6' : IDL.Nat64,
+    'events_count' : IDL.Nat64,
+    'total_collateral_received_e8s' : IDL.Nat64,
+  });
+  const LiquidationStatus = IDL.Variant({
+    'ClaimFailed' : IDL.Null,
+    'SwapFailed' : IDL.Null,
+    'ConfirmFailed' : IDL.Null,
+    'AdminResolved' : IDL.Null,
+    'TransferFailed' : IDL.Null,
+    'Completed' : IDL.Null,
+  });
+  const LiquidationRecordV1 = IDL.Record({
+    'id' : IDL.Nat64,
+    'status' : LiquidationStatus,
+    'ckusdc_transferred_e6' : IDL.Nat64,
+    'oracle_price_e8s' : IDL.Nat64,
+    'ckusdc_received_e6' : IDL.Nat64,
+    'error_message' : IDL.Opt(IDL.Text),
+    'icp_to_treasury_e8s' : IDL.Nat64,
+    'collateral_claimed_e8s' : IDL.Nat64,
+    'vault_id' : IDL.Nat64,
+    'slippage_bps' : IDL.Int32,
+    'timestamp' : IDL.Nat64,
+    'confirm_retry_count' : IDL.Nat8,
+    'debt_to_cover_e8s' : IDL.Nat64,
+    'effective_price_e8s' : IDL.Nat64,
+    'icp_swapped_e8s' : IDL.Nat64,
+  });
+  const LiquidationRecordVersioned = IDL.Variant({
+    'V1' : LiquidationRecordV1,
+  });
+  const LiquidatableVaultInfo = IDL.Record({
+    'collateral_amount' : IDL.Nat64,
+    'recommended_liquidation_amount' : IDL.Nat64,
+    'collateral_price_e8s' : IDL.Nat64,
+    'debt_amount' : IDL.Nat64,
+    'vault_id' : IDL.Nat64,
+    'collateral_type' : IDL.Principal,
+  });
+  return IDL.Service({
+    'admin_approve_pool' : IDL.Func([], [], []),
+    'admin_refresh_fees' : IDL.Func([], [IDL.Nat64, IDL.Nat64], []),
+    'admin_resolve_pool_ordering' : IDL.Func([], [], []),
+    'admin_retry_stuck_claim' : IDL.Func([IDL.Nat64], [], []),
+    'admin_sweep_ckusdc' : IDL.Func(
+        [IDL.Principal, IDL.Opt(IDL.Nat64)],
+        [],
+        [],
+      ),
+    'admin_test_swap' : IDL.Func([IDL.Nat64], [TestSwapResult], []),
+    'get_admin_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_admin_events' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(BotAdminEvent)],
+        ['query'],
+      ),
+    'get_bot_stats' : IDL.Func([], [BotStats], ['query']),
+    'get_liquidation' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Opt(LiquidationRecordVersioned)],
+        ['query'],
+      ),
+    'get_liquidation_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_liquidation_events' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidationRecordVersioned)],
+        ['query'],
+      ),
+    'get_liquidations' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(LiquidationRecordVersioned)],
+        ['query'],
+      ),
+    'get_stuck_liquidations' : IDL.Func(
+        [],
+        [IDL.Vec(LiquidationRecordVersioned)],
+        ['query'],
+      ),
+    'notify_liquidatable_vaults' : IDL.Func(
+        [IDL.Vec(LiquidatableVaultInfo)],
+        [],
+        [],
+      ),
+    'set_config' : IDL.Func([BotConfig], [], []),
+  });
+};
+export const init = ({ IDL }) => {
+  const BotConfig = IDL.Record({
+    'ckusdt_ledger' : IDL.Opt(IDL.Principal),
+    'icp_fee_e8s' : IDL.Opt(IDL.Nat64),
+    'admin' : IDL.Principal,
+    'backend_principal' : IDL.Principal,
+    'icpswap_zero_for_one' : IDL.Opt(IDL.Bool),
+    'ckusdc_ledger' : IDL.Principal,
+    'kong_swap_principal' : IDL.Opt(IDL.Principal),
+    'icp_ledger' : IDL.Principal,
+    'treasury_principal' : IDL.Principal,
+    'icpswap_pool' : IDL.Principal,
+    'icusd_ledger' : IDL.Opt(IDL.Principal),
+    'max_slippage_bps' : IDL.Nat16,
+    'ckusdc_fee_e6' : IDL.Opt(IDL.Nat64),
+    'three_pool_principal' : IDL.Opt(IDL.Principal),
+  });
+  const BotInitArgs = IDL.Record({ 'config' : BotConfig });
+  return [BotInitArgs];
+};

--- a/src/vault_frontend/src/lib/components/liquidations/BotLiquidationsTable.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/BotLiquidationsTable.svelte
@@ -1,0 +1,427 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    fetchBotLiquidations,
+    fetchBotLiquidationCount,
+    fetchStuckBotLiquidations,
+  } from '$services/explorer/explorerService';
+  import type { LiquidationRecordV1, LiquidationStatus } from '$declarations/liquidation_bot/liquidation_bot.did';
+  import LoadingSpinner from '../common/LoadingSpinner.svelte';
+
+  export let pageSize: number = 20;
+  /** Optional pre-filter: only show records with this status. */
+  export let initialStatusFilter: 'all' | 'completed' | 'failed' = 'all';
+  /** Hide records whose error_message contains "test_force_liquidate". */
+  export let hideTestRecords: boolean = true;
+
+  let loading = true;
+  let error = '';
+  let records: LiquidationRecordV1[] = [];
+  let stuckRecords: LiquidationRecordV1[] = [];
+  let total = 0n;
+  let loadedPages = 0;
+  let loadingMore = false;
+
+  let statusFilter: 'all' | 'completed' | 'failed' = initialStatusFilter;
+  let hideTests = hideTestRecords;
+
+  const E8S = 100_000_000;
+  const E6 = 1_000_000;
+
+  function statusName(status: LiquidationStatus): string {
+    return Object.keys(status)[0] ?? 'Unknown';
+  }
+
+  function isCompleted(status: LiquidationStatus): boolean {
+    return 'Completed' in status || 'AdminResolved' in status;
+  }
+
+  function isFailed(status: LiquidationStatus): boolean {
+    return 'SwapFailed' in status
+      || 'ClaimFailed' in status
+      || 'TransferFailed' in status
+      || 'ConfirmFailed' in status;
+  }
+
+  function statusClass(status: LiquidationStatus): string {
+    if ('Completed' in status) return 'ok';
+    if ('AdminResolved' in status) return 'admin';
+    if (isFailed(status)) return 'fail';
+    return '';
+  }
+
+  function statusLabel(status: LiquidationStatus): string {
+    const name = statusName(status);
+    if (name === 'SwapFailed') return 'Swap Failed';
+    if (name === 'ClaimFailed') return 'Claim Failed';
+    if (name === 'TransferFailed') return 'Transfer Failed';
+    if (name === 'ConfirmFailed') return 'Confirm Failed';
+    if (name === 'AdminResolved') return 'Admin Resolved';
+    return name;
+  }
+
+  function isTestRecord(r: LiquidationRecordV1): boolean {
+    const msg = r.error_message[0] ?? '';
+    return msg.includes('test_force_liquidate');
+  }
+
+  $: filtered = records.filter((r) => {
+    if (hideTests && isTestRecord(r)) return false;
+    if (statusFilter === 'completed' && !isCompleted(r.status)) return false;
+    if (statusFilter === 'failed' && !isFailed(r.status)) return false;
+    return true;
+  });
+
+  $: canLoadMore = BigInt(records.length) < total;
+
+  function fmtE8s(v: bigint | number, decimals = 4): string {
+    return (Number(v) / E8S).toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+
+  function fmtE6(v: bigint | number, decimals = 2): string {
+    return (Number(v) / E6).toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+
+  function fmtRelativeTime(ns: bigint): string {
+    const ms = Number(ns) / 1_000_000;
+    const date = new Date(ms);
+    const diffMs = Date.now() - ms;
+    const diffMin = Math.floor(diffMs / 60_000);
+    const diffHr = Math.floor(diffMs / 3_600_000);
+    const diffDay = Math.floor(diffMs / 86_400_000);
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffHr < 24) return `${diffHr}h ago`;
+    if (diffDay < 30) return `${diffDay}d ago`;
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  function fmtAbsoluteTime(ns: bigint): string {
+    const ms = Number(ns) / 1_000_000;
+    return new Date(ms).toLocaleString();
+  }
+
+  function fmtBps(bps: number): string {
+    if (!bps) return '—';
+    return `${(bps / 100).toFixed(2)}%`;
+  }
+
+  async function load() {
+    try {
+      loading = true;
+      error = '';
+      const [first, stuck] = await Promise.all([
+        fetchBotLiquidations(0, pageSize),
+        fetchStuckBotLiquidations(),
+      ]);
+      records = first.records;
+      total = first.total;
+      stuckRecords = stuck;
+      loadedPages = 1;
+    } catch (err: any) {
+      console.error('[BotLiquidationsTable] load failed:', err);
+      error = err?.message ?? 'Failed to load bot liquidation history';
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadMore() {
+    if (loadingMore || !canLoadMore) return;
+    try {
+      loadingMore = true;
+      const next = await fetchBotLiquidations(loadedPages, pageSize);
+      records = [...records, ...next.records];
+      loadedPages += 1;
+    } catch (err: any) {
+      console.error('[BotLiquidationsTable] loadMore failed:', err);
+      error = err?.message ?? 'Failed to load more records';
+    } finally {
+      loadingMore = false;
+    }
+  }
+
+  onMount(() => { load(); });
+</script>
+
+{#if loading}
+  <div class="state">
+    <LoadingSpinner />
+    <p class="state-text">Loading liquidation history…</p>
+  </div>
+{:else if error}
+  <div class="state">
+    <p class="state-text error">{error}</p>
+    <button class="btn-secondary" on:click={load}>Retry</button>
+  </div>
+{:else}
+  {#if stuckRecords.length > 0}
+    <div class="stuck-banner">
+      <div class="stuck-icon">!</div>
+      <div class="stuck-body">
+        <div class="stuck-title">{stuckRecords.length} stuck claim{stuckRecords.length === 1 ? '' : 's'} awaiting admin resolution</div>
+        <div class="stuck-detail">
+          {#each stuckRecords as r, i (r.id)}
+            <span>#{r.vault_id} ({statusLabel(r.status)}){i < stuckRecords.length - 1 ? ', ' : ''}</span>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <div class="filters">
+    <div class="filter-group">
+      <button
+        class="filter-btn"
+        class:active={statusFilter === 'all'}
+        on:click={() => (statusFilter = 'all')}
+      >All</button>
+      <button
+        class="filter-btn"
+        class:active={statusFilter === 'completed'}
+        on:click={() => (statusFilter = 'completed')}
+      >Completed</button>
+      <button
+        class="filter-btn"
+        class:active={statusFilter === 'failed'}
+        on:click={() => (statusFilter = 'failed')}
+      >Failed</button>
+    </div>
+    <label class="hide-tests">
+      <input type="checkbox" bind:checked={hideTests} />
+      <span>Hide test entries</span>
+    </label>
+    <span class="count">{filtered.length} of {records.length} loaded · {Number(total)} total</span>
+  </div>
+
+  {#if filtered.length === 0}
+    <div class="state">
+      <p class="state-text">No records match the current filter.</p>
+    </div>
+  {:else}
+    <div class="table-wrap">
+      <div class="table">
+        <div class="row head">
+          <span>Date</span>
+          <span>Status</span>
+          <span>Vault</span>
+          <span class="num">Debt</span>
+          <span class="num">Collateral</span>
+          <span class="num">→ Treasury</span>
+          <span class="num">Swapped</span>
+          <span class="num">ckUSDC</span>
+          <span class="num">Slip</span>
+        </div>
+        {#each filtered as r (r.id)}
+          {@const isTest = isTestRecord(r)}
+          <div class="row" class:is-test={isTest}>
+            <span class="date" title={fmtAbsoluteTime(r.timestamp)}>
+              {fmtRelativeTime(r.timestamp)}
+            </span>
+            <span class="status-cell">
+              <span class="status-pill {statusClass(r.status)}">{statusLabel(r.status)}</span>
+              {#if isTest}<span class="test-tag">test</span>{/if}
+            </span>
+            <span class="vault">#{r.vault_id.toString()}</span>
+            <span class="num">{fmtE8s(r.debt_to_cover_e8s, 4)}</span>
+            <span class="num">{fmtE8s(r.collateral_claimed_e8s, 4)}</span>
+            <span class="num">{fmtE8s(r.icp_to_treasury_e8s, 4)}</span>
+            <span class="num">{fmtE8s(r.icp_swapped_e8s, 4)}</span>
+            <span class="num">{r.ckusdc_received_e6 > 0n ? fmtE6(r.ckusdc_received_e6, 2) : '—'}</span>
+            <span class="num">{fmtBps(r.slippage_bps)}</span>
+          </div>
+          {#if r.error_message[0]}
+            <div class="row-error" class:on-success={isCompleted(r.status)}>
+              {isCompleted(r.status) ? 'Note: ' : 'Error: '}{r.error_message[0]}
+            </div>
+          {/if}
+        {/each}
+      </div>
+    </div>
+
+    {#if canLoadMore}
+      <div class="footer">
+        <button class="btn-secondary" on:click={loadMore} disabled={loadingMore}>
+          {loadingMore ? 'Loading…' : 'Load more'}
+        </button>
+      </div>
+    {/if}
+  {/if}
+{/if}
+
+<style>
+  .state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 3rem 1rem;
+  }
+  .state-text { color: var(--rumi-text-muted, #9ca3af); font-size: 0.875rem; }
+  .state-text.error { color: var(--rumi-error, #ef4444); }
+
+  .btn-secondary {
+    background: transparent;
+    color: var(--rumi-text-primary, #fff);
+    border: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.12));
+    padding: 0.45rem 0.9rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+  .btn-secondary:hover { border-color: var(--rumi-action, #3b82f6); }
+  .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .stuck-banner {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    background: rgba(239, 68, 68, 0.06);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+  }
+  .stuck-icon {
+    flex: 0 0 1.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--rumi-error, #ef4444);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.875rem;
+  }
+  .stuck-title { font-weight: 600; font-size: 0.875rem; color: var(--rumi-error, #ef4444); }
+  .stuck-detail { font-size: 0.75rem; color: var(--rumi-text-muted, #9ca3af); margin-top: 0.25rem; }
+
+  .filters {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+    font-size: 0.8125rem;
+  }
+  .filter-group {
+    display: inline-flex;
+    border: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.1));
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .filter-btn {
+    background: transparent;
+    color: var(--rumi-text-muted, #9ca3af);
+    border: none;
+    padding: 0.35rem 0.85rem;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    border-right: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.1));
+  }
+  .filter-btn:last-child { border-right: none; }
+  .filter-btn.active {
+    background: var(--rumi-action, #3b82f6);
+    color: white;
+  }
+  .hide-tests {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--rumi-text-muted, #9ca3af);
+    cursor: pointer;
+  }
+  .count { margin-left: auto; color: var(--rumi-text-muted, #6b7280); font-size: 0.75rem; }
+
+  .table-wrap {
+    border: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.06));
+    border-radius: 8px;
+    overflow-x: auto;
+  }
+  .table {
+    display: flex;
+    flex-direction: column;
+    min-width: 760px;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: 100px 130px 70px 1fr 1fr 1fr 1fr 1fr 60px;
+    gap: 0.5rem;
+    padding: 0.6rem 0.9rem;
+    align-items: center;
+    font-size: 0.8125rem;
+    border-bottom: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.04));
+    color: var(--rumi-text-primary, #fff);
+  }
+  .row:last-child { border-bottom: none; }
+  .row.head {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--rumi-text-muted, #6b7280);
+    font-weight: 600;
+    background: var(--rumi-bg-surface1, rgba(255, 255, 255, 0.02));
+  }
+  .row.is-test { opacity: 0.55; }
+  .num { text-align: right; font-variant-numeric: tabular-nums; }
+  .date { color: var(--rumi-text-secondary, #d1d5db); cursor: default; }
+  .vault { font-weight: 500; }
+
+  .status-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .status-pill {
+    display: inline-block;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .status-pill.ok {
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--rumi-success, #22c55e);
+  }
+  .status-pill.admin {
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--rumi-action, #60a5fa);
+  }
+  .status-pill.fail {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--rumi-error, #f87171);
+  }
+  .test-tag {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    color: var(--rumi-text-muted, #6b7280);
+    border: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.15));
+    border-radius: 4px;
+    padding: 0 0.3rem;
+  }
+
+  .row-error {
+    grid-column: 1 / -1;
+    padding: 0.35rem 0.9rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--rumi-error, #f87171);
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    border-bottom: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.04));
+  }
+  .row-error.on-success { color: var(--rumi-text-muted, #9ca3af); }
+
+  .footer {
+    display: flex;
+    justify-content: center;
+    padding: 1rem 0;
+  }
+</style>

--- a/src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/LiquidationBotTab.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { ApiClient } from '../../services/protocol/apiClient';
   import LoadingSpinner from '../common/LoadingSpinner.svelte';
+  import BotLiquidationsTable from './BotLiquidationsTable.svelte';
 
   interface BotStats {
     liquidation_bot_principal: string | null;
@@ -11,35 +12,15 @@
     total_debt_covered_e8s: bigint;
   }
 
-  interface BotEvent {
-    timestamp: bigint;
-    vault_id: bigint;
-    debt_covered_e8s: bigint;
-    collateral_received_e8s: bigint;
-    icusd_burned_e8s: bigint;
-    collateral_to_treasury_e8s: bigint;
-    swap_route: string;
-    effective_price_e8s: bigint;
-    slippage_bps: number;
-    success: boolean;
-    error_message: string | null;
-  }
-
   let loading = true;
   let error = '';
   let stats: BotStats | null = null;
-  let events: BotEvent[] = [];
 
   const E8S = 100_000_000;
 
   function formatE8s(val: bigint | number, decimals = 2): string {
     const n = Number(val) / E8S;
     return n.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
-  }
-
-  function formatDate(nanos: bigint): string {
-    const ms = Number(nanos) / 1_000_000;
-    return new Date(ms).toLocaleString();
   }
 
   function daysLeftInBudget(startNanos: bigint): number {
@@ -136,36 +117,13 @@
     <!-- Event Log -->
     <div class="card events-card">
       <h3 class="card-title">Liquidation Events</h3>
-      {#if events.length === 0}
-        <p class="empty-text">No liquidation events recorded yet.</p>
-      {:else}
-        <div class="events-table">
-          <div class="table-header">
-            <span>Time</span>
-            <span>Vault</span>
-            <span>Debt</span>
-            <span>Route</span>
-            <span>Status</span>
-          </div>
-          {#each events as evt}
-            <div class="table-row" class:failed={!evt.success}>
-              <span>{formatDate(evt.timestamp)}</span>
-              <span>#{evt.vault_id.toString()}</span>
-              <span>{formatE8s(evt.debt_covered_e8s)}</span>
-              <span>{evt.swap_route || '—'}</span>
-              <span class:success={evt.success} class:fail={!evt.success}>
-                {evt.success ? 'OK' : 'Failed'}
-              </span>
-            </div>
-          {/each}
-        </div>
-      {/if}
+      <BotLiquidationsTable />
     </div>
   {/if}
 </div>
 
 <style>
-  .bot-container { max-width: 820px; margin: 0 auto; }
+  .bot-container { max-width: 1100px; margin: 0 auto; }
 
   .loading-state, .error-state {
     display: flex;
@@ -251,42 +209,9 @@
     font-weight: 500;
     color: var(--rumi-text-primary, #fff);
   }
-  .stat-value.deficit { color: var(--rumi-warning, #f59e0b); }
   .stat-value.principal {
     font-size: 0.75rem;
     font-family: monospace;
     word-break: break-all;
   }
-
-  .empty-text {
-    color: var(--rumi-text-muted, #6b7280);
-    font-size: 0.875rem;
-    text-align: center;
-    padding: 2rem;
-  }
-
-  .events-table {
-    display: flex;
-    flex-direction: column;
-    font-size: 0.8125rem;
-  }
-  .table-header, .table-row {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1.5fr 1.5fr 1fr;
-    gap: 0.5rem;
-    padding: 0.5rem 0;
-    align-items: center;
-  }
-  .table-header {
-    color: var(--rumi-text-muted, #6b7280);
-    font-weight: 600;
-    border-bottom: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.06));
-  }
-  .table-row {
-    color: var(--rumi-text-primary, #fff);
-    border-bottom: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.03));
-  }
-  .table-row.failed { opacity: 0.6; }
-  .success { color: var(--rumi-success, #22c55e); }
-  .fail { color: var(--rumi-error, #ef4444); }
 </style>

--- a/src/vault_frontend/src/lib/config.ts
+++ b/src/vault_frontend/src/lib/config.ts
@@ -23,6 +23,8 @@ export const CANISTER_IDS = {
   THREEPOOL: "fohh4-yyaaa-aaaap-qtkpa-cai",
   // Rumi AMM (3USD/ICP constant-product pool)
   RUMI_AMM: "ijlzs-2yaaa-aaaap-quaaq-cai",
+  // Liquidation Bot (automated CDP liquidator with on-chain event log)
+  LIQUIDATION_BOT: "nygob-3qaaa-aaaap-qttcq-cai",
   // Rumi Analytics (time-series data, protocol metrics)
   ANALYTICS: "dtlu2-uqaaa-aaaap-qugcq-cai",
   // ICPswap pools (external DEX for routing)
@@ -97,6 +99,10 @@ export const CONFIG = {
 
   get ammCanisterId() {
     return CANISTER_IDS.RUMI_AMM;
+  },
+
+  get liquidationBotCanisterId() {
+    return CANISTER_IDS.LIQUIDATION_BOT;
   },
 
   get icpswap3UsdIcpPoolId() {

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -18,6 +18,13 @@ import type { _SERVICE as IcusdLedgerService } from '$declarations/icusd_ledger/
 import type { _SERVICE as IcusdIndexService } from '$declarations/icusd_index/icusd_index.did';
 import type { UserStabilityPosition } from '$declarations/rumi_stability_pool/rumi_stability_pool.did';
 import { idlFactory as stabilityPoolIDL } from '$declarations/rumi_stability_pool/rumi_stability_pool.did.js';
+import type {
+	_SERVICE as LiquidationBotService,
+	LiquidationRecordV1,
+	LiquidationRecordVersioned,
+	BotStats as BotCanisterStats,
+} from '$declarations/liquidation_bot/liquidation_bot.did';
+import { idlFactory as liquidationBotIDL } from '$declarations/liquidation_bot/liquidation_bot.did.js';
 
 // ── TTL constants (ms) ───────────────────────────────────────────────────────
 
@@ -860,6 +867,113 @@ export async function fetchBotStats(): Promise<any | null> {
 	} catch (err) {
 		console.error('[explorerService] fetchBotStats failed:', err);
 		return null;
+	}
+}
+
+// ── Bot canister: liquidation history ───────────────────────────────────────
+//
+// The protocol backend's `get_bot_stats` is an aggregate counter. The
+// per-liquidation log lives on the liquidation_bot canister itself
+// (nygob-3qaaa-aaaap-qttcq-cai). Wire its event log here so the same data
+// can power the Liquidate-page Bot tab and the explorer bot-history route.
+
+let liquidationBotActor: LiquidationBotService | null = null;
+function getLiquidationBotActor(): LiquidationBotService {
+	if (liquidationBotActor) return liquidationBotActor;
+	const agent = new HttpAgent({ host: CONFIG.host });
+	if (CONFIG.isLocal) {
+		agent.fetchRootKey().catch((err) =>
+			console.warn('[explorerService] liquidation_bot fetchRootKey failed:', err),
+		);
+	}
+	liquidationBotActor = Actor.createActor<LiquidationBotService>(liquidationBotIDL as any, {
+		agent,
+		canisterId: CONFIG.liquidationBotCanisterId,
+	});
+	return liquidationBotActor;
+}
+
+function unwrapVersioned(rec: LiquidationRecordVersioned): LiquidationRecordV1 {
+	return ('V1' in rec) ? rec.V1 : (rec as any);
+}
+
+export async function fetchBotCanisterStats(): Promise<BotCanisterStats | null> {
+	const key = 'liquidations:bot:canisterstats';
+	const cached = getCached<BotCanisterStats>(key, TTL.LIQUIDATIONS);
+	if (cached) return cached;
+	try {
+		const result = await getLiquidationBotActor().get_bot_stats();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchBotCanisterStats failed:', err);
+		return null;
+	}
+}
+
+export async function fetchBotLiquidationCount(): Promise<bigint> {
+	const key = 'liquidations:bot:count';
+	const cached = getCached<bigint>(key, TTL.LIQUIDATIONS);
+	if (cached !== null) return cached;
+	try {
+		const result = await getLiquidationBotActor().get_liquidation_count();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchBotLiquidationCount failed:', err);
+		return 0n;
+	}
+}
+
+/**
+ * Fetch a slice of the bot's liquidation log, newest-first.
+ *
+ * The bot's `get_liquidations(offset, limit)` returns records indexed
+ * from oldest (id 0) → newest. We translate `page`/`pageSize` into
+ * the offset that yields the newest `pageSize` records on page 0, the
+ * next-oldest on page 1, etc., so callers can scroll back through history.
+ */
+export async function fetchBotLiquidations(
+	page: number,
+	pageSize: number,
+): Promise<{ total: bigint; records: LiquidationRecordV1[] }> {
+	const key = `liquidations:bot:page:${page}:${pageSize}`;
+	const cached = getCached<{ total: bigint; records: LiquidationRecordV1[] }>(
+		key,
+		TTL.LIQUIDATIONS,
+	);
+	if (cached) return cached;
+
+	try {
+		const total = await fetchBotLiquidationCount();
+		if (total === 0n) return setCache(key, { total, records: [] });
+
+		const size = BigInt(pageSize);
+		const pageBig = BigInt(page);
+		// Newest-first paging: take a window ending at `total - page*pageSize`.
+		const endExclusive = total - pageBig * size;
+		if (endExclusive <= 0n) return setCache(key, { total, records: [] });
+		const windowSize = endExclusive < size ? endExclusive : size;
+		const offset = endExclusive - windowSize;
+		const versioned = await getLiquidationBotActor().get_liquidations(offset, windowSize);
+		// Reverse so newest-first within the page.
+		const records = versioned.map(unwrapVersioned).reverse();
+		return setCache(key, { total, records });
+	} catch (err) {
+		console.error('[explorerService] fetchBotLiquidations failed:', err);
+		return { total: 0n, records: [] };
+	}
+}
+
+export async function fetchStuckBotLiquidations(): Promise<LiquidationRecordV1[]> {
+	const key = 'liquidations:bot:stuck';
+	const cached = getCached<LiquidationRecordV1[]>(key, TTL.LIQUIDATIONS);
+	if (cached) return cached;
+	try {
+		const versioned = await getLiquidationBotActor().get_stuck_liquidations();
+		const records = versioned.map(unwrapVersioned);
+		return setCache(key, records);
+	} catch (err) {
+		console.error('[explorerService] fetchStuckBotLiquidations failed:', err);
+		return [];
 	}
 }
 

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -3,6 +3,7 @@ import {
   timeAgo, formatTimestamp, getTokenSymbol, getTokenDecimals,
   shortenPrincipal, getCanisterName
 } from '$utils/explorerHelpers';
+import { CANISTER_IDS } from '$lib/config';
 
 // ─── Types ────────────────────────────────────────────────────────────
 
@@ -1023,12 +1024,17 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
       const dec = getTokenDecimals(collPrincipal);
       const payment = fmtE8s(d.liquidator_payment);
       const collateral = fmtE8s(d.icp_to_liquidator, dec);
+      const liquidatorText = principalToText(optValue(d.liquidator) ?? d.liquidator);
+      const viaBot = liquidatorText === CANISTER_IDS.LIQUIDATION_BOT;
       fields.push(vaultField(d.vault_id));
       fields.push(amountField('Debt Repaid', d.liquidator_payment));
       fields.push(amountField('Collateral to Liquidator', d.icp_to_liquidator, dec, sym));
       if (d.protocol_fee_collateral !== undefined) {
         const fee = optValue(d.protocol_fee_collateral);
         if (fee !== undefined) fields.push(amountField('Protocol Fee', fee, dec, sym));
+      }
+      if (viaBot) {
+        fields.push(textField('Source', 'Liquidation Bot'));
       }
       pushIfPresent(fields, addressField('Liquidator', d.liquidator));
       if (d.icp_rate !== undefined) {
@@ -1040,8 +1046,11 @@ export function formatEvent(event: any, vaultCollateralMap?: Map<number, string>
       }
       if (ts) fields.push(timestampField(ts));
       return {
-        summary: `Vault #${d.vault_id} partially liquidated — ${payment} icUSD debt repaid, ${collateral} ${sym} seized`,
-        typeName, category, badgeColor, fields,
+        summary: viaBot
+          ? `Bot liquidated Vault #${d.vault_id} — ${payment} icUSD debt repaid, ${collateral} ${sym} seized`
+          : `Vault #${d.vault_id} partially liquidated — ${payment} icUSD debt repaid, ${collateral} ${sym} seized`,
+        typeName: viaBot ? 'Partial Liquidation (Bot)' : typeName,
+        category, badgeColor, fields,
       };
     }
 

--- a/src/vault_frontend/src/routes/explorer/liquidations/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/liquidations/+page.svelte
@@ -1,7 +1,132 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
-	// Absorbed by the Activity facet bar. `?type=liquidation` expands via
-	// TYPE_CATEGORY_ALIASES to the full set of liquidation event variants.
-	onMount(() => goto('/explorer/activity?type=liquidation', { replaceState: true }));
+	import BotLiquidationsTable from '$components/liquidations/BotLiquidationsTable.svelte';
+	import { fetchBotCanisterStats } from '$services/explorer/explorerService';
+	import type { BotStats } from '$declarations/liquidation_bot/liquidation_bot.did';
+
+	const E8S = 100_000_000;
+	const E6 = 1_000_000;
+
+	let botStats: BotStats | null = $state(null);
+
+	onMount(async () => {
+		botStats = await fetchBotCanisterStats();
+	});
+
+	function fmtE8s(v: bigint, decimals = 2): string {
+		return (Number(v) / E8S).toLocaleString(undefined, {
+			minimumFractionDigits: decimals,
+			maximumFractionDigits: decimals,
+		});
+	}
+
+	function fmtE6(v: bigint, decimals = 2): string {
+		return (Number(v) / E6).toLocaleString(undefined, {
+			minimumFractionDigits: decimals,
+			maximumFractionDigits: decimals,
+		});
+	}
 </script>
+
+<svelte:head>
+	<title>Liquidations · Rumi Explorer</title>
+</svelte:head>
+
+<div class="page">
+	<header class="page-head">
+		<h1>Liquidations</h1>
+		<p class="lede">
+			Vault liquidations that ran through the on-chain liquidation bot.
+			For the full activity feed of every liquidation source (bot, stability pool, manual),
+			open the <a href="/explorer/activity?type=liquidation">activity log</a>.
+		</p>
+	</header>
+
+	{#if botStats}
+		<div class="stats">
+			<div class="stat">
+				<span class="stat-label">Debt covered</span>
+				<span class="stat-value">{fmtE8s(botStats.total_debt_covered_e8s)} icUSD</span>
+			</div>
+			<div class="stat">
+				<span class="stat-label">Collateral received</span>
+				<span class="stat-value">{fmtE8s(botStats.total_collateral_received_e8s)} ICP</span>
+			</div>
+			<div class="stat">
+				<span class="stat-label">To treasury</span>
+				<span class="stat-value">{fmtE8s(botStats.total_collateral_to_treasury_e8s)} ICP</span>
+			</div>
+			<div class="stat">
+				<span class="stat-label">ckUSDC swapped</span>
+				<span class="stat-value">{fmtE6(botStats.total_ckusdc_deposited_e6)}</span>
+			</div>
+			<div class="stat">
+				<span class="stat-label">Records</span>
+				<span class="stat-value">{Number(botStats.events_count)}</span>
+			</div>
+		</div>
+	{/if}
+
+	<section>
+		<h2 class="section-title">Bot Liquidation History</h2>
+		<BotLiquidationsTable pageSize={25} />
+	</section>
+</div>
+
+<style>
+	.page { display: flex; flex-direction: column; gap: 1.5rem; }
+
+	.page-head h1 {
+		font-size: 1.75rem;
+		font-weight: 700;
+		margin: 0 0 0.5rem;
+		color: var(--rumi-text-primary, #fff);
+	}
+	.lede {
+		font-size: 0.9375rem;
+		color: var(--rumi-text-muted, #9ca3af);
+		margin: 0;
+		max-width: 60ch;
+	}
+	.lede a {
+		color: var(--rumi-action, #60a5fa);
+		text-decoration: none;
+	}
+	.lede a:hover { text-decoration: underline; }
+
+	.stats {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+		gap: 0.75rem;
+	}
+	.stat {
+		background: var(--rumi-bg-surface1, rgba(255, 255, 255, 0.03));
+		border: 1px solid var(--rumi-border, rgba(255, 255, 255, 0.06));
+		border-radius: 8px;
+		padding: 0.85rem 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.stat-label {
+		font-size: 0.6875rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--rumi-text-muted, #6b7280);
+	}
+	.stat-value {
+		font-size: 1rem;
+		font-weight: 500;
+		color: var(--rumi-text-primary, #fff);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.section-title {
+		font-size: 0.8125rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
+		color: var(--rumi-text-secondary, #9ca3af);
+		margin: 0 0 0.75rem;
+	}
+</style>


### PR DESCRIPTION
## Summary

- Surface the bot canister's own liquidation log in the Liquidate page Bot tab — previously the events table was a literal `let events = []` that never fetched.
- Replace the `/explorer/liquidations` redirect with a dedicated page showing aggregate bot stats + the same paged history.
- Tag partial-liquidation rows in the explorer activity feed whose liquidator is the bot principal with a `Source: Liquidation Bot` field and a "Partial Liquidation (Bot)" type name, so bot vs. manual is visible in the broader feed.

The data was already on chain — the bot canister (`nygob-3qaaa-aaaap-qttcq-cai`) exposes `get_liquidations`, `get_liquidation_count`, and `get_stuck_liquidations`. The frontend simply wasn't calling them.

### Why now

Yesterday's cascade and today's follow-ons (13 vaults liquidated 5/17 23:48–00:01, then 5 more on 5/18) showed the 130.11 icUSD total-debt-covered figure correctly on the bot tab, but the events table read "No liquidation events recorded yet" because of the dead initializer. The explorer activity feed showed the rows but with no way to distinguish bot vs. manual.

## Test plan

- [ ] Open `/liquidate` → Liquidation Bot tab. The previously-empty event log now lists the 18 real liquidations + 2 test entries (test entries hidden by default; toggle to show). Statuses are colour-pilled (Completed=green, *Failed=red, AdminResolved=blue). Slippage column reads `0.00%` for the test entries and small percentages for real ones. Filter buttons (All / Completed / Failed) and "Hide test entries" toggle work. "Load more" appears if total > 20.
- [ ] Open `/explorer/liquidations` (used to redirect away). It now renders a `Liquidations` page with aggregate stats (debt covered, collateral received, to treasury, ckUSDC swapped, records) and the same table at `pageSize=25`.
- [ ] Open `/explorer/activity?type=liquidation` and find a row from the 5/17 cluster. The row's type chip reads "Partial Liquidation (Bot)" and clicking it surfaces a "Source: Liquidation Bot" field above the existing Liquidator address.
- [ ] If any liquidations are currently stuck (TransferFailed / ConfirmFailed / ClaimFailed), a red banner appears above the table listing them.

## Notes for review

- `BotLiquidationsTable` is self-fetching with caching shared through `explorerService`'s 30s `TTL.LIQUIDATIONS` window, so opening both routes in sequence doesn't hammer the canister.
- Newest-first pagination is computed in the service (`fetchBotLiquidations(page, pageSize)`) by translating page index into an offset window from the tail of the bot's append-only log; this avoids holding all 149 records in memory.
- `LiquidationStatus` is the bot's V1 variant; rendering uses `Object.keys(status)[0]` to pluck the active key, so future variants will surface with their raw name instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)