### PR TITLE
fix(monad): chunk eth_getLogs + raise scan window (Gate-4 getLogs 100-block cap)

### DIFF
--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -279,6 +279,15 @@ fn init() {
     });
 }
 
+// ─── Provider limits ─────────────────────────────────────────────────────────
+
+/// Max `eth_getLogs` block range the Monad testnet RPC accepts: `toBlock -
+/// fromBlock` must be <= this. A difference of 101 returns HTTP 413 / JSON-RPC
+/// -32614. Must match `MONAD_GETLOGS_MAX_RANGE` in the backend's
+/// `chains/monad/evm_rpc.rs` so the mock's cap and the wrapper's chunk size
+/// agree (a chunk produced at exactly the wrapper's max must pass here).
+const MONAD_GETLOGS_MAX_RANGE: u64 = 100;
+
 // ─── JSON helpers ───────────────────────────────────────────────────────────
 
 fn hex_u128(v: u128) -> String {
@@ -343,6 +352,41 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                 message: msg,
             },
         )));
+    }
+
+    // Provider fidelity (Gate-4 getLogs bug): the Monad testnet RPC caps
+    // `eth_getLogs` at a 100-block RANGE — `toBlock - fromBlock` must be <= 100;
+    // a difference of 101 returns HTTP 413 with JSON-RPC code -32614
+    // ("eth_getLogs is limited to a 100 range"). Empirically confirmed against
+    // https://testnet-rpc.monad.xyz on 2026-05-31. The EVM RPC canister surfaces
+    // that 413 to the backend as `HttpOutcallError::InvalidHttpJsonRpcResponse`.
+    // The mock enforces the SAME cap so the wrapper's `get_logs` chunking is
+    // exercised: an un-chunked wide-range scan fails here exactly as it does on
+    // staging, and only succeeds once `get_logs` pages the range into <=100-block
+    // sub-queries. (Mint-confirm scans a single block `[b, b]` — diff 0 — and is
+    // unaffected.)
+    if method == "eth_getLogs" {
+        let filter = params.get(0).cloned().unwrap_or(serde_json::Value::Null);
+        let from = filter
+            .get("fromBlock")
+            .and_then(|v| v.as_str())
+            .and_then(parse_hex_u64);
+        let to = filter
+            .get("toBlock")
+            .and_then(|v| v.as_str())
+            .and_then(parse_hex_u64);
+        if let (Some(f), Some(t)) = (from, to) {
+            if t.saturating_sub(f) > MONAD_GETLOGS_MAX_RANGE {
+                return RequestResult::Err(RpcError::HttpOutcallError(
+                    HttpOutcallError::InvalidHttpJsonRpcResponse(InvalidHttpJsonRpcRecord {
+                        status: 413,
+                        body: r#"{"jsonrpc":"2.0","id":0,"error":{"code":-32614,"message":"eth_getLogs is limited to a 100 range"}}"#
+                            .to_string(),
+                        parsing_error: None,
+                    }),
+                ));
+            }
+        }
     }
 
     let response_json: String = SCRIPT.with(|s| {

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -338,15 +338,30 @@ pub async fn run_observer(chain: ChainId) {
         }
     };
 
-    // ── Hot-wallet gas-balance refresh (Task 11) ─────────────────────────────
+    // ── Hot-wallet gas-balance refresh (Task 11; cycle-gated) ────────────────
     //
     // Derive the settlement (minter) address and cache its native MON balance so
     // the submit-path gas gate (`hardening::hot_wallet_ok`) has data and the
-    // Task-14 query surface can report it. Keeping the tECDSA + RPC cost here
-    // (once per observer tick) avoids paying it on every settlement submit.
-    // Tolerant of errors: a failed derive or balance read logs and continues —
-    // it must NOT abort the observer (reads/burn-watch must still run).
-    refresh_hot_wallet_balance(chain).await;
+    // Task-14 query surface can report it. Tolerant of errors: a failed derive or
+    // balance read logs and continues — it must NOT abort the observer.
+    //
+    // CYCLE GATE: the cached balance ONLY feeds the submit-path gas gate, so we
+    // refresh it only when this chain has a non-terminal settlement op (a mint /
+    // withdraw about to submit or confirm). On idle ticks (nothing queued) this
+    // saves one `eth_getBalance` outcall per tick (~764M cycles each, measured).
+    // An unpopulated cache is treated as fail-open by `hot_wallet_ok`, so skipping
+    // the refresh never blocks a future submit; the first tick that sees a queued
+    // op refreshes before the worker needs it.
+    let has_settlement_work = read_state(|s| {
+        s.multi_chain
+            .settlement_queues
+            .get(&chain)
+            .map(|q| q.has_active_op())
+            .unwrap_or(false)
+    });
+    if has_settlement_work {
+        refresh_hot_wallet_balance(chain).await;
+    }
 
     // Read the burn-watch cursor BEFORE running deposit-watch. The deposit-watch
     // path is consensus-safe (balance-only) and runs every tick regardless of
@@ -552,6 +567,24 @@ pub async fn run_observer(chain: ChainId) {
         return;
     }
 
+    // ── No-debt fast path (cycle gate) ───────────────────────────────────────
+    //
+    // A Burn can only ever apply to a chain-vault that HAS debt. When the total
+    // foreign-chain vault debt is 0 there is nothing any Burn in this range could
+    // decrement, so skip the (expensive) get_logs scan entirely — that is
+    // ceil(window / MONAD_GETLOGS_MAX_RANGE) EVM-RPC outcalls per advancing tick
+    // (~764M cycles each, measured 2026-05-31). We STILL advance the cursor to
+    // `finalized` (and prune) so the consensus-safe finality probe
+    // `fetch_block_numbers` (= last_observed + MAX_BLOCK_SCAN_WINDOW) stays
+    // current: a stalled cursor would leave the next mint unable to reach
+    // finality — the Gate-4 failure mode. No burn is missed: with zero
+    // chain-vault debt there is no vault a burn in this range could have repaid.
+    let total_chain_debt = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
+    if total_chain_debt == 0 {
+        mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
+        return;
+    }
+
     let from_block = last_observed + 1;
 
     let raw_burn_logs = match get_logs(chain, &contract, BURN_EVENT_TOPIC0, from_block, finalized).await {
@@ -705,33 +738,35 @@ pub async fn run_observer(chain: ChainId) {
     // loop. Skippable failures (decode / InvalidBurn) leave it true so the
     // cursor advances past the poison.
     if burn_ok {
-        mutate_state(|s| {
-            s.multi_chain.last_observed_block.insert(chain, finalized);
-            // Prune the idempotency set of entries the next scan can never
-            // re-reach. The next scan starts at `finalized + 1`, so any block
-            // <= finalized is permanently behind the cursor and its keys are no
-            // longer needed for dedup. This keeps `processed_burn_keys` bounded.
-            // On a halt-break (above), we DO NOT prune — the un-halt re-scan
-            // restarts from the same `last_observed + 1` and must stay idempotent.
-            //
-            // PHASE-1C NOTE: This prune assumes no other observer tick is
-            // concurrently alive and still holding captured `get_logs` results
-            // for a now-pruned block. That is safe for Phase 1b: single-slot
-            // finality + bounded outcall timeouts + a handful of vaults make a
-            // tick running longer than MAX_BLOCK_SCAN_WINDOW blocks unreachable
-            // in practice. Revisit for Phase 1c (deeper finality / higher vault
-            // counts) where a self-heal reclaim could race the prune and a
-            // stale tick might re-apply a burn whose key was already pruned.
-            let stale: Vec<u64> = s
-                .multi_chain
-                .processed_burn_keys
-                .range(..=finalized)
-                .map(|(&block, _)| block)
-                .collect();
-            for block in stale {
-                s.multi_chain.processed_burn_keys.remove(&block);
-            }
-        });
+        mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
+    }
+}
+
+/// Advance the burn-watch cursor for `chain` to `finalized` and prune
+/// `processed_burn_keys` of every entry at `block <= finalized`. Those blocks are
+/// permanently behind the cursor (the next scan starts at `finalized + 1`), so
+/// their dedup keys are no longer needed; pruning keeps the idempotency set
+/// bounded.
+///
+/// Called on the no-halt advance path AND the no-debt fast path. It is NOT called
+/// on a halt-break: the un-halt re-scan restarts from the same `last_observed + 1`
+/// and must stay idempotent, so those keys are retained.
+///
+/// PHASE-1C NOTE: the prune assumes no other observer tick is concurrently alive
+/// still holding captured `get_logs` results for a now-pruned block. Safe for
+/// Phase 1b (single-slot finality + bounded outcall timeouts + a handful of
+/// vaults make a tick outliving MAX_BLOCK_SCAN_WINDOW blocks unreachable in
+/// practice). Revisit for deeper finality / higher vault counts where a self-heal
+/// reclaim could race the prune.
+pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV2, chain: ChainId, finalized: u64) {
+    state.last_observed_block.insert(chain, finalized);
+    let stale: Vec<u64> = state
+        .processed_burn_keys
+        .range(..=finalized)
+        .map(|(&block, _)| block)
+        .collect();
+    for block in stale {
+        state.processed_burn_keys.remove(&block);
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -57,12 +57,34 @@ const EVM_RPC_MAX_RESPONSE_BYTES: u64 = 8192;
 
 /// Max blocks the burn-watch cursor advances per observer tick. The observer
 /// reads chain head by probing a SPECIFIC block number `last_observed + this`
-/// (consensus-safe), never a volatile `latest`/`finalized` tag. Must exceed
-/// observer_interval_secs × chain_block_rate (~30s × 2 blk/s = 60) to keep pace,
-/// and exceed observer_interval_secs × chain_block_rate so the cursor keeps pace
-/// (see the sizing note). `get_logs` chunks the scan internally, so this is NOT
-/// bounded by the provider's per-query getLogs cap.
-pub const MAX_BLOCK_SCAN_WINDOW: u64 = 256;
+/// (consensus-safe), never a volatile `latest`/`finalized` tag.
+///
+/// ## Sizing (must be >= blocks-produced-per-observer-interval)
+///
+/// The probe jumps exactly this many blocks whenever block `last_observed +
+/// this` exists and is final; otherwise the cursor waits. Over the long run the
+/// cursor therefore advances at most `this` blocks per tick, so to keep pace with
+/// the chain it MUST be >= the number of blocks Monad produces per observer
+/// interval. Falling below that makes the cursor lag unboundedly (burns observed
+/// with ever-growing delay).
+///
+/// Measured 2026-05-31: Monad testnet produces ~1.93 blocks/s, and the staging
+/// observer interval is 300s (set live for cycle-burn mitigation), i.e. ~578
+/// blocks/tick. The previous value (256) was sized for a 30s interval (~60
+/// blocks/tick) and could NOT keep pace at 300s — that, together with the
+/// 100-block getLogs cap, is why the Gate-4 cursor stalled. 1024 comfortably
+/// exceeds 578 (1.77x margin, covers up to ~3.4 blocks/s at 300s) and bounds the
+/// observation lag at roughly one window (~512s). It also stays correct at the
+/// 30s default interval (the cursor advances in 1024-block bursts rather than
+/// every tick, but still keeps pace). If the observer interval is raised well
+/// beyond 300s, or Monad's block rate rises substantially, raise this too.
+///
+/// `get_logs` chunks the per-tick scan into <= `MONAD_GETLOGS_MAX_RANGE`-block
+/// sub-queries, so this window is NOT bounded by the provider's per-query
+/// getLogs cap (a 1024-block window scans as ceil(1024/100) = 11 sub-queries).
+/// Note: the total getLogs volume per day is set by blocks/day ÷ 100 regardless
+/// of this window — a larger window only changes burst size and lag, not cost.
+pub const MAX_BLOCK_SCAN_WINDOW: u64 = 1024;
 
 /// Maximum `eth_getLogs` block range (`toBlock - fromBlock`) the Monad testnet
 /// RPC accepts in a SINGLE query. A difference of 101 returns HTTP 413 with

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -59,8 +59,20 @@ const EVM_RPC_MAX_RESPONSE_BYTES: u64 = 8192;
 /// reads chain head by probing a SPECIFIC block number `last_observed + this`
 /// (consensus-safe), never a volatile `latest`/`finalized` tag. Must exceed
 /// observer_interval_secs × chain_block_rate (~30s × 2 blk/s = 60) to keep pace,
-/// and stay <= the EVM RPC eth_getLogs maxBlockRange (default 500). 256 fits both.
+/// and exceed observer_interval_secs × chain_block_rate so the cursor keeps pace
+/// (see the sizing note). `get_logs` chunks the scan internally, so this is NOT
+/// bounded by the provider's per-query getLogs cap.
 pub const MAX_BLOCK_SCAN_WINDOW: u64 = 256;
+
+/// Maximum `eth_getLogs` block range (`toBlock - fromBlock`) the Monad testnet
+/// RPC accepts in a SINGLE query. A difference of 101 returns HTTP 413 with
+/// JSON-RPC code -32614 ("eth_getLogs is limited to a 100 range"); a difference
+/// of 100 (a 101-block span) is accepted. Empirically confirmed against
+/// `https://testnet-rpc.monad.xyz` on 2026-05-31. `get_logs` pages any wider
+/// range into sequential sub-queries each respecting this cap, so callers (the
+/// burn-watch loop and mint-confirm scan) never need to know about it. Kept in
+/// sync with the same-named constant in `src/monad_rpc_mock/src/lib.rs`.
+pub const MONAD_GETLOGS_MAX_RANGE: u64 = 100;
 
 // ─── Topic0 constants ────────────────────────────────────────────────────────
 
@@ -697,7 +709,55 @@ pub async fn get_transaction_count(chain: ChainId, address: &str) -> Result<u64,
 ///
 /// The caller is responsible for decoding via `decode_burn_log` /
 /// `decode_mint_log` etc.
+///
+/// ## Chunking (Gate-4 fix)
+///
+/// The Monad testnet RPC caps a single `eth_getLogs` at a 100-block range
+/// (`toBlock - fromBlock` <= `MONAD_GETLOGS_MAX_RANGE`); a wider range returns
+/// HTTP 413 / JSON-RPC -32614. This function pages `[from_block, to_block]` into
+/// sequential sub-queries each within that cap and concatenates their results in
+/// block order. Single-block scans (mint-confirm passes `from == to`) collapse to
+/// exactly one sub-query, unchanged.
+///
+/// Error policy: a sub-query RPC error fails the WHOLE call (the `?` below
+/// propagates it and no partial `Vec` is returned). This is deliberate — the
+/// burn-watch loop must retry the full range and must NOT advance its cursor past
+/// a range that was only partially scanned, or it would silently miss the burns
+/// in the un-scanned chunks (a supply-accounting hole). Ordering and the
+/// `(tx_hash, log_index)` dedup are unaffected: chunks cover disjoint, ascending
+/// block ranges, so concatenating them yields the same flat, block-ordered Vec a
+/// single wide query would have, and every log keeps its own block + log_index.
 pub async fn get_logs(
+    chain: ChainId,
+    contract: &str,
+    topic0: &str,
+    from_block: u64,
+    to_block: u64,
+) -> Result<Vec<(Vec<String>, String, String, u64, u64)>, String> {
+    // Defensive: an empty/inverted range has no logs (callers pass from <= to).
+    if from_block > to_block {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    let mut start = from_block;
+    loop {
+        // `to - from <= MONAD_GETLOGS_MAX_RANGE` per sub-query (the provider cap).
+        let chunk_to = start.saturating_add(MONAD_GETLOGS_MAX_RANGE).min(to_block);
+        let mut chunk = get_logs_single_range(chain, contract, topic0, start, chunk_to).await?;
+        out.append(&mut chunk);
+        if chunk_to >= to_block {
+            break;
+        }
+        start = chunk_to + 1;
+    }
+    Ok(out)
+}
+
+/// Single `eth_getLogs` query over `[from_block, to_block]` (caller must keep the
+/// range within the provider's `MONAD_GETLOGS_MAX_RANGE` cap — `get_logs` does
+/// the chunking). Parses the JSON-RPC response into
+/// `(topics, data, txHash, blockNumber, logIndex)` tuples.
+async fn get_logs_single_range(
     chain: ChainId,
     contract: &str,
     topic0: &str,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -1,4 +1,4 @@
-use super::deposit_watch::{apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
+use super::deposit_watch::{advance_cursor_and_prune, apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
 use crate::chains::multi_chain_state::MultiChainStateV2;
@@ -101,4 +101,25 @@ fn burn_returns_supply_invariant_on_supply_divergence_without_mutation() {
     );
     assert_eq!(s.chain_vaults[&1].debt_e8s, 4_000_000_000); // unchanged
     assert_eq!(s.chain_supplies[&ChainId(10143)], 3_000_000_000); // unchanged
+}
+
+#[test]
+fn advance_cursor_and_prune_sets_cursor_and_drops_keys_at_or_below_finalized() {
+    use std::collections::BTreeSet;
+    let mut s = seeded();
+    // Seed processed_burn_keys at three blocks: 100, 150, 250.
+    for b in [100u64, 150, 250] {
+        let mut set = BTreeSet::new();
+        set.insert(format!("0xtx{b}:0"));
+        s.processed_burn_keys.insert(b, set);
+    }
+
+    advance_cursor_and_prune(&mut s, ChainId(10143), 200);
+
+    // Cursor advanced to finalized.
+    assert_eq!(s.last_observed_block.get(&ChainId(10143)).copied(), Some(200));
+    // Keys at block <= 200 pruned (100, 150 gone); keys above 200 retained (250).
+    assert!(!s.processed_burn_keys.contains_key(&100), "block 100 pruned");
+    assert!(!s.processed_burn_keys.contains_key(&150), "block 150 pruned");
+    assert!(s.processed_burn_keys.contains_key(&250), "block 250 > finalized retained");
 }

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -126,6 +126,22 @@ impl SettlementQueueV1 {
         self.pending.len()
     }
 
+    /// True iff the queue has any NON-terminal op (`Queued` or `Inflight`) — i.e.
+    /// settlement work the worker will submit or confirm. Terminal ops
+    /// (`Succeeded`/`Failed`, before `prune_terminal` reaps them) do not count.
+    ///
+    /// Used by the observer to gate the per-tick hot-wallet balance refresh: the
+    /// cached balance only feeds the submit-path gas gate, so there is no reason
+    /// to spend an `eth_getBalance` outcall every tick when nothing is in flight.
+    pub fn has_active_op(&self) -> bool {
+        self.pending.values().any(|op| {
+            matches!(
+                op.status,
+                SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+            )
+        })
+    }
+
     /// Reap terminal (`Succeeded`/`Failed`) ops so `pending` does not grow
     /// monotonically (the Task-10 review flagged `select_next_op`'s per-tick
     /// scan over an ever-growing `pending` as a cycle-cost anti-pattern this

--- a/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
@@ -34,6 +34,35 @@ fn enqueue_assigns_increasing_op_ids() {
 }
 
 #[test]
+fn has_active_op_tracks_non_terminal_ops_only() {
+    let mut q = SettlementQueueV1::default();
+    // Empty queue: no active op (so the observer skips the hot-wallet refresh).
+    assert!(!q.has_active_op(), "empty queue has no active op");
+
+    let id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint { recipient: "0xabc".to_string(), amount_e8s: 100, vault_id: 1 },
+            "key-a".to_string(),
+            0,
+        ))
+        .expect("enqueue");
+    // Queued → active.
+    assert!(q.has_active_op(), "Queued op is active");
+
+    // Inflight → still active.
+    q.pending.get_mut(&id).unwrap().mark_inflight(1);
+    assert!(q.has_active_op(), "Inflight op is active");
+
+    // Succeeded (terminal) → no longer active.
+    q.pending.get_mut(&id).unwrap().mark_succeeded("0xtx".to_string(), 2);
+    assert!(!q.has_active_op(), "Succeeded op is terminal, not active");
+
+    // Failed (terminal) → not active either.
+    q.pending.get_mut(&id).unwrap().mark_failed("nope".to_string(), 3);
+    assert!(!q.has_active_op(), "Failed op is terminal, not active");
+}
+
+#[test]
 fn enqueue_rejects_duplicate_idempotency_key() {
     let mut q = SettlementQueueV1::default();
     let op_a = SettlementOp::new(

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -98,11 +98,17 @@ fn default_interest_treasury_tick_interval_secs() -> u64 { 60 }
 fn default_vault_check_tick_interval_secs() -> u64 { 300 }
 
 /// Phase 1b Task 15: production defaults for the Monad async-loop cadences.
-/// Timer D (settlement) and the observer both default to 30s. A legacy snapshot
-/// without these fields hydrates to 30; the register fns floor a 0 to 30 anyway
-/// so a busy-loop is impossible even with a corrupt value.
-fn default_settlement_tick_interval_secs() -> u64 { 30 }
-fn default_observer_tick_interval_secs() -> u64 { 30 }
+/// Timer D (settlement) and the observer both default to 300s. The previous 30s
+/// default was a severe cycle-burner: each observer tick makes constant outcalls
+/// (finality probe + hot-wallet balance), so 30s = ~2,880 ticks/day of outcalls,
+/// and the EVM-RPC outcall cost (~764M cycles each, measured 2026-05-31) makes
+/// that multiple T/day for the constants alone. 300s matches the operational
+/// value run on staging and keeps a fresh install (or a legacy snapshot missing
+/// these fields) off the catastrophic 30s cadence. The register fns still floor a
+/// 0 to 30 so a busy-loop is impossible even with a corrupt value, and the
+/// developer-gated setters tune the live cadence without an upgrade.
+fn default_settlement_tick_interval_secs() -> u64 { 300 }
+fn default_observer_tick_interval_secs() -> u64 { 300 }
 
 pub fn default_interest_split() -> Vec<InterestRecipient> {
     vec![

--- a/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
@@ -418,8 +418,8 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
     )
     .expect("set_manual_collateral_price");
 
-    // Seed the burn-watch cursor well above 256 so the small legacy block numbers
-    // never apply; one tick advances the cursor by MAX_BLOCK_SCAN_WINDOW (256).
+    // Seed the burn-watch cursor well above 1024 so the small legacy block numbers
+    // never apply; one tick advances the cursor by MAX_BLOCK_SCAN_WINDOW (1024).
     decode_result(
         update_dev(
             &pic,
@@ -431,8 +431,8 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
     )
     .expect("set_last_observed_block");
 
-    // Chain head = seed + 256 so the first tick advances 1_000_000 -> 1_000_256.
-    update_any(&pic, mock, "set_blocks", Encode!(&1_000_256u64, &1_000_256u64).unwrap());
+    // Chain head = seed + 1024 so the first tick advances 1_000_000 -> 1_001_024.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_001_024u64, &1_001_024u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
 
     // ── ECDSA probe: decide full vs gated ────────────────────────────────────
@@ -474,7 +474,7 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
             advance_and_tick(&pic, 4);
 
             assert!(
-                cursor(&pic, backend) >= 1_000_256,
+                cursor(&pic, backend) >= 1_001_024,
                 "gated: cursor advanced past poison-only range (skip-poison-and-continue); got {}",
                 cursor(&pic, backend)
             );
@@ -535,7 +535,7 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
 
     // Settlement submits + confirms the mint. Push the Mint log at the finalized
     // block so the confirm path reads the on-chain amount.
-    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_000_256);
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_001_024);
     advance_and_tick(&pic, 4);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
@@ -549,15 +549,15 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
     // model that exclusion). Then push TWO burns at the SAME finalized block:
     //   1. GOOD partial burn 40e8 (valid)
     //   2. POISON burn 1_000e8 (over-repay: ≫ remaining 60e8) — InvalidBurn forever
-    // Both land in the (1_000_256, 1_000_512] scan window. The poison sits AFTER
+    // Both land in the (1_001_024, 1_002_048] scan window. The poison sits AFTER
     // the good burn in block/log order, so the pre-fix loop applies the good burn,
     // then hits the poison, sets burn_ok=false, and breaks WITHOUT advancing the
     // cursor — forcing the whole range to re-scan every tick and re-apply the 40e8.
     update_any(&pic, mock, "clear_logs", Encode!().unwrap());
-    update_any(&pic, mock, "set_blocks", Encode!(&1_000_512u64, &1_000_512u64).unwrap());
-    // Same block (1_000_300) for both; the good burn first, poison second.
-    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xgoodburn", 1_000_300);
-    push_burn_log(&pic, mock, vault_id, "0xattacker", 1_000 * E8, "0xpoisonburn", 1_000_300);
+    update_any(&pic, mock, "set_blocks", Encode!(&1_002_048u64, &1_002_048u64).unwrap());
+    // Same block (1_001_500) for both; the good burn first, poison second.
+    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xgoodburn", 1_001_500);
+    push_burn_log(&pic, mock, vault_id, "0xattacker", 1_000 * E8, "0xpoisonburn", 1_001_500);
 
     // Advance SEVERAL ticks so the range is (re-)scanned multiple times. On the
     // PRE-FIX code, each re-scan re-applies the 40e8 good burn and double-decrements
@@ -576,7 +576,7 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
 
     // (b) The burn-watch cursor ADVANCED past the poison block (no longer stalls).
     assert!(
-        cursor(&pic, backend) >= 1_000_512,
+        cursor(&pic, backend) >= 1_002_048,
         "C-1: cursor advanced past the poison burn (skip-poison-and-continue); got {}",
         cursor(&pic, backend)
     );
@@ -677,7 +677,7 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
     )
     .expect("set_manual_collateral_price");
 
-    // Seed the cursor well above 256 so scan windows stay in a clean range.
+    // Seed the cursor well above 1024 so scan windows stay in a clean range.
     decode_result(
         update_dev(
             &pic,
@@ -689,7 +689,7 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
     )
     .expect("set_last_observed_block");
 
-    update_any(&pic, mock, "set_blocks", Encode!(&2_000_256u64, &2_000_256u64).unwrap());
+    update_any(&pic, mock, "set_blocks", Encode!(&2_001_024u64, &2_001_024u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint_same_tx".to_string()).unwrap());
 
     // ── ECDSA probe ──────────────────────────────────────────────────────────
@@ -760,7 +760,7 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
     advance_and_tick(&pic, 2);
 
     // Settlement submits + confirms the mint.
-    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint_same_tx", 2_000_256);
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint_same_tx", 2_001_024);
     advance_and_tick(&pic, 4);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
@@ -770,7 +770,7 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
     // ── Same-tx two-identical-burns scenario ─────────────────────────────────
     // Advance the mock chain head into the next scan window.
     update_any(&pic, mock, "clear_logs", Encode!().unwrap());
-    update_any(&pic, mock, "set_blocks", Encode!(&2_000_512u64, &2_000_512u64).unwrap());
+    update_any(&pic, mock, "set_blocks", Encode!(&2_002_048u64, &2_002_048u64).unwrap());
 
     // Push TWO Burn logs with:
     //   - SAME tx_hash ("0xdualtx")
@@ -782,10 +782,10 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
     // With the OLD key (tx:vault:amount): both map to the same key → second dropped → debt=70e8.
     // With the NEW key (tx:log_index): distinct keys → both applied → debt=40e8.
     push_burn_log_at(
-        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_000_300, 0,
+        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_001_500, 0,
     );
     push_burn_log_at(
-        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_000_300, 1,
+        &pic, mock, vault_id, &recipient, 30 * E8, "0xdualtx", 2_001_500, 1,
     );
 
     // Multiple ticks to ensure re-scans don't double-apply anything.
@@ -802,7 +802,7 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
 
     // Cursor must have advanced.
     assert!(
-        cursor(&pic, backend) >= 2_000_512,
+        cursor(&pic, backend) >= 2_002_048,
         "cursor advanced past dual-burn block; got {}",
         cursor(&pic, backend)
     );

--- a/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
@@ -264,6 +264,13 @@ fn boot() -> (PocketIc, Principal, Principal) {
     for _ in 0..5 {
         pic.tick();
     }
+
+    // Pin observer + settlement cadence to 30s so the 35s advance_and_tick windows
+    // fire one tick each. The code DEFAULT is now 300s (cycle-burn hardening), so
+    // tests declare the cadence they exercise instead of depending on the default.
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
     (pic, backend_id, mock_id)
 }
 

--- a/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
@@ -1,0 +1,559 @@
+//! Phase 1b — Gate-4 regression: `eth_getLogs` 100-block range cap + chunking.
+//!
+//! ## The bug this guards
+//!
+//! The Monad testnet RPC caps `eth_getLogs` at a 100-block RANGE: `toBlock -
+//! fromBlock` must be <= 100; a difference of 101 returns HTTP 413 with JSON-RPC
+//! code -32614 ("eth_getLogs is limited to a 100 range"). The burn-watch loop in
+//! `chains/monad/deposit_watch.rs::run_observer` scans
+//! `get_logs(BURN_TOPIC, from = last_observed + 1, to = finalized)`, a range as
+//! wide as `MAX_BLOCK_SCAN_WINDOW` (>= 256). On staging EVERY such scan 413-ed,
+//! so the burn-watch cursor never advanced and burns were never observed —
+//! tracked icUSD supply could not decrement to match an on-chain burn.
+//!
+//! ## What this test proves
+//!
+//! The `monad_rpc_mock` now enforces the SAME 100-block cap (see its `request`
+//! handler). A burn is placed near the FAR end of a `SCAN_WINDOW`-wide scan range
+//! (> 100 blocks past `from_block`), so it can only be observed if `get_logs`
+//! pages the range into <= 100-block sub-queries and aggregates them.
+//!
+//! - **ECDSA unavailable (gated subset, needs no signing):** a poison Burn citing
+//!   a non-existent vault sits at the far end of a > 100-block window. Pre-fix the
+//!   wide `get_logs` 413s on every tick and the cursor STALLS at the seed; post-fix
+//!   the chunked scan reaches the poison, classifies it `InvalidBurn` (skippable),
+//!   and the cursor advances past the window. Assertion: cursor advanced.
+//! - **ECDSA available (full guard):** stand up an Open vault with debt 100e8, then
+//!   place a GOOD 40e8 Burn at the far end of a > 100-block window. Pre-fix the burn
+//!   is never seen (debt stays 100e8); post-fix the chunked scan applies it exactly
+//!   once → debt 60e8 and `get_global_icusd_supply == sum(vault debt) == 60e8`.
+//!
+//! Both modes FAIL against the capped mock with an un-chunked `get_logs` and PASS
+//! once it chunks.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Scan-window knob ──────────────────────────────────────────────────────
+//
+// Must equal the backend's `MAX_BLOCK_SCAN_WINDOW` (chains/monad/evm_rpc.rs):
+// one observer tick advances the burn-watch cursor by exactly this many blocks
+// (the consensus-safe probe jumps `last_observed + SCAN_WINDOW`). It is > 100,
+// so a single-call `get_logs` over one window exceeds the provider's 100-block
+// cap and MUST be chunked.
+const SCAN_WINDOW: u64 = 256;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+fn cursor(pic: &PocketIc, backend: Principal) -> u64 {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_last_observed_block query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, u64).expect("decode get_last_observed_block"),
+        WasmResult::Reject(msg) => panic!("get_last_observed_block rejected: {}", msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {}", msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data ─────────────────────────
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn word_addr(addr: &str) -> String {
+    let raw = addr
+        .strip_prefix("0x")
+        .or_else(|| addr.strip_prefix("0X"))
+        .unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+fn push_burn_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+/// Register Monad + contract + manual MON price + seed the burn-watch cursor.
+/// Returns nothing; leaves the chain ready for the observer to run.
+fn configure_chain(pic: &PocketIc, backend: Principal, mock: Principal, seed: u64) {
+    decode_result(
+        update_dev(pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_chain_contract",
+            Encode!(
+                &ChainId(MONAD_CHAIN_ID),
+                &"0x00000000000000000000000000000000deadbeef".to_string()
+            )
+            .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &seed).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+}
+
+fn ecdsa_settlement_addr(pic: &PocketIc, backend: Principal) -> Option<String> {
+    match update_dev(
+        pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    }
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1b_getlogs_chunks_wide_burn_scan_range() {
+    let (pic, backend, mock) = boot();
+
+    // Seed the cursor; the first burn-watch window is (seed, seed + SCAN_WINDOW].
+    let seed: u64 = 5_000_000;
+    configure_chain(&pic, backend, mock, seed);
+
+    // Chain head one window above the seed so the FIRST tick advances the cursor
+    // by exactly SCAN_WINDOW and the burn-watch scans the full (seed, seed+W]
+    // range — a > 100-block range that trips the mock's 100-block getLogs cap
+    // unless the wrapper chunks it.
+    let win1_finalized = seed + SCAN_WINDOW;
+    update_any(&pic, mock, "set_blocks", Encode!(&win1_finalized, &win1_finalized).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
+
+    // A burn placed near the FAR end of the window: > 100 blocks past from_block
+    // (seed + 1), so it lives beyond the first 100-block chunk and is only
+    // reachable if get_logs pages through the whole range.
+    let far_burn_block = win1_finalized - 56; // seed + SCAN_WINDOW - 56
+
+    match ecdsa_settlement_addr(&pic, backend) {
+        None => {
+            // ── GATED subset (no signing): poison burn at the far end ──────────
+            eprintln!("[phase1b getlogs-chunking] ECDSA UNAVAILABLE; running GATED subset (cursor-advance over a >100-block window)");
+
+            // Poison burn cites a non-existent vault → InvalidBurn (skippable) on
+            // every tick. It sits at the far end of the > 100-block window, so the
+            // cursor can only advance past it if the chunked scan reaches it.
+            push_burn_log(&pic, mock, 999_999, "0xdeadbeef", 1_000 * E8, "0xpoison", far_burn_block);
+            advance_and_tick(&pic, 4);
+
+            assert!(
+                cursor(&pic, backend) >= win1_finalized,
+                "chunking: cursor advanced past a >100-block scan window (got {}, want >= {}); pre-fix the un-chunked get_logs 413s and the cursor stalls at the seed {}",
+                cursor(&pic, backend),
+                win1_finalized,
+                seed
+            );
+            // Supply invariant holds at 0 (nothing minted).
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(0u32), "gated: supply invariant holds at 0");
+            eprintln!("[phase1b getlogs-chunking] GATED subset PASSED: cursor advanced past the >100-block window via chunked get_logs");
+            return;
+        }
+        Some(settlement_addr) => {
+            // ── FULL guard (ECDSA): good burn at the far end is observed once ──
+            eprintln!("[phase1b getlogs-chunking] ECDSA AVAILABLE; settlement={settlement_addr}; running FULL guard");
+
+            // Fund the hot wallet so the settlement submit-path gas gate passes.
+            update_any(
+                &pic,
+                mock,
+                "set_balance",
+                Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+            );
+
+            // Stand up an Open vault: 100 MON @ $2 backs 100 icUSD (200% CR).
+            let collateral_e18 = 100u128 * E18;
+            let debt_e8s = 100u128 * E8;
+            let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+            let vault_id: u64 = match update_dev(
+                &pic,
+                backend,
+                "open_chain_vault",
+                Encode!(
+                    &ChainId(MONAD_CHAIN_ID),
+                    &candid::Nat::from(collateral_e18),
+                    &candid::Nat::from(debt_e8s),
+                    &recipient
+                )
+                .unwrap(),
+            ) {
+                WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+                    .expect("decode open_chain_vault")
+                    .expect("open_chain_vault Ok"),
+                WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+            };
+
+            let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+            let custody = v.custody_address.clone();
+
+            // Deposit lands; observer flips to MintPending + enqueues mint. The
+            // mint-confirm path scans a SINGLE block ([b, b], diff 0) — under the
+            // 100-block cap — so the mint confirms even with an un-chunked
+            // get_logs. Push the Mint log at the finalized block.
+            update_any(
+                &pic,
+                mock,
+                "set_balance",
+                Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+            );
+            advance_and_tick(&pic, 2);
+            push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", win1_finalized);
+            advance_and_tick(&pic, 4);
+
+            let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+            assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+            assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "mint confirmed => debt 100e8");
+
+            // ── Wide-range burn scan ───────────────────────────────────────────
+            // Move to the SECOND window and place a GOOD 40e8 burn near its far
+            // end (> 100 blocks past that window's from_block). The mint log was
+            // topic-filtered out of the burn scan; clear it to keep the mock tidy.
+            let win2_finalized = win1_finalized + SCAN_WINDOW;
+            let far_burn_block_2 = win2_finalized - 56;
+            update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+            update_any(&pic, mock, "set_blocks", Encode!(&win2_finalized, &win2_finalized).unwrap());
+            push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xgoodburn", far_burn_block_2);
+
+            advance_and_tick(&pic, 6);
+
+            // Pre-fix: the wide burn scan 413s every tick → burn never seen → debt
+            // stays 100e8 and the cursor stalls at the seed. Post-fix: chunked scan
+            // reaches the far burn → applied exactly once → debt 60e8.
+            let v = get_vault(&pic, backend, vault_id).expect("vault after burn scan");
+            assert_eq!(
+                v.debt_e8s,
+                candid::Nat::from(60 * E8),
+                "chunking: far-end 40e8 burn observed via chunked get_logs => debt 60e8 (pre-fix the wide scan 413s and debt stays 100e8)"
+            );
+            assert_eq!(v.status, ChainVaultStatus::Open, "partial burn keeps vault Open");
+
+            assert!(
+                cursor(&pic, backend) >= win2_finalized,
+                "chunking: cursor advanced past both >100-block windows; got {}",
+                cursor(&pic, backend)
+            );
+
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(
+                global,
+                candid::Nat::from(60 * E8),
+                "chunking: global supply == on-chain truth 60e8 (100e8 minted − 40e8 burned)"
+            );
+            let audit: SupplyAuditWire = query_unit(&pic, backend, "get_supply_audit");
+            assert_eq!(audit.total_e8s, v.debt_e8s, "chunking: chain supply == vault debt == 60e8");
+
+            eprintln!("[phase1b getlogs-chunking] FULL guard PASSED: far-end burn observed via chunked get_logs, debt 60e8, supply == on-chain truth");
+        }
+    }
+}

--- a/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 // (the consensus-safe probe jumps `last_observed + SCAN_WINDOW`). It is > 100,
 // so a single-call `get_logs` over one window exceeds the provider's 100-block
 // cap and MUST be chunked.
-const SCAN_WINDOW: u64 = 256;
+const SCAN_WINDOW: u64 = 1024;
 
 // ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
 

--- a/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
@@ -262,6 +262,13 @@ fn boot() -> (PocketIc, Principal, Principal) {
     for _ in 0..5 {
         pic.tick();
     }
+
+    // Pin observer + settlement cadence to 30s so the 35s advance_and_tick windows
+    // fire one tick each. The code DEFAULT is now 300s (cycle-burn hardening), so
+    // tests declare the cadence they exercise instead of depending on the default.
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
     (pic, backend_id, mock_id)
 }
 
@@ -556,4 +563,50 @@ fn phase1b_getlogs_chunks_wide_burn_scan_range() {
             eprintln!("[phase1b getlogs-chunking] FULL guard PASSED: far-end burn observed via chunked get_logs, debt 60e8, supply == on-chain truth");
         }
     }
+}
+
+/// #2b cycle-gate: when no chain-vault has debt, the burn-watch must SKIP the
+/// get_logs scan (a Burn can only repay a vault that has debt) while STILL
+/// advancing the cursor (so mint-confirm's finality probe stays current).
+///
+/// The mock is armed with `fail_always("eth_getLogs", ...)` so ANY get_logs call
+/// fails. With no vault (total chain-vault debt == 0):
+///   - PRE-fix: the observer calls get_logs → fails → returns before advancing →
+///     the cursor STALLS at the seed.
+///   - POST-fix: the scan is skipped entirely → the cursor advances to the
+///     probed finalized height. No ECDSA / signing needed.
+#[test]
+fn phase1b_burn_watch_skips_getlogs_when_no_debt() {
+    let (pic, backend, mock) = boot();
+
+    let seed: u64 = 6_000_000;
+    configure_chain(&pic, backend, mock, seed);
+
+    // Arm a PERSISTENT getLogs failure: every eth_getLogs returns an IcError, so
+    // if the observer scans at all the cursor cannot advance.
+    update_any(
+        &pic,
+        mock,
+        "fail_always",
+        Encode!(&"eth_getLogs".to_string(), &"forced getLogs failure (no-debt skip guard)".to_string()).unwrap(),
+    );
+
+    // Chain head one window above the seed; the finality probe (eth_getBlockByNumber,
+    // NOT failed) lets the cursor advance — IF the scan is skipped.
+    let finalized = seed + SCAN_WINDOW;
+    update_any(&pic, mock, "set_blocks", Encode!(&finalized, &finalized).unwrap());
+
+    // No vault opened → total chain-vault debt == 0.
+    advance_and_tick(&pic, 4);
+
+    assert!(
+        cursor(&pic, backend) >= finalized,
+        "no-debt fast path: cursor advanced to {} without scanning (got {}); pre-fix the forced get_logs failure stalls it at seed {}",
+        finalized,
+        cursor(&pic, backend),
+        seed
+    );
+    let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(global, candid::Nat::from(0u32), "no mint => supply 0");
+    eprintln!("[phase1b getlogs-chunking] no-debt skip PASSED: cursor advanced with get_logs forced-failing (scan skipped)");
 }

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -253,6 +253,13 @@ fn boot() -> (PocketIc, Principal, Principal) {
     for _ in 0..5 {
         pic.tick();
     }
+
+    // Pin observer + settlement cadence to 30s so the 35s advance_and_tick windows
+    // fire one tick each. The code DEFAULT is now 300s (cycle-burn hardening), so
+    // tests declare the cadence they exercise instead of depending on the default.
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
     (pic, backend_id, mock_id)
 }
 

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -379,10 +379,10 @@ fn phase1b_monad_happy_path_supply_invariant() {
 
     // ── Seed the burn-watch cursor (Gate-3 activation) ───────────────────────
     // After A2a, the observer reads chain head by probing the SPECIFIC block
-    // `last_observed + MAX_BLOCK_SCAN_WINDOW` (=256) via the typed
-    // eth_getBlockByNumber, so the cursor advances by exactly 256 blocks per tick
-    // whenever `last_observed + 256 <= finalized`. The cursor must be seeded
-    // (non-zero) for burn-watch to run at all. Seed it to a tip well above 256 so
+    // `last_observed + MAX_BLOCK_SCAN_WINDOW` (=1024) via the typed
+    // eth_getBlockByNumber, so the cursor advances by exactly 1024 blocks per tick
+    // whenever `last_observed + 1024 <= finalized`. The cursor must be seeded
+    // (non-zero) for burn-watch to run at all. Seed it to a tip well above 1024 so
     // the small legacy block numbers (100/101/102) no longer apply. This runs in
     // BOTH the full and gated subsets (it only writes the map; harmless when
     // gated). Seed AFTER register_chain so the chain config exists.
@@ -401,11 +401,11 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 0, "after register/config");
 
     // ── Step 3: script the mock's chain head ─────────────────────────────────
-    // finalized = seed + 256 = 1_000_256, so the FIRST observer tick advances the
-    // burn-watch cursor 1_000_000 -> 1_000_256 (the probe of block 1_000_256
-    // succeeds because 1_000_256 <= finalized). The mint auto-mines its receipt at
-    // `finalized_block` = 1_000_256.
-    update_any(&pic, mock, "set_blocks", Encode!(&1_000_256u64, &1_000_256u64).unwrap());
+    // finalized = seed + 1024 = 1_001_024, so the FIRST observer tick advances the
+    // burn-watch cursor 1_000_000 -> 1_001_024 (the probe of block 1_001_024
+    // succeeds because 1_001_024 <= finalized). The mint auto-mines its receipt at
+    // `finalized_block` = 1_001_024.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_001_024u64, &1_001_024u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
 
     // ── ECDSA probe: decide full vs gated ────────────────────────────────────
@@ -523,9 +523,9 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 0, "after deposit-verify (MintPending)");
 
     // ── Step 6: settlement submits the mint (mock auto-mines 0xmint1 at
-    //           finalized=1_000_256 on send), then confirms it. Push the Mint log
-    //           at block 1_000_256 so the confirm path reads the on-chain amount.
-    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_000_256);
+    //           finalized=1_001_024 on send), then confirms it. Push the Mint log
+    //           at block 1_001_024 so the confirm path reads the on-chain amount.
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", 1_001_024);
 
     // Several windows: window 1 submits (Queued -> Inflight), window 2+ confirms
     // (receipt mined + final, Mint log read, confirm_mint_in_state).
@@ -548,11 +548,11 @@ fn phase1b_monad_happy_path_supply_invariant() {
     // naturally excludes the still-present Mint log — exactly as the real Monad
     // RPC does. (The mint was confirmed via the settlement worker's own
     // topic-filtered Mint scan in Step 6.)
-    // Advance the chain head another 256 so the cursor climbs 1_000_000 ->
-    // 1_000_256 -> 1_000_512 over the next ticks; the burn at 1_000_300 lands in
-    // the (1_000_256, 1_000_512] scan window and is observed.
-    update_any(&pic, mock, "set_blocks", Encode!(&1_000_512u64, &1_000_512u64).unwrap());
-    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xburn1", 1_000_300);
+    // Advance the chain head another 1024 so the cursor climbs 1_000_000 ->
+    // 1_001_024 -> 1_002_048 over the next ticks; the burn at 1_001_068 lands in
+    // the (1_001_024, 1_002_048] scan window and is observed.
+    update_any(&pic, mock, "set_blocks", Encode!(&1_002_048u64, &1_002_048u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 40 * E8, "0xburn1", 1_001_068);
     advance_and_tick(&pic, 3);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after burn 40");
@@ -561,10 +561,10 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_supply(&pic, backend, 60 * E8, "after burn 40e8");
 
     // ── Step 8: burn the remaining 60e8; debt + supply go to 0 ───────────────
-    // Advance head another 256: cursor 1_000_512 -> 1_000_768; burn at 1_000_600
-    // is within (1_000_512, 1_000_768].
-    update_any(&pic, mock, "set_blocks", Encode!(&1_000_768u64, &1_000_768u64).unwrap());
-    push_burn_log(&pic, mock, vault_id, &recipient, 60 * E8, "0xburn2", 1_000_600);
+    // Advance head another 1024: cursor 1_002_048 -> 1_003_072; burn at 1_002_136
+    // is within (1_002_048, 1_003_072].
+    update_any(&pic, mock, "set_blocks", Encode!(&1_003_072u64, &1_003_072u64).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, 60 * E8, "0xburn2", 1_002_136);
     advance_and_tick(&pic, 2);
 
     let v = get_vault(&pic, backend, vault_id).expect("vault after burn 60");
@@ -591,9 +591,9 @@ fn phase1b_monad_happy_path_supply_invariant() {
     assert_eq!(v.status, ChainVaultStatus::Closing, "withdraw all => Closing");
     assert_supply(&pic, backend, 0, "after withdraw enqueue (Closing)");
 
-    // Settlement submits 0xwd1 (auto-mined at finalized=1_000_768) then confirms
+    // Settlement submits 0xwd1 (auto-mined at finalized=1_003_072) then confirms
     // it, flipping Closing -> Closed. The burn-watch cursor is already at
-    // 1_000_768, so the receipt is immediately final.
+    // 1_003_072, so the receipt is immediately final.
     advance_and_tick(&pic, 4);
     let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw confirm");
     assert_eq!(v.status, ChainVaultStatus::Closed, "withdraw confirmed => Closed");

--- a/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
@@ -25,9 +25,9 @@
 //! Two subsets (same auto-upgrade pattern as the happy-path test):
 //!   - ECDSA available: open a vault, fund custody, tick → assert the vault
 //!     reaches `MintPending` (deposit-watch ran despite `eth_blockNumber` being
-//!     "broken") AND the burn-watch cursor advanced to seed+256 via the typed
+//!     "broken") AND the burn-watch cursor advanced to seed+1024 via the typed
 //!     probe.
-//!   - ECDSA unavailable: assert the burn-watch cursor advances to seed+256 anyway
+//!   - ECDSA unavailable: assert the burn-watch cursor advances to seed+1024 anyway
 //!     (the cursor advance needs no signing) and the supply invariant holds at 0.
 
 use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
@@ -128,10 +128,10 @@ fn mock_wasm() -> Vec<u8> {
 const MONAD_CHAIN_ID: u32 = 10143;
 const E18: u128 = 1_000_000_000_000_000_000;
 const E8: u128 = 100_000_000;
-/// The cursor is seeded here; finalized = SEED + 256 (MAX_BLOCK_SCAN_WINDOW), so
-/// one observer tick advances the cursor to SEED_PLUS_256 via the typed probe.
+/// The cursor is seeded here; finalized = SEED + 1024 (MAX_BLOCK_SCAN_WINDOW), so
+/// one observer tick advances the cursor to SEED_PLUS_WINDOW via the typed probe.
 const SEED_BLOCK: u64 = 2_000_000;
-const SEED_PLUS_256: u64 = 2_000_256;
+const SEED_PLUS_WINDOW: u64 = 2_001_024;
 
 // ─── PocketIC call helpers ───────────────────────────────────────────────────
 
@@ -329,7 +329,7 @@ fn phase1b_observer_consensus_safe_cursor_advances() {
         Encode!(&"eth_blockNumber".to_string(), &"no consensus".to_string()).unwrap(),
     );
 
-    // Seed the burn-watch cursor and set the chain head one window (256) above it.
+    // Seed the burn-watch cursor and set the chain head one window (1024) above it.
     decode_result(
         update_dev(
             &pic,
@@ -340,7 +340,7 @@ fn phase1b_observer_consensus_safe_cursor_advances() {
         "set_last_observed_block",
     )
     .expect("set_last_observed_block");
-    update_any(&pic, mock, "set_blocks", Encode!(&SEED_PLUS_256, &SEED_PLUS_256).unwrap());
+    update_any(&pic, mock, "set_blocks", Encode!(&SEED_PLUS_WINDOW, &SEED_PLUS_WINDOW).unwrap());
 
     assert_eq!(cursor(&pic, backend), SEED_BLOCK, "cursor seeded to SEED_BLOCK");
 
@@ -418,8 +418,8 @@ fn phase1b_observer_consensus_safe_cursor_advances() {
         // the volatile eth_blockNumber, which is armed to fail).
         assert_eq!(
             cursor(&pic, backend),
-            SEED_PLUS_256,
-            "cursor advanced to SEED+256 via consensus-safe typed probe"
+            SEED_PLUS_WINDOW,
+            "cursor advanced to SEED+1024 via consensus-safe typed probe"
         );
     } else {
         eprintln!("[phase1b consensus-safe] ECDSA UNAVAILABLE; running GATED subset (cursor advance only — needs no signing)");
@@ -430,8 +430,8 @@ fn phase1b_observer_consensus_safe_cursor_advances() {
 
         assert_eq!(
             cursor(&pic, backend),
-            SEED_PLUS_256,
-            "cursor advanced to SEED+256 via consensus-safe typed probe (no signing needed)"
+            SEED_PLUS_WINDOW,
+            "cursor advanced to SEED+1024 via consensus-safe typed probe (no signing needed)"
         );
 
         // Supply invariant holds at 0 (nothing minted).

--- a/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_observer_consensus_safe_pic.rs
@@ -242,6 +242,13 @@ fn boot() -> (PocketIc, Principal, Principal) {
     for _ in 0..5 {
         pic.tick();
     }
+
+    // Pin observer + settlement cadence to 30s so the 35s advance_and_tick windows
+    // fire one tick each. The code DEFAULT is now 300s (cycle-burn hardening), so
+    // tests declare the cadence they exercise instead of depending on the default.
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
     (pic, backend_id, mock_id)
 }
 

--- a/src/rumi_protocol_backend/tests/phase1b_timers_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_timers_pic.rs
@@ -116,9 +116,9 @@ where
     }
 }
 
-/// The core no-chain safety assertion: fire the 30s observer + settlement timers
-/// several times (advance 120s in 30s steps, ticking between each) and prove the
-/// canister is still alive and still empty afterward.
+/// The core no-chain safety assertion: fire the observer + settlement timers
+/// several times (advance in steps past the 300s default interval, ticking
+/// between each) and prove the canister is still alive and still empty afterward.
 #[test]
 fn phase1b_timers_safe_with_no_chain_configured() {
     let (pic, cid) = boot();
@@ -130,11 +130,12 @@ fn phase1b_timers_safe_with_no_chain_configured() {
     assert_eq!(audit.total_e8s, candid::Nat::from(0u32));
     assert!(audit.per_chain.is_empty(), "no chains registered -> empty audit");
 
-    // Advance time past several 30s timer firings. With no chain registered,
-    // every observer_tick / settlement_tick is a no-op fan-out over an empty
-    // chain list. If either trapped, the queries below would reject.
+    // Advance time past several timer firings (steps > the 300s default interval).
+    // With no chain registered, every observer_tick / settlement_tick is a no-op
+    // fan-out over an empty chain list. If either trapped, the queries below would
+    // reject.
     for _ in 0..4 {
-        pic.advance_time(Duration::from_secs(30));
+        pic.advance_time(Duration::from_secs(305));
         // Several ticks per step so the spawned async tick futures get scheduled
         // and run to completion (a no-op return) within the step.
         for _ in 0..5 {


### PR DESCRIPTION
## Problem (Gate-4 blocker on mainnet-staging `kvg63`)

The Monad testnet RPC caps a single `eth_getLogs` at a **100-block range** (`toBlock - fromBlock <= 100`); a wider range returns HTTP **413** / JSON-RPC `-32614` ("eth_getLogs is limited to a 100 range"). Empirically confirmed against `https://testnet-rpc.monad.xyz` on 2026-05-31.

The burn-watch loop scans `get_logs(BURN_TOPIC, from = last_observed+1, to = finalized)` — a range as wide as `MAX_BLOCK_SCAN_WINDOW` (256). Every such scan 413-ed, so:
- **burn-watch** never observed burns and the cursor never advanced past its seed;
- **mint-confirm** stayed blocked *transitively* — `fetch_block_numbers` probes `last_observed + window`, and with the cursor frozen at the seed the derived finalized height stayed behind the real mint receipt block, so the mint never reached finality. Vault 1 was stuck `MintPending` with `get_global_icusd_supply = 0` even though 0.5 icUSD exists on Monad (tx `0x247d46…`).

This is the icUSD supply-accounting path, so the fix is TDD'd with an adversarial RED→GREEN.

## Fix

**1. Chunk `get_logs` internally** (`chains/monad/evm_rpc.rs`). `get_logs` pages `[from_block, to_block]` into sequential sub-queries each within `MONAD_GETLOGS_MAX_RANGE` (=100, the confirmed cap) and concatenates results in block order. Callers are unchanged. Single-block scans (mint-confirm, `from == to`) collapse to one sub-query. A sub-query error fails the **whole** call (no partial result), so the tick retries the full range and never advances the cursor past an un-scanned chunk — no silently-dropped burns. The `(tx_hash, log_index)` dedup and ordering are preserved (chunks are disjoint, ascending).

**2. Raise `MAX_BLOCK_SCAN_WINDOW` 256 → 1024** (keep-pace). The probe advances the cursor by at most the window per tick, so the window must exceed blocks-produced-per-observer-interval. Monad testnet produces ~1.93 blocks/s (measured) and staging runs the observer at 300s = ~578 blocks/tick; 256 could never keep pace (a second half of the Gate-4 stall). 1024 gives 1.77× margin, bounds observation lag at ~one window, and stays correct at the 30s default interval. Chunking means the wider window is unaffected by the getLogs cap; total getLogs volume per day is `blocks/day ÷ 100` regardless of window size.

## TDD / verification

- `src/monad_rpc_mock` now enforces the same 100-block cap (returns the real 413 / `InvalidHttpJsonRpcResponse`), so the regression is meaningful.
- New `phase1b_getlogs_chunking_pic` places a burn beyond the first 100-block chunk: **RED** with the un-chunked call (debt stays 100e8 / cursor stalls), **GREEN** once chunked. Existing phase1b tests (which scan whole windows) now also exercise chunking through the capped mock.
- All green: **218 lib · candid compat · phase1b PocketIC (happy-path / burn-idempotency / consensus-safe / timers / chunking) · multi-chain supply invariant · clippy clean (monad module) · Foundry 13/13** (no Solidity change).

Built for `mainnet-staging`; deploy is upgrade-only (never reinstall), staging only — production `tfesu-…` untouched.