### PR TITLE
chore(amm): admin endpoint extraction + Phase 1 polish

### DIFF
--- a/src/rumi_amm/src/admin.rs
+++ b/src/rumi_amm/src/admin.rs
@@ -1,0 +1,506 @@
+//! Admin-gated endpoints for the Rumi AMM.
+//!
+//! Pure code move from `lib.rs` (no behavior change). Every function here
+//! is authorised via `crate::caller_is_admin()`, except `create_pool`,
+//! which falls back to a permissionless path when `pool_creation_open`
+//! is true.
+
+use candid::{Nat, Principal};
+use ic_cdk::update;
+use ic_canister_log::log;
+use std::collections::BTreeMap;
+
+use crate::caller_is_admin;
+use crate::derive_subaccount;
+use crate::logs::INFO;
+use crate::make_pool_id;
+use crate::state::{mutate_state, read_state};
+use crate::transfers::transfer_to_user;
+use crate::types::*;
+use crate::PoolGuard;
+
+#[update]
+fn create_pool(args: CreatePoolArgs) -> Result<PoolId, AmmError> {
+    // Admin exempt from maintenance mode — can set up pools while canister is locked
+    if read_state(|s| s.maintenance_mode) && caller_is_admin().is_err() {
+        return Err(AmmError::MaintenanceMode);
+    }
+
+    let is_admin = caller_is_admin().is_ok();
+
+    if !is_admin {
+        // Permissionless path: gate must be open, constant product only, fee clamped
+        if !read_state(|s| s.pool_creation_open) {
+            return Err(AmmError::PoolCreationClosed);
+        }
+        if args.curve != CurveType::ConstantProduct {
+            return Err(AmmError::Unauthorized);
+        }
+        if args.fee_bps < 1 || args.fee_bps > 1000 {
+            return Err(AmmError::FeeBpsOutOfRange);
+        }
+    }
+
+    // Validate fee_bps for all callers (admin included) to prevent creating
+    // permanently broken pools where compute_swap would always error
+    if args.fee_bps > 10_000 {
+        return Err(AmmError::FeeBpsOutOfRange);
+    }
+
+    if args.token_a == args.token_b {
+        return Err(AmmError::InvalidToken);
+    }
+
+    let pool_id = make_pool_id(args.token_a, args.token_b);
+
+    mutate_state(|s| {
+        if s.pools.contains_key(&pool_id) {
+            return Err(AmmError::PoolAlreadyExists);
+        }
+
+        let subaccount_a = derive_subaccount(&pool_id, "token_a");
+        let subaccount_b = derive_subaccount(&pool_id, "token_b");
+
+        // Ensure token_a/token_b are stored in sorted order matching pool_id
+        let (token_a, token_b) = if args.token_a.to_text() <= args.token_b.to_text() {
+            (args.token_a, args.token_b)
+        } else {
+            (args.token_b, args.token_a)
+        };
+
+        let pool = Pool {
+            token_a,
+            token_b,
+            reserve_a: 0,
+            reserve_b: 0,
+            fee_bps: args.fee_bps,
+            protocol_fee_bps: 0, // 100% to LPs initially
+            curve: args.curve,
+            lp_shares: BTreeMap::new(),
+            total_lp_shares: 0,
+            protocol_fees_a: 0,
+            protocol_fees_b: 0,
+            paused: false,
+            subaccount_a,
+            subaccount_b,
+            lp_rewards: BTreeMap::new(),
+            acc_reward_per_share: 0,
+            pending_no_lp: 0,
+            total_rewards_distributed: 0,
+            processed_donation_nonces: std::collections::VecDeque::new(),
+            reward_balance_snapshot: 0,
+        };
+
+        log!(INFO, "Pool created: {} (fee: {} bps, admin: {})", pool_id, args.fee_bps, is_admin);
+        s.pools.insert(pool_id.clone(), pool);
+        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::CreatePool {
+            pool_id: pool_id.clone(),
+            token_a,
+            token_b,
+            fee_bps: args.fee_bps,
+        });
+        Ok(pool_id)
+    })
+}
+
+#[update]
+fn set_fee(pool_id: PoolId, fee_bps: u16) -> Result<(), AmmError> {
+    let caller = ic_cdk::caller();
+    caller_is_admin()?;
+    if fee_bps > 10_000 {
+        return Err(AmmError::FeeBpsOutOfRange);
+    }
+    mutate_state(|s| {
+        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
+        pool.fee_bps = fee_bps;
+        log!(INFO, "Pool {} fee set to {} bps", pool_id, fee_bps);
+        s.record_admin_event(caller, AmmAdminAction::SetFee { pool_id: pool_id.clone(), fee_bps });
+        Ok(())
+    })
+}
+
+#[update]
+fn set_protocol_fee(pool_id: PoolId, protocol_fee_bps: u16) -> Result<(), AmmError> {
+    let caller = ic_cdk::caller();
+    caller_is_admin()?;
+    if protocol_fee_bps > 10_000 {
+        return Err(AmmError::FeeBpsOutOfRange);
+    }
+    mutate_state(|s| {
+        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
+        pool.protocol_fee_bps = protocol_fee_bps;
+        log!(INFO, "Pool {} protocol fee set to {} bps", pool_id, protocol_fee_bps);
+        s.record_admin_event(caller, AmmAdminAction::SetProtocolFee { pool_id: pool_id.clone(), protocol_fee_bps });
+        Ok(())
+    })
+}
+
+#[update]
+async fn withdraw_protocol_fees(pool_id: PoolId) -> Result<(u128, u128), AmmError> {
+    caller_is_admin()?;
+
+    // Acquire per-pool lock to prevent concurrent fee withdrawals
+    let _pool_guard = PoolGuard::new(pool_id.clone())?;
+
+    let (token_a, token_b, sub_a, sub_b, fees_a, fees_b, admin) = read_state(|s| {
+        let pool = s.pools.get(&pool_id).ok_or(AmmError::PoolNotFound)?;
+        Ok::<_, AmmError>((
+            pool.token_a, pool.token_b,
+            pool.subaccount_a, pool.subaccount_b,
+            pool.protocol_fees_a, pool.protocol_fees_b,
+            s.admin,
+        ))
+    })?;
+
+    if fees_a == 0 && fees_b == 0 {
+        return Ok((0, 0));
+    }
+
+    // Optimistic deduct: zero out fees in state BEFORE transferring.
+    mutate_state(|s| {
+        let pool = s.pools.get_mut(&pool_id).expect("pool must exist: verified at start of withdraw_protocol_fees");
+        pool.protocol_fees_a = 0;
+        pool.protocol_fees_b = 0;
+    });
+
+    let mut withdrawn_a = 0u128;
+    let mut withdrawn_b = 0u128;
+    let mut errors = Vec::new();
+
+    if fees_a > 0 {
+        match transfer_to_user(token_a, sub_a, admin, fees_a).await {
+            Ok(_) => withdrawn_a = fees_a,
+            Err(reason) => {
+                log!(INFO, "WARN: withdraw_protocol_fees transfer_a failed: {}. Rolling back.", reason);
+                errors.push(format!("token_a: {}", reason));
+            }
+        }
+    }
+
+    if fees_b > 0 {
+        match transfer_to_user(token_b, sub_b, admin, fees_b).await {
+            Ok(_) => withdrawn_b = fees_b,
+            Err(reason) => {
+                log!(INFO, "WARN: withdraw_protocol_fees transfer_b failed: {}. Rolling back.", reason);
+                errors.push(format!("token_b: {}", reason));
+            }
+        }
+    }
+
+    // Roll back any fees that failed to transfer
+    let rollback_a = fees_a - withdrawn_a;
+    let rollback_b = fees_b - withdrawn_b;
+    if rollback_a > 0 || rollback_b > 0 {
+        mutate_state(|s| {
+            let pool = s.pools.get_mut(&pool_id).expect("pool must exist: verified at start of withdraw_protocol_fees");
+            pool.protocol_fees_a += rollback_a;
+            pool.protocol_fees_b += rollback_b;
+        });
+    }
+
+    if !errors.is_empty() {
+        return Err(AmmError::TransferFailed {
+            token: "protocol_fees".to_string(),
+            reason: errors.join("; "),
+        });
+    }
+
+    log!(INFO, "Protocol fees withdrawn from {}: ({}, {})", pool_id, withdrawn_a, withdrawn_b);
+    mutate_state(|s| {
+        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::WithdrawProtocolFees {
+            pool_id: pool_id.clone(),
+            amount_a: withdrawn_a,
+            amount_b: withdrawn_b,
+        });
+    });
+    Ok((withdrawn_a, withdrawn_b))
+}
+
+#[update]
+fn pause_pool(pool_id: PoolId) -> Result<(), AmmError> {
+    let caller = ic_cdk::caller();
+    caller_is_admin()?;
+    mutate_state(|s| {
+        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
+        pool.paused = true;
+        log!(INFO, "Pool {} paused", pool_id);
+        s.record_admin_event(caller, AmmAdminAction::PausePool { pool_id: pool_id.clone() });
+        Ok(())
+    })
+}
+
+#[update]
+fn unpause_pool(pool_id: PoolId) -> Result<(), AmmError> {
+    let caller = ic_cdk::caller();
+    caller_is_admin()?;
+    mutate_state(|s| {
+        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
+        pool.paused = false;
+        log!(INFO, "Pool {} unpaused", pool_id);
+        s.record_admin_event(caller, AmmAdminAction::UnpausePool { pool_id: pool_id.clone() });
+        Ok(())
+    })
+}
+
+#[update]
+fn set_pool_creation_open(open: bool) -> Result<(), AmmError> {
+    caller_is_admin()?;
+    mutate_state(|s| s.pool_creation_open = open);
+    log!(INFO, "Pool creation open: {}", open);
+    mutate_state(|s| {
+        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::SetPoolCreationOpen { open });
+    });
+    Ok(())
+}
+
+#[update]
+fn set_admin(new_admin: Principal) -> Result<(), AmmError> {
+    caller_is_admin()?;
+    if new_admin == Principal::anonymous() {
+        return Err(AmmError::Unauthorized);
+    }
+    let old_admin = read_state(|s| s.admin);
+    mutate_state(|s| s.admin = new_admin);
+    log!(INFO, "Admin transferred: {} -> {}", old_admin, new_admin);
+    Ok(())
+}
+
+#[update]
+fn set_maintenance_mode(enabled: bool) -> Result<(), AmmError> {
+    caller_is_admin()?;
+    mutate_state(|s| s.maintenance_mode = enabled);
+    log!(INFO, "Maintenance mode: {}", enabled);
+    mutate_state(|s| {
+        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::SetMaintenanceMode { enabled });
+    });
+    Ok(())
+}
+
+/// Configure which principal is allowed to call `notify_reward_received`.
+/// Required before AMM1 earnings distribution can begin. Only callable
+/// by admin. Set to the rumi_protocol_backend canister principal.
+#[update]
+fn set_protocol_backend_principal(principal: Principal) -> Result<(), AmmError> {
+    caller_is_admin()?;
+    if principal == Principal::anonymous() {
+        return Err(AmmError::Unauthorized);
+    }
+    mutate_state(|s| s.protocol_backend_principal = Some(principal));
+    log!(INFO, "Protocol backend principal set to: {}", principal);
+    mutate_state(|s| {
+        s.record_admin_event(
+            ic_cdk::caller(),
+            AmmAdminAction::SetProtocolBackendPrincipal { backend: principal },
+        );
+    });
+    Ok(())
+}
+
+/// Admin recovery endpoint: burn whatever balance the AMM canister holds
+/// at a specific (ledger, subaccount) by transferring it to the ledger's
+/// minting account. ICRC-1 ledgers treat transfers to the minting
+/// account as burns and charge no fee on top.
+///
+/// Built as the recovery path for the 2026-05-19 AMM1 pool_id-mismatch
+/// incident, where `donate_icusd_to_amm1` minted icUSD into the AMM's
+/// `sha256("rumi_amm:rewards:3USD_ICP")` subaccount even though no pool
+/// is keyed off that pool_id (the actual 3USD/ICP pool ID is
+/// `make_pool_id(token_a, token_b)`). The stuck balance is unbacked
+/// icUSD and must be burned, not redirected.
+///
+/// Caller must be admin. `subaccount` must be exactly 32 bytes. If the
+/// canister's balance at the subaccount is at or below the ledger fee
+/// (typical `min_burn_amount`), returns `Ok(0)` (no-op). Otherwise
+/// transfers the full balance to the ledger's minting account and
+/// returns the burned amount on success.
+///
+/// Note: this burns the balance observed at the start of the call. If a
+/// concurrent mint arrives during the inter-canister awaits, the residual
+/// won't be burned — re-run the endpoint to clear it.
+#[update]
+async fn admin_burn_subaccount_balance(
+    ledger: Principal,
+    subaccount: Vec<u8>,
+) -> Result<u128, AmmError> {
+    use icrc_ledger_types::icrc1::account::Account;
+    use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
+
+    caller_is_admin()?;
+
+    // Subaccounts on ICRC-1 are fixed at 32 bytes.
+    if subaccount.len() != 32 {
+        return Err(AmmError::InvalidInput {
+            reason: format!("subaccount must be 32 bytes, got {}", subaccount.len()),
+        });
+    }
+    let mut sub = [0u8; 32];
+    sub.copy_from_slice(&subaccount);
+    // Render the subaccount as a 64-char lowercase hex string for the
+    // admin-event audit trail. Avoids pulling in the `hex` crate.
+    let subaccount_hex: String =
+        sub.iter().map(|b| format!("{:02x}", b)).collect();
+
+    // 1. Query the canister's balance at the target subaccount.
+    // Saturation note: ICRC-1 balances are bounded well below u128::MAX in
+    // any realistic scenario (icUSD total supply ~$10^4 e8s as of writing).
+    // Saturating to u128::MAX on overflow is the safer failure mode here:
+    // it would make the `balance <= fee` check below trivially false, so
+    // the transfer attempt itself would surface the impossible value as a
+    // ledger error rather than silently truncating.
+    let acct = Account {
+        owner: ic_cdk::id(),
+        subaccount: Some(sub),
+    };
+    let balance_call: Result<(Nat,), _> =
+        ic_cdk::call(ledger, "icrc1_balance_of", (acct,)).await;
+    let balance: u128 = match balance_call {
+        Ok((n,)) => n.0.try_into().unwrap_or(u128::MAX),
+        Err((code, msg)) => {
+            return Err(AmmError::TransferFailed {
+                token: "icUSD".to_string(),
+                reason: format!(
+                    "icrc1_balance_of rejected: {:?} {}",
+                    code, msg,
+                ),
+            });
+        }
+    };
+
+    // 2. Query the ledger's transfer fee. Same saturation rationale as above.
+    let fee_call: Result<(Nat,), _> = ic_cdk::call(ledger, "icrc1_fee", ()).await;
+    let fee: u128 = match fee_call {
+        Ok((n,)) => n.0.try_into().unwrap_or(u128::MAX),
+        Err((code, msg)) => {
+            return Err(AmmError::TransferFailed {
+                token: "icUSD".to_string(),
+                reason: format!("icrc1_fee rejected: {:?} {}", code, msg),
+            });
+        }
+    };
+
+    // 3. No-op if the balance is below `min_burn_amount`. ICRC-1 ledgers
+    // enforce `amount >= min_burn_amount` (typically equal to the transfer
+    // fee) on burns, so a balance at or below the fee cannot be burned.
+    if balance <= fee {
+        log!(
+            INFO,
+            "[admin_burn_subaccount_balance] no-op: balance={} fee={} for ledger {}",
+            balance,
+            fee,
+            ledger,
+        );
+        return Ok(0);
+    }
+
+    // 4. Resolve the ledger's minting account (required to burn).
+    let minting_call: Result<(Option<Account>,), _> =
+        ic_cdk::call(ledger, "icrc1_minting_account", ()).await;
+    let minting_account = match minting_call {
+        Ok((Some(a),)) => a,
+        Ok((None,)) => {
+            return Err(AmmError::TransferFailed {
+                token: "icUSD".to_string(),
+                reason: "ledger has no minting account; cannot burn".to_string(),
+            });
+        }
+        Err((code, msg)) => {
+            return Err(AmmError::TransferFailed {
+                token: "icUSD".to_string(),
+                reason: format!(
+                    "icrc1_minting_account rejected: {:?} {}",
+                    code, msg,
+                ),
+            });
+        }
+    };
+
+    // 5. Transfer the full balance from {self, sub} to the minting account.
+    // ICRC-1 ledgers treat transfers to the minting account as burns and
+    // charge no fee, so the source subaccount nets to 0.
+    let amount_to_burn = balance;
+    let args = TransferArg {
+        from_subaccount: Some(sub),
+        to: minting_account,
+        amount: Nat::from(amount_to_burn),
+        fee: None,
+        memo: Some(b"amm1_pool_id_recovery_burn".to_vec().into()),
+        created_at_time: Some(ic_cdk::api::time()),
+    };
+    let transfer_call: Result<(Result<Nat, TransferError>,), _> =
+        ic_cdk::call(ledger, "icrc1_transfer", (args,)).await;
+
+    let caller = ic_cdk::caller();
+    match transfer_call {
+        Ok((Ok(block_index),)) => {
+            let block_index_u64: u64 = block_index.0.clone().try_into().unwrap_or(u64::MAX);
+            log!(
+                INFO,
+                "[admin_burn_subaccount_balance] burned {} from ledger {} subaccount via burn-to-minting-account at block {}",
+                amount_to_burn,
+                ledger,
+                block_index_u64,
+            );
+            mutate_state(|s| {
+                s.record_admin_event(
+                    caller,
+                    AmmAdminAction::AdminBurnSubaccount {
+                        ledger,
+                        subaccount_hex: subaccount_hex.clone(),
+                        amount_burned: amount_to_burn,
+                        block_index: block_index_u64,
+                    },
+                );
+            });
+            Ok(amount_to_burn)
+        }
+        // A Duplicate from the ledger means the burn already landed at
+        // duplicate_of. Treat as success on the canonical amount, matching
+        // the pattern used by `transfer_to_user` / `burn_token_on_ledger`.
+        Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
+            let block_index_u64: u64 = duplicate_of.0.clone().try_into().unwrap_or(u64::MAX);
+            log!(
+                INFO,
+                "[admin_burn_subaccount_balance] burn deduped at ledger {} (previously landed at block {})",
+                ledger,
+                block_index_u64,
+            );
+            mutate_state(|s| {
+                s.record_admin_event(
+                    caller,
+                    AmmAdminAction::AdminBurnSubaccount {
+                        ledger,
+                        subaccount_hex: subaccount_hex.clone(),
+                        amount_burned: amount_to_burn,
+                        block_index: block_index_u64,
+                    },
+                );
+            });
+            Ok(amount_to_burn)
+        }
+        Ok((Err(e),)) => Err(AmmError::TransferFailed {
+            token: "icUSD".to_string(),
+            reason: format!("icrc1_transfer error: {:?}", e),
+        }),
+        Err((code, msg)) => Err(AmmError::TransferFailed {
+            token: "icUSD".to_string(),
+            reason: format!("icrc1_transfer call rejected: {:?} {}", code, msg),
+        }),
+    }
+}
+
+/// Admin: force-remove a pending claim without transferring (e.g., after manual resolution).
+#[update]
+fn resolve_pending_claim(claim_id: u64) -> Result<(), AmmError> {
+    let caller = ic_cdk::caller();
+    caller_is_admin()?;
+    mutate_state(|s| {
+        let before = s.pending_claims.len();
+        s.pending_claims.retain(|c| c.id != claim_id);
+        if s.pending_claims.len() == before {
+            return Err(AmmError::ClaimNotFound);
+        }
+        log!(INFO, "Pending claim #{} force-resolved by admin", claim_id);
+        s.record_admin_event(caller, AmmAdminAction::ResolvePendingClaim { claim_id });
+        Ok(())
+    })
+}

--- a/src/rumi_amm/src/lib.rs
+++ b/src/rumi_amm/src/lib.rs
@@ -899,6 +899,12 @@ async fn admin_burn_subaccount_balance(
         sub.iter().map(|b| format!("{:02x}", b)).collect();
 
     // 1. Query the canister's balance at the target subaccount.
+    // Saturation note: ICRC-1 balances are bounded well below u128::MAX in
+    // any realistic scenario (icUSD total supply ~$10^4 e8s as of writing).
+    // Saturating to u128::MAX on overflow is the safer failure mode here:
+    // it would make the `balance <= fee` check below trivially false, so
+    // the transfer attempt itself would surface the impossible value as a
+    // ledger error rather than silently truncating.
     let acct = Account {
         owner: ic_cdk::id(),
         subaccount: Some(sub),
@@ -918,7 +924,7 @@ async fn admin_burn_subaccount_balance(
         }
     };
 
-    // 2. Query the ledger's transfer fee.
+    // 2. Query the ledger's transfer fee. Same saturation rationale as above.
     let fee_call: Result<(Nat,), _> = ic_cdk::call(ledger, "icrc1_fee", ()).await;
     let fee: u128 = match fee_call {
         Ok((n,)) => n.0.try_into().unwrap_or(u128::MAX),

--- a/src/rumi_amm/src/lib.rs
+++ b/src/rumi_amm/src/lib.rs
@@ -14,6 +14,7 @@ pub mod rewards;
 pub mod transfers;
 pub mod icrc21;
 pub mod analytics;
+mod admin;
 mod logs;
 
 use crate::types::*;
@@ -33,12 +34,12 @@ thread_local! {
     static POOL_LOCKS: RefCell<BTreeSet<PoolId>> = RefCell::new(BTreeSet::new());
 }
 
-struct PoolGuard {
+pub(crate) struct PoolGuard {
     pool_id: PoolId,
 }
 
 impl PoolGuard {
-    fn new(pool_id: PoolId) -> Result<Self, AmmError> {
+    pub(crate) fn new(pool_id: PoolId) -> Result<Self, AmmError> {
         POOL_LOCKS.with(|locks| {
             if !locks.borrow_mut().insert(pool_id.clone()) {
                 return Err(AmmError::PoolBusy);
@@ -504,7 +505,7 @@ fn post_upgrade(_args: AmmInitArgs) {
 
 // ─── Helpers ───
 
-fn caller_is_admin() -> Result<(), AmmError> {
+pub(crate) fn caller_is_admin() -> Result<(), AmmError> {
     let caller = ic_cdk::caller();
     let admin = read_state(|s| s.admin);
     if caller != admin {
@@ -521,7 +522,7 @@ fn reject_anonymous() -> Result<(), AmmError> {
 }
 
 /// Derive a deterministic 32-byte subaccount from a pool ID and token label.
-fn derive_subaccount(pool_id: &str, token_label: &str) -> [u8; 32] {
+pub(crate) fn derive_subaccount(pool_id: &str, token_label: &str) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(pool_id.as_bytes());
     hasher.update(b"_");
@@ -533,7 +534,7 @@ fn derive_subaccount(pool_id: &str, token_label: &str) -> [u8; 32] {
 }
 
 /// Build pool ID from two token principals (sorted for determinism).
-fn make_pool_id(token_a: Principal, token_b: Principal) -> PoolId {
+pub(crate) fn make_pool_id(token_a: Principal, token_b: Principal) -> PoolId {
     let a = token_a.to_text();
     let b = token_b.to_text();
     if a <= b {
@@ -573,477 +574,6 @@ fn record_pending_claim(
             id, claimant, amount, token, pool_id);
         id
     })
-}
-
-// ─── Admin Endpoints ───
-
-#[update]
-fn create_pool(args: CreatePoolArgs) -> Result<PoolId, AmmError> {
-    // Admin exempt from maintenance mode — can set up pools while canister is locked
-    if read_state(|s| s.maintenance_mode) && caller_is_admin().is_err() {
-        return Err(AmmError::MaintenanceMode);
-    }
-
-    let is_admin = caller_is_admin().is_ok();
-
-    if !is_admin {
-        // Permissionless path: gate must be open, constant product only, fee clamped
-        if !read_state(|s| s.pool_creation_open) {
-            return Err(AmmError::PoolCreationClosed);
-        }
-        if args.curve != CurveType::ConstantProduct {
-            return Err(AmmError::Unauthorized);
-        }
-        if args.fee_bps < 1 || args.fee_bps > 1000 {
-            return Err(AmmError::FeeBpsOutOfRange);
-        }
-    }
-
-    // Validate fee_bps for all callers (admin included) to prevent creating
-    // permanently broken pools where compute_swap would always error
-    if args.fee_bps > 10_000 {
-        return Err(AmmError::FeeBpsOutOfRange);
-    }
-
-    if args.token_a == args.token_b {
-        return Err(AmmError::InvalidToken);
-    }
-
-    let pool_id = make_pool_id(args.token_a, args.token_b);
-
-    mutate_state(|s| {
-        if s.pools.contains_key(&pool_id) {
-            return Err(AmmError::PoolAlreadyExists);
-        }
-
-        let subaccount_a = derive_subaccount(&pool_id, "token_a");
-        let subaccount_b = derive_subaccount(&pool_id, "token_b");
-
-        // Ensure token_a/token_b are stored in sorted order matching pool_id
-        let (token_a, token_b) = if args.token_a.to_text() <= args.token_b.to_text() {
-            (args.token_a, args.token_b)
-        } else {
-            (args.token_b, args.token_a)
-        };
-
-        let pool = Pool {
-            token_a,
-            token_b,
-            reserve_a: 0,
-            reserve_b: 0,
-            fee_bps: args.fee_bps,
-            protocol_fee_bps: 0, // 100% to LPs initially
-            curve: args.curve,
-            lp_shares: BTreeMap::new(),
-            total_lp_shares: 0,
-            protocol_fees_a: 0,
-            protocol_fees_b: 0,
-            paused: false,
-            subaccount_a,
-            subaccount_b,
-            lp_rewards: BTreeMap::new(),
-            acc_reward_per_share: 0,
-            pending_no_lp: 0,
-            total_rewards_distributed: 0,
-            processed_donation_nonces: std::collections::VecDeque::new(),
-            reward_balance_snapshot: 0,
-        };
-
-        log!(INFO, "Pool created: {} (fee: {} bps, admin: {})", pool_id, args.fee_bps, is_admin);
-        s.pools.insert(pool_id.clone(), pool);
-        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::CreatePool {
-            pool_id: pool_id.clone(),
-            token_a,
-            token_b,
-            fee_bps: args.fee_bps,
-        });
-        Ok(pool_id)
-    })
-}
-
-#[update]
-fn set_fee(pool_id: PoolId, fee_bps: u16) -> Result<(), AmmError> {
-    let caller = ic_cdk::caller();
-    caller_is_admin()?;
-    if fee_bps > 10_000 {
-        return Err(AmmError::FeeBpsOutOfRange);
-    }
-    mutate_state(|s| {
-        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
-        pool.fee_bps = fee_bps;
-        log!(INFO, "Pool {} fee set to {} bps", pool_id, fee_bps);
-        s.record_admin_event(caller, AmmAdminAction::SetFee { pool_id: pool_id.clone(), fee_bps });
-        Ok(())
-    })
-}
-
-#[update]
-fn set_protocol_fee(pool_id: PoolId, protocol_fee_bps: u16) -> Result<(), AmmError> {
-    let caller = ic_cdk::caller();
-    caller_is_admin()?;
-    if protocol_fee_bps > 10_000 {
-        return Err(AmmError::FeeBpsOutOfRange);
-    }
-    mutate_state(|s| {
-        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
-        pool.protocol_fee_bps = protocol_fee_bps;
-        log!(INFO, "Pool {} protocol fee set to {} bps", pool_id, protocol_fee_bps);
-        s.record_admin_event(caller, AmmAdminAction::SetProtocolFee { pool_id: pool_id.clone(), protocol_fee_bps });
-        Ok(())
-    })
-}
-
-#[update]
-async fn withdraw_protocol_fees(pool_id: PoolId) -> Result<(u128, u128), AmmError> {
-    caller_is_admin()?;
-
-    // Acquire per-pool lock to prevent concurrent fee withdrawals
-    let _pool_guard = PoolGuard::new(pool_id.clone())?;
-
-    let (token_a, token_b, sub_a, sub_b, fees_a, fees_b, admin) = read_state(|s| {
-        let pool = s.pools.get(&pool_id).ok_or(AmmError::PoolNotFound)?;
-        Ok::<_, AmmError>((
-            pool.token_a, pool.token_b,
-            pool.subaccount_a, pool.subaccount_b,
-            pool.protocol_fees_a, pool.protocol_fees_b,
-            s.admin,
-        ))
-    })?;
-
-    if fees_a == 0 && fees_b == 0 {
-        return Ok((0, 0));
-    }
-
-    // Optimistic deduct: zero out fees in state BEFORE transferring.
-    mutate_state(|s| {
-        let pool = s.pools.get_mut(&pool_id).expect("pool must exist: verified at start of withdraw_protocol_fees");
-        pool.protocol_fees_a = 0;
-        pool.protocol_fees_b = 0;
-    });
-
-    let mut withdrawn_a = 0u128;
-    let mut withdrawn_b = 0u128;
-    let mut errors = Vec::new();
-
-    if fees_a > 0 {
-        match transfer_to_user(token_a, sub_a, admin, fees_a).await {
-            Ok(_) => withdrawn_a = fees_a,
-            Err(reason) => {
-                log!(INFO, "WARN: withdraw_protocol_fees transfer_a failed: {}. Rolling back.", reason);
-                errors.push(format!("token_a: {}", reason));
-            }
-        }
-    }
-
-    if fees_b > 0 {
-        match transfer_to_user(token_b, sub_b, admin, fees_b).await {
-            Ok(_) => withdrawn_b = fees_b,
-            Err(reason) => {
-                log!(INFO, "WARN: withdraw_protocol_fees transfer_b failed: {}. Rolling back.", reason);
-                errors.push(format!("token_b: {}", reason));
-            }
-        }
-    }
-
-    // Roll back any fees that failed to transfer
-    let rollback_a = fees_a - withdrawn_a;
-    let rollback_b = fees_b - withdrawn_b;
-    if rollback_a > 0 || rollback_b > 0 {
-        mutate_state(|s| {
-            let pool = s.pools.get_mut(&pool_id).expect("pool must exist: verified at start of withdraw_protocol_fees");
-            pool.protocol_fees_a += rollback_a;
-            pool.protocol_fees_b += rollback_b;
-        });
-    }
-
-    if !errors.is_empty() {
-        return Err(AmmError::TransferFailed {
-            token: "protocol_fees".to_string(),
-            reason: errors.join("; "),
-        });
-    }
-
-    log!(INFO, "Protocol fees withdrawn from {}: ({}, {})", pool_id, withdrawn_a, withdrawn_b);
-    mutate_state(|s| {
-        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::WithdrawProtocolFees {
-            pool_id: pool_id.clone(),
-            amount_a: withdrawn_a,
-            amount_b: withdrawn_b,
-        });
-    });
-    Ok((withdrawn_a, withdrawn_b))
-}
-
-#[update]
-fn pause_pool(pool_id: PoolId) -> Result<(), AmmError> {
-    let caller = ic_cdk::caller();
-    caller_is_admin()?;
-    mutate_state(|s| {
-        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
-        pool.paused = true;
-        log!(INFO, "Pool {} paused", pool_id);
-        s.record_admin_event(caller, AmmAdminAction::PausePool { pool_id: pool_id.clone() });
-        Ok(())
-    })
-}
-
-#[update]
-fn unpause_pool(pool_id: PoolId) -> Result<(), AmmError> {
-    let caller = ic_cdk::caller();
-    caller_is_admin()?;
-    mutate_state(|s| {
-        let pool = s.pools.get_mut(&pool_id).ok_or(AmmError::PoolNotFound)?;
-        pool.paused = false;
-        log!(INFO, "Pool {} unpaused", pool_id);
-        s.record_admin_event(caller, AmmAdminAction::UnpausePool { pool_id: pool_id.clone() });
-        Ok(())
-    })
-}
-
-#[update]
-fn set_pool_creation_open(open: bool) -> Result<(), AmmError> {
-    caller_is_admin()?;
-    mutate_state(|s| s.pool_creation_open = open);
-    log!(INFO, "Pool creation open: {}", open);
-    mutate_state(|s| {
-        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::SetPoolCreationOpen { open });
-    });
-    Ok(())
-}
-
-#[update]
-fn set_admin(new_admin: Principal) -> Result<(), AmmError> {
-    caller_is_admin()?;
-    if new_admin == Principal::anonymous() {
-        return Err(AmmError::Unauthorized);
-    }
-    let old_admin = read_state(|s| s.admin);
-    mutate_state(|s| s.admin = new_admin);
-    log!(INFO, "Admin transferred: {} -> {}", old_admin, new_admin);
-    Ok(())
-}
-
-#[update]
-fn set_maintenance_mode(enabled: bool) -> Result<(), AmmError> {
-    caller_is_admin()?;
-    mutate_state(|s| s.maintenance_mode = enabled);
-    log!(INFO, "Maintenance mode: {}", enabled);
-    mutate_state(|s| {
-        s.record_admin_event(ic_cdk::caller(), AmmAdminAction::SetMaintenanceMode { enabled });
-    });
-    Ok(())
-}
-
-/// Configure which principal is allowed to call `notify_reward_received`.
-/// Required before AMM1 earnings distribution can begin. Only callable
-/// by admin. Set to the rumi_protocol_backend canister principal.
-#[update]
-fn set_protocol_backend_principal(principal: Principal) -> Result<(), AmmError> {
-    caller_is_admin()?;
-    if principal == Principal::anonymous() {
-        return Err(AmmError::Unauthorized);
-    }
-    mutate_state(|s| s.protocol_backend_principal = Some(principal));
-    log!(INFO, "Protocol backend principal set to: {}", principal);
-    mutate_state(|s| {
-        s.record_admin_event(
-            ic_cdk::caller(),
-            AmmAdminAction::SetProtocolBackendPrincipal { backend: principal },
-        );
-    });
-    Ok(())
-}
-
-/// Admin recovery endpoint: burn whatever balance the AMM canister holds
-/// at a specific (ledger, subaccount) by transferring it to the ledger's
-/// minting account. ICRC-1 ledgers treat transfers to the minting
-/// account as burns and charge no fee on top.
-///
-/// Built as the recovery path for the 2026-05-19 AMM1 pool_id-mismatch
-/// incident, where `donate_icusd_to_amm1` minted icUSD into the AMM's
-/// `sha256("rumi_amm:rewards:3USD_ICP")` subaccount even though no pool
-/// is keyed off that pool_id (the actual 3USD/ICP pool ID is
-/// `make_pool_id(token_a, token_b)`). The stuck balance is unbacked
-/// icUSD and must be burned, not redirected.
-///
-/// Caller must be admin. `subaccount` must be exactly 32 bytes. If the
-/// canister's balance at the subaccount is at or below the ledger fee
-/// (typical `min_burn_amount`), returns `Ok(0)` (no-op). Otherwise
-/// transfers the full balance to the ledger's minting account and
-/// returns the burned amount on success.
-///
-/// Note: this burns the balance observed at the start of the call. If a
-/// concurrent mint arrives during the inter-canister awaits, the residual
-/// won't be burned — re-run the endpoint to clear it.
-#[update]
-async fn admin_burn_subaccount_balance(
-    ledger: Principal,
-    subaccount: Vec<u8>,
-) -> Result<u128, AmmError> {
-    use icrc_ledger_types::icrc1::account::Account;
-    use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
-
-    caller_is_admin()?;
-
-    // Subaccounts on ICRC-1 are fixed at 32 bytes.
-    if subaccount.len() != 32 {
-        return Err(AmmError::InvalidInput {
-            reason: format!("subaccount must be 32 bytes, got {}", subaccount.len()),
-        });
-    }
-    let mut sub = [0u8; 32];
-    sub.copy_from_slice(&subaccount);
-    // Render the subaccount as a 64-char lowercase hex string for the
-    // admin-event audit trail. Avoids pulling in the `hex` crate.
-    let subaccount_hex: String =
-        sub.iter().map(|b| format!("{:02x}", b)).collect();
-
-    // 1. Query the canister's balance at the target subaccount.
-    // Saturation note: ICRC-1 balances are bounded well below u128::MAX in
-    // any realistic scenario (icUSD total supply ~$10^4 e8s as of writing).
-    // Saturating to u128::MAX on overflow is the safer failure mode here:
-    // it would make the `balance <= fee` check below trivially false, so
-    // the transfer attempt itself would surface the impossible value as a
-    // ledger error rather than silently truncating.
-    let acct = Account {
-        owner: ic_cdk::id(),
-        subaccount: Some(sub),
-    };
-    let balance_call: Result<(Nat,), _> =
-        ic_cdk::call(ledger, "icrc1_balance_of", (acct,)).await;
-    let balance: u128 = match balance_call {
-        Ok((n,)) => n.0.try_into().unwrap_or(u128::MAX),
-        Err((code, msg)) => {
-            return Err(AmmError::TransferFailed {
-                token: "icUSD".to_string(),
-                reason: format!(
-                    "icrc1_balance_of rejected: {:?} {}",
-                    code, msg,
-                ),
-            });
-        }
-    };
-
-    // 2. Query the ledger's transfer fee. Same saturation rationale as above.
-    let fee_call: Result<(Nat,), _> = ic_cdk::call(ledger, "icrc1_fee", ()).await;
-    let fee: u128 = match fee_call {
-        Ok((n,)) => n.0.try_into().unwrap_or(u128::MAX),
-        Err((code, msg)) => {
-            return Err(AmmError::TransferFailed {
-                token: "icUSD".to_string(),
-                reason: format!("icrc1_fee rejected: {:?} {}", code, msg),
-            });
-        }
-    };
-
-    // 3. No-op if the balance is below `min_burn_amount`. ICRC-1 ledgers
-    // enforce `amount >= min_burn_amount` (typically equal to the transfer
-    // fee) on burns, so a balance at or below the fee cannot be burned.
-    if balance <= fee {
-        log!(
-            INFO,
-            "[admin_burn_subaccount_balance] no-op: balance={} fee={} for ledger {}",
-            balance,
-            fee,
-            ledger,
-        );
-        return Ok(0);
-    }
-
-    // 4. Resolve the ledger's minting account (required to burn).
-    let minting_call: Result<(Option<Account>,), _> =
-        ic_cdk::call(ledger, "icrc1_minting_account", ()).await;
-    let minting_account = match minting_call {
-        Ok((Some(a),)) => a,
-        Ok((None,)) => {
-            return Err(AmmError::TransferFailed {
-                token: "icUSD".to_string(),
-                reason: "ledger has no minting account; cannot burn".to_string(),
-            });
-        }
-        Err((code, msg)) => {
-            return Err(AmmError::TransferFailed {
-                token: "icUSD".to_string(),
-                reason: format!(
-                    "icrc1_minting_account rejected: {:?} {}",
-                    code, msg,
-                ),
-            });
-        }
-    };
-
-    // 5. Transfer the full balance from {self, sub} to the minting account.
-    // ICRC-1 ledgers treat transfers to the minting account as burns and
-    // charge no fee, so the source subaccount nets to 0.
-    let amount_to_burn = balance;
-    let args = TransferArg {
-        from_subaccount: Some(sub),
-        to: minting_account,
-        amount: Nat::from(amount_to_burn),
-        fee: None,
-        memo: Some(b"amm1_pool_id_recovery_burn".to_vec().into()),
-        created_at_time: Some(ic_cdk::api::time()),
-    };
-    let transfer_call: Result<(Result<Nat, TransferError>,), _> =
-        ic_cdk::call(ledger, "icrc1_transfer", (args,)).await;
-
-    let caller = ic_cdk::caller();
-    match transfer_call {
-        Ok((Ok(block_index),)) => {
-            let block_index_u64: u64 = block_index.0.clone().try_into().unwrap_or(u64::MAX);
-            log!(
-                INFO,
-                "[admin_burn_subaccount_balance] burned {} from ledger {} subaccount via burn-to-minting-account at block {}",
-                amount_to_burn,
-                ledger,
-                block_index_u64,
-            );
-            mutate_state(|s| {
-                s.record_admin_event(
-                    caller,
-                    AmmAdminAction::AdminBurnSubaccount {
-                        ledger,
-                        subaccount_hex: subaccount_hex.clone(),
-                        amount_burned: amount_to_burn,
-                        block_index: block_index_u64,
-                    },
-                );
-            });
-            Ok(amount_to_burn)
-        }
-        // A Duplicate from the ledger means the burn already landed at
-        // duplicate_of. Treat as success on the canonical amount, matching
-        // the pattern used by `transfer_to_user` / `burn_token_on_ledger`.
-        Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
-            let block_index_u64: u64 = duplicate_of.0.clone().try_into().unwrap_or(u64::MAX);
-            log!(
-                INFO,
-                "[admin_burn_subaccount_balance] burn deduped at ledger {} (previously landed at block {})",
-                ledger,
-                block_index_u64,
-            );
-            mutate_state(|s| {
-                s.record_admin_event(
-                    caller,
-                    AmmAdminAction::AdminBurnSubaccount {
-                        ledger,
-                        subaccount_hex: subaccount_hex.clone(),
-                        amount_burned: amount_to_burn,
-                        block_index: block_index_u64,
-                    },
-                );
-            });
-            Ok(amount_to_burn)
-        }
-        Ok((Err(e),)) => Err(AmmError::TransferFailed {
-            token: "icUSD".to_string(),
-            reason: format!("icrc1_transfer error: {:?}", e),
-        }),
-        Err((code, msg)) => Err(AmmError::TransferFailed {
-            token: "icUSD".to_string(),
-            reason: format!("icrc1_transfer call rejected: {:?} {}", code, msg),
-        }),
-    }
 }
 
 /// Receive a reward donation from the protocol backend. The caller is
@@ -1287,23 +817,6 @@ async fn claim_pending(claim_id: u64) -> Result<(), AmmError> {
 #[query]
 fn get_pending_claims() -> Vec<PendingClaim> {
     read_state(|s| s.pending_claims.clone())
-}
-
-/// Admin: force-remove a pending claim without transferring (e.g., after manual resolution).
-#[update]
-fn resolve_pending_claim(claim_id: u64) -> Result<(), AmmError> {
-    let caller = ic_cdk::caller();
-    caller_is_admin()?;
-    mutate_state(|s| {
-        let before = s.pending_claims.len();
-        s.pending_claims.retain(|c| c.id != claim_id);
-        if s.pending_claims.len() == before {
-            return Err(AmmError::ClaimNotFound);
-        }
-        log!(INFO, "Pending claim #{} force-resolved by admin", claim_id);
-        s.record_admin_event(caller, AmmAdminAction::ResolvePendingClaim { claim_id });
-        Ok(())
-    })
 }
 
 // ─── Core AMM ───


### PR DESCRIPTION
## Summary

Follow-up to PR #193 (AMM1 pool_id mismatch fix). Two non-functional cleanups from the code-quality review:

1. **`docs(amm)`** — Add a comment explaining why `Nat → u128` parsing in `admin_burn_subaccount_balance` saturates to `u128::MAX` on overflow rather than panicking. The realistic ICRC-1 balance/fee range is well below `u128`, and saturation surfaces as a ledger error instead of silent truncation.

2. **`refactor(amm)`** — Extract the 12 admin-gated endpoints from `lib.rs` into a new `admin.rs` module. **Pure code move** — no behavior change, no signature change, no Candid change.

## Lines

- `src/rumi_amm/src/lib.rs`: 2052 → 1565 (-487)
- `src/rumi_amm/src/admin.rs`: new file, 506 lines

## Extracted endpoints

- `create_pool`, `set_fee`, `set_protocol_fee`, `withdraw_protocol_fees`
- `pause_pool`, `unpause_pool`
- `set_pool_creation_open`, `set_admin`, `set_maintenance_mode`
- `set_protocol_backend_principal`
- `admin_burn_subaccount_balance`
- `resolve_pending_claim`

## Helpers promoted to `pub(crate)` in `lib.rs`

- `caller_is_admin()` — still referenced by `claim_pending` for the admin override path
- `derive_subaccount()`, `make_pool_id()` — used by `create_pool`
- `PoolGuard` + `PoolGuard::new()` — used by `withdraw_protocol_fees`

## Verification

- `cargo build -p rumi_amm` — clean
- `cargo test -p rumi_amm` (with PocketIC) — **71 tests pass, 0 fail, 1 ignored** (same counts as pre-refactor baseline)
- `git diff src/rumi_amm/rumi_amm.did` — empty (no Candid surface change)

## Why these are non-deploys

Neither commit changes wasm behavior. The polish commit adds a doc comment only. The refactor moves code between files without changing what gets exported on the canister surface. The next live AMM upgrade (whenever it happens) will pick these up incidentally.

## Test plan

- [x] Full AMM test suite green
- [x] Candid diff empty
- [x] lib.rs line count materially reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)