### PR TITLE
feat(explorer): protocol reserves card in Revenue lens

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/ProtocolReservesCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/ProtocolReservesCard.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { fetchProtocolReserves, type ProtocolReserve } from '$services/explorer/explorerService';
+
+  let reserves = $state<ProtocolReserve[]>([]);
+  let loading = $state(true);
+
+  onMount(async () => {
+    try {
+      reserves = await fetchProtocolReserves();
+    } catch (err) {
+      console.error('[ProtocolReservesCard] load failed:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  const totalUsd = $derived(reserves.reduce((s, r) => s + r.usd, 0));
+</script>
+
+<div class="explorer-card">
+  <h3 class="text-sm font-medium text-gray-300 mb-1">Protocol reserves</h3>
+  <p class="text-xs text-gray-500 mb-3">
+    Stablecoins held by <code class="text-gray-600">rumi_protocol_backend</code> as a redemption
+    buffer. Sourced from liquidation bot swap proceeds and ckUSDC / ckUSDT vault repayments;
+    drawn down by <code class="text-gray-600">redeem_reserves</code> before redemptions cascade
+    to user vaults.
+  </p>
+  {#if loading}
+    <div class="flex items-center justify-center py-6">
+      <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if reserves.length === 0}
+    <p class="text-sm text-gray-500 py-2">No reserve balances.</p>
+  {:else}
+    <table class="w-full text-sm">
+      <tbody>
+        {#each reserves as r (r.ledger)}
+          <tr class="border-b border-white/[0.03]">
+            <td class="py-1.5 px-2 text-gray-200">{r.symbol}</td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-300">
+              {(Number(r.balanceE8s) / Math.pow(10, r.decimals)).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+            <td class="py-1.5 px-2 text-right tabular-nums text-gray-100 font-medium">
+              ${r.usd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </td>
+          </tr>
+        {/each}
+        <tr class="border-t border-white/10">
+          <td class="py-1.5 px-2 text-xs text-gray-500 uppercase">Buffer</td>
+          <td></td>
+          <td class="py-1.5 px-2 text-right tabular-nums text-teal-300 font-semibold">
+            ${totalUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/RevenueLens.svelte
@@ -4,6 +4,7 @@
   import LensActivityPanel from '../LensActivityPanel.svelte';
   import MiniAreaChart from '../MiniAreaChart.svelte';
   import TreasuryHoldingsCard from '../TreasuryHoldingsCard.svelte';
+  import ProtocolReservesCard from '../ProtocolReservesCard.svelte';
   import {
     fetchFeeSeries, fetchApys, fetchFeeBreakdownWindow, type FeeBreakdown,
   } from '$services/explorer/analyticsService';
@@ -219,6 +220,8 @@
     {/if}
   </div>
 </div>
+
+<ProtocolReservesCard />
 
 <TreasuryHoldingsCard />
 

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -2249,3 +2249,58 @@ export async function fetchTreasuryHoldings(icpPriceUsd: number): Promise<Treasu
 	const result = balances.filter((b) => b.balanceE8s > 0n);
 	return setCache(key, result);
 }
+
+// ── Protocol reserves (redemption buffer) ────────────────────────────────────
+
+export type ProtocolReserve = {
+	symbol: string;
+	ledger: string;
+	balanceE8s: bigint;
+	decimals: number;
+	usd: number;
+};
+
+/**
+ * Ledgers the protocol holds as a redemption buffer. Populated by:
+ *   - liquidation_bot sweeping ckUSDC swap proceeds to the backend
+ *   - users repaying vault debt with ckUSDC / ckUSDT via repay_to_vault_with_stable
+ *
+ * Matches the on-chain `get_reserve_balances()` set (rumi_protocol_backend main.rs).
+ */
+const PROTOCOL_RESERVE_LEDGERS: Array<{
+	symbol: string;
+	principal: string;
+	decimals: number;
+}> = [
+	{ symbol: 'ckUSDC', principal: CANISTER_IDS.CKUSDC_LEDGER, decimals: 6 },
+	{ symbol: 'ckUSDT', principal: CANISTER_IDS.CKUSDT_LEDGER, decimals: 6 },
+];
+
+const PROTOCOL_PRINCIPAL = Principal.fromText(CANISTER_IDS.PROTOCOL);
+
+/**
+ * Query `icrc1_balance_of` on each reserve ledger using the rumi_protocol_backend
+ * principal as the account owner. Returns only tokens with a non-zero balance.
+ * All reserve assets are USD-pegged stablecoins, so usd === balance.
+ */
+export async function fetchProtocolReserves(): Promise<ProtocolReserve[]> {
+	const key = 'protocol:reserves';
+	const cached = getCached<ProtocolReserve[]>(key, TTL.TREASURY);
+	if (cached) return cached;
+
+	const balances = await Promise.all(
+		PROTOCOL_RESERVE_LEDGERS.map(async (l) => {
+			try {
+				const balanceE8s = await fetchIcrc1BalanceOf(l.principal, PROTOCOL_PRINCIPAL);
+				const usd = Number(balanceE8s) / Math.pow(10, l.decimals);
+				return { symbol: l.symbol, ledger: l.principal, balanceE8s, decimals: l.decimals, usd };
+			} catch (err) {
+				console.error(`[explorerService] fetchProtocolReserves ${l.symbol} failed:`, err);
+				return { symbol: l.symbol, ledger: l.principal, balanceE8s: 0n, decimals: l.decimals, usd: 0 };
+			}
+		}),
+	);
+
+	const result = balances.filter((b) => b.balanceE8s > 0n);
+	return setCache(key, result);
+}


### PR DESCRIPTION
## Summary

- Adds a `ProtocolReservesCard` to the Revenue lens showing the **ckUSDC + ckUSDT** balances held directly by `rumi_protocol_backend` (`tfesu-vyaaa-aaaap-qrd7a-cai`).
- These reserves are the **redemption buffer**: sourced from `liquidation_bot` swap proceeds and ckUSDC/ckUSDT vault repayments (`repay_to_vault_with_stable`), drawn down by `redeem_reserves` before redemptions cascade to user vaults.
- Previously only `rumi_treasury` holdings were surfaced, which conflated fee revenue with operational reserves.

## Why

The backend explicitly defines a reserve concept (`get_reserve_balances()`, `redeem_reserves()`) but the on-chain query returns `balance = 0` with a comment stating the frontend is expected to query ledgers directly. Until now nothing in the explorer did that, so users had no visibility into how much redemption pressure could be absorbed before user vaults are touched.

## What's shown

Live `icrc1_balance_of(rumi_protocol_backend)` on each reserve ledger, with subtitle explaining the role and source. Same visual treatment as the existing Treasury Holdings card, placed directly above it in the Revenue lens.

## Test plan

- [x] `svelte-check` clean on new/modified files
- [ ] Visit `/explorer?lens=revenue` on mainnet after deploy → confirm new card renders with current reserve balances
- [ ] Verify subtitle copy reads correctly and totals sum to the per-row USD values

🤖 Generated with [Claude Code](https://claude.com/claude-code)