### PR TITLE
fix(explorer): combined 3pool+AMM1 LP APY (display + faithful analytics amm_apy_pct)

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did
+++ b/src/declarations/rumi_analytics/rumi_analytics.did
@@ -1,20 +1,20 @@
 type AddressValuePoint = record {
   ts_ns : nat64;
-  value_usd_e8s : nat64;
   breakdown : vec AddressValueSourceBreakdown;
+  value_usd_e8s : nat64;
 };
 type AddressValueSeriesQuery = record {
   "principal" : principal;
-  window_ns : opt nat64;
   resolution_ns : opt nat64;
+  window_ns : opt nat64;
 };
 type AddressValueSeriesResponse = record {
   "principal" : principal;
-  window_ns : nat64;
   resolution_ns : nat64;
   generated_at_ns : nat64;
-  points : vec AddressValuePoint;
   approximate_sources : vec text;
+  window_ns : nat64;
+  points : vec AddressValuePoint;
 };
 type AddressValueSourceBreakdown = record {
   source : text;
@@ -34,8 +34,38 @@ type AdminEventLabelCount = record {
 type ApyQuery = record { window_days : opt nat32 };
 type ApyResponse = record {
   lp_apy_pct : opt float64;
+  amm_apy_pct : opt float64;
   window_days : nat32;
   sp_apy_pct : opt float64;
+};
+type AnalyticsAmmLiquidityEvent = record {
+  timestamp_ns : nat64;
+  source_event_id : nat64;
+  caller : principal;
+  pool_id : text;
+  action : LiquidityAction;
+  lp_shares : nat64;
+};
+type AnalyticsSwapEvent = record {
+  timestamp_ns : nat64;
+  source : SwapSource;
+  source_event_id : nat64;
+  caller : principal;
+  token_in : principal;
+  token_out : principal;
+  amount_in : nat64;
+  amount_out : nat64;
+  fee : nat64;
+};
+type LiquidityAction = variant { Add; Remove; RemoveOneCoin; Donate };
+type SwapSource = variant { ThreePool; Amm };
+type BackfillProgress = record {
+  cursor_after : nat64;
+  from : nat64;
+  scanned : nat64;
+  complete : bool;
+  emitted : nat64;
+  total_events : nat64;
 };
 type BalanceTrackerStats = record {
   token : principal;
@@ -156,20 +186,20 @@ type FastPriceSnapshot = record {
   timestamp_ns : nat64;
   prices : vec record { principal; float64; text };
 };
+type FeeBreakdownQuery = record { window_ns : opt nat64 };
+type FeeBreakdownResponse = record {
+  redemption_count : nat32;
+  borrow_count : nat32;
+  redemption_fees_icusd_e8s : nat64;
+  borrow_fees_icusd_e8s : nat64;
+  start_ns : nat64;
+  swap_count : nat32;
+  swap_fees_icusd_e8s : nat64;
+  end_ns : nat64;
+};
 type FeeCurveSeriesResponse = record {
   rows : vec HourlyFeeCurveSnapshot;
   next_from_ts : opt nat64;
-};
-type FeeBreakdownQuery = record { window_ns : opt nat64 };
-type FeeBreakdownResponse = record {
-  borrow_fees_icusd_e8s : nat64;
-  redemption_fees_icusd_e8s : nat64;
-  swap_fees_icusd_e8s : nat64;
-  borrow_count : nat32;
-  redemption_count : nat32;
-  swap_count : nat32;
-  start_ns : nat64;
-  end_ns : nat64;
 };
 type FeeSeriesResponse = record {
   rows : vec DailyFeeRollup;
@@ -259,6 +289,7 @@ type PriceSeriesResponse = record {
 type ProtocolSummary = record {
   peg : opt PegStatus;
   lp_apy_pct : opt float64;
+  amm_apy_pct : opt float64;
   timestamp_ns : nat64;
   sp_apy_pct : opt float64;
   total_debt_e8s : nat64;
@@ -278,6 +309,8 @@ type RangeQuery = record {
   limit : opt nat32;
 };
 type ResetErrorCountersArgs = record { sources : opt vec text };
+type Result = variant { Ok : BackfillProgress; Err : text };
+type Result_1 = variant { Ok; Err : text };
 type StabilitySeriesResponse = record {
   rows : vec DailyStabilityRow;
   next_from_ts : opt nat64;
@@ -388,6 +421,10 @@ type VolatilityResponse = record {
   annualized_vol_pct : float64;
 };
 service : (InitArgs) -> {
+  admin_backfill_add_margin_events : (nat64) -> (Result);
+  debug_get_amm_event_counts : () -> (nat64, nat64) query;
+  debug_get_amm_liquidity_events_raw : (nat64, nat64) -> (vec AnalyticsAmmLiquidityEvent) query;
+  debug_get_swap_events_raw : (nat64, nat64) -> (vec AnalyticsSwapEvent) query;
   get_address_value_series : (AddressValueSeriesQuery) -> (
       AddressValueSeriesResponse,
     ) query;
@@ -398,8 +435,10 @@ service : (InitArgs) -> {
   get_apys : (ApyQuery) -> (ApyResponse) query;
   get_collector_health : () -> (CollectorHealth) query;
   get_cycle_series : (RangeQuery) -> (CycleSeriesResponse) query;
+  get_fee_breakdown_window : (FeeBreakdownQuery) -> (
+      FeeBreakdownResponse,
+    ) query;
   get_fee_curve_series : (RangeQuery) -> (FeeCurveSeriesResponse) query;
-  get_fee_breakdown_window : (FeeBreakdownQuery) -> (FeeBreakdownResponse) query;
   get_fee_series : (RangeQuery) -> (FeeSeriesResponse) query;
   get_holder_series : (RangeQuery, principal) -> (HolderSeriesResponse) query;
   get_liquidation_series : (RangeQuery) -> (LiquidationSeriesResponse) query;
@@ -408,6 +447,7 @@ service : (InitArgs) -> {
   get_pool_routes : (PoolRoutesQuery) -> (PoolRoutesResponse) query;
   get_price_series : (RangeQuery) -> (PriceSeriesResponse) query;
   get_protocol_summary : () -> (ProtocolSummary) query;
+  get_sp_depositor_principals : () -> (vec principal) query;
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
   get_three_pool_series : (RangeQuery) -> (ThreePoolSeriesResponse) query;
@@ -416,7 +456,6 @@ service : (InitArgs) -> {
       TopCounterpartiesResponse,
     ) query;
   get_top_holders : (TopHoldersQuery) -> (TopHoldersResponse) query;
-  get_sp_depositor_principals : () -> (vec principal) query;
   get_top_sp_depositors : (TopSpDepositorsQuery) -> (
       TopSpDepositorsResponse,
     ) query;
@@ -427,6 +466,6 @@ service : (InitArgs) -> {
   get_volatility : (VolatilityQuery) -> (VolatilityResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   ping : () -> (text) query;
-  reset_error_counters : (ResetErrorCountersArgs) -> (variant { Ok; Err : text });
+  reset_error_counters : (ResetErrorCountersArgs) -> (Result_1);
   start_backfill : (principal) -> (text);
 }

--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -57,6 +57,7 @@ export interface AnalyticsSwapEvent {
 export interface ApyQuery { 'window_days' : [] | [number] }
 export interface ApyResponse {
   'lp_apy_pct' : [] | [number],
+  'amm_apy_pct' : [] | [number],
   'window_days' : number,
   'sp_apy_pct' : [] | [number],
 }
@@ -298,6 +299,7 @@ export interface ProtocolSummary {
   'peg' : [] | [PegStatus],
   'lp_apy_pct' : [] | [number],
   'timestamp_ns' : bigint,
+  'amm_apy_pct' : [] | [number],
   'median_cr_bps' : number,
   'sp_apy_pct' : [] | [number],
   'total_debt_e8s' : bigint,

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -80,6 +80,7 @@ export const idlFactory = ({ IDL }) => {
   const ApyQuery = IDL.Record({ 'window_days' : IDL.Opt(IDL.Nat32) });
   const ApyResponse = IDL.Record({
     'lp_apy_pct' : IDL.Opt(IDL.Float64),
+    'amm_apy_pct' : IDL.Opt(IDL.Float64),
     'window_days' : IDL.Nat32,
     'sp_apy_pct' : IDL.Opt(IDL.Float64),
   });
@@ -249,6 +250,7 @@ export const idlFactory = ({ IDL }) => {
     'peg' : IDL.Opt(PegStatus),
     'lp_apy_pct' : IDL.Opt(IDL.Float64),
     'timestamp_ns' : IDL.Nat64,
+    'amm_apy_pct' : IDL.Opt(IDL.Float64),
     'median_cr_bps' : IDL.Nat32,
     'sp_apy_pct' : IDL.Opt(IDL.Float64),
     'total_debt_e8s' : IDL.Nat64,

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -34,6 +34,7 @@ type AdminEventLabelCount = record {
 type ApyQuery = record { window_days : opt nat32 };
 type ApyResponse = record {
   lp_apy_pct : opt float64;
+  amm_apy_pct : opt float64;
   window_days : nat32;
   sp_apy_pct : opt float64;
 };
@@ -288,6 +289,7 @@ type PriceSeriesResponse = record {
 type ProtocolSummary = record {
   peg : opt PegStatus;
   lp_apy_pct : opt float64;
+  amm_apy_pct : opt float64;
   timestamp_ns : nat64;
   sp_apy_pct : opt float64;
   total_debt_e8s : nat64;

--- a/src/rumi_analytics/src/collectors/tvl.rs
+++ b/src/rumi_analytics/src/collectors/tvl.rs
@@ -9,11 +9,12 @@
 use crate::{sources, state, storage};
 
 pub async fn run() -> Result<(), String> {
-    let (backend_id, stability_pool_id, three_pool_id) = state::read_state(|s| {
+    let (backend_id, stability_pool_id, three_pool_id, amm_id) = state::read_state(|s| {
         (
             s.sources.backend,
             s.sources.stability_pool,
             s.sources.three_pool,
+            s.sources.amm,
         )
     });
 
@@ -65,6 +66,44 @@ pub async fn run() -> Result<(), String> {
             }
         };
 
+    // AMM1 (3USD/ICP) TVL + icUSD reward stream. Fully optional: any failure
+    // degrades to None and never aborts the row. The 3USD token IS the rumi_3pool
+    // canister, so we match it against the pool's token pair to find the pool id.
+    let (amm_tvl_usd_e8s, amm_rewards_e8s): (Option<u128>, Option<u128>) =
+        match sources::amm::resolve_amm1_pool_id(amm_id, three_pool_id).await {
+            Ok(pool_id) => {
+                // Latest TVL sample (most recent snapshot in the 1-day window).
+                let amm_tvl =
+                    match sources::amm::get_amm_tvl_series(amm_id, pool_id.clone(), 1).await {
+                        Ok(series) => series.last().map(|s| nat_to_u128(&s.tvl_usd_e8s)),
+                        Err(e) => {
+                            ic_cdk::println!("[tvl] amm tvl series error: {}", e);
+                            state::mutate_state(|s| s.error_counters.amm += 1);
+                            None
+                        }
+                    };
+                // Sum today's reward points (window=1 == current day). upsert_today is
+                // last-write-wins, so we store the running total, not an increment.
+                let amm_rewards =
+                    match sources::amm::get_amm_reward_series(amm_id, pool_id, 1).await {
+                        Ok(points) => {
+                            Some(points.iter().map(|p| nat_to_u128(&p.amount)).sum::<u128>())
+                        }
+                        Err(e) => {
+                            ic_cdk::println!("[tvl] amm reward series error: {}", e);
+                            state::mutate_state(|s| s.error_counters.amm += 1);
+                            None
+                        }
+                    };
+                (amm_tvl, amm_rewards)
+            }
+            Err(e) => {
+                ic_cdk::println!("[tvl] amm pool resolve error: {}", e);
+                state::mutate_state(|s| s.error_counters.amm += 1);
+                (None, None)
+            }
+        };
+
     // Convert f64 CR (e.g. 1.85 = 185%) to basis points (18500).
     // Saturate at u32::MAX to be safe; the source CR is bounded by protocol logic.
     let cr_bps = (status.total_collateral_ratio * 10_000.0)
@@ -81,9 +120,17 @@ pub async fn run() -> Result<(), String> {
         three_pool_reserve_2_e8s: tp_reserve_2,
         three_pool_virtual_price_e18: tp_virtual_price,
         three_pool_lp_supply_e8s: tp_lp_supply,
+        amm_tvl_usd_e8s,
+        amm_rewards_e8s,
     };
     storage::daily_tvl::push(row);
 
     state::mutate_state(|s| s.last_daily_snapshot_ns = ic_cdk::api::time());
     Ok(())
+}
+
+/// Convert a candid `Nat` to `u128`, saturating to 0 on overflow / parse failure.
+/// The decimal form of the inner `BigUint` is always plain digits (no separators).
+fn nat_to_u128(n: &candid::Nat) -> u128 {
+    n.0.to_string().parse::<u128>().unwrap_or(0)
 }

--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -278,10 +278,12 @@ pub fn get_apys(query: types::ApyQuery) -> types::ApyResponse {
     let stability_rows = storage::daily_stability::range(from, now, MAX_SNAPSHOT_LOAD);
 
     let lp_apy = compute_lp_apy(&swap_rollups, &tvl_rows, window_days);
+    let amm_apy = compute_amm_apy(&swap_rollups, &tvl_rows, window_days);
     let sp_apy = compute_sp_apy(&stability_rows, window_days);
 
     types::ApyResponse {
         lp_apy_pct: lp_apy,
+        amm_apy_pct: amm_apy,
         sp_apy_pct: sp_apy,
         window_days,
     }
@@ -328,6 +330,36 @@ pub fn compute_lp_apy(
     let daily_fees = total_fees as f64 / window_days as f64;
     let apy = (daily_fees / avg_tvl) * 365.0 * 100.0;
     Some(apy)
+}
+
+/// AMM1 LP APY: annualized (trading fees + icUSD rewards) yield.
+///
+/// Trading fees come from the swap rollups (`amm_fees_e8s`); the icUSD reward
+/// stream comes from the daily TVL rows (`amm_rewards_e8s`). Both are annualized
+/// against the average AMM1 TVL over the window. Returns `None` when AMM1 TVL is
+/// unavailable (no `amm_tvl_usd_e8s` rows, or it averages <= 0) so callers can
+/// fall back rather than display a bogus number.
+pub fn compute_amm_apy(
+    swap_rollups: &[storage::rollups::DailySwapRollup],
+    tvl_rows: &[storage::DailyTvlRow],
+    window_days: u32,
+) -> Option<f64> {
+    let fees: u128 = swap_rollups.iter().map(|r| r.amm_fees_e8s as u128).sum();
+    let rewards: u128 = tvl_rows.iter().filter_map(|r| r.amm_rewards_e8s).sum();
+    let tvl_vals: Vec<f64> = tvl_rows
+        .iter()
+        .filter_map(|r| r.amm_tvl_usd_e8s)
+        .map(|v| v as f64)
+        .collect();
+    if tvl_vals.is_empty() {
+        return None;
+    }
+    let avg_tvl = tvl_vals.iter().sum::<f64>() / tvl_vals.len() as f64;
+    if avg_tvl <= 0.0 {
+        return None;
+    }
+    let daily = (fees as f64 + rewards as f64) / window_days as f64;
+    Some((daily / avg_tvl) * 365.0 * 100.0)
 }
 
 /// Stability pool APY: annualized interest yield.
@@ -890,6 +922,7 @@ pub fn get_protocol_summary() -> types::ProtocolSummary {
     let tvl_rows = storage::daily_tvl::range(week_ago, now, MAX_SNAPSHOT_LOAD);
     let stability_rows = storage::daily_stability::range(week_ago, now, MAX_SNAPSHOT_LOAD);
     let lp_apy = compute_lp_apy(&swap_rollups, &tvl_rows, 7);
+    let amm_apy = compute_amm_apy(&swap_rollups, &tvl_rows, 7);
     let sp_apy = compute_sp_apy(&stability_rows, 7);
 
     // Price TWAPs over 1 hour.
@@ -909,6 +942,7 @@ pub fn get_protocol_summary() -> types::ProtocolSummary {
         swap_count_24h: activity.total_swaps,
         peg,
         lp_apy_pct: lp_apy,
+        amm_apy_pct: amm_apy,
         sp_apy_pct: sp_apy,
         prices,
     }
@@ -1226,6 +1260,39 @@ mod tests {
             three_pool_reserve_2_e8s: Some(reserve),
             three_pool_virtual_price_e18: None,
             three_pool_lp_supply_e8s: None,
+            amm_tvl_usd_e8s: None,
+            amm_rewards_e8s: None,
+        }
+    }
+
+    fn make_amm_tvl_row(amm_tvl_usd_e8s: u128, amm_rewards_e8s: u128) -> DailyTvlRow {
+        DailyTvlRow {
+            timestamp_ns: 1_000_000_000,
+            total_icp_collateral_e8s: 0,
+            total_icusd_supply_e8s: 0,
+            system_collateral_ratio_bps: 0,
+            stability_pool_deposits_e8s: None,
+            three_pool_reserve_0_e8s: None,
+            three_pool_reserve_1_e8s: None,
+            three_pool_reserve_2_e8s: None,
+            three_pool_virtual_price_e18: None,
+            three_pool_lp_supply_e8s: None,
+            amm_tvl_usd_e8s: Some(amm_tvl_usd_e8s),
+            amm_rewards_e8s: Some(amm_rewards_e8s),
+        }
+    }
+
+    /// Like `make_swap_rollup` but with the AMM1 trading-fee field populated.
+    fn make_amm_swap_rollup(amm_fees: u64) -> DailySwapRollup {
+        DailySwapRollup {
+            timestamp_ns: 1_000_000_000,
+            three_pool_swap_count: 0,
+            amm_swap_count: 10,
+            three_pool_volume_e8s: 0,
+            amm_volume_e8s: 1_000_000,
+            three_pool_fees_e8s: 0,
+            amm_fees_e8s: amm_fees,
+            unique_swappers: 5,
         }
     }
 
@@ -1274,6 +1341,31 @@ mod tests {
         // Need at least 2 rows to compute a delta
         let rows = vec![make_stability_row(100_000, 50)];
         assert!(compute_sp_apy(&rows, 1).is_none());
+    }
+
+    #[test]
+    fn amm_apy_basic() {
+        // amm_fees_e8s = 1_000_000, amm_rewards_e8s = 500_000, amm_tvl = 100_000_000,
+        // window = 1 day.
+        // daily = (1_000_000 + 500_000) / 1 = 1_500_000
+        // APY   = (1_500_000 / 100_000_000) * 365 * 100 = 547.5
+        let rollups = vec![make_amm_swap_rollup(1_000_000)];
+        let tvls = vec![make_amm_tvl_row(100_000_000, 500_000)];
+        let apy = compute_amm_apy(&rollups, &tvls, 1).unwrap();
+        assert!((apy - 547.5).abs() < 1e-6, "expected 547.5, got {}", apy);
+    }
+
+    #[test]
+    fn amm_apy_absent_fields_none() {
+        // TVL rows without amm_tvl_usd_e8s yield None even when fees/rewards exist.
+        let rollups = vec![make_amm_swap_rollup(1_000_000)];
+        let tvls = vec![make_tvl_row(100_000_000)];
+        assert!(compute_amm_apy(&rollups, &tvls, 1).is_none());
+    }
+
+    #[test]
+    fn amm_apy_empty() {
+        assert!(compute_amm_apy(&[], &[], 7).is_none());
     }
 
     #[test]

--- a/src/rumi_analytics/src/sources/amm.rs
+++ b/src/rumi_analytics/src/sources/amm.rs
@@ -94,3 +94,66 @@ pub async fn get_pools(amm: Principal) -> Result<Vec<AmmPoolInfo>, String> {
         .map_err(|(code, msg)| format!("get_pools: {:?} {}", code, msg))?;
     Ok(pools)
 }
+
+// --- AMM1 (3USD/ICP) APY inputs ---
+
+/// One day's icUSD reward stream for an AMM pool (e8s). `amount` is the running
+/// total distributed so far for that day (the analytics side stores it
+/// last-write-wins, so it is a total, not an increment).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct DailyRewardPoint {
+    pub day_start_ns: u64,
+    pub amount: candid::Nat,
+}
+
+/// A TVL snapshot for an AMM pool, as returned by `get_amm_tvl_series`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TvlSample {
+    pub pool_id: String,
+    pub timestamp: u64,
+    pub reserve_a: Nat,
+    pub reserve_b: Nat,
+    pub price_a_e8s: Nat,
+    pub price_b_e8s: Nat,
+    pub tvl_usd_e8s: Nat,
+}
+
+/// Recent TVL series for a pool (one sample per snapshot over `window_days`).
+pub async fn get_amm_tvl_series(
+    amm: Principal,
+    pool_id: String,
+    window_days: u32,
+) -> Result<Vec<TvlSample>, String> {
+    let (series,): (Vec<TvlSample>,) =
+        ic_cdk::call(amm, "get_amm_tvl_series", (pool_id, window_days))
+            .await
+            .map_err(|(code, msg)| format!("get_amm_tvl_series: {:?} {}", code, msg))?;
+    Ok(series)
+}
+
+/// Recent daily icUSD-reward series for a pool over `window_days`.
+pub async fn get_amm_reward_series(
+    amm: Principal,
+    pool_id: String,
+    window_days: u32,
+) -> Result<Vec<DailyRewardPoint>, String> {
+    let (series,): (Vec<DailyRewardPoint>,) =
+        ic_cdk::call(amm, "get_amm_reward_series", (pool_id, window_days))
+            .await
+            .map_err(|(code, msg)| format!("get_amm_reward_series: {:?} {}", code, msg))?;
+    Ok(series)
+}
+
+/// Resolve the pool_id of the AMM1 (3USD/ICP) pool by matching the 3USD principal
+/// (which IS the rumi_3pool canister) against each pool's token_a / token_b.
+///
+/// We do NOT hardcode a pool_id string (e.g. "3USD_ICP"): the AMM derives pool
+/// ids from token principals, so a literal won't match.
+pub async fn resolve_amm1_pool_id(amm: Principal, threeusd: Principal) -> Result<String, String> {
+    let pools = get_pools(amm).await?;
+    pools
+        .into_iter()
+        .find(|p| p.token_a == threeusd || p.token_b == threeusd)
+        .map(|p| p.pool_id)
+        .ok_or_else(|| format!("no AMM pool found for 3USD principal {}", threeusd))
+}

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -260,6 +260,10 @@ pub struct DailyTvlRow {
     pub three_pool_reserve_2_e8s: Option<u128>,
     pub three_pool_virtual_price_e18: Option<u128>,
     pub three_pool_lp_supply_e8s: Option<u128>,
+    // AMM1 (3USD/ICP) additions (trailing optionals; Candid decodes missing rows
+    // as None, matching the "Phase 3 additions" backward-compat pattern above).
+    pub amm_tvl_usd_e8s: Option<u128>,
+    pub amm_rewards_e8s: Option<u128>,
 }
 
 impl Storable for DailyTvlRow {

--- a/src/rumi_analytics/src/types.rs
+++ b/src/rumi_analytics/src/types.rs
@@ -205,6 +205,7 @@ pub struct ApyQuery {
 #[derive(CandidType, Clone, Debug)]
 pub struct ApyResponse {
     pub lp_apy_pct: Option<f64>,
+    pub amm_apy_pct: Option<f64>,
     pub sp_apy_pct: Option<f64>,
     pub window_days: u32,
 }
@@ -222,6 +223,7 @@ pub struct ProtocolSummary {
     pub swap_count_24h: u32,
     pub peg: Option<PegStatus>,
     pub lp_apy_pct: Option<f64>,
+    pub amm_apy_pct: Option<f64>,
     pub sp_apy_pct: Option<f64>,
     pub prices: Vec<TwapEntry>,
 }

--- a/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
@@ -17,6 +17,8 @@
   import { stabilityPoolService } from '$services/stabilityPoolService';
   import { e8sToNumber, formatCompact, CHART_COLORS } from '$utils/explorerChartHelpers';
   import { liveSpApyPct, liveLpApyPct } from '$utils/liveApy';
+  import { getThreePoolApy } from '$services/threePoolApyService';
+  import { getAmm1Apy, combinedBestLpApyPct } from '$services/amm1ApyService';
   import type { ProtocolSummary, PegStatus, TokenFlowEdge } from '$declarations/rumi_analytics/rumi_analytics.did';
 
   let summary: ProtocolSummary | null = $state(null);
@@ -29,6 +31,9 @@
   let analyticsSpApy: number | null = $state(null);
   let liveLp: number | null = $state(null);
   let liveSp: number | null = $state(null);
+  // Live 3pool/AMM1 APY inputs for the combined "best LP APY" headline vital.
+  let liveThreePoolApy: number | null = $state(null);
+  let liveAmm1Apy: number | null = $state(null);
   let poolsLoading = $state(true);
 
   type FlowWindowKey = '24h' | '7d' | '30d';
@@ -104,12 +109,39 @@
       console.error('[OverviewLens] live APY compute error:', err);
     }
     poolsLoading = false;
+
+    // Combined "best LP APY" inputs for the headline vital. These reuse the
+    // exact same cached services as the Swap "Earn up to" banner, so the
+    // Explorer and Swap surfaces never disagree. Graceful: each stays null on
+    // failure and the vital falls back to the 3pool-only number.
+    try {
+      const [tpR, ammR] = await Promise.allSettled([
+        getThreePoolApy(),
+        getAmm1Apy(),
+      ]);
+      if (tpR.status === 'fulfilled') liveThreePoolApy = tpR.value.total_apy_pct;
+      if (ammR.status === 'fulfilled') liveAmm1Apy = ammR.value.total_apy_pct;
+    } catch (err) {
+      console.error('[OverviewLens] combined LP APY compute error:', err);
+    }
   });
 
   const lpApy = $derived(liveLp ?? analyticsLpApy);
   const spApy = $derived(liveSp ?? analyticsSpApy);
   const lpApySub = $derived(liveLp != null ? 'live' : '7d');
   const spApySub = $derived(liveSp != null ? 'live' : '7d');
+
+  // Headline LP APY = the best per-dollar return across 3pool and AMM1 (AMM1
+  // stacks 3pool yield on its 3USD half). Matches the Swap "Earn up to" banner.
+  // Falls back to the 3pool-only number when the live inputs are unavailable.
+  const combinedLpApy = $derived.by(() =>
+    liveThreePoolApy != null && liveAmm1Apy != null
+      ? combinedBestLpApyPct(liveThreePoolApy, liveAmm1Apy)
+      : lpApy,
+  );
+  const combinedLpApySub = $derived(
+    liveThreePoolApy != null && liveAmm1Apy != null ? 'best · live' : lpApySub,
+  );
 
   const pegPct = $derived.by(() => {
     if (!pegStatus) return '--';
@@ -137,7 +169,7 @@
       { label: '24h Volume', value: `$${formatCompact(volume24h)}` },
       { label: '24h Swaps', value: Number(summary.swap_count_24h).toLocaleString() },
       { label: 'Peg', value: pegPct, tone: pegTone },
-      { label: 'LP APY', value: lpApy != null ? `${lpApy.toFixed(2)}%` : '--', sub: lpApySub },
+      { label: 'LP APY', value: combinedLpApy != null ? `${combinedLpApy.toFixed(2)}%` : '--', sub: combinedLpApySub },
       { label: 'SP APY', value: spApy != null ? `${spApy.toFixed(2)}%` : '--', sub: spApySub },
     ];
   });

--- a/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/OverviewLens.svelte
@@ -28,6 +28,7 @@
   let seriesLoading = $state(true);
   let pegStatus: PegStatus | null = $state(null);
   let analyticsLpApy: number | null = $state(null);
+  let analyticsAmmApy: number | null = $state(null);
   let analyticsSpApy: number | null = $state(null);
   let liveLp: number | null = $state(null);
   let liveSp: number | null = $state(null);
@@ -84,8 +85,10 @@
     if (pegR.status === 'fulfilled') pegStatus = pegR.value ?? null;
     if (apyR.status === 'fulfilled' && apyR.value) {
       const aLp = apyR.value.lp_apy_pct?.[0];
+      const aAmm = apyR.value.amm_apy_pct?.[0];
       const aSp = apyR.value.sp_apy_pct?.[0];
       if (typeof aLp === 'number') analyticsLpApy = aLp;
+      if (typeof aAmm === 'number') analyticsAmmApy = aAmm;
       if (typeof aSp === 'number') analyticsSpApy = aSp;
     }
 
@@ -134,11 +137,19 @@
   // Headline LP APY = the best per-dollar return across 3pool and AMM1 (AMM1
   // stacks 3pool yield on its 3USD half). Matches the Swap "Earn up to" banner.
   // Falls back to the 3pool-only number when the live inputs are unavailable.
-  const combinedLpApy = $derived.by(() =>
-    liveThreePoolApy != null && liveAmm1Apy != null
-      ? combinedBestLpApyPct(liveThreePoolApy, liveAmm1Apy)
-      : lpApy,
-  );
+  const combinedLpApy = $derived.by(() => {
+    // Live primary: best per-dollar of (3pool-only) vs (AMM1 + half 3pool).
+    if (liveThreePoolApy != null && liveAmm1Apy != null) {
+      return combinedBestLpApyPct(liveThreePoolApy, liveAmm1Apy);
+    }
+    // Analytics fallback: the canister now tracks a faithful AMM1 LP APY (trading
+    // fees + icUSD rewards), so combine it the same way when both values exist;
+    // otherwise fall back to the 3pool-only number (lpApy) as before.
+    if (analyticsLpApy != null && analyticsAmmApy != null) {
+      return combinedBestLpApyPct(analyticsLpApy, analyticsAmmApy);
+    }
+    return lpApy;
+  });
   const combinedLpApySub = $derived(
     liveThreePoolApy != null && liveAmm1Apy != null ? 'best · live' : lpApySub,
   );

--- a/src/vault_frontend/src/lib/services/amm1ApyService.ts
+++ b/src/vault_frontend/src/lib/services/amm1ApyService.ts
@@ -72,6 +72,25 @@ export function computeAmm1EffectiveApy(
   };
 }
 
+/**
+ * The protocol's headline "best LP APY": the better per-dollar return of
+ * staying in the 3pool standalone vs. providing AMM1 liquidity (which stacks
+ * 3pool yield on its 3USD half). Capital can only sit in one position at a
+ * time, so this is a max, not a blend.
+ *
+ * Single source of truth for both the Swap "Earn up to" banner and the
+ * Explorer "LP APY" vital so the two surfaces never disagree. Pure function.
+ */
+export function combinedBestLpApyPct(
+  threePoolApyPct: number,
+  amm1ApyPct: number,
+): number {
+  return Math.max(
+    threePoolApyPct,
+    amm1ApyPct + AMM1_THREEUSD_VALUE_SHARE * threePoolApyPct,
+  );
+}
+
 interface DailyRewardPoint {
   day_start_ns: bigint;
   amount: bigint;

--- a/src/vault_frontend/src/routes/swap/+page.svelte
+++ b/src/vault_frontend/src/routes/swap/+page.svelte
@@ -6,7 +6,7 @@
   import PoolListView from '../../lib/components/swap/PoolListView.svelte';
   import AmmLiquidityPanel from '../../lib/components/swap/AmmLiquidityPanel.svelte';
   import LiquidityInterface from '../../lib/components/swap/LiquidityInterface.svelte';
-  import { getAmm1Apy, AMM1_THREEUSD_VALUE_SHARE } from '../../lib/services/amm1ApyService';
+  import { getAmm1Apy, combinedBestLpApyPct } from '../../lib/services/amm1ApyService';
   import { getThreePoolApy } from '../../lib/services/threePoolApyService';
 
   let mode: 'swap' | 'liquidity' = 'swap';
@@ -21,12 +21,11 @@
   // and the AMM1 LP path stacks 3pool yield on its 3USD half:
   //   amm1Effective = amm1Apy + 0.5 * threePoolApy
   // The advertised number is whichever of the two paths wins per dollar.
+  // `combinedBestLpApyPct` is the shared source of truth (also used by the
+  // Explorer "LP APY" vital) so the two surfaces never disagree.
   $: combinedApy =
     threePoolApyPct !== null && ammApyPct !== null
-      ? Math.max(
-          threePoolApyPct,
-          ammApyPct + AMM1_THREEUSD_VALUE_SHARE * threePoolApyPct,
-        )
+      ? combinedBestLpApyPct(threePoolApyPct, ammApyPct)
       : null;
 
   onMount(() => {


### PR DESCRIPTION
## What

The Explorer's "Protocol Health" -> **LP APY** vital showed only the **3pool** LP APY (e.g. 2.72%), ignoring AMM1. Since AMM1 LPs also earn 3pool yield on the pool's 3USD half, that understated the real best yield. It now shows the same combined "best per-dollar" figure as the Swap **"Earn up to"** banner:

`LP APY = max(threePoolApy, amm1Apy + 0.5 x threePoolApy)`

This is the **full fix**: the display is corrected AND `rumi_analytics` now tracks AMM1 as a first-class citizen so the fallback/summary numbers include AMM1 too (not just the live path).

## Part 1 - Frontend display (commit `cf8dd7e`)

- **`amm1ApyService.ts`** - new shared pure helper `combinedBestLpApyPct()`, the single source of truth for the formula.
- **`swap/+page.svelte`** - the "Earn up to" banner now calls the shared helper (no behavior change, just DRY).
- **`OverviewLens.svelte`** - the headline "LP APY" vital uses the combined number, computed live from the same cached `getThreePoolApy()` / `getAmm1Apy()` calls the banner uses.

The separate **"3Pool LP APY"** detail cards (PoolHealthStrip, Revenue/Dexs lenses) are unchanged - they're explicitly pool-specific and remain 3pool-only.

## Part 2 - Canister: faithful `amm_apy_pct` (commit `352a265`)

`rumi_analytics` now computes a real AMM1 APY including **both** trading fees and the (dominant) **icUSD reward stream**, annualized vs AMM1 TVL.

- **storage** - appended two trailing `Option` fields to `DailyTvlRow` (`amm_tvl_usd_e8s`, `amm_rewards_e8s`). Backward-compatible; **no main-state change, no migration** (verified `state.rs` diff is empty).
- **sources/amm** - wraps `get_amm_tvl_series` + `get_amm_reward_series`; resolves the 3USD/ICP pool_id via `get_pools` (no hardcoded id).
- **collectors/tvl** - snapshots AMM1 TVL + that day's reward total each cycle, **degrading gracefully to `None`** on any rumi_amm call failure (never fails the TVL cycle).
- **queries/live** - `compute_amm_apy = ((amm_fees + amm_rewards)/days)/avg_amm_tvl * 365 * 100`, symmetric with `compute_lp_apy`. Exposed as `amm_apy_pct` on `ApyResponse` + `ProtocolSummary`.
- **did + declarations** regenerated (`dfx generate rumi_analytics`).
- **OverviewLens fallback** - when the live path is unavailable, it now combines analytics `lp_apy_pct` + `amm_apy_pct` (instead of degrading to 3pool-only).

**Warm-up:** `amm_apy_pct` returns `None` until the daily collector accrues rows post-deploy. The live frontend path stays primary and full-fidelity throughout, so the headline number is correct immediately; only the rarely-hit analytics fallback warms up.

## Verification

- `cargo test -p rumi_analytics --lib`: **111 passed / 0 failed** (incl. 3 new `compute_amm_apy` tests, percent-based, consistent with `compute_lp_apy`; e.g. `amm_apy_basic` asserts 547.5).
- `svelte-check`: edited frontend files introduce **0 new errors** (pre-existing repo errors are in unrelated files / unrelated to these edits).
- State-wipe safety independently verified: `state.rs` unchanged; `DailyTvlRow` gained only trailing `Option` fields.

## Deploy (separate, needs authorization)

This now requires a **`rumi_analytics` mainnet deploy** (full `InitArgs` on upgrade + `ic-wasm shrink` + `gzip`, per the canister's deploy notes) plus a `vault_frontend` asset deploy. Not done here. The pre-deploy hook will run unit + integration tests first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
