### PR TITLE
fix(vault_frontend): disable redeem when swap offers better rate

### DIFF
--- a/src/vault_frontend/src/routes/redeem/+page.svelte
+++ b/src/vault_frontend/src/routes/redeem/+page.svelte
@@ -505,7 +505,7 @@
           <button
             class="submit-btn"
             on:click={handleRedeem}
-            disabled={actionInProgress || !isConnected || icusdAmount <= 0 || icusdAmount > icusdBalance || isLoading}
+            disabled={actionInProgress || !isConnected || icusdAmount <= 0 || icusdAmount > icusdBalance || isLoading || swapIsBetter}
           >
             {#if !isConnected}
               Connect Wallet to Continue
@@ -513,6 +513,8 @@
               Processing Redemption...
             {:else if isLoading}
               Loading...
+            {:else if swapIsBetter}
+              Use Swap for Better Rate
             {:else}
               Redeem icUSD
             {/if}


### PR DESCRIPTION
## Summary

- Redeem button now disables when the swap router quotes a higher net value than redemption, forcing users to the AMM instead of accepting the worse rate.
- Button label switches to "Use Swap for Better Rate" so the disabled state is self-explanatory; the existing comparison banner above the button still shows the side-by-side numbers and the "Go to Swap →" link.
- No backend changes; no new services. The reactive \`swapIsBetter\` flag (already used to gate the banner) is reused for the button-disable check.

## Test plan

- [ ] On mainnet, enter an icUSD amount large enough to trigger the swap comparison; confirm the banner appears and the redeem button greys out with the new label.
- [ ] Confirm small amounts (< 0.01 icUSD) leave the button enabled (swap quote fetch is skipped at that threshold).
- [ ] Confirm that when AMM/3pool quotes fail (e.g., null \`bestSwapQuote\`), the button stays enabled and redemption works normally — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)