### PR TITLE
feat(airdrop): Phase 2b periodic poll timer (off by default)

### DIFF
--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -1,24 +1,27 @@
 # rumi_points — status
 
-**Phase 1 (scaffold): COMPLETE.** **Phase 2/3 (ingestion + auto-registration):
-COMPLETE and PocketIC-E2E-validated.** Merged to `main` (PR #217). Not yet deployed
-to mainnet; no mainnet canister id reserved.
+**Phase 1 (scaffold): COMPLETE.** **Phase 2 / 2b / 3 (ingestion + timer +
+auto-registration): COMPLETE and PocketIC-E2E-validated.** Merged to `main`
+(PR #217; Phase 2b in a follow-up). Not yet deployed to mainnet; no mainnet canister
+id reserved.
+
+Ingestion is now FUNCTIONAL: the off-by-default poll timer (Phase 2b) auto-polls the
+sources and auto-registers principals on their first qualifying in-season action.
+Still missing for a USEFUL airdrop: accrual (Phase 5) and 3USD verification (Phase 4).
 
 ## Deploy posture (why nothing is on mainnet yet)
-Deploying `rumi_points` to mainnet now would be premature and gains nothing:
-  - There is no periodic poll timer yet (Phase 2b), so it would not auto-ingest.
-  - There is no accrual yet (Phase 5), so it would register but award no points.
-  - A LATER deploy loses no data: the cursor starts at 0 and the source event logs
-    are unbounded (backend/3pool) or trim far above Season-1 volume (SP/AMM), so the
-    first poll backfills all in-season activity. So there is no "deploy early to
-    capture registrations" urgency.
-Deploy the backend + 3pool endpoint upgrades together with `rumi_points` once the
-timer (and ideally Phase 5 accrual) exist. Backend upgrade = ProtocolArg Upgrade
-variant + description; 3pool = dummy ThreePoolInitArgs; `rumi_points` = reserve a
-fresh mainnet id + add to `mainnet-live`. The pre-deploy hook runs the full suite.
+Not urgent, because a LATER deploy loses no data: the cursor starts at 0 and the
+source event logs are unbounded (backend/3pool) or trim far above Season-1 volume
+(SP/AMM), so the first poll backfills all in-season activity. There is no awarded
+value until Phase 5 accrual, so there is no rush to go live.
+
+When deploying: do the backend + 3pool endpoint upgrades together with `rumi_points`.
+Backend upgrade = ProtocolArg Upgrade variant + description; 3pool = dummy
+ThreePoolInitArgs; `rumi_points` = reserve a fresh mainnet id + add to `mainnet-live`,
+then admin `set_poll_enabled(true)` once sources are confirmed. The pre-deploy hook
+runs the full suite (including the POCKET_IC_BIN E2E).
 
 ## Next phases (fresh focused sessions)
-- Phase 2b: periodic poll timer (`setup_timers`), admin-tunable cadence.
 - Phase 4: 3USD verification (`min(recorded, wallet+SP+AMM)`), needs the
   `repayment_asset` upstream field for the 5x repayment window.
 - Phase 5: epoch driver + multiplier table + two-snapshot `min()` + the

--- a/src/rumi_points/rumi_points.did
+++ b/src/rumi_points/rumi_points.did
@@ -101,6 +101,8 @@ type SourceStatus = record {
 type IngestStatus = record {
   sources : vec SourceStatus;
   registered_count : nat64;
+  poll_enabled : bool;
+  poll_interval_secs : nat64;
 };
 
 service : (opt InitArgs) -> {
@@ -123,5 +125,7 @@ service : (opt InitArgs) -> {
   // Phase 2: ingestion control
   set_source_canister : (nat8, principal) -> (Result);
   trigger_poll : () -> (Result_1);
+  set_poll_enabled : (bool) -> (Result);
+  set_poll_interval_secs : (nat64) -> (Result);
   get_ingest_status : () -> (IngestStatus) query;
 };

--- a/src/rumi_points/src/main.rs
+++ b/src/rumi_points/src/main.rs
@@ -23,6 +23,8 @@ fn main() {}
 #[ic_cdk::init]
 fn init(args: Option<InitArgs>) {
     state::init_state(args, ic_cdk::caller());
+    // No-op while the poll timer is off by default; consistent entry point.
+    poll::setup_poll_timer();
     let cfg = state::points_config();
     log!(
         INFO,
@@ -42,6 +44,8 @@ fn pre_upgrade() {
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     state::restore_from_stable_or_trap();
+    // Timers do not survive upgrades: re-register from the persisted config.
+    poll::setup_poll_timer();
     let cfg = state::points_config();
     log!(
         INFO,
@@ -129,13 +133,30 @@ fn set_source_canister(source_tag: u8, canister: Principal) -> Result<(), Points
 }
 
 /// Admin-only manual poll of all configured sources. Returns the number of events
-/// applied. (No periodic timer in Phase 2; the production cadence is a follow-up.)
+/// applied. Works regardless of the periodic timer (used for the E2E and backfill).
 #[ic_cdk::update]
 async fn trigger_poll() -> Result<u64, PointsError> {
     if !state::is_admin(ic_cdk::caller()) {
         return Err(PointsError::Unauthorized);
     }
     Ok(poll::poll_all().await as u64)
+}
+
+/// Admin: turn the periodic poll timer on/off (Phase 2b). Off by default. Enable
+/// during the season after configuring sources; disable after season end.
+#[ic_cdk::update]
+fn set_poll_enabled(enabled: bool) -> Result<(), PointsError> {
+    state::set_poll_enabled(ic_cdk::caller(), enabled)?;
+    poll::setup_poll_timer();
+    Ok(())
+}
+
+/// Admin: set the poll cadence in seconds (clamped to a floor to bound cycle burn).
+#[ic_cdk::update]
+fn set_poll_interval_secs(secs: u64) -> Result<(), PointsError> {
+    state::set_poll_interval(ic_cdk::caller(), secs)?;
+    poll::setup_poll_timer();
+    Ok(())
 }
 
 #[ic_cdk::query]
@@ -151,6 +172,8 @@ fn get_ingest_status() -> IngestStatus {
     IngestStatus {
         sources,
         registered_count: state::registered_count(),
+        poll_enabled: state::poll_enabled(),
+        poll_interval_secs: state::poll_interval_secs(),
     }
 }
 

--- a/src/rumi_points/src/poll.rs
+++ b/src/rumi_points/src/poll.rs
@@ -18,12 +18,45 @@
 //! tick). Phase 2 exposes an admin `trigger_poll`; the production timer cadence is
 //! a small follow-up (`setup_timers`).
 
+use std::cell::RefCell;
+use std::time::Duration;
+
 use candid::Principal;
 use ic_cdk::api::call::RejectionCode;
+use ic_cdk_timers::TimerId;
 
 use crate::events::{self, SourceId};
 use crate::source_types::{amm, backend, stability_pool, three_pool};
 use crate::state;
+
+thread_local! {
+    /// The live poll-timer id (transient; timers do not survive upgrades).
+    static POLL_TIMER: RefCell<Option<TimerId>> = RefCell::new(None);
+}
+
+/// (Re)register the periodic poll timer from the persisted config (Phase 2b).
+/// Cancels any existing timer first. Called from `init` / `post_upgrade` (timers
+/// must be re-registered after an upgrade) and whenever the admin changes the
+/// poll config. Off by default: registers nothing until an operator enables it,
+/// so a fresh canister burns no cycles polling.
+pub fn setup_poll_timer() {
+    POLL_TIMER.with(|t| {
+        if let Some(id) = t.borrow_mut().take() {
+            ic_cdk_timers::clear_timer(id);
+        }
+    });
+    if state::poll_enabled() {
+        let interval = Duration::from_secs(state::poll_interval_secs());
+        let id = ic_cdk_timers::set_timer_interval(interval, || {
+            // poll_all is async; spawn it. Its single-poll guard handles the case
+            // where a tick fires while the previous poll is still in flight.
+            ic_cdk::spawn(async {
+                let _ = poll_all().await;
+            });
+        });
+        POLL_TIMER.with(|t| *t.borrow_mut() = Some(id));
+    }
+}
 
 // Per-call scan/batch bounds (kept under the source endpoints' own caps).
 const BACKEND_SCAN: u64 = 500;

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -69,6 +69,8 @@ const CURSORS_MEM_ID: MemoryId = MemoryId::new(8);
 // Phase 2: per-source canister principal (source tag -> canister id). Configurable
 // per environment (mainnet defaults seeded at init; admin overrides for local).
 const SOURCE_CANISTERS_MEM_ID: MemoryId = MemoryId::new(9);
+// Phase 2b: poll-timer config (key 0 = enabled 0/1, key 1 = interval seconds).
+const POLL_CONFIG_MEM_ID: MemoryId = MemoryId::new(10);
 
 const WASM_PAGE_SIZE: u64 = 65_536; // 64 KiB
 
@@ -244,6 +246,12 @@ thread_local! {
     /// local replica ids) via `set_source_canister`. Persists across upgrades.
     static SOURCE_CANISTERS: RefCell<StableBTreeMap<u8, StorablePrincipal, VMem>> =
         MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(SOURCE_CANISTERS_MEM_ID))));
+
+    /// Phase 2b: poll-timer config (key 0 = enabled, key 1 = interval seconds).
+    /// Persists across upgrades; the timer itself is re-registered in
+    /// `post_upgrade` from this config (timers do not survive upgrades).
+    static POLL_CONFIG: RefCell<StableBTreeMap<u8, u64, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(POLL_CONFIG_MEM_ID))));
 }
 
 // ── Excluded-principals seed (spec Section 11) ──────────────────────────────
@@ -669,6 +677,44 @@ pub fn source_canisters() -> Vec<(u8, Principal)> {
     SOURCE_CANISTERS.with(|m| m.borrow().iter().map(|(tag, p)| (tag, p.0)).collect())
 }
 
+// ── Phase 2b: poll-timer config ─────────────────────────────────────────────
+
+/// Default poll cadence. Conservative to bound cycle burn (each tick does up to
+/// four bounded inter-canister query calls); admin-tunable. 300s = 288 ticks/day.
+pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 300;
+/// Floor on the admin-set cadence, so it can never be turned into a cycle-burning
+/// near-heartbeat.
+pub const MIN_POLL_INTERVAL_SECS: u64 = 60;
+
+/// Is the periodic poll timer enabled? Defaults to OFF, so a fresh deploy never
+/// auto-polls (and burns no cycles) until an operator configures sources and
+/// enables it for the season.
+pub fn poll_enabled() -> bool {
+    POLL_CONFIG.with(|c| c.borrow().get(&0).unwrap_or(0) != 0)
+}
+
+pub fn poll_interval_secs() -> u64 {
+    POLL_CONFIG.with(|c| c.borrow().get(&1).unwrap_or(DEFAULT_POLL_INTERVAL_SECS))
+}
+
+pub fn set_poll_enabled(caller: Principal, enabled: bool) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    POLL_CONFIG.with(|c| {
+        c.borrow_mut().insert(0, enabled as u64);
+    });
+    Ok(())
+}
+
+/// Admin-set the poll cadence (clamped to `MIN_POLL_INTERVAL_SECS`).
+pub fn set_poll_interval(caller: Principal, secs: u64) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    let clamped = secs.max(MIN_POLL_INTERVAL_SECS);
+    POLL_CONFIG.with(|c| {
+        c.borrow_mut().insert(1, clamped);
+    });
+    Ok(())
+}
+
 /// Acquire the single-poll guard. Returns `true` if acquired (no poll was in
 /// flight); `false` means a poll is already running and the caller must abort.
 /// Pairs with `end_poll` (call it on every exit path, including errors).
@@ -947,5 +993,42 @@ mod tests {
     fn load_state_returns_none_when_nothing_saved() {
         // Fresh thread -> blob region never written -> None (no silent default).
         assert_eq!(load_state_from_stable(), None);
+    }
+
+    #[test]
+    fn poll_config_defaults_off_at_300s() {
+        init_default(tp(99));
+        assert!(!poll_enabled(), "poll timer is OFF by default");
+        assert_eq!(poll_interval_secs(), DEFAULT_POLL_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn admin_can_enable_and_set_interval() {
+        let admin = tp(99);
+        init_default(admin);
+        assert_eq!(set_poll_enabled(admin, true), Ok(()));
+        assert!(poll_enabled());
+        assert_eq!(set_poll_interval(admin, 600), Ok(()));
+        assert_eq!(poll_interval_secs(), 600);
+        assert_eq!(set_poll_enabled(admin, false), Ok(()));
+        assert!(!poll_enabled());
+    }
+
+    #[test]
+    fn poll_interval_is_floored() {
+        let admin = tp(99);
+        init_default(admin);
+        assert_eq!(set_poll_interval(admin, 5), Ok(())); // below the floor
+        assert_eq!(poll_interval_secs(), MIN_POLL_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn non_admin_cannot_change_poll_config() {
+        init_default(tp(99));
+        let intruder = tp(8);
+        assert_eq!(set_poll_enabled(intruder, true), Err(PointsError::Unauthorized));
+        assert_eq!(set_poll_interval(intruder, 120), Err(PointsError::Unauthorized));
+        assert!(!poll_enabled());
+        assert_eq!(poll_interval_secs(), DEFAULT_POLL_INTERVAL_SECS);
     }
 }

--- a/src/rumi_points/src/types.rs
+++ b/src/rumi_points/src/types.rs
@@ -231,6 +231,9 @@ pub struct SourceStatus {
 pub struct IngestStatus {
     pub sources: Vec<SourceStatus>,
     pub registered_count: u64,
+    /// Whether the periodic poll timer is running (Phase 2b).
+    pub poll_enabled: bool,
+    pub poll_interval_secs: u64,
 }
 
 /// Error surface for the admin / registration update endpoints.

--- a/src/rumi_points/tests/pocket_ic_ingest.rs
+++ b/src/rumi_points/tests/pocket_ic_ingest.rs
@@ -15,6 +15,7 @@
 use candid::{CandidType, Decode, Encode, Principal};
 use pocket_ic::{PocketIcBuilder, WasmResult};
 use serde::Deserialize;
+use std::time::Duration;
 
 const RUMI_POINTS_WASM: &[u8] =
     include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_points.wasm");
@@ -117,6 +118,61 @@ fn poll_ingests_backend_event_and_auto_registers() {
     };
     assert_eq!(applied2, Ok(0), "second poll ingests nothing (caught up)");
     assert!(is_registered(&pic, rp, synthetic_caller()), "still registered");
+}
+
+/// Phase 2b: the periodic timer (not a manual trigger) drives ingestion. Enable
+/// it, advance past one interval, and confirm the timer-driven poll auto-registered
+/// the event's caller.
+#[test]
+fn poll_timer_drives_ingestion() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    let mock = pic.create_canister();
+    pic.add_cycles(mock, 2_000_000_000_000);
+    pic.install_canister(mock, MOCK_SOURCE_WASM.to_vec(), Encode!().unwrap(), None);
+
+    let rp = pic.create_canister();
+    pic.add_cycles(rp, 4_000_000_000_000);
+    let init = InitArgs {
+        admin: Some(admin()),
+        excluded_principals: None,
+        season_start_ns: None,
+        season_end_ns: None,
+        snapshot_seed_commit: None,
+    };
+    pic.install_canister(rp, RUMI_POINTS_WASM.to_vec(), Encode!(&Some(init)).unwrap(), None);
+
+    admin_ok(&pic, rp, "set_source_canister", Encode!(&0u8, &mock).unwrap());
+
+    // Timer off by default; nobody registered, no manual poll.
+    assert!(!is_registered(&pic, rp, synthetic_caller()));
+
+    // Enable the timer at the minimum cadence.
+    admin_ok(&pic, rp, "set_poll_interval_secs", Encode!(&60u64).unwrap());
+    admin_ok(&pic, rp, "set_poll_enabled", Encode!(&true).unwrap());
+
+    // Advance past one interval and let the timer fire + the async poll complete.
+    pic.advance_time(Duration::from_secs(70));
+    for _ in 0..15 {
+        pic.tick();
+    }
+
+    assert!(
+        is_registered(&pic, rp, synthetic_caller()),
+        "the timer-driven poll should have auto-registered the event's caller"
+    );
+}
+
+/// Call an admin update returning `Result<(), PointsError>` and assert Ok.
+fn admin_ok(pic: &pocket_ic::PocketIc, rp: Principal, method: &str, args: Vec<u8>) {
+    let res = pic.update_call(rp, admin(), method, args).expect("admin call failed");
+    match res {
+        WasmResult::Reply(b) => {
+            let r: Result<(), PointsError> = Decode!(&b, Result<(), PointsError>).unwrap();
+            assert_eq!(r, Ok(()), "{method} should succeed for admin");
+        }
+        WasmResult::Reject(m) => panic!("{method} rejected: {m}"),
+    }
 }
 
 fn is_registered(pic: &pocket_ic::PocketIc, rp: Principal, who: Principal) -> bool {


### PR DESCRIPTION
Makes `rumi_points` ingestion auto-run. Builds on the Phase 2/3 ingestion merged in #217.

- **Off by default** so a fresh canister burns no cycles until an operator configures sources and enables it for the season.
- `POLL_CONFIG` stable map (MemoryId 10) for enabled + interval; admin `set_poll_enabled` / `set_poll_interval_secs` with a `MIN_POLL_INTERVAL_SECS` floor (default 300s) so the cadence can never become a cycle-burning near-heartbeat.
- `setup_poll_timer()` (re)arms `ic_cdk_timers::set_timer_interval`; the tick spawns `poll_all` (its single-poll guard handles overlap). `init` + `post_upgrade` call it (timers do NOT survive upgrades, so it re-arms from the persisted config).
- `get_ingest_status` reports `poll_enabled` + `poll_interval_secs`. `.did` + candid drift test updated.

**Validation:** 37 rumi_points unit tests (incl. poll-config defaults/floor/admin-gate) + a new PocketIC E2E (`poll_timer_drives_ingestion`) that enables the timer, advances past one interval, and asserts the timer-driven poll (no manual trigger) auto-registered the event's caller. Both E2E tests green.

Run the E2E:
```
cargo build --release --target wasm32-unknown-unknown -p rumi_points -p rumi_points_e2e_source
POCKET_IC_BIN=$PWD/pocket-ic cargo test -p rumi_points --test pocket_ic_ingest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)