### PR TITLE
fix(swap): bypass TokenService cache when refreshing after swap

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -89,8 +89,9 @@
       if ($walletStore.principal) {
         unusedBalances = await checkIcpswapUnusedBalances($walletStore.principal).catch(() => []);
       }
-      // Refresh wallet balances
-      walletStore.refreshBalance();
+      // Skip TokenService's 30s cache — recovery moves real funds and the user
+      // is staring at the balance to confirm it.
+      walletStore.refreshBalance({ skipCache: true });
     } catch (err: any) {
       error = `Recovery failed: ${err.message}`;
     } finally {
@@ -101,7 +102,7 @@
         unusedBalances = await checkIcpswapUnusedBalances($walletStore.principal).catch(() => []);
         if (unusedBalances.length > 0) preWarmRecovery(unusedBalances).catch(() => {});
       }
-      walletStore.refreshBalance();
+      walletStore.refreshBalance({ skipCache: true });
     }
   }
 
@@ -332,8 +333,11 @@
       }
     } finally {
       loading = false;
-      // Always refresh wallet balances and check for stuck deposits after swap
-      walletStore.refreshBalance();
+      // Always refresh wallet balances and check for stuck deposits after swap.
+      // skipCache bypasses TokenService's 30s cache so the destination balance
+      // reflects the just-completed swap immediately instead of showing the
+      // pre-swap value until the cache expires.
+      walletStore.refreshBalance({ skipCache: true });
       if ($walletStore.principal) {
         const stuck = await checkIcpswapUnusedBalances($walletStore.principal).catch(() => []);
         if (stuck.length > 0) {

--- a/src/vault_frontend/src/lib/stores/appDataStore.ts
+++ b/src/vault_frontend/src/lib/stores/appDataStore.ts
@@ -219,8 +219,17 @@ function createAppDataStore() {
 
     /**
      * WALLET BALANCES - Single source of truth
+     *
+     * `skipCache` bypasses TokenService's 30s balance cache (separate from this
+     * store's 5s cache controlled by `forceRefresh`). Required after balance-
+     * mutating user actions — otherwise the UI shows the pre-op balance until
+     * the TokenService cache expires.
      */
-    async fetchBalances(principal: Principal, forceRefresh = false): Promise<{ icpBalance: bigint; icusdBalance: bigint }> {
+    async fetchBalances(
+      principal: Principal,
+      forceRefresh = false,
+      opts?: { skipCache?: boolean },
+    ): Promise<{ icpBalance: bigint; icusdBalance: bigint }> {
       return new Promise((resolve, reject) => {
         const requestKey = `balances_${principal.toString()}`; // Move requestKey outside
         
@@ -268,7 +277,7 @@ function createAppDataStore() {
         });
 
         // Make the actual API call
-        this._fetchBalancesFromAPI(principal)
+        this._fetchBalancesFromAPI(principal, opts)
           .then(({ icpBalance, icusdBalance }) => {
             update(state => {
               state.activeRequests.delete(requestKey);
@@ -371,16 +380,19 @@ function createAppDataStore() {
       return ApiClient.getUserVaults(true); // Always force refresh from API
     },
 
-    async _fetchBalancesFromAPI(principal: Principal): Promise<{ icpBalance: bigint; icusdBalance: bigint }> {
+    async _fetchBalancesFromAPI(
+      principal: Principal,
+      opts?: { skipCache?: boolean },
+    ): Promise<{ icpBalance: bigint; icusdBalance: bigint }> {
       // Import here to avoid circular dependencies
       const { TokenService } = await import('../services/tokenService');
       const { CONFIG } = await import('../config');
-      
+
       const [icpBalance, icusdBalance] = await Promise.all([
-        TokenService.getTokenBalance(CONFIG.currentIcpLedgerId, principal),
-        TokenService.getTokenBalance(CONFIG.currentIcusdLedgerId, principal)
+        TokenService.getTokenBalance(CONFIG.currentIcpLedgerId, principal, opts),
+        TokenService.getTokenBalance(CONFIG.currentIcusdLedgerId, principal, opts)
       ]);
-      
+
       return { icpBalance, icusdBalance };
     }
   };

--- a/src/vault_frontend/src/lib/stores/wallet.ts
+++ b/src/vault_frontend/src/lib/stores/wallet.ts
@@ -46,7 +46,8 @@ function getOwner(principal: any): Principal {
  */
 async function fetchCollateralBalances(
   ownerPrincipal: Principal,
-  collateralPrices: Record<string, number>
+  collateralPrices: Record<string, number>,
+  opts?: { skipCache?: boolean },
 ): Promise<Record<string, TokenBalance>> {
   const { collateralStore } = await import('./collateralStore');
   const collaterals = await collateralStore.fetchSupportedCollateral();
@@ -56,7 +57,7 @@ async function fetchCollateralBalances(
   const nonIcp = collaterals.filter(c => c.ledgerCanisterId !== CANISTER_IDS.ICP_LEDGER);
   const results = await Promise.allSettled(
     nonIcp.map(async (c) => {
-      const raw = await TokenService.getTokenBalance(c.ledgerCanisterId, ownerPrincipal);
+      const raw = await TokenService.getTokenBalance(c.ledgerCanisterId, ownerPrincipal, opts);
       const value = Number(raw) / Math.pow(10, c.decimals);
       const displayDecimals = c.decimals > 6 ? 8 : 6;
       const factor = Math.pow(10, displayDecimals);
@@ -171,7 +172,7 @@ function createWalletStore() {
     }
   }
 
-  async function refreshBalance() {
+  async function refreshBalance(opts?: { skipCache?: boolean }) {
     try {
       const state = get(walletStore);
       if (!state.principal || !state.isConnected) {
@@ -179,7 +180,7 @@ function createWalletStore() {
         return;
       }
 
-      const { icpBalance, icusdBalance } = await appDataStore.fetchBalances(state.principal, true);
+      const { icpBalance, icusdBalance } = await appDataStore.fetchBalances(state.principal, true, opts);
       const protocolStatus = await appDataStore.fetchProtocolStatus();
       const icpPriceValue = protocolStatus?.lastIcpRate || 0;
 
@@ -189,9 +190,9 @@ function createWalletStore() {
       let threeUsdBalance = 0n;
       try {
         [ckusdtBalance, ckusdcBalance, threeUsdBalance] = await Promise.all([
-          TokenService.getTokenBalance(CONFIG.ckusdtLedgerId, state.principal),
-          TokenService.getTokenBalance(CONFIG.ckusdcLedgerId, state.principal),
-          TokenService.getTokenBalance(CONFIG.threePoolCanisterId, state.principal),
+          TokenService.getTokenBalance(CONFIG.ckusdtLedgerId, state.principal, opts),
+          TokenService.getTokenBalance(CONFIG.ckusdcLedgerId, state.principal, opts),
+          TokenService.getTokenBalance(CONFIG.threePoolCanisterId, state.principal, opts),
         ]);
       } catch (e) {
         console.warn('Failed to fetch stablecoin balances:', e);
@@ -205,7 +206,7 @@ function createWalletStore() {
       // Fetch collateral token balances (ckBTC, ckXAUT, etc.)
       let collateralBalances: Record<string, TokenBalance> = {};
       try {
-        collateralBalances = await fetchCollateralBalances(state.principal, {});
+        collateralBalances = await fetchCollateralBalances(state.principal, {}, opts);
       } catch (e) {
         console.warn('Failed to fetch collateral balances:', e);
       }


### PR DESCRIPTION
## Summary

- `walletStore.refreshBalance()` now accepts `{ skipCache: true }` and propagates it through `appDataStore.fetchBalances` and every direct `TokenService.getTokenBalance` call (ICP/icUSD, ckUSDT/ckUSDC/3USD, all collaterals)
- `SwapInterface.svelte`'s three post-op refresh sites (`handleSwap` finally, both halves of `handleRecover`) opt into the fresh fetch
- Verifier inside `handleSwap` already used `skipCache` for the `_arr` post-swap check; only the trailing UI refresh was hitting the cache

## Why

Reproduced 2026-05-22 on mainnet: a 45 icUSD → 16.42 ICP swap completed on-chain but the UI showed the unchanged ICP balance for ~30 seconds. Console showed `Using cached balance for ryjl3-...` repeatedly even though appDataStore logged `🆕 Fetching fresh balances...` — TokenService's 30s cache was masking the post-swap delta. Looks like the swap "didn't work" until the cache expires.

## Test plan

- [ ] On mainnet, swap icUSD → ICP and confirm the destination balance updates within ~1s of swap confirmation
- [ ] Repeat for 3USD → icUSD and ckUSDT → ICP to cover non-appDataStore tokens
- [ ] Recover stuck ICPswap funds via the Recover banner; confirm balances update immediately
- [ ] Confirm the 30s polling refresh still works (no regression for idle UI)

## Follow-up

VaultCard.svelte and StabilityPoolTab.svelte have the same stale-cache pattern after their balance-mutating ops — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)