### PR TITLE
feat: repay_and_close_vault compound method (Phase 3 of Oisy work)

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -545,6 +545,10 @@ type LiquidityStatus = record {
 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type RepayAndCloseSuccess = record {
+  repay_block_index : nat64;
+  collateral_return_block_index : opt nat64;
+};
 type PerCollateralRateCurve = record {
   markers : vec record { float64; float64 };
   base_rate : float64;
@@ -696,6 +700,7 @@ type Result_6 = variant { Ok : nat8; Err : ProtocolError };
 type Result_7 = variant { Ok : float64; Err : ProtocolError };
 type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
 type Result_9 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_13 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -901,6 +906,7 @@ service : (ProtocolArg) -> {
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
   redeem_reserves : (nat64, opt principal) -> (Result_11);
+  repay_and_close_vault : (VaultArg) -> (Result_13);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -810,6 +810,10 @@ export interface RateMarker {
   'multiplier' : Uint8Array | number[],
   'cr_level' : Uint8Array | number[],
 }
+export interface RepayAndCloseSuccess {
+  'collateral_return_block_index' : [] | [bigint],
+  'repay_block_index' : bigint,
+}
 export interface ReserveBalance {
   'balance' : bigint,
   'ledger' : Principal,
@@ -831,6 +835,8 @@ export type Result_10 = { 'Ok' : boolean } |
 export type Result_11 = { 'Ok' : ReserveRedemptionResult } |
   { 'Err' : ProtocolError };
 export type Result_12 = { 'Ok' : StabilityPoolLiquidationResult } |
+  { 'Err' : ProtocolError };
+export type Result_13 = { 'Ok' : RepayAndCloseSuccess } |
   { 'Err' : ProtocolError };
 export type Result_2 = { 'Ok' : string } |
   { 'Err' : ProtocolError };
@@ -1093,6 +1099,7 @@ export interface _SERVICE {
   'redeem_collateral' : ActorMethod<[Principal, bigint], Result_3>,
   'redeem_icp' : ActorMethod<[bigint], Result_3>,
   'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_11>,
+  'repay_and_close_vault' : ActorMethod<[VaultArg], Result_13>,
   'repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'repay_to_vault_with_stable' : ActorMethod<[VaultArgWithToken], Result_1>,
   'reset_bot_budget' : ActorMethod<[bigint], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -875,6 +875,14 @@ export const idlFactory = ({ IDL }) => {
     'Ok' : ReserveRedemptionResult,
     'Err' : ProtocolError,
   });
+  const RepayAndCloseSuccess = IDL.Record({
+    'collateral_return_block_index' : IDL.Opt(IDL.Nat64),
+    'repay_block_index' : IDL.Nat64,
+  });
+  const Result_13 = IDL.Variant({
+    'Ok' : RepayAndCloseSuccess,
+    'Err' : ProtocolError,
+  });
   const StabilityPoolLiquidationResult = IDL.Record({
     'fee' : IDL.Nat64,
     'collateral_price_e8s' : IDL.Nat64,
@@ -1147,6 +1155,7 @@ export const idlFactory = ({ IDL }) => {
         [Result_11],
         [],
       ),
+    'repay_and_close_vault' : IDL.Func([VaultArg], [Result_13], []),
     'repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'repay_to_vault_with_stable' : IDL.Func(
         [VaultArgWithToken],

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -545,6 +545,10 @@ type LiquidityStatus = record {
 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type RepayAndCloseSuccess = record {
+  repay_block_index : nat64;
+  collateral_return_block_index : opt nat64;
+};
 type PerCollateralRateCurve = record {
   markers : vec record { float64; float64 };
   base_rate : float64;
@@ -696,6 +700,7 @@ type Result_6 = variant { Ok : nat8; Err : ProtocolError };
 type Result_7 = variant { Ok : float64; Err : ProtocolError };
 type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
 type Result_9 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_13 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -901,6 +906,7 @@ service : (ProtocolArg) -> {
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
   redeem_reserves : (nat64, opt principal) -> (Result_11);
+  repay_and_close_vault : (VaultArg) -> (Result_13);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/src/icrc21.rs
+++ b/src/rumi_protocol_backend/src/icrc21.rs
@@ -297,7 +297,30 @@ fn generate_consent_message(method: &str, arg: &[u8]) -> Result<String, String> 
                 ),
             }
         }
-        
+
+        "repay_and_close_vault" => {
+            match try_decode_vault_arg(arg, "repay_and_close_vault")? {
+                Some(vault_arg) => Ok(format!(
+                    "## Repay and Close Vault\n\n\
+                    You are repaying **{}** to vault #{} and closing it.\n\n\
+                    This will:\n\
+                    - Burn the icUSD from your balance\n\
+                    - Return all remaining collateral to your wallet\n\
+                    - Remove the vault from the protocol",
+                    format_icusd_amount(vault_arg.amount),
+                    vault_arg.vault_id
+                )),
+                None => Ok(
+                    "## Repay and Close Vault\n\n\
+                    You are repaying icUSD to your vault and closing it.\n\n\
+                    This will:\n\
+                    - Burn the icUSD from your balance\n\
+                    - Return all remaining collateral to your wallet\n\
+                    - Remove the vault from the protocol".to_string()
+                ),
+            }
+        }
+
         "close_vault" => {
             match try_decode_u64(arg, "close_vault")? {
                 Some(vault_id) => Ok(format!(

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1432,6 +1432,15 @@ async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, Protocol
     check_postcondition(rumi_protocol_backend::vault::withdraw_and_close_vault(vault_id).await)
 }
 
+/// Compound repay + withdraw + close in a single canister call.
+/// Saves one Oisy consent screen for users closing borrowed vaults.
+#[candid_method(update)]
+#[update]
+async fn repay_and_close_vault(arg: VaultArg) -> Result<rumi_protocol_backend::vault::RepayAndCloseSuccess, ProtocolError> {
+    validate_call().await?;
+    check_postcondition(rumi_protocol_backend::vault::repay_and_close_vault(arg).await)
+}
+
 // Add the new liquidate vault endpoint
 #[candid_method(update)]
 #[update]

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -973,33 +973,31 @@ pub async fn borrow_from_vault(arg: VaultArg) -> Result<SuccessWithFee, Protocol
     }
 }
 
-pub async fn repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
-    let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("repay_vault_{}", arg.vault_id))?;
+/// Internal repay logic without guard management.
+///
+/// Called by both `repay_to_vault` (which acquires its own `repay_vault_{id}`
+/// guard) and `repay_and_close_vault` (which holds a single
+/// `repay_and_close_{id}` guard spanning repay + withdraw + close).
+///
+/// Performs interest accrual, validates caller/state, pulls icUSD via
+/// `icrc2_transfer_from`, records the repayment, and distributes the interest
+/// share to treasury.
+async fn repay_to_vault_internal(caller: Principal, arg: VaultArg) -> Result<u64, ProtocolError> {
     let amount: ICUSD = arg.amount.into();
 
     // Accrue interest before repayment so the correct debt balance is used.
     let now = ic_cdk::api::time();
     mutate_state(|s| s.accrue_single_vault(arg.vault_id, now));
 
-    let vault = match read_state(|s| s.vault_id_to_vaults.get(&arg.vault_id).cloned()) {
-        Some(v) => v,
-        None => {
-            guard_principal.fail();
-            return Err(ProtocolError::GenericError("Vault not found".to_string()));
-        }
-    };
+    let vault = read_state(|s| s.vault_id_to_vaults.get(&arg.vault_id).cloned())
+        .ok_or_else(|| ProtocolError::GenericError("Vault not found".to_string()))?;
 
-    if let Err(e) = require_vault_not_processing(&vault) {
-        guard_principal.fail();
-        return Err(e);
-    }
+    require_vault_not_processing(&vault)?;
 
     // Check collateral status allows repayment
     let collateral_status = read_state(|s| s.get_collateral_status(&vault.collateral_type));
     if let Some(status) = collateral_status {
         if !status.allows_repay() {
-            guard_principal.fail();
             return Err(ProtocolError::GenericError(
                 "Repayment is not allowed for this collateral type.".to_string(),
             ));
@@ -1007,12 +1005,10 @@ pub async fn repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
     }
 
     if caller != vault.owner {
-        guard_principal.fail();
         return Err(ProtocolError::CallerNotOwner);
     }
 
     if amount < read_state(|s| s.min_icusd_amount) {
-        guard_principal.fail();
         return Err(ProtocolError::AmountTooLow {
             minimum_amount: read_state(|s| s.min_icusd_amount).to_u64(),
         });
@@ -1033,24 +1029,33 @@ pub async fn repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
         amount
     };
 
-    if let Err(e) = check_min_vault_debt_after_repay(&vault, amount) {
-        guard_principal.fail();
-        return Err(e);
-    }
+    check_min_vault_debt_after_repay(&vault, amount)?;
 
     match transfer_icusd_from(amount, caller).await {
         Ok(block_index) => {
             let interest_share = mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
             crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
-            guard_principal.complete(); // Mark as completed
             Ok(block_index)
         }
-        Err(transfer_from_error) => {
-            guard_principal.fail(); // Mark as failed
-            Err(ProtocolError::TransferFromError(
-                transfer_from_error,
-                amount.to_u64(),
-            ))
+        Err(transfer_from_error) => Err(ProtocolError::TransferFromError(
+            transfer_from_error,
+            amount.to_u64(),
+        )),
+    }
+}
+
+pub async fn repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
+    let caller = ic_cdk::api::caller();
+    let guard_principal = GuardPrincipal::new(caller, &format!("repay_vault_{}", arg.vault_id))?;
+
+    match repay_to_vault_internal(caller, arg).await {
+        Ok(block_index) => {
+            guard_principal.complete();
+            Ok(block_index)
+        }
+        Err(e) => {
+            guard_principal.fail();
+            Err(e)
         }
     }
 }
@@ -1925,18 +1930,23 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
     }
 }
 
-pub async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
-    let caller = ic_cdk::caller();
-    // Use a specific name for better tracking
-    let _guard_principal = GuardPrincipal::new(caller, &format!("withdraw_and_close_{}", vault_id))?;
-    
+/// Internal withdraw-collateral-and-close logic without guard management.
+///
+/// Called by both `withdraw_and_close_vault` (which acquires its own
+/// `withdraw_and_close_{id}` guard) and `repay_and_close_vault` (which holds
+/// a single `repay_and_close_{id}` guard spanning repay + withdraw + close).
+///
+/// Forgives dust debt, validates collateral status, optimistically zeroes the
+/// vault's collateral, transfers it out, and deletes the vault entry. On
+/// transfer failure the collateral amount is restored and the vault stays open.
+async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> Result<Option<u64>, ProtocolError> {
     log!(
         INFO,
         "[withdraw_and_close] Request for vault #{} by principal {}",
         vault_id,
         caller
     );
-    
+
     // Check if the vault exists first
     let vault = read_state(|s| {
         s.vault_id_to_vaults
@@ -2104,6 +2114,77 @@ pub async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, Prot
     
     // Return the block index if we did a transfer, otherwise None
     Ok(block_index)
+}
+
+pub async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
+    let caller = ic_cdk::caller();
+    // Use a specific name for better tracking
+    let _guard_principal = GuardPrincipal::new(caller, &format!("withdraw_and_close_{}", vault_id))?;
+
+    withdraw_and_close_vault_internal(caller, vault_id).await
+}
+
+/// Compound repay + withdraw + close in a single canister call.
+///
+/// Pulls icUSD via `icrc2_transfer_from` to zero the vault's debt, then
+/// withdraws all collateral and deletes the vault — all under a single
+/// `repay_and_close_{vault_id}` guard. This lets Oisy / ICRC-49 signer
+/// wallets close a borrowed vault with 2 consent screens (approve + this
+/// call) instead of 4 (approve + repay + approve + withdraw_and_close)
+/// when calling the separate methods sequentially.
+///
+/// `arg.amount` is the icUSD amount to repay. Per `repay_to_vault_internal`,
+/// the amount is capped to actual debt and snaps to full-repayment if within
+/// 1% / 0.01 icUSD dust. If repay leaves any debt, the close phase fails
+/// and the vault stays open (but the partial repay is preserved on-chain).
+///
+/// Returns the icUSD repay block index and the optional collateral-return
+/// block index (None if the vault had no collateral, e.g. due to liquidation).
+#[derive(candid::CandidType, candid::Deserialize, Clone, Debug)]
+pub struct RepayAndCloseSuccess {
+    pub repay_block_index: u64,
+    pub collateral_return_block_index: Option<u64>,
+}
+
+pub async fn repay_and_close_vault(arg: VaultArg) -> Result<RepayAndCloseSuccess, ProtocolError> {
+    let caller = ic_cdk::api::caller();
+    let vault_id = arg.vault_id;
+    let guard_principal = GuardPrincipal::new(caller, &format!("repay_and_close_{}", vault_id))?;
+
+    // Phase 1: repay. On failure the guard fails and we propagate the error —
+    // no collateral movement attempted.
+    let repay_block_index = match repay_to_vault_internal(caller, arg).await {
+        Ok(idx) => idx,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(e);
+        }
+    };
+
+    // Phase 2: withdraw + close. If this fails (e.g. collateral transfer
+    // bounces), the repay is already on-chain — the vault stays open with
+    // debt=0 and full collateral, recoverable via the existing
+    // `withdraw_and_close_vault` endpoint. Surface a descriptive error.
+    match withdraw_and_close_vault_internal(caller, vault_id).await {
+        Ok(collateral_return_block_index) => {
+            guard_principal.complete();
+            Ok(RepayAndCloseSuccess {
+                repay_block_index,
+                collateral_return_block_index,
+            })
+        }
+        Err(e) => {
+            guard_principal.fail();
+            log!(
+                INFO,
+                "[repay_and_close_vault] Repay succeeded (block {}) but withdraw/close failed for vault #{}: {:?}. Vault is recoverable via withdraw_and_close_vault.",
+                repay_block_index,
+                vault_id,
+                e
+            );
+            Err(e)
+        }
+    }
 }
 
 pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {

--- a/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
+++ b/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
@@ -3877,3 +3877,138 @@ fn test_3usd_reserves_liquidation_non_sp_rejected() {
 
     log("🎉 TEST PASSED: test_3usd_reserves_liquidation_non_sp_rejected");
 }
+
+// ─── Phase 3: repay_and_close_vault compound method ─────────────────────────
+//
+// `repay_and_close_vault(vault_id, repay_amount)` collapses three user
+// actions (repay debt → withdraw collateral → close vault) into one canister
+// call so Oisy wallets see 2 consent screens instead of 4 when closing a
+// borrowed vault. Tests the happy path: a vault with both debt and collateral
+// becomes a fully-removed vault with collateral returned to the user.
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+struct RepayAndCloseSuccess {
+    repay_block_index: u64,
+    collateral_return_block_index: Option<u64>,
+}
+
+#[test]
+fn test_repay_and_close_vault_full_cycle() {
+    log("🧪 TEST STARTING: test_repay_and_close_vault_full_cycle");
+
+    let (pic, protocol_id, icp_ledger_id, icusd_ledger_id) = setup_protocol();
+
+    if !verify_icp_rate_available(&pic, protocol_id) {
+        log("⚠️ Skipping test due to missing ICP rate");
+        return;
+    }
+
+    let test_user = Principal::self_authenticating(&[1, 2, 3, 4]);
+    log(&format!("👤 Test user: {}", test_user));
+
+    // 1) Create vault with 50 ICP collateral
+    let collateral_amount = 5_000_000_000u64; // 50 ICP
+    let vault_id = create_test_vault(&pic, protocol_id, icp_ledger_id, test_user, collateral_amount)
+        .expect("create_test_vault should succeed");
+    log(&format!("🏦 Created vault #{} with {} ICP", vault_id, collateral_amount));
+
+    // 2) Borrow 20 icUSD against it
+    let borrow_amount = 2_000_000_000u64;
+    call_borrow_from_vault(&pic, protocol_id, test_user, VaultArg { vault_id, amount: borrow_amount })
+        .expect("borrow_from_vault should succeed");
+    log(&format!("💵 Borrowed {} icUSD", borrow_amount));
+
+    let vault_before = get_vault(&pic, protocol_id, test_user, vault_id);
+    assert_eq!(vault_before.borrowed_icusd_amount, borrow_amount, "borrow should be reflected in vault state");
+    assert_eq!(vault_before.icp_margin_amount, collateral_amount, "collateral should still be present");
+
+    // 3) Approve enough icUSD for repayment (use 1.5x as a safety buffer for accrued interest)
+    let approve_amount = borrow_amount * 3 / 2;
+    let approve_args = ApproveArgs {
+        fee: None, memo: None, from_subaccount: None, created_at_time: None,
+        amount: candid::Nat::from(approve_amount),
+        expected_allowance: None, expires_at: None,
+        spender: Account { owner: protocol_id, subaccount: None },
+    };
+    pic.update_call(
+        icusd_ledger_id, test_user, "icrc2_approve",
+        encode_args((approve_args,)).expect("encode icrc2_approve"),
+    ).expect("icrc2_approve call");
+    log("🔐 Approved icUSD for repayment");
+
+    // 4) Snapshot ICP balance before — collateral return should grow it.
+    let icp_balance_before = pic.update_call(
+        icp_ledger_id, test_user, "icrc1_balance_of",
+        encode_args((Account { owner: test_user, subaccount: None },)).expect("encode balance_of"),
+    ).expect("icp balance_of call");
+    let icp_balance_before: candid::Nat = match icp_balance_before {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode balance"),
+        WasmResult::Reject(err) => panic!("balance_of rejected: {}", err),
+    };
+    log(&format!("💰 ICP balance before close: {}", icp_balance_before));
+
+    // 5) Call repay_and_close_vault. This is the not-yet-implemented method —
+    //    the test should fail with "Canister has no update method" until the
+    //    implementation lands. After implementation, it must:
+    //      - pull `borrow_amount` icUSD via icrc2_transfer_from
+    //      - send the 50 ICP collateral (minus ledger fee) back to test_user
+    //      - delete the vault from state
+    let arg = VaultArg { vault_id, amount: borrow_amount };
+    let result = pic.update_call(
+        protocol_id, test_user, "repay_and_close_vault",
+        encode_args((arg,)).expect("encode repay_and_close_vault"),
+    ).expect("repay_and_close_vault call");
+
+    let success: RepayAndCloseSuccess = match result {
+        WasmResult::Reply(bytes) => {
+            match decode_one::<Result<RepayAndCloseSuccess, ProtocolError>>(&bytes) {
+                Ok(Ok(s)) => s,
+                Ok(Err(err)) => panic!("repay_and_close_vault returned error: {:?}", err),
+                Err(err) => panic!("failed to decode repay_and_close_vault response: {}", err),
+            }
+        }
+        WasmResult::Reject(err) => panic!("Canister rejected repay_and_close_vault: {}", err),
+    };
+    log(&format!("✅ repay_and_close_vault returned: {:?}", success));
+    assert!(success.repay_block_index > 0, "repay block index should be set");
+    assert!(success.collateral_return_block_index.is_some(), "collateral return block index should be set when collateral > 0");
+
+    // 6) Assert vault no longer exists. get_vault panics on missing — query
+    //    get_vaults directly and confirm the vault_id is absent.
+    let vaults_after = pic.query_call(
+        protocol_id, test_user, "get_vaults",
+        encode_args((Some(test_user),)).expect("encode get_vaults"),
+    ).expect("get_vaults call");
+    let vaults_after: Vec<CandidVault> = match vaults_after {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode get_vaults"),
+        WasmResult::Reject(err) => panic!("get_vaults rejected: {}", err),
+    };
+    assert!(
+        !vaults_after.iter().any(|v| v.vault_id == vault_id),
+        "vault #{} should be removed after repay_and_close_vault, still found in: {:?}",
+        vault_id, vaults_after.iter().map(|v| v.vault_id).collect::<Vec<_>>()
+    );
+    log(&format!("✅ Vault #{} is gone", vault_id));
+
+    // 7) Assert ICP balance grew. Expected: previous + collateral_amount - icp_fee.
+    //    Use a loose lower bound (95% of collateral) to absorb fee uncertainty.
+    let icp_balance_after = pic.update_call(
+        icp_ledger_id, test_user, "icrc1_balance_of",
+        encode_args((Account { owner: test_user, subaccount: None },)).expect("encode balance_of"),
+    ).expect("icp balance_of call");
+    let icp_balance_after: candid::Nat = match icp_balance_after {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode balance"),
+        WasmResult::Reject(err) => panic!("balance_of rejected: {}", err),
+    };
+    log(&format!("💰 ICP balance after close: {}", icp_balance_after));
+
+    let collateral_min_returned = candid::Nat::from(collateral_amount * 95 / 100);
+    let delta = icp_balance_after.clone() - icp_balance_before.clone();
+    assert!(
+        delta >= collateral_min_returned,
+        "ICP balance should grow by ~{} (got delta {})",
+        collateral_amount, delta
+    );
+
+    log("🎉 TEST PASSED: test_repay_and_close_vault_full_cycle");
+}

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -478,6 +478,17 @@
   // When no debt + max withdraw → this becomes a "Withdraw & Close" action
   $: isWithdrawAndClose = canClose && isMaxWithdraw;
 
+  // Detect if repay amount is the full debt (max). Only icUSD-denominated
+  // repays can be merged with close — the compound backend method takes icUSD.
+  $: isMaxRepay = (() => {
+    const amt = parseFloat(repayAmount);
+    return amt > 0 && maxRepayable > 0 && Math.abs(amt - maxRepayable) < 0.0001;
+  })();
+  // When repaying the full debt in icUSD AND the vault has collateral → offer
+  // "Repay & Close" via the backend repay_and_close_vault compound method.
+  // Saves one Oisy consent screen (3 popups → 2).
+  $: isRepayAndClose = repayTokenType === 'icUSD' && isMaxRepay && vaultCollateralAmount > 0;
+
   function clearMessages() { /* toasts auto-dismiss */ }
 
   function floorTo(val: number, decimals: number): string {
@@ -630,18 +641,30 @@
     clearMessages(); isProcessing = true;
     try {
       let result;
-      if (repayTokenType === 'icUSD') {
+      if (isRepayAndClose) {
+        // Compound: repay full debt + withdraw all collateral + close vault in
+        // one backend call (one Oisy consent screen instead of three).
+        result = await protocolManager.repayAndCloseVault(vault.vaultId, amount);
+      } else if (repayTokenType === 'icUSD') {
         result = await protocolManager.repayToVault(vault.vaultId, amount);
       } else {
         result = await protocolManager.repayToVaultWithStable(vault.vaultId, amount, repayTokenType);
       }
       if (result.success) {
+        const actionLabel = isRepayAndClose ? 'Repaid and closed vault' : `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType}`;
         const msg = result.oisyResilient
-          ? `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType} (wallet glitch ignored — operation confirmed on-chain).`
-          : `Repaid ${amount} ${repayTokenType === 'icUSD' ? 'icUSD' : repayTokenType}`;
+          ? `${actionLabel} (wallet glitch ignored — operation confirmed on-chain).`
+          : actionLabel;
         toastStore.success(msg, 8000); repayAmount = '';
         await new Promise(r => setTimeout(r, 1000));
-        await vaultStore.refreshVault(vault.vaultId); dispatch('updated');
+        // For repay-and-close, refresh the full vault list (vault is gone);
+        // for partial repay, refresh just this vault.
+        if (isRepayAndClose) {
+          await vaultStore.refreshVaults();
+        } else {
+          await vaultStore.refreshVault(vault.vaultId);
+        }
+        dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
@@ -971,7 +994,13 @@
                 {/if}
                 <button class="btn-submit btn-submit-debt" on:click={handleRepay}
                   disabled={isProcessing || !repayAmount || repayOverMax}>
-                  {isProcessing ? '...' : 'Repay'}
+                  {#if isProcessing}
+                    ...
+                  {:else if isRepayAndClose}
+                    Repay & Close
+                  {:else}
+                    Repay
+                  {/if}
                 </button>
               </div>
             {/if}

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -487,7 +487,20 @@
   // When repaying the full debt in icUSD AND the vault has collateral → offer
   // "Repay & Close" via the backend repay_and_close_vault compound method.
   // Saves one Oisy consent screen (3 popups → 2).
-  $: isRepayAndClose = repayTokenType === 'icUSD' && isMaxRepay && vaultCollateralAmount > 0;
+  //
+  // The MIN_ICUSD gate fences off the protocol's "stuck debt zone" — debt
+  // between DUST_DEBT_THRESHOLD (0.0005 icUSD) and MIN_ICUSD_AMOUNT (0.1
+  // icUSD) can't be repaid (backend rejects with AmountTooLow) and can't
+  // be dust-forgiven on close. Without this gate, a user with e.g. 0.05
+  // icUSD debt would see the button promise "Repay & Close" but get a
+  // misleading "Failed" toast when the backend rejected. With the gate,
+  // the button stays as plain "Repay" and the existing rejection-with-
+  // hint path applies (same as today's behavior — no regression).
+  $: isRepayAndClose =
+      repayTokenType === 'icUSD'
+      && isMaxRepay
+      && parseFloat(repayAmount) >= MIN_ICUSD
+      && vaultCollateralAmount > 0;
 
   function clearMessages() { /* toasts auto-dismiss */ }
 

--- a/src/vault_frontend/src/lib/services/ProtocolManager.ts
+++ b/src/vault_frontend/src/lib/services/ProtocolManager.ts
@@ -505,6 +505,48 @@ export class ProtocolManager {
   }
 
   /**
+   * Compound repay + close: pulls icUSD, zeroes debt, returns all collateral,
+   * removes vault — all in one backend call. Saves one Oisy consent screen
+   * vs. the separate repay → withdraw_and_close sequence.
+   */
+  async repayAndCloseVault(vaultId: number, icusdAmount: number): Promise<VaultOperationResult> {
+    // Oisy: bypass executeOperation entirely — its async overhead burns the browser
+    // user gesture context needed for the signer popup.
+    if (isOisyWallet()) {
+      return ApiClient.repayAndCloseVault(vaultId, icusdAmount);
+    }
+    return this.executeOperation(
+      `repayAndCloseVault:${vaultId}`,
+      () => ApiClient.repayAndCloseVault(vaultId, icusdAmount),
+      async () => {
+        await walletOperations.checkSufficientBalance(icusdAmount);
+
+        const amountE8s = BigInt(Math.floor(icusdAmount * 100_000_000));
+        const spenderCanisterId = CONFIG.currentCanisterId;
+
+        try {
+          const currentAllowance = await walletOperations.checkIcusdAllowance(spenderCanisterId);
+          const ICUSD_LEDGER_FEE = BigInt(100_000);
+          const requiredAllowance = amountE8s + ICUSD_LEDGER_FEE + ICUSD_LEDGER_FEE;
+
+          if (currentAllowance < requiredAllowance) {
+            processingStore.setStage(ProcessingStage.APPROVING);
+            const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
+            const approvalResult = await walletOperations.approveIcusdTransfer(LARGE_APPROVAL, spenderCanisterId);
+            if (!approvalResult.success) {
+              throw new Error(approvalResult.error || 'Failed to approve icUSD transfer');
+            }
+            await new Promise(resolve => setTimeout(resolve, 500));
+          }
+        } catch (err) {
+          console.error('icUSD allowance check/approval failed for repay_and_close:', err);
+          throw new Error(`Failed to ensure icUSD allowance: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        }
+      }
+    );
+  }
+
+  /**
    * Repay vault debt using ckUSDT or ckUSDC with proper ICRC-2 approval flow.
    * Mirrors the icUSD repay flow: check allowance → approve if needed → call backend.
    * Amount is in human-readable terms (e.g., 100.0 = 100 USDT).

--- a/src/vault_frontend/src/lib/services/protocol.ts
+++ b/src/vault_frontend/src/lib/services/protocol.ts
@@ -44,6 +44,7 @@ export class ProtocolService {
   static addMarginToVault = ApiClient.addMarginToVault;
   static repayToVault = ApiClient.repayToVault;
   static partialRepayToVault = ApiClient.repayToVault;
+  static repayAndCloseVault = ApiClient.repayAndCloseVault;
   static closeVault = ApiClient.closeVault;
   static getVaultHistory = ApiClient.getVaultHistory;
   static getVaultInterestRate = ApiClient.getVaultInterestRate;
@@ -125,6 +126,7 @@ export const protocolService = {
 
   // Add the new combined operation to the public API
   withdrawCollateralAndCloseVault: ProtocolService.withdrawCollateralAndCloseVault,
+  repayAndCloseVault: ProtocolService.repayAndCloseVault,
 
   // Wallet operations
   approveIcpTransfer: ProtocolService.approveIcpTransfer,

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -1313,6 +1313,140 @@ static async repayToVault(vaultId: number, icusdAmount: number): Promise<VaultOp
 }
 
 /**
+ * Compound repay + close in a single canister call.
+ *
+ * Combines what would otherwise be `repay_to_vault` followed by
+ * `withdraw_and_close_vault` into one call so Oisy wallets see 2 consent
+ * screens (approve icUSD + this call) instead of 4. Use this when the user
+ * wants to close a vault that still has outstanding debt — the backend
+ * pulls the icUSD, zeroes the debt, returns all collateral, and removes
+ * the vault under a single GuardPrincipal.
+ *
+ * Atomicity: if the repay phase fails, no state mutates. If the collateral
+ * return fails after repay succeeded, the vault stays open with debt=0 and
+ * the full collateral — recoverable via the existing
+ * `withdrawCollateralAndCloseVault` call. The error message surfaces this.
+ */
+static async repayAndCloseVault(vaultId: number, icusdAmount: number): Promise<VaultOperationResult> {
+  return ApiClient.executeSequentialOperation(async () => {
+    try {
+      console.log(`Repaying ${icusdAmount} icUSD and closing vault #${vaultId}`);
+
+      if (!isFinite(icusdAmount) || icusdAmount <= 0) {
+        return {
+          success: false,
+          error: `Invalid repayment amount: ${icusdAmount}. Amount must be a finite positive number.`
+        };
+      }
+
+      if (icusdAmount * E8S < MIN_ICUSD_AMOUNT) {
+        return {
+          success: false,
+          error: `Amount too low. Minimum repayment amount: ${MIN_ICUSD_AMOUNT / E8S} icUSD`
+        };
+      }
+
+      const amountE8s = BigInt(Math.floor(icusdAmount * E8S));
+      const actor = await ApiClient.getAuthenticatedActor();
+      const vaultArg = {
+        vault_id: BigInt(vaultId),
+        amount: amountE8s
+      };
+
+      // _arr verifier: the compound succeeded if the vault is gone. We can't
+      // use the borrowed-amount snapshot (vault is removed, snapshot lookup
+      // returns null) — query vault existence directly.
+      const verifyRepayCloseLanded = async () => {
+        const snap = await ApiClient.fetchVaultRawSnapshot(vaultId);
+        if (!snap) return false;
+        // Vault either fully gone, or husk with zero collateral and zero debt.
+        if (!snap.exists) return true;
+        return snap.collateralAmount === 0n && snap.borrowedIcusd === 0n;
+      };
+
+      // ─── Oisy path: sequential approve + repay_and_close_vault ───
+      const signerAgent = isOisyWallet() ? await pnp.getSignerAgent() : null;
+      if (signerAgent) {
+        console.log(`[Oisy] Sequential icUSD approve + repay_and_close_vault`);
+        const LARGE_APPROVAL = BigInt(100_000_000_000_000_000); // 1B icUSD in e8s
+        const icusdLedgerActor = await walletStore.getActor(
+          CONFIG.currentIcusdLedgerId, CONFIG.icusd_ledgerIDL
+        ) as any;
+
+        // 1) Approve icUSD (first consent screen, Tier 1 native).
+        const approveResult = await icusdLedgerActor.icrc2_approve({
+          amount: LARGE_APPROVAL,
+          spender: { owner: Principal.fromText(CONFIG.currentCanisterId), subaccount: [] },
+          expires_at: [], expected_allowance: [], memo: [], fee: [],
+          from_subaccount: [], created_at_time: []
+        });
+        if (approveResult && 'Err' in approveResult) {
+          return { success: false, error: `icUSD approval failed: ${JSON.stringify(approveResult.Err)}` };
+        }
+
+        // 2) repay_and_close_vault (second consent screen), guarded against _arr.
+        const result = await callWithOisyFalseNegativeGuard(
+          () => actor.repay_and_close_vault(vaultArg),
+          verifyRepayCloseLanded,
+          `Oisy repay_and_close vault #${vaultId} (${icusdAmount} icUSD)`
+        );
+
+        if (isOisyLandedSentinel(result)) {
+          return {
+            success: true,
+            vaultId,
+            message: `Vault #${vaultId} closed (confirmed on-chain after wallet error).`,
+            oisyResilient: true,
+          };
+        }
+
+        if ('Ok' in result) {
+          return {
+            success: true,
+            vaultId,
+            blockIndex: Number(result.Ok.repay_block_index),
+            message: `Vault #${vaultId} closed. Repay block: ${result.Ok.repay_block_index}, collateral return block: ${result.Ok.collateral_return_block_index?.[0] ?? 'none'}.`,
+          };
+        }
+        return { success: false, error: ApiClient.formatProtocolError(result.Err) };
+      }
+
+      // ─── Standard path (non-Oisy): user must have already approved icUSD ───
+      const result = await callWithOisyFalseNegativeGuard(
+        () => actor.repay_and_close_vault(vaultArg),
+        verifyRepayCloseLanded,
+        `repay_and_close vault #${vaultId} (${icusdAmount} icUSD)`
+      );
+
+      if (isOisyLandedSentinel(result)) {
+        return {
+          success: true,
+          vaultId,
+          message: `Vault #${vaultId} closed (confirmed on-chain after wallet error).`,
+          oisyResilient: true,
+        };
+      }
+
+      if ('Ok' in result) {
+        return {
+          success: true,
+          vaultId,
+          blockIndex: Number(result.Ok.repay_block_index),
+          message: `Vault #${vaultId} closed.`,
+        };
+      }
+      return { success: false, error: ApiClient.formatProtocolError(result.Err) };
+    } catch (err) {
+      console.error('Error in repay_and_close_vault:', err);
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error in repay_and_close_vault'
+      };
+    }
+  }, vaultId);
+}
+
+/**
  * Repay to vault using ckUSDT or ckUSDC (1:1 with icUSD).
  *
  * For Oisy wallets: if the stable allowance is insufficient, batches


### PR DESCRIPTION
## Summary

New `repay_and_close_vault` backend method collapses **repay debt → withdraw collateral → close vault** into a single canister call. For users closing a vault that still has outstanding icUSD debt via Oisy, this **reduces the consent-screen count from 4 to 2** (approve icUSD + this call). For ckUSDT/ckUSDC-denominated repays, partial repays, or already-debt-free vaults, the existing separate calls remain — UX is unchanged.

Phase 3 of the Oisy work started in PR #195. The lib migration removed the fake-batch ceremony but couldn't reduce the underlying consent-screen count on its own. This PR closes that gap for the highest-traffic flow.

## How it works

**Backend (`vault.rs`):**
- New `repay_and_close_vault(arg: VaultArg) -> Result<RepayAndCloseSuccess, ProtocolError>`
- Pulls icUSD via `icrc2_transfer_from`, zeroes the debt, transfers all collateral back to the user, deletes the vault entry — all under a single `repay_and_close_{vault_id}` `GuardPrincipal`.
- Implementation reuses the existing repay + withdraw_and_close logic via two new internal helpers (`repay_to_vault_internal` and `withdraw_and_close_vault_internal`). Same pattern as `borrow_from_vault_internal` used by `open_vault_and_borrow`. The existing public `repay_to_vault` / `withdraw_and_close_vault` endpoints are unchanged in behavior (they now just acquire their guard and delegate to the internal helper).

**Atomicity (per canister-security skill):**
- **Phase 1 failure (repay):** nothing mutates, error propagates clean.
- **Phase 2 failure (withdraw/close):** the repay is on-chain but the vault stays open with debt=0 and full collateral — fully recoverable via the existing `withdraw_and_close_vault` endpoint. Error is logged with a recovery hint and surfaced to the caller — no silent partial-success.
- `GuardPrincipal::Drop` releases the lock unconditionally on any exit path including traps; all three explicit exit paths consume the guard.

**Frontend wiring:**
- `apiClient.repayAndCloseVault(vaultId, icusdAmount)` — Oisy path (sequential approve + compound) and non-Oisy path (standard allowance + compound). The `_arr` false-negative guard verifies via 'vault is gone' check (the borrowed-amount snapshot can't be used because the vault is removed entirely).
- `ProtocolManager.repayAndCloseVault` — bypasses `executeOperation` for Oisy (preserves gesture context), uses standard path with allowance pre-check for others.
- `ProtocolService` / `protocolService` exports.
- `VaultCard.svelte` — the Repay button smart-toggles to **'Repay & Close'** when:
    - token is icUSD (compound only takes icUSD)
    - amount equals max repayable (full debt)
    - amount ≥ MIN_ICUSD (0.1) — fences the protocol's stuck-debt zone, see commit `95d580e`
    - vault still has collateral to return

**ICRC-21 consent message:** *'Repay X icUSD to vault #Y and close it. This will: burn icUSD, return collateral, remove vault.'*

## What's NOT covered (intentional)

- **ckUSDT/ckUSDC repay-and-close:** the backend method takes icUSD only. A `repay_with_stable_and_close_vault` companion would be a follow-up if usage data shows it's worth the additional surface area.
- **Stuck debt zone:** vaults with debt between DUST_DEBT_THRESHOLD (0.0005) and MIN_ICUSD_AMOUNT (0.1) can't be repaid or dust-forgiven. Pre-existing protocol gap, flagged as a separate task. Frontend gate added in `95d580e` so the new button doesn't promise a one-click close in this zone.
- **Trap-after-state-mutation hardening:** the existing `repay_to_vault` and `withdraw_and_close_vault` both have theoretical exposure if the inter-canister call's callback traps after state mutations. My compound inherits the same exposure (slightly worse blast radius since both phases are linked). Pre-existing, recoverable in all cases, flagged as a follow-up.

## TDD

New pocket-ic integration test `test_repay_and_close_vault_full_cycle` covers the happy path end-to-end (create vault with 50 ICP collateral + 20 icUSD borrow → repay_and_close → assert vault gone + ICP balance grew by ≥95% of collateral).

- Ran RED with `CanisterMethodNotFound` before implementation
- Ran GREEN after implementation
- Existing `test_repay_to_vault` / `test_open_vault` / `test_add_margin_to_vault` all still pass — the internal-extraction refactor didn't regress them

## Test plan

Backend:
- [x] `cargo build -p rumi_protocol_backend` clean (no new warnings)
- [x] `cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend` clean
- [x] `POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_tests test_repay_and_close_vault_full_cycle` passes
- [x] Regression: `test_repay_to_vault test_open_vault test_add_margin_to_vault` (7 tests) all pass

Frontend:
- [x] `npm run build` clean
- [x] Declarations regenerated from updated .did

Mainnet (after deploy authorization):
- [ ] Open a small vault with debt ≥ 0.1 icUSD
- [ ] Use repay panel, enter max debt amount as icUSD
- [ ] Confirm button label changes to **'Repay & Close'**
- [ ] Click → confirm 2 Oisy consent screens (approve + compound)
- [ ] Confirm vault is gone in vault list
- [ ] Confirm ICP balance grew by ~collateral amount minus fees
- [ ] Regression: open a vault with debt **< 0.1 icUSD** (stuck zone), click Max on repay → button should stay as plain **'Repay'**, not 'Repay & Close'

## Roll-back plan

Backend deploy is **additive** (new endpoint, no removed methods, no changed signatures), so:
- Frontend revert is sufficient to stop using the new method
- Backend method can stay deployed harmlessly
- Existing close flows (`repayToVault` → `withdrawCollateralAndCloseVault`) are unchanged and remain the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)