### PR TITLE
fix(explorer): reconcile bot stuck-record banner against live claim set

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -802,6 +802,7 @@ service : (ProtocolArg) -> {
   get_all_vaults : () -> (vec CandidVault) query;
   get_borrowing_fee : () -> (float64) query;
   get_bot_allowed_collateral_types : () -> (vec principal) query;
+  get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -964,6 +964,7 @@ export interface _SERVICE {
   'get_all_vaults' : ActorMethod<[], Array<CandidVault>>,
   'get_borrowing_fee' : ActorMethod<[], number>,
   'get_bot_allowed_collateral_types' : ActorMethod<[], Array<Principal>>,
+  'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
   'get_ckstable_repay_fee' : ActorMethod<[], number>,
   'get_collateral_config' : ActorMethod<[Principal], [] | [CollateralConfig]>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -932,6 +932,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Principal)],
         ['query'],
       ),
+    'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
     'get_ckstable_repay_fee' : IDL.Func([], [IDL.Float64], ['query']),
     'get_collateral_config' : IDL.Func(

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -811,6 +811,7 @@ service : (ProtocolArg) -> {
   get_all_vaults : () -> (vec CandidVault) query;
   get_borrowing_fee : () -> (float64) query;
   get_bot_allowed_collateral_types : () -> (vec principal) query;
+  get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
   get_ckstable_repay_fee : () -> (float64) query;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2955,6 +2955,20 @@ fn get_bot_stats() -> BotStatsResponse {
     })
 }
 
+/// Vault IDs with an open `BotClaim` on the protocol side.
+///
+/// Used by the explorer to reconcile the liquidation_bot's
+/// `get_stuck_liquidations` (a permanent history log) against the protocol's
+/// live claim set. A record can be `TransferFailed`/`ConfirmFailed` in the
+/// bot's log forever, but if the matching vault is no longer in `bot_claims`
+/// (e.g. resolved by Wave-11 BOT-001 auto-cancel or `admin_resolve_stuck_claim`),
+/// the explorer should not flag it as awaiting admin action.
+#[candid_method(query)]
+#[query]
+fn get_bot_claim_vault_ids() -> Vec<u64> {
+    read_state(|s| s.bot_claims.keys().copied().collect())
+}
+
 /// Admin-only: force-resolve a stuck bot claim. Used when the bot's ckUSDC transfer
 /// or confirm failed and the vault is stuck with bot_processing=true.
 ///

--- a/src/vault_frontend/src/lib/components/liquidations/BotLiquidationsTable.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/BotLiquidationsTable.svelte
@@ -4,6 +4,7 @@
     fetchBotLiquidations,
     fetchBotLiquidationCount,
     fetchStuckBotLiquidations,
+    fetchActiveBotClaimVaultIds,
   } from '$services/explorer/explorerService';
   import type { LiquidationRecordV1, LiquidationStatus } from '$declarations/liquidation_bot/liquidation_bot.did';
   import LoadingSpinner from '../common/LoadingSpinner.svelte';
@@ -116,13 +117,19 @@
     try {
       loading = true;
       error = '';
-      const [first, stuck] = await Promise.all([
+      const [first, stuck, activeClaims] = await Promise.all([
         fetchBotLiquidations(0, pageSize),
         fetchStuckBotLiquidations(),
+        fetchActiveBotClaimVaultIds(),
       ]);
       records = first.records;
       total = first.total;
-      stuckRecords = stuck;
+      // The bot's `get_stuck_liquidations` is its permanent history of
+      // failed records, but the protocol-side claim may have since been
+      // resolved (Wave-11 BOT-001 auto-cancel, or `admin_resolve_stuck_claim`).
+      // Only surface records whose vault is still in the protocol's
+      // active claim set so the banner reflects actionable items.
+      stuckRecords = stuck.filter((r) => activeClaims.has(BigInt(r.vault_id)));
       loadedPages = 1;
     } catch (err: any) {
       console.error('[BotLiquidationsTable] load failed:', err);

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -973,6 +973,29 @@ export async function fetchStuckBotLiquidations(): Promise<LiquidationRecordV1[]
 	}
 }
 
+/**
+ * Vault IDs with an open `BotClaim` on the protocol backend side.
+ *
+ * The bot canister's `get_stuck_liquidations` returns historical records
+ * with `TransferFailed`/`ConfirmFailed` status forever. After Wave-11 BOT-001
+ * (10-min auto-cancel) or `admin_resolve_stuck_claim` clears the protocol-side
+ * claim, the bot record stays — so the "stuck claim" banner should reconcile
+ * against the live protocol set, not the immutable bot log.
+ */
+export async function fetchActiveBotClaimVaultIds(): Promise<Set<bigint>> {
+	const key = 'liquidations:bot:active-claims';
+	const cached = getCached<Set<bigint>>(key, TTL.LIQUIDATIONS);
+	if (cached) return cached;
+	try {
+		const ids = await (publicActor as any).get_bot_claim_vault_ids();
+		const set = new Set<bigint>(Array.from(ids as ArrayLike<bigint>, (v) => BigInt(v)));
+		return setCache(key, set);
+	} catch (err) {
+		console.error('[explorerService] fetchActiveBotClaimVaultIds failed:', err);
+		return new Set();
+	}
+}
+
 // ── Treasury ─────────────────────────────────────────────────────────────────
 
 export async function fetchTreasuryStats(): Promise<any | null> {


### PR DESCRIPTION
## Summary

- Banner _"1 stuck claim awaiting admin resolution: #69 (Transfer Failed)"_ in the Liquidations lens was a permanent UX artifact: it sourced records from the liquidation_bot's `get_stuck_liquidations` history log, which never clears, even after the protocol resolved the claim via Wave-11 BOT-001 auto-cancel or `admin_resolve_stuck_claim`.
- Backend: new `get_bot_claim_vault_ids() -> Vec<u64>` query that returns keys of `s.bot_claims` (the live claim set).
- Frontend: `BotLiquidationsTable.load()` fetches both the bot's stuck list and the active-claim set in parallel and filters out records whose vault is no longer in `bot_claims`. Class fix — future BOT-001 auto-cancels will likewise clear the banner without manual intervention.

## Files

- `src/rumi_protocol_backend/src/main.rs` — new `#[query]`
- `src/rumi_protocol_backend/rumi_protocol_backend.did` + 3 declaration files
- `src/vault_frontend/src/lib/services/explorer/explorerService.ts` — `fetchActiveBotClaimVaultIds()` helper (Set\<bigint\>, 30s cache)
- `src/vault_frontend/src/lib/components/liquidations/BotLiquidationsTable.svelte` — filter `stuckRecords` against the active set

## Test plan

- [x] `cargo check -p rumi_protocol_backend` — clean
- [x] `svelte-check` — no new errors in changed files (pre-existing errors unrelated)
- [ ] Backend deploys + sanity-call `get_bot_claim_vault_ids()` returns `vec {}` (no active claims as of merge)
- [ ] Frontend redeploys + Liquidations lens shows banner gone for vault #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)