### PR TITLE
feat(airdrop): Season 1 points canister + source ingestion endpoints (Phases 1-2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7214,6 +7214,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumi_points"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "candid_parser",
+ "ciborium",
+ "ic-canister-log 0.2.0 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
+ "ic-cdk 0.12.2",
+ "ic-cdk-timers 0.10.0",
+ "ic-stable-structures",
+ "icrc-ledger-types 0.1.8 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "rumi_protocol_backend"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7225,8 +7225,18 @@ dependencies = [
  "ic-cdk-timers 0.10.0",
  "ic-stable-structures",
  "icrc-ledger-types 0.1.8 (git+https://github.com/Rumi-Protocol/ic?rev=fc278709)",
+ "pocket-ic",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "rumi_points_e2e_source"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk 0.12.2",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "src/rumi_3pool",
     "src/rumi_amm",
     "src/rumi_analytics",
+    "src/rumi_points",
     "src/xrc_demo/xrc_mock",
     "src/monad_rpc_mock",
     "src/liquidation_bot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "src/rumi_amm",
     "src/rumi_analytics",
     "src/rumi_points",
+    "src/rumi_points_e2e_source",
     "src/xrc_demo/xrc_mock",
     "src/monad_rpc_mock",
     "src/liquidation_bot",

--- a/dfx.json
+++ b/dfx.json
@@ -135,6 +135,14 @@
         { "name": "candid:service" }
       ]
     },
+    "rumi_points": {
+      "candid": "src/rumi_points/rumi_points.did",
+      "package": "rumi_points",
+      "type": "rust",
+      "metadata": [
+        { "name": "candid:service" }
+      ]
+    },
     "liquidation_bot": {
       "candid": "src/liquidation_bot/liquidation_bot.did",
       "package": "liquidation_bot",

--- a/icp.yaml
+++ b/icp.yaml
@@ -533,6 +533,27 @@ canisters:
         }
       })
 
+  # rumi_points: Season 1 airdrop points engine (Phase 1 scaffold, NEW canister).
+  # Rust canister built via the @dfinity/rust recipe. Raw release wasm is ~1.1 MB
+  # (well under the 2 MiB ingress limit), so the simple recipe form suffices; no
+  # shrink+gzip build-steps pipeline is needed. `shrink: true` matches the other
+  # recipe-built canisters. init_args is `(null)` so the init defaults apply:
+  # admin = deploying caller, excluded set = the 9 protocol-owned canisters,
+  # season window = the locked June 1 .. Aug 31 2026 defaults.
+  #
+  # DELIBERATELY local-only for now: this canister is NOT in `mainnet-live`.
+  # Reserving a mainnet canister id is irreversible and needs Rob's explicit OK
+  # (implementation plan Phase 1, task 8). It is added to the `local` environment
+  # list below purely for the local deploy + upgrade-survival verification.
+  - name: rumi_points
+    recipe:
+      type: "@dfinity/rust@v3.2.0"
+      configuration:
+        package: rumi_points
+        candid: src/rumi_points/rumi_points.did
+        shrink: true
+    init_args: '(null)'
+
 networks:
   - name: local
     mode: managed
@@ -778,3 +799,4 @@ environments:
       - rumi_stability_pool
       - rumi_treasury
       - rumi_amm
+      - rumi_points

--- a/src/rumi_3pool/rumi_3pool.did
+++ b/src/rumi_3pool/rumi_3pool.did
@@ -120,6 +120,12 @@ type LiquidityEventV2 = record {
   migrated : bool;
 };
 
+type ForwardLiquidityEventsV2 = record {
+  events : vec record { nat64; LiquidityEventV2 };
+  next_start : nat64;
+  reached_end : bool;
+};
+
 type QuoteSwapResult = record {
   token_in : nat8;
   token_out : nat8;
@@ -507,6 +513,7 @@ service : (ThreePoolInitArgs) -> {
   get_swap_events_v2 : (nat64, nat64) -> (vec SwapEventV2) query;
   get_swap_fees_over_window : (nat32) -> (nat) query;
   get_liquidity_events_v2 : (nat64, nat64) -> (vec LiquidityEventV2) query;
+  get_liquidity_events_v2_forward : (nat64, nat64) -> (ForwardLiquidityEventsV2) query;
   get_liquidity_event_count_v2 : () -> (nat64) query;
 
   // Explorer endpoints (E1-E14)

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -1043,6 +1043,31 @@ pub fn get_vp_snapshots() -> Vec<VirtualPriceSnapshot> {
 // Pure helpers below are independently unit-tested. The `#[query]` wrappers
 // just plumb live state into them.
 
+/// Pure forward-window helper: returns entries `[start, start+max_scan)` from a
+/// count-bounded indexed source (oldest-first, each tagged with its index), plus
+/// the resume cursor `next_start` and whether the scan reached the end. Generic
+/// so it is unit-testable without constructing events; `get_liquidity_events_v2_forward`
+/// plumbs the live `liq_v2` log into it. `max_scan` is capped to bound the reply.
+pub fn forward_window<T>(
+    count: u64,
+    start: u64,
+    max_scan: u64,
+    get: impl Fn(u64) -> Option<T>,
+) -> (Vec<(u64, T)>, u64, bool) {
+    const MAX_SCAN: u64 = 2000;
+    let scan = max_scan.min(MAX_SCAN);
+    let end = start.saturating_add(scan).min(count);
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < end {
+        if let Some(e) = get(i) {
+            out.push((i, e));
+        }
+        i += 1;
+    }
+    (out, end, end >= count)
+}
+
 /// Pure quote_swap: simulates a swap against the supplied balances.
 pub fn pure_quote_swap(
     i: u8,
@@ -1326,6 +1351,27 @@ pub fn get_liquidity_events_v2(limit: u64, offset: u64) -> Vec<LiquidityEventV2>
         out.reverse();
         out
     })
+}
+
+/// Forward, id-cursored read of the v2 liquidity event log for incremental
+/// ingestion (e.g. rumi_points). Unlike `get_liquidity_events_v2` (newest-first,
+/// offset-paged), this returns the window `[start, start+max_scan)` OLDEST-FIRST,
+/// each event paired with its log index (which equals its `id` for this unbounded
+/// StableLog), plus a `next_start` / `reached_end` cursor. A poller ingests every
+/// event exactly once by advancing `start := next_start` until `reached_end`.
+#[query]
+pub fn get_liquidity_events_v2_forward(
+    start: u64,
+    max_scan: u64,
+) -> crate::types::ForwardLiquidityEventsV2 {
+    let count = storage::liq_v2::len();
+    let (events, next_start, reached_end) =
+        forward_window(count, start, max_scan, storage::liq_v2::get);
+    crate::types::ForwardLiquidityEventsV2 {
+        events,
+        next_start,
+        reached_end,
+    }
 }
 
 /// Paginated newest-first read of the v2 swap event log.
@@ -2244,6 +2290,41 @@ pub fn test_corrupt_hash_cache_tip(bogus_hash: Vec<u8>) {
     let mut h = [0u8; 32];
     h.copy_from_slice(&bogus_hash);
     storage::push_bogus_hash_for_test(h);
+}
+
+#[cfg(test)]
+mod forward_window_tests {
+    use super::forward_window;
+
+    #[test]
+    fn windows_oldest_first_with_indices_and_cursor() {
+        let count = 3u64;
+        let get = |i: u64| if i < count { Some(i * 10) } else { None };
+
+        // Full scan: all three, tagged with their index, caught up.
+        let (evs, next, end) = forward_window(count, 0, 10, get);
+        assert_eq!(evs, vec![(0, 0), (1, 10), (2, 20)]);
+        assert_eq!(next, 3);
+        assert!(end);
+
+        // Bounded window [0,2): not yet caught up.
+        let (evs, next, end) = forward_window(count, 0, 2, get);
+        assert_eq!(evs, vec![(0, 0), (1, 10)]);
+        assert_eq!(next, 2);
+        assert!(!end);
+
+        // Resume from cursor 2: just the last one, caught up.
+        let (evs, next, end) = forward_window(count, 2, 10, get);
+        assert_eq!(evs, vec![(2, 20)]);
+        assert_eq!(next, 3);
+        assert!(end);
+
+        // Start past the end: empty, clamped to count, caught up.
+        let (evs, next, end) = forward_window(count, 5, 10, get);
+        assert!(evs.is_empty());
+        assert_eq!(next, 3);
+        assert!(end);
+    }
 }
 
 #[cfg(test)]

--- a/src/rumi_3pool/src/types.rs
+++ b/src/rumi_3pool/src/types.rs
@@ -308,6 +308,18 @@ pub struct LiquidityEventV2 {
     pub migrated: bool,
 }
 
+/// Response for `get_liquidity_events_v2_forward`: the forward window of v2
+/// liquidity events (oldest-first, each paired with its log index, which equals
+/// its `id` for this unbounded StableLog), plus a resume cursor for gap-free
+/// incremental ingestion (e.g. rumi_points). The poller advances
+/// `start := next_start` until `reached_end`.
+#[derive(CandidType, Clone, Debug)]
+pub struct ForwardLiquidityEventsV2 {
+    pub events: Vec<(u64, LiquidityEventV2)>,
+    pub next_start: u64,
+    pub reached_end: bool,
+}
+
 // ─── Admin Events ───
 
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]

--- a/src/rumi_points/Cargo.toml
+++ b/src/rumi_points/Cargo.toml
@@ -38,3 +38,4 @@ icrc-ledger-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc2787
 
 [dev-dependencies]
 candid_parser = "0.1"
+pocket-ic = "6.0.0"

--- a/src/rumi_points/Cargo.toml
+++ b/src/rumi_points/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "rumi_points"
+version = "0.1.0"
+edition = "2021"
+
+# rumi_points: Season 1 airdrop points engine (greenfield, Phase 1 scaffold).
+# Accrues dollar-days of qualifying activity per principal during the season,
+# publishes a leaderboard, and freezes a ledger that the LATER claim canister
+# (rumi_airdrop_claim) reads to compute pro_rata_share. This crate holds NO
+# claim / lock-tier / haircut logic; it only accrues total_points.
+#
+# Dependency VERSIONS are pinned to exactly match rumi_protocol_backend so the
+# shared IC-fork crates (rev fc278709) resolve to a single version across the
+# workspace. Do NOT bump these independently (ic-stable-structures 0.6.5 /
+# ic-cdk 0.12.0 are intentional; newer majors change the Storable trait shape).
+
+[[bin]]
+name = "rumi_points"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+# Reserved for later phases (gated test-only endpoints), mirrors the backend.
+test_endpoints = []
+
+[dependencies]
+candid = "0.10.6"
+ic-stable-structures = "0.6.5"
+ic-cdk = "0.12.0"
+ic-cdk-timers = "0.10.0"
+serde = { version = "1.0.210", features = ["derive"] }
+ciborium = "0.2.1"
+sha2 = "0.10.2"
+ic-canister-log = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
+icrc-ledger-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
+
+[dev-dependencies]
+candid_parser = "0.1"

--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -7,60 +7,55 @@ mainnet, no mainnet canister id reserved.
 Spec: `docs/specs/rumi-airdrop-spec-v2.md` (Section 7 data model, Section 11 excluded
 principals). Plan: `docs/plans/2026-05-03-airdrop-implementation-plan.md`.
 
-## Phase 2/3 progress
-Committed and tested (31 unit tests + candid drift test, all green):
-- `events.rs`: normalized `IngestedEvent`/`IngestKind`, the five Section-8
-  qualifying-action triggers, `apply_ingested_event` (auto-registers on first
-  qualifying in-season action; idempotent; excluded rejected), `ingest_batch`
-  (advances the per-source cursor). Pull-ingestion CORE.
-- `state.rs`: per-source cursors (StableBTreeMap, MemoryId 8), transient poll
-  guard, `in_season` gate.
-- `source_types.rs`: per-source candid mirror types + `normalize_*`, validated at
-  the candid layer (subset-decode, SP all-16-variants, migrated-row exclusion).
+## Phase 2/3: ingestion machinery COMPLETE in code (one E2E step remains)
+Two unmerged branches (both off `main`, NOT merged, NOT deployed):
 
-NOT yet built (the remaining Phase 2 machinery), blocked on a design decision:
-- The inter-canister poll loop, the source-canister-id config, the timer, and the
-  admin trigger/status endpoints.
-- The PocketIC end-to-end ingestion test (the plan's Phase 2 verification).
+**`feat/airdrop-points-canister`** (the points canister): normalized event model +
+the five Section-8 qualifying triggers + `apply_ingested_event`/`apply_events`
+(auto-register on first qualifying in-season action; idempotent; excluded rejected);
+per-source cursors (MemoryId 8) + poll guard + `in_season`; per-source candid mirror
+types + `normalize_*` (validated at the candid layer: subset decode, SP all-16
+variants, migrated-row exclusion, forward-response round-trips); the inter-canister
+`poll.rs` (backend/3pool advance to the endpoint's `next_start`, SP/AMM advance by
+count via `ingest_batch`; single-poll guard; per-source failures logged/skipped, no
+trap); source-canister config (MemoryId 9, mainnet-seeded, admin `set_source_canister`);
+admin `trigger_poll` + `get_ingest_status`. 33 unit tests + candid drift, all green.
 
-### Backend event-query pagination: RESOLVED (Rob chose the backend endpoint)
-`get_events_filtered` paginates newest-first by page number (no stable cursor) and
-`get_events` returns all ~95 variants (a subset mirror cannot decode unknown-variant
-values; confirmed by canary). Rob chose to add a clean forward endpoint.
+**`feat/source-forward-event-endpoints`** (source-side forward read endpoints):
+- backend `get_events_forward_filtered(start, max_scan, opt vec EventTypeFilter)`
+  (commit `51aa812`).
+- 3pool `get_liquidity_events_v2_forward(start, max_scan)` (commit `d35ed70`).
+Both read-only additive (no Event/state change, no UPG-002 risk), O(max_scan),
+unit-tested, .did + candid checks green. SP/AMM keep their existing oldest-first
+index APIs for Season 1 (their logs trim at 10k/50k, far above current volume, so
+`id==index` holds and advance-by-count is gap-free; documented; revisit at scale).
 
-DONE on branch `feat/backend-forward-filtered-events` (commit `51aa812`, NOT merged,
-local-only): `rumi_protocol_backend.get_events_forward_filtered(start, max_scan,
-opt vec EventTypeFilter) -> record { events: vec record { nat64; Event };
-next_start; reached_end }`. Read-only additive query (no Event/state change, no
-UPG-002 risk), O(max_scan) per call, unit-tested, .did regenerated + candid test
-green. The poller passes `start := next_start` until `reached_end`.
+Verified on a local replica: source config seeded; `trigger_poll` handles
+unreachable sources gracefully (Ok 0, cursors unchanged) and the poll guard releases
+(a second poll is not blocked); source config (MemoryId 9), cursors, registered
+principals, and excluded set all survive a real upgrade.
 
-### Remaining Phase 2 work (the poll layer + E2E) — next focused chunk
-1. Verify 3pool/SP/AMM `get_*_events(start,length)` paging (forward global-id window
-   vs newest-first/page). DO NOT assume forward-id after the backend surprise. If any
-   is page-based, it needs the same forward-endpoint treatment on that canister.
-2. Wire the inter-canister poll. IMPORTANT: the backend cursor advances to the
-   endpoint's `next_start` (a scan position), NOT `ingest_batch`'s `max(event_id)+1`.
-   Refactor an `apply_events` (no cursor) out of `ingest_batch` so the backend poll
-   reuses it and sets the cursor from `next_start`.
-3. Source-canister-id config (configurable per env; init args or a stable map +
-   admin setter — local ids differ from mainnet), a poll timer, and admin
-   trigger/status endpoints.
-4. PocketIC E2E (the plan's Phase 2 verification): deploy the sources + rumi_points,
-   generate real events, poll, assert auto-registration + cursor advance. Needs both
-   the rumi_points branch and the backend-endpoint branch together.
+### The ONLY remaining Phase 2 step: PocketIC E2E (live validation)
+Deploy the sources (backend+3pool with their forward endpoints, SP, AMM, ledgers) +
+rumi_points, generate real events (mint a vault, add 3pool liquidity, SP deposit),
+`trigger_poll`, assert auto-registration + correct cursor advance. This needs BOTH
+branches' code together (the project's PocketIC tests `include_bytes!` prebuilt
+wasms), so it requires a branch-combination decision (combine into one integration
+PR, or merge both to main first). The inter-canister poll is the one piece unit
+tests cannot cover; the E2E is its validation.
 
 ## What is real (and tested)
 - Stable-storage layout via `MemoryManager` (mirrors `rumi_protocol_backend::storage`).
 - Data model (`types.rs`), configurable excluded-principals set + admin setters,
   admin-gated `register_test_principal`, leaderboard, epoch-history reads.
 - Versioned-snapshot upgrade-safety pattern from day one (`Stored*` enums; recipe in
-  the `state.rs` module doc). 12 unit tests + a candid drift test, all green.
+  the `state.rs` module doc). 33 unit tests + a candid drift test, all green.
 - Verified on a local replica: every endpoint returns default state; a register +
   exclude survived a real upgrade (module hash changed, state persisted).
+- `events.rs` / `source_types.rs` / `poll.rs` are the real Phase 2/3 ingestion (see
+  the "ingestion machinery" section above), no longer skeleton.
 
 ## What is skeleton (later phases; signatures + doc comments only)
-- `events.rs`  — Phase 2 pull-based ingestion.
 - `epoch.rs`   — Phase 5 weekly two-snapshot `min()` accrual.
 - `valuation.rs` — Phase 4/5 asset valuation + 3USD verification.
 - `snapshot_seed.rs` — Phase 5 commit-reveal algorithm (its STATE types are real

--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -1,10 +1,43 @@
-# rumi_points — Phase 1 status
+# rumi_points — status
 
-**Phase 1 (points-canister scaffold): COMPLETE.** Branch `feat/airdrop-points-canister`
-(off `main`). Local-only; not deployed to mainnet, no mainnet canister id reserved.
+**Phase 1 (scaffold): COMPLETE.** **Phase 2/3 (ingestion + auto-registration): IN PROGRESS.**
+Branch `feat/airdrop-points-canister` (off `main`). Local-only; not deployed to
+mainnet, no mainnet canister id reserved.
 
 Spec: `docs/specs/rumi-airdrop-spec-v2.md` (Section 7 data model, Section 11 excluded
-principals). Plan: `docs/plans/2026-05-03-airdrop-implementation-plan.md` (Phase 1).
+principals). Plan: `docs/plans/2026-05-03-airdrop-implementation-plan.md`.
+
+## Phase 2/3 progress
+Committed and tested (31 unit tests + candid drift test, all green):
+- `events.rs`: normalized `IngestedEvent`/`IngestKind`, the five Section-8
+  qualifying-action triggers, `apply_ingested_event` (auto-registers on first
+  qualifying in-season action; idempotent; excluded rejected), `ingest_batch`
+  (advances the per-source cursor). Pull-ingestion CORE.
+- `state.rs`: per-source cursors (StableBTreeMap, MemoryId 8), transient poll
+  guard, `in_season` gate.
+- `source_types.rs`: per-source candid mirror types + `normalize_*`, validated at
+  the candid layer (subset-decode, SP all-16-variants, migrated-row exclusion).
+
+NOT yet built (the remaining Phase 2 machinery), blocked on a design decision:
+- The inter-canister poll loop, the source-canister-id config, the timer, and the
+  admin trigger/status endpoints.
+- The PocketIC end-to-end ingestion test (the plan's Phase 2 verification).
+
+### Blocker / decision needed: backend event-query pagination
+`rumi_protocol_backend.get_events_filtered` paginates NEWEST-FIRST by PAGE NUMBER
+(not a forward global-id cursor) and returns no `scan_end`, so it cannot drive
+stable incremental forward ingestion. The clean-forward endpoint `get_events`
+returns the full ~95-variant `Event`, which the 9-variant mirror cannot decode
+(candid rejects unknown-variant values; confirmed by canary). Options:
+  1. Mirror all ~95 backend variants and poll `get_events` forward by global id
+     (robust cursor, brittle/large mirror that breaks when upstream adds a variant).
+  2. Page-scan the filtered set each cycle keyed on a cached max global id (more
+     cross-canister work; the filtered set is recomputed O(N) per call).
+  3. Add a small FORWARD-filtered, id-cursored endpoint to the backend (cleanest,
+     but the backend has active Monad branches and a "do not touch" caution -> needs
+     Rob's OK; would ride a separate branch).
+The 3pool/SP/AMM `get_*_events(start,length)` pagination semantics are NOT yet
+verified; do that before wiring their poll cursors (do not assume forward-id).
 
 ## What is real (and tested)
 - Stable-storage layout via `MemoryManager` (mirrors `rumi_protocol_backend::storage`).

--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -1,0 +1,52 @@
+# rumi_points — Phase 1 status
+
+**Phase 1 (points-canister scaffold): COMPLETE.** Branch `feat/airdrop-points-canister`
+(off `main`). Local-only; not deployed to mainnet, no mainnet canister id reserved.
+
+Spec: `docs/specs/rumi-airdrop-spec-v2.md` (Section 7 data model, Section 11 excluded
+principals). Plan: `docs/plans/2026-05-03-airdrop-implementation-plan.md` (Phase 1).
+
+## What is real (and tested)
+- Stable-storage layout via `MemoryManager` (mirrors `rumi_protocol_backend::storage`).
+- Data model (`types.rs`), configurable excluded-principals set + admin setters,
+  admin-gated `register_test_principal`, leaderboard, epoch-history reads.
+- Versioned-snapshot upgrade-safety pattern from day one (`Stored*` enums; recipe in
+  the `state.rs` module doc). 12 unit tests + a candid drift test, all green.
+- Verified on a local replica: every endpoint returns default state; a register +
+  exclude survived a real upgrade (module hash changed, state persisted).
+
+## What is skeleton (later phases; signatures + doc comments only)
+- `events.rs`  — Phase 2 pull-based ingestion.
+- `epoch.rs`   — Phase 5 weekly two-snapshot `min()` accrual.
+- `valuation.rs` — Phase 4/5 asset valuation + 3USD verification.
+- `snapshot_seed.rs` — Phase 5 commit-reveal algorithm (its STATE types are real
+  and already in the stable layout).
+
+## Stable memory map (MemoryId -> structure; never reuse an id)
+| Id | Structure |
+|----|-----------|
+| 0  | `StableBTreeMap<Principal, StoredPrincipalState>` (per-principal accrual) |
+| 1/2| `StableLog<StoredPointEntry>` (append-only audit ledger) |
+| 3/4| `StableLog<StoredEpochSummary>` (per-epoch rollups) |
+| 5/6| `StableLog<StoredRevealedSeed>` (commit-reveal audit log; reserved, Phase 5) |
+| 7  | singleton `State` blob (8-byte LE len prefix + CBOR `StoredState::V1`) |
+
+## Excluded-principals seed (confirmed against canister_ids.json, 2026-06-01)
+9 protocol-owned canisters: rumi_protocol_backend, rumi_3pool, rumi_amm,
+rumi_stability_pool, rumi_treasury, liquidation_bot, icusd_ledger, icusd_index,
+threeusd_index. Deliberately excluded from the seed: rumi_analytics (no qualifying
+balances; admin can add). Founder/team are deliberately NOT excluded (spec Section 11).
+The set is admin-configurable; the seed is applied at init, enforcement reads the
+mutable set.
+
+## Two deliberate refinements of the spec's literal Section-7 shapes
+1. `PrincipalState` carries no inline `point_ledger: Vec<PointEntry>`; the audit
+   ledger is the separate global `StableLog<PointEntry>` the plan mandates.
+2. No `pro_rata_share` field — that is computed from the FROZEN ledger by the later
+   claim canister, not here.
+
+## Deferred from the Phase 1 task list (needs Rob)
+- Reserve a mainnet canister id + add to `canister_ids.json` / `mainnet-live`
+  (irreversible; requires explicit OK).
+
+## Do NOT start Phase 2 from here without re-reading the handoff + spec.

--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -23,21 +23,32 @@ NOT yet built (the remaining Phase 2 machinery), blocked on a design decision:
   admin trigger/status endpoints.
 - The PocketIC end-to-end ingestion test (the plan's Phase 2 verification).
 
-### Blocker / decision needed: backend event-query pagination
-`rumi_protocol_backend.get_events_filtered` paginates NEWEST-FIRST by PAGE NUMBER
-(not a forward global-id cursor) and returns no `scan_end`, so it cannot drive
-stable incremental forward ingestion. The clean-forward endpoint `get_events`
-returns the full ~95-variant `Event`, which the 9-variant mirror cannot decode
-(candid rejects unknown-variant values; confirmed by canary). Options:
-  1. Mirror all ~95 backend variants and poll `get_events` forward by global id
-     (robust cursor, brittle/large mirror that breaks when upstream adds a variant).
-  2. Page-scan the filtered set each cycle keyed on a cached max global id (more
-     cross-canister work; the filtered set is recomputed O(N) per call).
-  3. Add a small FORWARD-filtered, id-cursored endpoint to the backend (cleanest,
-     but the backend has active Monad branches and a "do not touch" caution -> needs
-     Rob's OK; would ride a separate branch).
-The 3pool/SP/AMM `get_*_events(start,length)` pagination semantics are NOT yet
-verified; do that before wiring their poll cursors (do not assume forward-id).
+### Backend event-query pagination: RESOLVED (Rob chose the backend endpoint)
+`get_events_filtered` paginates newest-first by page number (no stable cursor) and
+`get_events` returns all ~95 variants (a subset mirror cannot decode unknown-variant
+values; confirmed by canary). Rob chose to add a clean forward endpoint.
+
+DONE on branch `feat/backend-forward-filtered-events` (commit `51aa812`, NOT merged,
+local-only): `rumi_protocol_backend.get_events_forward_filtered(start, max_scan,
+opt vec EventTypeFilter) -> record { events: vec record { nat64; Event };
+next_start; reached_end }`. Read-only additive query (no Event/state change, no
+UPG-002 risk), O(max_scan) per call, unit-tested, .did regenerated + candid test
+green. The poller passes `start := next_start` until `reached_end`.
+
+### Remaining Phase 2 work (the poll layer + E2E) — next focused chunk
+1. Verify 3pool/SP/AMM `get_*_events(start,length)` paging (forward global-id window
+   vs newest-first/page). DO NOT assume forward-id after the backend surprise. If any
+   is page-based, it needs the same forward-endpoint treatment on that canister.
+2. Wire the inter-canister poll. IMPORTANT: the backend cursor advances to the
+   endpoint's `next_start` (a scan position), NOT `ingest_batch`'s `max(event_id)+1`.
+   Refactor an `apply_events` (no cursor) out of `ingest_batch` so the backend poll
+   reuses it and sets the cursor from `next_start`.
+3. Source-canister-id config (configurable per env; init args or a stable map +
+   admin setter — local ids differ from mainnet), a poll timer, and admin
+   trigger/status endpoints.
+4. PocketIC E2E (the plan's Phase 2 verification): deploy the sources + rumi_points,
+   generate real events, poll, assert auto-registration + cursor advance. Needs both
+   the rumi_points branch and the backend-endpoint branch together.
 
 ## What is real (and tested)
 - Stable-storage layout via `MemoryManager` (mirrors `rumi_protocol_backend::storage`).

--- a/src/rumi_points/rumi_points.did
+++ b/src/rumi_points/rumi_points.did
@@ -1,0 +1,109 @@
+// Candid interface for rumi_points (Season 1 airdrop points engine).
+// Phase 1 scaffold: read endpoints + admin-gated test registration / excluded-set
+// management. Event ingestion, epoch math, and the claim surface are later phases.
+// Kept structurally in sync with the Rust endpoints by the `candid_interface_matches_did_file`
+// test (src/main.rs).
+
+type AssetType = variant { IcUsd; CkUsdc; CkUsdt; ThreeUsd; Icp };
+
+type Venue = variant { Vault; ThreePool; StabilityPool; Amm };
+
+type QualifyingAction = variant {
+  MintIcUsd;
+  RepayVault;
+  Deposit3Pool;
+  DepositStabilityPool;
+  ProvideAmmLiquidity;
+};
+
+type DepositKey = record { venue : Venue; asset : AssetType };
+
+type DepositRecord = record {
+  asset : AssetType;
+  venue : Venue;
+  recorded_value_usd : nat;
+  deposited_at : nat64;
+  last_verified_at : nat64;
+};
+
+type RepaymentEvent = record {
+  asset : AssetType;
+  amount_usd : nat;
+  repaid_at : nat64;
+  window_end : nat64;
+};
+
+type PrincipalState = record {
+  "principal" : principal;
+  total_points : nat;
+  active_deposits : vec record { DepositKey; DepositRecord };
+  repayment_events : vec RepaymentEvent;
+  last_epoch_processed : nat64;
+  registered_at_ns : nat64;
+  first_qualifying_action : QualifyingAction;
+};
+
+type EpochSummary = record {
+  epoch_index : nat64;
+  epoch_start_ns : nat64;
+  epoch_end_ns : nat64;
+  total_points_all : nat;
+  points_accrued_this_epoch : nat;
+  active_principals : nat64;
+  registered_principals : nat64;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+};
+
+type LeaderboardEntry = record {
+  rank : nat32;
+  "principal" : principal;
+  total_points : nat;
+  estimated_share_bps : nat32;
+};
+
+type RegistrationInfo = record {
+  "principal" : principal;
+  registered_at_ns : nat64;
+  first_qualifying_action : QualifyingAction;
+};
+
+type PointsConfig = record {
+  admin : principal;
+  season_start_ns : nat64;
+  season_end_ns : nat64;
+  excluded_count : nat32;
+  registered_count : nat64;
+  current_epoch_index : nat64;
+  snapshot_seed_committed : bool;
+};
+
+type PointsError = variant { Unauthorized; Excluded };
+
+type InitArgs = record {
+  admin : opt principal;
+  excluded_principals : opt vec principal;
+  season_start_ns : opt nat64;
+  season_end_ns : opt nat64;
+  snapshot_seed_commit : opt blob;
+};
+
+type Result = variant { Ok; Err : PointsError };
+
+service : (opt InitArgs) -> {
+  // Reads
+  get_principal_state : (principal) -> (opt PrincipalState) query;
+  get_leaderboard : (nat32, nat32) -> (vec LeaderboardEntry) query;
+  get_epoch_history : (nat32, nat32) -> (vec EpochSummary) query;
+  is_registered : (principal) -> (bool) query;
+  get_registration_info : (principal) -> (opt RegistrationInfo) query;
+  is_excluded : (principal) -> (bool) query;
+  get_excluded_principals : () -> (vec principal) query;
+  get_points_config : () -> (PointsConfig) query;
+
+  // Admin-gated updates
+  register_test_principal : (principal) -> (Result);
+  add_excluded_principal : (principal) -> (Result);
+  remove_excluded_principal : (principal) -> (Result);
+  set_excluded_principals : (vec principal) -> (Result);
+};

--- a/src/rumi_points/rumi_points.did
+++ b/src/rumi_points/rumi_points.did
@@ -90,6 +90,19 @@ type InitArgs = record {
 
 type Result = variant { Ok; Err : PointsError };
 
+type Result_1 = variant { Ok : nat64; Err : PointsError };
+
+type SourceStatus = record {
+  tag : nat8;
+  canister : principal;
+  cursor : nat64;
+};
+
+type IngestStatus = record {
+  sources : vec SourceStatus;
+  registered_count : nat64;
+};
+
 service : (opt InitArgs) -> {
   // Reads
   get_principal_state : (principal) -> (opt PrincipalState) query;
@@ -106,4 +119,9 @@ service : (opt InitArgs) -> {
   add_excluded_principal : (principal) -> (Result);
   remove_excluded_principal : (principal) -> (Result);
   set_excluded_principals : (vec principal) -> (Result);
+
+  // Phase 2: ingestion control
+  set_source_canister : (nat8, principal) -> (Result);
+  trigger_poll : () -> (Result_1);
+  get_ingest_status : () -> (IngestStatus) query;
 };

--- a/src/rumi_points/src/epoch.rs
+++ b/src/rumi_points/src/epoch.rs
@@ -1,0 +1,39 @@
+//! Weekly epoch driver (spec Section 7, implementation plan Phase 5).
+//!
+//! PHASE 5 SCOPE (skeleton only here). Once per week the driver:
+//!   1. Derives two intra-epoch snapshot times via the commit-reveal seed
+//!      (`snapshot_seed::derive_snapshot_times`).
+//!   2. Captures per-principal balances at each snapshot into a transient buffer.
+//!   3. Accrues `dollar_days = active_value * multiplier * period / day` per
+//!      position, takes `min(snapshot_a, snapshot_b)` (closes end-of-epoch
+//!      sniping), and adds to `total_points`.
+//!   4. For matched ckUSDC+ckUSDT: `2 * min(USDC, USDT)` at 5x, remainder at 3x
+//!      (the dust-gaming fix).
+//!   5. For open repayment windows: `amount * elapsed_days_in_window * 5`,
+//!      truncated at season end.
+//!   6. Appends `PointEntry` rows and one `EpochSummary`, advances
+//!      `last_epoch_processed`, and closes the seed epoch.
+//!
+//! None of the multiplier / snapshot / min() math is implemented in Phase 1.
+
+#![allow(dead_code)] // Phase 5 surface.
+
+/// Length of one epoch. A week, expressed in nanoseconds (IC time unit).
+pub const EPOCH_DURATION_NS: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+/// Run one full weekly epoch: schedule both snapshots, accrue on close. Registered
+/// on a 1-week timer in `setup_timers` (Phase 5).
+pub async fn run_epoch() {
+    unimplemented!("Phase 5: weekly two-snapshot min() accrual");
+}
+
+/// Capture per-principal balances across all sources at a single snapshot.
+pub async fn take_snapshot(_epoch_index: u64, _snapshot_index: u8) {
+    unimplemented!("Phase 5");
+}
+
+/// Accrue one principal's points for a closing epoch from its two snapshots,
+/// returning the weekly `min()` delta. The multiplier table lives here.
+pub fn accrue_principal_epoch(_principal: candid::Principal, _epoch_index: u64) -> u128 {
+    unimplemented!("Phase 5");
+}

--- a/src/rumi_points/src/events.rs
+++ b/src/rumi_points/src/events.rs
@@ -1,0 +1,58 @@
+//! Event ingestion (spike 0.2, `2026-05-07-spike-0.2-event-ingestion-gaps.md`).
+//!
+//! PHASE 2 SCOPE (skeleton only here). Ingestion is PULL-BASED: `rumi_points`
+//! polls each source canister's existing `get_*_events(start, length)` query
+//! endpoints on a timer, processes new events idempotently keyed by event id,
+//! advances a per-source cursor, and updates `PrincipalState`. No upstream
+//! changes are required to start (the one needed change, `repayment_asset` on
+//! the backend `RepayToVault` event, is a SEPARATE branch and gates Phase 5, not
+//! Phase 1; do not touch the backend here).
+//!
+//! Sources and cursors (spike 0.2):
+//!   - rumi_protocol_backend  get_events                 (vault mint/repay/close/liquidate/redeem)
+//!   - rumi_3pool             get_liquidity_events_v2    (v2 ONLY; v1 lacks per-asset breakdown)
+//!   - rumi_stability_pool    get_pool_events            (deposit/withdraw/liquidation draw)
+//!   - rumi_amm               get_amm_liquidity_events   (LP add/remove)
+//!
+//! Each handler resolves the principal, auto-registers it on first sight
+//! (Phase 3), updates active deposits / repayment events, and writes a
+//! `PointEntry` audit row. Registration is gated to the season window by a
+//! `pre_season_active` flag so pre-June-1 test traffic does not accrue.
+
+#![allow(dead_code)] // Phase 2 surface.
+
+use candid::Principal;
+
+/// Per-source ingestion cursor (last event id processed). Phase 2 persists these
+/// in stable state; Phase 1 only declares the shape.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SourceCursors {
+    pub backend_event_id: u64,
+    pub three_pool_liquidity_event_id: u64,
+    pub stability_pool_event_id: u64,
+    pub amm_liquidity_event_id: u64,
+}
+
+/// Poll every source once, process new events idempotently, advance cursors.
+/// Registered on a ~60s timer in Phase 2 (`setup_timers`).
+pub async fn poll_all_sources() {
+    unimplemented!("Phase 2: pull-based ingestion across the four source canisters");
+}
+
+/// Handle one decoded backend event for `caller`. Auto-registers on first sight,
+/// then mutates the principal's deposit / repayment state and writes a ledger row.
+pub fn handle_backend_event(_caller: Principal /* , event: BackendEvent */) {
+    unimplemented!("Phase 2");
+}
+
+pub fn handle_three_pool_event(_caller: Principal /* , event: LiquidityEventV2 */) {
+    unimplemented!("Phase 2");
+}
+
+pub fn handle_stability_pool_event(_caller: Principal /* , event: PoolEvent */) {
+    unimplemented!("Phase 2");
+}
+
+pub fn handle_amm_event(_caller: Principal /* , event: AmmLiquidityEvent */) {
+    unimplemented!("Phase 2");
+}

--- a/src/rumi_points/src/events.rs
+++ b/src/rumi_points/src/events.rs
@@ -1,58 +1,339 @@
-//! Event ingestion (spike 0.2, `2026-05-07-spike-0.2-event-ingestion-gaps.md`).
+//! Event ingestion (spike 0.2, implementation plan Phase 2 + the auto-registration
+//! of Phase 3).
 //!
-//! PHASE 2 SCOPE (skeleton only here). Ingestion is PULL-BASED: `rumi_points`
-//! polls each source canister's existing `get_*_events(start, length)` query
-//! endpoints on a timer, processes new events idempotently keyed by event id,
-//! advances a per-source cursor, and updates `PrincipalState`. No upstream
-//! changes are required to start (the one needed change, `repayment_asset` on
-//! the backend `RepayToVault` event, is a SEPARATE branch and gates Phase 5, not
-//! Phase 1; do not touch the backend here).
+//! PULL-BASED: `rumi_points` polls each source canister's existing
+//! `get_*_events(start, length)` query endpoints on a timer, decodes each event
+//! into a normalized `IngestedEvent`, and applies it. Auto-registration enrolls a
+//! principal on its first qualifying action (spec Section 8). The wire decoding
+//! lives in `source_types.rs`; this module holds the normalized model, the
+//! apply/registration logic, and the cursor-advancing batch driver.
 //!
-//! Sources and cursors (spike 0.2):
-//!   - rumi_protocol_backend  get_events                 (vault mint/repay/close/liquidate/redeem)
-//!   - rumi_3pool             get_liquidity_events_v2    (v2 ONLY; v1 lacks per-asset breakdown)
-//!   - rumi_stability_pool    get_pool_events            (deposit/withdraw/liquidation draw)
-//!   - rumi_amm               get_amm_liquidity_events   (LP add/remove)
+//! Idempotency: each source has a monotonic cursor (`state::get_cursor`). A poll
+//! fetches `[cursor, cursor+batch)`, applies the batch, and advances the cursor
+//! to `max(event_id)+1` in a single post-await message (atomic on the IC, so a
+//! trap commits nothing). The `state::try_begin_poll` guard prevents two timers
+//! from ingesting the same range concurrently. Events below the cursor are never
+//! refetched, so no per-event dedup set is needed.
 //!
-//! Each handler resolves the principal, auto-registers it on first sight
-//! (Phase 3), updates active deposits / repayment events, and writes a
-//! `PointEntry` audit row. Registration is gated to the season window by a
-//! `pre_season_active` flag so pre-June-1 test traffic does not accrue.
-
-#![allow(dead_code)] // Phase 2 surface.
+//! PHASE BOUNDARY: this increment ingests events and auto-registers. Position /
+//! deposit-value tracking, the repayment 90-day window (which also needs the
+//! `repayment_asset` upstream field, a separate branch), 3USD verification, and
+//! accrual are Phase 4/5. `IngestKind` already carries the payload those phases
+//! need so the normalized model does not have to change later.
 
 use candid::Principal;
 
-/// Per-source ingestion cursor (last event id processed). Phase 2 persists these
-/// in stable state; Phase 1 only declares the shape.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct SourceCursors {
-    pub backend_event_id: u64,
-    pub three_pool_liquidity_event_id: u64,
-    pub stability_pool_event_id: u64,
-    pub amm_liquidity_event_id: u64,
+use crate::state;
+use crate::types::QualifyingAction;
+
+/// The four source canisters polled for events. The `tag` is the stable cursor
+/// key (see `state::get_cursor`); never renumber an existing tag.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceId {
+    Backend,
+    ThreePool,
+    StabilityPool,
+    Amm,
 }
 
-/// Poll every source once, process new events idempotently, advance cursors.
-/// Registered on a ~60s timer in Phase 2 (`setup_timers`).
-pub async fn poll_all_sources() {
-    unimplemented!("Phase 2: pull-based ingestion across the four source canisters");
+impl SourceId {
+    pub fn tag(self) -> u8 {
+        match self {
+            SourceId::Backend => 0,
+            SourceId::ThreePool => 1,
+            SourceId::StabilityPool => 2,
+            SourceId::Amm => 3,
+        }
+    }
 }
 
-/// Handle one decoded backend event for `caller`. Auto-registers on first sight,
-/// then mutates the principal's deposit / repayment state and writes a ledger row.
-pub fn handle_backend_event(_caller: Principal /* , event: BackendEvent */) {
-    unimplemented!("Phase 2");
+/// Normalized event, decoded from any source's wire format. Carries enough for
+/// Phase 2 (registration) and the payload Phase 4/5 will need (amounts, ledger,
+/// vault id) so the model is stable across phases.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IngestedEvent {
+    pub source: SourceId,
+    pub event_id: u64,
+    /// The acting principal, when the source event carries one. `None` for events
+    /// with no attributable caller (e.g. backend `close_vault` / `liquidate_vault`,
+    /// which carry only a vault id); those never trigger registration.
+    pub caller: Option<Principal>,
+    pub timestamp_ns: u64,
+    pub kind: IngestKind,
 }
 
-pub fn handle_three_pool_event(_caller: Principal /* , event: LiquidityEventV2 */) {
-    unimplemented!("Phase 2");
+/// Source-agnostic event classification.
+#[derive(Clone, Debug, PartialEq)]
+pub enum IngestKind {
+    // ── rumi_protocol_backend (vault) ──
+    /// Opened a vault; `borrowed_e8s` is the icUSD minted at open (may be 0).
+    VaultOpen { vault_id: u64, borrowed_e8s: u64 },
+    /// Borrowed (minted) more icUSD from an existing vault.
+    VaultBorrow { vault_id: u64, amount_e8s: u64 },
+    /// Repaid vault debt. Asset is not yet attributable (the `repayment_asset`
+    /// field is a separate upstream branch); the 5x ck-stable window is Phase 5.
+    VaultRepay { vault_id: u64, amount_e8s: u64 },
+    VaultClose { vault_id: u64 },
+    VaultLiquidated { vault_id: u64 },
+    VaultRedeemed { amount_e8s: u64 },
+
+    // ── rumi_3pool ── amounts are [icUSD, ckUSDT, ckUSDC] (3pool ordering).
+    ThreePoolAdd { amounts: [u128; 3] },
+    ThreePoolRemove { amounts: [u128; 3] },
+
+    // ── rumi_stability_pool ── `token_ledger` identifies the deposited asset.
+    SpDeposit { token_ledger: Principal, amount_e8s: u64 },
+    SpWithdraw { token_ledger: Principal, amount_e8s: u64 },
+
+    // ── rumi_amm ──
+    AmmAddLiquidity { pool_id: String, lp_shares: u128 },
+    AmmRemoveLiquidity { pool_id: String, lp_shares: u128 },
+
+    /// Ingested but not acted on in any current phase (e.g. a 3pool `Donate`, an
+    /// SP config event). Kept so the cursor still advances past it.
+    Other,
 }
 
-pub fn handle_stability_pool_event(_caller: Principal /* , event: PoolEvent */) {
-    unimplemented!("Phase 2");
+impl IngestKind {
+    /// The qualifying action this event represents, if it is one of the five
+    /// registration triggers (spec Section 8). `None` means "ingest but do not
+    /// enroll" (withdrawals, closes, liquidations, redemptions, config events).
+    pub fn qualifying_action(&self) -> Option<QualifyingAction> {
+        match self {
+            IngestKind::VaultOpen { borrowed_e8s, .. } if *borrowed_e8s > 0 => {
+                Some(QualifyingAction::MintIcUsd)
+            }
+            IngestKind::VaultBorrow { .. } => Some(QualifyingAction::MintIcUsd),
+            IngestKind::VaultRepay { .. } => Some(QualifyingAction::RepayVault),
+            IngestKind::ThreePoolAdd { .. } => Some(QualifyingAction::Deposit3Pool),
+            IngestKind::SpDeposit { .. } => Some(QualifyingAction::DepositStabilityPool),
+            IngestKind::AmmAddLiquidity { .. } => Some(QualifyingAction::ProvideAmmLiquidity),
+            _ => None,
+        }
+    }
 }
 
-pub fn handle_amm_event(_caller: Principal /* , event: AmmLiquidityEvent */) {
-    unimplemented!("Phase 2");
+/// Apply one normalized event. Phase 2/3: auto-register the caller on its first
+/// qualifying, in-season action. `register` is idempotent and rejects excluded
+/// principals, so this is safe to call for every matching event.
+pub fn apply_ingested_event(ev: &IngestedEvent) {
+    // Auto-registration on first qualifying, in-season action. `register` is
+    // idempotent and rejects excluded principals, so calling it for every
+    // matching event is safe and cheap.
+    if let (Some(action), Some(caller)) = (ev.kind.qualifying_action(), ev.caller) {
+        if state::in_season(ev.timestamp_ns) {
+            let _ = state::register(caller, ev.timestamp_ns, action);
+        }
+    }
+    // Position-value tracking, the repayment 90-day window, 3USD verification,
+    // and accrual are Phase 4/5 and read the payload carried on `ev.kind`.
 }
+
+/// Apply a decoded batch for a source and advance its cursor to
+/// `max(event_id) + 1`. Returns the number of events applied. This is the
+/// network-free, unit-testable core (the inter-canister fetch is in
+/// `poll_source`). An empty batch leaves the cursor unchanged.
+pub fn ingest_batch(source: SourceId, events: &[IngestedEvent]) -> usize {
+    let mut max_id: Option<u64> = None;
+    for ev in events {
+        apply_ingested_event(ev);
+        max_id = Some(max_id.map_or(ev.event_id, |m| m.max(ev.event_id)));
+    }
+    // Advance the cursor past the highest id seen. Only on a non-empty batch, so
+    // an empty fetch (caught up) leaves the cursor where it is.
+    if let Some(m) = max_id {
+        state::set_cursor(source.tag(), m + 1);
+    }
+    events.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state;
+    use crate::types::{InitArgs, QualifyingAction};
+
+    fn tp(n: u8) -> Principal {
+        Principal::from_slice(&[n, n, n, n, n])
+    }
+
+    fn in_season_ts() -> u64 {
+        crate::DEFAULT_SEASON_START_NS + 1_000
+    }
+
+    fn init() {
+        state::init_state(
+            Some(InitArgs {
+                admin: Some(tp(99)),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+    }
+
+    fn ev(source: SourceId, id: u64, caller: Option<Principal>, ts: u64, kind: IngestKind) -> IngestedEvent {
+        IngestedEvent {
+            source,
+            event_id: id,
+            caller,
+            timestamp_ns: ts,
+            kind,
+        }
+    }
+
+    #[test]
+    fn qualifying_action_maps_the_five_triggers() {
+        assert_eq!(
+            IngestKind::VaultBorrow { vault_id: 1, amount_e8s: 5 }.qualifying_action(),
+            Some(QualifyingAction::MintIcUsd)
+        );
+        assert_eq!(
+            IngestKind::VaultOpen { vault_id: 1, borrowed_e8s: 5 }.qualifying_action(),
+            Some(QualifyingAction::MintIcUsd)
+        );
+        // Opening a vault without minting is not a qualifying action.
+        assert_eq!(
+            IngestKind::VaultOpen { vault_id: 1, borrowed_e8s: 0 }.qualifying_action(),
+            None
+        );
+        assert_eq!(
+            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 5 }.qualifying_action(),
+            Some(QualifyingAction::RepayVault)
+        );
+        assert_eq!(
+            IngestKind::ThreePoolAdd { amounts: [0, 1, 0] }.qualifying_action(),
+            Some(QualifyingAction::Deposit3Pool)
+        );
+        assert_eq!(
+            IngestKind::SpDeposit { token_ledger: tp(1), amount_e8s: 5 }.qualifying_action(),
+            Some(QualifyingAction::DepositStabilityPool)
+        );
+        assert_eq!(
+            IngestKind::AmmAddLiquidity { pool_id: "3usd-icp".into(), lp_shares: 5 }.qualifying_action(),
+            Some(QualifyingAction::ProvideAmmLiquidity)
+        );
+        // Non-triggers.
+        assert_eq!(IngestKind::ThreePoolRemove { amounts: [0, 1, 0] }.qualifying_action(), None);
+        assert_eq!(IngestKind::VaultClose { vault_id: 1 }.qualifying_action(), None);
+        assert_eq!(IngestKind::Other.qualifying_action(), None);
+    }
+
+    #[test]
+    fn apply_auto_registers_on_first_qualifying_action() {
+        init();
+        let p = tp(10);
+        apply_ingested_event(&ev(
+            SourceId::ThreePool,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::ThreePoolAdd { amounts: [100, 0, 0] },
+        ));
+        assert!(state::is_registered(&p));
+        let st = state::get_principal_state(&p).unwrap();
+        assert_eq!(st.first_qualifying_action, QualifyingAction::Deposit3Pool);
+        assert_eq!(st.registered_at_ns, in_season_ts());
+    }
+
+    #[test]
+    fn apply_does_not_register_non_qualifying_event() {
+        init();
+        let p = tp(11);
+        apply_ingested_event(&ev(
+            SourceId::ThreePool,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::ThreePoolRemove { amounts: [100, 0, 0] },
+        ));
+        assert!(!state::is_registered(&p));
+    }
+
+    #[test]
+    fn apply_ignores_out_of_season_events() {
+        init();
+        let p = tp(12);
+        let before_season = crate::DEFAULT_SEASON_START_NS - 1;
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            Some(p),
+            before_season,
+            IngestKind::VaultBorrow { vault_id: 1, amount_e8s: 100 },
+        ));
+        assert!(!state::is_registered(&p));
+    }
+
+    #[test]
+    fn apply_does_not_register_excluded_principal() {
+        init();
+        let backend = Principal::from_text("tfesu-vyaaa-aaaap-qrd7a-cai").unwrap();
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            Some(backend),
+            in_season_ts(),
+            IngestKind::VaultBorrow { vault_id: 1, amount_e8s: 100 },
+        ));
+        assert!(!state::is_registered(&backend));
+    }
+
+    #[test]
+    fn apply_with_no_caller_is_a_noop() {
+        init();
+        // close_vault carries no caller, so there is nobody to register.
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            None,
+            in_season_ts(),
+            IngestKind::VaultClose { vault_id: 1 },
+        ));
+        assert_eq!(state::registered_count(), 0);
+    }
+
+    #[test]
+    fn ingest_batch_applies_all_and_advances_cursor() {
+        init();
+        let evs = vec![
+            ev(SourceId::ThreePool, 5, Some(tp(20)), in_season_ts(), IngestKind::ThreePoolAdd { amounts: [1, 0, 0] }),
+            ev(SourceId::ThreePool, 6, Some(tp(21)), in_season_ts(), IngestKind::ThreePoolAdd { amounts: [1, 0, 0] }),
+            ev(SourceId::ThreePool, 7, Some(tp(22)), in_season_ts(), IngestKind::ThreePoolRemove { amounts: [1, 0, 0] }),
+        ];
+        let n = ingest_batch(SourceId::ThreePool, &evs);
+        assert_eq!(n, 3);
+        assert!(state::is_registered(&tp(20)));
+        assert!(state::is_registered(&tp(21)));
+        assert!(!state::is_registered(&tp(22))); // remove is not a trigger
+        assert_eq!(state::get_cursor(SourceId::ThreePool.tag()), 8); // max id (7) + 1
+    }
+
+    #[test]
+    fn ingest_batch_empty_leaves_cursor_unchanged() {
+        init();
+        state::set_cursor(SourceId::Amm.tag(), 42);
+        let n = ingest_batch(SourceId::Amm, &[]);
+        assert_eq!(n, 0);
+        assert_eq!(state::get_cursor(SourceId::Amm.tag()), 42);
+    }
+
+    #[test]
+    fn ingest_batch_is_idempotent_on_reapply() {
+        init();
+        let evs = vec![ev(
+            SourceId::Backend,
+            0,
+            Some(tp(30)),
+            in_season_ts(),
+            IngestKind::VaultBorrow { vault_id: 1, amount_e8s: 100 },
+        )];
+        ingest_batch(SourceId::Backend, &evs);
+        let first = state::get_principal_state(&tp(30)).unwrap();
+        ingest_batch(SourceId::Backend, &evs); // re-apply same batch
+        let second = state::get_principal_state(&tp(30)).unwrap();
+        assert_eq!(first, second); // no double-register, no timestamp change
+        assert_eq!(state::registered_count(), 1);
+        assert_eq!(state::get_cursor(SourceId::Backend.tag()), 1);
+    }
+}
+

--- a/src/rumi_points/src/events.rs
+++ b/src/rumi_points/src/events.rs
@@ -129,19 +129,25 @@ pub fn apply_ingested_event(ev: &IngestedEvent) {
     // and accrual are Phase 4/5 and read the payload carried on `ev.kind`.
 }
 
-/// Apply a decoded batch for a source and advance its cursor to
-/// `max(event_id) + 1`. Returns the number of events applied. This is the
-/// network-free, unit-testable core (the inter-canister fetch is in
-/// `poll_source`). An empty batch leaves the cursor unchanged.
-pub fn ingest_batch(source: SourceId, events: &[IngestedEvent]) -> usize {
-    let mut max_id: Option<u64> = None;
+/// Apply a decoded batch of normalized events (auto-register etc.). Does NOT
+/// touch any cursor. Each poller advances its source cursor from that source's
+/// own resume signal: the forward endpoints (backend, 3pool) return an explicit
+/// `next_start`; the index endpoints (SP, AMM) advance by returned count (see
+/// `ingest_batch`). The network-free, unit-testable core of ingestion.
+pub fn apply_events(events: &[IngestedEvent]) {
     for ev in events {
         apply_ingested_event(ev);
-        max_id = Some(max_id.map_or(ev.event_id, |m| m.max(ev.event_id)));
     }
-    // Advance the cursor past the highest id seen. Only on a non-empty batch, so
-    // an empty fetch (caught up) leaves the cursor where it is.
-    if let Some(m) = max_id {
+}
+
+/// Apply a batch and advance the source cursor to `max(event_id) + 1`. Valid for
+/// the index endpoints (SP, AMM), where `id == index` holds until their logs trim
+/// (far beyond Season-1 volume at current TVL). The forward endpoints (backend,
+/// 3pool) instead set the cursor from the endpoint's returned `next_start`. An
+/// empty batch leaves the cursor unchanged. Returns the number applied.
+pub fn ingest_batch(source: SourceId, events: &[IngestedEvent]) -> usize {
+    apply_events(events);
+    if let Some(m) = events.iter().map(|e| e.event_id).max() {
         state::set_cursor(source.tag(), m + 1);
     }
     events.len()

--- a/src/rumi_points/src/lib.rs
+++ b/src/rumi_points/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod epoch;
 pub mod events;
+pub mod poll;
 pub mod snapshot_seed;
 pub mod source_types;
 pub mod state;

--- a/src/rumi_points/src/lib.rs
+++ b/src/rumi_points/src/lib.rs
@@ -1,0 +1,36 @@
+//! # rumi_points
+//!
+//! Season 1 airdrop points engine for Rumi Protocol (spec `rumi-airdrop-spec-v2.md`).
+//! Accrues dollar-days of qualifying activity per principal during the season
+//! (June 1 .. Aug 31, 2026), publishes a leaderboard, and freezes a points ledger
+//! that the LATER claim canister (`rumi_airdrop_claim`) reads to compute each
+//! user's `pro_rata_share` of the 5% Season-1 token pool.
+//!
+//! ## Phase 1 status (this scaffold)
+//! Real and tested: the stable-storage layout (`state.rs`), the data model
+//! (`types.rs`), the configurable excluded-principals set, test-only registration,
+//! and the versioned-snapshot upgrade-safety pattern. Skeleton (signatures + doc
+//! comments, land in later phases): `events.rs` (Phase 2 ingestion), `epoch.rs`
+//! and `valuation.rs` (Phase 5 multiplier / snapshot math), and the commit-reveal
+//! ALGORITHM in `snapshot_seed.rs` (Phase 5; its STATE types are real today).
+//!
+//! Out of scope here: event ingestion, the backend `repayment_asset` change,
+//! 3USD verification, epoch math, and the entire claim / lock-tier surface.
+
+pub mod epoch;
+pub mod events;
+pub mod snapshot_seed;
+pub mod state;
+pub mod types;
+pub mod valuation;
+
+/// Nanoseconds in one day (IC `ic_cdk::api::time()` is nanoseconds since epoch).
+pub const NANOS_PER_DAY: u64 = 24 * 60 * 60 * 1_000_000_000;
+
+/// Default season window, overridable via `InitArgs`. These are the locked
+/// hard dates from spec Section 15, precomputed in nanoseconds since the Unix
+/// epoch:
+///   - start: 2026-06-01T00:00:00Z
+///   - end:   2026-08-31T23:59:59Z
+pub const DEFAULT_SEASON_START_NS: u64 = 1_780_272_000_000_000_000;
+pub const DEFAULT_SEASON_END_NS: u64 = 1_788_220_799_000_000_000;

--- a/src/rumi_points/src/lib.rs
+++ b/src/rumi_points/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod epoch;
 pub mod events;
 pub mod snapshot_seed;
+pub mod source_types;
 pub mod state;
 pub mod types;
 pub mod valuation;

--- a/src/rumi_points/src/main.rs
+++ b/src/rumi_points/src/main.rs
@@ -6,11 +6,11 @@
 use candid::Principal;
 use ic_canister_log::{declare_log_buffer, log};
 
-use rumi_points::state;
 use rumi_points::types::{
-    EpochSummary, InitArgs, LeaderboardEntry, PointsConfig, PointsError, PrincipalState,
-    RegistrationInfo,
+    EpochSummary, IngestStatus, InitArgs, LeaderboardEntry, PointsConfig, PointsError,
+    PrincipalState, RegistrationInfo, SourceStatus,
 };
+use rumi_points::{poll, state};
 
 // Canister debug-log buffer (retrievable in later phases; for now feeds the
 // replica debug log on lifecycle events).
@@ -116,6 +116,42 @@ fn remove_excluded_principal(principal: Principal) -> Result<(), PointsError> {
 #[ic_cdk::update]
 fn set_excluded_principals(principals: Vec<Principal>) -> Result<(), PointsError> {
     state::set_excluded(ic_cdk::caller(), principals)
+}
+
+// ── Phase 2: ingestion control ──────────────────────────────────────────────
+
+/// Admin-set a source canister id (point the poller at the right canister per
+/// environment, e.g. local replica ids). Tag: 0 = backend, 1 = 3pool, 2 = SP,
+/// 3 = AMM.
+#[ic_cdk::update]
+fn set_source_canister(source_tag: u8, canister: Principal) -> Result<(), PointsError> {
+    state::set_source_canister(ic_cdk::caller(), source_tag, canister)
+}
+
+/// Admin-only manual poll of all configured sources. Returns the number of events
+/// applied. (No periodic timer in Phase 2; the production cadence is a follow-up.)
+#[ic_cdk::update]
+async fn trigger_poll() -> Result<u64, PointsError> {
+    if !state::is_admin(ic_cdk::caller()) {
+        return Err(PointsError::Unauthorized);
+    }
+    Ok(poll::poll_all().await as u64)
+}
+
+#[ic_cdk::query]
+fn get_ingest_status() -> IngestStatus {
+    let sources = state::source_canisters()
+        .into_iter()
+        .map(|(tag, canister)| SourceStatus {
+            tag,
+            canister,
+            cursor: state::get_cursor(tag),
+        })
+        .collect();
+    IngestStatus {
+        sources,
+        registered_count: state::registered_count(),
+    }
 }
 
 ic_cdk::export_candid!();

--- a/src/rumi_points/src/main.rs
+++ b/src/rumi_points/src/main.rs
@@ -1,0 +1,144 @@
+//! Canister entry points for `rumi_points`. The library (`lib.rs` + modules)
+//! holds the logic; this binary wires the IC lifecycle hooks and the candid
+//! query/update surface to it. Phase 1 exposes read endpoints plus an admin-only
+//! `register_test_principal` for proving upgrade survival before ingestion exists.
+
+use candid::Principal;
+use ic_canister_log::{declare_log_buffer, log};
+
+use rumi_points::state;
+use rumi_points::types::{
+    EpochSummary, InitArgs, LeaderboardEntry, PointsConfig, PointsError, PrincipalState,
+    RegistrationInfo,
+};
+
+// Canister debug-log buffer (retrievable in later phases; for now feeds the
+// replica debug log on lifecycle events).
+declare_log_buffer!(name = INFO, capacity = 2000);
+
+fn main() {}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+#[ic_cdk::init]
+fn init(args: Option<InitArgs>) {
+    state::init_state(args, ic_cdk::caller());
+    let cfg = state::points_config();
+    log!(
+        INFO,
+        "rumi_points init: admin={}, excluded={}, season=[{}..{}]",
+        cfg.admin,
+        cfg.excluded_count,
+        cfg.season_start_ns,
+        cfg.season_end_ns
+    );
+}
+
+#[ic_cdk::pre_upgrade]
+fn pre_upgrade() {
+    state::save_state_to_stable();
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    state::restore_from_stable_or_trap();
+    let cfg = state::points_config();
+    log!(
+        INFO,
+        "rumi_points post_upgrade: admin={}, excluded={}, registered={}",
+        cfg.admin,
+        cfg.excluded_count,
+        cfg.registered_count
+    );
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────
+
+#[ic_cdk::query]
+fn get_principal_state(principal: Principal) -> Option<PrincipalState> {
+    state::get_principal_state(&principal)
+}
+
+#[ic_cdk::query]
+fn get_leaderboard(offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+    state::leaderboard(offset, limit)
+}
+
+#[ic_cdk::query]
+fn get_epoch_history(offset: u32, limit: u32) -> Vec<EpochSummary> {
+    state::epoch_history(offset as u64, limit as u64)
+}
+
+#[ic_cdk::query]
+fn is_registered(principal: Principal) -> bool {
+    state::is_registered(&principal)
+}
+
+#[ic_cdk::query]
+fn get_registration_info(principal: Principal) -> Option<RegistrationInfo> {
+    state::registration_info(&principal)
+}
+
+#[ic_cdk::query]
+fn is_excluded(principal: Principal) -> bool {
+    state::is_excluded(&principal)
+}
+
+#[ic_cdk::query]
+fn get_excluded_principals() -> Vec<Principal> {
+    state::excluded_principals()
+}
+
+#[ic_cdk::query]
+fn get_points_config() -> PointsConfig {
+    state::points_config()
+}
+
+// ── Updates (admin-gated) ───────────────────────────────────────────────────
+
+/// Admin-only. Phase 1 testing aid: enrolls a principal so upgrade survival can
+/// be demonstrated before event ingestion (Phase 2/3) exists.
+#[ic_cdk::update]
+fn register_test_principal(principal: Principal) -> Result<(), PointsError> {
+    state::register_test_principal(ic_cdk::caller(), principal, ic_cdk::api::time())
+}
+
+#[ic_cdk::update]
+fn add_excluded_principal(principal: Principal) -> Result<(), PointsError> {
+    state::add_excluded(ic_cdk::caller(), principal)
+}
+
+#[ic_cdk::update]
+fn remove_excluded_principal(principal: Principal) -> Result<(), PointsError> {
+    state::remove_excluded(ic_cdk::caller(), principal)
+}
+
+#[ic_cdk::update]
+fn set_excluded_principals(principals: Vec<Principal>) -> Result<(), PointsError> {
+    state::set_excluded(ic_cdk::caller(), principals)
+}
+
+ic_cdk::export_candid!();
+
+#[cfg(test)]
+mod candid_tests {
+    use candid_parser::utils::{service_equal, CandidSource};
+    use std::path::Path;
+
+    /// The committed `rumi_points.did` must stay structurally equal to the
+    /// interface generated from the endpoint signatures. Catches schema drift.
+    #[test]
+    fn candid_interface_matches_did_file() {
+        let generated = super::__export_service();
+        service_equal(
+            CandidSource::Text(&generated),
+            CandidSource::File(Path::new("rumi_points.did")),
+        )
+        .unwrap_or_else(|e| {
+            panic!(
+                "rumi_points.did is out of sync with the canister interface:\n{e}\n\n\
+                 --- generated interface ---\n{generated}"
+            )
+        });
+    }
+}

--- a/src/rumi_points/src/poll.rs
+++ b/src/rumi_points/src/poll.rs
@@ -1,0 +1,147 @@
+//! Inter-canister event polling (Phase 2). Pull-based: each source is polled with
+//! a forward cursor, and the decoded events are normalized and applied
+//! (auto-registering principals on their first qualifying action).
+//!
+//! NOT unit-testable (inter-canister calls); validated by the PocketIC E2E. Every
+//! call result is handled (no `unwrap`/trap), so the single-poll guard always
+//! releases: a trap would otherwise leave `POLL_IN_PROGRESS` stuck (canister traps
+//! do not run Rust destructors). One source failing is logged and skipped without
+//! advancing its cursor, so it does not block the others.
+//!
+//! Cursor model (see `events.rs`):
+//!   - backend, 3pool: forward endpoints that return an explicit `next_start`.
+//!   - SP, AMM: oldest-first index endpoints; advance by returned count via
+//!     `ingest_batch` (valid while `id == index`, i.e. before their logs trim,
+//!     far beyond Season-1 volume at current TVL).
+//!
+//! There is intentionally NO periodic timer here (which would burn cycles every
+//! tick). Phase 2 exposes an admin `trigger_poll`; the production timer cadence is
+//! a small follow-up (`setup_timers`).
+
+use candid::Principal;
+use ic_cdk::api::call::RejectionCode;
+
+use crate::events::{self, SourceId};
+use crate::source_types::{amm, backend, stability_pool, three_pool};
+use crate::state;
+
+// Per-call scan/batch bounds (kept under the source endpoints' own caps).
+const BACKEND_SCAN: u64 = 500;
+const THREE_POOL_SCAN: u64 = 500;
+const SP_BATCH: u64 = 500;
+const AMM_BATCH: u64 = 200;
+
+type CallResult<T> = Result<T, (RejectionCode, String)>;
+
+/// Poll every configured source once, under the single-poll guard. Returns the
+/// number of events applied across all sources.
+pub async fn poll_all() -> usize {
+    if !state::try_begin_poll() {
+        return 0; // a poll is already in flight
+    }
+    let mut applied = 0;
+    applied += poll_backend().await;
+    applied += poll_three_pool().await;
+    applied += poll_stability_pool().await;
+    applied += poll_amm().await;
+    state::end_poll();
+    applied
+}
+
+fn source_canister(source: SourceId) -> Option<Principal> {
+    state::get_source_canister(source.tag())
+}
+
+async fn poll_backend() -> usize {
+    let canister = match source_canister(SourceId::Backend) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let tag = SourceId::Backend.tag();
+    let cursor = state::get_cursor(tag);
+    let res: CallResult<(backend::ForwardFilteredEventsResponse,)> = ic_cdk::call(
+        canister,
+        "get_events_forward_filtered",
+        (cursor, BACKEND_SCAN, Some(backend::points_event_filter())),
+    )
+    .await;
+    match res {
+        Ok((resp,)) => {
+            let (events, next_start, _reached_end) = backend::normalize_forward(resp);
+            let n = events.len();
+            events::apply_events(&events);
+            state::set_cursor(tag, next_start);
+            n
+        }
+        Err((code, msg)) => {
+            ic_cdk::println!("[poll] backend get_events_forward_filtered failed: {:?} {}", code, msg);
+            0
+        }
+    }
+}
+
+async fn poll_three_pool() -> usize {
+    let canister = match source_canister(SourceId::ThreePool) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let tag = SourceId::ThreePool.tag();
+    let cursor = state::get_cursor(tag);
+    let res: CallResult<(three_pool::ForwardLiquidityEventsV2,)> =
+        ic_cdk::call(canister, "get_liquidity_events_v2_forward", (cursor, THREE_POOL_SCAN)).await;
+    match res {
+        Ok((resp,)) => {
+            let (events, next_start, _reached_end) = three_pool::normalize_forward(resp);
+            let n = events.len();
+            events::apply_events(&events);
+            state::set_cursor(tag, next_start);
+            n
+        }
+        Err((code, msg)) => {
+            ic_cdk::println!("[poll] 3pool get_liquidity_events_v2_forward failed: {:?} {}", code, msg);
+            0
+        }
+    }
+}
+
+async fn poll_stability_pool() -> usize {
+    let canister = match source_canister(SourceId::StabilityPool) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let cursor = state::get_cursor(SourceId::StabilityPool.tag());
+    let res: CallResult<(Vec<stability_pool::PoolEvent>,)> =
+        ic_cdk::call(canister, "get_pool_events", (cursor, SP_BATCH)).await;
+    match res {
+        Ok((raw,)) => {
+            let events: Vec<_> = raw.into_iter().map(stability_pool::normalize).collect();
+            // Index endpoint: ingest_batch advances the cursor to max(id)+1 (== next
+            // index while id==index). See the trim caveat in events.rs.
+            events::ingest_batch(SourceId::StabilityPool, &events)
+        }
+        Err((code, msg)) => {
+            ic_cdk::println!("[poll] SP get_pool_events failed: {:?} {}", code, msg);
+            0
+        }
+    }
+}
+
+async fn poll_amm() -> usize {
+    let canister = match source_canister(SourceId::Amm) {
+        Some(c) => c,
+        None => return 0,
+    };
+    let cursor = state::get_cursor(SourceId::Amm.tag());
+    let res: CallResult<(Vec<amm::AmmLiquidityEvent>,)> =
+        ic_cdk::call(canister, "get_amm_liquidity_events", (cursor, AMM_BATCH)).await;
+    match res {
+        Ok((raw,)) => {
+            let events: Vec<_> = raw.into_iter().map(amm::normalize).collect();
+            events::ingest_batch(SourceId::Amm, &events)
+        }
+        Err((code, msg)) => {
+            ic_cdk::println!("[poll] AMM get_amm_liquidity_events failed: {:?} {}", code, msg);
+            0
+        }
+    }
+}

--- a/src/rumi_points/src/snapshot_seed.rs
+++ b/src/rumi_points/src/snapshot_seed.rs
@@ -1,0 +1,104 @@
+//! Snapshot-timing randomization (spike 0.3, `2026-05-07-spike-0.3-snapshot-randomization.md`).
+//!
+//! PHASE 1 SCOPE: the seed STATE types below are real and wired into the stable
+//! layout (they must survive upgrades), but the commit-reveal ALGORITHM is a
+//! documented skeleton. The `derive_snapshot_times` / `SeedManager` bodies land
+//! in Phase 5 alongside the weekly epoch driver. Do not implement them here.
+//!
+//! Mechanism (commit-reveal with hash-chained per-epoch seeds, RANDAO-style):
+//!   - At init the admin commits to a secret 32-byte seed S0 by storing only
+//!     `H0 = sha256(S0)` on-chain (`pending_commit`). S0 is revealed after week 1.
+//!   - `seed_N = sha256(seed_{N-1} || epoch_{N-1}_summary_hash)`.
+//!   - Two snapshot times per epoch are derived from `seed_N`, one in each half
+//!     of the week, so they are >= a few hours apart and unpredictable in
+//!     advance but verifiable after the reveal.
+//! Users cannot predict snapshot times; auditors can verify them post-hoc; the
+//! team cannot retroactively change them (each reveal locks the next commit).
+
+#![allow(dead_code)] // Phase 5 surface; types are used by the stable layout now.
+
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+
+/// In-flight seed singleton. Lives inside `state::State` (so it rides the
+/// versioned State blob across upgrades). `current_seed` is held privately until
+/// the epoch closes, then appended to the `RevealedSeed` audit log.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct SnapshotSeedSingleton {
+    /// `sha256` of the seed the NEXT epoch must reveal. `[0u8; 32]` means "not
+    /// yet committed" (Phase 1 default; admin/Phase 5 sets the real H0).
+    pub pending_commit: [u8; 32],
+    /// Plaintext seed for the current (open) epoch, revealed when it closes.
+    pub current_seed: Option<[u8; 32]>,
+}
+
+impl SnapshotSeedSingleton {
+    pub fn is_committed(&self) -> bool {
+        self.pending_commit != [0u8; 32]
+    }
+}
+
+/// One audit-log row per closed epoch (`StableLog<RevealedSeed>`). After an epoch
+/// closes anyone can recompute the snapshot times from `seed` and verify they
+/// match what actually fired.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct RevealedSeed {
+    pub epoch_index: u64,
+    pub seed: [u8; 32],
+    pub snapshot_time_a_ns: u64,
+    pub snapshot_time_b_ns: u64,
+    pub revealed_at_ns: u64,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum SeedError {
+    /// `sha256(seed_for_this_epoch)` did not equal the stored `pending_commit`.
+    /// Indicates state corruption or tampering; the caller must halt the epoch.
+    CommitMismatch,
+    /// `start_epoch` was given no seed for epoch 1 and none was derivable.
+    MissingSeed,
+}
+
+/// Derive the two intra-epoch snapshot timestamps from a seed (spike 0.3).
+///
+/// PHASE 5 (not implemented here). The algorithm, verbatim from the spike:
+/// split the epoch into halves, take `seed[0..8]` mod `half` as snapshot A's
+/// offset into the first half and `seed[8..16]` mod `half` as snapshot B's
+/// offset into the second half. Guarantees A precedes B with a real gap.
+pub fn derive_snapshot_times(
+    _seed: &[u8; 32],
+    _epoch_start_ns: u64,
+    _epoch_end_ns: u64,
+) -> (u64, u64) {
+    unimplemented!("Phase 5: implement per spike 0.3 derive_snapshot_times");
+}
+
+/// Owns the commit-reveal chain across epochs. PHASE 5: full implementation per
+/// the spike's `start_epoch` / `close_epoch` outline. Scaffolded here so the
+/// epoch driver can be written against a stable interface.
+pub struct SeedManager;
+
+impl SeedManager {
+    /// Verify the previously stored seed matches the pending commit, derive this
+    /// epoch's snapshot times, and store the (not-yet-revealed) seed.
+    pub fn start_epoch(
+        _singleton: &mut SnapshotSeedSingleton,
+        _epoch_index: u64,
+        _epoch_start_ns: u64,
+        _epoch_end_ns: u64,
+        _prev_epoch_summary_hash: [u8; 32],
+        _seed_for_this_epoch: Option<[u8; 32]>,
+    ) -> Result<(u64, u64), SeedError> {
+        unimplemented!("Phase 5: implement per spike 0.3 start_epoch");
+    }
+
+    /// Reveal the current seed, append it to the audit log, and compute the next
+    /// epoch's commit `H_{N+1} = sha256(seed_N || epoch_N_summary_hash)`.
+    pub fn close_epoch(
+        _singleton: &mut SnapshotSeedSingleton,
+        _epoch_index: u64,
+        _epoch_summary_hash: [u8; 32],
+    ) -> Result<RevealedSeed, SeedError> {
+        unimplemented!("Phase 5: implement per spike 0.3 close_epoch");
+    }
+}

--- a/src/rumi_points/src/source_types.rs
+++ b/src/rumi_points/src/source_types.rs
@@ -194,6 +194,28 @@ pub mod backend {
             kind,
         }
     }
+
+    /// Mirror of the backend's `get_events_forward_filtered` response (added on
+    /// branch feat/source-forward-event-endpoints). The poller advances its
+    /// backend cursor to `next_start` (a scan position), not `max(event_id)+1`.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct ForwardFilteredEventsResponse {
+        pub events: Vec<(u64, BackendEvent)>,
+        pub next_start: u64,
+        pub reached_end: bool,
+    }
+
+    /// Normalize a forward batch, returning the events plus `(next_start, reached_end)`.
+    pub fn normalize_forward(
+        resp: ForwardFilteredEventsResponse,
+    ) -> (Vec<IngestedEvent>, u64, bool) {
+        let events = resp
+            .events
+            .into_iter()
+            .map(|(id, ev)| normalize(id, ev))
+            .collect();
+        (events, resp.next_start, resp.reached_end)
+    }
 }
 
 // ── rumi_3pool ──────────────────────────────────────────────────────────────
@@ -240,6 +262,23 @@ pub mod three_pool {
             timestamp_ns: ev.timestamp,
             kind,
         }
+    }
+
+    /// Mirror of 3pool's `get_liquidity_events_v2_forward` response (added on
+    /// branch feat/source-forward-event-endpoints). Poller advances to `next_start`.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct ForwardLiquidityEventsV2 {
+        pub events: Vec<(u64, LiquidityEventV2)>,
+        pub next_start: u64,
+        pub reached_end: bool,
+    }
+
+    pub fn normalize_forward(
+        resp: ForwardLiquidityEventsV2,
+    ) -> (Vec<IngestedEvent>, u64, bool) {
+        // The tuple index equals ev.id here; normalize reads ev.id directly.
+        let events = resp.events.into_iter().map(|(_, ev)| normalize(ev)).collect();
+        (events, resp.next_start, resp.reached_end)
     }
 }
 
@@ -588,5 +627,60 @@ mod normalize_tests {
             out.kind,
             IngestKind::AmmAddLiquidity { pool_id: "3usd-icp".into(), lp_shares: 42 }
         );
+    }
+
+    #[test]
+    fn backend_forward_response_roundtrips_and_carries_cursor() {
+        let resp = backend::ForwardFilteredEventsResponse {
+            events: vec![
+                (
+                    10,
+                    backend::BackendEvent::BorrowFromVault {
+                        vault_id: 1,
+                        caller: Some(p(1)),
+                        borrowed_amount: 50,
+                        timestamp: Some(100),
+                    },
+                ),
+                (
+                    11,
+                    backend::BackendEvent::CloseVault { vault_id: 1, timestamp: Some(100) },
+                ),
+            ],
+            next_start: 12,
+            reached_end: true,
+        };
+        let (events, next_start, end) = backend::normalize_forward(roundtrip(&resp));
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_id, 10);
+        assert_eq!(events[0].kind, IngestKind::VaultBorrow { vault_id: 1, amount_e8s: 50 });
+        assert_eq!(events[1].kind, IngestKind::VaultClose { vault_id: 1 });
+        assert_eq!(next_start, 12); // poller advances backend cursor to next_start
+        assert!(end);
+    }
+
+    #[test]
+    fn three_pool_forward_response_roundtrips_and_carries_cursor() {
+        let resp = three_pool::ForwardLiquidityEventsV2 {
+            events: vec![(
+                5,
+                three_pool::LiquidityEventV2 {
+                    id: 5,
+                    timestamp: 100,
+                    caller: p(2),
+                    action: three_pool::LiquidityAction::AddLiquidity,
+                    amounts: vec![1, 2, 3],
+                    migrated: false,
+                },
+            )],
+            next_start: 6,
+            reached_end: false,
+        };
+        let (events, next_start, end) = three_pool::normalize_forward(roundtrip(&resp));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, 5);
+        assert_eq!(events[0].kind, IngestKind::ThreePoolAdd { amounts: [1, 2, 3] });
+        assert_eq!(next_start, 6);
+        assert!(!end);
     }
 }

--- a/src/rumi_points/src/source_types.rs
+++ b/src/rumi_points/src/source_types.rs
@@ -1,0 +1,592 @@
+//! Wire mirror types for the four source canisters (Phase 2), plus the
+//! `normalize_*` functions that turn a decoded source event into the normalized
+//! `events::IngestedEvent`. Types here are derived VERBATIM from each source's
+//! committed candid (extracted 2026-06-02). Only the fields/variants the points
+//! canister needs are mirrored.
+//!
+//! KEY DECODE QUESTION (resolved by the canary tests below): the backend's
+//! `get_events*` return type is the full ~95-variant `Event`. We only mirror the
+//! ~9 variants we care about and fetch with a server-side `types` filter so only
+//! those values come back. Candid's variant subtyping says a superset is NOT a
+//! subtype of a subset, so whether `Decode!` accepts a subset target against a
+//! superset wire type is the load-bearing assumption. The canary test pins it.
+
+#![allow(dead_code)] // request types + normalize are consumed by the poll layer next
+
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+use crate::events::{IngestedEvent, IngestKind, SourceId};
+
+fn to_amounts3(v: &[u128]) -> [u128; 3] {
+    [
+        v.first().copied().unwrap_or(0),
+        v.get(1).copied().unwrap_or(0),
+        v.get(2).copied().unwrap_or(0),
+    ]
+}
+
+// ── rumi_protocol_backend ───────────────────────────────────────────────────
+// The log return type is the full ~95-variant `Event`. We mirror only the 9
+// variants we act on and fetch with a `types` server-side filter so only those
+// VALUES come back (the first canary proves a subset target decodes them). Each
+// record declares only the fields we use; candid record width-subtyping ignores
+// the rest (block_index, fee_amount, icp_rate blobs, Mode, etc.).
+pub mod backend {
+    use super::*;
+
+    /// Argument to `get_events` / `get_events_filtered`. We send a `types` filter
+    /// limited to the variants we mirror; a subset variant value is a subtype of
+    /// the backend's full `EventTypeFilter`, so the call type-checks.
+    #[derive(CandidType, Clone, Debug)]
+    pub struct GetEventsArg {
+        pub principal: Option<Principal>,
+        pub types: Option<Vec<EventTypeFilter>>,
+        pub time_range: Option<EventTimeRange>,
+        pub start: u64,
+        pub collateral_token: Option<Principal>,
+        pub length: u64,
+        pub min_size_e8s: Option<u64>,
+        pub admin_labels: Option<Vec<String>>,
+    }
+
+    #[derive(CandidType, Clone, Debug)]
+    pub struct EventTimeRange {
+        pub start_ns: u64,
+        pub end_ns: u64,
+    }
+
+    /// The subset of the backend's `EventTypeFilter` we request server-side.
+    #[derive(CandidType, Clone, Debug)]
+    pub enum EventTypeFilter {
+        OpenVault,
+        Borrow,
+        Repay,
+        CloseVault,
+        Liquidation,
+        PartialLiquidation,
+        Redemption,
+        StabilityPoolDeposit,
+        StabilityPoolWithdraw,
+    }
+
+    /// The filter we send to only surface the events the points canister acts on.
+    pub fn points_event_filter() -> Vec<EventTypeFilter> {
+        vec![
+            EventTypeFilter::OpenVault,
+            EventTypeFilter::Borrow,
+            EventTypeFilter::Repay,
+            EventTypeFilter::CloseVault,
+            EventTypeFilter::Liquidation,
+            EventTypeFilter::PartialLiquidation,
+            EventTypeFilter::Redemption,
+        ]
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct BackendVault {
+        pub owner: Principal,
+        pub vault_id: u64,
+        pub borrowed_icusd_amount: u64,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub enum BackendEvent {
+        #[serde(rename = "open_vault")]
+        OpenVault {
+            vault: BackendVault,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "borrow_from_vault")]
+        BorrowFromVault {
+            vault_id: u64,
+            caller: Option<Principal>,
+            borrowed_amount: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "repay_to_vault")]
+        RepayToVault {
+            vault_id: u64,
+            caller: Option<Principal>,
+            repayed_amount: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "close_vault")]
+        CloseVault {
+            vault_id: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "liquidate_vault")]
+        LiquidateVault {
+            vault_id: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "partial_liquidate_vault")]
+        PartialLiquidateVault {
+            vault_id: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "redemption_on_vaults")]
+        RedemptionOnVaults {
+            owner: Principal,
+            icusd_amount: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "provide_liquidity")]
+        ProvideLiquidity {
+            caller: Principal,
+            amount: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "withdraw_liquidity")]
+        WithdrawLiquidity {
+            caller: Principal,
+            amount: u64,
+            timestamp: Option<u64>,
+        },
+    }
+
+    pub fn normalize(id: u64, ev: BackendEvent) -> IngestedEvent {
+        let (caller, ts, kind) = match ev {
+            BackendEvent::OpenVault { vault, timestamp } => (
+                Some(vault.owner),
+                timestamp,
+                IngestKind::VaultOpen {
+                    vault_id: vault.vault_id,
+                    borrowed_e8s: vault.borrowed_icusd_amount,
+                },
+            ),
+            BackendEvent::BorrowFromVault { vault_id, caller, borrowed_amount, timestamp } => (
+                caller,
+                timestamp,
+                IngestKind::VaultBorrow { vault_id, amount_e8s: borrowed_amount },
+            ),
+            BackendEvent::RepayToVault { vault_id, caller, repayed_amount, timestamp } => (
+                caller,
+                timestamp,
+                IngestKind::VaultRepay { vault_id, amount_e8s: repayed_amount },
+            ),
+            BackendEvent::CloseVault { vault_id, timestamp } => {
+                (None, timestamp, IngestKind::VaultClose { vault_id })
+            }
+            BackendEvent::LiquidateVault { vault_id, timestamp } => {
+                (None, timestamp, IngestKind::VaultLiquidated { vault_id })
+            }
+            BackendEvent::PartialLiquidateVault { vault_id, timestamp } => {
+                (None, timestamp, IngestKind::VaultLiquidated { vault_id })
+            }
+            BackendEvent::RedemptionOnVaults { owner, icusd_amount, timestamp } => (
+                Some(owner),
+                timestamp,
+                IngestKind::VaultRedeemed { amount_e8s: icusd_amount },
+            ),
+            // Legacy backend-side stability pool, superseded by the
+            // rumi_stability_pool canister; ignore to avoid double-counting.
+            BackendEvent::ProvideLiquidity { .. } | BackendEvent::WithdrawLiquidity { .. } => {
+                (None, None, IngestKind::Other)
+            }
+        };
+        IngestedEvent {
+            source: SourceId::Backend,
+            event_id: id,
+            caller,
+            timestamp_ns: ts.unwrap_or(0),
+            kind,
+        }
+    }
+}
+
+// ── rumi_3pool ──────────────────────────────────────────────────────────────
+pub mod three_pool {
+    use super::*;
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq)]
+    pub enum LiquidityAction {
+        AddLiquidity,
+        RemoveLiquidity,
+        RemoveOneCoin,
+        Donate,
+    }
+
+    /// `amounts` is `[icUSD, ckUSDT, ckUSDC]`. Only the fields we use are mirrored.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct LiquidityEventV2 {
+        pub id: u64,
+        pub timestamp: u64,
+        pub caller: Principal,
+        pub action: LiquidityAction,
+        pub amounts: Vec<u128>,
+        pub migrated: bool,
+    }
+
+    pub fn normalize(ev: LiquidityEventV2) -> IngestedEvent {
+        let amounts = to_amounts3(&ev.amounts);
+        // `migrated` rows are v1->v2 backfill (pre-season); exclude from accrual.
+        let kind = if ev.migrated {
+            IngestKind::Other
+        } else {
+            match ev.action {
+                LiquidityAction::AddLiquidity => IngestKind::ThreePoolAdd { amounts },
+                LiquidityAction::RemoveLiquidity | LiquidityAction::RemoveOneCoin => {
+                    IngestKind::ThreePoolRemove { amounts }
+                }
+                LiquidityAction::Donate => IngestKind::Other,
+            }
+        };
+        IngestedEvent {
+            source: SourceId::ThreePool,
+            event_id: ev.id,
+            caller: Some(ev.caller),
+            timestamp_ns: ev.timestamp,
+            kind,
+        }
+    }
+}
+
+// ── rumi_stability_pool ─────────────────────────────────────────────────────
+// `get_pool_events` has no server-side filter, so ALL variants can appear as
+// values. The second canary proves candid rejects unknown-variant values, so we
+// must mirror every variant. Ones we do not act on carry an empty record payload
+// (`{}`), which the wire record is a width-subtype of.
+pub mod stability_pool {
+    use super::*;
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub enum PoolEventType {
+        Deposit { token_ledger: Principal, amount: u64 },
+        Withdraw { token_ledger: Principal, amount: u64 },
+        DepositAs3USD { token_ledger: Principal, amount_in: u64, lp_minted: u64 },
+        ClaimCollateral {},
+        InterestReceived {},
+        OptOutCollateral {},
+        OptInCollateral {},
+        LiquidationNotification {},
+        LiquidationExecuted {},
+        StablecoinRegistered {},
+        CollateralRegistered {},
+        ConfigurationUpdated,
+        EmergencyPauseActivated,
+        OperationsResumed,
+        BalanceCorrected {},
+        CollateralGainCorrected {},
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct PoolEvent {
+        pub id: u64,
+        pub timestamp: u64,
+        pub caller: Principal,
+        pub event_type: PoolEventType,
+    }
+
+    pub fn normalize(ev: PoolEvent) -> IngestedEvent {
+        let kind = match ev.event_type {
+            PoolEventType::Deposit { token_ledger, amount } => {
+                IngestKind::SpDeposit { token_ledger, amount_e8s: amount }
+            }
+            // Deposit-as-3USD: the input asset funded a 3USD position in the SP.
+            PoolEventType::DepositAs3USD { token_ledger, amount_in, .. } => {
+                IngestKind::SpDeposit { token_ledger, amount_e8s: amount_in }
+            }
+            PoolEventType::Withdraw { token_ledger, amount } => {
+                IngestKind::SpWithdraw { token_ledger, amount_e8s: amount }
+            }
+            _ => IngestKind::Other,
+        };
+        IngestedEvent {
+            source: SourceId::StabilityPool,
+            event_id: ev.id,
+            caller: Some(ev.caller),
+            timestamp_ns: ev.timestamp,
+            kind,
+        }
+    }
+}
+
+// ── rumi_amm ────────────────────────────────────────────────────────────────
+pub mod amm {
+    use super::*;
+
+    #[derive(CandidType, Deserialize, Clone, Debug, PartialEq)]
+    pub enum AmmLiquidityAction {
+        AddLiquidity,
+        RemoveLiquidity,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct AmmLiquidityEvent {
+        pub id: u64,
+        pub caller: Principal,
+        pub pool_id: String,
+        pub action: AmmLiquidityAction,
+        pub lp_shares: u128,
+        pub timestamp: u64,
+    }
+
+    pub fn normalize(ev: AmmLiquidityEvent) -> IngestedEvent {
+        let kind = match ev.action {
+            AmmLiquidityAction::AddLiquidity => IngestKind::AmmAddLiquidity {
+                pool_id: ev.pool_id,
+                lp_shares: ev.lp_shares,
+            },
+            AmmLiquidityAction::RemoveLiquidity => IngestKind::AmmRemoveLiquidity {
+                pool_id: ev.pool_id,
+                lp_shares: ev.lp_shares,
+            },
+        };
+        IngestedEvent {
+            source: SourceId::Amm,
+            event_id: ev.id,
+            caller: Some(ev.caller),
+            timestamp_ns: ev.timestamp,
+            kind,
+        }
+    }
+}
+
+#[cfg(test)]
+mod canary {
+    use candid::{CandidType, Decode, Encode};
+    use serde::Deserialize;
+
+    // Encoder side: a 3-variant "superset" (mimics the backend's big Event).
+    #[derive(CandidType, Deserialize)]
+    enum Superset {
+        A(u64),
+        B(u32),
+        C, // a variant absent from the decoder's subset type
+    }
+
+    // Decoder side: a 2-variant "subset" (mimics our 9-of-95 mirror).
+    #[derive(CandidType, Deserialize, Debug, PartialEq)]
+    enum Subset {
+        A(u64),
+        B(u32),
+    }
+
+    /// The load-bearing assumption: a value whose tag IS in the subset decodes,
+    /// even though the wire type table also declares the extra variant `C`.
+    #[test]
+    fn decode_shared_variant_from_superset_wire_type() {
+        let bytes = Encode!(&Superset::A(7)).unwrap();
+        let got = Decode!(&bytes, Subset).unwrap();
+        assert_eq!(got, Subset::A(7));
+
+        let bytes_b = Encode!(&Superset::B(9)).unwrap();
+        let got_b = Decode!(&bytes_b, Subset).unwrap();
+        assert_eq!(got_b, Subset::B(9));
+    }
+
+    /// And the inverse we rely on for ARGS: a subset value encodes and decodes
+    /// against a superset target (this direction is plain subtyping and must work).
+    #[test]
+    fn decode_subset_value_into_superset_target() {
+        let bytes = Encode!(&Subset::A(7)).unwrap();
+        let got = Decode!(&bytes, Superset).unwrap();
+        assert!(matches!(got, Superset::A(7)));
+    }
+
+    // Does candid honor serde's #[serde(other)] catch-all when the wire VALUE is
+    // a variant absent from the target? If yes, sources with no server-side
+    // filter (the stability pool) need only mirror the variants they act on plus
+    // one catch-all, instead of all 16.
+    #[derive(CandidType, Deserialize, Debug, PartialEq)]
+    enum SubsetWithOther {
+        A(u64),
+        #[serde(other)]
+        Unknown,
+    }
+
+    /// Pins the NEGATIVE result: candid does NOT honor `#[serde(other)]`. A wire
+    /// value whose variant is absent from the target fails to decode. This is WHY
+    /// unfiltered sources (the stability pool) must mirror every variant that can
+    /// appear in their log, and why the backend (which CAN filter server-side)
+    /// only mirrors its 9 and passes a `types` filter.
+    #[test]
+    fn candid_does_not_honor_serde_other_catch_all() {
+        let bytes = Encode!(&Superset::C).unwrap(); // C is absent from SubsetWithOther
+        let decoded = Decode!(&bytes, SubsetWithOther);
+        assert!(
+            decoded.is_err(),
+            "if candid ever gains serde(other) support, the SP mirror can be slimmed to a subset"
+        );
+    }
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::*;
+    use crate::events::{IngestKind, SourceId};
+    use candid::{Decode, Encode};
+
+    fn p(n: u8) -> Principal {
+        Principal::from_slice(&[n, n, n, n, n])
+    }
+
+    /// Candid round-trip through a mirror type (proves it is candid-valid and
+    /// decodes the way the wire would encode it).
+    fn roundtrip<T: CandidType + for<'de> Deserialize<'de>>(v: &T) -> T {
+        let bytes = Encode!(v).unwrap();
+        Decode!(&bytes, T).unwrap()
+    }
+
+    #[test]
+    fn backend_borrow_normalizes_to_vault_borrow() {
+        let ev = backend::BackendEvent::BorrowFromVault {
+            vault_id: 3,
+            caller: Some(p(1)),
+            borrowed_amount: 500,
+            timestamp: Some(123),
+        };
+        let out = backend::normalize(7, roundtrip(&ev));
+        assert_eq!(out.source, SourceId::Backend);
+        assert_eq!(out.event_id, 7);
+        assert_eq!(out.caller, Some(p(1)));
+        assert_eq!(out.timestamp_ns, 123);
+        assert_eq!(out.kind, IngestKind::VaultBorrow { vault_id: 3, amount_e8s: 500 });
+    }
+
+    #[test]
+    fn backend_open_uses_vault_owner_and_borrowed_amount() {
+        let ev = backend::BackendEvent::OpenVault {
+            vault: backend::BackendVault { owner: p(2), vault_id: 9, borrowed_icusd_amount: 1000 },
+            timestamp: Some(50),
+        };
+        let out = backend::normalize(1, roundtrip(&ev));
+        assert_eq!(out.caller, Some(p(2)));
+        assert_eq!(out.kind, IngestKind::VaultOpen { vault_id: 9, borrowed_e8s: 1000 });
+    }
+
+    #[test]
+    fn backend_close_has_no_caller() {
+        let ev = backend::BackendEvent::CloseVault { vault_id: 4, timestamp: Some(1) };
+        let out = backend::normalize(2, roundtrip(&ev));
+        assert_eq!(out.caller, None);
+        assert_eq!(out.kind, IngestKind::VaultClose { vault_id: 4 });
+    }
+
+    /// Decisive backend case: a value encoded by a SUPERSET type (an extra
+    /// variant in the type table, mimicking the real ~95-variant Event) decodes
+    /// into our 9-variant mirror.
+    #[derive(CandidType, Deserialize)]
+    enum BackendSuperset {
+        #[serde(rename = "borrow_from_vault")]
+        BorrowFromVault {
+            vault_id: u64,
+            caller: Option<Principal>,
+            borrowed_amount: u64,
+            timestamp: Option<u64>,
+        },
+        #[serde(rename = "some_variant_we_do_not_mirror")]
+        SomethingElse { x: u64 },
+    }
+
+    #[test]
+    fn backend_subset_decodes_value_from_superset_wire_type() {
+        let bytes = Encode!(&BackendSuperset::BorrowFromVault {
+            vault_id: 5,
+            caller: Some(p(3)),
+            borrowed_amount: 250,
+            timestamp: Some(99),
+        })
+        .unwrap();
+        let ev = Decode!(&bytes, backend::BackendEvent).unwrap();
+        assert_eq!(
+            backend::normalize(0, ev).kind,
+            IngestKind::VaultBorrow { vault_id: 5, amount_e8s: 250 }
+        );
+    }
+
+    #[test]
+    fn three_pool_add_carries_amounts_and_migrated_is_excluded() {
+        let ev = three_pool::LiquidityEventV2 {
+            id: 2,
+            timestamp: 10,
+            caller: p(1),
+            action: three_pool::LiquidityAction::AddLiquidity,
+            amounts: vec![100, 200, 300],
+            migrated: false,
+        };
+        assert_eq!(
+            three_pool::normalize(roundtrip(&ev)).kind,
+            IngestKind::ThreePoolAdd { amounts: [100, 200, 300] }
+        );
+
+        let migrated = three_pool::LiquidityEventV2 {
+            id: 3,
+            timestamp: 10,
+            caller: p(1),
+            action: three_pool::LiquidityAction::AddLiquidity,
+            amounts: vec![1, 2, 3],
+            migrated: true,
+        };
+        assert_eq!(three_pool::normalize(migrated).kind, IngestKind::Other);
+    }
+
+    #[test]
+    fn sp_deposit_normalizes_and_unhandled_payload_variant_decodes() {
+        let ev = stability_pool::PoolEvent {
+            id: 1,
+            timestamp: 5,
+            caller: p(1),
+            event_type: stability_pool::PoolEventType::Deposit { token_ledger: p(9), amount: 77 },
+        };
+        assert_eq!(
+            stability_pool::normalize(roundtrip(&ev)).kind,
+            IngestKind::SpDeposit { token_ledger: p(9), amount_e8s: 77 }
+        );
+
+        // A wire value of an unhandled variant that really carries a record
+        // payload must still decode into our empty-payload mirror variant.
+        #[derive(CandidType)]
+        enum SpFull {
+            LiquidationExecuted {
+                vault_id: u64,
+                stables_consumed_e8s: u64,
+                collateral_gained: u64,
+                collateral_type: Principal,
+                success: bool,
+            },
+        }
+        #[derive(CandidType)]
+        struct SpEventFull {
+            id: u64,
+            timestamp: u64,
+            caller: Principal,
+            event_type: SpFull,
+        }
+        let bytes = Encode!(&SpEventFull {
+            id: 2,
+            timestamp: 6,
+            caller: p(1),
+            event_type: SpFull::LiquidationExecuted {
+                vault_id: 1,
+                stables_consumed_e8s: 1,
+                collateral_gained: 1,
+                collateral_type: p(2),
+                success: true,
+            },
+        })
+        .unwrap();
+        let decoded = Decode!(&bytes, stability_pool::PoolEvent).unwrap();
+        assert_eq!(stability_pool::normalize(decoded).kind, IngestKind::Other);
+    }
+
+    #[test]
+    fn amm_add_normalizes_to_provide_liquidity() {
+        let ev = amm::AmmLiquidityEvent {
+            id: 1,
+            caller: p(1),
+            pool_id: "3usd-icp".into(),
+            action: amm::AmmLiquidityAction::AddLiquidity,
+            lp_shares: 42,
+            timestamp: 8,
+        };
+        let out = amm::normalize(roundtrip(&ev));
+        assert_eq!(out.caller, Some(p(1)));
+        assert_eq!(
+            out.kind,
+            IngestKind::AmmAddLiquidity { pool_id: "3usd-icp".into(), lp_shares: 42 }
+        );
+    }
+}

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -1,0 +1,833 @@
+//! Stable-storage layer and Phase 1 state logic.
+//!
+//! Mirrors the established `rumi_protocol_backend::storage` pattern: a
+//! `thread_local!` `MemoryManager` partitions stable memory, each structure gets
+//! ONE `MemoryId` that is NEVER reused, entries are CBOR-encoded with ciborium,
+//! and the singleton config blob uses the 8-byte little-endian length prefix with
+//! a corrupt-length sanity check (`save_state_to_stable` / `load_state_from_stable`).
+//!
+//! ## Stable memory map (MemoryId -> structure)
+//! | Id | Structure                                            | Backs                          |
+//! |----|------------------------------------------------------|--------------------------------|
+//! | 0  | `StableBTreeMap<Principal, StoredPrincipalState>`    | per-principal accrual state    |
+//! | 1  | `StableLog` index  } `StoredPointEntry`              | append-only audit ledger       |
+//! | 2  | `StableLog` data   }                                 |                                |
+//! | 3  | `StableLog` index  } `StoredEpochSummary`            | per-epoch rollups              |
+//! | 4  | `StableLog` data   }                                 |                                |
+//! | 5  | `StableLog` index  } `StoredRevealedSeed`            | commit-reveal audit log (0.3)  |
+//! | 6  | `StableLog` data   }                                 |                                |
+//! | 7  | singleton blob (8-byte len prefix + CBOR)            | `State` (admin/excluded/season/seed) |
+//!
+//! ## Versioned-snapshot pattern (UPG-002 safety) -- READ BEFORE ADDING A FIELD
+//! Every at-rest type is wrapped in an externally-tagged `Stored*` enum whose
+//! CBOR carries the version tag (`{"V1": {...}}`). Adding a field to a logical
+//! type (`PrincipalState`, `State`, ...) WITHOUT this discipline silently wipes
+//! state on the next upgrade (`#[serde(default)]` does NOT save you with the
+//! Candid path, and we want the same guarantee for the ciborium path).
+//!
+//! To add a field to e.g. `PrincipalState`:
+//!   1. Copy TODAY's `PrincipalState` shape into a frozen `struct PrincipalStateV1`.
+//!   2. Add the field to `PrincipalState` (now the "current" / V2 shape).
+//!   3. Change the enum to `{ V1(PrincipalStateV1), V2(PrincipalState) }`.
+//!   4. Add `impl From<PrincipalStateV1> for PrincipalState` (default the new field).
+//!   5. In `into_current`, map `V1(old) => old.into()`. Write the current shape as `V2`.
+//! Old `{"V1": ...}` bytes keep decoding into the frozen V1 struct, then migrate
+//! on read. No wipe. This is the `AmmStateV<N>` pattern that the project already
+//! relies on after the 2026-05-18 AMM state-wipe incident.
+
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+
+use candid::Principal;
+use ic_stable_structures::{
+    log::Log as StableLog,
+    memory_manager::{MemoryId, MemoryManager, VirtualMemory},
+    storable::{Bound, Storable},
+    DefaultMemoryImpl, Memory, StableBTreeMap,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::snapshot_seed::{RevealedSeed, SnapshotSeedSingleton};
+use crate::types::{
+    EpochSummary, InitArgs, LeaderboardEntry, PointEntry, PointSource, PointsConfig, PointsError,
+    PrincipalState, QualifyingAction, RegistrationInfo,
+};
+
+// ── Memory ids (never reuse) ────────────────────────────────────────────────
+
+const PRINCIPAL_STATE_MEM_ID: MemoryId = MemoryId::new(0);
+const POINT_LEDGER_INDEX_MEM_ID: MemoryId = MemoryId::new(1);
+const POINT_LEDGER_DATA_MEM_ID: MemoryId = MemoryId::new(2);
+const EPOCH_SUMMARY_INDEX_MEM_ID: MemoryId = MemoryId::new(3);
+const EPOCH_SUMMARY_DATA_MEM_ID: MemoryId = MemoryId::new(4);
+const REVEALED_SEEDS_INDEX_MEM_ID: MemoryId = MemoryId::new(5);
+const REVEALED_SEEDS_DATA_MEM_ID: MemoryId = MemoryId::new(6);
+const STATE_BLOB_MEM_ID: MemoryId = MemoryId::new(7);
+
+const WASM_PAGE_SIZE: u64 = 65_536; // 64 KiB
+
+type VMem = VirtualMemory<DefaultMemoryImpl>;
+
+// ── At-rest versioned wrappers ──────────────────────────────────────────────
+
+/// Versioned wrapper for per-principal state. See the module doc for the
+/// field-addition recipe. TODAY there is one version.
+#[derive(Serialize, Deserialize)]
+pub enum StoredPrincipalState {
+    V1(PrincipalState),
+}
+
+impl StoredPrincipalState {
+    fn into_current(self) -> PrincipalState {
+        match self {
+            StoredPrincipalState::V1(v) => v,
+        }
+    }
+    fn from_current(v: PrincipalState) -> Self {
+        StoredPrincipalState::V1(v)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum StoredPointEntry {
+    V1(PointEntry),
+}
+
+impl StoredPointEntry {
+    #[allow(dead_code)] // ledger read path (personal breakdown) lands in Phase 6
+    fn into_current(self) -> PointEntry {
+        match self {
+            StoredPointEntry::V1(v) => v,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum StoredEpochSummary {
+    V1(EpochSummary),
+}
+
+impl StoredEpochSummary {
+    fn into_current(self) -> EpochSummary {
+        match self {
+            StoredEpochSummary::V1(v) => v,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum StoredRevealedSeed {
+    V1(RevealedSeed),
+}
+
+impl StoredRevealedSeed {
+    #[allow(dead_code)] // read path lands with the Phase 5 reveal query
+    fn into_current(self) -> RevealedSeed {
+        match self {
+            StoredRevealedSeed::V1(v) => v,
+        }
+    }
+}
+
+/// Singleton config (admin, excluded set, season window, epoch counter, in-flight
+/// seed). Held on the heap during execution and serialized to the `STATE_BLOB`
+/// region on `pre_upgrade`, mirroring the backend. NOT candid-facing.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct State {
+    pub admin: Principal,
+    pub excluded_principals: BTreeSet<Principal>,
+    pub season_start_ns: u64,
+    pub season_end_ns: u64,
+    pub current_epoch_index: u64,
+    pub snapshot_seed: SnapshotSeedSingleton,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum StoredState {
+    V1(State),
+}
+
+/// CBOR `Storable` impl (ciborium), `Bound::Unbounded` per the stable-memory
+/// skill's guidance (avoids the bounded-max-size break when a field is added).
+macro_rules! impl_cbor_storable {
+    ($t:ty) => {
+        impl Storable for $t {
+            fn to_bytes(&self) -> Cow<'_, [u8]> {
+                let mut buf = Vec::new();
+                ciborium::ser::into_writer(self, &mut buf)
+                    .expect(concat!("failed to CBOR-encode ", stringify!($t)));
+                Cow::Owned(buf)
+            }
+            fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+                ciborium::de::from_reader(bytes.as_ref())
+                    .expect(concat!("failed to CBOR-decode ", stringify!($t)))
+            }
+            const BOUND: Bound = Bound::Unbounded;
+        }
+    };
+}
+
+impl_cbor_storable!(StoredPrincipalState);
+impl_cbor_storable!(StoredPointEntry);
+impl_cbor_storable!(StoredEpochSummary);
+impl_cbor_storable!(StoredRevealedSeed);
+
+/// `StableBTreeMap` key wrapper. ic-stable-structures 0.6.5 does not provide a
+/// `Storable` impl for `Principal`, so we wrap it. A principal is at most 29
+/// bytes; bounded (not fixed) so short principals do not waste space.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
+pub struct StorablePrincipal(pub Principal);
+
+impl Storable for StorablePrincipal {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.0.as_slice().to_vec())
+    }
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        StorablePrincipal(Principal::from_slice(bytes.as_ref()))
+    }
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 29,
+        is_fixed_size: false,
+    };
+}
+
+// ── Thread-local stable storage ─────────────────────────────────────────────
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    static PRINCIPALS: RefCell<StableBTreeMap<StorablePrincipal, StoredPrincipalState, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(PRINCIPAL_STATE_MEM_ID))));
+
+    static POINT_LEDGER: RefCell<StableLog<StoredPointEntry, VMem, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(
+            StableLog::init(m.borrow().get(POINT_LEDGER_INDEX_MEM_ID), m.borrow().get(POINT_LEDGER_DATA_MEM_ID))
+                .expect("failed to init point ledger")
+        ));
+
+    static EPOCH_SUMMARIES: RefCell<StableLog<StoredEpochSummary, VMem, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(
+            StableLog::init(m.borrow().get(EPOCH_SUMMARY_INDEX_MEM_ID), m.borrow().get(EPOCH_SUMMARY_DATA_MEM_ID))
+                .expect("failed to init epoch summaries")
+        ));
+
+    static REVEALED_SEEDS: RefCell<StableLog<StoredRevealedSeed, VMem, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(
+            StableLog::init(m.borrow().get(REVEALED_SEEDS_INDEX_MEM_ID), m.borrow().get(REVEALED_SEEDS_DATA_MEM_ID))
+                .expect("failed to init revealed seeds")
+        ));
+
+    /// Singleton config, heap-resident during execution (restored from the blob
+    /// in `post_upgrade`, populated fresh in `init`).
+    static STATE: RefCell<Option<State>> = RefCell::new(None);
+}
+
+// ── Excluded-principals seed (spec Section 11) ──────────────────────────────
+
+/// The protocol-OWNED canister principals seeded into the excluded set at init.
+/// These hold balances that would otherwise accrue dollar-days and route the
+/// airdrop pool into the protocol's own infrastructure. Confirmed against
+/// `canister_ids.json` (2026-06-01). Founder/team principals are deliberately
+/// NOT here (see spec Section 11). `rumi_analytics` is deliberately omitted (it
+/// holds no qualifying balances); the admin can add it via `add_excluded`.
+///
+/// These literals are the SEED applied to mutable state at init; enforcement
+/// reads the mutable `State.excluded_principals` set, not these constants, so the
+/// set stays admin-configurable.
+pub fn protocol_owned_canister_seed() -> Vec<Principal> {
+    [
+        "tfesu-vyaaa-aaaap-qrd7a-cai", // rumi_protocol_backend
+        "fohh4-yyaaa-aaaap-qtkpa-cai", // rumi_3pool
+        "ijlzs-2yaaa-aaaap-quaaq-cai", // rumi_amm
+        "tmhzi-dqaaa-aaaap-qrd6q-cai", // rumi_stability_pool
+        "tlg74-oiaaa-aaaap-qrd6a-cai", // rumi_treasury
+        "nygob-3qaaa-aaaap-qttcq-cai", // liquidation_bot
+        "t6bor-paaaa-aaaap-qrd5q-cai", // icusd_ledger
+        "6niqu-siaaa-aaaap-qrjeq-cai", // icusd_index
+        "jagpu-pyaaa-aaaap-qtm6q-cai", // threeusd_index
+    ]
+    .iter()
+    .map(|s| Principal::from_text(s).expect("invalid protocol-owned principal literal"))
+    .collect()
+}
+
+// ── State access helpers ────────────────────────────────────────────────────
+
+pub fn with_state<R>(f: impl FnOnce(&State) -> R) -> R {
+    STATE.with(|s| f(s.borrow().as_ref().expect("state not initialized")))
+}
+
+pub fn with_state_mut<R>(f: impl FnOnce(&mut State) -> R) -> R {
+    STATE.with(|s| f(s.borrow_mut().as_mut().expect("state not initialized")))
+}
+
+fn require_admin(caller: Principal) -> Result<(), PointsError> {
+    with_state(|s| {
+        if s.admin == caller {
+            Ok(())
+        } else {
+            Err(PointsError::Unauthorized)
+        }
+    })
+}
+
+// ── Phase 1 logic (TDD targets; implemented after the failing tests) ────────
+
+/// Build the singleton `State` from init args (defaulting admin to `caller`,
+/// excluded set to the protocol-owned seed, and the season window to the locked
+/// defaults) and install it on the heap. Called from `#[init]`.
+pub fn init_state(args: Option<InitArgs>, caller: Principal) {
+    let args = args.unwrap_or_default();
+    let admin = args.admin.unwrap_or(caller);
+    let excluded_principals: BTreeSet<Principal> = args
+        .excluded_principals
+        .unwrap_or_else(protocol_owned_canister_seed)
+        .into_iter()
+        .collect();
+    let snapshot_seed = SnapshotSeedSingleton {
+        pending_commit: args.snapshot_seed_commit.unwrap_or([0u8; 32]),
+        current_seed: None,
+    };
+    let state = State {
+        admin,
+        excluded_principals,
+        season_start_ns: args.season_start_ns.unwrap_or(crate::DEFAULT_SEASON_START_NS),
+        season_end_ns: args.season_end_ns.unwrap_or(crate::DEFAULT_SEASON_END_NS),
+        current_epoch_index: 0,
+        snapshot_seed,
+    };
+    STATE.with(|cell| *cell.borrow_mut() = Some(state));
+}
+
+/// Is this principal in the configurable excluded set? Checked at the
+/// registration / accrual boundary (full accrual enforcement lands in Phase 3).
+pub fn is_excluded(p: &Principal) -> bool {
+    with_state(|s| s.excluded_principals.contains(p))
+}
+
+pub fn excluded_principals() -> Vec<Principal> {
+    with_state(|s| s.excluded_principals.iter().cloned().collect())
+}
+
+pub fn add_excluded(caller: Principal, p: Principal) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    with_state_mut(|s| {
+        s.excluded_principals.insert(p);
+    });
+    Ok(())
+}
+
+pub fn remove_excluded(caller: Principal, p: Principal) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    with_state_mut(|s| {
+        s.excluded_principals.remove(&p);
+    });
+    Ok(())
+}
+
+pub fn set_excluded(caller: Principal, principals: Vec<Principal>) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    with_state_mut(|s| {
+        s.excluded_principals = principals.into_iter().collect();
+    });
+    Ok(())
+}
+
+/// Register a principal (idempotent). Rejects excluded principals. Writes a
+/// zero-point `Registration` audit marker on first registration. This is the
+/// boundary the auto-registration ingestion (Phase 3) will also call.
+pub fn register(
+    principal: Principal,
+    now_ns: u64,
+    action: QualifyingAction,
+) -> Result<PrincipalState, PointsError> {
+    if is_excluded(&principal) {
+        return Err(PointsError::Excluded);
+    }
+    if let Some(existing) = get_principal_state(&principal) {
+        // Idempotent: never overwrite the original registration timestamp/action.
+        return Ok(existing);
+    }
+    let ps = PrincipalState::new(principal, now_ns, action);
+    put_principal_state(ps.clone());
+    append_point_entry(PointEntry {
+        principal,
+        epoch_index: current_epoch_index(),
+        points_delta: 0,
+        source: PointSource::Registration,
+        recorded_at_ns: now_ns,
+    });
+    Ok(ps)
+}
+
+/// Admin-only test registration (Phase 1 only). Lets us seed state to prove
+/// upgrade survival before ingestion exists.
+pub fn register_test_principal(
+    caller: Principal,
+    principal: Principal,
+    now_ns: u64,
+) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    // Phase 1 test enrollment uses a fixed placeholder action; real ingestion
+    // (Phase 3) records the true first qualifying action.
+    register(principal, now_ns, QualifyingAction::MintIcUsd)?;
+    Ok(())
+}
+
+/// Ranked leaderboard (desc by points, principal as tiebreak), paginated, with
+/// each entry's estimated share of the 5% pool in basis points.
+pub fn leaderboard(offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+    let mut all: Vec<(Principal, u128)> = PRINCIPALS.with(|m| {
+        m.borrow()
+            .iter()
+            .map(|(k, v)| (k.0, v.into_current().total_points))
+            .collect()
+    });
+    // Highest points first; principal id as a stable tiebreak.
+    all.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let total_points_all: u128 = all.iter().map(|(_, pts)| *pts).sum();
+
+    all.into_iter()
+        .enumerate()
+        .skip(offset as usize)
+        .take(limit as usize)
+        .map(|(idx, (principal, total_points))| {
+            let estimated_share_bps = if total_points_all == 0 {
+                0
+            } else {
+                (total_points.saturating_mul(10_000) / total_points_all) as u32
+            };
+            LeaderboardEntry {
+                rank: idx as u32 + 1,
+                principal,
+                total_points,
+                estimated_share_bps,
+            }
+        })
+        .collect()
+}
+
+pub fn epoch_history(offset: u64, limit: u64) -> Vec<EpochSummary> {
+    EPOCH_SUMMARIES.with(|l| {
+        let log = l.borrow();
+        let len = log.len();
+        let mut out = Vec::new();
+        let mut i = offset;
+        while i < len && (out.len() as u64) < limit {
+            if let Some(s) = log.get(i) {
+                out.push(s.into_current());
+            }
+            i += 1;
+        }
+        out
+    })
+}
+
+/// Serialize the heap `State` (as `StoredState::V1`) to the singleton blob with
+/// the 8-byte little-endian length prefix. Called from `#[pre_upgrade]`.
+pub fn save_state_to_stable() {
+    let bytes = with_state(|s| {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&StoredState::V1(s.clone()), &mut buf)
+            .expect("failed to serialize State to CBOR");
+        buf
+    });
+    MEMORY_MANAGER.with(|m| {
+        let mem = m.borrow().get(STATE_BLOB_MEM_ID);
+        let total_bytes = 8 + bytes.len() as u64;
+        let pages_needed = (total_bytes + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+        let current_pages = mem.size();
+        if pages_needed > current_pages {
+            assert!(
+                mem.grow(pages_needed - current_pages) != -1,
+                "failed to grow state memory"
+            );
+        }
+        mem.write(0, &(bytes.len() as u64).to_le_bytes());
+        mem.write(8, &bytes);
+    });
+}
+
+/// Restore the heap `State` from the singleton blob. Returns `None` if nothing
+/// was saved or the blob is corrupt. Called from `#[post_upgrade]`.
+pub fn load_state_from_stable() -> Option<State> {
+    MEMORY_MANAGER.with(|m| {
+        let mem = m.borrow().get(STATE_BLOB_MEM_ID);
+        if mem.size() == 0 {
+            return None;
+        }
+        let mut len_bytes = [0u8; 8];
+        mem.read(0, &mut len_bytes);
+        let len = u64::from_le_bytes(len_bytes);
+        if len == 0 {
+            return None;
+        }
+        // Sanity check: the recorded length must fit in allocated memory (minus
+        // the 8-byte prefix). Guards against a corrupt / partially-written blob.
+        let mem_bytes = mem.size() * WASM_PAGE_SIZE;
+        if len > mem_bytes.saturating_sub(8) {
+            ic_cdk::println!(
+                "[upgrade] corrupt state length {} exceeds memory size {}",
+                len,
+                mem_bytes
+            );
+            return None;
+        }
+        let mut buf = vec![0u8; len as usize];
+        mem.read(8, &mut buf);
+        match ciborium::de::from_reader::<StoredState, _>(buf.as_slice()) {
+            Ok(StoredState::V1(s)) => Some(s),
+            Err(e) => {
+                ic_cdk::println!("[upgrade] failed to deserialize State: {:?}", e);
+                None
+            }
+        }
+    })
+}
+
+/// `post_upgrade` entry point: load the singleton blob and install it. Traps
+/// rather than silently re-initializing, so a failed restore is loud (never a
+/// silent wipe). The `StableBTreeMap` / `StableLog` structures auto-restore from
+/// stable memory independently and need no action here.
+pub fn restore_from_stable_or_trap() {
+    match load_state_from_stable() {
+        Some(s) => STATE.with(|cell| *cell.borrow_mut() = Some(s)),
+        None => ic_cdk::trap(
+            "post_upgrade: no saved State found in the singleton blob; refusing to silently reset",
+        ),
+    }
+}
+
+// ── Thin accessors (plumbing exercised by the behavioral tests) ─────────────
+
+pub fn get_principal_state(p: &Principal) -> Option<PrincipalState> {
+    PRINCIPALS.with(|m| m.borrow().get(&StorablePrincipal(*p)).map(|s| s.into_current()))
+}
+
+fn put_principal_state(ps: PrincipalState) {
+    PRINCIPALS.with(|m| {
+        m.borrow_mut()
+            .insert(StorablePrincipal(ps.principal), StoredPrincipalState::from_current(ps));
+    });
+}
+
+pub fn is_registered(p: &Principal) -> bool {
+    PRINCIPALS.with(|m| m.borrow().contains_key(&StorablePrincipal(*p)))
+}
+
+pub fn registration_info(p: &Principal) -> Option<RegistrationInfo> {
+    get_principal_state(p).map(|ps| RegistrationInfo {
+        principal: ps.principal,
+        registered_at_ns: ps.registered_at_ns,
+        first_qualifying_action: ps.first_qualifying_action,
+    })
+}
+
+pub fn registered_count() -> u64 {
+    PRINCIPALS.with(|m| m.borrow().len())
+}
+
+pub fn current_epoch_index() -> u64 {
+    with_state(|s| s.current_epoch_index)
+}
+
+pub fn append_point_entry(entry: PointEntry) {
+    POINT_LEDGER.with(|l| {
+        l.borrow()
+            .append(&StoredPointEntry::V1(entry))
+            .expect("failed to append point entry");
+    });
+}
+
+pub fn point_ledger_len() -> u64 {
+    POINT_LEDGER.with(|l| l.borrow().len())
+}
+
+#[allow(dead_code)] // wired by the Phase 5 epoch driver
+pub fn append_epoch_summary(summary: EpochSummary) {
+    EPOCH_SUMMARIES.with(|l| {
+        l.borrow()
+            .append(&StoredEpochSummary::V1(summary))
+            .expect("failed to append epoch summary");
+    });
+}
+
+pub fn epoch_count() -> u64 {
+    EPOCH_SUMMARIES.with(|l| l.borrow().len())
+}
+
+/// Number of revealed commit-reveal seeds (one per closed epoch). The log is
+/// reserved in the stable layout now (MemoryIds 5/6); Phase 5 appends to it and
+/// adds the public `get_revealed_seed` query.
+pub fn revealed_seed_count() -> u64 {
+    REVEALED_SEEDS.with(|l| l.borrow().len())
+}
+
+pub fn points_config() -> PointsConfig {
+    with_state(|s| PointsConfig {
+        admin: s.admin,
+        season_start_ns: s.season_start_ns,
+        season_end_ns: s.season_end_ns,
+        excluded_count: s.excluded_principals.len() as u32,
+        registered_count: registered_count(),
+        current_epoch_index: s.current_epoch_index,
+        snapshot_seed_committed: s.snapshot_seed.is_committed(),
+    })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+// Native unit tests exercise the real stable structures: off-wasm,
+// `DefaultMemoryImpl` is a heap-backed `VectorMemory`, and libtest runs each
+// test on its own freshly spawned thread, so each test gets a clean set of
+// thread-local stable structures.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AssetType, DepositKey, DepositRecord, EpochSummary, InitArgs, PrincipalState,
+        QualifyingAction, RepaymentEvent, Venue,
+    };
+    use std::collections::BTreeMap;
+
+    fn tp(n: u8) -> Principal {
+        Principal::from_slice(&[n, n, n, n, n])
+    }
+
+    fn backend_principal() -> Principal {
+        Principal::from_text("tfesu-vyaaa-aaaap-qrd7a-cai").unwrap()
+    }
+
+    fn init_default(admin: Principal) {
+        init_state(
+            Some(InitArgs {
+                admin: Some(admin),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+    }
+
+    #[test]
+    fn excluded_seed_marks_protocol_canisters_and_not_founder() {
+        init_default(tp(99));
+        // The 9 protocol-owned canisters are seeded.
+        assert_eq!(excluded_principals().len(), 9);
+        assert!(is_excluded(&backend_principal()));
+        // A founder / outside principal is NOT excluded (spec Section 11).
+        assert!(!is_excluded(&tp(1)));
+    }
+
+    #[test]
+    fn admin_defaults_to_caller_when_unset() {
+        init_state(None, tp(7));
+        assert_eq!(points_config().admin, tp(7));
+        // Default seed applied when excluded_principals is None.
+        assert_eq!(excluded_principals().len(), 9);
+    }
+
+    #[test]
+    fn admin_can_add_and_remove_excluded_but_non_admin_cannot() {
+        let admin = tp(99);
+        init_default(admin);
+        let target = tp(5);
+
+        assert_eq!(add_excluded(admin, target), Ok(()));
+        assert!(is_excluded(&target));
+        assert_eq!(remove_excluded(admin, target), Ok(()));
+        assert!(!is_excluded(&target));
+
+        // A non-admin is rejected and the set is unchanged.
+        let intruder = tp(8);
+        assert_eq!(add_excluded(intruder, tp(6)), Err(PointsError::Unauthorized));
+        assert!(!is_excluded(&tp(6)));
+    }
+
+    #[test]
+    fn set_excluded_replaces_the_whole_set() {
+        let admin = tp(99);
+        init_default(admin);
+        assert_eq!(set_excluded(admin, vec![tp(1), tp(2)]), Ok(()));
+        assert_eq!(excluded_principals().len(), 2);
+        assert!(is_excluded(&tp(1)));
+        assert!(is_excluded(&tp(2)));
+        // The protocol-owned seed was replaced, so the backend is no longer in.
+        assert!(!is_excluded(&backend_principal()));
+    }
+
+    #[test]
+    fn register_creates_state_writes_marker_and_is_idempotent() {
+        init_default(tp(99));
+        let p = tp(10);
+        assert_eq!(point_ledger_len(), 0);
+
+        let created = register(p, 1_000, QualifyingAction::Deposit3Pool).unwrap();
+        assert_eq!(created.registered_at_ns, 1_000);
+        assert_eq!(created.first_qualifying_action, QualifyingAction::Deposit3Pool);
+        assert!(is_registered(&p));
+        assert_eq!(registered_count(), 1);
+        // One zero-point registration marker in the audit ledger.
+        assert_eq!(point_ledger_len(), 1);
+
+        // Re-register with a different timestamp: idempotent, no overwrite, no new marker.
+        let again = register(p, 9_999, QualifyingAction::MintIcUsd).unwrap();
+        assert_eq!(again.registered_at_ns, 1_000);
+        assert_eq!(again.first_qualifying_action, QualifyingAction::Deposit3Pool);
+        assert_eq!(registered_count(), 1);
+        assert_eq!(point_ledger_len(), 1);
+    }
+
+    #[test]
+    fn register_rejects_excluded_principals() {
+        init_default(tp(99));
+        let excluded = backend_principal();
+        assert_eq!(
+            register(excluded, 1, QualifyingAction::MintIcUsd),
+            Err(PointsError::Excluded)
+        );
+        assert!(!is_registered(&excluded));
+        assert_eq!(registered_count(), 0);
+    }
+
+    #[test]
+    fn register_test_principal_is_admin_gated() {
+        let admin = tp(99);
+        init_default(admin);
+        let p = tp(11);
+
+        assert_eq!(
+            register_test_principal(tp(8), p, 1),
+            Err(PointsError::Unauthorized)
+        );
+        assert!(!is_registered(&p));
+
+        assert_eq!(register_test_principal(admin, p, 1), Ok(()));
+        assert!(is_registered(&p));
+    }
+
+    #[test]
+    fn leaderboard_ranks_by_points_desc_with_share_and_pagination() {
+        // Inject principals with known points via the private accessor.
+        let mk = |p: Principal, pts: u128| PrincipalState {
+            principal: p,
+            total_points: pts,
+            active_deposits: BTreeMap::new(),
+            repayment_events: Vec::new(),
+            last_epoch_processed: 0,
+            registered_at_ns: 1,
+            first_qualifying_action: QualifyingAction::MintIcUsd,
+        };
+        put_principal_state(mk(tp(1), 300));
+        put_principal_state(mk(tp(2), 100));
+        put_principal_state(mk(tp(3), 200));
+
+        let board = leaderboard(0, 10);
+        assert_eq!(board.len(), 3);
+        // Desc by points: 300, 200, 100.
+        assert_eq!(board[0].principal, tp(1));
+        assert_eq!(board[0].rank, 1);
+        assert_eq!(board[0].total_points, 300);
+        assert_eq!(board[0].estimated_share_bps, 5000); // 300/600
+        assert_eq!(board[1].principal, tp(3));
+        assert_eq!(board[1].rank, 2);
+        assert_eq!(board[1].estimated_share_bps, 3333); // 200/600
+        assert_eq!(board[2].principal, tp(2));
+        assert_eq!(board[2].rank, 3);
+        assert_eq!(board[2].estimated_share_bps, 1666); // 100/600
+
+        // Pagination: offset 1, limit 1 -> second-ranked only.
+        let page = leaderboard(1, 1);
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].principal, tp(3));
+        assert_eq!(page[0].rank, 2);
+    }
+
+    #[test]
+    fn principal_state_versioned_roundtrip_through_stable_map() {
+        // Exercises the ciborium round-trip of the full record, including the
+        // struct-keyed BTreeMap and the repayment vec.
+        let p = tp(20);
+        let mut deposits = BTreeMap::new();
+        let rec = DepositRecord {
+            asset: AssetType::CkUsdc,
+            venue: Venue::ThreePool,
+            recorded_value_usd: 1_234,
+            deposited_at: 42,
+            last_verified_at: 43,
+        };
+        deposits.insert(rec.key(), rec.clone());
+        let ps = PrincipalState {
+            principal: p,
+            total_points: 7,
+            active_deposits: deposits,
+            repayment_events: vec![RepaymentEvent {
+                asset: AssetType::CkUsdt,
+                amount_usd: 500,
+                repaid_at: 10,
+                window_end: 20,
+            }],
+            last_epoch_processed: 3,
+            registered_at_ns: 99,
+            first_qualifying_action: QualifyingAction::RepayVault,
+        };
+        put_principal_state(ps.clone());
+        let got = get_principal_state(&p).expect("present");
+        assert_eq!(got, ps);
+        assert_eq!(
+            got.active_deposits.get(&DepositKey {
+                venue: Venue::ThreePool,
+                asset: AssetType::CkUsdc
+            }),
+            Some(&rec)
+        );
+    }
+
+    #[test]
+    fn epoch_history_appends_and_paginates() {
+        let mk = |i: u64| EpochSummary {
+            epoch_index: i,
+            epoch_start_ns: i * 10,
+            epoch_end_ns: i * 10 + 5,
+            total_points_all: (i as u128) * 100,
+            points_accrued_this_epoch: (i as u128) * 10,
+            active_principals: i,
+            registered_principals: i,
+            snapshot_a_ns: 0,
+            snapshot_b_ns: 0,
+        };
+        append_epoch_summary(mk(0));
+        append_epoch_summary(mk(1));
+        assert_eq!(epoch_count(), 2);
+
+        let all = epoch_history(0, 10);
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].epoch_index, 0);
+        assert_eq!(all[1].epoch_index, 1);
+
+        let page = epoch_history(1, 1);
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].epoch_index, 1);
+    }
+
+    #[test]
+    fn state_blob_survives_save_load_roundtrip() {
+        let admin = tp(99);
+        init_default(admin);
+        // Mutate the singleton so the round-trip is meaningful.
+        add_excluded(admin, tp(3)).unwrap();
+        let before = with_state(|s| s.clone());
+
+        save_state_to_stable();
+        let loaded = load_state_from_stable().expect("state should load after save");
+        assert_eq!(loaded, before);
+        assert!(loaded.excluded_principals.contains(&tp(3)));
+    }
+
+    #[test]
+    fn load_state_returns_none_when_nothing_saved() {
+        // Fresh thread -> blob region never written -> None (no silent default).
+        assert_eq!(load_state_from_stable(), None);
+    }
+}

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -64,6 +64,8 @@ const EPOCH_SUMMARY_DATA_MEM_ID: MemoryId = MemoryId::new(4);
 const REVEALED_SEEDS_INDEX_MEM_ID: MemoryId = MemoryId::new(5);
 const REVEALED_SEEDS_DATA_MEM_ID: MemoryId = MemoryId::new(6);
 const STATE_BLOB_MEM_ID: MemoryId = MemoryId::new(7);
+// Phase 2: per-source ingestion cursors (source tag -> last-processed event id).
+const CURSORS_MEM_ID: MemoryId = MemoryId::new(8);
 
 const WASM_PAGE_SIZE: u64 = 65_536; // 64 KiB
 
@@ -222,6 +224,17 @@ thread_local! {
     /// Singleton config, heap-resident during execution (restored from the blob
     /// in `post_upgrade`, populated fresh in `init`).
     static STATE: RefCell<Option<State>> = RefCell::new(None);
+
+    /// Phase 2: per-source ingestion cursor (source tag -> last-processed event
+    /// id + 1). Persists across upgrades so we never re-ingest from zero. Both
+    /// key and value are primitives with built-in `Storable` impls.
+    static CURSORS: RefCell<StableBTreeMap<u8, u64, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(CURSORS_MEM_ID))));
+
+    /// Phase 2: transient re-entrancy guard so two overlapping poll timers do not
+    /// double-ingest from the same cursor. NOT persisted (a fresh canister / a
+    /// post-upgrade heap always starts with no poll in flight).
+    static POLL_IN_PROGRESS: RefCell<bool> = RefCell::new(false);
 }
 
 // ── Excluded-principals seed (spec Section 11) ──────────────────────────────
@@ -575,6 +588,46 @@ pub fn points_config() -> PointsConfig {
         current_epoch_index: s.current_epoch_index,
         snapshot_seed_committed: s.snapshot_seed.is_committed(),
     })
+}
+
+// ── Phase 2: ingestion cursors, poll guard, season gating ───────────────────
+
+/// Last-processed cursor for a source (its next `get_*_events` start id). 0 if
+/// the source has never been polled.
+pub fn get_cursor(source_tag: u8) -> u64 {
+    CURSORS.with(|c| c.borrow().get(&source_tag).unwrap_or(0))
+}
+
+pub fn set_cursor(source_tag: u8, next_start_id: u64) {
+    CURSORS.with(|c| {
+        c.borrow_mut().insert(source_tag, next_start_id);
+    });
+}
+
+/// Acquire the single-poll guard. Returns `true` if acquired (no poll was in
+/// flight); `false` means a poll is already running and the caller must abort.
+/// Pairs with `end_poll` (call it on every exit path, including errors).
+pub fn try_begin_poll() -> bool {
+    POLL_IN_PROGRESS.with(|p| {
+        let mut p = p.borrow_mut();
+        if *p {
+            false
+        } else {
+            *p = true;
+            true
+        }
+    })
+}
+
+pub fn end_poll() {
+    POLL_IN_PROGRESS.with(|p| *p.borrow_mut() = false);
+}
+
+/// Is `ts_ns` within the configured season window (inclusive)? Registration and
+/// accrual only happen for in-season activity; pre-season activity does not
+/// retroactively enroll a principal (spec Section 8).
+pub fn in_season(ts_ns: u64) -> bool {
+    with_state(|s| ts_ns >= s.season_start_ns && ts_ns <= s.season_end_ns)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -66,6 +66,9 @@ const REVEALED_SEEDS_DATA_MEM_ID: MemoryId = MemoryId::new(6);
 const STATE_BLOB_MEM_ID: MemoryId = MemoryId::new(7);
 // Phase 2: per-source ingestion cursors (source tag -> last-processed event id).
 const CURSORS_MEM_ID: MemoryId = MemoryId::new(8);
+// Phase 2: per-source canister principal (source tag -> canister id). Configurable
+// per environment (mainnet defaults seeded at init; admin overrides for local).
+const SOURCE_CANISTERS_MEM_ID: MemoryId = MemoryId::new(9);
 
 const WASM_PAGE_SIZE: u64 = 65_536; // 64 KiB
 
@@ -235,6 +238,12 @@ thread_local! {
     /// double-ingest from the same cursor. NOT persisted (a fresh canister / a
     /// post-upgrade heap always starts with no poll in flight).
     static POLL_IN_PROGRESS: RefCell<bool> = RefCell::new(false);
+
+    /// Phase 2: per-source canister principal (source tag -> canister id). Seeded
+    /// with mainnet defaults at init; the admin overrides per environment (e.g.
+    /// local replica ids) via `set_source_canister`. Persists across upgrades.
+    static SOURCE_CANISTERS: RefCell<StableBTreeMap<u8, StorablePrincipal, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(SOURCE_CANISTERS_MEM_ID))));
 }
 
 // ── Excluded-principals seed (spec Section 11) ──────────────────────────────
@@ -286,6 +295,11 @@ fn require_admin(caller: Principal) -> Result<(), PointsError> {
     })
 }
 
+/// Public admin predicate, for endpoints that gate on a bool.
+pub fn is_admin(caller: Principal) -> bool {
+    with_state(|s| s.admin == caller)
+}
+
 // ── Phase 1 logic (TDD targets; implemented after the failing tests) ────────
 
 /// Build the singleton `State` from init args (defaulting admin to `caller`,
@@ -312,6 +326,19 @@ pub fn init_state(args: Option<InitArgs>, caller: Principal) {
         snapshot_seed,
     };
     STATE.with(|cell| *cell.borrow_mut() = Some(state));
+
+    // Seed the source-canister ids with mainnet defaults on a fresh install. The
+    // admin overrides per environment (e.g. local replica ids) via
+    // `set_source_canister`. Only seeds an empty map so it is a no-op if somehow
+    // re-entered with config already present.
+    SOURCE_CANISTERS.with(|m| {
+        let mut m = m.borrow_mut();
+        if m.is_empty() {
+            for (tag, p) in source_canister_seed() {
+                m.insert(tag, StorablePrincipal(p));
+            }
+        }
+    });
 }
 
 /// Is this principal in the configurable excluded set? Checked at the
@@ -602,6 +629,44 @@ pub fn set_cursor(source_tag: u8, next_start_id: u64) {
     CURSORS.with(|c| {
         c.borrow_mut().insert(source_tag, next_start_id);
     });
+}
+
+/// Mainnet source-canister ids seeded at init (source tag -> canister id):
+/// 0 = backend, 1 = 3pool, 2 = stability pool, 3 = AMM (see `events::SourceId`).
+/// Confirmed against canister_ids.json (2026-06-01).
+pub fn source_canister_seed() -> Vec<(u8, Principal)> {
+    [
+        (0u8, "tfesu-vyaaa-aaaap-qrd7a-cai"), // rumi_protocol_backend
+        (1u8, "fohh4-yyaaa-aaaap-qtkpa-cai"), // rumi_3pool
+        (2u8, "tmhzi-dqaaa-aaaap-qrd6q-cai"), // rumi_stability_pool
+        (3u8, "ijlzs-2yaaa-aaaap-quaaq-cai"), // rumi_amm
+    ]
+    .iter()
+    .map(|(tag, s)| (*tag, Principal::from_text(s).expect("invalid source principal literal")))
+    .collect()
+}
+
+/// The configured canister id for a source tag, or `None` if unset.
+pub fn get_source_canister(source_tag: u8) -> Option<Principal> {
+    SOURCE_CANISTERS.with(|m| m.borrow().get(&source_tag).map(|p| p.0))
+}
+
+/// Admin-set a source canister id (e.g. point at local replica ids).
+pub fn set_source_canister(
+    caller: Principal,
+    source_tag: u8,
+    canister: Principal,
+) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    SOURCE_CANISTERS.with(|m| {
+        m.borrow_mut().insert(source_tag, StorablePrincipal(canister));
+    });
+    Ok(())
+}
+
+/// All configured source canisters as `(tag, id)` pairs, for the status query.
+pub fn source_canisters() -> Vec<(u8, Principal)> {
+    SOURCE_CANISTERS.with(|m| m.borrow().iter().map(|(tag, p)| (tag, p.0)).collect())
 }
 
 /// Acquire the single-poll guard. Returns `true` if acquired (no poll was in

--- a/src/rumi_points/src/types.rs
+++ b/src/rumi_points/src/types.rs
@@ -216,6 +216,23 @@ pub struct PointsConfig {
     pub snapshot_seed_committed: bool,
 }
 
+/// One source's ingestion state (Phase 2 ops observability).
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct SourceStatus {
+    /// Source tag: 0 = backend, 1 = 3pool, 2 = stability pool, 3 = AMM.
+    pub tag: u8,
+    pub canister: Principal,
+    /// Next `start` to poll from (the forward cursor).
+    pub cursor: u64,
+}
+
+/// Pull-ingestion status across all configured sources.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct IngestStatus {
+    pub sources: Vec<SourceStatus>,
+    pub registered_count: u64,
+}
+
 /// Error surface for the admin / registration update endpoints.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum PointsError {

--- a/src/rumi_points/src/types.rs
+++ b/src/rumi_points/src/types.rs
@@ -1,0 +1,243 @@
+//! Data model for the Season 1 points engine (spec `rumi-airdrop-spec-v2.md`
+//! Section 7). These are the candid-facing, logical types used throughout the
+//! crate. Their AT-REST representation is wrapped in versioned `Stored*` enums
+//! in `state.rs` so fields can be added later without triggering a stable-memory
+//! wipe (UPG-002). See the recipe doc-comment on each `Stored*` enum.
+//!
+//! Two deliberate refinements of the spec's literal struct shapes, both made for
+//! stable-storage scalability and both called out in the Phase 1 status note:
+//!   1. `PrincipalState` does NOT carry an inline `point_ledger: Vec<PointEntry>`.
+//!      The implementation plan (Phase 1, task 4) mandates a SEPARATE global
+//!      `StableLog<PointEntry>` audit ledger; the per-principal view is derived
+//!      by filtering that log. Storing an unbounded Vec inside every BTreeMap
+//!      value would rewrite the whole value on every accrual.
+//!   2. (Naming) `pro_rata_share` is intentionally absent. That value is computed
+//!      from the FROZEN ledger by the LATER claim canister, not here (spec
+//!      Section 9). This canister only accrues `total_points`.
+
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+// ── Enums ───────────────────────────────────────────────────────────────────
+
+/// Asset a position / deposit / repayment is denominated in. USD-pegged stables
+/// are valued at $1.00 (spec Section 7, no peg-aware cap). ICP is valued via the
+/// protocol XRC oracle at epoch time (Phase 5, see `valuation.rs`).
+#[derive(
+    CandidType, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub enum AssetType {
+    IcUsd,
+    CkUsdc,
+    CkUsdt,
+    ThreeUsd,
+    Icp,
+}
+
+/// Where a position is held. Determines which multiplier-table row applies
+/// (spec Section 4).
+#[derive(
+    CandidType, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub enum Venue {
+    /// Vault debt outstanding + ckUSDC/ckUSDT repayment window.
+    Vault,
+    /// `rumi_3pool` deposits (icUSD 1x, single ck-stable 3x, matched pair 5x).
+    ThreePool,
+    /// `rumi_stability_pool` deposits (icUSD 1x, 3USD 2x).
+    StabilityPool,
+    /// `rumi_amm` 3USD/ICP LP (2x).
+    Amm,
+}
+
+/// The first qualifying action that auto-registered a principal (spec Section 8).
+/// Registration is implicit: the first event of any of these kinds enrolls the
+/// principal. Activity before registration does NOT retroactively earn points.
+#[derive(CandidType, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QualifyingAction {
+    MintIcUsd,
+    RepayVault,
+    Deposit3Pool,
+    DepositStabilityPool,
+    ProvideAmmLiquidity,
+}
+
+/// What activity produced a ledger row, for audit / personal breakdown display.
+#[derive(CandidType, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PointSource {
+    /// Auto-registration marker (zero points, records enrollment).
+    Registration,
+    IcUsdDebt,
+    IcUsd3Pool,
+    CkStable3PoolUnmatched,
+    CkStable3PoolMatched,
+    VaultRepayment,
+    IcUsdStabilityPool,
+    ThreeUsdStabilityPool,
+    AmmLp,
+}
+
+// ── Per-principal records (spec Section 7) ──────────────────────────────────
+
+/// Logical key for a principal's active deposits. A principal holds at most one
+/// active deposit per (venue, asset) pair; a new deposit event for the same pair
+/// updates the existing record's recorded value rather than appending.
+#[derive(
+    CandidType, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub struct DepositKey {
+    pub venue: Venue,
+    pub asset: AssetType,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct DepositRecord {
+    pub asset: AssetType,
+    pub venue: Venue,
+    /// Recorded USD value at deposit time. The accrued value each epoch is
+    /// `min(recorded_value_usd, verified_3usd)` for 3pool deposits (spec
+    /// Section 5); this is the recorded upper bound.
+    pub recorded_value_usd: u128,
+    pub deposited_at: u64,
+    pub last_verified_at: u64,
+}
+
+impl DepositRecord {
+    pub fn key(&self) -> DepositKey {
+        DepositKey {
+            venue: self.venue,
+            asset: self.asset,
+        }
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct RepaymentEvent {
+    /// Only ckUSDC | ckUSDT repayments qualify for the 5x window (spec Section 6).
+    pub asset: AssetType,
+    pub amount_usd: u128,
+    pub repaid_at: u64,
+    /// `repaid_at + 90 days`, capped at season end.
+    pub window_end: u64,
+}
+
+/// Per-principal accrual state. The bulk of canister storage: one of these per
+/// registered principal, held in a `StableBTreeMap<Principal, _>` (see
+/// `state.rs`). `total_points` is the season-to-date sum; the claim canister
+/// later derives `pro_rata_share` from the frozen totals.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PrincipalState {
+    pub principal: Principal,
+    pub total_points: u128,
+    /// Keyed by (venue, asset). See `DepositKey`.
+    pub active_deposits: BTreeMap<DepositKey, DepositRecord>,
+    pub repayment_events: Vec<RepaymentEvent>,
+    pub last_epoch_processed: u64,
+    pub registered_at_ns: u64,
+    pub first_qualifying_action: QualifyingAction,
+}
+
+impl PrincipalState {
+    /// A freshly registered principal with no accrual yet.
+    pub fn new(principal: Principal, registered_at_ns: u64, action: QualifyingAction) -> Self {
+        Self {
+            principal,
+            total_points: 0,
+            active_deposits: BTreeMap::new(),
+            repayment_events: Vec::new(),
+            last_epoch_processed: 0,
+            registered_at_ns,
+            first_qualifying_action: action,
+        }
+    }
+}
+
+// ── Append-only ledger rows ─────────────────────────────────────────────────
+
+/// One row in the global append-only audit ledger (`StableLog<PointEntry>`).
+/// Every accrual and the registration marker write one of these, tagged with the
+/// principal so a per-principal view can be reconstructed by filtering.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PointEntry {
+    pub principal: Principal,
+    pub epoch_index: u64,
+    pub points_delta: u128,
+    pub source: PointSource,
+    pub recorded_at_ns: u64,
+}
+
+/// Per-epoch rollup written once when an epoch closes (`StableLog<EpochSummary>`).
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct EpochSummary {
+    pub epoch_index: u64,
+    pub epoch_start_ns: u64,
+    pub epoch_end_ns: u64,
+    pub total_points_all: u128,
+    pub points_accrued_this_epoch: u128,
+    pub active_principals: u64,
+    pub registered_principals: u64,
+    /// Snapshot timestamps actually used this epoch (revealed after close;
+    /// 0 until Phase 5 wires the snapshot scheduler).
+    pub snapshot_a_ns: u64,
+    pub snapshot_b_ns: u64,
+}
+
+// ── Query view types ────────────────────────────────────────────────────────
+
+/// One row of the public leaderboard (spec Section 10). The canister returns the
+/// full principal; the frontend truncates it for display ("abcde...wxyz").
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct LeaderboardEntry {
+    pub rank: u32,
+    pub principal: Principal,
+    pub total_points: u128,
+    /// Estimated share of the 5% Season-1 pool, in basis points (0..=10000).
+    /// 0 during the season's early life when totals are tiny / zero.
+    pub estimated_share_bps: u32,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct RegistrationInfo {
+    pub principal: Principal,
+    pub registered_at_ns: u64,
+    pub first_qualifying_action: QualifyingAction,
+}
+
+/// Read-only snapshot of admin-configurable parameters, for the ops dashboard.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PointsConfig {
+    pub admin: Principal,
+    pub season_start_ns: u64,
+    pub season_end_ns: u64,
+    pub excluded_count: u32,
+    pub registered_count: u64,
+    pub current_epoch_index: u64,
+    pub snapshot_seed_committed: bool,
+}
+
+/// Error surface for the admin / registration update endpoints.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum PointsError {
+    /// Caller is not the configured admin.
+    Unauthorized,
+    /// Principal is in the excluded set (protocol-owned canisters, etc.) and
+    /// cannot register or accrue (spec Section 11).
+    Excluded,
+}
+
+/// Optional init / upgrade argument. All fields default sensibly so a bare local
+/// deploy (`'(null)'`) works; mainnet deploy supplies the real admin + season.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Default)]
+pub struct InitArgs {
+    /// Admin principal. Defaults to the deploying caller if `None`.
+    pub admin: Option<Principal>,
+    /// Excluded principals. Defaults to the protocol-owned canister seed if
+    /// `None` (see `state::protocol_owned_canister_seed`).
+    pub excluded_principals: Option<Vec<Principal>>,
+    /// Season window. Defaults to June 1 2026 .. Aug 31 2026 23:59:59 UTC.
+    pub season_start_ns: Option<u64>,
+    pub season_end_ns: Option<u64>,
+    /// Commit-reveal seed hash H0 (spike 0.3). `None` until Phase 5 wires it.
+    pub snapshot_seed_commit: Option<[u8; 32]>,
+}

--- a/src/rumi_points/src/valuation.rs
+++ b/src/rumi_points/src/valuation.rs
@@ -1,0 +1,30 @@
+//! Asset valuation (spec Section 7 "Asset valuation", implementation plan Phase 5).
+//!
+//! PHASE 5 SCOPE (skeleton only here).
+//!   - ckUSDC, ckUSDT, icUSD, 3USD: valued at $1.00. No peg-aware cap (dropped
+//!     from v1). Face value only.
+//!   - ICP: protocol XRC oracle at epoch time (the same source the backend uses).
+//!   - LP positions: derived from underlying pool reserves at the epoch boundary,
+//!     cached once per snapshot to avoid repeated cross-canister queries.
+//!
+//! The 3USD verification rule (spec Section 5) also lives at this layer in
+//! Phase 4: `active_deposit_value = min(recorded_deposit, verified_3usd)` where
+//! `verified_3usd = wallet + stability_pool + amm_lp_3usd_share`, summed across
+//! the three venues a holder can keep 3USD in.
+
+#![allow(dead_code)] // Phase 4/5 surface.
+
+use crate::types::AssetType;
+use icrc_ledger_types::icrc1::account::Account;
+
+/// USD value (in whole-dollar fixed-point, scaling TBD in Phase 5) of `amount`
+/// units of `asset`. Stables resolve to face value; ICP requires the oracle.
+pub fn value_usd(_asset: AssetType, _amount: u128) -> u128 {
+    unimplemented!("Phase 5: $1 stables, XRC for ICP");
+}
+
+/// Sum of a principal's verified 3USD across wallet + stability pool + AMM LP
+/// share (spec Section 5), used to cap 3pool deposit accrual. Phase 4.
+pub async fn verified_3usd(_account: Account) -> u128 {
+    unimplemented!("Phase 4: wallet + SP + AMM LP 3USD verification");
+}

--- a/src/rumi_points/tests/pocket_ic_ingest.rs
+++ b/src/rumi_points/tests/pocket_ic_ingest.rs
@@ -1,0 +1,130 @@
+//! PocketIC end-to-end: rumi_points ingests a forward-filtered backend event from
+//! a mock source canister and auto-registers the acting principal.
+//!
+//! Validates the one path unit tests cannot: the live inter-canister poll
+//! (`trigger_poll` -> `ic_cdk::call` -> candid decode of the source response ->
+//! normalize -> `register` -> cursor advance). The mock's response types match the
+//! backend `.did` structurally; the 95-variant superset-decode case is covered by
+//! the canary tests in `source_types.rs`.
+//!
+//! Build the wasms first:
+//!   cargo build --release --target wasm32-unknown-unknown -p rumi_points -p rumi_points_e2e_source
+//! Run (the pocket-ic binary is at the repo root):
+//!   POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_points --test pocket_ic_ingest
+
+use candid::{CandidType, Decode, Encode, Principal};
+use pocket_ic::{PocketIcBuilder, WasmResult};
+use serde::Deserialize;
+
+const RUMI_POINTS_WASM: &[u8] =
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_points.wasm");
+const MOCK_SOURCE_WASM: &[u8] =
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_points_e2e_source.wasm");
+
+// Minimal candid mirrors of the rumi_points interface used by this test.
+#[derive(CandidType)]
+struct InitArgs {
+    admin: Option<Principal>,
+    excluded_principals: Option<Vec<Principal>>,
+    season_start_ns: Option<u64>,
+    season_end_ns: Option<u64>,
+    snapshot_seed_commit: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Debug, PartialEq)]
+enum PointsError {
+    Unauthorized,
+    Excluded,
+}
+
+fn admin() -> Principal {
+    Principal::from_slice(&[9; 10])
+}
+
+/// The synthetic borrow event's caller, hard-coded in the mock. Not in the
+/// excluded set, so it registers.
+fn synthetic_caller() -> Principal {
+    Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap()
+}
+
+#[test]
+fn poll_ingests_backend_event_and_auto_registers() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    // Install the mock source canister (no init args).
+    let mock = pic.create_canister();
+    pic.add_cycles(mock, 2_000_000_000_000);
+    pic.install_canister(mock, MOCK_SOURCE_WASM.to_vec(), Encode!().unwrap(), None);
+
+    // Install rumi_points with admin set explicitly.
+    let rp = pic.create_canister();
+    pic.add_cycles(rp, 4_000_000_000_000);
+    let init = InitArgs {
+        admin: Some(admin()),
+        excluded_principals: None,
+        season_start_ns: None,
+        season_end_ns: None,
+        snapshot_seed_commit: None,
+    };
+    pic.install_canister(
+        rp,
+        RUMI_POINTS_WASM.to_vec(),
+        Encode!(&Some(init)).unwrap(),
+        None,
+    );
+
+    // Point the backend source (tag 0) at the mock (admin-gated).
+    let set_res = pic
+        .update_call(rp, admin(), "set_source_canister", Encode!(&0u8, &mock).unwrap())
+        .expect("set_source_canister call failed");
+    match set_res {
+        WasmResult::Reply(b) => {
+            let r: Result<(), PointsError> = Decode!(&b, Result<(), PointsError>).unwrap();
+            assert_eq!(r, Ok(()), "set_source_canister should succeed for admin");
+        }
+        WasmResult::Reject(m) => panic!("set_source_canister rejected: {m}"),
+    }
+
+    // Nobody is registered yet.
+    assert!(!is_registered(&pic, rp, synthetic_caller()));
+
+    // Trigger the poll: rumi_points calls the mock's get_events_forward_filtered,
+    // decodes the synthetic borrow event, and auto-registers its caller.
+    let poll_res = pic
+        .update_call(rp, admin(), "trigger_poll", Encode!().unwrap())
+        .expect("trigger_poll call failed");
+    let applied: Result<u64, PointsError> = match poll_res {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, PointsError>).unwrap(),
+        WasmResult::Reject(m) => panic!("trigger_poll rejected: {m}"),
+    };
+    assert_eq!(applied, Ok(1), "exactly one event should be ingested");
+
+    // The acting principal is now registered; an unrelated one is not.
+    assert!(
+        is_registered(&pic, rp, synthetic_caller()),
+        "the borrow event's caller should be auto-registered"
+    );
+    assert!(!is_registered(&pic, rp, Principal::from_slice(&[8; 5])));
+
+    // A second poll is a no-op: the mock returns empty past the cursor, so nothing
+    // new is applied (and the cursor does not regress).
+    let poll_res2 = pic
+        .update_call(rp, admin(), "trigger_poll", Encode!().unwrap())
+        .expect("second trigger_poll failed");
+    let applied2: Result<u64, PointsError> = match poll_res2 {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, PointsError>).unwrap(),
+        WasmResult::Reject(m) => panic!("second trigger_poll rejected: {m}"),
+    };
+    assert_eq!(applied2, Ok(0), "second poll ingests nothing (caught up)");
+    assert!(is_registered(&pic, rp, synthetic_caller()), "still registered");
+}
+
+fn is_registered(pic: &pocket_ic::PocketIc, rp: Principal, who: Principal) -> bool {
+    let res = pic
+        .query_call(rp, Principal::anonymous(), "is_registered", Encode!(&who).unwrap())
+        .expect("is_registered call failed");
+    match res {
+        WasmResult::Reply(b) => Decode!(&b, bool).unwrap(),
+        WasmResult::Reject(m) => panic!("is_registered rejected: {m}"),
+    }
+}

--- a/src/rumi_points_e2e_source/Cargo.toml
+++ b/src/rumi_points_e2e_source/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rumi_points_e2e_source"
+version = "0.1.0"
+edition = "2021"
+description = "Test-only mock source canister for the rumi_points ingestion E2E. Serves a synthetic forward-filtered backend event so the live poll -> decode -> normalize -> auto-register path can be exercised in PocketIC without standing up the full backend."
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.10.6"
+ic-cdk = "0.12.0"
+serde = { version = "1.0.210", features = ["derive"] }

--- a/src/rumi_points_e2e_source/src/lib.rs
+++ b/src/rumi_points_e2e_source/src/lib.rs
@@ -1,0 +1,93 @@
+//! Test-only mock of `rumi_protocol_backend.get_events_forward_filtered` for the
+//! rumi_points ingestion E2E. Its response types match the backend `.did`
+//! structurally, so rumi_points' real poll path (inter-canister call -> candid
+//! decode -> normalize -> auto-register -> cursor advance) is exercised exactly as
+//! it would be against the real backend. The 95-variant superset-decode case is
+//! covered separately by the canary tests in `source_types.rs`.
+//!
+//! Behavior: the first forward window (start == 0) returns one synthetic
+//! `borrow_from_vault` for `ryjl3-tyaaa-aaaaa-aaaba-cai` at an in-season
+//! timestamp, with `next_start = 1, reached_end = true`. Subsequent windows are
+//! empty (caught up).
+
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+/// The subset of the backend's `EventTypeFilter` that rumi_points sends. We only
+/// need to DECODE it (the mock ignores the filter), and the values rumi_points
+/// sends are all among these.
+#[derive(CandidType, Deserialize, Clone)]
+enum EventTypeFilter {
+    OpenVault,
+    CloseVault,
+    Borrow,
+    Repay,
+    Liquidation,
+    PartialLiquidation,
+    Redemption,
+    StabilityPoolDeposit,
+    StabilityPoolWithdraw,
+}
+
+/// A faithful subset of the backend `Event` (snake_case candid labels via serde
+/// rename, matching the real enum). Only the variants this mock emits.
+#[derive(CandidType, Deserialize, Clone)]
+enum Event {
+    #[serde(rename = "borrow_from_vault")]
+    BorrowFromVault {
+        block_index: u64,
+        vault_id: u64,
+        timestamp: Option<u64>,
+        fee_amount: u64,
+        caller: Option<Principal>,
+        borrowed_amount: u64,
+    },
+    #[serde(rename = "close_vault")]
+    CloseVault {
+        vault_id: u64,
+        block_index: Option<u64>,
+        timestamp: Option<u64>,
+    },
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct ForwardFilteredEventsResponse {
+    events: Vec<(u64, Event)>,
+    next_start: u64,
+    reached_end: bool,
+}
+
+/// Within the rumi_points default season window (June 1 .. Aug 31 2026).
+const IN_SEASON_TS_NS: u64 = 1_780_300_000_000_000_000;
+
+#[ic_cdk::query]
+fn get_events_forward_filtered(
+    start: u64,
+    _max_scan: u64,
+    _types: Option<Vec<EventTypeFilter>>,
+) -> ForwardFilteredEventsResponse {
+    if start == 0 {
+        let caller = Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap();
+        ForwardFilteredEventsResponse {
+            events: vec![(
+                0,
+                Event::BorrowFromVault {
+                    block_index: 0,
+                    vault_id: 1,
+                    timestamp: Some(IN_SEASON_TS_NS),
+                    fee_amount: 0,
+                    caller: Some(caller),
+                    borrowed_amount: 1_000,
+                },
+            )],
+            next_start: 1,
+            reached_end: true,
+        }
+    } else {
+        ForwardFilteredEventsResponse {
+            events: vec![],
+            next_start: start,
+            reached_end: true,
+        }
+    }
+}

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -577,6 +577,11 @@ type EventsByPrincipalPagedResponse = record {
 };
 type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
+type ForwardFilteredEventsResponse = record {
+  next_start : nat64;
+  reached_end : bool;
+  events : vec record { nat64; Event };
+};
 type GasStrategy = variant {
   NotApplicable;
   SolanaPriorityFee : record { lamports_per_cu_ceiling : nat64 };
@@ -969,6 +974,9 @@ service : (ProtocolArg) -> {
       EventsByPrincipalPagedResponse,
     ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
+  get_events_forward_filtered : (nat64, nat64, opt vec EventTypeFilter) -> (
+      ForwardFilteredEventsResponse,
+    ) query;
   get_fees : (nat64) -> (Fees) query;
   get_fees_for_collateral : (principal, nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -369,6 +369,25 @@ pub struct GetEventsFilteredResponse {
     pub events: Vec<(u64, crate::event::Event)>,
 }
 
+/// Response for `get_events_forward_filtered`: events matching the type filter
+/// within the forward scan window, each paired with its GLOBAL event-log index,
+/// plus a resume cursor. Drives gap-free, id-cursored incremental ingestion by an
+/// off-chain/inter-canister poller (e.g. `rumi_points`), unlike
+/// `get_events_filtered`, which is newest-first and paged by page number.
+///
+/// A poller ingests every matching event exactly once by passing `start = 0` and
+/// then `start := next_start` on each call until `reached_end`, after which it
+/// resumes from the same cursor as new events append (no gaps, no repeats).
+#[derive(candid::CandidType, Clone)]
+pub struct ForwardFilteredEventsResponse {
+    /// Matching events as `(global_log_index, event)`, oldest-first.
+    pub events: Vec<(u64, crate::event::Event)>,
+    /// Global log index to pass as the next `start`.
+    pub next_start: u64,
+    /// True when the scan reached the tail of the log (poller is caught up).
+    pub reached_end: bool,
+}
+
 /// Output cap on `get_vault_history` (DOS-001 legacy entry point) and
 /// page-size cap on `get_vault_history_paged`. Bounds the per-call
 /// reply size; for full historical access callers page via

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -12,7 +12,7 @@ use rumi_protocol_backend::{
     ReserveRedemptionResult, ReserveBalance, CollateralTotals, CollateralInterestInfo, PerCollateralRateCurve,
     VaultArgWithToken, StableTokenType, InterestSplitArg,
     GetSnapshotsArg, ProtocolSnapshot, CollateralSnapshot,
-    GetEventsFilteredResponse, StabilityPoolLiquidationResult,
+    GetEventsFilteredResponse, ForwardFilteredEventsResponse, StabilityPoolLiquidationResult,
     VaultHistoryPagedResponse, EventsByPrincipalPagedResponse, VaultsPageResponse,
     SupplyAudit, SupplyAuditEntry,
     MAX_VAULT_HISTORY, MAX_EVENTS_BY_PRINCIPAL_LEGACY, MAX_EVENTS_BY_PRINCIPAL_SCAN,
@@ -1634,6 +1634,71 @@ fn get_events_filtered(args: GetEventsArg) -> GetEventsFilteredResponse {
     };
     write_filtered_events_cache(cache_key, now, &resp);
     resp
+}
+
+/// Forward, id-cursored, type-filtered event scan for incremental ingestion.
+/// Scans the window `[start, start+max_scan)` of the global event log (oldest
+/// first), returns the events passing the `types` filter paired with their
+/// GLOBAL log index, and a `next_start` cursor to resume from without gaps or
+/// repeats.
+///
+/// Unlike `get_events_filtered` (newest-first, paged by page number, no stable
+/// cursor), this is a forward window keyed on the stable global index. A poller
+/// ingests every matching event exactly once by advancing `start := next_start`
+/// until `reached_end`, then resumes from the same cursor as new events append.
+/// `events().enumerate().skip(start)` seeks in O(1) (`EventIterator::nth`), so
+/// per-call cost is O(max_scan) regardless of how deep `start` is. Only the
+/// `types` facet is applied (principal/collateral/size/time are not), matching
+/// the points-canister ingestion use case. Added for `rumi_points` (airdrop).
+const FORWARD_FILTERED_MAX_SCAN: u64 = 2000;
+
+/// Pure forward-scan + type-filter + cursor logic, generic over the event source
+/// so it is unit-testable with a `Vec<Event>`. `count` is the total event count
+/// (the resume cursor is clamped to it). Production passes `events()` +
+/// `count_events()`; the O(1) seek of `EventIterator::nth` keeps the real scan at
+/// O(max_scan) regardless of `start`.
+fn scan_events_forward_filtered<I: Iterator<Item = Event>>(
+    source: I,
+    start: u64,
+    max_scan: u64,
+    count: u64,
+    types_set: Option<&std::collections::HashSet<EventTypeFilter>>,
+) -> ForwardFilteredEventsResponse {
+    let scan = max_scan.min(FORWARD_FILTERED_MAX_SCAN);
+    let empty_lookup = std::collections::HashMap::new();
+    let matched: Vec<(u64, Event)> = source
+        .enumerate()
+        .skip(start as usize)
+        .take(scan as usize)
+        .filter(|(_, e)| {
+            e.passes_filters(types_set, None, None, None, None, None, &empty_lookup, 0)
+        })
+        .map(|(i, e)| (i as u64, e))
+        .collect();
+    let next_start = start.saturating_add(scan).min(count);
+    ForwardFilteredEventsResponse {
+        events: matched,
+        next_start,
+        reached_end: next_start >= count,
+    }
+}
+
+#[candid_method(query)]
+#[query]
+fn get_events_forward_filtered(
+    start: u64,
+    max_scan: u64,
+    types: Option<Vec<EventTypeFilter>>,
+) -> ForwardFilteredEventsResponse {
+    if ic_cdk::api::data_certificate().is_none() {
+        ic_cdk::trap("update call rejected");
+    }
+    let types_set: Option<std::collections::HashSet<EventTypeFilter>> = types
+        .as_ref()
+        .filter(|v| !v.is_empty())
+        .map(|v| v.iter().cloned().collect());
+    let count = rumi_protocol_backend::storage::count_events();
+    scan_events_forward_filtered(events(), start, max_scan, count, types_set.as_ref())
 }
 
 /// Build `vault_id → collateral_type` by walking `OpenVault` events.
@@ -6575,6 +6640,51 @@ fn icrc28_trusted_origins() -> rumi_protocol_backend::icrc21::Icrc28TrustedOrigi
 #[query]
 fn icrc10_supported_standards() -> Vec<rumi_protocol_backend::icrc21::StandardRecord> {
     rumi_protocol_backend::icrc21::icrc10_supported_standards()
+}
+
+// Validates the forward, id-cursored, type-filtered scan that backs
+// `get_events_forward_filtered` (the rumi_points ingestion endpoint): window
+// bounding, global-index tagging, type filtering, and the resume cursor.
+#[test]
+fn forward_filtered_scan_windows_filters_and_advances_cursor() {
+    use std::collections::HashSet;
+
+    let close = |id: u64| Event::CloseVault {
+        vault_id: id,
+        block_index: None,
+        timestamp: Some(100),
+    };
+    let evs = vec![close(0), close(1), close(2)];
+    let count = evs.len() as u64;
+    let close_filter: HashSet<EventTypeFilter> = HashSet::from([EventTypeFilter::CloseVault]);
+    let borrow_filter: HashSet<EventTypeFilter> = HashSet::from([EventTypeFilter::Borrow]);
+
+    let ids = |r: &ForwardFilteredEventsResponse| r.events.iter().map(|(i, _)| *i).collect::<Vec<_>>();
+
+    // Full scan: all three match, tagged with their global indices, caught up.
+    let r = scan_events_forward_filtered(evs.clone().into_iter(), 0, 10, count, Some(&close_filter));
+    assert_eq!(ids(&r), vec![0, 1, 2]);
+    assert_eq!(r.next_start, 3);
+    assert!(r.reached_end);
+
+    // Bounded window [0,2): only indices 0,1; not yet caught up.
+    let r = scan_events_forward_filtered(evs.clone().into_iter(), 0, 2, count, Some(&close_filter));
+    assert_eq!(ids(&r), vec![0, 1]);
+    assert_eq!(r.next_start, 2);
+    assert!(!r.reached_end);
+
+    // Resume from cursor 2: only index 2, then caught up.
+    let r = scan_events_forward_filtered(evs.clone().into_iter(), 2, 10, count, Some(&close_filter));
+    assert_eq!(ids(&r), vec![2]);
+    assert_eq!(r.next_start, 3);
+    assert!(r.reached_end);
+
+    // A non-matching filter yields no events but still advances the cursor (so a
+    // poller never stalls on a quiet range).
+    let r = scan_events_forward_filtered(evs.into_iter(), 0, 10, count, Some(&borrow_filter));
+    assert!(r.events.is_empty());
+    assert_eq!(r.next_start, 3);
+    assert!(r.reached_end);
 }
 
 // Checks the real candid interface against the one declared in the did file

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1690,9 +1690,12 @@ fn get_events_forward_filtered(
     max_scan: u64,
     types: Option<Vec<EventTypeFilter>>,
 ) -> ForwardFilteredEventsResponse {
-    if ic_cdk::api::data_certificate().is_none() {
-        ic_cdk::trap("update call rejected");
-    }
+    // NOTE: intentionally NO `data_certificate()` "update call rejected" guard
+    // here (unlike `get_events_filtered`). This endpoint is designed to be polled
+    // by another canister (rumi_points) via an inter-canister call, which runs in
+    // replicated context where `data_certificate()` is `None`; the guard would
+    // reject every poll. The scan is O(max_scan)-bounded, so replicated execution
+    // is acceptable.
     let types_set: Option<std::collections::HashSet<EventTypeFilter>> = types
         .as_ref()
         .filter(|v| !v.is_empty())


### PR DESCRIPTION
Builds the Season 1 airdrop **points canister** (`rumi_points`) and the source-side read endpoints it ingests from. Per `docs/specs/rumi-airdrop-spec-v2.md` and the 2026-05-03 implementation plan. Local-only: `rumi_points` is NOT in `mainnet-live` and no mainnet canister id is reserved yet.

## Phase 1 — scaffold (`src/rumi_points/`)
- Stable storage via `MemoryManager` (mirrors `rumi_protocol_backend::storage`): `StableBTreeMap<Principal, PrincipalState>`, append-only `StableLog`s for the point ledger / epoch summaries / revealed seeds, and a versioned singleton `State` blob (8-byte len prefix + CBOR).
- **Versioned-snapshot pattern from day one** (`Stored*::V1` enums) for UPG-002 safety, with the field-addition recipe documented.
- Configurable **excluded-principals** set seeded with the 9 protocol-owned canisters (admin setters; checked at the register boundary). Founder/team not excluded (spec Section 11).

## Phase 2/3 — pull ingestion + auto-registration
- Normalized event model + the five Section-8 qualifying triggers; `apply_ingested_event` auto-registers a principal on its first qualifying, in-season action (idempotent; excluded rejected).
- Per-source candid mirror types + `normalize_*`, validated at the candid layer (subset decode, SP all-16 variants, migrated-row exclusion). Canary tests pin the decode rules.
- `poll.rs`: inter-canister poll across all four sources under a single-poll guard; backend/3pool advance to the endpoint's `next_start`, SP/AMM advance by count; per-source failures logged/skipped (no trap). Admin `trigger_poll` / `set_source_canister` / `get_ingest_status` (no periodic timer yet — cycle cost).
- Source-canister config (MemoryId 9, mainnet-seeded, admin override).

## Source-side forward read endpoints
- **backend** `get_events_forward_filtered(start, max_scan, opt vec EventTypeFilter)` and **3pool** `get_liquidity_events_v2_forward(start, max_scan)`: read-only additive, O(max_scan), unit-tested. Needed because `get_events_filtered` / `get_liquidity_events_v2` paginate newest-first (no stable forward cursor). SP/AMM keep their existing oldest-first index APIs for Season 1 (logs trim at 10k/50k, far above current volume).
- **Fix:** removed the `data_certificate().is_none() -> trap` guard from the backend forward endpoint — it rejects replicated/inter-canister calls, so it would have rejected every rumi_points poll. Caught while building the E2E.

## Validation
- 33 `rumi_points` unit tests + a candid drift test; backend (229) and 3pool (106) unit suites green (no regression).
- **PocketIC E2E** (`tests/pocket_ic_ingest.rs` + a mock source canister): live poll -> candid decode -> normalize -> auto-register -> cursor advance, asserted end to end.
- Local replica: default-state reads, register/exclude survive a real upgrade, source config (MemoryId 9) + cursors survive upgrade, `trigger_poll` handles unreachable sources gracefully and the poll guard releases.

## Out of scope (later phases)
Phase 4 (3USD verification), Phase 5 (epoch / multiplier / accrual math + snapshot scheduler), and the claim canister (lock tiers / haircut). `epoch.rs` / `valuation.rs` and the `snapshot_seed` algorithm are documented skeletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)