### PR TITLE
fix(ui): refresh wallet balance after vault and pool ops

### DIFF
--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -116,7 +116,7 @@
 
   function handleSuccess() {
     loadAllData();
-    walletStore.refreshBalance();
+    walletStore.refreshBalance({ skipCache: true });
   }
 </script>
 

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -567,7 +567,9 @@
           ? `Added ${amount} ${collateralSymbol} (wallet glitch ignored — operation confirmed on-chain).`
           : `Added ${amount} ${collateralSymbol}`;
         toastStore.success(msg, 8000); addCollateralAmount = '';
-        await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
+        await vaultStore.refreshVault(vault.vaultId);
+        walletStore.refreshBalance({ skipCache: true });
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
     } finally { isProcessing = false; }
@@ -594,7 +596,9 @@
           ? `Withdrew ${amount} ${collateralSymbol} (wallet glitch ignored — operation confirmed on-chain).`
           : `Withdrew ${amount} ${collateralSymbol}`;
         toastStore.success(msg, 8000); withdrawAmount = '';
-        await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
+        await vaultStore.refreshVault(vault.vaultId);
+        walletStore.refreshBalance({ skipCache: true });
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
     } finally { isProcessing = false; }
@@ -615,7 +619,9 @@
           ? `Borrowed ${amount} icUSD (wallet glitch ignored — operation confirmed on-chain).`
           : `Borrowed ${amount} icUSD`;
         toastStore.success(msg, 8000); borrowAmount = '';
-        await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
+        await vaultStore.refreshVault(vault.vaultId);
+        walletStore.refreshBalance({ skipCache: true });
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
     } finally { isProcessing = false; }
@@ -640,7 +646,9 @@
           : `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType}`;
         toastStore.success(msg, 8000); repayAmount = '';
         await new Promise(r => setTimeout(r, 1000));
-        await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
+        await vaultStore.refreshVault(vault.vaultId);
+        walletStore.refreshBalance({ skipCache: true });
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -663,7 +671,9 @@
           ? 'Vault closed. Collateral returned. (Wallet glitch ignored — confirmed on-chain.)'
           : 'Vault closed. Collateral returned.';
         toastStore.success(msg, 8000);
-        await vaultStore.refreshVaults(); dispatch('updated');
+        await vaultStore.refreshVaults();
+        walletStore.refreshBalance({ skipCache: true });
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) { toastStore.error(err instanceof Error ? err.message : 'Unknown error', 8000);
     } finally { isWithdrawingAndClosing = false; }

--- a/src/vault_frontend/src/routes/3usd/+page.svelte
+++ b/src/vault_frontend/src/routes/3usd/+page.svelte
@@ -110,7 +110,7 @@
 
   function handleSuccess() {
     loadAllData();
-    walletStore.refreshBalance();
+    walletStore.refreshBalance({ skipCache: true });
   }
 </script>
 


### PR DESCRIPTION
## Summary
Follow-up to #197 — same root cause (TokenService cache returning stale balances immediately after a balance-mutating op), other sites that had the same bug.

- **VaultCard.svelte**: all five vault handlers (add collateral, withdraw, borrow, repay, withdraw-and-close) now call `walletStore.refreshBalance({ skipCache: true })` after the on-chain op succeeds. Previously they only refreshed vault state, leaving wallet balances (ICP / collateral / icUSD / ckUSDT / ckUSDC) stale until the 30s polling tick.
- **StabilityPoolTab.svelte** and **routes/3usd/+page.svelte**: already called `walletStore.refreshBalance()` on success, but without `skipCache`. Both updated to pass `skipCache: true`.

Wallet refresh is fired non-blocking between the vault refresh and the `'updated'` dispatch — matches the existing fire-and-forget pattern in StabilityPoolTab and avoids a stray error toast on top of the success toast if the cache-busting refresh ever fails.

## Test plan
- [x] `npm run check` in `src/vault_frontend` — 32 errors / 49 warnings, identical to baseline. Zero new.
- [ ] Manually verify on mainnet after deploy: wallet balance updates immediately after deposit / withdraw / borrow / repay / close on a vault, after SP deposit / withdraw, and after 3pool mint / redeem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)