### PR TITLE
fix(wallet): guard window.ic.plug.agent before reading getPrincipal

### DIFF
--- a/src/vault_frontend/src/lib/stores/wallet.ts
+++ b/src/vault_frontend/src/lib/stores/wallet.ts
@@ -294,7 +294,7 @@ function createWalletStore() {
       console.log('Cleaning up any stale operations for newly connected wallet');
 
       if (typeof window !== 'undefined' && window.ic?.plug) {
-        if (typeof window.ic.plug.agent.getPrincipal === 'function') {
+        if (window.ic.plug.agent && typeof window.ic.plug.agent.getPrincipal === 'function') {
           try {
             const dummyPromise = window.ic.plug.agent.getPrincipal() as Promise<unknown>;
             dummyPromise.catch(() => {});


### PR DESCRIPTION
## Summary

Fixes a console error during wallet connect for users who have the Plug browser extension installed but connect via a different wallet (e.g. Oisy).

`cleanupPendingOperations()` in \`src/vault_frontend/src/lib/stores/wallet.ts\` only guards on \`window.ic?.plug\`, then dereferences \`window.ic.plug.agent.getPrincipal\`. Plug injects \`window.ic.plug\` regardless of connection state, but \`window.ic.plug.agent\` is \`undefined\` until someone actually connects through Plug — so the dereference throws:

\`\`\`
Cannot read properties of undefined (reading 'getPrincipal')
\`\`\`

The error is swallowed by the outer try/catch, so nothing breaks functionally. It just prints a red error in the console on every non-Plug connect, which scares users.

One-line fix: add the missing guard on \`window.ic.plug.agent\` before reading its methods. The \`else if\` branch on line 304 reads \`window.ic.plug.requestBalance\` directly (not \`.agent\`), so it doesn't share the bug.

## Test plan

- [ ] Connect with Oisy on a browser that also has the Plug extension installed
- [ ] Confirm the \`Error cleaning up pending operations: ...getPrincipal...\` line no longer appears in the console
- [ ] Plug-connect flow still works (hits the \`agent.getPrincipal\` branch with a real agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)