### PR TITLE
feat(swap): show effective AMM1 APY incl. 3USD pass-through + fix Earn-up-to hero

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
@@ -10,8 +10,12 @@
     getAmm1Apy,
     getPendingEarnings,
     claimAmm1Rewards,
+    computeAmm1EffectiveApy,
+    AMM1_THREEUSD_VALUE_SHARE,
     type Amm1ApyResult,
+    type Amm1EffectiveApy,
   } from '../../services/amm1ApyService';
+  import { getThreePoolApy } from '../../services/threePoolApyService';
 
   const dispatch = createEventDispatcher();
 
@@ -51,6 +55,14 @@
     fees_7d_usd: 0,
     rewards_7d_usd: 0,
     source_window_days: 7,
+  };
+  // 3pool APY, fetched alongside AMM1's so we can show the effective
+  // (AMM1 + pass-through-3USD) yield instead of AMM1-only.
+  let threePoolApyPct = 0;
+  let effective: Amm1EffectiveApy = {
+    amm1_apy_pct: 0,
+    passthrough_3pool_apy_pct: 0,
+    total_apy_pct: 0,
   };
   let pendingE8s: bigint = 0n;
   let claiming = false;
@@ -97,7 +109,13 @@
 
   async function refreshAmm1() {
     try {
-      apy = await getAmm1Apy();
+      const [ammApy, tpApy] = await Promise.all([
+        getAmm1Apy(),
+        getThreePoolApy().catch(() => ({ total_apy_pct: 0 })),
+      ]);
+      apy = ammApy;
+      threePoolApyPct = tpApy.total_apy_pct;
+      effective = computeAmm1EffectiveApy(ammApy, threePoolApyPct);
     } catch (e) {
       console.warn('Failed to refresh AMM1 APY:', e);
     }
@@ -325,8 +343,11 @@
       <span class="pool-dot" style="background:#34d399"></span>
       <span class="pool-dot" style="background:#29abe2"></span>
       <span class="overview-name">3USD / ICP</span>
-      <span class="apy-pill" title="{apy.trading_fee_apy_pct.toFixed(1)}% trading fees + {apy.reward_apy_pct.toFixed(1)}% protocol earnings (7-day)">
-        {apy.total_apy_pct.toFixed(1)}% APY
+      <span
+        class="apy-pill"
+        title="{apy.trading_fee_apy_pct.toFixed(2)}% trading fees + {apy.reward_apy_pct.toFixed(2)}% protocol rewards + {effective.passthrough_3pool_apy_pct.toFixed(2)}% 3USD yield ({(AMM1_THREEUSD_VALUE_SHARE * 100).toFixed(0)}% of 3pool's {threePoolApyPct.toFixed(2)}%, since ~half the pool's value is 3USD)"
+      >
+        {effective.total_apy_pct.toFixed(1)}% APY
       </span>
     </div>
     <div class="overview-stats">

--- a/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
+++ b/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
@@ -5,12 +5,15 @@
     threePoolService,
     POOL_TOKENS,
     formatTokenAmount,
-    calculateTotalApy,
   } from '../../services/threePoolService';
   import { ammService, type PoolInfo } from '../../services/ammService';
-  import { getAmm1Apy, type Amm1ApyResult } from '../../services/amm1ApyService';
-  import { ProtocolService } from '../../services/protocol';
-  import { publicActor } from '../../services/protocol/apiClient';
+  import {
+    getAmm1Apy,
+    computeAmm1EffectiveApy,
+    AMM1_THREEUSD_VALUE_SHARE,
+    type Amm1ApyResult,
+  } from '../../services/amm1ApyService';
+  import { getThreePoolApy } from '../../services/threePoolApyService';
   import { CANISTER_IDS } from '../../config';
   import type { PoolStatus } from '../../services/threePoolService';
 
@@ -29,6 +32,13 @@
   let ammApy: Amm1ApyResult | null = null;
   let showThreePoolTooltip = false;
   let showAmmTooltip = false;
+
+  // Effective AMM1 APY = AMM1's own APY + 50% × 3pool APY (pass-through on
+  // the 3USD half of the reserve). Null until both pools' APYs resolve.
+  $: ammEffective =
+    ammApy !== null && threePoolApyPct !== null
+      ? computeAmm1EffectiveApy(ammApy, threePoolApyPct)
+      : null;
 
   $: isConnected = $walletStore.isConnected;
 
@@ -76,56 +86,10 @@
   }
 
   async function loadThreePoolApy() {
-    if (!threePoolStatus) return;
-
-    const [protocolStatus, interestSplit, swapFees7d] = await Promise.all([
-      ProtocolService.getProtocolStatus().catch(() => null),
-      (publicActor.get_interest_split() as Promise<{ destination: string; bps: bigint }[]>).catch(() => null),
-      threePoolService.getSwapFeesOverWindow(7).catch(() => 0n),
-    ]);
-
-    if (!protocolStatus || !threePoolStatus) {
-      threePoolApyPct = 0;
-      return;
-    }
-
-    // TVL in normalized e8s (3pool stores 6/6/8 decimals natively)
-    let poolTvlE8s = 0;
-    for (let i = 0; i < threePoolStatus.balances.length; i++) {
-      const token = POOL_TOKENS[i];
-      if (token) {
-        const normalized = token.decimals === 8
-          ? Number(threePoolStatus.balances[i])
-          : Number(threePoolStatus.balances[i]) * 100;
-        poolTvlE8s += normalized;
-      }
-    }
-    const poolTvlIcusd = poolTvlE8s / 1e8;
-
-    const threePoolEntry = interestSplit?.find(e => e.destination === 'three_pool');
-    const threePoolShareBps = threePoolEntry ? Number(threePoolEntry.bps) : 5000;
-
-    // Break out interest vs swap-fee APR components for the tooltip
-    if (poolTvlIcusd > 0) {
-      const share = threePoolShareBps / 10_000;
-      let interestApr = 0;
-      for (const info of protocolStatus.perCollateralInterest) {
-        if (info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-        interestApr += (info.weightedInterestRate * share * info.totalDebtE8s) / poolTvlIcusd;
-      }
-      const fees7dIcusd = Number(swapFees7d) / 1e8;
-      const swapFeeApr = (fees7dIcusd / poolTvlIcusd) * (365 / 7);
-      threePoolInterestAprPct = interestApr * 100;
-      threePoolSwapFeeAprPct = swapFeeApr * 100;
-    }
-
-    const apy = calculateTotalApy(
-      threePoolShareBps,
-      protocolStatus.perCollateralInterest,
-      poolTvlIcusd,
-      swapFees7d,
-    );
-    threePoolApyPct = apy !== null ? apy * 100 : 0;
+    const r = await getThreePoolApy();
+    threePoolInterestAprPct = r.interest_apr_pct;
+    threePoolSwapFeeAprPct = r.swap_fee_apr_pct;
+    threePoolApyPct = r.total_apy_pct;
   }
 
   async function loadAmmApy() {
@@ -232,21 +196,27 @@
             on:mouseover|stopPropagation={() => { showAmmTooltip = true; }}
             on:mouseleave={() => { showAmmTooltip = false; }}
           >
-            {#if ammApy === null}
+            {#if ammApy === null || ammEffective === null}
               <span class="apy-loading">… APY</span>
             {:else}
               <svg class="apy-arrow" width="9" height="9" viewBox="0 0 10 10" fill="none">
                 <path d="M5 8V2M5 2L2 5M5 2L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>
-              {ammApy.total_apy_pct.toFixed(1)}% APY
+              {ammEffective.total_apy_pct.toFixed(1)}% APY
             {/if}
 
-            {#if showAmmTooltip && ammApy !== null}
+            {#if showAmmTooltip && ammApy !== null && ammEffective !== null}
               <div class="apy-tooltip">
                 <div class="apy-tooltip-caret"></div>
                 <p>
                   Rewards {ammApy.reward_apy_pct.toFixed(2)}% + Swap fees {ammApy.trading_fee_apy_pct.toFixed(2)}%
-                  = total {ammApy.total_apy_pct.toFixed(2)}%
+                  + 3USD yield {ammEffective.passthrough_3pool_apy_pct.toFixed(2)}%
+                  = total {ammEffective.total_apy_pct.toFixed(2)}%
+                </p>
+                <p class="apy-tooltip-foot">
+                  3USD yield is {(AMM1_THREEUSD_VALUE_SHARE * 100).toFixed(0)}% of 3pool APY
+                  ({threePoolApyPct !== null ? threePoolApyPct.toFixed(2) : '—'}%) since
+                  the pool holds ~half its value in 3USD.
                 </p>
               </div>
             {/if}
@@ -470,6 +440,14 @@
   }
 
   .apy-tooltip p { margin: 0; }
+
+  .apy-tooltip-foot {
+    margin-top: 0.375rem !important;
+    padding-top: 0.375rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    color: #94a3b8;
+    font-size: 0.625rem;
+  }
 
   /* ── Explainer under the cards ── */
   .liquidity-explainer {

--- a/src/vault_frontend/src/lib/services/amm1ApyService.ts
+++ b/src/vault_frontend/src/lib/services/amm1ApyService.ts
@@ -41,6 +41,37 @@ export interface Amm1ApyResult {
   source_window_days: number;
 }
 
+export interface Amm1EffectiveApy {
+  // AMM1's own earnings (trading fees + icUSD rewards stream).
+  amm1_apy_pct: number;
+  // Pass-through 3pool yield on the 3USD half of the pool.
+  passthrough_3pool_apy_pct: number;
+  // Sum of the above — what an LP actually earns per dollar deployed.
+  total_apy_pct: number;
+}
+
+// A constant-product AMM held near equilibrium by arbitrage keeps ~50% of
+// its value in each side. The 3USD side accrues 3pool yield via virtual-price
+// growth; the ICP side does not. So an LP's effective yield is AMM1's own
+// APY plus half of the 3pool APY.
+export const AMM1_THREEUSD_VALUE_SHARE = 0.5;
+
+/**
+ * Combine AMM1's standalone APY with the 3pool yield embedded in the
+ * 3USD half of the AMM1 reserve. Pure function — no IO.
+ */
+export function computeAmm1EffectiveApy(
+  amm1: Amm1ApyResult,
+  threePoolApyPct: number,
+): Amm1EffectiveApy {
+  const passthrough = threePoolApyPct * AMM1_THREEUSD_VALUE_SHARE;
+  return {
+    amm1_apy_pct: amm1.total_apy_pct,
+    passthrough_3pool_apy_pct: passthrough,
+    total_apy_pct: amm1.total_apy_pct + passthrough,
+  };
+}
+
 interface DailyRewardPoint {
   day_start_ns: bigint;
   amount: bigint;

--- a/src/vault_frontend/src/lib/services/threePoolApyService.ts
+++ b/src/vault_frontend/src/lib/services/threePoolApyService.ts
@@ -1,0 +1,110 @@
+// 3pool APY service.
+//
+// Consolidates the fetch-and-compute pipeline for the 3pool's LP APY so
+// each consumer (Swap hero, PoolListView, AmmLiquidityPanel pass-through)
+// can call a single cached helper instead of wiring up four parallel
+// queries and re-deriving the breakdown.
+//
+// The pure math still lives in `calculateTotalApy` (threePoolService.ts);
+// this module is just the orchestrator + cache + breakdown surfaces.
+
+import {
+  threePoolService,
+  calculateTotalApy,
+  POOL_TOKENS,
+} from './threePoolService';
+import { ProtocolService } from './protocol';
+import { publicActor } from './protocol/apiClient';
+
+export interface ThreePoolApyResult {
+  total_apy_pct: number;
+  interest_apr_pct: number;
+  swap_fee_apr_pct: number;
+  pool_tvl_icusd: number;
+  three_pool_share_bps: number;
+}
+
+const APY_CACHE_TTL_MS = 30_000;
+let _apyCache: { value: ThreePoolApyResult; expires: number } | null = null;
+
+/**
+ * Get cached 3pool LP APY. 30s TTL.
+ *
+ * Components:
+ *   - interest_apr  = sum over collaterals of (rate × share × debt / TVL)
+ *   - swap_fee_apr  = fees_7d / TVL × (365/7)
+ *   - total_apy     = (1 + (interest_apr + swap_fee_apr)/365)^365 - 1
+ *
+ * Returns 0% APY (with zero components) on any partial failure rather than
+ * throwing, since the callers render UI badges that should degrade
+ * gracefully.
+ */
+export async function getThreePoolApy(): Promise<ThreePoolApyResult> {
+  if (_apyCache && _apyCache.expires > Date.now()) {
+    return _apyCache.value;
+  }
+
+  const [status, protocolStatus, interestSplit, swapFees7d] = await Promise.all([
+    threePoolService.getPoolStatus(),
+    ProtocolService.getProtocolStatus().catch(() => null),
+    (publicActor.get_interest_split() as Promise<
+      { destination: string; bps: bigint }[]
+    >).catch(() => null),
+    threePoolService.getSwapFeesOverWindow(7).catch(() => 0n),
+  ]);
+
+  // TVL in icUSD-equivalent (normalize 6-dec stables to 8-dec via ×100).
+  let poolTvlE8s = 0;
+  for (let i = 0; i < status.balances.length; i++) {
+    const token = POOL_TOKENS[i];
+    if (!token) continue;
+    const normalized =
+      token.decimals === 8
+        ? Number(status.balances[i])
+        : Number(status.balances[i]) * 100;
+    poolTvlE8s += normalized;
+  }
+  const poolTvlIcusd = poolTvlE8s / 1e8;
+
+  const threePoolEntry = interestSplit?.find(
+    (e) => e.destination === 'three_pool',
+  );
+  const threePoolShareBps = threePoolEntry ? Number(threePoolEntry.bps) : 5000;
+
+  let interestAprPct = 0;
+  let swapFeeAprPct = 0;
+  let totalApyPct = 0;
+
+  if (protocolStatus && poolTvlIcusd > 0) {
+    const share = threePoolShareBps / 10_000;
+    let interestApr = 0;
+    for (const info of protocolStatus.perCollateralInterest) {
+      if (info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
+      interestApr +=
+        (info.weightedInterestRate * share * info.totalDebtE8s) / poolTvlIcusd;
+    }
+    const fees7dIcusd = Number(swapFees7d) / 1e8;
+    const swapFeeApr = (fees7dIcusd / poolTvlIcusd) * (365 / 7);
+    interestAprPct = interestApr * 100;
+    swapFeeAprPct = swapFeeApr * 100;
+
+    const apy = calculateTotalApy(
+      threePoolShareBps,
+      protocolStatus.perCollateralInterest,
+      poolTvlIcusd,
+      swapFees7d,
+    );
+    totalApyPct = apy !== null ? apy * 100 : 0;
+  }
+
+  const result: ThreePoolApyResult = {
+    total_apy_pct: totalApyPct,
+    interest_apr_pct: interestAprPct,
+    swap_fee_apr_pct: swapFeeAprPct,
+    pool_tvl_icusd: poolTvlIcusd,
+    three_pool_share_bps: threePoolShareBps,
+  };
+
+  _apyCache = { value: result, expires: Date.now() + APY_CACHE_TTL_MS };
+  return result;
+}

--- a/src/vault_frontend/src/routes/swap/+page.svelte
+++ b/src/vault_frontend/src/routes/swap/+page.svelte
@@ -6,31 +6,27 @@
   import PoolListView from '../../lib/components/swap/PoolListView.svelte';
   import AmmLiquidityPanel from '../../lib/components/swap/AmmLiquidityPanel.svelte';
   import LiquidityInterface from '../../lib/components/swap/LiquidityInterface.svelte';
-  import { getAmm1Apy } from '../../lib/services/amm1ApyService';
-  import {
-    threePoolService,
-    calculateTotalApy,
-    POOL_TOKENS,
-  } from '../../lib/services/threePoolService';
-  import { ammService, type PoolInfo } from '../../lib/services/ammService';
-  import { ProtocolService } from '../../lib/services/protocol';
-  import { publicActor } from '../../lib/services/protocol/apiClient';
-  import { CANISTER_IDS } from '../../lib/config';
+  import { getAmm1Apy, AMM1_THREEUSD_VALUE_SHARE } from '../../lib/services/amm1ApyService';
+  import { getThreePoolApy } from '../../lib/services/threePoolApyService';
 
   let mode: 'swap' | 'liquidity' = 'swap';
   let liquidityView: 'list' | 'threepool' | 'amm' = 'list';
 
   // APY state for the combined hero. Each null while loading.
   let threePoolApyPct: number | null = null;
-  let threePoolTvlIcusd = 0;
   let ammApyPct: number | null = null;
-  let ammTvlIcusd = 0;
 
-  // TVL-weighted combined APY. Only computed once both pools resolve.
+  // "Earn up to" is the best per-dollar yield available, not a weighted
+  // blend of the two pools. Capital can only be in one position at a time,
+  // and the AMM1 LP path stacks 3pool yield on its 3USD half:
+  //   amm1Effective = amm1Apy + 0.5 * threePoolApy
+  // The advertised number is whichever of the two paths wins per dollar.
   $: combinedApy =
-    threePoolApyPct !== null && ammApyPct !== null && (threePoolTvlIcusd + ammTvlIcusd) > 0
-      ? (threePoolApyPct * threePoolTvlIcusd + ammApyPct * ammTvlIcusd) /
-        (threePoolTvlIcusd + ammTvlIcusd)
+    threePoolApyPct !== null && ammApyPct !== null
+      ? Math.max(
+          threePoolApyPct,
+          ammApyPct + AMM1_THREEUSD_VALUE_SHARE * threePoolApyPct,
+        )
       : null;
 
   onMount(() => {
@@ -40,58 +36,11 @@
   });
 
   async function loadThreePoolApy() {
-    const [status, protocolStatus, interestSplit, swapFees7d] = await Promise.all([
-      threePoolService.getPoolStatus(),
-      ProtocolService.getProtocolStatus().catch(() => null),
-      (publicActor.get_interest_split() as Promise<{ destination: string; bps: bigint }[]>).catch(() => null),
-      threePoolService.getSwapFeesOverWindow(7).catch(() => 0n),
-    ]);
-
-    let poolTvlE8s = 0;
-    for (let i = 0; i < status.balances.length; i++) {
-      const token = POOL_TOKENS[i];
-      if (token) {
-        const normalized = token.decimals === 8
-          ? Number(status.balances[i])
-          : Number(status.balances[i]) * 100;
-        poolTvlE8s += normalized;
-      }
-    }
-    threePoolTvlIcusd = poolTvlE8s / 1e8;
-
-    if (!protocolStatus) {
-      threePoolApyPct = 0;
-      return;
-    }
-    const threePoolEntry = interestSplit?.find(e => e.destination === 'three_pool');
-    const threePoolShareBps = threePoolEntry ? Number(threePoolEntry.bps) : 5000;
-    const apy = calculateTotalApy(
-      threePoolShareBps,
-      protocolStatus.perCollateralInterest,
-      threePoolTvlIcusd,
-      swapFees7d,
-    );
-    threePoolApyPct = apy !== null ? apy * 100 : 0;
+    const r = await getThreePoolApy();
+    threePoolApyPct = r.total_apy_pct;
   }
 
   async function loadAmmApy() {
-    const pools = await ammService.getPools().catch(() => [] as PoolInfo[]);
-    const threePoolId = CANISTER_IDS.THREEPOOL;
-    const icpLedgerId = CANISTER_IDS.ICP_LEDGER;
-    const ammPool = pools.find(p => {
-      const a = p.token_a.toText();
-      const b = p.token_b.toText();
-      return (a === threePoolId && b === icpLedgerId) || (a === icpLedgerId && b === threePoolId);
-    });
-    if (!ammPool) {
-      ammApyPct = 0;
-      ammTvlIcusd = 0;
-      return;
-    }
-    const isTokenA3USD = ammPool.token_a.toText() === threePoolId;
-    const threeUsdReserve = isTokenA3USD ? ammPool.reserve_a : ammPool.reserve_b;
-    // Approximate USD TVL as 2x the 3USD-side reserve (balanced-pool assumption)
-    ammTvlIcusd = (Number(threeUsdReserve) / 1e8) * 2;
     const r = await getAmm1Apy();
     ammApyPct = r.total_apy_pct;
   }


### PR DESCRIPTION
## Summary
- AMM1 (3USD/ICP) card was advertising only its own trading-fee + reward APY (~2.2%), ignoring the 3pool yield embedded in the 3USD half of the pool — LPs effectively earn AMM1 + 0.5 × 3pool APY (~3.65% today)
- Swap hero \"Earn up to\" was a TVL-weighted blend of the two pools (~2.47%); for a \"best per-dollar yield\" CTA the correct number is `max(threePool, amm1Effective)` (~3.65% today)
- Consolidated the duplicated 3pool APY fetch logic into `threePoolApyService.ts`

## Changes
- **new** `src/lib/services/threePoolApyService.ts` — cached helper (30s TTL) returning `{ total_apy_pct, interest_apr_pct, swap_fee_apr_pct, pool_tvl_icusd, three_pool_share_bps }`. Replaces inline fetch+compute in two callers.
- `src/lib/services/amm1ApyService.ts` — exports `AMM1_THREEUSD_VALUE_SHARE = 0.5`, `Amm1EffectiveApy` type, and pure `computeAmm1EffectiveApy(amm1, threePoolApyPct)` helper.
- `src/routes/swap/+page.svelte` — hero uses `max(threePool, ammEffective)`; ~60 lines of duplicated APY logic deleted.
- `src/lib/components/swap/PoolListView.svelte` — AMM1 card shows effective total; tooltip now reads `Rewards X% + Swap fees Y% + 3USD yield Z% = total W%` with a sub-line explaining the 50% pass-through.
- `src/lib/components/swap/AmmLiquidityPanel.svelte` — pill shows effective total; `title` attribute breaks down all three components.

## Why the math is right
A constant-product AMM held near equilibrium by arbitrage keeps ~50% of its value in each side. The 3USD side accrues 3pool yield via virtual-price growth; the ICP side does not. So an LP's effective yield per dollar deployed is AMM1's own APY plus half of the 3pool APY.

The hero is a per-dollar \"up to\" number, not an average — capital can only be in one position at a time, so the ceiling is whichever of `threePool` or `amm1 + 0.5*threePool` is higher.

## Test plan
- [ ] Visit `/swap` (Swap tab): hero shows ~3.65% (was 2.47%)
- [ ] Switch to Liquidity tab: 3pool card unchanged (~2.9%), AMM1 card shows ~3.65% (was 2.2%)
- [ ] Hover AMM1 card APY badge: tooltip shows three-line breakdown ending with `total W%`, plus the 50% pass-through explainer
- [ ] Click AMM1 pool: detail panel pill matches the card; native tooltip on hover lists rewards + swap fees + 3USD yield with the 3pool APY in parens
- [ ] No regressions on 3pool card or its tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)