### PR TITLE
feat(monad): Phase 1c notify-then-verify burn observation (O(burns), not O(blocks))

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -968,6 +968,8 @@ export type Result_12 = { 'Ok' : RepayAndCloseSuccess } |
   { 'Err' : ProtocolError };
 export type Result_13 = { 'Ok' : StabilityPoolLiquidationResult } |
   { 'Err' : ProtocolError };
+export type Result_14 = { 'Ok' : number } |
+  { 'Err' : ProtocolError };
 export type Result_2 = { 'Ok' : string } |
   { 'Err' : ProtocolError };
 export type Result_3 = { 'Ok' : SuccessWithFee } |
@@ -1269,6 +1271,7 @@ export interface _SERVICE {
   'set_bot_cr_tolerance_bps' : ActorMethod<[bigint], Result>,
   'set_breaker_window_debt_ceiling_e8s' : ActorMethod<[bigint], Result>,
   'set_breaker_window_ns' : ActorMethod<[bigint], Result>,
+  'set_burn_watch_poll_enabled' : ActorMethod<[number, boolean], Result>,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
   'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_check_vaults_alert_band_bps' : ActorMethod<[bigint], Result>,
@@ -1362,6 +1365,7 @@ export interface _SERVICE {
     [bigint, bigint, bigint, Principal],
     Result_13
   >,
+  'submit_burn_proof' : ActorMethod<[number, string], Result_14>,
   'unfreeze_protocol' : ActorMethod<[], Result>,
   'update_collateral_config' : ActorMethod<
     [Principal, CollateralConfig],

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -1035,6 +1035,7 @@ export const idlFactory = ({ IDL }) => {
     'ledger_kind' : SpProofLedger,
     'vault_id_memo' : IDL.Nat64,
   });
+  const Result_14 = IDL.Variant({ 'Ok' : IDL.Nat32, 'Err' : ProtocolError });
   return IDL.Service({
     'add_collateral_token' : IDL.Func([AddCollateralArg], [Result], []),
     'add_margin_to_vault' : IDL.Func([VaultArg], [Result_1], []),
@@ -1333,6 +1334,11 @@ export const idlFactory = ({ IDL }) => {
     'set_bot_cr_tolerance_bps' : IDL.Func([IDL.Nat64], [Result], []),
     'set_breaker_window_debt_ceiling_e8s' : IDL.Func([IDL.Nat64], [Result], []),
     'set_breaker_window_ns' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_burn_watch_poll_enabled' : IDL.Func(
+        [IDL.Nat32, IDL.Bool],
+        [Result],
+        [],
+      ),
     'set_chain_config' : IDL.Func(
         [IDL.Nat32, UpdateChainConfigArg],
         [Result],
@@ -1507,6 +1513,7 @@ export const idlFactory = ({ IDL }) => {
         [Result_13],
         [],
       ),
+    'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_14], []),
     'unfreeze_protocol' : IDL.Func([], [Result], []),
     'update_collateral_config' : IDL.Func(
         [IDL.Principal, CollateralConfig],

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -208,9 +208,17 @@ pub enum MultiGetBlockByNumberResult {
 
 // ─── Scripted state ───────────────────────────────────────────────────────
 
-/// A scripted log entry the mock returns from `eth_getLogs`.
+/// A scripted log entry the mock returns from `eth_getLogs` and (when stored on
+/// a `Receipt`) from `eth_getTransactionReceipt`.
 #[derive(Clone, Debug)]
 struct ScriptedLog {
+    /// Emitting contract address (lowercased). Empty for logs pushed via
+    /// `push_log`/`push_log_at` (the `eth_getLogs` path filters by the request's
+    /// `address` field, not the log's own, so it does not need this). Set by
+    /// `push_receipt_log` so the rendered `eth_getTransactionReceipt` log JSON
+    /// includes an `"address"` field — burn-proof verification rejects logs not
+    /// emitted by the configured icUSD contract.
+    address: String,
     topics: Vec<String>,
     data: String,
     tx_hash: String,
@@ -228,6 +236,10 @@ struct Receipt {
     /// status 0x1 (true) vs 0x0 (false, reverted).
     ok: bool,
     block: u64,
+    /// Logs emitted by this transaction, rendered into the
+    /// `eth_getTransactionReceipt` `"logs"` array. Empty for receipts created by
+    /// `set_receipt` / the `eth_sendRawTransaction` auto-mine path.
+    logs: Vec<ScriptedLog>,
 }
 
 #[derive(Default)]
@@ -456,7 +468,7 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                 let fin = script.finalized_block;
                 script.receipts.insert(
                     tx_hash.to_lowercase(),
-                    Receipt { ok: true, block: fin },
+                    Receipt { ok: true, block: fin, logs: vec![] },
                 );
                 format!(
                     r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#,
@@ -471,12 +483,37 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                     .unwrap_or("")
                     .to_lowercase();
                 match script.receipts.get(&txhash) {
-                    Some(r) => format!(
-                        r#"{{"jsonrpc":"2.0","id":{},"result":{{"status":{:?},"blockNumber":{:?}}}}}"#,
-                        id,
-                        if r.ok { "0x1" } else { "0x0" },
-                        hex_u64(r.block)
-                    ),
+                    Some(r) => {
+                        let logs_json = r
+                            .logs
+                            .iter()
+                            .map(|log| {
+                                let topics_json = log
+                                    .topics
+                                    .iter()
+                                    .map(|t| format!("{:?}", t))
+                                    .collect::<Vec<_>>()
+                                    .join(",");
+                                format!(
+                                    r#"{{"address":{:?},"topics":[{}],"data":{:?},"transactionHash":{:?},"blockNumber":{:?},"logIndex":{:?}}}"#,
+                                    log.address,
+                                    topics_json,
+                                    log.data,
+                                    log.tx_hash,
+                                    hex_u64(log.block),
+                                    hex_u64(log.log_index)
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        format!(
+                            r#"{{"jsonrpc":"2.0","id":{},"result":{{"status":{:?},"blockNumber":{:?},"logs":[{}]}}}}"#,
+                            id,
+                            if r.ok { "0x1" } else { "0x0" },
+                            hex_u64(r.block),
+                            logs_json
+                        )
+                    }
                     None => format!(r#"{{"jsonrpc":"2.0","id":{},"result":null}}"#, id),
                 }
             }
@@ -602,7 +639,7 @@ fn set_receipt(txhash: String, ok: bool, block: u64) {
     SCRIPT.with(|s| {
         s.borrow_mut()
             .receipts
-            .insert(txhash.to_lowercase(), Receipt { ok, block });
+            .insert(txhash.to_lowercase(), Receipt { ok, block, logs: vec![] });
     });
 }
 
@@ -623,6 +660,7 @@ fn push_log(topics: Vec<String>, data: String, tx_hash: String, block: u64) {
         let mut s = s.borrow_mut();
         let log_index = s.logs.len() as u64;
         s.logs.push(ScriptedLog {
+            address: String::new(),
             topics,
             data,
             tx_hash,
@@ -641,6 +679,42 @@ fn push_log(topics: Vec<String>, data: String, tx_hash: String, block: u64) {
 fn push_log_at(topics: Vec<String>, data: String, tx_hash: String, block: u64, log_index: u64) {
     SCRIPT.with(|s| {
         s.borrow_mut().logs.push(ScriptedLog {
+            address: String::new(),
+            topics,
+            data,
+            tx_hash,
+            block,
+            log_index,
+        });
+    });
+}
+
+/// Push a scripted log onto a transaction's RECEIPT (returned by
+/// `eth_getTransactionReceipt`, NOT `eth_getLogs`). Creates the receipt if it
+/// does not yet exist (mined+ok at block 0; raise its block with `set_receipt`
+/// or `set_blocks` + a fresh push as needed). The log's `address` is rendered
+/// into the receipt JSON so burn-proof verification can reject logs from a
+/// non-icUSD contract. The `log_index` is stored verbatim so the dedup key
+/// `(tx_hash, log_index)` is stable across re-submits.
+#[ic_cdk_macros::update]
+fn push_receipt_log(
+    tx_hash: String,
+    address: String,
+    topics: Vec<String>,
+    data: String,
+    log_index: u64,
+) {
+    SCRIPT.with(|s| {
+        let mut s = s.borrow_mut();
+        let key = tx_hash.to_lowercase();
+        let r = s.receipts.entry(key).or_insert(Receipt {
+            ok: true,
+            block: 0,
+            logs: vec![],
+        });
+        let block = r.block;
+        r.logs.push(ScriptedLog {
+            address: address.to_lowercase(),
             topics,
             data,
             tx_hash,

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -805,6 +805,7 @@ type Result_13 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
+type Result_14 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
@@ -1055,6 +1056,7 @@ service : (ProtocolArg) -> {
   set_bot_cr_tolerance_bps : (nat64) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
+  set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
@@ -1127,6 +1129,7 @@ service : (ProtocolArg) -> {
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
       Result_13,
     );
+  submit_burn_proof : (nat32, text) -> (Result_14);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -4,17 +4,17 @@
 //! state-shape rules without spinning up PocketIC.
 
 use super::config::{
-    ChainAdminError, ChainConfigV1, ChainId, ChainStatus, RegisterChainArg,
+    ChainAdminError, ChainConfigV2, ChainId, ChainStatus, RegisterChainArg,
     UpdateChainConfigArg,
 };
-use super::multi_chain_state::MultiChainStateV2;
+use super::multi_chain_state::MultiChainStateV3;
 use super::settlement_queue::SettlementQueueV1;
 
 pub fn register_chain_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     arg: RegisterChainArg,
     now_ns: u64,
-) -> Result<ChainConfigV1, ChainAdminError> {
+) -> Result<ChainConfigV2, ChainAdminError> {
     if arg.rpc_endpoints.is_empty() {
         return Err(ChainAdminError::InvalidConfig(
             "rpc_endpoints must contain at least one URL".into(),
@@ -23,7 +23,7 @@ pub fn register_chain_in_state(
     if state.chain_configs.contains_key(&arg.chain_id) {
         return Err(ChainAdminError::ChainAlreadyRegistered(arg.chain_id));
     }
-    let cfg = ChainConfigV1 {
+    let cfg = ChainConfigV2 {
         chain_id: arg.chain_id,
         display_name: arg.display_name,
         rpc_endpoints: arg.rpc_endpoints,
@@ -32,6 +32,9 @@ pub fn register_chain_in_state(
         chain_native_decimals: arg.chain_native_decimals,
         registered_at_ns: now_ns,
         status: ChainStatus::Registered,
+        // Phase 1c: notify-then-verify is the default; the continuous poll-scan
+        // starts OFF and is enabled per-chain only via set_burn_watch_poll_enabled.
+        burn_watch_poll_enabled: false,
     };
     state.chain_configs.insert(arg.chain_id, cfg.clone());
     state.chain_supplies.insert(arg.chain_id, 0);
@@ -40,7 +43,7 @@ pub fn register_chain_in_state(
 }
 
 pub fn disable_chain_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     let cfg = state
@@ -58,7 +61,7 @@ pub fn disable_chain_in_state(
 /// would be a silent state leak). All-or-nothing: every rejection path returns
 /// before the first mutation, so a refused delete leaves the chain fully intact.
 pub fn delete_chain_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     if !state.chain_configs.contains_key(&chain_id) {
@@ -92,7 +95,7 @@ pub fn delete_chain_in_state(
 }
 
 pub fn update_chain_config_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain_id: ChainId,
     update: UpdateChainConfigArg,
 ) -> Result<(), ChainAdminError> {

--- a/src/rumi_protocol_backend/src/chains/config.rs
+++ b/src/rumi_protocol_backend/src/chains/config.rs
@@ -48,8 +48,51 @@ pub struct ChainConfigV1 {
     pub status: ChainStatus,
 }
 
+/// Phase 1c snapshot. Carries every `ChainConfigV1` field verbatim (so a
+/// V1-shaped CBOR sub-map maps each by name straight across) and adds the
+/// notify-then-verify emergency poll flag.
+///
+/// `burn_watch_poll_enabled` carries `#[serde(default)]` so a `ChainConfigV1`
+/// CBOR sub-map (which lacks this key entirely) decodes into `ChainConfigV2`
+/// without error, defaulting the flag to `false`. The V1-carried fields are
+/// NOT decorated because V1 always wrote them and they must be present in any
+/// valid snapshot. State persists via ciborium (CBOR + serde, see
+/// `storage.rs`), which decodes structs as field-name-keyed maps and fills a
+/// missing key from `#[serde(default)]` rather than failing — this is the SAME
+/// mechanism that makes the `MultiChainStateV1 -> V2` add-a-field decode safe
+/// (proven by `tests_multi_chain_state_v2`). It is NOT a Candid `Decode!` of a
+/// fixed record, so an added serde-default field cannot trip the AMM-style
+/// state-wipe fallback (2026-05-18 incident).
+///
+/// Add the NEXT field by bumping to `ChainConfigV3` (keep V2 verbatim), adding
+/// `#[serde(default)]` on the new field, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct ChainConfigV2 {
+    // carried verbatim from V1 — always present in any valid snapshot
+    pub chain_id: ChainId,
+    pub display_name: String,
+    pub rpc_endpoints: Vec<String>,
+    /// Blocks past head before a deposit/event is treated as committed.
+    pub finality_depth: u32,
+    pub gas_strategy: GasStrategy,
+    /// Decimals of the chain-native gas asset (18 for EVM, 9 for Solana SOL).
+    pub chain_native_decimals: u8,
+    /// `ic_cdk::api::time()` nanoseconds when this config was first registered.
+    pub registered_at_ns: u64,
+    pub status: ChainStatus,
+    /// Phase 1c: emergency continuous `eth_getLogs` burn-watch poll-scan toggle.
+    /// `false` (default) = notify-then-verify only (the observer advances its
+    /// cursor without scanning logs, and burns are applied via the pull-based
+    /// `submit_burn_proof` endpoint). `true` = re-enable the legacy continuous
+    /// scan for a targeted catch-up. Developer-gated via
+    /// `set_burn_watch_poll_enabled`. New in V2 — `#[serde(default)]` lets a V1
+    /// CBOR sub-map decode cleanly to `false`.
+    #[serde(default)]
+    pub burn_watch_poll_enabled: bool,
+}
+
 /// Active alias. Rebind to a later version when a field is added.
-pub type ChainConfig = ChainConfigV1;
+pub type ChainConfig = ChainConfigV2;
 
 /// Caller-supplied registration payload. Distinct from the persisted
 /// `ChainConfigV1` so the admin endpoint can fill `registered_at_ns` and

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -21,7 +21,7 @@ pub mod monad;
 
 pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};
-pub use multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
+pub use multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
 pub use settlement_queue::{SettlementOp, SettlementQueueV1};
 pub use supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
 

--- a/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
@@ -1,9 +1,13 @@
 //! Phase 1c notify-then-verify: turn a verified tx receipt into applied burns.
 use crate::chains::config::ChainId;
 use crate::chains::monad::deposit_watch::apply_burn_to_state;
-use crate::chains::monad::evm_rpc::{decode_burn_log, BurnLog, TxReceiptWithLogs, BURN_EVENT_TOPIC0};
+use crate::chains::monad::evm_rpc::{
+    decode_burn_log, get_transaction_receipt_with_logs, is_block_final, BurnLog,
+    TxReceiptWithLogs, BURN_EVENT_TOPIC0,
+};
 use crate::chains::multi_chain_state::MultiChainStateV2;
 use crate::logs::INFO;
+use crate::state::{mutate_state, read_state};
 use ic_canister_log::log;
 
 /// Apply every `Burn` log in `receipt` that was emitted by `contract` to protocol
@@ -83,4 +87,82 @@ pub fn apply_receipt_burns_to_state(
         }
     }
     Ok(applied)
+}
+
+#[derive(Debug)]
+pub enum BurnProofError {
+    NoContract,
+    Pending,      // receipt not yet mined
+    Reverted,     // status != 0x1
+    NotFinal,     // mined but not buried under finality_depth
+    Rpc(String),
+    Halt(String), // halt-class invariant failure
+}
+
+/// Fetch the receipt for `tx_hash`, verify success + finality, and apply any Burn
+/// logs from the configured contract. Returns the count newly applied. No state
+/// borrow is held across the awaits.
+///
+/// The notify path must emit a `ChainBurnObserved` event per applied burn so that
+/// analytics sees notify-path burns the same way it sees poll-path burns (the poll
+/// loop in `deposit_watch.rs` emits one per applied burn). We capture the applied
+/// `Vec<BurnLog>` from the (synchronous) `apply_receipt_burns_to_state` and emit the
+/// events OUTSIDE the `mutate_state` closure, after a successful apply.
+pub async fn verify_and_apply_burn_proof(
+    chain: ChainId,
+    tx_hash: &str,
+) -> Result<u32, BurnProofError> {
+    // Lowercase the caller-supplied hash before it reaches the core: it becomes the
+    // dedup key, so mixed casing must not be able to bypass dedup and double-apply.
+    let tx = tx_hash.to_ascii_lowercase();
+
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned())
+        .ok_or(BurnProofError::NoContract)?;
+    let finality_depth = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.finality_depth as u64)
+    })
+    .unwrap_or(1);
+
+    let receipt = match get_transaction_receipt_with_logs(chain, &tx)
+        .await
+        .map_err(BurnProofError::Rpc)?
+    {
+        Some(r) => r,
+        None => return Err(BurnProofError::Pending),
+    };
+    if !receipt.success {
+        return Err(BurnProofError::Reverted);
+    }
+    if !is_block_final(chain, receipt.block_number, finality_depth)
+        .await
+        .map_err(BurnProofError::Rpc)?
+    {
+        return Err(BurnProofError::NotFinal);
+    }
+
+    // Apply synchronously (no `.await` inside), capturing the burns newly applied.
+    let applied: Vec<BurnLog> = mutate_state(|s| {
+        apply_receipt_burns_to_state(&mut s.multi_chain, chain, &contract, &tx, &receipt)
+    })
+    .map_err(BurnProofError::Halt)?;
+
+    // Emit one ChainBurnObserved event per applied burn, mirroring the poll path
+    // (deposit_watch.rs line 686). record_event is its own call, done outside the
+    // mutate_state closure above, only after a successful apply.
+    let now = ic_cdk::api::time();
+    for burn in &applied {
+        crate::storage::record_event(&crate::event::Event::ChainBurnObserved {
+            chain_id: chain,
+            vault_id: burn.vault_id,
+            amount_e8s: burn.amount_e8s,
+            tx_hash: burn.tx_hash.clone(),
+            block_number: burn.block_number,
+            timestamp: now,
+        });
+    }
+
+    Ok(applied.len() as u32)
 }

--- a/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
@@ -1,0 +1,86 @@
+//! Phase 1c notify-then-verify: turn a verified tx receipt into applied burns.
+use crate::chains::config::ChainId;
+use crate::chains::monad::deposit_watch::apply_burn_to_state;
+use crate::chains::monad::evm_rpc::{decode_burn_log, BurnLog, TxReceiptWithLogs, BURN_EVENT_TOPIC0};
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::logs::INFO;
+use ic_canister_log::log;
+
+/// Apply every `Burn` log in `receipt` that was emitted by `contract` to protocol
+/// state, deduped on `(tx_hash, log_index)` via `processed_burn_keys`. Returns the
+/// burns newly applied (the caller emits a `ChainBurnObserved` event per entry and
+/// uses the count). Caller MUST have verified `receipt.success` and finality, and
+/// MUST pass a normalized (lowercased) `tx_hash`, before calling. Trust rules:
+///  - only logs whose `address == contract` (case-insensitive) and whose
+///    `topics[0] == BURN_EVENT_TOPIC0` are considered (a user cannot forge a burn
+///    by emitting their own event);
+///  - amount + vault_id come FROM the log, never from caller input;
+///  - already-seen `(tx_hash, log_index)` is skipped (idempotent re-submit);
+///  - a halt-class `apply_burn_to_state` error aborts the whole call (Err) so the
+///    invariant machinery halts; an InvalidBurn (unknown vault / over-repay) is
+///    skipped-and-recorded (cannot ever succeed), matching the poll path.
+///
+/// On a halt-class abort, burns already applied earlier in this receipt stay
+/// committed with their keys recorded (no `.await` in this synchronous loop, so
+/// apply+record commit in one message slice) — a retry re-skips them and
+/// re-attempts the halting burn. This matches the audited poll-path C-1 semantics.
+pub fn apply_receipt_burns_to_state(
+    state: &mut MultiChainStateV2,
+    _chain: ChainId,
+    contract: &str,
+    tx_hash: &str,
+    receipt: &TxReceiptWithLogs,
+) -> Result<Vec<BurnLog>, String> {
+    let mut applied: Vec<BurnLog> = Vec::new();
+    for (address, topics, data, log_index) in &receipt.logs {
+        if !address.eq_ignore_ascii_case(contract) {
+            continue;
+        }
+        if topics
+            .first()
+            .map(|t| !t.eq_ignore_ascii_case(BURN_EVENT_TOPIC0))
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        let burn = match decode_burn_log(topics, data, tx_hash, receipt.block_number) {
+            Ok(b) => b,
+            Err(e) => {
+                log!(INFO, "[burn_proof] decode failed (skip): {}", e);
+                continue;
+            }
+        };
+        let key = format!("{}:{}", burn.tx_hash, log_index);
+        let seen = state
+            .processed_burn_keys
+            .get(&burn.block_number)
+            .map(|set| set.contains(&key))
+            .unwrap_or(false);
+        if seen {
+            continue;
+        }
+        let total = state.total_chain_vault_debt_e8s();
+        match apply_burn_to_state(state, &burn, total) {
+            Ok(()) => {
+                state
+                    .processed_burn_keys
+                    .entry(burn.block_number)
+                    .or_default()
+                    .insert(key);
+                applied.push(burn.clone());
+            }
+            Err(crate::chains::monad::deposit_watch::BurnApplyError::InvalidBurn(msg)) => {
+                log!(INFO, "[burn_proof] invalid burn skipped: {}", msg);
+                state
+                    .processed_burn_keys
+                    .entry(burn.block_number)
+                    .or_default()
+                    .insert(key);
+            }
+            Err(crate::chains::monad::deposit_watch::BurnApplyError::SupplyInvariant(e)) => {
+                return Err(format!("halt-class supply invariant: {:?}", e));
+            }
+        }
+    }
+    Ok(applied)
+}

--- a/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
@@ -5,7 +5,7 @@ use crate::chains::monad::evm_rpc::{
     decode_burn_log, get_transaction_receipt_with_logs, is_block_final, BurnLog,
     TxReceiptWithLogs, BURN_EVENT_TOPIC0,
 };
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use ic_canister_log::log;
@@ -29,7 +29,7 @@ use ic_canister_log::log;
 /// apply+record commit in one message slice) — a retry re-skips them and
 /// re-attempts the halting burn. This matches the audited poll-path C-1 semantics.
 pub fn apply_receipt_burns_to_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     _chain: ChainId,
     contract: &str,
     tx_hash: &str,

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -10,7 +10,7 @@
 //! observed at finality (settlement worker, Task 10).
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
@@ -155,7 +155,7 @@ pub fn collateral_ratio_e4(collateral_e18: u128, price_e8: u64, debt_e8s: u128) 
 /// - declared CR `< min_cr_e4` -> `BelowMinCr`
 #[allow(clippy::too_many_arguments)]
 pub fn open_chain_vault_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain: ChainId,
     owner: Principal,
     custody_address: String,
@@ -237,7 +237,7 @@ pub fn open_chain_vault_in_state(
 /// rejected enqueue leaves the vault `AwaitingDeposit` and the queue unchanged,
 /// and the next deposit-watch tick retries cleanly.
 pub fn verify_deposit_and_enqueue_mint_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     vault_id: u64,
     observed_balance_e18: u128,
     now_ns: u64,
@@ -332,7 +332,7 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
 ///
 /// So a rejected enqueue leaves the vault and its collateral untouched.
 pub fn withdraw_collateral_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     vault_id: u64,
     amount_e18: u128,
     dest_address: String,
@@ -437,7 +437,7 @@ pub fn withdraw_collateral_in_state(
 /// (A non-Open zero-collateral vault is NOT short-circuited — it falls through
 /// to the delegate's gate and rejects with `WrongStatus`.)
 pub fn close_chain_vault_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     vault_id: u64,
     dest_address: String,
     min_cr_e4: u64,

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -42,7 +42,7 @@
 use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
@@ -95,7 +95,7 @@ impl std::fmt::Display for BurnApplyError {
 /// of a u128 collateral balance is not a realistic failure mode but we guard
 /// it anyway). Returns `Err` if the vault is not found.
 pub fn credit_deposit_to_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     vault_id: u64,
     amount_e18: u128,
 ) -> Result<(), String> {
@@ -145,7 +145,7 @@ pub fn credit_deposit_to_state(
 /// burner==owner constraint if griefing (uninvited debt repayment) becomes a
 /// concern; for Phase 1b it is accepted.
 pub fn apply_burn_to_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     burn: &super::evm_rpc::BurnLog,
     total_debt_e8s: u128,
 ) -> Result<(), BurnApplyError> {
@@ -585,6 +585,33 @@ pub async fn run_observer(chain: ChainId) {
         return;
     }
 
+    // ── Notify-then-verify gate (Phase 1c) ───────────────────────────────────
+    //
+    // The continuous block-by-block `eth_getLogs` burn-scan below costs
+    // O(blocks produced) per chain (~1.3T cycles/day on Monad regardless of
+    // burn activity). Phase 1c demotes it to OFF by default: burns are applied
+    // via the pull-based `submit_burn_proof` endpoint (one
+    // `eth_getTransactionReceipt` per ACTUAL burn). The poll-scan is kept only
+    // as a developer-gated emergency catch-up tool (`set_burn_watch_poll_enabled`).
+    //
+    // When the flag is OFF we STILL advance the cursor to `finalized` (and
+    // prune), exactly like the no-debt fast path: the consensus-safe finality
+    // probe (`fetch_block_numbers` = last_observed + MAX_BLOCK_SCAN_WINDOW)
+    // must stay current so the mint-confirm path can reach finality. A stalled
+    // cursor was the Gate-4 failure mode. No burn is lost — `submit_burn_proof`
+    // verifies each burn's receipt directly and is independent of this cursor.
+    let poll_enabled = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.burn_watch_poll_enabled)
+            .unwrap_or(false)
+    });
+    if !poll_enabled {
+        mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
+        return;
+    }
+
     let from_block = last_observed + 1;
 
     let raw_burn_logs = match get_logs(chain, &contract, BURN_EVENT_TOPIC0, from_block, finalized).await {
@@ -758,7 +785,7 @@ pub async fn run_observer(chain: ChainId) {
 /// vaults make a tick outliving MAX_BLOCK_SCAN_WINDOW blocks unreachable in
 /// practice). Revisit for deeper finality / higher vault counts where a self-heal
 /// reclaim could race the prune.
-pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV2, chain: ChainId, finalized: u64) {
+pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV3, chain: ChainId, finalized: u64) {
     state.last_observed_block.insert(chain, finalized);
     let stale: Vec<u64> = state
         .processed_burn_keys

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -682,6 +682,14 @@ pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
     }
 }
 
+/// True iff block `block + finality_depth` exists & is final on `chain` — i.e.
+/// `block` is buried under at least `finality_depth` confirmations. Consensus-safe
+/// (probes a SPECIFIC number). On a probe error, propagates Err (caller retries).
+pub async fn is_block_final(chain: ChainId, block: u64, finality_depth: u64) -> Result<bool, String> {
+    let target = block.saturating_add(finality_depth);
+    Ok(eth_get_block_number_at(chain, target).await?.is_some())
+}
+
 /// Returns the ETH/native balance (in wei) of `address` at the latest block.
 pub async fn get_balance(chain: ChainId, address: &str) -> Result<u128, String> {
     let payload = format!(

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -861,6 +861,70 @@ pub async fn get_transaction_receipt(
     Ok(Some((success, block_number)))
 }
 
+/// A transaction receipt plus its logs. `logs` entries are
+/// `(address_lowercased, topics, data, log_index)`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxReceiptWithLogs {
+    pub success: bool,
+    pub block_number: u64,
+    pub logs: Vec<(String, Vec<String>, String, u64)>,
+}
+
+/// Pure parser for an `eth_getTransactionReceipt` JSON-RPC response string.
+/// Returns Ok(None) if the receipt is null (tx still pending).
+pub fn parse_receipt_with_logs(text: &str) -> Result<Option<TxReceiptWithLogs>, String> {
+    let val: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| format!("eth_getTransactionReceipt parse: {}", e))?;
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_getTransactionReceipt RPC error: {}", err));
+    }
+    if val["result"].is_null() {
+        return Ok(None);
+    }
+    let res = &val["result"];
+    let success = parse_hex_quantity(res["status"].as_str().unwrap_or("0x0"))? == 1;
+    let block_number = parse_hex_quantity(
+        res["blockNumber"]
+            .as_str()
+            .ok_or_else(|| format!("receipt missing blockNumber in {:?}", text))?,
+    )? as u64;
+    let mut logs = Vec::new();
+    if let Some(arr) = res["logs"].as_array() {
+        for (position, entry) in arr.iter().enumerate() {
+            let address = entry["address"].as_str().unwrap_or("").to_lowercase();
+            let topics: Vec<String> = entry["topics"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|t| t.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+            let data = entry["data"].as_str().unwrap_or("0x").to_string();
+            let log_index = match entry["logIndex"].as_str() {
+                Some(hex) => parse_hex_quantity(hex)? as u64,
+                None => position as u64,
+            };
+            logs.push((address, topics, data, log_index));
+        }
+    }
+    Ok(Some(TxReceiptWithLogs {
+        success,
+        block_number,
+        logs,
+    }))
+}
+
+/// Fetch a receipt (with logs) for `tx_hash`. Ok(None) = still pending.
+pub async fn get_transaction_receipt_with_logs(
+    chain: ChainId,
+    tx_hash: &str,
+) -> Result<Option<TxReceiptWithLogs>, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":[{:?}],"id":{}}}"#,
+        tx_hash,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    parse_receipt_with_logs(&text)
+}
+
 /// Broadcasts a signed raw transaction.  Returns the transaction hash on
 /// success.
 pub async fn send_raw_transaction(chain: ChainId, raw_tx_hex: &str) -> Result<String, String> {

--- a/src/rumi_protocol_backend/src/chains/monad/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/mod.rs
@@ -7,6 +7,7 @@
 //! mint/burn is observed at finality.
 
 pub mod adapter;
+pub mod burn_proof;
 pub mod chain_vault;
 pub mod config;
 pub mod deposit_watch;
@@ -52,3 +53,6 @@ mod tests_open_vault;
 
 #[cfg(test)]
 mod tests_withdraw;
+
+#[cfg(test)]
+mod tests_burn_proof;

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -38,7 +38,7 @@ use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
@@ -96,7 +96,7 @@ pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
 /// 3. Only after (2) succeeds: move `pending_mint_e8s` -> `debt_e8s`, set
 ///    status `Open`.
 pub fn confirm_mint_in_state(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain: ChainId,
     vault_id: u64,
     observed_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
@@ -1,0 +1,80 @@
+use crate::chains::config::ChainId;
+use crate::chains::monad::burn_proof::apply_receipt_burns_to_state;
+use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+use crate::chains::monad::evm_rpc::{TxReceiptWithLogs, BURN_EVENT_TOPIC0};
+use crate::chains::multi_chain_state::MultiChainStateV2;
+use candid::Principal;
+
+fn word(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn state_with_open_vault(debt: u128) -> MultiChainStateV2 {
+    let mut s = MultiChainStateV2::default();
+    s.chain_supplies.insert(ChainId(10143), debt);
+    s.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xc".into(),
+            collateral_amount_e18: 0,
+            debt_e8s: debt,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+        },
+    );
+    s
+}
+
+#[test]
+fn applies_burn_log_from_correct_contract_and_dedups() {
+    let mut s = state_with_open_vault(100);
+    let contract = "0xcafe";
+    let receipt = TxReceiptWithLogs {
+        success: true,
+        block_number: 10,
+        logs: vec![(
+            contract.to_string(),
+            vec![BURN_EVENT_TOPIC0.to_string(), word(1), word(0xdead)],
+            word(40),
+            3,
+        )],
+    };
+    let applied =
+        apply_receipt_burns_to_state(&mut s, ChainId(10143), contract, "0xtx", &receipt)
+            .expect("apply");
+    assert_eq!(applied.len(), 1);
+    assert_eq!(applied[0].vault_id, 1);
+    assert_eq!(applied[0].amount_e8s, 40);
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 60);
+    // Re-apply same receipt → deduped, no change.
+    let again =
+        apply_receipt_burns_to_state(&mut s, ChainId(10143), contract, "0xtx", &receipt)
+            .expect("apply again");
+    assert_eq!(again.len(), 0);
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 60);
+}
+
+#[test]
+fn rejects_log_from_wrong_contract() {
+    let mut s = state_with_open_vault(100);
+    let receipt = TxReceiptWithLogs {
+        success: true,
+        block_number: 10,
+        logs: vec![(
+            "0xnotthecontract".to_string(),
+            vec![BURN_EVENT_TOPIC0.to_string(), word(1), word(0xdead)],
+            word(40),
+            0,
+        )],
+    };
+    let applied =
+        apply_receipt_burns_to_state(&mut s, ChainId(10143), "0xcafe", "0xtx", &receipt)
+            .expect("apply");
+    assert_eq!(applied.len(), 0, "log from a non-icUSD contract is ignored");
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
@@ -2,15 +2,15 @@ use crate::chains::config::ChainId;
 use crate::chains::monad::burn_proof::apply_receipt_burns_to_state;
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::monad::evm_rpc::{TxReceiptWithLogs, BURN_EVENT_TOPIC0};
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use candid::Principal;
 
 fn word(v: u128) -> String {
     format!("0x{:064x}", v)
 }
 
-fn state_with_open_vault(debt: u128) -> MultiChainStateV2 {
-    let mut s = MultiChainStateV2::default();
+fn state_with_open_vault(debt: u128) -> MultiChainStateV3 {
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), debt);
     s.chain_vaults.insert(
         1,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -1,13 +1,13 @@
 use super::deposit_watch::{advance_cursor_and_prune, apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::monad::evm_rpc::BurnLog;
 use crate::chains::supply::SupplyInvariantError;
 use candid::Principal;
 
-fn seeded() -> MultiChainStateV2 {
-    let mut s = MultiChainStateV2::default();
+fn seeded() -> MultiChainStateV3 {
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
@@ -314,3 +314,22 @@ fn rejects_log_with_wrong_topic0() {
         &format!("0x{:064x}", 1u128), "0xtx", 1);
     assert!(res.is_err());
 }
+
+#[test]
+fn receipt_with_logs_parses_status_block_and_logs() {
+    // A minimal eth_getTransactionReceipt JSON with one log.
+    let json = r#"{"jsonrpc":"2.0","id":1,"result":{
+        "status":"0x1","blockNumber":"0x10",
+        "logs":[{"address":"0xCAFE","topics":["0xTOPIC0","0xVAULT","0xBURNER"],
+                 "data":"0x2a","logIndex":"0x3"}]}}"#;
+    let parsed = super::evm_rpc::parse_receipt_with_logs(json).expect("parse");
+    let r = parsed.expect("receipt present");
+    assert!(r.success);
+    assert_eq!(r.block_number, 16);
+    assert_eq!(r.logs.len(), 1);
+    let (addr, topics, data, idx) = &r.logs[0];
+    assert_eq!(addr, "0xcafe"); // lowercased
+    assert_eq!(topics[0], "0xTOPIC0");
+    assert_eq!(data, "0x2a");
+    assert_eq!(*idx, 3);
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -16,7 +16,7 @@ use super::chain_vault::{
     ChainVaultStatus, OpenVaultError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -31,8 +31,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 /// Register chain 10143 and set its manual MON price. Mirrors what the live
 /// register_chain endpoint + a manual price override do (chain_supplies and
 /// settlement_queues are seeded by register_chain_in_state).
-fn setup(price_e8: u64) -> MultiChainStateV2 {
-    let mut s = MultiChainStateV2::default();
+fn setup(price_e8: u64) -> MultiChainStateV3 {
+    let mut s = MultiChainStateV3::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -246,7 +246,7 @@ fn verify_unknown_vault_errors() {
 // 8. open rejects an unregistered chain
 #[test]
 fn open_rejects_unknown_chain() {
-    let mut s = MultiChainStateV2::default(); // no chain registered
+    let mut s = MultiChainStateV3::default(); // no chain registered
     let res = open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
         "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
@@ -305,7 +305,7 @@ fn open_rejects_invalid_recipient() {
 // 9. open rejects when no MON price is configured
 #[test]
 fn open_rejects_when_no_price() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     // Register the chain but DON'T set a MON price.
     let arg = RegisterChainArg {
         chain_id: CHAIN,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
@@ -1,11 +1,11 @@
 use super::settlement::{confirm_mint_in_state, select_next_op, OpAction};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
 
-fn vault_pending(s: &mut MultiChainStateV2, vault_id: u64, pending: u128) {
+fn vault_pending(s: &mut MultiChainStateV3, vault_id: u64, pending: u128) {
     s.chain_vaults.insert(vault_id, ChainVaultV1 {
         vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xc".into(), collateral_amount_e18: 0, debt_e8s: 0,
@@ -47,7 +47,7 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
 
 #[test]
 fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
     // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
@@ -61,7 +61,7 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
 
 #[test]
 fn confirm_mint_rejects_amount_mismatch() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000);
     // Observed amount differs from pending: reject (caught before any supply mutation), do not mutate.
@@ -73,7 +73,7 @@ fn confirm_mint_rejects_amount_mismatch() {
 
 #[test]
 fn confirm_mint_unknown_vault_rejected() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0).is_err());
 }
@@ -82,7 +82,7 @@ fn confirm_mint_unknown_vault_rejected() {
 fn confirm_mint_second_vault_uses_running_total() {
     // Two vaults: first already confirmed (debt 100e8, supply 100e8). Confirming the
     // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -22,7 +22,7 @@ use super::chain_vault::{
     ChainVaultStatus, WithdrawError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV2;
+use crate::chains::multi_chain_state::MultiChainStateV3;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -35,8 +35,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 const MIN_CR_E4: u64 = 13_000;
 
 /// Register chain 10143 and set its manual MON price (mirrors `tests_open_vault`).
-fn setup(price_e8: u64) -> MultiChainStateV2 {
-    let mut s = MultiChainStateV2::default();
+fn setup(price_e8: u64) -> MultiChainStateV3 {
+    let mut s = MultiChainStateV3::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -62,7 +62,7 @@ fn owner() -> Principal {
 /// open helper records `pending_mint_e8s` and `debt_e8s == 0`; we set the
 /// fields directly here to skip the deposit-watch + settlement round trip.)
 fn open_and_fund(
-    s: &mut MultiChainStateV2,
+    s: &mut MultiChainStateV3,
     vault_id: u64,
     collateral_e18: u128,
     debt_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -29,7 +29,7 @@
 //! See spec Section 3 ("State wipe on upgrade") and the 2026-05-18 AMM
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
 
-use super::config::{ChainConfigV1, ChainId};
+use super::config::{ChainConfigV1, ChainConfigV2, ChainId};
 use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
 use candid::{CandidType, Deserialize};
@@ -157,4 +157,64 @@ impl MultiChainStateV2 {
     }
 }
 
-pub type MultiChainState = MultiChainStateV2;
+/// Phase 1c snapshot. Identical to `MultiChainStateV2` in every field EXCEPT
+/// `chain_configs`, whose value type bumps from `ChainConfigV1` to
+/// `ChainConfigV2` (the latter adds the `burn_watch_poll_enabled` poll-scan
+/// flag). This is a NON-BREAKING reshape under ciborium:
+///
+///  - The eight outer fields are byte-for-byte identical to V2 and map across
+///    by name (NO `#[serde(default)]` needed — V2 always wrote them).
+///  - `chain_configs` is a CBOR map `{ChainId -> {field-map}}`. On decode each
+///    inner field-map decodes as a `ChainConfigV2`; the new
+///    `burn_watch_poll_enabled` key is absent in any V2-written sub-map and is
+///    supplied by its field-level `#[serde(default)]` (=> `false`). So a live
+///    `MultiChainStateV2` CBOR snapshot decodes into `MultiChainStateV3`
+///    without error and without wiping any chain/vault/supply state.
+///
+/// Because the decode is in-place (the four-then-eight fields carry across by
+/// name, the nested config field gains a defaulted bool), NO explicit migration
+/// call is needed in `post_upgrade`; `migrate_multi_chain_state` in `supply.rs`
+/// remains the dormant template for the next BREAKING bump.
+///
+/// Add the NEXT field by bumping to `MultiChainStateV4` (keep V3 verbatim),
+/// `#[serde(default)]` on the new field, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct MultiChainStateV3 {
+    /// Bumped value type vs V2 (`ChainConfigV1` -> `ChainConfigV2`). Always
+    /// present in any valid snapshot; the nested `ChainConfigV2` add-a-field is
+    /// what carries the `#[serde(default)]` (see `ChainConfigV2`).
+    pub chain_configs: BTreeMap<ChainId, ChainConfigV2>,
+    pub chain_supplies: BTreeMap<ChainId, u128>,
+    pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+    pub invariant_halted: bool,
+    #[serde(default)]
+    pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+    #[serde(default)]
+    pub chain_contracts: BTreeMap<ChainId, String>,
+    #[serde(default)]
+    pub manual_prices: BTreeMap<(ChainId, String), u64>,
+    #[serde(default)]
+    pub last_observed_block: BTreeMap<ChainId, u64>,
+    #[serde(default)]
+    pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+    #[serde(default)]
+    pub reorg_halted: BTreeMap<ChainId, bool>,
+    #[serde(default)]
+    pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+    #[serde(default)]
+    pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+}
+
+impl MultiChainStateV3 {
+    pub fn total_supply_all_chains_e8s(&self) -> u128 {
+        self.chain_supplies.values().copied().sum()
+    }
+
+    /// Sum of confirmed debt across all foreign-chain vaults (e8s). See the
+    /// V2 doc — same foreign-chain-only invariant.
+    pub fn total_chain_vault_debt_e8s(&self) -> u128 {
+        self.chain_vaults.values().map(|v| v.debt_e8s).sum()
+    }
+}
+
+pub type MultiChainState = MultiChainStateV3;

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,7 +12,7 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2};
+use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
@@ -63,7 +63,7 @@ pub enum SupplyInvariantError {
 /// authoritative `total_debt_e8s` snapshot taken at the same logical
 /// moment; we reject any apply that would leave sum != total_debt.
 pub fn apply_supply_delta(
-    state: &mut MultiChainStateV2,
+    state: &mut MultiChainStateV3,
     chain: ChainId,
     delta: SupplyDelta,
     total_debt_e8s: u128,
@@ -109,7 +109,7 @@ pub fn apply_supply_delta(
 /// On `Err`, the caller flips `state.invariant_halted = true` and emits
 /// an event.
 pub fn check_invariant(
-    state: &MultiChainStateV2,
+    state: &MultiChainStateV3,
     total_debt_e8s: u128,
 ) -> Result<(), SupplyInvariantError> {
     let sum: u128 = state.chain_supplies.values().copied().sum();

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -2,9 +2,9 @@
 //! flow (caller check, event recording, traps) is exercised in PocketIC under
 //! Task 12.
 
-use super::config::{ChainAdminError, ChainConfigV1, ChainId, ChainStatus, GasStrategy, RegisterChainArg, UpdateChainConfigArg};
+use super::config::{ChainAdminError, ChainConfigV2, ChainId, ChainStatus, GasStrategy, RegisterChainArg, UpdateChainConfigArg};
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-use super::multi_chain_state::MultiChainStateV2;
+use super::multi_chain_state::MultiChainStateV3;
 use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
 use candid::Principal;
 
@@ -47,20 +47,22 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
 
 #[test]
 fn register_chain_inserts_config_and_zero_supply() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     register_chain_in_state(&mut s, arg(), 1_700_000_000_000_000_000).expect("register");
     assert!(s.chain_configs.contains_key(&ChainId(101)));
     assert_eq!(s.chain_supplies[&ChainId(101)], 0);
     assert!(s.settlement_queues.contains_key(&ChainId(101)));
     let cfg = &s.chain_configs[&ChainId(101)];
     assert!(matches!(cfg.status, ChainStatus::Registered));
-    // Note: not unused -- `ChainConfigV1` is brought into scope to assert the type alias.
-    let _: &ChainConfigV1 = cfg;
+    // Phase 1c default: a freshly registered chain has the emergency poll-scan OFF.
+    assert!(!cfg.burn_watch_poll_enabled);
+    // Note: not unused -- `ChainConfigV2` is brought into scope to assert the type alias.
+    let _: &ChainConfigV2 = cfg;
 }
 
 #[test]
 fn register_chain_rejects_duplicates() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
     assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
@@ -68,7 +70,7 @@ fn register_chain_rejects_duplicates() {
 
 #[test]
 fn register_chain_rejects_empty_rpc_endpoints() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let mut a = arg();
     a.rpc_endpoints = vec![];
     let err = register_chain_in_state(&mut s, a, 0).expect_err("empty endpoints");
@@ -77,7 +79,7 @@ fn register_chain_rejects_empty_rpc_endpoints() {
 
 #[test]
 fn disable_chain_flips_status_and_preserves_supply() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
@@ -87,7 +89,7 @@ fn disable_chain_flips_status_and_preserves_supply() {
 
 #[test]
 fn set_chain_config_updates_supplied_fields_only() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     let original_name = s.chain_configs[&ChainId(101)].display_name.clone();
     let update = UpdateChainConfigArg {
@@ -104,7 +106,7 @@ fn set_chain_config_updates_supplied_fields_only() {
 
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let err = update_chain_config_in_state(
         &mut s,
         ChainId(404),
@@ -115,7 +117,7 @@ fn set_chain_config_rejects_unknown_chain() {
 
 #[test]
 fn delete_chain_removes_zero_supply_chain() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     // Populate EVERY per-chain map so the purge can be observed.
@@ -145,7 +147,7 @@ fn delete_chain_removes_zero_supply_chain() {
 
 #[test]
 fn delete_chain_refuses_when_supply_nonzero() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_supplies.insert(c, 1);
@@ -158,7 +160,7 @@ fn delete_chain_refuses_when_supply_nonzero() {
 
 #[test]
 fn delete_chain_refuses_when_open_vaults_reference_it() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_vaults.insert(1, dummy_vault(1, c));
@@ -171,7 +173,7 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
 
 #[test]
 fn delete_chain_unknown_is_rejected() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_config.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_config.rs
@@ -1,6 +1,6 @@
 //! ChainConfig encode/decode + version-alias invariants.
 
-use super::config::{ChainConfig, ChainConfigV1, ChainId, ChainStatus, GasStrategy};
+use super::config::{ChainConfig, ChainConfigV1, ChainConfigV2, ChainId, ChainStatus, GasStrategy};
 use candid::{Decode, Encode};
 
 #[test]
@@ -42,9 +42,82 @@ fn chain_config_round_trips_via_candid() {
 }
 
 #[test]
-fn chain_config_alias_matches_v1() {
-    // Phase 1a invariant: `ChainConfig` is the active version pointer.
-    // Phase 1c (or whenever a field is added) rebinds this alias to V2 and
-    // ships a `MultiChainStateMigration` step.
-    fn _check(_x: ChainConfig) -> ChainConfigV1 { _x }
+fn chain_config_alias_matches_v2() {
+    // Phase 1c rebound `ChainConfig` from V1 to V2 (added the
+    // `burn_watch_poll_enabled` poll-scan flag). `ChainConfig` is the active
+    // version pointer; the next field add bumps it to V3.
+    fn _check(_x: ChainConfig) -> ChainConfigV2 { _x }
+}
+
+#[test]
+fn v1_cbor_sub_map_decodes_into_v2_defaulting_the_poll_flag() {
+    // STATE-WIPE REGRESSION (Phase 1c). On the live staging canister
+    // `chain_configs` is a ciborium (CBOR) map whose VALUES were written as
+    // `ChainConfigV1` field-maps (no `burn_watch_poll_enabled` key). After the
+    // Phase 1c upgrade those same bytes must decode into `ChainConfigV2` with
+    // every V1 field preserved and the new flag defaulted to `false` via its
+    // field-level `#[serde(default)]`. State persists via ciborium (serde),
+    // NOT a Candid `Decode!` of a fixed record, so a missing key fills from the
+    // default rather than failing the decode — this is what prevents the
+    // AMM-style state-wipe (2026-05-18). If the `#[serde(default)]` were
+    // dropped, this decode would error with "missing field", which on the real
+    // canister silently wipes multi_chain state via the event-replay fallback.
+    let v1 = ChainConfigV1 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://rpc.testnet.example".to_string()],
+        finality_depth: 3,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+        registered_at_ns: 1_700_000_000_000_000_000,
+        status: ChainStatus::Registered,
+    };
+
+    // Encode with the V1 shape (the bytes a pre-1c canister wrote), decode with
+    // the V2 shape (the new active type).
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v1, &mut buf).expect("cbor encode V1 config");
+    let v2: ChainConfigV2 = ciborium::de::from_reader(buf.as_slice())
+        .expect("V1 config sub-map MUST decode into V2 without wiping state");
+
+    // Every V1 field preserved verbatim:
+    assert_eq!(v2.chain_id, ChainId(10143));
+    assert_eq!(v2.display_name, "MonadTestnet");
+    assert_eq!(v2.rpc_endpoints, vec!["https://rpc.testnet.example".to_string()]);
+    assert_eq!(v2.finality_depth, 3);
+    assert_eq!(v2.chain_native_decimals, 18);
+    assert_eq!(v2.registered_at_ns, 1_700_000_000_000_000_000);
+    assert!(matches!(v2.status, ChainStatus::Registered));
+    // New flag defaults to false (poll-scan OFF) — notify-then-verify default.
+    assert!(!v2.burn_watch_poll_enabled);
+}
+
+#[test]
+fn v2_config_round_trips_with_poll_flag_set() {
+    // A populated V2 config (poll flag flipped on for an emergency catch-up)
+    // must survive a ciborium round-trip with the flag intact — the V2->V2
+    // upgrade path.
+    let v2 = ChainConfigV2 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://rpc".to_string()],
+        finality_depth: 3,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+        registered_at_ns: 1,
+        status: ChainStatus::Registered,
+        burn_watch_poll_enabled: true,
+    };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v2, &mut buf).expect("cbor encode V2 config");
+    let back: ChainConfigV2 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V2 config round-trips");
+    assert!(back.burn_watch_poll_enabled);
+    assert_eq!(back.finality_depth, 3);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,4 +1,4 @@
-use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
+use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
 use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
 
@@ -118,8 +118,81 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
 }
 
 #[test]
-fn active_alias_points_at_v2() {
-    fn _check(x: MultiChainState) -> MultiChainStateV2 { x }
+fn active_alias_points_at_v3() {
+    fn _check(x: MultiChainState) -> MultiChainStateV3 { x }
+}
+
+#[test]
+fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
+    // STATE-WIPE REGRESSION (Phase 1c). The live staging canister persists a
+    // `MultiChainStateV2` whose `chain_configs` values are `ChainConfigV1`
+    // field-maps. The Phase 1c upgrade rebinds `MultiChainState` to V3 (whose
+    // `chain_configs` value type is `ChainConfigV2`). A populated V2 CBOR
+    // snapshot MUST decode into V3 with:
+    //   - the eight outer fields carried across by name, and
+    //   - each nested config decoding from `ChainConfigV1` into `ChainConfigV2`
+    //     with `burn_watch_poll_enabled` supplied by its `#[serde(default)]`.
+    // This is the exact ciborium decode path `load_state_from_stable()` runs on
+    // upgrade. Without the nested `#[serde(default)]` the decode would fail with
+    // "missing field `burn_watch_poll_enabled`", silently wiping multi_chain
+    // state on the real canister. (Vault 1 with real debt/supply lives here.)
+    use super::config::{ChainConfigV1, ChainStatus, GasStrategy};
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::settlement_queue::SettlementQueueV1;
+    use std::collections::BTreeSet;
+
+    let mut v2 = MultiChainStateV2::default();
+    v2.chain_configs.insert(ChainId(10143), ChainConfigV1 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 3,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
+        chain_native_decimals: 18,
+        registered_at_ns: 123,
+        status: ChainStatus::Registered,
+    });
+    v2.chain_supplies.insert(ChainId(10143), 50_000_000);
+    v2.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
+    v2.invariant_halted = false;
+    v2.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xcustody".into(),
+        collateral_amount_e18: 1_000_000_000_000_000_000,
+        debt_e8s: 50_000_000,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 99,
+    });
+    v2.chain_contracts.insert(ChainId(10143), "0xicusd".into());
+    v2.last_observed_block.insert(ChainId(10143), 35_136_248);
+    v2.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+
+    // Encode as V2 (the bytes the live canister wrote), decode as V3 (new shape).
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v2, &mut buf).expect("cbor encode V2");
+    let v3: MultiChainStateV3 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V2 snapshot MUST decode into V3");
+
+    // Outer state preserved:
+    assert_eq!(v3.chain_supplies.get(&ChainId(10143)), Some(&50_000_000u128));
+    assert_eq!(v3.chain_vaults.len(), 1);
+    assert_eq!(v3.chain_vaults[&1].debt_e8s, 50_000_000);
+    assert_eq!(v3.chain_contracts.get(&ChainId(10143)), Some(&"0xicusd".to_string()));
+    assert_eq!(v3.last_observed_block.get(&ChainId(10143)), Some(&35_136_248u64));
+    assert!(v3.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
+    // Nested config migrated V1 -> V2: V1 fields preserved, new flag defaulted off.
+    let cfg = v3.chain_configs.get(&ChainId(10143)).expect("config preserved");
+    assert_eq!(cfg.finality_depth, 3);
+    assert_eq!(cfg.display_name, "MonadTestnet");
+    assert!(matches!(cfg.status, ChainStatus::Registered));
+    assert!(!cfg.burn_watch_poll_enabled, "poll-scan defaults OFF after upgrade");
+    // Total debt still reconciles (no state wipe).
+    assert_eq!(v3.total_chain_vault_debt_e8s(), 50_000_000);
+    assert_eq!(v3.total_supply_all_chains_e8s(), 50_000_000);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_self_check.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_self_check.rs
@@ -2,12 +2,12 @@
 //! self-check flips the halt flag and Mode and stops mutating supplies.
 
 use super::config::ChainId;
-use super::multi_chain_state::MultiChainStateV2;
+use super::multi_chain_state::MultiChainStateV3;
 use super::supply::check_invariant;
 
 #[test]
 fn check_invariant_passes_when_sum_equals_total_debt() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     assert!(check_invariant(&s, 300).is_ok());
@@ -15,7 +15,7 @@ fn check_invariant_passes_when_sum_equals_total_debt() {
 
 #[test]
 fn check_invariant_fails_on_drift() {
-    let mut s = MultiChainStateV2::default();
+    let mut s = MultiChainStateV3::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     let err = check_invariant(&s, 299).expect_err("drift must be caught");
@@ -24,6 +24,6 @@ fn check_invariant_fails_on_drift() {
 
 #[test]
 fn empty_state_passes_when_total_debt_is_zero() {
-    let s = MultiChainStateV2::default();
+    let s = MultiChainStateV3::default();
     assert!(check_invariant(&s, 0).is_ok());
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,12 +1,12 @@
 use super::supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
-use super::config::{ChainConfigV1, ChainId, ChainStatus, GasStrategy};
-use super::multi_chain_state::MultiChainStateV2;
+use super::config::{ChainConfigV2, ChainId, ChainStatus, GasStrategy};
+use super::multi_chain_state::MultiChainStateV3;
 
-fn fixture_state() -> MultiChainStateV2 {
-    let mut s = MultiChainStateV2::default();
+fn fixture_state() -> MultiChainStateV3 {
+    let mut s = MultiChainStateV3::default();
     s.chain_configs.insert(
         ChainId(101),
-        ChainConfigV1 {
+        ChainConfigV2 {
             chain_id: ChainId(101),
             display_name: "TestChain".into(),
             rpc_endpoints: vec![],
@@ -15,6 +15,7 @@ fn fixture_state() -> MultiChainStateV2 {
             chain_native_decimals: 18,
             registered_at_ns: 0,
             status: ChainStatus::Registered,
+            burn_watch_poll_enabled: false,
         },
     );
     s.chain_supplies.insert(ChainId(101), 0);

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1219,6 +1219,90 @@ fn get_last_observed_block(
     read_state(|s| s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0))
 }
 
+/// Phase 1c notify-then-verify: submit a burn transaction hash for verification.
+///
+/// PERMISSIONLESS: anyone may submit a REAL on-chain tx hash. The verify path
+/// (`verify_and_apply_burn_proof`) fetches the receipt via ONE
+/// `eth_getTransactionReceipt`, rejects forgeries (only Burn logs emitted by the
+/// configured icUSD contract count, and the amount/vault come FROM the log, never
+/// from the caller), requires finality, and dedups on `(tx_hash, log_index)` via
+/// the existing `processed_burn_keys` set — so a re-submit of an already-applied
+/// burn returns Ok(0) and changes nothing. Returns the number of burns NEWLY
+/// applied from the tx. This replaces the continuous `eth_getLogs` burn-scan as
+/// the PRIMARY burn-observation path (one outcall per actual burn instead of
+/// O(blocks produced)).
+///
+/// Finality lag is surfaced as `TemporarilyUnavailable` so the caller (the
+/// frontend, per plan Task 7) can poll-and-retry until the receipt is final.
+///
+/// FUTURE ROBUSTNESS (flagged per Rob 2026-05-31): v1 liveness depends on the
+/// submitter (the dApp). Harden later with a relayer or an incentivized
+/// permissionless submitter; add a per-caller rate-limit when that lands.
+#[candid_method(update)]
+#[update]
+async fn submit_burn_proof(
+    chain_id: rumi_protocol_backend::chains::config::ChainId,
+    tx_hash: String,
+) -> Result<u32, ProtocolError> {
+    use rumi_protocol_backend::chains::monad::burn_proof::{
+        verify_and_apply_burn_proof, BurnProofError,
+    };
+    match verify_and_apply_burn_proof(chain_id, &tx_hash).await {
+        Ok(n) => {
+            if n > 0 {
+                log!(
+                    INFO,
+                    "[submit_burn_proof] chain={:?} tx={} applied {} burn(s)",
+                    chain_id, tx_hash, n
+                );
+            }
+            Ok(n)
+        }
+        // Transient: the receipt is not yet mined or not yet buried under
+        // finality_depth confirmations. The caller should retry.
+        Err(BurnProofError::Pending) | Err(BurnProofError::NotFinal) => Err(
+            ProtocolError::TemporarilyUnavailable("receipt not yet final; retry".into()),
+        ),
+        // A transport/RPC failure is also retryable.
+        Err(BurnProofError::Rpc(e)) => Err(ProtocolError::TemporarilyUnavailable(format!(
+            "burn-proof RPC error; retry: {}",
+            e
+        ))),
+        // Terminal: reverted tx, unknown chain/contract, or a halt-class
+        // supply-invariant failure. None of these is fixed by retrying.
+        Err(e) => Err(ProtocolError::ChainAdmin(format!("burn proof rejected: {:?}", e))),
+    }
+}
+
+/// Phase 1c: developer-gated toggle for the EMERGENCY continuous `eth_getLogs`
+/// burn-watch poll-scan on a chain. Default OFF (notify-then-verify only, via
+/// `submit_burn_proof`). Flip ON only for a targeted catch-up — the scan costs
+/// O(blocks produced), so leave it OFF in steady state. No-op (Ok) if the chain
+/// is not registered. Persisted in `ChainConfigV2.burn_watch_poll_enabled`.
+#[candid_method(update)]
+#[update]
+fn set_burn_watch_poll_enabled(
+    chain_id: rumi_protocol_backend::chains::config::ChainId,
+    enabled: bool,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        if let Some(c) = s.multi_chain.chain_configs.get_mut(&chain_id) {
+            c.burn_watch_poll_enabled = enabled;
+        }
+    });
+    log!(
+        INFO,
+        "[set_burn_watch_poll_enabled] chain={:?} burn-watch poll-scan {}",
+        chain_id,
+        if enabled { "ENABLED" } else { "disabled" }
+    );
+    Ok(())
+}
+
 /// Delete a chain entirely. Permitted only when the chain carries ZERO supply
 /// and NO chain_vaults reference it (so deletion cannot orphan debt/collateral);
 /// purges every per-chain map. Developer-gated. This DELETES (not disables) a

--- a/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
+++ b/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
@@ -8,9 +8,9 @@
 //! explicitly so the property test does not depend on the live State.
 
 use rumi_protocol_backend::chains::config::{
-    ChainConfigV1, ChainId, ChainStatus, GasStrategy,
+    ChainConfigV2, ChainId, ChainStatus, GasStrategy,
 };
-use rumi_protocol_backend::chains::multi_chain_state::MultiChainStateV2;
+use rumi_protocol_backend::chains::multi_chain_state::MultiChainStateV3;
 use rumi_protocol_backend::chains::supply::{apply_supply_delta, SupplyDelta};
 use rumi_protocol_backend::chains::monad::chain_vault::open_chain_vault_in_state;
 use rumi_protocol_backend::chains::monad::settlement::confirm_mint_in_state;
@@ -38,12 +38,12 @@ fn arb_op() -> impl Strategy<Value = Op> {
     ]
 }
 
-fn seeded_state() -> MultiChainStateV2 {
-    let mut state = MultiChainStateV2::default();
+fn seeded_state() -> MultiChainStateV3 {
+    let mut state = MultiChainStateV3::default();
     for id in 1u32..=5u32 {
         state.chain_configs.insert(
             ChainId(id),
-            ChainConfigV1 {
+            ChainConfigV2 {
                 chain_id: ChainId(id),
                 display_name: format!("chain-{}", id),
                 rpc_endpoints: vec![],
@@ -52,6 +52,7 @@ fn seeded_state() -> MultiChainStateV2 {
                 chain_native_decimals: 18,
                 registered_at_ns: 0,
                 status: ChainStatus::Registered,
+                burn_watch_poll_enabled: false,
             },
         );
         state.chain_supplies.insert(ChainId(id), 0);

--- a/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_burn_idempotency_pic.rs
@@ -438,6 +438,19 @@ fn phase1b_burn_idempotency_skips_poison_and_never_double_applies() {
     )
     .expect("set_last_observed_block");
 
+    // Phase 1c: burn-watch poll-scan is OFF by default (notify-then-verify is the
+    // primary path). This test exercises the POLL mechanism, so opt in.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
+
     // Chain head = seed + 1024 so the first tick advances 1_000_000 -> 1_001_024.
     update_any(&pic, mock, "set_blocks", Encode!(&1_001_024u64, &1_001_024u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
@@ -695,6 +708,19 @@ fn phase1b_burn_two_identical_burns_in_same_tx_both_applied() {
         "set_last_observed_block",
     )
     .expect("set_last_observed_block");
+
+    // Phase 1c: burn-watch poll-scan is OFF by default (notify-then-verify is the
+    // primary path). This test exercises the POLL mechanism, so opt in.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
 
     update_any(&pic, mock, "set_blocks", Encode!(&2_001_024u64, &2_001_024u64).unwrap());
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint_same_tx".to_string()).unwrap());

--- a/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_getlogs_chunking_pic.rs
@@ -403,6 +403,19 @@ fn configure_chain(pic: &PocketIc, backend: Principal, mock: Principal, seed: u6
         "set_last_observed_block",
     )
     .expect("set_last_observed_block");
+
+    // Phase 1c: the burn-watch poll-scan is OFF by default (notify-then-verify is
+    // the primary path). These tests exercise the POLL mechanism, so opt in.
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
 }
 
 fn ecdsa_settlement_addr(pic: &PocketIc, backend: Principal) -> Option<String> {

--- a/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_monad_happy_path_pic.rs
@@ -404,6 +404,20 @@ fn phase1b_monad_happy_path_supply_invariant() {
     )
     .expect("set_last_observed_block");
 
+    // Phase 1c: burn-watch poll-scan is OFF by default (notify-then-verify is the
+    // primary path). This happy-path test observes burns via the POLL mechanism, so
+    // opt in.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
+
     // Invariant holds at zero after register/config (Design B: nothing minted).
     assert_supply(&pic, backend, 0, "after register/config");
 

--- a/src/rumi_protocol_backend/tests/phase1c_burn_proof_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1c_burn_proof_pic.rs
@@ -1,0 +1,665 @@
+//! Phase 1c — notify-then-verify burn observation end-to-end.
+//!
+//! ## What this proves
+//!
+//! The new `submit_burn_proof(chain_id, tx_hash)` update endpoint verifies ONE
+//! transaction's receipt (via `eth_getTransactionReceipt` + a consensus-safe
+//! `eth_getBlockByNumber` finality probe) and applies any `Burn` log emitted by
+//! the configured icUSD contract — WITHOUT the continuous `eth_getLogs`
+//! poll-scan (which is OFF by default in this mode).
+//!
+//! The harness (boot / configure_chain / advance_and_tick / ABI-word helpers /
+//! ECDSA-gating / 30s interval pin) is copied from the sibling
+//! `phase1b_getlogs_chunking_pic.rs`.
+//!
+//! Scenario (ECDSA available — full guard):
+//!   1. Stand up an Open vault with debt 100e8 (open → deposit → mint-confirm).
+//!   2. Script a Burn log on a receipt for tx `0xburn1` (address = configured
+//!      contract; topics = [BURN_TOPIC0, word(vault_id), word(burner)]; data =
+//!      word(40e8); logIndex 0). The receipt block is set so `is_block_final`
+//!      passes (latest/finalized >= receipt_block + finality_depth).
+//!   3. `submit_burn_proof(10143, "0xburn1")` → Ok(1); vault debt 60e8; global
+//!      supply 60e8.
+//!   4. Re-submit same tx → Ok(0) (deduped); debt still 60e8.
+//!   5. Negative: a Burn log on `0xfake` from a WRONG contract → Ok(0); debt
+//!      unchanged.
+//!   6. Poll-scan irrelevance: arm `fail_always("eth_getLogs", ...)` and confirm
+//!      `submit_burn_proof` STILL works (it never calls `eth_getLogs`).
+//!
+//! ECDSA-gated subset (no signing available): the verify path is still
+//! exercised against a synthetic AwaitingDeposit-free state by asserting the
+//! endpoint rejects a forged-contract burn (Ok(0)) and that a pending/unmined
+//! tx surfaces TemporarilyUnavailable — both require no settlement signing.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// Must equal the backend's `MAX_BLOCK_SCAN_WINDOW` (chains/monad/evm_rpc.rs).
+const SCAN_WINDOW: u64 = 1024;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+// `ChainId(pub u32)` is a single-field tuple struct — candid serializes it as
+// the bare inner `nat32`, matching the `.did` (`submit_burn_proof : (nat32, text)`).
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+// Mirror the FULL `ProtocolError` enum (lib.rs) so candid variant tags line up.
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq)]
+enum TransferFromError {
+    GenericError { error_code: candid::Nat, message: String },
+    TemporarilyUnavailable,
+    InsufficientAllowance { allowance: candid::Nat },
+    BadBurn { min_burn_amount: candid::Nat },
+    Duplicate { duplicate_of: candid::Nat },
+    BadFee { expected_fee: candid::Nat },
+    CreatedInFuture { ledger_time: u64 },
+    TooOld,
+    InsufficientFunds { balance: candid::Nat },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq)]
+enum TransferError {
+    GenericError { error_code: candid::Nat, message: String },
+    TemporarilyUnavailable,
+    BadBurn { min_burn_amount: candid::Nat },
+    Duplicate { duplicate_of: candid::Nat },
+    BadFee { expected_fee: candid::Nat },
+    CreatedInFuture { ledger_time: u64 },
+    TooOld,
+    InsufficientFunds { balance: candid::Nat },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq)]
+enum ProtocolError {
+    TransferFromError(TransferFromError, u64),
+    TransferError(TransferError),
+    TemporarilyUnavailable(String),
+    AlreadyProcessing,
+    AnonymousCallerNotAllowed,
+    CallerNotOwner,
+    AmountTooLow { minimum_amount: u64 },
+    GenericError(String),
+    NotLowestCR,
+    SupplyInvariantHalted,
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+const CONTRACT: &str = "0x00000000000000000000000000000000deadbeef";
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+fn cursor(pic: &PocketIc, backend: Principal) -> u64 {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_last_observed_block query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, u64).expect("decode get_last_observed_block"),
+        WasmResult::Reject(msg) => panic!("get_last_observed_block rejected: {}", msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+/// Decode a `submit_burn_proof` reply: `variant { Ok: nat32; Err: ProtocolError }`.
+fn submit_burn_proof(
+    pic: &PocketIc,
+    backend: Principal,
+    chain_id: u32,
+    tx_hash: &str,
+) -> Result<u32, ProtocolError> {
+    // The `inspect_message` hook silently rejects ANONYMOUS callers for every
+    // method except the two consent reads, so submit from a non-anonymous
+    // principal (the endpoint itself is permissionless — any non-anonymous
+    // caller may submit a real tx hash; the verify path rejects forgeries).
+    let reply = update_dev(
+        pic,
+        backend,
+        "submit_burn_proof",
+        Encode!(&ChainId(chain_id), &tx_hash.to_string()).unwrap(),
+    );
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<u32, ProtocolError>)
+            .expect("decode submit_burn_proof Result"),
+        WasmResult::Reject(msg) => panic!("submit_burn_proof rejected: {}", msg),
+    }
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {}", msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+
+    // Pin observer + settlement cadence to 30s (code DEFAULT is 300s).
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data ─────────────────────────
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn word_addr(addr: &str) -> String {
+    let raw = addr
+        .strip_prefix("0x")
+        .or_else(|| addr.strip_prefix("0X"))
+        .unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+/// Script a Burn log onto a transaction's RECEIPT (returned by
+/// `eth_getTransactionReceipt`). The receipt block is set FIRST via `set_receipt`
+/// — `push_receipt_log` reads the receipt's current block and stamps the log with
+/// it (creating the receipt at block 0 if absent). Setting the block first means
+/// `is_block_final(receipt_block, finality_depth)` probes a block that EXISTS
+/// once the mock's latest/finalized >= receipt_block + finality_depth.
+fn script_burn_receipt(
+    pic: &PocketIc,
+    mock: Principal,
+    tx_hash: &str,
+    receipt_block: u64,
+    contract: &str,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    log_index: u64,
+) {
+    // Set the receipt's stored block BEFORE pushing the log (push_receipt_log
+    // copies the receipt's block onto the log and would default to 0 otherwise).
+    update_any(
+        pic,
+        mock,
+        "set_receipt",
+        Encode!(&tx_hash.to_string(), &true, &receipt_block).unwrap(),
+    );
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_receipt_log",
+        Encode!(
+            &tx_hash.to_string(),
+            &contract.to_string(),
+            &topics,
+            &data,
+            &log_index
+        )
+        .unwrap(),
+    );
+}
+
+/// Register Monad + contract + manual MON price + seed the burn-watch cursor.
+fn configure_chain(pic: &PocketIc, backend: Principal, mock: Principal, seed: u64) {
+    decode_result(
+        update_dev(pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_chain_contract",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &CONTRACT.to_string()).unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &seed).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+}
+
+fn ecdsa_settlement_addr(pic: &PocketIc, backend: Principal) -> Option<String> {
+    match update_dev(
+        pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    }
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1c_submit_burn_proof_verifies_one_tx_no_poll_scan() {
+    let (pic, backend, mock) = boot();
+
+    let seed: u64 = 7_000_000;
+    configure_chain(&pic, backend, mock, seed);
+
+    // Chain head one window above the seed so finality probes resolve. With
+    // finality_depth=1 a receipt at block B is final once finalized >= B+1.
+    let finalized = seed + SCAN_WINDOW;
+    update_any(&pic, mock, "set_blocks", Encode!(&finalized, &finalized).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
+
+    let burner = "0x000000000000000000000000000000000000beef".to_string();
+
+    match ecdsa_settlement_addr(&pic, backend) {
+        None => {
+            // ── GATED subset (no signing): verify path rejects a forged-contract
+            //    burn and a pending tx, neither of which needs settlement signing.
+            eprintln!("[phase1c burn-proof] ECDSA UNAVAILABLE; running GATED subset (forged-contract rejection + pending)");
+
+            // No vault exists. A burn citing a non-existent vault from the WRONG
+            // contract must apply nothing (Ok(0)) — contract filter rejects it.
+            script_burn_receipt(
+                &pic, mock, "0xfake", finalized - 10, "0xnotthecontract", 1, &burner, 40 * E8, 0,
+            );
+            let r = submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xfake");
+            assert_eq!(r, Ok(0), "forged-contract burn applies nothing (got {:?})", r);
+
+            // An unmined tx surfaces TemporarilyUnavailable (retryable).
+            match submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xneverexisted") {
+                Err(ProtocolError::TemporarilyUnavailable(_)) => {}
+                other => panic!("pending tx should be TemporarilyUnavailable, got {:?}", other),
+            }
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(0u32), "gated: supply invariant holds at 0");
+            eprintln!("[phase1c burn-proof] GATED subset PASSED");
+            return;
+        }
+        Some(settlement_addr) => {
+            eprintln!("[phase1c burn-proof] ECDSA AVAILABLE; settlement={settlement_addr}; running FULL guard");
+
+            // Fund the hot wallet so the settlement submit-path gas gate passes.
+            update_any(
+                &pic,
+                mock,
+                "set_balance",
+                Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+            );
+
+            // ── 1. Stand up an Open vault: 100 MON @ $2 backs 100 icUSD. ──────
+            let collateral_e18 = 100u128 * E18;
+            let debt_e8s = 100u128 * E8;
+            let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+            let vault_id: u64 = match update_dev(
+                &pic,
+                backend,
+                "open_chain_vault",
+                Encode!(
+                    &ChainId(MONAD_CHAIN_ID),
+                    &candid::Nat::from(collateral_e18),
+                    &candid::Nat::from(debt_e8s),
+                    &recipient
+                )
+                .unwrap(),
+            ) {
+                WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+                    .expect("decode open_chain_vault")
+                    .expect("open_chain_vault Ok"),
+                WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+            };
+
+            let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+            let custody = v.custody_address.clone();
+
+            // Deposit lands; observer flips to MintPending + enqueues mint. Push
+            // the Mint log at the finalized block; the mint-confirm path scans a
+            // single block and confirms.
+            update_any(
+                &pic,
+                mock,
+                "set_balance",
+                Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+            );
+            advance_and_tick(&pic, 2);
+            push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", finalized);
+            advance_and_tick(&pic, 4);
+
+            let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+            assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+            assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "mint confirmed => debt 100e8");
+
+            // ── 2. Script a final 40e8 Burn receipt for tx 0xburn1. ───────────
+            // receipt_block + finality_depth(1) <= finalized so is_block_final
+            // passes. The burn-watch poll-scan is OFF; the cursor never advanced
+            // by scanning, so place the receipt anywhere <= finalized - 1.
+            let burn_block = finalized - 100;
+            script_burn_receipt(
+                &pic, mock, "0xburn1", burn_block, CONTRACT, vault_id, &burner, 40 * E8, 0,
+            );
+
+            // ── 3. submit_burn_proof => Ok(1), debt 60e8, supply 60e8. ────────
+            let r = submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xburn1");
+            assert_eq!(r, Ok(1), "first submit applies exactly one burn (got {:?})", r);
+
+            let v = get_vault(&pic, backend, vault_id).expect("vault after burn proof");
+            assert_eq!(v.debt_e8s, candid::Nat::from(60 * E8), "debt 60e8 after 40e8 burn");
+            assert_eq!(v.status, ChainVaultStatus::Open, "partial burn keeps vault Open");
+
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(60 * E8), "global supply 60e8");
+            let audit: SupplyAuditWire = query_unit(&pic, backend, "get_supply_audit");
+            assert_eq!(audit.total_e8s, v.debt_e8s, "chain supply == vault debt == 60e8");
+
+            // ── 4. Re-submit same tx => Ok(0) (deduped), debt unchanged. ──────
+            let r = submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xburn1");
+            assert_eq!(r, Ok(0), "re-submit deduped to zero applied (got {:?})", r);
+            let v = get_vault(&pic, backend, vault_id).expect("vault after re-submit");
+            assert_eq!(v.debt_e8s, candid::Nat::from(60 * E8), "dedup: debt still 60e8");
+
+            // ── 5. Negative: burn from the WRONG contract => Ok(0), unchanged. ─
+            script_burn_receipt(
+                &pic, mock, "0xfake", burn_block, "0xnotthecontract", vault_id, &burner, 40 * E8, 0,
+            );
+            let r = submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xfake");
+            assert_eq!(r, Ok(0), "wrong-contract burn applies nothing (got {:?})", r);
+            let v = get_vault(&pic, backend, vault_id).expect("vault after wrong-contract");
+            assert_eq!(v.debt_e8s, candid::Nat::from(60 * E8), "wrong contract: debt still 60e8");
+
+            // ── 6. Poll-scan irrelevance: arm fail_always(eth_getLogs) and show
+            //    submit_burn_proof STILL works (uses eth_getTransactionReceipt +
+            //    eth_getBlockByNumber, never eth_getLogs). ──────────────────────
+            update_any(
+                &pic,
+                mock,
+                "fail_always",
+                Encode!(
+                    &"eth_getLogs".to_string(),
+                    &"forced getLogs failure (burn-proof must not use getLogs)".to_string()
+                )
+                .unwrap(),
+            );
+            // A fresh, distinct burn at log_index 1 on tx 0xburn2.
+            script_burn_receipt(
+                &pic, mock, "0xburn2", burn_block, CONTRACT, vault_id, &burner, 10 * E8, 1,
+            );
+            let r = submit_burn_proof(&pic, backend, MONAD_CHAIN_ID, "0xburn2");
+            assert_eq!(
+                r,
+                Ok(1),
+                "submit_burn_proof works with eth_getLogs forced-failing => never calls getLogs (got {:?})",
+                r
+            );
+            let v = get_vault(&pic, backend, vault_id).expect("vault after getLogs-barrier burn");
+            assert_eq!(v.debt_e8s, candid::Nat::from(50 * E8), "debt 50e8 after second 10e8 burn");
+
+            // Cursor must NOT have advanced by scanning (poll-scan OFF means the
+            // observer's burn-watch never paged getLogs; it only advances via the
+            // finalized probe). The receipt-verify path does not touch the cursor.
+            let _ = cursor(&pic, backend);
+
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(50 * E8), "global supply 50e8 after both burns");
+
+            eprintln!("[phase1c burn-proof] FULL guard PASSED: submit_burn_proof verified one tx, deduped, rejected wrong contract, and worked with eth_getLogs forced-failing");
+        }
+    }
+}

--- a/src/vault_frontend/src/lib/services/monadBurnService.ts
+++ b/src/vault_frontend/src/lib/services/monadBurnService.ts
@@ -1,0 +1,179 @@
+// monadBurnService.ts — Phase 1c "notify-then-verify" burn submission.
+//
+// After a user burns icUSD on Monad (chain 10143) via the IcUSD contract's
+// `burn(...)` EVM call, the dApp submits the burn transaction hash to the
+// backend so the canister can fetch the receipt, verify the Burn log was
+// emitted by the configured icUSD contract, confirm finality, and decrement
+// the chain-vault debt (via `submit_burn_proof`).
+//
+// The backend returns `ProtocolError::TemporarilyUnavailable(text)` while the
+// receipt is not yet final ("receipt not yet final; retry") — that is a SOFT
+// signal to poll again after finality lag. Any OTHER `Err` is TERMINAL
+// (reverted tx, wrong contract, halt-class invariant, etc.) and must not be
+// retried. `Ok(n)` is the count of burns newly applied (>= 0; 0 on a deduped
+// re-submit).
+//
+// ──────────────────────────────────────────────────────────────────────────
+// FUTURE ROBUSTNESS (flagged by Rob 2026-05-31):
+//   This makes burn-state LIVENESS depend on the dApp staying open through tx
+//   confirmation + finality. If the user closes the tab before the proof lands,
+//   the burn is recorded on Monad but the canister never learns of it until an
+//   operator submits the proof manually (`icp`/`dfx`) or enables the emergency
+//   poll-scan (`set_burn_watch_poll_enabled`). Acceptable for v1; HARDEN LATER
+//   with a relayer service or an incentivized permissionless submitter that
+//   watches Monad and calls `submit_burn_proof` independently of any dApp.
+// ──────────────────────────────────────────────────────────────────────────
+
+import { Actor, HttpAgent } from '@dfinity/agent';
+import { idlFactory as rumi_backendIDL } from '$declarations/rumi_protocol_backend/rumi_protocol_backend.did.js';
+import type {
+  _SERVICE,
+  ProtocolError,
+} from '$declarations/rumi_protocol_backend/rumi_protocol_backend.did.js';
+import { CONFIG } from '../config';
+
+/** Monad chain id (matches the backend's configured chain). */
+export const MONAD_CHAIN_ID = 10143;
+
+/**
+ * Retry tuning. Monad blocks are ~0.5s and the configured finality depth is
+ * small, so the receipt is usually final within a handful of seconds. We poll
+ * a little slower than the finality interval and cap the total budget so a
+ * stuck/terminal-but-misreported case can't loop forever.
+ */
+export interface SubmitBurnProofOptions {
+  /** Delay between retries while the backend reports not-yet-final, ms. */
+  pollIntervalMs?: number;
+  /** Maximum number of attempts (including the first). */
+  maxAttempts?: number;
+  /** Optional progress callback, invoked before each retry wait. */
+  onRetry?: (attempt: number, message: string) => void;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<SubmitBurnProofOptions, 'onRetry'>> = {
+  // ~finality interval: poll every 6s, up to ~3 minutes total.
+  pollIntervalMs: 6_000,
+  maxAttempts: 30,
+};
+
+export interface SubmitBurnProofResult {
+  /** True if the backend applied (or had already applied) the burn. */
+  ok: boolean;
+  /** Number of burns newly applied by this call (0 on a deduped re-submit). */
+  applied: number;
+  /** Human-readable error on terminal failure or exhausted retries. */
+  error?: string;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True when a `ProtocolError` means "not final yet — retry". */
+function isRetryable(err: ProtocolError): boolean {
+  return 'TemporarilyUnavailable' in err && typeof err.TemporarilyUnavailable === 'string';
+}
+
+/** Best-effort human-readable rendering of a terminal `ProtocolError`. */
+function describeError(err: ProtocolError): string {
+  if ('TemporarilyUnavailable' in err && typeof err.TemporarilyUnavailable === 'string') {
+    return `Service temporarily unavailable: ${err.TemporarilyUnavailable}`;
+  }
+  if ('GenericError' in err && typeof err.GenericError === 'string') {
+    return err.GenericError;
+  }
+  if ('ChainAdmin' in err && typeof (err as { ChainAdmin?: unknown }).ChainAdmin === 'string') {
+    return `Burn verification failed: ${(err as { ChainAdmin: string }).ChainAdmin}`;
+  }
+  return `Burn verification failed: ${JSON.stringify(err)}`;
+}
+
+/**
+ * Anonymous backend actor. `submit_burn_proof` is permissionless (the backend
+ * verifies the on-chain receipt and dedups; the caller cannot forge a burn), so
+ * an anonymous actor is sufficient and avoids a wallet round-trip per poll.
+ */
+function getBackendActor(): _SERVICE {
+  const agent = new HttpAgent({ host: CONFIG.host });
+  if (CONFIG.isLocal) {
+    agent.fetchRootKey().catch((err) => {
+      console.warn('monadBurnService: failed to fetch root key (local only):', err);
+    });
+  }
+  return Actor.createActor<_SERVICE>(rumi_backendIDL as any, {
+    agent,
+    canisterId: CONFIG.currentCanisterId,
+  });
+}
+
+/**
+ * Submit a Monad burn tx hash to the backend and poll until the receipt is
+ * final. Resolves once the backend returns `Ok` (burn applied or already
+ * applied) or a terminal error, or once the retry budget is exhausted.
+ *
+ * @param chainId   EVM chain id of the burn (use {@link MONAD_CHAIN_ID}).
+ * @param txHash    The confirmed `IcUSD.burn(...)` transaction hash (0x…).
+ * @param options   Retry tuning + optional progress callback.
+ *
+ * TODO (wire-up): This is ready to use but not yet called from a UI flow —
+ * the Monad burn UI does not exist in vault_frontend yet (no chain-vault burn
+ * screen, no IcUSD.burn EVM call). Once that flow lands, call this right after
+ * the burn tx confirms in the user's wallet, show "confirming burn on-chain…"
+ * while it polls, and refresh the vault view on `ok` so the decremented debt
+ * is reflected. See plan Task 7.
+ */
+export async function submitBurnProof(
+  chainId: number,
+  txHash: string,
+  options: SubmitBurnProofOptions = {},
+): Promise<SubmitBurnProofResult> {
+  const { pollIntervalMs, maxAttempts } = { ...DEFAULT_OPTIONS, ...options };
+  const actor = getBackendActor();
+
+  let lastMessage = 'Burn proof submission did not complete';
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await actor.submit_burn_proof(chainId, txHash);
+
+      if ('Ok' in result) {
+        return { ok: true, applied: Number(result.Ok) };
+      }
+
+      // 'Err' in result
+      const err = result.Err;
+      if (isRetryable(err)) {
+        lastMessage = describeError(err);
+        if (attempt < maxAttempts) {
+          options.onRetry?.(attempt, lastMessage);
+          await sleep(pollIntervalMs);
+          continue;
+        }
+        // Budget exhausted while still not final.
+        return {
+          ok: false,
+          applied: 0,
+          error: `Burn not confirmed on-chain after ${maxAttempts} attempts; it may still finalize. Last status: ${lastMessage}`,
+        };
+      }
+
+      // Terminal error — do not retry.
+      return { ok: false, applied: 0, error: describeError(err) };
+    } catch (e) {
+      // Transient transport/agent error — treat like a retryable poll, but
+      // still bounded by the attempt budget.
+      lastMessage = e instanceof Error ? e.message : String(e);
+      console.warn(`monadBurnService: submit_burn_proof attempt ${attempt} threw:`, e);
+      if (attempt < maxAttempts) {
+        options.onRetry?.(attempt, lastMessage);
+        await sleep(pollIntervalMs);
+        continue;
+      }
+      return {
+        ok: false,
+        applied: 0,
+        error: `Burn proof submission failed after ${maxAttempts} attempts: ${lastMessage}`,
+      };
+    }
+  }
+
+  return { ok: false, applied: 0, error: lastMessage };
+}


### PR DESCRIPTION
## Why

The Phase 1b burn-watch *polls*: every observer tick it scans the new block range for `Burn` logs via `eth_getLogs`. Cost is **O(blocks produced)** — ~1,660 getLogs/day (~1.3T cycles/day) on Monad's ~2-block/s chain, *whether or not any burn happened*. This PR replaces that with a **pull-based** path: the burner submits the burn tx hash, and the canister verifies that one transaction. Cost becomes **O(actual burns)** (~1 outcall/burn). Symmetric with the mint-confirm path that already verifies one tx's logs.

Implements the plan at `docs/superpowers/plans/2026-05-31-phase1c-notify-then-verify-burns.md` (local; `docs/` is gitignored). Built subagent-driven, TDD per task, with a full security review of the trust core (T3) and a full upgrade-safety review of the state-version bump (T5).

## What

- **`submit_burn_proof(chain_id, tx_hash)`** (permissionless): fetches the receipt on-chain (`eth_getTransactionReceipt`), verifies `status==success` + finality (`is_block_final`, consensus-safe specific-block probe), then applies any `Burn` log **emitted by the configured icUSD contract** (address + topic0 check) through the existing `apply_burn_to_state` + `(tx_hash, log_index)` dedup. Amount/vault come from the log, never caller input. Emits `ChainBurnObserved` per burn (analytics parity). Returns `TemporarilyUnavailable` on not-yet-final (caller retries), terminal `ChainAdmin` otherwise.
- **`set_burn_watch_poll_enabled(chain_id, bool)`** (dev-gated) + the poll-scan is now **OFF by default** (notify-then-verify is primary). When off, the observer advances its cursor without scanning (keeps mint-confirm finality current — no Gate-4 regression).
- **Upgrade-safe** via versioned snapshots: `ChainConfigV1→V2` (adds `burn_watch_poll_enabled`, `#[serde(default)]`) + `MultiChainStateV2→V3`. Persistence is ciborium/CBOR + serde (field-name keyed), so the live V2 staging snapshot decodes into V3 cleanly — **not** the AMM UPG-002 candid-Decode failure mode. Regression tests encode a populated V2 snapshot (vault 1 debt 50M + supply + cursor + keys) and prove it survives into V3 with the flag defaulting off.
- **Frontend** `monadBurnService.submitBurnProof` (retry on not-final) + regenerated declarations. No Monad burn UI exists yet, so it's ready-with-TODO for the future burn flow. **FUTURE ROBUSTNESS:** v1 liveness depends on the dApp submitting; harden later with a relayer.
- **Backstop note (decided with Rob):** a complete log-sweep backstop costs the SAME as continuous polling (total blocks scanned is unchanged), so there's no cheap version. The only cheap+complete safety net is `eth_call` state reconciliation (O(vaults), needs a contract view) — deferred as plan Task 8.

## Verification

All green: **226 lib · candid compat · clippy clean · phase1c e2e (submit→apply, dedup, wrong-contract reject, works with `fail_always(eth_getLogs)`) · all phase1b PocketIC · multi_chain supply invariant · phase1a scaffolding.** The phase1b poll-path tests now opt into the poll-scan (they declare the mechanism they exercise).

Not deployed. After deploy with the poll flag off, burn-watch idle cost → ~0 and `submit_burn_proof` becomes the burn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)