### PR TITLE
refactor(oisy): migrate to @icp-sdk/signer v5, drop fake ICRC-112 batching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@dfinity/cbor": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
-      "integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.3.tgz",
+      "integrity": "sha512-5GX+9tAf29r94Pxv8nCzrv2/t+AkOfem/c/G61+FA2Wadq7THvc5cvr/AVLH0LpukVfNSWRRHvl1fkCdiB9MMQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@dfinity/identity": {
@@ -945,17 +945,26 @@
       }
     },
     "node_modules/@icp-sdk/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-5.4.0.tgz",
+      "integrity": "sha512-yedhCkHIhCxI65W8id99Mi8fUgSyqKSTbD57AphquNcFV2/3Rjykng0/6H08mHswKydDcv6Y0+e8aPdrznewCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/cbor": "^0.2.2",
+        "@dfinity/cbor": "^0.2.3",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
         "asn1js": "^3.0.7"
+      }
+    },
+    "node_modules/@icp-sdk/signer": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/signer/-/signer-5.3.1.tgz",
+      "integrity": "sha512-2IJOdAnAit6SLZU3FTfPK0he4kCR+mr3IunDk62PgZCQKzvJ2DyV8FPBIceDpMSOXJLuXEMwd9E4Hdc53n0nrw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@icp-sdk/core": "^5"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -6190,6 +6199,8 @@
         "@dfinity/identity": "2.3.0",
         "@dfinity/ledger-icp": "2.6.8",
         "@dfinity/principal": "2.3.0",
+        "@icp-sdk/core": "^5.4.0",
+        "@icp-sdk/signer": "^5.3.1",
         "@slide-computer/signer": "^4.2.2",
         "@slide-computer/signer-agent": "^4.2.2",
         "@slide-computer/signer-web": "^4.2.2",

--- a/src/vault_frontend/package.json
+++ b/src/vault_frontend/package.json
@@ -55,6 +55,8 @@
 		"@dfinity/identity": "2.3.0",
 		"@dfinity/ledger-icp": "2.6.8",
 		"@dfinity/principal": "2.3.0",
+		"@icp-sdk/core": "^5.4.0",
+		"@icp-sdk/signer": "^5.3.1",
 		"@slide-computer/signer": "^4.2.2",
 		"@slide-computer/signer-agent": "^4.2.2",
 		"@slide-computer/signer-web": "^4.2.2",

--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -181,7 +181,7 @@
       error = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
       // Run quote + signer/fee pre-warm in parallel so the click handler stays
-      // synchronous all the way to signerAgent.execute() (Oisy popup gate).
+      // synchronous all the way to the first Oisy consent screen (popup gate).
       const [route] = await Promise.all([
         resolveRoute(fromToken, toToken, amountRaw),
         preWarmOisySigner(),

--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -44,6 +44,19 @@
   let recovering = false;
   let recoveryMessage = '';
 
+  // Pre-quote snapshot of destination-token balance.
+  //
+  // The Oisy `_arr` false-negative verifier needs the destination balance
+  // BEFORE the swap to compare against the balance AFTER. We must NOT await
+  // this query inside the click handler — it burns the browser's user-gesture
+  // window and trips Oisy's "Signer window should not be opened outside of
+  // click handler" guard.
+  //
+  // Captured during `fetchQuote()` (already an async context, no popup gate
+  // yet). Reset on token-switch / form-clear so a stale snapshot never
+  // carries across a different `toToken`.
+  let beforeToBalanceSnapshot: bigint | null = null;
+
   $: isConnected = $walletStore.isConnected;
   $: fromToken = AMM_TOKENS[fromIdx];
   $: toToken = AMM_TOKENS[toIdx];
@@ -180,17 +193,27 @@
       quoting = true;
       error = '';
       const amountRaw = parseTokenAmount(String(amount), fromToken.decimals);
-      // Run quote + signer/fee pre-warm in parallel so the click handler stays
-      // synchronous all the way to the first Oisy consent screen (popup gate).
-      const [route] = await Promise.all([
+      const walletState = get(walletStore);
+      // Run quote + signer/fee pre-warm + destination-balance snapshot in
+      // parallel so the click handler stays synchronous all the way to the
+      // first Oisy consent screen (popup gate). Awaiting any of these inside
+      // handleSwap would burn the browser's user-gesture window and trip
+      // Oisy's "Signer window should not be opened outside of click handler"
+      // guard.
+      const [route, , , snapshot] = await Promise.all([
         resolveRoute(fromToken, toToken, amountRaw),
         preWarmOisySigner(),
         preWarmOisyFees(),
+        walletState.principal
+          ? TokenService.getTokenBalance(toToken.ledgerId, walletState.principal, { skipCache: true }).catch(() => null)
+          : Promise.resolve(null),
       ]);
       currentRoute = route;
+      beforeToBalanceSnapshot = snapshot as bigint | null;
       midMarketRate = await fetchMidMarketRate(currentRoute);
     } catch (err: any) {
       currentRoute = null;
+      beforeToBalanceSnapshot = null;
       error = `Quote failed: ${err.message}`;
       console.warn('Quote failed:', err.message, err);
     } finally {
@@ -217,6 +240,7 @@
     toIdx = tmp;
     amount = '';
     currentRoute = null;
+    beforeToBalanceSnapshot = null;
     error = '';
   }
 
@@ -226,6 +250,7 @@
     showFromDropdown = false;
     amount = '';
     currentRoute = null;
+    beforeToBalanceSnapshot = null;
     error = '';
   }
 
@@ -234,6 +259,7 @@
     toIdx = index;
     showToDropdown = false;
     currentRoute = null;
+    beforeToBalanceSnapshot = null;
     error = '';
   }
 
@@ -282,13 +308,13 @@
         return;
       }
 
-      // Oisy false-negative resilience: capture pre-swap destination
-      // balance so we can verify the swap landed on-chain even if
-      // Oisy returns its `_arr` error in the JSON-RPC response.
+      // Oisy false-negative resilience: read the pre-swap destination
+      // balance synchronously from the snapshot captured during fetchQuote().
+      // Awaiting a balance query here would burn the gesture window — the
+      // verifier compares against this snapshot if Oisy returns its `_arr`
+      // error.
       const walletState = get(walletStore);
-      const beforeToBalance = walletState.principal
-        ? await TokenService.getTokenBalance(toToken.ledgerId, walletState.principal, { skipCache: true }).catch(() => null)
-        : null;
+      const beforeToBalance = beforeToBalanceSnapshot;
 
       const swapResult = await callWithOisyFalseNegativeGuard(
         () => executeRoute(currentRoute!, fromToken, toToken, amountRaw, slippageBps),

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -547,8 +547,9 @@
     if (addOverMax) { toastStore.error(`Exceeds wallet balance (${formatNumber(maxAddCollateral, 4)} ${collateralSymbol})`, 8000); return; }
     clearMessages(); isProcessing = true;
     try {
-      // Oisy: skip pre-approval — ApiClient ICRC-112 batch handles approve+add_margin
-      // in a single popup. Any async work here burns the browser user gesture context.
+      // Oisy: skip pre-approval — ApiClient handles approve+add_margin as two
+      // sequential consent screens. Any async work here burns the browser user
+      // gesture context before the first Oisy popup opens.
       if (!isOisyWallet()) {
         const ledgerCanisterId = vaultCollateralInfo?.ledgerCanisterId ?? CONFIG.currentIcpLedgerId;
         const amountRaw = BigInt(Math.floor(amount * collateralDecimalsFactor));

--- a/src/vault_frontend/src/lib/services/amm1ApyService.ts
+++ b/src/vault_frontend/src/lib/services/amm1ApyService.ts
@@ -373,16 +373,14 @@ export async function claimAmm1Rewards(): Promise<
     const oisyDetected = isOisyWallet();
 
     if (oisyDetected && wallet.principal) {
+      console.log(`[Oisy] Sequential AMM1 claim_rewards via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const ammActor = createOisyActor(
         AMM_CANISTER_ID,
         rewardsIdlFactory as any,
         signerAgent,
       );
-      signerAgent.batch();
-      const claimPromise = ammActor.claim_rewards(poolId);
-      await signerAgent.execute();
-      const result = (await claimPromise) as
+      const result = (await ammActor.claim_rewards(poolId)) as
         | { Ok: bigint }
         | { Err: any };
       if ('Err' in result) return { error: formatClaimError(result.Err) };

--- a/src/vault_frontend/src/lib/services/ammService.ts
+++ b/src/vault_frontend/src/lib/services/ammService.ts
@@ -114,9 +114,9 @@ export function tokenFee(token: AmmToken): Promise<bigint> {
 
 /**
  * Synchronous version of `tokenFee`. Returns the cached fee or the hardcoded
- * fallback. Use inside Oisy signer-batch code paths where a click-handler
- * gesture window must be preserved (no `await` between click and
- * `signerAgent.execute()`). Callers MUST ensure the cache is warmed first via
+ * fallback. Use inside Oisy signer code paths where a click-handler gesture
+ * window must be preserved (no `await` between click and the first Oisy
+ * popup). Callers MUST ensure the cache is warmed first via
  * `preWarmOisyFees()` during the quote phase.
  */
 export function tokenFeeCached(token: AmmToken): bigint {
@@ -334,27 +334,24 @@ class AmmService {
     const approveAmt = await approvalAmount(amountIn, inputToken);
 
     if (oisyDetected && wallet.principal) {
+      console.log(`[Oisy] Sequential approve + AMM swap via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const ledgerActor = createOisyActor(inputToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
       const ammActor = createOisyActor(AMM_CANISTER_ID, canisterIDLs.rumi_amm, signerAgent);
 
-      signerAgent.batch();
-      const approvePromise = ledgerActor.icrc2_approve({
+      // 1) Approve (first Oisy consent screen, Tier 1 native).
+      const approveResult = await ledgerActor.icrc2_approve({
         amount: approveAmt,
         spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: [],
       });
-
-      signerAgent.batch();
-      const swapPromise = ammActor.swap(poolId, tokenIn, amountIn, minAmountOut);
-
-      await signerAgent.execute();
-      const [approveResult, swapResult] = await Promise.all([approvePromise, swapPromise]);
-
       if (approveResult && 'Err' in approveResult) {
         throw new Error(`Approval failed: ${JSON.stringify(approveResult.Err)}`);
       }
+
+      // 2) AMM swap (second Oisy consent screen).
+      const swapResult = await ammActor.swap(poolId, tokenIn, amountIn, minAmountOut);
       if ('Err' in swapResult) throw new Error(this.formatError(swapResult.Err));
       return swapResult.Ok;
     } else {
@@ -398,44 +395,40 @@ class AmmService {
     const approveB = amountB > 0n ? await approvalAmount(amountB, tokenB) : 0n;
 
     if (oisyDetected && wallet.principal) {
+      console.log(`[Oisy] Sequential approve(s) + AMM add_liquidity via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
-      const approvePromises: Promise<any>[] = [];
 
+      // 1) Approve token A (first Oisy consent screen, if needed).
       if (amountA > 0n) {
         const ledgerA = createOisyActor(tokenA.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
-        signerAgent.batch();
-        approvePromises.push(ledgerA.icrc2_approve({
+        const approveResultA = await ledgerA.icrc2_approve({
           amount: approveA,
           spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
-        }));
+        });
+        if (approveResultA && 'Err' in approveResultA) {
+          throw new Error(`Approval failed for ${tokenA.symbol}: ${JSON.stringify(approveResultA.Err)}`);
+        }
       }
 
+      // 2) Approve token B (second consent screen, if needed).
       if (amountB > 0n) {
         const ledgerB = createOisyActor(tokenB.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
-        signerAgent.batch();
-        approvePromises.push(ledgerB.icrc2_approve({
+        const approveResultB = await ledgerB.icrc2_approve({
           amount: approveB,
           spender: { owner: Principal.fromText(AMM_CANISTER_ID), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: [],
-        }));
+        });
+        if (approveResultB && 'Err' in approveResultB) {
+          throw new Error(`Approval failed for ${tokenB.symbol}: ${JSON.stringify(approveResultB.Err)}`);
+        }
       }
 
+      // 3) add_liquidity (final consent screen).
       const ammActor = createOisyActor(AMM_CANISTER_ID, canisterIDLs.rumi_amm, signerAgent);
-      signerAgent.batch();
-      const addPromise = ammActor.add_liquidity(poolId, amountA, amountB, minLpShares);
-
-      await signerAgent.execute();
-      const results = await Promise.all([...approvePromises, addPromise]);
-
-      for (let i = 0; i < approvePromises.length; i++) {
-        const r = results[i];
-        if (r && 'Err' in r) throw new Error(`Approval failed: ${JSON.stringify(r.Err)}`);
-      }
-
-      const addResult = results[results.length - 1];
+      const addResult = await ammActor.add_liquidity(poolId, amountA, amountB, minLpShares);
       if ('Err' in addResult) throw new Error(this.formatError(addResult.Err));
       return addResult.Ok;
     } else {

--- a/src/vault_frontend/src/lib/services/oisySigner.ts
+++ b/src/vault_frontend/src/lib/services/oisySigner.ts
@@ -1,36 +1,36 @@
 /**
- * Direct Oisy signer integration using @slide-computer/signer v4.
+ * Direct Oisy signer integration using @icp-sdk/signer v5.
  *
- * PNP bundles @slide-computer/signer-agent v3.20.0 internally but doesn't
- * expose the SignerAgent. v3's agent also pre-checks ICRC-21 on target
- * canisters, which fails for canisters that don't implement it.
+ * Migrated from @slide-computer/signer v4 on 2026-05-21. Thomas Gladdines
+ * (author of both libs, now at DFINITY) confirmed that ICRC-112 batching
+ * was never adopted by wallets — @slide-computer faked batch() by issuing
+ * sequential ICRC-49 calls under the hood. This caused the intermittent
+ * `_arr` undefined errors we saw between sequential calls (Principal type
+ * mismatch in Oisy v2.0.0's switch from @icp-sdk/auth v4 to v6).
  *
- * This module creates a v4 SignerAgent that delegates consent to the Oisy
- * signer (Tier 1 for known ICRC methods, Tier 3 blind request for custom
- * methods). This lets us call custom canister methods (stability pool
- * deposit, withdraw, etc.) through Oisy without requiring ICRC-21.
+ * The v5 lib has no batch/commit/execute. Each canister call is independent.
+ * Multiple sequential awaits open one Oisy popup window and surface as
+ * separate consent screens within it.
+ *
+ * The SignerAgent.create() method returns an Agent (drop-in HttpAgent) that
+ * can be passed to @dfinity/agent's Actor.createActor().
  *
  * Usage:
- *   import { getOisySignerAgent, createOisyActor, clearOisySigner } from './oisySigner';
- *
  *   const signerAgent = await getOisySignerAgent(principal);
  *   const actor = createOisyActor(canisterId, idlFactory, signerAgent);
- *
- *   signerAgent.batch();
- *   actor.icrc2_approve(...);
- *   signerAgent.batch();
- *   actor.deposit(...);
- *   await signerAgent.execute();
+ *   await actor.icrc2_approve(...);   // first consent screen
+ *   await actor.deposit(...);          // second consent screen
  */
 
-import { Signer } from '@slide-computer/signer';
-import { SignerAgent } from '@slide-computer/signer-agent';
-import { PostMessageTransport } from '@slide-computer/signer-web';
+import { Signer } from '@icp-sdk/signer';
+import { SignerAgent } from '@icp-sdk/signer/agent';
+import { PostMessageTransport } from '@icp-sdk/signer/web';
+import { Principal as IcpSdkPrincipal } from '@icp-sdk/core/principal';
 import { Actor } from '@dfinity/agent';
 import type { Principal } from '@dfinity/principal';
 
-// Module-level Signer — lightweight, no popup until first signing request.
-// windowOpenerFeatures opens Oisy as a popup instead of a new tab.
+// Module-level Signer. Lightweight — no popup until first signing request.
+// windowOpenerFeatures shapes Oisy as a popup window rather than a tab.
 const oisySigner = new Signer({
   transport: new PostMessageTransport({
     url: 'https://oisy.com/sign',
@@ -42,34 +42,48 @@ let cachedAgent: any = null;
 let cachedPrincipalText: string | null = null;
 
 /**
- * Get or create a v4 SignerAgent for the given principal.
- * The SignerAgent is cached and reused across mutations.
- * Creating it does NOT open a popup — the popup opens on execute().
+ * Get or create a v5 SignerAgent for the given principal.
+ *
+ * The agent is cached across mutations within a session. Creating it does NOT
+ * open a popup — the popup opens on the first canister call routed through it.
+ *
+ * Returns a proxy that no-ops `batch()` and `execute()` so un-migrated call
+ * sites continue to work during the v4 → v5 migration. The proxy is removed
+ * in Phase 4 of the migration once all call sites are converted to plain
+ * sequential awaits.
+ *
+ * @param principal Dfinity Principal of the connected account
+ * @returns A SignerAgent compatible with @dfinity/agent Actor.createActor()
  */
 export async function getOisySignerAgent(principal: Principal): Promise<any> {
   const principalText = principal.toText();
 
-  // Reuse cached agent if principal hasn't changed
   if (cachedAgent && cachedPrincipalText === principalText) {
     return cachedAgent;
   }
 
-  // Let SignerAgent create its own @icp-sdk/core HttpAgent internally.
-  // Passing @dfinity/agent's HttpAgent causes a rootKey type mismatch:
-  // @dfinity returns ArrayBuffer but @icp-sdk/core expects Uint8Array,
-  // which breaks certificate validation after signing.
-  cachedAgent = await SignerAgent.create({
-    signer: oisySigner as any,
-    account: principal as any,
+  // Convert @dfinity/principal → @icp-sdk/core/principal via text representation.
+  // The two libs have separate Principal classes; passing one to the other
+  // directly causes a `_arr` mismatch (the v4-era bug).
+  const sdkPrincipal = IcpSdkPrincipal.fromText(principalText);
+
+  const realAgent = await SignerAgent.create({
+    signer: oisySigner,
+    account: sdkPrincipal,
   });
 
+  cachedAgent = withCompatShim(realAgent);
   cachedPrincipalText = principalText;
   return cachedAgent;
 }
 
 /**
- * Create an actor that routes calls through the Oisy v4 SignerAgent.
- * This actor supports batch()/execute() for ICRC-112 batched signing.
+ * Create an actor that routes calls through the v5 SignerAgent.
+ * Drop-in @dfinity/agent Actor — supports any IDL factory generated by didc.
+ *
+ * The `agent: signerAgent as any` cast is intentional: v5's SignerAgent and
+ * @dfinity/agent's HttpAgent are siblings, not identical types. Same pattern
+ * we used with v4.
  */
 export function createOisyActor(
   canisterId: string,
@@ -77,15 +91,62 @@ export function createOisyActor(
   signerAgent: any,
 ): any {
   return Actor.createActor(idlFactory, {
-    agent: signerAgent,
+    agent: signerAgent as any,
     canisterId,
   });
 }
 
 /**
- * Clear cached signer agent (call on disconnect).
+ * Clear cached signer agent (call on wallet disconnect).
  */
 export function clearOisySigner(): void {
   cachedAgent = null;
   cachedPrincipalText = null;
+}
+
+// ─── Migration compat shim ──────────────────────────────────────────────────
+//
+// During the v4 → v5 migration, call sites still invoke
+// `signerAgent.batch()` and `signerAgent.execute()`. The v4 library faked
+// these as sequential ICRC-49 calls under the hood — they were never real
+// atomic batches. v5 has no batch concept at all.
+//
+// We wrap the real v5 agent in a Proxy that no-ops batch/execute, letting
+// us migrate the 91 call sites one file at a time without breaking
+// un-migrated paths. Each call still goes through the v5 agent normally;
+// the batch/execute "ceremony" is just stripped.
+//
+// Once all call sites are migrated (Phase 4), this shim and its logging
+// helper are removed and `getOisySignerAgent` returns the raw agent.
+// ────────────────────────────────────────────────────────────────────────────
+
+let shimLogCount = 0;
+
+function withCompatShim(realAgent: any): any {
+  return new Proxy(realAgent, {
+    get(target, prop, receiver) {
+      if (prop === 'batch') {
+        return () => {
+          if (shimLogCount++ < 3) {
+            console.debug(
+              '[oisySigner v5 shim] batch() called — no-op. ' +
+              'Migrate this call site to sequential awaits (Phase 2 of migration).'
+            );
+          }
+        };
+      }
+      if (prop === 'execute') {
+        return async () => {
+          if (shimLogCount++ < 3) {
+            console.debug(
+              '[oisySigner v5 shim] execute() called — no-op. ' +
+              'Migrate this call site to sequential awaits (Phase 2 of migration).'
+            );
+          }
+        };
+      }
+      // Forward everything else to the real agent
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 }

--- a/src/vault_frontend/src/lib/services/oisySigner.ts
+++ b/src/vault_frontend/src/lib/services/oisySigner.ts
@@ -47,10 +47,12 @@ let cachedPrincipalText: string | null = null;
  * The agent is cached across mutations within a session. Creating it does NOT
  * open a popup — the popup opens on the first canister call routed through it.
  *
- * Returns a proxy that no-ops `batch()` and `execute()` so un-migrated call
- * sites continue to work during the v4 → v5 migration. The proxy is removed
- * in Phase 4 of the migration once all call sites are converted to plain
- * sequential awaits.
+ * Returns the raw v5 SignerAgent (no Proxy wrapping). The earlier Proxy-based
+ * compat shim that no-op'd batch()/execute() was removed once Phase 2 of the
+ * migration converted all call sites to plain sequential awaits — the Proxy
+ * broke methods that access the class's `#private` fields (the v5 SignerAgent
+ * uses ES private slots internally, and Proxy + `#private` is incompatible
+ * because `this` inside the method becomes the Proxy, not the real instance).
  *
  * @param principal Dfinity Principal of the connected account
  * @returns A SignerAgent compatible with @dfinity/agent Actor.createActor()
@@ -67,12 +69,11 @@ export async function getOisySignerAgent(principal: Principal): Promise<any> {
   // directly causes a `_arr` mismatch (the v4-era bug).
   const sdkPrincipal = IcpSdkPrincipal.fromText(principalText);
 
-  const realAgent = await SignerAgent.create({
+  cachedAgent = await SignerAgent.create({
     signer: oisySigner,
     account: sdkPrincipal,
   });
 
-  cachedAgent = withCompatShim(realAgent);
   cachedPrincipalText = principalText;
   return cachedAgent;
 }
@@ -102,51 +103,4 @@ export function createOisyActor(
 export function clearOisySigner(): void {
   cachedAgent = null;
   cachedPrincipalText = null;
-}
-
-// ─── Migration compat shim ──────────────────────────────────────────────────
-//
-// During the v4 → v5 migration, call sites still invoke
-// `signerAgent.batch()` and `signerAgent.execute()`. The v4 library faked
-// these as sequential ICRC-49 calls under the hood — they were never real
-// atomic batches. v5 has no batch concept at all.
-//
-// We wrap the real v5 agent in a Proxy that no-ops batch/execute, letting
-// us migrate the 91 call sites one file at a time without breaking
-// un-migrated paths. Each call still goes through the v5 agent normally;
-// the batch/execute "ceremony" is just stripped.
-//
-// Once all call sites are migrated (Phase 4), this shim and its logging
-// helper are removed and `getOisySignerAgent` returns the raw agent.
-// ────────────────────────────────────────────────────────────────────────────
-
-let shimLogCount = 0;
-
-function withCompatShim(realAgent: any): any {
-  return new Proxy(realAgent, {
-    get(target, prop, receiver) {
-      if (prop === 'batch') {
-        return () => {
-          if (shimLogCount++ < 3) {
-            console.debug(
-              '[oisySigner v5 shim] batch() called — no-op. ' +
-              'Migrate this call site to sequential awaits (Phase 2 of migration).'
-            );
-          }
-        };
-      }
-      if (prop === 'execute') {
-        return async () => {
-          if (shimLogCount++ < 3) {
-            console.debug(
-              '[oisySigner v5 shim] execute() called — no-op. ' +
-              'Migrate this call site to sequential awaits (Phase 2 of migration).'
-            );
-          }
-        };
-      }
-      // Forward everything else to the real agent
-      return Reflect.get(target, prop, receiver);
-    },
-  });
 }

--- a/src/vault_frontend/src/lib/services/pnp.ts
+++ b/src/vault_frontend/src/lib/services/pnp.ts
@@ -320,22 +320,50 @@ export const pnp = {
   },
 
   /**
-   * Get the SignerAgent from the current PNP adapter (Oisy/NFID).
+   * Get a SignerAgent for the current wallet, if it's an Oisy/signer-style wallet.
    * Returns null for non-signer wallets (Plug, II) or when not connected.
-   * Used for ICRC-112 batching: approve + action in a single signer popup.
    *
-   * The SignerAgent exposes batch()/execute()/clear() for ICRC-112 batched calls.
-   * Sequential batching: batch() → queue call A → batch() → queue call B → execute()
-   * sends a single signer popup with ordered sequences.
+   * Migrated 2026-05-21 from @slide-computer/signer v4 to @icp-sdk/signer v5.
+   * Per Thomas Gladdines (lib author), ICRC-112 batching was never adopted by
+   * wallets — the v4 batch()/execute() faked it as sequential ICRC-49 calls.
+   * The v5 agent has no batch concept; each call is independent. During the
+   * migration window, call sites that still invoke batch()/execute() get a
+   * Proxy shim from oisySigner.ts that no-ops them.
+   *
+   * This method is now async because the v5 SignerAgent.create() is async.
    */
-  getSignerAgent(): any {
+  async getSignerAgent(): Promise<any> {
     try {
-      const provider = globalPnp?.provider;
-      if (provider && 'getSignerAgent' in provider) {
-        return (provider as any).getSignerAgent();
+      // Only Oisy uses the signer model in our config
+      const lastWallet = typeof window !== 'undefined'
+        ? localStorage.getItem('rumi_last_wallet')
+        : null;
+      if (!lastWallet?.toLowerCase().includes('oisy')) {
+        return null;
       }
-      return null;
-    } catch {
+
+      // Get the connected principal from PNP's account
+      const account = globalPnp?.account;
+      const ownerRaw: any = account?.owner;
+      if (!ownerRaw) return null;
+
+      let principal: Principal;
+      if (ownerRaw instanceof Principal) {
+        principal = ownerRaw;
+      } else if (typeof ownerRaw === 'string') {
+        principal = Principal.fromText(ownerRaw);
+      } else if (typeof ownerRaw?.toText === 'function') {
+        principal = Principal.fromText(ownerRaw.toText());
+      } else if (typeof ownerRaw?.toString === 'function') {
+        principal = Principal.fromText(ownerRaw.toString());
+      } else {
+        return null;
+      }
+
+      const { getOisySignerAgent } = await import('./oisySigner');
+      return await getOisySignerAgent(principal);
+    } catch (err) {
+      console.error('[pnp] getSignerAgent failed:', err);
       return null;
     }
   }

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -468,15 +468,15 @@ private static async refreshVaultData(): Promise<void> {
             const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
             if (signerAgent) {
-              console.log(`[Oisy] Using ICRC-112 batched approve+open_vault`);
+              console.log(`[Oisy] Sequential approve + open_vault via @icp-sdk/signer v5`);
               const requestedAllowance = amountRaw * 105n / 100n;
 
-              // Get actors that will route through the SignerAgent
+              // Get the ledger actor (routes through Oisy signer)
               const ledgerActor = await walletStore.getActor(ledgerCanisterId, CONFIG.icp_ledgerIDL) as any;
 
-              // Sequence 0: approve
-              signerAgent.batch();
-              const approvePromise = ledgerActor.icrc2_approve({
+              // 1) Approve (first Oisy consent screen). icrc2_approve is handled
+              //    natively by Oisy at Tier 1 — no ICRC-21 needed on the ledger.
+              const approveResult = await ledgerActor.icrc2_approve({
                 amount: requestedAllowance,
                 spender: {
                   owner: Principal.fromText(CONFIG.currentCanisterId),
@@ -489,39 +489,29 @@ private static async refreshVaultData(): Promise<void> {
                 from_subaccount: [],
                 created_at_time: []
               });
+              if (approveResult && 'Err' in approveResult) {
+                return {
+                  success: false,
+                  error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}`
+                };
+              }
 
-              // Sequence 1: open_vault (runs after approve completes)
-              signerAgent.batch();
-              const vaultPromise = actor.open_vault(amountRaw, collateralTypeOpt);
-
-              // Fire both as a single ICRC-112 batch request → one Oisy popup
-              const batchResult = await callWithOisyFalseNegativeGuard(
-                async () => {
-                  await signerAgent.execute();
-                  return Promise.all([approvePromise, vaultPromise]);
-                },
+              // 2) Open vault (second Oisy consent screen).
+              //    Wrapped with _arr false-negative guard since the backend method
+              //    is custom and prone to Oisy's Principal serialization bug.
+              const result = await callWithOisyFalseNegativeGuard(
+                () => actor.open_vault(amountRaw, collateralTypeOpt),
                 verifyOpenLanded,
-                `Oisy batched approve+open_vault ${collateralAmount} ${symbol}`
+                `Oisy open_vault ${collateralAmount} ${symbol}`
               );
 
-              if (isOisyLandedSentinel(batchResult)) {
-                // Look up the newly-opened vault to populate vaultId for the UI.
+              if (isOisyLandedSentinel(result)) {
                 const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
                 return {
                   success: true,
                   vaultId: found?.vaultId,
                   blockIndex: undefined,
                   oisyResilient: true,
-                };
-              }
-
-              const [approveResult, result] = batchResult;
-
-              // Check approve result
-              if (approveResult && 'Err' in approveResult) {
-                return {
-                  success: false,
-                  error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}`
                 };
               }
 
@@ -729,15 +719,14 @@ static async openVaultAndBorrow(
         const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
         if (signerAgent) {
-          console.log(`[Oisy] Using ICRC-112 batched approve+open_vault_and_borrow`);
+          console.log(`[Oisy] Sequential approve + open_vault_and_borrow via @icp-sdk/signer v5`);
           const oisyLedgerFee = BigInt(collateralInfo?.ledgerFee ?? 10_000);
           const requestedAllowance = amountRaw + oisyLedgerFee * 2n;
 
           const ledgerActor = await walletStore.getActor(ledgerCanisterId, CONFIG.icp_ledgerIDL) as any;
 
-          // Sequence 0: approve
-          signerAgent.batch();
-          const approvePromise = ledgerActor.icrc2_approve({
+          // 1) Approve (first Oisy consent screen, native Tier 1 handling).
+          const approveResult = await ledgerActor.icrc2_approve({
             amount: requestedAllowance,
             spender: {
               owner: Principal.fromText(CONFIG.currentCanisterId),
@@ -750,22 +739,18 @@ static async openVaultAndBorrow(
             from_subaccount: [],
             created_at_time: []
           });
+          if (approveResult && 'Err' in approveResult) {
+            return { success: false, error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}` };
+          }
 
-          // Sequence 1: open_vault_and_borrow (runs after approve completes)
-          signerAgent.batch();
-          const vaultPromise = actor.open_vault_and_borrow(amountRaw, borrowRaw, collateralTypeOpt);
-
-          // Fire both as a single ICRC-112 batch request → one Oisy popup
-          const batchResult = await callWithOisyFalseNegativeGuard(
-            async () => {
-              await signerAgent.execute();
-              return Promise.all([approvePromise, vaultPromise]);
-            },
+          // 2) open_vault_and_borrow (second consent screen), guarded against _arr.
+          const result = await callWithOisyFalseNegativeGuard(
+            () => actor.open_vault_and_borrow(amountRaw, borrowRaw, collateralTypeOpt),
             verifyOpenAndBorrowLanded,
-            `Oisy batched approve+open_vault_and_borrow ${collateralAmount} ${symbol}`
+            `Oisy open_vault_and_borrow ${collateralAmount} ${symbol}`
           );
 
-          if (isOisyLandedSentinel(batchResult)) {
+          if (isOisyLandedSentinel(result)) {
             const found = beforeIds ? await ApiClient.findNewlyOpenedVault(beforeIds) : null;
             return {
               success: true,
@@ -773,12 +758,6 @@ static async openVaultAndBorrow(
               blockIndex: undefined,
               oisyResilient: true,
             };
-          }
-
-          const [approveResult, result] = batchResult;
-
-          if (approveResult && 'Err' in approveResult) {
-            return { success: false, error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}` };
           }
 
           if ('Ok' in result) {
@@ -1015,13 +994,12 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
       const marginSignerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
       if (marginSignerAgent) {
-        console.log(`[Oisy] Using ICRC-112 batched approve+add_margin for vault #${vaultId}`);
+        console.log(`[Oisy] Sequential approve + add_margin for vault #${vaultId}`);
 
         const ledgerActor = await walletStore.getActor(ledgerCanisterId, CONFIG.icp_ledgerIDL) as any;
 
-        // Sequence 0: approve
-        marginSignerAgent.batch();
-        const approvePromise = ledgerActor.icrc2_approve({
+        // 1) Approve (first Oisy consent screen).
+        const approveResult = await ledgerActor.icrc2_approve({
           amount: bufferAmount,
           spender: {
             owner: Principal.fromText(CONFIG.currentCanisterId),
@@ -1034,46 +1012,34 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
           from_subaccount: [],
           created_at_time: []
         });
+        if (approveResult && 'Err' in approveResult) {
+          return {
+            success: false,
+            error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}`
+          };
+        }
 
-        // Sequence 1: add_margin_to_vault (runs after approve completes)
-        marginSignerAgent.batch();
-        const marginPromise = actor.add_margin_to_vault({
-          vault_id: BigInt(vaultId),
-          amount: amountRaw
-        });
-
-        // Fire both as a single ICRC-112 batch request → one Oisy popup.
-        // The Oisy `_arr` false-negative can surface from any of these
-        // awaits, so wrap the whole batched-execute in the resilience guard.
-        const batchResult = await callWithOisyFalseNegativeGuard(
-          async () => {
-            await marginSignerAgent.execute();
-            return Promise.all([approvePromise, marginPromise]);
-          },
+        // 2) add_margin_to_vault (second consent screen), guarded against _arr.
+        const marginResult = await callWithOisyFalseNegativeGuard(
+          () => actor.add_margin_to_vault({
+            vault_id: BigInt(vaultId),
+            amount: amountRaw
+          }),
           async () => {
             if (beforeCollateral === null) return false;
             const after = await ApiClient.getRawCollateralAmount(vaultId);
             if (after === null) return false;
             return after - beforeCollateral >= (amountRaw * 95n) / 100n;
           },
-          `Oisy batched approve+add_margin ${collateralAmount} ${symbol} to vault #${vaultId}`
+          `Oisy add_margin ${collateralAmount} ${symbol} to vault #${vaultId}`
         );
 
-        if (isOisyLandedSentinel(batchResult)) {
+        if (isOisyLandedSentinel(marginResult)) {
           return {
             success: true,
             vaultId,
             blockIndex: undefined,
             oisyResilient: true,
-          };
-        }
-
-        const [approveResult, marginResult] = batchResult;
-
-        if (approveResult && 'Err' in approveResult) {
-          return {
-            success: false,
-            error: `${symbol} approval failed: ${JSON.stringify(approveResult.Err)}`
           };
         }
 
@@ -1278,41 +1244,34 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
       // is idempotent (overwrites with a large allowance each time).
       const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
       if (signerAgent) {
-        console.log(`[Oisy] Batching icUSD approve + repay_to_vault`);
+        console.log(`[Oisy] Sequential icUSD approve + repay_to_vault`);
         const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
         const icusdLedgerActor = await walletStore.getActor(
           CONFIG.currentIcusdLedgerId, CONFIG.icusd_ledgerIDL
         ) as any;
 
-        signerAgent.batch();
-        const approvePromise = icusdLedgerActor.icrc2_approve({
+        // 1) Approve icUSD (first consent screen, Tier 1 native).
+        const approveResult = await icusdLedgerActor.icrc2_approve({
           amount: LARGE_APPROVAL,
           spender: { owner: Principal.fromText(CONFIG.currentCanisterId), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: []
         });
-
-        signerAgent.batch();
-        const repayPromise = actor.repay_to_vault(vaultArg);
-
-        const batchResult = await callWithOisyFalseNegativeGuard(
-          async () => {
-            await signerAgent.execute();
-            return Promise.all([approvePromise, repayPromise]);
-          },
-          verifyRepayLanded,
-          `Oisy batched approve+repay ${icusdAmount} icUSD to vault #${vaultId}`
-        );
-
-        if (isOisyLandedSentinel(batchResult)) {
-          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
-        }
-
-        const [approveResult, result] = batchResult;
-
         if (approveResult && 'Err' in approveResult) {
           return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
         }
+
+        // 2) repay_to_vault (second consent screen), guarded against _arr.
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.repay_to_vault(vaultArg),
+          verifyRepayLanded,
+          `Oisy repay ${icusdAmount} icUSD to vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+        }
+
         if ('Ok' in result) {
           return { success: true, vaultId, blockIndex: Number(result.Ok) };
         } else {
@@ -1414,35 +1373,28 @@ static async repayToVaultWithStable(
           stableLedgerId, CONFIG.icusd_ledgerIDL
         ) as any;
 
-        signerAgent.batch();
-        const approvePromise = stableLedgerActor.icrc2_approve({
+        // 1) Approve stable token (first consent screen, Tier 1 native).
+        const approveResult = await stableLedgerActor.icrc2_approve({
           amount: LARGE_APPROVAL,
           spender: { owner: Principal.fromText(CONFIG.currentCanisterId), subaccount: [] },
           expires_at: [], expected_allowance: [], memo: [], fee: [],
           from_subaccount: [], created_at_time: []
         });
-
-        signerAgent.batch();
-        const repayPromise = actor.repay_to_vault_with_stable(vaultArgWithToken);
-
-        const batchResult = await callWithOisyFalseNegativeGuard(
-          async () => {
-            await signerAgent.execute();
-            return Promise.all([approvePromise, repayPromise]);
-          },
-          verifyRepayLanded,
-          `Oisy batched approve+repay ${amount} ${tokenType} to vault #${vaultId}`
-        );
-
-        if (isOisyLandedSentinel(batchResult)) {
-          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
-        }
-
-        const [approveResult, result] = batchResult;
-
         if (approveResult && 'Err' in approveResult) {
           return { success: false, error: `${tokenType} approval failed: ${JSON.stringify(approveResult.Err)}` };
         }
+
+        // 2) repay_to_vault_with_stable (second consent screen), guarded against _arr.
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.repay_to_vault_with_stable(vaultArgWithToken),
+          verifyRepayLanded,
+          `Oisy repay ${amount} ${tokenType} to vault #${vaultId}`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return { success: true, vaultId, blockIndex: undefined, oisyResilient: true };
+        }
+
         if ('Ok' in result) {
           return { success: true, vaultId, blockIndex: Number(result.Ok) };
         } else {
@@ -1923,34 +1875,32 @@ static async repayToVaultWithStable(
         // async canister query that burns the browser user gesture context.
         const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
         if (signerAgent) {
-          console.log(`[Oisy] Batching icUSD approve + redeem_reserves`);
+          console.log(`[Oisy] Sequential icUSD approve + redeem_reserves`);
           const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
           const icusdLedgerActor = await walletStore.getActor(
             CONFIG.currentIcusdLedgerId, CONFIG.icusd_ledgerIDL
           ) as any;
           const actor = await ApiClient.getAuthenticatedActor();
 
-          signerAgent.batch();
-          const approvePromise = icusdLedgerActor.icrc2_approve({
+          // 1) Approve icUSD (first consent screen, Tier 1 native).
+          const approveResult = await icusdLedgerActor.icrc2_approve({
             amount: LARGE_APPROVAL,
             spender: { owner: Principal.fromText(spenderCanisterId), subaccount: [] },
             expires_at: [], expected_allowance: [], memo: [], fee: [],
             from_subaccount: [], created_at_time: []
           });
+          if (approveResult && 'Err' in approveResult) {
+            return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
+          }
 
-          signerAgent.batch();
-          const redeemPromise = actor.redeem_reserves(icusdE8s, preferredOpt);
-
-          const batchResult = await callWithOisyFalseNegativeGuard(
-            async () => {
-              await signerAgent.execute();
-              return Promise.all([approvePromise, redeemPromise]);
-            },
+          // 2) redeem_reserves (second consent screen), guarded against _arr.
+          const result = await callWithOisyFalseNegativeGuard(
+            () => actor.redeem_reserves(icusdE8s, preferredOpt),
             verifyRedeemLanded,
-            `Oisy batched approve+redeem_reserves ${icusdAmount} icUSD`
+            `Oisy redeem_reserves ${icusdAmount} icUSD`
           );
 
-          if (isOisyLandedSentinel(batchResult)) {
+          if (isOisyLandedSentinel(result)) {
             return {
               success: true,
               blockIndex: undefined,
@@ -1959,11 +1909,6 @@ static async repayToVaultWithStable(
             };
           }
 
-          const [approveResult, result] = batchResult;
-
-          if (approveResult && 'Err' in approveResult) {
-            return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
-          }
           if ('Ok' in result) {
             const r = result.Ok;
             return {
@@ -2958,30 +2903,27 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
           const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
-            console.log(`[Oisy] Batching icUSD approve + liquidate_vault_partial`);
+            console.log(`[Oisy] Sequential icUSD approve + liquidate_vault_partial`);
             const LARGE_APPROVAL = BigInt(100_000_000_000_000_000);
             const icusdLedgerActor = await walletStore.getActor(
               CONFIG.currentIcusdLedgerId, CONFIG.icusd_ledgerIDL
             ) as any;
             const actor = await ApiClient.getAuthenticatedActor();
 
-            signerAgent.batch();
-            const approvePromise = icusdLedgerActor.icrc2_approve({
+            // 1) Approve icUSD (first consent screen, Tier 1 native).
+            const approveResult = await icusdLedgerActor.icrc2_approve({
               amount: LARGE_APPROVAL,
               spender: { owner: Principal.fromText(spenderCanisterId), subaccount: [] },
               expires_at: [], expected_allowance: [], memo: [], fee: [],
               from_subaccount: [], created_at_time: []
             });
-
-            signerAgent.batch();
-            const liqPromise = actor.liquidate_vault_partial({ vault_id: BigInt(vaultId), amount: icusdAmountE8s });
-
-            await signerAgent.execute();
-            const [approveResult, result] = await Promise.all([approvePromise, liqPromise]);
-
             if (approveResult && 'Err' in approveResult) {
               return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
             }
+
+            // 2) liquidate_vault_partial (second consent screen).
+            const result = await actor.liquidate_vault_partial({ vault_id: BigInt(vaultId), amount: icusdAmountE8s });
+
             if ('Ok' in result) {
               return { success: true, vaultId, blockIndex: Number(result.Ok.block_index), feePaid: Number(result.Ok.fee_amount_paid) / E8S };
             } else {
@@ -3095,7 +3037,7 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
           const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
-            console.log(`[Oisy] Batching ${tokenType} approve + liquidate_vault_partial_with_stable`);
+            console.log(`[Oisy] Sequential ${tokenType} approve + liquidate_vault_partial_with_stable`);
             const LARGE_APPROVAL = BigInt(1_000_000_000_000_000);
             const stableLedgerId = CONFIG.getStableLedgerId(tokenType);
             const stableLedgerActor = await walletStore.getActor(
@@ -3103,23 +3045,20 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
             ) as any;
             const actor = await ApiClient.getAuthenticatedActor();
 
-            signerAgent.batch();
-            const approvePromise = stableLedgerActor.icrc2_approve({
+            // 1) Approve stable token (first consent screen, Tier 1 native).
+            const approveResult = await stableLedgerActor.icrc2_approve({
               amount: LARGE_APPROVAL,
               spender: { owner: Principal.fromText(spenderCanisterId), subaccount: [] },
               expires_at: [], expected_allowance: [], memo: [], fee: [],
               from_subaccount: [], created_at_time: []
             });
-
-            signerAgent.batch();
-            const liqPromise = actor.liquidate_vault_partial_with_stable(vaultArgWithToken);
-
-            await signerAgent.execute();
-            const [approveResult, result] = await Promise.all([approvePromise, liqPromise]);
-
             if (approveResult && 'Err' in approveResult) {
               return { success: false, error: `${tokenType} approval failed: ${JSON.stringify(approveResult.Err)}` };
             }
+
+            // 2) liquidate_vault_partial_with_stable (second consent screen).
+            const result = await actor.liquidate_vault_partial_with_stable(vaultArgWithToken);
+
             if ('Ok' in result) {
               return { success: true, vaultId, blockIndex: Number(result.Ok.block_index), feePaid: Number(result.Ok.fee_amount_paid) / E8S };
             } else {
@@ -3197,30 +3136,27 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
           const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
-            console.log(`[Oisy] Batching icUSD approve + liquidate_vault`);
+            console.log(`[Oisy] Sequential icUSD approve + liquidate_vault`);
             const LARGE_APPROVAL = BigInt(100_000_000_000_000_000);
             const icusdLedgerActor = await walletStore.getActor(
               CONFIG.currentIcusdLedgerId, CONFIG.icusd_ledgerIDL
             ) as any;
             const actor = await ApiClient.getAuthenticatedActor();
 
-            signerAgent.batch();
-            const approvePromise = icusdLedgerActor.icrc2_approve({
+            // 1) Approve icUSD (first consent screen, Tier 1 native).
+            const approveResult = await icusdLedgerActor.icrc2_approve({
               amount: LARGE_APPROVAL,
               spender: { owner: Principal.fromText(spenderCanisterId), subaccount: [] },
               expires_at: [], expected_allowance: [], memo: [], fee: [],
               from_subaccount: [], created_at_time: []
             });
-
-            signerAgent.batch();
-            const liqPromise = actor.liquidate_vault(BigInt(vaultId));
-
-            await signerAgent.execute();
-            const [approveResult, result] = await Promise.all([approvePromise, liqPromise]);
-
             if (approveResult && 'Err' in approveResult) {
               return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
             }
+
+            // 2) liquidate_vault (second consent screen).
+            const result = await actor.liquidate_vault(BigInt(vaultId));
+
             if ('Ok' in result) {
               return { success: true, vaultId, blockIndex: Number(result.Ok.block_index), feePaid: Number(result.Ok.fee_amount_paid) / E8S };
             } else {

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -465,7 +465,7 @@ private static async refreshVaultData(): Promise<void> {
             // Batches approve + open_vault into a single signer popup via ICRC-112.
             // The SignerAgent natively handles icrc2_approve consent (Tier 1) so
             // the ICP ledger's lack of ICRC-21 is not an issue.
-            const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+            const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
             if (signerAgent) {
               console.log(`[Oisy] Using ICRC-112 batched approve+open_vault`);
@@ -726,7 +726,7 @@ static async openVaultAndBorrow(
         };
 
         // ─── Oisy ICRC-112 batched path ───
-        const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+        const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
         if (signerAgent) {
           console.log(`[Oisy] Using ICRC-112 batched approve+open_vault_and_borrow`);
@@ -1012,7 +1012,7 @@ static async addMarginToVault(vaultId: number, collateralAmount: number, collate
 
       // ─── Oisy ICRC-112 batched path ───
       // Batches approve + add_margin into a single signer popup via ICRC-112.
-      const marginSignerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+      const marginSignerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
 
       if (marginSignerAgent) {
         console.log(`[Oisy] Using ICRC-112 batched approve+add_margin for vault #${vaultId}`);
@@ -1276,7 +1276,7 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
       // Always batch approve+repay — skipping the allowance check eliminates an
       // async canister query that burns the browser user gesture context. The approve
       // is idempotent (overwrites with a large allowance each time).
-      const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+      const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
       if (signerAgent) {
         console.log(`[Oisy] Batching icUSD approve + repay_to_vault`);
         const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
@@ -1405,7 +1405,7 @@ static async repayToVaultWithStable(
       // ─── Oisy ICRC-112 batched path ───
       // Always batch approve+repay — skipping the allowance check eliminates an
       // async canister query that burns the browser user gesture context.
-      const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+      const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
       if (signerAgent) {
         console.log(`[Oisy] Batching ${tokenType} approve + repay_to_vault_with_stable`);
         const LARGE_APPROVAL = BigInt(1_000_000_000_000_000); // 1B in e6s
@@ -1921,7 +1921,7 @@ static async repayToVaultWithStable(
         // ─── Oisy ICRC-112 batched path ───
         // Always batch approve+redeem — skipping the allowance check eliminates an
         // async canister query that burns the browser user gesture context.
-        const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+        const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
         if (signerAgent) {
           console.log(`[Oisy] Batching icUSD approve + redeem_reserves`);
           const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
@@ -2956,7 +2956,7 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
 
           // ─── Oisy ICRC-112 batched path ───
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
-          const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+          const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
             console.log(`[Oisy] Batching icUSD approve + liquidate_vault_partial`);
             const LARGE_APPROVAL = BigInt(100_000_000_000_000_000);
@@ -3093,7 +3093,7 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
 
           // ─── Oisy ICRC-112 batched path ───
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
-          const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+          const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
             console.log(`[Oisy] Batching ${tokenType} approve + liquidate_vault_partial_with_stable`);
             const LARGE_APPROVAL = BigInt(1_000_000_000_000_000);
@@ -3195,7 +3195,7 @@ static async withdrawCollateralAndCloseVault(vaultId: number): Promise<VaultOper
 
           // ─── Oisy ICRC-112 batched path ───
           // Always batch approve+liquidate — skip allowance check to preserve gesture context.
-          const signerAgent = isOisyWallet() ? pnp.getSignerAgent() : null;
+          const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
           if (signerAgent) {
             console.log(`[Oisy] Batching icUSD approve + liquidate_vault`);
             const LARGE_APPROVAL = BigInt(100_000_000_000_000_000);

--- a/src/vault_frontend/src/lib/services/stabilityPoolService.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.ts
@@ -239,7 +239,8 @@ class StabilityPoolService {
     const oisyDetected = isOisyWallet();
 
     if (oisyDetected && wallet.principal) {
-      // ─── Oisy ICRC-112 batched path (v4 direct signer) ───
+      // ─── Oisy sequential path (v5: no batch concept) ───
+      console.log(`[Oisy] Sequential approve + SP deposit via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
 
       const ledgerActor = createOisyActor(
@@ -251,26 +252,19 @@ class StabilityPoolService {
 
       const requestedAllowance = amount * 105n / 100n;
 
-      // Sequence 0: approve (Tier 1 — signer handles natively)
-      signerAgent.batch();
-      const approvePromise = ledgerActor.icrc2_approve({
+      // 1) Approve (first Oisy consent screen, Tier 1 native).
+      const approveResult = await ledgerActor.icrc2_approve({
         amount: requestedAllowance,
         spender: { owner: Principal.fromText(STABILITY_POOL_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: []
       });
-
-      // Sequence 1: deposit (Tier 3 — blind request consent)
-      signerAgent.batch();
-      const depositPromise = poolActor.deposit(tokenLedger, amount);
-
-      // Fire both as a single ICRC-112 batch request → one Oisy popup
-      await signerAgent.execute();
-      const [approveResult, result] = await Promise.all([approvePromise, depositPromise]);
-
       if (approveResult && 'Err' in approveResult) {
         throw new Error(`Approval failed: ${JSON.stringify(approveResult.Err)}`);
       }
+
+      // 2) Deposit (second Oisy consent screen, Tier 3 blind-request).
+      const result = await poolActor.deposit(tokenLedger, amount);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -310,14 +304,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP withdraw via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const withdrawPromise = poolActor.withdraw(tokenLedger, amount);
-      await signerAgent.execute();
-      const result = await withdrawPromise;
+      const result = await poolActor.withdraw(tokenLedger, amount);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -337,14 +329,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP claim_collateral via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const claimPromise = poolActor.claim_collateral(collateralLedger);
-      await signerAgent.execute();
-      const result = await claimPromise;
+      const result = await poolActor.claim_collateral(collateralLedger);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -366,14 +356,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP claim_all_collateral via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const claimPromise = poolActor.claim_all_collateral();
-      await signerAgent.execute();
-      const result = await claimPromise;
+      const result = await poolActor.claim_all_collateral();
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -395,14 +383,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP opt_out_collateral via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const optPromise = poolActor.opt_out_collateral(collateralType);
-      await signerAgent.execute();
-      const result = await optPromise;
+      const result = await poolActor.opt_out_collateral(collateralType);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -422,14 +408,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP opt_in_collateral via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const optPromise = poolActor.opt_in_collateral(collateralType);
-      await signerAgent.execute();
-      const result = await optPromise;
+      const result = await poolActor.opt_in_collateral(collateralType);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }
@@ -449,14 +433,12 @@ class StabilityPoolService {
     if (!wallet.isConnected) throw new Error('Wallet not connected');
 
     if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP execute_liquidation via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
       const poolActor = createOisyActor(
         STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
       );
-      signerAgent.batch();
-      const liqPromise = poolActor.execute_liquidation(vaultId);
-      await signerAgent.execute();
-      const result = await liqPromise;
+      const result = await poolActor.execute_liquidation(vaultId);
       if ('Err' in result) {
         throw new Error(this.formatError(result.Err));
       }

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -574,8 +574,8 @@ export async function preWarmOisySigner(): Promise<void> {
  * Pre-warm the live ICRC-1 fee cache for every AMM token so the Oisy executors
  * can read fees synchronously via `tokenFeeCached` / `getCachedLedgerFee`.
  *
- * The Oisy executors must not `await` between the user's click and
- * `signerAgent.execute()` or the browser blocks the popup with a
+ * The Oisy executors must not `await` between the user's click and the first
+ * Oisy consent screen or the browser blocks the popup with a
  * "Signer window should not be opened outside of click handler" error. By
  * fetching every relevant fee during the quote phase (5-min cache TTL), the
  * click-handler path stays fully synchronous.
@@ -594,13 +594,19 @@ export async function preWarmOisyFees(): Promise<void> {
 }
 
 // ──────────────────────────────────────────────────────────────
-// Oisy-batched multi-hop execution
+// Oisy sequential multi-hop execution (v5: no batch concept)
 //
-// CRITICAL: These functions must NOT make any async canister calls.
-// All estimates and pool IDs come pre-computed from resolveRoute()
-// (stored on the SwapRoute object). The signer agent is pre-warmed
-// during the quote phase. This ensures signerAgent.execute() opens
-// its popup synchronously within the browser's click handler context.
+// Each hop becomes its own Oisy consent screen. The user sees one popup
+// per `await` against an actor created via `createOisyActor`. We preserve
+// the pre-warming + pre-computed-estimate discipline because the FIRST
+// popup still has to land inside the browser's click-handler gesture
+// window — any pre-popup `await` would burn that window and trip Oisy's
+// "Signer window should not be opened outside of click handler" guard.
+//
+// CRITICAL: These functions must NOT make any async canister calls
+// before the first Oisy consent screen. All estimates and pool IDs come
+// pre-computed from resolveRoute() (stored on the SwapRoute object). The
+// signer agent is pre-warmed during the quote phase.
 // ──────────────────────────────────────────────────────────────
 
 const THREEPOOL_ID = CANISTER_IDS.THREEPOOL;
@@ -608,14 +614,15 @@ const AMM_ID = CANISTER_IDS.RUMI_AMM;
 const ICP_LEDGER_ID = CANISTER_IDS.ICP_LEDGER;
 
 /**
- * Stablecoin → ICP (Oisy batched):
+ * Stablecoin → ICP (Oisy sequential, v5):
  * 1. Approve stablecoin → 3pool
  * 2. Approve 3USD → AMM (pre-approve estimated amount)
  * 3. 3pool.add_liquidity
  * 4. AMM.swap (using estimated 3USD amount)
  *
- * All estimates come from route.intermediateOutput / route.estimatedOutput
- * which were computed during resolveRoute(). No canister queries here.
+ * Each step is its own Oisy consent screen. All estimates come from
+ * route.intermediateOutput / route.estimatedOutput which were computed
+ * during resolveRoute(). No canister queries here before the first popup.
  */
 async function executeStableToIcpOisy(
   route: SwapRoute,
@@ -647,58 +654,51 @@ async function executeStableToIcpOisy(
   const fromFee = tokenFeeCached(from);
 
   // Signer agent was pre-warmed during quote phase — cached, no popup
+  console.log('[Oisy] Sequential stable→ICP route (3pool + AMM) via @icp-sdk/signer v5');
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const stableLedger = createOisyActor(fromPoolToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
   const threeUsdLedger = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
   const ammActor = createOisyActor(AMM_ID, canisterIDLs.rumi_amm, signerAgent);
 
-  // Step 1: Approve stablecoin → 3pool
-  signerAgent.batch();
-  const p1 = stableLedger.icrc2_approve({
+  // Step 1: Approve stablecoin → 3pool (first consent screen, Tier 1 native)
+  const r1 = await stableLedger.icrc2_approve({
     amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r1 && 'Err' in r1) throw new Error(`Stablecoin approval failed: ${JSON.stringify(r1.Err)}`);
 
   // Step 2: Approve 3USD → AMM (generous: estimate + 1% buffer)
   const threeUsdApprovalAmt = threeUsdEstimate * 101n / 100n;
-  signerAgent.batch();
-  const p2 = threeUsdLedger.icrc2_approve({
+  const r2 = await threeUsdLedger.icrc2_approve({
     amount: threeUsdApprovalAmt,
     spender: { owner: Principal.fromText(AMM_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r2 && 'Err' in r2) throw new Error(`3USD approval failed: ${JSON.stringify(r2.Err)}`);
 
-  // Step 3: 3pool deposit
-  signerAgent.batch();
-  const p3 = threeUsdLedger.add_liquidity(amounts, threeUsdMinOutput);
+  // Step 3: 3pool deposit (mints 3USD into caller's account)
+  const r3 = await threeUsdLedger.add_liquidity(amounts, threeUsdMinOutput);
+  if ('Err' in r3) throw new Error(`3pool deposit failed: ${JSON.stringify(r3.Err)}`);
 
   // Step 4: AMM swap (use estimated 3USD amount — slippage protection via minOutput)
-  signerAgent.batch();
-  const p4 = ammActor.swap(poolId, Principal.fromText(THREEPOOL_ID), threeUsdEstimate, icpMinOutput);
-
-  // This opens the signer popup — must happen close to click handler
-  await signerAgent.execute();
-  const [r1, r2, r3, r4] = await Promise.all([p1, p2, p3, p4]);
-
-  if (r1 && 'Err' in r1) throw new Error(`Stablecoin approval failed: ${JSON.stringify(r1.Err)}`);
-  if (r2 && 'Err' in r2) throw new Error(`3USD approval failed: ${JSON.stringify(r2.Err)}`);
-  if ('Err' in r3) throw new Error(`3pool deposit failed: ${JSON.stringify(r3.Err)}`);
+  const r4 = await ammActor.swap(poolId, Principal.fromText(THREEPOOL_ID), threeUsdEstimate, icpMinOutput);
   if ('Err' in r4) throw new Error(`AMM swap failed: ${JSON.stringify(r4.Err)}`);
   return r4.Ok.amount_out;
 }
 
 /**
- * ICP → Stablecoin (Oisy batched):
+ * ICP → Stablecoin (Oisy sequential, v5):
  * 1. Approve ICP → AMM
  * 2. AMM.swap ICP → 3USD
  * 3. 3pool.remove_one_coin (burns 3USD LP, no approval needed)
  *
- * All estimates come from route.intermediateOutput / route.estimatedOutput.
- * No canister queries here.
+ * Each step is its own Oisy consent screen. All estimates come from
+ * route.intermediateOutput / route.estimatedOutput. No canister queries
+ * before the first popup.
  */
 async function executeIcpToStableOisy(
   route: SwapRoute,
@@ -727,41 +727,34 @@ async function executeIcpToStableOisy(
   const icpFee = tokenFeeCached(icpToken);
 
   // Signer agent was pre-warmed during quote phase — cached, no popup
+  console.log('[Oisy] Sequential ICP→stable route (AMM + 3pool) via @icp-sdk/signer v5');
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const icpLedger = createOisyActor(ICP_LEDGER_ID, CONFIG.icusd_ledgerIDL, signerAgent);
   const ammActor = createOisyActor(AMM_ID, canisterIDLs.rumi_amm, signerAgent);
   const poolActor = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
 
-  // Step 1: Approve ICP → AMM
-  signerAgent.batch();
-  const p1 = icpLedger.icrc2_approve({
+  // Step 1: Approve ICP → AMM (first consent screen, Tier 1 native)
+  const r1 = await icpLedger.icrc2_approve({
     amount: amountIn + icpFee * 2n,
     spender: { owner: Principal.fromText(AMM_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r1 && 'Err' in r1) throw new Error(`ICP approval failed: ${JSON.stringify(r1.Err)}`);
 
   // Step 2: AMM swap ICP → 3USD
-  signerAgent.batch();
-  const p2 = ammActor.swap(poolId, Principal.fromText(ICP_LEDGER_ID), amountIn, threeUsdMinOutput);
+  const r2 = await ammActor.swap(poolId, Principal.fromText(ICP_LEDGER_ID), amountIn, threeUsdMinOutput);
+  if ('Err' in r2) throw new Error(`AMM swap failed: ${JSON.stringify(r2.Err)}`);
 
   // Step 3: 3pool redeem 3USD → stablecoin (no approval: burns caller's LP tokens)
-  signerAgent.batch();
-  const p3 = poolActor.remove_one_coin(threeUsdEstimate, to.threePoolIndex, stableMinOutput);
-
-  // This opens the signer popup — must happen close to click handler
-  await signerAgent.execute();
-  const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
-
-  if (r1 && 'Err' in r1) throw new Error(`ICP approval failed: ${JSON.stringify(r1.Err)}`);
-  if ('Err' in r2) throw new Error(`AMM swap failed: ${JSON.stringify(r2.Err)}`);
+  const r3 = await poolActor.remove_one_coin(threeUsdEstimate, to.threePoolIndex, stableMinOutput);
   if ('Err' in r3) throw new Error(`3pool redeem failed: ${JSON.stringify(r3.Err)}`);
   return r3.Ok;
 }
 
 /**
- * Stablecoin → ICP via ICPswap (Oisy batched):
+ * Stablecoin → ICP via ICPswap (Oisy sequential, v5):
  * 1. Approve stablecoin → 3pool (for add_liquidity)
  * 2. 3pool.add_liquidity (burns stablecoin, mints 3USD)
  * 3. Approve 3USD → ICPswap pool (for depositFrom)
@@ -769,10 +762,12 @@ async function executeIcpToStableOisy(
  * 5. ICPswap.swap 3USD → ICP
  * 6. ICPswap.withdraw ICP to caller
  *
- * Known limitation: ICPswap withdraw amount must be pre-committed (no async
- * query between swap and withdraw in a batch). We use icpMinOutput as the
- * withdraw amount. Any positive slippage (pool pays more than minimum) stays
- * on the pool's internal subaccount and can be recovered manually later.
+ * Each step is its own Oisy consent screen.
+ *
+ * Known limitation: ICPswap withdraw amount is pre-committed to `icpMinOutput`
+ * to keep behavior identical to the v4 fake-batched path. Any positive
+ * slippage (pool pays more than minimum) stays on the pool's internal
+ * subaccount and can be recovered manually via recoverIcpswapBalance.
  */
 async function executeStableToIcpOisyIcpswap(
   route: SwapRoute,
@@ -806,83 +801,78 @@ async function executeStableToIcpOisyIcpswap(
   const threeUsdFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' });
   const icpFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.ICP_LEDGER, decimals: 8, symbol: 'ICP' });
 
+  console.log('[Oisy] Sequential stable→ICP via ICPswap (6 hops) via @icp-sdk/signer v5');
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const stableLedger = createOisyActor(fromPoolToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
   const threeUsdLedger = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
   const icpswapPool = createOisyActor(icpswapPoolId, canisterIDLs.icpswap_pool, signerAgent);
 
-  // Step 1: approve stablecoin → 3pool
-  signerAgent.batch();
-  const p1 = stableLedger.icrc2_approve({
+  // Step 1: approve stablecoin → 3pool (first consent screen, Tier 1 native)
+  const r1 = await stableLedger.icrc2_approve({
     amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r1 && 'Err' in r1) throw new Error(`Stablecoin approval failed: ${JSON.stringify(r1.Err)}`);
 
   // Step 2: 3pool deposit (burns stablecoin, mints 3USD)
-  signerAgent.batch();
-  const p2 = threeUsdLedger.add_liquidity(amounts, threeUsdMinOutput);
+  const r2 = await threeUsdLedger.add_liquidity(amounts, threeUsdMinOutput);
+  if ('Err' in r2) throw new Error(`3pool deposit failed: ${JSON.stringify(r2.Err)}`);
 
   // Step 3: approve 3USD → ICPswap pool (depositFrom is ICRC-2 pull)
   const threeUsdApprovalAmt = threeUsdEstimate * 101n / 100n;
-  signerAgent.batch();
-  const p3 = threeUsdLedger.icrc2_approve({
+  const r3 = await threeUsdLedger.icrc2_approve({
     amount: threeUsdApprovalAmt,
     spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r3 && 'Err' in r3) throw new Error(`3USD approval failed: ${JSON.stringify(r3.Err)}`);
 
   // Step 4: ICPswap depositFrom (pulls 3USD via ICRC-2)
-  signerAgent.batch();
-  const p4 = icpswapPool.depositFrom({
+  const r4 = await icpswapPool.depositFrom({
     token: CANISTER_IDS.THREEPOOL,
     amount: threeUsdEstimate,
     fee: threeUsdFee,
   });
+  if ('err' in r4) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r4.err)}`);
 
   // Step 5: ICPswap swap (uses pre-committed 3USD amount; slippage via amountOutMinimum)
-  signerAgent.batch();
-  const p5 = icpswapPool.swap({
+  const r5 = await icpswapPool.swap({
     amountIn: threeUsdEstimate.toString(),
     zeroForOne,
     amountOutMinimum: icpMinOutput.toString(),
   });
+  if ('err' in r5) throw new Error(`ICPswap swap failed: ${JSON.stringify(r5.err)}`);
 
   // Step 6: ICPswap withdraw to caller's ICP ledger account.
-  // Pre-committed amount; we can't await p5 before building p6 in a batch.
-  signerAgent.batch();
-  const p6 = icpswapPool.withdraw({
+  // Pre-committed amount (matches the v4 fake-batch behavior; recoverIcpswapBalance
+  // is used to claim any positive slippage stranded on the pool's subaccount).
+  const r6 = await icpswapPool.withdraw({
     token: CANISTER_IDS.ICP_LEDGER,
     amount: icpMinOutput,
     fee: icpFee,
   });
-
-  await signerAgent.execute();
-  const [r1, r2, r3, r4, r5, r6] = await Promise.all([p1, p2, p3, p4, p5, p6]);
-
-  if (r1 && 'Err' in r1) throw new Error(`Stablecoin approval failed: ${JSON.stringify(r1.Err)}`);
-  if ('Err' in r2) throw new Error(`3pool deposit failed: ${JSON.stringify(r2.Err)}`);
-  if (r3 && 'Err' in r3) throw new Error(`3USD approval failed: ${JSON.stringify(r3.Err)}`);
-  if ('err' in r4) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r4.err)}`);
-  if ('err' in r5) throw new Error(`ICPswap swap failed: ${JSON.stringify(r5.err)}`);
   if ('err' in r6) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r6.err)}`);
   return (r6 as { ok: bigint }).ok;
 }
 
 /**
- * ICP → Stablecoin via ICPswap (Oisy batched):
+ * ICP → Stablecoin via ICPswap (Oisy sequential, v5):
  * 1. Approve ICP → ICPswap pool (for depositFrom)
  * 2. ICPswap.depositFrom ICP
  * 3. ICPswap.swap ICP → 3USD
  * 4. ICPswap.withdraw 3USD to caller
  * 5. 3pool.remove_one_coin (burns caller's LP, no allowance needed)
  *
+ * Each step is its own Oisy consent screen.
+ *
  * Same withdraw-amount limitation as the stable→ICP case: we pass
- * threeUsdMinFromSwap as the withdraw amount. Positive slippage stays on
- * the pool's internal subaccount for manual recovery.
+ * threeUsdMinFromSwap as the withdraw amount (matches v4 fake-batch
+ * behavior). Positive slippage stays on the pool's internal subaccount
+ * for manual recovery via recoverIcpswapBalance.
  */
 async function executeIcpToStableOisyIcpswap(
   route: SwapRoute,
@@ -912,74 +902,68 @@ async function executeIcpToStableOisyIcpswap(
   const icpFee = tokenFeeCached(icpToken);
   const threeUsdFee = getCachedLedgerFee({ ledgerId: CANISTER_IDS.THREEPOOL, decimals: 8, symbol: '3USD' });
 
+  console.log('[Oisy] Sequential ICP→stable via ICPswap (5 hops) via @icp-sdk/signer v5');
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const icpLedger = createOisyActor(ICP_LEDGER_ID, CONFIG.icusd_ledgerIDL, signerAgent);
   const icpswapPool = createOisyActor(icpswapPoolId, canisterIDLs.icpswap_pool, signerAgent);
   const poolActor = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
 
-  // Step 1: approve ICP → ICPswap pool
-  signerAgent.batch();
-  const p1 = icpLedger.icrc2_approve({
+  // Step 1: approve ICP → ICPswap pool (first consent screen, Tier 1 native)
+  const r1 = await icpLedger.icrc2_approve({
     amount: amountIn + icpFee * 2n,
     spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r1 && 'Err' in r1) throw new Error(`ICP approval failed: ${JSON.stringify(r1.Err)}`);
 
   // Step 2: ICPswap depositFrom (pulls ICP)
-  signerAgent.batch();
-  const p2 = icpswapPool.depositFrom({
+  const r2 = await icpswapPool.depositFrom({
     token: ICP_LEDGER_ID,
     amount: amountIn,
     fee: icpFee,
   });
+  if ('err' in r2) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r2.err)}`);
 
   // Step 3: ICPswap swap ICP → 3USD
-  signerAgent.batch();
-  const p3 = icpswapPool.swap({
+  const r3 = await icpswapPool.swap({
     amountIn: amountIn.toString(),
     zeroForOne,
     amountOutMinimum: threeUsdMinFromSwap.toString(),
   });
+  if ('err' in r3) throw new Error(`ICPswap swap failed: ${JSON.stringify(r3.err)}`);
 
   // Step 4: ICPswap withdraw 3USD to caller
-  signerAgent.batch();
-  const p4 = icpswapPool.withdraw({
+  const r4 = await icpswapPool.withdraw({
     token: CANISTER_IDS.THREEPOOL,
     amount: threeUsdMinFromSwap,
     fee: threeUsdFee,
   });
+  if ('err' in r4) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r4.err)}`);
 
   // Step 5: 3pool remove_one_coin (3USD → target stablecoin)
   // remove_one_coin burns the caller's LP directly (no ICRC-2 allowance required).
   // We pass threeUsdMinFromSwap (conservative) to match the withdraw amount.
-  signerAgent.batch();
-  const p5 = poolActor.remove_one_coin(threeUsdMinFromSwap, to.threePoolIndex, stableMinOutput);
-
-  await signerAgent.execute();
-  const [r1, r2, r3, r4, r5] = await Promise.all([p1, p2, p3, p4, p5]);
-
-  if (r1 && 'Err' in r1) throw new Error(`ICP approval failed: ${JSON.stringify(r1.Err)}`);
-  if ('err' in r2) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r2.err)}`);
-  if ('err' in r3) throw new Error(`ICPswap swap failed: ${JSON.stringify(r3.err)}`);
-  if ('err' in r4) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r4.err)}`);
+  const r5 = await poolActor.remove_one_coin(threeUsdMinFromSwap, to.threePoolIndex, stableMinOutput);
   if ('Err' in r5) throw new Error(`3pool redeem failed: ${JSON.stringify(r5.Err)}`);
   return r5.Ok;
 }
 
 /**
- * Direct ICPswap pool swap (Oisy batched). Used by both `icusd_icp_direct`
- * (icUSD <-> ICP) and `amm_swap` (3USD <-> ICP) when ICPswap wins the quote.
+ * Direct ICPswap pool swap (Oisy sequential, v5). Used by both
+ * `icusd_icp_direct` (icUSD <-> ICP) and `amm_swap` (3USD <-> ICP) when
+ * ICPswap wins the quote.
  *
  * 1. Approve input token -> ICPswap pool
  * 2. ICPswap.depositFrom (pulls input via ICRC-2)
  * 3. ICPswap.swap
  * 4. ICPswap.withdraw (output to caller)
  *
- * Same withdraw-amount limitation as the other ICPswap Oisy helpers:
- * withdraw amount is pre-committed to minOut; positive slippage stays on
- * the pool's internal subaccount until recovered.
+ * Each step is its own Oisy consent screen. Same withdraw-amount
+ * limitation as the other ICPswap Oisy helpers: withdraw amount is
+ * pre-committed to minOut; positive slippage stays on the pool's
+ * internal subaccount until recovered via recoverIcpswapBalance.
  */
 async function executeIcpswapDirectOisy(
   route: SwapRoute,
@@ -1009,50 +993,43 @@ async function executeIcpswapDirectOisy(
   const fromFee = tokenFeeCached(from);
   const toFee = tokenFeeCached(to);
 
+  console.log('[Oisy] Sequential ICPswap direct swap (4 hops) via @icp-sdk/signer v5');
   const signerAgent = await getOisySignerAgent(wallet.principal);
 
   const fromLedger = createOisyActor(from.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
   const icpswapPool = createOisyActor(icpswapPoolId, canisterIDLs.icpswap_pool, signerAgent);
 
-  // Step 1: approve input -> ICPswap pool
-  signerAgent.batch();
-  const p1 = fromLedger.icrc2_approve({
+  // Step 1: approve input -> ICPswap pool (first consent screen, Tier 1 native)
+  const r1 = await fromLedger.icrc2_approve({
     amount: amountIn + fromFee * 2n,
     spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
     expires_at: [], expected_allowance: [], memo: [], fee: [],
     from_subaccount: [], created_at_time: [],
   });
+  if (r1 && 'Err' in r1) throw new Error(`${from.symbol} approval failed: ${JSON.stringify(r1.Err)}`);
 
   // Step 2: ICPswap depositFrom
-  signerAgent.batch();
-  const p2 = icpswapPool.depositFrom({
+  const r2 = await icpswapPool.depositFrom({
     token: from.ledgerId,
     amount: amountIn,
     fee: fromFee,
   });
+  if ('err' in r2) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r2.err)}`);
 
   // Step 3: ICPswap swap
-  signerAgent.batch();
-  const p3 = icpswapPool.swap({
+  const r3 = await icpswapPool.swap({
     amountIn: amountIn.toString(),
     zeroForOne,
     amountOutMinimum: minOut.toString(),
   });
+  if ('err' in r3) throw new Error(`ICPswap swap failed: ${JSON.stringify(r3.err)}`);
 
   // Step 4: ICPswap withdraw
-  signerAgent.batch();
-  const p4 = icpswapPool.withdraw({
+  const r4 = await icpswapPool.withdraw({
     token: to.ledgerId,
     amount: minOut,
     fee: toFee,
   });
-
-  await signerAgent.execute();
-  const [r1, r2, r3, r4] = await Promise.all([p1, p2, p3, p4]);
-
-  if (r1 && 'Err' in r1) throw new Error(`${from.symbol} approval failed: ${JSON.stringify(r1.Err)}`);
-  if ('err' in r2) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r2.err)}`);
-  if ('err' in r3) throw new Error(`ICPswap swap failed: ${JSON.stringify(r3.err)}`);
   if ('err' in r4) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r4.err)}`);
   return (r4 as { ok: bigint }).ok;
 }
@@ -1197,6 +1174,7 @@ export async function recoverIcpswapBalance(
   if (isOisyWallet() && wallet.principal) {
     // Oisy path: signer agent + fees are pre-warmed by preWarmRecovery(),
     // so these calls resolve from cache synchronously (no real await).
+    console.log('[Oisy] Sequential ICPswap recovery withdraws via @icp-sdk/signer v5');
     const signerAgent = await getOisySignerAgent(wallet.principal);
 
     // Synchronous fee reads from cache (pre-warmed, with hardcoded fallback)
@@ -1208,43 +1186,30 @@ export async function recoverIcpswapBalance(
       : 0n;
     const poolActor = createOisyActor(balance.poolId, canisterIDLs.icpswap_pool, signerAgent);
 
-    const promises: Promise<any>[] = [];
+    const willRecoverToken0 = balance.token0.amount > DUST_THRESHOLD;
+    const willRecoverToken1 = balance.token1.amount > DUST_THRESHOLD;
 
-    if (balance.token0.amount > DUST_THRESHOLD) {
-      signerAgent.batch();
-      promises.push(
-        poolActor.withdraw({
-          token: balance.token0.canisterId,
-          amount: balance.token0.amount,
-          fee: fee0,
-        }),
-      );
-    }
-    if (balance.token1.amount > DUST_THRESHOLD) {
-      signerAgent.batch();
-      promises.push(
-        poolActor.withdraw({
-          token: balance.token1.canisterId,
-          amount: balance.token1.amount,
-          fee: fee1,
-        }),
-      );
-    }
-
-    if (promises.length > 0) {
+    if (willRecoverToken0 || willRecoverToken1) {
       try {
-        await signerAgent.execute();
-        const results = await Promise.all(promises);
-        let idx = 0;
-        if (balance.token0.amount > DUST_THRESHOLD) {
-          const r = results[idx++];
-          if (r && 'ok' in r) token0Recovered = r.ok;
-          else if (r && 'err' in r) console.error('token0 withdraw error:', r.err);
+        if (willRecoverToken0) {
+          // First consent screen: withdraw token0
+          const r0 = await poolActor.withdraw({
+            token: balance.token0.canisterId,
+            amount: balance.token0.amount,
+            fee: fee0,
+          });
+          if (r0 && 'ok' in r0) token0Recovered = r0.ok;
+          else if (r0 && 'err' in r0) console.error('token0 withdraw error:', r0.err);
         }
-        if (balance.token1.amount > DUST_THRESHOLD) {
-          const r = results[idx++];
-          if (r && 'ok' in r) token1Recovered = r.ok;
-          else if (r && 'err' in r) console.error('token1 withdraw error:', r.err);
+        if (willRecoverToken1) {
+          // Second consent screen (if token0 also queued): withdraw token1
+          const r1 = await poolActor.withdraw({
+            token: balance.token1.canisterId,
+            amount: balance.token1.amount,
+            fee: fee1,
+          });
+          if (r1 && 'ok' in r1) token1Recovered = r1.ok;
+          else if (r1 && 'err' in r1) console.error('token1 withdraw error:', r1.err);
         }
       } catch (executeErr: any) {
         // Oisy _arr false-negative: the on-chain call often succeeds even
@@ -1256,10 +1221,10 @@ export async function recoverIcpswapBalance(
           const after = await queryPoolUnusedBalance(balance.poolId, wallet.principal!);
           if (after) {
             // If balance dropped, the withdrawal succeeded
-            if (balance.token0.amount > DUST_THRESHOLD && after.balance0 < balance.token0.amount) {
+            if (willRecoverToken0 && after.balance0 < balance.token0.amount) {
               token0Recovered = balance.token0.amount - after.balance0;
             }
-            if (balance.token1.amount > DUST_THRESHOLD && after.balance1 < balance.token1.amount) {
+            if (willRecoverToken1 && after.balance1 < balance.token1.amount) {
               token1Recovered = balance.token1.amount - after.balance1;
             }
           }

--- a/src/vault_frontend/src/lib/services/threePoolService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolService.ts
@@ -438,7 +438,8 @@ class ThreePoolService {
     const approveAmt = await approvalAmount(dxRaw, fromToken);
 
     if (oisyDetected && wallet.principal) {
-      // ─── Oisy ICRC-112 batched path ───
+      // ─── Oisy sequential path (v5: no batch concept) ───
+      console.log(`[Oisy] Sequential approve + 3pool swap via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
 
       const ledgerActor = createOisyActor(
@@ -448,25 +449,19 @@ class ThreePoolService {
         THREEPOOL_CANISTER_ID, canisterIDLs.three_pool, signerAgent
       );
 
-      // Sequence 0: approve
-      signerAgent.batch();
-      const approvePromise = ledgerActor.icrc2_approve({
+      // 1) Approve (first Oisy consent screen, Tier 1 native).
+      const approveResult = await ledgerActor.icrc2_approve({
         amount: approveAmt,
         spender: { owner: Principal.fromText(THREEPOOL_CANISTER_ID), subaccount: [] },
         expires_at: [], expected_allowance: [], memo: [], fee: [],
         from_subaccount: [], created_at_time: []
       });
-
-      // Sequence 1: swap
-      signerAgent.batch();
-      const swapPromise = poolActor.swap(fromIndex, toIndex, dxRaw, minDyRaw);
-
-      await signerAgent.execute();
-      const [approveResult, swapResult] = await Promise.all([approvePromise, swapPromise]);
-
       if (approveResult && 'Err' in approveResult) {
         throw new Error(`Approval failed: ${JSON.stringify(approveResult.Err)}`);
       }
+
+      // 2) Swap (second Oisy consent screen).
+      const swapResult = await poolActor.swap(fromIndex, toIndex, dxRaw, minDyRaw);
       if ('Err' in swapResult) {
         throw new Error(this.formatError(swapResult.Err));
       }
@@ -526,43 +521,36 @@ class ThreePoolService {
     };
 
     if (oisyDetected && wallet.principal) {
-      // ─── Oisy ICRC-112 batched path ───
+      // ─── Oisy sequential path (v5: no batch concept) ───
+      console.log(`[Oisy] Sequential approve(s) + 3pool add_liquidity via @icp-sdk/signer v5`);
       const signerAgent = await getOisySignerAgent(wallet.principal);
 
-      // Queue approvals for each non-zero token
-      const approvePromises: Promise<any>[] = [];
+      // 1) Approve each non-zero token sequentially (Tier 1 native consent screens).
       for (let k = 0; k < 3; k++) {
         if (amounts[k] > 0n) {
           const token = POOL_TOKENS[k];
           const ledgerActor = createOisyActor(token.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
-          signerAgent.batch();
-          approvePromises.push(ledgerActor.icrc2_approve({
+          const approveResult = await ledgerActor.icrc2_approve({
             amount: approveAmounts[k],
             spender, expires_at: [], expected_allowance: [], memo: [], fee: [],
             from_subaccount: [], created_at_time: []
-          }));
+          });
+          if (approveResult && 'Err' in approveResult) {
+            throw new Error(`Approval failed for ${token.symbol}: ${JSON.stringify(approveResult.Err)}`);
+          }
         }
       }
 
-      // Queue add_liquidity call
+      // 2) add_liquidity (final consent screen), guarded against _arr false-negative.
       const poolActor = createOisyActor(THREEPOOL_CANISTER_ID, canisterIDLs.three_pool, signerAgent);
-      signerAgent.batch();
-      const addPromise = poolActor.add_liquidity(amounts, minLp);
-
       const guarded = await callWithOisyFalseNegativeGuard(
         async () => {
-          await signerAgent.execute();
-          const results = await Promise.all([...approvePromises, addPromise]);
-          for (let i = 0; i < approvePromises.length; i++) {
-            const r = results[i];
-            if (r && 'Err' in r) throw new Error(`Approval failed: ${JSON.stringify(r.Err)}`);
-          }
-          const addResult = results[results.length - 1] as { Ok: bigint } | { Err: any };
+          const addResult = await poolActor.add_liquidity(amounts, minLp) as { Ok: bigint } | { Err: any };
           if ('Err' in addResult) throw new Error(this.formatError(addResult.Err));
           return addResult.Ok;
         },
         verifyAddLanded,
-        `Oisy batched 3pool add_liquidity`
+        `Oisy 3pool add_liquidity`
       );
       return guarded;
     } else {


### PR DESCRIPTION
## Summary

Migrates the Oisy wallet integration from `@slide-computer/signer` v4 to `@icp-sdk/signer` v5 (Thomas Gladdines' actively-maintained DFINITY library). Drops the fake ICRC-112 `batch()`/`execute()` ceremony from 26 call sites across 7 files in favor of plain sequential awaits.

**Origin:** Oisy support thread (May 12) where Thomas (author of both libs, `@sea-snake` at DFINITY) confirmed:

> Batch transactions (ICRC-112) were a WIP standard that was never adopted by wallets. The @slide-computer/signer lib used to handle this unsupported case by making multiple ICRC-49 calls under the hood. I'd recommend the Rumi team switch to @icp-sdk/signer and implement multiple canister calls through a loop of method calls.

This PR is that loop-of-method-calls migration.

## Mainnet verification (2026-05-22)

All four critical Oisy code paths validated against deployed asset state. On-chain balance deltas confirmed via `dfx canister call ... icrc1_balance_of`:

| Test | Path | On-chain | Status |
|---|---|---|---|
| Connect Oisy | v5 `SignerAgent.create` | principal recognized, 9 vaults loaded | ✅ |
| Open vault + borrow | `apiClient.ts` → PNP actor | vault #185 created, +0.1 ICP collateral, +0.1 icUSD borrow | ✅ |
| ckUSDT → ICP swap | Rumi-only (`executeStableToIcpOisy`, 4 hops) | -0.52 ckUSDT, +0.1885 ICP | ✅ (after one `_arr` retry) |
| icUSD → ICP swap | ICPswap direct (`executeIcpswapDirectOisy`, 4 hops) | -45.002 icUSD, +16.42 ICP | ✅ |

The ckUSDT swap failed once with the intermittent upstream Oisy `_arr` Principal-serialization bug ([dfinity/oisy-wallet#12689](https://github.com/dfinity/oisy-wallet/issues/12689)), but worked cleanly on retry. The migration's `callWithOisyFalseNegativeGuard` correctly did NOT fake a success when the swap genuinely hadn't landed.

## Two bugs surfaced and fixed during smoke-testing

Both committed to this branch:

- **`ee91a8c` — gesture context burn in `handleSwap`.** The `_arr` verifier needs a pre-swap destination-balance snapshot. `handleSwap` was awaiting that snapshot inline (after the click), burning the browser's user-gesture window and tripping Oisy's "Signer window should not be opened outside of click handler" guard. Fix matches the 2026-05-07 incident pattern: capture snapshot during `fetchQuote` (already async, no popup gate yet), read synchronously in `handleSwap`, reset on `flipTokens` / `selectFrom` / `selectTo`.

- **`1e64f62` — Proxy + ES `#private` field incompatibility.** The migration-window compat shim that no-op'd `batch()`/`execute()` wrapped the v5 `SignerAgent` in a `Proxy`. v5's SignerAgent uses ES2022 `#private` class fields internally — and `Proxy` + `#private` is incompatible (inside a method called through the proxy, `this` is the proxy, and `this.#private` throws). Vault open worked because `apiClient.ts` uses PNP's bundled-v3 actor (never touches my v5 agent). Swap/AMM/3pool/SP/AMM1 went through `createOisyActor` and hit the proxy. Fix: drop the shim entirely — Phase 2 already migrated all 26 call sites, so the shim had no real consumers.

## What's in this PR (Phase 1 + 2 + main merge)

| Commit | What |
|---|---|
| `f55be4a` | Rewrite `oisySigner.ts` on `@icp-sdk/signer` v5 |
| `c3ab33a` | `pnp.getSignerAgent()` is async, returns v5 agent. 9 callers in apiClient.ts get `await` |
| `d818e00` | `apiClient.ts`: 9 Oisy paths → sequential awaits |
| `adf490d` | 5 service files + 2 components: 17 more blocks → sequential awaits |
| `ee91a8c` | Move `beforeToBalance` snapshot into `fetchQuote` (smoke-test surfaced) |
| `1e64f62` | Drop Proxy compat shim (smoke-test surfaced) |
| `e735df1` | Merge `main` → picks up PR #196 (Plug-cleanup guard) |

Net: **+449/-484 lines** (~35 fewer lines of code), one whole library swapped, all 91 `batch()/execute()` calls removed.

## What's deferred to follow-up PRs

- **Phase 3 — `repay_and_close_vault` compound backend method.** Saves one consent screen on the close-vault flow (3 popups → 2). Touches state-mutation paths, needs TDD + pocket-ic test + its own review window.
- **Phase 4 — drop `@slide-computer/*` deps.** Saves ~80kb bundle. Trivial once Phases 1–3 are baked.
- **Follow-up — stale balance cache after swap.** Cosmetic UI bug (verified working swap looks like it failed for ~30s because `walletStore.refreshBalance()` hits the TokenService cache). Already flagged as a separate task. Not introduced by this PR.

## What's preserved

- `callWithOisyFalseNegativeGuard` / `isOisyLandedSentinel`: the `_arr` false-negative resilience layer stays. v5 may handle Principal types more correctly than v4 (uses `@icp-sdk/core` Principal natively), but the bug is on Oisy's response-serialization side, not the lib — so the guard continues to earn its keep.
- `preCacheVaultSnapshot` / `preWarmOisySigner` / `preWarmOisyFees`: gesture-context pre-warming is still essential. The FIRST Oisy popup must open synchronously from the click handler.
- All non-Oisy paths (Plug, II): completely untouched.

## Roll-back plan

Asset-state-only change. `git revert <merge-commit> && dfx deploy vault_frontend --network ic --identity rumi_identity` rolls it back in 60 seconds. No backend wasm touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)