### PR TITLE
fix(ui): refresh wallet with skipCache in redeem, manual liq, transfer receipt

### DIFF
--- a/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.svelte
@@ -371,7 +371,7 @@
       loadLiquidatableVaults(); loadAllVaults();
     });
     refreshIcpPrice();
-    if ($wallet.isConnected) wallet.refreshBalance().catch(() => {});
+    if ($wallet.isConnected) wallet.refreshBalance({ skipCache: true }).catch(() => {});
     const pi = setInterval(refreshIcpPrice, 30000);
     const vi = setInterval(() => {
       collateralStore.fetchSupportedCollateral(true).then(() => { collateralVersion++; });
@@ -381,7 +381,7 @@
   });
 
   $: if ($wallet.isConnected && !walletIcusd && !walletCkusdt && !walletCkusdc) {
-    wallet.refreshBalance().catch(() => {});
+    wallet.refreshBalance({ skipCache: true }).catch(() => {});
   }
 </script>
 

--- a/src/vault_frontend/src/lib/services/TransferReceiptManager.ts
+++ b/src/vault_frontend/src/lib/services/TransferReceiptManager.ts
@@ -180,7 +180,7 @@ export class TransferReceiptManager {
         this.saveReceipt(receipt);
         
         // Refresh balances
-        await walletStore.refreshBalance();
+        await walletStore.refreshBalance({ skipCache: true });
         
         return { success: true };
       } else {

--- a/src/vault_frontend/src/routes/redeem/+page.svelte
+++ b/src/vault_frontend/src/routes/redeem/+page.svelte
@@ -241,7 +241,7 @@
       // (backend query can't do inter-canister calls, so it always returns 0)
       await fetchReserveBalances();
 
-      if (isConnected) await wallet.refreshBalance();
+      if (isConnected) await wallet.refreshBalance({ skipCache: true });
     } catch (error) {
       console.error('Error fetching protocol data:', error);
     } finally {
@@ -292,7 +292,7 @@
             successMessage = msg;
           }
           icusdAmount = 0;
-          await wallet.refreshBalance();
+          await wallet.refreshBalance({ skipCache: true });
           fetchData();
         } else {
           // Oisy two-step: approval succeeded, show as info not error
@@ -315,7 +315,7 @@
             successMessage = `Redeemed ~${formatNumber(icpEstimate)} ICP for ${formatStableTx(icusdAmount)} icUSD`;
           }
           icusdAmount = 0;
-          await wallet.refreshBalance();
+          await wallet.refreshBalance({ skipCache: true });
         } else {
           errorMessage = result.error || 'Failed to redeem ICP';
         }


### PR DESCRIPTION
## Summary

Same root cause as [#197](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/197) (swaps) and [#198](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/198) (vault + stability-pool ops): `TokenService` caches per-ledger balances, so an immediate `walletStore.refreshBalance()` right after a balance-mutating op returns the **pre-op cached value**, and the wallet UI sits stale until the 30s polling tick.

This PR fixes the three remaining call sites that mutate wallet balances:

- `src/vault_frontend/src/routes/redeem/+page.svelte` — 3 sites (initial protocol-data fetch, reserve-redemption success, ICP-vault-redemption success). Every redemption changes both the received-stable balance and the burned-icUSD balance.
- `src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.svelte` — 2 sites (onMount + reactive fallback). `.catch(() => {})` preserved.
- `src/vault_frontend/src/lib/services/TransferReceiptManager.ts` — 1 site (post-claim refresh). `await` preserved.

Six one-line changes total (`refreshBalance()` → `refreshBalance({ skipCache: true })`). The `skipCache` option already exists on `walletStore.refreshBalance` (defined in `src/vault_frontend/src/lib/stores/wallet.ts:175`) and threads through to `TokenService.getTokenBalance`. No new infrastructure.

After this PR, every `walletStore.refreshBalance(...)` call that follows a balance-mutating action across the vault_frontend uses `skipCache: true`. Polling and connect/disconnect refreshes inside `wallet.ts` and `WalletConnector.svelte` are left as-is (no recent stale-value bug there, and they don't need to bypass the cache).

## Test plan

- [x] `cd src/vault_frontend && npm run check` — still 32 errors / 49 warnings, identical to baseline. Zero new.
- [ ] Manual smoke: connect wallet → redeem some icUSD → wallet balances reflect new totals immediately (no 30s lag).
- [ ] Manual smoke: connect wallet → liquidate an undercollateralized vault from Manual Liquidations → liquidator's collateral wallet reflects payout immediately.
- [ ] Manual smoke: trigger a pending transfer that hits `TransferReceiptManager.claimReceipt` → wallet refreshes with fresh balances.