### PR TITLE
feat(monad): supply-equality backstop for Phase 1c notify-then-verify (#214 Task 8)

### DIFF
--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -259,6 +259,9 @@ struct Script {
     next_send_hash: Option<String>,
     /// Scripted logs returned (range-filtered) by eth_getLogs.
     logs: Vec<ScriptedLog>,
+    /// Scripted ERC-20 totalSupply (e8s) returned by `eth_call` of selector
+    /// 0x18160ddd. Defaults to 0; a test sets it via `set_total_supply`.
+    total_supply: u128,
     /// One-shot failure injection: JSON-RPC `method` -> message. When the NEXT
     /// `request` for that method arrives, the mock returns a real-wire-shaped
     /// `RpcError::HttpOutcallError(IcError{ code: SysTransient, message })`
@@ -586,6 +589,16 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                     items.join(",")
                 )
             }
+            "eth_call" => {
+                // params = [{to, data}, "0x<block>"]. The observer's supply gate
+                // calls totalSupply() (selector 0x18160ddd) at a specific block.
+                // Return the scripted total_supply as a left-padded 32-byte word
+                // (the ABI encoding of a uint256), exactly as a real node would.
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"result":"0x{:064x}"}}"#,
+                    id, script.total_supply
+                )
+            }
             other => {
                 // Unknown method: a JSON-RPC error so an unexpected wrapper call
                 // is loud rather than silently mis-parsed.
@@ -729,6 +742,11 @@ fn clear_logs() {
     SCRIPT.with(|s| {
         s.borrow_mut().logs.clear();
     });
+}
+
+#[ic_cdk_macros::update]
+fn set_total_supply(value: u128) {
+    SCRIPT.with(|s| s.borrow_mut().total_supply = value);
 }
 
 /// Arm a one-shot real-wire IcError for the NEXT `request` whose JSON-RPC

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -49,7 +49,7 @@ use crate::state::{mutate_state, read_state};
 use crate::Mode;
 
 use super::chain_vault::{verify_deposit_and_enqueue_mint_in_state, ChainVaultStatus};
-use super::evm_rpc::{decode_burn_log, fetch_block_numbers, get_balance, get_logs, BURN_EVENT_TOPIC0};
+use super::evm_rpc::{decode_burn_log, erc20_total_supply_at, fetch_block_numbers, get_balance, get_logs, BURN_EVENT_TOPIC0};
 use super::{hardening, tecdsa};
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
@@ -604,21 +604,25 @@ pub async fn run_observer(chain: ChainId) {
         return;
     }
 
-    // ── Notify-then-verify gate (Phase 1c) ───────────────────────────────────
+    // ── Notify-then-verify gate + supply-equality backstop (Phase 1c / #215) ──
     //
-    // The continuous block-by-block `eth_getLogs` burn-scan below costs
-    // O(blocks produced) per chain (~1.3T cycles/day on Monad regardless of
-    // burn activity). Phase 1c demotes it to OFF by default: burns are applied
-    // via the pull-based `submit_burn_proof` endpoint (one
-    // `eth_getTransactionReceipt` per ACTUAL burn). The poll-scan is kept only
-    // as a developer-gated emergency catch-up tool (`set_burn_watch_poll_enabled`).
+    // Phase 1c (#214) demotes the continuous block-by-block `eth_getLogs` burn
+    // sweep to OFF by default: burns are applied via the pull-based
+    // `submit_burn_proof` endpoint (one `eth_getTransactionReceipt` per ACTUAL
+    // burn). The dev-gated `burn_watch_poll_enabled` flag re-enables a full
+    // catch-up sweep for emergencies.
     //
-    // When the flag is OFF we STILL advance the cursor to `finalized` (and
-    // prune), exactly like the no-debt fast path: the consensus-safe finality
-    // probe (`fetch_block_numbers` = last_observed + MAX_BLOCK_SCAN_WINDOW)
-    // must stay current so the mint-confirm path can reach finality. A stalled
-    // cursor was the Gate-4 failure mode. No burn is lost — `submit_burn_proof`
-    // verifies each burn's receipt directly and is independent of this cursor.
+    // When the poll is OFF (default) we add a cheap O(1)/tick safety net (the
+    // #215 supply gate, the "Task 8" backstop #214 deferred): probe the icUSD
+    // `totalSupply()` at `finalized` (a specific, consensus-safe block) and
+    // compare it to our recorded `chain_supplies[chain]`. The canister is the
+    // SOLE minter, so with no mint in flight a drop below `recorded` means a
+    // burn landed that `submit_burn_proof` never caught; ONLY then do we run the
+    // (expensive) catch-up sweep to find it. A match, a mint in flight, or a
+    // probe error all stay in the cheap path (advance cursor + return) because
+    // `submit_burn_proof` remains the primary catch, so a flaky probe can never
+    // reintroduce the per-tick sweep cost. The cursor still advances + prunes so
+    // mint-confirm finality stays current (a stalled cursor was the Gate-4 bug).
     let poll_enabled = read_state(|s| {
         s.multi_chain
             .chain_configs
@@ -627,8 +631,50 @@ pub async fn run_observer(chain: ChainId) {
             .unwrap_or(false)
     });
     if !poll_enabled {
-        mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
-        return;
+        let recorded_supply = read_state(|s| {
+            s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0)
+        });
+        let has_inflight_mint = read_state(|s| {
+            s.multi_chain
+                .settlement_queues
+                .get(&chain)
+                .map(|q| q.has_active_mint_op())
+                .unwrap_or(false)
+        });
+        // Run the catch-up sweep ONLY on a proven divergence: no mint in flight
+        // AND a readable totalSupply that fails `can_skip_burn_scan` (it differs
+        // from `recorded`). Mint-in-flight and probe errors fall through to the
+        // cheap advance-and-return path below.
+        let diverged = if has_inflight_mint {
+            false
+        } else {
+            match erc20_total_supply_at(chain, &contract, finalized).await {
+                Ok(onchain_supply) => {
+                    let skip = can_skip_burn_scan(onchain_supply, recorded_supply, has_inflight_mint);
+                    if !skip {
+                        log!(
+                            INFO,
+                            "[observer chain={:?}] backstop: onchain totalSupply {} != recorded {}; running catch-up sweep",
+                            chain, onchain_supply, recorded_supply
+                        );
+                    }
+                    !skip
+                }
+                Err(e) => {
+                    log!(
+                        INFO,
+                        "[observer chain={:?}] backstop: totalSupply probe failed ({}); staying in notify-then-verify cheap path",
+                        chain, e
+                    );
+                    false
+                }
+            }
+        };
+        if !diverged {
+            mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
+            return;
+        }
+        // diverged: fall through to the catch-up sweep to find the unsubmitted burn.
     }
 
     let from_block = last_observed + 1;

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -89,23 +89,27 @@ impl std::fmt::Display for BurnApplyError {
     }
 }
 
-/// Decide whether the burn-watch `eth_getLogs` sweep can be SKIPPED this tick.
+/// Decide whether the burn-watch catch-up sweep should run this tick (the
+/// notify-then-verify backstop). Returns `true` (scan) ONLY when no mint op is
+/// in flight AND the chain's on-chain icUSD `totalSupply` has dropped BELOW the
+/// canister's confirmed `chain_supplies[chain]`.
 ///
-/// Returns `true` (skip) ONLY when the chain's on-chain icUSD `totalSupply`
-/// EXACTLY equals the canister's confirmed `chain_supplies[chain]` AND no mint
-/// op is in flight. The canister is the SOLE minter, so with no mint in flight
-/// the on-chain supply can differ from `recorded` only via a burn the canister
-/// has not yet applied; equality therefore means there is nothing for the sweep
-/// to find. A mint in flight could mask a burn (mint +X, burn -X net to zero
-/// supply delta), so any in-flight mint forces a scan. Any inequality
-/// (including the "impossible" on-chain > recorded anomaly) also forces a scan;
-/// the Timer-B `check_invariant` self-check is the divergence backstop.
-pub fn can_skip_burn_scan(
+/// The canister is the SOLE minter, so a burn (the only thing the sweep finds)
+/// strictly LOWERS supply. `onchain >= recorded` therefore means no unsubmitted
+/// burn: equal = in sync; GREATER = a mint EXCESS (e.g. an RPC-false-negative
+/// mint that landed on-chain but was never credited to `chain_supplies`). A
+/// mint excess is NOT a burn and must NOT trigger the sweep: it is permanent, so
+/// scanning on `!=` would scan the full window every tick forever, silently
+/// reintroducing the per-tick `eth_getLogs` cost the backstop exists to avoid.
+/// A mint in flight could mask a burn in the supply delta, so we stay in the
+/// cheap path during the (short, infrequent) mint window; `submit_burn_proof`
+/// plus the next post-confirm tick reconcile any burn then.
+pub fn backstop_should_scan(
     onchain_total_supply_e8s: u128,
     recorded_supply_e8s: u128,
     has_inflight_mint: bool,
 ) -> bool {
-    !has_inflight_mint && onchain_total_supply_e8s == recorded_supply_e8s
+    !has_inflight_mint && onchain_total_supply_e8s < recorded_supply_e8s
 }
 
 /// Credit a confirmed on-chain deposit to a ChainVaultV1 record.
@@ -642,23 +646,24 @@ pub async fn run_observer(chain: ChainId) {
                 .unwrap_or(false)
         });
         // Run the catch-up sweep ONLY on a proven divergence: no mint in flight
-        // AND a readable totalSupply that fails `can_skip_burn_scan` (it differs
-        // from `recorded`). Mint-in-flight and probe errors fall through to the
-        // cheap advance-and-return path below.
-        let diverged = if has_inflight_mint {
+        // AND a readable totalSupply that has DROPPED below `recorded` (an
+        // unsubmitted burn). Mint-in-flight, probe errors, and a mint EXCESS
+        // (onchain > recorded) all fall through to the cheap advance-and-return
+        // path below.
+        let should_scan = if has_inflight_mint {
             false
         } else {
             match erc20_total_supply_at(chain, &contract, finalized).await {
                 Ok(onchain_supply) => {
-                    let skip = can_skip_burn_scan(onchain_supply, recorded_supply, has_inflight_mint);
-                    if !skip {
+                    let scan = backstop_should_scan(onchain_supply, recorded_supply, has_inflight_mint);
+                    if scan {
                         log!(
                             INFO,
-                            "[observer chain={:?}] backstop: onchain totalSupply {} != recorded {}; running catch-up sweep",
+                            "[observer chain={:?}] backstop: onchain totalSupply {} < recorded {}; unsubmitted burn, running catch-up sweep",
                             chain, onchain_supply, recorded_supply
                         );
                     }
-                    !skip
+                    scan
                 }
                 Err(e) => {
                     log!(
@@ -670,7 +675,7 @@ pub async fn run_observer(chain: ChainId) {
                 }
             }
         };
-        if !diverged {
+        if !should_scan {
             mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
             return;
         }

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -89,6 +89,25 @@ impl std::fmt::Display for BurnApplyError {
     }
 }
 
+/// Decide whether the burn-watch `eth_getLogs` sweep can be SKIPPED this tick.
+///
+/// Returns `true` (skip) ONLY when the chain's on-chain icUSD `totalSupply`
+/// EXACTLY equals the canister's confirmed `chain_supplies[chain]` AND no mint
+/// op is in flight. The canister is the SOLE minter, so with no mint in flight
+/// the on-chain supply can differ from `recorded` only via a burn the canister
+/// has not yet applied; equality therefore means there is nothing for the sweep
+/// to find. A mint in flight could mask a burn (mint +X, burn -X net to zero
+/// supply delta), so any in-flight mint forces a scan. Any inequality
+/// (including the "impossible" on-chain > recorded anomaly) also forces a scan;
+/// the Timer-B `check_invariant` self-check is the divergence backstop.
+pub fn can_skip_burn_scan(
+    onchain_total_supply_e8s: u128,
+    recorded_supply_e8s: u128,
+    has_inflight_mint: bool,
+) -> bool {
+    !has_inflight_mint && onchain_total_supply_e8s == recorded_supply_e8s
+}
+
 /// Credit a confirmed on-chain deposit to a ChainVaultV1 record.
 ///
 /// Increments `collateral_amount_e18` by `amount_e18` (saturating — overflow

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -108,6 +108,11 @@ pub const BURN_EVENT_TOPIC0: &str =
 pub const MINT_EVENT_TOPIC0: &str =
     "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
 
+/// `keccak256("totalSupply()")[:4]`, the ERC-20 `totalSupply()` selector.
+/// `IcUSD.sol` uses 8 decimals, so the returned value is e8s (1:1 with the
+/// ICP-side `chain_supplies` accounting, no scaling needed).
+pub const TOTAL_SUPPLY_SELECTOR: &str = "0x18160ddd";
+
 // ─── Candid types for the EVM RPC canister `request` method ─────────────────
 //
 // Source: live .did of `7hfb6-caaaa-aaaar-qadga-cai` (fetched 2026-05-28).
@@ -339,6 +344,23 @@ pub fn parse_hex_quantity(s: &str) -> Result<u128, String> {
         .ok_or_else(|| format!("missing 0x prefix: {:?}", s))?;
     u128::from_str_radix(hex, 16)
         .map_err(|e| format!("invalid hex quantity {:?}: {}", s, e))
+}
+
+/// Decode an `eth_call` result word (a 0x-prefixed 32-byte ABI uint) into a
+/// `u128`. Rejects an empty `"0x"` (a revert/empty return, which must NOT be
+/// read as 0, or the supply gate would wrongly believe supply dropped to zero)
+/// and any value exceeding `u128::MAX` (icUSD supply cannot approach that, so a
+/// larger value signals a malformed response, fail loudly rather than wrap).
+pub fn parse_eth_call_u128(result_hex: &str) -> Result<u128, String> {
+    let hex = result_hex
+        .strip_prefix("0x")
+        .or_else(|| result_hex.strip_prefix("0X"))
+        .ok_or_else(|| format!("eth_call result missing 0x prefix: {:?}", result_hex))?;
+    if hex.is_empty() {
+        return Err(format!("eth_call returned empty result {:?} (revert/empty)", result_hex));
+    }
+    u128::from_str_radix(hex, 16)
+        .map_err(|e| format!("eth_call result {:?} not a u128: {}", result_hex, e))
 }
 
 // ─── BurnLog ─────────────────────────────────────────────────────────────────
@@ -704,6 +726,36 @@ pub async fn get_balance(chain: ChainId, address: &str) -> Result<u128, String> 
         .as_str()
         .ok_or_else(|| format!("eth_getBalance: missing result in {:?}", text))?;
     parse_hex_quantity(hex)
+}
+
+/// Returns the ERC-20 `totalSupply()` of `contract` at a SPECIFIC block number
+/// (e8s for icUSD). Issued via `eth_call` at the fixed block `block`, a
+/// specific number is byte-identical across the EVM RPC canister's replicas, so
+/// HTTPS-outcall consensus is reached (the same reason `fetch_block_numbers`
+/// probes a fixed number, never `latest`). Used by the observer's supply gate
+/// to decide whether a burn could have occurred since the last scan.
+pub async fn erc20_total_supply_at(
+    chain: ChainId,
+    contract: &str,
+    block: u64,
+) -> Result<u128, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"to":{:?},"data":{:?}}},"0x{:x}"],"id":{}}}"#,
+        contract,
+        TOTAL_SUPPLY_SELECTOR,
+        block,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_call(totalSupply) parse: {}", e))?;
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_call(totalSupply) RPC error: {}", err));
+    }
+    let hex = val["result"]
+        .as_str()
+        .ok_or_else(|| format!("eth_call(totalSupply): missing result in {:?}", text))?;
+    parse_eth_call_u128(hex)
 }
 
 /// Returns the transaction count (nonce) of `address` at the latest block.

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -125,18 +125,21 @@ fn advance_cursor_and_prune_sets_cursor_and_drops_keys_at_or_below_finalized() {
 }
 
 #[test]
-fn supply_gate_skips_only_on_exact_match_and_no_inflight_mint() {
-    use super::deposit_watch::can_skip_burn_scan;
-    // Equal + no mint in flight -> skip (no unobserved burn possible).
-    assert!(can_skip_burn_scan(1_000, 1_000, false));
-    // Equal but a mint is in flight -> scan (a mint could mask a burn).
-    assert!(!can_skip_burn_scan(1_000, 1_000, true));
-    // On-chain below recorded -> a burn happened -> scan.
-    assert!(!can_skip_burn_scan(900, 1_000, false));
-    // On-chain above recorded (anomaly under sole-minter) -> scan.
-    assert!(!can_skip_burn_scan(1_100, 1_000, false));
-    // Below + in-flight mint -> scan.
-    assert!(!can_skip_burn_scan(900, 1_000, true));
-    // Zero/zero, no mint -> skip (degenerate but valid).
-    assert!(can_skip_burn_scan(0, 0, false));
+fn backstop_scans_only_on_supply_drop_and_no_inflight_mint() {
+    use super::deposit_watch::backstop_should_scan;
+    // On-chain BELOW recorded + no mint in flight -> an unsubmitted burn -> scan.
+    assert!(backstop_should_scan(900, 1_000, false));
+    // Equal -> in sync, nothing for the sweep to find -> skip.
+    assert!(!backstop_should_scan(1_000, 1_000, false));
+    // On-chain ABOVE recorded -> a mint EXCESS (e.g. an RPC-false-negative mint
+    // that landed but was never credited), NOT a burn -> skip. Scanning here
+    // would repeat every tick forever; this is the bug the backstop fix closes.
+    assert!(!backstop_should_scan(1_100, 1_000, false));
+    // Below but a mint is in flight -> stay cheap (submit_burn_proof + the
+    // post-confirm tick reconcile) -> skip.
+    assert!(!backstop_should_scan(900, 1_000, true));
+    // Equal + in-flight -> skip.
+    assert!(!backstop_should_scan(1_000, 1_000, true));
+    // Zero/zero -> skip.
+    assert!(!backstop_should_scan(0, 0, false));
 }

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -123,3 +123,20 @@ fn advance_cursor_and_prune_sets_cursor_and_drops_keys_at_or_below_finalized() {
     assert!(!s.processed_burn_keys.contains_key(&150), "block 150 pruned");
     assert!(s.processed_burn_keys.contains_key(&250), "block 250 > finalized retained");
 }
+
+#[test]
+fn supply_gate_skips_only_on_exact_match_and_no_inflight_mint() {
+    use super::deposit_watch::can_skip_burn_scan;
+    // Equal + no mint in flight -> skip (no unobserved burn possible).
+    assert!(can_skip_burn_scan(1_000, 1_000, false));
+    // Equal but a mint is in flight -> scan (a mint could mask a burn).
+    assert!(!can_skip_burn_scan(1_000, 1_000, true));
+    // On-chain below recorded -> a burn happened -> scan.
+    assert!(!can_skip_burn_scan(900, 1_000, false));
+    // On-chain above recorded (anomaly under sole-minter) -> scan.
+    assert!(!can_skip_burn_scan(1_100, 1_000, false));
+    // Below + in-flight mint -> scan.
+    assert!(!can_skip_burn_scan(900, 1_000, true));
+    // Zero/zero, no mint -> skip (degenerate but valid).
+    assert!(can_skip_burn_scan(0, 0, false));
+}

--- a/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_evm_rpc.rs
@@ -333,3 +333,20 @@ fn receipt_with_logs_parses_status_block_and_logs() {
     assert_eq!(data, "0x2a");
     assert_eq!(*idx, 3);
 }
+
+#[test]
+fn parse_eth_call_u128_decodes_padded_word() {
+    use crate::chains::monad::evm_rpc::parse_eth_call_u128;
+    // A 32-byte ABI word for 1_000_000, left-padded to 64 hex chars.
+    let word = format!("0x{:064x}", 1_000_000u128);
+    assert_eq!(parse_eth_call_u128(&word).unwrap(), 1_000_000u128);
+    // Zero supply.
+    assert_eq!(parse_eth_call_u128(&format!("0x{:064x}", 0u128)).unwrap(), 0u128);
+    // Empty result ("0x") -> error, NOT 0.
+    assert!(parse_eth_call_u128("0x").is_err());
+    // Non-hex -> error.
+    assert!(parse_eth_call_u128("0xzz").is_err());
+    // A value exceeding u128 (full 32-byte max) -> error rather than silent wrap.
+    let too_big = format!("0x{}", "f".repeat(64));
+    assert!(parse_eth_call_u128(&too_big).is_err());
+}

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -142,6 +142,21 @@ impl SettlementQueueV1 {
         })
     }
 
+    /// True iff the queue has a NON-terminal `Mint` op (`Queued` or `Inflight`).
+    /// Distinct from `has_active_op` (which also counts `NativeWithdrawal`):
+    /// only a `Mint` changes on-chain icUSD `totalSupply`, so only a live mint
+    /// can mask a burn from the observer's supply-equality gate
+    /// (`can_skip_burn_scan`). Terminal (`Succeeded`/`Failed`) ops never count.
+    pub fn has_active_mint_op(&self) -> bool {
+        self.pending.values().any(|op| {
+            matches!(op.kind, SettlementOpKind::Mint { .. })
+                && matches!(
+                    op.status,
+                    SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                )
+        })
+    }
+
     /// Reap terminal (`Succeeded`/`Failed`) ops so `pending` does not grow
     /// monotonically (the Task-10 review flagged `select_next_op`'s per-tick
     /// scan over an ever-growing `pending` as a cycle-cost anti-pattern this

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -145,8 +145,8 @@ impl SettlementQueueV1 {
     /// True iff the queue has a NON-terminal `Mint` op (`Queued` or `Inflight`).
     /// Distinct from `has_active_op` (which also counts `NativeWithdrawal`):
     /// only a `Mint` changes on-chain icUSD `totalSupply`, so only a live mint
-    /// can mask a burn from the observer's supply-equality gate
-    /// (`can_skip_burn_scan`). Terminal (`Succeeded`/`Failed`) ops never count.
+    /// can mask a burn from the observer's supply-equality backstop
+    /// (`backstop_should_scan`). Terminal (`Succeeded`/`Failed`) ops never count.
     pub fn has_active_mint_op(&self) -> bool {
         self.pending.values().any(|op| {
             matches!(op.kind, SettlementOpKind::Mint { .. })

--- a/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
@@ -108,3 +108,36 @@ fn op_status_transitions_only_to_terminal_states() {
     op.mark_succeeded("0xdeadbeef".to_string(), 1_700_000_000_001_000_000);
     assert!(matches!(op.status, SettlementOpStatus::Succeeded { .. }));
 }
+
+#[test]
+fn has_active_mint_op_true_only_for_live_mint() {
+    let mut q = SettlementQueueV1::default();
+    assert!(!q.has_active_mint_op(), "empty queue has no active mint");
+
+    // A live (Queued) NativeWithdrawal must NOT count, it does not change supply.
+    q.enqueue(SettlementOp::new(
+        SettlementOpKind::NativeWithdrawal { recipient: "0xabc".into(), amount_e18: 1, vault_id: 1 },
+        "w1".into(),
+        0,
+    ))
+    .unwrap();
+    assert!(!q.has_active_mint_op(), "withdrawal-only queue has no active mint");
+
+    // A Queued Mint counts.
+    let mint_id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint { recipient: "0xabc".into(), amount_e8s: 100, vault_id: 2 },
+            "m1".into(),
+            0,
+        ))
+        .unwrap();
+    assert!(q.has_active_mint_op(), "queued mint counts");
+
+    // An Inflight Mint counts.
+    q.pending.get_mut(&mint_id).unwrap().mark_inflight(1);
+    assert!(q.has_active_mint_op(), "inflight mint counts");
+
+    // A terminal (Succeeded) Mint does NOT count.
+    q.pending.get_mut(&mint_id).unwrap().mark_succeeded("0xhash".into(), 2);
+    assert!(!q.has_active_mint_op(), "succeeded mint does not count");
+}

--- a/src/rumi_protocol_backend/tests/phase1b_supply_gate_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_supply_gate_pic.rs
@@ -695,5 +695,66 @@ fn phase1b_supply_gate_skips_on_match_scans_on_drop() {
         PHASE_B_FINALIZED
     );
 
-    eprintln!("[supply-gate] FULL two-phase gate proof PASSED");
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Phase C: onchain totalSupply > chain_supplies (a mint EXCESS) => sweep SKIPPED
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Regression for the backstop fix: an on-chain supply ABOVE recorded
+    // chain_supplies is a mint excess (e.g. an RPC-false-negative mint that
+    // landed but was never credited), NOT a burn. It is permanent, so the
+    // backstop must NOT scan on it (scanning would repeat every tick forever and
+    // reintroduce the per-tick sweep cost). We set onchain supply ABOVE recorded
+    // and plant a trap burn in the window; the backstop must skip (trap NOT
+    // applied) yet still advance the cursor.
+    const PHASE_C_FINALIZED: u64 = PHASE_B_FINALIZED + MAX_BLOCK_SCAN_WINDOW;
+    let recorded_after_b = DEBT_E8S - REAL_BURN_AMOUNT; // chain_supplies now
+    let onchain_excess = recorded_after_b + 10 * E8; // mint excess above recorded
+
+    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &PHASE_B_FINALIZED).unwrap(),
+        ),
+        "set_last_observed_block (Phase C re-seed)",
+    )
+    .expect("set_last_observed_block Phase C");
+    update_any(&pic, mock, "set_total_supply", Encode!(&onchain_excess).unwrap());
+    push_burn_log(
+        &pic,
+        mock,
+        vault_id,
+        &recipient,
+        REAL_BURN_AMOUNT,
+        "0xburnC_trap",
+        PHASE_B_FINALIZED + 50,
+    );
+    update_any(&pic, mock, "set_blocks", Encode!(&PHASE_C_FINALIZED, &PHASE_C_FINALIZED).unwrap());
+    advance_and_tick(&pic, 1);
+
+    let v_c = get_vault(&pic, backend, vault_id).expect("vault in Phase C");
+    assert_eq!(
+        v_c.debt_e8s,
+        candid::Nat::from(recorded_after_b),
+        "Phase C: debt unchanged (a mint excess must NOT trigger a scan)"
+    );
+    let global_c: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(
+        global_c,
+        candid::Nat::from(recorded_after_b),
+        "Phase C: chain_supplies unchanged on a mint excess"
+    );
+    assert_eq!(
+        cursor(&pic, backend),
+        PHASE_C_FINALIZED,
+        "Phase C: cursor still advanced (skip path ran advance_cursor_and_prune)"
+    );
+    eprintln!(
+        "[supply-gate] Phase C PASSED: mint excess (onchain {} > recorded {}), trap burn NOT applied, cursor advanced to {}",
+        onchain_excess, recorded_after_b, PHASE_C_FINALIZED
+    );
+
+    eprintln!("[supply-gate] FULL three-phase gate proof PASSED");
 }

--- a/src/rumi_protocol_backend/tests/phase1b_supply_gate_pic.rs
+++ b/src/rumi_protocol_backend/tests/phase1b_supply_gate_pic.rs
@@ -1,0 +1,699 @@
+//! Phase 1b — Supply-equality gate: skip-on-match, scan-on-drop.
+//!
+//! ## What this test proves
+//!
+//! The observer (`run_observer`) gained a supply-equality gate just before its
+//! `eth_getLogs` burn sweep. Each advancing tick (when `total_chain_vault_debt > 0`
+//! and no mint is in flight) it probes the icUSD contract's `totalSupply()` via
+//! `eth_call` at the finalized block and compares it to `chain_supplies[chain]`:
+//!
+//! - If `onchain_totalSupply == recorded` (and no mint in flight): SKIP the burn
+//!   `get_logs` sweep, just advance the cursor (`advance_cursor_and_prune`) and
+//!   return. No burn can have occurred — the canister is the sole minter.
+//! - If `onchain < recorded` (a burn dropped supply): run the sweep and apply.
+//! - On any probe error or in-flight mint: run the sweep (fall through).
+//!
+//! The mock supports `eth_call` returning a scripted value via `set_total_supply(u128)`.
+//!
+//! ## ECDSA gating (same auto-upgrade pattern as the other phase1b tests)
+//!
+//! The full path needs threshold-ECDSA to reach an Open vault with confirmed debt.
+//! When PocketIC cannot provision `test_key_1`, the test runs a GATED subset that
+//! asserts the supply gate is inert on a chain with zero debt (the no-debt fast path
+//! means the gate is never even reached), and AUTO-UPGRADES to the full two-phase
+//! gate proof on an ECDSA-capable PocketIC.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types ──────────────────────────────────────────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MONAD_CHAIN_ID: u32 = 10143;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+/// keccak256("Mint(uint256,address,uint256)") — must match evm_rpc.rs.
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+/// keccak256("Burn(uint256,address,uint256)") — must match evm_rpc.rs.
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+
+// ─── PocketIC call helpers ────────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {}", msg),
+    }
+}
+
+/// Read the burn-watch cursor for the Monad chain.
+fn cursor(pic: &PocketIc, backend: Principal) -> u64 {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_last_observed_block query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, u64).expect("decode get_last_observed_block"),
+        WasmResult::Reject(msg) => panic!("get_last_observed_block rejected: {}", msg),
+    }
+}
+
+// ─── Boot ─────────────────────────────────────────────────────────────────────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+
+    // Pin observer + settlement cadence to 30s so the 35s advance_and_tick windows
+    // fire one tick each. The default is 300s (cycle-burn hardening).
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data ─────────────────────────
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn word_addr(addr: &str) -> String {
+    let raw = addr
+        .strip_prefix("0x")
+        .or_else(|| addr.strip_prefix("0X"))
+        .unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+fn push_burn_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        BURN_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(burner),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}
+
+// ─── Shared setup: registers Monad, seeds cursor, reaches Open vault with
+//     debt = 100e8. Returns (vault_id, recipient, settlement_addr).
+//     Returns None for settlement_addr when ECDSA is unavailable (gated subset).
+fn setup_chain(
+    pic: &PocketIc,
+    backend: Principal,
+    mock: Principal,
+    cursor_seed: u64,
+    finalized_block: u64,
+) -> Option<(u64, String, String)> {
+    // Point the backend's Monad wrapper at the mock.
+    decode_result(
+        update_dev(pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+
+    // Register Monad + contract + manual MON price.
+    let reg = RegisterChainArg {
+        chain_id: ChainId(MONAD_CHAIN_ID),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://mock-monad-rpc.invalid".to_string()],
+        finality_depth: 1,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+    };
+    decode_result(
+        update_dev(pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_chain_contract",
+            Encode!(
+                &ChainId(MONAD_CHAIN_ID),
+                &"0x00000000000000000000000000000000deadbeef".to_string()
+            )
+            .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    // $2.00 / MON in e8.
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &"MON".to_string(), &200_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // Seed the burn-watch cursor.
+    decode_result(
+        update_dev(
+            pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &cursor_seed).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+
+    // Script the mock: chain head = finalized_block.
+    update_any(pic, mock, "set_blocks", Encode!(&finalized_block, &finalized_block).unwrap());
+    update_any(pic, mock, "set_next_send_hash", Encode!(&"0xmint1".to_string()).unwrap());
+
+    // ECDSA probe: decides full vs gated.
+    let settlement_addr = match update_dev(
+        pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(MONAD_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            Ok(Err(e)) => {
+                eprintln!("[supply-gate] ECDSA UNAVAILABLE (Err: {e:?}); running GATED subset");
+                None
+            }
+            Err(decode_err) => {
+                eprintln!("[supply-gate] get_chain_settlement_address decode error ({decode_err}); running GATED subset");
+                None
+            }
+        },
+        WasmResult::Reject(msg) => {
+            eprintln!("[supply-gate] ECDSA UNAVAILABLE (rejected: {msg}); running GATED subset");
+            None
+        }
+    };
+
+    let settlement_addr = settlement_addr?;
+
+    // Fund the settlement (hot-wallet) address.
+    update_any(
+        pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000u128 * E18)).unwrap(),
+    );
+
+    // Open a vault: 100 MON @ $2 = $200 backing 100 icUSD => 200% CR.
+    let collateral_e18 = 100u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(MONAD_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+
+    let v = get_vault(pic, backend, vault_id).expect("vault exists after open");
+    let custody = v.custody_address.clone();
+
+    // Deposit lands; observer flips to MintPending + enqueues mint.
+    update_any(
+        pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(pic, 2);
+
+    // Settlement submits + confirms the mint. Push the Mint log at finalized_block.
+    push_mint_log(pic, mock, vault_id, &recipient, debt_e8s, "0xmint1", finalized_block);
+    advance_and_tick(pic, 4);
+
+    // Assert: vault is Open with debt = 100e8, chain_supplies[MONAD] = 100e8.
+    let v = get_vault(pic, backend, vault_id).expect("vault after mint confirm");
+    assert_eq!(v.status, ChainVaultStatus::Open, "setup: mint confirmed => Open");
+    assert_eq!(
+        v.debt_e8s,
+        candid::Nat::from(debt_e8s),
+        "setup: debt = 100e8 after mint confirm"
+    );
+    let global: candid::Nat = query_unit(pic, backend, "get_global_icusd_supply");
+    assert_eq!(global, candid::Nat::from(100 * E8), "setup: supply = 100e8 after mint confirm");
+
+    Some((vault_id, recipient, settlement_addr))
+}
+
+// ─── The test ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1b_supply_gate_skips_on_match_scans_on_drop() {
+    // The consensus-safe probe in fetch_block_numbers checks block
+    // last_observed + MAX_BLOCK_SCAN_WINDOW (1024). So after setup leaves the
+    // cursor at FINALIZED_0 = cursor_seed + 1024, the next advancing tick
+    // requires finalized >= FINALIZED_0 + 1024.
+    const CURSOR_SEED: u64 = 1_000_000;
+    const FINALIZED_0: u64 = 1_001_024; // cursor_seed + 1024 = setup's finalized block
+    const DEBT_E8S: u128 = 100 * E8;
+    const TRAP_BURN_AMOUNT: u128 = 40 * E8; // would decrement debt if scan ran
+
+    let (pic, backend, mock) = boot();
+
+    // ── Common setup: reach Open vault with debt = 100e8 ─────────────────────
+    let setup = setup_chain(&pic, backend, mock, CURSOR_SEED, FINALIZED_0);
+
+    let (vault_id, recipient) = match setup {
+        Some((vid, rec, addr)) => {
+            eprintln!("[supply-gate] ECDSA AVAILABLE; settlement={addr}; running FULL two-phase gate proof");
+            (vid, rec)
+        }
+        None => {
+            // GATED SUBSET: no Open vault with debt possible. Assert the supply
+            // invariant holds at 0 and return green. AUTO-UPGRADES on ECDSA-capable PocketIC.
+            let global: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+            assert_eq!(global, candid::Nat::from(0u32), "gated: supply invariant holds at 0");
+            eprintln!("[supply-gate] GATED subset PASSED: supply invariant at 0");
+            return;
+        }
+    };
+
+    // After setup the cursor is at FINALIZED_0. The consensus-safe probe uses
+    // last_observed + MAX_BLOCK_SCAN_WINDOW (1024) to check if the next window
+    // is final. So to get an advancing tick from FINALIZED_0, the mock finalized
+    // block must be >= FINALIZED_0 + 1024. Use exactly FINALIZED_0 + 1024.
+    const MAX_BLOCK_SCAN_WINDOW: u64 = 1024;
+    const PHASE_A_FINALIZED: u64 = FINALIZED_0 + MAX_BLOCK_SCAN_WINDOW; // 1_002_048
+    // Burn trap in the middle of that window.
+    const TRAP_BURN_BLOCK: u64 = FINALIZED_0 + 50;
+
+    // Phase B: re-seed cursor to FINALIZED_0, same window applies.
+    const PHASE_B_FINALIZED: u64 = FINALIZED_0 + MAX_BLOCK_SCAN_WINDOW; // same 1_002_048
+    const REAL_BURN_BLOCK: u64 = FINALIZED_0 + 50;
+    const REAL_BURN_AMOUNT: u128 = 40 * E8;
+
+    // After setup the cursor is at FINALIZED_0. Verify.
+    assert_eq!(
+        cursor(&pic, backend),
+        FINALIZED_0,
+        "pre-Phase A: cursor at FINALIZED_0 after mint confirm"
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Phase A: onchain totalSupply == chain_supplies => sweep SKIPPED
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Script:
+    //   - onchain supply = DEBT_E8S (matches recorded chain_supplies[MONAD])
+    //   - A Burn log (TRAP_BURN_AMOUNT) in the scan window (FINALIZED_0+1 ..= PHASE_A_FINALIZED)
+    //     is pushed as a TRAP: if the gate wrongly allowed the scan, this burn
+    //     would decrement debt. We assert debt is UNCHANGED after the tick.
+    //   - The finalized block advances to PHASE_A_FINALIZED (= cursor + 1024) so
+    //     fetch_block_numbers probes that block, finds it exists, and returns
+    //     (PHASE_A_FINALIZED, PHASE_A_FINALIZED) — an advancing tick.
+
+    // Set onchain supply equal to the recorded supply — gate should skip.
+    update_any(&pic, mock, "set_total_supply", Encode!(&DEBT_E8S).unwrap());
+
+    // Push a trap Burn log in the window. Topic-filtered by the mock's getLogs
+    // (only returned for BURN topic0 scans); if the gate incorrectly ran the
+    // sweep, this burn would apply and reduce debt.
+    push_burn_log(
+        &pic,
+        mock,
+        vault_id,
+        &recipient,
+        TRAP_BURN_AMOUNT,
+        "0xburnA_trap",
+        TRAP_BURN_BLOCK,
+    );
+
+    // Advance the mock chain head to PHASE_A_FINALIZED.
+    // fetch_block_numbers probes block (cursor+1024 = PHASE_A_FINALIZED); the mock
+    // returns that block as existing, so finalized = PHASE_A_FINALIZED > last_observed.
+    update_any(&pic, mock, "set_blocks", Encode!(&PHASE_A_FINALIZED, &PHASE_A_FINALIZED).unwrap());
+
+    // Run one observer tick.
+    advance_and_tick(&pic, 1);
+
+    // Assert Phase A: gate skipped the sweep — debt and supply are UNCHANGED.
+    let v_a = get_vault(&pic, backend, vault_id).expect("vault in Phase A");
+    assert_eq!(
+        v_a.debt_e8s,
+        candid::Nat::from(DEBT_E8S),
+        "Phase A: debt unchanged (trap Burn log was NOT applied — sweep skipped)"
+    );
+    assert_eq!(v_a.status, ChainVaultStatus::Open, "Phase A: vault still Open");
+
+    let global_a: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(
+        global_a,
+        candid::Nat::from(DEBT_E8S),
+        "Phase A: chain_supplies[MONAD] unchanged (sweep skipped)"
+    );
+
+    // Assert Phase A: cursor ADVANCED to PHASE_A_FINALIZED (skip path ran
+    // advance_cursor_and_prune, proving it was the skip path and not an early bail).
+    assert_eq!(
+        cursor(&pic, backend),
+        PHASE_A_FINALIZED,
+        "Phase A: cursor advanced to PHASE_A_FINALIZED (skip path ran advance_cursor_and_prune)"
+    );
+
+    eprintln!(
+        "[supply-gate] Phase A PASSED: supply matched ({}), trap burn NOT applied, cursor advanced to {}",
+        DEBT_E8S, PHASE_A_FINALIZED
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Phase B: onchain totalSupply < chain_supplies => sweep RUNS and applies burn
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Re-seed the cursor to FINALIZED_0 so the same block window
+    // (FINALIZED_0+1 ..= PHASE_B_FINALIZED) is re-scanned. We set onchain supply
+    // to DEBT_E8S - REAL_BURN_AMOUNT (supply dropped) and push a real Burn log.
+    // The Phase A trap burn ("0xburnA_trap", TRAP_BURN_AMOUNT=40e8) is still in
+    // the mock's log list. After the real burn (40e8) applies, debt = 60e8.
+    // The trap burn's dedup key ("0xburnA_trap:N") was NOT recorded in Phase A
+    // (Phase A skipped the scan entirely), so on Phase B's scan the trap burn IS
+    // seen. However: the real burn (40e8) applies first (same block, lower log
+    // index since push_log auto-assigns indices in push order — real burn was
+    // pushed second, but its tx_hash is different so ordering is by log_index in
+    // the block). To keep the scenario unambiguous, we clear Phase A's trap log
+    // and push only the real burn for Phase B.
+
+    // Clear all logs so only the real Phase B burn is in the window.
+    update_any(&pic, mock, "clear_logs", Encode!().unwrap());
+
+    // Re-seed cursor to FINALIZED_0 so Phase B scans (FINALIZED_0+1..=PHASE_B_FINALIZED).
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(MONAD_CHAIN_ID), &FINALIZED_0).unwrap(),
+        ),
+        "set_last_observed_block (Phase B re-seed)",
+    )
+    .expect("set_last_observed_block Phase B");
+
+    // Set onchain supply to DEBT_E8S - REAL_BURN_AMOUNT (supply dropped by burn).
+    let supply_after_burn = DEBT_E8S - REAL_BURN_AMOUNT;
+    update_any(&pic, mock, "set_total_supply", Encode!(&supply_after_burn).unwrap());
+
+    // Push the real Burn log for Phase B.
+    push_burn_log(
+        &pic,
+        mock,
+        vault_id,
+        &recipient,
+        REAL_BURN_AMOUNT,
+        "0xburnB_real",
+        REAL_BURN_BLOCK,
+    );
+
+    // Set mock finalized to PHASE_B_FINALIZED so fetch_block_numbers succeeds.
+    update_any(&pic, mock, "set_blocks", Encode!(&PHASE_B_FINALIZED, &PHASE_B_FINALIZED).unwrap());
+
+    // Run one observer tick.
+    advance_and_tick(&pic, 1);
+
+    // Assert Phase B: sweep RAN and applied the real burn.
+    let v_b = get_vault(&pic, backend, vault_id).expect("vault in Phase B");
+    assert_eq!(
+        v_b.debt_e8s,
+        candid::Nat::from(DEBT_E8S - REAL_BURN_AMOUNT),
+        "Phase B: debt decremented by REAL_BURN_AMOUNT (sweep ran and applied burn)"
+    );
+    assert_eq!(v_b.status, ChainVaultStatus::Open, "Phase B: vault still Open");
+
+    let global_b: candid::Nat = query_unit(&pic, backend, "get_global_icusd_supply");
+    assert_eq!(
+        global_b,
+        candid::Nat::from(DEBT_E8S - REAL_BURN_AMOUNT),
+        "Phase B: chain_supplies[MONAD] decremented (sweep ran and applied burn)"
+    );
+
+    // Cursor must have advanced to PHASE_B_FINALIZED.
+    assert_eq!(
+        cursor(&pic, backend),
+        PHASE_B_FINALIZED,
+        "Phase B: cursor advanced to PHASE_B_FINALIZED after burn applied"
+    );
+
+    eprintln!(
+        "[supply-gate] Phase B PASSED: supply dropped ({} -> {}), real burn applied, debt {} = supply {}, cursor advanced to {}",
+        DEBT_E8S,
+        supply_after_burn,
+        DEBT_E8S - REAL_BURN_AMOUNT,
+        DEBT_E8S - REAL_BURN_AMOUNT,
+        PHASE_B_FINALIZED
+    );
+
+    eprintln!("[supply-gate] FULL two-phase gate proof PASSED");
+}


### PR DESCRIPTION
## Summary

Follow-up to #214 (Phase 1c notify-then-verify, merged + on staging). This adds the cheap safety-net backstop #214 explicitly deferred (its "Task 8").

#214 made `submit_burn_proof` the primary burn path and turned the per-tick `eth_getLogs` sweep OFF by default. Its one gap: liveness depends on the dApp submitting each burn tx (no relayer yet). This PR closes that gap without a relayer. When the poll is off, the observer does one cheap, consensus-safe `totalSupply()` probe per tick at the finalized block and compares it to the canister's recorded `chain_supplies[chain]`. The canister is the sole minter, so with no mint in flight a drop below `recorded` means a burn landed that `submit_burn_proof` never caught, and only then does it run the catch-up sweep to find it. A supply match, a mint in flight, or a probe error all stay in the cheap path (submit_burn_proof remains primary), so a flaky probe can never reintroduce the per-tick sweep cost.

## What

- `can_skip_burn_scan` (pure), `SettlementQueueV1::has_active_mint_op`, `erc20_total_supply_at` (consensus-safe `eth_call` of `totalSupply()` at a specific block) + `parse_eth_call_u128`.
- Wired into `run_observer`'s poll-off path as the backstop. The poll-on path is unchanged: the dev-gated catch-up sweep still runs in full.
- No new persisted state.

## Verification

- 229 lib tests; full Monad PocketIC suite green (happy path, burn idempotency, getLogs chunking, phase1c burn-proof, supply invariant) plus a new skip/scan proof of the backstop (`phase1b_supply_gate_pic`).
- Rebased onto #214 (`dffa3e9`); the poll-on regression tests pass unchanged (they bypass the backstop).

## Not deployed

Follow-up only. #214 is what is live on staging. Deploy this when the backstop is wanted (it adds ~1 cheap `totalSupply` outcall per advancing tick when the poll is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)