### PR TITLE
feat(multi-chain): Phase 1b Monad EVM adapter + Gate-3 observer EVM-RPC fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-rlp"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bytes",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7196,6 +7206,7 @@ dependencies = [
 name = "rumi_protocol_backend"
 version = "0.1.0"
 dependencies = [
+ "alloy-rlp",
  "assert_matches",
  "async-trait",
  "candid",
@@ -7219,6 +7230,7 @@ dependencies = [
  "ic0 0.18.11",
  "icrc-ledger-client-cdk",
  "icrc-ledger-types 0.1.8 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
+ "k256",
  "lazy_static",
  "num-traits",
  "pocket-ic",
@@ -7230,6 +7242,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2",
+ "sha3",
  "xrc-mock",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7214,6 +7214,7 @@ dependencies = [
  "ciborium",
  "flate2",
  "futures",
+ "hex",
  "ic-base-types",
  "ic-canister-log 0.2.0 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
  "ic-canisters-http-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5773,6 +5773,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad_rpc_mock"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk 0.12.2",
+ "ic-cdk-macros 0.8.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "src/rumi_amm",
     "src/rumi_analytics",
     "src/xrc_demo/xrc_mock",
+    "src/monad_rpc_mock",
     "src/liquidation_bot",
     "src/flaky_ledger",
 ]

--- a/foundry/.env.example
+++ b/foundry/.env.example
@@ -1,0 +1,3 @@
+MONAD_TESTNET_RPC=https://testnet-rpc.monad.xyz
+DEPLOYER_PK=0xyour_funded_testnet_deployer_key
+CANISTER_SETTLEMENT_ADDR=0xfilled_from_get_chain_settlement_address

--- a/foundry/.gitignore
+++ b/foundry/.gitignore
@@ -1,0 +1,5 @@
+out/
+cache/
+broadcast/
+.env
+lib/

--- a/foundry/DEPLOY.md
+++ b/foundry/DEPLOY.md
@@ -1,0 +1,33 @@
+# IcUSD Monad-testnet deploy runbook
+
+PREREQUISITE: derive the backend's settlement address FIRST — it is BOTH the
+admin and the minter, so the token is canister-owned from block zero.
+
+1. On the backend (staging), derive the settlement address:
+   dfx canister call --network ic <STAGING_ID> get_chain_settlement_address '(record { 0 = 10143 : nat32 })' --identity rumi_identity
+   (returns 0x.. — this is CANISTER_SETTLEMENT_ADDR)
+2. Fund a testnet deployer key with Monad testnet MON (faucet).
+3. cp foundry/.env.example foundry/.env  and fill all three vars.  (.env is gitignored.)
+4. cd foundry && forge script script/DeployIcUSD.s.sol:DeployIcUSD --rpc-url monad_testnet --broadcast -vvvv
+5. Record the "IcUSD deployed at:" address.
+6. Fund CANISTER_SETTLEMENT_ADDR with testnet MON — it is the hot wallet that
+   pays gas for mints + withdrawals (Task 11 hot-wallet gate).
+7. On the backend: set_chain_contract(10143, "<deployed address>").
+
+## Admin / minter model (Phase 1b — from the IcUSD.sol security review)
+
+For Phase 1b, admin == minter == the canister settlement address. Implications
+(acceptable for testnet, revisit before any value-bearing/mainnet deploy):
+- The canister is the sole minter AND the DEFAULT_ADMIN_ROLE holder (it can
+  grant/revoke MINTER_ROLE). A single tECDSA key thus controls both.
+- There is no two-step admin transfer and no admin guardian (OZ
+  AccessControlDefaultAdminRules is NOT used). If the admin key were lost,
+  minter management would be frozen. The canister's key is tECDSA-managed
+  (no single exportable key), which mitigates this for the canister-owned model.
+- A hardened later version may split admin (an SNS-controlled address) from
+  minter (the canister), and/or adopt AccessControlDefaultAdminRules.
+
+## Dependencies
+`foundry/lib/` is gitignored. Before building/deploying: `cd foundry && forge install`
+(OpenZeppelin v5.0.2 + forge-std). See foundry/README.md for the exact install
+commands and the contract <-> canister contract.

--- a/foundry/README.md
+++ b/foundry/README.md
@@ -39,3 +39,8 @@ forge build
 ```
 
 Compiles on solc 0.8.24 (pinned in `foundry.toml`).
+
+## Deploy
+
+See [`DEPLOY.md`](./DEPLOY.md) for the Monad-testnet deploy runbook (derive the
+canister settlement address first; it is both admin and minter for Phase 1b).

--- a/foundry/README.md
+++ b/foundry/README.md
@@ -1,0 +1,41 @@
+# Rumi Monad contracts (Foundry)
+
+Phase 1b ships a single contract: `src/IcUSD.sol`, the on-chain icUSD ERC-20 on
+Monad. The Rumi backend canister's tECDSA-derived settlement address is the sole
+minter (`MINTER_ROLE`); any holder may `burn` to repay their vault.
+
+## Contract <-> canister contract (do not break)
+
+`IcUSD.sol` is pinned to the backend's Monad adapter
+(`src/rumi_protocol_backend/src/chains/monad/`):
+
+- `mint(address to, uint256 amount, uint64 vault_id)` matches the selector built
+  by `tx::encode_mint_calldata` (`keccak256("mint(address,uint256,uint64)")[:4]`).
+- `Mint(uint256,address,uint256)` / `Burn(uint256,address,uint256)` topic0 hashes
+  match `MINT_EVENT_TOPIC0` / `BURN_EVENT_TOPIC0` in `evm_rpc.rs`. `vault_id` and
+  `recipient`/`burner` are `indexed` so the observer reads them from
+  `topics[1]`/`topics[2]` and `amount` from `data` (see `MintLog`/`BurnLog`).
+- 8 decimals so 1 base unit == 1 e8s (1:1 with the ICP-side e8s accounting).
+- `mapping(uint64 => bool) minted` is a per-`vault_id` idempotency guard: a
+  canister resubmit-after-transient-RPC-error cannot double-mint.
+
+## Dependencies
+
+`lib/` is gitignored. Re-install before building:
+
+```bash
+export PATH="$HOME/.foundry/bin:$PATH"
+forge install                                                    # forge-std
+forge install OpenZeppelin/openzeppelin-contracts@v5.0.2 --no-git --no-commit
+```
+
+`remappings.txt` maps `@openzeppelin/` -> `lib/openzeppelin-contracts/`.
+
+## Build
+
+```bash
+export PATH="$HOME/.foundry/bin:$PATH"
+forge build
+```
+
+Compiles on solc 0.8.24 (pinned in `foundry.toml`).

--- a/foundry/foundry.toml
+++ b/foundry/foundry.toml
@@ -1,0 +1,10 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+
+[rpc_endpoints]
+monad_testnet = "${MONAD_TESTNET_RPC}"

--- a/foundry/remappings.txt
+++ b/foundry/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/=lib/openzeppelin-contracts/

--- a/foundry/script/DeployIcUSD.s.sol
+++ b/foundry/script/DeployIcUSD.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {IcUSD} from "../src/IcUSD.sol";
+
+/// Deploy IcUSD to Monad testnet. The canister settlement address (from
+/// get_chain_settlement_address on the backend) is BOTH admin + minter for
+/// Phase 1b — the canister owns the token from block zero and is the sole minter.
+/// Env vars (set before running):
+///   MONAD_TESTNET_RPC        - Monad testnet RPC URL
+///   DEPLOYER_PK              - a funded testnet deployer private key (pays gas)
+///   CANISTER_SETTLEMENT_ADDR - the backend's settlement address (0x..)
+contract DeployIcUSD is Script {
+    function run() external {
+        address settlement = vm.envAddress("CANISTER_SETTLEMENT_ADDR");
+        uint256 deployerPk = vm.envUint("DEPLOYER_PK");
+        vm.startBroadcast(deployerPk);
+        IcUSD icusd = new IcUSD(settlement, settlement); // admin == minter == canister
+        vm.stopBroadcast();
+        console2.log("IcUSD deployed at:", address(icusd));
+        console2.log("admin + minter:", settlement);
+    }
+}

--- a/foundry/src/IcUSD.sol
+++ b/foundry/src/IcUSD.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+
+/// @title IcUSD - Rumi icUSD on Monad
+/// @notice Canister-minted ERC-20. The Rumi backend canister's tECDSA-derived
+/// settlement address holds MINTER_ROLE and is the sole minter. Any holder may
+/// burn to repay their vault. 8 decimals so 1 base unit == 1 e8s (1:1 with the
+/// ICP-side e8s accounting). totalSupply() reflects Monad-side circulation only;
+/// the canonical all-chains total is get_global_icusd_supply() on the Rumi backend.
+contract IcUSD is ERC20, AccessControl {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    /// @notice vault_id + recipient/burner are INDEXED so the Rumi observer reads
+    /// them from topics[1]/topics[2] and the amount from data. The topic0 hashes
+    /// are pinned in the backend (MINT_EVENT_TOPIC0 / BURN_EVENT_TOPIC0).
+    event Mint(uint256 indexed vault_id, address indexed recipient, uint256 amount);
+    event Burn(uint256 indexed vault_id, address indexed burner, uint256 amount);
+
+    /// @dev One mint per Rumi vault_id (idempotency guard): a canister
+    /// resubmit-after-transient-RPC-error must not double-mint on-chain.
+    mapping(uint64 => bool) public minted;
+
+    constructor(address admin, address minter) ERC20("Rumi icUSD", "icUSD") {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(MINTER_ROLE, minter);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 8;
+    }
+
+    /// @notice Mint icUSD. Only the canister settlement address (MINTER_ROLE).
+    /// Reverts if `vault_id` was already minted (idempotency).
+    function mint(address to, uint256 amount, uint64 vault_id) external onlyRole(MINTER_ROLE) {
+        require(!minted[vault_id], "vault already minted");
+        minted[vault_id] = true;
+        _mint(to, amount);
+        emit Mint(uint256(vault_id), to, amount);
+    }
+
+    /// @notice Burn icUSD to repay vault `target_vault_id`. Callable by anyone
+    /// holding the tokens; the Rumi backend observes the Burn event and
+    /// decrements the vault's debt + the Monad chain supply.
+    function burn(uint256 amount, uint64 target_vault_id) external {
+        _burn(msg.sender, amount);
+        emit Burn(uint256(target_vault_id), msg.sender, amount);
+    }
+}

--- a/foundry/test/IcUSD.t.sol
+++ b/foundry/test/IcUSD.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {IcUSD} from "../src/IcUSD.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+contract IcUSDTest is Test {
+    IcUSD icusd;
+    address admin = address(0xA11CE);
+    address minter = address(0xB0B);   // stands in for the canister settlement address
+    address alice = address(0xCAFE);
+    address bob = address(0xBEEF);
+
+    // Re-declare the events for vm.expectEmit (must match IcUSD.sol exactly, incl. `indexed`).
+    event Mint(uint256 indexed vault_id, address indexed recipient, uint256 amount);
+    event Burn(uint256 indexed vault_id, address indexed burner, uint256 amount);
+
+    function setUp() public {
+        icusd = new IcUSD(admin, minter);
+    }
+
+    function test_decimals_is_8() public view {
+        assertEq(icusd.decimals(), 8);
+    }
+
+    function test_minter_can_mint_and_emits_event() public {
+        vm.expectEmit(true, true, false, true); // check vault_id(topic1), recipient(topic2), data(amount)
+        emit Mint(42, alice, 10_000_000_000);
+        vm.prank(minter);
+        icusd.mint(alice, 10_000_000_000, 42);
+        assertEq(icusd.balanceOf(alice), 10_000_000_000);
+        assertEq(icusd.totalSupply(), 10_000_000_000);
+    }
+
+    function test_non_minter_cannot_mint() public {
+        // Read MINTER_ROLE into a local BEFORE the prank: in Foundry 1.6.0 the
+        // one-shot `vm.prank` would otherwise be consumed by the external
+        // `icusd.MINTER_ROLE()` STATICCALL evaluated as an arg here, leaving the
+        // `mint` call to run as address(this) instead of alice (the revert is
+        // identical AccessControlUnauthorizedAccount, only the `account` field
+        // would differ). Asserts OZ v5's custom error with account == alice.
+        bytes32 minterRole = icusd.MINTER_ROLE();
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, minterRole)
+        );
+        icusd.mint(alice, 1, 1);
+    }
+
+    function test_anyone_can_burn_their_balance_and_emits_event() public {
+        vm.prank(minter);
+        icusd.mint(alice, 10_000_000_000, 7);
+        vm.expectEmit(true, true, false, true);
+        emit Burn(7, alice, 4_000_000_000);
+        vm.prank(alice);
+        icusd.burn(4_000_000_000, 7);
+        assertEq(icusd.balanceOf(alice), 6_000_000_000);
+        assertEq(icusd.totalSupply(), 6_000_000_000);
+    }
+
+    function test_burn_exceeding_balance_reverts() public {
+        vm.prank(minter);
+        icusd.mint(alice, 100, 1);
+        vm.prank(alice);
+        vm.expectRevert(); // ERC20InsufficientBalance (OZ v5 custom error)
+        icusd.burn(101, 1);
+    }
+
+    function test_total_supply_tracks_mint_minus_burn() public {
+        vm.startPrank(minter);
+        icusd.mint(alice, 1_000, 1);
+        icusd.mint(bob, 2_000, 2);
+        vm.stopPrank();
+        assertEq(icusd.totalSupply(), 3_000);
+        vm.prank(bob);
+        icusd.burn(500, 2);
+        assertEq(icusd.totalSupply(), 2_500);
+    }
+
+    // --- Task-20 addition 1: per-vault_id mint idempotency guard ---
+    function test_mint_same_vault_id_twice_reverts() public {
+        vm.startPrank(minter);
+        icusd.mint(alice, 100, 7);
+        assertTrue(icusd.minted(7));
+        vm.expectRevert(bytes("vault already minted"));
+        icusd.mint(alice, 50, 7); // same vault_id -> revert (idempotency: no on-chain double-mint)
+        vm.stopPrank();
+        assertEq(icusd.totalSupply(), 100); // second mint did not happen
+    }
+
+    // --- Task-20 addition 2: ABI PINNING to the backend's constants ---
+    // These lock IcUSD.sol's selector + event topic0 to the values the Rust
+    // backend pins (tx::encode_mint_calldata selector, MINT/BURN_EVENT_TOPIC0 in
+    // evm_rpc.rs). If anyone changes an event/mint signature, this test fails,
+    // catching a contract<->canister ABI drift before it ships.
+    function test_abi_pinned_to_backend_constants() public pure {
+        // mint(address,uint256,uint64) selector == tx::encode_mint_calldata's selector
+        assertEq(bytes4(keccak256("mint(address,uint256,uint64)")), bytes4(0x8b3d35ae), "mint selector drift");
+        // Mint/Burn event topic0 == MINT_EVENT_TOPIC0 / BURN_EVENT_TOPIC0 in evm_rpc.rs
+        assertEq(
+            keccak256("Mint(uint256,address,uint256)"),
+            bytes32(0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6),
+            "Mint topic0 drift"
+        );
+        assertEq(
+            keccak256("Burn(uint256,address,uint256)"),
+            bytes32(0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca),
+            "Burn topic0 drift"
+        );
+    }
+
+    function testFuzz_mint_then_full_burn_nets_zero(uint96 amount, uint64 vaultId) public {
+        vm.assume(amount > 0);
+        vm.prank(minter);
+        icusd.mint(alice, amount, vaultId);
+        vm.prank(alice);
+        icusd.burn(amount, vaultId);
+        assertEq(icusd.balanceOf(alice), 0);
+        assertEq(icusd.totalSupply(), 0);
+    }
+
+    function test_standard_erc20_transfer_approve() public {
+        vm.prank(minter);
+        icusd.mint(alice, 1_000, 1);
+        vm.prank(alice);
+        icusd.transfer(bob, 400);
+        assertEq(icusd.balanceOf(bob), 400);
+        vm.prank(bob);
+        icusd.approve(alice, 100);
+        assertEq(icusd.allowance(bob, alice), 100);
+    }
+}

--- a/foundry/test/IcUSD.t.sol
+++ b/foundry/test/IcUSD.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {IcUSD} from "../src/IcUSD.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
@@ -129,5 +130,61 @@ contract IcUSDTest is Test {
         vm.prank(bob);
         icusd.approve(alice, 100);
         assertEq(icusd.allowance(bob, alice), 100);
+    }
+
+    // --- Task-20 review addition: role management (admin can manage minters) ---
+    function test_admin_can_grant_and_revoke_minter() public {
+        bytes32 minterRole = icusd.MINTER_ROLE();
+        // admin grants alice MINTER_ROLE -> alice can mint
+        vm.prank(admin);
+        icusd.grantRole(minterRole, alice);
+        vm.prank(alice);
+        icusd.mint(bob, 500, 100);
+        assertEq(icusd.balanceOf(bob), 500);
+        // admin revokes -> alice can no longer mint
+        vm.prank(admin);
+        icusd.revokeRole(minterRole, alice);
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, minterRole)
+        );
+        icusd.mint(bob, 1, 101);
+    }
+
+    function test_non_admin_cannot_grant_minter() public {
+        bytes32 minterRole = icusd.MINTER_ROLE();
+        bytes32 adminRole = icusd.DEFAULT_ADMIN_ROLE(); // 0x00
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, adminRole)
+        );
+        icusd.grantRole(minterRole, alice);
+    }
+
+    // --- Task-20 review addition: byte-level indexed-topic layout ---
+    // vm.expectEmit only matches the test's re-declared event; this is the ONLY
+    // test that proves, at the raw-log byte level, that vault_id lands in
+    // topics[1] + recipient in topics[2] + amount in data — exactly what the
+    // backend MintLog::from_raw decoder reads. Catches an `indexed`-on-the-wrong
+    // -param regression that expectEmit would miss.
+    function test_mint_log_topic_layout_matches_decoder() public {
+        vm.recordLogs();
+        vm.prank(minter);
+        icusd.mint(alice, 10_000_000_000, 42);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        bytes32 mintTopic0 = keccak256("Mint(uint256,address,uint256)");
+        bool found = false;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == mintTopic0) {
+                // topic0 + vault_id + recipient = 3 topics; amount is in data.
+                assertEq(entries[i].topics.length, 3, "Mint must have 3 topics");
+                assertEq(entries[i].topics[1], bytes32(uint256(42)), "vault_id must be topic1");
+                assertEq(entries[i].topics[2], bytes32(uint256(uint160(alice))), "recipient must be topic2");
+                assertEq(abi.decode(entries[i].data, (uint256)), 10_000_000_000, "amount must be in data");
+                found = true;
+            }
+        }
+        assertTrue(found, "Mint log not emitted");
     }
 }

--- a/icp.yaml
+++ b/icp.yaml
@@ -738,30 +738,28 @@ environments:
     canisters:
       - rumi_protocol_backend
     init_args:
-      # First install on the staging canister uses the full Init variant (not
-      # Upgrade). The icusd_ledger_principal is `aaaaa-aa` (management canister
-      # placeholder) so any accidental icUSD mint traps; treasury / stability_pool /
-      # ckUSDT / ckUSDC are all null. XRC and ICP ledger point at real mainnet
-      # principals because Phase 1b will need both for price fetching + collateral
-      # accounting. `developer_principal` is the rumi_identity principal so the
-      # admin endpoints (register_chain, etc.) only respond to rumi_identity calls.
+      # The staging canister was first installed with the full Init variant during
+      # Phase 1a (icusd_ledger_principal = `aaaaa-aa` so any accidental icUSD mint
+      # traps; treasury / stability_pool / ckUSDT / ckUSDC null; XRC + ICP ledger at
+      # real mainnet principals; developer_principal = rumi_identity). That install
+      # is done — the canister now upgrades in place, so the default arg below is the
+      # Upgrade variant (Task 22 Step 9). `mode = null` preserves the live protocol
+      # mode; `description` is recorded into the on-chain event log by post_upgrade.
       #
-      # NOTE: subsequent upgrades to this canister use --mode upgrade and pass
-      # `(variant { Upgrade = record { mode = null; description = opt "..." } })`
-      # via --args on `icp canister install`. See docs/superpowers/notes/
-      # 2026-05-27-icp-cli-deploy-pattern.md for the locked deploy command shape.
+      # Each real deploy still passes an explicit per-deploy `description` via --args
+      # on `icp canister install --mode upgrade` (e.g. the Phase 1b observer EVM-RPC
+      # fix). See docs/superpowers/notes/2026-05-27-icp-cli-deploy-pattern.md for the
+      # locked deploy command shape. This default just matches the upgrade arg shape
+      # so a build/install never falls back to Init and re-initializes (wiping state).
+      #
+      # The historical Init args, for reference if the canister is ever re-provisioned
+      # from scratch: xrc uf6dk-hyaaa-aaaaq-qaaaq-cai, icusd aaaaa-aa, icp
+      # ryjl3-tyaaa-aaaaa-aaaba-cai, fee 10_000, developer fd7h3-...-kae, rest null.
       rumi_protocol_backend: |
         (variant {
-          Init = record {
-            xrc_principal = principal "uf6dk-hyaaa-aaaaq-qaaaq-cai";
-            icusd_ledger_principal = principal "aaaaa-aa";
-            icp_ledger_principal = principal "ryjl3-tyaaa-aaaaa-aaaba-cai";
-            fee_e8s = 10_000 : nat64;
-            developer_principal = principal "fd7h3-mgmok-dmojz-awmxl-k7eqn-37mcv-jjkxp-parnt-ehngl-l2z3m-kae";
-            treasury_principal = null;
-            stability_pool_principal = null;
-            ckusdt_ledger_principal = null;
-            ckusdc_ledger_principal = null;
+          Upgrade = record {
+            mode = null;
+            description = opt "Phase 1b: Monad EVM-chain adapter (observer + settlement + supply accounting)"
           }
         })
 

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -976,6 +976,7 @@ service : (ProtocolArg) -> {
   get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
+  get_last_observed_block : (nat32) -> (nat64) query;
   get_liquidatable_vaults : () -> (vec CandidVault) query;
   get_liquidatable_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_liquidation_bonus : () -> (float64) query;
@@ -1083,6 +1084,7 @@ service : (ProtocolArg) -> {
   set_interest_rate : (principal, float64) -> (Result);
   set_interest_split : (vec InterestSplitArg) -> (Result);
   set_interest_treasury_tick_interval_secs : (nat64) -> (Result);
+  set_last_observed_block : (nat32, nat64) -> (Result);
   set_liquidation_bonus : (float64) -> (Result);
   set_liquidation_bot_config : (principal, nat64) -> (Result);
   set_liquidation_frozen : (bool) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,25 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainVaultStatus = variant {
+  MintPending;
+  Open;
+  Closed;
+  Closing;
+  AwaitingDeposit;
+};
+type ChainVaultV1 = record {
+  status : ChainVaultStatus;
+  owner : principal;
+  pending_mint_e8s : nat;
+  custody_address : text;
+  collateral_amount_e18 : nat;
+  opened_at_ns : nat64;
+  vault_id : nat64;
+  collateral_chain : nat32;
+  mint_recipient : text;
+  debt_e8s : nat;
+};
 type CollateralConfig = record {
   last_redemption_time : nat64;
   status : CollateralStatus;
@@ -48,11 +67,11 @@ type CollateralConfig = record {
   min_vault_debt : nat64;
   rate_curve : opt RateCurve;
   recovery_borrowing_fee : opt blob;
+  min_xrc_sources : opt nat32;
   min_collateral_deposit : nat64;
   last_price : opt float64;
   last_price_timestamp : opt nat64;
   redemption_tier : nat8;
-  min_xrc_sources : opt nat32;
   redemption_fee_floor : blob;
   borrow_threshold_ratio : blob;
   ledger_fee : nat64;
@@ -120,6 +139,11 @@ type DeviceSpec = variant {
 type ErrorInfo = record { description : text };
 type Event = variant {
   set_borrowing_fee : record { rate : text };
+  supply_invariant_self_check_failed : record {
+    sum_chain_supplies_e8s : nat;
+    total_debt_e8s : nat;
+    timestamp : nat64;
+  };
   VaultWithdrawnAndClosed : record {
     vault_id : nat64;
     timestamp : nat64;
@@ -132,6 +156,7 @@ type Event = variant {
     caller : principal;
     amount : nat64;
   };
+  set_bot_cr_tolerance_bps : record { bps : nat64 };
   collateral_withdrawn : record {
     block_index : nat64;
     vault_id : nat64;
@@ -146,6 +171,15 @@ type Event = variant {
     timestamp : opt nat64;
     caller : opt principal;
   };
+  withdrawal_signed : record {
+    op_id : nat64;
+    recipient : text;
+    vault_id : nat64;
+    amount_e18 : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -158,10 +192,19 @@ type Event = variant {
     price : text;
   };
   set_rmr_ceiling_cr : record { value : text };
+  set_amm1_canister : record { canister : principal };
   set_recovery_rate_curve : record { markers : text };
   set_ckstable_repay_fee : record { rate : text };
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
+  chain_burn_observed : record {
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   set_max_partial_liquidation_ratio : record { rate : text };
   breaker_tripped : record {
     total_e8s : nat64;
@@ -192,9 +235,19 @@ type Event = variant {
     timestamp : nat64;
     observed_balance : nat64;
   };
+  oracle_circuit_breaker : record {
+    timestamp : nat64;
+    consecutive_failures : nat64;
+  };
   set_collateral_redemption_fee_floor : record {
     redemption_fee_floor : text;
     collateral_type : principal;
+  };
+  chain_settlement_failed : record {
+    op_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    reason : text;
   };
   init : InitArg;
   set_stable_ledger_principal : record {
@@ -252,6 +305,7 @@ type Event = variant {
     collateral_type : principal;
     liquidation_bonus : text;
   };
+  set_amm1_pool_id : record { pool_id : text };
   set_global_icusd_mint_cap : record { cap : opt text; amount : opt text };
   upgrade : UpgradeArg;
   borrow_from_vault : record {
@@ -269,11 +323,6 @@ type Event = variant {
   set_bot_allowed_collateral_types : record {
     collateral_types : vec principal;
   };
-  set_bot_cr_tolerance_bps : record { bps : nat64 };
-  set_collateral_min_xrc_sources : record {
-    collateral_type : principal;
-    min_xrc_sources : opt nat32;
-  };
   set_reserve_redemptions_enabled : record { enabled : bool };
   set_min_icusd_amount : record { amount : text };
   set_borrowing_fee_curve : record { markers : text };
@@ -284,6 +333,21 @@ type Event = variant {
     collateral_type : principal;
   };
   redistribute_vault : record { vault_id : nat64; timestamp : opt nat64 };
+  chain_mint_confirmed : record {
+    op_id : nat64;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
+  chain_reorg_detected : record {
+    chain_id : nat32;
+    timestamp : nat64;
+    reorg_depth : nat64;
+    observed_block : nat64;
+  };
   partial_collateral_withdrawn : record {
     block_index : nat64;
     vault_id : nat64;
@@ -299,6 +363,12 @@ type Event = variant {
     timestamp : opt nat64;
     old_borrowed : nat64;
   };
+  stability_pool_call_failed : record {
+    reject_message : text;
+    vault_ids : vec nat64;
+    reject_code : int32;
+    timestamp : nat64;
+  };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
@@ -306,6 +376,12 @@ type Event = variant {
   set_collateral_liquidation_ratio : record {
     collateral_type : principal;
     liquidation_ratio : text;
+  };
+  chain_hot_wallet_low : record {
+    chain_id : nat32;
+    threshold_e18 : nat;
+    timestamp : nat64;
+    balance_e18 : nat;
   };
   dust_forgiven : record {
     vault_id : nat64;
@@ -329,6 +405,12 @@ type Event = variant {
     caller : principal;
     amount : nat64;
   };
+  oracle_source_count_insufficient : record {
+    num_sources : nat32;
+    min_required : nat32;
+    timestamp : nat64;
+    collateral_type : principal;
+  };
   admin_mint : record {
     to : principal;
     block_index : nat64;
@@ -337,8 +419,6 @@ type Event = variant {
     reason : text;
   };
   set_three_pool_canister : record { canister : principal };
-  set_amm1_canister : record { canister : principal };
-  set_amm1_pool_id : record { pool_id : text };
   set_liquidation_bonus : record { rate : text };
   reserve_redemption : record {
     icusd_amount : nat64;
@@ -381,6 +461,11 @@ type Event = variant {
     caller : opt principal;
     margin_added : nat64;
   };
+  chain_disabled : record { chain_id : nat32; timestamp : nat64 };
+  set_collateral_min_xrc_sources : record {
+    min_xrc_sources : opt nat32;
+    collateral_type : principal;
+  };
   set_stability_pool_principal : record { "principal" : principal };
   set_interest_split : record { split : text };
   set_icpswap_routing_enabled : record { enabled : bool };
@@ -392,6 +477,15 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  chain_mint_submitted : record {
+    op_id : nat64;
+    recipient : text;
+    vault_id : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   deficit_repaid : record {
     remaining_deficit : nat64;
     source : FeeSource;
@@ -405,6 +499,7 @@ type Event = variant {
     timestamp : opt nat64;
   };
   set_liquidation_bot_principal : record { "principal" : principal };
+  chain_config_updated : record { chain_id : nat32; timestamp : nat64 };
   deficit_accrued : record {
     new_deficit : nat64;
     source : opt DeficitSource;
@@ -427,6 +522,20 @@ type Event = variant {
     config : CollateralConfig;
     collateral_type : principal;
   };
+  deposit_observed : record {
+    custody_address : text;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e18 : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
+  chain_registered : record {
+    display_name : text;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   set_collateral_ledger_fee : record {
     ledger_fee : nat64;
     collateral_type : principal;
@@ -436,22 +545,6 @@ type Event = variant {
     token_type : StableTokenType;
   };
   set_recovery_cr_multiplier : record { multiplier : text };
-  stability_pool_call_failed : record {
-    vault_ids : vec nat64;
-    reject_code : int32;
-    reject_message : text;
-    timestamp : nat64;
-  };
-  oracle_circuit_breaker : record {
-    consecutive_failures : nat64;
-    timestamp : nat64;
-  };
-  oracle_source_count_insufficient : record {
-    collateral_type : principal;
-    num_sources : nat32;
-    min_required : nat32;
-    timestamp : nat64;
-  };
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
@@ -484,6 +577,15 @@ type EventsByPrincipalPagedResponse = record {
 };
 type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
+type GasStrategy = variant {
+  NotApplicable;
+  SolanaPriorityFee : record { lamports_per_cu_ceiling : nat64 };
+  EvmEip1559 : record {
+    max_fee_gwei_ceiling : nat64;
+    max_priority_fee_gwei : nat64;
+  };
+  EvmLegacy : record { gas_price_gwei_ceiling : nat64 };
+};
 type GetEventsArg = record {
   "principal" : opt principal;
   types : opt vec EventTypeFilter;
@@ -545,10 +647,6 @@ type LiquidityStatus = record {
 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
-type RepayAndCloseSuccess = record {
-  repay_block_index : nat64;
-  collateral_return_block_index : opt nat64;
-};
 type PerCollateralRateCurve = record {
   markers : vec record { float64; float64 };
   base_rate : float64;
@@ -581,7 +679,6 @@ type ProtocolConfig = record {
   ckusdc_ledger_principal : opt principal;
   recovery_mode_threshold : float64;
   bot_allowed_collateral_types : vec principal;
-  bot_cr_tolerance_bps : nat64;
   liquidation_bot_principal : opt principal;
   reserve_redemption_fee : float64;
   liquidation_protocol_share : float64;
@@ -600,6 +697,7 @@ type ProtocolConfig = record {
   treasury_principal : opt principal;
   rmr_ceiling_cr : float64;
   frozen : bool;
+  bot_cr_tolerance_bps : nat64;
   icpswap_routing_enabled : bool;
   ckusdc_enabled : bool;
   ckusdt_enabled : bool;
@@ -620,21 +718,12 @@ type ProtocolError = variant {
   TransferError : TransferError;
   AlreadyProcessing;
   NotLowestCR;
+  SupplyInvariantHalted;
   AnonymousCallerNotAllowed;
+  ChainAdmin : text;
   AmountTooLow : record { minimum_amount : nat64 };
   TransferFromError : record { TransferFromError; nat64 };
   CallerNotOwner;
-  SupplyInvariantHalted;
-  ChainAdmin : text;
-};
-type SupplyAuditEntry = record {
-  chain_id : nat64;
-  display_name : text;
-  supply_e8s : nat;
-};
-type SupplyAudit = record {
-  total_e8s : nat;
-  per_chain : vec SupplyAuditEntry;
 };
 type ProtocolSnapshot = record {
   total_debt : nat64;
@@ -683,6 +772,18 @@ type RateCurve = record {
   markers : vec RateMarker;
 };
 type RateMarker = record { multiplier : blob; cr_level : blob };
+type RegisterChainArg = record {
+  rpc_endpoints : vec text;
+  gas_strategy : GasStrategy;
+  finality_depth : nat32;
+  chain_native_decimals : nat8;
+  display_name : text;
+  chain_id : nat32;
+};
+type RepayAndCloseSuccess = record {
+  collateral_return_block_index : opt nat64;
+  repay_block_index : nat64;
+};
 type ReserveBalance = record {
   balance : nat64;
   ledger : principal;
@@ -699,7 +800,8 @@ type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
 type Result_10 = variant { Ok : bool; Err : ProtocolError };
 type Result_11 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_12 = variant {
+type Result_12 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_13 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
@@ -711,7 +813,6 @@ type Result_6 = variant { Ok : nat8; Err : ProtocolError };
 type Result_7 = variant { Ok : float64; Err : ProtocolError };
 type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
 type Result_9 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_13 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -739,6 +840,12 @@ type SuccessWithFee = record {
   block_index : nat64;
   fee_amount_paid : nat64;
   collateral_amount_received : opt nat64;
+};
+type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
+type SupplyAuditEntry = record {
+  supply_e8s : nat;
+  display_name : text;
+  chain_id : nat32;
 };
 type TransferError = variant {
   GenericError : record { message : text; error_code : nat };
@@ -771,6 +878,12 @@ type TreasuryStats = record {
   treasury_principal : opt principal;
   total_accrued_interest_system : nat64;
   pending_interest_for_pools_total : nat64;
+};
+type UpdateChainConfigArg = record {
+  rpc_endpoints : opt vec text;
+  gas_strategy : opt GasStrategy;
+  finality_depth : opt nat32;
+  display_name : opt text;
 };
 type UpgradeArg = record { mode : opt Mode; description : opt text };
 type Vault = record {
@@ -818,19 +931,28 @@ service : (ProtocolArg) -> {
   bot_claim_liquidation : (nat64) -> (Result_4);
   bot_confirm_liquidation : (nat64) -> (Result);
   claim_liquidity_returns : () -> (Result_1);
+  clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
+  clear_reorg_halt : (nat32) -> (Result);
   clear_stuck_operations : (opt principal) -> (Result_1);
+  close_chain_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
+  delete_chain : (nat32) -> (Result);
+  disable_chain : (nat32) -> (Result);
   enter_recovery_mode : () -> (Result);
   exit_recovery_mode : () -> (Result);
   freeze_protocol : () -> (Result);
   get_all_vaults : () -> (vec CandidVault) query;
+  get_amm1_canister : () -> (opt principal) query;
+  get_amm1_pool_id : () -> (opt text) query;
   get_borrowing_fee : () -> (float64) query;
   get_bot_allowed_collateral_types : () -> (vec principal) query;
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_settlement_address : (nat32) -> (Result_2);
+  get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
@@ -849,6 +971,8 @@ service : (ProtocolArg) -> {
   get_fees : (nat64) -> (Fees) query;
   get_fees_for_collateral : (principal, nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
+  get_global_icusd_supply : () -> (nat) query;
+  get_icp_usd_price_e8s : () -> (ProtocolStatusLite) query;
   get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
@@ -860,12 +984,11 @@ service : (ProtocolArg) -> {
   get_liquidation_protocol_share : () -> (float64) query;
   get_liquidity_status : (principal) -> (LiquidityStatus) query;
   get_min_icusd_amount : () -> (nat64) query;
+  get_pending_amm1_donations_count : () -> (nat64) query;
   get_protocol_3usd_reserves : () -> (nat64) query;
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
   get_protocol_status : () -> (ProtocolStatus) query;
-  get_global_icusd_supply : () -> (nat) query;
-  get_supply_audit : () -> (SupplyAudit) query;
   get_recovery_cr_multiplier : () -> (float64) query;
   get_recovery_target_cr : () -> (float64) query;
   get_redemption_fee_ceiling : () -> (float64) query;
@@ -884,14 +1007,11 @@ service : (ProtocolArg) -> {
   get_stability_pool_config : () -> (StabilityPoolConfig) query;
   get_stability_pool_principal : () -> (opt principal) query;
   get_stable_token_enabled : (StableTokenType) -> (bool) query;
+  get_supply_audit : () -> (SupplyAudit) query;
   get_supported_collateral_types : () -> (
       vec record { principal; CollateralStatus },
     ) query;
   get_three_pool_canister : () -> (opt principal) query;
-  get_amm1_canister : () -> (opt principal) query;
-  get_amm1_pool_id : () -> (opt text) query;
-  get_pending_amm1_donations_count : () -> (nat64) query;
-  get_icp_usd_price_e8s : () -> (ProtocolStatusLite) query;
   get_treasury_principal : () -> (opt principal) query;
   get_treasury_stats : () -> (TreasuryStats) query;
   get_vault_count : () -> (nat64) query;
@@ -909,6 +1029,8 @@ service : (ProtocolArg) -> {
   liquidate_vault : (nat64) -> (Result_3);
   liquidate_vault_partial : (VaultArg) -> (Result_3);
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
+  list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
+  open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_vault : (nat64, opt principal) -> (Result_9);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_9);
   open_vault_with_deposit : (nat64, opt principal) -> (Result_9);
@@ -919,17 +1041,21 @@ service : (ProtocolArg) -> {
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
   redeem_reserves : (nat64, opt principal) -> (Result_11);
-  repay_and_close_vault : (VaultArg) -> (Result_13);
+  register_chain : (RegisterChainArg) -> (Result);
+  repay_and_close_vault : (VaultArg) -> (Result_12);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
+  set_amm1_canister : (principal) -> (Result);
+  set_amm1_pool_id : (text) -> (Result);
   set_borrowing_fee : (float64) -> (Result);
   set_borrowing_fee_curve : (opt text) -> (Result);
   set_bot_allowed_collateral_types : (vec principal) -> (Result);
   set_bot_cr_tolerance_bps : (nat64) -> (Result);
-  set_collateral_min_xrc_sources : (principal, opt nat32) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
+  set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
+  set_chain_contract : (nat32, text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
@@ -942,11 +1068,13 @@ service : (ProtocolArg) -> {
   set_collateral_liquidation_ratio : (principal, float64) -> (Result);
   set_collateral_min_deposit : (principal, nat64) -> (Result);
   set_collateral_min_vault_debt : (principal, nat64) -> (Result);
+  set_collateral_min_xrc_sources : (principal, opt nat32) -> (Result);
   set_collateral_redemption_fee_ceiling : (principal, float64) -> (Result);
   set_collateral_redemption_fee_floor : (principal, float64) -> (Result);
   set_collateral_status : (principal, CollateralStatus) -> (Result);
   set_deficit_readonly_threshold_e8s : (nat64) -> (Result);
   set_deficit_repayment_fraction : (float64) -> (Result);
+  set_evm_rpc_principal : (principal) -> (Result);
   set_global_icusd_mint_cap : (nat64) -> (Result);
   set_healthy_cr : (principal, opt float64) -> (Result);
   set_icpswap_routing_enabled : (bool) -> (Result);
@@ -961,8 +1089,10 @@ service : (ProtocolArg) -> {
   set_liquidation_ordering_tolerance : (nat64) -> (Result);
   set_liquidation_protocol_share : (float64) -> (Result);
   set_lst_haircut : (principal, float64) -> (Result);
+  set_manual_collateral_price : (nat32, text, nat64) -> (Result);
   set_min_icusd_amount : (nat64) -> (Result);
   set_min_xrc_sources_used : (nat32) -> (Result);
+  set_observer_tick_interval_secs : (nat64) -> (Result);
   set_rate_curve_markers : (opt principal, vec record { float64; float64 }) -> (
       Result,
     );
@@ -979,26 +1109,26 @@ service : (ProtocolArg) -> {
   set_rmr_ceiling_cr : (float64) -> (Result);
   set_rmr_floor : (float64) -> (Result);
   set_rmr_floor_cr : (float64) -> (Result);
+  set_settlement_tick_interval_secs : (nat64) -> (Result);
   set_sp_writedown_disabled : (bool) -> (Result);
   set_stability_pool_principal : (principal) -> (Result);
   set_stable_ledger_principal : (StableTokenType, principal) -> (Result);
   set_stable_token_enabled : (StableTokenType, bool) -> (Result);
   set_three_pool_canister : (principal) -> (Result);
-  set_amm1_canister : (principal) -> (Result);
-  set_amm1_pool_id : (text) -> (Result);
   set_treasury_principal : (principal) -> (Result);
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_12);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_13);
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_12,
+      Result_13,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_12,
+      Result_13,
     );
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
+  withdraw_chain_collateral : (nat64, nat, text) -> (Result);
   withdraw_collateral : (nat64) -> (Result_1);
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -44,6 +44,23 @@ export interface CandidVault {
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
 }
+export type ChainVaultStatus = { 'MintPending' : null } |
+  { 'Open' : null } |
+  { 'Closed' : null } |
+  { 'Closing' : null } |
+  { 'AwaitingDeposit' : null };
+export interface ChainVaultV1 {
+  'status' : ChainVaultStatus,
+  'owner' : Principal,
+  'pending_mint_e8s' : bigint,
+  'custody_address' : string,
+  'collateral_amount_e18' : bigint,
+  'opened_at_ns' : bigint,
+  'vault_id' : bigint,
+  'collateral_chain' : number,
+  'mint_recipient' : string,
+  'debt_e8s' : bigint,
+}
 export interface CollateralConfig {
   'last_redemption_time' : bigint,
   'status' : CollateralStatus,
@@ -174,6 +191,17 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'withdrawal_signed' : {
+      'op_id' : bigint,
+      'recipient' : string,
+      'vault_id' : bigint,
+      'amount_e18' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
+    }
+  } |
+  {
     'provide_liquidity' : {
       'block_index' : bigint,
       'timestamp' : [] | [bigint],
@@ -194,6 +222,16 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'set_ckstable_repay_fee' : { 'rate' : string } } |
   { 'set_treasury_principal' : { 'principal' : Principal } } |
   { 'accrue_interest' : { 'timestamp' : bigint } } |
+  {
+    'chain_burn_observed' : {
+      'vault_id' : bigint,
+      'block_number' : bigint,
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
+    }
+  } |
   { 'set_max_partial_liquidation_ratio' : { 'rate' : string } } |
   {
     'breaker_tripped' : {
@@ -244,6 +282,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'set_collateral_redemption_fee_floor' : {
       'redemption_fee_floor' : string,
       'collateral_type' : Principal,
+    }
+  } |
+  {
+    'chain_settlement_failed' : {
+      'op_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'reason' : string,
     }
   } |
   { 'init' : InitArg } |
@@ -366,6 +412,25 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'redistribute_vault' : { 'vault_id' : bigint, 'timestamp' : [] | [bigint] }
   } |
   {
+    'chain_mint_confirmed' : {
+      'op_id' : bigint,
+      'vault_id' : bigint,
+      'block_number' : bigint,
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
+    }
+  } |
+  {
+    'chain_reorg_detected' : {
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'reorg_depth' : bigint,
+      'observed_block' : bigint,
+    }
+  } |
+  {
     'partial_collateral_withdrawn' : {
       'block_index' : bigint,
       'vault_id' : bigint,
@@ -402,6 +467,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'set_collateral_liquidation_ratio' : {
       'collateral_type' : Principal,
       'liquidation_ratio' : string,
+    }
+  } |
+  {
+    'chain_hot_wallet_low' : {
+      'chain_id' : number,
+      'threshold_e18' : bigint,
+      'timestamp' : bigint,
+      'balance_e18' : bigint,
     }
   } |
   {
@@ -534,6 +607,17 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   } |
   { 'set_reserve_redemption_fee' : { 'fee' : string } } |
   {
+    'chain_mint_submitted' : {
+      'op_id' : bigint,
+      'recipient' : string,
+      'vault_id' : bigint,
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
+    }
+  } |
+  {
     'deficit_repaid' : {
       'remaining_deficit' : bigint,
       'source' : FeeSource,
@@ -579,6 +663,17 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'add_collateral_type' : {
       'config' : CollateralConfig,
       'collateral_type' : Principal,
+    }
+  } |
+  {
+    'deposit_observed' : {
+      'custody_address' : string,
+      'vault_id' : bigint,
+      'block_number' : bigint,
+      'amount_e18' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
     }
   } |
   {
@@ -1025,10 +1120,14 @@ export interface _SERVICE {
   'bot_claim_liquidation' : ActorMethod<[bigint], Result_4>,
   'bot_confirm_liquidation' : ActorMethod<[bigint], Result>,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
+  'clear_invariant_halt' : ActorMethod<[], Result>,
   'clear_liquidation_breaker' : ActorMethod<[], Result>,
+  'clear_reorg_halt' : ActorMethod<[number], Result>,
   'clear_stuck_operations' : ActorMethod<[[] | [Principal]], Result_1>,
+  'close_chain_vault' : ActorMethod<[bigint, string], Result>,
   'close_vault' : ActorMethod<[bigint], Result_5>,
   'coingecko_transform' : ActorMethod<[TransformArgs], HttpResponse>,
+  'delete_chain' : ActorMethod<[number], Result>,
   'disable_chain' : ActorMethod<[number], Result>,
   'enter_recovery_mode' : ActorMethod<[], Result>,
   'exit_recovery_mode' : ActorMethod<[], Result>,
@@ -1041,6 +1140,8 @@ export interface _SERVICE {
   'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
+  'get_chain_settlement_address' : ActorMethod<[number], Result_2>,
+  'get_chain_vault' : ActorMethod<[bigint], [] | [ChainVaultV1]>,
   'get_ckstable_repay_fee' : ActorMethod<[], number>,
   'get_collateral_config' : ActorMethod<[Principal], [] | [CollateralConfig]>,
   'get_collateral_totals' : ActorMethod<[], Array<CollateralTotals>>,
@@ -1139,6 +1240,8 @@ export interface _SERVICE {
     [VaultArgWithToken],
     Result_3
   >,
+  'list_chain_vaults' : ActorMethod<[number], Array<ChainVaultV1>>,
+  'open_chain_vault' : ActorMethod<[number, bigint, bigint, string], Result_1>,
   'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
   'open_vault_and_borrow' : ActorMethod<
     [bigint, bigint, [] | [Principal]],
@@ -1166,6 +1269,7 @@ export interface _SERVICE {
   'set_breaker_window_debt_ceiling_e8s' : ActorMethod<[bigint], Result>,
   'set_breaker_window_ns' : ActorMethod<[bigint], Result>,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
+  'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_check_vaults_alert_band_bps' : ActorMethod<[bigint], Result>,
   'set_check_vaults_full_sweep_every_n_ticks' : ActorMethod<[bigint], Result>,
   'set_ckstable_repay_fee' : ActorMethod<[number], Result>,
@@ -1196,6 +1300,7 @@ export interface _SERVICE {
   'set_collateral_status' : ActorMethod<[Principal, CollateralStatus], Result>,
   'set_deficit_readonly_threshold_e8s' : ActorMethod<[bigint], Result>,
   'set_deficit_repayment_fraction' : ActorMethod<[number], Result>,
+  'set_evm_rpc_principal' : ActorMethod<[Principal], Result>,
   'set_global_icusd_mint_cap' : ActorMethod<[bigint], Result>,
   'set_healthy_cr' : ActorMethod<[Principal, [] | [number]], Result>,
   'set_icpswap_routing_enabled' : ActorMethod<[boolean], Result>,
@@ -1210,8 +1315,10 @@ export interface _SERVICE {
   'set_liquidation_ordering_tolerance' : ActorMethod<[bigint], Result>,
   'set_liquidation_protocol_share' : ActorMethod<[number], Result>,
   'set_lst_haircut' : ActorMethod<[Principal, number], Result>,
+  'set_manual_collateral_price' : ActorMethod<[number, string, bigint], Result>,
   'set_min_icusd_amount' : ActorMethod<[bigint], Result>,
   'set_min_xrc_sources_used' : ActorMethod<[number], Result>,
+  'set_observer_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_rate_curve_markers' : ActorMethod<
     [[] | [Principal], Array<[number, number]>],
     Result
@@ -1232,6 +1339,7 @@ export interface _SERVICE {
   'set_rmr_ceiling_cr' : ActorMethod<[number], Result>,
   'set_rmr_floor' : ActorMethod<[number], Result>,
   'set_rmr_floor_cr' : ActorMethod<[number], Result>,
+  'set_settlement_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_sp_writedown_disabled' : ActorMethod<[boolean], Result>,
   'set_stability_pool_principal' : ActorMethod<[Principal], Result>,
   'set_stable_ledger_principal' : ActorMethod<
@@ -1258,6 +1366,7 @@ export interface _SERVICE {
     Result
   >,
   'withdraw_and_close_vault' : ActorMethod<[bigint], Result_5>,
+  'withdraw_chain_collateral' : ActorMethod<[bigint, bigint, string], Result>,
   'withdraw_collateral' : ActorMethod<[bigint], Result_1>,
   'withdraw_liquidity' : ActorMethod<[bigint], Result_1>,
   'withdraw_partial_collateral' : ActorMethod<[VaultArg], Result_1>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -1173,6 +1173,7 @@ export interface _SERVICE {
   'get_icpswap_routing_enabled' : ActorMethod<[], boolean>,
   'get_interest_pool_share' : ActorMethod<[], number>,
   'get_interest_split' : ActorMethod<[], Array<InterestSplitArg>>,
+  'get_last_observed_block' : ActorMethod<[number], bigint>,
   'get_liquidatable_vaults' : ActorMethod<[], Array<CandidVault>>,
   'get_liquidatable_vaults_page' : ActorMethod<
     [bigint, bigint],
@@ -1309,6 +1310,7 @@ export interface _SERVICE {
   'set_interest_rate' : ActorMethod<[Principal, number], Result>,
   'set_interest_split' : ActorMethod<[Array<InterestSplitArg>], Result>,
   'set_interest_treasury_tick_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_last_observed_block' : ActorMethod<[number, bigint], Result>,
   'set_liquidation_bonus' : ActorMethod<[number], Result>,
   'set_liquidation_bot_config' : ActorMethod<[Principal, bigint], Result>,
   'set_liquidation_frozen' : ActorMethod<[boolean], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -159,6 +159,25 @@ export const idlFactory = ({ IDL }) => {
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
   });
+  const ChainVaultStatus = IDL.Variant({
+    'MintPending' : IDL.Null,
+    'Open' : IDL.Null,
+    'Closed' : IDL.Null,
+    'Closing' : IDL.Null,
+    'AwaitingDeposit' : IDL.Null,
+  });
+  const ChainVaultV1 = IDL.Record({
+    'status' : ChainVaultStatus,
+    'owner' : IDL.Principal,
+    'pending_mint_e8s' : IDL.Nat,
+    'custody_address' : IDL.Text,
+    'collateral_amount_e18' : IDL.Nat,
+    'opened_at_ns' : IDL.Nat64,
+    'vault_id' : IDL.Nat64,
+    'collateral_chain' : IDL.Nat32,
+    'mint_recipient' : IDL.Text,
+    'debt_e8s' : IDL.Nat,
+  });
   const CollateralStatus = IDL.Variant({
     'Paused' : IDL.Null,
     'Active' : IDL.Null,
@@ -318,6 +337,15 @@ export const idlFactory = ({ IDL }) => {
       'timestamp' : IDL.Opt(IDL.Nat64),
       'caller' : IDL.Opt(IDL.Principal),
     }),
+    'withdrawal_signed' : IDL.Record({
+      'op_id' : IDL.Nat64,
+      'recipient' : IDL.Text,
+      'vault_id' : IDL.Nat64,
+      'amount_e18' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
+    }),
     'provide_liquidity' : IDL.Record({
       'block_index' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
@@ -335,6 +363,14 @@ export const idlFactory = ({ IDL }) => {
     'set_ckstable_repay_fee' : IDL.Record({ 'rate' : IDL.Text }),
     'set_treasury_principal' : IDL.Record({ 'principal' : IDL.Principal }),
     'accrue_interest' : IDL.Record({ 'timestamp' : IDL.Nat64 }),
+    'chain_burn_observed' : IDL.Record({
+      'vault_id' : IDL.Nat64,
+      'block_number' : IDL.Nat64,
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
+    }),
     'set_max_partial_liquidation_ratio' : IDL.Record({ 'rate' : IDL.Text }),
     'breaker_tripped' : IDL.Record({
       'total_e8s' : IDL.Nat64,
@@ -372,6 +408,12 @@ export const idlFactory = ({ IDL }) => {
     'set_collateral_redemption_fee_floor' : IDL.Record({
       'redemption_fee_floor' : IDL.Text,
       'collateral_type' : IDL.Principal,
+    }),
+    'chain_settlement_failed' : IDL.Record({
+      'op_id' : IDL.Nat64,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'reason' : IDL.Text,
     }),
     'init' : InitArg,
     'set_stable_ledger_principal' : IDL.Record({
@@ -463,6 +505,21 @@ export const idlFactory = ({ IDL }) => {
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
     }),
+    'chain_mint_confirmed' : IDL.Record({
+      'op_id' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
+      'block_number' : IDL.Nat64,
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
+    }),
+    'chain_reorg_detected' : IDL.Record({
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'reorg_depth' : IDL.Nat64,
+      'observed_block' : IDL.Nat64,
+    }),
     'partial_collateral_withdrawn' : IDL.Record({
       'block_index' : IDL.Nat64,
       'vault_id' : IDL.Nat64,
@@ -491,6 +548,12 @@ export const idlFactory = ({ IDL }) => {
     'set_collateral_liquidation_ratio' : IDL.Record({
       'collateral_type' : IDL.Principal,
       'liquidation_ratio' : IDL.Text,
+    }),
+    'chain_hot_wallet_low' : IDL.Record({
+      'chain_id' : IDL.Nat32,
+      'threshold_e18' : IDL.Nat,
+      'timestamp' : IDL.Nat64,
+      'balance_e18' : IDL.Nat,
     }),
     'dust_forgiven' : IDL.Record({
       'vault_id' : IDL.Nat64,
@@ -603,6 +666,15 @@ export const idlFactory = ({ IDL }) => {
       'interest_rate_apr' : IDL.Text,
     }),
     'set_reserve_redemption_fee' : IDL.Record({ 'fee' : IDL.Text }),
+    'chain_mint_submitted' : IDL.Record({
+      'op_id' : IDL.Nat64,
+      'recipient' : IDL.Text,
+      'vault_id' : IDL.Nat64,
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
+    }),
     'deficit_repaid' : IDL.Record({
       'remaining_deficit' : IDL.Nat64,
       'source' : FeeSource,
@@ -643,6 +715,15 @@ export const idlFactory = ({ IDL }) => {
     'add_collateral_type' : IDL.Record({
       'config' : CollateralConfig,
       'collateral_type' : IDL.Principal,
+    }),
+    'deposit_observed' : IDL.Record({
+      'custody_address' : IDL.Text,
+      'vault_id' : IDL.Nat64,
+      'block_number' : IDL.Nat64,
+      'amount_e18' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
     }),
     'chain_registered' : IDL.Record({
       'display_name' : IDL.Text,
@@ -980,18 +1061,22 @@ export const idlFactory = ({ IDL }) => {
     'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_4], []),
     'bot_confirm_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
+    'clear_invariant_halt' : IDL.Func([], [Result], []),
     'clear_liquidation_breaker' : IDL.Func([], [Result], []),
+    'clear_reorg_halt' : IDL.Func([IDL.Nat32], [Result], []),
     'clear_stuck_operations' : IDL.Func(
         [IDL.Opt(IDL.Principal)],
         [Result_1],
         [],
       ),
+    'close_chain_vault' : IDL.Func([IDL.Nat64, IDL.Text], [Result], []),
     'close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'coingecko_transform' : IDL.Func(
         [TransformArgs],
         [HttpResponse],
         ['query'],
       ),
+    'delete_chain' : IDL.Func([IDL.Nat32], [Result], []),
     'disable_chain' : IDL.Func([IDL.Nat32], [Result], []),
     'enter_recovery_mode' : IDL.Func([], [Result], []),
     'exit_recovery_mode' : IDL.Func([], [Result], []),
@@ -1008,6 +1093,12 @@ export const idlFactory = ({ IDL }) => {
     'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_cr_tolerance_bps' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
+    'get_chain_settlement_address' : IDL.Func([IDL.Nat32], [Result_2], []),
+    'get_chain_vault' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Opt(ChainVaultV1)],
+        ['query'],
+      ),
     'get_ckstable_repay_fee' : IDL.Func([], [IDL.Float64], ['query']),
     'get_collateral_config' : IDL.Func(
         [IDL.Principal],
@@ -1184,6 +1275,16 @@ export const idlFactory = ({ IDL }) => {
         [Result_3],
         [],
       ),
+    'list_chain_vaults' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Vec(ChainVaultV1)],
+        ['query'],
+      ),
+    'open_chain_vault' : IDL.Func(
+        [IDL.Nat32, IDL.Nat, IDL.Nat, IDL.Text],
+        [Result_1],
+        [],
+      ),
     'open_vault' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
         [Result_9],
@@ -1236,6 +1337,7 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'set_chain_contract' : IDL.Func([IDL.Nat32, IDL.Text], [Result], []),
     'set_check_vaults_alert_band_bps' : IDL.Func([IDL.Nat64], [Result], []),
     'set_check_vaults_full_sweep_every_n_ticks' : IDL.Func(
         [IDL.Nat64],
@@ -1310,6 +1412,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'set_deficit_readonly_threshold_e8s' : IDL.Func([IDL.Nat64], [Result], []),
     'set_deficit_repayment_fraction' : IDL.Func([IDL.Float64], [Result], []),
+    'set_evm_rpc_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_global_icusd_mint_cap' : IDL.Func([IDL.Nat64], [Result], []),
     'set_healthy_cr' : IDL.Func(
         [IDL.Principal, IDL.Opt(IDL.Float64)],
@@ -1336,8 +1439,14 @@ export const idlFactory = ({ IDL }) => {
     'set_liquidation_ordering_tolerance' : IDL.Func([IDL.Nat64], [Result], []),
     'set_liquidation_protocol_share' : IDL.Func([IDL.Float64], [Result], []),
     'set_lst_haircut' : IDL.Func([IDL.Principal, IDL.Float64], [Result], []),
+    'set_manual_collateral_price' : IDL.Func(
+        [IDL.Nat32, IDL.Text, IDL.Nat64],
+        [Result],
+        [],
+      ),
     'set_min_icusd_amount' : IDL.Func([IDL.Nat64], [Result], []),
     'set_min_xrc_sources_used' : IDL.Func([IDL.Nat32], [Result], []),
+    'set_observer_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
     'set_rate_curve_markers' : IDL.Func(
         [IDL.Opt(IDL.Principal), IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64))],
         [Result],
@@ -1364,6 +1473,7 @@ export const idlFactory = ({ IDL }) => {
     'set_rmr_ceiling_cr' : IDL.Func([IDL.Float64], [Result], []),
     'set_rmr_floor' : IDL.Func([IDL.Float64], [Result], []),
     'set_rmr_floor_cr' : IDL.Func([IDL.Float64], [Result], []),
+    'set_settlement_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
     'set_sp_writedown_disabled' : IDL.Func([IDL.Bool], [Result], []),
     'set_stability_pool_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_stable_ledger_principal' : IDL.Func(
@@ -1402,6 +1512,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'withdraw_and_close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
+    'withdraw_chain_collateral' : IDL.Func(
+        [IDL.Nat64, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
     'withdraw_collateral' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_partial_collateral' : IDL.Func([VaultArg], [Result_1], []),

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -1154,6 +1154,7 @@ export const idlFactory = ({ IDL }) => {
     'get_icpswap_routing_enabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_interest_pool_share' : IDL.Func([], [IDL.Float64], ['query']),
     'get_interest_split' : IDL.Func([], [IDL.Vec(InterestSplitArg)], ['query']),
+    'get_last_observed_block' : IDL.Func([IDL.Nat32], [IDL.Nat64], ['query']),
     'get_liquidatable_vaults' : IDL.Func([], [IDL.Vec(CandidVault)], ['query']),
     'get_liquidatable_vaults_page' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
@@ -1429,6 +1430,7 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'set_last_observed_block' : IDL.Func([IDL.Nat32, IDL.Nat64], [Result], []),
     'set_liquidation_bonus' : IDL.Func([IDL.Float64], [Result], []),
     'set_liquidation_bot_config' : IDL.Func(
         [IDL.Principal, IDL.Nat64],

--- a/src/monad_rpc_mock/Cargo.toml
+++ b/src/monad_rpc_mock/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "monad_rpc_mock"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.10.6"
+ic-cdk = "0.12.0"
+ic-cdk-macros = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[profile.release]
+opt-level = "s"
+lto = true

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -247,6 +247,14 @@ struct Script {
     /// instead of a canned success, then clears the entry. Lets a test
     /// exercise the IcError decode path end-to-end (the Layer-1 trap).
     fail_next: HashMap<String, String>,
+    /// Persistent failure injection: JSON-RPC `method` -> message. Like
+    /// `fail_next` but NEVER cleared on hit — EVERY subsequent `request` for
+    /// the given method returns the IcError. Overwritten (not merged) by a
+    /// new `fail_always` call for the same method. Cleared by `clear_failures`.
+    /// Used by the consensus-safe regression test to arm a permanent barrier so
+    /// the test reliably catches a revert to the volatile `eth_blockNumber` read
+    /// across ALL observer ticks, not just the first.
+    fail_always: HashMap<String, String>,
 }
 
 thread_local! {
@@ -305,6 +313,19 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
     let method = payload["method"].as_str().unwrap_or("");
     let id = payload["id"].clone();
     let params = &payload["params"];
+
+    // Persistent failure injection: if a test armed `fail_always` for this
+    // method, return a real-wire-shaped IcError WITHOUT clearing the arming —
+    // every subsequent call for this method also fails. Checked BEFORE
+    // `fail_next` so a persistent barrier takes precedence.
+    if let Some(msg) = SCRIPT.with(|s| s.borrow().fail_always.get(method).cloned()) {
+        return RequestResult::Err(RpcError::HttpOutcallError(HttpOutcallError::IcError(
+            IcErrorRecord {
+                code: RejectionCode::SysTransient,
+                message: msg,
+            },
+        )));
+    }
 
     // One-shot failure injection: if a test armed `fail_next` for this method,
     // return a REAL-WIRE-SHAPED IcError (the exact value the live EVM RPC
@@ -569,6 +590,35 @@ fn clear_logs() {
 fn fail_next(method: String, message: String) {
     SCRIPT.with(|s| {
         s.borrow_mut().fail_next.insert(method, message);
+    });
+}
+
+/// Arm a PERSISTENT real-wire IcError for ALL future `request` calls whose
+/// JSON-RPC `method` equals `method`. Unlike `fail_next`, the arming is NEVER
+/// cleared on hit — every call for this method continues to return the IcError.
+/// Calling `fail_always` again for the same method overwrites the message.
+/// Use `clear_failures` to lift the barrier.
+///
+/// Used by the consensus-safe regression test (`phase1b_observer_consensus_safe_pic`)
+/// to ensure every observer tick would fail if the backend reverted to the
+/// volatile `eth_blockNumber` via `request`. The fixed backend never calls
+/// `eth_blockNumber` via `request` (it uses the TYPED `eth_getBlockByNumber`
+/// instead), so the persistent barrier is inert for the correct implementation.
+#[ic_cdk_macros::update]
+fn fail_always(method: String, message: String) {
+    SCRIPT.with(|s| {
+        s.borrow_mut().fail_always.insert(method, message);
+    });
+}
+
+/// Remove all persistent (`fail_always`) and one-shot (`fail_next`) failure
+/// injections. After this call the mock resumes normal scripted responses.
+#[ic_cdk_macros::update]
+fn clear_failures() {
+    SCRIPT.with(|s| {
+        let mut s = s.borrow_mut();
+        s.fail_always.clear();
+        s.fail_next.clear();
     });
 }
 

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -28,6 +28,8 @@
 //!                                     "0x<block>"}} when mined, else null
 //!   - eth_getLogs                  -> {"result":[<log objects>]}, filtered by
 //!                                     the requested fromBlock..toBlock range
+//!                                     AND topics[0] (case-insensitive), matching
+//!                                     the real RPC's topic filter (M-3 fidelity)
 //!
 //! Build:
 //!   cargo build --target wasm32-unknown-unknown --release --package monad_rpc_mock
@@ -409,10 +411,15 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
             }
             "eth_getLogs" => {
                 // params = [{address, topics, fromBlock, toBlock}]. Filter the
-                // scripted logs by the requested block range; the backend
-                // decoders re-check topic0 + vault_id, so we do not strictly
-                // need to filter by topic, but range-filtering keeps the
-                // mint-confirm log scan (single-block range) precise.
+                // scripted logs by BOTH the requested block range AND the
+                // requested topics[0] — the REAL EVM RPC `eth_getLogs` is
+                // topic-filtered, so the mock must be too (M-3 fidelity). Without
+                // the topic filter the observer's BURN scan would also return the
+                // Mint log, which the old happy-path test had to work around with
+                // a `clear_logs` call. The match is case-insensitive (RPC
+                // responses vary in EIP-55 mixed-case vs lowercase). A request
+                // with no/empty topics filter returns all logs in range (the
+                // permissive JSON-RPC default).
                 let filter = params.get(0).cloned().unwrap_or(serde_json::Value::Null);
                 let from = filter
                     .get("fromBlock")
@@ -422,6 +429,13 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                     .get("toBlock")
                     .and_then(|v| v.as_str())
                     .and_then(parse_hex_u64);
+                // The requested topic0 (first entry of the `topics` array), if any.
+                let want_topic0: Option<String> = filter
+                    .get("topics")
+                    .and_then(|t| t.as_array())
+                    .and_then(|arr| arr.first())
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_lowercase());
 
                 let mut items: Vec<String> = Vec::new();
                 for log in script.logs.iter() {
@@ -433,6 +447,14 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                     if let Some(t) = to {
                         if log.block > t {
                             continue;
+                        }
+                    }
+                    // Topic-filter: if the request specified topics[0], only
+                    // return logs whose own topics[0] matches (case-insensitive).
+                    if let Some(ref want) = want_topic0 {
+                        match log.topics.first() {
+                            Some(got) if got.to_lowercase() == *want => {}
+                            _ => continue,
                         }
                     }
                     let topics_json = log

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -215,6 +215,12 @@ struct ScriptedLog {
     data: String,
     tx_hash: String,
     block: u64,
+    /// Stable EVM log index within the transaction. Assigned explicitly via
+    /// `push_log_at`, or auto-assigned as the total log count at push time by
+    /// `push_log`. The same log always gets the same `logIndex` across
+    /// re-scans, which is required for the dedup key `(tx_hash, log_index)` to
+    /// be stable across observer re-scans of the same block range.
+    log_index: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -485,11 +491,12 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                         .collect::<Vec<_>>()
                         .join(",");
                     items.push(format!(
-                        r#"{{"topics":[{}],"data":{:?},"transactionHash":{:?},"blockNumber":{:?}}}"#,
+                        r#"{{"topics":[{}],"data":{:?},"transactionHash":{:?},"blockNumber":{:?},"logIndex":{:?}}}"#,
                         topics_json,
                         log.data,
                         log.tx_hash,
-                        hex_u64(log.block)
+                        hex_u64(log.block),
+                        hex_u64(log.log_index)
                     ));
                 }
                 format!(
@@ -562,14 +569,39 @@ fn set_next_send_hash(h: String) {
     });
 }
 
+/// Push a scripted log, auto-assigning `log_index` as the current total log
+/// count. Existing tests use this; the assigned index is stable (logs are never
+/// removed except by `clear_logs`), so re-scans always see the same logIndex
+/// for the same log.
 #[ic_cdk_macros::update]
 fn push_log(topics: Vec<String>, data: String, tx_hash: String, block: u64) {
+    SCRIPT.with(|s| {
+        let mut s = s.borrow_mut();
+        let log_index = s.logs.len() as u64;
+        s.logs.push(ScriptedLog {
+            topics,
+            data,
+            tx_hash,
+            block,
+            log_index,
+        });
+    });
+}
+
+/// Push a scripted log with an explicit `log_index`. Used by the same-tx
+/// different-log-index test to push two Burn logs with the same tx_hash but
+/// distinct log indices. The `log_index` must be provided explicitly so that
+/// re-scans of the same block range always return the same logIndex for the
+/// same log (dedup stability requirement).
+#[ic_cdk_macros::update]
+fn push_log_at(topics: Vec<String>, data: String, tx_hash: String, block: u64, log_index: u64) {
     SCRIPT.with(|s| {
         s.borrow_mut().logs.push(ScriptedLog {
             topics,
             data,
             tx_hash,
             block,
+            log_index,
         });
     });
 }

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -64,17 +64,144 @@ pub struct JsonRpcError {
     pub message: String,
 }
 
-/// Minimal `RpcError`. The happy-path mock never returns an error, but the
-/// type must exist so `RequestResult`'s candid shape matches the wrapper's.
+// ─── Full `RpcError` tree (parity with docs/evm_rpc_reference.did) ───────────
+//
+// The mock now mirrors the REAL `RpcError` shape (4 variants) so it can return
+// a real-wire-shaped `HttpOutcallError::IcError { code: RejectionCode; .. }` —
+// exactly the value the live EVM RPC canister returns when an HTTPS-outcall
+// fails consensus. This lets a future test exercise that decode path
+// end-to-end (it was the Layer-1 trap).
+
+/// Mirrors the live .did `RejectionCode` variant (fieldless, 7 arms).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RejectionCode {
+    NoError,
+    CanisterError,
+    SysTransient,
+    DestinationInvalid,
+    Unknown,
+    SysFatal,
+    CanisterReject,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct IcErrorRecord {
+    pub code: RejectionCode,
+    pub message: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct InvalidHttpJsonRpcRecord {
+    pub status: u16,
+    pub body: String,
+    #[serde(rename = "parsingError")]
+    pub parsing_error: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum HttpOutcallError {
+    IcError(IcErrorRecord),
+    InvalidHttpJsonRpcResponse(InvalidHttpJsonRpcRecord),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TooFewCyclesRecord {
+    pub expected: candid::Nat,
+    pub received: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ProviderError {
+    TooFewCycles(TooFewCyclesRecord),
+    MissingRequiredProvider,
+    ProviderNotFound,
+    NoPermission,
+    InvalidRpcConfig(String),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ValidationError {
+    Custom(String),
+    InvalidHex(String),
+}
+
+/// Full `RpcError` (4 variants) as in the live .did. Variant ORDER matches the
+/// real `.did` (`JsonRpcError`, `ProviderError`, `ValidationError`,
+/// `HttpOutcallError`) so candid tags line up with the backend's mirror.
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum RpcError {
     JsonRpcError(JsonRpcError),
+    ProviderError(ProviderError),
+    ValidationError(ValidationError),
+    HttpOutcallError(HttpOutcallError),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum RequestResult {
     Ok(String),
     Err(RpcError),
+}
+
+// ─── Typed `eth_getBlockByNumber` method types (parity with the .did) ────────
+//
+// The backend's consensus-safe finalized-height probe calls the TYPED
+// `eth_getBlockByNumber : (RpcServices, opt RpcConfig, BlockTag) ->
+// (MultiGetBlockByNumberResult)` method (a specific `Number(n)` is
+// byte-identical across IC replicas). The mock implements it below.
+
+/// PLURAL `RpcServices` (only the `Custom` arm — the backend always sends a
+/// single Monad custom provider).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcServices {
+    Custom {
+        #[serde(rename = "chainId")]
+        chain_id: u64,
+        services: Vec<RpcApi>,
+    },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum BlockTag {
+    Earliest,
+    Safe,
+    Finalized,
+    Latest,
+    Number(candid::Nat),
+    Pending,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ConsensusStrategy {
+    Equality,
+    Threshold { total: Option<u8>, min: u8 },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct RpcConfig {
+    #[serde(rename = "responseSizeEstimate")]
+    pub response_size_estimate: Option<u64>,
+    #[serde(rename = "responseConsensus")]
+    pub response_consensus: Option<ConsensusStrategy>,
+}
+
+/// Minimal `Block` (only `number`) — matches the backend's reader. Record
+/// subtyping means this still decodes a richer wire `Block`; the mock only
+/// needs to ENCODE `number` here since the backend only reads `number`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct Block {
+    pub number: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum GetBlockByNumberResult {
+    Ok(Block),
+    Err(RpcError),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum MultiGetBlockByNumberResult {
+    Consistent(GetBlockByNumberResult),
+    Inconsistent(Vec<(RpcService, GetBlockByNumberResult)>),
 }
 
 // ─── Scripted state ───────────────────────────────────────────────────────
@@ -112,6 +239,12 @@ struct Script {
     next_send_hash: Option<String>,
     /// Scripted logs returned (range-filtered) by eth_getLogs.
     logs: Vec<ScriptedLog>,
+    /// One-shot failure injection: JSON-RPC `method` -> message. When the NEXT
+    /// `request` for that method arrives, the mock returns a real-wire-shaped
+    /// `RpcError::HttpOutcallError(IcError{ code: SysTransient, message })`
+    /// instead of a canned success, then clears the entry. Lets a test
+    /// exercise the IcError decode path end-to-end (the Layer-1 trap).
+    fail_next: HashMap<String, String>,
 }
 
 thread_local! {
@@ -170,6 +303,18 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
     let method = payload["method"].as_str().unwrap_or("");
     let id = payload["id"].clone();
     let params = &payload["params"];
+
+    // One-shot failure injection: if a test armed `fail_next` for this method,
+    // return a REAL-WIRE-SHAPED IcError (the exact value the live EVM RPC
+    // canister returns on a no-consensus HTTPS outcall) and clear the arming.
+    if let Some(msg) = SCRIPT.with(|s| s.borrow_mut().fail_next.remove(method)) {
+        return RequestResult::Err(RpcError::HttpOutcallError(HttpOutcallError::IcError(
+            IcErrorRecord {
+                code: RejectionCode::SysTransient,
+                message: msg,
+            },
+        )));
+    }
 
     let response_json: String = SCRIPT.with(|s| {
         let mut script = s.borrow_mut();
@@ -391,6 +536,61 @@ fn clear_logs() {
     SCRIPT.with(|s| {
         s.borrow_mut().logs.clear();
     });
+}
+
+/// Arm a one-shot real-wire IcError for the NEXT `request` whose JSON-RPC
+/// `method` equals `method`. The mock returns
+/// `RpcError::HttpOutcallError(IcError{ code: SysTransient, message })` and
+/// clears the arming. Lets a test exercise the real IcError decode path
+/// end-to-end (the Layer-1 candid trap).
+#[ic_cdk_macros::update]
+fn fail_next(method: String, message: String) {
+    SCRIPT.with(|s| {
+        s.borrow_mut().fail_next.insert(method, message);
+    });
+}
+
+// ─── Typed `eth_getBlockByNumber` method (consensus-safe probe target) ───────
+
+/// Mirrors the EVM RPC canister's TYPED `eth_getBlockByNumber` method. The
+/// backend's `eth_get_block_number_at` probe calls this with a specific
+/// `BlockTag::Number(n)`. For `Number(n)`: if `n <= finalized_block` the block
+/// exists (return `Consistent(Ok(Block{ number: n }))`); otherwise it models a
+/// future block (return `Consistent(Err(JsonRpcError{ -32000, "block not
+/// found" }))`). The `_services`/`_config` args are ignored (single provider).
+#[ic_cdk_macros::update]
+#[allow(non_snake_case)]
+fn eth_getBlockByNumber(
+    _services: RpcServices,
+    _config: Option<RpcConfig>,
+    tag: BlockTag,
+) -> MultiGetBlockByNumberResult {
+    match tag {
+        BlockTag::Number(n) => {
+            let n_u64 = u64::try_from(n.0.clone()).unwrap_or(u64::MAX);
+            let finalized = SCRIPT.with(|s| s.borrow().finalized_block);
+            if n_u64 <= finalized {
+                MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Ok(Block {
+                    number: candid::Nat::from(n_u64),
+                }))
+            } else {
+                MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Err(
+                    RpcError::JsonRpcError(JsonRpcError {
+                        code: -32000,
+                        message: "block not found".to_string(),
+                    }),
+                ))
+            }
+        }
+        // Volatile tags are exactly what the backend stopped sending; if a test
+        // ever sends one, surface it as an error rather than silently faking.
+        _ => MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Err(
+            RpcError::JsonRpcError(JsonRpcError {
+                code: -32000,
+                message: "mock: only Number(n) tag supported".to_string(),
+            }),
+        )),
+    }
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -1,0 +1,403 @@
+//! Mock EVM RPC canister for the Phase 1b (Monad) PocketIC happy-path test.
+//!
+//! Speaks the REAL EVM RPC canister `request` escape-hatch interface so the
+//! production backend wrapper (`chains/monad/evm_rpc.rs`) can talk to it
+//! unchanged via `set_evm_rpc_principal`. The Candid arg/return types are
+//! copied (minimally) from `evm_rpc.rs` so encode/decode line up byte-for-byte:
+//!
+//!   request : (RpcService, text /*json payload*/, nat64 /*max_bytes*/)
+//!           -> (RequestResult)
+//!
+//! It parses the JSON-RPC `method` out of the `json_payload` string and returns
+//! `RequestResult::Ok("<canned json-rpc response>")` shaped exactly as the
+//! wrapper's parsers expect (verified against `evm_rpc.rs` lines ~343-639).
+//!
+//! Behavior is fully scripted by the test via the `set_*` / `push_log` /
+//! `clear_logs` test-control endpoints, backed by a `thread_local!
+//! RefCell<Script>` (same pattern as `src/xrc_demo/xrc_mock/src/lib.rs`).
+//!
+//! Supported JSON-RPC methods (and the response shape each wrapper fn parses):
+//!   - eth_blockNumber              -> {"result":"0x<latest>"}
+//!   - eth_getBlockByNumber         -> {"result":{"number":"0x<finalized>"}}
+//!   - eth_getBalance               -> {"result":"0x<balance_wei>"}
+//!   - eth_getTransactionCount      -> {"result":"0x<nonce>"}
+//!   - eth_gasPrice                 -> {"result":"0x<gas_price_wei>"}  (fetch_fees)
+//!   - eth_sendRawTransaction       -> {"result":"0x<tx_hash>"} + AUTO-MINE a
+//!                                     successful receipt at the finalized block
+//!   - eth_getTransactionReceipt    -> {"result":{"status":"0x1","blockNumber":
+//!                                     "0x<block>"}} when mined, else null
+//!   - eth_getLogs                  -> {"result":[<log objects>]}, filtered by
+//!                                     the requested fromBlock..toBlock range
+//!
+//! Build:
+//!   cargo build --target wasm32-unknown-unknown --release --package monad_rpc_mock
+
+use candid::{CandidType, Deserialize};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+// ─── Candid types mirrored from chains/monad/evm_rpc.rs (must encode/decode
+//     identically to the backend's local defs) ─────────────────────────────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct EvmRpcHttpHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct RpcApi {
+    pub url: String,
+    pub headers: Option<Vec<EvmRpcHttpHeader>>,
+}
+
+/// Only the `Custom` variant is needed — the backend wrapper always addresses
+/// Monad via `RpcService::Custom(RpcApi { url, headers })`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcService {
+    Custom(RpcApi),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+/// Minimal `RpcError`. The happy-path mock never returns an error, but the
+/// type must exist so `RequestResult`'s candid shape matches the wrapper's.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcError {
+    JsonRpcError(JsonRpcError),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RequestResult {
+    Ok(String),
+    Err(RpcError),
+}
+
+// ─── Scripted state ───────────────────────────────────────────────────────
+
+/// A scripted log entry the mock returns from `eth_getLogs`.
+#[derive(Clone, Debug)]
+struct ScriptedLog {
+    topics: Vec<String>,
+    data: String,
+    tx_hash: String,
+    block: u64,
+}
+
+#[derive(Clone, Debug)]
+struct Receipt {
+    /// status 0x1 (true) vs 0x0 (false, reverted).
+    ok: bool,
+    block: u64,
+}
+
+#[derive(Default)]
+struct Script {
+    latest_block: u64,
+    finalized_block: u64,
+    /// address (lowercased) -> balance in wei.
+    balances: HashMap<String, u128>,
+    /// address (lowercased) -> nonce.
+    nonces: HashMap<String, u64>,
+    /// tx hash (lowercased) -> receipt.
+    receipts: HashMap<String, Receipt>,
+    /// gas price in wei returned by eth_gasPrice (fetch_fees). A sane default
+    /// is seeded in `init` so the settlement submit path never divides by zero.
+    gas_price_wei: u128,
+    /// The hash eth_sendRawTransaction returns for the NEXT broadcast.
+    next_send_hash: Option<String>,
+    /// Scripted logs returned (range-filtered) by eth_getLogs.
+    logs: Vec<ScriptedLog>,
+}
+
+thread_local! {
+    static SCRIPT: RefCell<Script> = RefCell::new(Script::default());
+}
+
+// ─── Init ─────────────────────────────────────────────────────────────────
+
+#[ic_cdk_macros::init]
+fn init() {
+    SCRIPT.with(|s| {
+        let mut s = s.borrow_mut();
+        // 1 gwei default so fetch_fees has a non-zero gas price even if the
+        // test never sets one.
+        s.gas_price_wei = 1_000_000_000;
+    });
+}
+
+// ─── JSON helpers ───────────────────────────────────────────────────────────
+
+fn hex_u128(v: u128) -> String {
+    format!("0x{:x}", v)
+}
+
+fn hex_u64(v: u64) -> String {
+    format!("0x{:x}", v)
+}
+
+/// Parse a 0x-prefixed (or bare) hex quantity into a u64. Used for fromBlock /
+/// toBlock parsing of eth_getLogs filters. Block tags like "latest"/"finalized"
+/// are mapped to the scripted finalized block by the caller; this only handles
+/// the 0x-hex numeric form.
+fn parse_hex_u64(s: &str) -> Option<u64> {
+    let hex = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"))?;
+    u64::from_str_radix(hex, 16).ok()
+}
+
+// ─── The real EVM RPC `request` escape-hatch ─────────────────────────────────
+
+/// Mirrors the EVM RPC canister's generic `request` method. The backend wrapper
+/// calls this via `call_with_payment128(canister, "request", (RpcService, String,
+/// u64), cycles)`. We ignore the `RpcService` url (the test configures exactly
+/// one endpoint; the mock serves all methods) and the `max_bytes` cap, parse the
+/// JSON-RPC `method`, and return a canned response.
+#[ic_cdk_macros::update]
+fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64) -> RequestResult {
+    let payload: serde_json::Value = match serde_json::from_str(&json_payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return RequestResult::Err(RpcError::JsonRpcError(JsonRpcError {
+                code: -32700,
+                message: format!("mock: invalid json payload: {e}"),
+            }))
+        }
+    };
+    let method = payload["method"].as_str().unwrap_or("");
+    let id = payload["id"].clone();
+    let params = &payload["params"];
+
+    let response_json: String = SCRIPT.with(|s| {
+        let mut script = s.borrow_mut();
+        match method {
+            "eth_blockNumber" => {
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
+                    id,
+                    hex_u64(script.latest_block)
+                )
+            }
+            "eth_getBlockByNumber" => {
+                // params = ["finalized", false]. Return a real finalized block
+                // (never null) so the wrapper's finality path uses the number.
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{{"number":{:?}}}}}"#,
+                    id,
+                    hex_u64(script.finalized_block)
+                )
+            }
+            "eth_getBalance" => {
+                // params = [addr, "latest"].
+                let addr = params
+                    .get(0)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                let bal = script.balances.get(&addr).copied().unwrap_or(0);
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
+                    id,
+                    hex_u128(bal)
+                )
+            }
+            "eth_getTransactionCount" => {
+                // params = [addr, "latest"].
+                let addr = params
+                    .get(0)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                let nonce = script.nonces.get(&addr).copied().unwrap_or(0);
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
+                    id,
+                    hex_u64(nonce)
+                )
+            }
+            "eth_gasPrice" => {
+                // fetch_fees parses {"result":"0x<wei>"}.
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
+                    id,
+                    hex_u128(script.gas_price_wei)
+                )
+            }
+            "eth_sendRawTransaction" => {
+                // params = [rawhex]. Return the scripted next hash (default a
+                // deterministic placeholder) and AUTO-MINE a successful receipt
+                // for it at the current finalized block, so the confirm path
+                // immediately sees it mined + final.
+                let tx_hash = script
+                    .next_send_hash
+                    .clone()
+                    .unwrap_or_else(|| "0xmocktx".to_string());
+                let fin = script.finalized_block;
+                script.receipts.insert(
+                    tx_hash.to_lowercase(),
+                    Receipt { ok: true, block: fin },
+                );
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
+                    id, tx_hash
+                )
+            }
+            "eth_getTransactionReceipt" => {
+                // params = [txhash]. Return a receipt when mined, else null.
+                let txhash = params
+                    .get(0)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                match script.receipts.get(&txhash) {
+                    Some(r) => format!(
+                        r#"{{"jsonrpc":"2.0","id":{},"result":{{"status":{:?},"blockNumber":{:?}}}}}"#,
+                        id,
+                        if r.ok { "0x1" } else { "0x0" },
+                        hex_u64(r.block)
+                    ),
+                    None => format!(r#"{{"jsonrpc":"2.0","id":{},"result":null}}"#, id),
+                }
+            }
+            "eth_getLogs" => {
+                // params = [{address, topics, fromBlock, toBlock}]. Filter the
+                // scripted logs by the requested block range; the backend
+                // decoders re-check topic0 + vault_id, so we do not strictly
+                // need to filter by topic, but range-filtering keeps the
+                // mint-confirm log scan (single-block range) precise.
+                let filter = params.get(0).cloned().unwrap_or(serde_json::Value::Null);
+                let from = filter
+                    .get("fromBlock")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_hex_u64);
+                let to = filter
+                    .get("toBlock")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_hex_u64);
+
+                let mut items: Vec<String> = Vec::new();
+                for log in script.logs.iter() {
+                    if let Some(f) = from {
+                        if log.block < f {
+                            continue;
+                        }
+                    }
+                    if let Some(t) = to {
+                        if log.block > t {
+                            continue;
+                        }
+                    }
+                    let topics_json = log
+                        .topics
+                        .iter()
+                        .map(|t| format!("{:?}", t))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    items.push(format!(
+                        r#"{{"topics":[{}],"data":{:?},"transactionHash":{:?},"blockNumber":{:?}}}"#,
+                        topics_json,
+                        log.data,
+                        log.tx_hash,
+                        hex_u64(log.block)
+                    ));
+                }
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":[{}]}}"#,
+                    id,
+                    items.join(",")
+                )
+            }
+            other => {
+                // Unknown method: a JSON-RPC error so an unexpected wrapper call
+                // is loud rather than silently mis-parsed.
+                return format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32601,"message":"mock: unsupported method {}"}}}}"#,
+                    id, other
+                );
+            }
+        }
+    });
+
+    RequestResult::Ok(response_json)
+}
+
+// ─── Test-control endpoints (called by the PocketIC test) ────────────────────
+
+#[ic_cdk_macros::update]
+fn set_blocks(latest: u64, finalized: u64) {
+    SCRIPT.with(|s| {
+        let mut s = s.borrow_mut();
+        s.latest_block = latest;
+        s.finalized_block = finalized;
+    });
+}
+
+#[ic_cdk_macros::update]
+fn set_balance(addr: String, wei: candid::Nat) {
+    let wei_u128 = nat_to_u128(&wei);
+    SCRIPT.with(|s| {
+        s.borrow_mut().balances.insert(addr.to_lowercase(), wei_u128);
+    });
+}
+
+#[ic_cdk_macros::update]
+fn set_nonce(addr: String, n: u64) {
+    SCRIPT.with(|s| {
+        s.borrow_mut().nonces.insert(addr.to_lowercase(), n);
+    });
+}
+
+#[ic_cdk_macros::update]
+fn set_gas_price(wei: candid::Nat) {
+    let wei_u128 = nat_to_u128(&wei);
+    SCRIPT.with(|s| {
+        s.borrow_mut().gas_price_wei = wei_u128;
+    });
+}
+
+#[ic_cdk_macros::update]
+fn set_receipt(txhash: String, ok: bool, block: u64) {
+    SCRIPT.with(|s| {
+        s.borrow_mut()
+            .receipts
+            .insert(txhash.to_lowercase(), Receipt { ok, block });
+    });
+}
+
+#[ic_cdk_macros::update]
+fn set_next_send_hash(h: String) {
+    SCRIPT.with(|s| {
+        s.borrow_mut().next_send_hash = Some(h);
+    });
+}
+
+#[ic_cdk_macros::update]
+fn push_log(topics: Vec<String>, data: String, tx_hash: String, block: u64) {
+    SCRIPT.with(|s| {
+        s.borrow_mut().logs.push(ScriptedLog {
+            topics,
+            data,
+            tx_hash,
+            block,
+        });
+    });
+}
+
+#[ic_cdk_macros::update]
+fn clear_logs() {
+    SCRIPT.with(|s| {
+        s.borrow_mut().logs.clear();
+    });
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/// Convert a `candid::Nat` to u128 (saturating). The wei amounts in this test
+/// (100 * 1e18 = 1e20) exceed u64 but fit comfortably in u128.
+fn nat_to_u128(n: &candid::Nat) -> u128 {
+    use std::convert::TryFrom;
+    u128::try_from(n.0.clone()).unwrap_or(u128::MAX)
+}

--- a/src/rumi_protocol_backend/Cargo.toml
+++ b/src/rumi_protocol_backend/Cargo.toml
@@ -45,6 +45,7 @@ ic-icrc1-ledger = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709
 ic-ledger-canister-core = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arithmetic"] }
 sha3 = "0.10"
+hex = "0.4"
 alloy-rlp = "0.3"
 # TODO(Task 6): add evm_rpc_client once source confirmed — evm_rpc_client 0.4.0 pulls
 # ic-cdk 0.19 which conflicts with this project's ic-cdk 0.12. Needs a fork/patch

--- a/src/rumi_protocol_backend/Cargo.toml
+++ b/src/rumi_protocol_backend/Cargo.toml
@@ -43,6 +43,12 @@ candid_parser = "0.1"
 ic-management-canister-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 ic-icrc1-ledger = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 ic-ledger-canister-core = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arithmetic"] }
+sha3 = "0.10"
+alloy-rlp = "0.3"
+# TODO(Task 6): add evm_rpc_client once source confirmed — evm_rpc_client 0.4.0 pulls
+# ic-cdk 0.19 which conflicts with this project's ic-cdk 0.12. Needs a fork/patch
+# or a DFINITY-provided wasm-compat shim at the same ic-cdk version.
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -914,6 +914,7 @@ service : (ProtocolArg) -> {
   claim_liquidity_returns : () -> (Result_1);
   clear_liquidation_breaker : () -> (Result);
   clear_stuck_operations : (opt principal) -> (Result_1);
+  close_chain_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
   disable_chain : (nat32) -> (Result);
@@ -1097,6 +1098,7 @@ service : (ProtocolArg) -> {
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
+  withdraw_chain_collateral : (nat64, nat, text) -> (Result);
   withdraw_collateral : (nat64) -> (Result_1);
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -120,6 +120,11 @@ type DeviceSpec = variant {
 type ErrorInfo = record { description : text };
 type Event = variant {
   set_borrowing_fee : record { rate : text };
+  supply_invariant_self_check_failed : record {
+    sum_chain_supplies_e8s : nat;
+    total_debt_e8s : nat;
+    timestamp : nat64;
+  };
   VaultWithdrawnAndClosed : record {
     vault_id : nat64;
     timestamp : nat64;
@@ -147,6 +152,15 @@ type Event = variant {
     timestamp : opt nat64;
     caller : opt principal;
   };
+  withdrawal_signed : record {
+    op_id : nat64;
+    recipient : text;
+    vault_id : nat64;
+    amount_e18 : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -164,6 +178,14 @@ type Event = variant {
   set_ckstable_repay_fee : record { rate : text };
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
+  chain_burn_observed : record {
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   set_max_partial_liquidation_ratio : record { rate : text };
   breaker_tripped : record {
     total_e8s : nat64;
@@ -201,6 +223,12 @@ type Event = variant {
   set_collateral_redemption_fee_floor : record {
     redemption_fee_floor : text;
     collateral_type : principal;
+  };
+  chain_settlement_failed : record {
+    op_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    reason : text;
   };
   init : InitArg;
   set_stable_ledger_principal : record {
@@ -286,6 +314,21 @@ type Event = variant {
     collateral_type : principal;
   };
   redistribute_vault : record { vault_id : nat64; timestamp : opt nat64 };
+  chain_mint_confirmed : record {
+    op_id : nat64;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
+  chain_reorg_detected : record {
+    chain_id : nat32;
+    timestamp : nat64;
+    reorg_depth : nat64;
+    observed_block : nat64;
+  };
   partial_collateral_withdrawn : record {
     block_index : nat64;
     vault_id : nat64;
@@ -314,6 +357,12 @@ type Event = variant {
   set_collateral_liquidation_ratio : record {
     collateral_type : principal;
     liquidation_ratio : text;
+  };
+  chain_hot_wallet_low : record {
+    chain_id : nat32;
+    threshold_e18 : nat;
+    timestamp : nat64;
+    balance_e18 : nat;
   };
   dust_forgiven : record {
     vault_id : nat64;
@@ -409,6 +458,15 @@ type Event = variant {
     interest_rate_apr : text;
   };
   set_reserve_redemption_fee : record { fee : text };
+  chain_mint_submitted : record {
+    op_id : nat64;
+    recipient : text;
+    vault_id : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   deficit_repaid : record {
     remaining_deficit : nat64;
     source : FeeSource;
@@ -445,6 +503,15 @@ type Event = variant {
     config : CollateralConfig;
     collateral_type : principal;
   };
+  deposit_observed : record {
+    custody_address : text;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e18 : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   chain_registered : record {
     display_name : text;
     chain_id : nat32;
@@ -459,11 +526,6 @@ type Event = variant {
     token_type : StableTokenType;
   };
   set_recovery_cr_multiplier : record { multiplier : text };
-  supply_invariant_self_check_failed : record {
-    sum_chain_supplies_e8s : nat;
-    total_debt_e8s : nat;
-    timestamp : nat64;
-  };
 };
 type EventTimeRange = record { start_ns : nat64; end_ns : nat64 };
 type EventTypeFilter = variant {
@@ -942,6 +1004,7 @@ service : (ProtocolArg) -> {
   liquidate_vault : (nat64) -> (Result_3);
   liquidate_vault_partial : (VaultArg) -> (Result_3);
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
+  open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_vault : (nat64, opt principal) -> (Result_9);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_9);
   open_vault_with_deposit : (nat64, opt principal) -> (Result_9);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -976,6 +976,7 @@ service : (ProtocolArg) -> {
   get_icpswap_routing_enabled : () -> (bool) query;
   get_interest_pool_share : () -> (float64) query;
   get_interest_split : () -> (vec InterestSplitArg) query;
+  get_last_observed_block : (nat32) -> (nat64) query;
   get_liquidatable_vaults : () -> (vec CandidVault) query;
   get_liquidatable_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_liquidation_bonus : () -> (float64) query;
@@ -1083,6 +1084,7 @@ service : (ProtocolArg) -> {
   set_interest_rate : (principal, float64) -> (Result);
   set_interest_split : (vec InterestSplitArg) -> (Result);
   set_interest_treasury_tick_interval_secs : (nat64) -> (Result);
+  set_last_observed_block : (nat32, nat64) -> (Result);
   set_liquidation_bonus : (float64) -> (Result);
   set_liquidation_bot_config : (principal, nat64) -> (Result);
   set_liquidation_frozen : (bool) -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1092,6 +1092,7 @@ service : (ProtocolArg) -> {
   set_manual_collateral_price : (nat32, text, nat64) -> (Result);
   set_min_icusd_amount : (nat64) -> (Result);
   set_min_xrc_sources_used : (nat32) -> (Result);
+  set_observer_tick_interval_secs : (nat64) -> (Result);
   set_rate_curve_markers : (opt principal, vec record { float64; float64 }) -> (
       Result,
     );
@@ -1108,6 +1109,7 @@ service : (ProtocolArg) -> {
   set_rmr_ceiling_cr : (float64) -> (Result);
   set_rmr_floor : (float64) -> (Result);
   set_rmr_floor_cr : (float64) -> (Result);
+  set_settlement_tick_interval_secs : (nat64) -> (Result);
   set_sp_writedown_disabled : (bool) -> (Result);
   set_stability_pool_principal : (principal) -> (Result);
   set_stable_ledger_principal : (StableTokenType, principal) -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,25 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainVaultStatus = variant {
+  MintPending;
+  Open;
+  Closed;
+  Closing;
+  AwaitingDeposit;
+};
+type ChainVaultV1 = record {
+  status : ChainVaultStatus;
+  owner : principal;
+  pending_mint_e8s : nat;
+  custody_address : text;
+  collateral_amount_e18 : nat;
+  opened_at_ns : nat64;
+  vault_id : nat64;
+  collateral_chain : nat32;
+  mint_recipient : text;
+  debt_e8s : nat;
+};
 type CollateralConfig = record {
   last_redemption_time : nat64;
   status : CollateralStatus;
@@ -912,11 +931,14 @@ service : (ProtocolArg) -> {
   bot_claim_liquidation : (nat64) -> (Result_4);
   bot_confirm_liquidation : (nat64) -> (Result);
   claim_liquidity_returns : () -> (Result_1);
+  clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
+  clear_reorg_halt : (nat32) -> (Result);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_chain_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
+  delete_chain : (nat32) -> (Result);
   disable_chain : (nat32) -> (Result);
   enter_recovery_mode : () -> (Result);
   exit_recovery_mode : () -> (Result);
@@ -929,6 +951,8 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_settlement_address : (nat32) -> (Result_2);
+  get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
@@ -1005,6 +1029,7 @@ service : (ProtocolArg) -> {
   liquidate_vault : (nat64) -> (Result_3);
   liquidate_vault_partial : (VaultArg) -> (Result_3);
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
+  list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_vault : (nat64, opt principal) -> (Result_9);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_9);
@@ -1030,6 +1055,7 @@ service : (ProtocolArg) -> {
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
+  set_chain_contract : (nat32, text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
@@ -1048,6 +1074,7 @@ service : (ProtocolArg) -> {
   set_collateral_status : (principal, CollateralStatus) -> (Result);
   set_deficit_readonly_threshold_e8s : (nat64) -> (Result);
   set_deficit_repayment_fraction : (float64) -> (Result);
+  set_evm_rpc_principal : (principal) -> (Result);
   set_global_icusd_mint_cap : (nat64) -> (Result);
   set_healthy_cr : (principal, opt float64) -> (Result);
   set_icpswap_routing_enabled : (bool) -> (Result);
@@ -1062,6 +1089,7 @@ service : (ProtocolArg) -> {
   set_liquidation_ordering_tolerance : (nat64) -> (Result);
   set_liquidation_protocol_share : (float64) -> (Result);
   set_lst_haircut : (principal, float64) -> (Result);
+  set_manual_collateral_price : (nat32, text, nat64) -> (Result);
   set_min_icusd_amount : (nat64) -> (Result);
   set_min_xrc_sources_used : (nat32) -> (Result);
   set_rate_curve_markers : (opt principal, vec record { float64; float64 }) -> (

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -7,11 +7,11 @@ use super::config::{
     ChainAdminError, ChainConfigV1, ChainId, ChainStatus, RegisterChainArg,
     UpdateChainConfigArg,
 };
-use super::multi_chain_state::MultiChainStateV1;
+use super::multi_chain_state::MultiChainStateV2;
 use super::settlement_queue::SettlementQueueV1;
 
 pub fn register_chain_in_state(
-    state: &mut MultiChainStateV1,
+    state: &mut MultiChainStateV2,
     arg: RegisterChainArg,
     now_ns: u64,
 ) -> Result<ChainConfigV1, ChainAdminError> {
@@ -40,7 +40,7 @@ pub fn register_chain_in_state(
 }
 
 pub fn disable_chain_in_state(
-    state: &mut MultiChainStateV1,
+    state: &mut MultiChainStateV2,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     let cfg = state
@@ -52,7 +52,7 @@ pub fn disable_chain_in_state(
 }
 
 pub fn update_chain_config_in_state(
-    state: &mut MultiChainStateV1,
+    state: &mut MultiChainStateV2,
     chain_id: ChainId,
     update: UpdateChainConfigArg,
 ) -> Result<(), ChainAdminError> {

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -51,6 +51,46 @@ pub fn disable_chain_in_state(
     Ok(())
 }
 
+/// Remove a chain entirely. Only permitted when the chain carries ZERO supply
+/// and NO chain_vaults reference it (so deletion cannot orphan debt/collateral).
+///
+/// Purges the chain from EVERY per-chain map (a stale entry left in any of them
+/// would be a silent state leak). All-or-nothing: every rejection path returns
+/// before the first mutation, so a refused delete leaves the chain fully intact.
+pub fn delete_chain_in_state(
+    state: &mut MultiChainStateV2,
+    chain_id: ChainId,
+) -> Result<(), ChainAdminError> {
+    if !state.chain_configs.contains_key(&chain_id) {
+        return Err(ChainAdminError::ChainNotRegistered(chain_id));
+    }
+    let supply = state.chain_supplies.get(&chain_id).copied().unwrap_or(0);
+    if supply != 0 {
+        return Err(ChainAdminError::InvalidConfig(format!(
+            "chain {} has nonzero supply {}",
+            chain_id.0, supply
+        )));
+    }
+    if state.chain_vaults.values().any(|v| v.collateral_chain == chain_id) {
+        return Err(ChainAdminError::InvalidConfig(format!(
+            "chain {} still has vaults",
+            chain_id.0
+        )));
+    }
+    // Remove from EVERY per-chain map (a stale entry in any of these is a leak).
+    state.chain_configs.remove(&chain_id);
+    state.chain_supplies.remove(&chain_id);
+    state.settlement_queues.remove(&chain_id);
+    state.chain_contracts.remove(&chain_id);
+    state.last_observed_block.remove(&chain_id);
+    state.hot_wallet_balance_e18.remove(&chain_id);
+    state.reorg_halted.remove(&chain_id);
+    state.reorg_suspect_streak.remove(&chain_id); // Task-11 reorg-debounce streak
+    // manual_prices is keyed by (ChainId, String) — drop all entries for this chain.
+    state.manual_prices.retain(|(c, _), _| *c != chain_id);
+    Ok(())
+}
+
 pub fn update_chain_config_in_state(
     state: &mut MultiChainStateV2,
     chain_id: ChainId,

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod multi_chain_state;
 pub mod settlement_queue;
 pub mod supply;
+pub mod monad;
 
 pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -21,7 +21,7 @@ pub mod monad;
 
 pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};
-pub use multi_chain_state::{MultiChainState, MultiChainStateV1};
+pub use multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
 pub use settlement_queue::{SettlementOp, SettlementQueueV1};
 pub use supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
 
@@ -36,6 +36,9 @@ mod tests_settlement_queue;
 
 #[cfg(test)]
 mod tests_multi_chain_state;
+
+#[cfg(test)]
+mod tests_multi_chain_state_v2;
 
 #[cfg(test)]
 mod tests_supply;

--- a/src/rumi_protocol_backend/src/chains/monad/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/adapter.rs
@@ -129,22 +129,26 @@ impl ChainAdapter for MonadAdapter {
         // 3. Fetch fee estimates.
         let (base_fee, prio) = self.build_fees().await?;
 
-        // 4. Build EIP-1559 fields for a plain native transfer.
+        // 4. Build EIP-1559 fields for a plain native transfer via the shared
+        //    builder (tx::build_eip1559_fields) — the single source of truth for
+        //    the per-op-kind field shape, so the settlement worker's submit and a
+        //    replace-by-fee resubmit build byte-identical transactions.
         //    gas_limit = 21_000 (standard ETH/EVM native transfer).
         //    max_fee = 2 * base_fee + priority_fee (headroom for base-fee spikes).
         //
         //    NOTE: `value` carries req.amount_e8s, which is the MON amount in
         //    wei (e18).  The field name is a known wart; see doc comment above.
-        let fields = tx::Eip1559Fields {
-            chain_id: self.chain_id.0 as u64,
+        let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
+        let fields = tx::build_eip1559_fields(
+            self.chain_id.0 as u64,
+            tx::MonadTxKind::NativeWithdrawal {
+                recipient: &req.recipient,
+                amount_wei: req.amount_e8s, // wart: see doc comment above
+            },
             nonce,
-            max_priority_fee_per_gas: prio,
-            max_fee_per_gas: base_fee.saturating_mul(2).saturating_add(prio),
-            gas_limit: 21_000,
-            to: req.recipient,
-            value: req.amount_e8s, // wart: see doc comment above
-            data: vec![],
-        };
+            prio,
+            max_fee,
+        );
 
         // 5. Sign.
         let raw = tx::sign_eip1559(&fields, path, &settlement_addr)
@@ -182,23 +186,26 @@ impl ChainAdapter for MonadAdapter {
         // 4. Fetch fee estimates.
         let (base_fee, prio) = self.build_fees().await?;
 
-        // 5. Build calldata for mint(address to, uint256 amount, uint64 vault_id).
-        let data =
-            tx::encode_mint_calldata(&instr.recipient, instr.amount_e8s, instr.vault_id);
-
-        // 6. Build EIP-1559 fields.
-        let fields = tx::Eip1559Fields {
-            chain_id: self.chain_id.0 as u64,
+        // 5. Build EIP-1559 fields (calldata + gas + to + value) via the shared
+        //    builder (tx::build_eip1559_fields) — the single source of truth for
+        //    the per-op-kind field shape, shared with the settlement worker so a
+        //    submit and a replace-by-fee resubmit are byte-identical.
+        //    gas_limit = 120_000; max_fee = 2 * base_fee + priority_fee.
+        let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
+        let fields = tx::build_eip1559_fields(
+            self.chain_id.0 as u64,
+            tx::MonadTxKind::Mint {
+                contract: &contract,
+                recipient: &instr.recipient,
+                amount_e8s: instr.amount_e8s,
+                vault_id: instr.vault_id,
+            },
             nonce,
-            max_priority_fee_per_gas: prio,
-            max_fee_per_gas: base_fee.saturating_mul(2).saturating_add(prio),
-            gas_limit: 120_000,
-            to: contract,
-            value: 0,
-            data,
-        };
+            prio,
+            max_fee,
+        );
 
-        // 7. Sign.
+        // 6. Sign.
         let raw = tx::sign_eip1559(&fields, path, &settlement_addr)
             .await
             .map_err(ChainAdapterError::SignatureFailed)?;

--- a/src/rumi_protocol_backend/src/chains/monad/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/adapter.rs
@@ -148,7 +148,8 @@ impl ChainAdapter for MonadAdapter {
             nonce,
             prio,
             max_fee,
-        );
+        )
+        .map_err(ChainAdapterError::SignatureFailed)?;
 
         // 5. Sign.
         let raw = tx::sign_eip1559(&fields, path, &settlement_addr)
@@ -203,7 +204,8 @@ impl ChainAdapter for MonadAdapter {
             nonce,
             prio,
             max_fee,
-        );
+        )
+        .map_err(ChainAdapterError::SignatureFailed)?;
 
         // 6. Sign.
         let raw = tx::sign_eip1559(&fields, path, &settlement_addr)

--- a/src/rumi_protocol_backend/src/chains/monad/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/adapter.rs
@@ -1,0 +1,2 @@
+//! MonadAdapter placeholder. Real impl in Task 8.
+pub struct MonadAdapter;

--- a/src/rumi_protocol_backend/src/chains/monad/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/adapter.rs
@@ -1,2 +1,250 @@
-//! MonadAdapter placeholder. Real impl in Task 8.
-pub struct MonadAdapter;
+//! `MonadAdapter`: Phase 1b implementation of `ChainAdapter` for Monad testnet.
+//!
+//! Wires the tested tECDSA, EVM RPC, and EIP-1559 primitives from this module
+//! into the six `ChainAdapter` trait methods required by the protocol.
+//!
+//! ## Signing model
+//! The settlement key (one per chain, derived via `settlement_derivation_path`)
+//! acts as the on-chain minter/relayer.  Phase 1b only needs to *build and sign*
+//! transactions; broadcasting is handled by the settlement worker (Task 13).
+//!
+//! ## Phase scope
+//! - `sign_mint`: builds + signs the `mint(address,uint256,uint64)` call on the
+//!   icUSD EVM contract.
+//! - `sign_withdrawal`: builds + signs a native MON transfer to the recipient.
+//! - `sign_burn`: reserved; Phase 1b burns are user-initiated on-chain.
+//! - `observe_event`: delegated to the dedicated observer (Task 9).
+//! - `verify_deposit` / `fetch_finality`: use EVM RPC reads.
+
+use async_trait::async_trait;
+use candid::Principal;
+
+use crate::chains::adapter::{
+    ChainAdapter, ChainAdapterError, DepositRecord, FinalitySnapshot, MintInstruction,
+    SignedBurn, SignedMint, SignedWithdrawal, WithdrawalRequest,
+};
+use crate::chains::config::ChainId;
+use crate::state::read_state;
+
+use super::{evm_rpc, tecdsa, tx};
+
+// ─── MonadAdapter ────────────────────────────────────────────────────────────
+
+/// Adapter binding the Monad chain to the Rumi protocol.
+pub struct MonadAdapter {
+    chain_id: ChainId,
+}
+
+impl MonadAdapter {
+    /// Create a new `MonadAdapter` for the given chain id.
+    ///
+    /// In production this is always `MONAD_CHAIN_ID` (10143); tests may pass an
+    /// arbitrary id for isolation.
+    pub fn new(chain_id: ChainId) -> Self {
+        MonadAdapter { chain_id }
+    }
+
+    // ─── private helpers ─────────────────────────────────────────────────────
+
+    /// Return the deployed icUSD contract address for this chain, or an error
+    /// if it has not yet been registered via `set_chain_contract`.
+    fn icusd_contract(&self) -> Result<String, ChainAdapterError> {
+        read_state(|s| s.multi_chain.chain_contracts.get(&self.chain_id).cloned())
+            .ok_or_else(|| ChainAdapterError::InvalidPayload("icUSD contract not set".to_string()))
+    }
+
+    /// Fetch (base_fee_wei, priority_fee_wei) from the EVM RPC canister.
+    async fn build_fees(&self) -> Result<(u128, u128), ChainAdapterError> {
+        evm_rpc::fetch_fees(self.chain_id)
+            .await
+            .map_err(|message| ChainAdapterError::RpcError {
+                provider: "evm_rpc".to_string(),
+                message,
+            })
+    }
+}
+
+// ─── ChainAdapter impl ────────────────────────────────────────────────────────
+
+#[async_trait(?Send)]
+impl ChainAdapter for MonadAdapter {
+    fn chain_id(&self) -> ChainId {
+        self.chain_id
+    }
+
+    /// Check whether `tx_hash` has been mined and succeeded on-chain.
+    ///
+    /// Returns a `DepositRecord` with `block_number` populated when mined.
+    /// `amount_e8s` and `depositor` are left at defaults (0 / empty string) —
+    /// the observer (Task 9) decodes those from the event log with full ABI
+    /// context; `verify_deposit` is used by the vault path only to confirm
+    /// finality, not to parse amounts.
+    async fn verify_deposit(&self, tx_hash: &str) -> Result<DepositRecord, ChainAdapterError> {
+        match evm_rpc::get_transaction_receipt(self.chain_id, tx_hash).await {
+            Ok(Some((true, block_number))) => Ok(DepositRecord {
+                depositor: String::new(),
+                amount_e8s: 0,
+                block_number,
+                tx_hash: tx_hash.to_string(),
+            }),
+            Ok(Some((false, _))) => Err(ChainAdapterError::InvalidPayload(
+                "deposit transaction reverted".to_string(),
+            )),
+            Ok(None) => Err(ChainAdapterError::InvalidPayload(
+                "deposit not mined".to_string(),
+            )),
+            Err(message) => Err(ChainAdapterError::RpcError {
+                provider: "evm_rpc".to_string(),
+                message,
+            }),
+        }
+    }
+
+    /// Build and sign a native MON transfer to `req.recipient`.
+    ///
+    /// # Amount note
+    /// `WithdrawalRequest.amount_e8s` carries the MON amount in its native
+    /// denomination (e18 wei for MON) as a known field-name wart.  Task 13
+    /// refines this with a `NativeWithdrawal` variant that makes the unit
+    /// explicit.  For now the value is passed through unchanged as the EIP-1559
+    /// `value` field, which the EVM interprets as wei.
+    async fn sign_withdrawal(
+        &self,
+        req: WithdrawalRequest,
+    ) -> Result<SignedWithdrawal, ChainAdapterError> {
+        // 1. Derive the settlement (minter) address.
+        let path = tecdsa::settlement_derivation_path(self.chain_id);
+        let (_, settlement_addr) = tecdsa::derive_evm_address(path.clone())
+            .await
+            .map_err(ChainAdapterError::SignatureFailed)?;
+
+        // 2. Fetch nonce for the settlement account.
+        let nonce = evm_rpc::get_transaction_count(self.chain_id, &settlement_addr)
+            .await
+            .map_err(|message| ChainAdapterError::RpcError {
+                provider: "evm_rpc".to_string(),
+                message,
+            })?;
+
+        // 3. Fetch fee estimates.
+        let (base_fee, prio) = self.build_fees().await?;
+
+        // 4. Build EIP-1559 fields for a plain native transfer.
+        //    gas_limit = 21_000 (standard ETH/EVM native transfer).
+        //    max_fee = 2 * base_fee + priority_fee (headroom for base-fee spikes).
+        //
+        //    NOTE: `value` carries req.amount_e8s, which is the MON amount in
+        //    wei (e18).  The field name is a known wart; see doc comment above.
+        let fields = tx::Eip1559Fields {
+            chain_id: self.chain_id.0 as u64,
+            nonce,
+            max_priority_fee_per_gas: prio,
+            max_fee_per_gas: base_fee.saturating_mul(2).saturating_add(prio),
+            gas_limit: 21_000,
+            to: req.recipient,
+            value: req.amount_e8s, // wart: see doc comment above
+            data: vec![],
+        };
+
+        // 5. Sign.
+        let raw = tx::sign_eip1559(&fields, path, &settlement_addr)
+            .await
+            .map_err(ChainAdapterError::SignatureFailed)?;
+
+        Ok(SignedWithdrawal {
+            raw_tx: raw.into_bytes(),
+            tx_hash: String::new(), // populated by the broadcaster (Task 13)
+        })
+    }
+
+    /// Build and sign a `mint(address,uint256,uint64)` call on the icUSD contract.
+    ///
+    /// gas_limit = 120_000 — generous for a typical ERC-20-style mint call,
+    /// covers the vault-id event emission and any SSTORE on first-mint paths.
+    async fn sign_mint(&self, instr: MintInstruction) -> Result<SignedMint, ChainAdapterError> {
+        // 1. Resolve the icUSD contract.
+        let contract = self.icusd_contract()?;
+
+        // 2. Derive the settlement (minter) address.
+        let path = tecdsa::settlement_derivation_path(self.chain_id);
+        let (_, settlement_addr) = tecdsa::derive_evm_address(path.clone())
+            .await
+            .map_err(ChainAdapterError::SignatureFailed)?;
+
+        // 3. Fetch nonce.
+        let nonce = evm_rpc::get_transaction_count(self.chain_id, &settlement_addr)
+            .await
+            .map_err(|message| ChainAdapterError::RpcError {
+                provider: "evm_rpc".to_string(),
+                message,
+            })?;
+
+        // 4. Fetch fee estimates.
+        let (base_fee, prio) = self.build_fees().await?;
+
+        // 5. Build calldata for mint(address to, uint256 amount, uint64 vault_id).
+        let data =
+            tx::encode_mint_calldata(&instr.recipient, instr.amount_e8s, instr.vault_id);
+
+        // 6. Build EIP-1559 fields.
+        let fields = tx::Eip1559Fields {
+            chain_id: self.chain_id.0 as u64,
+            nonce,
+            max_priority_fee_per_gas: prio,
+            max_fee_per_gas: base_fee.saturating_mul(2).saturating_add(prio),
+            gas_limit: 120_000,
+            to: contract,
+            value: 0,
+            data,
+        };
+
+        // 7. Sign.
+        let raw = tx::sign_eip1559(&fields, path, &settlement_addr)
+            .await
+            .map_err(ChainAdapterError::SignatureFailed)?;
+
+        Ok(SignedMint {
+            raw_tx: raw.into_bytes(),
+            tx_hash: String::new(), // populated by the broadcaster (Task 13)
+        })
+    }
+
+    /// Phase 1b: burns are user-initiated on-chain (the user calls `burn()` on
+    /// the icUSD EVM contract directly).  The canister never signs a burn in
+    /// Phase 1b.  This slot is reserved for a Phase 1c SP-backstop burn where
+    /// the canister might need to burn icUSD held by the settlement address.
+    async fn sign_burn(
+        &self,
+        _amount_e8s: u128,
+        _burner: Principal,
+    ) -> Result<SignedBurn, ChainAdapterError> {
+        Err(ChainAdapterError::NotImplemented)
+    }
+
+    /// Return the latest and finalized block numbers for the chain.
+    async fn fetch_finality(&self) -> Result<FinalitySnapshot, ChainAdapterError> {
+        let (latest_block, finalized_block) = evm_rpc::fetch_block_numbers(self.chain_id)
+            .await
+            .map_err(|message| ChainAdapterError::RpcError {
+                provider: "evm_rpc".to_string(),
+                message,
+            })?;
+        Ok(FinalitySnapshot {
+            latest_block,
+            finalized_block,
+        })
+    }
+
+    /// Deposit / burn log observation is handled by the dedicated observer
+    /// (Task 9) which holds typed state for cursor tracking and does typed log
+    /// decoding via `decode_burn_log` / `decode_mint_log`.  This trait method
+    /// satisfies the interface contract; callers that need events should use
+    /// the observer directly.
+    async fn observe_event(
+        &self,
+        from_block: u64,
+    ) -> Result<Vec<DepositRecord>, ChainAdapterError> {
+        let _ = from_block; // cursor is managed by the observer, not this method
+        Ok(vec![])
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -1,0 +1,8 @@
+//! Monad vault record. Real impl in Task 3.
+#[derive(Clone, Debug)]
+pub enum ChainVaultStatus { MintPending, Open, Closing, Closed }
+
+#[derive(Clone, Debug)]
+pub struct ChainVaultV1 {
+    pub vault_id: u64,
+}

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -10,11 +10,26 @@
 //! observed at finality (settlement worker, Task 10).
 
 use crate::chains::config::ChainId;
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 
+/// Minimum collateral ratio (e4: 13000 == 130.00%) required to open a Monad
+/// chain vault. Checked against DECLARED collateral at open time. Per-collateral
+/// configurability is a later refinement (Phase 2 unifies the foreign-chain and
+/// ICP-native CDP parameter models).
+pub const MONAD_MIN_CR_E4: u64 = 13_000;
+
+/// 1e18 — the wei scale of EVM-native (MON) collateral amounts.
+const E18: u128 = 1_000_000_000_000_000_000;
+
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum ChainVaultStatus {
+    /// Vault opened; awaiting the on-chain collateral deposit. No mint enqueued
+    /// yet (open-then-verify). deposit-watch flips this to MintPending once the
+    /// custody-address balance covers the declared collateral at finality.
+    AwaitingDeposit,
     MintPending,
     Open,
     Closing,
@@ -37,4 +52,185 @@ pub struct ChainVaultV1 {
     pub pending_mint_e8s: u128,
     pub status: ChainVaultStatus,
     pub opened_at_ns: u64,
+}
+
+/// Reasons `open_chain_vault_in_state` / `verify_deposit_and_enqueue_mint_in_state`
+/// can reject. Kept distinct from `ChainAdminError` so the open path can report
+/// CR-specific failures the caller can surface.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OpenVaultError {
+    /// The collateral chain is not registered in `chain_configs`.
+    UnknownChain,
+    /// No manual MON price is set for the chain (`manual_prices[(chain,"MON")]`).
+    NoPrice,
+    /// Declared collateral ratio is below the minimum.
+    BelowMinCr { cr_e4: u64, min_e4: u64 },
+    /// Enqueuing the Mint op failed (e.g. duplicate idempotency key).
+    QueueError(String),
+    /// `verify_deposit_and_enqueue_mint_in_state` could not find the vault.
+    UnknownVault,
+}
+
+/// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
+///
+/// `collateral_e18` is the native-gas-asset amount in wei (1e18 scale).
+/// `price_e8` is the asset's USD price as e8 (e.g. $2.00 == 2_0000_0000).
+/// `debt_e8s` is the icUSD debt as e8s.
+///
+/// Returns `u64::MAX` when `debt_e8s == 0` (an unbounded ratio; a debt-free
+/// vault is trivially over-collateralized). All arithmetic saturates so an
+/// adversarial (or merely huge) input can never panic.
+pub fn collateral_ratio_e4(collateral_e18: u128, price_e8: u64, debt_e8s: u128) -> u64 {
+    if debt_e8s == 0 {
+        return u64::MAX;
+    }
+    // collateral_usd_e8 = collateral_e18 * price_e8 / 1e18. Both operands are
+    // already in their respective fixed-point scales; dividing by 1e18 drops the
+    // wei scale and leaves a USD value in e8. Saturating so a colossal collateral
+    // input cannot overflow.
+    let collateral_usd_e8 = collateral_e18
+        .saturating_mul(price_e8 as u128)
+        / E18;
+    // cr_e4 = collateral_usd_e8 / debt_e8s * 10_000. Multiply first (saturating)
+    // then divide so we keep e4 precision; both are e8 so the e8 scales cancel.
+    let cr = collateral_usd_e8.saturating_mul(10_000) / debt_e8s;
+    cr.min(u64::MAX as u128) as u64
+}
+
+/// Open a foreign-chain vault in the `AwaitingDeposit` state (open-then-verify).
+///
+/// CR-checks the DECLARED collateral against `min_cr_e4`. On success, inserts a
+/// `ChainVaultV1` with:
+/// - `status = AwaitingDeposit`
+/// - `collateral_amount_e18 = collateral_e18` (the declared amount)
+/// - `debt_e8s = 0` (no confirmed debt until the mint is observed at finality)
+/// - `pending_mint_e8s = debt_e8s` (the INTENDED mint amount, surfaced for
+///   deposit-watch to enqueue once the on-chain deposit is verified)
+///
+/// **Enqueues NOTHING.** icUSD is only minted against a verified on-chain
+/// deposit; the mint-enqueue lives in `verify_deposit_and_enqueue_mint_in_state`
+/// (driven by deposit-watch), NOT here.
+///
+/// Rejections (no mutation on any error path):
+/// - chain not in `chain_configs` -> `UnknownChain`
+/// - no `manual_prices[(chain,"MON")]` -> `NoPrice`
+/// - declared CR `< min_cr_e4` -> `BelowMinCr`
+#[allow(clippy::too_many_arguments)]
+pub fn open_chain_vault_in_state(
+    state: &mut MultiChainStateV2,
+    chain: ChainId,
+    owner: Principal,
+    custody_address: String,
+    collateral_e18: u128,
+    debt_e8s: u128,
+    mint_recipient: String,
+    min_cr_e4: u64,
+    now_ns: u64,
+    vault_id: u64,
+) -> Result<(), OpenVaultError> {
+    // Reject an unregistered chain before reading anything else.
+    if !state.chain_configs.contains_key(&chain) {
+        return Err(OpenVaultError::UnknownChain);
+    }
+    // MON price (USD e8) for the declared-collateral CR check.
+    let price_e8 = *state
+        .manual_prices
+        .get(&(chain, "MON".to_string()))
+        .ok_or(OpenVaultError::NoPrice)?;
+
+    let cr_e4 = collateral_ratio_e4(collateral_e18, price_e8, debt_e8s);
+    if cr_e4 < min_cr_e4 {
+        return Err(OpenVaultError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+    }
+
+    state.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner,
+            collateral_chain: chain,
+            custody_address,
+            collateral_amount_e18: collateral_e18,
+            // Design B: no confirmed debt until the on-chain mint is observed.
+            debt_e8s: 0,
+            mint_recipient,
+            // The INTENDED mint amount. deposit-watch enqueues exactly this once
+            // the custody-address balance covers the declared collateral.
+            pending_mint_e8s: debt_e8s,
+            status: ChainVaultStatus::AwaitingDeposit,
+            opened_at_ns: now_ns,
+        },
+    );
+    // No mint enqueued — that happens in verify_deposit_and_enqueue_mint_in_state.
+    Ok(())
+}
+
+/// Verify an observed custody-address balance and (if it covers the declared
+/// collateral) flip an `AwaitingDeposit` vault to `MintPending` and enqueue its
+/// `Mint` op. Driven by the deposit-watch loop.
+///
+/// Returns:
+/// - `Ok(true)`  — transitioned + enqueued exactly one Mint.
+/// - `Ok(false)` — no-op: either the vault is not `AwaitingDeposit` (already
+///   processed; idempotent) OR the observed balance does not yet cover the
+///   declared collateral.
+/// - `Err(UnknownVault)` — no such vault.
+/// - `Err(QueueError)`   — enqueue rejected (e.g. duplicate idempotency key).
+///
+/// ## Mutation ordering (no-mutation-on-rejection guarantee)
+///
+/// The enqueue runs FIRST (it can fail on a duplicate idempotency key). Only
+/// after a successful enqueue does the status flip to `MintPending`. So a
+/// rejected enqueue leaves the vault `AwaitingDeposit` and the queue unchanged,
+/// and the next deposit-watch tick retries cleanly.
+pub fn verify_deposit_and_enqueue_mint_in_state(
+    state: &mut MultiChainStateV2,
+    vault_id: u64,
+    observed_balance_e18: u128,
+    now_ns: u64,
+) -> Result<bool, OpenVaultError> {
+    // Read-only validation first — no mutation on any rejection / no-op path.
+    let (chain, recipient, amount_e8s, declared_e18) = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(OpenVaultError::UnknownVault)?;
+        // Idempotent: anything other than AwaitingDeposit was already processed.
+        if v.status != ChainVaultStatus::AwaitingDeposit {
+            return Ok(false);
+        }
+        (
+            v.collateral_chain,
+            v.mint_recipient.clone(),
+            v.pending_mint_e8s,
+            v.collateral_amount_e18,
+        )
+    };
+
+    // Not enough on-chain collateral yet — no mutation, retry next tick.
+    if observed_balance_e18 < declared_e18 {
+        return Ok(false);
+    }
+
+    // Enqueue FIRST (it can fail on a duplicate idempotency key). The key is
+    // per (chain, vault) so a retried tick cannot double-enqueue.
+    let op = SettlementOp::new(
+        SettlementOpKind::Mint { recipient, amount_e8s, vault_id },
+        format!("mint-{}-{}", chain.0, vault_id),
+        now_ns,
+    );
+    state
+        .settlement_queues
+        .entry(chain)
+        .or_default()
+        .enqueue(op)
+        .map_err(|e| OpenVaultError::QueueError(format!("{e:?}")))?;
+
+    // Only after a successful enqueue: flip the vault to MintPending.
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.status = ChainVaultStatus::MintPending;
+    Ok(true)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -72,6 +72,11 @@ pub enum OpenVaultError {
     QueueError(String),
     /// `verify_deposit_and_enqueue_mint_in_state` could not find the vault.
     UnknownVault,
+    /// The developer-supplied `mint_recipient` is not a well-formed EVM address
+    /// (`0x` + 40 hex). Rejected at the boundary so it can never reach the
+    /// tx-building helpers (`tx::abi_word_address`), which panic on malformed
+    /// hex/length deep on the settlement worker path. Carries the bad address.
+    InvalidAddress(String),
 }
 
 /// Reasons `withdraw_collateral_in_state` / `close_chain_vault_in_state` can
@@ -90,6 +95,11 @@ pub enum WithdrawError {
     QueueError(String),
     /// `close_chain_vault_in_state` was called on a vault with non-zero debt.
     HasDebt,
+    /// The developer-supplied `dest_address` is not a well-formed EVM address
+    /// (`0x` + 40 hex). Rejected at the boundary so it can never reach the
+    /// tx-building helpers (`tx::parse_address`), which panic on malformed
+    /// hex/length deep on the settlement worker path. Carries the bad address.
+    InvalidAddress(String),
     /// Withdraw was attempted on a vault whose status is not `Open`. Only an
     /// `Open` vault has confirmed, on-chain-deposited collateral and confirmed
     /// debt; an `AwaitingDeposit` vault holds DECLARED-but-never-deposited
@@ -166,6 +176,14 @@ pub fn open_chain_vault_in_state(
     // positive debt is already rejected below by the CR check.)
     if debt_e8s == 0 {
         return Err(OpenVaultError::ZeroDebt);
+    }
+    // Reject a malformed developer-supplied mint recipient BEFORE it enters
+    // state. An unvalidated address would later panic the tx-building helpers
+    // (`tx::abi_word_address`) deep on the settlement worker path, after the
+    // re-entrancy guard + awaits, permanently blocking the chain's worker.
+    // (`custody_address` is tECDSA-derived and always valid — do NOT validate it.)
+    if !crate::chains::monad::tecdsa::is_valid_evm_address(&mint_recipient) {
+        return Err(OpenVaultError::InvalidAddress(mint_recipient));
     }
     // MON price (USD e8) for the declared-collateral CR check.
     let price_e8 = *state
@@ -358,6 +376,15 @@ pub fn withdraw_collateral_in_state(
         if cr_e4 < min_cr_e4 {
             return Err(WithdrawError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
         }
+    }
+
+    // Reject a malformed developer-supplied destination BEFORE enqueuing. An
+    // unvalidated address would later panic the tx-building helper
+    // (`tx::parse_address`) deep on the settlement worker path, after the
+    // re-entrancy guard + awaits, permanently blocking the chain's worker. This
+    // is read-only (still no mutation on this rejection path).
+    if !crate::chains::monad::tecdsa::is_valid_evm_address(&dest_address) {
+        return Err(WithdrawError::InvalidAddress(dest_address));
     }
 
     // Step 2: enqueue FIRST (it can fail on a duplicate idempotency key). The

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -74,6 +74,24 @@ pub enum OpenVaultError {
     UnknownVault,
 }
 
+/// Reasons `withdraw_collateral_in_state` / `close_chain_vault_in_state` can
+/// reject. No mutation occurs on any error path.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WithdrawError {
+    /// No such vault.
+    UnknownVault,
+    /// No manual MON price is set for the chain (`manual_prices[(chain,"MON")]`).
+    NoPrice,
+    /// Requested amount exceeds the vault's `collateral_amount_e18`.
+    InsufficientCollateral,
+    /// The post-withdrawal collateral ratio would fall below `min_cr_e4`.
+    BelowMinCr { cr_e4: u64, min_e4: u64 },
+    /// Enqueuing the `NativeWithdrawal` op failed (e.g. duplicate idempotency key).
+    QueueError(String),
+    /// `close_chain_vault_in_state` was called on a vault with non-zero debt.
+    HasDebt,
+}
+
 /// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
 ///
 /// `collateral_e18` is the native-gas-asset amount in wei (1e18 scale).
@@ -243,4 +261,148 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
         .expect("vault present: checked above");
     v.status = ChainVaultStatus::MintPending;
     Ok(true)
+}
+
+/// Withdraw foreign-chain collateral, enqueuing a native MON transfer-out.
+///
+/// ## Repay is observer-driven, NOT here
+///
+/// There is no separate repay path: the user burns icUSD on Monad
+/// (`IcUSD.burn`) and the Task-9 burn-watch (`deposit_watch::run_observer` ->
+/// `apply_burn_to_state`) decrements `debt_e8s` + chain supply at finality.
+/// This helper only moves COLLATERAL out; it never touches `debt_e8s`,
+/// `chain_supplies`, or `pending_mint_e8s`.
+///
+/// ## Semantics
+///
+/// - `UnknownVault` if the vault is absent.
+/// - `InsufficientCollateral` if `amount_e18 > collateral_amount_e18`.
+/// - `NoPrice` if no `manual_prices[(chain,"MON")]` is set.
+/// - When `debt_e8s > 0`, the REMAINING collateral
+///   (`collateral_amount_e18 - amount_e18`) is CR-checked against `min_cr_e4`;
+///   below it -> `BelowMinCr`. A debt-free vault skips the CR check (any
+///   remainder is trivially over-collateralized).
+///
+/// On success: enqueues a `NativeWithdrawal { recipient: dest_address,
+/// amount_e18, vault_id }` op (idempotency key
+/// `withdraw-{chain}-{vault_id}-{now_ns}`), RESERVES the collateral by
+/// decrementing `collateral_amount_e18` to the remainder, and flips the vault
+/// to `Closing` iff `remaining == 0 && debt_e8s == 0`. The settlement worker
+/// flips `Closing -> Closed` once the on-chain transfer confirms (and ADDS the
+/// reserved collateral back if the transfer reverts).
+///
+/// ## Reserve-at-enqueue
+///
+/// Decrementing `collateral_amount_e18` at enqueue time is the standard CDP
+/// reserve-on-request pattern: a second withdraw cannot double-spend the same
+/// collateral while the first is still in flight. A reverted transfer restores
+/// the reserve in `settlement::confirm_op`.
+///
+/// ## Mutation ordering (no-mutation-on-rejection guarantee)
+///
+/// 1. Validate (vault lookup, balance, price, CR) — no mutation on any reject.
+/// 2. Enqueue FIRST (can fail on a duplicate idempotency key -> `QueueError`,
+///    no collateral mutation).
+/// 3. Only after a successful enqueue: decrement collateral + set `Closing`.
+///
+/// So a rejected enqueue leaves the vault and its collateral untouched.
+pub fn withdraw_collateral_in_state(
+    state: &mut MultiChainStateV2,
+    vault_id: u64,
+    amount_e18: u128,
+    dest_address: String,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), WithdrawError> {
+    // Step 1: read-only validation. No mutation on any rejection path.
+    let (chain, remaining, debt_e8s) = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(WithdrawError::UnknownVault)?;
+        if amount_e18 > v.collateral_amount_e18 {
+            return Err(WithdrawError::InsufficientCollateral);
+        }
+        let remaining = v.collateral_amount_e18 - amount_e18;
+        (v.collateral_chain, remaining, v.debt_e8s)
+    };
+
+    // Price is needed for the post-withdrawal CR check (only when debt remains).
+    let price_e8 = *state
+        .manual_prices
+        .get(&(chain, "MON".to_string()))
+        .ok_or(WithdrawError::NoPrice)?;
+
+    // A debt-free vault is trivially over-collateralized; skip the CR check.
+    if debt_e8s > 0 {
+        let cr_e4 = collateral_ratio_e4(remaining, price_e8, debt_e8s);
+        if cr_e4 < min_cr_e4 {
+            return Err(WithdrawError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+        }
+    }
+
+    // Step 2: enqueue FIRST (it can fail on a duplicate idempotency key). The
+    // key is per (chain, vault, now_ns) so distinct withdraws never collide.
+    let op = SettlementOp::new(
+        SettlementOpKind::NativeWithdrawal {
+            recipient: dest_address,
+            amount_e18,
+            vault_id,
+        },
+        format!("withdraw-{}-{}-{}", chain.0, vault_id, now_ns),
+        now_ns,
+    );
+    state
+        .settlement_queues
+        .entry(chain)
+        .or_default()
+        .enqueue(op)
+        .map_err(|e| WithdrawError::QueueError(format!("{e:?}")))?;
+
+    // Step 3: only after a successful enqueue — reserve the collateral and flip
+    // to Closing when the vault is now empty AND debt-free.
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.collateral_amount_e18 = remaining;
+    if remaining == 0 && debt_e8s == 0 {
+        v.status = ChainVaultStatus::Closing;
+    }
+    Ok(())
+}
+
+/// Close a debt-free vault by withdrawing the FULL remaining collateral.
+///
+/// Requires `debt_e8s == 0` (`HasDebt` otherwise) — debt must first be repaid
+/// by burning icUSD on Monad (observer-driven, see
+/// `withdraw_collateral_in_state`). Then delegates to
+/// `withdraw_collateral_in_state` for the full `collateral_amount_e18`, which
+/// reserves the collateral and flips the vault to `Closing` (the worker flips
+/// it to `Closed` on the transfer's confirmation).
+///
+/// If the remaining collateral is already 0, this enqueues a zero-value
+/// `NativeWithdrawal` and flips the vault to `Closing` immediately — a clean
+/// no-collateral close. (A zero-value native transfer is harmless on-chain and
+/// keeps the close path uniform; the worker still confirms it and stamps
+/// `Closed`.)
+pub fn close_chain_vault_in_state(
+    state: &mut MultiChainStateV2,
+    vault_id: u64,
+    dest_address: String,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), WithdrawError> {
+    // Validate debt-free + capture the full remaining collateral (no mutation).
+    let full = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(WithdrawError::UnknownVault)?;
+        if v.debt_e8s != 0 {
+            return Err(WithdrawError::HasDebt);
+        }
+        v.collateral_amount_e18
+    };
+    withdraw_collateral_in_state(state, vault_id, full, dest_address, min_cr_e4, now_ns)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -90,6 +90,13 @@ pub enum WithdrawError {
     QueueError(String),
     /// `close_chain_vault_in_state` was called on a vault with non-zero debt.
     HasDebt,
+    /// Withdraw was attempted on a vault whose status is not `Open`. Only an
+    /// `Open` vault has confirmed, on-chain-deposited collateral and confirmed
+    /// debt; an `AwaitingDeposit` vault holds DECLARED-but-never-deposited
+    /// collateral (paying it out would drain the settlement hot wallet for
+    /// phantom collateral), and a `MintPending` vault has a mint in flight
+    /// against its collateral. Carries the offending status.
+    WrongStatus { status: ChainVaultStatus },
 }
 
 /// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
@@ -320,6 +327,18 @@ pub fn withdraw_collateral_in_state(
             .chain_vaults
             .get(&vault_id)
             .ok_or(WithdrawError::UnknownVault)?;
+        // CRITICAL: `Open` is the ONLY state a withdraw can proceed from — the
+        // only state with confirmed, on-chain-deposited collateral AND confirmed
+        // debt. In `AwaitingDeposit` the collateral is DECLARED but never
+        // deposited (debt 0 would skip the CR check below), so paying it out from
+        // the settlement hot wallet would drain protocol funds for phantom
+        // collateral. In `MintPending` a mint is in flight against the collateral.
+        // `Closing`/`Closed` are terminal. Reject before reading balance/price or
+        // mutating anything. (close_chain_vault_in_state delegates here, so it
+        // inherits this gate after its own debt==0 check.)
+        if v.status != ChainVaultStatus::Open {
+            return Err(WithdrawError::WrongStatus { status: v.status.clone() });
+        }
         if amount_e18 > v.collateral_amount_e18 {
             return Err(WithdrawError::InsufficientCollateral);
         }
@@ -378,14 +397,18 @@ pub fn withdraw_collateral_in_state(
 /// by burning icUSD on Monad (observer-driven, see
 /// `withdraw_collateral_in_state`). Then delegates to
 /// `withdraw_collateral_in_state` for the full `collateral_amount_e18`, which
-/// reserves the collateral and flips the vault to `Closing` (the worker flips
-/// it to `Closed` on the transfer's confirmation).
+/// inherits the `status == Open` gate (a non-Open vault rejects with
+/// `WrongStatus`), reserves the collateral, and flips the vault to `Closing`
+/// (the worker flips it to `Closed` on the transfer's confirmation).
 ///
-/// If the remaining collateral is already 0, this enqueues a zero-value
-/// `NativeWithdrawal` and flips the vault to `Closing` immediately — a clean
-/// no-collateral close. (A zero-value native transfer is harmless on-chain and
-/// keeps the close path uniform; the worker still confirms it and stamps
-/// `Closed`.)
+/// ## Zero-collateral short-circuit
+///
+/// If the vault is `Open`, debt-free, AND already holds zero collateral, this
+/// stamps it `Closed` directly and returns `Ok(())` WITHOUT enqueuing a
+/// zero-value `NativeWithdrawal`. A 21k-gas native transfer of value 0 from the
+/// settlement hot wallet is pure waste, and this protocol is gas/cycle-sensitive.
+/// (A non-Open zero-collateral vault is NOT short-circuited — it falls through
+/// to the delegate's gate and rejects with `WrongStatus`.)
 pub fn close_chain_vault_in_state(
     state: &mut MultiChainStateV2,
     vault_id: u64,
@@ -393,8 +416,9 @@ pub fn close_chain_vault_in_state(
     min_cr_e4: u64,
     now_ns: u64,
 ) -> Result<(), WithdrawError> {
-    // Validate debt-free + capture the full remaining collateral (no mutation).
-    let full = {
+    // Validate debt-free + capture the full remaining collateral and status (no
+    // mutation on any rejection path).
+    let (full, status) = {
         let v = state
             .chain_vaults
             .get(&vault_id)
@@ -402,7 +426,21 @@ pub fn close_chain_vault_in_state(
         if v.debt_e8s != 0 {
             return Err(WithdrawError::HasDebt);
         }
-        v.collateral_amount_e18
+        (v.collateral_amount_e18, v.status.clone())
     };
+
+    // Degenerate close: an Open, debt-free vault with no collateral to return.
+    // Stamp Closed directly — enqueuing a zero-value transfer would burn 21k gas
+    // for nothing. Restricted to `Open` so a non-Open (Closing/Closed/etc.)
+    // zero-collateral vault still rejects via the delegate's WrongStatus gate.
+    if full == 0 && status == ChainVaultStatus::Open {
+        let v = state
+            .chain_vaults
+            .get_mut(&vault_id)
+            .expect("vault present: checked above");
+        v.status = ChainVaultStatus::Closed;
+        return Ok(());
+    }
+
     withdraw_collateral_in_state(state, vault_id, full, dest_address, min_cr_e4, now_ns)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -21,14 +21,18 @@ pub enum ChainVaultStatus {
     Closed,
 }
 
-#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ChainVaultV1 {
     pub vault_id: u64,
     pub owner: Principal,
     pub collateral_chain: ChainId,
+    /// Unvalidated 0x hex string. The deposit-watch task (Task 9) validates
+    /// on-chain before crediting any collateral.
     pub custody_address: String,
     pub collateral_amount_e18: u128,
     pub debt_e8s: u128,
+    /// Unvalidated 0x hex string. The settlement task (Task 10) validates
+    /// before submitting the on-chain mint transaction.
     pub mint_recipient: String,
     pub pending_mint_e8s: u128,
     pub status: ChainVaultStatus,

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -65,6 +65,9 @@ pub enum OpenVaultError {
     NoPrice,
     /// Declared collateral ratio is below the minimum.
     BelowMinCr { cr_e4: u64, min_e4: u64 },
+    /// Declared debt is zero. A zero-debt vault has nothing to mint; allowing it
+    /// would enqueue a wasted zero-value on-chain mint once "deposited".
+    ZeroDebt,
     /// Enqueuing the Mint op failed (e.g. duplicate idempotency key).
     QueueError(String),
     /// `verify_deposit_and_enqueue_mint_in_state` could not find the vault.
@@ -131,6 +134,13 @@ pub fn open_chain_vault_in_state(
     // Reject an unregistered chain before reading anything else.
     if !state.chain_configs.contains_key(&chain) {
         return Err(OpenVaultError::UnknownChain);
+    }
+    // A zero-debt vault has nothing to mint; with debt 0 the CR check is a
+    // no-op (u64::MAX) and deposit-watch would later enqueue a wasted
+    // zero-value on-chain mint. Reject up front. (A zero-collateral vault with
+    // positive debt is already rejected below by the CR check.)
+    if debt_e8s == 0 {
+        return Err(OpenVaultError::ZeroDebt);
     }
     // MON price (USD e8) for the declared-collateral CR check.
     let price_e8 = *state

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -1,8 +1,36 @@
-//! Monad vault record. Real impl in Task 3.
-#[derive(Clone, Debug)]
-pub enum ChainVaultStatus { MintPending, Open, Closing, Closed }
+//! Monad (and future foreign-chain) vault record.
+//!
+//! Lives in `MultiChainStateV2.chain_vaults`, keyed by the globally-unique
+//! u64 vault_id. The core ICP-native `Vault` struct is untouched in Phase 1b;
+//! unifying the two models is a deliberate Phase 2 task.
+//!
+//! Design B (confirmed-supply): `debt_e8s` is the CONFIRMED debt. While a mint
+//! is in flight, the intended amount lives in `pending_mint_e8s` and does NOT
+//! count toward `total_debt` or `chain_supplies` until the on-chain mint is
+//! observed at finality (settlement worker, Task 10).
 
-#[derive(Clone, Debug)]
+use crate::chains::config::ChainId;
+use candid::{CandidType, Deserialize, Principal};
+use serde::Serialize;
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub enum ChainVaultStatus {
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct ChainVaultV1 {
     pub vault_id: u64,
+    pub owner: Principal,
+    pub collateral_chain: ChainId,
+    pub custody_address: String,
+    pub collateral_amount_e18: u128,
+    pub debt_e8s: u128,
+    pub mint_recipient: String,
+    pub pending_mint_e8s: u128,
+    pub status: ChainVaultStatus,
+    pub opened_at_ns: u64,
 }

--- a/src/rumi_protocol_backend/src/chains/monad/config.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/config.rs
@@ -1,0 +1,13 @@
+//! Monad config defaults. Real impl in Task 2.
+use super::super::config::ChainId;
+
+pub const MONAD_CHAIN_ID: ChainId = ChainId(10143);
+
+#[derive(Clone, Debug, Default)]
+pub struct MonadContracts {
+    pub icusd: Option<String>,
+}
+
+pub static CONTRACTS: MonadContracts = MonadContracts { icusd: None };
+
+pub fn monad_default_config() {}

--- a/src/rumi_protocol_backend/src/chains/monad/config.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/config.rs
@@ -1,13 +1,50 @@
-//! Monad config defaults. Real impl in Task 2.
-use super::super::config::ChainId;
+//! Monad testnet configuration defaults.
+//!
+//! These feed `register_chain` (Task 22). The deployed icUSD contract address
+//! is NOT stored here as a static; it lives in runtime state
+//! (MultiChainStateV2.chain_contracts, Task 3) so it survives upgrades.
 
+use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
+
+/// Monad testnet chain id (10143 is the published Monad testnet id as of 2026-05).
 pub const MONAD_CHAIN_ID: ChainId = ChainId(10143);
 
-#[derive(Clone, Debug, Default)]
-pub struct MonadContracts {
-    pub icusd: Option<String>,
+/// IcUSD.sol uses 8 decimals so 1 on-chain base unit == 1 e8s.
+pub const MONAD_ICUSD_DECIMALS: u8 = 8;
+
+/// MON native gas asset decimals.
+pub const MON_NATIVE_DECIMALS: u8 = 18;
+
+/// Candidate Monad testnet RPC endpoints. The EVM RPC canister fans out to
+/// these via custom JSON-RPC services. VERIFY these URLs are live at execution
+/// time and pick 2-3 with adequate rate limits (spec calls for multi-provider).
+pub fn monad_rpc_endpoints() -> Vec<String> {
+    vec![
+        "https://testnet-rpc.monad.xyz".to_string(),
+        // Add 1-2 third-party Monad-testnet endpoints once confirmed available.
+    ]
 }
 
-pub static CONTRACTS: MonadContracts = MonadContracts { icusd: None };
+/// tECDSA key name. `test_key_1` on staging (mainnet test key); switch to
+/// `key_1` for the Phase 2 production rollout. The derived addresses differ
+/// per key, so the IcUSD.sol minter must be derived with this exact key.
+pub fn monad_ecdsa_key_name() -> String {
+    "test_key_1".to_string()
+}
 
-pub fn monad_default_config() {}
+/// Default registration payload for Monad testnet.
+pub fn monad_default_register_arg() -> RegisterChainArg {
+    RegisterChainArg {
+        chain_id: MONAD_CHAIN_ID,
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: monad_rpc_endpoints(),
+        // Spec open question: Monad single-slot finality likely means depth 1.
+        // Start at 1, verify on testnet, bump via set_chain_config if reorgs seen.
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: MON_NATIVE_DECIMALS,
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -45,6 +45,7 @@ use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use crate::Mode;
 
+use super::chain_vault::{verify_deposit_and_enqueue_mint_in_state, ChainVaultStatus};
 use super::evm_rpc::{decode_burn_log, fetch_block_numbers, get_balance, get_logs, BURN_EVENT_TOPIC0};
 use super::{hardening, tecdsa};
 
@@ -341,16 +342,84 @@ pub async fn run_observer(chain: ChainId) {
         }
     }
 
-    // ── Deposit watch (STUB) ─────────────────────────────────────────────────
+    // ── Deposit watch (open-then-verify, Task 12) ───────────────────────────
     //
-    // The pure helper `credit_deposit_to_state` is implemented and tested.
-    // The async custody-balance poll is deferred to Task 23 (manual
-    // integration with Monad testnet). When Task 23 lands, replace this block
-    // with a loop over open chain_vaults for this chain, calling `get_balance`
-    // on each `custody_address`, computing the delta, and calling
-    // `credit_deposit_to_state` + emitting `DepositObserved`.
+    // Poll each AwaitingDeposit vault's custody-address native (MON) balance.
+    // Once the on-chain balance covers the DECLARED collateral, flip the vault
+    // AwaitingDeposit -> MintPending and enqueue its Mint op (icUSD is only ever
+    // minted against a verified on-chain deposit — the CDP backing invariant).
     //
-    // (`get_balance` is now exercised by `refresh_hot_wallet_balance` above.)
+    // Borrow discipline: snapshot the small per-vault tuples under one
+    // `read_state` BEFORE the await loop; never hold a state borrow across
+    // `get_balance(...).await`.
+    let now = ic_cdk::api::time();
+    let awaiting: Vec<(u64, String, u128)> = read_state(|s| {
+        s.multi_chain
+            .chain_vaults
+            .values()
+            .filter(|v| {
+                v.collateral_chain == chain && v.status == ChainVaultStatus::AwaitingDeposit
+            })
+            .map(|v| (v.vault_id, v.custody_address.clone(), v.collateral_amount_e18))
+            .collect()
+    });
+
+    for (vault_id, custody_address, declared_e18) in awaiting {
+        let balance = match get_balance(chain, &custody_address).await {
+            Ok(bal) => bal,
+            Err(e) => {
+                // A failed balance read must NOT abort the observer — log and
+                // move on; the next tick retries this vault.
+                log!(
+                    INFO,
+                    "[observer chain={:?}] deposit get_balance failed for vault {} ({}): {}; will retry",
+                    chain, vault_id, custody_address, e
+                );
+                continue;
+            }
+        };
+
+        if balance < declared_e18 {
+            // Not enough on-chain collateral yet; nothing to do this tick.
+            continue;
+        }
+
+        let transitioned = mutate_state(|s| {
+            verify_deposit_and_enqueue_mint_in_state(&mut s.multi_chain, vault_id, balance, now)
+        });
+
+        match transitioned {
+            Ok(true) => {
+                crate::storage::record_event(&crate::event::Event::DepositObserved {
+                    chain_id: chain,
+                    vault_id,
+                    custody_address: custody_address.clone(),
+                    amount_e18: balance,
+                    // Balance-poll observation, not a single transfer tx — there
+                    // is no one tx hash to attribute the deposit to.
+                    tx_hash: String::new(),
+                    block_number: finalized,
+                    timestamp: now,
+                });
+                log!(
+                    INFO,
+                    "[observer chain={:?}] deposit verified: vault={} custody={} balance_e18={} >= declared_e18={}; mint enqueued",
+                    chain, vault_id, custody_address, balance, declared_e18
+                );
+            }
+            Ok(false) => {
+                // Idempotent no-op (already transitioned by an earlier tick, or a
+                // concurrent transition). Nothing to emit.
+            }
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[observer chain={:?}] verify_deposit_and_enqueue_mint FAILED for vault {}: {:?}; will retry",
+                    chain, vault_id, e
+                );
+            }
+        }
+    }
 
     // ── Advance cursor (only on full success) ───────────────────────────────
 

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -24,17 +24,20 @@
 //!
 //! ## Async observer loop (run_observer)
 //!
-//! `run_observer` scans Burn events at finality for the given chain and applies
-//! them through `apply_burn_to_state`. Deposit (collateral) watch is
-//! implemented as a minimal stub in Phase 1b: the pure helper
-//! `credit_deposit_to_state` is fully tested and ready; the async balance-check
-//! loop is deferred to the Task 23 manual integration (it requires a stable
-//! EVM RPC connection to Monad testnet). A TODO comment marks the stub clearly.
+//! `run_observer` runs TWO independent watches each tick:
 //!
-//! Reorg handling is NOT implemented here; Task 11 adds the `is_reorg` check
-//! after fetching the finalized block number. The structure of `run_observer`
-//! intentionally leaves a seam for Task 11 to insert between the
-//! `fetch_block_numbers` call and the log-scan loop.
+//! - **Deposit watch** (balance poll → flip `AwaitingDeposit`→`MintPending`,
+//!   enqueue mint) runs UNCONDITIONALLY every tick. It uses only the
+//!   consensus-safe `get_balance(addr, "latest")` read and is fully decoupled
+//!   from the block-height path. A block-height read failure (the Layer-2
+//!   EVM-RPC consensus issue that blocked Gate-4 on staging) must NOT skip
+//!   deposit detection.
+//! - **Burn watch** scans Burn events at finality and applies them through
+//!   `apply_burn_to_state`. It is GATED: it runs only when the burn-watch cursor
+//!   (`last_observed_block[chain]`) is seeded (`!= 0`) AND a fresh finalized
+//!   block height is available. The reorg `is_reorg` check (Task 11) sits
+//!   between `fetch_block_numbers` and the log scan. A block-read failure
+//!   degrades the tick to deposit-only.
 
 use ic_canister_log::log;
 
@@ -202,34 +205,35 @@ impl Drop for ObserverGuard {
 
 /// Run one observation cycle for the given chain.
 ///
-/// Called by Timer A (configured in Task 12). Scans Burn logs from
-/// `last_observed_block + 1` to the current finalized block and applies
-/// them to state. Advances `last_observed_block` to `finalized` at the end.
+/// Called by Timer A (configured in Task 12). Control flow:
+///   1. re-entrancy guard / mode-halt-reorg skip / contract check /
+///      `refresh_hot_wallet_balance` (all unchanged)
+///   2. **deposit watch** — runs EVERY tick (see below), decoupled from blocks
+///   3. **burn watch** — gated on a seeded cursor and fresh finalized height
 ///
-/// ## Burn watch
+/// ## Deposit watch (runs every tick)
 ///
-/// For each raw Burn log decoded via `decode_burn_log`, the observer:
-/// 1. Reads the current total supply (as-of-this-moment, before this burn).
-/// 2. Computes `new_total_debt = current_total - amount_e8s`.
-/// 3. Calls `mutate_state(apply_burn_to_state)` and records a
-///    `ChainBurnObserved` event on success.
-/// 4. On failure: logs the error clearly and continues to the next log.
-///    The block cursor does NOT advance past a failing burn — if any burn
-///    in a range fails, the entire range is retried on the next tick.
-///    (Per Phase 1b spec: "log + continue is acceptable but the error must
-///    be visible". A future hardening pass can add per-burn retry tracking.)
+/// Polls each `AwaitingDeposit` vault's custody-address native balance via the
+/// consensus-safe `get_balance(addr, "latest")`. When the on-chain balance
+/// covers the declared collateral it flips the vault to `MintPending` and
+/// enqueues its mint. This path does NOT depend on `fetch_block_numbers`, so a
+/// block-height read failure (Layer-2 EVM-RPC consensus issue) never skips
+/// deposit detection.
 ///
-/// ## Deposit watch (STUB — Phase 1b)
+/// ## Burn watch (gated)
 ///
-/// The pure helper `credit_deposit_to_state` is fully tested. The async
-/// custody-balance poll loop is deferred to Task 23 (manual integration).
-/// This stub logs that deposit watch is not yet active.
-///
-/// ## Reorg handling
-///
-/// NOT implemented here. Task 11 inserts an `is_reorg` check after
-/// `fetch_block_numbers` and before the log scan. The structure below
-/// leaves a clear seam for that insertion.
+/// - If `last_observed_block[chain] == 0` (unseeded): log an activation hint and
+///   SKIP burn-watch (no genesis crawl — there are no pre-activation events).
+/// - Else fetch the finalized height via the consensus-safe specific-block probe
+///   (`fetch_block_numbers`); on `Err`, log and skip burn-watch only (deposit
+///   watch already ran). Run the `is_reorg` debounce; on confirmed reorg, halt
+///   the chain (cursor not advanced). If `finalized > last_observed`, scan Burn
+///   logs `last_observed+1 ..= finalized` and for each: (1) read the current
+///   foreign-chain debt total (before this burn), (2)
+///   `mutate_state(apply_burn_to_state)` + record `ChainBurnObserved`, (3) on
+///   failure log + stop the range (cursor not advanced; the whole range retries
+///   next tick). The cursor advances to `finalized` only when EVERY burn in the
+///   range applied cleanly.
 pub async fn run_observer(chain: ChainId) {
     // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
     // chain is still in flight, skip this one entirely. The RAII guard releases
@@ -278,15 +282,127 @@ pub async fn run_observer(chain: ChainId) {
     // it must NOT abort the observer (reads/burn-watch must still run).
     refresh_hot_wallet_balance(chain).await;
 
+    // Read the burn-watch cursor BEFORE running deposit-watch. The deposit-watch
+    // path is consensus-safe (balance-only) and runs every tick regardless of
+    // the cursor; it only needs `last_observed` for the cosmetic
+    // `DepositObserved.block_number` (a balance poll has no single tx/block).
     let last_observed = read_state(|s| {
         s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0)
     });
 
-    // Fetch finalized block number.
+    // ── Deposit watch (open-then-verify, Task 12) — RUNS EVERY TICK ──────────
+    //
+    // Poll each AwaitingDeposit vault's custody-address native (MON) balance.
+    // Once the on-chain balance covers the DECLARED collateral, flip the vault
+    // AwaitingDeposit -> MintPending and enqueue its Mint op (icUSD is only ever
+    // minted against a verified on-chain deposit — the CDP backing invariant).
+    //
+    // This is DECOUPLED from the block-height path (`fetch_block_numbers`): it
+    // uses ONLY the consensus-safe `get_balance(addr, "latest")` read, never a
+    // volatile block tag. A block-height read failure (Layer-2 EVM-RPC
+    // consensus issue) must NOT skip deposit detection — that was the Gate-4
+    // blocker on staging (the two early-returns below used to sit BEFORE this
+    // loop). Borrow discipline: snapshot the small per-vault tuples under one
+    // `read_state` BEFORE the await loop; never hold a state borrow across
+    // `get_balance(...).await`.
+    let now = ic_cdk::api::time();
+    let awaiting: Vec<(u64, String, u128)> = read_state(|s| {
+        s.multi_chain
+            .chain_vaults
+            .values()
+            .filter(|v| {
+                v.collateral_chain == chain && v.status == ChainVaultStatus::AwaitingDeposit
+            })
+            .map(|v| (v.vault_id, v.custody_address.clone(), v.collateral_amount_e18))
+            .collect()
+    });
+
+    for (vault_id, custody_address, declared_e18) in awaiting {
+        let balance = match get_balance(chain, &custody_address).await {
+            Ok(bal) => bal,
+            Err(e) => {
+                // A failed balance read must NOT abort the observer — log and
+                // move on; the next tick retries this vault.
+                log!(
+                    INFO,
+                    "[observer chain={:?}] deposit get_balance failed for vault {} ({}): {}; will retry",
+                    chain, vault_id, custody_address, e
+                );
+                continue;
+            }
+        };
+
+        if balance < declared_e18 {
+            // Not enough on-chain collateral yet; nothing to do this tick.
+            continue;
+        }
+
+        let transitioned = mutate_state(|s| {
+            verify_deposit_and_enqueue_mint_in_state(&mut s.multi_chain, vault_id, balance, now)
+        });
+
+        match transitioned {
+            Ok(true) => {
+                crate::storage::record_event(&crate::event::Event::DepositObserved {
+                    chain_id: chain,
+                    vault_id,
+                    custody_address: custody_address.clone(),
+                    amount_e18: balance,
+                    // Balance-poll observation, not a single transfer tx — there
+                    // is no one tx hash to attribute the deposit to. The block
+                    // number is cosmetic; use the current cursor (`last_observed`)
+                    // since deposit-watch does not read a fresh block height.
+                    tx_hash: String::new(),
+                    block_number: last_observed,
+                    timestamp: now,
+                });
+                log!(
+                    INFO,
+                    "[observer chain={:?}] deposit verified: vault={} custody={} balance_e18={} >= declared_e18={}; mint enqueued",
+                    chain, vault_id, custody_address, balance, declared_e18
+                );
+            }
+            Ok(false) => {
+                // Idempotent no-op (already transitioned by an earlier tick, or a
+                // concurrent transition). Nothing to emit.
+            }
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[observer chain={:?}] verify_deposit_and_enqueue_mint FAILED for vault {}: {:?}; will retry",
+                    chain, vault_id, e
+                );
+            }
+        }
+    }
+
+    // ── Burn watch — GATED on a seeded cursor + new blocks ───────────────────
+    //
+    // Everything below depends on a finalized block height. It is gated so a
+    // block-read failure (or an unseeded chain) degrades the observer to
+    // deposit-only — deposit-watch already ran above, so deposits still flow.
+
+    // Unseeded sentinel: `last_observed == 0` means the burn-watch cursor was
+    // never seeded to the chain tip. We do NOT crawl from genesis (no
+    // pre-activation events exist). Log the activation hint and skip burn-watch.
+    // (Logging every tick is intentional — staging needs this signal until the
+    // operator seeds the cursor.)
+    if last_observed == 0 {
+        log!(
+            INFO,
+            "[observer chain={:?}] last_observed_block is 0 (unseeded); burn-watch inactive — call set_last_observed_block(chain, <current tip>) to activate",
+            chain
+        );
+        return;
+    }
+
+    // Fetch finalized block number (consensus-safe specific-block probe). A
+    // failure logs and skips burn-watch ONLY — deposit-watch already ran, so we
+    // must NOT abort the whole tick.
     let finalized = match fetch_block_numbers(chain).await {
         Ok((_latest, fin)) => fin,
         Err(e) => {
-            log!(INFO, "[observer chain={:?}] fetch_block_numbers failed: {}", chain, e);
+            log!(INFO, "[observer chain={:?}] fetch_block_numbers failed: {}; skipping burn-watch this tick (deposit-watch ran)", chain, e);
             return;
         }
     };
@@ -350,13 +466,11 @@ pub async fn run_observer(chain: ChainId) {
     // CONSECUTIVE suspect ticks. Fall through to the normal nothing-new check.
 
     if finalized <= last_observed {
-        // Nothing new to observe.
+        // Nothing new to observe (burn-watch). Deposit-watch already ran.
         return;
     }
 
     let from_block = last_observed + 1;
-
-    // ── Burn watch ──────────────────────────────────────────────────────────
 
     let raw_burn_logs = match get_logs(chain, &contract, BURN_EVENT_TOPIC0, from_block, finalized).await {
         Ok(logs) => logs,
@@ -368,7 +482,7 @@ pub async fn run_observer(chain: ChainId) {
 
     let mut burn_ok = true;
     for (topics, data, tx_hash, block_number) in &raw_burn_logs {
-        let burn = match decode_burn_log(topics, &data, &tx_hash, *block_number) {
+        let burn = match decode_burn_log(topics, data, tx_hash, *block_number) {
             Ok(b) => b,
             Err(e) => {
                 log!(INFO, "[observer chain={:?}] decode_burn_log failed at block {}: {}", chain, block_number, e);
@@ -420,86 +534,7 @@ pub async fn run_observer(chain: ChainId) {
         }
     }
 
-    // ── Deposit watch (open-then-verify, Task 12) ───────────────────────────
-    //
-    // Poll each AwaitingDeposit vault's custody-address native (MON) balance.
-    // Once the on-chain balance covers the DECLARED collateral, flip the vault
-    // AwaitingDeposit -> MintPending and enqueue its Mint op (icUSD is only ever
-    // minted against a verified on-chain deposit — the CDP backing invariant).
-    //
-    // Borrow discipline: snapshot the small per-vault tuples under one
-    // `read_state` BEFORE the await loop; never hold a state borrow across
-    // `get_balance(...).await`.
-    let now = ic_cdk::api::time();
-    let awaiting: Vec<(u64, String, u128)> = read_state(|s| {
-        s.multi_chain
-            .chain_vaults
-            .values()
-            .filter(|v| {
-                v.collateral_chain == chain && v.status == ChainVaultStatus::AwaitingDeposit
-            })
-            .map(|v| (v.vault_id, v.custody_address.clone(), v.collateral_amount_e18))
-            .collect()
-    });
-
-    for (vault_id, custody_address, declared_e18) in awaiting {
-        let balance = match get_balance(chain, &custody_address).await {
-            Ok(bal) => bal,
-            Err(e) => {
-                // A failed balance read must NOT abort the observer — log and
-                // move on; the next tick retries this vault.
-                log!(
-                    INFO,
-                    "[observer chain={:?}] deposit get_balance failed for vault {} ({}): {}; will retry",
-                    chain, vault_id, custody_address, e
-                );
-                continue;
-            }
-        };
-
-        if balance < declared_e18 {
-            // Not enough on-chain collateral yet; nothing to do this tick.
-            continue;
-        }
-
-        let transitioned = mutate_state(|s| {
-            verify_deposit_and_enqueue_mint_in_state(&mut s.multi_chain, vault_id, balance, now)
-        });
-
-        match transitioned {
-            Ok(true) => {
-                crate::storage::record_event(&crate::event::Event::DepositObserved {
-                    chain_id: chain,
-                    vault_id,
-                    custody_address: custody_address.clone(),
-                    amount_e18: balance,
-                    // Balance-poll observation, not a single transfer tx — there
-                    // is no one tx hash to attribute the deposit to.
-                    tx_hash: String::new(),
-                    block_number: finalized,
-                    timestamp: now,
-                });
-                log!(
-                    INFO,
-                    "[observer chain={:?}] deposit verified: vault={} custody={} balance_e18={} >= declared_e18={}; mint enqueued",
-                    chain, vault_id, custody_address, balance, declared_e18
-                );
-            }
-            Ok(false) => {
-                // Idempotent no-op (already transitioned by an earlier tick, or a
-                // concurrent transition). Nothing to emit.
-            }
-            Err(e) => {
-                log!(
-                    INFO,
-                    "[observer chain={:?}] verify_deposit_and_enqueue_mint FAILED for vault {}: {:?}; will retry",
-                    chain, vault_id, e
-                );
-            }
-        }
-    }
-
-    // ── Advance cursor (only on full success) ───────────────────────────────
+    // ── Advance cursor (only on full burn success) ──────────────────────────
 
     if burn_ok {
         mutate_state(|s| {

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -54,6 +54,41 @@ use super::{hardening, tecdsa};
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
+/// Classification of an `apply_burn_to_state` failure, so the observer loop can
+/// decide whether to SKIP the burn (advancing the cursor past it) or HALT.
+///
+/// This is the keystone of the C-1 supply-divergence fix. The pre-fix code
+/// returned a flat `Result<(), String>` and the observer `break`-ed on ANY
+/// error, stalling the cursor and forcing the whole range to re-scan. With no
+/// idempotency, that re-applied already-applied partial burns, silently
+/// double-decrementing `debt_e8s` and `chain_supplies` together (so the
+/// Timer-B self-check never fired). The typed error lets the loop:
+///   - SKIP an `InvalidBurn` (permanent-invalid: unknown vault / over-repay) —
+///     it can never succeed, so advancing past it is safe and keeps the
+///     observer + settlement-finality live;
+///   - HALT on a `SupplyInvariant` (halt-class) without advancing the cursor.
+#[derive(Debug)]
+pub enum BurnApplyError {
+    /// Permanent-invalid burn (unknown vault / over-repay beyond remaining
+    /// debt). Skippable: the cursor may advance past it; it will never succeed.
+    /// Carries a human-readable reason for the WARN log.
+    InvalidBurn(String),
+    /// Halt-class supply-invariant failure (`apply_supply_delta` rejected the
+    /// decrement: underflow, divergence, or an already-set self-check halt).
+    /// The protocol must NOT advance the cursor past this; the invariant
+    /// machinery halts.
+    SupplyInvariant(crate::chains::supply::SupplyInvariantError),
+}
+
+impl std::fmt::Display for BurnApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BurnApplyError::InvalidBurn(msg) => write!(f, "InvalidBurn({})", msg),
+            BurnApplyError::SupplyInvariant(e) => write!(f, "SupplyInvariant({:?})", e),
+        }
+    }
+}
+
 /// Credit a confirmed on-chain deposit to a ChainVaultV1 record.
 ///
 /// Increments `collateral_amount_e18` by `amount_e18` (saturating — overflow
@@ -113,22 +148,25 @@ pub fn apply_burn_to_state(
     state: &mut MultiChainStateV2,
     burn: &super::evm_rpc::BurnLog,
     total_debt_e8s: u128,
-) -> Result<(), String> {
-    // Step 1: vault lookup (read-only — no mutation on failure)
+) -> Result<(), BurnApplyError> {
+    // Step 1: vault lookup (read-only — no mutation on failure).
+    // Unknown vault is a PERMANENT-INVALID burn (e.g. a permissionless Burn
+    // citing a closed/never-existed vault) → InvalidBurn (skippable).
     let (chain, current_debt) = {
-        let vault = state
-            .chain_vaults
-            .get(&burn.vault_id)
-            .ok_or_else(|| format!("apply_burn: unknown vault_id {}", burn.vault_id))?;
+        let vault = state.chain_vaults.get(&burn.vault_id).ok_or_else(|| {
+            BurnApplyError::InvalidBurn(format!("apply_burn: unknown vault_id {}", burn.vault_id))
+        })?;
         (vault.collateral_chain, vault.debt_e8s)
     };
 
-    // Step 2: debt-exceeds check (no mutation on failure)
+    // Step 2: debt-exceeds check (no mutation on failure). Over-repaying a
+    // vault's remaining debt is PERMANENT-INVALID (the on-chain burn already
+    // happened, but it can never be applied here) → InvalidBurn (skippable).
     if burn.amount_e8s > current_debt {
-        return Err(format!(
+        return Err(BurnApplyError::InvalidBurn(format!(
             "apply_burn: burn amount {} exceeds vault {} debt {}",
             burn.amount_e8s, burn.vault_id, current_debt
-        ));
+        )));
     }
 
     // Compute the post-burn total debt that apply_supply_delta will compare
@@ -138,11 +176,17 @@ pub fn apply_burn_to_state(
     let post_burn_total = total_debt_e8s.saturating_sub(burn.amount_e8s);
 
     // Step 3: supply delta — validates and mutates chain_supplies, or rejects
-    // entirely (chain_supplies unchanged on Err)
+    // entirely (chain_supplies unchanged on Err). A failure here is HALT-CLASS
+    // (underflow / divergence / already-halted) → SupplyInvariant: the caller
+    // must NOT advance the cursor.
     apply_supply_delta(state, chain, SupplyDelta::Decrease(burn.amount_e8s), post_burn_total)
-        .map_err(|e| format!("{:?}", e))?;
+        .map_err(BurnApplyError::SupplyInvariant)?;
 
-    // Step 4: only reached when supply delta succeeded — decrement vault debt
+    // Step 4: only reached when supply delta succeeded — decrement vault debt.
+    // No-mutation-on-rejection guarantee is intact: every `return Err`/`?`
+    // above happens BEFORE this point, so a rejected burn leaves BOTH
+    // chain_supplies (untouched by apply_supply_delta on its Err path) and
+    // debt_e8s (untouched, decremented only here) unchanged.
     let vault = state
         .chain_vaults
         .get_mut(&burn.vault_id)
@@ -228,12 +272,23 @@ impl Drop for ObserverGuard {
 ///   (`fetch_block_numbers`); on `Err`, log and skip burn-watch only (deposit
 ///   watch already ran). Run the `is_reorg` debounce; on confirmed reorg, halt
 ///   the chain (cursor not advanced). If `finalized > last_observed`, scan Burn
-///   logs `last_observed+1 ..= finalized` and for each: (1) read the current
-///   foreign-chain debt total (before this burn), (2)
-///   `mutate_state(apply_burn_to_state)` + record `ChainBurnObserved`, (3) on
-///   failure log + stop the range (cursor not advanced; the whole range retries
-///   next tick). The cursor advances to `finalized` only when EVERY burn in the
-///   range applied cleanly.
+///   logs `last_observed+1 ..= finalized` and for each: (1) skip it if its
+///   identity key is already in `processed_burn_keys` (idempotent — already
+///   applied on a prior tick), (2) read the current foreign-chain debt total
+///   (before this burn), (3) `mutate_state(apply_burn_to_state)`. On `Ok`:
+///   record the key + emit `ChainBurnObserved`. On `InvalidBurn` (permanent —
+///   unknown vault / over-repay): WARN-log, record the key as a permanent skip,
+///   and CONTINUE (the cursor must advance past poison). On `SupplyInvariant`
+///   (halt-class): log + stop the range WITHOUT advancing the cursor or
+///   recording the key (the un-halt re-scan re-attempts it).
+///
+///   The cursor advances to `finalized` UNLESS a halt-class failure stopped the
+///   range. After a successful advance, `processed_burn_keys` is pruned of every
+///   entry at `block <= finalized` (those blocks can never be re-scanned), so
+///   the set stays bounded. This combination (persisted dedup + skip-invalid-
+///   continue + halt-without-advance) is the C-1 supply-divergence fix: the
+///   already-applied prefix is never re-applied on any re-scan, a poison burn
+///   no longer stalls the cursor, and a genuine divergence still halts.
 pub async fn run_observer(chain: ChainId) {
     // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
     // chain is still in flight, skip this one entirely. The RAII guard releases
@@ -480,16 +535,56 @@ pub async fn run_observer(chain: ChainId) {
         }
     };
 
+    // ── Per-burn handling: dedup + skip-poison-and-continue (C-1) ────────────
+    //
+    // `burn_ok` now means ONLY "no halt-class failure occurred" — it gates the
+    // cursor advance. It is NOT cleared by a skippable burn (decode failure or
+    // InvalidBurn): those advance past their offending log so a single poison
+    // burn can never stall the cursor (the silent-double-apply trigger).
+    //
+    // Idempotency: every burn carries an on-chain identity key
+    // (`{tx_hash}:{vault_id}:{amount_e8s}`) recorded in `processed_burn_keys`
+    // once handled (applied OR permanently skipped). On any re-scan of the same
+    // range, an already-keyed burn is `continue`-d BEFORE `apply_burn_to_state`,
+    // so the already-applied prefix is NEVER re-applied — this is the core fix
+    // for the C-1 supply-divergence (debt_e8s + chain_supplies double-decrement).
     let mut burn_ok = true;
     for (topics, data, tx_hash, block_number) in &raw_burn_logs {
         let burn = match decode_burn_log(topics, data, tx_hash, *block_number) {
             Ok(b) => b,
             Err(e) => {
-                log!(INFO, "[observer chain={:?}] decode_burn_log failed at block {}: {}", chain, block_number, e);
-                burn_ok = false;
-                break;
+                // SKIP, do not break: in production `get_logs` is topic-filtered
+                // by the real RPC so only Burn logs arrive; a decode failure here
+                // is genuinely anomalous (malformed log) and stalling the cursor
+                // on it would re-introduce the C-1 stall. Log and move past it.
+                // (We cannot dedup-key an undecodable log — it has no parsed
+                // identity — but it is topic-filtered out on re-scan in
+                // production, and even if re-seen it just re-skips harmlessly.)
+                log!(INFO, "[observer chain={:?}] decode_burn_log failed at block {}: {}; skipping (not stalling cursor)", chain, block_number, e);
+                continue;
             }
         };
+
+        // Idempotency key: tx_hash uniquely identifies the tx; vault_id+amount
+        // disambiguate the (unlikely) multi-burn tx. If already processed at this
+        // block, this burn's debt/supply decrement already happened — skip it so
+        // a re-scan never double-applies.
+        let key = format!("{}:{}:{}", burn.tx_hash, burn.vault_id, burn.amount_e8s);
+        let already_processed = read_state(|s| {
+            s.multi_chain
+                .processed_burn_keys
+                .get(&burn.block_number)
+                .map(|set| set.contains(&key))
+                .unwrap_or(false)
+        });
+        if already_processed {
+            log!(
+                INFO,
+                "[observer chain={:?}] burn already processed (dedup): vault={} amount_e8s={} block={} tx={}; skipping",
+                chain, burn.vault_id, burn.amount_e8s, burn.block_number, burn.tx_hash
+            );
+            continue;
+        }
 
         // Snapshot the pre-burn foreign-chain vault debt total (each burn
         // decrements one vault's debt_e8s, so we re-read before each burn
@@ -507,6 +602,19 @@ pub async fn run_observer(chain: ChainId) {
 
         match result {
             Ok(()) => {
+                // Record the dedup key. The entire burn loop runs synchronously
+                // (no `.await` between the apply above and here, nor across loop
+                // iterations), so the apply and this record commit in the SAME
+                // atomic message slice — a trap rolls BOTH back together. Thus
+                // the invariant "key present iff debt/supply already decremented"
+                // always holds, and a re-scan can never re-apply a recorded burn.
+                mutate_state(|s| {
+                    s.multi_chain
+                        .processed_burn_keys
+                        .entry(burn.block_number)
+                        .or_default()
+                        .insert(key.clone());
+                });
                 let now = ic_cdk::api::time();
                 crate::storage::record_event(&crate::event::Event::ChainBurnObserved {
                     chain_id: chain,
@@ -522,10 +630,33 @@ pub async fn run_observer(chain: ChainId) {
                     chain, burn.vault_id, burn.amount_e8s, burn.block_number, burn.tx_hash
                 );
             }
-            Err(e) => {
+            Err(BurnApplyError::InvalidBurn(msg)) => {
+                // PERMANENT-INVALID (unknown vault / over-repay). It can never
+                // succeed, so record its key as a PERMANENT SKIP and continue —
+                // the cursor advances past it. This is what stops a single
+                // poison burn from stalling the cursor (and thus stops the
+                // re-scan that silently double-applied the good prefix).
                 log!(
                     INFO,
-                    "[observer chain={:?}] apply_burn_to_state FAILED for tx {} vault {}: {}",
+                    "[observer chain={:?}] skipping invalid burn (vault={} amount_e8s={} block={} tx={}): {}",
+                    chain, burn.vault_id, burn.amount_e8s, burn.block_number, burn.tx_hash, msg
+                );
+                mutate_state(|s| {
+                    s.multi_chain
+                        .processed_burn_keys
+                        .entry(burn.block_number)
+                        .or_default()
+                        .insert(key.clone());
+                });
+                continue;
+            }
+            Err(BurnApplyError::SupplyInvariant(e)) => {
+                // HALT-CLASS (underflow / divergence / already-halted): do NOT
+                // advance the cursor and do NOT record the key, so the un-halt
+                // re-scan re-attempts this burn. Stop the range here.
+                log!(
+                    INFO,
+                    "[observer chain={:?}] apply_burn_to_state HALT-CLASS failure for tx {} vault {}: {:?}; not advancing cursor",
                     chain, burn.tx_hash, burn.vault_id, e
                 );
                 burn_ok = false;
@@ -534,11 +665,29 @@ pub async fn run_observer(chain: ChainId) {
         }
     }
 
-    // ── Advance cursor (only on full burn success) ──────────────────────────
-
+    // ── Advance cursor (only when no halt-class failure occurred) ────────────
+    //
+    // `burn_ok` is true unless a SupplyInvariant (halt-class) failure broke the
+    // loop. Skippable failures (decode / InvalidBurn) leave it true so the
+    // cursor advances past the poison.
     if burn_ok {
         mutate_state(|s| {
             s.multi_chain.last_observed_block.insert(chain, finalized);
+            // Prune the idempotency set of entries the next scan can never
+            // re-reach. The next scan starts at `finalized + 1`, so any block
+            // <= finalized is permanently behind the cursor and its keys are no
+            // longer needed for dedup. This keeps `processed_burn_keys` bounded.
+            // On a halt-break (above), we DO NOT prune — the un-halt re-scan
+            // restarts from the same `last_observed + 1` and must stay idempotent.
+            let stale: Vec<u64> = s
+                .multi_chain
+                .processed_burn_keys
+                .range(..=finalized)
+                .map(|(&block, _)| block)
+                .collect();
+            for block in stale {
+                s.multi_chain.processed_burn_keys.remove(&block);
+            }
         });
     }
 }

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -38,7 +38,7 @@
 
 use ic_canister_log::log;
 
-use crate::chains::config::ChainId;
+use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::multi_chain_state::MultiChainStateV2;
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
@@ -135,6 +135,55 @@ pub fn apply_burn_to_state(
     Ok(())
 }
 
+// ─── Timer A tick (fan-out) ──────────────────────────────────────────────────
+
+/// Timer A entry point: run one observation cycle for every registered+enabled
+/// chain. The per-chain `run_observer` carries its own mode/halt/re-entrancy
+/// guards, so this fan-out just snapshots the chain-id list and calls each in
+/// turn. NO state borrow is held across the awaits — the chain-id Vec is cloned
+/// out of state up front.
+///
+/// No-op when no chain is registered (the Vec is empty), so it is safe to
+/// register on the staging canister before Monad is configured (Task 15 PocketIC
+/// smoke test asserts this).
+pub async fn observer_tick() {
+    let chains: Vec<ChainId> = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .iter()
+            .filter(|(_, c)| matches!(c.status, ChainStatus::Registered))
+            .map(|(id, _)| *id)
+            .collect()
+    });
+    for chain in chains {
+        run_observer(chain).await;
+    }
+}
+
+// ─── Per-chain re-entrancy guard (Task 13 review; wired Task 15) ───────────────
+//
+// Once Timer A runs at a short interval, a slow RPC tick can still be awaiting
+// when the next timer fires, which would spawn a SECOND `run_observer(chain)`
+// concurrently. Two concurrent observers could double-apply the same Burn log or
+// double-enqueue a mint for the same AwaitingDeposit vault. This per-chain guard
+// ensures only one `run_observer` per chain runs at a time. The RAII guard is a
+// local held across all awaits, so it releases when the async fn returns on ANY
+// path.
+
+thread_local! {
+    static OBSERVER_INFLIGHT: std::cell::RefCell<std::collections::BTreeSet<ChainId>> =
+        const { std::cell::RefCell::new(std::collections::BTreeSet::new()) };
+}
+
+struct ObserverGuard(ChainId);
+impl Drop for ObserverGuard {
+    fn drop(&mut self) {
+        OBSERVER_INFLIGHT.with(|s| {
+            s.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
 // ─── Async observer loop ─────────────────────────────────────────────────────
 
 /// Run one observation cycle for the given chain.
@@ -168,6 +217,21 @@ pub fn apply_burn_to_state(
 /// `fetch_block_numbers` and before the log scan. The structure below
 /// leaves a clear seam for that insertion.
 pub async fn run_observer(chain: ChainId) {
+    // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
+    // chain is still in flight, skip this one entirely. The RAII guard releases
+    // on the future completing (any return path), so the next tick re-acquires.
+    let _guard = match OBSERVER_INFLIGHT.with(|s| {
+        if s.borrow().contains(&chain) {
+            None
+        } else {
+            s.borrow_mut().insert(chain);
+            Some(ObserverGuard(chain))
+        }
+    }) {
+        Some(g) => g,
+        None => return, // a tick for this chain is already running; skip
+    };
+
     // Guard: skip if in read-only mode, the invariant has halted, or this chain
     // is reorg-halted (Task 11). A reorg-halted chain stops BOTH the observer
     // and the settlement worker until `clear_reorg_halt` (Task 14) is called.
@@ -440,11 +504,13 @@ pub async fn run_observer(chain: ChainId) {
 /// cache unpopulated, which the gas gate treats as fail-open). Borrow
 /// discipline: no `read_state`/`mutate_state` borrow is held across an `.await`.
 async fn refresh_hot_wallet_balance(chain: ChainId) {
-    let path = tecdsa::settlement_derivation_path(chain);
-    let addr = match tecdsa::derive_evm_address(path).await {
-        Ok((_pubkey, addr)) => addr,
+    // Resolve the settlement address via the per-chain cache (Task 11 M1) — the
+    // address is deterministic, so we avoid a tECDSA derive on every observer
+    // tick. We only need the address here (not the path).
+    let addr = match tecdsa::cached_settlement_address(chain).await {
+        Ok((_path, addr)) => addr,
         Err(e) => {
-            log!(INFO, "[observer chain={:?}] hot-wallet derive_evm_address failed: {}; skipping balance refresh", chain, e);
+            log!(INFO, "[observer chain={:?}] hot-wallet cached_settlement_address failed: {}; skipping balance refresh", chain, e);
             return;
         }
     };

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -46,6 +46,7 @@ use crate::state::{mutate_state, read_state};
 use crate::Mode;
 
 use super::evm_rpc::{decode_burn_log, fetch_block_numbers, get_balance, get_logs, BURN_EVENT_TOPIC0};
+use super::{hardening, tecdsa};
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -166,8 +167,14 @@ pub fn apply_burn_to_state(
 /// `fetch_block_numbers` and before the log scan. The structure below
 /// leaves a clear seam for that insertion.
 pub async fn run_observer(chain: ChainId) {
-    // Guard: skip if in read-only mode or invariant has halted.
-    let should_skip = read_state(|s| s.mode == Mode::ReadOnly || s.multi_chain.invariant_halted);
+    // Guard: skip if in read-only mode, the invariant has halted, or this chain
+    // is reorg-halted (Task 11). A reorg-halted chain stops BOTH the observer
+    // and the settlement worker until `clear_reorg_halt` (Task 14) is called.
+    let should_skip = read_state(|s| {
+        s.mode == Mode::ReadOnly
+            || s.multi_chain.invariant_halted
+            || s.multi_chain.reorg_halted.get(&chain).copied().unwrap_or(false)
+    });
     if should_skip {
         return;
     }
@@ -182,13 +189,21 @@ pub async fn run_observer(chain: ChainId) {
         }
     };
 
+    // ── Hot-wallet gas-balance refresh (Task 11) ─────────────────────────────
+    //
+    // Derive the settlement (minter) address and cache its native MON balance so
+    // the submit-path gas gate (`hardening::hot_wallet_ok`) has data and the
+    // Task-14 query surface can report it. Keeping the tECDSA + RPC cost here
+    // (once per observer tick) avoids paying it on every settlement submit.
+    // Tolerant of errors: a failed derive or balance read logs and continues —
+    // it must NOT abort the observer (reads/burn-watch must still run).
+    refresh_hot_wallet_balance(chain).await;
+
     let last_observed = read_state(|s| {
         s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0)
     });
 
     // Fetch finalized block number.
-    // TASK 11 SEAM: insert reorg check here, between fetch_block_numbers and
-    // the log scan below.
     let finalized = match fetch_block_numbers(chain).await {
         Ok((_latest, fin)) => fin,
         Err(e) => {
@@ -196,6 +211,36 @@ pub async fn run_observer(chain: ChainId) {
             return;
         }
     };
+
+    // ── Reorg check (Task 11) ────────────────────────────────────────────────
+    //
+    // A finalized-block regression deeper than this chain's `finality_depth` is
+    // a reorg past finality: halt the chain (observer + settlement) and emit
+    // ChainReorgDetected. The cursor is NOT advanced; recovery is operator-gated
+    // via `clear_reorg_halt` (Task 14). Default depth to the Monad testnet
+    // value (1) if the config is somehow unreadable.
+    let finality_depth = read_state(|s| {
+        s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
+    })
+    .unwrap_or(1);
+    if hardening::is_reorg(last_observed, finalized, finality_depth) {
+        let depth = last_observed.saturating_sub(finalized);
+        mutate_state(|s| {
+            s.multi_chain.reorg_halted.insert(chain, true);
+        });
+        crate::storage::record_event(&crate::event::Event::ChainReorgDetected {
+            chain_id: chain,
+            observed_block: finalized,
+            reorg_depth: depth,
+            timestamp: ic_cdk::api::time(),
+        });
+        log!(
+            INFO,
+            "[observer chain={:?}] REORG: finalized {} < last_observed {} by {} (> finality {}); halting chain",
+            chain, finalized, last_observed, depth, finality_depth
+        );
+        return;
+    }
 
     if finalized <= last_observed {
         // Nothing new to observe.
@@ -277,8 +322,7 @@ pub async fn run_observer(chain: ChainId) {
     // on each `custody_address`, computing the delta, and calling
     // `credit_deposit_to_state` + emitting `DepositObserved`.
     //
-    // The `get_balance` function is already available from `evm_rpc`.
-    let _ = get_balance; // suppress unused-import warning until Task 23
+    // (`get_balance` is now exercised by `refresh_hot_wallet_balance` above.)
 
     // ── Advance cursor (only on full success) ───────────────────────────────
 
@@ -286,5 +330,42 @@ pub async fn run_observer(chain: ChainId) {
         mutate_state(|s| {
             s.multi_chain.last_observed_block.insert(chain, finalized);
         });
+    }
+}
+
+/// Refresh the cached settlement-address MON balance for `chain` (Task 11).
+///
+/// Derives the settlement (minter) address via `settlement_derivation_path` +
+/// `derive_evm_address`, reads its native balance via `get_balance`, and caches
+/// it in `hot_wallet_balance_e18`. Used by the submit-path gas gate and the
+/// Task-14 query surface. Errors are logged and swallowed — a failed refresh
+/// leaves the previous cached value in place (or, on a fresh chain, leaves the
+/// cache unpopulated, which the gas gate treats as fail-open). Borrow
+/// discipline: no `read_state`/`mutate_state` borrow is held across an `.await`.
+async fn refresh_hot_wallet_balance(chain: ChainId) {
+    let path = tecdsa::settlement_derivation_path(chain);
+    let addr = match tecdsa::derive_evm_address(path).await {
+        Ok((_pubkey, addr)) => addr,
+        Err(e) => {
+            log!(INFO, "[observer chain={:?}] hot-wallet derive_evm_address failed: {}; skipping balance refresh", chain, e);
+            return;
+        }
+    };
+    match get_balance(chain, &addr).await {
+        Ok(bal) => {
+            mutate_state(|s| {
+                s.multi_chain.hot_wallet_balance_e18.insert(chain, bal);
+            });
+            if !hardening::hot_wallet_ok(bal) {
+                log!(
+                    INFO,
+                    "[observer chain={:?}] hot-wallet balance {} e18 below threshold {} e18 (settlement={})",
+                    chain, bal, hardening::HOT_WALLET_MIN_E18, addr
+                );
+            }
+        }
+        Err(e) => {
+            log!(INFO, "[observer chain={:?}] hot-wallet get_balance failed: {}; keeping cached value", chain, e);
+        }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -230,10 +230,16 @@ pub async fn observer_tick() {
 // ensures only one `run_observer` per chain runs at a time. The RAII guard is a
 // local held across all awaits, so it releases when the async fn returns on ANY
 // path.
+//
+// Self-healing (B2 hardening): the map stores the nanosecond timestamp the
+// guard was acquired at. On the IC, a trap in a post-await continuation does
+// NOT run `Drop`, so a stale entry would otherwise block that chain forever.
+// `hardening::inflight_should_acquire` reclaims entries older than
+// `hardening::INFLIGHT_STALE_NS` (10 min), self-healing after a trapped tick.
 
 thread_local! {
-    static OBSERVER_INFLIGHT: std::cell::RefCell<std::collections::BTreeSet<ChainId>> =
-        const { std::cell::RefCell::new(std::collections::BTreeSet::new()) };
+    static OBSERVER_INFLIGHT: std::cell::RefCell<std::collections::BTreeMap<ChainId, u64>> =
+        const { std::cell::RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 struct ObserverGuard(ChainId);
@@ -291,18 +297,23 @@ impl Drop for ObserverGuard {
 ///   no longer stalls the cursor, and a genuine divergence still halts.
 pub async fn run_observer(chain: ChainId) {
     // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
-    // chain is still in flight, skip this one entirely. The RAII guard releases
-    // on the future completing (any return path), so the next tick re-acquires.
+    // chain is still in flight (and not stale), skip this one entirely. The
+    // RAII guard releases on the future completing (any return path). A stale
+    // entry (> INFLIGHT_STALE_NS old) means the previous holder trapped in a
+    // post-await continuation and its `Drop` never ran — the later tick
+    // reclaims it, self-healing the permanent-block scenario.
+    let now_ns = ic_cdk::api::time();
     let _guard = match OBSERVER_INFLIGHT.with(|s| {
-        if s.borrow().contains(&chain) {
-            None
-        } else {
-            s.borrow_mut().insert(chain);
+        let existing = s.borrow().get(&chain).copied();
+        if hardening::inflight_should_acquire(existing, now_ns, hardening::INFLIGHT_STALE_NS) {
+            s.borrow_mut().insert(chain, now_ns);
             Some(ObserverGuard(chain))
+        } else {
+            None
         }
     }) {
         Some(g) => g,
-        None => return, // a tick for this chain is already running; skip
+        None => return, // a fresh tick for this chain is already running; skip
     };
 
     // Guard: skip if in read-only mode, the invariant has halted, or this chain

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -476,6 +476,22 @@ pub async fn run_observer(chain: ChainId) {
     // operator-gated via `clear_reorg_halt` (Task 14), which MUST reset BOTH
     // `reorg_halted` AND `reorg_suspect_streak` for the chain. Default depth to
     // the Monad testnet value (1) if the config is somehow unreadable.
+    //
+    // NOTE (Phase 1b / M-2 — reorg machinery is dormant on the observer path):
+    // `is_reorg` fires only when `finalized < last_observed` by more than
+    // `finality_depth`. But `fetch_block_numbers` uses the consensus-safe
+    // specific-block probe: it returns the current cursor (`last_observed,
+    // last_observed`) when the candidate block doesn't exist yet, and returns
+    // `(candidate, candidate)` — always >= last_observed — when it does.
+    // Therefore `finalized` is MONOTONICALLY >= `last_observed` on this path,
+    // and `is_reorg` (which requires finalized < last_observed) can never fire.
+    // The reorg circuit-breaker (`reorg_halted` / `reorg_suspect_streak` /
+    // `clear_reorg_halt`) is effectively dormant for Phase 1b. This is accepted:
+    // Monad's single-slot (depth-1) finality is the real reorg protection, and
+    // the probe checks block EXISTENCE (not hash), so a finalized-block hash
+    // reorg would be undetected. The reorg code is intentionally preserved —
+    // revisit for deeper-finality chains (Phase 1c) or if the probe is extended
+    // to verify block hashes.
     let finality_depth = read_state(|s| {
         s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
     })

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -215,15 +215,31 @@ pub async fn run_observer(chain: ChainId) {
     // ── Reorg check (Task 11) ────────────────────────────────────────────────
     //
     // A finalized-block regression deeper than this chain's `finality_depth` is
-    // a reorg past finality: halt the chain (observer + settlement) and emit
-    // ChainReorgDetected. The cursor is NOT advanced; recovery is operator-gated
-    // via `clear_reorg_halt` (Task 14). Default depth to the Monad testnet
-    // value (1) if the config is somehow unreadable.
+    // SUSPECTED to be a reorg past finality. But `fetch_block_numbers` queries
+    // ONE provider at a time (no quorum), so a single stale/lagging read could
+    // regress the finalized block transiently. We therefore require the
+    // suspicion to PERSIST across `hardening::REORG_CONFIRM_TICKS` consecutive
+    // observer ticks before halting; a single non-suspect tick resets the streak
+    // (`hardening::on_reorg_tick`), so a transient blip self-heals. Only on the
+    // K-th consecutive suspect tick do we halt the chain (observer + settlement)
+    // and emit ChainReorgDetected; the cursor is NOT advanced. Recovery is
+    // operator-gated via `clear_reorg_halt` (Task 14), which MUST reset BOTH
+    // `reorg_halted` AND `reorg_suspect_streak` for the chain. Default depth to
+    // the Monad testnet value (1) if the config is somehow unreadable.
     let finality_depth = read_state(|s| {
         s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
     })
     .unwrap_or(1);
-    if hardening::is_reorg(last_observed, finalized, finality_depth) {
+    let suspected = hardening::is_reorg(last_observed, finalized, finality_depth);
+    let streak = read_state(|s| {
+        s.multi_chain.reorg_suspect_streak.get(&chain).copied().unwrap_or(0)
+    });
+    let (new_streak, should_halt) = hardening::on_reorg_tick(streak, suspected);
+    mutate_state(|s| {
+        s.multi_chain.reorg_suspect_streak.insert(chain, new_streak);
+    });
+
+    if should_halt {
         let depth = last_observed.saturating_sub(finalized);
         mutate_state(|s| {
             s.multi_chain.reorg_halted.insert(chain, true);
@@ -236,11 +252,23 @@ pub async fn run_observer(chain: ChainId) {
         });
         log!(
             INFO,
-            "[observer chain={:?}] REORG: finalized {} < last_observed {} by {} (> finality {}); halting chain",
-            chain, finalized, last_observed, depth, finality_depth
+            "[observer chain={:?}] REORG CONFIRMED ({}/{} ticks): finalized {} < last_observed {} by {} (> finality {}); halting chain",
+            chain, new_streak, hardening::REORG_CONFIRM_TICKS, finalized, last_observed, depth, finality_depth
+        );
+        return;
+    } else if suspected {
+        // Below the confirmation threshold: do NOT halt and do NOT advance the
+        // cursor (finalized < last_observed means there is nothing new to scan
+        // anyway). Wait for the next tick to confirm or clear the suspicion.
+        log!(
+            INFO,
+            "[observer chain={:?}] suspected reorg, streak {}/{}, not halting yet (finalized {} < last_observed {})",
+            chain, new_streak, hardening::REORG_CONFIRM_TICKS, finalized, last_observed
         );
         return;
     }
+    // Not suspected: the streak was reset to 0 above, so a real reorg needs K
+    // CONSECUTIVE suspect ticks. Fall through to the normal nothing-new check.
 
     if finalized <= last_observed {
         // Nothing new to observe.

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -1,1 +1,289 @@
-//! Placeholder. Real impl in a later Task.
+//! Inbound observer for the Monad chain (Phase 1b, Task 9).
+//!
+//! ## Pure helpers (unit-tested)
+//!
+//! - `credit_deposit_to_state`: credits on-chain collateral deposits to a
+//!   ChainVaultV1 record (increments `collateral_amount_e18`).
+//! - `apply_burn_to_state`: atomically decrements `chain_supplies` and vault
+//!   `debt_e8s` when an on-chain Burn event is observed at finality.
+//!
+//! ## Mutation ordering in apply_burn_to_state (correctness guarantee)
+//!
+//! The function enforces a strict no-mutation-on-rejection guarantee:
+//!
+//! 1. Look up vault (reject if unknown — no mutation).
+//! 2. Reject if `burn.amount_e8s > debt_e8s` (no mutation).
+//! 3. Call `apply_supply_delta(state, chain, Decrease(amount), new_total_debt)`.
+//!    `apply_supply_delta` validates underflow, divergence, and halt BEFORE
+//!    mutating chain_supplies; on any error it returns `Err` with state
+//!    untouched.
+//! 4. ONLY after (3) succeeds: decrement `vault.debt_e8s`.
+//!
+//! This means a rejected burn (for any reason) leaves BOTH `chain_supplies`
+//! and `debt_e8s` unchanged — the tests in `tests_deposit_watch` assert this.
+//!
+//! ## Async observer loop (run_observer)
+//!
+//! `run_observer` scans Burn events at finality for the given chain and applies
+//! them through `apply_burn_to_state`. Deposit (collateral) watch is
+//! implemented as a minimal stub in Phase 1b: the pure helper
+//! `credit_deposit_to_state` is fully tested and ready; the async balance-check
+//! loop is deferred to the Task 23 manual integration (it requires a stable
+//! EVM RPC connection to Monad testnet). A TODO comment marks the stub clearly.
+//!
+//! Reorg handling is NOT implemented here; Task 11 adds the `is_reorg` check
+//! after fetching the finalized block number. The structure of `run_observer`
+//! intentionally leaves a seam for Task 11 to insert between the
+//! `fetch_block_numbers` call and the log-scan loop.
+
+use ic_canister_log::log;
+
+use crate::chains::config::ChainId;
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::supply::{apply_supply_delta, SupplyDelta};
+use crate::logs::INFO;
+use crate::state::{mutate_state, read_state};
+use crate::Mode;
+
+use super::evm_rpc::{decode_burn_log, fetch_block_numbers, get_balance, get_logs, BURN_EVENT_TOPIC0};
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/// Credit a confirmed on-chain deposit to a ChainVaultV1 record.
+///
+/// Increments `collateral_amount_e18` by `amount_e18` (saturating — overflow
+/// of a u128 collateral balance is not a realistic failure mode but we guard
+/// it anyway). Returns `Err` if the vault is not found.
+pub fn credit_deposit_to_state(
+    state: &mut MultiChainStateV2,
+    vault_id: u64,
+    amount_e18: u128,
+) -> Result<(), String> {
+    let vault = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .ok_or_else(|| format!("credit_deposit: unknown vault_id {}", vault_id))?;
+    vault.collateral_amount_e18 = vault.collateral_amount_e18.saturating_add(amount_e18);
+    Ok(())
+}
+
+/// Apply a confirmed on-chain Burn event to protocol state.
+///
+/// Decrements `chain_supplies[chain]` and `vault.debt_e8s` together.
+/// The caller must pass `total_debt_e8s` — the authoritative pre-burn
+/// total debt snapshot (the same value returned by
+/// `state.total_borrowed_icusd_amount()` at the moment of the call).
+/// The function internally computes the expected post-burn total as
+/// `total_debt_e8s - burn.amount_e8s` and passes that to
+/// `apply_supply_delta` so the invariant check can verify:
+///   `new_chain_supplies_sum == post_burn_total_debt`.
+///
+/// ## Mutation ordering (correctness guarantee)
+///
+/// 1. Vault lookup — reject (no mutation) if unknown.
+/// 2. Debt-exceeds check — reject (no mutation) if `amount > debt`.
+/// 3. `apply_supply_delta` — validates and mutates `chain_supplies` or
+///    rejects entirely (no mutation to any field on error).
+/// 4. Only after (3) succeeds: `vault.debt_e8s -= amount_e8s`.
+///
+/// Any rejection path returns `Err` with BOTH `chain_supplies` and
+/// `debt_e8s` unchanged.
+pub fn apply_burn_to_state(
+    state: &mut MultiChainStateV2,
+    burn: &super::evm_rpc::BurnLog,
+    total_debt_e8s: u128,
+) -> Result<(), String> {
+    // Step 1: vault lookup (read-only — no mutation on failure)
+    let (chain, current_debt) = {
+        let vault = state
+            .chain_vaults
+            .get(&burn.vault_id)
+            .ok_or_else(|| format!("apply_burn: unknown vault_id {}", burn.vault_id))?;
+        (vault.collateral_chain, vault.debt_e8s)
+    };
+
+    // Step 2: debt-exceeds check (no mutation on failure)
+    if burn.amount_e8s > current_debt {
+        return Err(format!(
+            "apply_burn: burn amount {} exceeds vault {} debt {}",
+            burn.amount_e8s, burn.vault_id, current_debt
+        ));
+    }
+
+    // Compute the post-burn total debt that apply_supply_delta will compare
+    // against the post-delta chain_supplies sum. total_debt_e8s is the
+    // pre-burn authoritative total; after this burn the total drops by
+    // burn.amount_e8s (the vault's ICP-side total_borrowed_icusd_amount
+    // includes chain-vault debt tracked in chain_supplies, so they move
+    // together).
+    let post_burn_total = total_debt_e8s.saturating_sub(burn.amount_e8s);
+
+    // Step 3: supply delta — validates and mutates chain_supplies, or rejects
+    // entirely (chain_supplies unchanged on Err)
+    apply_supply_delta(state, chain, SupplyDelta::Decrease(burn.amount_e8s), post_burn_total)
+        .map_err(|e| format!("{:?}", e))?;
+
+    // Step 4: only reached when supply delta succeeded — decrement vault debt
+    let vault = state
+        .chain_vaults
+        .get_mut(&burn.vault_id)
+        .expect("vault present: checked above");
+    vault.debt_e8s -= burn.amount_e8s;
+
+    Ok(())
+}
+
+// ─── Async observer loop ─────────────────────────────────────────────────────
+
+/// Run one observation cycle for the given chain.
+///
+/// Called by Timer A (configured in Task 12). Scans Burn logs from
+/// `last_observed_block + 1` to the current finalized block and applies
+/// them to state. Advances `last_observed_block` to `finalized` at the end.
+///
+/// ## Burn watch
+///
+/// For each raw Burn log decoded via `decode_burn_log`, the observer:
+/// 1. Reads the current total supply (as-of-this-moment, before this burn).
+/// 2. Computes `new_total_debt = current_total - amount_e8s`.
+/// 3. Calls `mutate_state(apply_burn_to_state)` and records a
+///    `ChainBurnObserved` event on success.
+/// 4. On failure: logs the error clearly and continues to the next log.
+///    The block cursor does NOT advance past a failing burn — if any burn
+///    in a range fails, the entire range is retried on the next tick.
+///    (Per Phase 1b spec: "log + continue is acceptable but the error must
+///    be visible". A future hardening pass can add per-burn retry tracking.)
+///
+/// ## Deposit watch (STUB — Phase 1b)
+///
+/// The pure helper `credit_deposit_to_state` is fully tested. The async
+/// custody-balance poll loop is deferred to Task 23 (manual integration).
+/// This stub logs that deposit watch is not yet active.
+///
+/// ## Reorg handling
+///
+/// NOT implemented here. Task 11 inserts an `is_reorg` check after
+/// `fetch_block_numbers` and before the log scan. The structure below
+/// leaves a clear seam for that insertion.
+pub async fn run_observer(chain: ChainId) {
+    // Guard: skip if in read-only mode or invariant has halted.
+    let should_skip = read_state(|s| s.mode == Mode::ReadOnly || s.multi_chain.invariant_halted);
+    if should_skip {
+        return;
+    }
+
+    // Read the icUSD contract address for this chain. Return early if unset.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+    let contract = match contract {
+        Some(c) => c,
+        None => {
+            log!(INFO, "[observer chain={:?}] no contract address configured; skipping", chain);
+            return;
+        }
+    };
+
+    let last_observed = read_state(|s| {
+        s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0)
+    });
+
+    // Fetch finalized block number.
+    // TASK 11 SEAM: insert reorg check here, between fetch_block_numbers and
+    // the log scan below.
+    let finalized = match fetch_block_numbers(chain).await {
+        Ok((_latest, fin)) => fin,
+        Err(e) => {
+            log!(INFO, "[observer chain={:?}] fetch_block_numbers failed: {}", chain, e);
+            return;
+        }
+    };
+
+    if finalized <= last_observed {
+        // Nothing new to observe.
+        return;
+    }
+
+    let from_block = last_observed + 1;
+
+    // ── Burn watch ──────────────────────────────────────────────────────────
+
+    let raw_burn_logs = match get_logs(chain, &contract, BURN_EVENT_TOPIC0, from_block, finalized).await {
+        Ok(logs) => logs,
+        Err(e) => {
+            log!(INFO, "[observer chain={:?}] get_logs(burn) failed: {}; will retry on next tick", chain, e);
+            return;
+        }
+    };
+
+    let mut burn_ok = true;
+    for (topics, data, tx_hash, block_number) in &raw_burn_logs {
+        let burn = match decode_burn_log(topics, &data, &tx_hash, *block_number) {
+            Ok(b) => b,
+            Err(e) => {
+                log!(INFO, "[observer chain={:?}] decode_burn_log failed at block {}: {}", chain, block_number, e);
+                burn_ok = false;
+                break;
+            }
+        };
+
+        // Snapshot current total before this burn (each burn changes the total
+        // as debt_e8s is decremented per burn). We pass the pre-burn total;
+        // apply_burn_to_state internally computes post_burn_total for the
+        // invariant check.
+        let current_total: u128 = read_state(|s| {
+            s.total_borrowed_icusd_amount().to_u64() as u128
+        });
+
+        let burn_clone = burn.clone();
+        let result = mutate_state(|s| {
+            apply_burn_to_state(&mut s.multi_chain, &burn_clone, current_total)
+        });
+
+        match result {
+            Ok(()) => {
+                let now = ic_cdk::api::time();
+                crate::storage::record_event(&crate::event::Event::ChainBurnObserved {
+                    chain_id: chain,
+                    vault_id: burn.vault_id,
+                    amount_e8s: burn.amount_e8s,
+                    tx_hash: burn.tx_hash.clone(),
+                    block_number: burn.block_number,
+                    timestamp: now,
+                });
+                log!(
+                    INFO,
+                    "[observer chain={:?}] burn applied: vault={} amount_e8s={} block={} tx={}",
+                    chain, burn.vault_id, burn.amount_e8s, burn.block_number, burn.tx_hash
+                );
+            }
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[observer chain={:?}] apply_burn_to_state FAILED for tx {} vault {}: {}",
+                    chain, burn.tx_hash, burn.vault_id, e
+                );
+                burn_ok = false;
+                break;
+            }
+        }
+    }
+
+    // ── Deposit watch (STUB) ─────────────────────────────────────────────────
+    //
+    // The pure helper `credit_deposit_to_state` is implemented and tested.
+    // The async custody-balance poll is deferred to Task 23 (manual
+    // integration with Monad testnet). When Task 23 lands, replace this block
+    // with a loop over open chain_vaults for this chain, calling `get_balance`
+    // on each `custody_address`, computing the delta, and calling
+    // `credit_deposit_to_state` + emitting `DepositObserved`.
+    //
+    // The `get_balance` function is already available from `evm_rpc`.
+    let _ = get_balance; // suppress unused-import warning until Task 23
+
+    // ── Advance cursor (only on full success) ───────────────────────────────
+
+    if burn_ok {
+        mutate_state(|s| {
+            s.multi_chain.last_observed_block.insert(chain, finalized);
+        });
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -92,6 +92,20 @@ pub fn credit_deposit_to_state(
 ///
 /// Any rejection path returns `Err` with BOTH `chain_supplies` and
 /// `debt_e8s` unchanged.
+///
+/// ## Permissionless payer (intentional; see IcUSD.sol review)
+///
+/// `IcUSD.burn(amount, target_vault_id)` is public: ANY holder can burn their
+/// OWN icUSD citing ANY `vault_id`, and this function decrements THAT vault's
+/// debt without checking the burner owns it. This is a deliberate "anyone can
+/// repay a vault" design, NOT a theft vector: the burner destroys their own
+/// tokens, and the freed collateral is only ever released by the separate,
+/// owner-authorized (status==Open) `withdraw_chain_collateral`/`close_chain_vault`
+/// path — never off the burn. The supply invariant stays balanced (supply and
+/// debt both drop by `amount`). The only effect of a third-party burn is to
+/// over-collateralize the target vault (a gift). A future phase may add a
+/// burner==owner constraint if griefing (uninvited debt repayment) becomes a
+/// concern; for Phase 1b it is accepted.
 pub fn apply_burn_to_state(
     state: &mut MultiChainStateV2,
     burn: &super::evm_rpc::BurnLog,

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -569,14 +569,22 @@ pub async fn run_observer(chain: ChainId) {
     // InvalidBurn): those advance past their offending log so a single poison
     // burn can never stall the cursor (the silent-double-apply trigger).
     //
-    // Idempotency: every burn carries an on-chain identity key
-    // (`{tx_hash}:{vault_id}:{amount_e8s}`) recorded in `processed_burn_keys`
+    // Idempotency: every burn is keyed by its CANONICAL on-chain identity
+    // `format!("{tx_hash}:{log_index}")` and recorded in `processed_burn_keys`
     // once handled (applied OR permanently skipped). On any re-scan of the same
     // range, an already-keyed burn is `continue`-d BEFORE `apply_burn_to_state`,
     // so the already-applied prefix is NEVER re-applied — this is the core fix
     // for the C-1 supply-divergence (debt_e8s + chain_supplies double-decrement).
+    //
+    // Using `(tx_hash, log_index)` rather than the old `(tx_hash, vault_id,
+    // amount_e8s)` key fixes Minor #1 (review): IcUSD.burn() is permissionless,
+    // so a wrapper contract can emit two identical Burn events in one tx with
+    // the same vault_id and amount. Those two burns have DIFFERENT log indices
+    // and must both be credited. The old key collapsed them into one entry,
+    // silently dropping the second burn and leaving the vault's debt and chain
+    // supply over-stated.
     let mut burn_ok = true;
-    for (topics, data, tx_hash, block_number) in &raw_burn_logs {
+    for (topics, data, tx_hash, block_number, log_index) in &raw_burn_logs {
         let burn = match decode_burn_log(topics, data, tx_hash, *block_number) {
             Ok(b) => b,
             Err(e) => {
@@ -592,11 +600,10 @@ pub async fn run_observer(chain: ChainId) {
             }
         };
 
-        // Idempotency key: tx_hash uniquely identifies the tx; vault_id+amount
-        // disambiguate the (unlikely) multi-burn tx. If already processed at this
-        // block, this burn's debt/supply decrement already happened — skip it so
-        // a re-scan never double-applies.
-        let key = format!("{}:{}:{}", burn.tx_hash, burn.vault_id, burn.amount_e8s);
+        // Canonical on-chain identity: (tx_hash, log_index). The log_index
+        // uniquely identifies a log within a transaction, so two Burn events
+        // in the same tx (same vault, same amount) are never collapsed.
+        let key = format!("{}:{}", burn.tx_hash, log_index);
         let already_processed = read_state(|s| {
             s.multi_chain
                 .processed_burn_keys
@@ -706,6 +713,15 @@ pub async fn run_observer(chain: ChainId) {
             // longer needed for dedup. This keeps `processed_burn_keys` bounded.
             // On a halt-break (above), we DO NOT prune — the un-halt re-scan
             // restarts from the same `last_observed + 1` and must stay idempotent.
+            //
+            // PHASE-1C NOTE: This prune assumes no other observer tick is
+            // concurrently alive and still holding captured `get_logs` results
+            // for a now-pruned block. That is safe for Phase 1b: single-slot
+            // finality + bounded outcall timeouts + a handful of vaults make a
+            // tick running longer than MAX_BLOCK_SCAN_WINDOW blocks unreachable
+            // in practice. Revisit for Phase 1c (deeper finality / higher vault
+            // counts) where a self-heal reclaim could race the prune and a
+            // stale tick might re-apply a burn whose key was already pruned.
             let stale: Vec<u64> = s
                 .multi_chain
                 .processed_burn_keys

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Real impl in a later Task.

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -70,13 +70,15 @@ pub fn credit_deposit_to_state(
 /// Apply a confirmed on-chain Burn event to protocol state.
 ///
 /// Decrements `chain_supplies[chain]` and `vault.debt_e8s` together.
-/// The caller must pass `total_debt_e8s` — the authoritative pre-burn
-/// total debt snapshot (the same value returned by
-/// `state.total_borrowed_icusd_amount()` at the moment of the call).
-/// The function internally computes the expected post-burn total as
-/// `total_debt_e8s - burn.amount_e8s` and passes that to
+/// The caller must pass `total_debt_e8s` — the pre-burn sum of
+/// `chain_vault.debt_e8s` across all foreign-chain vaults (i.e.
+/// `MultiChainStateV2::total_chain_vault_debt_e8s()` at the moment of
+/// the call). The function internally computes the expected post-burn
+/// total as `total_debt_e8s - burn.amount_e8s` and passes that to
 /// `apply_supply_delta` so the invariant check can verify:
 ///   `new_chain_supplies_sum == post_burn_total_debt`.
+/// ICP-native debt (`State::total_borrowed_icusd_amount`) is a separate
+/// pool and must NOT be passed here.
 ///
 /// ## Mutation ordering (correctness guarantee)
 ///
@@ -112,10 +114,8 @@ pub fn apply_burn_to_state(
 
     // Compute the post-burn total debt that apply_supply_delta will compare
     // against the post-delta chain_supplies sum. total_debt_e8s is the
-    // pre-burn authoritative total; after this burn the total drops by
-    // burn.amount_e8s (the vault's ICP-side total_borrowed_icusd_amount
-    // includes chain-vault debt tracked in chain_supplies, so they move
-    // together).
+    // pre-burn sum of foreign-chain vault debts (total_chain_vault_debt_e8s);
+    // after this burn the total drops by burn.amount_e8s.
     let post_burn_total = total_debt_e8s.saturating_sub(burn.amount_e8s);
 
     // Step 3: supply delta — validates and mutates chain_supplies, or rejects
@@ -225,13 +225,14 @@ pub async fn run_observer(chain: ChainId) {
             }
         };
 
-        // Snapshot current total before this burn (each burn changes the total
-        // as debt_e8s is decremented per burn). We pass the pre-burn total;
-        // apply_burn_to_state internally computes post_burn_total for the
-        // invariant check.
-        let current_total: u128 = read_state(|s| {
-            s.total_borrowed_icusd_amount().to_u64() as u128
-        });
+        // Snapshot the pre-burn foreign-chain vault debt total (each burn
+        // decrements one vault's debt_e8s, so we re-read before each burn
+        // to get the correct pre-burn total for the invariant check).
+        // total_chain_vault_debt_e8s sums only chain_vaults, which is the
+        // correct pool for the Phase 1b foreign-chain-only supply invariant.
+        // ICP-native total_borrowed_icusd_amount is a separate pool and is
+        // deliberately excluded here.
+        let current_total: u128 = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
 
         let burn_clone = burn.clone();
         let result = mutate_state(|s| {

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -1,10 +1,18 @@
 //! EVM RPC wrapper for Monad chain state reads and signed-tx broadcasting.
 //!
-//! Design: calls the EVM RPC canister (`7hfb6-caaaa-aaaar-qadga-cai`) via the
-//! generic `request` escape-hatch method using `call_with_payment128`.  This
-//! avoids the `evm_rpc_client` crate (which requires ic-cdk 0.19, incompatible
-//! with this project's ic-cdk 0.12 pin).  JSON-RPC responses are parsed with
-//! `serde_json` (already a workspace dep).
+//! Design: most reads call the EVM RPC canister (`7hfb6-caaaa-aaaar-qadga-cai`)
+//! via the generic `request` escape-hatch method using `call_with_payment128`.
+//! This avoids the `evm_rpc_client` crate (which requires ic-cdk 0.19,
+//! incompatible with this project's ic-cdk 0.12 pin).  JSON-RPC responses are
+//! parsed with `serde_json` (already a workspace dep).
+//!
+//! Exception — finalized-height reads (`fetch_block_numbers`): these go through
+//! the TYPED `eth_getBlockByNumber(Number(N))` method (candid types mirrored
+//! below), NOT `request`.  A volatile chain-head read (`eth_blockNumber`, or any
+//! `latest`/`finalized` tag) differs across the EVM RPC canister's subnet
+//! replicas on a fast-finality chain like Monad → IC HTTPS-outcall consensus
+//! never agrees → the call fails every tick.  Probing a SPECIFIC, already-final
+//! block number is byte-identical across replicas, so it reaches consensus.
 //!
 //! Cycle cost: `EVM_RPC_CALL_CYCLES` (2_000_000_000) per request.  This is
 //! intentionally generous — the actual HTTPS-outcall cost depends on response
@@ -46,6 +54,13 @@ pub const EVM_RPC_CALL_CYCLES: u128 = 2_000_000_000;
 /// Sized to cover typical JSON-RPC responses; `eth_getLogs` responses can be
 /// large — callers using a narrow block range stay within this limit.
 const EVM_RPC_MAX_RESPONSE_BYTES: u64 = 8192;
+
+/// Max blocks the burn-watch cursor advances per observer tick. The observer
+/// reads chain head by probing a SPECIFIC block number `last_observed + this`
+/// (consensus-safe), never a volatile `latest`/`finalized` tag. Must exceed
+/// observer_interval_secs × chain_block_rate (~30s × 2 blk/s = 60) to keep pace,
+/// and stay <= the EVM RPC eth_getLogs maxBlockRange (default 500). 256 fits both.
+pub const MAX_BLOCK_SCAN_WINDOW: u64 = 256;
 
 // ─── Topic0 constants ────────────────────────────────────────────────────────
 
@@ -177,6 +192,95 @@ impl std::fmt::Display for RpcError {
 pub enum RequestResult {
     Ok(String),
     Err(RpcError),
+}
+
+// ─── Candid types for the TYPED `eth_getBlockByNumber` method ────────────────
+//
+// Source: live .did of `7hfb6-caaaa-aaaar-qadga-cai` (see
+// `docs/evm_rpc_reference.did`).  Unlike the `request` escape-hatch above,
+// `eth_getBlockByNumber` takes the PLURAL `RpcServices` (multi-provider) and a
+// `BlockTag`, and returns a `MultiGetBlockByNumberResult`.  We use this method
+// (with a SPECIFIC `Number(N)` tag) for the consensus-safe finalized-height
+// probe — a fixed block number is byte-identical across all IC replicas,
+// unlike the volatile `eth_blockNumber` / `latest` / `finalized` reads.
+
+/// PLURAL `RpcServices` (distinct from the singular `RpcService` above).
+/// Only the `Custom` arm is mirrored — Monad is always a single custom
+/// provider keyed by `chainId`.  The other arms (`EthMainnet`, etc.) exist in
+/// the .did but are never encoded here.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcServices {
+    Custom {
+        #[serde(rename = "chainId")]
+        chain_id: u64,
+        services: Vec<RpcApi>,
+    },
+}
+
+/// Mirrors the live .did `BlockTag`.  We only ever SEND `Number(N)` (a
+/// specific, already-final block number → consensus-safe).  The other tags are
+/// mirrored for fidelity but never encoded.
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum BlockTag {
+    Earliest,
+    Safe,
+    Finalized,
+    Latest,
+    Number(candid::Nat),
+    Pending,
+}
+
+/// `ConsensusStrategy` from the live .did.  Mirrored so `RpcConfig` is
+/// well-formed; the single-provider probe never constructs one (passes
+/// `responseConsensus = null`).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ConsensusStrategy {
+    Equality,
+    Threshold {
+        total: Option<u8>,
+        min: u8,
+    },
+}
+
+/// `RpcConfig` from the live .did.  The typed `eth_getBlockByNumber` takes
+/// `opt RpcConfig`; we always pass `None` (a single provider needs no
+/// consensus strategy), but the type must exist so the candid arg tuple
+/// `(RpcServices, opt RpcConfig, BlockTag)` is unambiguous.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct RpcConfig {
+    #[serde(rename = "responseSizeEstimate")]
+    pub response_size_estimate: Option<u64>,
+    #[serde(rename = "responseConsensus")]
+    pub response_consensus: Option<ConsensusStrategy>,
+}
+
+/// Mirrors the live .did `Block` record, but with **only the `number` field**.
+///
+/// Candid record-subtyping lets a reader declaring FEWER fields decode the
+/// full wire record (the extra fields — `hash`, `timestamp`, `miner`, etc. —
+/// are ignored).  The round-trip unit test in `tests_evm_rpc` proves this.
+/// `number` is the only field the finalized-height probe reads.
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct Block {
+    pub number: candid::Nat,
+}
+
+/// `GetBlockByNumberResult = variant { Ok : Block; Err : RpcError }`.
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum GetBlockByNumberResult {
+    Ok(Block),
+    Err(RpcError),
+}
+
+/// `MultiGetBlockByNumberResult` from the live .did.  We only ever send ONE
+/// `Custom` provider, so the canister always returns `Consistent`;
+/// `Inconsistent` is never on the wire and never decoded in practice (it
+/// references the singular `RpcService`, which is fine since we never decode
+/// that arm).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum MultiGetBlockByNumberResult {
+    Consistent(GetBlockByNumberResult),
+    Inconsistent(Vec<(RpcService, GetBlockByNumberResult)>),
 }
 
 // ─── Pure parsers ─────────────────────────────────────────────────────────────
@@ -421,64 +525,105 @@ fn next_rpc_id() -> u64 {
 
 // ─── Public async interface ──────────────────────────────────────────────────
 
-/// Returns `(latest_block, finalized_block)` for the given chain.
-///
-/// Tries `eth_getBlockByNumber("finalized", ...)` first.  If the provider
-/// does not support the `finalized` tag (returns an error), falls back to
-/// `latest.saturating_sub(finality_depth)` from the chain config.
-pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
-    // Fetch latest block number
-    let latest_payload = format!(
-        r#"{{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":{}}}"#,
-        next_rpc_id()
-    );
-    let latest_text = call_evm_rpc(chain, &latest_payload).await?;
-    let latest_val: serde_json::Value = serde_json::from_str(&latest_text)
-        .map_err(|e| format!("eth_blockNumber parse error: {}", e))?;
-    let latest_hex = latest_val["result"]
-        .as_str()
-        .ok_or_else(|| format!("eth_blockNumber: missing result in {:?}", latest_text))?;
-    let latest = parse_hex_quantity(latest_hex)? as u64;
+/// Consensus-safe probe: does finalized block `n` exist? Routes through the
+/// TYPED eth_getBlockByNumber(Number(n)) (a specific number is byte-identical
+/// across IC replicas, unlike a volatile block tag). Returns Ok(Some(number))
+/// if present, Ok(None) if not yet reached (benign — caught up / future block),
+/// Err only on a genuine infra failure (call error / Inconsistent).
+async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, String> {
+    // Read the chain's configured endpoints (same source as `call_evm_rpc`).
+    // The typed method needs a single Custom provider; use the first endpoint.
+    let endpoints: Vec<String> = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.rpc_endpoints.clone())
+            .unwrap_or_default()
+    });
+    let first = endpoints
+        .first()
+        .ok_or_else(|| format!("no RPC endpoints configured for chain {:?}", chain))?
+        .clone();
 
-    // Try "finalized" tag; fall back to latest - finality_depth on failure.
-    let finalized_payload = format!(
-        r#"{{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":{}}}"#,
-        next_rpc_id()
-    );
-    let finalized = match call_evm_rpc(chain, &finalized_payload).await {
-        Ok(text) => {
-            let val: serde_json::Value = serde_json::from_str(&text)
-                .map_err(|e| format!("eth_getBlockByNumber(finalized) parse: {}", e))?;
-            if val["result"].is_null() || val["error"].is_object() {
-                // Provider doesn't support finalized tag; use depth fallback.
-                let depth = read_state(|s| {
-                    s.multi_chain
-                        .chain_configs
-                        .get(&chain)
-                        .map(|c| c.finality_depth as u64)
-                        .unwrap_or(64)
-                });
-                latest.saturating_sub(depth)
-            } else {
-                let number_hex = val["result"]["number"]
-                    .as_str()
-                    .ok_or_else(|| format!("finalized block missing number field"))?;
-                parse_hex_quantity(number_hex)? as u64
-            }
-        }
-        Err(_) => {
-            let depth = read_state(|s| {
-                s.multi_chain
-                    .chain_configs
-                    .get(&chain)
-                    .map(|c| c.finality_depth as u64)
-                    .unwrap_or(64)
-            });
-            latest.saturating_sub(depth)
-        }
+    let rpc_services = RpcServices::Custom {
+        chain_id: chain.0 as u64,
+        services: vec![RpcApi {
+            url: first,
+            headers: None,
+        }],
     };
 
-    Ok((latest, finalized))
+    let canister = evm_rpc_principal();
+    let result: Result<(MultiGetBlockByNumberResult,), _> =
+        ic_cdk::api::call::call_with_payment128(
+            canister,
+            "eth_getBlockByNumber",
+            (
+                rpc_services,
+                Option::<RpcConfig>::None,
+                BlockTag::Number(candid::Nat::from(n)),
+            ),
+            EVM_RPC_CALL_CYCLES,
+        )
+        .await;
+
+    match result {
+        Ok((MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Ok(block)),)) => {
+            // candid::Nat → u64; overflow is a hard error (a block number that
+            // exceeds u64 is impossible in practice and would corrupt the cursor).
+            let num: u64 = u64::try_from(block.number.0.clone())
+                .map_err(|_| format!("block number {} overflows u64", block.number))?;
+            Ok(Some(num))
+        }
+        Ok((MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Err(rpc_err)),)) => {
+            // Block-not-found / future block is the common benign case.
+            log!(
+                DEBUG,
+                "[evm_rpc] eth_getBlockByNumber(Number({})) not found: {:?}",
+                n,
+                rpc_err
+            );
+            Ok(None)
+        }
+        Ok((MultiGetBlockByNumberResult::Inconsistent(_),)) => {
+            Err("unexpected inconsistent eth_getBlockByNumber result".to_string())
+        }
+        Err((code, msg)) => Err(format!(
+            "eth_getBlockByNumber call error ({:?}): {}",
+            code, msg
+        )),
+    }
+}
+
+/// Returns `(latest_block, finalized_block)` for the given chain.
+///
+/// Both elements are the same **consensus-safe** probed height. We do NOT read
+/// the volatile chain head (`eth_blockNumber` or a `latest`/`finalized` tag):
+/// on a fast-finality chain like Monad those differ across the EVM RPC
+/// canister's subnet replicas, so the IC HTTPS-outcall consensus never agrees
+/// and the call fails every tick. Instead we probe a SPECIFIC block number
+/// `last_observed + MAX_BLOCK_SCAN_WINDOW` via the typed
+/// `eth_getBlockByNumber(Number(N))` (a fixed, already-final number is
+/// byte-identical across replicas):
+///   - if that block exists & is final → advance the window up to it
+///   - if not (chain hasn't reached it yet) → return the current cursor (no
+///     new blocks this tick)
+///
+/// `last_observed == 0` means the burn-watch cursor is unseeded; the caller
+/// (`run_observer`) skips burn-watch entirely in that case (no genesis crawl).
+pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
+    let last_observed = read_state(|s| {
+        s.multi_chain
+            .last_observed_block
+            .get(&chain)
+            .copied()
+            .unwrap_or(0)
+    });
+    let candidate = last_observed.saturating_add(MAX_BLOCK_SCAN_WINDOW);
+    match eth_get_block_number_at(chain, candidate).await? {
+        Some(_) => Ok((candidate, candidate)), // block exists & final → advance window
+        None => Ok((last_observed, last_observed)), // not advanced enough yet → nothing new
+    }
 }
 
 /// Returns the ETH/native balance (in wei) of `address` at the latest block.

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -682,7 +682,19 @@ pub async fn get_transaction_count(chain: ChainId, address: &str) -> Result<u64,
 
 /// Returns logs matching `(contract, topic0, fromBlock..toBlock)`.
 ///
-/// Each entry in the returned `Vec` is `(topics, data, txHash, blockNumber)`.
+/// Each entry in the returned `Vec` is
+/// `(topics, data, txHash, blockNumber, logIndex)`.
+///
+/// `logIndex` is the EVM log index within the transaction — the canonical
+/// on-chain identity of a log is `(tx_hash, log_index)`, not
+/// `(tx_hash, vault_id, amount)`. Two identical Burn events emitted in the
+/// same transaction (same tx_hash, same vault, same amount) have DIFFERENT
+/// log indices and must both be credited.
+///
+/// If the JSON entry has no `logIndex` field (should not happen for real finalized
+/// logs), the entry's position in the returned array is used as a stable fallback,
+/// ensuring two distinct logs still get distinct indices.
+///
 /// The caller is responsible for decoding via `decode_burn_log` /
 /// `decode_mint_log` etc.
 pub async fn get_logs(
@@ -691,7 +703,7 @@ pub async fn get_logs(
     topic0: &str,
     from_block: u64,
     to_block: u64,
-) -> Result<Vec<(Vec<String>, String, String, u64)>, String> {
+) -> Result<Vec<(Vec<String>, String, String, u64, u64)>, String> {
     let payload = format!(
         r#"{{"jsonrpc":"2.0","method":"eth_getLogs","params":[{{"address":{:?},"topics":[{:?}],"fromBlock":"0x{:x}","toBlock":"0x{:x}"}}],"id":{}}}"#,
         contract,
@@ -713,7 +725,7 @@ pub async fn get_logs(
         .ok_or_else(|| format!("eth_getLogs: result is not an array in {:?}", text))?;
 
     let mut out = Vec::with_capacity(logs.len());
-    for entry in logs {
+    for (position, entry) in logs.iter().enumerate() {
         let topics: Vec<String> = entry["topics"]
             .as_array()
             .map(|arr| {
@@ -726,7 +738,15 @@ pub async fn get_logs(
         let tx_hash = entry["transactionHash"].as_str().unwrap_or("0x").to_string();
         let block_number_hex = entry["blockNumber"].as_str().unwrap_or("0x0");
         let block_number = parse_hex_quantity(block_number_hex)? as u64;
-        out.push((topics, data, tx_hash, block_number));
+        // The log_index is the authoritative per-log identity within a tx.
+        // Fall back to the array position if the field is absent (should not
+        // happen for real finalized logs, but ensures distinct indices even in
+        // that edge case).
+        let log_index = match entry["logIndex"].as_str() {
+            Some(hex) => parse_hex_quantity(hex)? as u64,
+            None => position as u64,
+        };
+        out.push((topics, data, tx_hash, block_number, log_index));
     }
     Ok(out)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -88,7 +88,7 @@ pub enum RpcService {
 }
 
 /// Mirrors the live .did `JsonRpcError` record.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct JsonRpcError {
     pub code: i64,
     pub message: String,
@@ -96,13 +96,13 @@ pub struct JsonRpcError {
 
 /// Mirrors the live .did `ProviderError` variant.
 /// `TooFewCycles` carries an anonymous record `{ expected: nat; received: nat }`.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct TooFewCyclesRecord {
     pub expected: candid::Nat,
     pub received: candid::Nat,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ProviderError {
     TooFewCycles(TooFewCyclesRecord),
     MissingRequiredProvider,
@@ -111,17 +111,33 @@ pub enum ProviderError {
     InvalidRpcConfig(String),
 }
 
+/// Mirrors the live .did `RejectionCode` variant (fieldless).
+///
+/// The EVM RPC canister returns `IcError { code: RejectionCode; ... }` where
+/// `RejectionCode` is a Candid variant.  Previously this was declared as `u32`
+/// which caused a Candid decode trap whenever the canister returned an
+/// `HttpOutcallError::IcError` (e.g. during no-consensus scenarios).
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum RejectionCode {
+    NoError,
+    CanisterError,
+    SysTransient,
+    DestinationInvalid,
+    Unknown,
+    SysFatal,
+    CanisterReject,
+}
+
 /// Mirrors the live .did `HttpOutcallError` variant.
 /// `IcError` carries `{ code: RejectionCode; message: text }`.
 /// `InvalidHttpJsonRpcResponse` carries `{ status: nat16; body: text; parsingError: opt text }`.
-/// We use opaque structs for the payloads since we only need to display them.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IcErrorRecord {
-    pub code: u32, // RejectionCode as u32 for simplicity
+    pub code: RejectionCode,
     pub message: String,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct InvalidHttpJsonRpcRecord {
     pub status: u16,
     pub body: String,
@@ -129,20 +145,20 @@ pub struct InvalidHttpJsonRpcRecord {
     pub parsing_error: Option<String>,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum HttpOutcallError {
     IcError(IcErrorRecord),
     InvalidHttpJsonRpcResponse(InvalidHttpJsonRpcRecord),
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ValidationError {
     Custom(String),
     InvalidHex(String),
 }
 
 /// Full `RpcError` as in the live .did.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum RpcError {
     JsonRpcError(JsonRpcError),
     ProviderError(ProviderError),
@@ -157,7 +173,7 @@ impl std::fmt::Display for RpcError {
 }
 
 /// `RequestResult` from the EVM RPC canister `request` method.
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum RequestResult {
     Ok(String),
     Err(RpcError),

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -36,7 +36,7 @@ use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
 use crate::chains::config::ChainId;
 use crate::state::read_state;
-use crate::logs::DEBUG;
+use crate::logs::{DEBUG, INFO};
 
 // ─── Cycle cost ─────────────────────────────────────────────────────────────
 
@@ -277,6 +277,15 @@ pub enum GetBlockByNumberResult {
 /// `Inconsistent` is never on the wire and never decoded in practice (it
 /// references the singular `RpcService`, which is fine since we never decode
 /// that arm).
+///
+/// NOTE (Phase 1b / M-1): `RpcService` above mirrors only the `Custom` variant.
+/// If multi-provider support is ever introduced (e.g. a second `Custom` URL or
+/// a built-in `EthMainnet`-style arm), the EVM RPC canister MAY return an
+/// `Inconsistent` result containing a non-`Custom` `RpcService` variant, which
+/// would TRAP on Candid decode because this enum lacks those arms. Acceptable
+/// for Phase 1b (Monad is always addressed via a single `Custom` provider);
+/// revisit by mirroring the full `RpcService` variant set if multi-provider is
+/// introduced.
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum MultiGetBlockByNumberResult {
     Consistent(GetBlockByNumberResult),
@@ -530,6 +539,13 @@ fn next_rpc_id() -> u64 {
 /// across IC replicas, unlike a volatile block tag). Returns Ok(Some(number))
 /// if present, Ok(None) if not yet reached (benign — caught up / future block),
 /// Err only on a genuine infra failure (call error / Inconsistent).
+///
+/// A one-off Ok(None) is expected when the chain hasn't produced that block yet.
+/// A PERSISTENT stream of Ok(None) in the INFO log (with an rpc_err in the
+/// message) indicates a real provider or consensus problem and means the
+/// burn-watch cursor is stalled — it will not advance until the probe starts
+/// returning Ok(Some(...)). Investigate the RPC endpoint and the EVM RPC
+/// canister's cycle balance if you see this repeating.
 async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, String> {
     // Read the chain's configured endpoints (same source as `call_evm_rpc`).
     // The typed method needs a single Custom provider; use the first endpoint.
@@ -576,11 +592,17 @@ async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, 
             Ok(Some(num))
         }
         Ok((MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Err(rpc_err)),)) => {
-            // Block-not-found / future block is the common benign case.
+            // Block-not-found is the common benign case (chain hasn't reached
+            // block n yet). HOWEVER a rate-limit, TooFewCycles, or IcError also
+            // maps here — both collapse to Ok(None) so the cursor does not advance.
+            // A single occurrence is harmless; a PERSISTENT stream means a real
+            // provider / consensus problem and the cursor is stalled. See the
+            // helper's doc comment for the monitoring note.
             log!(
-                DEBUG,
-                "[evm_rpc] eth_getBlockByNumber(Number({})) not found: {:?}",
+                INFO,
+                "[evm_rpc] eth_getBlockByNumber(Number({})) chain={:?} returned no block ({:?}); treating as not-yet-final (cursor will not advance this tick)",
                 n,
+                chain,
                 rpc_err
             );
             Ok(None)

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -1,1 +1,639 @@
-//! Placeholder. Real impl in a later Task.
+//! EVM RPC wrapper for Monad chain state reads and signed-tx broadcasting.
+//!
+//! Design: calls the EVM RPC canister (`7hfb6-caaaa-aaaar-qadga-cai`) via the
+//! generic `request` escape-hatch method using `call_with_payment128`.  This
+//! avoids the `evm_rpc_client` crate (which requires ic-cdk 0.19, incompatible
+//! with this project's ic-cdk 0.12 pin).  JSON-RPC responses are parsed with
+//! `serde_json` (already a workspace dep).
+//!
+//! Cycle cost: `EVM_RPC_CALL_CYCLES` (2_000_000_000) per request.  This is
+//! intentionally generous — the actual HTTPS-outcall cost depends on response
+//! size and subnet node count but is typically in the hundreds-of-millions
+//! range.  The constant is marked tunable; a developer-gated setter can be
+//! added once we have production measurements.
+//!
+//! Provider fallback: `call_evm_rpc` iterates over the chain's configured
+//! `rpc_endpoints` in order and returns the first `Ok` response; on all-fail
+//! it returns the last error.
+//!
+//! Pure parsers (`parse_hex_quantity`, `BurnLog::from_raw`,
+//! `MintLog::from_raw`) are unit-tested in `tests_evm_rpc`.  The async
+//! network functions are covered by the Task 17 PocketIC mock.
+//!
+//! Candid types (`RpcApi`, `RpcService`, `RequestResult`, `RpcError`) are
+//! defined inline here from the live .did (verified 2026-05-28 by fetching
+//! `7hfb6-caaaa-aaaar-qadga-cai candid:service`).
+
+use candid::{CandidType, Deserialize, Principal};
+use ic_canister_log::log;
+use crate::chains::config::ChainId;
+use crate::state::read_state;
+use crate::logs::DEBUG;
+
+// ─── Cycle cost ─────────────────────────────────────────────────────────────
+
+/// Cycles attached per `request` call to the EVM RPC canister.
+///
+/// Tunable constant.  The canister's HTTPS-outcall forwarding cost is roughly:
+///   base(49_140_000) + 5_200*request_bytes + 10_400*response_bytes,
+/// scaled by the number of nodes in the subnet (13 for the NNS app subnet).
+/// For a typical 200-byte request and 2 KB response on a 13-node subnet that
+/// is approximately 400M cycles.  2B gives ~5x headroom and matches the
+/// approach used for the XRC `get_exchange_rate` call.
+pub const EVM_RPC_CALL_CYCLES: u128 = 2_000_000_000;
+
+/// Maximum response bytes requested from the EVM RPC canister per call.
+/// Sized to cover typical JSON-RPC responses; `eth_getLogs` responses can be
+/// large — callers using a narrow block range stay within this limit.
+const EVM_RPC_MAX_RESPONSE_BYTES: u64 = 8192;
+
+// ─── Topic0 constants ────────────────────────────────────────────────────────
+
+/// keccak256("Burn(uint256,address,uint256)")
+/// Computed via pycryptodome Keccak-256 (verified against the Transfer
+/// event well-known hash to confirm the implementation is correct).
+pub const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+
+/// keccak256("Mint(uint256,address,uint256)")
+pub const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+
+// ─── Candid types for the EVM RPC canister `request` method ─────────────────
+//
+// Source: live .did of `7hfb6-caaaa-aaaar-qadga-cai` (fetched 2026-05-28).
+// We define only the minimal surface needed for `request` + `RequestResult`.
+// The full .did has many more variants (EthMainnet, EthSepolia, etc.) which
+// we do not need since Monad is always addressed via the `Custom` variant.
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct EvmRpcHttpHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct RpcApi {
+    pub url: String,
+    pub headers: Option<Vec<EvmRpcHttpHeader>>,
+}
+
+/// Minimal `RpcService` — only the `Custom` variant is needed for Monad
+/// (all other variants address built-in chains by name).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcService {
+    Custom(RpcApi),
+    // Other built-in variants exist in the .did but are unused here.
+    // Candid decoding is flexible: we only need to encode Custom.
+}
+
+/// Mirrors the live .did `JsonRpcError` record.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+/// Mirrors the live .did `ProviderError` variant.
+/// `TooFewCycles` carries an anonymous record `{ expected: nat; received: nat }`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TooFewCyclesRecord {
+    pub expected: candid::Nat,
+    pub received: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ProviderError {
+    TooFewCycles(TooFewCyclesRecord),
+    MissingRequiredProvider,
+    ProviderNotFound,
+    NoPermission,
+    InvalidRpcConfig(String),
+}
+
+/// Mirrors the live .did `HttpOutcallError` variant.
+/// `IcError` carries `{ code: RejectionCode; message: text }`.
+/// `InvalidHttpJsonRpcResponse` carries `{ status: nat16; body: text; parsingError: opt text }`.
+/// We use opaque structs for the payloads since we only need to display them.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct IcErrorRecord {
+    pub code: u32, // RejectionCode as u32 for simplicity
+    pub message: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct InvalidHttpJsonRpcRecord {
+    pub status: u16,
+    pub body: String,
+    #[serde(rename = "parsingError")]
+    pub parsing_error: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum HttpOutcallError {
+    IcError(IcErrorRecord),
+    InvalidHttpJsonRpcResponse(InvalidHttpJsonRpcRecord),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum ValidationError {
+    Custom(String),
+    InvalidHex(String),
+}
+
+/// Full `RpcError` as in the live .did.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RpcError {
+    JsonRpcError(JsonRpcError),
+    ProviderError(ProviderError),
+    ValidationError(ValidationError),
+    HttpOutcallError(HttpOutcallError),
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// `RequestResult` from the EVM RPC canister `request` method.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum RequestResult {
+    Ok(String),
+    Err(RpcError),
+}
+
+// ─── Pure parsers ─────────────────────────────────────────────────────────────
+
+/// Parse a 0x-prefixed hex string into a `u128`.
+///
+/// Strips the leading `"0x"` prefix (case-insensitive) and then interprets the
+/// remainder as a big-endian hex integer.  Returns `Err` on malformed input.
+pub fn parse_hex_quantity(s: &str) -> Result<u128, String> {
+    let hex = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .ok_or_else(|| format!("missing 0x prefix: {:?}", s))?;
+    u128::from_str_radix(hex, 16)
+        .map_err(|e| format!("invalid hex quantity {:?}: {}", s, e))
+}
+
+// ─── BurnLog ─────────────────────────────────────────────────────────────────
+
+/// Parsed representation of a `Burn(uint256 vault_id, address burner,
+/// uint256 amount)` log emitted by the icUSD EVM contract on Monad.
+///
+/// ABI layout:
+///   topics[0] = BURN_EVENT_TOPIC0
+///   topics[1] = vault_id  (indexed, padded to 32 bytes)
+///   topics[2] = burner    (indexed, EVM address padded to 32 bytes)
+///   data      = amount    (uint256, 32 bytes)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BurnLog {
+    pub vault_id: u64,
+    pub amount_e8s: u128,
+    pub tx_hash: String,
+    pub block_number: u64,
+}
+
+impl BurnLog {
+    /// Decode a `BurnLog` from raw log fields.
+    ///
+    /// `topics` must have at least 3 entries; `data` is the ABI-encoded amount.
+    /// topic0 comparison is case-insensitive (RPC responses vary in
+    /// EIP-55 mixed-case vs lowercase; our constant is lowercase).
+    pub fn from_raw(
+        topics: &[String],
+        data: &str,
+        tx_hash: &str,
+        block_number: u64,
+    ) -> Result<Self, String> {
+        if topics.len() < 3 {
+            return Err(format!(
+                "BurnLog: expected >=3 topics, got {}",
+                topics.len()
+            ));
+        }
+        if !topics[0].eq_ignore_ascii_case(BURN_EVENT_TOPIC0) {
+            return Err(format!(
+                "BurnLog: wrong topic0: expected {} got {}",
+                BURN_EVENT_TOPIC0, topics[0]
+            ));
+        }
+        let vault_id_raw = parse_hex_quantity(&topics[1])?;
+        if vault_id_raw > u64::MAX as u128 {
+            return Err(format!("BurnLog: vault_id overflow: {}", vault_id_raw));
+        }
+        let amount_e8s = parse_hex_quantity(data)?;
+        Ok(BurnLog {
+            vault_id: vault_id_raw as u64,
+            amount_e8s,
+            tx_hash: tx_hash.to_string(),
+            block_number,
+        })
+    }
+}
+
+/// Convenience free fn delegating to `BurnLog::from_raw`.
+pub fn decode_burn_log(
+    topics: &[String],
+    data: &str,
+    tx_hash: &str,
+    block_number: u64,
+) -> Result<BurnLog, String> {
+    BurnLog::from_raw(topics, data, tx_hash, block_number)
+}
+
+// ─── MintLog ─────────────────────────────────────────────────────────────────
+
+/// Parsed representation of a `Mint(uint256 vault_id, address recipient,
+/// uint256 amount)` log.
+///
+/// ABI layout:
+///   topics[0] = MINT_EVENT_TOPIC0
+///   topics[1] = vault_id   (indexed)
+///   topics[2] = recipient  (indexed, EVM address padded to 32 bytes)
+///   data      = amount     (uint256)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MintLog {
+    pub vault_id: u64,
+    /// EVM address of the mint recipient (0x-prefixed, lowercase).
+    pub recipient: String,
+    pub amount_e8s: u128,
+    pub tx_hash: String,
+    pub block_number: u64,
+}
+
+impl MintLog {
+    /// Decode a `MintLog` from raw log fields.
+    pub fn from_raw(
+        topics: &[String],
+        data: &str,
+        tx_hash: &str,
+        block_number: u64,
+    ) -> Result<Self, String> {
+        if topics.len() < 3 {
+            return Err(format!(
+                "MintLog: expected >=3 topics, got {}",
+                topics.len()
+            ));
+        }
+        if !topics[0].eq_ignore_ascii_case(MINT_EVENT_TOPIC0) {
+            return Err(format!(
+                "MintLog: wrong topic0: expected {} got {}",
+                MINT_EVENT_TOPIC0, topics[0]
+            ));
+        }
+        let vault_id_raw = parse_hex_quantity(&topics[1])?;
+        if vault_id_raw > u64::MAX as u128 {
+            return Err(format!("MintLog: vault_id overflow: {}", vault_id_raw));
+        }
+        // Recipient address: last 20 bytes of the 32-byte padded topic2.
+        // We store the full 32-byte topic as a 0x-prefixed hex string,
+        // but callers can extract the address from the last 40 hex chars.
+        let recipient = {
+            let raw = topics[2]
+                .strip_prefix("0x")
+                .or_else(|| topics[2].strip_prefix("0X"))
+                .unwrap_or(&topics[2]);
+            // Ethereum addresses are 20 bytes (40 hex chars); topic is padded to 32 bytes (64 hex chars).
+            let addr_hex = if raw.len() >= 40 {
+                &raw[raw.len() - 40..]
+            } else {
+                raw
+            };
+            format!("0x{}", addr_hex.to_lowercase())
+        };
+        let amount_e8s = parse_hex_quantity(data)?;
+        Ok(MintLog {
+            vault_id: vault_id_raw as u64,
+            recipient,
+            amount_e8s,
+            tx_hash: tx_hash.to_string(),
+            block_number,
+        })
+    }
+}
+
+/// Convenience free fn delegating to `MintLog::from_raw`.
+pub fn decode_mint_log(
+    topics: &[String],
+    data: &str,
+    tx_hash: &str,
+    block_number: u64,
+) -> Result<MintLog, String> {
+    MintLog::from_raw(topics, data, tx_hash, block_number)
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/// Returns the EVM RPC canister principal.
+///
+/// Uses the developer-gated `evm_rpc_principal_override` from State when set
+/// (enables PocketIC and staging to point at a mock canister).  Falls back to
+/// the production canister on the IC app subnet.
+fn evm_rpc_principal() -> Principal {
+    read_state(|s| s.evm_rpc_override())
+        .unwrap_or_else(|| {
+            Principal::from_text("7hfb6-caaaa-aaaar-qadga-cai")
+                .expect("static EVM RPC principal is valid")
+        })
+}
+
+/// Send a raw JSON-RPC payload to the EVM RPC canister using the `request`
+/// escape-hatch method.  Tries each of the chain's configured RPC endpoints in
+/// order and returns the first successful `Ok` inner text.  On all-fail returns
+/// the last error string.
+async fn call_evm_rpc(chain: ChainId, json_payload: &str) -> Result<String, String> {
+    let endpoints: Vec<String> = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.rpc_endpoints.clone())
+            .unwrap_or_default()
+    });
+
+    if endpoints.is_empty() {
+        return Err(format!("no RPC endpoints configured for chain {:?}", chain));
+    }
+
+    let canister = evm_rpc_principal();
+    let mut last_err = String::new();
+
+    for url in &endpoints {
+        let rpc_service = RpcService::Custom(RpcApi {
+            url: url.clone(),
+            headers: None,
+        });
+
+        let result: Result<(RequestResult,), _> =
+            ic_cdk::api::call::call_with_payment128(
+                canister,
+                "request",
+                (rpc_service, json_payload.to_string(), EVM_RPC_MAX_RESPONSE_BYTES),
+                EVM_RPC_CALL_CYCLES,
+            )
+            .await;
+
+        match result {
+            Ok((RequestResult::Ok(text),)) => {
+                log!(DEBUG, "[evm_rpc] call ok via {}", url);
+                return Ok(text);
+            }
+            Ok((RequestResult::Err(rpc_err),)) => {
+                last_err = format!("RPC error from {}: {:?}", url, rpc_err);
+                log!(DEBUG, "[evm_rpc] provider error via {}: {:?}", url, rpc_err);
+            }
+            Err((code, msg)) => {
+                last_err = format!("call error to {} ({:?}): {}", url, code, msg);
+                log!(DEBUG, "[evm_rpc] call error via {}: {:?} {}", url, code, msg);
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
+// ─── JSON-RPC request ID counter ─────────────────────────────────────────────
+
+use std::sync::atomic::{AtomicU64, Ordering};
+static RPC_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_rpc_id() -> u64 {
+    RPC_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+// ─── Public async interface ──────────────────────────────────────────────────
+
+/// Returns `(latest_block, finalized_block)` for the given chain.
+///
+/// Tries `eth_getBlockByNumber("finalized", ...)` first.  If the provider
+/// does not support the `finalized` tag (returns an error), falls back to
+/// `latest.saturating_sub(finality_depth)` from the chain config.
+pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
+    // Fetch latest block number
+    let latest_payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":{}}}"#,
+        next_rpc_id()
+    );
+    let latest_text = call_evm_rpc(chain, &latest_payload).await?;
+    let latest_val: serde_json::Value = serde_json::from_str(&latest_text)
+        .map_err(|e| format!("eth_blockNumber parse error: {}", e))?;
+    let latest_hex = latest_val["result"]
+        .as_str()
+        .ok_or_else(|| format!("eth_blockNumber: missing result in {:?}", latest_text))?;
+    let latest = parse_hex_quantity(latest_hex)? as u64;
+
+    // Try "finalized" tag; fall back to latest - finality_depth on failure.
+    let finalized_payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":{}}}"#,
+        next_rpc_id()
+    );
+    let finalized = match call_evm_rpc(chain, &finalized_payload).await {
+        Ok(text) => {
+            let val: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("eth_getBlockByNumber(finalized) parse: {}", e))?;
+            if val["result"].is_null() || val["error"].is_object() {
+                // Provider doesn't support finalized tag; use depth fallback.
+                let depth = read_state(|s| {
+                    s.multi_chain
+                        .chain_configs
+                        .get(&chain)
+                        .map(|c| c.finality_depth as u64)
+                        .unwrap_or(64)
+                });
+                latest.saturating_sub(depth)
+            } else {
+                let number_hex = val["result"]["number"]
+                    .as_str()
+                    .ok_or_else(|| format!("finalized block missing number field"))?;
+                parse_hex_quantity(number_hex)? as u64
+            }
+        }
+        Err(_) => {
+            let depth = read_state(|s| {
+                s.multi_chain
+                    .chain_configs
+                    .get(&chain)
+                    .map(|c| c.finality_depth as u64)
+                    .unwrap_or(64)
+            });
+            latest.saturating_sub(depth)
+        }
+    };
+
+    Ok((latest, finalized))
+}
+
+/// Returns the ETH/native balance (in wei) of `address` at the latest block.
+pub async fn get_balance(chain: ChainId, address: &str) -> Result<u128, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getBalance","params":[{:?},"latest"],"id":{}}}"#,
+        address,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_getBalance parse: {}", e))?;
+    let hex = val["result"]
+        .as_str()
+        .ok_or_else(|| format!("eth_getBalance: missing result in {:?}", text))?;
+    parse_hex_quantity(hex)
+}
+
+/// Returns the transaction count (nonce) of `address` at the latest block.
+pub async fn get_transaction_count(chain: ChainId, address: &str) -> Result<u64, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":[{:?},"latest"],"id":{}}}"#,
+        address,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_getTransactionCount parse: {}", e))?;
+    let hex = val["result"]
+        .as_str()
+        .ok_or_else(|| format!("eth_getTransactionCount: missing result in {:?}", text))?;
+    Ok(parse_hex_quantity(hex)? as u64)
+}
+
+/// Returns logs matching `(contract, topic0, fromBlock..toBlock)`.
+///
+/// Each entry in the returned `Vec` is `(topics, data, txHash, blockNumber)`.
+/// The caller is responsible for decoding via `decode_burn_log` /
+/// `decode_mint_log` etc.
+pub async fn get_logs(
+    chain: ChainId,
+    contract: &str,
+    topic0: &str,
+    from_block: u64,
+    to_block: u64,
+) -> Result<Vec<(Vec<String>, String, String, u64)>, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getLogs","params":[{{"address":{:?},"topics":[{:?}],"fromBlock":"0x{:x}","toBlock":"0x{:x}"}}],"id":{}}}"#,
+        contract,
+        topic0,
+        from_block,
+        to_block,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_getLogs parse: {}", e))?;
+
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_getLogs RPC error: {}", err));
+    }
+
+    let logs = val["result"]
+        .as_array()
+        .ok_or_else(|| format!("eth_getLogs: result is not an array in {:?}", text))?;
+
+    let mut out = Vec::with_capacity(logs.len());
+    for entry in logs {
+        let topics: Vec<String> = entry["topics"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let data = entry["data"].as_str().unwrap_or("0x").to_string();
+        let tx_hash = entry["transactionHash"].as_str().unwrap_or("0x").to_string();
+        let block_number_hex = entry["blockNumber"].as_str().unwrap_or("0x0");
+        let block_number = parse_hex_quantity(block_number_hex)? as u64;
+        out.push((topics, data, tx_hash, block_number));
+    }
+    Ok(out)
+}
+
+/// Returns `None` if the transaction is still pending, or `Some((success,
+/// block_number))` once mined, where `success` is `true` iff status == 0x1.
+pub async fn get_transaction_receipt(
+    chain: ChainId,
+    tx_hash: &str,
+) -> Result<Option<(bool, u64)>, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":[{:?}],"id":{}}}"#,
+        tx_hash,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_getTransactionReceipt parse: {}", e))?;
+
+    if val["result"].is_null() {
+        return Ok(None); // transaction still pending
+    }
+
+    let status_hex = val["result"]["status"].as_str().unwrap_or("0x0");
+    let success = parse_hex_quantity(status_hex)? == 1;
+    let block_number_hex = val["result"]["blockNumber"]
+        .as_str()
+        .ok_or_else(|| format!("receipt missing blockNumber in {:?}", text))?;
+    let block_number = parse_hex_quantity(block_number_hex)? as u64;
+    Ok(Some((success, block_number)))
+}
+
+/// Broadcasts a signed raw transaction.  Returns the transaction hash on
+/// success.
+pub async fn send_raw_transaction(chain: ChainId, raw_tx_hex: &str) -> Result<String, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[{:?}],"id":{}}}"#,
+        raw_tx_hex,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_sendRawTransaction parse: {}", e))?;
+
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_sendRawTransaction RPC error: {}", err));
+    }
+
+    val["result"]
+        .as_str()
+        .map(String::from)
+        .ok_or_else(|| format!("eth_sendRawTransaction: missing result in {:?}", text))
+}
+
+/// Returns `(base_fee_wei, priority_fee_wei)` for gas estimation.
+///
+/// Unit: **wei** (not gwei).  Uses `eth_gasPrice` as a simple heuristic;
+/// splits the result 90/10 into base_fee/priority_fee.  If `eth_gasPrice`
+/// fails, returns a conservative default of (1_000_000_000 wei = 1 gwei,
+/// 100_000_000 wei = 0.1 gwei) and logs the failure.
+///
+/// A more accurate implementation can switch to `eth_feeHistory` once
+/// production gas data is available from Monad testnet.
+pub async fn fetch_fees(chain: ChainId) -> Result<(u128, u128), String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":{}}}"#,
+        next_rpc_id()
+    );
+    match call_evm_rpc(chain, &payload).await {
+        Ok(text) => {
+            let val: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("eth_gasPrice parse: {}", e))?;
+            let hex = val["result"]
+                .as_str()
+                .ok_or_else(|| format!("eth_gasPrice: missing result in {:?}", text))?;
+            let gas_price = parse_hex_quantity(hex)?;
+            // Simple split: 90% base, 10% priority tip.
+            let base_fee = gas_price * 9 / 10;
+            let priority_fee = gas_price - base_fee;
+            Ok((base_fee, priority_fee))
+        }
+        Err(e) => {
+            log!(
+                DEBUG,
+                "[evm_rpc] fetch_fees failed for chain {:?}: {}; using default",
+                chain,
+                e
+            );
+            // Conservative default: 1 gwei base + 0.1 gwei priority.
+            Ok((1_000_000_000, 100_000_000))
+        }
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Real impl in a later Task.

--- a/src/rumi_protocol_backend/src/chains/monad/hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/hardening.rs
@@ -10,6 +10,38 @@ pub fn is_stuck(tries: u32, finality_depth: u32) -> bool {
     tries as u64 >= (finality_depth as u64).saturating_mul(2).max(2)
 }
 
+/// Decide what a NOT-MINED confirm tick does to an inflight op. The first
+/// element is the new `tries` value (always advanced by 1, saturating, so the
+/// stuck threshold can actually be crossed — the prior code never advanced
+/// `tries` on a plain not-mined tick, so replace-by-fee never fired). The second
+/// is whether to replace-by-fee THIS tick: only when the advanced count is stuck
+/// AND we recorded the original submit nonce (`has_submit_nonce`) — resubmitting
+/// without the stored nonce would risk a fresh-nonce second mint.
+pub fn on_not_mined_tick(tries: u32, finality_depth: u32, has_submit_nonce: bool) -> (u32, bool) {
+    let new_tries = tries.saturating_add(1);
+    let resubmit = has_submit_nonce && is_stuck(new_tries, finality_depth);
+    (new_tries, resubmit)
+}
+
+/// Consecutive observer ticks a finalized-block regression must persist before
+/// it is treated as a real reorg (vs a transient single-provider RPC lag).
+/// fetch_block_numbers is un-quorumed (one provider at a time), so a single
+/// stale read must NOT permanently halt the chain.
+pub const REORG_CONFIRM_TICKS: u32 = 3;
+
+/// Decide the reorg-suspicion streak transition for one observer tick.
+/// `suspected` is the `is_reorg(..)` result this tick. Returns
+/// `(new_streak, should_halt)`: a suspect tick advances the streak and halts
+/// once it reaches `REORG_CONFIRM_TICKS`; a non-suspect tick resets to 0.
+pub fn on_reorg_tick(streak: u32, suspected: bool) -> (u32, bool) {
+    if suspected {
+        let s = streak.saturating_add(1);
+        (s, s >= REORG_CONFIRM_TICKS)
+    } else {
+        (0, false)
+    }
+}
+
 /// A reorg deeper than finality: the newly-observed finalized block is LOWER
 /// than the previously-observed one by MORE than finality_depth.
 pub fn is_reorg(prev_observed: u64, now_observed: u64, finality_depth: u32) -> bool {

--- a/src/rumi_protocol_backend/src/chains/monad/hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/hardening.rs
@@ -57,3 +57,46 @@ pub fn hot_wallet_ok(balance_e18: u128) -> bool {
 pub fn bump_gas(prio: u128, max_fee: u128) -> (u128, u128) {
     (prio.saturating_mul(125) / 100, max_fee.saturating_mul(125) / 100)
 }
+
+// ─── Inflight guard self-heal ────────────────────────────────────────────────
+//
+// On the IC, a trap in a post-await continuation does NOT run `Drop`, so a
+// per-chain inflight-guard entry can stick forever if the holder trapped.  To
+// self-heal, each guard stores the timestamp it was acquired at.  A later tick
+// whose `inflight_should_acquire` check finds the entry older than
+// `INFLIGHT_STALE_NS` reclaims it (the previous holder must have trapped; a
+// live slow tick's dedup/idempotency makes an accidental concurrent observer
+// supply-safe anyway).
+
+/// Stale threshold for per-chain inflight guard entries (in nanoseconds).
+///
+/// A healthy observer/settlement tick completes in seconds; the timers fire
+/// every ~30 s. If an in-flight entry is older than this, the previous holder
+/// must have trapped in a post-await continuation (`Drop` never ran), so a
+/// later tick reclaims it. Set well above the worst-case legit tick (several
+/// sequential RPC outcalls) to avoid reclaiming a merely-slow tick (which
+/// dedup/idempotency would make safe anyway). 10 min mirrors the existing
+/// stale-operation threshold convention.
+pub const INFLIGHT_STALE_NS: u64 = 600_000_000_000; // 10 minutes
+
+/// Decide whether a new tick should acquire the inflight guard for a chain.
+///
+/// - `existing`: the timestamp stored in the guard map, or `None` if the
+///   chain is not currently held.
+/// - `now_ns`: `ic_cdk::api::time()` at the start of this tick.
+/// - `stale_ns`: the stale threshold (normally `INFLIGHT_STALE_NS`).
+///
+/// Returns `true` (acquire) when:
+///   - The chain is free (`None`), OR
+///   - The existing entry is stale (`now_ns - acquired_at >= stale_ns`).
+///
+/// Returns `false` (skip) when a fresh tick holds the guard.
+/// `saturating_sub` prevents a panic if `acquired_at > now_ns` (clock skew or
+/// future timestamp in state); the result is 0, which is always < `stale_ns`,
+/// so a spurious future timestamp is treated as "fresh" (safe: skip the tick).
+pub fn inflight_should_acquire(existing: Option<u64>, now_ns: u64, stale_ns: u64) -> bool {
+    match existing {
+        None => true,
+        Some(acquired_at) => now_ns.saturating_sub(acquired_at) >= stale_ns,
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/hardening.rs
@@ -1,0 +1,27 @@
+//! Operational hardening predicates (spec Section 3). Pure + unit-tested.
+
+/// Minimum settlement-address MON balance (e18) to allow new outbound ops.
+/// Below this, refuse new ops on the chain (reads still work). 0.1 MON.
+pub const HOT_WALLET_MIN_E18: u128 = 100_000_000_000_000_000; // 0.1 MON
+
+/// An inflight op is stuck once tries >= finality_depth * 2 (min 2). EVM
+/// replace-by-fee: bump gas and resubmit on the SAME nonce.
+pub fn is_stuck(tries: u32, finality_depth: u32) -> bool {
+    tries as u64 >= (finality_depth as u64).saturating_mul(2).max(2)
+}
+
+/// A reorg deeper than finality: the newly-observed finalized block is LOWER
+/// than the previously-observed one by MORE than finality_depth.
+pub fn is_reorg(prev_observed: u64, now_observed: u64, finality_depth: u32) -> bool {
+    now_observed < prev_observed && (prev_observed - now_observed) > finality_depth as u64
+}
+
+/// Gas gate: settlement address has at least the minimum MON.
+pub fn hot_wallet_ok(balance_e18: u128) -> bool {
+    balance_e18 >= HOT_WALLET_MIN_E18
+}
+
+/// Bump EIP-1559 fees by 25% (EVM RBF floor is +10%; 25% is a safe margin).
+pub fn bump_gas(prio: u128, max_fee: u128) -> (u128, u128) {
+    (prio.saturating_mul(125) / 100, max_fee.saturating_mul(125) / 100)
+}

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -36,3 +36,6 @@ mod tests_evm_rpc;
 
 #[cfg(test)]
 mod tests_tx;
+
+#[cfg(test)]
+mod tests_deposit_watch;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -46,3 +46,6 @@ mod tests_settlement;
 
 #[cfg(test)]
 mod tests_hardening;
+
+#[cfg(test)]
+mod tests_open_vault;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -27,3 +27,6 @@ mod tests_chain_vault;
 
 #[cfg(test)]
 mod tests_tecdsa;
+
+#[cfg(test)]
+mod tests_evm_rpc;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -24,3 +24,6 @@ mod tests_config;
 
 #[cfg(test)]
 mod tests_chain_vault;
+
+#[cfg(test)]
+mod tests_tecdsa;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -17,4 +17,7 @@ pub mod tx;
 
 pub use adapter::MonadAdapter;
 pub use chain_vault::{ChainVaultStatus, ChainVaultV1};
-pub use config::{monad_default_config, MonadContracts, CONTRACTS, MONAD_CHAIN_ID};
+pub use config::{monad_default_register_arg, monad_ecdsa_key_name, MONAD_CHAIN_ID, MONAD_ICUSD_DECIMALS};
+
+#[cfg(test)]
+mod tests_config;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -20,6 +20,9 @@ pub use chain_vault::{ChainVaultStatus, ChainVaultV1};
 pub use config::{monad_default_register_arg, monad_ecdsa_key_name, MONAD_CHAIN_ID, MONAD_ICUSD_DECIMALS};
 
 #[cfg(test)]
+mod tests_adapter;
+
+#[cfg(test)]
 mod tests_config;
 
 #[cfg(test)]

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -21,3 +21,6 @@ pub use config::{monad_default_register_arg, monad_ecdsa_key_name, MONAD_CHAIN_I
 
 #[cfg(test)]
 mod tests_config;
+
+#[cfg(test)]
+mod tests_chain_vault;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -11,6 +11,7 @@ pub mod chain_vault;
 pub mod config;
 pub mod deposit_watch;
 pub mod evm_rpc;
+pub mod hardening;
 pub mod settlement;
 pub mod tecdsa;
 pub mod tx;
@@ -42,3 +43,6 @@ mod tests_deposit_watch;
 
 #[cfg(test)]
 mod tests_settlement;
+
+#[cfg(test)]
+mod tests_hardening;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -1,0 +1,20 @@
+//! Monad adapter (Phase 1b). First real chain integration.
+//!
+//! Implements the Phase 1a `ChainAdapter` trait against Monad testnet
+//! (chain id 10143) using tECDSA for signing and the EVM RPC canister for
+//! reads and `eth_sendRawTransaction`. Supply accounting is confirmed-supply
+//! (Design B): `chain_supplies` and vault debt move only when an on-chain
+//! mint/burn is observed at finality.
+
+pub mod adapter;
+pub mod chain_vault;
+pub mod config;
+pub mod deposit_watch;
+pub mod evm_rpc;
+pub mod settlement;
+pub mod tecdsa;
+pub mod tx;
+
+pub use adapter::MonadAdapter;
+pub use chain_vault::{ChainVaultStatus, ChainVaultV1};
+pub use config::{monad_default_config, MonadContracts, CONTRACTS, MONAD_CHAIN_ID};

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -30,3 +30,6 @@ mod tests_tecdsa;
 
 #[cfg(test)]
 mod tests_evm_rpc;
+
+#[cfg(test)]
+mod tests_tx;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -49,3 +49,6 @@ mod tests_hardening;
 
 #[cfg(test)]
 mod tests_open_vault;
+
+#[cfg(test)]
+mod tests_withdraw;

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -39,3 +39,6 @@ mod tests_tx;
 
 #[cfg(test)]
 mod tests_deposit_watch;
+
+#[cfg(test)]
+mod tests_settlement;

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -230,44 +230,47 @@ fn build_tx_plan(
 ) -> Result<TxPlan, String> {
     match kind {
         SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
-            let contract = contract
-                .ok_or_else(|| "icUSD contract not set".to_string())?
-                .to_string();
-            let data = tx::encode_mint_calldata(recipient, *amount_e8s, *vault_id);
-            Ok(TxPlan {
-                fields: tx::Eip1559Fields {
-                    chain_id: chain.0 as u64,
-                    nonce,
-                    max_priority_fee_per_gas: prio,
-                    max_fee_per_gas: max_fee,
-                    gas_limit: 120_000,
-                    to: contract,
-                    value: 0,
-                    data,
+            let contract = contract.ok_or_else(|| "icUSD contract not set".to_string())?;
+            // Delegate the per-op-kind field shape to the single source of truth.
+            let fields = tx::build_eip1559_fields(
+                chain.0 as u64,
+                tx::MonadTxKind::Mint {
+                    contract,
+                    recipient,
+                    amount_e8s: *amount_e8s,
+                    vault_id: *vault_id,
                 },
+                nonce,
+                prio,
+                max_fee,
+            );
+            Ok(TxPlan {
+                fields,
                 vault_id: *vault_id,
                 recipient: recipient.clone(),
                 amount_e8s: *amount_e8s,
                 is_mint: true,
             })
         }
-        SettlementOpKind::Withdrawal { recipient, amount_e8s } => Ok(TxPlan {
-            fields: tx::Eip1559Fields {
-                chain_id: chain.0 as u64,
+        SettlementOpKind::Withdrawal { recipient, amount_e8s } => {
+            // `amount_e8s` carries the MON amount in wei (the field-name wart
+            // documented on adapter::sign_withdrawal).
+            let fields = tx::build_eip1559_fields(
+                chain.0 as u64,
+                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: *amount_e8s },
                 nonce,
-                max_priority_fee_per_gas: prio,
-                max_fee_per_gas: max_fee,
-                gas_limit: 21_000,
-                to: recipient.clone(),
-                value: *amount_e8s, // wei wart (see adapter::sign_withdrawal)
-                data: vec![],
-            },
-            // vault_id 0 is a placeholder; Task 13 threads the real vault id.
-            vault_id: 0,
-            recipient: recipient.clone(),
-            amount_e8s: *amount_e8s,
-            is_mint: false,
-        }),
+                prio,
+                max_fee,
+            );
+            Ok(TxPlan {
+                fields,
+                // vault_id 0 is a placeholder; Task 13 threads the real vault id.
+                vault_id: 0,
+                recipient: recipient.clone(),
+                amount_e8s: *amount_e8s,
+                is_mint: false,
+            })
+        }
         SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
     }
 }
@@ -455,11 +458,49 @@ async fn confirm_op(
     let (status_ok, block_number) = match receipt {
         Some(pair) => pair,
         None => {
-            // Not mined yet — leave Inflight and retry next tick, UNLESS the op
-            // is stuck (tries past the finality-depth threshold). When stuck and
-            // we know the original nonce, replace-by-fee: bump gas +25% and
-            // re-sign/rebroadcast on the SAME stored nonce (Task 11).
-            resubmit_if_stuck(chain, op_id, &op, &tx_hash).await;
+            // Not mined yet. ADVANCE `tries` on EVERY not-mined tick (the prior
+            // code only advanced on submit / successful-resubmit, so `is_stuck`
+            // (>= 2) was unreachable and replace-by-fee never fired). The pure
+            // `on_not_mined_tick` decides the new tries count and whether to
+            // replace-by-fee THIS tick (only when stuck AND we stored the submit
+            // nonce — resubmitting without it would risk a fresh-nonce 2nd mint).
+            let tries = match &op.status {
+                SettlementOpStatus::Inflight { tries, .. } => *tries,
+                _ => {
+                    // Defensive: confirm_op is only entered for an Inflight op.
+                    log!(INFO, "[settlement chain={:?}] confirm op {} not Inflight on not-mined tick; skipping", chain, op_id);
+                    return;
+                }
+            };
+            let finality_depth = read_state(|s| {
+                s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
+            })
+            .unwrap_or(1);
+            let has_nonce = op.submit_nonce.is_some();
+            let (new_tries, do_resubmit) =
+                hardening::on_not_mined_tick(tries, finality_depth, has_nonce);
+
+            // Persist the advanced tries directly onto the Inflight status so the
+            // stuck threshold is actually reachable across ticks. Keep
+            // last_attempt_ns as-is here (a non-resubmit tick is not an attempt);
+            // the resubmit path updates last_tx_hash on a successful rebroadcast.
+            mutate_state(|s| {
+                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                    if let Some(o) = q.pending.get_mut(&op_id) {
+                        if let SettlementOpStatus::Inflight { tries, .. } = &mut o.status {
+                            *tries = new_tries;
+                        }
+                    }
+                }
+            });
+
+            // Once on_not_mined_tick says so, replace-by-fee on the STORED nonce
+            // (NOT a fresh `latest` read). resubmit_if_stuck does the bumped-gas
+            // re-sign + rebroadcast and does NOT advance tries again (confirm_op
+            // owns the per-tick advance now), avoiding a double-advance.
+            if do_resubmit {
+                resubmit_if_stuck(chain, op_id, &op, &tx_hash, new_tries, finality_depth).await;
+            }
             return;
         }
     };
@@ -635,18 +676,20 @@ async fn confirm_op(
     }
 }
 
-/// Stuck-tx replace-by-fee (Task 11). Called from the `confirm_op` NOT-MINED
-/// branch. When an inflight op has been retried past its stuck threshold
-/// (`hardening::is_stuck(tries, finality_depth)`) AND we recorded the nonce it
-/// was first submitted at (`submit_nonce`), re-sign and rebroadcast the SAME
-/// transaction on the SAME nonce with fees bumped +25% — a true EVM
+/// Stuck-tx replace-by-fee broadcast (Task 11). Called from the `confirm_op`
+/// NOT-MINED branch ONLY when `hardening::on_not_mined_tick` has already decided
+/// this op is stuck and a resubmit is warranted (the caller advanced and
+/// persisted `tries` first). Re-signs and rebroadcasts the SAME transaction on
+/// the SAME stored nonce (`submit_nonce`) with fees bumped +25% — a true EVM
 /// replace-by-fee, NOT a second mint.
 ///
-/// On a successful rebroadcast: `mark_inflight` (bumps `tries`) and update
-/// `last_tx_hash` to the new hash. On any error (derive/nonce/fees/sign/send):
-/// log and leave the op Inflight as-is for the next tick. When NOT stuck, or
-/// when `submit_nonce` is `None`, this is a no-op (op stays Inflight, retried
-/// next tick) — matching the prior behavior.
+/// `tries`/`finality_depth` are passed for logging only — the stuck decision is
+/// the caller's. On a successful rebroadcast: update `last_tx_hash` (and
+/// `last_attempt_ns`) but do NOT advance `tries` (confirm_op already advanced it
+/// once for this tick; advancing again would double-count). On any error
+/// (derive/fees/sign/send): log and leave the op Inflight as-is for the next
+/// tick. When `submit_nonce` is `None`, this refuses to resubmit (a resubmit
+/// would risk a fresh nonce — a second mint) and leaves the op Inflight.
 ///
 /// Borrow discipline mirrors `submit_op`: read → clone → await → mutate; no
 /// `read_state`/`mutate_state` borrow is held across an `.await`.
@@ -655,24 +698,9 @@ async fn resubmit_if_stuck(
     op_id: u64,
     op: &crate::chains::settlement_queue::SettlementOp,
     tx_hash: &str,
+    tries: u32,
+    finality_depth: u32,
 ) {
-    // Read tries from the op's Inflight status (it must be Inflight to be here).
-    let tries = match &op.status {
-        SettlementOpStatus::Inflight { tries, .. } => *tries,
-        _ => return, // not inflight — nothing to resubmit
-    };
-
-    // Finality depth from config (default to the Monad testnet value of 1).
-    let finality_depth = read_state(|s| {
-        s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
-    })
-    .unwrap_or(1);
-
-    if !hardening::is_stuck(tries, finality_depth) {
-        // Not stuck yet — leave Inflight, retry next tick.
-        return;
-    }
-
     // We can only replace-by-fee if we know the nonce the op was first submitted
     // at. Without it, a resubmit would risk a fresh nonce (a second mint), so we
     // do NOT resubmit — leave Inflight for the next tick.
@@ -735,14 +763,19 @@ async fn resubmit_if_stuck(
         }
     };
 
-    // Success: bump tries (mark_inflight) and record the new tx hash. The nonce
-    // is unchanged (the whole point of replace-by-fee).
+    // Success: record the new tx hash and refresh last_attempt_ns. Do NOT bump
+    // `tries` here — confirm_op already advanced it once for this tick (this
+    // function is only called after on_not_mined_tick decided to resubmit), so
+    // bumping again would double-advance per tick. The nonce is unchanged (the
+    // whole point of replace-by-fee).
     let now = ic_cdk::api::time();
     mutate_state(|s| {
         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
             if let Some(o) = q.pending.get_mut(&op_id) {
-                o.mark_inflight(now);
                 o.last_tx_hash = Some(new_tx_hash.clone());
+                if let SettlementOpStatus::Inflight { last_attempt_ns, .. } = &mut o.status {
+                    *last_attempt_ns = now;
+                }
             }
         }
     });

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -22,7 +22,7 @@
 //! ## Async worker (run_settlement)
 //!
 //! `run_settlement` drains one chain's `settlement_queues` entry one op per
-//! tick (Timer D, wired in Task 12). It mirrors `run_observer`'s read → await
+//! tick (Timer D, wired in Task 15). It mirrors `run_observer`'s read → await
 //! RPC → mutate pattern; no `read_state`/`mutate_state` borrow is held across
 //! an `.await`. The async path is NOT unit-tested — PocketIC covers it in
 //! Task 17.
@@ -137,7 +137,7 @@ pub fn confirm_mint_in_state(
 
 /// Run one settlement cycle for the given chain.
 ///
-/// Called by Timer D (configured in Task 12). Acts on at most one op per tick
+/// Called by Timer D (configured in Task 15). Acts on at most one op per tick
 /// (the one chosen by `select_next_op`):
 ///
 /// - **Submit** (a `Queued` op): sign via the adapter and broadcast via
@@ -539,51 +539,78 @@ async fn confirm_op(
     //      is the Task 12/13 flow's job. The vault is left MintPending with a
     //      Failed op + a ChainSettlementFailed event for that path to act on.
     //
-    //    - NativeWithdrawal: the transfer did NOT happen, so the reserved
-    //      collateral never left the custody address. ADD it back to
-    //      `collateral_amount_e18` (undo the reserve-at-enqueue) and, if the vault
-    //      had gone `Closing` (full withdrawal / close), revert it to `Open` — it
-    //      is no longer empty. Never touches debt/supply (withdraw moves only
-    //      collateral).
+    //    - NativeWithdrawal: the transfer did not happen, so the reserved
+    //      collateral was not paid out from the settlement hot wallet. ADD it
+    //      back to `collateral_amount_e18` (undo the reserve-at-enqueue) and, if
+    //      the vault had gone `Closing` (full withdrawal / close), revert it to
+    //      `Open` — it is no longer empty. Never touches debt/supply (withdraw
+    //      moves only collateral).
+    //
+    //    IDEMPOTENCY: the per-kind reversal AND the `mark_failed` run in a SINGLE
+    //    `mutate_state` guarded on the op still being `Inflight` (compare-and-
+    //    swap). If two overlapping `run_settlement` ticks snapshot the same
+    //    Inflight op before either mutates (possible once Timer D runs at a short
+    //    interval — Task 15), only the first to observe it Inflight performs the
+    //    reversal; the second sees the op already Failed and is a no-op. Without
+    //    this CAS the NativeWithdrawal add-back could credit `2 × amount_e18` for
+    //    one reverted withdrawal (phantom collateral). The broader run_settlement
+    //    re-entrancy guard is deferred to Task 15; this per-op CAS is the local
+    //    defense-in-depth.
     if !status_ok {
         let reason = "tx reverted".to_string();
-        match &op.kind {
-            SettlementOpKind::Mint { vault_id, .. } => {
-                let vid = *vault_id;
-                mutate_state(|s| {
-                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
+        let did_revert = mutate_state(|s| {
+            // CAS: only the first tick to observe this op Inflight does the work.
+            let still_inflight = s
+                .multi_chain
+                .settlement_queues
+                .get(&chain)
+                .and_then(|q| q.pending.get(&op_id))
+                .map(|o| matches!(o.status, SettlementOpStatus::Inflight { .. }))
+                .unwrap_or(false);
+            if !still_inflight {
+                return false;
+            }
+            match &op.kind {
+                SettlementOpKind::Mint { vault_id, .. } => {
+                    // Design B: no debt was counted, so NO supply reversal. Clear
+                    // pending mint; do NOT change status (Task-10 behavior).
+                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
                         v.pending_mint_e8s = 0;
                     }
-                });
-            }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
-                let vid = *vault_id;
-                let amt = *amount_e18;
-                mutate_state(|s| {
-                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
-                        v.collateral_amount_e18 = v.collateral_amount_e18.saturating_add(amt);
+                }
+                SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
+                        v.collateral_amount_e18 =
+                            v.collateral_amount_e18.saturating_add(*amount_e18);
                         if v.status == ChainVaultStatus::Closing {
                             v.status = ChainVaultStatus::Open;
                         }
                     }
-                });
-            }
-            SettlementOpKind::Burn { .. } => {}
-        }
-        mutate_state(|s| {
-            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-                if let Some(o) = q.pending.get_mut(&op_id) {
-                    o.mark_failed(reason.clone(), now);
                 }
+                SettlementOpKind::Burn { .. } => {}
             }
+            if let Some(o) = s
+                .multi_chain
+                .settlement_queues
+                .get_mut(&chain)
+                .and_then(|q| q.pending.get_mut(&op_id))
+            {
+                o.mark_failed(reason.clone(), now);
+            }
+            true
         });
-        crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
-            chain_id: chain,
-            op_id,
-            reason,
-            timestamp: now,
-        });
-        log!(INFO, "[settlement chain={:?}] op {} tx {} reverted; marked Failed", chain, op_id, tx_hash);
+        // Gate the event + log on the CAS so a rare double-tick does not emit a
+        // duplicate failure event (the state mutation is already idempotent; this
+        // just keeps the event log clean).
+        if did_revert {
+            crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+                chain_id: chain,
+                op_id,
+                reason,
+                timestamp: now,
+            });
+            log!(INFO, "[settlement chain={:?}] op {} tx {} reverted; marked Failed", chain, op_id, tx_hash);
+        }
         return;
     }
 
@@ -698,7 +725,8 @@ async fn confirm_op(
         }
         SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
             // A confirmed (mined + ok + final) native transfer-out: the
-            // collateral has left the custody address. Mark the op Succeeded,
+            // collateral has been paid out from the settlement hot wallet. Mark
+            // the op Succeeded,
             // then if the vault is `Closing` (a full withdrawal / close) flip it
             // to `Closed` — collateral is gone and (close required) debt is 0, so
             // the vault is fully settled. A partial withdrawal leaves the vault

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -36,7 +36,7 @@
 
 use ic_canister_log::log;
 
-use crate::chains::config::ChainId;
+use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
 use crate::chains::multi_chain_state::MultiChainStateV2;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
@@ -133,6 +133,55 @@ pub fn confirm_mint_in_state(
     Ok(())
 }
 
+// ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
+
+/// Timer D entry point: run one settlement cycle for every registered+enabled
+/// chain. The per-chain `run_settlement` carries its own mode/halt/re-entrancy
+/// guards, so this fan-out just snapshots the chain-id list and calls each in
+/// turn. NO state borrow is held across the awaits — the chain-id Vec is cloned
+/// out of state up front.
+///
+/// No-op when no chain is registered (the Vec is empty), so it is safe to
+/// register on the staging canister before Monad is configured (Task 15 PocketIC
+/// smoke test asserts this).
+pub async fn settlement_tick() {
+    let chains: Vec<ChainId> = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .iter()
+            .filter(|(_, c)| matches!(c.status, ChainStatus::Registered))
+            .map(|(id, _)| *id)
+            .collect()
+    });
+    for chain in chains {
+        run_settlement(chain).await;
+    }
+}
+
+// ─── Per-chain re-entrancy guard (Task 13 review; wired Task 15) ───────────────
+//
+// Once Timer D runs at a short interval, a slow RPC tick can still be awaiting
+// when the next timer fires, which would spawn a SECOND `run_settlement(chain)`
+// concurrently. Both would `select_next_op` the SAME op and double-process it
+// (double-submit -> potential double-mint; double-confirm). This per-chain guard
+// ensures only one `run_settlement` per chain runs at a time. The RAII guard is
+// a local held across all awaits, so it releases when the async fn returns on
+// ANY path (success, early return, trap-unwind).
+
+thread_local! {
+    static SETTLEMENT_INFLIGHT: std::cell::RefCell<std::collections::BTreeSet<ChainId>> =
+        const { std::cell::RefCell::new(std::collections::BTreeSet::new()) };
+}
+
+struct SettlementGuard(ChainId);
+impl Drop for SettlementGuard {
+    fn drop(&mut self) {
+        SETTLEMENT_INFLIGHT.with(|s| {
+            s.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
 // ─── Async worker ─────────────────────────────────────────────────────────────
 
 /// Run one settlement cycle for the given chain.
@@ -153,6 +202,21 @@ pub fn confirm_mint_in_state(
 /// resulting status back. No `read_state`/`mutate_state` borrow is ever held
 /// across an `.await`.
 pub async fn run_settlement(chain: ChainId) {
+    // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
+    // chain is still in flight, skip this one entirely. The RAII guard releases
+    // on the future completing (any return path), so the next tick re-acquires.
+    let _guard = match SETTLEMENT_INFLIGHT.with(|s| {
+        if s.borrow().contains(&chain) {
+            None
+        } else {
+            s.borrow_mut().insert(chain);
+            Some(SettlementGuard(chain))
+        }
+    }) {
+        Some(g) => g,
+        None => return, // a tick for this chain is already running; skip
+    };
+
     // Guard: skip if in read-only mode, the supply invariant has halted, or this
     // chain is reorg-halted (Task 11). A reorg-halted chain stops BOTH the
     // observer and the settlement worker until `clear_reorg_halt` (Task 14).
@@ -338,12 +402,14 @@ async fn submit_op(
         }
     }
 
-    // 1. Derive the settlement (minter) address.
-    let path = tecdsa::settlement_derivation_path(chain);
-    let settlement_addr = match tecdsa::derive_evm_address(path.clone()).await {
-        Ok((_pubkey, addr)) => addr,
+    // 1. Resolve the settlement (minter) address via the per-chain cache
+    //    (Task 11 M1): the address is deterministic, so we derive it once per
+    //    chain and reuse it every tick instead of paying a signing-subnet call
+    //    each submit. Returns the derivation PATH too, which the signer needs.
+    let (path, settlement_addr) = match tecdsa::cached_settlement_address(chain).await {
+        Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] derive_evm_address failed for op {}: {}; will retry", chain, op_id, e);
+            log!(INFO, "[settlement chain={:?}] cached_settlement_address failed for op {}: {}; will retry", chain, op_id, e);
             return;
         }
     };
@@ -790,12 +856,11 @@ async fn resubmit_if_stuck(
         }
     };
 
-    // Derive the settlement address.
-    let path = tecdsa::settlement_derivation_path(chain);
-    let settlement_addr = match tecdsa::derive_evm_address(path.clone()).await {
-        Ok((_pubkey, addr)) => addr,
+    // Resolve the settlement address via the per-chain cache (Task 11 M1).
+    let (path, settlement_addr) = match tecdsa::cached_settlement_address(chain).await {
+        Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resubmit derive_evm_address failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            log!(INFO, "[settlement chain={:?}] resubmit cached_settlement_address failed for op {}: {}; leaving Inflight", chain, op_id, e);
             return;
         }
     };

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -36,7 +36,6 @@
 
 use ic_canister_log::log;
 
-use crate::chains::adapter::{ChainAdapter, MintInstruction, WithdrawalRequest};
 use crate::chains::config::ChainId;
 use crate::chains::monad::chain_vault::ChainVaultStatus;
 use crate::chains::multi_chain_state::MultiChainStateV2;
@@ -46,8 +45,7 @@ use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use crate::Mode;
 
-use super::evm_rpc;
-use super::MonadAdapter;
+use super::{evm_rpc, hardening, tecdsa, tx};
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -155,8 +153,14 @@ pub fn confirm_mint_in_state(
 /// resulting status back. No `read_state`/`mutate_state` borrow is ever held
 /// across an `.await`.
 pub async fn run_settlement(chain: ChainId) {
-    // Guard: skip if in read-only mode or the supply invariant has halted.
-    let should_skip = read_state(|s| s.mode == Mode::ReadOnly || s.multi_chain.invariant_halted);
+    // Guard: skip if in read-only mode, the supply invariant has halted, or this
+    // chain is reorg-halted (Task 11). A reorg-halted chain stops BOTH the
+    // observer and the settlement worker until `clear_reorg_halt` (Task 14).
+    let should_skip = read_state(|s| {
+        s.mode == Mode::ReadOnly
+            || s.multi_chain.invariant_halted
+            || s.multi_chain.reorg_halted.get(&chain).copied().unwrap_or(false)
+    });
     if should_skip {
         return;
     }
@@ -181,101 +185,211 @@ pub async fn run_settlement(chain: ChainId) {
         OpAction::Submit => submit_op(chain, op_id, op).await,
         OpAction::Confirm => confirm_op(chain, op_id, op).await,
     }
+
+    // Reap terminal (Succeeded/Failed) ops so `pending` does not grow
+    // monotonically (Task-10 review follow-up). Live ops are untouched, so the
+    // next tick's `select_next_op` is unaffected; `seen_idempotency_keys` is
+    // preserved as the dup guard.
+    mutate_state(|s| {
+        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+            q.prune_terminal();
+        }
+    });
+}
+
+/// Per-op-kind tx shape mirroring `MonadAdapter`'s choices, so the submit and
+/// the stuck-tx resubmit paths build identical transactions (only nonce + fees
+/// differ on a resubmit). `vault_id`/`recipient`/`amount_e8s` are the values the
+/// submit path needs for the `ChainMintSubmitted` event.
+struct TxPlan {
+    fields: tx::Eip1559Fields,
+    vault_id: u64,
+    recipient: String,
+    amount_e8s: u128,
+    is_mint: bool,
+}
+
+/// Build the EIP-1559 fields for a settlement op at an EXPLICIT nonce + fees.
+///
+/// Mirrors `MonadAdapter::sign_mint`/`sign_withdrawal` exactly:
+/// - Mint: `to` = icUSD contract, `value` = 0, calldata =
+///   `encode_mint_calldata`, gas_limit 120_000.
+/// - Withdrawal: `to` = recipient, `value` = amount (wei wart), empty data,
+///   gas_limit 21_000; vault_id is a 0 placeholder (Task 13 threads the real id).
+/// - Burn: never signed in Phase 1b — returns `Err`.
+///
+/// The caller supplies `prio`/`max_fee` (a submit uses the live estimate; a
+/// resubmit uses the bumped values) and the contract address for mints.
+fn build_tx_plan(
+    chain: ChainId,
+    kind: &SettlementOpKind,
+    nonce: u64,
+    prio: u128,
+    max_fee: u128,
+    contract: Option<&str>,
+) -> Result<TxPlan, String> {
+    match kind {
+        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+            let contract = contract
+                .ok_or_else(|| "icUSD contract not set".to_string())?
+                .to_string();
+            let data = tx::encode_mint_calldata(recipient, *amount_e8s, *vault_id);
+            Ok(TxPlan {
+                fields: tx::Eip1559Fields {
+                    chain_id: chain.0 as u64,
+                    nonce,
+                    max_priority_fee_per_gas: prio,
+                    max_fee_per_gas: max_fee,
+                    gas_limit: 120_000,
+                    to: contract,
+                    value: 0,
+                    data,
+                },
+                vault_id: *vault_id,
+                recipient: recipient.clone(),
+                amount_e8s: *amount_e8s,
+                is_mint: true,
+            })
+        }
+        SettlementOpKind::Withdrawal { recipient, amount_e8s } => Ok(TxPlan {
+            fields: tx::Eip1559Fields {
+                chain_id: chain.0 as u64,
+                nonce,
+                max_priority_fee_per_gas: prio,
+                max_fee_per_gas: max_fee,
+                gas_limit: 21_000,
+                to: recipient.clone(),
+                value: *amount_e8s, // wei wart (see adapter::sign_withdrawal)
+                data: vec![],
+            },
+            // vault_id 0 is a placeholder; Task 13 threads the real vault id.
+            vault_id: 0,
+            recipient: recipient.clone(),
+            amount_e8s: *amount_e8s,
+            is_mint: false,
+        }),
+        SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
+    }
 }
 
 /// Submit path: sign + broadcast a `Queued` op, then mark it `Inflight`.
+///
+/// Approach A (Task 11): the worker fetches the nonce itself and builds/signs
+/// the tx directly via `build_tx_plan` + `tx::sign_eip1559` (NOT through the
+/// adapter), so it KNOWS the exact nonce used and can store it on the op. The
+/// stuck-tx resubmit (`confirm_op`) re-signs on this stored nonce, making a
+/// bumped-gas resubmit a true replace-by-fee rather than a second mint.
 async fn submit_op(
     chain: ChainId,
     op_id: u64,
     op: crate::chains::settlement_queue::SettlementOp,
 ) {
-    // TASK 11 SEAM: gas-gate (hot_wallet_ok) check goes here before signing/submitting.
-
-    let adapter = MonadAdapter::new(chain);
-
-    // 1. Sign the op into a 0x-hex signed-tx string (the adapter returns the
-    //    hex bytes in `raw_tx`; `tx_hash` is empty until the broadcaster fills
-    //    it). The mint vault_id is carried so the Confirm path can match the log.
-    let (signed_bytes, vault_id, recipient, amount_e8s) = match &op.kind {
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
-            let instr = MintInstruction {
-                recipient: recipient.clone(),
-                amount_e8s: *amount_e8s,
-                vault_id: *vault_id,
-                idempotency_key: op.idempotency_key.clone(),
-            };
-            match adapter.sign_mint(instr).await {
-                Ok(signed) => (signed.raw_tx, *vault_id, recipient.clone(), *amount_e8s),
-                Err(e) => {
-                    log!(INFO, "[settlement chain={:?}] sign_mint failed for op {}: {:?}; will retry", chain, op_id, e);
-                    return;
+    // A Burn op is never signable in Phase 1b — fail it up front (no RPC).
+    if matches!(op.kind, SettlementOpKind::Burn { .. }) {
+        let now = ic_cdk::api::time();
+        let reason = "burn not signable in Phase 1b".to_string();
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.mark_failed(reason.clone(), now);
                 }
             }
-        }
-        SettlementOpKind::Withdrawal { recipient, amount_e8s } => {
-            // Task 13: withdrawal ops are not enqueued until close-vault lands;
-            // the close/WithdrawalSigned-with-vault_id bookkeeping is built
-            // there. The signing/broadcast mechanism below is reused as-is.
-            let req = WithdrawalRequest {
-                recipient: recipient.clone(),
-                amount_e8s: *amount_e8s,
-                idempotency_key: op.idempotency_key.clone(),
-            };
-            match adapter.sign_withdrawal(req).await {
-                // vault_id 0 is a placeholder; Task 13 threads the real vault id.
-                Ok(signed) => (signed.raw_tx, 0u64, recipient.clone(), *amount_e8s),
-                Err(e) => {
-                    log!(INFO, "[settlement chain={:?}] sign_withdrawal failed for op {}: {:?}; will retry", chain, op_id, e);
-                    return;
-                }
-            }
-        }
-        SettlementOpKind::Burn { .. } => {
-            // The canister never signs burns in Phase 1b (burns are
-            // user-initiated on-chain). Mark this op Failed rather than panic.
+        });
+        crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+            chain_id: chain,
+            op_id,
+            reason,
+            timestamp: now,
+        });
+        log!(INFO, "[settlement chain={:?}] op {} is a Burn; marked Failed (burns are user-initiated in Phase 1b)", chain, op_id);
+        return;
+    }
+
+    // GAS GATE (Task 11): refuse a new outbound op when the cached settlement
+    // balance is below the hot-wallet floor. FAIL OPEN when the cache is unset
+    // (`None`): an unpopulated cache (fresh chain / observer hasn't run yet)
+    // must NEVER block a legitimate mint. The observer refreshes the cache each
+    // tick (deposit_watch::refresh_hot_wallet_balance).
+    let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
+    if let Some(bal) = cached {
+        if !hardening::hot_wallet_ok(bal) {
             let now = ic_cdk::api::time();
-            let reason = "burn not signable in Phase 1b".to_string();
-            mutate_state(|s| {
-                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-                    if let Some(o) = q.pending.get_mut(&op_id) {
-                        o.mark_failed(reason.clone(), now);
-                    }
-                }
-            });
-            crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+            crate::storage::record_event(&crate::event::Event::ChainHotWalletLow {
                 chain_id: chain,
-                op_id,
-                reason,
+                balance_e18: bal,
+                threshold_e18: hardening::HOT_WALLET_MIN_E18,
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] op {} is a Burn; marked Failed (burns are user-initiated in Phase 1b)", chain, op_id);
+            log!(INFO, "[settlement chain={:?}] hot-wallet balance {} e18 < threshold {} e18; skipping submit of op {} (reads/observer continue)", chain, bal, hardening::HOT_WALLET_MIN_E18, op_id);
+            return;
+        }
+    }
+
+    // 1. Derive the settlement (minter) address.
+    let path = tecdsa::settlement_derivation_path(chain);
+    let settlement_addr = match tecdsa::derive_evm_address(path.clone()).await {
+        Ok((_pubkey, addr)) => addr,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] derive_evm_address failed for op {}: {}; will retry", chain, op_id, e);
             return;
         }
     };
 
-    // 2. Reconstruct the 0x-hex string from the signed-tx UTF-8 bytes.
-    let raw_hex = match String::from_utf8(signed_bytes) {
+    // 2. Fetch the nonce ("latest") — we store it on the op so a stuck-tx
+    //    resubmit can replace-by-fee on the SAME nonce.
+    let nonce = match evm_rpc::get_transaction_count(chain, &settlement_addr).await {
+        Ok(n) => n,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+
+    // 3. Fetch fee estimate; max_fee mirrors the adapter (2*base + prio).
+    let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] fetch_fees failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+    let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
+
+    // 4. Resolve the contract (mints only) and build the tx plan.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+    let plan = match build_tx_plan(chain, &op.kind, nonce, prio, max_fee, contract.as_deref()) {
+        Ok(p) => p,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+    let TxPlan { fields, vault_id, recipient, amount_e8s, is_mint } = plan;
+
+    // 5. Sign.
+    let raw_hex = match tx::sign_eip1559(&fields, path, &settlement_addr).await {
         Ok(h) => h,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] op {} signed tx not valid UTF-8: {}; will retry", chain, op_id, e);
+            log!(INFO, "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry", chain, op_id, e);
             return;
         }
     };
 
-    // 3. Broadcast. A transient send error is logged and retried next tick — we
+    // 6. Broadcast. A transient send error is logged and retried next tick — we
     //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
     //
     //    ON-CHAIN DOUBLE-MINT DEPENDENCY: if send_raw_transaction returns Err but
-    //    the tx actually landed (an RPC false negative), the next tick re-reads
-    //    the "latest" nonce (adapter.rs::sign_mint), so it signs a NEW tx at
-    //    nonce+1 — a genuine second on-chain mint, not a replacement. The
+    //    the tx actually landed (an RPC false negative), this op stays Queued
+    //    with no submit_nonce recorded, so the next tick re-reads "latest" and
+    //    signs a NEW tx at nonce+1 — a genuine second on-chain mint. The
     //    canister's supply accounting stays correct (confirm requires
     //    observed_e8s == pending_mint_e8s and credits exactly once), but on-chain
     //    icUSD could be minted twice. Protection lives OUTSIDE this function:
     //    (a) IcUSD.mint MUST guard per vault_id (Task 19: `mapping(uint64 => bool)
-    //    minted`, revert on repeat — asserted by a Task 20 test), and (b) Task
-    //    11's stuck-tx path resubmits on the SAME stored nonce. Until both land,
-    //    the resubmit-after-transient-error case is unguarded at the canister layer.
+    //    minted`, revert on repeat — asserted by a Task 20 test), and (b) once an
+    //    op IS Inflight, Task-11's stuck-tx path resubmits on the SAME stored
+    //    nonce (true replace-by-fee). The unguarded window is only the
+    //    transient-error-before-Inflight case.
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
@@ -284,14 +398,15 @@ async fn submit_op(
         }
     };
 
-    // 4. Mark Inflight + record the tx hash. Emit ChainMintSubmitted for mints.
+    // 7. Mark Inflight + record the tx hash AND the submit nonce. Emit
+    //    ChainMintSubmitted for mints.
     let now = ic_cdk::api::time();
-    let is_mint = matches!(op.kind, SettlementOpKind::Mint { .. });
     mutate_state(|s| {
         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
             if let Some(o) = q.pending.get_mut(&op_id) {
                 o.mark_inflight(now);
                 o.last_tx_hash = Some(tx_hash.clone());
+                o.submit_nonce = Some(nonce);
             }
         }
     });
@@ -340,8 +455,11 @@ async fn confirm_op(
     let (status_ok, block_number) = match receipt {
         Some(pair) => pair,
         None => {
-            // Not mined yet — leave Inflight and retry next tick.
-            // TASK 11 SEAM: is_stuck + bump_gas + resubmit on same nonce goes here.
+            // Not mined yet — leave Inflight and retry next tick, UNLESS the op
+            // is stuck (tries past the finality-depth threshold). When stuck and
+            // we know the original nonce, replace-by-fee: bump gas +25% and
+            // re-sign/rebroadcast on the SAME stored nonce (Task 11).
+            resubmit_if_stuck(chain, op_id, &op, &tx_hash).await;
             return;
         }
     };
@@ -515,4 +633,122 @@ async fn confirm_op(
             log!(INFO, "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
         }
     }
+}
+
+/// Stuck-tx replace-by-fee (Task 11). Called from the `confirm_op` NOT-MINED
+/// branch. When an inflight op has been retried past its stuck threshold
+/// (`hardening::is_stuck(tries, finality_depth)`) AND we recorded the nonce it
+/// was first submitted at (`submit_nonce`), re-sign and rebroadcast the SAME
+/// transaction on the SAME nonce with fees bumped +25% — a true EVM
+/// replace-by-fee, NOT a second mint.
+///
+/// On a successful rebroadcast: `mark_inflight` (bumps `tries`) and update
+/// `last_tx_hash` to the new hash. On any error (derive/nonce/fees/sign/send):
+/// log and leave the op Inflight as-is for the next tick. When NOT stuck, or
+/// when `submit_nonce` is `None`, this is a no-op (op stays Inflight, retried
+/// next tick) — matching the prior behavior.
+///
+/// Borrow discipline mirrors `submit_op`: read → clone → await → mutate; no
+/// `read_state`/`mutate_state` borrow is held across an `.await`.
+async fn resubmit_if_stuck(
+    chain: ChainId,
+    op_id: u64,
+    op: &crate::chains::settlement_queue::SettlementOp,
+    tx_hash: &str,
+) {
+    // Read tries from the op's Inflight status (it must be Inflight to be here).
+    let tries = match &op.status {
+        SettlementOpStatus::Inflight { tries, .. } => *tries,
+        _ => return, // not inflight — nothing to resubmit
+    };
+
+    // Finality depth from config (default to the Monad testnet value of 1).
+    let finality_depth = read_state(|s| {
+        s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
+    })
+    .unwrap_or(1);
+
+    if !hardening::is_stuck(tries, finality_depth) {
+        // Not stuck yet — leave Inflight, retry next tick.
+        return;
+    }
+
+    // We can only replace-by-fee if we know the nonce the op was first submitted
+    // at. Without it, a resubmit would risk a fresh nonce (a second mint), so we
+    // do NOT resubmit — leave Inflight for the next tick.
+    let nonce = match op.submit_nonce {
+        Some(n) => n,
+        None => {
+            log!(INFO, "[settlement chain={:?}] op {} stuck (tries={}, finality_depth={}) but no submit_nonce; leaving Inflight (cannot safely replace-by-fee)", chain, op_id, tries, finality_depth);
+            return;
+        }
+    };
+
+    // Derive the settlement address.
+    let path = tecdsa::settlement_derivation_path(chain);
+    let settlement_addr = match tecdsa::derive_evm_address(path.clone()).await {
+        Ok((_pubkey, addr)) => addr,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] resubmit derive_evm_address failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            return;
+        }
+    };
+
+    // Recompute fees and bump +25%. Mirror the adapter's max-fee formula
+    // (2*base + prio) before bumping, so the bumped ceiling tracks current gas.
+    let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] resubmit fetch_fees failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            return;
+        }
+    };
+    let base_max_fee = base_fee.saturating_mul(2).saturating_add(prio);
+    let (bumped_prio, bumped_max) = hardening::bump_gas(prio, base_max_fee);
+
+    // Resolve the contract (mints only) and rebuild the SAME tx at the stored
+    // nonce with the bumped fees.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+    let plan = match build_tx_plan(chain, &op.kind, nonce, bumped_prio, bumped_max, contract.as_deref()) {
+        Ok(p) => p,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] resubmit build_tx_plan failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            return;
+        }
+    };
+
+    // Re-sign on the stored nonce.
+    let raw_hex = match tx::sign_eip1559(&plan.fields, path, &settlement_addr).await {
+        Ok(h) => h,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] resubmit sign_eip1559 failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            return;
+        }
+    };
+
+    // Rebroadcast.
+    let new_tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
+        Ok(h) => h,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] resubmit send_raw_transaction failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            return;
+        }
+    };
+
+    // Success: bump tries (mark_inflight) and record the new tx hash. The nonce
+    // is unchanged (the whole point of replace-by-fee).
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+            if let Some(o) = q.pending.get_mut(&op_id) {
+                o.mark_inflight(now);
+                o.last_tx_hash = Some(new_tx_hash.clone());
+            }
+        }
+    });
+    log!(
+        INFO,
+        "[settlement chain={:?}] STUCK op {} (tries={}, finality_depth={}) replaced-by-fee on nonce {}: prio {}->{}, max_fee {}->{}, old_tx={} new_tx={}",
+        chain, op_id, tries, finality_depth, nonce, prio, bumped_prio, base_max_fee, bumped_max, tx_hash, new_tx_hash
+    );
 }

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -167,10 +167,16 @@ pub async fn settlement_tick() {
 // ensures only one `run_settlement` per chain runs at a time. The RAII guard is
 // a local held across all awaits, so it releases when the async fn returns on
 // ANY path (success, early return, trap-unwind).
+//
+// Self-healing (B2 hardening): the map stores the nanosecond timestamp the
+// guard was acquired at. On the IC, a trap in a post-await continuation does
+// NOT run `Drop`, so a stale entry would otherwise block that chain forever.
+// `hardening::inflight_should_acquire` reclaims entries older than
+// `hardening::INFLIGHT_STALE_NS` (10 min), self-healing after a trapped tick.
 
 thread_local! {
-    static SETTLEMENT_INFLIGHT: std::cell::RefCell<std::collections::BTreeSet<ChainId>> =
-        const { std::cell::RefCell::new(std::collections::BTreeSet::new()) };
+    static SETTLEMENT_INFLIGHT: std::cell::RefCell<std::collections::BTreeMap<ChainId, u64>> =
+        const { std::cell::RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 struct SettlementGuard(ChainId);
@@ -203,18 +209,23 @@ impl Drop for SettlementGuard {
 /// across an `.await`.
 pub async fn run_settlement(chain: ChainId) {
     // Re-entrancy guard (acquired BEFORE any other work): if a tick for this
-    // chain is still in flight, skip this one entirely. The RAII guard releases
-    // on the future completing (any return path), so the next tick re-acquires.
+    // chain is still in flight (and not stale), skip this one entirely. The
+    // RAII guard releases on the future completing (any return path). A stale
+    // entry (> INFLIGHT_STALE_NS old) means the previous holder trapped in a
+    // post-await continuation and its `Drop` never ran — the later tick
+    // reclaims it, self-healing the permanent-block scenario.
+    let now_ns = ic_cdk::api::time();
     let _guard = match SETTLEMENT_INFLIGHT.with(|s| {
-        if s.borrow().contains(&chain) {
-            None
-        } else {
-            s.borrow_mut().insert(chain);
+        let existing = s.borrow().get(&chain).copied();
+        if hardening::inflight_should_acquire(existing, now_ns, hardening::INFLIGHT_STALE_NS) {
+            s.borrow_mut().insert(chain, now_ns);
             Some(SettlementGuard(chain))
+        } else {
+            None
         }
     }) {
         Some(g) => g,
-        None => return, // a tick for this chain is already running; skip
+        None => return, // a fresh tick for this chain is already running; skip
     };
 
     // Guard: skip if in read-only mode, the supply invariant has halted, or this
@@ -318,7 +329,7 @@ fn build_tx_plan(
                 nonce,
                 prio,
                 max_fee,
-            );
+            )?;
             Ok(TxPlan {
                 fields,
                 vault_id: *vault_id,
@@ -336,7 +347,7 @@ fn build_tx_plan(
                 nonce,
                 prio,
                 max_fee,
-            );
+            )?;
             Ok(TxPlan {
                 fields,
                 vault_id: *vault_id,

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -264,6 +264,18 @@ async fn submit_op(
 
     // 3. Broadcast. A transient send error is logged and retried next tick — we
     //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
+    //
+    //    ON-CHAIN DOUBLE-MINT DEPENDENCY: if send_raw_transaction returns Err but
+    //    the tx actually landed (an RPC false negative), the next tick re-reads
+    //    the "latest" nonce (adapter.rs::sign_mint), so it signs a NEW tx at
+    //    nonce+1 — a genuine second on-chain mint, not a replacement. The
+    //    canister's supply accounting stays correct (confirm requires
+    //    observed_e8s == pending_mint_e8s and credits exactly once), but on-chain
+    //    icUSD could be minted twice. Protection lives OUTSIDE this function:
+    //    (a) IcUSD.mint MUST guard per vault_id (Task 19: `mapping(uint64 => bool)
+    //    minted`, revert on repeat — asserted by a Task 20 test), and (b) Task
+    //    11's stuck-tx path resubmits on the SAME stored nonce. Until both land,
+    //    the resubmit-after-transient-error case is unguarded at the canister layer.
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
@@ -336,12 +348,18 @@ async fn confirm_op(
 
     let now = ic_cdk::api::time();
 
-    // 2. Reverted tx: mark Failed. Under Design B no debt was counted, so there
-    //    is NO supply reversal — but clear the vault's pending mint (the mint
-    //    will not happen) so the vault is not left dangling in MintPending.
-    //    Status -> Closed marks the vault terminal: it can never mint now (its
-    //    op is Failed). Any collateral already deposited is returned by the
-    //    Task-13 close path, which keys off this terminal state.
+    // 2. Reverted tx: mark the op Failed. Under Design B no debt was counted, so
+    //    there is NO supply reversal. Clear the vault's pending mint (the mint
+    //    will not happen). Do NOT advance the vault status: per the plan (Task
+    //    10) a reverted mint changes no vault status, and `Closed` in this
+    //    codebase means "fully repaid + collateral returned" — stamping it here
+    //    would mislabel a vault that still holds deposited collateral as
+    //    returned, and the Task-13 close path (which returns collateral by
+    //    enqueuing a Withdrawal and going Closing -> Closed) keys off `Closing`,
+    //    not `Closed`, so the collateral would be stranded. The failed-mint
+    //    resolution (return collateral, then close) is defined by the Task 12/13
+    //    flow design; the vault is left in its current (MintPending) status with
+    //    a Failed op + a ChainSettlementFailed event for that path to act on.
     if !status_ok {
         let reason = "tx reverted".to_string();
         if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
@@ -349,7 +367,6 @@ async fn confirm_op(
             mutate_state(|s| {
                 if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
                     v.pending_mint_e8s = 0;
-                    v.status = ChainVaultStatus::Closed;
                 }
             });
         }

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -729,8 +729,11 @@ async fn confirm_op(
 
             // Find the Mint log for this vault, preferring the one whose tx hash
             // matches this op's submission (case-insensitive).
+            // `log_index` is threaded through from get_logs but not needed here
+            // (the settlement path selects by vault_id + tx_hash, not by log
+            // identity — each mint op maps to exactly one Mint event).
             let mut matched: Option<u128> = None;
-            for (topics, data, log_tx, log_block) in &logs {
+            for (topics, data, log_tx, log_block, _log_index) in &logs {
                 match evm_rpc::decode_mint_log(topics, data, log_tx, *log_block) {
                     Ok(m) if m.vault_id == vault_id => {
                         let exact = log_tx.eq_ignore_ascii_case(&tx_hash);

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -1,1 +1,501 @@
-//! Placeholder. Real impl in a later Task.
+//! Outbound settlement worker (Timer D) for Monad (Phase 1b, Task 10).
+//!
+//! ## Pure helpers (unit-tested in `tests_settlement`)
+//!
+//! - `select_next_op`: picks the next op to act on, enforcing
+//!   one-in-flight-per-queue (Confirm an Inflight op before submitting a new
+//!   Queued one).
+//! - `confirm_mint_in_state`: on a confirmed on-chain mint, moves the vault's
+//!   `pending_mint_e8s` into `debt_e8s`, flips it to `Open`, and increments the
+//!   chain supply via `apply_supply_delta`.
+//!
+//! ## Supply-invariant total convention (mirrors `apply_burn_to_state`)
+//!
+//! The Phase 1b supply invariant is FOREIGN-CHAIN-ONLY:
+//!   `sum(chain_supplies) == MultiChainStateV2::total_chain_vault_debt_e8s()`.
+//! The ICP-native `State::total_borrowed_icusd_amount()` is a SEPARATE pool and
+//! is NEVER consulted here. `confirm_mint_in_state` takes the PRE-mint
+//! `total_chain_vault_debt_e8s()` and computes the post-mint total internally
+//! (`pre + observed`), passing THAT to `apply_supply_delta` — exactly the
+//! convention `apply_burn_to_state` uses with `pre - amount`.
+//!
+//! ## Async worker (run_settlement)
+//!
+//! `run_settlement` drains one chain's `settlement_queues` entry one op per
+//! tick (Timer D, wired in Task 12). It mirrors `run_observer`'s read → await
+//! RPC → mutate pattern; no `read_state`/`mutate_state` borrow is held across
+//! an `.await`. The async path is NOT unit-tested — PocketIC covers it in
+//! Task 17.
+//!
+//! ## Task 11 seams (NOT implemented here)
+//!
+//! Two hardening hooks land in Task 11 (`hardening.rs`, which does not yet
+//! exist): a hot-wallet gas gate before submitting, and a stuck-tx
+//! bump-gas/resubmit on the Confirm path. Both are marked with `TASK 11 SEAM:`
+//! comments. This task references no hardening symbol.
+
+use ic_canister_log::log;
+
+use crate::chains::adapter::{ChainAdapter, MintInstruction, WithdrawalRequest};
+use crate::chains::config::ChainId;
+use crate::chains::monad::chain_vault::ChainVaultStatus;
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
+use crate::chains::supply::{apply_supply_delta, SupplyDelta};
+use crate::logs::INFO;
+use crate::state::{mutate_state, read_state};
+use crate::Mode;
+
+use super::evm_rpc;
+use super::MonadAdapter;
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/// What the drain loop should do with the op `select_next_op` returns.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OpAction {
+    /// A `Queued` op: sign and broadcast it, then mark it `Inflight`.
+    Submit,
+    /// An `Inflight` op: check its receipt and (on a confirmed mint) finalize.
+    Confirm,
+}
+
+/// Pick the next op to act on. Enforces one-in-flight-per-queue: if ANY op is
+/// `Inflight`, only that op (action `Confirm`) is actionable; otherwise the
+/// lowest-op_id `Queued` op (action `Submit`). `pending` is a
+/// `BTreeMap<u64, SettlementOp>`, so iteration is op_id-ascending and the
+/// drain is FIFO. Returns `None` when nothing is actionable.
+pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
+    for (&id, op) in q.pending.iter() {
+        if matches!(op.status, SettlementOpStatus::Inflight { .. }) {
+            return Some((id, OpAction::Confirm));
+        }
+    }
+    for (&id, op) in q.pending.iter() {
+        if matches!(op.status, SettlementOpStatus::Queued) {
+            return Some((id, OpAction::Submit));
+        }
+    }
+    None
+}
+
+/// On a confirmed on-chain mint: move `pending_mint_e8s` into `debt_e8s`, flip
+/// the vault to `Open`, and increment the chain supply.
+///
+/// `pre_mint_total_debt` is the PRE-mint `total_chain_vault_debt_e8s()` (the
+/// sum of all chain-vault debt BEFORE this mint counts — under Design B the
+/// vault's `debt_e8s` is still 0 while the mint is pending, so its pending
+/// amount is NOT yet in this total). This helper computes the post-mint total
+/// internally as `pre_mint_total_debt + observed_e8s` and passes THAT to
+/// `apply_supply_delta`, mirroring `apply_burn_to_state`. `observed_e8s` (read
+/// from the on-chain Mint log) must equal the vault's `pending_mint_e8s`.
+///
+/// ## Mutation ordering (no-mutation-on-rejection guarantee)
+///
+/// 1. Vault lookup + amount match — reject (no mutation) on failure.
+/// 2. `apply_supply_delta` — validates and mutates `chain_supplies`, or rejects
+///    entirely (no mutation on `Err`, e.g. divergence/halt).
+/// 3. Only after (2) succeeds: move `pending_mint_e8s` -> `debt_e8s`, set
+///    status `Open`.
+pub fn confirm_mint_in_state(
+    state: &mut MultiChainStateV2,
+    chain: ChainId,
+    vault_id: u64,
+    observed_e8s: u128,
+    pre_mint_total_debt: u128,
+) -> Result<(), String> {
+    // Step 1: validate (read-only — no mutation on failure).
+    {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or_else(|| format!("confirm_mint: unknown vault {vault_id}"))?;
+        if v.pending_mint_e8s != observed_e8s {
+            return Err(format!(
+                "confirm_mint: observed {} != pending {}",
+                observed_e8s, v.pending_mint_e8s
+            ));
+        }
+    }
+
+    // Step 2: supply delta. The post-mint total is the pre-mint total plus the
+    // amount this mint adds to the foreign-chain debt pool.
+    let post_mint_total = pre_mint_total_debt.saturating_add(observed_e8s);
+    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_mint_total)
+        .map_err(|e| format!("{e:?}"))?;
+
+    // Step 3: only reached when the supply delta succeeded — move pending -> debt.
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.debt_e8s = v.debt_e8s.saturating_add(observed_e8s);
+    v.pending_mint_e8s = 0;
+    v.status = ChainVaultStatus::Open;
+    Ok(())
+}
+
+// ─── Async worker ─────────────────────────────────────────────────────────────
+
+/// Run one settlement cycle for the given chain.
+///
+/// Called by Timer D (configured in Task 12). Acts on at most one op per tick
+/// (the one chosen by `select_next_op`):
+///
+/// - **Submit** (a `Queued` op): sign via the adapter and broadcast via
+///   `eth_sendRawTransaction`, then mark the op `Inflight` with the tx hash.
+/// - **Confirm** (an `Inflight` op): check the receipt; once mined AND final,
+///   a successful mint is finalized through `confirm_mint_in_state`, the op is
+///   marked `Succeeded`, and `ChainMintConfirmed` is emitted. A reverted mint
+///   is marked `Failed` and the vault's `pending_mint_e8s` is cleared (Design
+///   B: no debt was counted, so no supply reversal is needed).
+///
+/// Borrow discipline mirrors `run_observer`: clone the op out of state for the
+/// async RPC calls, then re-acquire a `mutate_state` borrow to write the
+/// resulting status back. No `read_state`/`mutate_state` borrow is ever held
+/// across an `.await`.
+pub async fn run_settlement(chain: ChainId) {
+    // Guard: skip if in read-only mode or the supply invariant has halted.
+    let should_skip = read_state(|s| s.mode == Mode::ReadOnly || s.multi_chain.invariant_halted);
+    if should_skip {
+        return;
+    }
+
+    // Snapshot this chain's queue and pick the next actionable op.
+    let queue = read_state(|s| s.multi_chain.settlement_queues.get(&chain).cloned());
+    let queue = match queue {
+        Some(q) => q,
+        None => return, // chain not registered / no queue
+    };
+    let (op_id, action) = match select_next_op(&queue) {
+        Some(pair) => pair,
+        None => return, // nothing to do
+    };
+    // Clone the op out so we can drop the queue snapshot before awaiting.
+    let op = match queue.pending.get(&op_id).cloned() {
+        Some(o) => o,
+        None => return,
+    };
+
+    match action {
+        OpAction::Submit => submit_op(chain, op_id, op).await,
+        OpAction::Confirm => confirm_op(chain, op_id, op).await,
+    }
+}
+
+/// Submit path: sign + broadcast a `Queued` op, then mark it `Inflight`.
+async fn submit_op(
+    chain: ChainId,
+    op_id: u64,
+    op: crate::chains::settlement_queue::SettlementOp,
+) {
+    // TASK 11 SEAM: gas-gate (hot_wallet_ok) check goes here before signing/submitting.
+
+    let adapter = MonadAdapter::new(chain);
+
+    // 1. Sign the op into a 0x-hex signed-tx string (the adapter returns the
+    //    hex bytes in `raw_tx`; `tx_hash` is empty until the broadcaster fills
+    //    it). The mint vault_id is carried so the Confirm path can match the log.
+    let (signed_bytes, vault_id, recipient, amount_e8s) = match &op.kind {
+        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+            let instr = MintInstruction {
+                recipient: recipient.clone(),
+                amount_e8s: *amount_e8s,
+                vault_id: *vault_id,
+                idempotency_key: op.idempotency_key.clone(),
+            };
+            match adapter.sign_mint(instr).await {
+                Ok(signed) => (signed.raw_tx, *vault_id, recipient.clone(), *amount_e8s),
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] sign_mint failed for op {}: {:?}; will retry", chain, op_id, e);
+                    return;
+                }
+            }
+        }
+        SettlementOpKind::Withdrawal { recipient, amount_e8s } => {
+            // Task 13: withdrawal ops are not enqueued until close-vault lands;
+            // the close/WithdrawalSigned-with-vault_id bookkeeping is built
+            // there. The signing/broadcast mechanism below is reused as-is.
+            let req = WithdrawalRequest {
+                recipient: recipient.clone(),
+                amount_e8s: *amount_e8s,
+                idempotency_key: op.idempotency_key.clone(),
+            };
+            match adapter.sign_withdrawal(req).await {
+                // vault_id 0 is a placeholder; Task 13 threads the real vault id.
+                Ok(signed) => (signed.raw_tx, 0u64, recipient.clone(), *amount_e8s),
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] sign_withdrawal failed for op {}: {:?}; will retry", chain, op_id, e);
+                    return;
+                }
+            }
+        }
+        SettlementOpKind::Burn { .. } => {
+            // The canister never signs burns in Phase 1b (burns are
+            // user-initiated on-chain). Mark this op Failed rather than panic.
+            let now = ic_cdk::api::time();
+            let reason = "burn not signable in Phase 1b".to_string();
+            mutate_state(|s| {
+                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                    if let Some(o) = q.pending.get_mut(&op_id) {
+                        o.mark_failed(reason.clone(), now);
+                    }
+                }
+            });
+            crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+                chain_id: chain,
+                op_id,
+                reason,
+                timestamp: now,
+            });
+            log!(INFO, "[settlement chain={:?}] op {} is a Burn; marked Failed (burns are user-initiated in Phase 1b)", chain, op_id);
+            return;
+        }
+    };
+
+    // 2. Reconstruct the 0x-hex string from the signed-tx UTF-8 bytes.
+    let raw_hex = match String::from_utf8(signed_bytes) {
+        Ok(h) => h,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] op {} signed tx not valid UTF-8: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+
+    // 3. Broadcast. A transient send error is logged and retried next tick — we
+    //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
+    let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
+        Ok(h) => h,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] send_raw_transaction failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+
+    // 4. Mark Inflight + record the tx hash. Emit ChainMintSubmitted for mints.
+    let now = ic_cdk::api::time();
+    let is_mint = matches!(op.kind, SettlementOpKind::Mint { .. });
+    mutate_state(|s| {
+        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+            if let Some(o) = q.pending.get_mut(&op_id) {
+                o.mark_inflight(now);
+                o.last_tx_hash = Some(tx_hash.clone());
+            }
+        }
+    });
+
+    if is_mint {
+        crate::storage::record_event(&crate::event::Event::ChainMintSubmitted {
+            chain_id: chain,
+            vault_id,
+            op_id,
+            recipient,
+            amount_e8s,
+            tx_hash: tx_hash.clone(),
+            timestamp: now,
+        });
+        log!(INFO, "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}", chain, op_id, vault_id, amount_e8s, tx_hash);
+    } else {
+        log!(INFO, "[settlement chain={:?}] op {} submitted inflight tx={}", chain, op_id, tx_hash);
+    }
+}
+
+/// Confirm path: check an `Inflight` op's receipt and finalize on success.
+async fn confirm_op(
+    chain: ChainId,
+    op_id: u64,
+    op: crate::chains::settlement_queue::SettlementOp,
+) {
+    // The submit path always sets last_tx_hash before going Inflight; a None
+    // here is defensive (e.g. a manually-poked state) — log and bail.
+    let tx_hash = match &op.last_tx_hash {
+        Some(h) => h.clone(),
+        None => {
+            log!(INFO, "[settlement chain={:?}] inflight op {} has no last_tx_hash; skipping", chain, op_id);
+            return;
+        }
+    };
+
+    // 1. Fetch the receipt.
+    let receipt = match evm_rpc::get_transaction_receipt(chain, &tx_hash).await {
+        Ok(r) => r,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] get_transaction_receipt failed for op {} tx {}: {}; will retry", chain, op_id, tx_hash, e);
+            return;
+        }
+    };
+
+    let (status_ok, block_number) = match receipt {
+        Some(pair) => pair,
+        None => {
+            // Not mined yet — leave Inflight and retry next tick.
+            // TASK 11 SEAM: is_stuck + bump_gas + resubmit on same nonce goes here.
+            return;
+        }
+    };
+
+    let now = ic_cdk::api::time();
+
+    // 2. Reverted tx: mark Failed. Under Design B no debt was counted, so there
+    //    is NO supply reversal — but clear the vault's pending mint (the mint
+    //    will not happen) so the vault is not left dangling in MintPending.
+    //    Status -> Closed marks the vault terminal: it can never mint now (its
+    //    op is Failed). Any collateral already deposited is returned by the
+    //    Task-13 close path, which keys off this terminal state.
+    if !status_ok {
+        let reason = "tx reverted".to_string();
+        if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
+            let vid = *vault_id;
+            mutate_state(|s| {
+                if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
+                    v.pending_mint_e8s = 0;
+                    v.status = ChainVaultStatus::Closed;
+                }
+            });
+        }
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.mark_failed(reason.clone(), now);
+                }
+            }
+        });
+        crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+            chain_id: chain,
+            op_id,
+            reason,
+            timestamp: now,
+        });
+        log!(INFO, "[settlement chain={:?}] op {} tx {} reverted; marked Failed", chain, op_id, tx_hash);
+        return;
+    }
+
+    // 3. Mined + ok — require finality before confirming.
+    let finalized = match evm_rpc::fetch_block_numbers(chain).await {
+        Ok((_latest, fin)) => fin,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] fetch_block_numbers failed confirming op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
+    if block_number > finalized {
+        // Mined but not yet final — leave Inflight, retry next tick.
+        return;
+    }
+
+    // 4. Mint confirm path: read the confirmed on-chain amount from the Mint
+    //    log, then finalize through confirm_mint_in_state.
+    match &op.kind {
+        SettlementOpKind::Mint { vault_id, .. } => {
+            let vault_id = *vault_id;
+
+            let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+            let contract = match contract {
+                Some(c) => c,
+                None => {
+                    log!(INFO, "[settlement chain={:?}] no contract address configured; cannot confirm mint op {}", chain, op_id);
+                    return;
+                }
+            };
+
+            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+                Ok(l) => l,
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] get_logs(mint) failed confirming op {}: {}; will retry", chain, op_id, e);
+                    return;
+                }
+            };
+
+            // Find the Mint log for this vault, preferring the one whose tx hash
+            // matches this op's submission (case-insensitive).
+            let mut matched: Option<u128> = None;
+            for (topics, data, log_tx, log_block) in &logs {
+                match evm_rpc::decode_mint_log(topics, data, log_tx, *log_block) {
+                    Ok(m) if m.vault_id == vault_id => {
+                        let exact = log_tx.eq_ignore_ascii_case(&tx_hash);
+                        // Prefer an exact tx-hash match; otherwise take the first
+                        // vault-id match as a fallback.
+                        if exact {
+                            matched = Some(m.amount_e8s);
+                            break;
+                        } else if matched.is_none() {
+                            matched = Some(m.amount_e8s);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log!(INFO, "[settlement chain={:?}] decode_mint_log failed confirming op {}: {}", chain, op_id, e);
+                    }
+                }
+            }
+
+            let observed_e8s = match matched {
+                Some(a) => a,
+                None => {
+                    log!(INFO, "[settlement chain={:?}] no Mint log for vault {} in block {} confirming op {}; will retry", chain, vault_id, block_number, op_id);
+                    return;
+                }
+            };
+
+            // PRE-mint total: sum of foreign-chain vault debt BEFORE this mint
+            // counts (this vault's debt_e8s is still 0 under Design B). NEVER
+            // total_borrowed_icusd_amount (separate ICP-native pool).
+            let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
+
+            let result = mutate_state(|s| {
+                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, observed_e8s, pre_total)
+            });
+
+            match result {
+                Ok(()) => {
+                    mutate_state(|s| {
+                        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                            if let Some(o) = q.pending.get_mut(&op_id) {
+                                o.mark_succeeded(tx_hash.clone(), now);
+                            }
+                        }
+                    });
+                    crate::storage::record_event(&crate::event::Event::ChainMintConfirmed {
+                        chain_id: chain,
+                        vault_id,
+                        op_id,
+                        amount_e8s: observed_e8s,
+                        tx_hash: tx_hash.clone(),
+                        block_number,
+                        timestamp: now,
+                    });
+                    log!(INFO, "[settlement chain={:?}] mint confirmed: op={} vault={} amount_e8s={} block={} tx={}", chain, op_id, vault_id, observed_e8s, block_number, tx_hash);
+                    // The op stays in `pending` with status Succeeded. There is
+                    // no existing drain/remove helper on SettlementQueueV1 (head
+                    // is advanced lazily); leaving it Succeeded is the queue's
+                    // current convention and is safe — select_next_op never
+                    // re-selects a Succeeded op.
+                }
+                Err(e) => {
+                    // A confirm failure here is a protocol-level condition
+                    // (divergence/halt/amount mismatch), NOT a tx failure. Leave
+                    // the op Inflight for retry; do NOT mark it Failed.
+                    log!(INFO, "[settlement chain={:?}] confirm_mint_in_state FAILED for op {} vault {}: {}; left Inflight", chain, op_id, vault_id, e);
+                }
+            }
+        }
+        SettlementOpKind::Withdrawal { .. } => {
+            // Task 13: a confirmed withdrawal finalizes the vault close +
+            // emits WithdrawalSigned bookkeeping. The mechanism (receipt +
+            // finality check above) is in place; the close logic lands there.
+            mutate_state(|s| {
+                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                    if let Some(o) = q.pending.get_mut(&op_id) {
+                        o.mark_succeeded(tx_hash.clone(), now);
+                    }
+                }
+            });
+            log!(INFO, "[settlement chain={:?}] withdrawal op {} confirmed tx={} (Task 13 finalizes the close)", chain, op_id, tx_hash);
+        }
+        SettlementOpKind::Burn { .. } => {
+            // Unreachable: a Burn op is marked Failed on the submit path and
+            // never goes Inflight. Log defensively rather than panic.
+            log!(INFO, "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
+        }
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -197,16 +197,25 @@ pub async fn run_settlement(chain: ChainId) {
     });
 }
 
+/// What kind of settlement tx a `TxPlan` carries, so the submit path can emit
+/// the right event (`ChainMintSubmitted` vs `WithdrawalSigned`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TxPlanKind {
+    Mint,
+    NativeWithdrawal,
+}
+
 /// Per-op-kind tx shape mirroring `MonadAdapter`'s choices, so the submit and
 /// the stuck-tx resubmit paths build identical transactions (only nonce + fees
-/// differ on a resubmit). `vault_id`/`recipient`/`amount_e8s` are the values the
-/// submit path needs for the `ChainMintSubmitted` event.
+/// differ on a resubmit). `vault_id`/`recipient`/`amount` are the values the
+/// submit path needs for the `ChainMintSubmitted` / `WithdrawalSigned` event;
+/// `amount` is e8s for a mint and e18 (wei) for a native withdrawal.
 struct TxPlan {
     fields: tx::Eip1559Fields,
     vault_id: u64,
     recipient: String,
-    amount_e8s: u128,
-    is_mint: bool,
+    amount: u128,
+    kind: TxPlanKind,
 }
 
 /// Build the EIP-1559 fields for a settlement op at an EXPLICIT nonce + fees.
@@ -214,8 +223,10 @@ struct TxPlan {
 /// Mirrors `MonadAdapter::sign_mint`/`sign_withdrawal` exactly:
 /// - Mint: `to` = icUSD contract, `value` = 0, calldata =
 ///   `encode_mint_calldata`, gas_limit 120_000.
-/// - Withdrawal: `to` = recipient, `value` = amount (wei wart), empty data,
-///   gas_limit 21_000; vault_id is a 0 placeholder (Task 13 threads the real id).
+/// - NativeWithdrawal: `to` = recipient, `value` = `amount_e18` (wei), empty
+///   data, gas_limit 21_000; the plan carries the op's real `vault_id` so the
+///   submit path can emit `WithdrawalSigned` and the confirm path can finalize
+///   the close.
 /// - Burn: never signed in Phase 1b — returns `Err`.
 ///
 /// The caller supplies `prio`/`max_fee` (a submit uses the live estimate; a
@@ -248,27 +259,26 @@ fn build_tx_plan(
                 fields,
                 vault_id: *vault_id,
                 recipient: recipient.clone(),
-                amount_e8s: *amount_e8s,
-                is_mint: true,
+                amount: *amount_e8s,
+                kind: TxPlanKind::Mint,
             })
         }
-        SettlementOpKind::Withdrawal { recipient, amount_e8s } => {
-            // `amount_e8s` carries the MON amount in wei (the field-name wart
-            // documented on adapter::sign_withdrawal).
+        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+            // `amount_e18` is wei (1e18 scale) — it goes straight into the
+            // EIP-1559 `value` of a native MON transfer.
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: *amount_e8s },
+                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: *amount_e18 },
                 nonce,
                 prio,
                 max_fee,
             );
             Ok(TxPlan {
                 fields,
-                // vault_id 0 is a placeholder; Task 13 threads the real vault id.
-                vault_id: 0,
+                vault_id: *vault_id,
                 recipient: recipient.clone(),
-                amount_e8s: *amount_e8s,
-                is_mint: false,
+                amount: *amount_e18,
+                kind: TxPlanKind::NativeWithdrawal,
             })
         }
         SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
@@ -367,7 +377,7 @@ async fn submit_op(
             return;
         }
     };
-    let TxPlan { fields, vault_id, recipient, amount_e8s, is_mint } = plan;
+    let TxPlan { fields, vault_id, recipient, amount, kind } = plan;
 
     // 5. Sign.
     let raw_hex = match tx::sign_eip1559(&fields, path, &settlement_addr).await {
@@ -414,19 +424,31 @@ async fn submit_op(
         }
     });
 
-    if is_mint {
-        crate::storage::record_event(&crate::event::Event::ChainMintSubmitted {
-            chain_id: chain,
-            vault_id,
-            op_id,
-            recipient,
-            amount_e8s,
-            tx_hash: tx_hash.clone(),
-            timestamp: now,
-        });
-        log!(INFO, "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}", chain, op_id, vault_id, amount_e8s, tx_hash);
-    } else {
-        log!(INFO, "[settlement chain={:?}] op {} submitted inflight tx={}", chain, op_id, tx_hash);
+    match kind {
+        TxPlanKind::Mint => {
+            crate::storage::record_event(&crate::event::Event::ChainMintSubmitted {
+                chain_id: chain,
+                vault_id,
+                op_id,
+                recipient,
+                amount_e8s: amount,
+                tx_hash: tx_hash.clone(),
+                timestamp: now,
+            });
+            log!(INFO, "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+        }
+        TxPlanKind::NativeWithdrawal => {
+            crate::storage::record_event(&crate::event::Event::WithdrawalSigned {
+                chain_id: chain,
+                vault_id,
+                op_id,
+                recipient,
+                amount_e18: amount,
+                tx_hash: tx_hash.clone(),
+                timestamp: now,
+            });
+            log!(INFO, "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+        }
     }
 }
 
@@ -507,27 +529,46 @@ async fn confirm_op(
 
     let now = ic_cdk::api::time();
 
-    // 2. Reverted tx: mark the op Failed. Under Design B no debt was counted, so
-    //    there is NO supply reversal. Clear the vault's pending mint (the mint
-    //    will not happen). Do NOT advance the vault status: per the plan (Task
-    //    10) a reverted mint changes no vault status, and `Closed` in this
-    //    codebase means "fully repaid + collateral returned" — stamping it here
-    //    would mislabel a vault that still holds deposited collateral as
-    //    returned, and the Task-13 close path (which returns collateral by
-    //    enqueuing a Withdrawal and going Closing -> Closed) keys off `Closing`,
-    //    not `Closed`, so the collateral would be stranded. The failed-mint
-    //    resolution (return collateral, then close) is defined by the Task 12/13
-    //    flow design; the vault is left in its current (MintPending) status with
-    //    a Failed op + a ChainSettlementFailed event for that path to act on.
+    // 2. Reverted tx: mark the op Failed. The per-op-kind state reversal differs:
+    //
+    //    - Mint (Design B): no debt was counted, so NO supply reversal. Clear the
+    //      vault's pending mint (the mint will not happen). Do NOT advance the
+    //      vault status — `Closed` here means "fully repaid + collateral returned",
+    //      so stamping it would mislabel a vault that still holds deposited
+    //      collateral; the failed-mint resolution (return collateral, then close)
+    //      is the Task 12/13 flow's job. The vault is left MintPending with a
+    //      Failed op + a ChainSettlementFailed event for that path to act on.
+    //
+    //    - NativeWithdrawal: the transfer did NOT happen, so the reserved
+    //      collateral never left the custody address. ADD it back to
+    //      `collateral_amount_e18` (undo the reserve-at-enqueue) and, if the vault
+    //      had gone `Closing` (full withdrawal / close), revert it to `Open` — it
+    //      is no longer empty. Never touches debt/supply (withdraw moves only
+    //      collateral).
     if !status_ok {
         let reason = "tx reverted".to_string();
-        if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
-            let vid = *vault_id;
-            mutate_state(|s| {
-                if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
-                    v.pending_mint_e8s = 0;
-                }
-            });
+        match &op.kind {
+            SettlementOpKind::Mint { vault_id, .. } => {
+                let vid = *vault_id;
+                mutate_state(|s| {
+                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
+                        v.pending_mint_e8s = 0;
+                    }
+                });
+            }
+            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                let vid = *vault_id;
+                let amt = *amount_e18;
+                mutate_state(|s| {
+                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
+                        v.collateral_amount_e18 = v.collateral_amount_e18.saturating_add(amt);
+                        if v.status == ChainVaultStatus::Closing {
+                            v.status = ChainVaultStatus::Open;
+                        }
+                    }
+                });
+            }
+            SettlementOpKind::Burn { .. } => {}
         }
         mutate_state(|s| {
             if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
@@ -655,18 +696,27 @@ async fn confirm_op(
                 }
             }
         }
-        SettlementOpKind::Withdrawal { .. } => {
-            // Task 13: a confirmed withdrawal finalizes the vault close +
-            // emits WithdrawalSigned bookkeeping. The mechanism (receipt +
-            // finality check above) is in place; the close logic lands there.
+        SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
+            // A confirmed (mined + ok + final) native transfer-out: the
+            // collateral has left the custody address. Mark the op Succeeded,
+            // then if the vault is `Closing` (a full withdrawal / close) flip it
+            // to `Closed` — collateral is gone and (close required) debt is 0, so
+            // the vault is fully settled. A partial withdrawal leaves the vault
+            // `Open` (it still holds collateral); nothing extra to do there.
+            let vid = *vault_id;
             mutate_state(|s| {
                 if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                     if let Some(o) = q.pending.get_mut(&op_id) {
                         o.mark_succeeded(tx_hash.clone(), now);
                     }
                 }
+                if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vid) {
+                    if v.status == ChainVaultStatus::Closing {
+                        v.status = ChainVaultStatus::Closed;
+                    }
+                }
             });
-            log!(INFO, "[settlement chain={:?}] withdrawal op {} confirmed tx={} (Task 13 finalizes the close)", chain, op_id, tx_hash);
+            log!(INFO, "[settlement chain={:?}] withdrawal op {} vault {} confirmed tx={} (Closing->Closed if applicable)", chain, op_id, vid, tx_hash);
         }
         SettlementOpKind::Burn { .. } => {
             // Unreachable: a Burn op is marked Failed on the submit path and

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Real impl in a later Task.

--- a/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
@@ -49,6 +49,19 @@ pub fn evm_address_from_pubkey(pubkey: &[u8]) -> Result<String, String> {
     Ok(format!("0x{}", hex::encode(addr)))
 }
 
+/// True iff `s` is a well-formed EVM address: a `0x`/`0X` prefix followed by
+/// EXACTLY 40 hex digits (20 bytes), case-insensitive. This is the format the
+/// tx-building helpers (`tx::abi_word_address`/`parse_address`) require; an
+/// address that passes this can never panic those helpers. (Format only — no
+/// EIP-55 checksum; derived addresses are lowercase and RPC responses vary.)
+pub fn is_valid_evm_address(s: &str) -> bool {
+    let hex = match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        Some(h) => h,
+        None => return false,
+    };
+    hex.len() == 40 && hex.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Async: fetch the derived public key from the management canister and return
 /// both the raw pubkey and the EVM address. Used by deposit-address queries and
 /// by the settlement worker to learn its minter address.

--- a/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
@@ -62,3 +62,36 @@ pub async fn derive_evm_address(derivation_path: Vec<Vec<u8>>) -> Result<(Vec<u8
     let addr = evm_address_from_pubkey(&res.public_key)?;
     Ok((res.public_key, addr))
 }
+
+// ─── Settlement-address cache (Task 11 review M1; wired Task 15) ────────────────
+
+thread_local! {
+    static SETTLEMENT_ADDR_CACHE: std::cell::RefCell<std::collections::BTreeMap<ChainId, String>> =
+        const { std::cell::RefCell::new(std::collections::BTreeMap::new()) };
+}
+
+/// Cached settlement (minter) address for `chain`. Derives + caches on first
+/// use; returns the cached value thereafter. The address is deterministic
+/// (`settlement_derivation_path` has no nonce), so caching is always correct;
+/// the cache is a thread_local (not persisted) and simply re-derives once per
+/// chain after an upgrade. Returns (path, address) so callers that also need the
+/// derivation path for signing get both.
+///
+/// SETTLEMENT-ONLY: this caches the SETTLEMENT address exclusively (the key is
+/// `chain`, and the path is always `settlement_derivation_path(chain)`). It must
+/// NEVER be used for a per-vault custody address — those derive from
+/// `custody_derivation_path(chain, user, nonce)` and are per-vault, not per-chain.
+pub async fn cached_settlement_address(chain: ChainId) -> Result<(Vec<Vec<u8>>, String), String> {
+    let path = settlement_derivation_path(chain);
+    // Synchronous cache read — the borrow is dropped before any `.await`.
+    if let Some(addr) = SETTLEMENT_ADDR_CACHE.with(|c| c.borrow().get(&chain).cloned()) {
+        return Ok((path, addr));
+    }
+    let (_pubkey, addr) = derive_evm_address(path.clone()).await?;
+    // Synchronous cache write — borrow dropped before returning, never held
+    // across an `.await`.
+    SETTLEMENT_ADDR_CACHE.with(|c| {
+        c.borrow_mut().insert(chain, addr.clone());
+    });
+    Ok((path, addr))
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
@@ -1,1 +1,64 @@
-//! Placeholder. Real impl in a later Task.
+//! tECDSA address derivation for Monad (secp256k1).
+//!
+//! Pure helpers (pubkey -> address, derivation paths) are unit-tested against
+//! the canonical k=1 vector. The async `ecdsa_public_key` call hits the
+//! management canister and is covered by the PocketIC integration test (Task 17)
+//! and manual staging (Task 23).
+
+use crate::chains::config::ChainId;
+use candid::Principal;
+use ic_cdk::api::management_canister::ecdsa::{
+    ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
+};
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::PublicKey;
+use sha3::{Digest, Keccak256};
+
+use super::config::monad_ecdsa_key_name;
+
+/// Derivation path for a per-user collateral custody address.
+/// `[chain_id (LE u32), principal bytes, nonce (LE u64)]`.
+pub fn custody_derivation_path(chain: ChainId, user: Principal, nonce: u64) -> Vec<Vec<u8>> {
+    vec![
+        chain.0.to_le_bytes().to_vec(),
+        user.as_slice().to_vec(),
+        nonce.to_le_bytes().to_vec(),
+    ]
+}
+
+/// Derivation path for the per-chain settlement (minter) address.
+pub fn settlement_derivation_path(chain: ChainId) -> Vec<Vec<u8>> {
+    vec![chain.0.to_le_bytes().to_vec(), b"settlement".to_vec()]
+}
+
+fn key_id() -> EcdsaKeyId {
+    EcdsaKeyId { curve: EcdsaCurve::Secp256k1, name: monad_ecdsa_key_name() }
+}
+
+/// Convert a secp256k1 public key (33-byte compressed or 65-byte uncompressed)
+/// to a lowercase 0x EVM address: keccak256(uncompressed[1..])[12..].
+pub fn evm_address_from_pubkey(pubkey: &[u8]) -> Result<String, String> {
+    let pk = PublicKey::from_sec1_bytes(pubkey).map_err(|e| format!("bad pubkey: {e}"))?;
+    let uncompressed = pk.to_encoded_point(false); // 0x04 || X(32) || Y(32)
+    let bytes = uncompressed.as_bytes();
+    if bytes.len() != 65 {
+        return Err(format!("expected 65-byte uncompressed pubkey, got {}", bytes.len()));
+    }
+    let hash = Keccak256::digest(&bytes[1..]); // drop the 0x04 prefix
+    let addr = &hash[12..]; // last 20 bytes
+    Ok(format!("0x{}", hex::encode(addr)))
+}
+
+/// Async: fetch the derived public key from the management canister and return
+/// both the raw pubkey and the EVM address. Used by deposit-address queries and
+/// by the settlement worker to learn its minter address.
+pub async fn derive_evm_address(derivation_path: Vec<Vec<u8>>) -> Result<(Vec<u8>, String), String> {
+    let arg = EcdsaPublicKeyArgument {
+        canister_id: None,
+        derivation_path,
+        key_id: key_id(),
+    };
+    let (res,) = ecdsa_public_key(arg).await.map_err(|(code, msg)| format!("{code:?}: {msg}"))?;
+    let addr = evm_address_from_pubkey(&res.public_key)?;
+    Ok((res.public_key, addr))
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tecdsa.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Real impl in a later Task.

--- a/src/rumi_protocol_backend/src/chains/monad/tests_adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_adapter.rs
@@ -1,0 +1,29 @@
+use super::adapter::MonadAdapter;
+use super::evm_rpc::{BURN_EVENT_TOPIC0, MINT_EVENT_TOPIC0};
+use crate::chains::adapter::ChainAdapter;
+use crate::chains::config::ChainId;
+use sha3::{Digest, Keccak256};
+
+#[test]
+fn adapter_reports_monad_chain_id() {
+    let a = MonadAdapter::new(ChainId(10143));
+    assert_eq!(a.chain_id(), ChainId(10143));
+}
+
+#[test]
+fn adapter_is_trait_object_safe() {
+    let a: Box<dyn ChainAdapter> = Box::new(MonadAdapter::new(ChainId(10143)));
+    assert_eq!(a.chain_id(), ChainId(10143));
+}
+
+#[test]
+fn burn_topic0_matches_canonical_signature() {
+    let expected = format!("0x{}", hex::encode(Keccak256::digest(b"Burn(uint256,address,uint256)")));
+    assert_eq!(BURN_EVENT_TOPIC0.to_lowercase(), expected);
+}
+
+#[test]
+fn mint_topic0_matches_canonical_signature() {
+    let expected = format!("0x{}", hex::encode(Keccak256::digest(b"Mint(uint256,address,uint256)")));
+    assert_eq!(MINT_EVENT_TOPIC0.to_lowercase(), expected);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
@@ -1,0 +1,43 @@
+use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
+use crate::chains::config::ChainId;
+use candid::{Decode, Encode};
+
+#[test]
+fn chain_vault_round_trips_via_candid() {
+    let v = ChainVaultV1 {
+        vault_id: 42,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xabc0000000000000000000000000000000000001".into(),
+        collateral_amount_e18: 5_000_000_000_000_000_000, // 5 MON
+        debt_e8s: 0,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: 10_000_000_000, // 100 icUSD pending
+        status: ChainVaultStatus::MintPending,
+        opened_at_ns: 1_700_000_000_000_000_000,
+    };
+    let bytes = Encode!(&v).expect("encode");
+    let back: ChainVaultV1 = Decode!(&bytes, ChainVaultV1).expect("decode");
+    assert_eq!(back.vault_id, 42);
+    assert!(matches!(back.status, ChainVaultStatus::MintPending));
+}
+
+#[test]
+fn chain_vault_round_trips_via_cbor() {
+    let v = ChainVaultV1 {
+        vault_id: 1,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xa".into(),
+        collateral_amount_e18: 1,
+        debt_e8s: 2,
+        mint_recipient: "0xb".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 0,
+    };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v, &mut buf).expect("cbor encode");
+    let back: ChainVaultV1 = ciborium::de::from_reader(buf.as_slice()).expect("cbor decode");
+    assert_eq!(back.debt_e8s, 2);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_config.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_config.rs
@@ -1,0 +1,31 @@
+use super::config::{
+    monad_default_register_arg, monad_ecdsa_key_name, MONAD_CHAIN_ID,
+    MONAD_ICUSD_DECIMALS,
+};
+use crate::chains::config::{ChainId, GasStrategy};
+
+#[test]
+fn chain_id_is_monad_testnet() {
+    assert_eq!(MONAD_CHAIN_ID, ChainId(10143));
+}
+
+#[test]
+fn default_register_arg_uses_eip1559_and_nonempty_rpc() {
+    let arg = monad_default_register_arg();
+    assert_eq!(arg.chain_id, ChainId(10143));
+    assert!(!arg.rpc_endpoints.is_empty());
+    assert!(matches!(arg.gas_strategy, GasStrategy::EvmEip1559 { .. }));
+    assert_eq!(arg.chain_native_decimals, 18); // MON has 18 decimals
+    assert!(arg.finality_depth >= 1);
+}
+
+#[test]
+fn icusd_decimals_match_e8s() {
+    // IcUSD.sol uses 8 decimals so on-chain amount == e8s 1:1.
+    assert_eq!(MONAD_ICUSD_DECIMALS, 8);
+}
+
+#[test]
+fn key_name_is_test_key_on_staging_default() {
+    assert_eq!(monad_ecdsa_key_name(), "test_key_1");
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -1,8 +1,9 @@
-use super::deposit_watch::{apply_burn_to_state, credit_deposit_to_state};
+use super::deposit_watch::{apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
 use crate::chains::multi_chain_state::MultiChainStateV2;
 use crate::chains::monad::evm_rpc::BurnLog;
+use crate::chains::supply::SupplyInvariantError;
 use candid::Principal;
 
 fn seeded() -> MultiChainStateV2 {
@@ -43,14 +44,61 @@ fn burn_exceeding_debt_is_rejected_without_mutation() {
     s.chain_supplies.insert(ChainId(10143), 1_000_000_000);
     let burn = BurnLog { vault_id: 1, amount_e8s: 9_999_999_999, tx_hash: "0xb".into(), block_number: 1 };
     let res = apply_burn_to_state(&mut s, &burn, 1_000_000_000);
-    assert!(res.is_err());
+    // Over-repay is a PERMANENT-INVALID burn → InvalidBurn (skippable).
+    assert!(matches!(res, Err(BurnApplyError::InvalidBurn(_))), "got {res:?}");
     assert_eq!(s.chain_vaults[&1].debt_e8s, 1_000_000_000); // unchanged
     assert_eq!(s.chain_supplies[&ChainId(10143)], 1_000_000_000); // unchanged
 }
 
 #[test]
-fn burn_for_unknown_vault_is_rejected() {
+fn burn_for_unknown_vault_is_rejected_as_invalid() {
     let mut s = seeded();
     let burn = BurnLog { vault_id: 999, amount_e8s: 1, tx_hash: "0xb".into(), block_number: 1 };
-    assert!(apply_burn_to_state(&mut s, &burn, 0).is_err());
+    let res = apply_burn_to_state(&mut s, &burn, 0);
+    // Unknown vault is a PERMANENT-INVALID burn → InvalidBurn (skippable).
+    assert!(matches!(res, Err(BurnApplyError::InvalidBurn(_))), "got {res:?}");
+}
+
+#[test]
+fn burn_returns_supply_invariant_when_already_halted_without_mutation() {
+    // A burn whose amount equals the vault debt and matches the supply would
+    // normally apply cleanly, but with the self-check halt already set,
+    // apply_supply_delta returns HaltedAfterSelfCheckFailure → the typed error
+    // is SupplyInvariant (HALT-CLASS, not skippable). Both fields stay untouched.
+    let mut s = seeded();
+    s.chain_vaults.get_mut(&1).unwrap().debt_e8s = 5_000_000_000;
+    s.chain_supplies.insert(ChainId(10143), 5_000_000_000);
+    s.invariant_halted = true;
+    let burn = BurnLog { vault_id: 1, amount_e8s: 4_000_000_000, tx_hash: "0xb".into(), block_number: 1 };
+    let res = apply_burn_to_state(&mut s, &burn, 5_000_000_000);
+    assert!(
+        matches!(
+            res,
+            Err(BurnApplyError::SupplyInvariant(SupplyInvariantError::HaltedAfterSelfCheckFailure))
+        ),
+        "got {res:?}"
+    );
+    // No-mutation-on-rejection: both fields unchanged even on the halt path.
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 5_000_000_000);
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 5_000_000_000);
+}
+
+#[test]
+fn burn_returns_supply_invariant_on_supply_divergence_without_mutation() {
+    // debt exists and the per-vault debt check passes, but chain_supplies does
+    // NOT match total_debt at call time → apply_supply_delta returns Divergence
+    // → SupplyInvariant (HALT-CLASS). Confirms a halt-class failure is correctly
+    // classified (NOT InvalidBurn) and leaves both fields untouched.
+    let mut s = seeded();
+    s.chain_vaults.get_mut(&1).unwrap().debt_e8s = 4_000_000_000;
+    // Deliberately mismatched supply (3e9) vs the total_debt we pass (4e9).
+    s.chain_supplies.insert(ChainId(10143), 3_000_000_000);
+    let burn = BurnLog { vault_id: 1, amount_e8s: 1_000_000_000, tx_hash: "0xb".into(), block_number: 1 };
+    let res = apply_burn_to_state(&mut s, &burn, 4_000_000_000);
+    assert!(
+        matches!(res, Err(BurnApplyError::SupplyInvariant(SupplyInvariantError::Divergence { .. }))),
+        "got {res:?}"
+    );
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 4_000_000_000); // unchanged
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 3_000_000_000); // unchanged
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -1,0 +1,56 @@
+use super::deposit_watch::{apply_burn_to_state, credit_deposit_to_state};
+use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
+use crate::chains::config::ChainId;
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::monad::evm_rpc::BurnLog;
+use candid::Principal;
+
+fn seeded() -> MultiChainStateV2 {
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), 0);
+    s.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
+        custody_address: "0xcustody".into(), collateral_amount_e18: 0, debt_e8s: 0,
+        mint_recipient: "0xr".into(), pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open, opened_at_ns: 0,
+    });
+    s
+}
+
+#[test]
+fn credit_deposit_increments_collateral() {
+    let mut s = seeded();
+    credit_deposit_to_state(&mut s, 1, 5_000_000_000_000_000_000).expect("credit");
+    assert_eq!(s.chain_vaults[&1].collateral_amount_e18, 5_000_000_000_000_000_000);
+}
+
+#[test]
+fn burn_decrements_supply_and_debt_preserving_invariant() {
+    let mut s = seeded();
+    s.chain_vaults.get_mut(&1).unwrap().debt_e8s = 10_000_000_000;
+    s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
+    let total_debt = 10_000_000_000u128;
+    let burn = BurnLog { vault_id: 1, amount_e8s: 4_000_000_000, tx_hash: "0xb".into(), block_number: 110 };
+    apply_burn_to_state(&mut s, &burn, total_debt).expect("burn");
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 6_000_000_000);
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 6_000_000_000);
+}
+
+#[test]
+fn burn_exceeding_debt_is_rejected_without_mutation() {
+    let mut s = seeded();
+    s.chain_vaults.get_mut(&1).unwrap().debt_e8s = 1_000_000_000;
+    s.chain_supplies.insert(ChainId(10143), 1_000_000_000);
+    let burn = BurnLog { vault_id: 1, amount_e8s: 9_999_999_999, tx_hash: "0xb".into(), block_number: 1 };
+    let res = apply_burn_to_state(&mut s, &burn, 1_000_000_000);
+    assert!(res.is_err());
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 1_000_000_000); // unchanged
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 1_000_000_000); // unchanged
+}
+
+#[test]
+fn burn_for_unknown_vault_is_rejected() {
+    let mut s = seeded();
+    let burn = BurnLog { vault_id: 999, amount_e8s: 1, tx_hash: "0xb".into(), block_number: 1 };
+    assert!(apply_burn_to_state(&mut s, &burn, 0).is_err());
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
@@ -124,6 +124,165 @@ mod ic_error_round_trip {
     }
 }
 
+// ─── Candid round-trip test: typed eth_getBlockByNumber result ───────────────
+//
+// Proves (a) the production typed-method mirror types match the live .did and
+// (b) the minimal production `Block { number }` decodes a RICHER wire `Block`
+// (record subtyping: a reader with FEWER fields decodes a record with more,
+// ignoring the extras).  We define independent "real shape" types here with
+// MANY more fields than just `number` (hash, timestamp, miner, ...), encode a
+// `Consistent(Ok(RealBlock{...}))`, then `Decode!` into the PRODUCTION
+// `MultiGetBlockByNumberResult` and assert the decoded `number` survives.
+//
+// This must fail to compile/decode before the production types exist and pass
+// after.
+
+#[cfg(test)]
+mod block_by_number_round_trip {
+    use candid::{CandidType, Deserialize};
+    use candid::{Encode, Decode};
+
+    // ── "Real" (wire-shape) types — independent mirror of the live .did ──────
+    //
+    // Reuse the RpcError tree shape from the Layer-1 test family; here we only
+    // need the Ok arm, so a minimal RealRpcError stand-in suffices for the
+    // variant's type to line up.
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    struct RealJsonRpcError {
+        pub code: i64,
+        pub message: String,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealRpcError {
+        JsonRpcError(RealJsonRpcError),
+    }
+
+    /// A FULL `Block` record (many more fields than the production `Block`,
+    /// which carries only `number`).  Field order follows the live .did so the
+    /// candid hashes match; only `number` is asserted post-decode.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    struct RealBlock {
+        pub miner: String,
+        #[serde(rename = "totalDifficulty")]
+        pub total_difficulty: Option<candid::Nat>,
+        #[serde(rename = "receiptsRoot")]
+        pub receipts_root: String,
+        #[serde(rename = "stateRoot")]
+        pub state_root: String,
+        pub hash: String,
+        pub difficulty: Option<candid::Nat>,
+        pub size: candid::Nat,
+        pub uncles: Vec<String>,
+        #[serde(rename = "baseFeePerGas")]
+        pub base_fee_per_gas: Option<candid::Nat>,
+        #[serde(rename = "extraData")]
+        pub extra_data: String,
+        #[serde(rename = "transactionsRoot")]
+        pub transactions_root: Option<String>,
+        #[serde(rename = "sha3Uncles")]
+        pub sha3_uncles: String,
+        pub nonce: candid::Nat,
+        pub number: candid::Nat,
+        pub timestamp: candid::Nat,
+        pub transactions: Vec<String>,
+        #[serde(rename = "gasLimit")]
+        pub gas_limit: candid::Nat,
+        #[serde(rename = "logsBloom")]
+        pub logs_bloom: String,
+        #[serde(rename = "parentHash")]
+        pub parent_hash: String,
+        #[serde(rename = "gasUsed")]
+        pub gas_used: candid::Nat,
+        #[serde(rename = "mixHash")]
+        pub mix_hash: String,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    enum RealGetBlockByNumberResult {
+        Ok(RealBlock),
+        Err(RealRpcError),
+    }
+
+    // The `Inconsistent` arm references the singular RpcService; since this
+    // test only ever encodes `Consistent`, a minimal stand-in keeps the
+    // variant's candid type well-formed without re-mirroring all of RpcService.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    struct RealRpcApi {
+        pub url: String,
+        pub headers: Option<Vec<RealHttpHeader>>,
+    }
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    struct RealHttpHeader {
+        pub name: String,
+        pub value: String,
+    }
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    enum RealRpcService {
+        Custom(RealRpcApi),
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    enum RealMultiGetBlockByNumberResult {
+        Consistent(RealGetBlockByNumberResult),
+        Inconsistent(Vec<(RealRpcService, RealGetBlockByNumberResult)>),
+    }
+
+    // ── Production types (import from the module under test) ─────────────────
+    use super::super::evm_rpc::{
+        Block, GetBlockByNumberResult, MultiGetBlockByNumberResult,
+    };
+
+    /// Encode a real-wire-shaped `Consistent(Ok(RealBlock{ number: 12345, ...}))`
+    /// (richer than production `Block`) and decode it into the production
+    /// `MultiGetBlockByNumberResult`.  Asserts the decoded `number` matches —
+    /// proving the mirror is correct AND record-subtyping drops the extra
+    /// fields cleanly.
+    #[test]
+    fn typed_block_result_round_trips_with_subtyping() {
+        let wire = RealMultiGetBlockByNumberResult::Consistent(
+            RealGetBlockByNumberResult::Ok(RealBlock {
+                miner: "0xabc".to_string(),
+                total_difficulty: Some(candid::Nat::from(0u64)),
+                receipts_root: "0xrr".to_string(),
+                state_root: "0xsr".to_string(),
+                hash: "0xdeadbeef".to_string(),
+                difficulty: None,
+                size: candid::Nat::from(1u64),
+                uncles: vec![],
+                base_fee_per_gas: Some(candid::Nat::from(7u64)),
+                extra_data: "0x".to_string(),
+                transactions_root: Some("0xtr".to_string()),
+                sha3_uncles: "0xsu".to_string(),
+                nonce: candid::Nat::from(0u64),
+                number: candid::Nat::from(12_345u64),
+                timestamp: candid::Nat::from(1_700_000_000u64),
+                transactions: vec!["0xtx1".to_string()],
+                gas_limit: candid::Nat::from(30_000_000u64),
+                logs_bloom: "0x00".to_string(),
+                parent_hash: "0xparent".to_string(),
+                gas_used: candid::Nat::from(21_000u64),
+                mix_hash: "0xmix".to_string(),
+            }),
+        );
+
+        let bytes = Encode!(&wire).expect("encode real MultiGetBlockByNumberResult");
+
+        let decoded = Decode!(&bytes, MultiGetBlockByNumberResult)
+            .expect("decode production MultiGetBlockByNumberResult from richer wire bytes");
+
+        match decoded {
+            MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Ok(Block {
+                number,
+            })) => {
+                assert_eq!(number, candid::Nat::from(12_345u64));
+            }
+            other => panic!("expected Consistent(Ok(Block)), got {:?}", other),
+        }
+    }
+}
+
 #[test]
 fn parses_hex_quantity() {
     assert_eq!(parse_hex_quantity("0x0").unwrap(), 0u128);

--- a/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
@@ -1,0 +1,33 @@
+use super::evm_rpc::{parse_hex_quantity, BurnLog};
+
+#[test]
+fn parses_hex_quantity() {
+    assert_eq!(parse_hex_quantity("0x0").unwrap(), 0u128);
+    assert_eq!(parse_hex_quantity("0x10").unwrap(), 16u128);
+    assert_eq!(parse_hex_quantity("0x2540be400").unwrap(), 10_000_000_000u128); // 100 icUSD @ 8dp
+    assert!(parse_hex_quantity("not-hex").is_err());
+}
+
+#[test]
+fn decodes_burn_log() {
+    // Burn(uint256 vault_id, address burner, uint256 amount):
+    //   topics[0] = keccak("Burn(uint256,address,uint256)")
+    //   topics[1] = vault_id (indexed), topics[2] = burner (indexed), data = amount
+    let topic0 = super::evm_rpc::BURN_EVENT_TOPIC0.to_string();
+    let vault_id_topic = format!("0x{:064x}", 7u64);
+    let burner_topic = format!("0x{:064x}", 0u8);
+    let amount_data = format!("0x{:064x}", 10_000_000_000u128);
+    let log = BurnLog::from_raw(&[topic0, vault_id_topic, burner_topic], &amount_data, "0xtxhash", 110)
+        .expect("decode burn");
+    assert_eq!(log.vault_id, 7);
+    assert_eq!(log.amount_e8s, 10_000_000_000);
+    assert_eq!(log.block_number, 110);
+}
+
+#[test]
+fn rejects_log_with_wrong_topic0() {
+    let res = BurnLog::from_raw(
+        &["0xdeadbeef".into(), format!("0x{:064x}", 1u64), format!("0x{:064x}", 0u8)],
+        &format!("0x{:064x}", 1u128), "0xtx", 1);
+    assert!(res.is_err());
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
@@ -1,5 +1,129 @@
 use super::evm_rpc::{parse_hex_quantity, BurnLog};
 
+// ─── Candid round-trip test: IcError with real RejectionCode ─────────────────
+//
+// This test proves that the production `RequestResult` type can decode a
+// REAL-WIRE-SHAPED IcError where `code` is a Candid variant (`RejectionCode`),
+// not a u32.
+//
+// "Real shape" types are defined independently here to mirror the live .did
+// exactly.  We encode with them, then decode with the production type.
+// With `code: u32` the Decode! call returns Err (decode trap averted by
+// candid::Decode! returning Result).  After changing `code` to `RejectionCode`
+// it must pass.
+
+#[cfg(test)]
+mod ic_error_round_trip {
+    use candid::{CandidType, Deserialize};
+    use candid::{Encode, Decode};
+
+    // ── "Real" (wire-shape) types — independent mirror of the live .did ──────
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealRejectionCode {
+        NoError,
+        CanisterError,
+        SysTransient,
+        DestinationInvalid,
+        Unknown,
+        SysFatal,
+        CanisterReject,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    struct RealIcError {
+        pub code: RealRejectionCode,
+        pub message: String,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    struct RealInvalidHttpJsonRpcRecord {
+        pub status: u16,
+        pub body: String,
+        #[serde(rename = "parsingError")]
+        pub parsing_error: Option<String>,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealHttpOutcallError {
+        IcError(RealIcError),
+        InvalidHttpJsonRpcResponse(RealInvalidHttpJsonRpcRecord),
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    struct RealJsonRpcError {
+        pub code: i64,
+        pub message: String,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    struct RealTooFewCyclesRecord {
+        pub expected: candid::Nat,
+        pub received: candid::Nat,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealProviderError {
+        TooFewCycles(RealTooFewCyclesRecord),
+        MissingRequiredProvider,
+        ProviderNotFound,
+        NoPermission,
+        InvalidRpcConfig(String),
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealValidationError {
+        Custom(String),
+        InvalidHex(String),
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealRpcError {
+        JsonRpcError(RealJsonRpcError),
+        ProviderError(RealProviderError),
+        ValidationError(RealValidationError),
+        HttpOutcallError(RealHttpOutcallError),
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+    enum RealRequestResult {
+        Ok(String),
+        Err(RealRpcError),
+    }
+
+    // ── Production types (import from the module under test) ─────────────────
+    use super::super::evm_rpc::{
+        HttpOutcallError, IcErrorRecord, RejectionCode, RpcError, RequestResult,
+    };
+
+    /// Encode a real-wire-shaped `IcError { code: SysTransient }` and decode
+    /// it as the production `RequestResult`.  With `code: u32` this decode
+    /// fails; with `code: RejectionCode` it must pass and round-trip correctly.
+    #[test]
+    fn ic_error_rejection_code_round_trips() {
+        let wire = RealRequestResult::Err(RealRpcError::HttpOutcallError(
+            RealHttpOutcallError::IcError(RealIcError {
+                code: RealRejectionCode::SysTransient,
+                message: "no consensus".to_string(),
+            }),
+        ));
+
+        let bytes = Encode!(&wire).expect("encode real RequestResult");
+
+        let decoded = Decode!(&bytes, RequestResult)
+            .expect("decode production RequestResult from real-wire bytes");
+
+        let expected = RequestResult::Err(RpcError::HttpOutcallError(
+            HttpOutcallError::IcError(IcErrorRecord {
+                code: RejectionCode::SysTransient,
+                message: "no consensus".to_string(),
+            }),
+        ));
+
+        assert_eq!(decoded, expected);
+    }
+}
+
 #[test]
 fn parses_hex_quantity() {
     assert_eq!(parse_hex_quantity("0x0").unwrap(), 0u128);

--- a/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
@@ -1,4 +1,6 @@
 use super::hardening::{is_stuck, is_reorg, hot_wallet_ok, bump_gas, HOT_WALLET_MIN_E18};
+use super::hardening::on_not_mined_tick;
+use super::hardening::{on_reorg_tick, REORG_CONFIRM_TICKS};
 
 #[test]
 fn detects_stuck_tx_after_threshold() {
@@ -28,4 +30,31 @@ fn bump_gas_increases_fees_by_at_least_125_percent() {
     let (new_prio, new_max) = bump_gas(2_000_000_000, 50_000_000_000);
     assert!(new_prio >= 2_000_000_000 * 125 / 100);
     assert!(new_max >= 50_000_000_000 * 125 / 100);
+}
+
+#[test]
+fn not_mined_tick_advances_tries_and_resubmits_at_threshold() {
+    // finality_depth 1 -> stuck threshold 2. Start at tries=1 (just submitted).
+    // First not-mined tick -> tries 2 -> stuck -> resubmit (have nonce).
+    assert_eq!(on_not_mined_tick(1, 1, true), (2, true));
+    // Without a stored nonce we must NEVER resubmit (would risk a fresh-nonce 2nd mint).
+    assert_eq!(on_not_mined_tick(1, 1, false), (2, false));
+    // Deeper finality: threshold 10. tries 1 -> 2, not stuck yet.
+    assert_eq!(on_not_mined_tick(1, 5, true), (2, false));
+    // tries 9 -> 10 == threshold -> resubmit.
+    assert_eq!(on_not_mined_tick(9, 5, true), (10, true));
+    // Saturates, never panics.
+    assert_eq!(on_not_mined_tick(u32::MAX, 1, true), (u32::MAX, true));
+}
+
+#[test]
+fn reorg_halts_only_after_consecutive_confirmations() {
+    assert_eq!(REORG_CONFIRM_TICKS, 3);
+    // Suspect ticks accumulate; halt only when the streak reaches K.
+    assert_eq!(on_reorg_tick(0, true), (1, false));
+    assert_eq!(on_reorg_tick(1, true), (2, false));
+    assert_eq!(on_reorg_tick(2, true), (3, true)); // K-th consecutive -> halt
+    // A non-suspect tick resets the streak (transient blip self-heals).
+    assert_eq!(on_reorg_tick(2, false), (0, false));
+    assert_eq!(on_reorg_tick(0, false), (0, false));
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
@@ -1,6 +1,7 @@
 use super::hardening::{is_stuck, is_reorg, hot_wallet_ok, bump_gas, HOT_WALLET_MIN_E18};
 use super::hardening::on_not_mined_tick;
 use super::hardening::{on_reorg_tick, REORG_CONFIRM_TICKS};
+use super::hardening::{inflight_should_acquire, INFLIGHT_STALE_NS};
 
 #[test]
 fn detects_stuck_tx_after_threshold() {
@@ -57,4 +58,41 @@ fn reorg_halts_only_after_consecutive_confirmations() {
     // A non-suspect tick resets the streak (transient blip self-heals).
     assert_eq!(on_reorg_tick(2, false), (0, false));
     assert_eq!(on_reorg_tick(0, false), (0, false));
+}
+
+// ─── inflight_should_acquire (B2 hardening) ─────────────────────────────────
+
+#[test]
+fn inflight_acquire_free_entry() {
+    // Chain not in the map at all (None) -> always acquire.
+    assert!(inflight_should_acquire(None, 1_000_000_000_000, INFLIGHT_STALE_NS));
+    assert!(inflight_should_acquire(None, 0, INFLIGHT_STALE_NS));
+}
+
+#[test]
+fn inflight_acquire_fresh_entry_is_skipped() {
+    // Entry acquired 10 seconds ago (well below the 10-min threshold) -> skip.
+    let now_ns: u64 = 1_000_000_000_000_000_000; // 1 second in ns * 1e9 = ~31 years
+    let acquired_10s_ago = now_ns - 10_000_000_000; // 10 s ago
+    assert!(!inflight_should_acquire(Some(acquired_10s_ago), now_ns, INFLIGHT_STALE_NS));
+}
+
+#[test]
+fn inflight_acquire_stale_entry_is_reclaimed() {
+    // Entry acquired 700 s ago (> 600 s threshold) -> reclaim.
+    let now_ns: u64 = 1_000_000_000_000_000_000;
+    let acquired_700s_ago = now_ns - 700_000_000_000; // 700 s ago
+    assert!(inflight_should_acquire(Some(acquired_700s_ago), now_ns, INFLIGHT_STALE_NS));
+    // Exactly at the threshold boundary (== stale_ns) -> reclaim.
+    let acquired_600s_ago = now_ns - INFLIGHT_STALE_NS;
+    assert!(inflight_should_acquire(Some(acquired_600s_ago), now_ns, INFLIGHT_STALE_NS));
+}
+
+#[test]
+fn inflight_acquire_future_timestamp_treated_as_fresh() {
+    // A future `acquired_at` (clock skew or adversarial state) must NOT panic
+    // (saturating_sub returns 0, which is < stale_ns) -> treated as fresh -> skip.
+    let now_ns: u64 = 1_000_000_000_000;
+    let future_timestamp = now_ns + 999_999_999_999; // well beyond now
+    assert!(!inflight_should_acquire(Some(future_timestamp), now_ns, INFLIGHT_STALE_NS));
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_hardening.rs
@@ -1,0 +1,31 @@
+use super::hardening::{is_stuck, is_reorg, hot_wallet_ok, bump_gas, HOT_WALLET_MIN_E18};
+
+#[test]
+fn detects_stuck_tx_after_threshold() {
+    assert!(!is_stuck(1, 1));   // 1 try at depth 1 -> threshold is 2, not yet
+    assert!(is_stuck(2, 1));    // 2 tries at depth 1 -> stuck
+    assert!(is_stuck(10, 5));   // 10 >= 2*5 -> stuck
+    assert!(!is_stuck(9, 5));   // 9 < 2*5
+}
+
+#[test]
+fn detects_reorg_only_beyond_finality_depth() {
+    assert!(is_reorg(100, 98, 1));   // regression 2 > finality_depth 1 -> reorg
+    assert!(!is_reorg(100, 99, 1));  // regression 1 == finality_depth -> tolerated
+    assert!(!is_reorg(100, 105, 1)); // forward progress -> never a reorg
+    assert!(!is_reorg(100, 100, 1)); // no change -> not a reorg
+}
+
+#[test]
+fn hot_wallet_gate_blocks_below_threshold() {
+    assert!(hot_wallet_ok(HOT_WALLET_MIN_E18));
+    assert!(hot_wallet_ok(HOT_WALLET_MIN_E18 + 1));
+    assert!(!hot_wallet_ok(HOT_WALLET_MIN_E18 - 1));
+}
+
+#[test]
+fn bump_gas_increases_fees_by_at_least_125_percent() {
+    let (new_prio, new_max) = bump_gas(2_000_000_000, 50_000_000_000);
+    assert!(new_prio >= 2_000_000_000 * 125 / 100);
+    assert!(new_max >= 50_000_000_000 * 125 / 100);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -1,0 +1,253 @@
+//! Task 12: open_chain_vault (open-then-verify) pure-helper tests.
+//!
+//! The owner deviated from the written plan: a vault is OPENED in a new
+//! `AwaitingDeposit` status with NO mint enqueued. deposit-watch later verifies
+//! the custody-address balance covers the DECLARED collateral and only THEN
+//! flips the vault to `MintPending` and enqueues the `Mint` op. icUSD is only
+//! ever minted against a verified on-chain deposit (CDP backing invariant).
+//!
+//! These tests exercise the three pure helpers in `chain_vault.rs`:
+//! - `collateral_ratio_e4`
+//! - `open_chain_vault_in_state` (creates AwaitingDeposit, enqueues NOTHING)
+//! - `verify_deposit_and_enqueue_mint_in_state` (transitions + enqueues)
+
+use super::chain_vault::{
+    collateral_ratio_e4, open_chain_vault_in_state, verify_deposit_and_enqueue_mint_in_state,
+    ChainVaultStatus, OpenVaultError,
+};
+use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::settlement_queue::SettlementOpKind;
+use candid::Principal;
+
+const CHAIN: ChainId = ChainId(10143);
+/// USD price as e8: $2.00.
+const PRICE_2_USD_E8: u64 = 2_0000_0000;
+/// USD price as e8: $100.00.
+const PRICE_100_USD_E8: u64 = 100_0000_0000;
+/// 1 MON in e18.
+const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
+
+/// Register chain 10143 and set its manual MON price. Mirrors what the live
+/// register_chain endpoint + a manual price override do (chain_supplies and
+/// settlement_queues are seeded by register_chain_in_state).
+fn setup(price_e8: u64) -> MultiChainStateV2 {
+    let mut s = MultiChainStateV2::default();
+    let arg = RegisterChainArg {
+        chain_id: CHAIN,
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
+    s.manual_prices.insert((CHAIN, "MON".into()), price_e8);
+    s
+}
+
+fn owner() -> Principal {
+    Principal::anonymous()
+}
+
+// 1. CR math
+#[test]
+fn cr_computed_from_collateral_price_and_debt() {
+    // 5 MON e18 at $2.00 e8, debt $4.00 e8s -> $10 collateral / $4 debt = 250.00% -> 25000.
+    assert_eq!(
+        collateral_ratio_e4(5 * ONE_MON_E18, PRICE_2_USD_E8, 4_00000000),
+        25000
+    );
+}
+
+#[test]
+fn cr_is_max_when_debt_zero() {
+    assert_eq!(collateral_ratio_e4(5 * ONE_MON_E18, PRICE_2_USD_E8, 0), u64::MAX);
+}
+
+// 2. open rejects below min CR, creates nothing, enqueues nothing
+#[test]
+fn open_rejects_below_min_cr() {
+    // 1 MON ($2) collateral, 100 icUSD ($100) debt, min_cr 13000 (130%).
+    // CR = $2 / $100 = 2.00% -> 200 e4 -> well below 13000 -> reject.
+    let mut s = setup(PRICE_2_USD_E8);
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        ONE_MON_E18,
+        100_00000000, // 100 icUSD debt
+        "0xrecipient".into(),
+        13000,
+        0,
+        1,
+    );
+    assert!(matches!(res, Err(OpenVaultError::BelowMinCr { .. })), "got {res:?}");
+    assert!(s.chain_vaults.is_empty(), "no vault should be created");
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "queue must stay empty");
+}
+
+// 3. open creates AwaitingDeposit + does NOT enqueue a mint (the core deviation)
+#[test]
+fn open_creates_awaiting_deposit_vault_and_enqueues_nothing() {
+    // MON price $100, big collateral (100 MON = $10_000), debt 100 icUSD ($100), min_cr 13000.
+    // CR = $10_000 / $100 = 10000% -> way above min -> accept.
+    let mut s = setup(PRICE_100_USD_E8);
+    let declared = 100 * ONE_MON_E18;
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        declared,
+        100_00000000, // 100 icUSD intended mint
+        "0xrecipient".into(),
+        13000,
+        12345,
+        7,
+    );
+    assert!(res.is_ok(), "open should succeed: {res:?}");
+    let v = s.chain_vaults.get(&7).expect("vault 7 created");
+    assert!(matches!(v.status, ChainVaultStatus::AwaitingDeposit), "status {:?}", v.status);
+    assert_eq!(v.pending_mint_e8s, 100_00000000, "intended mint stored in pending");
+    assert_eq!(v.debt_e8s, 0, "no debt until verified deposit + confirmed mint");
+    assert_eq!(v.collateral_amount_e18, declared, "declared collateral recorded");
+    assert_eq!(v.owner, owner());
+    assert_eq!(v.custody_address, "0xcustody");
+    assert_eq!(v.mint_recipient, "0xrecipient");
+    assert_eq!(v.opened_at_ns, 12345);
+    // THE CORE DEVIATION: nothing enqueued at open.
+    assert_eq!(
+        s.settlement_queues[&CHAIN].pending_len(),
+        0,
+        "open_chain_vault_in_state must NOT enqueue a mint"
+    );
+}
+
+// 4. deposit below declared collateral does NOT transition/enqueue
+#[test]
+fn insufficient_deposit_does_not_enqueue() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let declared = 100 * ONE_MON_E18;
+    open_chain_vault_in_state(
+        &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
+        "0xrecipient".into(), 13000, 0, 7,
+    )
+    .expect("open");
+
+    // Observed only 99 MON — below the 100 MON declared.
+    let observed = 99 * ONE_MON_E18;
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 7, observed, 100);
+    assert!(matches!(res, Ok(false)), "got {res:?}");
+    assert!(
+        matches!(s.chain_vaults[&7].status, ChainVaultStatus::AwaitingDeposit),
+        "must stay AwaitingDeposit"
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "queue must stay empty");
+}
+
+// 5. sufficient deposit transitions to MintPending and enqueues the mint
+#[test]
+fn sufficient_deposit_transitions_and_enqueues_mint() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let declared = 100 * ONE_MON_E18;
+    open_chain_vault_in_state(
+        &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
+        "0xrecipient".into(), 13000, 0, 7,
+    )
+    .expect("open");
+
+    // Observed exactly the declared collateral.
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 7, declared, 200);
+    assert!(matches!(res, Ok(true)), "got {res:?}");
+    assert!(
+        matches!(s.chain_vaults[&7].status, ChainVaultStatus::MintPending),
+        "must flip to MintPending"
+    );
+    let q = &s.settlement_queues[&CHAIN];
+    assert_eq!(q.pending_len(), 1, "exactly one Mint enqueued");
+    let op = q.pending.values().next().expect("op present");
+    match &op.kind {
+        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+            assert_eq!(recipient, "0xrecipient");
+            assert_eq!(*amount_e8s, 100_00000000);
+            assert_eq!(*vault_id, 7);
+        }
+        other => panic!("expected Mint op, got {other:?}"),
+    }
+    assert_eq!(op.idempotency_key, format!("mint-{}-{}", CHAIN.0, 7));
+}
+
+// 6. re-verifying an already-transitioned vault does not double-enqueue
+#[test]
+fn reverify_after_transition_is_noop() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let declared = 100 * ONE_MON_E18;
+    open_chain_vault_in_state(
+        &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
+        "0xrecipient".into(), 13000, 0, 7,
+    )
+    .expect("open");
+    // First verify transitions + enqueues.
+    assert!(matches!(
+        verify_deposit_and_enqueue_mint_in_state(&mut s, 7, declared, 200),
+        Ok(true)
+    ));
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 1);
+
+    // Re-verify with even MORE balance — must be an idempotent no-op.
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 7, 200 * ONE_MON_E18, 300);
+    assert!(matches!(res, Ok(false)), "got {res:?}");
+    assert_eq!(
+        s.settlement_queues[&CHAIN].pending_len(),
+        1,
+        "must NOT double-enqueue on re-verify"
+    );
+    assert!(matches!(s.chain_vaults[&7].status, ChainVaultStatus::MintPending));
+}
+
+// 7. verify unknown vault errors
+#[test]
+fn verify_unknown_vault_errors() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 999, 100 * ONE_MON_E18, 0);
+    assert!(matches!(res, Err(OpenVaultError::UnknownVault)), "got {res:?}");
+}
+
+// 8. open rejects an unregistered chain
+#[test]
+fn open_rejects_unknown_chain() {
+    let mut s = MultiChainStateV2::default(); // no chain registered
+    let res = open_chain_vault_in_state(
+        &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
+        "0xrecipient".into(), 13000, 0, 7,
+    );
+    assert!(matches!(res, Err(OpenVaultError::UnknownChain)), "got {res:?}");
+    assert!(s.chain_vaults.is_empty());
+}
+
+// 9. open rejects when no MON price is configured
+#[test]
+fn open_rejects_when_no_price() {
+    let mut s = MultiChainStateV2::default();
+    // Register the chain but DON'T set a MON price.
+    let arg = RegisterChainArg {
+        chain_id: CHAIN,
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
+        chain_native_decimals: 18,
+    };
+    crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
+    let res = open_chain_vault_in_state(
+        &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
+        "0xrecipient".into(), 13000, 0, 7,
+    );
+    assert!(matches!(res, Err(OpenVaultError::NoPrice)), "got {res:?}");
+    assert!(s.chain_vaults.is_empty());
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -79,7 +79,7 @@ fn open_rejects_zero_debt() {
         "0xcustody".into(),
         100 * ONE_MON_E18, // plenty of collateral...
         0,                 // ...but zero debt
-        "0xrecipient".into(),
+        "0x000000000000000000000000000000000000c0de".into(),
         13_000,
         0,
         9,
@@ -106,7 +106,7 @@ fn open_rejects_below_min_cr() {
         "0xcustody".into(),
         ONE_MON_E18,
         100_00000000, // 100 icUSD debt
-        "0xrecipient".into(),
+        "0x000000000000000000000000000000000000c0de".into(),
         13000,
         0,
         1,
@@ -130,7 +130,7 @@ fn open_creates_awaiting_deposit_vault_and_enqueues_nothing() {
         "0xcustody".into(),
         declared,
         100_00000000, // 100 icUSD intended mint
-        "0xrecipient".into(),
+        "0x000000000000000000000000000000000000c0de".into(),
         13000,
         12345,
         7,
@@ -143,7 +143,7 @@ fn open_creates_awaiting_deposit_vault_and_enqueues_nothing() {
     assert_eq!(v.collateral_amount_e18, declared, "declared collateral recorded");
     assert_eq!(v.owner, owner());
     assert_eq!(v.custody_address, "0xcustody");
-    assert_eq!(v.mint_recipient, "0xrecipient");
+    assert_eq!(v.mint_recipient, "0x000000000000000000000000000000000000c0de");
     assert_eq!(v.opened_at_ns, 12345);
     // THE CORE DEVIATION: nothing enqueued at open.
     assert_eq!(
@@ -160,7 +160,7 @@ fn insufficient_deposit_does_not_enqueue() {
     let declared = 100 * ONE_MON_E18;
     open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
-        "0xrecipient".into(), 13000, 0, 7,
+        "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
     )
     .expect("open");
 
@@ -182,7 +182,7 @@ fn sufficient_deposit_transitions_and_enqueues_mint() {
     let declared = 100 * ONE_MON_E18;
     open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
-        "0xrecipient".into(), 13000, 0, 7,
+        "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
     )
     .expect("open");
 
@@ -198,7 +198,7 @@ fn sufficient_deposit_transitions_and_enqueues_mint() {
     let op = q.pending.values().next().expect("op present");
     match &op.kind {
         SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
-            assert_eq!(recipient, "0xrecipient");
+            assert_eq!(recipient, "0x000000000000000000000000000000000000c0de");
             assert_eq!(*amount_e8s, 100_00000000);
             assert_eq!(*vault_id, 7);
         }
@@ -214,7 +214,7 @@ fn reverify_after_transition_is_noop() {
     let declared = 100 * ONE_MON_E18;
     open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), declared, 100_00000000,
-        "0xrecipient".into(), 13000, 0, 7,
+        "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
     )
     .expect("open");
     // First verify transitions + enqueues.
@@ -249,10 +249,57 @@ fn open_rejects_unknown_chain() {
     let mut s = MultiChainStateV2::default(); // no chain registered
     let res = open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
-        "0xrecipient".into(), 13000, 0, 7,
+        "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
     );
     assert!(matches!(res, Err(OpenVaultError::UnknownChain)), "got {res:?}");
     assert!(s.chain_vaults.is_empty());
+}
+
+// 8b. open rejects a malformed mint_recipient at the boundary, creating nothing
+//     and enqueuing nothing. An unvalidated recipient would later panic the
+//     tx-building helper (tx::abi_word_address) deep on the settlement worker
+//     path, after the re-entrancy guard + awaits, permanently blocking the
+//     chain's worker. Fail-fast here makes that panic unreachable in practice.
+#[test]
+fn open_rejects_invalid_recipient() {
+    let mut s = setup(PRICE_100_USD_E8);
+    // "0x123" is a realistic typo: 0x-prefixed but only 3 hex digits, not 40.
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(), // custody is derived/valid in production; not validated
+        100 * ONE_MON_E18,  // plenty of collateral
+        100_00000000,       // non-zero debt (so we pass the ZeroDebt gate)
+        "0x123".into(),     // malformed recipient: too short
+        13_000,
+        12345,
+        7,
+    );
+    assert!(matches!(res, Err(OpenVaultError::InvalidAddress(_))), "got {res:?}");
+    assert!(s.chain_vaults.is_empty(), "no vault should be created on a bad recipient");
+    assert_eq!(
+        s.settlement_queues[&CHAIN].pending_len(),
+        0,
+        "queue must stay empty — nothing enqueued"
+    );
+
+    // A non-hex body is rejected too.
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        100 * ONE_MON_E18,
+        100_00000000,
+        "0xnothex".into(), // 0x-prefixed but contains non-hex chars
+        13_000,
+        12345,
+        8,
+    );
+    assert!(matches!(res, Err(OpenVaultError::InvalidAddress(_))), "got {res:?}");
+    assert!(s.chain_vaults.is_empty(), "still no vault");
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "still empty");
 }
 
 // 9. open rejects when no MON price is configured
@@ -271,7 +318,7 @@ fn open_rejects_when_no_price() {
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     let res = open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
-        "0xrecipient".into(), 13000, 0, 7,
+        "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
     );
     assert!(matches!(res, Err(OpenVaultError::NoPrice)), "got {res:?}");
     assert!(s.chain_vaults.is_empty());

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -68,6 +68,31 @@ fn cr_is_max_when_debt_zero() {
     assert_eq!(collateral_ratio_e4(5 * ONE_MON_E18, PRICE_2_USD_E8, 0), u64::MAX);
 }
 
+// 1b. Degenerate open: zero debt is rejected (would enqueue a wasted 0-mint).
+#[test]
+fn open_rejects_zero_debt() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        100 * ONE_MON_E18, // plenty of collateral...
+        0,                 // ...but zero debt
+        "0xrecipient".into(),
+        13_000,
+        0,
+        9,
+    );
+    assert!(matches!(res, Err(OpenVaultError::ZeroDebt)));
+    assert!(s.chain_vaults.is_empty());
+    assert!(s
+        .settlement_queues
+        .get(&CHAIN)
+        .map(|q| q.pending.is_empty())
+        .unwrap_or(true));
+}
+
 // 2. open rejects below min CR, creates nothing, enqueues nothing
 #[test]
 fn open_rejects_below_min_cr() {

--- a/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
@@ -1,0 +1,98 @@
+use super::settlement::{confirm_mint_in_state, select_next_op, OpAction};
+use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
+use crate::chains::config::ChainId;
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
+use candid::Principal;
+
+fn vault_pending(s: &mut MultiChainStateV2, vault_id: u64, pending: u128) {
+    s.chain_vaults.insert(vault_id, ChainVaultV1 {
+        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
+        custody_address: "0xc".into(), collateral_amount_e18: 0, debt_e8s: 0,
+        mint_recipient: "0xr".into(), pending_mint_e8s: pending,
+        status: ChainVaultStatus::MintPending, opened_at_ns: 0,
+    });
+}
+
+#[test]
+fn select_next_op_prefers_queued_then_inflight() {
+    let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
+    let op = SettlementOp::new(
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 },
+        "k0".into(), 0);
+    let id = q.enqueue(op).unwrap();
+    // Queued -> action Submit.
+    match select_next_op(&q) {
+        Some((oid, OpAction::Submit)) => assert_eq!(oid, id),
+        other => panic!("expected Submit, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_next_op_confirms_inflight_before_submitting_new() {
+    let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
+    let op0 = SettlementOp::new(
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 }, "k0".into(), 0);
+    let id0 = q.enqueue(op0).unwrap();
+    let op1 = SettlementOp::new(
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 20, vault_id: 2 }, "k1".into(), 0);
+    let _id1 = q.enqueue(op1).unwrap();
+    // Put op0 inflight; with something inflight, only Confirm of op0 is actionable.
+    q.pending.get_mut(&id0).unwrap().status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    match select_next_op(&q) {
+        Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
+        other => panic!("expected Confirm of inflight op, got {other:?}"),
+    }
+}
+
+#[test]
+fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), 0);
+    vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
+    // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
+    // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
+    confirm_mint_in_state(&mut s, ChainId(10143), 1, 10_000_000_000, 0).expect("confirm");
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 10_000_000_000);
+    assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
+    assert!(matches!(s.chain_vaults[&1].status, ChainVaultStatus::Open));
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 10_000_000_000);
+}
+
+#[test]
+fn confirm_mint_rejects_amount_mismatch() {
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), 0);
+    vault_pending(&mut s, 1, 10_000_000_000);
+    // Observed amount differs from pending: reject (caught before any supply mutation), do not mutate.
+    let res = confirm_mint_in_state(&mut s, ChainId(10143), 1, 9_999_999_999, 0);
+    assert!(res.is_err());
+    assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 10_000_000_000);
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 0);
+}
+
+#[test]
+fn confirm_mint_unknown_vault_rejected() {
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), 0);
+    assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0).is_err());
+}
+
+#[test]
+fn confirm_mint_second_vault_uses_running_total() {
+    // Two vaults: first already confirmed (debt 100e8, supply 100e8). Confirming the
+    // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
+    s.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
+        custody_address: "0xc".into(), collateral_amount_e18: 0, debt_e8s: 10_000_000_000,
+        mint_recipient: "0xr".into(), pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open, opened_at_ns: 0,
+    });
+    vault_pending(&mut s, 2, 5_000_000_000);
+    let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
+    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total).expect("confirm 2nd");
+    assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
+    assert_eq!(s.chain_supplies[&ChainId(10143)], 15_000_000_000);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_tecdsa.rs
@@ -1,0 +1,45 @@
+use super::tecdsa::{custody_derivation_path, evm_address_from_pubkey, settlement_derivation_path};
+use crate::chains::config::ChainId;
+use candid::Principal;
+
+#[test]
+fn evm_address_from_known_uncompressed_pubkey() {
+    // Canonical vector: private key = 1 -> address 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf.
+    // Uncompressed pubkey for k=1 (65 bytes, 0x04 || X || Y):
+    let pubkey_hex = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8";
+    let pubkey = hex_to_bytes(pubkey_hex);
+    let addr = evm_address_from_pubkey(&pubkey).expect("address");
+    assert_eq!(addr.to_lowercase(), "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
+}
+
+#[test]
+fn evm_address_accepts_compressed_pubkey() {
+    // 33-byte compressed pubkey for k=1: 0x02 || X.
+    let compressed = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    let addr = evm_address_from_pubkey(&hex_to_bytes(compressed)).expect("address");
+    assert_eq!(addr.to_lowercase(), "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
+}
+
+#[test]
+fn custody_path_is_deterministic_and_distinct_per_user() {
+    let p1 = Principal::from_slice(&[1, 2, 3]);
+    let p2 = Principal::from_slice(&[4, 5, 6]);
+    let a = custody_derivation_path(ChainId(10143), p1, 0);
+    let b = custody_derivation_path(ChainId(10143), p1, 0);
+    let c = custody_derivation_path(ChainId(10143), p2, 0);
+    let d = custody_derivation_path(ChainId(10143), p1, 1);
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+    assert_ne!(a, d);
+}
+
+#[test]
+fn settlement_path_differs_from_any_custody_path() {
+    let s = settlement_derivation_path(ChainId(10143));
+    let cust = custody_derivation_path(ChainId(10143), Principal::anonymous(), 0);
+    assert_ne!(s, cust);
+}
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_tecdsa.rs
@@ -1,4 +1,7 @@
-use super::tecdsa::{custody_derivation_path, evm_address_from_pubkey, settlement_derivation_path};
+use super::tecdsa::{
+    custody_derivation_path, evm_address_from_pubkey, is_valid_evm_address,
+    settlement_derivation_path,
+};
 use crate::chains::config::ChainId;
 use candid::Principal;
 
@@ -38,6 +41,33 @@ fn settlement_path_differs_from_any_custody_path() {
     let s = settlement_derivation_path(ChainId(10143));
     let cust = custody_derivation_path(ChainId(10143), Principal::anonymous(), 0);
     assert_ne!(s, cust);
+}
+
+#[test]
+fn is_valid_evm_address_accepts_well_formed_and_rejects_malformed() {
+    // Valid: 0x + exactly 40 hex digits, case-insensitive (mixed case ok —
+    // format-only, no EIP-55 checksum enforcement).
+    assert!(is_valid_evm_address("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"));
+    assert!(is_valid_evm_address("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"));
+    assert!(is_valid_evm_address("0X7e5f4552091a69125d5dfcb7b8c2659029395bdf")); // 0X prefix
+    assert!(is_valid_evm_address("0x0000000000000000000000000000000000000000")); // all-zero, 40 hex
+    assert!(is_valid_evm_address("0x000000000000000000000000000000000000c0de"));
+
+    // Missing 0x prefix.
+    assert!(!is_valid_evm_address("7e5f4552091a69125d5dfcb7b8c2659029395bdf"));
+    // Wrong length: 39 hex (one short).
+    assert!(!is_valid_evm_address("0x7e5f4552091a69125d5dfcb7b8c2659029395bd"));
+    // Wrong length: 41 hex (one long).
+    assert!(!is_valid_evm_address("0x7e5f4552091a69125d5dfcb7b8c2659029395bdff"));
+    // Zero-length hex body.
+    assert!(!is_valid_evm_address("0x"));
+    // Empty string.
+    assert!(!is_valid_evm_address(""));
+    // Non-hex characters (40 chars but contains 'g', 'r', etc.).
+    assert!(!is_valid_evm_address("0xgggggggggggggggggggggggggggggggggggggggg"));
+    assert!(!is_valid_evm_address("0xrecipient")); // realistic placeholder typo
+    // 0x followed by a too-short numeric body.
+    assert!(!is_valid_evm_address("0x123"));
 }
 
 fn hex_to_bytes(s: &str) -> Vec<u8> {

--- a/src/rumi_protocol_backend/src/chains/monad/tests_tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_tx.rs
@@ -15,7 +15,10 @@
 
 use alloy_rlp::Encodable;
 
-use super::tx::{assemble_signed_tx, encode_mint_calldata, encode_transfer_calldata, signing_hash, Eip1559Fields};
+use super::tx::{
+    assemble_signed_tx, encode_mint_calldata, encode_transfer_calldata, signing_hash,
+    Eip1559Fields,
+};
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -140,7 +143,8 @@ fn minimal_bytes_for(mut n: usize) -> Vec<u8> {
 fn mint_calldata_has_correct_selector() {
     // mint(address,uint256,uint64): 4-byte selector + 3*32-byte args = 100 bytes.
     let calldata =
-        encode_mint_calldata("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 10_000_000_000, 42);
+        encode_mint_calldata("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 10_000_000_000, 42)
+            .expect("valid address");
     assert_eq!(calldata.len(), 4 + 32 * 3);
     assert_ne!(&calldata[0..4], &[0u8; 4]);
 }
@@ -150,7 +154,8 @@ fn transfer_calldata_encodes_address_and_amount() {
     let calldata = encode_transfer_calldata(
         "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
         5_000_000_000_000_000_000,
-    );
+    )
+    .expect("valid address");
     assert_eq!(calldata.len(), 4 + 32 * 2);
 }
 
@@ -214,7 +219,7 @@ fn signing_hash_matches_reference_byte_for_byte() {
     // Our implementation's signing hash = keccak256(0x02 || rlp([...]))
     use sha3::{Digest, Keccak256};
     let ref_hash: [u8; 32] = Keccak256::digest(&ref_payload).into();
-    let our_hash = signing_hash(&fields);
+    let our_hash = signing_hash(&fields).expect("valid address");
 
     assert_eq!(
         our_hash, ref_hash,
@@ -324,7 +329,7 @@ fn round_trip_sign_and_recover() {
         value: 0,
         data: hex_to_bytes("a9059cbb000000000000000000000000deadbeef"),
     };
-    let hash = signing_hash(&fields);
+    let hash = signing_hash(&fields).expect("valid address");
 
     // Sign with k256 — deterministic (RFC 6979).
     let (sig, _recovery_id): (Signature, _) =
@@ -408,7 +413,7 @@ fn known_vector_signing_hash_matches_geth() {
         "cc270e91ffb8f5a6c2eed711e9a59eb128d857e90ca31600ec51a7dad621178f",
     );
 
-    let our_hash = signing_hash(&fields);
+    let our_hash = signing_hash(&fields).expect("valid address");
     assert_eq!(
         our_hash.as_slice(),
         expected_hash.as_slice(),
@@ -416,4 +421,81 @@ fn known_vector_signing_hash_matches_geth() {
         hex::encode(our_hash),
         hex::encode(&expected_hash)
     );
+}
+
+// ─── error-path tests (B1 hardening) ────────────────────────────────────────
+//
+// Validate that malformed addresses return `Err` (not a panic) from both
+// `abi_word_address` (via `encode_mint_calldata` / `encode_transfer_calldata`)
+// and `parse_address` (via `signing_hash` / `assemble_signed_tx`).  The
+// boundary validation at `set_chain_contract` / `open_chain_vault` / withdraw+
+// close makes these unreachable in production, but a panic in a post-await
+// continuation would permanently block the settlement worker by holding the
+// re-entrancy guard without ever running its `Drop`.  Returning `Err` instead
+// lets the submit/confirm paths log-and-skip normally.
+
+use super::tx::{abi_word_address_test, parse_address_test};
+
+/// `abi_word_address` returns `Err` on bad hex (not a panic).
+#[test]
+fn abi_word_address_rejects_bad_hex() {
+    let result = abi_word_address_test("0xnotvalidhex");
+    assert!(result.is_err(), "expected Err for bad hex, got Ok");
+}
+
+/// `abi_word_address` returns `Err` when the hex is valid but not 20 bytes.
+#[test]
+fn abi_word_address_rejects_wrong_length() {
+    // 19 bytes of valid hex (38 hex chars)
+    let result = abi_word_address_test("0x7e5f4552091a69125d5dfcb7b8c2659029395b");
+    assert!(result.is_err(), "expected Err for 19-byte address, got Ok");
+    // 21 bytes of valid hex (42 hex chars)
+    let result = abi_word_address_test("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf00");
+    assert!(result.is_err(), "expected Err for 21-byte address, got Ok");
+}
+
+/// `parse_address` returns `Err` on bad hex (not a panic).
+#[test]
+fn parse_address_rejects_bad_hex() {
+    let result = parse_address_test("0xnotvalidhex");
+    assert!(result.is_err(), "expected Err for bad hex, got Ok");
+}
+
+/// `parse_address` returns `Err` when the hex is valid but not 20 bytes.
+#[test]
+fn parse_address_rejects_wrong_length() {
+    // 18 bytes (36 hex chars)
+    let result = parse_address_test("0x7e5f4552091a69125d5dfcb7b8c265902939");
+    assert!(result.is_err(), "expected Err for 18-byte address, got Ok");
+}
+
+/// `signing_hash` surfaces `Err` when the `to` address is malformed (no panic).
+#[test]
+fn signing_hash_returns_err_on_malformed_to() {
+    let fields = Eip1559Fields {
+        chain_id: 1,
+        nonce: 0,
+        max_priority_fee_per_gas: 1_000_000_000,
+        max_fee_per_gas: 10_000_000_000,
+        gas_limit: 21_000,
+        to: "not-an-address".into(),
+        value: 0,
+        data: vec![],
+    };
+    let result = signing_hash(&fields);
+    assert!(result.is_err(), "expected Err for malformed to address, got Ok");
+}
+
+/// `encode_mint_calldata` surfaces `Err` on a malformed recipient (no panic).
+#[test]
+fn encode_mint_calldata_returns_err_on_malformed_address() {
+    let result = encode_mint_calldata("0xbadhex!", 1_000_000, 1);
+    assert!(result.is_err(), "expected Err for bad hex recipient, got Ok");
+}
+
+/// `encode_transfer_calldata` surfaces `Err` on a malformed recipient (no panic).
+#[test]
+fn encode_transfer_calldata_returns_err_on_malformed_address() {
+    let result = encode_transfer_calldata("0xbadhex!", 1_000_000);
+    assert!(result.is_err(), "expected Err for bad hex recipient, got Ok");
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tests_tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_tx.rs
@@ -1,0 +1,419 @@
+//! Tests for EIP-1559 transaction encoding, calldata helpers, and tECDSA sign.
+//!
+//! Cross-check strategy:
+//!   1. Structural tests (calldata length + selector sanity).
+//!   2. Byte-for-byte reference cross-check: we construct the same EIP-1559
+//!      unsigned / signed encoding INDEPENDENTLY using raw alloy-rlp primitives
+//!      (already a production dep) and assert our `signing_hash` and
+//!      `assemble_signed_tx` match exactly.  No external crate required; two
+//!      independent Rust implementations of the same spec must produce
+//!      identical bytes.
+//!   3. Round-trip recover test: sign the hash with a fixed k256 key, recover
+//!      y_parity, independently ecrecover, assert recovered address matches.
+//!   4. Known external test vector (Ethereum EIP-1559 canonical example) for
+//!      additional assurance.
+
+use alloy_rlp::Encodable;
+
+use super::tx::{assemble_signed_tx, encode_mint_calldata, encode_transfer_calldata, signing_hash, Eip1559Fields};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+}
+
+// Build the exact same RLP-encoded signed payload from scratch using raw
+// alloy-rlp, mirroring the EIP-1559 spec rule-by-rule.  This is the
+// independent reference implementation used in the cross-check.
+fn reference_encode_eip1559(
+    chain_id: u64,
+    nonce: u64,
+    max_priority_fee_per_gas: u128,
+    max_fee_per_gas: u128,
+    gas_limit: u64,
+    to_hex: &str,   // "0x…" 20-byte hex
+    value: u128,
+    data: &[u8],
+    // sig: None => unsigned payload; Some((r, s, y_parity)) => signed
+    sig: Option<(&[u8; 32], &[u8; 32], u8)>,
+) -> Vec<u8> {
+    let to_bytes = hex_to_bytes(to_hex);
+    assert_eq!(to_bytes.len(), 20, "to must be 20 bytes");
+
+    let mut buf = Vec::new();
+    // Prefix byte 0x02
+    buf.push(0x02u8);
+
+    // Collect each field into a list for encoding.
+    // alloy-rlp's encode_list takes an iterator of Encodable items but all must
+    // be the same type, so we encode each field individually and concatenate
+    // the payload bytes, then wrap with the list header manually.
+
+    let mut payload = Vec::new();
+    chain_id.encode(&mut payload);
+    nonce.encode(&mut payload);
+    max_priority_fee_per_gas.encode(&mut payload);
+    max_fee_per_gas.encode(&mut payload);
+    gas_limit.encode(&mut payload);
+    // `to`: 20-byte string.  In alloy-rlp a byte slice is encoded as a string.
+    // A 20-byte string header = 0x80 + 20 = 0x94.
+    payload.push(0x94u8);
+    payload.extend_from_slice(&to_bytes);
+    // value
+    value.encode(&mut payload);
+    // data: byte string — [u8] implements Encodable as an RLP byte string.
+    data.encode(&mut payload);
+    // access_list: empty list = 0xc0
+    payload.push(0xc0u8);
+
+    if let Some((r_arr, s_arr, y)) = sig {
+        // y_parity
+        (y as u64).encode(&mut payload);
+        // r and s: minimal big-endian (strip leading zeros)
+        let r_stripped = strip_leading_zeros(r_arr);
+        encode_minimal_bytes(r_stripped, &mut payload);
+        let s_stripped = strip_leading_zeros(s_arr);
+        encode_minimal_bytes(s_stripped, &mut payload);
+    }
+
+    // Wrap with RLP list header
+    write_list_header(payload.len(), &mut buf);
+    buf.extend_from_slice(&payload);
+    buf
+}
+
+/// Strip leading zero bytes from a 32-byte big-endian integer.
+fn strip_leading_zeros(b: &[u8; 32]) -> &[u8] {
+    let first_nonzero = b.iter().position(|&x| x != 0).unwrap_or(32);
+    &b[first_nonzero..]
+}
+
+/// Encode bytes as an RLP byte string (NOT as an integer).
+/// Zero-length => 0x80.  Single byte < 0x80 => that byte directly.
+/// Otherwise: string header + bytes.
+fn encode_minimal_bytes(b: &[u8], out: &mut Vec<u8>) {
+    if b.is_empty() {
+        out.push(0x80);
+    } else if b.len() == 1 && b[0] < 0x80 {
+        out.push(b[0]);
+    } else {
+        write_string_header(b.len(), out);
+        out.extend_from_slice(b);
+    }
+}
+
+fn write_string_header(len: usize, out: &mut Vec<u8>) {
+    if len <= 55 {
+        out.push(0x80 + len as u8);
+    } else {
+        let len_bytes = minimal_bytes_for(len);
+        out.push(0xb7 + len_bytes.len() as u8);
+        out.extend_from_slice(&len_bytes);
+    }
+}
+
+fn write_list_header(payload_len: usize, out: &mut Vec<u8>) {
+    if payload_len <= 55 {
+        out.push(0xc0 + payload_len as u8);
+    } else {
+        let len_bytes = minimal_bytes_for(payload_len);
+        out.push(0xf7 + len_bytes.len() as u8);
+        out.extend_from_slice(&len_bytes);
+    }
+}
+
+fn minimal_bytes_for(mut n: usize) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    while n > 0 {
+        bytes.push(n as u8);
+        n >>= 8;
+    }
+    bytes.reverse();
+    bytes
+}
+
+// ─── structural tests ───────────────────────────────────────────────────────
+
+#[test]
+fn mint_calldata_has_correct_selector() {
+    // mint(address,uint256,uint64): 4-byte selector + 3*32-byte args = 100 bytes.
+    let calldata =
+        encode_mint_calldata("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 10_000_000_000, 42);
+    assert_eq!(calldata.len(), 4 + 32 * 3);
+    assert_ne!(&calldata[0..4], &[0u8; 4]);
+}
+
+#[test]
+fn transfer_calldata_encodes_address_and_amount() {
+    let calldata = encode_transfer_calldata(
+        "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+        5_000_000_000_000_000_000,
+    );
+    assert_eq!(calldata.len(), 4 + 32 * 2);
+}
+
+#[test]
+fn signed_tx_assembly_is_rlp_type2() {
+    let fields = Eip1559Fields {
+        chain_id: 10143,
+        nonce: 0,
+        max_priority_fee_per_gas: 2_000_000_000,
+        max_fee_per_gas: 50_000_000_000,
+        gas_limit: 120_000,
+        to: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf".into(),
+        value: 0,
+        data: vec![0xde, 0xad, 0xbe, 0xef],
+    };
+    let r = [0x11u8; 32];
+    let s = [0x22u8; 32];
+    let signed = assemble_signed_tx(&fields, &r, &s, 0).expect("assemble");
+    assert_eq!(signed[0], 0x02);
+}
+
+// ─── byte-for-byte reference cross-check ────────────────────────────────────
+//
+// We build the same transaction two ways:
+//   A) Our tx.rs implementation under test.
+//   B) The `reference_encode_eip1559` function above (pure alloy-rlp, encodes
+//      each field step-by-step following the EIP-1559 spec literally).
+//
+// Neither calls the other; they share only the input fields.  A byte-for-byte
+// match proves our implementation is spec-correct.
+//
+// We deliberately choose (r, s) values that include leading zeros so the test
+// catches the "encode r/s as raw 32-byte string" bug.
+
+#[test]
+fn signing_hash_matches_reference_byte_for_byte() {
+    let fields = Eip1559Fields {
+        chain_id: 10143,
+        nonce: 5,
+        max_priority_fee_per_gas: 1_500_000_000,
+        max_fee_per_gas: 30_000_000_000,
+        gas_limit: 200_000,
+        to: "0xabcdef1234567890abcdef1234567890abcdef12".into(),
+        value: 1_000_000_000_000_000_000u128,
+        data: vec![0xca, 0xfe, 0xba, 0xbe],
+    };
+
+    // Build reference unsigned payload: 0x02 || rlp([chain_id, nonce, ...])
+    let ref_payload = reference_encode_eip1559(
+        fields.chain_id,
+        fields.nonce,
+        fields.max_priority_fee_per_gas,
+        fields.max_fee_per_gas,
+        fields.gas_limit,
+        &fields.to,
+        fields.value,
+        &fields.data,
+        None,
+    );
+
+    // Our implementation's signing hash = keccak256(0x02 || rlp([...]))
+    use sha3::{Digest, Keccak256};
+    let ref_hash: [u8; 32] = Keccak256::digest(&ref_payload).into();
+    let our_hash = signing_hash(&fields);
+
+    assert_eq!(
+        our_hash, ref_hash,
+        "signing hash mismatch\nours:      {}\nreference: {}",
+        hex::encode(our_hash),
+        hex::encode(ref_hash)
+    );
+}
+
+/// Exercise a leading-zero r to prove we strip zeros correctly.
+/// We pick r = [0x00, 0x00, 0x11, …] (2 leading zeros) and
+/// s = [0x00, 0x22, …] (1 leading zero).
+#[test]
+fn signed_tx_matches_reference_with_leading_zero_r_and_s() {
+    let fields = Eip1559Fields {
+        chain_id: 1,
+        nonce: 0,
+        max_priority_fee_per_gas: 1_000_000_000,
+        max_fee_per_gas: 20_000_000_000,
+        gas_limit: 21_000,
+        to: "0x000000000000000000000000000000000000dead".into(),
+        value: 100_000_000_000_000_000u128,
+        data: vec![],
+    };
+
+    // r has 2 leading zeros, s has 1 leading zero — exercises strip_leading_zeros.
+    let mut r = [0u8; 32];
+    r[0] = 0x00;
+    r[1] = 0x00;
+    r[2] = 0x11;
+    for i in 3..32 {
+        r[i] = 0xAA;
+    }
+    let mut s = [0u8; 32];
+    s[0] = 0x00;
+    s[1] = 0x22;
+    for i in 2..32 {
+        s[i] = 0xBB;
+    }
+
+    let our_signed = assemble_signed_tx(&fields, &r, &s, 1).expect("assemble");
+
+    let ref_signed = reference_encode_eip1559(
+        fields.chain_id,
+        fields.nonce,
+        fields.max_priority_fee_per_gas,
+        fields.max_fee_per_gas,
+        fields.gas_limit,
+        &fields.to,
+        fields.value,
+        &fields.data,
+        Some((&r, &s, 1)),
+    );
+
+    assert_eq!(
+        our_signed, ref_signed,
+        "signed tx mismatch (leading-zero r/s)\nours:      {}\nreference: {}",
+        hex::encode(&our_signed),
+        hex::encode(&ref_signed)
+    );
+
+    // Additionally verify the leading-zero bytes were actually stripped in the
+    // output (proves the test would catch a non-stripping impl).
+    // The r field (30 significant bytes) must not be preceded by 0x00 in the encoding.
+    // We scan the signed bytes for a run of 0x00 0x11 0xAA (our r's first real bytes).
+    let r_marker = &[0x11u8, 0xAAu8, 0xAAu8];
+    let found = our_signed.windows(3).any(|w| w == r_marker);
+    assert!(found, "r marker bytes not found in signed tx");
+    // And confirm 0x00 0x00 0x11 does NOT appear (leading zeros stripped).
+    let bad_prefix = &[0x00u8, 0x00u8, 0x11u8];
+    let not_found = !our_signed.windows(3).any(|w| w == bad_prefix);
+    assert!(not_found, "leading zeros found in r encoding — they were not stripped");
+}
+
+/// Full round-trip: sign with a fixed k256 key, run recover_y_parity, then
+/// independently ecrecover and assert the recovered address equals the key's
+/// EVM address.
+#[test]
+fn round_trip_sign_and_recover() {
+    use k256::ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey, VerifyingKey};
+    use super::tx::recover_y_parity;
+    use super::tecdsa::evm_address_from_pubkey;
+
+    // Fixed signing key (private key scalar = 1, the canonical test vector).
+    let sk_bytes = {
+        let mut b = [0u8; 32];
+        b[31] = 1;
+        b
+    };
+    let signing_key = SigningKey::from_bytes(&sk_bytes.into()).expect("signing key");
+    let vk = VerifyingKey::from(&signing_key);
+    let pk_uncompressed = {
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        vk.to_encoded_point(false).as_bytes().to_vec()
+    };
+    let expected_addr = evm_address_from_pubkey(&pk_uncompressed).expect("addr");
+    // Should be the canonical k=1 address.
+    assert_eq!(expected_addr.to_lowercase(), "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
+
+    let fields = Eip1559Fields {
+        chain_id: 10143,
+        nonce: 7,
+        max_priority_fee_per_gas: 2_000_000_000,
+        max_fee_per_gas: 50_000_000_000,
+        gas_limit: 150_000,
+        to: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".into(),
+        value: 0,
+        data: hex_to_bytes("a9059cbb000000000000000000000000deadbeef"),
+    };
+    let hash = signing_hash(&fields);
+
+    // Sign with k256 — deterministic (RFC 6979).
+    let (sig, _recovery_id): (Signature, _) =
+        signing_key.sign_prehash_recoverable(&hash).expect("sign");
+    let sig_bytes = sig.to_bytes();
+    let r: [u8; 32] = sig_bytes[..32].try_into().unwrap();
+    let s: [u8; 32] = sig_bytes[32..].try_into().unwrap();
+
+    // Recover y_parity using our implementation.
+    let parity = recover_y_parity(&hash, &r, &s, &expected_addr).expect("recover parity");
+    assert!(parity == 0 || parity == 1, "parity must be 0 or 1, got {parity}");
+
+    // Assemble the signed tx.
+    let signed = assemble_signed_tx(&fields, &r, &s, parity).expect("assemble");
+    assert_eq!(signed[0], 0x02, "first byte must be 0x02");
+
+    // Independent ecrecover: parse r, s, parity from the assembled tx and verify.
+    let sig2 = k256::ecdsa::Signature::from_scalars(r, s).expect("sig from scalars");
+    let rid = k256::ecdsa::RecoveryId::new(parity == 1, false);
+    let recovered_vk =
+        VerifyingKey::recover_from_prehash(&hash, &sig2, rid).expect("ecrecover");
+    let recovered_pk = {
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        recovered_vk.to_encoded_point(false).as_bytes().to_vec()
+    };
+    let recovered_addr = evm_address_from_pubkey(&recovered_pk).expect("recovered addr");
+    assert_eq!(
+        recovered_addr.to_lowercase(),
+        expected_addr.to_lowercase(),
+        "ecrecover address mismatch"
+    );
+}
+
+// ─── known external test vector ─────────────────────────────────────────────
+//
+// Ethereum EIP-1559 test vector from the official go-ethereum test suite:
+// https://github.com/ethereum/go-ethereum/blob/v1.13.14/core/types/transaction_signing_test.go
+//
+// Transaction fields:
+//   chain_id:             1
+//   nonce:                0
+//   max_priority_fee:     1 gwei  (1_000_000_000)
+//   max_fee:              1 gwei  (1_000_000_000)
+//   gas_limit:            21_000
+//   to:                   0x3535353535353535353535353535353535353535
+//   value:                1000
+//   data:                 []
+//   Private key (hex):    4646464646464646464646464646464646464646464646464646464646464646
+//
+// The expected signing hash was computed from the go-ethereum signer.
+// Reference: EIP-1559 signing hash = keccak256(0x02 || rlp([chain_id, nonce,
+//            max_priority_fee, max_fee, gas, to, value, data, access_list]))
+//
+// Note: this test ONLY validates the signing hash (unsigned payload), not the
+// full signed encoding, because go-ethereum uses secp256k1-go for signing and
+// the signature bytes differ from k256.  The hash comparison is the critical
+// correctness check for our RLP encoding.
+
+#[test]
+fn known_vector_signing_hash_matches_geth() {
+    let fields = Eip1559Fields {
+        chain_id: 1,
+        nonce: 0,
+        max_priority_fee_per_gas: 1_000_000_000,
+        max_fee_per_gas: 1_000_000_000,
+        gas_limit: 21_000,
+        to: "0x3535353535353535353535353535353535353535".into(),
+        value: 1000,
+        data: vec![],
+    };
+
+    // Expected hash: computed independently via two methods:
+    //   1. Python eth-account + eth-keys ecrecover verification:
+    //      Account.sign_transaction(tx, key_46x32) => r,s,v recovered via
+    //      eth_keys.Signature.recover_public_key_from_msg_hash(hash) =>
+    //      recovered == 0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F (expected).
+    //   2. Python coincurve.PublicKey.from_signature_and_message(sig, hash, hasher=None) => same address.
+    //   Unsigned payload hex: 02e90180843b9aca00843b9aca008252089435353535353535353535353535353535353535358203e880c0
+    //   keccak256(above) = cc270e91ffb8f5a6c2eed711e9a59eb128d857e90ca31600ec51a7dad621178f
+    let expected_hash = hex_to_bytes(
+        "cc270e91ffb8f5a6c2eed711e9a59eb128d857e90ca31600ec51a7dad621178f",
+    );
+
+    let our_hash = signing_hash(&fields);
+    assert_eq!(
+        our_hash.as_slice(),
+        expected_hash.as_slice(),
+        "known-vector hash mismatch\nours:     {}\nexpected: {}",
+        hex::encode(our_hash),
+        hex::encode(&expected_hash)
+    );
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -1,0 +1,245 @@
+//! Task 13: withdraw + close pure-helper tests.
+//!
+//! `withdraw_collateral_in_state` is the CDP collateral-out path. It CR-checks
+//! the REMAINING collateral against `min_cr_e4` (skipping the check entirely
+//! when the vault is debt-free), RESERVES the withdrawn collateral by
+//! decrementing `collateral_amount_e18` at enqueue time (so a second withdraw
+//! cannot double-spend the same collateral before the first confirms), and
+//! enqueues a `NativeWithdrawal` op carrying the real `vault_id`. A vault that
+//! becomes empty AND is debt-free flips to `Closing` (the worker flips it to
+//! `Closed` once the on-chain transfer confirms).
+//!
+//! `close_chain_vault_in_state` is debt-free full withdrawal: it requires
+//! `debt_e8s == 0` (`HasDebt` otherwise), then withdraws the full remaining
+//! collateral via the same helper.
+//!
+//! Mutation ordering (no-mutation-on-rejection): validate -> enqueue (can fail
+//! -> `QueueError`, no collateral mutation) -> decrement collateral + set
+//! `Closing`. A rejected enqueue leaves the vault untouched.
+
+use super::chain_vault::{
+    close_chain_vault_in_state, open_chain_vault_in_state, withdraw_collateral_in_state,
+    ChainVaultStatus, WithdrawError,
+};
+use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::settlement_queue::SettlementOpKind;
+use candid::Principal;
+
+const CHAIN: ChainId = ChainId(10143);
+/// USD price as e8: $100.00.
+const PRICE_100_USD_E8: u64 = 100_0000_0000;
+/// 1 MON in e18.
+const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
+/// 130.00% min CR (matches `MONAD_MIN_CR_E4`).
+const MIN_CR_E4: u64 = 13_000;
+
+/// Register chain 10143 and set its manual MON price (mirrors `tests_open_vault`).
+fn setup(price_e8: u64) -> MultiChainStateV2 {
+    let mut s = MultiChainStateV2::default();
+    let arg = RegisterChainArg {
+        chain_id: CHAIN,
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
+    s.manual_prices.insert((CHAIN, "MON".into()), price_e8);
+    s
+}
+
+fn owner() -> Principal {
+    Principal::anonymous()
+}
+
+/// Open a vault at `collateral_e18` / `debt_e8s` and drive it to the `Open`
+/// state with confirmed debt, so the withdraw tests exercise a live vault. (The
+/// open helper records `pending_mint_e8s` and `debt_e8s == 0`; we set the
+/// fields directly here to skip the deposit-watch + settlement round trip.)
+fn open_and_fund(
+    s: &mut MultiChainStateV2,
+    vault_id: u64,
+    collateral_e18: u128,
+    debt_e8s: u128,
+) {
+    // Use a debt large enough that the open CR check passes regardless, then
+    // overwrite the fields to the desired live shape.
+    open_chain_vault_in_state(
+        s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        collateral_e18,
+        // Open requires non-zero debt; pass a token amount, then overwrite.
+        1,
+        "0xrecipient".into(),
+        0, // min_cr 0 so open always succeeds for setup
+        0,
+        vault_id,
+    )
+    .expect("open for setup");
+    let v = s.chain_vaults.get_mut(&vault_id).expect("vault present");
+    v.debt_e8s = debt_e8s;
+    v.pending_mint_e8s = 0;
+    v.status = ChainVaultStatus::Open;
+}
+
+// 1. full withdraw of a debt-free vault closes it (Closing) + enqueues one
+//    NativeWithdrawal carrying the real vault_id and the e18 amount.
+#[test]
+fn full_withdraw_when_debt_free_sets_closing_and_enqueues() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 0); // 5 MON, debt 0
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        5 * ONE_MON_E18, // withdraw the full 5 MON
+        "0xdest".into(),
+        MIN_CR_E4,
+        555,
+    );
+    assert!(res.is_ok(), "full debt-free withdraw should succeed: {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 0, "collateral fully reserved out");
+    assert!(
+        matches!(v.status, ChainVaultStatus::Closing),
+        "empty + debt-free vault flips to Closing, got {:?}",
+        v.status
+    );
+
+    let q = &s.settlement_queues[&CHAIN];
+    assert_eq!(q.pending_len(), 1, "exactly one NativeWithdrawal enqueued");
+    let op = q.pending.values().next().expect("op present");
+    match &op.kind {
+        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+            assert_eq!(recipient, "0xdest");
+            assert_eq!(*amount_e18, 5 * ONE_MON_E18);
+            assert_eq!(*vault_id, 7, "op carries the real vault_id");
+        }
+        other => panic!("expected NativeWithdrawal op, got {other:?}"),
+    }
+    assert_eq!(op.idempotency_key, format!("withdraw-{}-{}-{}", CHAIN.0, 7, 555));
+}
+
+// 2. partial withdraw keeping CR above min stays Open.
+#[test]
+fn partial_withdraw_keeping_cr_above_min_is_allowed() {
+    let mut s = setup(PRICE_100_USD_E8);
+    // debt 100 icUSD ($100), price $100/MON, 5 MON ($500).
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_00000000);
+
+    // withdraw 1 MON -> 4 MON ($400) / $100 = 400% CR -> well above 130%.
+    let res =
+        withdraw_collateral_in_state(&mut s, 7, ONE_MON_E18, "0xdest".into(), MIN_CR_E4, 100);
+    assert!(res.is_ok(), "partial withdraw above min CR should succeed: {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 4 * ONE_MON_E18, "1 MON reserved out");
+    assert!(
+        matches!(v.status, ChainVaultStatus::Open),
+        "vault with remaining debt + collateral stays Open, got {:?}",
+        v.status
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 1, "one withdrawal enqueued");
+}
+
+// 3. withdraw that would break min CR is rejected, no mutation, no enqueue.
+#[test]
+fn withdraw_breaking_min_cr_is_rejected() {
+    let mut s = setup(PRICE_100_USD_E8);
+    // debt 100 icUSD ($100), 5 MON ($500).
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_00000000);
+
+    // withdraw 4.9 MON -> 0.1 MON ($10) left -> CR 10% < 130% -> reject.
+    let withdraw_amt = 4 * ONE_MON_E18 + ONE_MON_E18 * 9 / 10; // 4.9 MON
+    let res =
+        withdraw_collateral_in_state(&mut s, 7, withdraw_amt, "0xdest".into(), MIN_CR_E4, 0);
+    assert!(matches!(res, Err(WithdrawError::BelowMinCr { .. })), "got {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 5 * ONE_MON_E18, "collateral unchanged on reject");
+    assert!(matches!(v.status, ChainVaultStatus::Open), "status unchanged");
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "queue must stay empty");
+}
+
+// 4. withdraw exceeding balance is rejected, unchanged.
+#[test]
+fn withdraw_exceeding_balance_is_rejected() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, ONE_MON_E18, 0); // 1 MON, debt-free
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        2 * ONE_MON_E18, // withdraw 2 MON > 1 MON balance
+        "0xdest".into(),
+        MIN_CR_E4,
+        0,
+    );
+    assert!(matches!(res, Err(WithdrawError::InsufficientCollateral)), "got {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, ONE_MON_E18, "collateral unchanged");
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "queue empty");
+}
+
+// 5. unknown vault errors.
+#[test]
+fn withdraw_unknown_vault_errors() {
+    let mut s = setup(PRICE_100_USD_E8);
+    let res =
+        withdraw_collateral_in_state(&mut s, 999, ONE_MON_E18, "0xdest".into(), MIN_CR_E4, 0);
+    assert!(matches!(res, Err(WithdrawError::UnknownVault)), "got {res:?}");
+}
+
+// 6. close requires debt == 0: a vault with debt is rejected with HasDebt, no
+//    mutation, no enqueue.
+#[test]
+fn close_with_debt_is_rejected() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_00000000); // has debt
+
+    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 0);
+    assert!(matches!(res, Err(WithdrawError::HasDebt)), "got {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 5 * ONE_MON_E18, "unchanged");
+    assert!(matches!(v.status, ChainVaultStatus::Open), "unchanged");
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0, "queue empty");
+}
+
+// 7. close on a debt-free vault withdraws the full remainder + sets Closing.
+#[test]
+fn close_debt_free_withdraws_full_and_sets_closing() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 3 * ONE_MON_E18, 0); // 3 MON, debt-free
+
+    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 999);
+    assert!(res.is_ok(), "debt-free close should succeed: {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 0, "full collateral reserved out");
+    assert!(
+        matches!(v.status, ChainVaultStatus::Closing),
+        "close flips to Closing, got {:?}",
+        v.status
+    );
+    let q = &s.settlement_queues[&CHAIN];
+    assert_eq!(q.pending_len(), 1, "one NativeWithdrawal enqueued");
+    let op = q.pending.values().next().expect("op present");
+    match &op.kind {
+        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+            assert_eq!(recipient, "0xdest");
+            assert_eq!(*amount_e18, 3 * ONE_MON_E18, "full remaining collateral");
+            assert_eq!(*vault_id, 7);
+        }
+        other => panic!("expected NativeWithdrawal op, got {other:?}"),
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -243,3 +243,152 @@ fn close_debt_free_withdraws_full_and_sets_closing() {
         other => panic!("expected NativeWithdrawal op, got {other:?}"),
     }
 }
+
+// 8. CRITICAL: withdraw from an AwaitingDeposit vault is rejected with no
+//    mutation and no enqueue. The declared collateral was NEVER deposited
+//    on-chain; paying it out from the settlement hot wallet would drain
+//    protocol funds for phantom collateral.
+#[test]
+fn withdraw_from_awaiting_deposit_is_rejected() {
+    let mut s = setup(PRICE_100_USD_E8);
+    // Open a vault: it starts AwaitingDeposit with declared collateral but NO
+    // on-chain deposit and debt 0. Do NOT drive it to Open.
+    open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        owner(),
+        "0xcustody".into(),
+        5 * ONE_MON_E18, // declared collateral, never deposited
+        1,               // open requires non-zero debt
+        "0xrecipient".into(),
+        0, // min_cr 0 so open succeeds
+        0,
+        7,
+    )
+    .expect("open for setup");
+    assert!(
+        matches!(s.chain_vaults[&7].status, ChainVaultStatus::AwaitingDeposit),
+        "vault should start AwaitingDeposit"
+    );
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        5 * ONE_MON_E18,
+        "0xdest".into(),
+        MIN_CR_E4,
+        555,
+    );
+    assert!(
+        matches!(
+            res,
+            Err(WithdrawError::WrongStatus { status: ChainVaultStatus::AwaitingDeposit })
+        ),
+        "withdraw from AwaitingDeposit must reject with WrongStatus, got {res:?}"
+    );
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(
+        v.collateral_amount_e18,
+        5 * ONE_MON_E18,
+        "collateral UNCHANGED on rejection"
+    );
+    assert!(
+        matches!(v.status, ChainVaultStatus::AwaitingDeposit),
+        "status unchanged"
+    );
+    assert!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0) == 0,
+        "settlement queue must be EMPTY — no payout enqueued"
+    );
+}
+
+// 9. CRITICAL: withdraw from a MintPending vault is rejected with no mutation
+//    and no enqueue. A mint is in flight authorized against this collateral;
+//    pulling it out from under the in-flight mint must be impossible.
+#[test]
+fn withdraw_from_mint_pending_is_rejected() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 0);
+    // Force MintPending directly (pure-state test).
+    s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::MintPending;
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        ONE_MON_E18,
+        "0xdest".into(),
+        MIN_CR_E4,
+        100,
+    );
+    assert!(
+        matches!(
+            res,
+            Err(WithdrawError::WrongStatus { status: ChainVaultStatus::MintPending })
+        ),
+        "withdraw from MintPending must reject with WrongStatus, got {res:?}"
+    );
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 5 * ONE_MON_E18, "collateral UNCHANGED");
+    assert!(matches!(v.status, ChainVaultStatus::MintPending), "status unchanged");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
+        0,
+        "settlement queue must be EMPTY"
+    );
+}
+
+// 10. close inherits the FIX 1 gate via delegation: a close on a non-Open,
+//     debt-free vault (here Closing) rejects with WrongStatus AFTER the
+//     debt==0 check, with no mutation and no enqueue. (Closing is reached via
+//     a prior full withdraw; a reverted close returns the vault to Open via
+//     the settlement revert path, so retry works without close-from-Closing.)
+#[test]
+fn close_from_closing_is_rejected_via_gate() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 3 * ONE_MON_E18, 0); // debt-free
+    // Force Closing directly (a vault mid-withdrawal). debt is still 0.
+    s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::Closing;
+
+    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 777);
+    assert!(
+        matches!(
+            res,
+            Err(WithdrawError::WrongStatus { status: ChainVaultStatus::Closing })
+        ),
+        "close on a Closing vault must reject with WrongStatus, got {res:?}"
+    );
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 3 * ONE_MON_E18, "collateral unchanged");
+    assert!(matches!(v.status, ChainVaultStatus::Closing), "status unchanged");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
+        0,
+        "queue empty",
+    );
+}
+
+// 11. FIX 3: closing an Open, debt-free, ZERO-collateral vault short-circuits
+//     to Closed WITHOUT enqueuing a wasted zero-value NativeWithdrawal.
+#[test]
+fn close_zero_collateral_short_circuits_to_closed_no_enqueue() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 0, 0); // Open, debt-free, zero collateral
+
+    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 888);
+    assert!(res.is_ok(), "zero-collateral close should succeed: {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 0, "still zero collateral");
+    assert!(
+        matches!(v.status, ChainVaultStatus::Closed),
+        "zero-collateral close goes straight to Closed, got {:?}",
+        v.status
+    );
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
+        0,
+        "NO zero-value NativeWithdrawal enqueued",
+    );
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -77,7 +77,7 @@ fn open_and_fund(
         collateral_e18,
         // Open requires non-zero debt; pass a token amount, then overwrite.
         1,
-        "0xrecipient".into(),
+        "0x000000000000000000000000000000000000c0de".into(),
         0, // min_cr 0 so open always succeeds for setup
         0,
         vault_id,
@@ -100,7 +100,7 @@ fn full_withdraw_when_debt_free_sets_closing_and_enqueues() {
         &mut s,
         7,
         5 * ONE_MON_E18, // withdraw the full 5 MON
-        "0xdest".into(),
+        "0x000000000000000000000000000000000000dead".into(),
         MIN_CR_E4,
         555,
     );
@@ -119,7 +119,7 @@ fn full_withdraw_when_debt_free_sets_closing_and_enqueues() {
     let op = q.pending.values().next().expect("op present");
     match &op.kind {
         SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
-            assert_eq!(recipient, "0xdest");
+            assert_eq!(recipient, "0x000000000000000000000000000000000000dead");
             assert_eq!(*amount_e18, 5 * ONE_MON_E18);
             assert_eq!(*vault_id, 7, "op carries the real vault_id");
         }
@@ -137,7 +137,7 @@ fn partial_withdraw_keeping_cr_above_min_is_allowed() {
 
     // withdraw 1 MON -> 4 MON ($400) / $100 = 400% CR -> well above 130%.
     let res =
-        withdraw_collateral_in_state(&mut s, 7, ONE_MON_E18, "0xdest".into(), MIN_CR_E4, 100);
+        withdraw_collateral_in_state(&mut s, 7, ONE_MON_E18, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 100);
     assert!(res.is_ok(), "partial withdraw above min CR should succeed: {res:?}");
 
     let v = s.chain_vaults.get(&7).expect("vault present");
@@ -160,7 +160,7 @@ fn withdraw_breaking_min_cr_is_rejected() {
     // withdraw 4.9 MON -> 0.1 MON ($10) left -> CR 10% < 130% -> reject.
     let withdraw_amt = 4 * ONE_MON_E18 + ONE_MON_E18 * 9 / 10; // 4.9 MON
     let res =
-        withdraw_collateral_in_state(&mut s, 7, withdraw_amt, "0xdest".into(), MIN_CR_E4, 0);
+        withdraw_collateral_in_state(&mut s, 7, withdraw_amt, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 0);
     assert!(matches!(res, Err(WithdrawError::BelowMinCr { .. })), "got {res:?}");
 
     let v = s.chain_vaults.get(&7).expect("vault present");
@@ -179,7 +179,7 @@ fn withdraw_exceeding_balance_is_rejected() {
         &mut s,
         7,
         2 * ONE_MON_E18, // withdraw 2 MON > 1 MON balance
-        "0xdest".into(),
+        "0x000000000000000000000000000000000000dead".into(),
         MIN_CR_E4,
         0,
     );
@@ -195,7 +195,7 @@ fn withdraw_exceeding_balance_is_rejected() {
 fn withdraw_unknown_vault_errors() {
     let mut s = setup(PRICE_100_USD_E8);
     let res =
-        withdraw_collateral_in_state(&mut s, 999, ONE_MON_E18, "0xdest".into(), MIN_CR_E4, 0);
+        withdraw_collateral_in_state(&mut s, 999, ONE_MON_E18, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 0);
     assert!(matches!(res, Err(WithdrawError::UnknownVault)), "got {res:?}");
 }
 
@@ -206,7 +206,7 @@ fn close_with_debt_is_rejected() {
     let mut s = setup(PRICE_100_USD_E8);
     open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_00000000); // has debt
 
-    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 0);
+    let res = close_chain_vault_in_state(&mut s, 7, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 0);
     assert!(matches!(res, Err(WithdrawError::HasDebt)), "got {res:?}");
 
     let v = s.chain_vaults.get(&7).expect("vault present");
@@ -221,7 +221,7 @@ fn close_debt_free_withdraws_full_and_sets_closing() {
     let mut s = setup(PRICE_100_USD_E8);
     open_and_fund(&mut s, 7, 3 * ONE_MON_E18, 0); // 3 MON, debt-free
 
-    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 999);
+    let res = close_chain_vault_in_state(&mut s, 7, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 999);
     assert!(res.is_ok(), "debt-free close should succeed: {res:?}");
 
     let v = s.chain_vaults.get(&7).expect("vault present");
@@ -236,7 +236,7 @@ fn close_debt_free_withdraws_full_and_sets_closing() {
     let op = q.pending.values().next().expect("op present");
     match &op.kind {
         SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
-            assert_eq!(recipient, "0xdest");
+            assert_eq!(recipient, "0x000000000000000000000000000000000000dead");
             assert_eq!(*amount_e18, 3 * ONE_MON_E18, "full remaining collateral");
             assert_eq!(*vault_id, 7);
         }
@@ -260,7 +260,7 @@ fn withdraw_from_awaiting_deposit_is_rejected() {
         "0xcustody".into(),
         5 * ONE_MON_E18, // declared collateral, never deposited
         1,               // open requires non-zero debt
-        "0xrecipient".into(),
+        "0x000000000000000000000000000000000000c0de".into(),
         0, // min_cr 0 so open succeeds
         0,
         7,
@@ -275,7 +275,7 @@ fn withdraw_from_awaiting_deposit_is_rejected() {
         &mut s,
         7,
         5 * ONE_MON_E18,
-        "0xdest".into(),
+        "0x000000000000000000000000000000000000dead".into(),
         MIN_CR_E4,
         555,
     );
@@ -317,7 +317,7 @@ fn withdraw_from_mint_pending_is_rejected() {
         &mut s,
         7,
         ONE_MON_E18,
-        "0xdest".into(),
+        "0x000000000000000000000000000000000000dead".into(),
         MIN_CR_E4,
         100,
     );
@@ -351,7 +351,7 @@ fn close_from_closing_is_rejected_via_gate() {
     // Force Closing directly (a vault mid-withdrawal). debt is still 0.
     s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::Closing;
 
-    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 777);
+    let res = close_chain_vault_in_state(&mut s, 7, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 777);
     assert!(
         matches!(
             res,
@@ -376,7 +376,7 @@ fn close_zero_collateral_short_circuits_to_closed_no_enqueue() {
     let mut s = setup(PRICE_100_USD_E8);
     open_and_fund(&mut s, 7, 0, 0); // Open, debt-free, zero collateral
 
-    let res = close_chain_vault_in_state(&mut s, 7, "0xdest".into(), MIN_CR_E4, 888);
+    let res = close_chain_vault_in_state(&mut s, 7, "0x000000000000000000000000000000000000dead".into(), MIN_CR_E4, 888);
     assert!(res.is_ok(), "zero-collateral close should succeed: {res:?}");
 
     let v = s.chain_vaults.get(&7).expect("vault present");
@@ -390,5 +390,45 @@ fn close_zero_collateral_short_circuits_to_closed_no_enqueue() {
         s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
         0,
         "NO zero-value NativeWithdrawal enqueued",
+    );
+}
+
+// 12. withdraw with a malformed dest_address is rejected at the boundary with no
+//     mutation and no enqueue. An unvalidated dest would later panic the
+//     tx-building helper (tx::parse_address) deep on the settlement worker path,
+//     after the re-entrancy guard + awaits, permanently blocking the chain's
+//     worker. Fail-fast here makes that panic unreachable in practice. The vault
+//     is Open with confirmed collateral + debt, so the InvalidAddress check is
+//     reached (it sits after the status==Open + balance + CR gates).
+#[test]
+fn withdraw_rejects_invalid_dest() {
+    let mut s = setup(PRICE_100_USD_E8);
+    // 5 MON ($500), debt 100 icUSD ($100) — a healthy Open vault. A 1 MON
+    // withdraw would leave 400% CR, so only the bad dest can reject it.
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_00000000);
+
+    // "0x123" is 0x-prefixed but only 3 hex digits (not 40) — a realistic typo.
+    let res = withdraw_collateral_in_state(&mut s, 7, ONE_MON_E18, "0x123".into(), MIN_CR_E4, 100);
+    assert!(matches!(res, Err(WithdrawError::InvalidAddress(_))), "got {res:?}");
+
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 5 * ONE_MON_E18, "collateral UNCHANGED on reject");
+    assert!(matches!(v.status, ChainVaultStatus::Open), "status unchanged");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
+        0,
+        "settlement queue must be EMPTY — nothing enqueued",
+    );
+
+    // A non-hex body is rejected too (still no mutation, still no enqueue).
+    let res =
+        withdraw_collateral_in_state(&mut s, 7, ONE_MON_E18, "0xnothex".into(), MIN_CR_E4, 101);
+    assert!(matches!(res, Err(WithdrawError::InvalidAddress(_))), "got {res:?}");
+    let v = s.chain_vaults.get(&7).expect("vault present");
+    assert_eq!(v.collateral_amount_e18, 5 * ONE_MON_E18, "still unchanged");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).map(|q| q.pending_len()).unwrap_or(0),
+        0,
+        "still empty",
     );
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tx.rs
@@ -36,6 +36,58 @@ pub struct Eip1559Fields {
     pub data: Vec<u8>,
 }
 
+/// The per-op-kind shape of a Monad settlement transaction (what varies between
+/// a mint and a native withdrawal: `to`, `value`, calldata, gas_limit).
+pub enum MonadTxKind<'a> {
+    /// `mint(address,uint256,uint64)` on the icUSD EVM contract.
+    Mint { contract: &'a str, recipient: &'a str, amount_e8s: u128, vault_id: u64 },
+    /// A native MON transfer (`amount_wei` carried in the EIP-1559 `value`).
+    NativeWithdrawal { recipient: &'a str, amount_wei: u128 },
+}
+
+/// Single source of truth for the per-op-kind EIP-1559 field shape (gas_limit,
+/// calldata, to, value). Both the settlement worker (`build_tx_plan`) and
+/// `MonadAdapter::sign_*` call this so a submit and a replace-by-fee resubmit
+/// build byte-identical transactions (only nonce + fees differ). Two
+/// independent builders that MUST stay identical are a latent double-mint
+/// hazard: if one drifts (e.g. a gas_limit change), a replace-by-fee resubmit
+/// stops replacing and becomes a second on-chain mint.
+///
+/// - Mint: `to` = icUSD contract, `value` = 0, calldata = `encode_mint_calldata`,
+///   gas_limit 120_000.
+/// - Native withdrawal: `to` = recipient, `value` = amount (wei), empty data,
+///   gas_limit 21_000.
+pub fn build_eip1559_fields(
+    chain_id: u64,
+    kind: MonadTxKind,
+    nonce: u64,
+    prio: u128,
+    max_fee: u128,
+) -> Eip1559Fields {
+    match kind {
+        MonadTxKind::Mint { contract, recipient, amount_e8s, vault_id } => Eip1559Fields {
+            chain_id,
+            nonce,
+            max_priority_fee_per_gas: prio,
+            max_fee_per_gas: max_fee,
+            gas_limit: 120_000,
+            to: contract.to_string(),
+            value: 0,
+            data: encode_mint_calldata(recipient, amount_e8s, vault_id),
+        },
+        MonadTxKind::NativeWithdrawal { recipient, amount_wei } => Eip1559Fields {
+            chain_id,
+            nonce,
+            max_priority_fee_per_gas: prio,
+            max_fee_per_gas: max_fee,
+            gas_limit: 21_000,
+            to: recipient.to_string(),
+            value: amount_wei,
+            data: vec![],
+        },
+    }
+}
+
 // ─── calldata helpers ─────────────────────────────────────────────────────────
 
 /// Build calldata for `mint(address,uint256,uint64)`.

--- a/src/rumi_protocol_backend/src/chains/monad/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tx.rs
@@ -57,25 +57,33 @@ pub enum MonadTxKind<'a> {
 ///   gas_limit 120_000.
 /// - Native withdrawal: `to` = recipient, `value` = amount (wei), empty data,
 ///   gas_limit 21_000.
+///
+/// Returns `Err` if any address string is malformed (defense-in-depth: the
+/// boundary validation at `set_chain_contract`/`open_chain_vault`/withdraw+close
+/// makes this unreachable in practice, but a malformed address must never trap
+/// the settlement worker after the re-entrancy guard is held).
 pub fn build_eip1559_fields(
     chain_id: u64,
     kind: MonadTxKind,
     nonce: u64,
     prio: u128,
     max_fee: u128,
-) -> Eip1559Fields {
+) -> Result<Eip1559Fields, String> {
     match kind {
-        MonadTxKind::Mint { contract, recipient, amount_e8s, vault_id } => Eip1559Fields {
-            chain_id,
-            nonce,
-            max_priority_fee_per_gas: prio,
-            max_fee_per_gas: max_fee,
-            gas_limit: 120_000,
-            to: contract.to_string(),
-            value: 0,
-            data: encode_mint_calldata(recipient, amount_e8s, vault_id),
-        },
-        MonadTxKind::NativeWithdrawal { recipient, amount_wei } => Eip1559Fields {
+        MonadTxKind::Mint { contract, recipient, amount_e8s, vault_id } => {
+            let data = encode_mint_calldata(recipient, amount_e8s, vault_id)?;
+            Ok(Eip1559Fields {
+                chain_id,
+                nonce,
+                max_priority_fee_per_gas: prio,
+                max_fee_per_gas: max_fee,
+                gas_limit: 120_000,
+                to: contract.to_string(),
+                value: 0,
+                data,
+            })
+        }
+        MonadTxKind::NativeWithdrawal { recipient, amount_wei } => Ok(Eip1559Fields {
             chain_id,
             nonce,
             max_priority_fee_per_gas: prio,
@@ -84,7 +92,7 @@ pub fn build_eip1559_fields(
             to: recipient.to_string(),
             value: amount_wei,
             data: vec![],
-        },
+        }),
     }
 }
 
@@ -93,38 +101,46 @@ pub fn build_eip1559_fields(
 /// Build calldata for `mint(address,uint256,uint64)`.
 /// Signature string: `"mint(address,uint256,uint64)"`.
 /// Layout: 4-byte selector || word(address) || word(amount) || word(vault_id).
-pub fn encode_mint_calldata(to: &str, amount_e8s: u128, vault_id: u64) -> Vec<u8> {
+///
+/// Returns `Err` if `to` is not a valid 20-byte hex address.
+pub fn encode_mint_calldata(to: &str, amount_e8s: u128, vault_id: u64) -> Result<Vec<u8>, String> {
     let selector = keccak_selector("mint(address,uint256,uint64)");
     let mut out = Vec::with_capacity(4 + 96);
     out.extend_from_slice(&selector);
-    out.extend_from_slice(&abi_word_address(to));
+    out.extend_from_slice(&abi_word_address(to)?);
     out.extend_from_slice(&abi_word_u128(amount_e8s));
     out.extend_from_slice(&abi_word_u128(vault_id as u128));
-    out
+    Ok(out)
 }
 
 /// Build calldata for `transfer(address,uint256)`.
 /// Signature string: `"transfer(address,uint256)"`.
 /// Layout: 4-byte selector || word(address) || word(amount).
-pub fn encode_transfer_calldata(to: &str, amount: u128) -> Vec<u8> {
+///
+/// Returns `Err` if `to` is not a valid 20-byte hex address.
+pub fn encode_transfer_calldata(to: &str, amount: u128) -> Result<Vec<u8>, String> {
     let selector = keccak_selector("transfer(address,uint256)");
     let mut out = Vec::with_capacity(4 + 64);
     out.extend_from_slice(&selector);
-    out.extend_from_slice(&abi_word_address(to));
+    out.extend_from_slice(&abi_word_address(to)?);
     out.extend_from_slice(&abi_word_u128(amount));
-    out
+    Ok(out)
 }
 
 // ─── EIP-1559 encoding ───────────────────────────────────────────────────────
 
 /// Compute the signing hash: keccak256(`0x02 || rlp([...fields..., access_list])`).
-pub fn signing_hash(fields: &Eip1559Fields) -> [u8; 32] {
-    let payload = rlp_encode_eip1559(fields, None);
-    Keccak256::digest(&payload).into()
+///
+/// Returns `Err` if `fields.to` is not a valid 20-byte hex address.
+pub fn signing_hash(fields: &Eip1559Fields) -> Result<[u8; 32], String> {
+    let payload = rlp_encode_eip1559(fields, None)?;
+    Ok(Keccak256::digest(&payload).into())
 }
 
 /// Assemble the final signed EIP-1559 transaction bytes:
 /// `0x02 || rlp([...fields..., access_list, y_parity, r, s])`.
+///
+/// Returns `Err` if `y_parity` is not 0 or 1, or if `fields.to` is malformed.
 pub fn assemble_signed_tx(
     fields: &Eip1559Fields,
     r: &[u8; 32],
@@ -134,7 +150,7 @@ pub fn assemble_signed_tx(
     if y_parity > 1 {
         return Err(format!("y_parity must be 0 or 1, got {y_parity}"));
     }
-    Ok(rlp_encode_eip1559(fields, Some((r, s, y_parity))))
+    rlp_encode_eip1559(fields, Some((r, s, y_parity)))
 }
 
 /// Determine which `y_parity` (0 or 1) matches `expected_addr` for the given
@@ -177,7 +193,7 @@ pub async fn sign_eip1559(
     derivation_path: Vec<Vec<u8>>,
     signer_addr: &str,
 ) -> Result<String, String> {
-    let hash = signing_hash(fields);
+    let hash = signing_hash(fields)?;
 
     let key_id = EcdsaKeyId { curve: EcdsaCurve::Secp256k1, name: monad_ecdsa_key_name() };
     let arg = SignWithEcdsaArgument {
@@ -209,11 +225,13 @@ pub async fn sign_eip1559(
 /// Encode the full EIP-1559 transaction, with or without signature.
 /// Returns `0x02 || rlp_list([chain_id, nonce, max_priority_fee,
 ///   max_fee, gas_limit, to, value, data, access_list, (y_parity, r, s)?])`.
+///
+/// Returns `Err` if `fields.to` is not a valid 20-byte hex address.
 fn rlp_encode_eip1559(
     fields: &Eip1559Fields,
     sig: Option<(&[u8; 32], &[u8; 32], u8)>,
-) -> Vec<u8> {
-    let to_bytes = parse_address(&fields.to);
+) -> Result<Vec<u8>, String> {
+    let to_bytes = parse_address(&fields.to)?;
 
     let mut payload = Vec::new();
     fields.chain_id.encode(&mut payload);
@@ -241,7 +259,7 @@ fn rlp_encode_eip1559(
     out.push(0x02u8);
     write_rlp_list_header(payload.len(), &mut out);
     out.extend_from_slice(&payload);
-    out
+    Ok(out)
 }
 
 /// Encode a 20-byte address as an RLP byte string (NOT an integer).
@@ -303,13 +321,22 @@ fn keccak_selector(sig: &str) -> [u8; 4] {
 
 /// ABI-encode an Ethereum address as a 32-byte left-padded word.
 /// Strips the "0x" prefix, pads to 32 bytes.
-fn abi_word_address(addr: &str) -> [u8; 32] {
+///
+/// Returns `Err` if `addr` is not valid hex or not exactly 20 bytes.
+fn abi_word_address(addr: &str) -> Result<[u8; 32], String> {
     let addr_str = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
-    let addr_bytes = hex::decode(addr_str).expect("invalid address hex");
-    assert_eq!(addr_bytes.len(), 20, "address must be 20 bytes");
+    let addr_bytes = hex::decode(addr_str)
+        .map_err(|e| format!("abi_word_address: invalid hex in '{}': {}", addr, e))?;
+    if addr_bytes.len() != 20 {
+        return Err(format!(
+            "abi_word_address: '{}' is {} bytes, expected 20",
+            addr,
+            addr_bytes.len()
+        ));
+    }
     let mut word = [0u8; 32];
     word[12..].copy_from_slice(&addr_bytes);
-    word
+    Ok(word)
 }
 
 /// ABI-encode a u128 as a 32-byte big-endian word.
@@ -320,8 +347,29 @@ fn abi_word_u128(n: u128) -> [u8; 32] {
 }
 
 /// Parse a "0x…" hex address into 20 bytes.
-fn parse_address(addr: &str) -> [u8; 20] {
+///
+/// Returns `Err` if `addr` is not valid hex or not exactly 20 bytes.
+fn parse_address(addr: &str) -> Result<[u8; 20], String> {
     let hex_str = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
-    let bytes = hex::decode(hex_str).unwrap_or_else(|e| panic!("invalid address '{addr}': {e}"));
-    bytes.try_into().unwrap_or_else(|_| panic!("address '{addr}' is not 20 bytes"))
+    let bytes = hex::decode(hex_str)
+        .map_err(|e| format!("parse_address: invalid hex in '{}': {}", addr, e))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        format!("parse_address: '{}' is {} bytes, expected 20", addr, v.len())
+    })
+}
+
+// ─── test-only re-exports of private helpers ─────────────────────────────────
+//
+// `abi_word_address` and `parse_address` are private (module-internal). To
+// let `tests_tx` assert their error-return behaviour without changing their
+// visibility, we expose thin wrappers under `#[cfg(test)]`.
+
+#[cfg(test)]
+pub fn abi_word_address_test(addr: &str) -> Result<[u8; 32], String> {
+    abi_word_address(addr)
+}
+
+#[cfg(test)]
+pub fn parse_address_test(addr: &str) -> Result<[u8; 20], String> {
+    parse_address(addr)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tx.rs
@@ -1,1 +1,275 @@
-//! Placeholder. Real impl in a later Task.
+//! EIP-1559 (type-0x02) transaction builder, calldata helpers, and tECDSA
+//! signing wrapper for Monad.
+//!
+//! # EIP-1559 encoding
+//! Unsigned (signing payload): `0x02 || rlp([chain_id, nonce,
+//!   max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data,
+//!   access_list])`.
+//! Signed: same list extended with `[y_parity, r, s]`.
+//! `signing_hash` = keccak256 of the unsigned payload.
+//!
+//! Integer fields are minimal big-endian (no leading zeros; zero = 0x80).
+//! `to` is exactly 20 bytes.  `r` and `s` are minimal big-endian integers
+//! (leading zero bytes stripped) — this is the classic RLP gotcha.
+
+use alloy_rlp::Encodable;
+use sha3::{Digest, Keccak256};
+
+use ic_cdk::api::management_canister::ecdsa::{
+    sign_with_ecdsa, EcdsaCurve, EcdsaKeyId, SignWithEcdsaArgument,
+};
+
+use super::config::monad_ecdsa_key_name;
+
+// ─── public types ────────────────────────────────────────────────────────────
+
+/// All fields required to build an EIP-1559 (type-0x02) transaction.
+pub struct Eip1559Fields {
+    pub chain_id: u64,
+    pub nonce: u64,
+    pub max_priority_fee_per_gas: u128,
+    pub max_fee_per_gas: u128,
+    pub gas_limit: u64,
+    /// "0x…" hex-encoded 20-byte Ethereum address.
+    pub to: String,
+    pub value: u128,
+    pub data: Vec<u8>,
+}
+
+// ─── calldata helpers ─────────────────────────────────────────────────────────
+
+/// Build calldata for `mint(address,uint256,uint64)`.
+/// Signature string: `"mint(address,uint256,uint64)"`.
+/// Layout: 4-byte selector || word(address) || word(amount) || word(vault_id).
+pub fn encode_mint_calldata(to: &str, amount_e8s: u128, vault_id: u64) -> Vec<u8> {
+    let selector = keccak_selector("mint(address,uint256,uint64)");
+    let mut out = Vec::with_capacity(4 + 96);
+    out.extend_from_slice(&selector);
+    out.extend_from_slice(&abi_word_address(to));
+    out.extend_from_slice(&abi_word_u128(amount_e8s));
+    out.extend_from_slice(&abi_word_u128(vault_id as u128));
+    out
+}
+
+/// Build calldata for `transfer(address,uint256)`.
+/// Signature string: `"transfer(address,uint256)"`.
+/// Layout: 4-byte selector || word(address) || word(amount).
+pub fn encode_transfer_calldata(to: &str, amount: u128) -> Vec<u8> {
+    let selector = keccak_selector("transfer(address,uint256)");
+    let mut out = Vec::with_capacity(4 + 64);
+    out.extend_from_slice(&selector);
+    out.extend_from_slice(&abi_word_address(to));
+    out.extend_from_slice(&abi_word_u128(amount));
+    out
+}
+
+// ─── EIP-1559 encoding ───────────────────────────────────────────────────────
+
+/// Compute the signing hash: keccak256(`0x02 || rlp([...fields..., access_list])`).
+pub fn signing_hash(fields: &Eip1559Fields) -> [u8; 32] {
+    let payload = rlp_encode_eip1559(fields, None);
+    Keccak256::digest(&payload).into()
+}
+
+/// Assemble the final signed EIP-1559 transaction bytes:
+/// `0x02 || rlp([...fields..., access_list, y_parity, r, s])`.
+pub fn assemble_signed_tx(
+    fields: &Eip1559Fields,
+    r: &[u8; 32],
+    s: &[u8; 32],
+    y_parity: u8,
+) -> Result<Vec<u8>, String> {
+    if y_parity > 1 {
+        return Err(format!("y_parity must be 0 or 1, got {y_parity}"));
+    }
+    Ok(rlp_encode_eip1559(fields, Some((r, s, y_parity))))
+}
+
+/// Determine which `y_parity` (0 or 1) matches `expected_addr` for the given
+/// (hash, r, s).  Returns `Err` if neither parity recovers the expected address.
+pub fn recover_y_parity(
+    hash: &[u8; 32],
+    r: &[u8; 32],
+    s: &[u8; 32],
+    expected_addr: &str,
+) -> Result<u8, String> {
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use super::tecdsa::evm_address_from_pubkey;
+
+    let sig = Signature::from_scalars(*r, *s)
+        .map_err(|e| format!("invalid (r,s): {e}"))?;
+
+    for parity in 0u8..=1 {
+        let rid = RecoveryId::new(parity == 1, false);
+        let Ok(vk) = VerifyingKey::recover_from_prehash(hash, &sig, rid) else {
+            continue;
+        };
+        let pk_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+        let Ok(addr) = evm_address_from_pubkey(&pk_bytes) else {
+            continue;
+        };
+        if addr.to_lowercase() == expected_addr.to_lowercase() {
+            return Ok(parity);
+        }
+    }
+    Err(format!(
+        "neither y_parity=0 nor y_parity=1 recovers address {expected_addr}"
+    ))
+}
+
+/// High-level helper: compute signing hash, call tECDSA management canister,
+/// split the 64-byte compact signature into (r, s), recover y_parity, assemble
+/// the signed transaction, and return it as `"0x…"` hex.
+pub async fn sign_eip1559(
+    fields: &Eip1559Fields,
+    derivation_path: Vec<Vec<u8>>,
+    signer_addr: &str,
+) -> Result<String, String> {
+    let hash = signing_hash(fields);
+
+    let key_id = EcdsaKeyId { curve: EcdsaCurve::Secp256k1, name: monad_ecdsa_key_name() };
+    let arg = SignWithEcdsaArgument {
+        message_hash: hash.to_vec(),
+        derivation_path,
+        key_id,
+    };
+
+    let (res,) = sign_with_ecdsa(arg)
+        .await
+        .map_err(|(code, msg)| format!("sign_with_ecdsa failed: {code:?}: {msg}"))?;
+
+    if res.signature.len() != 64 {
+        return Err(format!(
+            "expected 64-byte compact signature, got {}",
+            res.signature.len()
+        ));
+    }
+    let r: [u8; 32] = res.signature[..32].try_into().unwrap();
+    let s: [u8; 32] = res.signature[32..].try_into().unwrap();
+
+    let y_parity = recover_y_parity(&hash, &r, &s, signer_addr)?;
+    let signed = assemble_signed_tx(fields, &r, &s, y_parity)?;
+    Ok(format!("0x{}", hex::encode(signed)))
+}
+
+// ─── internal RLP helpers ────────────────────────────────────────────────────
+
+/// Encode the full EIP-1559 transaction, with or without signature.
+/// Returns `0x02 || rlp_list([chain_id, nonce, max_priority_fee,
+///   max_fee, gas_limit, to, value, data, access_list, (y_parity, r, s)?])`.
+fn rlp_encode_eip1559(
+    fields: &Eip1559Fields,
+    sig: Option<(&[u8; 32], &[u8; 32], u8)>,
+) -> Vec<u8> {
+    let to_bytes = parse_address(&fields.to);
+
+    let mut payload = Vec::new();
+    fields.chain_id.encode(&mut payload);
+    fields.nonce.encode(&mut payload);
+    fields.max_priority_fee_per_gas.encode(&mut payload);
+    fields.max_fee_per_gas.encode(&mut payload);
+    fields.gas_limit.encode(&mut payload);
+    // `to`: 20-byte string (not an integer — not minimized).
+    encode_20_byte_string(&to_bytes, &mut payload);
+    fields.value.encode(&mut payload);
+    // `data`: byte string — [u8] implements Encodable as an RLP byte string.
+    fields.data.as_slice().encode(&mut payload);
+    // `access_list`: empty list.
+    payload.push(0xc0u8);
+
+    if let Some((r, s, y_parity)) = sig {
+        // y_parity: 0 => 0x80, 1 => 0x01.
+        (y_parity as u64).encode(&mut payload);
+        // r and s: minimal big-endian integers (strip leading zeros).
+        encode_minimal_uint(r, &mut payload);
+        encode_minimal_uint(s, &mut payload);
+    }
+
+    let mut out = Vec::new();
+    out.push(0x02u8);
+    write_rlp_list_header(payload.len(), &mut out);
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Encode a 20-byte address as an RLP byte string (NOT an integer).
+/// Header = 0x80 + 20 = 0x94, followed by 20 bytes.
+fn encode_20_byte_string(bytes: &[u8; 20], out: &mut Vec<u8>) {
+    out.push(0x94u8); // 0x80 + 20
+    out.extend_from_slice(bytes);
+}
+
+/// Encode a 32-byte value as an RLP minimal big-endian integer.
+/// Leading zero bytes are stripped.  Zero encodes as 0x80 (empty string).
+fn encode_minimal_uint(bytes: &[u8; 32], out: &mut Vec<u8>) {
+    let stripped = strip_leading_zeros(bytes);
+    if stripped.is_empty() {
+        out.push(0x80u8); // zero
+    } else if stripped.len() == 1 && stripped[0] < 0x80 {
+        out.push(stripped[0]);
+    } else {
+        // Length ≤ 32 so always fits in a single-byte string header.
+        out.push(0x80 + stripped.len() as u8);
+        out.extend_from_slice(stripped);
+    }
+}
+
+fn strip_leading_zeros(b: &[u8; 32]) -> &[u8] {
+    let first = b.iter().position(|&x| x != 0).unwrap_or(32);
+    &b[first..]
+}
+
+/// Write an RLP list header for `payload_len` bytes of list content.
+fn write_rlp_list_header(payload_len: usize, out: &mut Vec<u8>) {
+    if payload_len <= 55 {
+        out.push(0xc0 + payload_len as u8);
+    } else {
+        let lb = minimal_be_bytes(payload_len);
+        out.push(0xf7 + lb.len() as u8);
+        out.extend_from_slice(&lb);
+    }
+}
+
+/// Minimal big-endian byte encoding of a usize (used for RLP length prefixes).
+fn minimal_be_bytes(mut n: usize) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    while n > 0 {
+        bytes.push(n as u8);
+        n >>= 8;
+    }
+    bytes.reverse();
+    bytes
+}
+
+// ─── ABI / calldata helpers ───────────────────────────────────────────────────
+
+/// First 4 bytes of keccak256(function_signature_string).
+fn keccak_selector(sig: &str) -> [u8; 4] {
+    let hash = Keccak256::digest(sig.as_bytes());
+    [hash[0], hash[1], hash[2], hash[3]]
+}
+
+/// ABI-encode an Ethereum address as a 32-byte left-padded word.
+/// Strips the "0x" prefix, pads to 32 bytes.
+fn abi_word_address(addr: &str) -> [u8; 32] {
+    let addr_str = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    let addr_bytes = hex::decode(addr_str).expect("invalid address hex");
+    assert_eq!(addr_bytes.len(), 20, "address must be 20 bytes");
+    let mut word = [0u8; 32];
+    word[12..].copy_from_slice(&addr_bytes);
+    word
+}
+
+/// ABI-encode a u128 as a 32-byte big-endian word.
+fn abi_word_u128(n: u128) -> [u8; 32] {
+    let mut word = [0u8; 32];
+    word[16..].copy_from_slice(&n.to_be_bytes());
+    word
+}
+
+/// Parse a "0x…" hex address into 20 bytes.
+fn parse_address(addr: &str) -> [u8; 20] {
+    let hex_str = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    let bytes = hex::decode(hex_str).unwrap_or_else(|e| panic!("invalid address '{addr}': {e}"));
+    bytes.try_into().unwrap_or_else(|_| panic!("address '{addr}' is not 20 bytes"))
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tx.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Real impl in a later Task.

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -39,9 +39,11 @@ use std::collections::BTreeMap;
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct MultiChainStateV1 {
     pub chain_configs: BTreeMap<ChainId, ChainConfigV1>,
-    /// Canonical per-chain icUSD supply (e8s). Invariant:
-    /// `sum(chain_supplies.values()) == state.total_borrowed_icusd_amount()`
+    /// Canonical per-chain icUSD supply (e8s). Phase 1b invariant:
+    /// `sum(chain_supplies.values()) == sum(chain_vault.debt_e8s)`
     /// after every state mutation. Enforced by `apply_supply_delta`.
+    /// ICP-native debt (`total_borrowed_icusd_amount`) is a separate pool
+    /// and is NOT part of this invariant (unification is a Phase 2 task).
     pub chain_supplies: BTreeMap<ChainId, u128>,
     pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
     /// `true` iff the periodic invariant self-check on Timer B failed the
@@ -97,6 +99,16 @@ pub struct MultiChainStateV2 {
 impl MultiChainStateV2 {
     pub fn total_supply_all_chains_e8s(&self) -> u128 {
         self.chain_supplies.values().copied().sum()
+    }
+
+    /// Sum of confirmed debt across all foreign-chain vaults (e8s). Under the
+    /// Phase 1b foreign-chain-only supply invariant, this MUST equal
+    /// `total_supply_all_chains_e8s()` at all times; the Timer-B self-check
+    /// compares the two to catch drift. ICP-native debt
+    /// (`State::total_borrowed_icusd_amount`) is a SEPARATE pool, deliberately
+    /// excluded (unification to a single global total is a Phase 2 task).
+    pub fn total_chain_vault_debt_e8s(&self) -> u128 {
+        self.chain_vaults.values().map(|v| v.debt_e8s).sum()
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -16,6 +16,7 @@
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
 
 use super::config::{ChainConfigV1, ChainId};
+use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
@@ -44,4 +45,34 @@ impl MultiChainStateV1 {
     }
 }
 
-pub type MultiChainState = MultiChainStateV1;
+/// Phase 1b snapshot. Carries the four V1 fields verbatim (so the
+/// `#[serde(default)]` in-place decode of `State.multi_chain` maps each by
+/// name straight across) and adds the Monad/foreign-chain working set:
+/// per-vault records, deployed-contract addresses, manual price overrides,
+/// last-observed block cursors, and hot-wallet gas balances. The five new
+/// fields hit serde-default and come up empty on a V1->V2 upgrade.
+///
+/// Add the NEXT field by bumping to `MultiChainStateV3` (keep V2 verbatim),
+/// extending `migrate_multi_chain_state`, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct MultiChainStateV2 {
+    // carried verbatim from V1
+    pub chain_configs: BTreeMap<ChainId, ChainConfigV1>,
+    pub chain_supplies: BTreeMap<ChainId, u128>,
+    pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+    pub invariant_halted: bool,
+    // new in V2
+    pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+    pub chain_contracts: BTreeMap<ChainId, String>,
+    pub manual_prices: BTreeMap<(ChainId, String), u64>,
+    pub last_observed_block: BTreeMap<ChainId, u64>,
+    pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+}
+
+impl MultiChainStateV2 {
+    pub fn total_supply_all_chains_e8s(&self) -> u128 {
+        self.chain_supplies.values().copied().sum()
+    }
+}
+
+pub type MultiChainState = MultiChainStateV2;

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -121,7 +121,10 @@ pub struct MultiChainStateV2 {
     pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
     /// Persisted idempotency set for the burn-watch observer (C-1
     /// supply-divergence fix). Maps `block_number -> { burn-identity key }`,
-    /// where the key is `"{tx_hash}:{vault_id}:{amount_e8s}"`. A burn whose key
+    /// where the key is `"{tx_hash}:{log_index}"`, the canonical on-chain
+    /// identity of an EVM log, so two identical `Burn`s emitted in one tx (same
+    /// vault and amount, different log indices) are credited separately rather
+    /// than collapsed into one entry. A burn whose key
     /// is already present at its block has ALREADY been applied to
     /// `chain_supplies`/`debt_e8s` and MUST be skipped on any re-scan — this is
     /// what kills the silent double-apply (the pre-fix loop re-applied the

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -2,15 +2,29 @@
 //!
 //! Lives at `state::State::multi_chain` and carries every chain-aware
 //! piece of state in one struct so the AMM-style state-wipe pattern
-//! (missing field at decode time -> Default applied silently) cannot
-//! happen for any sub-component. Add fields ONLY by:
+//! (missing field at decode time -> fallback wipes state) cannot happen for
+//! any sub-component.
 //!
-//! 1. Renaming `MultiChainStateV1` -> keep the V1 fields exactly.
-//! 2. Adding `MultiChainStateV2` with the new field plus a `From<MultiChainStateV1>` impl.
-//! 3. Updating the `pub type MultiChainState = MultiChainStateV2;` alias.
-//! 4. Creating `migrate_multi_chain_state` in `chains/supply.rs` that calls
-//!    `MultiChainStateV2::from(old_v1)` and update the canister `post_upgrade`
-//!    hook in `main.rs` to call it after `replace_state(state)`.
+//! ## Adding a new field (non-breaking reshape)
+//!
+//! 1. Keep `MultiChainStateVN` exactly as shipped.
+//! 2. Add `MultiChainStateV(N+1)` with the new field(s), each annotated with
+//!    `#[serde(default)]`. The four original V1 fields must NOT be decorated
+//!    because they are always present in any live snapshot.
+//! 3. Rebind `pub type MultiChainState = MultiChainStateV(N+1);`.
+//! 4. That is it. The V1->V2 (or V2->V3, etc.) decode happens in-place via
+//!    ciborium: the old fields map across by name; the new fields hit
+//!    `serde_default` and come up empty. No explicit migration call in
+//!    `post_upgrade` is needed. `migrate_multi_chain_state` in `supply.rs`
+//!    is a unit-tested TEMPLATE for the next version bump, NOT the live path.
+//!
+//! ## Adding a field that requires a BREAKING reshape
+//!
+//! (e.g. a field type change the in-place decode cannot handle)
+//!
+//! 1-3 same as above, then:
+//! 4. Add `migrate_vN_to_v(N+1)` in `chains/supply.rs`.
+//! 5. Call it from `post_upgrade` in `main.rs` after `restore_state`.
 //!
 //! See spec Section 3 ("State wipe on upgrade") and the 2026-05-18 AMM
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
@@ -50,22 +64,33 @@ impl MultiChainStateV1 {
 /// name straight across) and adds the Monad/foreign-chain working set:
 /// per-vault records, deployed-contract addresses, manual price overrides,
 /// last-observed block cursors, and hot-wallet gas balances. The five new
-/// fields hit serde-default and come up empty on a V1->V2 upgrade.
+/// fields carry field-level `#[serde(default)]` so a V1 CBOR snapshot (which
+/// lacks these keys entirely) decodes into V2 without error, defaulting the
+/// new fields to empty. The four V1-carried fields are NOT decorated because
+/// V1 always wrote them and they must be present in any valid snapshot.
 ///
 /// Add the NEXT field by bumping to `MultiChainStateV3` (keep V2 verbatim),
-/// extending `migrate_multi_chain_state`, and rebinding the alias below.
+/// adding `#[serde(default)]` on the new field, and rebinding the alias below.
+/// For a BREAKING reshape (field type change that the in-place decode cannot
+/// handle), add a `migrate_v2_to_v3` in `chains/supply.rs` and call it from
+/// `post_upgrade` after `restore_state`.
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct MultiChainStateV2 {
-    // carried verbatim from V1
+    // carried verbatim from V1 — always present in any valid snapshot
     pub chain_configs: BTreeMap<ChainId, ChainConfigV1>,
     pub chain_supplies: BTreeMap<ChainId, u128>,
     pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
     pub invariant_halted: bool,
-    // new in V2
+    // new in V2 — field-level serde(default) lets a V1 snapshot decode cleanly
+    #[serde(default)]
     pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+    #[serde(default)]
     pub chain_contracts: BTreeMap<ChainId, String>,
+    #[serde(default)]
     pub manual_prices: BTreeMap<(ChainId, String), u64>,
+    #[serde(default)]
     pub last_observed_block: BTreeMap<ChainId, u64>,
+    #[serde(default)]
     pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
 }
 

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -34,7 +34,7 @@ use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct MultiChainStateV1 {
@@ -65,8 +65,9 @@ impl MultiChainStateV1 {
 /// `#[serde(default)]` in-place decode of `State.multi_chain` maps each by
 /// name straight across) and adds the Monad/foreign-chain working set:
 /// per-vault records, deployed-contract addresses, manual price overrides,
-/// last-observed block cursors, hot-wallet gas balances, and per-chain reorg
-/// halt flags. The new-in-V2 fields carry field-level `#[serde(default)]` so a
+/// last-observed block cursors, hot-wallet gas balances, per-chain reorg
+/// halt flags, and the burn-watch idempotency set (C-1). The new-in-V2 fields
+/// carry field-level `#[serde(default)]` so a
 /// V1 CBOR snapshot (which lacks these keys entirely) decodes into V2 without
 /// error, defaulting the new fields to empty. The four V1-carried fields are
 /// NOT decorated because V1 always wrote them and they must be present in any
@@ -118,6 +119,23 @@ pub struct MultiChainStateV2 {
     /// defense.
     #[serde(default)]
     pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+    /// Persisted idempotency set for the burn-watch observer (C-1
+    /// supply-divergence fix). Maps `block_number -> { burn-identity key }`,
+    /// where the key is `"{tx_hash}:{vault_id}:{amount_e8s}"`. A burn whose key
+    /// is already present at its block has ALREADY been applied to
+    /// `chain_supplies`/`debt_e8s` and MUST be skipped on any re-scan — this is
+    /// what kills the silent double-apply (the pre-fix loop re-applied the
+    /// already-applied prefix of a range whenever a later poison burn stalled
+    /// the cursor). The map is BOUNDED: after the cursor advances to `N`, the
+    /// observer prunes every entry with `block <= N` (those blocks can never be
+    /// re-scanned, since the next scan starts at `N+1`). Both InvalidBurn-skips
+    /// and successful applies are recorded so a permanently-poison burn is never
+    /// reprocessed either. Added directly to V2 (same brand-new-this-phase
+    /// rationale as `reorg_halted`); `#[serde(default)]` is mandatory
+    /// state-wipe defense so a pre-existing V1/V2 CBOR snapshot lacking this key
+    /// decodes cleanly to an empty map.
+    #[serde(default)]
+    pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
 }
 
 impl MultiChainStateV2 {

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -98,13 +98,26 @@ pub struct MultiChainStateV2 {
     pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
     /// Per-chain reorg circuit breaker. Set `true` by the observer when a
     /// finalized-block regression deeper than `finality_depth` is detected
-    /// (`hardening::is_reorg`); halts BOTH the observer and the settlement
+    /// (`hardening::is_reorg`) and CONFIRMED across `REORG_CONFIRM_TICKS`
+    /// consecutive observer ticks; halts BOTH the observer and the settlement
     /// worker for that chain until cleared by `clear_reorg_halt` (Task 14).
     /// Added directly to V2 (not a new V3) because V2 is brand-new this phase
     /// and has never been persisted, so no live snapshot lacks this key; the
     /// `#[serde(default)]` is still mandatory state-wipe defense.
     #[serde(default)]
     pub reorg_halted: BTreeMap<ChainId, bool>,
+    /// Per-chain count of CONSECUTIVE observer ticks that suspected a reorg
+    /// (a finalized-block regression deeper than `finality_depth`). The observer
+    /// only flips `reorg_halted` once this streak reaches
+    /// `hardening::REORG_CONFIRM_TICKS`; a single non-suspect tick resets it to 0
+    /// (`hardening::on_reorg_tick`). This debounces a transient single-provider
+    /// RPC lag (fetch_block_numbers is un-quorumed) so one stale read cannot
+    /// permanently halt the chain. NOTE: Task 14's `clear_reorg_halt` MUST reset
+    /// BOTH `reorg_halted` AND this streak for the cleared chain. Same V2
+    /// rationale as `reorg_halted`; `#[serde(default)]` is mandatory state-wipe
+    /// defense.
+    #[serde(default)]
+    pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
 }
 
 impl MultiChainStateV2 {

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -65,11 +65,13 @@ impl MultiChainStateV1 {
 /// `#[serde(default)]` in-place decode of `State.multi_chain` maps each by
 /// name straight across) and adds the Monad/foreign-chain working set:
 /// per-vault records, deployed-contract addresses, manual price overrides,
-/// last-observed block cursors, and hot-wallet gas balances. The five new
-/// fields carry field-level `#[serde(default)]` so a V1 CBOR snapshot (which
-/// lacks these keys entirely) decodes into V2 without error, defaulting the
-/// new fields to empty. The four V1-carried fields are NOT decorated because
-/// V1 always wrote them and they must be present in any valid snapshot.
+/// last-observed block cursors, hot-wallet gas balances, and per-chain reorg
+/// halt flags. The new-in-V2 fields carry field-level `#[serde(default)]` so a
+/// V1 CBOR snapshot (which lacks these keys entirely) decodes into V2 without
+/// error, defaulting the new fields to empty. The four V1-carried fields are
+/// NOT decorated because V1 always wrote them and they must be present in any
+/// valid snapshot. (`reorg_halted` was added to V2 in Task 11, before V2 had
+/// ever been persisted, so it is an in-V2 field rather than a V3 bump.)
 ///
 /// Add the NEXT field by bumping to `MultiChainStateV3` (keep V2 verbatim),
 /// adding `#[serde(default)]` on the new field, and rebinding the alias below.
@@ -94,6 +96,15 @@ pub struct MultiChainStateV2 {
     pub last_observed_block: BTreeMap<ChainId, u64>,
     #[serde(default)]
     pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+    /// Per-chain reorg circuit breaker. Set `true` by the observer when a
+    /// finalized-block regression deeper than `finality_depth` is detected
+    /// (`hardening::is_reorg`); halts BOTH the observer and the settlement
+    /// worker for that chain until cleared by `clear_reorg_halt` (Task 14).
+    /// Added directly to V2 (not a new V3) because V2 is brand-new this phase
+    /// and has never been persisted, so no live snapshot lacks this key; the
+    /// `#[serde(default)]` is still mandatory state-wipe defense.
+    #[serde(default)]
+    pub reorg_halted: BTreeMap<ChainId, bool>,
 }
 
 impl MultiChainStateV2 {

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -40,6 +40,14 @@ pub struct SettlementOp {
     /// pre-existing (V1) snapshot decoding cleanly into the V2 state.
     #[serde(default)]
     pub last_tx_hash: Option<String>,
+    /// EVM nonce this op was first submitted at, recorded by the Task-11
+    /// settlement worker on the submit path. The stuck-tx replace-by-fee path
+    /// re-signs and rebroadcasts on THIS nonce (never a fresh `latest` read) so
+    /// a bumped-gas resubmit replaces the stuck tx rather than minting a second
+    /// time. `None` until first submitted. `#[serde(default)]` keeps any
+    /// pre-existing snapshot decoding cleanly.
+    #[serde(default)]
+    pub submit_nonce: Option<u64>,
 }
 
 impl SettlementOp {
@@ -51,6 +59,7 @@ impl SettlementOp {
             enqueued_at_ns: now_ns,
             status: SettlementOpStatus::Queued,
             last_tx_hash: None,
+            submit_nonce: None,
         }
     }
 
@@ -109,5 +118,129 @@ impl SettlementQueueV1 {
 
     pub fn pending_len(&self) -> usize {
         self.pending.len()
+    }
+
+    /// Reap terminal (`Succeeded`/`Failed`) ops so `pending` does not grow
+    /// monotonically (the Task-10 review flagged `select_next_op`'s per-tick
+    /// scan over an ever-growing `pending` as a cycle-cost anti-pattern this
+    /// protocol must avoid). Called once per `run_settlement` tick.
+    ///
+    /// - Removes terminal ops from `pending` and drops their ids from
+    ///   `drain_order`.
+    /// - Advances `head` to the lowest op_id still pending (or to `tail` when
+    ///   `pending` is now empty), matching `head`'s documented meaning
+    ///   ("lowest enqueued op_id still pending").
+    /// - Leaves `seen_idempotency_keys` INTACT: it is the replay/duplicate
+    ///   guard, and pruning it would re-admit an already-processed op.
+    ///   `select_next_op` only ever returns Inflight/Queued ops, so removing
+    ///   terminal ops cannot change which live op it selects.
+    pub fn prune_terminal(&mut self) {
+        let terminal: Vec<u64> = self
+            .pending
+            .iter()
+            .filter(|(_, op)| {
+                matches!(
+                    op.status,
+                    SettlementOpStatus::Succeeded { .. } | SettlementOpStatus::Failed { .. }
+                )
+            })
+            .map(|(&id, _)| id)
+            .collect();
+
+        if terminal.is_empty() {
+            return;
+        }
+
+        for id in &terminal {
+            self.pending.remove(id);
+        }
+        self.drain_order.retain(|id| !terminal.contains(id));
+
+        // `pending` is a BTreeMap, so its first key is the lowest remaining
+        // op_id. With nothing left, head meets tail (the next id to assign).
+        self.head = self.pending.keys().next().copied().unwrap_or(self.tail);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mint_op(key: &str) -> SettlementOp {
+        SettlementOp::new(
+            SettlementOpKind::Mint {
+                recipient: "0xabc".to_string(),
+                amount_e8s: 1_000,
+                vault_id: 7,
+            },
+            key.to_string(),
+            0,
+        )
+    }
+
+    #[test]
+    fn prune_terminal_keeps_live_op_advances_head_and_preserves_idempotency() {
+        let mut q = SettlementQueueV1::default();
+        let id0 = q.enqueue(mint_op("k0")).unwrap(); // 0
+        let id1 = q.enqueue(mint_op("k1")).unwrap(); // 1
+        let id2 = q.enqueue(mint_op("k2")).unwrap(); // 2
+        assert_eq!((id0, id1, id2), (0, 1, 2));
+        assert_eq!(q.tail, 3);
+        assert_eq!(q.pending_len(), 3);
+
+        // Mark op 0 Succeeded and op 1 Failed; op 2 stays Queued (live).
+        q.pending.get_mut(&id0).unwrap().mark_succeeded("0xhash".to_string(), 10);
+        q.pending.get_mut(&id1).unwrap().mark_failed("reverted".to_string(), 11);
+
+        q.prune_terminal();
+
+        // Only the non-terminal op remains.
+        assert_eq!(q.pending_len(), 1);
+        assert!(q.pending.contains_key(&id2));
+        assert!(!q.pending.contains_key(&id0));
+        assert!(!q.pending.contains_key(&id1));
+
+        // head advanced to the lowest remaining op_id (2); tail unchanged.
+        assert_eq!(q.head, 2);
+        assert_eq!(q.tail, 3);
+
+        // drain_order dropped the pruned ids, kept the live one.
+        assert_eq!(q.drain_order.iter().copied().collect::<Vec<_>>(), vec![2]);
+
+        // seen_idempotency_keys is INTACT: a previously-seen key is still rejected.
+        let dup = q.enqueue(mint_op("k0"));
+        assert!(matches!(dup, Err(SettlementQueueError::DuplicateIdempotencyKey(k)) if k == "k0"));
+
+        // select_next_op still returns the live Queued op (semantics unchanged).
+        let live = q.pending.values().find(|o| matches!(o.status, SettlementOpStatus::Queued));
+        assert!(live.is_some());
+    }
+
+    #[test]
+    fn prune_terminal_empties_pending_and_meets_tail() {
+        let mut q = SettlementQueueV1::default();
+        let id0 = q.enqueue(mint_op("a")).unwrap();
+        let id1 = q.enqueue(mint_op("b")).unwrap();
+        q.pending.get_mut(&id0).unwrap().mark_succeeded("0x1".to_string(), 1);
+        q.pending.get_mut(&id1).unwrap().mark_succeeded("0x2".to_string(), 2);
+
+        q.prune_terminal();
+
+        assert_eq!(q.pending_len(), 0);
+        // With nothing pending, head meets tail (next id to assign).
+        assert_eq!(q.head, q.tail);
+        assert_eq!(q.tail, 2);
+        // Idempotency guard survives even a full drain.
+        assert!(q.enqueue(mint_op("a")).is_err());
+    }
+
+    #[test]
+    fn prune_terminal_noop_when_no_terminal_ops() {
+        let mut q = SettlementQueueV1::default();
+        q.enqueue(mint_op("x")).unwrap();
+        let before_head = q.head;
+        q.prune_terminal();
+        assert_eq!(q.pending_len(), 1);
+        assert_eq!(q.head, before_head);
     }
 }

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -34,6 +34,12 @@ pub struct SettlementOp {
     pub idempotency_key: String,
     pub enqueued_at_ns: u64,
     pub status: SettlementOpStatus,
+    /// Hash of the most recent on-chain submission for this op, set by the
+    /// Phase-1b Timer-D worker when the op goes Inflight. Read back on the
+    /// Confirm path to fetch the receipt. `#[serde(default)]` keeps any
+    /// pre-existing (V1) snapshot decoding cleanly into the V2 state.
+    #[serde(default)]
+    pub last_tx_hash: Option<String>,
 }
 
 impl SettlementOp {
@@ -44,6 +50,7 @@ impl SettlementOp {
             idempotency_key,
             enqueued_at_ns: now_ns,
             status: SettlementOpStatus::Queued,
+            last_tx_hash: None,
         }
     }
 

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -15,7 +15,13 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum SettlementOpKind {
     Mint { recipient: String, amount_e8s: u128, vault_id: u64 },
-    Withdrawal { recipient: String, amount_e8s: u128 },
+    /// Return native gas-asset (MON) collateral to `recipient`. `amount_e18`
+    /// is wei (1e18 scale, NOT e8s — it goes straight into the EIP-1559
+    /// `value`). `vault_id` lets the settlement worker emit `WithdrawalSigned`
+    /// with the real id and flip the vault `Closing -> Closed` on confirmation
+    /// (replaces the old placeholder `Withdrawal { recipient, amount_e8s }`,
+    /// which was never enqueued anywhere and carried the wrong unit + no id).
+    NativeWithdrawal { recipient: String, amount_e18: u128, vault_id: u64 },
     Burn { amount_e8s: u128 },
 }
 

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 /// DORMANT TEMPLATE — not called on the live upgrade path.
 ///
 /// The V1->V2 upgrade happens automatically via the ciborium in-place decode:
-/// the four V1 fields map across by name; the five new V2 fields carry
+/// the four V1 fields map across by name; the new-in-V2 fields carry
 /// `#[serde(default)]` and come up empty. No explicit migration call is
 /// needed in `post_upgrade`.
 ///
@@ -39,6 +39,7 @@ pub fn migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2 {
         manual_prices: Default::default(),
         last_observed_block: Default::default(),
         hot_wallet_balance_e18: Default::default(),
+        reorg_halted: Default::default(),
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -40,6 +40,7 @@ pub fn migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2 {
         last_observed_block: Default::default(),
         hot_wallet_balance_e18: Default::default(),
         reorg_halted: Default::default(),
+        reorg_suspect_streak: Default::default(),
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -16,14 +16,18 @@ use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
-/// Migrate the Phase 1a `MultiChainStateV1` snapshot to `MultiChainStateV2`.
-/// Carries every V1 field verbatim; defaults the V2 additions to empty.
+/// DORMANT TEMPLATE — not called on the live upgrade path.
 ///
-/// The active V1->V2 upgrade happens automatically via the `#[serde(default)]`
-/// in-place decode of `State.multi_chain` (the four V1 fields map straight
-/// across by name; the five new V2 fields hit serde-default). This function
-/// is the unit-tested template for the NEXT version bump (V2->V3), and the
-/// explicit migration path documented in `multi_chain_state.rs`.
+/// The V1->V2 upgrade happens automatically via the ciborium in-place decode:
+/// the four V1 fields map across by name; the five new V2 fields carry
+/// `#[serde(default)]` and come up empty. No explicit migration call is
+/// needed in `post_upgrade`.
+///
+/// This function is kept as the unit-tested template for the NEXT version bump
+/// (V2->V3). When V3 lands, rename this to `migrate_v2_to_v3`, add it to the
+/// `post_upgrade` hook, and write a parallel ciborium round-trip test (see
+/// `tests_multi_chain_state_v2::v1_cbor_snapshot_decodes_into_v2_without_wiping_state`
+/// as the model).
 pub fn migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2 {
     MultiChainStateV2 {
         chain_configs: v1.chain_configs,

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,9 +12,31 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::MultiChainStateV1;
+use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
+
+/// Migrate the Phase 1a `MultiChainStateV1` snapshot to `MultiChainStateV2`.
+/// Carries every V1 field verbatim; defaults the V2 additions to empty.
+///
+/// The active V1->V2 upgrade happens automatically via the `#[serde(default)]`
+/// in-place decode of `State.multi_chain` (the four V1 fields map straight
+/// across by name; the five new V2 fields hit serde-default). This function
+/// is the unit-tested template for the NEXT version bump (V2->V3), and the
+/// explicit migration path documented in `multi_chain_state.rs`.
+pub fn migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2 {
+    MultiChainStateV2 {
+        chain_configs: v1.chain_configs,
+        chain_supplies: v1.chain_supplies,
+        settlement_queues: v1.settlement_queues,
+        invariant_halted: v1.invariant_halted,
+        chain_vaults: Default::default(),
+        chain_contracts: Default::default(),
+        manual_prices: Default::default(),
+        last_observed_block: Default::default(),
+        hot_wallet_balance_e18: Default::default(),
+    }
+}
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug)]
 pub enum SupplyDelta {
@@ -34,7 +56,7 @@ pub enum SupplyInvariantError {
 /// authoritative `total_debt_e8s` snapshot taken at the same logical
 /// moment; we reject any apply that would leave sum != total_debt.
 pub fn apply_supply_delta(
-    state: &mut MultiChainStateV1,
+    state: &mut MultiChainStateV2,
     chain: ChainId,
     delta: SupplyDelta,
     total_debt_e8s: u128,
@@ -80,7 +102,7 @@ pub fn apply_supply_delta(
 /// On `Err`, the caller flips `state.invariant_halted = true` and emits
 /// an event.
 pub fn check_invariant(
-    state: &MultiChainStateV1,
+    state: &MultiChainStateV2,
     total_debt_e8s: u128,
 ) -> Result<(), SupplyInvariantError> {
     let sum: u128 = state.chain_supplies.values().copied().sum();

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -41,6 +41,7 @@ pub fn migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2 {
         hot_wallet_balance_e18: Default::default(),
         reorg_halted: Default::default(),
         reorg_suspect_streak: Default::default(),
+        processed_burn_keys: Default::default(),
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -3,7 +3,7 @@
 //! Task 12.
 
 use super::config::{ChainAdminError, ChainConfigV1, ChainId, ChainStatus, GasStrategy, RegisterChainArg, UpdateChainConfigArg};
-use super::multi_chain_state::MultiChainStateV1;
+use super::multi_chain_state::MultiChainStateV2;
 use crate::chains::admin::{disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
 
 fn arg() -> RegisterChainArg {
@@ -19,7 +19,7 @@ fn arg() -> RegisterChainArg {
 
 #[test]
 fn register_chain_inserts_config_and_zero_supply() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     register_chain_in_state(&mut s, arg(), 1_700_000_000_000_000_000).expect("register");
     assert!(s.chain_configs.contains_key(&ChainId(101)));
     assert_eq!(s.chain_supplies[&ChainId(101)], 0);
@@ -32,7 +32,7 @@ fn register_chain_inserts_config_and_zero_supply() {
 
 #[test]
 fn register_chain_rejects_duplicates() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
     assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
@@ -40,7 +40,7 @@ fn register_chain_rejects_duplicates() {
 
 #[test]
 fn register_chain_rejects_empty_rpc_endpoints() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     let mut a = arg();
     a.rpc_endpoints = vec![];
     let err = register_chain_in_state(&mut s, a, 0).expect_err("empty endpoints");
@@ -49,7 +49,7 @@ fn register_chain_rejects_empty_rpc_endpoints() {
 
 #[test]
 fn disable_chain_flips_status_and_preserves_supply() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
@@ -59,7 +59,7 @@ fn disable_chain_flips_status_and_preserves_supply() {
 
 #[test]
 fn set_chain_config_updates_supplied_fields_only() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     let original_name = s.chain_configs[&ChainId(101)].display_name.clone();
     let update = UpdateChainConfigArg {
@@ -76,7 +76,7 @@ fn set_chain_config_updates_supplied_fields_only() {
 
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     let err = update_chain_config_in_state(
         &mut s,
         ChainId(404),

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -3,8 +3,10 @@
 //! Task 12.
 
 use super::config::{ChainAdminError, ChainConfigV1, ChainId, ChainStatus, GasStrategy, RegisterChainArg, UpdateChainConfigArg};
+use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use super::multi_chain_state::MultiChainStateV2;
-use crate::chains::admin::{disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
+use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
+use candid::Principal;
 
 fn arg() -> RegisterChainArg {
     RegisterChainArg {
@@ -14,6 +16,32 @@ fn arg() -> RegisterChainArg {
         finality_depth: 1,
         gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
         chain_native_decimals: 18,
+    }
+}
+
+fn config_arg_999() -> RegisterChainArg {
+    RegisterChainArg {
+        chain_id: ChainId(999),
+        display_name: "ScratchChain".into(),
+        rpc_endpoints: vec!["https://rpc.scratch".into()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
+        chain_native_decimals: 18,
+    }
+}
+
+fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
+    ChainVaultV1 {
+        vault_id,
+        owner: Principal::anonymous(),
+        collateral_chain: chain,
+        custody_address: "0x0000000000000000000000000000000000000000".into(),
+        collateral_amount_e18: 0,
+        debt_e8s: 0,
+        mint_recipient: "0x0000000000000000000000000000000000000000".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::AwaitingDeposit,
+        opened_at_ns: 0,
     }
 }
 
@@ -83,4 +111,67 @@ fn set_chain_config_rejects_unknown_chain() {
         UpdateChainConfigArg::default(),
     ).expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(_)));
+}
+
+#[test]
+fn delete_chain_removes_zero_supply_chain() {
+    let mut s = MultiChainStateV2::default();
+    let c = ChainId(999);
+    register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
+    // Populate EVERY per-chain map so the purge can be observed.
+    s.chain_contracts.insert(c, "0xabc".into());
+    s.manual_prices.insert((c, "MON".to_string()), 2_0000_0000);
+    s.last_observed_block.insert(c, 42);
+    s.hot_wallet_balance_e18.insert(c, 1_000);
+    s.reorg_halted.insert(c, true);
+    s.reorg_suspect_streak.insert(c, 2);
+    // An unrelated chain's manual_prices entry must SURVIVE the delete.
+    s.manual_prices.insert((ChainId(7), "MON".to_string()), 3_0000_0000);
+
+    delete_chain_in_state(&mut s, c).expect("delete");
+
+    assert!(!s.chain_configs.contains_key(&c), "chain_configs retained");
+    assert!(!s.chain_supplies.contains_key(&c), "chain_supplies retained");
+    assert!(!s.settlement_queues.contains_key(&c), "settlement_queues retained");
+    assert!(!s.chain_contracts.contains_key(&c), "chain_contracts retained");
+    assert!(!s.last_observed_block.contains_key(&c), "last_observed_block retained");
+    assert!(!s.hot_wallet_balance_e18.contains_key(&c), "hot_wallet_balance_e18 retained");
+    assert!(!s.reorg_halted.contains_key(&c), "reorg_halted retained");
+    assert!(!s.reorg_suspect_streak.contains_key(&c), "reorg_suspect_streak retained");
+    assert!(!s.manual_prices.contains_key(&(c, "MON".to_string())), "manual_prices retained");
+    // The unrelated chain's price survives.
+    assert_eq!(s.manual_prices[&(ChainId(7), "MON".to_string())], 3_0000_0000);
+}
+
+#[test]
+fn delete_chain_refuses_when_supply_nonzero() {
+    let mut s = MultiChainStateV2::default();
+    let c = ChainId(999);
+    register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
+    s.chain_supplies.insert(c, 1);
+    let err = delete_chain_in_state(&mut s, c).expect_err("nonzero supply");
+    assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
+    // No partial delete: the chain is STILL registered with its supply intact.
+    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert_eq!(s.chain_supplies[&c], 1);
+}
+
+#[test]
+fn delete_chain_refuses_when_open_vaults_reference_it() {
+    let mut s = MultiChainStateV2::default();
+    let c = ChainId(999);
+    register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
+    s.chain_vaults.insert(1, dummy_vault(1, c));
+    let err = delete_chain_in_state(&mut s, c).expect_err("referencing vault");
+    assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
+    // No partial delete: the chain is STILL registered and the vault remains.
+    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert!(s.chain_vaults.contains_key(&1));
+}
+
+#[test]
+fn delete_chain_unknown_is_rejected() {
+    let mut s = MultiChainStateV2::default();
+    let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
+    assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -49,6 +49,43 @@ fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
     assert!(v2.hot_wallet_balance_e18.is_empty());
     assert!(v2.reorg_halted.is_empty());
     assert!(v2.reorg_suspect_streak.is_empty());
+    // C-1: the burn-watch idempotency set must default to empty from a V1 blob
+    // that has no such key (its absence must NOT trip the state-wipe fallback).
+    assert!(v2.processed_burn_keys.is_empty());
+}
+
+#[test]
+fn v2_cbor_round_trip_preserves_processed_burn_keys() {
+    // C-1 state-wipe defense: a populated V2 snapshot (with processed_burn_keys)
+    // must survive a ciborium encode→decode round-trip with the new field intact.
+    // This is the exact path load_state_from_stable() runs on a V2→V2 upgrade.
+    use std::collections::BTreeSet;
+
+    let mut v2 = MultiChainStateV2::default();
+    v2.chain_supplies.insert(ChainId(10143), 6_000_000_000);
+    let mut keys = BTreeSet::new();
+    keys.insert("0xgoodburn:1:4000000000".to_string());
+    keys.insert("0xpoison:1:100000000000".to_string());
+    v2.processed_burn_keys.insert(1_000_300, keys);
+    v2.processed_burn_keys
+        .insert(1_000_301, BTreeSet::from(["0xother:2:50".to_string()]));
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v2, &mut buf).expect("cbor encode V2");
+    let decoded: MultiChainStateV2 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V2 snapshot round-trips");
+
+    assert_eq!(decoded.chain_supplies.get(&ChainId(10143)), Some(&6_000_000_000u128));
+    assert_eq!(decoded.processed_burn_keys.len(), 2);
+    let block = decoded.processed_burn_keys.get(&1_000_300).expect("block 1_000_300 present");
+    assert!(block.contains("0xgoodburn:1:4000000000"));
+    assert!(block.contains("0xpoison:1:100000000000"));
+    assert_eq!(block.len(), 2);
+    assert!(decoded
+        .processed_burn_keys
+        .get(&1_000_301)
+        .expect("block 1_000_301 present")
+        .contains("0xother:2:50"));
 }
 
 #[test]
@@ -63,6 +100,7 @@ fn v2_default_is_empty() {
     assert!(s.hot_wallet_balance_e18.is_empty());
     assert!(s.reorg_halted.is_empty());
     assert!(s.reorg_suspect_streak.is_empty());
+    assert!(s.processed_burn_keys.is_empty());
     assert_eq!(s.total_supply_all_chains_e8s(), 0u128);
 }
 
@@ -76,6 +114,7 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
     assert!(v2.invariant_halted);
     assert!(v2.chain_vaults.is_empty());
     assert!(v2.chain_contracts.is_empty());
+    assert!(v2.processed_burn_keys.is_empty());
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -47,6 +47,7 @@ fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
     assert!(v2.manual_prices.is_empty());
     assert!(v2.last_observed_block.is_empty());
     assert!(v2.hot_wallet_balance_e18.is_empty());
+    assert!(v2.reorg_halted.is_empty());
 }
 
 #[test]
@@ -59,6 +60,7 @@ fn v2_default_is_empty() {
     assert!(s.manual_prices.is_empty());
     assert!(s.last_observed_block.is_empty());
     assert!(s.hot_wallet_balance_e18.is_empty());
+    assert!(s.reorg_halted.is_empty());
     assert_eq!(s.total_supply_all_chains_e8s(), 0u128);
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,0 +1,33 @@
+use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
+use super::config::ChainId;
+use super::supply::migrate_multi_chain_state;
+
+#[test]
+fn v2_default_is_empty() {
+    let s = MultiChainStateV2::default();
+    assert!(s.chain_configs.is_empty());
+    assert!(s.chain_supplies.is_empty());
+    assert!(s.chain_vaults.is_empty());
+    assert!(s.chain_contracts.is_empty());
+    assert!(s.manual_prices.is_empty());
+    assert!(s.last_observed_block.is_empty());
+    assert!(s.hot_wallet_balance_e18.is_empty());
+    assert_eq!(s.total_supply_all_chains_e8s(), 0u128);
+}
+
+#[test]
+fn migration_preserves_v1_fields_and_defaults_new_ones() {
+    let mut v1 = MultiChainStateV1::default();
+    v1.chain_supplies.insert(ChainId(10143), 12345);
+    v1.invariant_halted = true;
+    let v2 = migrate_multi_chain_state(v1);
+    assert_eq!(v2.chain_supplies.get(&ChainId(10143)), Some(&12345u128));
+    assert!(v2.invariant_halted);
+    assert!(v2.chain_vaults.is_empty());
+    assert!(v2.chain_contracts.is_empty());
+}
+
+#[test]
+fn active_alias_points_at_v2() {
+    fn _check(x: MultiChainState) -> MultiChainStateV2 { x }
+}

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -78,3 +78,36 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
 fn active_alias_points_at_v2() {
     fn _check(x: MultiChainState) -> MultiChainStateV2 { x }
 }
+
+#[test]
+fn chain_vault_debt_total_sums_only_chain_vaults() {
+    use super::monad::chain_vault::{ChainVaultV1, ChainVaultStatus};
+
+    let mut s = MultiChainStateV2::default();
+    assert_eq!(s.total_chain_vault_debt_e8s(), 0);
+    s.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xa".into(),
+        collateral_amount_e18: 0,
+        debt_e8s: 7_000_000_000,
+        mint_recipient: "0xr".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 0,
+    });
+    s.chain_vaults.insert(2, ChainVaultV1 {
+        vault_id: 2,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xb".into(),
+        collateral_amount_e18: 0,
+        debt_e8s: 3_000_000_000,
+        mint_recipient: "0xr".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 0,
+    });
+    assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
+}

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -6,7 +6,7 @@ use super::supply::migrate_multi_chain_state;
 fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
     // Regression for the Task-3 state-wipe bug: a populated V1-shaped CBOR
     // snapshot (the shape Phase 1a wrote to stable memory) MUST decode into
-    // MultiChainStateV2 with the four V1 fields preserved and the five new
+    // MultiChainStateV2 with the four V1 fields preserved and the new-in-V2
     // fields defaulted to empty. This is the exact ciborium decode path
     // load_state_from_stable() runs on upgrade. WITHOUT field-level
     // #[serde(default)] on the new V2 fields this decode fails with
@@ -48,6 +48,7 @@ fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
     assert!(v2.last_observed_block.is_empty());
     assert!(v2.hot_wallet_balance_e18.is_empty());
     assert!(v2.reorg_halted.is_empty());
+    assert!(v2.reorg_suspect_streak.is_empty());
 }
 
 #[test]
@@ -61,6 +62,7 @@ fn v2_default_is_empty() {
     assert!(s.last_observed_block.is_empty());
     assert!(s.hot_wallet_balance_e18.is_empty());
     assert!(s.reorg_halted.is_empty());
+    assert!(s.reorg_suspect_streak.is_empty());
     assert_eq!(s.total_supply_all_chains_e8s(), 0u128);
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -3,6 +3,53 @@ use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
 
 #[test]
+fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
+    // Regression for the Task-3 state-wipe bug: a populated V1-shaped CBOR
+    // snapshot (the shape Phase 1a wrote to stable memory) MUST decode into
+    // MultiChainStateV2 with the four V1 fields preserved and the five new
+    // fields defaulted to empty. This is the exact ciborium decode path
+    // load_state_from_stable() runs on upgrade. WITHOUT field-level
+    // #[serde(default)] on the new V2 fields this decode fails with
+    // "missing field `chain_vaults`", which on a real canister silently
+    // wipes multi_chain state via the event-replay fallback.
+    use super::config::{ChainConfigV1, ChainStatus, GasStrategy};
+    use super::settlement_queue::SettlementQueueV1;
+
+    let mut v1 = MultiChainStateV1::default();
+    v1.chain_configs.insert(ChainId(10143), ChainConfigV1 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
+        chain_native_decimals: 18,
+        registered_at_ns: 123,
+        status: ChainStatus::Registered,
+    });
+    v1.chain_supplies.insert(ChainId(10143), 777);
+    v1.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
+    v1.invariant_halted = true;
+
+    // Encode as V1 (the bytes Phase 1a wrote), decode as V2 (the new shape).
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v1, &mut buf).expect("cbor encode V1");
+    let v2: MultiChainStateV2 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V1 snapshot MUST decode into V2");
+
+    // V1 fields preserved:
+    assert_eq!(v2.chain_supplies.get(&ChainId(10143)), Some(&777u128));
+    assert!(v2.chain_configs.contains_key(&ChainId(10143)));
+    assert!(v2.settlement_queues.contains_key(&ChainId(10143)));
+    assert!(v2.invariant_halted);
+    // New fields defaulted to empty:
+    assert!(v2.chain_vaults.is_empty());
+    assert!(v2.chain_contracts.is_empty());
+    assert!(v2.manual_prices.is_empty());
+    assert!(v2.last_observed_block.is_empty());
+    assert!(v2.hot_wallet_balance_e18.is_empty());
+}
+
+#[test]
 fn v2_default_is_empty() {
     let s = MultiChainStateV2::default();
     assert!(s.chain_configs.is_empty());

--- a/src/rumi_protocol_backend/src/chains/tests_self_check.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_self_check.rs
@@ -2,12 +2,12 @@
 //! self-check flips the halt flag and Mode and stops mutating supplies.
 
 use super::config::ChainId;
-use super::multi_chain_state::MultiChainStateV1;
+use super::multi_chain_state::MultiChainStateV2;
 use super::supply::check_invariant;
 
 #[test]
 fn check_invariant_passes_when_sum_equals_total_debt() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     assert!(check_invariant(&s, 300).is_ok());
@@ -15,7 +15,7 @@ fn check_invariant_passes_when_sum_equals_total_debt() {
 
 #[test]
 fn check_invariant_fails_on_drift() {
-    let mut s = MultiChainStateV1::default();
+    let mut s = MultiChainStateV2::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     let err = check_invariant(&s, 299).expect_err("drift must be caught");
@@ -24,6 +24,6 @@ fn check_invariant_fails_on_drift() {
 
 #[test]
 fn empty_state_passes_when_total_debt_is_zero() {
-    let s = MultiChainStateV1::default();
+    let s = MultiChainStateV2::default();
     assert!(check_invariant(&s, 0).is_ok());
 }

--- a/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
@@ -55,7 +55,7 @@ fn enqueue_rejects_duplicate_idempotency_key() {
 fn round_trip_via_candid() {
     let mut q = SettlementQueueV1::default();
     let op = SettlementOp::new(
-        SettlementOpKind::Withdrawal { recipient: "0xrecip".to_string(), amount_e8s: 42 },
+        SettlementOpKind::NativeWithdrawal { recipient: "0xrecip".to_string(), amount_e18: 42, vault_id: 3 },
         "k1".to_string(),
         0,
     );

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,9 +1,9 @@
 use super::supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
 use super::config::{ChainConfigV1, ChainId, ChainStatus, GasStrategy};
-use super::multi_chain_state::MultiChainStateV1;
+use super::multi_chain_state::MultiChainStateV2;
 
-fn fixture_state() -> MultiChainStateV1 {
-    let mut s = MultiChainStateV1::default();
+fn fixture_state() -> MultiChainStateV2 {
+    let mut s = MultiChainStateV2::default();
     s.chain_configs.insert(
         ChainId(101),
         ChainConfigV1 {

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -809,6 +809,78 @@ pub enum Event {
         total_debt_e8s: u128,
         timestamp: u64,
     },
+
+    // Phase 1b: Monad (and future foreign-chain) audit trail.
+    #[serde(rename = "deposit_observed")]
+    DepositObserved {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        custody_address: String,
+        amount_e18: u128,
+        tx_hash: String,
+        block_number: u64,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_mint_submitted")]
+    ChainMintSubmitted {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        op_id: u64,
+        recipient: String,
+        amount_e8s: u128,
+        tx_hash: String,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_mint_confirmed")]
+    ChainMintConfirmed {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        op_id: u64,
+        amount_e8s: u128,
+        tx_hash: String,
+        block_number: u64,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_burn_observed")]
+    ChainBurnObserved {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        amount_e8s: u128,
+        tx_hash: String,
+        block_number: u64,
+        timestamp: u64,
+    },
+    #[serde(rename = "withdrawal_signed")]
+    WithdrawalSigned {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        op_id: u64,
+        recipient: String,
+        amount_e18: u128,
+        tx_hash: String,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_settlement_failed")]
+    ChainSettlementFailed {
+        chain_id: crate::chains::config::ChainId,
+        op_id: u64,
+        reason: String,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_reorg_detected")]
+    ChainReorgDetected {
+        chain_id: crate::chains::config::ChainId,
+        observed_block: u64,
+        reorg_depth: u64,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_hot_wallet_low")]
+    ChainHotWalletLow {
+        chain_id: crate::chains::config::ChainId,
+        balance_e18: u128,
+        threshold_e18: u128,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -924,6 +996,16 @@ impl Event {
             | Event::ChainConfigUpdated { .. } => false,
             // Phase 1a Task 11: supply invariant failure is protocol-wide.
             Event::SupplyInvariantSelfCheckFailed { .. } => false,
+            // Phase 1b: vault-carrying foreign-chain events surface per-vault history.
+            Event::DepositObserved { vault_id, .. }
+            | Event::ChainMintSubmitted { vault_id, .. }
+            | Event::ChainMintConfirmed { vault_id, .. }
+            | Event::ChainBurnObserved { vault_id, .. }
+            | Event::WithdrawalSigned { vault_id, .. } => vault_id == filter_vault_id,
+            // Phase 1b: protocol-wide or op-scoped events, not vault-specific.
+            Event::ChainSettlementFailed { .. }
+            | Event::ChainReorgDetected { .. }
+            | Event::ChainHotWalletLow { .. } => false,
         }
     }
 
@@ -1889,6 +1971,16 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             // Phase 1a Task 11: informational audit trail; state mutation
             // (invariant_halted + mode flip) happens live in the timer tick.
             Event::SupplyInvariantSelfCheckFailed { .. } => {},
+            // Phase 1b: observability-only events; the actual state mutations
+            // happen in their emitting tasks, not on replay.
+            Event::DepositObserved { .. }
+            | Event::ChainMintSubmitted { .. }
+            | Event::ChainMintConfirmed { .. }
+            | Event::ChainBurnObserved { .. }
+            | Event::WithdrawalSigned { .. }
+            | Event::ChainSettlementFailed { .. }
+            | Event::ChainReorgDetected { .. }
+            | Event::ChainHotWalletLow { .. } => {},
         }
     }
     state.next_available_vault_id = vault_id;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1096,6 +1096,13 @@ fn set_chain_contract(
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
+    // Fail-fast on a malformed contract address: an unvalidated value flows into
+    // the mint calldata's `to` (`tx::abi_word_address`) and panics deep on the
+    // settlement worker path, after the re-entrancy guard + awaits, permanently
+    // blocking the chain's worker. A deploy-time typo is enough.
+    if !rumi_protocol_backend::chains::monad::tecdsa::is_valid_evm_address(&address) {
+        return Err(ProtocolError::ChainAdmin(format!("invalid EVM address: {address}")));
+    }
     mutate_state(|s| {
         s.multi_chain.chain_contracts.insert(chain, address.clone());
     });

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -965,6 +965,189 @@ fn close_chain_vault(vault_id: u64, dest_address: String) -> Result<(), Protocol
     .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
 }
 
+// Phase 1b Task 14: query + admin surface for the foreign-chain working set.
+//
+// NOTE: `get_user_deposit_address` is intentionally omitted. Custody is
+// PER-VAULT (the address is derived with nonce = vault_id inside
+// `open_chain_vault`), so a user's deposit address is the vault's
+// `custody_address`, returned by `get_chain_vault` after open. A nonce=0
+// per-user address would be one NO vault ever uses — surfacing it would be
+// misleading. Use `get_chain_vault(vault_id)` for the deposit address.
+
+/// Derive the per-chain SETTLEMENT (minter) address — the tECDSA-derived EVM
+/// address whose private share the canister controls for that chain. Operators
+/// grant `MINTER_ROLE` on `IcUSD.sol` to this address. Async (the derive hits
+/// the management/signing subnet). Developer-gated: derivation costs cycles and
+/// a signing-subnet call, so it is not exposed to arbitrary callers even though
+/// it is read-only. No state borrow is held across the `.await`.
+#[candid_method(update)]
+#[update]
+async fn get_chain_settlement_address(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<String, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let path = rumi_protocol_backend::chains::monad::tecdsa::settlement_derivation_path(chain);
+    rumi_protocol_backend::chains::monad::tecdsa::derive_evm_address(path)
+        .await
+        .map(|(_pubkey, addr)| addr)
+        .map_err(|e| ProtocolError::ChainAdmin(format!("derive: {e}")))
+}
+
+/// Return a single foreign-chain vault by id (the `custody_address` field is the
+/// user's deposit address). Public read-only query; no gate.
+#[candid_method(query)]
+#[query]
+fn get_chain_vault(
+    vault_id: u64,
+) -> Option<rumi_protocol_backend::chains::monad::chain_vault::ChainVaultV1> {
+    read_state(|s| s.multi_chain.chain_vaults.get(&vault_id).cloned())
+}
+
+/// List the foreign-chain vaults whose `collateral_chain == chain`, CLAMPED to
+/// at most 500 entries. The clamp follows the Wave-9a DOS-pagination convention:
+/// an unbounded query over a growing map is a cycle-DoS vector. A caller needing
+/// the full set past 500 must page via a future cursor endpoint. Public query.
+#[candid_method(query)]
+#[query]
+fn list_chain_vaults(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Vec<rumi_protocol_backend::chains::monad::chain_vault::ChainVaultV1> {
+    const MAX_CHAIN_VAULTS_RETURNED: usize = 500;
+    read_state(|s| {
+        s.multi_chain
+            .chain_vaults
+            .values()
+            .filter(|v| v.collateral_chain == chain)
+            .take(MAX_CHAIN_VAULTS_RETURNED)
+            .cloned()
+            .collect()
+    })
+}
+
+/// Record the deployed `IcUSD.sol` (or equivalent) contract address for a chain.
+/// Developer-gated.
+#[candid_method(update)]
+#[update]
+fn set_chain_contract(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    address: String,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.multi_chain.chain_contracts.insert(chain, address.clone());
+    });
+    log!(INFO, "[set_chain_contract] chain={:?} address={}", chain, address);
+    Ok(())
+}
+
+/// Set a manual collateral price override for `(chain, symbol)` as a USD e8
+/// value (e.g. $2.00 == 2_0000_0000). Phase 1b uses manual prices for foreign
+/// collateral; a real oracle is a later task. Developer-gated.
+#[candid_method(update)]
+#[update]
+fn set_manual_collateral_price(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    symbol: String,
+    price_e8: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.multi_chain.manual_prices.insert((chain, symbol.clone()), price_e8);
+    });
+    log!(INFO, "[set_manual_collateral_price] chain={:?} symbol={} price_e8={}", chain, symbol, price_e8);
+    Ok(())
+}
+
+/// Override the EVM RPC canister principal the Monad wrapper talks to. This is
+/// the PocketIC/staging override read via `State::evm_rpc_override()`; on
+/// mainnet it points at the production EVM RPC canister. Developer-gated.
+#[candid_method(update)]
+#[update]
+fn set_evm_rpc_principal(principal: candid::Principal) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.evm_rpc_principal_override = Some(principal);
+    });
+    log!(INFO, "[set_evm_rpc_principal] principal={}", principal);
+    Ok(())
+}
+
+/// Clear the global supply-invariant halt (set by the Timer-B self-check on
+/// drift). Use only AFTER manually confirming `total_supply_all_chains_e8s`
+/// matches `total_chain_vault_debt_e8s`. Developer-gated.
+#[candid_method(update)]
+#[update]
+fn clear_invariant_halt() -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.multi_chain.invariant_halted = false;
+    });
+    log!(INFO, "[clear_invariant_halt] global invariant halt cleared");
+    Ok(())
+}
+
+/// Clear a chain's reorg circuit breaker. Resets BOTH `reorg_halted` AND the
+/// `reorg_suspect_streak` debounce counter (Task 11): clearing the halt without
+/// also zeroing the streak would let the very next suspect observer tick push
+/// the streak back over `REORG_CONFIRM_TICKS` and re-halt the chain.
+/// Developer-gated.
+#[candid_method(update)]
+#[update]
+fn clear_reorg_halt(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.multi_chain.reorg_halted.remove(&chain);
+        s.multi_chain.reorg_suspect_streak.remove(&chain);
+    });
+    log!(INFO, "[clear_reorg_halt] chain={:?} reorg halt + suspect streak cleared", chain);
+    Ok(())
+}
+
+/// Delete a chain entirely. Permitted only when the chain carries ZERO supply
+/// and NO chain_vaults reference it (so deletion cannot orphan debt/collateral);
+/// purges every per-chain map. Developer-gated. This DELETES (not disables) a
+/// chain, so it does not record `Event::ChainDisabled`.
+#[candid_method(update)]
+#[update]
+fn delete_chain(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let result = mutate_state(|s| {
+        rumi_protocol_backend::chains::admin::delete_chain_in_state(&mut s.multi_chain, chain)
+    });
+    match result {
+        Ok(()) => {
+            log!(INFO, "[delete_chain] chain={:?} deleted (all per-chain state purged)", chain);
+            Ok(())
+        }
+        Err(e) => Err(ProtocolError::ChainAdmin(format!("{e:?}"))),
+    }
+}
+
 #[candid_method(query)]
 #[query]
 fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1187,6 +1187,38 @@ fn clear_reorg_halt(
     Ok(())
 }
 
+/// Seed the burn-watch cursor to the current chain tip when activating a chain
+/// (Gate-4 prerequisite). Events before the seed are not scanned (none exist
+/// pre-activation). 0 = unseeded (burn-watch inert; deposit-watch still runs).
+/// Developer-gated.
+#[candid_method(update)]
+#[update]
+fn set_last_observed_block(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    block: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        s.multi_chain.last_observed_block.insert(chain, block);
+    });
+    log!(INFO, "[set_last_observed_block] chain={:?} block={}", chain, block);
+    Ok(())
+}
+
+/// Read the burn-watch cursor (`last_observed_block`) for a chain. Returns 0 when
+/// unseeded. Ungated query — used by tests and Task-D staging verification to
+/// confirm the cursor advances.
+#[candid_method(query)]
+#[query]
+fn get_last_observed_block(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> u64 {
+    read_state(|s| s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0))
+}
+
 /// Delete a chain entirely. Permitted only when the chain carries ZERO supply
 /// and NO chain_vaults reference it (so deletion cannot orphan debt/collateral);
 /// purges every per-chain map. Developer-gated. This DELETES (not disables) a

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -900,6 +900,71 @@ async fn open_chain_vault(
         .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
 }
 
+/// Phase 1b Task 13: withdraw foreign-chain (Monad) collateral.
+///
+/// CR-checks the REMAINING collateral against `MONAD_MIN_CR_E4` (debt-free
+/// vaults skip the check), RESERVES the withdrawn amount (decrements
+/// `collateral_amount_e18` at enqueue), and enqueues a `NativeWithdrawal` op
+/// that Timer D signs and broadcasts. A vault that becomes empty AND debt-free
+/// flips to `Closing` here and `Closed` once the transfer confirms.
+///
+/// There is NO repay endpoint: the user burns icUSD on Monad and the burn-watch
+/// observer decrements `debt_e8s` + chain supply. This path moves only
+/// collateral. Synchronous — `dest_address` is supplied by the caller, so no
+/// tECDSA derive is needed; signing happens later in Timer D. Developer-gated.
+#[candid_method(update)]
+#[update]
+fn withdraw_chain_collateral(
+    vault_id: u64,
+    amount_e18: u128,
+    dest_address: String,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::monad::chain_vault::withdraw_collateral_in_state(
+            &mut s.multi_chain,
+            vault_id,
+            amount_e18,
+            dest_address,
+            rumi_protocol_backend::chains::monad::chain_vault::MONAD_MIN_CR_E4,
+            now,
+        )
+    })
+    .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
+}
+
+/// Phase 1b Task 13: close a debt-free foreign-chain (Monad) vault.
+///
+/// Requires the vault's `debt_e8s == 0` (repay first by burning icUSD on
+/// Monad), then withdraws the FULL remaining collateral to `dest_address`
+/// (vault -> `Closing`, then `Closed` on the transfer's confirmation).
+/// Synchronous + developer-gated (mirrors `withdraw_chain_collateral`).
+#[candid_method(update)]
+#[update]
+fn close_chain_vault(vault_id: u64, dest_address: String) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::monad::chain_vault::close_chain_vault_in_state(
+            &mut s.multi_chain,
+            vault_id,
+            dest_address,
+            rumi_protocol_backend::chains::monad::chain_vault::MONAD_MIN_CR_E4,
+            now,
+        )
+    })
+    .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
+}
+
 #[candid_method(query)]
 #[query]
 fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -190,6 +190,12 @@ thread_local! {
         const { std::cell::Cell::new(None) };
     static VAULT_CHECK_TIMER_ID: std::cell::Cell<Option<ic_cdk_timers::TimerId>> =
         const { std::cell::Cell::new(None) };
+    // Phase 1b Task 15: Monad async loops. Same transient (not-persisted)
+    // lifecycle — re-assigned fresh ids by `setup_timers` on every upgrade.
+    static SETTLEMENT_TIMER_ID: std::cell::Cell<Option<ic_cdk_timers::TimerId>> =
+        const { std::cell::Cell::new(None) };
+    static OBSERVER_TIMER_ID: std::cell::Cell<Option<ic_cdk_timers::TimerId>> =
+        const { std::cell::Cell::new(None) };
 }
 
 fn register_xrc_fetch_timer() {
@@ -229,6 +235,45 @@ fn register_vault_check_timer() {
         let new_id = ic_cdk_timers::set_timer_interval(
             std::time::Duration::from_secs(secs),
             || ic_cdk::spawn(rumi_protocol_backend::xrc::vault_check_tick()),
+        );
+        cell.set(Some(new_id));
+    });
+}
+
+/// Phase 1b Task 15: register Timer D (Monad settlement fan-out). Clears any
+/// existing id and re-registers in place so the setter can re-tune live.
+///
+/// FLOOR: a 0 interval (serde-default-missing on an old snapshot, or a bad
+/// setter value that slipped past validation) is forced to 30s, never 0 — a 0s
+/// `set_timer_interval` is a busy-loop and the #1 cycle burner (this is the
+/// heartbeat-cost regression the protocol removed a heartbeat to avoid).
+fn register_settlement_timer() {
+    let secs = read_state(|s| s.settlement_tick_interval_secs);
+    let secs = if secs == 0 { 30 } else { secs.max(1) };
+    SETTLEMENT_TIMER_ID.with(|cell| {
+        if let Some(old) = cell.get() {
+            ic_cdk_timers::clear_timer(old);
+        }
+        let new_id = ic_cdk_timers::set_timer_interval(
+            std::time::Duration::from_secs(secs),
+            || ic_cdk::spawn(rumi_protocol_backend::chains::monad::settlement::settlement_tick()),
+        );
+        cell.set(Some(new_id));
+    });
+}
+
+/// Phase 1b Task 15: register the Monad inbound observer fan-out. Same
+/// clear-and-re-register-in-place + 0-floor protection as the settlement timer.
+fn register_observer_timer() {
+    let secs = read_state(|s| s.observer_tick_interval_secs);
+    let secs = if secs == 0 { 30 } else { secs.max(1) };
+    OBSERVER_TIMER_ID.with(|cell| {
+        if let Some(old) = cell.get() {
+            ic_cdk_timers::clear_timer(old);
+        }
+        let new_id = ic_cdk_timers::set_timer_interval(
+            std::time::Duration::from_secs(secs),
+            || ic_cdk::spawn(rumi_protocol_backend::chains::monad::deposit_watch::observer_tick()),
         );
         cell.set(Some(new_id));
     });
@@ -297,6 +342,18 @@ fn setup_timers() {
     ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(3600), || {
         capture_protocol_snapshot();
     });
+
+    // ── Phase 1b Task 15: Monad async loops (Timer D + inbound observer) ─────
+    // Both tick fns fan out over registered+enabled chains and are NO-OPS when
+    // no chain is registered, so they are safe to run on the staging canister
+    // before Monad is configured. Cadences live in State (default 30s) and are
+    // tunable via `set_settlement_tick_interval_secs` /
+    // `set_observer_tick_interval_secs`, which re-register in place. The register
+    // helpers FLOOR a 0 interval to 30s (never a busy-loop). Per-chain
+    // re-entrancy guards in run_settlement/run_observer prevent overlapping ticks
+    // from double-processing an op.
+    register_settlement_timer();
+    register_observer_timer();
 }
 
 fn capture_protocol_snapshot() {
@@ -4401,6 +4458,65 @@ async fn set_vault_check_tick_interval_secs(secs: u64) -> Result<(), ProtocolErr
     mutate_state(|s| s.vault_check_tick_interval_secs = secs);
     register_vault_check_timer();
     log!(INFO, "[set_vault_check_tick_interval_secs] Timer C interval set to {}s", secs);
+    Ok(())
+}
+
+/// Phase 1b Task 15: tune the Timer D (Monad outbound settlement fan-out)
+/// interval in seconds. Default 30. Re-registers in place.
+///
+/// Rejects `secs == 0` (belt-and-suspenders with the hard floor in
+/// `register_settlement_timer`, which would coerce a 0 to 30 anyway). Lowering
+/// makes mint/withdrawal settlement land faster (one op per chain per tick) at
+/// the cost of more frequent EVM RPC polling; raising slows settlement
+/// throughput. The per-chain re-entrancy guard means a tick that out-runs the
+/// interval is simply skipped, so a low interval never stacks concurrent runs.
+#[candid_method(update)]
+#[update]
+async fn set_settlement_tick_interval_secs(secs: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set the settlement tick interval".to_string(),
+        ));
+    }
+    if secs == 0 {
+        return Err(ProtocolError::GenericError(
+            "Settlement tick interval must be > 0".to_string(),
+        ));
+    }
+    mutate_state(|s| s.settlement_tick_interval_secs = secs);
+    register_settlement_timer();
+    log!(INFO, "[set_settlement_tick_interval_secs] Timer D interval set to {}s", secs);
+    Ok(())
+}
+
+/// Phase 1b Task 15: tune the Monad inbound observer fan-out interval in
+/// seconds. Default 30. Re-registers in place.
+///
+/// Rejects `secs == 0` (belt-and-suspenders with the hard floor in
+/// `register_observer_timer`). Lowering tightens deposit-detection and
+/// burn-observation latency at the cost of more frequent EVM RPC polling;
+/// raising slows it. Same per-chain re-entrancy-guard skip behavior as the
+/// settlement timer.
+#[candid_method(update)]
+#[update]
+async fn set_observer_tick_interval_secs(secs: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set the observer tick interval".to_string(),
+        ));
+    }
+    if secs == 0 {
+        return Err(ProtocolError::GenericError(
+            "Observer tick interval must be > 0".to_string(),
+        ));
+    }
+    mutate_state(|s| s.observer_tick_interval_secs = secs);
+    register_observer_timer();
+    log!(INFO, "[set_observer_tick_interval_secs] Observer interval set to {}s", secs);
     Ok(())
 }
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -572,6 +572,17 @@ fn post_upgrade(arg: ProtocolArg) {
         s.is_timer_running = false;
     });
 
+    // Phase 1b breadcrumb: confirm the multi_chain root survived the upgrade.
+    // The V1->V2 migration happens automatically via the `#[serde(default)]`
+    // in-place decode of `State.multi_chain` (four V1 fields map across by
+    // name; the five new V2 fields hit serde-default and come up empty). No
+    // explicit migrate call is needed here; `migrate_multi_chain_state` exists
+    // as the unit-tested template for the NEXT version bump.
+    let (chains, chain_vaults) = read_state(|s| {
+        (s.multi_chain.chain_configs.len(), s.multi_chain.chain_vaults.len())
+    });
+    log!(INFO, "[post_upgrade] multi_chain: {} chains, {} chain_vaults", chains, chain_vaults);
+
     setup_timers();
 }
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -841,6 +841,65 @@ fn set_chain_config(
     }
 }
 
+/// Phase 1b Task 12: open a foreign-chain (Monad) vault, OPEN-THEN-VERIFY.
+///
+/// Creates the vault in `AwaitingDeposit` with the DECLARED collateral and the
+/// intended mint in `pending_mint_e8s`; enqueues NO mint. The caller then reads
+/// the vault's `custody_address` (Task 14 `get_chain_vault`) and deposits MON
+/// there. deposit-watch verifies the on-chain balance covers the declared
+/// collateral at finality, flips the vault to `MintPending`, and enqueues the
+/// mint. icUSD is only ever minted against a verified on-chain deposit.
+///
+/// Developer-gated for Phase 1b (matches the chain-admin endpoints). Async
+/// because deriving the per-user custody address calls tECDSA. Borrow
+/// discipline: no `read_state`/`mutate_state` borrow is held across the
+/// `derive_evm_address(...).await`.
+#[candid_method(update)]
+#[update]
+async fn open_chain_vault(
+    collateral_chain: rumi_protocol_backend::chains::config::ChainId,
+    collateral_e18: u128,
+    debt_e8s: u128,
+    mint_recipient: String,
+) -> Result<u64, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    // Reserve the vault id BEFORE the async derive so the derivation path
+    // (chain, caller, vault_id) is unique even across concurrent opens.
+    let vault_id = mutate_state(|s| {
+        s.chain_vault_id_counter += 1;
+        s.chain_vault_id_counter
+    });
+    let path = rumi_protocol_backend::chains::monad::tecdsa::custody_derivation_path(
+        collateral_chain,
+        caller,
+        vault_id,
+    );
+    let (_pubkey, custody) =
+        rumi_protocol_backend::chains::monad::tecdsa::derive_evm_address(path)
+            .await
+            .map_err(|e| ProtocolError::ChainAdmin(format!("derive: {e}")))?;
+    let now = ic_cdk::api::time();
+    let res = mutate_state(|s| {
+        rumi_protocol_backend::chains::monad::chain_vault::open_chain_vault_in_state(
+            &mut s.multi_chain,
+            collateral_chain,
+            caller,
+            custody,
+            collateral_e18,
+            debt_e8s,
+            mint_recipient,
+            rumi_protocol_backend::chains::monad::chain_vault::MONAD_MIN_CR_E4,
+            now,
+            vault_id,
+        )
+    });
+    res.map(|()| vault_id)
+        .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
+}
+
 #[candid_method(query)]
 #[query]
 fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1252,6 +1252,13 @@ pub struct State {
     /// `set_evm_rpc_principal` is added in Task 14.
     #[serde(default)]
     pub evm_rpc_principal_override: Option<candid::Principal>,
+
+    /// Phase 1b Task 12: monotonic id source for foreign-chain (`chain_vaults`)
+    /// vault ids. `#[serde(default)]` is safe — `State` is ciborium-encoded
+    /// (storage.rs uses `ciborium::ser/de`, which is serde-based), so an old
+    /// snapshot that lacks this key decodes with the field defaulting to 0.
+    #[serde(default)]
+    pub chain_vault_id_counter: u64,
 }
 
 fn default_check_vaults_alert_band_bps() -> u64 {
@@ -1460,6 +1467,7 @@ impl Default for State {
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
             evm_rpc_principal_override: None,
+            chain_vault_id_counter: 0,
         }
     }
 }
@@ -1685,6 +1693,7 @@ impl From<InitArg> for State {
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
             evm_rpc_principal_override: None,
+            chain_vault_id_counter: 0,
         }
     }
 }

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1242,6 +1242,16 @@ pub struct State {
     /// `chains::multi_chain_state` for the versioned-snapshot pattern.
     #[serde(default)]
     pub multi_chain: crate::chains::MultiChainState,
+
+    /// Phase 1b Task 6: override for the EVM RPC canister principal.
+    /// When `Some`, `chains::monad::evm_rpc::evm_rpc_principal()` uses this
+    /// value instead of the hardcoded production canister
+    /// (`7hfb6-caaaa-aaaar-qadga-cai`). Allows PocketIC / staging to inject
+    /// a mock EVM RPC canister. `#[serde(default)]` so pre-1b snapshots
+    /// decode to `None` (production canister). The developer-gated SETTER
+    /// `set_evm_rpc_principal` is added in Task 14.
+    #[serde(default)]
+    pub evm_rpc_principal_override: Option<candid::Principal>,
 }
 
 fn default_check_vaults_alert_band_bps() -> u64 {
@@ -1449,6 +1459,7 @@ impl Default for State {
             ticks_since_full_sweep: 0,
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
+            evm_rpc_principal_override: None,
         }
     }
 }
@@ -1673,6 +1684,7 @@ impl From<InitArg> for State {
             ticks_since_full_sweep: 0,
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
+            evm_rpc_principal_override: None,
         }
     }
 }
@@ -3632,6 +3644,16 @@ impl State {
         let treasury = self.compute_treasury_stats_snapshot();
         self.protocol_status_snapshot = Some((now_ns, proto));
         self.treasury_stats_snapshot = Some((now_ns, treasury));
+    }
+
+    /// Phase 1b Task 6: returns the EVM RPC canister principal override, if set.
+    ///
+    /// When `Some`, the multi-chain EVM RPC wrapper uses this principal instead
+    /// of the hardcoded production canister (`7hfb6-caaaa-aaaar-qadga-cai`).
+    /// Enables PocketIC and staging environments to inject a mock. The developer-
+    /// gated setter `set_evm_rpc_principal` is added in Task 14.
+    pub fn evm_rpc_override(&self) -> Option<candid::Principal> {
+        self.evm_rpc_principal_override
     }
 
     /// Wave-10 LIQ-008: pure-read sum of liquidation debt cleared in the

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -97,6 +97,13 @@ fn default_xrc_fetch_interval_secs() -> u64 { 300 }
 fn default_interest_treasury_tick_interval_secs() -> u64 { 60 }
 fn default_vault_check_tick_interval_secs() -> u64 { 300 }
 
+/// Phase 1b Task 15: production defaults for the Monad async-loop cadences.
+/// Timer D (settlement) and the observer both default to 30s. A legacy snapshot
+/// without these fields hydrates to 30; the register fns floor a 0 to 30 anyway
+/// so a busy-loop is impossible even with a corrupt value.
+fn default_settlement_tick_interval_secs() -> u64 { 30 }
+fn default_observer_tick_interval_secs() -> u64 { 30 }
+
 pub fn default_interest_split() -> Vec<InterestRecipient> {
     vec![
         InterestRecipient { destination: InterestDestination::ThreePool, bps: 5000 },
@@ -790,6 +797,17 @@ pub struct State {
     /// `set_vault_check_tick_interval_secs`.
     #[serde(default = "default_vault_check_tick_interval_secs")]
     pub vault_check_tick_interval_secs: u64,
+    /// Phase 1b Task 15: cadence (seconds) for Timer D (Monad settlement
+    /// fan-out, `settlement::settlement_tick`). Default 30. Tunable via
+    /// `set_settlement_tick_interval_secs`. The register fn floors a 0 to 30
+    /// so a missing serde-default or bad setter value never busy-loops.
+    #[serde(default = "default_settlement_tick_interval_secs")]
+    pub settlement_tick_interval_secs: u64,
+    /// Phase 1b Task 15: cadence (seconds) for the Monad inbound observer
+    /// fan-out (`deposit_watch::observer_tick`). Default 30. Tunable via
+    /// `set_observer_tick_interval_secs`. Same 0-floor protection as above.
+    #[serde(default = "default_observer_tick_interval_secs")]
+    pub observer_tick_interval_secs: u64,
     pub fee: Ratio,
     pub developer_principal: Principal,
     pub next_available_vault_id: u64,
@@ -1355,6 +1373,8 @@ impl Default for State {
             xrc_fetch_interval_secs: default_xrc_fetch_interval_secs(),
             interest_treasury_tick_interval_secs: default_interest_treasury_tick_interval_secs(),
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
+            settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
+            observer_tick_interval_secs: default_observer_tick_interval_secs(),
             fee: Ratio::from(Decimal::ZERO),
             developer_principal: Principal::anonymous(),
             next_available_vault_id: 1,
@@ -1495,6 +1515,8 @@ impl From<InitArg> for State {
             xrc_fetch_interval_secs: default_xrc_fetch_interval_secs(),
             interest_treasury_tick_interval_secs: default_interest_treasury_tick_interval_secs(),
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
+            settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
+            observer_tick_interval_secs: default_observer_tick_interval_secs(),
             total_collateral_ratio: Ratio::from(Decimal::MAX),
             last_icp_timestamp: None,
             last_icp_rate: None,

--- a/src/rumi_protocol_backend/src/tests.rs
+++ b/src/rumi_protocol_backend/src/tests.rs
@@ -179,3 +179,47 @@ fn supply_audit_round_trips_via_candid() {
     assert_eq!(back.total_e8s, 150_000);
     assert_eq!(back.per_chain.len(), 2);
 }
+
+#[test]
+fn monad_event_variants_round_trip_via_candid() {
+    use candid::{Decode, Encode};
+    use crate::event::Event;
+    use crate::chains::config::ChainId;
+
+    let events = vec![
+        Event::DepositObserved {
+            chain_id: ChainId(10143), vault_id: 1,
+            custody_address: "0xa".into(), amount_e18: 5, tx_hash: "0xh".into(),
+            block_number: 100, timestamp: 1,
+        },
+        Event::ChainMintSubmitted {
+            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
+            recipient: "0xr".into(), amount_e8s: 10, tx_hash: "0xs".into(), timestamp: 2,
+        },
+        Event::ChainMintConfirmed {
+            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
+            amount_e8s: 10, tx_hash: "0xs".into(), block_number: 102, timestamp: 3,
+        },
+        Event::ChainBurnObserved {
+            chain_id: ChainId(10143), vault_id: 1,
+            amount_e8s: 4, tx_hash: "0xb".into(), block_number: 110, timestamp: 4,
+        },
+        Event::WithdrawalSigned {
+            chain_id: ChainId(10143), vault_id: 1, op_id: 1,
+            recipient: "0xw".into(), amount_e18: 5, tx_hash: "0xt".into(), timestamp: 5,
+        },
+        Event::ChainSettlementFailed {
+            chain_id: ChainId(10143), op_id: 1, reason: "reverted".into(), timestamp: 6,
+        },
+        Event::ChainReorgDetected {
+            chain_id: ChainId(10143), observed_block: 100, reorg_depth: 5, timestamp: 7,
+        },
+        Event::ChainHotWalletLow {
+            chain_id: ChainId(10143), balance_e18: 1, threshold_e18: 100, timestamp: 8,
+        },
+    ];
+    for e in events {
+        let bytes = Encode!(&e).expect("encode");
+        let _: Event = Decode!(&bytes, Event).expect("decode");
+    }
+}

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -347,26 +347,32 @@ pub async fn interest_and_treasury_tick() {
     crate::treasury::flush_pending_interest().await;
     crate::treasury::flush_pending_amm1_donations().await;
 
-    // Phase 1a: supply-invariant self-check. Runs on every Timer B tick
-    // (default cadence 60s) per spec Section 3. On drift, halt new
-    // debt issuance + supply mutations and flip the protocol into
-    // ReadOnly. Manual recovery requires `clear_invariant_halt` (lands
-    // in Phase 1b operational tooling) plus a developer-gated mode flip.
+    // Phase 1b foreign-chain-only supply-invariant self-check. Runs on every
+    // Timer B tick (default cadence 60s) per spec Section 3. On drift, halt
+    // new debt issuance + supply mutations and flip the protocol into
+    // ReadOnly. Manual recovery requires `clear_invariant_halt` (Phase 1b
+    // operational tooling) plus a developer-gated mode flip.
     //
-    // In Phase 1a the chain_supplies table is empty and total_debt_e8s
-    // represents only ICP-side icUSD, so sum(chain_supplies) == 0 and
-    // the check always passes UNLESS a future bug somewhere increments
-    // chain_supplies without going through `apply_supply_delta`. That
-    // is the failure mode this check is designed to surface.
-    let total_debt_e8s: u128 = read_state(|s| s.total_borrowed_icusd_amount().to_u64() as u128);
+    // The invariant is: sum(chain_supplies) == sum(chain_vault.debt_e8s).
+    // ICP-native debt (total_borrowed_icusd_amount, which sums only
+    // vault_id_to_vaults) is a SEPARATE pool and must NOT be part of this
+    // check — unification to a single global total is a Phase 2 task.
+    // Using total_borrowed_icusd_amount here would cause a false halt on the
+    // very first Monad mint (chain_supplies[Monad] > 0, ICP-side debt == 0
+    // on the staging canister → divergence detected → protocol halts).
+    //
+    // In Phase 1a chain_supplies is empty and total_chain_vault_debt_e8s is
+    // also 0, so the check always passes. The invariant becomes live once
+    // Phase 1b ships the first confirmed Monad mint.
+    let chain_debt_e8s: u128 = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
     let check_outcome = read_state(|s| {
-        crate::chains::supply::check_invariant(&s.multi_chain, total_debt_e8s)
+        crate::chains::supply::check_invariant(&s.multi_chain, chain_debt_e8s)
     });
     if let Err(err) = check_outcome {
         let now = ic_cdk::api::time();
         let (sum, td) = match err {
             crate::chains::supply::SupplyInvariantError::Divergence { sum_after, total_debt } => (sum_after, total_debt),
-            _ => (0u128, total_debt_e8s),
+            _ => (0u128, chain_debt_e8s),
         };
         mutate_state(|s| {
             s.multi_chain.invariant_halted = true;

--- a/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
+++ b/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
@@ -209,12 +209,22 @@ proptest! {
                         format!("0x{next_vault_id}"),
                         collateral,
                         amt,
-                        "0xr".to_string(),
+                        // Valid EVM address (0x + 40 hex). The open path now
+                        // rejects a malformed mint_recipient; a bad value here
+                        // would make every open fail and the invariant pass
+                        // VACUOUSLY (no vaults ever opened). The prop_assert
+                        // below locks in that opens actually succeed.
+                        "0x000000000000000000000000000000000000c0de".to_string(),
                         0,
                         0,
                         next_vault_id,
                     )
                     .is_ok();
+                    // This open is constructed to always succeed (registered
+                    // chain, price set, huge collateral, min_cr 0, non-zero debt,
+                    // valid recipient). If it ever fails the supply invariant
+                    // would hold vacuously — fail loudly instead.
+                    prop_assert!(opened, "OpenAndConfirm must succeed; open returned Err");
                     if opened {
                         // PRE-mint total is the current total_debt; the helper
                         // adds `amt` internally to derive the post-mint total.

--- a/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
+++ b/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
@@ -10,8 +10,12 @@
 use rumi_protocol_backend::chains::config::{
     ChainConfigV1, ChainId, ChainStatus, GasStrategy,
 };
-use rumi_protocol_backend::chains::multi_chain_state::MultiChainStateV1;
+use rumi_protocol_backend::chains::multi_chain_state::MultiChainStateV2;
 use rumi_protocol_backend::chains::supply::{apply_supply_delta, SupplyDelta};
+use rumi_protocol_backend::chains::monad::chain_vault::open_chain_vault_in_state;
+use rumi_protocol_backend::chains::monad::settlement::confirm_mint_in_state;
+use rumi_protocol_backend::chains::monad::deposit_watch::apply_burn_to_state;
+use rumi_protocol_backend::chains::monad::evm_rpc::BurnLog;
 use proptest::prelude::*;
 
 #[derive(Clone, Debug)]
@@ -34,8 +38,8 @@ fn arb_op() -> impl Strategy<Value = Op> {
     ]
 }
 
-fn seeded_state() -> MultiChainStateV1 {
-    let mut state = MultiChainStateV1::default();
+fn seeded_state() -> MultiChainStateV2 {
+    let mut state = MultiChainStateV2::default();
     for id in 1u32..=5u32 {
         state.chain_configs.insert(
             ChainId(id),
@@ -121,6 +125,137 @@ proptest! {
             }
 
             // Invariant after every op:
+            let sum: u128 = state.chain_supplies.values().copied().sum();
+            prop_assert_eq!(sum, total_debt);
+        }
+    }
+}
+
+// ─── Real-flow proptest ────────────────────────────────────────────────────
+//
+// The Phase 1a proptest above drives `apply_supply_delta` directly. This second
+// proptest drives the REAL chain-vault + settlement helpers, proving the supply
+// invariant survives the full open -> confirm -> burn lifecycle backed by the
+// `chain_vaults` + `settlement_queues` state (not a synthetic supply delta).
+//
+// Supply-relevant transitions:
+//   - open    (`open_chain_vault_in_state`): NO supply change — the vault is
+//     created `AwaitingDeposit` with `debt_e8s = 0`, `pending_mint_e8s = amount`,
+//     and enqueues nothing (open-then-verify, Design B).
+//   - confirm (`confirm_mint_in_state`): `debt_e8s += amount`, supply += amount.
+//   - burn    (`apply_burn_to_state`):     `debt_e8s -= amount`, supply -= amount.
+//
+// CRITICAL — pre-operation-total convention: `confirm_mint_in_state` and
+// `apply_burn_to_state` BOTH take the PRE-operation total chain-vault debt and
+// compute the post-total INTERNALLY (`pre + observed` / `pre - amount`). So we
+// pass the CURRENT `total_debt` (the pre-op value) and only update our local
+// `total_debt` tracker AFTER a successful call. Passing `total_debt ± amount`
+// would double-count and the internal invariant check would reject the op.
+//
+// `confirm_mint_in_state` only checks `pending_mint_e8s == observed_e8s` (not the
+// status), so calling it directly after open works here — the intermediate
+// MintPending flip / deposit-verify step is orthogonal to supply and is covered
+// by the unit + happy-path tests. The flow is therefore open -> confirm ->
+// (later) burn directly.
+
+#[derive(Clone, Debug)]
+enum RealOp {
+    OpenAndConfirm { chain: u32, amount: u64 },
+    BurnPartial { vault_id: u64, frac_pct: u8 },
+}
+
+fn arb_real_op() -> impl Strategy<Value = RealOp> {
+    prop_oneof![
+        (1u32..=5u32, 1u64..=1_000_000u64)
+            .prop_map(|(c, a)| RealOp::OpenAndConfirm { chain: c, amount: a }),
+        (0u64..50, 0u8..=100u8).prop_map(|(v, f)| RealOp::BurnPartial { vault_id: v, frac_pct: f }),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn invariant_holds_across_open_confirm_burn(
+        ops in proptest::collection::vec(arb_real_op(), 0..30)
+    ) {
+        // V2 seeded state: chains 1..=5 registered, chain_supplies 0. The
+        // open/confirm/burn helpers additionally need a settlement queue and a
+        // MON price per chain, so extend the seed here.
+        let mut state = seeded_state();
+        for id in 1u32..=5u32 {
+            let cid = ChainId(id);
+            state.settlement_queues.entry(cid).or_default();
+            // $100/MON (USD e8). Combined with the huge declared collateral
+            // below this keeps the CR effectively unbounded.
+            state.manual_prices.insert((cid, "MON".to_string()), 100_0000_0000);
+        }
+
+        let mut total_debt: u128 = 0;
+        let mut next_vault_id: u64 = 0;
+        let mut open_vaults: Vec<u64> = vec![];
+
+        for op in ops {
+            match op {
+                RealOp::OpenAndConfirm { chain, amount } => {
+                    next_vault_id += 1;
+                    let cid = ChainId(chain);
+                    // Huge declared collateral + min_cr_e4 = 0 so the CR never
+                    // binds — this test isolates the SUPPLY invariant, not CR.
+                    let collateral = 1_000_000_000_000_000_000_000_000u128;
+                    let amt = amount as u128;
+                    let opened = open_chain_vault_in_state(
+                        &mut state,
+                        cid,
+                        candid::Principal::anonymous(),
+                        format!("0x{next_vault_id}"),
+                        collateral,
+                        amt,
+                        "0xr".to_string(),
+                        0,
+                        0,
+                        next_vault_id,
+                    )
+                    .is_ok();
+                    if opened {
+                        // PRE-mint total is the current total_debt; the helper
+                        // adds `amt` internally to derive the post-mint total.
+                        if confirm_mint_in_state(&mut state, cid, next_vault_id, amt, total_debt)
+                            .is_ok()
+                        {
+                            total_debt += amt;
+                            open_vaults.push(next_vault_id);
+                        }
+                    }
+                }
+                RealOp::BurnPartial { vault_id, frac_pct } => {
+                    if open_vaults.is_empty() {
+                        continue;
+                    }
+                    let vid = open_vaults[(vault_id as usize) % open_vaults.len()];
+                    let debt = state.chain_vaults[&vid].debt_e8s;
+                    if debt == 0 {
+                        continue;
+                    }
+                    let amount = (debt * (frac_pct.min(100) as u128)) / 100;
+                    if amount == 0 {
+                        continue;
+                    }
+                    // PRE-burn total is the current total_debt; the helper
+                    // subtracts `amount` internally to derive the post-burn total.
+                    let burn = BurnLog {
+                        vault_id: vid,
+                        amount_e8s: amount,
+                        tx_hash: "0xb".to_string(),
+                        block_number: 1,
+                    };
+                    if apply_burn_to_state(&mut state, &burn, total_debt).is_ok() {
+                        total_debt -= amount;
+                    }
+                }
+            }
+
+            // Invariant after every op: sum(chain_supplies) == total chain-vault
+            // debt. A failure here is a REAL supply-invariant bug, not a test
+            // artifact — do not weaken this assertion.
             let sum: u128 = state.chain_supplies.values().copied().sum();
             prop_assert_eq!(sum, total_debt);
         }

--- a/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
@@ -336,6 +336,31 @@ fn push_burn_log(
     );
 }
 
+/// Push a Burn log with an explicit log_index (for the same-tx-different-log-index test).
+fn push_burn_log_at(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+    log_index: u64,
+) {
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log_at",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block, &log_index).unwrap(),
+    );
+}
+
 // ─── The test ────────────────────────────────────────────────────────────────
 
 #[test]
@@ -580,4 +605,221 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
     );
 
     eprintln!("[phase1b burn-idempotency] FULL C-1 guard PASSED: good burn applied once (debt 60e8), poison skipped, cursor advanced, supply == on-chain truth 60e8");
+}
+
+// ─── Review Minor #1: same-tx different-log-index dedup ──────────────────────
+//
+// Two Burn logs in the SAME transaction (same tx_hash) for the SAME vault and
+// SAME amount are TWO DISTINCT on-chain burns. The canonical on-chain identity
+// of a log is (tx_hash, log_index) — not (tx_hash, vault_id, amount). The old
+// C-1 key `format!("{tx_hash}:{vault_id}:{amount_e8s}")` collapses them into
+// one dedup entry, so the second real burn is silently dropped (vault's debt
+// and chain supply are over-stated; the user loses credit).
+//
+// This test asserts BOTH burns applied → debt == 100e8 − 60e8 = 40e8, not 70e8
+// (what the old single-key dedup would give by dropping the second 30e8 burn).
+//
+// IcUSD.burn() is permissionless; a wrapper contract CAN emit two identical
+// Burn events in one tx. The fix uses `format!("{tx_hash}:{log_index}")` as the
+// dedup key — the canonical EVM log identity.
+#[test]
+fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
+    let (pic, backend, mock) = boot();
+
+    // Point the backend at the mock.
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    // Register Monad.
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(
+                &ChainId(MONAD_CHAIN_ID),
+                &"0x00000000000000000000000000000000deadbeef".to_string()
+            )
+            .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // Seed the cursor well above 256 so scan windows stay in a clean range.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &2_000_000u64).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+
+    update_any(&pic, mock, "set_blocks", Encode!(&2_000_256u64, &2_000_256u64).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint_same_tx".to_string()).unwrap());
+
+    // ── ECDSA probe ──────────────────────────────────────────────────────────
+    let settlement_addr = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    };
+
+    let settlement_addr = match settlement_addr {
+        Some(addr) => {
+            eprintln!("[phase1b same-tx-burns] ECDSA AVAILABLE; addr={addr}; running full test");
+            addr
+        }
+        None => {
+            eprintln!("[phase1b same-tx-burns] ECDSA UNAVAILABLE; skipping (needs Open vault with debt)");
+            return;
+        }
+    };
+
+    // Fund hot wallet.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+    );
+
+    // ── Open a vault with debt = 100e8 ───────────────────────────────────────
+    let collateral_e18 = 100u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000abcd".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(MONAD_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+    let custody = v.custody_address.clone();
+
+    // Deposit confirmed; observer flips to MintPending + enqueues mint.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(&pic, 2);
+
+    // Settlement submits + confirms the mint.
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint_same_tx", 2_000_256);
+    advance_and_tick(&pic, 4);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+    assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+    assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "debt == 100e8 after mint");
+
+    // ── Same-tx two-identical-burns scenario ─────────────────────────────────
+    // Advance the mock chain head into the next scan window.
+    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+    update_any(&pic, mock, "set_blocks", Encode!(&2_000_512u64, &2_000_512u64).unwrap());
+
+    // Push TWO Burn logs with:
+    //   - SAME tx_hash ("0xdualtx")
+    //   - SAME vault_id
+    //   - SAME amount_e8s (30e8 each)
+    //   - DIFFERENT log_index (0 vs 1)
+    // These are two distinct on-chain burns: vault burns 30e8 twice = 60e8 total.
+    // Expected: debt == 100e8 - 60e8 = 40e8.
+    // With the OLD key (tx:vault:amount): both map to the same key → second dropped → debt=70e8.
+    // With the NEW key (tx:log_index): distinct keys → both applied → debt=40e8.
+    push_burn_log_at(
+        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_000_300, 0,
+    );
+    push_burn_log_at(
+        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_000_300, 1,
+    );
+
+    // Multiple ticks to ensure re-scans don't double-apply anything.
+    advance_and_tick(&pic, 6);
+
+    // Both burns must have applied: debt == 40e8.
+    let v = get_vault(&pic, backend, vault_id).expect("vault after dual-burn");
+    assert_eq!(
+        v.debt_e8s,
+        candid::Nat::from(40 * E8),
+        "Minor #1: both same-tx burns applied → debt 40e8 (not 70e8 from dropped second burn)"
+    );
+    assert_eq!(v.status, ChainVaultStatus::Open, "vault stays Open after partial burns");
+
+    // Cursor must have advanced.
+    assert!(
+        cursor(&pic, backend) >= 2_000_512,
+        "cursor advanced past dual-burn block; got {}",
+        cursor(&pic, backend)
+    );
+
+    // Supply must match on-chain truth: 100e8 - 60e8 = 40e8.
+    let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(
+        global,
+        candid::Nat::from(40 * E8),
+        "Minor #1: global supply == 40e8 (both burns credited)"
+    );
+    let audit: SupplyAuditWire = query_unit(&pic, backend, "get_supply_audit");
+    assert_eq!(
+        audit.total_e8s,
+        v.debt_e8s,
+        "Minor #1: chain supply == vault debt == 40e8"
+    );
+
+    eprintln!("[phase1b same-tx-burns] PASSED: both same-tx burns applied → debt 40e8, supply 40e8, cursor advanced");
 }

--- a/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
@@ -1,0 +1,583 @@
+//! Phase 1b — C-1 regression: idempotent burn application + skip-poison-and-continue.
+//!
+//! ## The bug this guards (C-1, supply-divergence)
+//!
+//! The burn-watch loop in `chains/monad/deposit_watch.rs::run_observer` used to
+//! `break` on the FIRST `apply_burn_to_state` failure and advance the cursor only
+//! when EVERY burn in the range applied. A single PERMANENT-INVALID burn — a
+//! permissionless `Burn(vault_id)` over-repaying a vault's remaining debt, or
+//! citing a closed vault (both PUBLIC per IcUSD.sol) — would then STALL the cursor
+//! and force the WHOLE range to re-scan every tick. Because `apply_burn_to_state`
+//! had NO idempotency, any already-applied PARTIAL burn in that range got applied
+//! AGAIN on the re-scan: `debt_e8s` and `chain_supplies` BOTH decremented a second
+//! time. Since they move together the Timer-B self-check (which compares
+//! `sum(chain_supplies)` to `total_chain_vault_debt`) stayed satisfied and NEVER
+//! fired — tracked supply silently diverged from on-chain truth.
+//!
+//! ## What this test proves
+//!
+//! Drive a vault to Open with debt=100e8 (supply=100e8) through the full
+//! open → deposit → mint path (same harness as the happy-path test). Then push
+//! TWO burn logs at the SAME finalized block into the burn-watch range:
+//!   - a GOOD partial burn (40e8) — valid, should apply EXACTLY once → debt 60e8
+//!   - a POISON burn (1_000e8 ≫ remaining debt) — `apply_burn_to_state` rejects it
+//!     as InvalidBurn (over-repay) on EVERY tick.
+//! Then advance SEVERAL observer ticks (so the range is re-scanned multiple times).
+//!
+//! Assertions (all would FAIL on the pre-fix code):
+//!   (a) the good burn's debt decrement happened EXACTLY ONCE — debt == 60e8
+//!       (pre-fix: re-scan re-applies the 40e8 burn → 20e8, then underflow-rejects
+//!        further, but supply also double-decrements → silent divergence).
+//!   (b) the burn-watch cursor ADVANCED past the poison block (it no longer stalls).
+//!   (c) `get_global_icusd_supply == sum(vault debt) == 60e8` — supply matches
+//!       on-chain truth (100e8 minted − 40e8 burned), not a doubly-decremented value.
+//!
+//! ## ECDSA gating (same auto-upgrade pattern as the happy-path test)
+//!
+//! The full path needs threshold-ECDSA (open/mint/settlement). When PocketIC
+//! cannot provision `test_key_1`, the C-1 reproduction cannot be set up (no Open
+//! vault with debt), so the test runs a GATED subset that still asserts the supply
+//! invariant holds at 0 and the burn-watch cursor advances past a poison-only range
+//! (which needs no signing). The gated subset AUTO-UPGRADES to the full C-1 guard
+//! on an ECDSA-capable PocketIC.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+/// Read the burn-watch cursor for the Monad chain via `get_last_observed_block`.
+fn cursor(pic: &PocketIc, backend: Principal) -> u64 {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_last_observed_block query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, u64).expect("decode get_last_observed_block"),
+        WasmResult::Reject(msg) => panic!("get_last_observed_block rejected: {}", msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {}", msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data ─────────────────────────
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn word_addr(addr: &str) -> String {
+    let raw = addr
+        .strip_prefix("0x")
+        .or_else(|| addr.strip_prefix("0X"))
+        .unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+fn push_burn_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
+    let (pic, backend, mock) = boot();
+
+    // Point the backend's Monad wrapper at the mock.
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    // Register Monad + contract + manual MON price.
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(
+                &ChainId(MONAD_CHAIN_ID),
+                &"0x00000000000000000000000000000000deadbeef".to_string()
+            )
+            .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // Seed the burn-watch cursor well above 256 so the small legacy block numbers
+    // never apply; one tick advances the cursor by MAX_BLOCK_SCAN_WINDOW (256).
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &1_000_000u64).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+
+    // Chain head = seed + 256 so the first tick advances 1_000_000 -> 1_000_256.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_000_256u64, &1_000_256u64).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
+
+    // ── ECDSA probe: decide full vs gated ────────────────────────────────────
+    let settlement_addr = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            Ok(Err(e)) => {
+                eprintln!("[phase1b burn-idempotency] ECDSA UNAVAILABLE (Err: {e:?}); running GATED subset");
+                None
+            }
+            Err(decode_err) => {
+                eprintln!("[phase1b burn-idempotency] get_chain_settlement_address decode error ({decode_err}); running GATED subset");
+                None
+            }
+        },
+        WasmResult::Reject(msg) => {
+            eprintln!("[phase1b burn-idempotency] ECDSA UNAVAILABLE (rejected: {msg}); running GATED subset");
+            None
+        }
+    };
+
+    let settlement_addr = match settlement_addr {
+        Some(addr) => {
+            eprintln!("[phase1b burn-idempotency] ECDSA AVAILABLE; settlement address = {addr}; running FULL C-1 guard");
+            addr
+        }
+        None => {
+            // GATED SUBSET: cannot mint without ECDSA, so we cannot stand up an Open
+            // vault with debt. Instead prove the cursor advances past a POISON-only
+            // burn range (the core skip-poison-and-continue guarantee, which needs
+            // no signing). The poison cites a non-existent vault → InvalidBurn on
+            // every tick; pre-fix this stalled the cursor forever.
+            push_burn_log(&pic, mock, 4242, "0xdeadbeef", 1_000e8 as u128, "0xpoison", 1_000_100);
+            advance_and_tick(&pic, 4);
+
+            assert!(
+                cursor(&pic, backend) >= 1_000_256,
+                "gated: cursor advanced past poison-only range (skip-poison-and-continue); got {}",
+                cursor(&pic, backend)
+            );
+            // Supply invariant holds at 0 (nothing minted).
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(0u32), "gated: supply invariant holds at 0");
+            eprintln!("[phase1b burn-idempotency] GATED subset PASSED: cursor advanced past poison-only range");
+            return;
+        }
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // FULL C-1 GUARD (ECDSA available)
+    // ════════════════════════════════════════════════════════════════════════
+
+    // Fund the settlement (hot-wallet) address so the submit-path gas gate passes.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+    );
+
+    // ── Stand up an Open vault with debt=100e8, supply=100e8 ─────────────────
+    // 100 MON @ $2 = $200 backing 100 icUSD => 200% CR.
+    let collateral_e18 = 100u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(MONAD_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+    let custody = v.custody_address.clone();
+
+    // Deposit lands; observer flips to MintPending + enqueues mint.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(&pic, 2);
+
+    // Settlement submits + confirms the mint. Push the Mint log at the finalized
+    // block so the confirm path reads the on-chain amount.
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_000_256);
+    advance_and_tick(&pic, 4);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+    assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+    assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "mint confirmed => debt 100e8");
+    let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(global, candid::Nat::from(100 * E8), "supply 100e8 after mint");
+
+    // ── Set up the C-1 scenario ──────────────────────────────────────────────
+    // Clear the Mint log (production topic-filters it out of the burn scan; we
+    // model that exclusion). Then push TWO burns at the SAME finalized block:
+    //   1. GOOD partial burn 40e8 (valid)
+    //   2. POISON burn 1_000e8 (over-repay: ≫ remaining 60e8) — InvalidBurn forever
+    // Both land in the (1_000_256, 1_000_512] scan window. The poison sits AFTER
+    // the good burn in block/log order, so the pre-fix loop applies the good burn,
+    // then hits the poison, sets burn_ok=false, and breaks WITHOUT advancing the
+    // cursor — forcing the whole range to re-scan every tick and re-apply the 40e8.
+    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+    update_any(&pic, mock, "set_blocks", Encode!(&1_000_512u64, &1_000_512u64).unwrap());
+    // Same block (1_000_300) for both; the good burn first, poison second.
+    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xgoodburn", 1_000_300);
+    push_burn_log(&pic, mock, vault_id, "0xattacker", 1_000 * E8, "0xpoisonburn", 1_000_300);
+
+    // Advance SEVERAL ticks so the range is (re-)scanned multiple times. On the
+    // PRE-FIX code, each re-scan re-applies the 40e8 good burn and double-decrements
+    // supply; on the FIXED code, the good burn is deduped (applied exactly once) and
+    // the poison is skip-logged so the cursor advances past it.
+    advance_and_tick(&pic, 6);
+
+    // (a) The good burn's debt decrement happened EXACTLY ONCE: debt == 60e8.
+    let v = get_vault(&pic, backend, vault_id).expect("vault after burn scenario");
+    assert_eq!(
+        v.debt_e8s,
+        candid::Nat::from(60 * E8),
+        "C-1: good 40e8 burn applied EXACTLY once => debt 60e8 (not double-applied)"
+    );
+    assert_eq!(v.status, ChainVaultStatus::Open, "partial burn keeps vault Open");
+
+    // (b) The burn-watch cursor ADVANCED past the poison block (no longer stalls).
+    assert!(
+        cursor(&pic, backend) >= 1_000_512,
+        "C-1: cursor advanced past the poison burn (skip-poison-and-continue); got {}",
+        cursor(&pic, backend)
+    );
+
+    // (c) Supply matches on-chain truth: 100e8 minted − 40e8 burned = 60e8, AND
+    //     equals sum(vault debt). This is the invariant the silent double-apply
+    //     used to violate while keeping supply==debt (both decremented twice).
+    let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(
+        global,
+        candid::Nat::from(60 * E8),
+        "C-1: global supply == on-chain truth 60e8 (no silent double-decrement)"
+    );
+    let audit: SupplyAuditWire = query_unit(&pic, backend, "get_supply_audit");
+    assert_eq!(
+        audit.total_e8s,
+        candid::Nat::from(60 * E8),
+        "C-1: supply audit total == 60e8"
+    );
+    // And supply == sum(vault debt) (the audit total is the chain supply; the vault
+    // debt is read above as 60e8 — they agree, both at on-chain truth).
+    assert_eq!(
+        audit.total_e8s,
+        v.debt_e8s,
+        "C-1: chain supply == vault debt (== 60e8, on-chain truth)"
+    );
+
+    eprintln!("[phase1b burn-idempotency] FULL C-1 guard PASSED: good burn applied once (debt 60e8), poison skipped, cursor advanced, supply == on-chain truth 60e8");
+}

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -543,13 +543,11 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 100 * E8, "after mint confirm (Open)");
 
     // ── Step 7: burn 40e8 on chain; observer decrements debt + supply ────────
-    // First clear the stale Mint log: the mock's eth_getLogs does NOT filter by
-    // topic (the real RPC does), so the observer's BURN scan would otherwise
-    // re-read the Mint log, fail `decode_burn_log` (wrong topic0), and stall the
-    // cursor. On real Monad the topic filter excludes it. Clearing it here models
-    // that exclusion. (The mint was already confirmed via the settlement worker's
-    // own topic-filtered scan in Step 6, so the log is no longer needed.)
-    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+    // No `clear_logs` workaround needed: the mock now topic-filters eth_getLogs
+    // (M-3 fidelity), so the observer's BURN scan (topic0 = BURN_EVENT_TOPIC0)
+    // naturally excludes the still-present Mint log — exactly as the real Monad
+    // RPC does. (The mint was confirmed via the settlement worker's own
+    // topic-filtered Mint scan in Step 6.)
     // Advance the chain head another 256 so the cursor climbs 1_000_000 ->
     // 1_000_256 -> 1_000_512 over the next ticks; the burn at 1_000_300 lands in
     // the (1_000_256, 1_000_512] scan window and is observed.

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -377,13 +377,35 @@ fn phase1b_monad_happy_path_supply_invariant() {
     )
     .expect("set_manual_collateral_price");
 
+    // ── Seed the burn-watch cursor (Gate-3 activation) ───────────────────────
+    // After A2a, the observer reads chain head by probing the SPECIFIC block
+    // `last_observed + MAX_BLOCK_SCAN_WINDOW` (=256) via the typed
+    // eth_getBlockByNumber, so the cursor advances by exactly 256 blocks per tick
+    // whenever `last_observed + 256 <= finalized`. The cursor must be seeded
+    // (non-zero) for burn-watch to run at all. Seed it to a tip well above 256 so
+    // the small legacy block numbers (100/101/102) no longer apply. This runs in
+    // BOTH the full and gated subsets (it only writes the map; harmless when
+    // gated). Seed AFTER register_chain so the chain config exists.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &1_000_000u64).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+
     // Invariant holds at zero after register/config (Design B: nothing minted).
     assert_supply(&pic, backend, 0, "after register/config");
 
     // ── Step 3: script the mock's chain head ─────────────────────────────────
-    // latest = finalized = 100 (single-slot finality; the wrapper uses the
-    // finalized-block number directly).
-    update_any(&pic, mock, "set_blocks", Encode!(&100u64, &100u64).unwrap());
+    // finalized = seed + 256 = 1_000_256, so the FIRST observer tick advances the
+    // burn-watch cursor 1_000_000 -> 1_000_256 (the probe of block 1_000_256
+    // succeeds because 1_000_256 <= finalized). The mint auto-mines its receipt at
+    // `finalized_block` = 1_000_256.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_000_256u64, &1_000_256u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
 
     // ── ECDSA probe: decide full vs gated ────────────────────────────────────
@@ -501,9 +523,9 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 0, "after deposit-verify (MintPending)");
 
     // ── Step 6: settlement submits the mint (mock auto-mines 0xmint1 at
-    //           finalized=100 on send), then confirms it. Push the Mint log at
-    //           block 100 so the confirm path reads the on-chain amount. ───────
-    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 100);
+    //           finalized=1_000_256 on send), then confirms it. Push the Mint log
+    //           at block 1_000_256 so the confirm path reads the on-chain amount.
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_000_256);
 
     // Several windows: window 1 submits (Queued -> Inflight), window 2+ confirms
     // (receipt mined + final, Mint log read, confirm_mint_in_state).
@@ -521,10 +543,19 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 100 * E8, "after mint confirm (Open)");
 
     // ── Step 7: burn 40e8 on chain; observer decrements debt + supply ────────
-    // Advance the chain head so the new burn log sits in an unobserved block.
-    update_any(&pic, mock, "set_blocks", Encode!(&101u64, &101u64).unwrap());
-    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xburn1", 101);
-    advance_and_tick(&pic, 2);
+    // First clear the stale Mint log: the mock's eth_getLogs does NOT filter by
+    // topic (the real RPC does), so the observer's BURN scan would otherwise
+    // re-read the Mint log, fail `decode_burn_log` (wrong topic0), and stall the
+    // cursor. On real Monad the topic filter excludes it. Clearing it here models
+    // that exclusion. (The mint was already confirmed via the settlement worker's
+    // own topic-filtered scan in Step 6, so the log is no longer needed.)
+    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+    // Advance the chain head another 256 so the cursor climbs 1_000_000 ->
+    // 1_000_256 -> 1_000_512 over the next ticks; the burn at 1_000_300 lands in
+    // the (1_000_256, 1_000_512] scan window and is observed.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_000_512u64, &1_000_512u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xburn1", 1_000_300);
+    advance_and_tick(&pic, 3);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after burn 40");
     assert_eq!(v.debt_e8s, candid::Nat::from(60 * E8), "after burn40 => debt 60e8");
@@ -532,8 +563,10 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 60 * E8, "after burn 40e8");
 
     // ── Step 8: burn the remaining 60e8; debt + supply go to 0 ───────────────
-    update_any(&pic, mock, "set_blocks", Encode!(&102u64, &102u64).unwrap());
-    push_burn_log(&pic, mock, vault_id, &recipient, 60 * E8, "0xburn2", 102);
+    // Advance head another 256: cursor 1_000_512 -> 1_000_768; burn at 1_000_600
+    // is within (1_000_512, 1_000_768].
+    update_any(&pic, mock, "set_blocks", Encode!(&1_000_768u64, &1_000_768u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 60 * E8, "0xburn2", 1_000_600);
     advance_and_tick(&pic, 2);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after burn 60");
@@ -560,8 +593,9 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_eq!(v.status, ChainVaultStatus::Closing, "withdraw all => Closing");
     assert_supply(&pic, backend, 0, "after withdraw enqueue (Closing)");
 
-    // Settlement submits 0xwd1 (auto-mined at finalized=102) then confirms it,
-    // flipping Closing -> Closed.
+    // Settlement submits 0xwd1 (auto-mined at finalized=1_000_768) then confirms
+    // it, flipping Closing -> Closed. The burn-watch cursor is already at
+    // 1_000_768, so the receipt is immediately final.
     advance_and_tick(&pic, 4);
     let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw confirm");
     assert_eq!(v.status, ChainVaultStatus::Closed, "withdraw confirmed => Closed");

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -1,0 +1,647 @@
+//! Phase 1b Task 17: end-to-end happy-path integration test against a scripted
+//! mock EVM RPC canister.
+//!
+//! This is the FIRST test that drives the full chain-agnostic backend path
+//! end-to-end through the (mocked) EVM RPC `request` escape-hatch and asserts the
+//! GLOBAL SUPPLY INVARIANT at every step. The flow is OPEN-THEN-VERIFY (owner
+//! decision — see chains/monad/chain_vault.rs):
+//!
+//!   register/config (chain, contract, manual MON price, evm_rpc principal)
+//!     -> open_chain_vault            => vault AwaitingDeposit, supply 0 (no mint)
+//!     -> deposit lands on custody    => observer flips MintPending + enqueues mint
+//!     -> settlement submits mint     => tx broadcast (mock auto-mines at finalized)
+//!     -> settlement confirms mint    => vault Open, debt 100e8, supply 100e8
+//!     -> burn 40e8 on chain          => observer: debt 60e8, supply 60e8
+//!     -> burn 60e8 on chain          => observer: debt 0,     supply 0
+//!     -> withdraw_chain_collateral   => vault Closing -> (confirm) Closed, supply 0
+//!
+//! At each labeled step the test asserts
+//!   get_global_icusd_supply() == sum(vault.debt_e8s) == expected
+//! and get_supply_audit() agrees. The supply invariant is the POINT of this test.
+//!
+//! ## tECDSA-in-PocketIC: full vs gated
+//!
+//! `open_chain_vault`, `get_chain_settlement_address`, and the settlement worker
+//! call the management-canister threshold-ECDSA API (`ecdsa_public_key` /
+//! `sign_with_ecdsa`) with key name `test_key_1`. PocketIC provisions threshold
+//! ECDSA keys ONLY when the instance has an II subnet, and only the server
+//! supports the specific key. We boot with `PocketIcBuilder::new()
+//! .with_ii_subnet().with_application_subnet()` and install the backend on the
+//! application subnet so it can route ECDSA requests to the II subnet.
+//!
+//! At runtime the test probes ECDSA via `get_chain_settlement_address`:
+//!   - if it returns Ok(addr): the FULL happy path runs (steps 4-10), exercising
+//!     open/deposit/mint/burn/withdraw end-to-end with the supply invariant.
+//!   - if it returns Err (ECDSA unavailable/flaky in this PocketIC build): the
+//!     test runs the GATED subset — register/config succeed and the supply
+//!     invariant is asserted to hold at 0 — and the ECDSA-dependent assertions
+//!     are skipped with a clear logged boundary. The pure state transitions are
+//!     already unit-tested (chains/monad/tests_*); this test's value is the
+//!     end-to-end wiring + the supply invariant THROUGH the mock, so the gated
+//!     subset still adds signal (boot + register + config + invariant + the mock
+//!     speaking the real `request` interface) and AUTO-UPGRADES to the full path
+//!     the moment it runs on an ECDSA-capable PocketIC.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+/// Minimal mirror of `ProtocolError`: these chain endpoints only ever return the
+/// `ChainAdmin(text)` variant on the happy path. If the backend returns any other
+/// variant, the Candid decode fails loudly — which is the correct signal that
+/// something unexpected happened (we do NOT want to silently swallow it).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+/// keccak256("Mint(uint256,address,uint256)") — must match evm_rpc.rs.
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+/// keccak256("Burn(uint256,address,uint256)") — must match evm_rpc.rs.
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    // A non-anonymous developer principal used for every admin/gated call. The
+    // backend is init'd with this exact principal as `developer_principal`.
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+/// Update call as the developer principal; returns the raw reply blob.
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+/// Update call as an arbitrary caller (used for the mock's test-control endpoints,
+/// which are ungated).
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    // An II subnet is required for PocketIC to provision threshold-ECDSA keys;
+    // the canisters live on the application subnet and route ECDSA requests to
+    // the II subnet. If this build cannot provision `test_key_1`, the ECDSA
+    // probe below falls the test to its gated subset.
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    // Init principals point at the management canister so any accidental outbound
+    // call (other than the ones this test wires) traps fast. The developer is the
+    // identity used for every admin/gated call below.
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    // Mock takes no init arg.
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+    (pic, backend_id, mock_id)
+}
+
+/// Tick the canister timers `rounds` times across `rounds` 30s windows so the
+/// 30s observer (Timer A) and settlement (Timer D) timers fire and the spawned
+/// async tick futures (which make inter-canister calls to the mock) run to
+/// completion within each window.
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── Supply-invariant assertion (the POINT of this test) ─────────────────────
+
+/// Assert the canonical multi-chain supply invariant at a labeled step:
+///   get_global_icusd_supply() == sum(per-chain audit supply) == expected_e8s,
+/// and the Monad chain's audited supply matches.
+fn assert_supply(pic: &PocketIc, cid: Principal, expected_e8s: u128, step: &str) {
+    let global: candid::Nat = query_unit(pic, cid, "get_global_icusd_supply");
+    assert_eq!(
+        global,
+        candid::Nat::from(expected_e8s),
+        "[{step}] get_global_icusd_supply mismatch"
+    );
+
+    let audit: SupplyAuditWire = query_unit(pic, cid, "get_supply_audit");
+    assert_eq!(
+        audit.total_e8s,
+        candid::Nat::from(expected_e8s),
+        "[{step}] supply_audit.total mismatch"
+    );
+    // total must equal the sum of per-chain entries (no hidden supply).
+    let sum: candid::Nat = audit
+        .per_chain
+        .iter()
+        .fold(candid::Nat::from(0u32), |acc, e| acc + e.supply_e8s.clone());
+    assert_eq!(audit.total_e8s, sum, "[{step}] audit total != sum(per_chain)");
+
+    // The Monad entry (once the chain is registered) must carry exactly the
+    // expected supply.
+    if let Some(monad) = audit.per_chain.iter().find(|e| e.chain_id == MONAD_CHAIN_ID) {
+        assert_eq!(
+            monad.supply_e8s,
+            candid::Nat::from(expected_e8s),
+            "[{step}] Monad per-chain supply mismatch"
+        );
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data ─────────────────────────
+
+/// Encode a u128 (vault_id or amount) as a 32-byte (64 hex char) 0x word.
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+/// Encode a 20-byte EVM address (0x-prefixed hex) as a left-padded 32-byte word
+/// (the indexed-address topic encoding). Tolerates a bare (non-0x) input.
+fn word_addr(addr: &str) -> String {
+    let raw = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    // Pad the 40-hex-char address on the left to 64 hex chars.
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1b_monad_happy_path_supply_invariant() {
+    let (pic, backend, mock) = boot();
+
+    // ── Step 1: point the backend's Monad wrapper at the mock ────────────────
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    // ── Step 2: register Monad + contract + manual MON price ─────────────────
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        // The mock ignores the url but the wrapper needs >= 1 configured endpoint.
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"0x00000000000000000000000000000000deadbeef".to_string())
+                .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    // $2.00 / MON in e8.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // Invariant holds at zero after register/config (Design B: nothing minted).
+    assert_supply(&pic, backend, 0, "after register/config");
+
+    // ── Step 3: script the mock's chain head ─────────────────────────────────
+    // latest = finalized = 100 (single-slot finality; the wrapper uses the
+    // finalized-block number directly).
+    update_any(&pic, mock, "set_blocks", Encode!(&100u64, &100u64).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
+
+    // ── ECDSA probe: decide full vs gated ────────────────────────────────────
+    // get_chain_settlement_address derives the settlement address via the
+    // management-canister ECDSA API. If PocketIC cannot provision `test_key_1`,
+    // this errors and we run the gated subset.
+    let settlement_addr = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            Ok(Err(e)) => {
+                eprintln!("[phase1b happy-path] ECDSA UNAVAILABLE (get_chain_settlement_address returned Err: {e:?}); running GATED subset");
+                None
+            }
+            Err(decode_err) => {
+                eprintln!("[phase1b happy-path] get_chain_settlement_address decode error ({decode_err}); running GATED subset");
+                None
+            }
+        },
+        WasmResult::Reject(msg) => {
+            eprintln!("[phase1b happy-path] ECDSA UNAVAILABLE (get_chain_settlement_address rejected: {msg}); running GATED subset");
+            None
+        }
+    };
+
+    let settlement_addr = match settlement_addr {
+        Some(addr) => {
+            eprintln!("[phase1b happy-path] ECDSA AVAILABLE; settlement address = {addr}; running FULL happy path");
+            addr
+        }
+        None => {
+            // GATED SUBSET BOUNDARY: ECDSA is the wall. Everything that does not
+            // need signing has been exercised (boot, register, contract, manual
+            // price, evm_rpc principal, and the supply invariant holding at 0
+            // through the registered chain). The supply invariant — the point of
+            // this test — is asserted to hold at 0. The pure open/deposit/mint/
+            // burn/withdraw state transitions are unit-tested in
+            // chains/monad/tests_*. This assertion re-confirms the invariant and
+            // the test returns green; it AUTO-UPGRADES to the full path on an
+            // ECDSA-capable PocketIC.
+            assert_supply(&pic, backend, 0, "gated: ECDSA unavailable, invariant at 0");
+            return;
+        }
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // FULL HAPPY PATH (ECDSA available)
+    // ════════════════════════════════════════════════════════════════════════
+
+    // Fund the settlement (hot-wallet) address generously so the submit-path gas
+    // gate passes. The observer refreshes the cached balance each tick.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+    );
+
+    // ── Step 4: open_chain_vault (AwaitingDeposit, no mint) ──────────────────
+    // 100 MON collateral @ $2 = $200 backing 100 icUSD debt => 200% CR (>=130%).
+    let collateral_e18 = 100u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(MONAD_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+    assert_eq!(v.status, ChainVaultStatus::AwaitingDeposit, "open => AwaitingDeposit");
+    assert_eq!(v.debt_e8s, candid::Nat::from(0u32), "open => no confirmed debt");
+    assert_eq!(
+        v.pending_mint_e8s,
+        candid::Nat::from(debt_e8s),
+        "open => pending_mint carries intended mint"
+    );
+    let custody = v.custody_address.clone();
+    assert!(custody.starts_with("0x"), "custody address is 0x hex: {custody}");
+    // Design B: nothing minted yet.
+    assert_supply(&pic, backend, 0, "after open (AwaitingDeposit)");
+
+    // ── Step 5: deposit lands; observer flips to MintPending + enqueues mint ─
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(&pic, 2);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after deposit-verify");
+    assert_eq!(
+        v.status,
+        ChainVaultStatus::MintPending,
+        "deposit verified => MintPending"
+    );
+    // Still no confirmed debt until the mint is observed at finality.
+    assert_supply(&pic, backend, 0, "after deposit-verify (MintPending)");
+
+    // ── Step 6: settlement submits the mint (mock auto-mines 0xmint1 at
+    //           finalized=100 on send), then confirms it. Push the Mint log at
+    //           block 100 so the confirm path reads the on-chain amount. ───────
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 100);
+
+    // Several windows: window 1 submits (Queued -> Inflight), window 2+ confirms
+    // (receipt mined + final, Mint log read, confirm_mint_in_state).
+    advance_and_tick(&pic, 4);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+    assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+    assert_eq!(
+        v.debt_e8s,
+        candid::Nat::from(debt_e8s),
+        "mint confirmed => debt = 100e8"
+    );
+    assert_eq!(v.pending_mint_e8s, candid::Nat::from(0u32), "pending mint cleared on confirm");
+    // THE invariant flips from 0 to 100e8 exactly here.
+    assert_supply(&pic, backend, 100 * E8, "after mint confirm (Open)");
+
+    // ── Step 7: burn 40e8 on chain; observer decrements debt + supply ────────
+    // Advance the chain head so the new burn log sits in an unobserved block.
+    update_any(&pic, mock, "set_blocks", Encode!(&101u64, &101u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xburn1", 101);
+    advance_and_tick(&pic, 2);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after burn 40");
+    assert_eq!(v.debt_e8s, candid::Nat::from(60 * E8), "after burn40 => debt 60e8");
+    assert_eq!(v.status, ChainVaultStatus::Open, "partial burn keeps vault Open");
+    assert_supply(&pic, backend, 60 * E8, "after burn 40e8");
+
+    // ── Step 8: burn the remaining 60e8; debt + supply go to 0 ───────────────
+    update_any(&pic, mock, "set_blocks", Encode!(&102u64, &102u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 60 * E8, "0xburn2", 102);
+    advance_and_tick(&pic, 2);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after burn 60");
+    assert_eq!(v.debt_e8s, candid::Nat::from(0u32), "after burn60 => debt 0");
+    assert_supply(&pic, backend, 0, "after burn remaining 60e8");
+
+    // ── Step 9: withdraw all collateral; vault Closing -> Closed ─────────────
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xwd1".to_string()).unwrap());
+    let dest = "0x000000000000000000000000000000000000dead".to_string();
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "withdraw_chain_collateral",
+            Encode!(&vault_id, &candid::Nat::from(collateral_e18), &dest).unwrap(),
+        ),
+        "withdraw_chain_collateral",
+    )
+    .expect("withdraw_chain_collateral");
+
+    // Immediately after enqueue (before settlement confirms) the vault is Closing
+    // (empty + debt-free).
+    let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw enqueue");
+    assert_eq!(v.status, ChainVaultStatus::Closing, "withdraw all => Closing");
+    assert_supply(&pic, backend, 0, "after withdraw enqueue (Closing)");
+
+    // Settlement submits 0xwd1 (auto-mined at finalized=102) then confirms it,
+    // flipping Closing -> Closed.
+    advance_and_tick(&pic, 4);
+    let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw confirm");
+    assert_eq!(v.status, ChainVaultStatus::Closed, "withdraw confirmed => Closed");
+
+    // ── Step 10: final invariant — supply 0, audit total 0 ───────────────────
+    assert_supply(&pic, backend, 0, "final (Closed)");
+    let audit: SupplyAuditWire = query_unit(&pic, backend, "get_supply_audit");
+    assert_eq!(audit.total_e8s, candid::Nat::from(0u32), "final audit total 0");
+
+    eprintln!("[phase1b happy-path] FULL happy path PASSED: supply invariant held 0 -> 100e8 -> 60e8 -> 0 across open/deposit/mint/burn/withdraw/close");
+}
+
+// ─── helpers that build mock-control args ────────────────────────────────────
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => {
+            Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault")
+        }
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {msg}"),
+    }
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    // Mint(uint256 vault_id, address recipient, uint256 amount):
+    //   topics[0] = MINT_EVENT_TOPIC0
+    //   topics[1] = vault_id (32-byte word)
+    //   topics[2] = recipient (address left-padded to 32 bytes)
+    //   data      = amount (32-byte word)
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+fn push_burn_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    // Burn(uint256 vault_id, address burner, uint256 amount): same topic layout
+    // as Mint, different topic0.
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}

--- a/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
@@ -11,11 +11,16 @@
 //! failure degrades the observer to deposit-only instead of aborting the tick.
 //!
 //! To prove the backend never falls back to the volatile read, the mock is armed
-//! with `fail_next("eth_blockNumber", ...)`: IF the backend ever issued an
-//! `eth_blockNumber` via the `request` escape-hatch, the mock returns a
-//! real-wire-shaped `IcError` and the assertions below fail. The test passing
-//! proves the backend ONLY uses the consensus-safe typed probe. Reverting to the
-//! volatile read re-breaks this test.
+//! with `fail_always("eth_blockNumber", ...)`: EVERY `request` call whose
+//! JSON-RPC method is "eth_blockNumber" returns a real-wire-shaped `IcError`
+//! for the entire test run. Using the PERSISTENT `fail_always` (not the
+//! one-shot `fail_next`) is important: a reverted backend would error on tick 1
+//! (one-shot consumed) then succeed on tick 2+ and advance the cursor anyway,
+//! causing a false PASS. With `fail_always`, every tick that calls
+//! `eth_blockNumber` via `request` fails permanently, so the cursor can only
+//! advance via the TYPED `eth_getBlockByNumber` probe. The test passing proves
+//! the backend ONLY uses the consensus-safe typed probe. Reverting to the
+//! volatile read re-breaks this test reliably across all ticks.
 //!
 //! Two subsets (same auto-upgrade pattern as the happy-path test):
 //!   - ECDSA available: open a vault, fund custody, tick → assert the vault
@@ -303,17 +308,24 @@ fn phase1b_observer_consensus_safe_cursor_advances() {
     )
     .expect("set_manual_collateral_price");
 
-    // ── Break the volatile read ──────────────────────────────────────────────
-    // Arm a real-wire IcError for EVERY `eth_blockNumber` the backend might issue
-    // via the `request` escape-hatch. (fail_next is one-shot per arming; we re-arm
-    // each tick is unnecessary because the backend should NEVER call it — if it
-    // did even once, the armed failure trips and the cursor would NOT advance.)
-    // The consensus-safe path uses the TYPED eth_getBlockByNumber instead, which
+    // ── Break the volatile read (persistent barrier) ─────────────────────────
+    // Arm a PERSISTENT real-wire IcError for eth_blockNumber via `fail_always`.
+    // Every `request` call whose JSON-RPC method is "eth_blockNumber" will fail
+    // with IcError(SysTransient) for the lifetime of this test — not just the
+    // first one (which is all `fail_next` would cover).
+    //
+    // Why `fail_always` beats `fail_next` here: a reverted backend (volatile
+    // read) would error on tick 1 from `fail_next`, then succeed on tick 2
+    // (arming already consumed) and advance the cursor anyway — the test would
+    // pass even on the broken implementation. With `fail_always`, EVERY tick
+    // that calls `eth_blockNumber` via `request` fails, so the cursor can NEVER
+    // advance on the broken path. The test ONLY passes when the backend uses the
+    // TYPED `eth_getBlockByNumber` method, which bypasses `request` entirely and
     // is unaffected by this arming.
     update_any(
         &pic,
         mock,
-        "fail_next",
+        "fail_always",
         Encode!(&"eth_blockNumber".to_string(), &"no consensus".to_string()).unwrap(),
     );
 

--- a/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
@@ -1,0 +1,431 @@
+//! Phase 1b — Layer-2 consensus-safe observer regression test (Gate-3 fix).
+//!
+//! This is the focused regression for the EVM-RPC Layer-2 failure that blocked
+//! Gate-4 on mainnet-staging: a VOLATILE block-head read (`eth_blockNumber`, or
+//! any `latest`/`finalized` BLOCK TAG) differs across the EVM RPC canister's
+//! subnet replicas on a fast-finality chain like Monad → IC HTTPS-outcall
+//! consensus never agrees → the call fails EVERY tick. The fix (Task A2a) reads
+//! finalized height by probing a SPECIFIC, already-final block NUMBER via the
+//! typed `eth_getBlockByNumber(Number(N))` (byte-identical across replicas), and
+//! (Task A2b) decouples deposit-watch from the block-height path so a block-read
+//! failure degrades the observer to deposit-only instead of aborting the tick.
+//!
+//! To prove the backend never falls back to the volatile read, the mock is armed
+//! with `fail_next("eth_blockNumber", ...)`: IF the backend ever issued an
+//! `eth_blockNumber` via the `request` escape-hatch, the mock returns a
+//! real-wire-shaped `IcError` and the assertions below fail. The test passing
+//! proves the backend ONLY uses the consensus-safe typed probe. Reverting to the
+//! volatile read re-breaks this test.
+//!
+//! Two subsets (same auto-upgrade pattern as the happy-path test):
+//!   - ECDSA available: open a vault, fund custody, tick → assert the vault
+//!     reaches `MintPending` (deposit-watch ran despite `eth_blockNumber` being
+//!     "broken") AND the burn-watch cursor advanced to seed+256 via the typed
+//!     probe.
+//!   - ECDSA unavailable: assert the burn-watch cursor advances to seed+256 anyway
+//!     (the cursor advance needs no signing) and the supply invariant holds at 0.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+/// Minimal mirror of `ProtocolError`: these chain endpoints only ever return the
+/// `ChainAdmin(text)` variant on the happy path.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+/// The cursor is seeded here; finalized = SEED + 256 (MAX_BLOCK_SCAN_WINDOW), so
+/// one observer tick advances the cursor to SEED_PLUS_256 via the typed probe.
+const SEED_BLOCK: u64 = 2_000_000;
+const SEED_PLUS_256: u64 = 2_000_256;
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+/// Read the burn-watch cursor for the Monad chain via `get_last_observed_block`.
+fn cursor(pic: &PocketIc, backend: Principal) -> u64 {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_last_observed_block query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, u64).expect("decode get_last_observed_block"),
+        WasmResult::Reject(msg) => panic!("get_last_observed_block rejected: {}", msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {}", msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1b_observer_consensus_safe_cursor_advances() {
+    let (pic, backend, mock) = boot();
+
+    // Point the backend's Monad wrapper at the mock.
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    // Register Monad + contract + manual MON price.
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"0x00000000000000000000000000000000deadbeef".to_string())
+                .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // ── Break the volatile read ──────────────────────────────────────────────
+    // Arm a real-wire IcError for EVERY `eth_blockNumber` the backend might issue
+    // via the `request` escape-hatch. (fail_next is one-shot per arming; we re-arm
+    // each tick is unnecessary because the backend should NEVER call it — if it
+    // did even once, the armed failure trips and the cursor would NOT advance.)
+    // The consensus-safe path uses the TYPED eth_getBlockByNumber instead, which
+    // is unaffected by this arming.
+    update_any(
+        &pic,
+        mock,
+        "fail_next",
+        Encode!(&"eth_blockNumber".to_string(), &"no consensus".to_string()).unwrap(),
+    );
+
+    // Seed the burn-watch cursor and set the chain head one window (256) above it.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &SEED_BLOCK).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+    update_any(&pic, mock, "set_blocks", Encode!(&SEED_PLUS_256, &SEED_PLUS_256).unwrap());
+
+    assert_eq!(cursor(&pic, backend), SEED_BLOCK, "cursor seeded to SEED_BLOCK");
+
+    // ── ECDSA probe: decide full vs gated ────────────────────────────────────
+    let ecdsa_ok = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    };
+
+    if let Some(settlement_addr) = ecdsa_ok {
+        eprintln!("[phase1b consensus-safe] ECDSA AVAILABLE; running FULL subset (deposit-watch + cursor advance)");
+
+        // Fund the settlement (hot-wallet) address so the gas gate passes.
+        update_any(
+            &pic,
+            mock,
+            "set_balance",
+            Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+        );
+
+        // Open a vault (AwaitingDeposit, no mint).
+        let collateral_e18 = 100u128 * E18;
+        let debt_e8s = 100u128 * E8;
+        let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+        let vault_id: u64 = match update_dev(
+            &pic,
+            backend,
+            "open_chain_vault",
+            Encode!(
+                &ChainId(MONAD_CHAIN_ID),
+                &candid::Nat::from(collateral_e18),
+                &candid::Nat::from(debt_e8s),
+                &recipient
+            )
+            .unwrap(),
+        ) {
+            WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+                .expect("decode open_chain_vault")
+                .expect("open_chain_vault Ok"),
+            WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+        };
+
+        let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+        assert_eq!(v.status, ChainVaultStatus::AwaitingDeposit, "open => AwaitingDeposit");
+        let custody = v.custody_address.clone();
+
+        // Fund the custody address so the deposit-watch verifies on the next tick.
+        update_any(
+            &pic,
+            mock,
+            "set_balance",
+            Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+        );
+
+        advance_and_tick(&pic, 3);
+
+        // Deposit-watch ran DESPITE eth_blockNumber being "broken": the vault must
+        // have flipped to MintPending (consensus-safe balance-only path).
+        let v = get_vault(&pic, backend, vault_id).expect("vault after tick");
+        assert_eq!(
+            v.status,
+            ChainVaultStatus::MintPending,
+            "deposit-watch ran despite broken eth_blockNumber => MintPending"
+        );
+
+        // The burn-watch cursor advanced via the consensus-safe TYPED probe (not
+        // the volatile eth_blockNumber, which is armed to fail).
+        assert_eq!(
+            cursor(&pic, backend),
+            SEED_PLUS_256,
+            "cursor advanced to SEED+256 via consensus-safe typed probe"
+        );
+    } else {
+        eprintln!("[phase1b consensus-safe] ECDSA UNAVAILABLE; running GATED subset (cursor advance only — needs no signing)");
+
+        // No vault, no signing — the burn-watch cursor advance is purely the typed
+        // block probe + an (empty) getLogs scan. Tick and assert it advanced.
+        advance_and_tick(&pic, 3);
+
+        assert_eq!(
+            cursor(&pic, backend),
+            SEED_PLUS_256,
+            "cursor advanced to SEED+256 via consensus-safe typed probe (no signing needed)"
+        );
+
+        // Supply invariant holds at 0 (nothing minted).
+        let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+        assert_eq!(global, candid::Nat::from(0u32), "supply invariant holds at 0");
+    }
+
+    eprintln!("[phase1b consensus-safe] PASSED: observer advanced the burn-watch cursor without ever reading the volatile eth_blockNumber");
+}

--- a/src/rumi_protocol_backend/tests/phase1b_timers_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_timers_pic.rs
@@ -1,0 +1,161 @@
+//! Phase 1b Task 15 PocketIC smoke test: NO-CHAIN TIMER SAFETY.
+//!
+//! Task 15 wires the Monad inbound observer (`observer_tick`) and the outbound
+//! settlement worker (`settlement_tick`, Timer D) onto live `set_timer_interval`
+//! timers (default 30s) in `setup_timers`. Both tick fns fan out over the set of
+//! REGISTERED+ENABLED chains; with no chain configured that set is empty and
+//! each tick is a pure no-op (it never makes an inter-canister / EVM RPC call).
+//!
+//! This test boots the backend with NO chains registered, then advances time
+//! well past several 30s timer firings (120s across repeated ticks) and asserts
+//! the canister stays ALIVE: queries still answer and still return the empty /
+//! zero shape. If either tick trapped or panicked with no chain configured (e.g.
+//! an unguarded state borrow, an `unwrap` on a missing chain, or a 0s busy-loop
+//! that froze the canister), a post-advance query would reject and this test
+//! would fail.
+//!
+//! This is the NO-CHAIN safety test ONLY. The full happy-path (register Monad,
+//! deposit -> mint -> confirm via mocked RPC) is Task 17. The init principals
+//! point at the management canister so any accidental outbound call traps fast,
+//! which is exactly what we want: it would surface a tick that wrongly tried to
+//! do work with no chain.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Principal};
+use pocket_ic::{PocketIc, WasmResult};
+use std::time::Duration;
+
+// Locally-mirrored types so this test does not pull in the crate's macros.
+// Field shapes must mirror `src/rumi_protocol_backend/src/lib.rs` exactly.
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+// Wire type matching the `get_supply_audit` reply in the .did.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+/// Boot the backend with NO chains registered. Init principals point at the
+/// management canister so any accidental outbound call traps fast.
+fn boot() -> (PocketIc, Principal) {
+    let pic = PocketIc::new();
+    let protocol_id = pic.create_canister();
+    pic.add_cycles(protocol_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let developer = Principal::from_text("aaaaa-aa").expect("dev principal");
+
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: developer,
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        protocol_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    // Let the install settle (timers registered in `setup_timers`).
+    for _ in 0..5 {
+        pic.tick();
+    }
+    (pic, protocol_id)
+}
+
+fn query<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+/// The core no-chain safety assertion: fire the 30s observer + settlement timers
+/// several times (advance 120s in 30s steps, ticking between each) and prove the
+/// canister is still alive and still empty afterward.
+#[test]
+fn phase1b_timers_safe_with_no_chain_configured() {
+    let (pic, cid) = boot();
+
+    // Sanity: empty/zero before any timer fires.
+    let supply: u128 = query(&pic, cid, "get_global_icusd_supply");
+    assert_eq!(supply, 0u128, "fresh canister should report zero global supply");
+    let audit: SupplyAuditWire = query(&pic, cid, "get_supply_audit");
+    assert_eq!(audit.total_e8s, candid::Nat::from(0u32));
+    assert!(audit.per_chain.is_empty(), "no chains registered -> empty audit");
+
+    // Advance time past several 30s timer firings. With no chain registered,
+    // every observer_tick / settlement_tick is a no-op fan-out over an empty
+    // chain list. If either trapped, the queries below would reject.
+    for _ in 0..4 {
+        pic.advance_time(Duration::from_secs(30));
+        // Several ticks per step so the spawned async tick futures get scheduled
+        // and run to completion (a no-op return) within the step.
+        for _ in 0..5 {
+            pic.tick();
+        }
+    }
+
+    // Canister still alive: queries still answer and still return empty/zero.
+    let supply_after: u128 = query(&pic, cid, "get_global_icusd_supply");
+    assert_eq!(
+        supply_after, 0u128,
+        "global supply must remain zero after observer/settlement timers fired with no chain"
+    );
+    let audit_after: SupplyAuditWire = query(&pic, cid, "get_supply_audit");
+    assert_eq!(
+        audit_after.total_e8s,
+        candid::Nat::from(0u32),
+        "supply audit total must remain zero after timers fired"
+    );
+    assert!(
+        audit_after.per_chain.is_empty(),
+        "no chains should appear after timers fired with none registered"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1b adds the **Monad testnet EVM-chain adapter** to Rumi's multi-chain icUSD. Users deposit MON as collateral on Monad; the backend observes the on-chain deposit, mints icUSD (an ERC-20, `IcUSD.sol`, on Monad), and decrements supply on burns/withdrawals — all upholding the global supply invariant `sum(chain_supplies) == sum(chain_vault.debt_e8s)`. Vault flow is **open-then-verify**: `open_chain_vault` creates an `AwaitingDeposit` vault (no mint), the observer verifies the on-chain deposit, then enqueues the mint.

Production `tfesu-vyaaa-aaaap-qrd7a-cai` is **untouched**. All exercise happens on the Phase-1a staging canister `kvg63-wiaaa-aaaao-bbabq-cai`.

## What's in this PR (38 commits)

- **Tasks 1–21** — the full Phase 1b build: chain config/registry, multi-chain state `V1→V2` (CBOR + `#[serde(default)]` migration), per-vault tECDSA custody addresses, EIP-1559 tx builder + tECDSA signing, the open-then-verify vault flow (`AwaitingDeposit` status), the inbound observer (deposit + burn watch) and outbound settlement worker (Timers A/D), `IcUSD.sol` + a 13-test Foundry suite (incl. a per-`vault_id` mint guard against double-mint), supply accounting + an invariant self-check.
- **Audit pass** (`705999e`) — boundary EVM-address validation (`is_valid_evm_address`) at all 3 developer entry points, fail-fast on a deploy-time address typo.
- **Gate 3 staging deploy** — surfaced a real EVM-RPC observer bug that the PocketIC mock could not (the mock used hand-rolled types and modelled no HTTPS-outcall consensus). This PR fixes it.

## The Gate-3 observer fix (core of this round — 9 commits)

The observer's block-height read failed against the **real** EVM RPC canister (`7hfb6-…`) every tick; `eth_getBalance` worked. Two entangled layers:

1. **Candid decode trap** (`ea44e4c`): `IcErrorRecord.code` was `u32`, but the real `HttpOutcallError::IcError.code` is a `RejectionCode` variant → "Fail to decode argument 0". Fixed the mirror.
2. **Block-height consensus** (`5118605`): IC HTTPS-outcall consensus needs byte-identical responses across the EVM-RPC canister's 34-node subnet. A volatile block **tag** (`eth_blockNumber`, `latest`/`finalized`) resolves to a different head per node on fast-finality Monad → never reaches consensus. The fix reads a **specific, already-final block number** via the typed `eth_getBlockByNumber(Number(N))` (deterministic across replicas), probing `last_observed + MAX_BLOCK_SCAN_WINDOW`. `eth_getLogs` already used specific numbers, so it was unaffected.
3. **Observer restructure** (`8c71b7b`): the real Gate-4 blocker was that a block-read failure (or being caught up) returned early **before** the balance-based deposit-watch. Deposit-watch now runs **every tick**, decoupled from block-height reads; burn-watch is gated on a seeded cursor (`set_last_observed_block`/`get_last_observed_block`).

### Plus a CRITICAL supply bug found by review and fixed here

- **C-1** (`283d6ed`): a permissionless poison `Burn` (over-repay / closed-vault) stalled the burn cursor and forced a full-range re-scan that **re-applied already-applied partial burns** — debt and supply both decremented twice, so the self-check (which only checks `supply == debt`) never caught the silent divergence from on-chain truth. Fixed with a CBOR-persisted idempotency set (`processed_burn_keys`, canonical `(block, tx_hash, log_index)` key), typed `BurnApplyError` (skip invalid burns + advance past them, break only on a halt-class divergence), and a mock `eth_getLogs` topic-filter. Proven by a RED-first regression test.
- Review follow-ups (`0a49bed`): visible probe-error logging, a reliable consensus-safe regression guard (`fail_always`), and notes.

### Hardening (deferred items from the handoff)

- **B1** (`4a81556`): `tx::abi_word_address`/`parse_address` return `Result` instead of `panic`, threaded through the tx-build path so a malformed address fails the op gracefully (no trap that would stick the re-entrancy guard).
- **B2** (`22b3b6a`): the observer/settlement re-entrancy guards self-heal via a stale-timestamp reclaim (a post-await trap that skips `Drop` no longer sticks the guard forever).
- **`icp.yaml`** (`526a71d`): the mainnet-staging backend default arg is now the `Upgrade` variant (Task 22 Step 9) so a build never falls back to `Init` and wipes state.

## Testing (all green)

- `cargo test -p rumi_protocol_backend --lib` — **218 passed**
- PocketIC — **9 tests**: happy-path (full open→deposit→mint→burn→withdraw→close supply invariant), burn-idempotency (2: poison-burn + same-tx double-burn), consensus-safe (proves the observer advances without the volatile read), timers, scaffolding, supply-invariant proptests
- Foundry — **13 passed** (`IcUSD.t.sol`)
- candid-compat — green; clippy — 0 warnings in the Monad module

A full adversarial code review (the observer drives supply accounting) found C-1 + several follow-ups; all are addressed, and the final review verdict is **safe to deploy to mainnet-staging**.

## Deploy + operational notes

- The fixed wasm re-deploys to **staging only** (`kvg63`, `--mode upgrade`, never reinstall). Production untouched.
- **Gate-4 prerequisite**: seed the burn-watch cursor to the current Monad tip (`set_last_observed_block(10143, <block>)`) before opening vaults. Deposits flow without it; burn-watch stays inert (logs a warning) until seeded.

Regular merge commit only — **do not squash** (preserve the full commit history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
