### PR TITLE
feat(airdrop): Phase 4+5 points accrual engine for rumi_points

### DIFF
--- a/src/rumi_points/STATUS.md
+++ b/src/rumi_points/STATUS.md
@@ -1,13 +1,22 @@
 # rumi_points — status
 
 **Phase 1 (scaffold): COMPLETE.** **Phase 2 / 2b / 3 (ingestion + timer +
-auto-registration): COMPLETE and PocketIC-E2E-validated.** Merged to `main`
-(PR #217; Phase 2b in a follow-up). Not yet deployed to mainnet; no mainnet canister
-id reserved.
+auto-registration): COMPLETE and PocketIC-E2E-validated, merged to `main`** (PR #217).
+**Phase 4 (3USD verification) + Phase 5 (accrual engine): COMPLETE on branch
+`feat/airdrop-phase5-accrual`** (NOT yet merged, NOT deployed). 126 lib unit tests +
+candid drift + 4 PocketIC E2E (2 ingest + 2 accrual), all green; zero warnings.
 
-Ingestion is now FUNCTIONAL: the off-by-default poll timer (Phase 2b) auto-polls the
-sources and auto-registers principals on their first qualifying in-season action.
-Still missing for a USEFUL airdrop: accrual (Phase 5) and 3USD verification (Phase 4).
+The canister is now a FULL airdrop engine: ingestion auto-registers, the weekly
+epoch driver captures two randomized intra-epoch snapshots of every registered
+principal's balances, takes `min()` (anti-sniping), applies the multiplier table
+with 3USD verification, accrues dollar-days, and reveals the commit-reveal seed.
+Design doc: `docs/notes/2026-06-02-phase5-accrual-design.md` (gitignored, local).
+
+Phase 5 blocker carried forward: the 5x ckUSDC/ckUSDT repayment window is GATED on
+the upstream backend `RepayToVault.repayment_asset` field (not yet built). The full
+window machinery + tests exist; `IngestKind::VaultRepay` carries `repayment_asset:
+Option<Principal>` (normalized to `None` until upstream lands), and the window is
+skipped (logged) while it is `None`. Flip the backend normalizer when it ships.
 
 ## Deploy posture (why nothing is on mainnet yet)
 Not urgent, because a LATER deploy loses no data: the cursor starts at 0 and the
@@ -22,12 +31,21 @@ then admin `set_poll_enabled(true)` once sources are confirmed. The pre-deploy h
 runs the full suite (including the POCKET_IC_BIN E2E).
 
 ## Next phases (fresh focused sessions)
-- Phase 4: 3USD verification (`min(recorded, wallet+SP+AMM)`), needs the
-  `repayment_asset` upstream field for the 5x repayment window.
-- Phase 5: epoch driver + multiplier table + two-snapshot `min()` + the
-  commit-reveal snapshot scheduler (`epoch.rs`, `valuation.rs`, `snapshot_seed.rs`
-  are documented skeletons today).
+- Phase 6: frontend integration (confetti enrollment, personal status, leaderboard).
 - Phases 7-8: the claim canister (liquid + lock-tier haircut ladder).
+- Upstream: add `repayment_asset` to the backend `RepayToVault` event (separate
+  backend branch), then flip `source_types::backend::normalize` to read it and the
+  5x window activates with no other change here.
+
+## Phase 5 review follow-ups (deferred, non-blocking)
+From the 2026-06-02 code review (no critical/high bugs found). Fixed in-branch:
+ICP non-finite-rate guard, repayment-window pruning at close, atomic-trap on the
+(unreachable) seed-close failure, per-principal source-id caching. Still open:
+- `epoch.rs` capture has no STALL counter if a source stays unreachable past a
+  snapshot time (the epoch safely never closes; visible via `get_epoch_status`,
+  recoverable via `force_epoch_tick`). Consider surfacing a stall count.
+- `set_asset_ledger` / `set_source_canister` accept any `u8` tag (admin-only;
+  out-of-range writes a harmless dead entry). Minor range-validation nicety.
 
 Spec: `docs/specs/rumi-airdrop-spec-v2.md` (Section 7 data model, Section 11 excluded
 principals). Plan: `docs/plans/2026-05-03-airdrop-implementation-plan.md`.
@@ -86,11 +104,19 @@ wire, though the `source_types` canary already pins the superset-decode rule.
 - `events.rs` / `source_types.rs` / `poll.rs` are the real Phase 2/3 ingestion (see
   the "ingestion machinery" section above), no longer skeleton.
 
-## What is skeleton (later phases; signatures + doc comments only)
-- `epoch.rs`   — Phase 5 weekly two-snapshot `min()` accrual.
-- `valuation.rs` — Phase 4/5 asset valuation + 3USD verification.
-- `snapshot_seed.rs` — Phase 5 commit-reveal algorithm (its STATE types are real
-  and already in the stable layout).
+## Phase 4/5 modules (now REAL, fully tested; no longer skeleton)
+- `accrual.rs` (new) — pure accrual math: `SnapshotWeights` (the MemoryId-11 value),
+  the multiplier table (`snapshot_weights`), 3USD `apply_verification`, `min_by_total`
+  (keeps the smaller-TOTAL snapshot whole, not field-wise), `scale_by_period`,
+  `accrue_principal` (close-time), `build_snapshot_inputs` (AMM share + vp), and the
+  `repayment_points` window math. ~29 unit tests.
+- `epoch.rs` — the periodic state-machine driver (`next_action`), chunked async
+  snapshot capture with resume cursor, `start_season` bootstrap, epoch close, the
+  commit-reveal `summary_hash`, and all inter-canister `fetch_*` helpers.
+- `valuation.rs` — `value_usd_e8s` (face + ck `*100` + ICP oracle, non-finite-guarded),
+  `value_lp_at_vp`, `value_stable_usd_e8s`.
+- `snapshot_seed.rs` — `derive_snapshot_times` + `SeedManager::start_epoch/close_epoch`
+  implemented per spike 0.3 (13 tests incl. the 3-epoch hash chain).
 
 ## Stable memory map (MemoryId -> structure; never reuse an id)
 | Id | Structure |
@@ -98,8 +124,17 @@ wire, though the `source_types` canary already pins the superset-decode rule.
 | 0  | `StableBTreeMap<Principal, StoredPrincipalState>` (per-principal accrual) |
 | 1/2| `StableLog<StoredPointEntry>` (append-only audit ledger) |
 | 3/4| `StableLog<StoredEpochSummary>` (per-epoch rollups) |
-| 5/6| `StableLog<StoredRevealedSeed>` (commit-reveal audit log; reserved, Phase 5) |
-| 7  | singleton `State` blob (8-byte LE len prefix + CBOR `StoredState::V1`) |
+| 5/6| `StableLog<StoredRevealedSeed>` (commit-reveal audit log; Phase 5, wired) |
+| 7  | singleton `State` blob (8-byte LE len prefix + CBOR `StoredState::V2`) |
+| 8  | per-source ingestion cursors |
+| 9  | per-source canister ids (mainnet-seeded) |
+| 10 | poll-timer config |
+| 11 | `StableBTreeMap<Principal, StoredSnapshotWeights>` (open-epoch min buffer) |
+| 12 | asset-ledger registry (asset tag -> ledger; mainnet-seeded, admin override) |
+| 13 | epoch-driver config (enabled / interval) |
+
+`State` is now `StoredState::{ V1(StateV1), V2(State) }`: V2 adds `open_epoch`. Old
+V1 blob bytes decode via `From<StateV1>` (defaulting `open_epoch=None`); no wipe.
 
 ## Excluded-principals seed (confirmed against canister_ids.json, 2026-06-01)
 9 protocol-owned canisters: rumi_protocol_backend, rumi_3pool, rumi_amm,
@@ -119,4 +154,13 @@ mutable set.
 - Reserve a mainnet canister id + add to `canister_ids.json` / `mainnet-live`
   (irreversible; requires explicit OK).
 
-## Do NOT start Phase 2 from here without re-reading the handoff + spec.
+## Operating the epoch driver (Phase 5)
+OFF by default (like the poll timer). To run a season: enable the poll + confirm
+registrations, then admin `start_season(S0)` (the 32-byte secret seed; commit `H0 =
+sha256(S0)` at init via `snapshot_seed_commit`). `start_season` opens epoch 0 and
+enables the driver. `get_epoch_status` shows the open epoch + driver state;
+`force_epoch_tick` steps the machine manually (ops recovery / E2E);
+`get_revealed_seed(i)` + `get_pending_commit` expose the audit chain. Asset/source
+ids are admin-overridable for local/test (`set_asset_ledger` / `set_source_canister`).
+
+## Next: Phase 6 (frontend) or merge + deploy this branch (needs Rob's OK).

--- a/src/rumi_points/rumi_points.did
+++ b/src/rumi_points/rumi_points.did
@@ -1,131 +1,135 @@
-// Candid interface for rumi_points (Season 1 airdrop points engine).
-// Phase 1 scaffold: read endpoints + admin-gated test registration / excluded-set
-// management. Event ingestion, epoch math, and the claim surface are later phases.
-// Kept structurally in sync with the Rust endpoints by the `candid_interface_matches_did_file`
-// test (src/main.rs).
-
-type AssetType = variant { IcUsd; CkUsdc; CkUsdt; ThreeUsd; Icp };
-
-type Venue = variant { Vault; ThreePool; StabilityPool; Amm };
-
-type QualifyingAction = variant {
-  MintIcUsd;
-  RepayVault;
-  Deposit3Pool;
-  DepositStabilityPool;
-  ProvideAmmLiquidity;
-};
-
-type DepositKey = record { venue : Venue; asset : AssetType };
-
+type AssetType = variant { Icp; IcUsd; CkUsdc; CkUsdt; ThreeUsd };
+type DepositKey = record { asset : AssetType; venue : Venue };
 type DepositRecord = record {
   asset : AssetType;
   venue : Venue;
-  recorded_value_usd : nat;
-  deposited_at : nat64;
   last_verified_at : nat64;
+  deposited_at : nat64;
+  recorded_value_usd : nat;
 };
-
-type RepaymentEvent = record {
-  asset : AssetType;
-  amount_usd : nat;
-  repaid_at : nat64;
-  window_end : nat64;
+type EpochStatus = record {
+  open_epoch : opt OpenEpoch;
+  snapshot_seed_committed : bool;
+  driver_interval_secs : nat64;
+  revealed_seed_count : nat64;
+  current_epoch_index : nat64;
+  driver_enabled : bool;
 };
-
-type PrincipalState = record {
-  "principal" : principal;
-  total_points : nat;
-  active_deposits : vec record { DepositKey; DepositRecord };
-  repayment_events : vec RepaymentEvent;
-  last_epoch_processed : nat64;
-  registered_at_ns : nat64;
-  first_qualifying_action : QualifyingAction;
-};
-
 type EpochSummary = record {
   epoch_index : nat64;
-  epoch_start_ns : nat64;
-  epoch_end_ns : nat64;
-  total_points_all : nat;
   points_accrued_this_epoch : nat;
-  active_principals : nat64;
+  epoch_start_ns : nat64;
   registered_principals : nat64;
+  active_principals : nat64;
+  total_points_all : nat;
   snapshot_a_ns : nat64;
   snapshot_b_ns : nat64;
+  epoch_end_ns : nat64;
 };
-
+type IngestStatus = record {
+  registered_count : nat64;
+  poll_interval_secs : nat64;
+  poll_enabled : bool;
+  sources : vec SourceStatus;
+};
+type InitArgs = record {
+  admin : opt principal;
+  excluded_principals : opt vec principal;
+  snapshot_seed_commit : opt blob;
+  season_start_ns : opt nat64;
+  season_end_ns : opt nat64;
+};
 type LeaderboardEntry = record {
-  rank : nat32;
   "principal" : principal;
   total_points : nat;
+  rank : nat32;
   estimated_share_bps : nat32;
 };
-
+type OpenEpoch = record {
+  epoch_index : nat64;
+  epoch_start_ns : nat64;
+  a_cursor : opt principal;
+  b_complete : bool;
+  b_cursor : opt principal;
+  a_complete : bool;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+  epoch_end_ns : nat64;
+};
+type PointsConfig = record {
+  admin : principal;
+  registered_count : nat64;
+  snapshot_seed_committed : bool;
+  excluded_count : nat32;
+  season_start_ns : nat64;
+  season_end_ns : nat64;
+  current_epoch_index : nat64;
+};
+type PointsError = variant { Unauthorized; Excluded };
+type PrincipalState = record {
+  "principal" : principal;
+  registered_at_ns : nat64;
+  total_points : nat;
+  repayment_events : vec RepaymentEvent;
+  first_qualifying_action : QualifyingAction;
+  active_deposits : vec record { DepositKey; DepositRecord };
+  last_epoch_processed : nat64;
+};
+type QualifyingAction = variant {
+  ProvideAmmLiquidity;
+  MintIcUsd;
+  Deposit3Pool;
+  DepositStabilityPool;
+  RepayVault;
+};
 type RegistrationInfo = record {
   "principal" : principal;
   registered_at_ns : nat64;
   first_qualifying_action : QualifyingAction;
 };
-
-type PointsConfig = record {
-  admin : principal;
-  season_start_ns : nat64;
-  season_end_ns : nat64;
-  excluded_count : nat32;
-  registered_count : nat64;
-  current_epoch_index : nat64;
-  snapshot_seed_committed : bool;
+type RepaymentEvent = record {
+  asset : AssetType;
+  repaid_at : nat64;
+  amount_usd : nat;
+  window_end : nat64;
 };
-
-type PointsError = variant { Unauthorized; Excluded };
-
-type InitArgs = record {
-  admin : opt principal;
-  excluded_principals : opt vec principal;
-  season_start_ns : opt nat64;
-  season_end_ns : opt nat64;
-  snapshot_seed_commit : opt blob;
-};
-
 type Result = variant { Ok; Err : PointsError };
-
-type Result_1 = variant { Ok : nat64; Err : PointsError };
-
-type SourceStatus = record {
-  tag : nat8;
-  canister : principal;
-  cursor : nat64;
+type Result_1 = variant { Ok; Err : text };
+type Result_2 = variant { Ok : nat64; Err : PointsError };
+type RevealedSeed = record {
+  revealed_at_ns : nat64;
+  epoch_index : nat64;
+  seed : blob;
+  snapshot_time_a_ns : nat64;
+  snapshot_time_b_ns : nat64;
 };
-
-type IngestStatus = record {
-  sources : vec SourceStatus;
-  registered_count : nat64;
-  poll_enabled : bool;
-  poll_interval_secs : nat64;
-};
-
+type SourceStatus = record { tag : nat8; cursor : nat64; canister : principal };
+type Venue = variant { Amm; ThreePool; Vault; StabilityPool };
 service : (opt InitArgs) -> {
-  // Reads
-  get_principal_state : (principal) -> (opt PrincipalState) query;
-  get_leaderboard : (nat32, nat32) -> (vec LeaderboardEntry) query;
-  get_epoch_history : (nat32, nat32) -> (vec EpochSummary) query;
-  is_registered : (principal) -> (bool) query;
-  get_registration_info : (principal) -> (opt RegistrationInfo) query;
-  is_excluded : (principal) -> (bool) query;
-  get_excluded_principals : () -> (vec principal) query;
-  get_points_config : () -> (PointsConfig) query;
-
-  // Admin-gated updates
-  register_test_principal : (principal) -> (Result);
   add_excluded_principal : (principal) -> (Result);
+  force_epoch_tick : () -> (Result);
+  get_asset_ledgers : () -> (vec record { nat8; principal }) query;
+  get_epoch_history : (nat32, nat32) -> (vec EpochSummary) query;
+  get_epoch_status : () -> (EpochStatus) query;
+  get_excluded_principals : () -> (vec principal) query;
+  get_ingest_status : () -> (IngestStatus) query;
+  get_leaderboard : (nat32, nat32) -> (vec LeaderboardEntry) query;
+  get_pending_commit : () -> (blob) query;
+  get_points_config : () -> (PointsConfig) query;
+  get_principal_state : (principal) -> (opt PrincipalState) query;
+  get_registration_info : (principal) -> (opt RegistrationInfo) query;
+  get_revealed_seed : (nat64) -> (opt RevealedSeed) query;
+  is_excluded : (principal) -> (bool) query;
+  is_registered : (principal) -> (bool) query;
+  register_test_principal : (principal) -> (Result);
   remove_excluded_principal : (principal) -> (Result);
+  set_asset_ledger : (nat8, principal) -> (Result);
+  set_epoch_driver_enabled : (bool) -> (Result);
+  set_epoch_driver_interval_secs : (nat64) -> (Result);
   set_excluded_principals : (vec principal) -> (Result);
-
-  // Phase 2: ingestion control
-  set_source_canister : (nat8, principal) -> (Result);
-  trigger_poll : () -> (Result_1);
   set_poll_enabled : (bool) -> (Result);
   set_poll_interval_secs : (nat64) -> (Result);
-  get_ingest_status : () -> (IngestStatus) query;
-};
+  set_source_canister : (nat8, principal) -> (Result);
+  start_season : (blob) -> (Result_1);
+  trigger_poll : () -> (Result_2);
+}

--- a/src/rumi_points/src/accrual.rs
+++ b/src/rumi_points/src/accrual.rs
@@ -1,0 +1,630 @@
+//! Pure accrual math (spec Sections 4-6, implementation plan Phase 5). NO IC
+//! calls: the snapshot driver (`epoch.rs`) fetches balances/prices and feeds them
+//! here as `usd_e8s`, so every multiplier, verification, min(), and repayment-
+//! window rule is unit-testable in isolation.
+//!
+//! `SnapshotWeights` are the per-source "weighted values" (value x multiplier) at
+//! one snapshot, in `usd_e8s`. The two intra-epoch snapshots reduce by
+//! `min_by_total` (keep the smaller-TOTAL snapshot's WHOLE breakdown, closing
+//! cross-position sniping), then `scale_by_period` turns the weighted value into
+//! `usd_e8s`-days points. Repayment-window points (Section 6) are computed
+//! separately and added OUTSIDE the min() (a past repayment cannot be sniped).
+
+#![allow(dead_code)] // wired by the Phase 5 accrual driver
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{AssetType, PointSource, RepaymentEvent};
+use crate::valuation::{value_lp_at_vp, value_usd_e8s, SnapshotPrices};
+use crate::NANOS_PER_DAY;
+
+/// Per-source weighted values (value x multiplier, `usd_e8s`) captured at one
+/// snapshot. Also the at-rest value of the MemoryId-11 snapshot buffer (wrapped in
+/// a versioned `Stored*` enum in `state.rs`).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SnapshotWeights {
+    /// icUSD vault debt outstanding, 1x.
+    pub icusd_debt: u128,
+    /// icUSD deposited in the 3pool, 1x (after verification).
+    pub icusd_3pool: u128,
+    /// Matched ckUSDC+ckUSDT in the 3pool, `2*min(usdc,usdt)` at 5x.
+    pub ck_matched: u128,
+    /// Unmatched ck-stable in the 3pool, `|usdc-usdt|` at 3x.
+    pub ck_unmatched: u128,
+    /// icUSD in the stability pool, 1x.
+    pub icusd_sp: u128,
+    /// 3USD in the stability pool, 2x.
+    pub threeusd_sp: u128,
+    /// 3USD/ICP AMM LP, 2x.
+    pub amm_lp: u128,
+}
+
+impl SnapshotWeights {
+    /// Sum of all seven weighted values (the principal's snapshot total).
+    pub fn total(&self) -> u128 {
+        self.icusd_debt
+            .saturating_add(self.icusd_3pool)
+            .saturating_add(self.ck_matched)
+            .saturating_add(self.ck_unmatched)
+            .saturating_add(self.icusd_sp)
+            .saturating_add(self.threeusd_sp)
+            .saturating_add(self.amm_lp)
+    }
+
+    /// Non-zero `(source, weight)` pairs, for writing one `PointEntry` per active
+    /// activity. Skips zero fields so no empty ledger rows are written.
+    pub fn by_source(&self) -> Vec<(PointSource, u128)> {
+        [
+            (PointSource::IcUsdDebt, self.icusd_debt),
+            (PointSource::IcUsd3Pool, self.icusd_3pool),
+            (PointSource::CkStable3PoolMatched, self.ck_matched),
+            (PointSource::CkStable3PoolUnmatched, self.ck_unmatched),
+            (PointSource::IcUsdStabilityPool, self.icusd_sp),
+            (PointSource::ThreeUsdStabilityPool, self.threeusd_sp),
+            (PointSource::AmmLp, self.amm_lp),
+        ]
+        .into_iter()
+        .filter(|(_, weight)| *weight > 0)
+        .collect()
+    }
+}
+
+/// Reduce the two intra-epoch snapshots: keep the snapshot with the SMALLER total
+/// (its WHOLE breakdown, not a field-wise min, so a user cannot hold position X at
+/// snapshot A and position Y at snapshot B and collect both). Ties keep `a`.
+pub fn min_by_total(a: SnapshotWeights, b: SnapshotWeights) -> SnapshotWeights {
+    if a.total() <= b.total() {
+        a
+    } else {
+        b
+    }
+}
+
+/// Turn weighted values (`usd_e8s`) into `usd_e8s`-days points by holding the
+/// snapshot value over `period_ns`: each field `* period_ns / NANOS_PER_DAY`.
+pub fn scale_by_period(w: SnapshotWeights, period_ns: u64) -> SnapshotWeights {
+    let scale = |v: u128| v.saturating_mul(period_ns as u128) / NANOS_PER_DAY as u128;
+    SnapshotWeights {
+        icusd_debt: scale(w.icusd_debt),
+        icusd_3pool: scale(w.icusd_3pool),
+        ck_matched: scale(w.ck_matched),
+        ck_unmatched: scale(w.ck_unmatched),
+        icusd_sp: scale(w.icusd_sp),
+        threeusd_sp: scale(w.threeusd_sp),
+        amm_lp: scale(w.amm_lp),
+    }
+}
+
+/// 0.5% upward tolerance on verified 3USD (spec open-question #3 / Phase 4),
+/// absorbing rounding and dust without rewarding fragmentation.
+const VERIFICATION_TOLERANCE_NUM: u128 = 1005;
+const VERIFICATION_TOLERANCE_DEN: u128 = 1000;
+
+/// One principal's snapshot inputs, all `usd_e8s`, fetched by the driver
+/// (`epoch.rs`) so the math here stays pure.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SnapshotInputs {
+    /// Sum of the principal's current vault debt (icUSD face, 1:1 `usd_e8s`).
+    pub vault_debt: u128,
+    /// Recorded 3pool deposit composition (from `active_deposits`), `usd_e8s`.
+    pub recorded_3pool_icusd: u128,
+    pub recorded_3pool_usdc: u128,
+    pub recorded_3pool_usdt: u128,
+    /// Wallet + SP + AMM 3USD valued at `virtual_price`, summed (pre-tolerance).
+    pub verified_3usd: u128,
+    /// Stability-pool balances.
+    pub sp_icusd: u128,
+    pub sp_3usd: u128,
+    /// AMM LP value (3USD share + ICP share), pre-multiplier.
+    pub amm_lp_value: u128,
+}
+
+/// Apply the 0.5% upward tolerance to raw verified 3USD.
+fn verification_cap(verified_3usd: u128) -> u128 {
+    verified_3usd.saturating_mul(VERIFICATION_TOLERANCE_NUM) / VERIFICATION_TOLERANCE_DEN
+}
+
+/// Scale the recorded 3pool composition down by the verification factor
+/// `min(cap, total) / total` (spec Section 5), applied uniformly so the
+/// matched/unmatched split is unaffected by where we scale. Returns the effective
+/// (icUSD, ckUSDC, ckUSDT) values in `usd_e8s`.
+fn apply_verification(
+    recorded_icusd: u128,
+    recorded_usdc: u128,
+    recorded_usdt: u128,
+    cap: u128,
+) -> (u128, u128, u128) {
+    let total = recorded_icusd
+        .saturating_add(recorded_usdc)
+        .saturating_add(recorded_usdt);
+    if total == 0 {
+        return (0, 0, 0);
+    }
+    let capped = cap.min(total);
+    let scale = |r: u128| r.saturating_mul(capped) / total;
+    (scale(recorded_icusd), scale(recorded_usdc), scale(recorded_usdt))
+}
+
+/// One principal's per-source weighted values at a snapshot (the multiplier table,
+/// spec Section 4). The caller skips excluded principals.
+pub fn snapshot_weights(inp: &SnapshotInputs) -> SnapshotWeights {
+    let (eff_icusd, eff_usdc, eff_usdt) = apply_verification(
+        inp.recorded_3pool_icusd,
+        inp.recorded_3pool_usdc,
+        inp.recorded_3pool_usdt,
+        verification_cap(inp.verified_3usd),
+    );
+    SnapshotWeights {
+        icusd_debt: inp.vault_debt,
+        icusd_3pool: eff_icusd,
+        // matched value 2*min(usdc,usdt) at 5x; unmatched |usdc-usdt| at 3x.
+        ck_matched: eff_usdc.min(eff_usdt).saturating_mul(2).saturating_mul(5),
+        ck_unmatched: eff_usdc.abs_diff(eff_usdt).saturating_mul(3),
+        icusd_sp: inp.sp_icusd,
+        threeusd_sp: inp.sp_3usd.saturating_mul(2),
+        amm_lp: inp.amm_lp_value.saturating_mul(2),
+    }
+}
+
+/// Points for one repayment event's overlap with one epoch (spec Section 6),
+/// computed OUTSIDE the snapshot min() because a past repayment cannot be sniped:
+/// `amount_usd_e8s * 5 * overlap_ns / NANOS_PER_DAY`. `epoch_end_capped` is
+/// `min(epoch_end, season_end)`; `window_end` is already capped at season end when
+/// the event is recorded. Returns 0 when the window and epoch do not overlap.
+pub fn repayment_points(
+    amount_usd_e8s: u128,
+    repaid_at: u64,
+    window_end: u64,
+    epoch_start: u64,
+    epoch_end_capped: u64,
+) -> u128 {
+    let overlap_start = repaid_at.max(epoch_start);
+    let overlap_end = window_end.min(epoch_end_capped);
+    let overlap_ns = overlap_end.saturating_sub(overlap_start);
+    amount_usd_e8s
+        .saturating_mul(5)
+        .saturating_mul(overlap_ns as u128)
+        / NANOS_PER_DAY as u128
+}
+
+/// Raw per-principal query results at a snapshot, all `usd_e8s` except the AMM LP
+/// counts (LP units) and reserves (`usd_e8s` for 3USD, native e8s for ICP). The
+/// driver fills this from inter-canister queries; `build_snapshot_inputs` turns it
+/// into `SnapshotInputs` (the AMM share math + virtual-price verification).
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct RawSnapshot {
+    pub vault_debt: u128,
+    pub recorded_icusd: u128,
+    pub recorded_usdc: u128,
+    pub recorded_usdt: u128,
+    /// Wallet 3USD/LP balance (3pool `icrc1_balance_of`).
+    pub wallet_3usd: u128,
+    pub sp_icusd: u128,
+    pub sp_3usd: u128,
+    /// AMM 3USD/ICP pool: the principal's LP, the pool's total LP, and reserves.
+    pub amm_user_lp: u128,
+    pub amm_total_lp: u128,
+    pub amm_reserve_3usd: u128,
+    pub amm_reserve_icp: u128,
+}
+
+/// Assemble `SnapshotInputs` from raw query results: derive the AMM 3USD/ICP shares
+/// from the LP ratio, value the LP position at face, and value the verification
+/// total (wallet + SP + AMM 3USD) at `virtual_price`.
+pub fn build_snapshot_inputs(raw: &RawSnapshot, prices: &SnapshotPrices) -> SnapshotInputs {
+    let (amm_3usd_share, amm_icp_share) = if raw.amm_total_lp == 0 {
+        (0, 0)
+    } else {
+        (
+            raw.amm_user_lp.saturating_mul(raw.amm_reserve_3usd) / raw.amm_total_lp,
+            raw.amm_user_lp.saturating_mul(raw.amm_reserve_icp) / raw.amm_total_lp,
+        )
+    };
+    // AMM LP position at face: 3USD share ($1) + ICP share at the oracle rate.
+    let amm_lp_value =
+        amm_3usd_share.saturating_add(value_usd_e8s(AssetType::Icp, amm_icp_share, prices));
+    // Verification cap at virtual_price across all three 3USD venues.
+    let verified_3usd = value_lp_at_vp(
+        raw.wallet_3usd
+            .saturating_add(raw.sp_3usd)
+            .saturating_add(amm_3usd_share),
+        prices.virtual_price,
+    );
+    SnapshotInputs {
+        vault_debt: raw.vault_debt,
+        recorded_3pool_icusd: raw.recorded_icusd,
+        recorded_3pool_usdc: raw.recorded_usdc,
+        recorded_3pool_usdt: raw.recorded_usdt,
+        verified_3usd,
+        sp_icusd: raw.sp_icusd,
+        sp_3usd: raw.sp_3usd,
+        amm_lp_value,
+    }
+}
+
+/// Close-time accrual for one principal: scale the min-snapshot weights over the
+/// epoch period into per-source points, then add the repayment-window points
+/// (OUTSIDE the min). Returns the per-source ledger entries and the total delta.
+pub fn accrue_principal(
+    min_weights: SnapshotWeights,
+    repayments: &[RepaymentEvent],
+    epoch_start: u64,
+    epoch_end_capped: u64,
+) -> (Vec<(PointSource, u128)>, u128) {
+    let period_ns = epoch_end_capped.saturating_sub(epoch_start);
+    let mut entries = scale_by_period(min_weights, period_ns).by_source();
+    let repay_total = repayments.iter().fold(0u128, |acc, r| {
+        acc.saturating_add(repayment_points(
+            r.amount_usd,
+            r.repaid_at,
+            r.window_end,
+            epoch_start,
+            epoch_end_capped,
+        ))
+    });
+    if repay_total > 0 {
+        entries.push((PointSource::VaultRepayment, repay_total));
+    }
+    let total = entries
+        .iter()
+        .fold(0u128, |acc, (_, p)| acc.saturating_add(*p));
+    (entries, total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NS_PER_WEEK: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+    fn inputs() -> SnapshotInputs {
+        SnapshotInputs::default()
+    }
+
+    fn w(
+        icusd_debt: u128,
+        icusd_3pool: u128,
+        ck_matched: u128,
+        ck_unmatched: u128,
+        icusd_sp: u128,
+        threeusd_sp: u128,
+        amm_lp: u128,
+    ) -> SnapshotWeights {
+        SnapshotWeights {
+            icusd_debt,
+            icusd_3pool,
+            ck_matched,
+            ck_unmatched,
+            icusd_sp,
+            threeusd_sp,
+            amm_lp,
+        }
+    }
+
+    #[test]
+    fn total_sums_all_seven_fields() {
+        assert_eq!(w(1, 2, 4, 8, 16, 32, 64).total(), 127);
+        assert_eq!(SnapshotWeights::default().total(), 0);
+    }
+
+    #[test]
+    fn min_by_total_keeps_the_smaller_total_as_a_whole() {
+        // a's total (100) < b's total (200), but b dominates a field-wise. The
+        // result must equal a entirely, proving it is NOT a field-wise min.
+        let a = w(100, 0, 0, 0, 0, 0, 0); // total 100
+        let b = w(50, 50, 50, 50, 0, 0, 0); // total 200, larger in 3 fields
+        assert_eq!(min_by_total(a, b), a);
+        assert_eq!(min_by_total(b, a), a);
+    }
+
+    #[test]
+    fn min_by_total_ties_keep_first() {
+        let a = w(10, 0, 0, 0, 0, 0, 0);
+        let b = w(0, 10, 0, 0, 0, 0, 0); // same total, different breakdown
+        assert_eq!(min_by_total(a, b), a);
+    }
+
+    #[test]
+    fn scale_by_period_full_week_multiplies_each_field_by_seven() {
+        let scaled = scale_by_period(w(100, 200, 0, 0, 0, 0, 0), NS_PER_WEEK);
+        assert_eq!(scaled.icusd_debt, 700);
+        assert_eq!(scaled.icusd_3pool, 1_400);
+    }
+
+    #[test]
+    fn scale_by_period_partial_days() {
+        // One full day -> x1; half a day -> halved.
+        assert_eq!(scale_by_period(w(100, 0, 0, 0, 0, 0, 0), NANOS_PER_DAY).icusd_debt, 100);
+        assert_eq!(
+            scale_by_period(w(100, 0, 0, 0, 0, 0, 0), NANOS_PER_DAY / 2).icusd_debt,
+            50
+        );
+    }
+
+    #[test]
+    fn by_source_maps_nonzero_fields_only() {
+        let got = w(10, 0, 5, 0, 0, 7, 0).by_source();
+        assert_eq!(
+            got,
+            vec![
+                (PointSource::IcUsdDebt, 10),
+                (PointSource::CkStable3PoolMatched, 5),
+                (PointSource::ThreeUsdStabilityPool, 7),
+            ]
+        );
+        assert!(SnapshotWeights::default().by_source().is_empty());
+    }
+
+    // ── verification factor (spec Section 5) ──
+
+    #[test]
+    fn verification_cap_applies_half_percent_tolerance() {
+        assert_eq!(verification_cap(1_000), 1_005);
+        assert_eq!(verification_cap(0), 0);
+    }
+
+    #[test]
+    fn verification_full_holding_does_not_scale() {
+        // cap >= total -> factor 1 -> effective == recorded.
+        assert_eq!(apply_verification(100, 200, 300, 10_000), (100, 200, 300));
+    }
+
+    #[test]
+    fn verification_half_holding_scales_proportionally() {
+        // recorded total 200, cap 100 -> factor 0.5.
+        assert_eq!(apply_verification(0, 100, 100, 100), (0, 50, 50));
+    }
+
+    #[test]
+    fn verification_zero_holding_zeros_everything() {
+        assert_eq!(apply_verification(100, 200, 300, 0), (0, 0, 0));
+    }
+
+    #[test]
+    fn verification_over_recorded_caps_at_recorded() {
+        // Holding more 3USD than recorded never inflates above the recorded value.
+        assert_eq!(apply_verification(100, 0, 0, 10_000), (100, 0, 0));
+    }
+
+    #[test]
+    fn verification_zero_recorded_is_zero_regardless_of_cap() {
+        assert_eq!(apply_verification(0, 0, 0, 999), (0, 0, 0));
+    }
+
+    // ── multiplier table (spec Section 4) ──
+
+    #[test]
+    fn snapshot_weights_apply_each_multiplier() {
+        let got = snapshot_weights(&SnapshotInputs {
+            vault_debt: 100,
+            recorded_3pool_icusd: 100,
+            verified_3usd: 1_000_000, // ample -> factor 1
+            sp_icusd: 100,
+            sp_3usd: 100,
+            amm_lp_value: 100,
+            ..inputs()
+        });
+        assert_eq!(got.icusd_debt, 100); // 1x
+        assert_eq!(got.icusd_3pool, 100); // 1x
+        assert_eq!(got.icusd_sp, 100); // 1x
+        assert_eq!(got.threeusd_sp, 200); // 2x
+        assert_eq!(got.amm_lp, 200); // 2x
+        assert_eq!(got.ck_matched, 0);
+        assert_eq!(got.ck_unmatched, 0);
+    }
+
+    #[test]
+    fn matched_pair_accrues_5x_unmatched_3x() {
+        let got = snapshot_weights(&SnapshotInputs {
+            recorded_3pool_usdc: 50,
+            recorded_3pool_usdt: 30,
+            verified_3usd: 1_000_000,
+            ..inputs()
+        });
+        // matched value 2*min(50,30)=60 at 5x -> 300; unmatched |50-30|=20 at 3x -> 60.
+        assert_eq!(got.ck_matched, 300);
+        assert_eq!(got.ck_unmatched, 60);
+    }
+
+    #[test]
+    fn equal_pair_is_fully_matched() {
+        let got = snapshot_weights(&SnapshotInputs {
+            recorded_3pool_usdc: 40,
+            recorded_3pool_usdt: 40,
+            verified_3usd: 1_000_000,
+            ..inputs()
+        });
+        assert_eq!(got.ck_matched, 2 * 40 * 5); // 400
+        assert_eq!(got.ck_unmatched, 0);
+    }
+
+    #[test]
+    fn dust_pairing_does_not_flip_the_whole_position_to_5x() {
+        // The v1 exploit: $1 of ckUSDT next to $50,000 of ckUSDC. Only the matched
+        // $2 gets 5x; the rest stays 3x.
+        let got = snapshot_weights(&SnapshotInputs {
+            recorded_3pool_usdc: 50_000,
+            recorded_3pool_usdt: 1,
+            verified_3usd: 1_000_000,
+            ..inputs()
+        });
+        assert_eq!(got.ck_matched, 2 * 1 * 5); // 10
+        assert_eq!(got.ck_unmatched, (50_000 - 1) * 3); // 149_997
+    }
+
+    #[test]
+    fn verification_scales_the_3pool_multiplier_split() {
+        // Holding only half the recorded 3USD halves the matched points.
+        let got = snapshot_weights(&SnapshotInputs {
+            recorded_3pool_usdc: 100,
+            recorded_3pool_usdt: 100,
+            verified_3usd: 100, // recorded total 200, cap ~100 -> factor 0.5
+            ..inputs()
+        });
+        // eff 50/50 -> matched 2*50*5 = 500 (vs 1000 at full holding).
+        assert_eq!(got.ck_matched, 500);
+        assert_eq!(got.ck_unmatched, 0);
+    }
+
+    #[test]
+    fn tolerance_grants_full_credit_within_half_percent() {
+        // verified 1000, recorded 1003 (within 0.5%): cap 1005 -> capped 1003 -> full.
+        let got = snapshot_weights(&SnapshotInputs {
+            recorded_3pool_icusd: 1_003,
+            verified_3usd: 1_000,
+            ..inputs()
+        });
+        assert_eq!(got.icusd_3pool, 1_003);
+    }
+
+    // ── repayment window (spec Section 6, OUTSIDE the min()) ──
+
+    const DOLLAR_1000: u128 = 1_000 * 100_000_000; // $1000 in usd_e8s
+
+    #[test]
+    fn repayment_full_epoch_overlap_is_amount_times_days_times_five() {
+        // The window spans the whole 7-day epoch.
+        let pts = repayment_points(DOLLAR_1000, 0, 100 * NANOS_PER_DAY, 0, NS_PER_WEEK);
+        assert_eq!(pts, DOLLAR_1000 * 5 * 7);
+    }
+
+    #[test]
+    fn repayment_partial_overlap_when_repaid_mid_epoch() {
+        // Repaid on day 3 of a [0, 7d] epoch -> 4 days of overlap.
+        let pts = repayment_points(DOLLAR_1000, 3 * NANOS_PER_DAY, 100 * NANOS_PER_DAY, 0, NS_PER_WEEK);
+        assert_eq!(pts, DOLLAR_1000 * 5 * 4);
+    }
+
+    #[test]
+    fn repayment_truncated_at_season_end() {
+        // epoch_end_capped (2 days) < window_end -> only 2 days count.
+        let pts = repayment_points(DOLLAR_1000, 0, 100 * NANOS_PER_DAY, 0, 2 * NANOS_PER_DAY);
+        assert_eq!(pts, DOLLAR_1000 * 5 * 2);
+    }
+
+    #[test]
+    fn repayment_window_end_caps_overlap() {
+        // window_end (3 days) < epoch_end_capped (7 days) -> 3 days count.
+        let pts = repayment_points(DOLLAR_1000, 0, 3 * NANOS_PER_DAY, 0, NS_PER_WEEK);
+        assert_eq!(pts, DOLLAR_1000 * 5 * 3);
+    }
+
+    #[test]
+    fn repayment_no_overlap_is_zero() {
+        // Repaid after the epoch ends.
+        assert_eq!(
+            repayment_points(DOLLAR_1000, 10 * NANOS_PER_DAY, 100 * NANOS_PER_DAY, 0, NS_PER_WEEK),
+            0
+        );
+        // Window ended before the epoch starts.
+        assert_eq!(
+            repayment_points(DOLLAR_1000, 0, NANOS_PER_DAY, 2 * NANOS_PER_DAY, NS_PER_WEEK),
+            0
+        );
+    }
+
+    #[test]
+    fn repayment_sliced_across_epochs_sums_to_the_whole_window() {
+        // Spec example: $1000 over a 47-day window -> 235,000 dollar-days, summed
+        // over the 7-day epochs it spans (6 full weeks + a 5-day tail).
+        let window_end = 47 * NANOS_PER_DAY;
+        let mut total = 0u128;
+        let mut start = 0u64;
+        while start < window_end {
+            let end_capped = (start + NS_PER_WEEK).min(window_end);
+            total += repayment_points(DOLLAR_1000, 0, window_end, start, end_capped);
+            start += NS_PER_WEEK;
+        }
+        assert_eq!(total, DOLLAR_1000 * 5 * 47); // 235,000 dollar-days x 1e8
+    }
+
+    // ── snapshot-input assembly + close-time accrual (step 8c) ──
+
+    fn prices(icp_rate: f64, virtual_price: u128) -> SnapshotPrices {
+        SnapshotPrices { icp_rate, virtual_price }
+    }
+
+    const VP1: u128 = 1_000_000_000_000_000_000; // virtual_price 1.0
+
+    #[test]
+    fn build_inputs_derives_amm_shares_and_vp_verification() {
+        let raw = RawSnapshot {
+            vault_debt: 1_000,
+            recorded_icusd: 11,
+            recorded_usdc: 22,
+            recorded_usdt: 33,
+            wallet_3usd: 300,
+            sp_icusd: 77,
+            sp_3usd: 50,
+            amm_user_lp: 50,
+            amm_total_lp: 100,            // 50% share
+            amm_reserve_3usd: 200,        // share -> 100 (3USD, usd_e8s)
+            amm_reserve_icp: 200_000_000, // share -> 1 ICP
+        };
+        let got = build_snapshot_inputs(&raw, &prices(5.0, VP1));
+        assert_eq!(got.vault_debt, 1_000);
+        assert_eq!(got.recorded_3pool_icusd, 11);
+        assert_eq!(got.recorded_3pool_usdc, 22);
+        assert_eq!(got.recorded_3pool_usdt, 33);
+        assert_eq!(got.sp_icusd, 77);
+        assert_eq!(got.sp_3usd, 50);
+        // AMM LP value = 3USD share (100 at $1) + ICP share (1 ICP at $5 = 5e8).
+        assert_eq!(got.amm_lp_value, 100 + 500_000_000);
+        // verified = (wallet 300 + sp 50 + amm share 100) at vp 1.0 = 450.
+        assert_eq!(got.verified_3usd, 450);
+    }
+
+    #[test]
+    fn build_inputs_handles_zero_amm_total_lp() {
+        let raw = RawSnapshot {
+            wallet_3usd: 10,
+            sp_3usd: 5,
+            amm_total_lp: 0, // empty pool: no division by zero, no share
+            amm_reserve_3usd: 999,
+            amm_user_lp: 7,
+            ..Default::default()
+        };
+        let got = build_snapshot_inputs(&raw, &prices(5.0, VP1));
+        assert_eq!(got.amm_lp_value, 0);
+        assert_eq!(got.verified_3usd, 15); // (10 + 5 + 0) at vp 1.0
+    }
+
+    #[test]
+    fn accrue_principal_scales_weights_and_adds_repayment() {
+        let weights = SnapshotWeights { icusd_debt: 100, threeusd_sp: 50, ..Default::default() };
+        let repayments = vec![RepaymentEvent {
+            asset: AssetType::CkUsdc,
+            amount_usd: 1_000 * 100_000_000, // $1000
+            repaid_at: 0,
+            window_end: u64::MAX,
+        }];
+        // Full-week epoch: balance fields x7; the repayment overlaps all 7 days.
+        let (entries, total) = accrue_principal(weights, &repayments, 0, NS_PER_WEEK);
+        assert!(entries.contains(&(PointSource::IcUsdDebt, 700)));
+        assert!(entries.contains(&(PointSource::ThreeUsdStabilityPool, 350)));
+        let repay = 1_000 * 100_000_000u128 * 5 * 7;
+        assert!(entries.contains(&(PointSource::VaultRepayment, repay)));
+        assert_eq!(total, 700 + 350 + repay);
+    }
+
+    #[test]
+    fn accrue_principal_no_activity_is_empty() {
+        let (entries, total) = accrue_principal(SnapshotWeights::default(), &[], 0, NS_PER_WEEK);
+        assert!(entries.is_empty());
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn accrue_principal_omits_out_of_window_repayment() {
+        let repayments = vec![RepaymentEvent {
+            asset: AssetType::CkUsdt,
+            amount_usd: 100,
+            repaid_at: 10 * NANOS_PER_DAY, // starts after this epoch ends
+            window_end: 20 * NANOS_PER_DAY,
+        }];
+        let (entries, total) =
+            accrue_principal(SnapshotWeights::default(), &repayments, 0, NS_PER_WEEK);
+        assert!(entries.is_empty());
+        assert_eq!(total, 0);
+    }
+}

--- a/src/rumi_points/src/epoch.rs
+++ b/src/rumi_points/src/epoch.rs
@@ -18,22 +18,607 @@
 
 #![allow(dead_code)] // Phase 5 surface.
 
+use std::cell::RefCell;
+use std::time::Duration;
+
+use candid::{Nat, Principal};
+use ic_cdk::api::call::RejectionCode;
+use ic_cdk_timers::TimerId;
+use icrc_ledger_types::icrc1::account::Account;
+
+use crate::accrual::{self, RawSnapshot};
+use crate::events::SourceId;
+use crate::snapshot_seed::{sha256, SeedError, SeedManager};
+use crate::source_types::balances;
+use crate::state;
+use crate::types::{AssetType, EpochSummary, OpenEpoch};
+use crate::valuation::SnapshotPrices;
+
 /// Length of one epoch. A week, expressed in nanoseconds (IC time unit).
 pub const EPOCH_DURATION_NS: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
 
-/// Run one full weekly epoch: schedule both snapshots, accrue on close. Registered
-/// on a 1-week timer in `setup_timers` (Phase 5).
-pub async fn run_epoch() {
-    unimplemented!("Phase 5: weekly two-snapshot min() accrual");
+/// Bounds of epoch `index`: `[season_start + index*EPOCH, min(start + EPOCH,
+/// season_end)]`. The last epoch is partial (truncated at season end).
+pub fn epoch_bounds(index: u64, season_start_ns: u64, season_end_ns: u64) -> (u64, u64) {
+    let start = season_start_ns.saturating_add(index.saturating_mul(EPOCH_DURATION_NS));
+    let end = start.saturating_add(EPOCH_DURATION_NS).min(season_end_ns);
+    (start, end)
 }
 
-/// Capture per-principal balances across all sources at a single snapshot.
-pub async fn take_snapshot(_epoch_index: u64, _snapshot_index: u8) {
-    unimplemented!("Phase 5");
+/// What the periodic driver should do on this tick (state machine, spec Section 7).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DriverAction {
+    /// Nothing to do yet (waiting for a snapshot time, the epoch end, or the
+    /// season start / next epoch).
+    Idle,
+    /// Open the next epoch (index >= 1 only; epoch 0 is bootstrapped by the admin
+    /// `start_season`, which provides the secret seed S0).
+    Start,
+    CaptureA,
+    CaptureB,
+    Close,
 }
 
-/// Accrue one principal's points for a closing epoch from its two snapshots,
-/// returning the weekly `min()` delta. The multiplier table lives here.
-pub fn accrue_principal_epoch(_principal: candid::Principal, _epoch_index: u64) -> u128 {
-    unimplemented!("Phase 5");
+/// Decide the driver's action. Pure: the caller (the timer tick) reads
+/// `now`/season/open-epoch from state, then performs the returned action. Assumes
+/// the driver is enabled (the tick checks that before calling).
+pub fn next_action(
+    open: &Option<OpenEpoch>,
+    now: u64,
+    season_start: u64,
+    season_end: u64,
+    current_index: u64,
+) -> DriverAction {
+    match open {
+        Some(oe) => {
+            if !oe.a_complete {
+                step_when(now >= oe.snapshot_a_ns, DriverAction::CaptureA)
+            } else if !oe.b_complete {
+                step_when(now >= oe.snapshot_b_ns, DriverAction::CaptureB)
+            } else {
+                step_when(now >= oe.epoch_end_ns, DriverAction::Close)
+            }
+        }
+        // Epoch 0 is operator-bootstrapped (it needs the secret seed); the driver
+        // only auto-starts epochs >= 1, whose seed is pre-loaded by the prior close.
+        None if current_index == 0 => DriverAction::Idle,
+        None => {
+            let (start, _) = epoch_bounds(current_index, season_start, season_end);
+            step_when(start < season_end && now >= start, DriverAction::Start)
+        }
+    }
+}
+
+fn step_when(ready: bool, action: DriverAction) -> DriverAction {
+    if ready {
+        action
+    } else {
+        DriverAction::Idle
+    }
+}
+
+thread_local! {
+    /// The live epoch-driver timer (transient; re-registered in `post_upgrade`).
+    static EPOCH_TIMER: RefCell<Option<TimerId>> = RefCell::new(None);
+}
+
+/// Principals captured per driver tick. Season-1 scale fits one tick; larger
+/// seasons span several (the cursor in `OpenEpoch` resumes between ticks).
+const CAPTURE_CHUNK: u64 = 100;
+
+type CallResult<T> = Result<T, (RejectionCode, String)>;
+
+#[derive(Clone, Copy)]
+enum Snapshot {
+    A,
+    B,
+}
+
+/// The 3USD/ICP AMM pool, oriented so `reserve_3usd` is the 3USD leg regardless of
+/// the pool's `token_a`/`token_b` order.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AmmPool {
+    pub pool_id: String,
+    pub reserve_3usd: u128,
+    pub reserve_icp: u128,
+    pub total_lp: u128,
+}
+
+/// Pick the 3USD/ICP pool from `pools` and orient its reserves. `None` if absent.
+pub fn pick_amm_pool(
+    pools: &[balances::PoolInfo],
+    threeusd: Principal,
+    icp: Principal,
+) -> Option<AmmPool> {
+    pools.iter().find_map(|p| {
+        let pair = [p.token_a, p.token_b];
+        if !(pair.contains(&threeusd) && pair.contains(&icp)) {
+            return None;
+        }
+        // Orient so reserve_3usd is the 3USD leg regardless of token order.
+        let (reserve_3usd, reserve_icp) = if p.token_a == threeusd {
+            (p.reserve_a, p.reserve_b)
+        } else {
+            (p.reserve_b, p.reserve_a)
+        };
+        Some(AmmPool {
+            pool_id: p.pool_id.clone(),
+            reserve_3usd,
+            reserve_icp,
+            total_lp: p.total_lp_shares,
+        })
+    })
+}
+
+/// Why `start_season` was rejected.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartSeasonError {
+    /// `now` is outside `[season_start, season_end)`.
+    SeasonInactive,
+    /// Epoch 0 is already open or past (the season was already started).
+    AlreadyStarted,
+    /// The provided seed did not match the committed `H0`.
+    Seed(SeedError),
+}
+
+// ── Timer (mirrors the poll timer: OFF by default, re-registered post-upgrade) ──
+
+pub fn setup_epoch_timer() {
+    EPOCH_TIMER.with(|t| {
+        if let Some(id) = t.borrow_mut().take() {
+            ic_cdk_timers::clear_timer(id);
+        }
+    });
+    if state::epoch_driver_enabled() {
+        let interval = Duration::from_secs(state::epoch_driver_interval_secs());
+        let id = ic_cdk_timers::set_timer_interval(interval, || {
+            ic_cdk::spawn(async {
+                epoch_driver_tick().await;
+            });
+        });
+        EPOCH_TIMER.with(|t| *t.borrow_mut() = Some(id));
+    }
+}
+
+// ── Bootstrap: the admin opens epoch 0 with the secret seed S0 ──
+
+pub fn start_season(initial_seed: [u8; 32], now: u64) -> Result<(), StartSeasonError> {
+    let (season_start, season_end) = state::season_bounds();
+    if now < season_start || now >= season_end {
+        return Err(StartSeasonError::SeasonInactive);
+    }
+    if state::current_epoch_index() != 0 || state::get_open_epoch().is_some() {
+        return Err(StartSeasonError::AlreadyStarted);
+    }
+    open_new_epoch(0, Some(initial_seed), now).map_err(StartSeasonError::Seed)
+}
+
+/// Derive the epoch's seed + snapshot times, install a fresh `OpenEpoch`, and clear
+/// the snapshot buffer. Epoch 0 passes `Some(S0)`; epochs >= 1 pass `None` (the
+/// pre-loaded `current_seed` is used).
+fn open_new_epoch(index: u64, seed_arg: Option<[u8; 32]>, _now: u64) -> Result<(), SeedError> {
+    let (season_start, season_end) = state::season_bounds();
+    let (start, end) = epoch_bounds(index, season_start, season_end);
+    let (a_ns, b_ns) =
+        state::with_state_mut(|s| SeedManager::start_epoch(&mut s.snapshot_seed, start, end, seed_arg))?;
+    state::snapshot_buffer_clear();
+    state::set_open_epoch(Some(OpenEpoch {
+        epoch_index: index,
+        epoch_start_ns: start,
+        epoch_end_ns: end,
+        snapshot_a_ns: a_ns,
+        snapshot_b_ns: b_ns,
+        a_cursor: None,
+        a_complete: false,
+        b_cursor: None,
+        b_complete: false,
+    }));
+    Ok(())
+}
+
+// ── Periodic driver tick ──
+
+/// The timer callback: run a tick only while the driver is enabled.
+pub async fn epoch_driver_tick() {
+    if state::epoch_driver_enabled() {
+        run_tick().await;
+    }
+}
+
+/// One state-machine step, regardless of the enabled flag (admin `force_epoch_tick`
+/// and the E2E drive this directly). The single-tick guard still applies.
+pub async fn run_tick() {
+    if !state::try_begin_epoch() {
+        return; // a tick is already in flight
+    }
+    let now = ic_cdk::api::time();
+    let (season_start, season_end) = state::season_bounds();
+    let open = state::get_open_epoch();
+    let index = state::current_epoch_index();
+    match next_action(&open, now, season_start, season_end, index) {
+        DriverAction::Idle => {}
+        DriverAction::Start => {
+            if let Err(e) = open_new_epoch(index, None, now) {
+                ic_cdk::println!("[epoch] start of epoch {} failed: {:?}", index, e);
+            }
+        }
+        DriverAction::CaptureA => capture(Snapshot::A).await,
+        DriverAction::CaptureB => capture(Snapshot::B).await,
+        DriverAction::Close => close_current_epoch(now),
+    }
+    state::end_epoch_guard();
+}
+
+// ── Snapshot capture (one chunk per tick) ──
+
+async fn capture(which: Snapshot) {
+    let mut open = match state::get_open_epoch() {
+        Some(o) => o,
+        None => return,
+    };
+    let ctx = match fetch_context().await {
+        Some(c) => c,
+        None => return, // a snapshot-wide source was unreachable; retry next tick
+    };
+    let cursor = match which {
+        Snapshot::A => open.a_cursor,
+        Snapshot::B => open.b_cursor,
+    };
+    let chunk = state::registered_chunk_after(cursor, CAPTURE_CHUNK);
+    for p in &chunk {
+        if state::is_excluded(p) {
+            continue;
+        }
+        let raw = fetch_raw_snapshot(*p, &ctx).await;
+        let weights = accrual::snapshot_weights(&accrual::build_snapshot_inputs(&raw, &ctx.prices));
+        match which {
+            Snapshot::A => state::snapshot_buffer_put(*p, weights),
+            Snapshot::B => state::snapshot_buffer_merge_min(*p, weights),
+        }
+    }
+    // A short chunk means the registered set is exhausted: this snapshot is done.
+    let done = (chunk.len() as u64) < CAPTURE_CHUNK;
+    let last = chunk.last().copied();
+    match which {
+        Snapshot::A => {
+            open.a_cursor = if done { None } else { last };
+            open.a_complete = done;
+        }
+        Snapshot::B => {
+            open.b_cursor = if done { None } else { last };
+            open.b_complete = done;
+        }
+    }
+    state::set_open_epoch(Some(open));
+}
+
+// ── Epoch close ──
+
+fn close_current_epoch(now: u64) {
+    let open = match state::get_open_epoch() {
+        Some(o) => o,
+        None => return,
+    };
+    let stats =
+        state::run_close_accrual(open.epoch_index, open.epoch_start_ns, open.epoch_end_ns, now);
+    let summary = EpochSummary {
+        epoch_index: open.epoch_index,
+        epoch_start_ns: open.epoch_start_ns,
+        epoch_end_ns: open.epoch_end_ns,
+        total_points_all: stats.total_points_all,
+        points_accrued_this_epoch: stats.points_accrued,
+        active_principals: stats.active_principals,
+        registered_principals: stats.registered_principals,
+        snapshot_a_ns: open.snapshot_a_ns,
+        snapshot_b_ns: open.snapshot_b_ns,
+    };
+    let hash = summary_hash(&summary);
+    match state::with_state_mut(|s| {
+        SeedManager::close_epoch(
+            &mut s.snapshot_seed,
+            open.epoch_index,
+            open.snapshot_a_ns,
+            open.snapshot_b_ns,
+            now,
+            hash,
+        )
+    }) {
+        Ok(revealed) => state::append_revealed_seed(revealed),
+        // Unreachable in the live flow (`current_seed` is always `Some` once an
+        // epoch is open). If it ever happens, trap to roll the whole close back
+        // atomically rather than advance the index with a broken (reused) seed.
+        Err(e) => ic_cdk::trap(&format!(
+            "[epoch] seed close of epoch {} failed ({:?}); halting to avoid a broken seed chain",
+            open.epoch_index, e
+        )),
+    }
+    state::append_epoch_summary(summary);
+    state::advance_epoch_index();
+    state::set_open_epoch(None);
+}
+
+/// Deterministic hash binding the next seed to this epoch's chain state (spike 0.3).
+fn summary_hash(s: &EpochSummary) -> [u8; 32] {
+    let mut buf = Vec::with_capacity(64);
+    buf.extend_from_slice(&s.epoch_index.to_le_bytes());
+    buf.extend_from_slice(&s.total_points_all.to_le_bytes());
+    buf.extend_from_slice(&s.registered_principals.to_le_bytes());
+    buf.extend_from_slice(&s.points_accrued_this_epoch.to_le_bytes());
+    buf.extend_from_slice(&s.snapshot_a_ns.to_le_bytes());
+    buf.extend_from_slice(&s.snapshot_b_ns.to_le_bytes());
+    sha256(&[&buf])
+}
+
+// ── Inter-canister fetch helpers (validated by the PocketIC E2E) ──
+
+/// Snapshot-wide values fetched once per capture (not per principal), including
+/// the resolved source-canister ids so the per-principal pass does not re-read them.
+struct SnapshotContext {
+    prices: SnapshotPrices,
+    amm: Option<AmmPool>,
+    icusd_ledger: Principal,
+    threeusd_ledger: Principal,
+    backend: Principal,
+    threepool: Principal,
+    sp: Option<Principal>,
+    amm_canister: Principal,
+}
+
+async fn fetch_context() -> Option<SnapshotContext> {
+    let backend = state::get_source_canister(SourceId::Backend.tag())?;
+    let threepool = state::get_source_canister(SourceId::ThreePool.tag())?;
+    let amm_canister = state::get_source_canister(SourceId::Amm.tag())?;
+    let sp = state::get_source_canister(SourceId::StabilityPool.tag());
+    let icp_rate = fetch_icp_rate(backend).await?;
+    let virtual_price = fetch_virtual_price(threepool).await?;
+    let threeusd = state::get_asset_ledger(AssetType::ThreeUsd)?;
+    let icp = state::get_asset_ledger(AssetType::Icp)?;
+    let icusd = state::get_asset_ledger(AssetType::IcUsd)?;
+    let amm = fetch_amm_pool(amm_canister, threeusd, icp).await;
+    Some(SnapshotContext {
+        prices: SnapshotPrices { icp_rate, virtual_price },
+        amm,
+        icusd_ledger: icusd,
+        threeusd_ledger: threeusd,
+        backend,
+        threepool,
+        sp,
+        amm_canister,
+    })
+}
+
+async fn fetch_raw_snapshot(p: Principal, ctx: &SnapshotContext) -> RawSnapshot {
+    let vault_debt = fetch_vault_debt(ctx.backend, p).await;
+    let wallet_3usd = fetch_wallet_3usd(ctx.threepool, p).await;
+    let (sp_icusd, sp_3usd) = match ctx.sp {
+        Some(c) => fetch_sp_position(c, p, ctx.icusd_ledger, ctx.threeusd_ledger).await,
+        None => (0, 0),
+    };
+    let amm_user_lp = match &ctx.amm {
+        Some(pool) => fetch_amm_lp(ctx.amm_canister, &pool.pool_id, p).await,
+        None => 0,
+    };
+
+    let (recorded_icusd, recorded_usdc, recorded_usdt) = state::recorded_3pool_composition(&p);
+    let (amm_total_lp, amm_reserve_3usd, amm_reserve_icp) = match &ctx.amm {
+        Some(pool) => (pool.total_lp, pool.reserve_3usd, pool.reserve_icp),
+        None => (0, 0, 0),
+    };
+    RawSnapshot {
+        vault_debt,
+        recorded_icusd,
+        recorded_usdc,
+        recorded_usdt,
+        wallet_3usd,
+        sp_icusd,
+        sp_3usd,
+        amm_user_lp,
+        amm_total_lp,
+        amm_reserve_3usd,
+        amm_reserve_icp,
+    }
+}
+
+async fn fetch_icp_rate(backend: Principal) -> Option<f64> {
+    let res: CallResult<(balances::ProtocolStatus,)> =
+        ic_cdk::call(backend, "get_protocol_status", ()).await;
+    match res {
+        Ok((s,)) if s.last_icp_rate.is_finite() && s.last_icp_rate > 0.0 => Some(s.last_icp_rate),
+        Ok((s,)) => {
+            // A corrupt (non-finite / non-positive) oracle rate aborts the whole
+            // capture to retry next tick, rather than valuing ICP positions wrong.
+            ic_cdk::println!("[epoch] get_protocol_status returned bad icp_rate {}; aborting capture", s.last_icp_rate);
+            None
+        }
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_protocol_status failed: {:?} {}", c, m);
+            None
+        }
+    }
+}
+
+async fn fetch_virtual_price(threepool: Principal) -> Option<u128> {
+    let res: CallResult<(balances::PoolStatus,)> =
+        ic_cdk::call(threepool, "get_pool_status", ()).await;
+    match res {
+        Ok((s,)) => Some(s.virtual_price),
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_pool_status failed: {:?} {}", c, m);
+            None
+        }
+    }
+}
+
+async fn fetch_amm_pool(amm: Principal, threeusd: Principal, icp: Principal) -> Option<AmmPool> {
+    let res: CallResult<(Vec<balances::PoolInfo>,)> = ic_cdk::call(amm, "get_pools", ()).await;
+    match res {
+        Ok((pools,)) => pick_amm_pool(&pools, threeusd, icp),
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_pools failed: {:?} {}", c, m);
+            None
+        }
+    }
+}
+
+async fn fetch_vault_debt(backend: Principal, p: Principal) -> u128 {
+    let res: CallResult<(Vec<balances::CandidVault>,)> =
+        ic_cdk::call(backend, "get_vaults", (Some(p),)).await;
+    match res {
+        Ok((vaults,)) => vaults
+            .iter()
+            .fold(0u128, |acc, v| acc.saturating_add(v.borrowed_icusd_amount as u128)),
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_vaults failed: {:?} {}", c, m);
+            0
+        }
+    }
+}
+
+async fn fetch_wallet_3usd(threepool: Principal, p: Principal) -> u128 {
+    let account = Account { owner: p, subaccount: None };
+    let res: CallResult<(Nat,)> = ic_cdk::call(threepool, "icrc1_balance_of", (account,)).await;
+    match res {
+        Ok((bal,)) => nat_to_u128(&bal),
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] icrc1_balance_of failed: {:?} {}", c, m);
+            0
+        }
+    }
+}
+
+async fn fetch_sp_position(
+    sp: Principal,
+    p: Principal,
+    icusd: Principal,
+    threeusd: Principal,
+) -> (u128, u128) {
+    let res: CallResult<(Option<balances::UserStabilityPosition>,)> =
+        ic_cdk::call(sp, "get_user_position", (Some(p),)).await;
+    match res {
+        Ok((Some(pos),)) => {
+            let bal = |l: &Principal| pos.stablecoin_balances.get(l).copied().unwrap_or(0) as u128;
+            (bal(&icusd), bal(&threeusd))
+        }
+        Ok((None,)) => (0, 0),
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_user_position failed: {:?} {}", c, m);
+            (0, 0)
+        }
+    }
+}
+
+async fn fetch_amm_lp(amm: Principal, pool_id: &str, p: Principal) -> u128 {
+    let res: CallResult<(u128,)> =
+        ic_cdk::call(amm, "get_lp_balance", (pool_id.to_string(), p)).await;
+    match res {
+        Ok((lp,)) => lp,
+        Err((c, m)) => {
+            ic_cdk::println!("[epoch] get_lp_balance failed: {:?} {}", c, m);
+            0
+        }
+    }
+}
+
+/// candid `Nat` -> `u128`, saturating (balances never exceed `u128` in practice).
+fn nat_to_u128(n: &Nat) -> u128 {
+    let digits: String = n.to_string().chars().filter(|c| c.is_ascii_digit()).collect();
+    digits.parse::<u128>().unwrap_or(u128::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const E: u64 = EPOCH_DURATION_NS;
+
+    #[test]
+    fn epoch_bounds_full_partial_and_offset() {
+        // Full epochs from season start 0.
+        assert_eq!(epoch_bounds(0, 0, 100 * E), (0, E));
+        assert_eq!(epoch_bounds(1, 0, 100 * E), (E, 2 * E));
+        // Season-start offset carries through.
+        assert_eq!(epoch_bounds(0, 1_000, 1_000 + 100 * E), (1_000, 1_000 + E));
+        // The last epoch is truncated at season end.
+        assert_eq!(epoch_bounds(1, 0, E + 100), (E, E + 100));
+    }
+
+    fn oe(a_complete: bool, b_complete: bool) -> OpenEpoch {
+        OpenEpoch {
+            epoch_index: 0,
+            epoch_start_ns: 0,
+            epoch_end_ns: 1_000,
+            snapshot_a_ns: 100,
+            snapshot_b_ns: 500,
+            a_cursor: None,
+            a_complete,
+            b_cursor: None,
+            b_complete,
+        }
+    }
+
+    #[test]
+    fn open_epoch_captures_a_then_b_then_closes() {
+        assert_eq!(next_action(&Some(oe(false, false)), 99, 0, 2_000, 0), DriverAction::Idle);
+        assert_eq!(next_action(&Some(oe(false, false)), 100, 0, 2_000, 0), DriverAction::CaptureA);
+        assert_eq!(next_action(&Some(oe(true, false)), 499, 0, 2_000, 0), DriverAction::Idle);
+        assert_eq!(next_action(&Some(oe(true, false)), 500, 0, 2_000, 0), DriverAction::CaptureB);
+        assert_eq!(next_action(&Some(oe(true, true)), 999, 0, 2_000, 0), DriverAction::Idle);
+        assert_eq!(next_action(&Some(oe(true, true)), 1_000, 0, 2_000, 0), DriverAction::Close);
+    }
+
+    #[test]
+    fn epoch_zero_is_idle_until_start_season_opens_it() {
+        // No open epoch and index 0: the driver waits for the operator bootstrap.
+        assert_eq!(next_action(&None, u64::MAX, 0, 2_000, 0), DriverAction::Idle);
+    }
+
+    #[test]
+    fn subsequent_epoch_starts_when_due_and_in_season() {
+        // Index 1, now at epoch-1 start, well inside the season -> Start.
+        assert_eq!(next_action(&None, E, 0, 100 * E, 1), DriverAction::Start);
+        // Before epoch-1 start -> Idle.
+        assert_eq!(next_action(&None, E - 1, 0, 100 * E, 1), DriverAction::Idle);
+        // Next epoch's start is at/after season end -> season over -> Idle.
+        assert_eq!(next_action(&None, u64::MAX, 0, E, 1), DriverAction::Idle);
+    }
+
+    use crate::source_types::balances::PoolInfo;
+
+    fn pr(n: u8) -> Principal {
+        Principal::from_slice(&[n, n, n, n, n])
+    }
+    fn pool(id: &str, ta: Principal, tb: Principal, ra: u128, rb: u128, lp: u128) -> PoolInfo {
+        PoolInfo {
+            pool_id: id.into(),
+            token_a: ta,
+            token_b: tb,
+            reserve_a: ra,
+            reserve_b: rb,
+            total_lp_shares: lp,
+        }
+    }
+
+    #[test]
+    fn pick_amm_pool_orients_reserves_when_token_a_is_3usd() {
+        let (three, icp) = (pr(1), pr(2));
+        let got = pick_amm_pool(&[pool("x", three, icp, 100, 200, 50)], three, icp).unwrap();
+        assert_eq!(
+            got,
+            AmmPool { pool_id: "x".into(), reserve_3usd: 100, reserve_icp: 200, total_lp: 50 }
+        );
+    }
+
+    #[test]
+    fn pick_amm_pool_orients_reserves_when_token_b_is_3usd() {
+        let (three, icp) = (pr(1), pr(2));
+        let got = pick_amm_pool(&[pool("y", icp, three, 200, 100, 50)], three, icp).unwrap();
+        assert_eq!(got.reserve_3usd, 100);
+        assert_eq!(got.reserve_icp, 200);
+    }
+
+    #[test]
+    fn pick_amm_pool_none_when_pair_absent() {
+        let (three, icp) = (pr(1), pr(2));
+        assert!(pick_amm_pool(&[pool("z", pr(3), pr(4), 1, 1, 1)], three, icp).is_none());
+    }
 }

--- a/src/rumi_points/src/events.rs
+++ b/src/rumi_points/src/events.rs
@@ -24,7 +24,8 @@
 use candid::Principal;
 
 use crate::state;
-use crate::types::QualifyingAction;
+use crate::types::{AssetType, QualifyingAction};
+use crate::valuation;
 
 /// The four source canisters polled for events. The `tag` is the stable cursor
 /// key (see `state::get_cursor`); never renumber an existing tag.
@@ -70,9 +71,16 @@ pub enum IngestKind {
     VaultOpen { vault_id: u64, borrowed_e8s: u64 },
     /// Borrowed (minted) more icUSD from an existing vault.
     VaultBorrow { vault_id: u64, amount_e8s: u64 },
-    /// Repaid vault debt. Asset is not yet attributable (the `repayment_asset`
-    /// field is a separate upstream branch); the 5x ck-stable window is Phase 5.
-    VaultRepay { vault_id: u64, amount_e8s: u64 },
+    /// Repaid vault debt. `repayment_asset` is the ledger the debt was repaid with,
+    /// needed to tell a qualifying ckUSDC/ckUSDT repayment (5x window, spec Section
+    /// 6) from an icUSD burn or collateral closure. The upstream backend field is
+    /// not live yet, so the normalizer sets it `None` and the 5x window is skipped
+    /// (logged) until it lands.
+    VaultRepay {
+        vault_id: u64,
+        amount_e8s: u64,
+        repayment_asset: Option<candid::Principal>,
+    },
     VaultClose { vault_id: u64 },
     VaultLiquidated { vault_id: u64 },
     VaultRedeemed { amount_e8s: u64 },
@@ -117,16 +125,85 @@ impl IngestKind {
 /// qualifying, in-season action. `register` is idempotent and rejects excluded
 /// principals, so this is safe to call for every matching event.
 pub fn apply_ingested_event(ev: &IngestedEvent) {
-    // Auto-registration on first qualifying, in-season action. `register` is
-    // idempotent and rejects excluded principals, so calling it for every
-    // matching event is safe and cheap.
-    if let (Some(action), Some(caller)) = (ev.kind.qualifying_action(), ev.caller) {
-        if state::in_season(ev.timestamp_ns) {
-            let _ = state::register(caller, ev.timestamp_ns, action);
+    let caller = match ev.caller {
+        Some(c) => c,
+        None => return, // close/liquidate carry no principal; nothing to attribute
+    };
+    // Everything is gated to in-season activity by a non-excluded principal.
+    if !state::in_season(ev.timestamp_ns) || state::is_excluded(&caller) {
+        return;
+    }
+    // Auto-register on the first qualifying action (idempotent).
+    if let Some(action) = ev.kind.qualifying_action() {
+        let _ = state::register(caller, ev.timestamp_ns, action);
+    }
+    // Position / repayment tracking only applies to already-registered principals
+    // (a non-qualifying first event, e.g. a withdraw, never enrolls anyone, and
+    // has no recorded position to adjust).
+    if !state::is_registered(&caller) {
+        return;
+    }
+    match &ev.kind {
+        IngestKind::ThreePoolAdd { amounts } => apply_3pool(caller, amounts, true, ev.timestamp_ns),
+        IngestKind::ThreePoolRemove { amounts } => {
+            apply_3pool(caller, amounts, false, ev.timestamp_ns)
+        }
+        IngestKind::VaultRepay { repayment_asset, amount_e8s, .. } => {
+            apply_repayment(caller, *repayment_asset, *amount_e8s, ev.timestamp_ns)
+        }
+        // Vault debt, SP, and AMM positions are read live at each snapshot (the
+        // hybrid model), so their events only register; they are not tracked here.
+        _ => {}
+    }
+}
+
+/// Update the recorded 3pool composition from an add/remove. `amounts` ordering is
+/// `[icUSD, ckUSDT, ckUSDC]` (3pool wire order), in native decimals; normalized to
+/// `usd_e8s` here so the snapshot accrual reads a common scale.
+fn apply_3pool(caller: Principal, amounts: &[u128; 3], add: bool, now_ns: u64) {
+    let legs = [
+        (AssetType::IcUsd, amounts[0]),
+        (AssetType::CkUsdt, amounts[1]),
+        (AssetType::CkUsdc, amounts[2]),
+    ];
+    for (asset, native) in legs {
+        if native > 0 {
+            let usd = valuation::value_stable_usd_e8s(asset, native);
+            state::update_3pool_recorded(caller, asset, usd, add, now_ns);
         }
     }
-    // Position-value tracking, the repayment 90-day window, 3USD verification,
-    // and accrual are Phase 4/5 and read the payload carried on `ev.kind`.
+}
+
+/// Open a 90-day window for a qualifying ckUSDC/ckUSDT repayment (spec Section 6).
+/// Skips (with a log) when the asset is absent (the upstream `repayment_asset`
+/// field is not live) or is not a ck-stable (an icUSD burn / collateral closure
+/// does not qualify).
+fn apply_repayment(
+    caller: Principal,
+    repayment_asset: Option<Principal>,
+    amount_e8s: u64,
+    now_ns: u64,
+) {
+    let ledger = match repayment_asset {
+        Some(l) => l,
+        None => {
+            log_ingest("vault repay without repayment_asset; skipping 5x window");
+            return;
+        }
+    };
+    if let Some(asset @ (AssetType::CkUsdc | AssetType::CkUsdt)) = state::classify_ledger(&ledger) {
+        let usd = valuation::value_stable_usd_e8s(asset, amount_e8s as u128);
+        state::record_repayment(caller, asset, usd, now_ns);
+    }
+}
+
+/// On-chain log; a no-op in native unit tests (the `ic0` host import is
+/// unavailable off-wasm, where `ic_cdk::println!` would panic).
+fn log_ingest(msg: &str) {
+    #[cfg(target_arch = "wasm32")]
+    ic_cdk::println!("[ingest] {}", msg);
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = msg;
 }
 
 /// Apply a decoded batch of normalized events (auto-register etc.). Does NOT
@@ -157,7 +234,20 @@ pub fn ingest_batch(source: SourceId, events: &[IngestedEvent]) -> usize {
 mod tests {
     use super::*;
     use crate::state;
-    use crate::types::{InitArgs, QualifyingAction};
+    use crate::types::{AssetType, DepositKey, InitArgs, QualifyingAction, Venue};
+
+    fn ckusdc() -> Principal {
+        Principal::from_text("xevnm-gaaaa-aaaar-qafnq-cai").unwrap()
+    }
+    fn icusd() -> Principal {
+        Principal::from_text("t6bor-paaaa-aaaap-qrd5q-cai").unwrap()
+    }
+    fn recorded_3pool(p: &Principal, asset: AssetType) -> Option<u128> {
+        state::get_principal_state(p)?
+            .active_deposits
+            .get(&DepositKey { venue: Venue::ThreePool, asset })
+            .map(|r| r.recorded_value_usd)
+    }
 
     fn tp(n: u8) -> Principal {
         Principal::from_slice(&[n, n, n, n, n])
@@ -203,7 +293,7 @@ mod tests {
             None
         );
         assert_eq!(
-            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 5 }.qualifying_action(),
+            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 5, repayment_asset: None }.qualifying_action(),
             Some(QualifyingAction::RepayVault)
         );
         assert_eq!(
@@ -340,6 +430,94 @@ mod tests {
         assert_eq!(first, second); // no double-register, no timestamp change
         assert_eq!(state::registered_count(), 1);
         assert_eq!(state::get_cursor(SourceId::Backend.tag()), 1);
+    }
+
+    // ── Phase 4/5: position + repayment tracking ──
+
+    #[test]
+    fn threepool_add_records_normalized_composition() {
+        init();
+        let p = tp(40);
+        // amounts are [icUSD (8-dec), ckUSDT (6-dec), ckUSDC (6-dec)].
+        apply_ingested_event(&ev(
+            SourceId::ThreePool,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::ThreePoolAdd { amounts: [100_000_000, 2_000_000, 3_000_000] },
+        ));
+        assert_eq!(recorded_3pool(&p, AssetType::IcUsd), Some(100_000_000)); // 8-dec, x1
+        assert_eq!(recorded_3pool(&p, AssetType::CkUsdt), Some(200_000_000)); // 6-dec, x100
+        assert_eq!(recorded_3pool(&p, AssetType::CkUsdc), Some(300_000_000)); // 6-dec, x100
+    }
+
+    #[test]
+    fn threepool_remove_decrements_recorded_value() {
+        init();
+        let p = tp(41);
+        apply_ingested_event(&ev(
+            SourceId::ThreePool,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::ThreePoolAdd { amounts: [0, 0, 5_000_000] }, // $5 ckUSDC
+        ));
+        apply_ingested_event(&ev(
+            SourceId::ThreePool,
+            1,
+            Some(p),
+            in_season_ts(),
+            IngestKind::ThreePoolRemove { amounts: [0, 0, 2_000_000] }, // remove $2
+        ));
+        assert_eq!(recorded_3pool(&p, AssetType::CkUsdc), Some(300_000_000)); // $3 left
+    }
+
+    #[test]
+    fn vault_repay_with_ckusdc_opens_a_window() {
+        init();
+        let p = tp(42);
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 1_000_000, repayment_asset: Some(ckusdc()) },
+        ));
+        let st = state::get_principal_state(&p).unwrap();
+        assert_eq!(st.repayment_events.len(), 1);
+        assert_eq!(st.repayment_events[0].asset, AssetType::CkUsdc);
+        assert_eq!(st.repayment_events[0].amount_usd, 100_000_000); // $1, 6-dec x100
+    }
+
+    #[test]
+    fn vault_repay_without_asset_registers_but_opens_no_window() {
+        init();
+        let p = tp(43);
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 1_000_000, repayment_asset: None },
+        ));
+        assert!(state::is_registered(&p)); // repay is a qualifying action
+        assert!(state::get_principal_state(&p).unwrap().repayment_events.is_empty());
+    }
+
+    #[test]
+    fn vault_repay_with_icusd_opens_no_window() {
+        init();
+        let p = tp(44);
+        apply_ingested_event(&ev(
+            SourceId::Backend,
+            0,
+            Some(p),
+            in_season_ts(),
+            IngestKind::VaultRepay { vault_id: 1, amount_e8s: 1_000_000, repayment_asset: Some(icusd()) },
+        ));
+        assert!(state::is_registered(&p));
+        // An icUSD-burn repayment does not qualify for the 5x window (spec Section 6).
+        assert!(state::get_principal_state(&p).unwrap().repayment_events.is_empty());
     }
 }
 

--- a/src/rumi_points/src/lib.rs
+++ b/src/rumi_points/src/lib.rs
@@ -17,6 +17,7 @@
 //! Out of scope here: event ingestion, the backend `repayment_asset` change,
 //! 3USD verification, epoch math, and the entire claim / lock-tier surface.
 
+pub mod accrual;
 pub mod epoch;
 pub mod events;
 pub mod poll;

--- a/src/rumi_points/src/main.rs
+++ b/src/rumi_points/src/main.rs
@@ -6,11 +6,12 @@
 use candid::Principal;
 use ic_canister_log::{declare_log_buffer, log};
 
+use rumi_points::snapshot_seed::RevealedSeed;
 use rumi_points::types::{
-    EpochSummary, IngestStatus, InitArgs, LeaderboardEntry, PointsConfig, PointsError,
+    EpochStatus, EpochSummary, IngestStatus, InitArgs, LeaderboardEntry, PointsConfig, PointsError,
     PrincipalState, RegistrationInfo, SourceStatus,
 };
-use rumi_points::{poll, state};
+use rumi_points::{epoch, poll, state};
 
 // Canister debug-log buffer (retrievable in later phases; for now feeds the
 // replica debug log on lifecycle events).
@@ -23,8 +24,9 @@ fn main() {}
 #[ic_cdk::init]
 fn init(args: Option<InitArgs>) {
     state::init_state(args, ic_cdk::caller());
-    // No-op while the poll timer is off by default; consistent entry point.
+    // No-op while both timers are off by default; consistent entry points.
     poll::setup_poll_timer();
+    epoch::setup_epoch_timer();
     let cfg = state::points_config();
     log!(
         INFO,
@@ -44,8 +46,9 @@ fn pre_upgrade() {
 #[ic_cdk::post_upgrade]
 fn post_upgrade() {
     state::restore_from_stable_or_trap();
-    // Timers do not survive upgrades: re-register from the persisted config.
+    // Timers do not survive upgrades: re-register both from the persisted config.
     poll::setup_poll_timer();
+    epoch::setup_epoch_timer();
     let cfg = state::points_config();
     log!(
         INFO,
@@ -175,6 +178,82 @@ fn get_ingest_status() -> IngestStatus {
         poll_enabled: state::poll_enabled(),
         poll_interval_secs: state::poll_interval_secs(),
     }
+}
+
+// ── Phase 5: epoch driver + commit-reveal audit ─────────────────────────────
+
+/// Admin: open Season 1's epoch 0 with the secret seed S0 (verified against the
+/// committed H0), then enable the periodic driver. Call once, in-season, after the
+/// poll has registered participants. `initial_seed` is the 32-byte S0.
+#[ic_cdk::update]
+fn start_season(initial_seed: Vec<u8>) -> Result<(), String> {
+    let caller = ic_cdk::caller();
+    if !state::is_admin(caller) {
+        return Err("unauthorized".to_string());
+    }
+    let seed: [u8; 32] = initial_seed
+        .try_into()
+        .map_err(|_| "initial_seed must be exactly 32 bytes".to_string())?;
+    epoch::start_season(seed, ic_cdk::api::time()).map_err(|e| format!("{:?}", e))?;
+    state::set_epoch_driver_enabled(caller, true).map_err(|e| format!("{:?}", e))?;
+    epoch::setup_epoch_timer();
+    Ok(())
+}
+
+/// Admin: turn the epoch driver on/off (off by default; on after `start_season`).
+#[ic_cdk::update]
+fn set_epoch_driver_enabled(enabled: bool) -> Result<(), PointsError> {
+    state::set_epoch_driver_enabled(ic_cdk::caller(), enabled)?;
+    epoch::setup_epoch_timer();
+    Ok(())
+}
+
+/// Admin: set the driver cadence in seconds (clamped to a floor).
+#[ic_cdk::update]
+fn set_epoch_driver_interval_secs(secs: u64) -> Result<(), PointsError> {
+    state::set_epoch_driver_interval(ic_cdk::caller(), secs)?;
+    epoch::setup_epoch_timer();
+    Ok(())
+}
+
+/// Admin: advance the epoch state machine one step now (ops recovery / E2E),
+/// independent of the enabled flag.
+#[ic_cdk::update]
+async fn force_epoch_tick() -> Result<(), PointsError> {
+    if !state::is_admin(ic_cdk::caller()) {
+        return Err(PointsError::Unauthorized);
+    }
+    epoch::run_tick().await;
+    Ok(())
+}
+
+/// Admin: override an asset's ledger id (point at local/test ledgers). Tags:
+/// 0 = icUSD, 1 = 3USD, 2 = ckUSDC, 3 = ckUSDT, 4 = ICP.
+#[ic_cdk::update]
+fn set_asset_ledger(asset_tag: u8, ledger: Principal) -> Result<(), PointsError> {
+    state::set_asset_ledger(ic_cdk::caller(), asset_tag, ledger)
+}
+
+#[ic_cdk::query]
+fn get_asset_ledgers() -> Vec<(u8, Principal)> {
+    state::asset_ledgers()
+}
+
+#[ic_cdk::query]
+fn get_epoch_status() -> EpochStatus {
+    state::epoch_status()
+}
+
+/// The revealed seed for a CLOSED epoch, for post-hoc snapshot-time verification.
+#[ic_cdk::query]
+fn get_revealed_seed(epoch_index: u64) -> Option<RevealedSeed> {
+    state::get_revealed_seed(epoch_index)
+}
+
+/// The hash the next epoch's seed must reveal (record it now, verify after reveal).
+#[ic_cdk::query]
+fn get_pending_commit() -> Vec<u8> {
+    state::get_pending_commit().to_vec()
 }
 
 ic_cdk::export_candid!();

--- a/src/rumi_points/src/snapshot_seed.rs
+++ b/src/rumi_points/src/snapshot_seed.rs
@@ -19,6 +19,18 @@
 
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// SHA-256 over the concatenation of `parts`. The commit-reveal chain and the
+/// epoch-summary hash both use this; kept here so the hashing convention has one
+/// home.
+pub(crate) fn sha256(parts: &[&[u8]]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update(part);
+    }
+    hasher.finalize().into()
+}
 
 /// In-flight seed singleton. Lives inside `state::State` (so it rides the
 /// versioned State blob across upgrades). `current_seed` is held privately until
@@ -66,11 +78,22 @@ pub enum SeedError {
 /// offset into the first half and `seed[8..16]` mod `half` as snapshot B's
 /// offset into the second half. Guarantees A precedes B with a real gap.
 pub fn derive_snapshot_times(
-    _seed: &[u8; 32],
-    _epoch_start_ns: u64,
-    _epoch_end_ns: u64,
+    seed: &[u8; 32],
+    epoch_start_ns: u64,
+    epoch_end_ns: u64,
 ) -> (u64, u64) {
-    unimplemented!("Phase 5: implement per spike 0.3 derive_snapshot_times");
+    let half = epoch_end_ns.saturating_sub(epoch_start_ns) / 2;
+    if half == 0 {
+        // Degenerate (empty) epoch: nothing to spread the snapshots across.
+        // Collapse both to the start and avoid the modulo-by-zero panic.
+        return (epoch_start_ns, epoch_start_ns);
+    }
+    // First 8 bytes place snapshot A somewhere in the first half of the epoch;
+    // the next 8 place snapshot B in the second half. The split guarantees A
+    // precedes B with a real gap (spike 0.3).
+    let a_offset = u64::from_le_bytes(seed[0..8].try_into().unwrap()) % half;
+    let b_offset = u64::from_le_bytes(seed[8..16].try_into().unwrap()) % half;
+    (epoch_start_ns + a_offset, epoch_start_ns + half + b_offset)
 }
 
 /// Owns the commit-reveal chain across epochs. PHASE 5: full implementation per
@@ -79,26 +102,238 @@ pub fn derive_snapshot_times(
 pub struct SeedManager;
 
 impl SeedManager {
-    /// Verify the previously stored seed matches the pending commit, derive this
-    /// epoch's snapshot times, and store the (not-yet-revealed) seed.
+    /// Resolve this epoch's seed (the explicit arg for epoch 0, else the
+    /// pre-loaded `current_seed` from the prior close), verify it against the
+    /// pending commit (when committed), stash it as the open epoch's seed, and
+    /// return the two snapshot times. `CommitMismatch` halts on tampering;
+    /// `MissingSeed` if neither an arg nor a pre-loaded seed is available.
     pub fn start_epoch(
-        _singleton: &mut SnapshotSeedSingleton,
-        _epoch_index: u64,
-        _epoch_start_ns: u64,
-        _epoch_end_ns: u64,
-        _prev_epoch_summary_hash: [u8; 32],
-        _seed_for_this_epoch: Option<[u8; 32]>,
+        singleton: &mut SnapshotSeedSingleton,
+        epoch_start_ns: u64,
+        epoch_end_ns: u64,
+        seed_for_this_epoch: Option<[u8; 32]>,
     ) -> Result<(u64, u64), SeedError> {
-        unimplemented!("Phase 5: implement per spike 0.3 start_epoch");
+        let seed = seed_for_this_epoch
+            .or(singleton.current_seed)
+            .ok_or(SeedError::MissingSeed)?;
+        if singleton.is_committed() && sha256(&[&seed]) != singleton.pending_commit {
+            // The seed for this epoch must hash to the commit locked in by the
+            // previous reveal (or the init H0). A mismatch means corruption or
+            // tampering; the driver must halt, not silently re-roll the times.
+            return Err(SeedError::CommitMismatch);
+        }
+        singleton.current_seed = Some(seed);
+        Ok(derive_snapshot_times(&seed, epoch_start_ns, epoch_end_ns))
     }
 
-    /// Reveal the current seed, append it to the audit log, and compute the next
-    /// epoch's commit `H_{N+1} = sha256(seed_N || epoch_N_summary_hash)`.
+    /// Reveal the open epoch's seed as a `RevealedSeed` (the caller appends it to
+    /// the audit log), then pre-load the next epoch's seed
+    /// `next = sha256(seed || summary_hash)` and its commit `sha256(next)`. The
+    /// snapshot times and reveal timestamp are passed in (kept by the driver in
+    /// `State.open_epoch`) so the singleton needs no extra fields.
     pub fn close_epoch(
-        _singleton: &mut SnapshotSeedSingleton,
-        _epoch_index: u64,
-        _epoch_summary_hash: [u8; 32],
+        singleton: &mut SnapshotSeedSingleton,
+        epoch_index: u64,
+        snapshot_a_ns: u64,
+        snapshot_b_ns: u64,
+        now_ns: u64,
+        epoch_summary_hash: [u8; 32],
     ) -> Result<RevealedSeed, SeedError> {
-        unimplemented!("Phase 5: implement per spike 0.3 close_epoch");
+        let seed = singleton.current_seed.ok_or(SeedError::MissingSeed)?;
+        let revealed = RevealedSeed {
+            epoch_index,
+            seed,
+            snapshot_time_a_ns: snapshot_a_ns,
+            snapshot_time_b_ns: snapshot_b_ns,
+            revealed_at_ns: now_ns,
+        };
+        // Chain the next epoch's seed off this one plus the epoch's summary, then
+        // lock its commit. The reveal of THIS seed (returned to the caller) fixes
+        // the next commit, so the team cannot retroactively change future times.
+        let next = sha256(&[&seed, &epoch_summary_hash]);
+        singleton.pending_commit = sha256(&[&next]);
+        singleton.current_seed = Some(next);
+        Ok(revealed)
+    }
+}
+
+#[cfg(test)]
+mod derive_tests {
+    use super::*;
+
+    /// One week in nanoseconds, matching `epoch::EPOCH_DURATION_NS`.
+    const WK: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+    #[test]
+    fn derive_is_deterministic() {
+        let seed = [7u8; 32];
+        let first = derive_snapshot_times(&seed, 1_000, 1_000 + WK);
+        let again = derive_snapshot_times(&seed, 1_000, 1_000 + WK);
+        assert_eq!(first, again);
+    }
+
+    #[test]
+    fn derive_zero_seed_hits_start_and_midpoint() {
+        // seed[0..8] == 0 -> a offset 0 -> a == start.
+        // seed[8..16] == 0 -> b offset 0 -> b == start + half (the midpoint).
+        let start = 1_000u64;
+        let (a, b) = derive_snapshot_times(&[0u8; 32], start, start + WK);
+        assert_eq!(a, start);
+        assert_eq!(b, start + WK / 2);
+    }
+
+    #[test]
+    fn derive_keeps_a_in_first_half_b_in_second() {
+        let start = 500u64;
+        let end = start + WK;
+        let half = WK / 2;
+        // An arbitrary seed with distinct low/high bytes.
+        let mut seed = [0u8; 32];
+        for (i, byte) in seed.iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(37).wrapping_add(3);
+        }
+        let (a, b) = derive_snapshot_times(&seed, start, end);
+        assert!(start <= a && a < start + half, "a={a} must be in the first half");
+        assert!(start + half <= b && b < end, "b={b} must be in the second half");
+        assert!(a < b, "snapshot A must precede snapshot B");
+    }
+
+    #[test]
+    fn derive_different_seeds_produce_different_times() {
+        let start = 0u64;
+        let zero = derive_snapshot_times(&[0u8; 32], start, start + WK);
+        let mut other = [0u8; 32];
+        other[0] = 0xAB; // perturb the A offset
+        other[8] = 0xCD; // perturb the B offset
+        let perturbed = derive_snapshot_times(&other, start, start + WK);
+        assert_ne!(zero, perturbed);
+    }
+
+    #[test]
+    fn derive_zero_duration_does_not_panic() {
+        // half == 0 must not panic on the modulo; both snapshots collapse to start.
+        let (a, b) = derive_snapshot_times(&[9u8; 32], 1_234, 1_234);
+        assert_eq!((a, b), (1_234, 1_234));
+    }
+}
+
+#[cfg(test)]
+mod seed_manager_tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+
+    /// Independent sha256 (computed straight from the `sha2` crate) so the tests
+    /// verify the manager's hashing against a reference, not against itself.
+    fn h(parts: &[&[u8]]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        for p in parts {
+            hasher.update(p);
+        }
+        hasher.finalize().into()
+    }
+
+    const WK: u64 = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+    /// A singleton committed to `seed` (H0 = sha256(seed)), no open seed yet.
+    fn committed(seed: &[u8; 32]) -> SnapshotSeedSingleton {
+        SnapshotSeedSingleton {
+            pending_commit: h(&[seed]),
+            current_seed: None,
+        }
+    }
+
+    #[test]
+    fn start_epoch_returns_derived_times_and_stashes_seed() {
+        let s0 = [3u8; 32];
+        let mut sing = committed(&s0);
+        let times = SeedManager::start_epoch(&mut sing, 1_000, 1_000 + WK, Some(s0)).unwrap();
+        assert_eq!(times, derive_snapshot_times(&s0, 1_000, 1_000 + WK));
+        assert_eq!(sing.current_seed, Some(s0));
+    }
+
+    #[test]
+    fn start_epoch_rejects_commit_mismatch() {
+        let s0 = [3u8; 32];
+        let mut sing = committed(&s0); // commit is sha256(s0)
+        let wrong = [4u8; 32];
+        let err = SeedManager::start_epoch(&mut sing, 0, WK, Some(wrong)).unwrap_err();
+        assert_eq!(err, SeedError::CommitMismatch);
+        assert_eq!(sing.current_seed, None); // unchanged on rejection
+    }
+
+    #[test]
+    fn start_epoch_missing_seed_errors() {
+        let mut sing = committed(&[3u8; 32]); // committed, but no current_seed and no arg
+        let err = SeedManager::start_epoch(&mut sing, 0, WK, None).unwrap_err();
+        assert_eq!(err, SeedError::MissingSeed);
+    }
+
+    #[test]
+    fn start_epoch_uses_current_seed_when_arg_is_none() {
+        // Epoch >= 1: the prior close pre-loaded current_seed and its commit.
+        let seed1 = [11u8; 32];
+        let mut sing = SnapshotSeedSingleton {
+            pending_commit: h(&[&seed1]),
+            current_seed: Some(seed1),
+        };
+        let times = SeedManager::start_epoch(&mut sing, 0, WK, None).unwrap();
+        assert_eq!(times, derive_snapshot_times(&seed1, 0, WK));
+        assert_eq!(sing.current_seed, Some(seed1));
+    }
+
+    #[test]
+    fn start_epoch_uncommitted_accepts_any_seed() {
+        // pending_commit all-zero => not committed => no verification gate.
+        let mut sing = SnapshotSeedSingleton::default();
+        assert!(!sing.is_committed());
+        let any = [42u8; 32];
+        assert!(SeedManager::start_epoch(&mut sing, 0, WK, Some(any)).is_ok());
+        assert_eq!(sing.current_seed, Some(any));
+    }
+
+    #[test]
+    fn close_epoch_reveals_seed_and_preloads_next_commit() {
+        let s0 = [3u8; 32];
+        let mut sing = committed(&s0);
+        let (a, b) = SeedManager::start_epoch(&mut sing, 0, WK, Some(s0)).unwrap();
+        let summary = [9u8; 32];
+
+        let revealed = SeedManager::close_epoch(&mut sing, 0, a, b, 777, summary).unwrap();
+        assert_eq!(revealed.epoch_index, 0);
+        assert_eq!(revealed.seed, s0);
+        assert_eq!(revealed.snapshot_time_a_ns, a);
+        assert_eq!(revealed.snapshot_time_b_ns, b);
+        assert_eq!(revealed.revealed_at_ns, 777);
+
+        // Next epoch's seed is sha256(seed || summary); its commit is sha256(next).
+        let next = h(&[&s0, &summary]);
+        assert_eq!(sing.current_seed, Some(next));
+        assert_eq!(sing.pending_commit, h(&[&next]));
+    }
+
+    #[test]
+    fn close_without_open_seed_errors() {
+        let mut sing = committed(&[3u8; 32]); // current_seed is None
+        let err = SeedManager::close_epoch(&mut sing, 0, 1, 2, 3, [0u8; 32]).unwrap_err();
+        assert_eq!(err, SeedError::MissingSeed);
+    }
+
+    #[test]
+    fn hash_chain_holds_across_three_epochs() {
+        let s0 = [5u8; 32];
+        let mut sing = committed(&s0);
+
+        // Epoch 0: provided S0.
+        let (a0, b0) = SeedManager::start_epoch(&mut sing, 0, WK, Some(s0)).unwrap();
+        SeedManager::close_epoch(&mut sing, 0, a0, b0, 1, [1u8; 32]).unwrap();
+
+        // Epoch 1: derived seed, no arg; the pre-loaded commit must verify.
+        let (a1, b1) = SeedManager::start_epoch(&mut sing, WK, 2 * WK, None)
+            .expect("epoch 1 seed must satisfy the pending commit");
+        SeedManager::close_epoch(&mut sing, 1, a1, b1, 2, [2u8; 32]).unwrap();
+
+        // Epoch 2: same, chain still intact.
+        SeedManager::start_epoch(&mut sing, 2 * WK, 3 * WK, None)
+            .expect("epoch 2 seed must satisfy the pending commit");
     }
 }

--- a/src/rumi_points/src/source_types.rs
+++ b/src/rumi_points/src/source_types.rs
@@ -164,7 +164,14 @@ pub mod backend {
             BackendEvent::RepayToVault { vault_id, caller, repayed_amount, timestamp } => (
                 caller,
                 timestamp,
-                IngestKind::VaultRepay { vault_id, amount_e8s: repayed_amount },
+                // `repayment_asset` is gated: the upstream backend `RepayToVault`
+                // event does not carry it yet, so it stays `None` and the 5x
+                // ck-stable window is skipped until the field ships.
+                IngestKind::VaultRepay {
+                    vault_id,
+                    amount_e8s: repayed_amount,
+                    repayment_asset: None,
+                },
             ),
             BackendEvent::CloseVault { vault_id, timestamp } => {
                 (None, timestamp, IngestKind::VaultClose { vault_id })
@@ -383,6 +390,53 @@ pub mod amm {
     }
 }
 
+// ── Balance / position queries (Phase 5 snapshot capture) ───────────────────
+// Minimal candid mirrors of each source's READ endpoints. Record width-subtyping
+// lets us declare only the fields the snapshot driver reads; everything else on
+// the wire is ignored.
+pub mod balances {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// `rumi_protocol_backend::get_vaults(opt principal) -> vec CandidVault`. The
+    /// debt already includes accrued interest.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct CandidVault {
+        pub borrowed_icusd_amount: u64,
+    }
+
+    /// `rumi_protocol_backend::get_protocol_status() -> ProtocolStatus`.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct ProtocolStatus {
+        pub last_icp_rate: f64,
+    }
+
+    /// `rumi_3pool::get_pool_status() -> PoolStatus` (1e18-scaled virtual price).
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct PoolStatus {
+        pub virtual_price: u128,
+    }
+
+    /// `rumi_stability_pool::get_user_position(opt principal) -> opt
+    /// UserStabilityPosition`. Balances are per-ledger native decimals (icUSD and
+    /// 3USD are both 8-dec), already compounded for liquidation draws.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct UserStabilityPosition {
+        pub stablecoin_balances: BTreeMap<Principal, u64>,
+    }
+
+    /// `rumi_amm::get_pools() -> vec PoolInfo`. Reserves are native e8s.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    pub struct PoolInfo {
+        pub pool_id: String,
+        pub token_a: Principal,
+        pub token_b: Principal,
+        pub reserve_a: u128,
+        pub reserve_b: u128,
+        pub total_lp_shares: u128,
+    }
+}
+
 #[cfg(test)]
 mod canary {
     use candid::{CandidType, Decode, Encode};
@@ -449,6 +503,81 @@ mod canary {
             decoded.is_err(),
             "if candid ever gains serde(other) support, the SP mirror can be slimmed to a subset"
         );
+    }
+}
+
+#[cfg(test)]
+mod balances_tests {
+    use super::balances::*;
+    use candid::{CandidType, Decode, Encode, Principal};
+    use std::collections::BTreeMap;
+
+    fn p(n: u8) -> Principal {
+        Principal::from_slice(&[n, n, n, n, n])
+    }
+
+    /// The subset vault decodes from a wider on-wire vault (record width subtyping).
+    #[test]
+    fn candid_vault_decodes_from_wider_wire() {
+        #[derive(CandidType)]
+        struct WireVault {
+            owner: Principal,
+            vault_id: u64,
+            borrowed_icusd_amount: u64,
+            collateral_amount: u64,
+            accrued_interest: u64,
+        }
+        let bytes = Encode!(&vec![WireVault {
+            owner: p(1),
+            vault_id: 7,
+            borrowed_icusd_amount: 12_345,
+            collateral_amount: 9,
+            accrued_interest: 3,
+        }])
+        .unwrap();
+        let got = Decode!(&bytes, Vec<CandidVault>).unwrap();
+        assert_eq!(got[0].borrowed_icusd_amount, 12_345);
+    }
+
+    #[test]
+    fn protocol_status_decodes_rate_from_wider_wire() {
+        #[derive(CandidType)]
+        struct WireStatus {
+            last_icp_rate: f64,
+            last_icp_timestamp: u64,
+            total_debt: u64,
+        }
+        let bytes = Encode!(&WireStatus {
+            last_icp_rate: 5.5,
+            last_icp_timestamp: 1,
+            total_debt: 2,
+        })
+        .unwrap();
+        assert_eq!(Decode!(&bytes, ProtocolStatus).unwrap().last_icp_rate, 5.5);
+    }
+
+    #[test]
+    fn user_position_decodes_balance_map() {
+        let mut balances = BTreeMap::new();
+        balances.insert(p(2), 500u64);
+        let bytes = Encode!(&Some(UserStabilityPosition { stablecoin_balances: balances })).unwrap();
+        let got = Decode!(&bytes, Option<UserStabilityPosition>).unwrap().unwrap();
+        assert_eq!(got.stablecoin_balances.get(&p(2)), Some(&500));
+    }
+
+    #[test]
+    fn pool_info_round_trips() {
+        let info = PoolInfo {
+            pool_id: "a_b".into(),
+            token_a: p(1),
+            token_b: p(2),
+            reserve_a: 100,
+            reserve_b: 200,
+            total_lp_shares: 300,
+        };
+        let got = Decode!(&Encode!(&vec![info]).unwrap(), Vec<PoolInfo>).unwrap();
+        assert_eq!(got[0].reserve_a, 100);
+        assert_eq!(got[0].total_lp_shares, 300);
     }
 }
 

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -48,10 +48,12 @@ use ic_stable_structures::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::accrual::{self, SnapshotWeights};
 use crate::snapshot_seed::{RevealedSeed, SnapshotSeedSingleton};
 use crate::types::{
-    EpochSummary, InitArgs, LeaderboardEntry, PointEntry, PointSource, PointsConfig, PointsError,
-    PrincipalState, QualifyingAction, RegistrationInfo,
+    AssetType, DepositKey, DepositRecord, EpochStatus, EpochSummary, InitArgs, LeaderboardEntry,
+    OpenEpoch, PointEntry, PointSource, PointsConfig, PointsError, PrincipalState, QualifyingAction,
+    RegistrationInfo, RepaymentEvent, Venue,
 };
 
 // ── Memory ids (never reuse) ────────────────────────────────────────────────
@@ -71,6 +73,13 @@ const CURSORS_MEM_ID: MemoryId = MemoryId::new(8);
 const SOURCE_CANISTERS_MEM_ID: MemoryId = MemoryId::new(9);
 // Phase 2b: poll-timer config (key 0 = enabled 0/1, key 1 = interval seconds).
 const POLL_CONFIG_MEM_ID: MemoryId = MemoryId::new(10);
+// Phase 5: running-min snapshot weights for the OPEN epoch (cleared at close).
+const SNAPSHOT_BUFFER_MEM_ID: MemoryId = MemoryId::new(11);
+// Phase 5: asset-ledger registry (asset tag -> ledger principal), mainnet-seeded,
+// admin-overridable for local/test.
+const ASSET_LEDGERS_MEM_ID: MemoryId = MemoryId::new(12);
+// Phase 5: epoch-driver config (key 0 = enabled 0/1, key 1 = interval seconds).
+const EPOCH_CONFIG_MEM_ID: MemoryId = MemoryId::new(13);
 
 const WASM_PAGE_SIZE: u64 = 65_536; // 64 KiB
 
@@ -137,11 +146,26 @@ impl StoredRevealedSeed {
     }
 }
 
-/// Singleton config (admin, excluded set, season window, epoch counter, in-flight
-/// seed). Held on the heap during execution and serialized to the `STATE_BLOB`
-/// region on `pre_upgrade`, mirroring the backend. NOT candid-facing.
+/// Versioned wrapper for the per-principal running-min snapshot weights (the
+/// MemoryId-11 buffer for the open epoch). See the module doc for the recipe.
+#[derive(Serialize, Deserialize)]
+pub enum StoredSnapshotWeights {
+    V1(SnapshotWeights),
+}
+
+impl StoredSnapshotWeights {
+    fn into_current(self) -> SnapshotWeights {
+        match self {
+            StoredSnapshotWeights::V1(v) => v,
+        }
+    }
+}
+
+/// FROZEN V1 shape of `State` (pre-Phase-5). Old `{"V1": ...}` blob bytes decode
+/// into this, then migrate forward via `From`. NEVER change these fields; add new
+/// state to the current `State` (a new `StoredState` version) instead.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct State {
+pub struct StateV1 {
     pub admin: Principal,
     pub excluded_principals: BTreeSet<Principal>,
     pub season_start_ns: u64,
@@ -150,9 +174,58 @@ pub struct State {
     pub snapshot_seed: SnapshotSeedSingleton,
 }
 
+/// Singleton config (admin, excluded set, season window, epoch counter, in-flight
+/// seed, open-epoch driver state). Held on the heap during execution and
+/// serialized to the `STATE_BLOB` region on `pre_upgrade`, mirroring the backend.
+/// NOT candid-facing.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct State {
+    pub admin: Principal,
+    pub excluded_principals: BTreeSet<Principal>,
+    pub season_start_ns: u64,
+    pub season_end_ns: u64,
+    pub current_epoch_index: u64,
+    pub snapshot_seed: SnapshotSeedSingleton,
+    /// Phase 5: in-flight open epoch (periodic-driver state). `None` between
+    /// epochs and before the season starts.
+    pub open_epoch: Option<OpenEpoch>,
+}
+
+impl From<StateV1> for State {
+    fn from(v: StateV1) -> Self {
+        State {
+            admin: v.admin,
+            excluded_principals: v.excluded_principals,
+            season_start_ns: v.season_start_ns,
+            season_end_ns: v.season_end_ns,
+            current_epoch_index: v.current_epoch_index,
+            snapshot_seed: v.snapshot_seed,
+            open_epoch: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub enum StoredState {
-    V1(State),
+    V1(StateV1),
+    V2(State),
+}
+
+impl StoredState {
+    fn into_current(self) -> State {
+        match self {
+            StoredState::V1(old) => old.into(),
+            StoredState::V2(s) => s,
+        }
+    }
+}
+
+/// Decode a singleton-blob payload (either version) into the current `State`. Old
+/// `V1` bytes migrate forward; `None` on a corrupt/undecodable blob.
+fn decode_stored_state(bytes: &[u8]) -> Option<State> {
+    ciborium::de::from_reader::<StoredState, _>(bytes)
+        .ok()
+        .map(StoredState::into_current)
 }
 
 /// CBOR `Storable` impl (ciborium), `Bound::Unbounded` per the stable-memory
@@ -179,6 +252,7 @@ impl_cbor_storable!(StoredPrincipalState);
 impl_cbor_storable!(StoredPointEntry);
 impl_cbor_storable!(StoredEpochSummary);
 impl_cbor_storable!(StoredRevealedSeed);
+impl_cbor_storable!(StoredSnapshotWeights);
 
 /// `StableBTreeMap` key wrapper. ic-stable-structures 0.6.5 does not provide a
 /// `Storable` impl for `Principal`, so we wrap it. A principal is at most 29
@@ -241,6 +315,10 @@ thread_local! {
     /// post-upgrade heap always starts with no poll in flight).
     static POLL_IN_PROGRESS: RefCell<bool> = RefCell::new(false);
 
+    /// Phase 5: transient guard so overlapping epoch-driver ticks never double-run
+    /// a capture or close. NOT persisted (a fresh heap starts with no tick running).
+    static EPOCH_IN_PROGRESS: RefCell<bool> = RefCell::new(false);
+
     /// Phase 2: per-source canister principal (source tag -> canister id). Seeded
     /// with mainnet defaults at init; the admin overrides per environment (e.g.
     /// local replica ids) via `set_source_canister`. Persists across upgrades.
@@ -252,6 +330,22 @@ thread_local! {
     /// `post_upgrade` from this config (timers do not survive upgrades).
     static POLL_CONFIG: RefCell<StableBTreeMap<u8, u64, VMem>> =
         MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(POLL_CONFIG_MEM_ID))));
+
+    /// Phase 5: running-MIN snapshot weights per principal for the OPEN epoch.
+    /// Snapshot A inserts; snapshot B keeps `min_by_total` vs A; the close consumes
+    /// and clears it. Stable so a mid-epoch upgrade keeps captured snapshots.
+    static SNAPSHOT_BUFFER: RefCell<StableBTreeMap<StorablePrincipal, StoredSnapshotWeights, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(SNAPSHOT_BUFFER_MEM_ID))));
+
+    /// Phase 5: asset-ledger registry (asset tag -> ledger principal). Seeded with
+    /// mainnet ids at init; admin overrides per environment (local/test).
+    static ASSET_LEDGERS: RefCell<StableBTreeMap<u8, StorablePrincipal, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(ASSET_LEDGERS_MEM_ID))));
+
+    /// Phase 5: epoch-driver config (key 0 = enabled, key 1 = interval seconds).
+    /// Mirrors POLL_CONFIG; the driver timer is re-registered in `post_upgrade`.
+    static EPOCH_CONFIG: RefCell<StableBTreeMap<u8, u64, VMem>> =
+        MEMORY_MANAGER.with(|m| RefCell::new(StableBTreeMap::init(m.borrow().get(EPOCH_CONFIG_MEM_ID))));
 }
 
 // ── Excluded-principals seed (spec Section 11) ──────────────────────────────
@@ -332,6 +426,7 @@ pub fn init_state(args: Option<InitArgs>, caller: Principal) {
         season_end_ns: args.season_end_ns.unwrap_or(crate::DEFAULT_SEASON_END_NS),
         current_epoch_index: 0,
         snapshot_seed,
+        open_epoch: None,
     };
     STATE.with(|cell| *cell.borrow_mut() = Some(state));
 
@@ -343,6 +438,17 @@ pub fn init_state(args: Option<InitArgs>, caller: Principal) {
         let mut m = m.borrow_mut();
         if m.is_empty() {
             for (tag, p) in source_canister_seed() {
+                m.insert(tag, StorablePrincipal(p));
+            }
+        }
+    });
+
+    // Seed the asset-ledger registry with mainnet ids (Phase 5). Admin overrides
+    // per environment via `set_asset_ledger`. No-op if already populated.
+    ASSET_LEDGERS.with(|m| {
+        let mut m = m.borrow_mut();
+        if m.is_empty() {
+            for (tag, p) in asset_ledger_seed() {
                 m.insert(tag, StorablePrincipal(p));
             }
         }
@@ -478,7 +584,7 @@ pub fn epoch_history(offset: u64, limit: u64) -> Vec<EpochSummary> {
 pub fn save_state_to_stable() {
     let bytes = with_state(|s| {
         let mut buf = Vec::new();
-        ciborium::ser::into_writer(&StoredState::V1(s.clone()), &mut buf)
+        ciborium::ser::into_writer(&StoredState::V2(s.clone()), &mut buf)
             .expect("failed to serialize State to CBOR");
         buf
     });
@@ -525,13 +631,11 @@ pub fn load_state_from_stable() -> Option<State> {
         }
         let mut buf = vec![0u8; len as usize];
         mem.read(8, &mut buf);
-        match ciborium::de::from_reader::<StoredState, _>(buf.as_slice()) {
-            Ok(StoredState::V1(s)) => Some(s),
-            Err(e) => {
-                ic_cdk::println!("[upgrade] failed to deserialize State: {:?}", e);
-                None
-            }
+        let decoded = decode_stored_state(&buf);
+        if decoded.is_none() {
+            ic_cdk::println!("[upgrade] failed to deserialize State blob");
         }
+        decoded
     })
 }
 
@@ -621,6 +725,18 @@ pub fn points_config() -> PointsConfig {
         excluded_count: s.excluded_principals.len() as u32,
         registered_count: registered_count(),
         current_epoch_index: s.current_epoch_index,
+        snapshot_seed_committed: s.snapshot_seed.is_committed(),
+    })
+}
+
+/// Epoch-driver status for the ops dashboard (Phase 5).
+pub fn epoch_status() -> EpochStatus {
+    with_state(|s| EpochStatus {
+        current_epoch_index: s.current_epoch_index,
+        driver_enabled: epoch_driver_enabled(),
+        driver_interval_secs: epoch_driver_interval_secs(),
+        open_epoch: s.open_epoch.clone(),
+        revealed_seed_count: revealed_seed_count(),
         snapshot_seed_committed: s.snapshot_seed.is_committed(),
     })
 }
@@ -741,6 +857,375 @@ pub fn in_season(ts_ns: u64) -> bool {
     with_state(|s| ts_ns >= s.season_start_ns && ts_ns <= s.season_end_ns)
 }
 
+// ── Phase 5: snapshot-weights buffer (MemoryId 11) ──────────────────────────
+// Per-principal running-min weights for the open epoch. The capture/merge logic
+// lives in the driver (`epoch.rs`); these are the storage primitives it uses.
+
+/// Store a principal's snapshot weights.
+pub fn snapshot_buffer_put(p: Principal, w: SnapshotWeights) {
+    SNAPSHOT_BUFFER.with(|b| {
+        b.borrow_mut()
+            .insert(StorablePrincipal(p), StoredSnapshotWeights::V1(w));
+    });
+}
+
+/// Read a principal's buffered weights, if any.
+pub fn snapshot_buffer_get(p: &Principal) -> Option<SnapshotWeights> {
+    SNAPSHOT_BUFFER.with(|b| b.borrow().get(&StorablePrincipal(*p)).map(|s| s.into_current()))
+}
+
+/// Drop a principal's buffered weights.
+pub fn snapshot_buffer_remove(p: &Principal) {
+    SNAPSHOT_BUFFER.with(|b| {
+        b.borrow_mut().remove(&StorablePrincipal(*p));
+    });
+}
+
+/// All buffered `(principal, weights)`, for the epoch-close accrual pass.
+pub fn snapshot_buffer_entries() -> Vec<(Principal, SnapshotWeights)> {
+    SNAPSHOT_BUFFER.with(|b| {
+        b.borrow()
+            .iter()
+            .map(|(k, v)| (k.0, v.into_current()))
+            .collect()
+    })
+}
+
+pub fn snapshot_buffer_len() -> u64 {
+    SNAPSHOT_BUFFER.with(|b| b.borrow().len())
+}
+
+/// Empty the buffer (called at epoch close, before the next epoch opens).
+pub fn snapshot_buffer_clear() {
+    SNAPSHOT_BUFFER.with(|b| {
+        let mut map = b.borrow_mut();
+        let keys: Vec<StorablePrincipal> = map.iter().map(|(k, _)| k).collect();
+        for k in keys {
+            map.remove(&k);
+        }
+    });
+}
+
+// ── Phase 5: asset-ledger registry (MemoryId 12) ────────────────────────────
+
+/// Stable tag for an asset's ledger-registry slot. NEVER renumber.
+pub fn asset_tag(asset: AssetType) -> u8 {
+    match asset {
+        AssetType::IcUsd => 0,
+        AssetType::ThreeUsd => 1,
+        AssetType::CkUsdc => 2,
+        AssetType::CkUsdt => 3,
+        AssetType::Icp => 4,
+    }
+}
+
+/// Mainnet ledger principals seeded at init (asset tag -> ledger). 3USD's "ledger"
+/// is the rumi_3pool canister itself (the LP token). Confirmed 2026-06-02.
+pub fn asset_ledger_seed() -> Vec<(u8, Principal)> {
+    [
+        (0u8, "t6bor-paaaa-aaaap-qrd5q-cai"), // icUSD
+        (1u8, "fohh4-yyaaa-aaaap-qtkpa-cai"), // 3USD (= rumi_3pool)
+        (2u8, "xevnm-gaaaa-aaaar-qafnq-cai"), // ckUSDC
+        (3u8, "cngnf-vqaaa-aaaar-qag4q-cai"), // ckUSDT
+        (4u8, "ryjl3-tyaaa-aaaaa-aaaba-cai"), // ICP
+    ]
+    .iter()
+    .map(|(t, s)| (*t, Principal::from_text(s).expect("invalid asset ledger literal")))
+    .collect()
+}
+
+/// The configured ledger principal for an asset, or `None` if unset.
+pub fn get_asset_ledger(asset: AssetType) -> Option<Principal> {
+    ASSET_LEDGERS.with(|m| m.borrow().get(&asset_tag(asset)).map(|p| p.0))
+}
+
+/// Classify a ledger principal to its asset, or `None` if it is not a tracked
+/// stable/ICP ledger (used to type SP deposits and vault-repayment assets).
+pub fn classify_ledger(ledger: &Principal) -> Option<AssetType> {
+    [
+        AssetType::IcUsd,
+        AssetType::ThreeUsd,
+        AssetType::CkUsdc,
+        AssetType::CkUsdt,
+        AssetType::Icp,
+    ]
+    .into_iter()
+    .find(|a| get_asset_ledger(*a).as_ref() == Some(ledger))
+}
+
+/// Admin: override an asset's ledger id (e.g. point at local-replica ledgers).
+pub fn set_asset_ledger(caller: Principal, tag: u8, ledger: Principal) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    ASSET_LEDGERS.with(|m| {
+        m.borrow_mut().insert(tag, StorablePrincipal(ledger));
+    });
+    Ok(())
+}
+
+/// All configured `(tag, ledger)` pairs, for the status query.
+pub fn asset_ledgers() -> Vec<(u8, Principal)> {
+    ASSET_LEDGERS.with(|m| m.borrow().iter().map(|(t, p)| (t, p.0)).collect())
+}
+
+// ── Phase 5: epoch-driver config (MemoryId 13) ──────────────────────────────
+// Mirrors POLL_CONFIG: the weekly epoch state machine is driven by a periodic
+// timer, OFF by default, re-registered from this config in `post_upgrade`.
+
+pub const DEFAULT_EPOCH_DRIVER_INTERVAL_SECS: u64 = 300;
+pub const MIN_EPOCH_DRIVER_INTERVAL_SECS: u64 = 60;
+
+pub fn epoch_driver_enabled() -> bool {
+    EPOCH_CONFIG.with(|c| c.borrow().get(&0).unwrap_or(0) != 0)
+}
+
+pub fn epoch_driver_interval_secs() -> u64 {
+    EPOCH_CONFIG.with(|c| c.borrow().get(&1).unwrap_or(DEFAULT_EPOCH_DRIVER_INTERVAL_SECS))
+}
+
+pub fn set_epoch_driver_enabled(caller: Principal, enabled: bool) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    EPOCH_CONFIG.with(|c| {
+        c.borrow_mut().insert(0, enabled as u64);
+    });
+    Ok(())
+}
+
+pub fn set_epoch_driver_interval(caller: Principal, secs: u64) -> Result<(), PointsError> {
+    require_admin(caller)?;
+    let clamped = secs.max(MIN_EPOCH_DRIVER_INTERVAL_SECS);
+    EPOCH_CONFIG.with(|c| {
+        c.borrow_mut().insert(1, clamped);
+    });
+    Ok(())
+}
+
+// ── Phase 5/4: ingestion-driven per-principal state (events.rs writes these) ──
+
+/// 90-day repayment window length (spec Section 6).
+pub const REPAYMENT_WINDOW_NS: u64 = 90 * crate::NANOS_PER_DAY;
+
+/// Add to (or subtract from) a principal's recorded 3pool deposit for one asset
+/// (the event-tracked composition deciding the 1x/3x/5x split). Subtraction
+/// saturates at 0 and drops the record when it reaches 0. No-op if unregistered.
+pub fn update_3pool_recorded(
+    principal: Principal,
+    asset: AssetType,
+    amount_usd_e8s: u128,
+    add: bool,
+    now_ns: u64,
+) {
+    let mut ps = match get_principal_state(&principal) {
+        Some(p) => p,
+        None => return,
+    };
+    let key = DepositKey { venue: Venue::ThreePool, asset };
+    if add {
+        let rec = ps.active_deposits.entry(key).or_insert_with(|| DepositRecord {
+            asset,
+            venue: Venue::ThreePool,
+            recorded_value_usd: 0,
+            deposited_at: now_ns,
+            last_verified_at: now_ns,
+        });
+        rec.recorded_value_usd = rec.recorded_value_usd.saturating_add(amount_usd_e8s);
+        rec.last_verified_at = now_ns;
+    } else if let Some(rec) = ps.active_deposits.get_mut(&key) {
+        rec.recorded_value_usd = rec.recorded_value_usd.saturating_sub(amount_usd_e8s);
+        rec.last_verified_at = now_ns;
+        if rec.recorded_value_usd == 0 {
+            ps.active_deposits.remove(&key);
+        }
+    }
+    put_principal_state(ps);
+}
+
+/// Record a qualifying ckUSDC/ckUSDT vault repayment, opening a 90-day points
+/// window capped at season end (spec Section 6). No-op if unregistered.
+pub fn record_repayment(
+    principal: Principal,
+    asset: AssetType,
+    amount_usd_e8s: u128,
+    repaid_at: u64,
+) {
+    let mut ps = match get_principal_state(&principal) {
+        Some(p) => p,
+        None => return,
+    };
+    let season_end = with_state(|s| s.season_end_ns);
+    let window_end = repaid_at.saturating_add(REPAYMENT_WINDOW_NS).min(season_end);
+    ps.repayment_events.push(RepaymentEvent {
+        asset,
+        amount_usd: amount_usd_e8s,
+        repaid_at,
+        window_end,
+    });
+    put_principal_state(ps);
+}
+
+// ── Phase 5: open-epoch state + close-time accrual (driven by epoch.rs) ──────
+
+pub fn get_open_epoch() -> Option<OpenEpoch> {
+    with_state(|s| s.open_epoch.clone())
+}
+
+pub fn set_open_epoch(open: Option<OpenEpoch>) {
+    with_state_mut(|s| s.open_epoch = open);
+}
+
+pub fn season_bounds() -> (u64, u64) {
+    with_state(|s| (s.season_start_ns, s.season_end_ns))
+}
+
+/// Aggregate result of an epoch close, used to build the `EpochSummary`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CloseStats {
+    pub total_points_all: u128,
+    pub points_accrued: u128,
+    pub active_principals: u64,
+    pub registered_principals: u64,
+}
+
+/// Close-time accrual over every registered principal: scale each one's min-
+/// snapshot weights over the epoch period, add repayment-window points, write the
+/// per-source `PointEntry` rows, and bump `total_points`. Excluded principals are
+/// skipped (spec Section 11). Clears the snapshot buffer at the end.
+pub fn run_close_accrual(
+    epoch_index: u64,
+    epoch_start: u64,
+    epoch_end_capped: u64,
+    now_ns: u64,
+) -> CloseStats {
+    // Snapshot the principal set first (cannot mutate PRINCIPALS while iterating).
+    let principals: Vec<Principal> =
+        PRINCIPALS.with(|m| m.borrow().iter().map(|(k, _)| k.0).collect());
+    let mut points_accrued = 0u128;
+    let mut active = 0u64;
+    for p in &principals {
+        if is_excluded(p) {
+            continue; // excluded principals never accrue (spec Section 11)
+        }
+        let mut ps = match get_principal_state(p) {
+            Some(s) => s,
+            None => continue,
+        };
+        let min_weights = snapshot_buffer_get(p).unwrap_or_default();
+        let (entries, delta) =
+            accrual::accrue_principal(min_weights, &ps.repayment_events, epoch_start, epoch_end_capped);
+        for (source, pts) in entries {
+            append_point_entry(PointEntry {
+                principal: *p,
+                epoch_index,
+                points_delta: pts,
+                source,
+                recorded_at_ns: now_ns,
+            });
+        }
+        if delta > 0 {
+            ps.total_points = ps.total_points.saturating_add(delta);
+            active += 1;
+        }
+        ps.last_epoch_processed = epoch_index;
+        // Drop repayment windows that can no longer overlap any future epoch, so
+        // the per-principal vec stays bounded (no unbounded growth in the value).
+        ps.repayment_events.retain(|r| r.window_end > epoch_end_capped);
+        put_principal_state(ps);
+        points_accrued = points_accrued.saturating_add(delta);
+    }
+    snapshot_buffer_clear();
+    let total_points_all = PRINCIPALS.with(|m| {
+        m.borrow()
+            .iter()
+            .fold(0u128, |acc, (_, v)| acc.saturating_add(v.into_current().total_points))
+    });
+    CloseStats {
+        total_points_all,
+        points_accrued,
+        active_principals: active,
+        registered_principals: principals.len() as u64,
+    }
+}
+
+/// Snapshot B: keep `min_by_total(A, B)` for a principal already captured at A. A
+/// principal absent at A (registered between snapshots, or zero at A) is left out:
+/// the two-snapshot min is 0, so they earn no balance points this epoch.
+pub fn snapshot_buffer_merge_min(p: Principal, weights: SnapshotWeights) {
+    if let Some(existing) = snapshot_buffer_get(&p) {
+        snapshot_buffer_put(p, accrual::min_by_total(existing, weights));
+    }
+}
+
+/// The next chunk of registered principals (sorted) strictly after `cursor`
+/// (`None` = from the start), up to `limit`. Drives the chunked snapshot capture.
+pub fn registered_chunk_after(cursor: Option<Principal>, limit: u64) -> Vec<Principal> {
+    PRINCIPALS.with(|m| {
+        let map = m.borrow();
+        let keys = map.iter().map(|(k, _)| k.0);
+        match cursor {
+            Some(c) => keys.filter(|p| *p > c).take(limit as usize).collect(),
+            None => keys.take(limit as usize).collect(),
+        }
+    })
+}
+
+/// Acquire the single-tick epoch-driver guard (pairs with `end_epoch_guard`).
+pub fn try_begin_epoch() -> bool {
+    EPOCH_IN_PROGRESS.with(|p| {
+        let mut p = p.borrow_mut();
+        if *p {
+            false
+        } else {
+            *p = true;
+            true
+        }
+    })
+}
+
+pub fn end_epoch_guard() {
+    EPOCH_IN_PROGRESS.with(|p| *p.borrow_mut() = false);
+}
+
+/// A principal's recorded 3pool deposit composition `(icUSD, ckUSDC, ckUSDT)` in
+/// `usd_e8s` (the event-tracked side of the hybrid model). Zero for an unknown
+/// principal or an empty leg.
+pub fn recorded_3pool_composition(p: &Principal) -> (u128, u128, u128) {
+    match get_principal_state(p) {
+        Some(ps) => {
+            let leg = |asset| {
+                ps.active_deposits
+                    .get(&DepositKey { venue: Venue::ThreePool, asset })
+                    .map(|r| r.recorded_value_usd)
+                    .unwrap_or(0)
+            };
+            (leg(AssetType::IcUsd), leg(AssetType::CkUsdc), leg(AssetType::CkUsdt))
+        }
+        None => (0, 0, 0),
+    }
+}
+
+/// Append a revealed seed to the commit-reveal audit log (one row per closed epoch).
+pub fn append_revealed_seed(seed: RevealedSeed) {
+    REVEALED_SEEDS.with(|l| {
+        l.borrow()
+            .append(&StoredRevealedSeed::V1(seed))
+            .expect("failed to append revealed seed");
+    });
+}
+
+/// The revealed seed for a CLOSED epoch (the log index equals the epoch index).
+pub fn get_revealed_seed(epoch_index: u64) -> Option<RevealedSeed> {
+    REVEALED_SEEDS.with(|l| l.borrow().get(epoch_index).map(|s| s.into_current()))
+}
+
+/// Advance `current_epoch_index` (called at epoch close).
+pub fn advance_epoch_index() {
+    with_state_mut(|s| s.current_epoch_index = s.current_epoch_index.saturating_add(1));
+}
+
+/// The hash the next epoch's seed must reveal (spike 0.3 public audit value).
+pub fn get_pending_commit() -> [u8; 32] {
+    with_state(|s| s.snapshot_seed.pending_commit)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 // Native unit tests exercise the real stable structures: off-wasm,
 // `DefaultMemoryImpl` is a heap-backed `VectorMemory`, and libtest runs each
@@ -751,7 +1236,7 @@ pub fn in_season(ts_ns: u64) -> bool {
 mod tests {
     use super::*;
     use crate::types::{
-        AssetType, DepositKey, DepositRecord, EpochSummary, InitArgs, PrincipalState,
+        AssetType, DepositKey, DepositRecord, EpochSummary, InitArgs, OpenEpoch, PrincipalState,
         QualifyingAction, RepaymentEvent, Venue,
     };
     use std::collections::BTreeMap;
@@ -996,6 +1481,58 @@ mod tests {
     }
 
     #[test]
+    fn state_v1_blob_migrates_to_v2_with_no_open_epoch() {
+        // Simulate a pre-Phase-5 blob: a StoredState::V1 payload from old bytes.
+        let v1 = StateV1 {
+            admin: tp(1),
+            excluded_principals: [tp(2)].into_iter().collect(),
+            season_start_ns: 100,
+            season_end_ns: 200,
+            current_epoch_index: 3,
+            snapshot_seed: SnapshotSeedSingleton {
+                pending_commit: [7u8; 32],
+                current_seed: Some([8u8; 32]),
+            },
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&StoredState::V1(v1.clone()), &mut bytes).unwrap();
+
+        let migrated = decode_stored_state(&bytes).expect("V1 blob must decode and migrate");
+        assert_eq!(migrated.admin, tp(1));
+        assert!(migrated.excluded_principals.contains(&tp(2)));
+        assert_eq!(migrated.season_start_ns, 100);
+        assert_eq!(migrated.current_epoch_index, 3);
+        assert_eq!(migrated.snapshot_seed, v1.snapshot_seed);
+        assert_eq!(migrated.open_epoch, None); // the new field defaults on migration
+    }
+
+    #[test]
+    fn state_v2_blob_round_trips_with_open_epoch() {
+        let state = State {
+            admin: tp(1),
+            excluded_principals: BTreeSet::new(),
+            season_start_ns: 0,
+            season_end_ns: 0,
+            current_epoch_index: 5,
+            snapshot_seed: SnapshotSeedSingleton::default(),
+            open_epoch: Some(OpenEpoch {
+                epoch_index: 5,
+                epoch_start_ns: 10,
+                epoch_end_ns: 20,
+                snapshot_a_ns: 12,
+                snapshot_b_ns: 18,
+                a_cursor: Some(tp(9)),
+                a_complete: true,
+                b_cursor: None,
+                b_complete: false,
+            }),
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&StoredState::V2(state.clone()), &mut bytes).unwrap();
+        assert_eq!(decode_stored_state(&bytes), Some(state));
+    }
+
+    #[test]
     fn poll_config_defaults_off_at_300s() {
         init_default(tp(99));
         assert!(!poll_enabled(), "poll timer is OFF by default");
@@ -1030,5 +1567,355 @@ mod tests {
         assert_eq!(set_poll_interval(intruder, 120), Err(PointsError::Unauthorized));
         assert!(!poll_enabled());
         assert_eq!(poll_interval_secs(), DEFAULT_POLL_INTERVAL_SECS);
+    }
+
+    // ── Phase 5: snapshot buffer ──
+
+    fn sw(debt: u128) -> SnapshotWeights {
+        SnapshotWeights { icusd_debt: debt, ..Default::default() }
+    }
+
+    #[test]
+    fn snapshot_buffer_put_get_round_trip() {
+        let p = tp(40);
+        assert_eq!(snapshot_buffer_get(&p), None);
+        snapshot_buffer_put(p, sw(123));
+        assert_eq!(snapshot_buffer_get(&p), Some(sw(123)));
+        assert_eq!(snapshot_buffer_len(), 1);
+    }
+
+    #[test]
+    fn snapshot_buffer_remove_and_clear() {
+        snapshot_buffer_put(tp(1), sw(1));
+        snapshot_buffer_put(tp(2), sw(2));
+        snapshot_buffer_remove(&tp(1));
+        assert_eq!(snapshot_buffer_get(&tp(1)), None);
+        assert_eq!(snapshot_buffer_len(), 1);
+        snapshot_buffer_clear();
+        assert_eq!(snapshot_buffer_len(), 0);
+        assert!(snapshot_buffer_entries().is_empty());
+    }
+
+    #[test]
+    fn snapshot_buffer_entries_lists_all() {
+        snapshot_buffer_put(tp(5), sw(50));
+        snapshot_buffer_put(tp(6), sw(60));
+        let mut got = snapshot_buffer_entries();
+        got.sort_by_key(|(p, _)| *p);
+        assert_eq!(got, vec![(tp(5), sw(50)), (tp(6), sw(60))]);
+    }
+
+    // ── Phase 5: asset-ledger registry ──
+
+    #[test]
+    fn asset_ledger_seed_classifies_mainnet_ledgers() {
+        init_default(tp(99));
+        let icusd = Principal::from_text("t6bor-paaaa-aaaap-qrd5q-cai").unwrap();
+        let threeusd = Principal::from_text("fohh4-yyaaa-aaaap-qtkpa-cai").unwrap();
+        let ckusdc = Principal::from_text("xevnm-gaaaa-aaaar-qafnq-cai").unwrap();
+        let icp = Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap();
+        assert_eq!(classify_ledger(&icusd), Some(AssetType::IcUsd));
+        assert_eq!(classify_ledger(&threeusd), Some(AssetType::ThreeUsd));
+        assert_eq!(classify_ledger(&ckusdc), Some(AssetType::CkUsdc));
+        assert_eq!(get_asset_ledger(AssetType::Icp), Some(icp));
+        // An unknown ledger is not classified.
+        assert_eq!(classify_ledger(&tp(123)), None);
+    }
+
+    #[test]
+    fn admin_can_override_asset_ledger_for_local() {
+        let admin = tp(99);
+        init_default(admin);
+        let local = tp(50);
+        assert_eq!(
+            set_asset_ledger(admin, asset_tag(AssetType::CkUsdc), local),
+            Ok(())
+        );
+        assert_eq!(get_asset_ledger(AssetType::CkUsdc), Some(local));
+        assert_eq!(classify_ledger(&local), Some(AssetType::CkUsdc));
+        // Non-admin rejected.
+        assert_eq!(set_asset_ledger(tp(8), 0, tp(7)), Err(PointsError::Unauthorized));
+    }
+
+    // ── Phase 5: epoch-driver config ──
+
+    #[test]
+    fn epoch_driver_defaults_off_at_300s() {
+        init_default(tp(99));
+        assert!(!epoch_driver_enabled());
+        assert_eq!(epoch_driver_interval_secs(), DEFAULT_EPOCH_DRIVER_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn admin_can_enable_and_floor_epoch_driver_interval() {
+        let admin = tp(99);
+        init_default(admin);
+        assert_eq!(set_epoch_driver_enabled(admin, true), Ok(()));
+        assert!(epoch_driver_enabled());
+        assert_eq!(set_epoch_driver_interval(admin, 5), Ok(())); // below the floor
+        assert_eq!(epoch_driver_interval_secs(), MIN_EPOCH_DRIVER_INTERVAL_SECS);
+        assert_eq!(
+            set_epoch_driver_enabled(tp(8), false),
+            Err(PointsError::Unauthorized)
+        );
+    }
+
+    // ── Phase 5/4: ingestion-driven state ──
+
+    fn key_3pool(asset: AssetType) -> DepositKey {
+        DepositKey { venue: Venue::ThreePool, asset }
+    }
+
+    #[test]
+    fn update_3pool_recorded_adds_subtracts_and_drops_at_zero() {
+        init_default(tp(99));
+        let p = tp(30);
+        register(p, 1, QualifyingAction::Deposit3Pool).unwrap();
+        let key = key_3pool(AssetType::CkUsdc);
+
+        update_3pool_recorded(p, AssetType::CkUsdc, 100, true, 5);
+        assert_eq!(get_principal_state(&p).unwrap().active_deposits[&key].recorded_value_usd, 100);
+
+        update_3pool_recorded(p, AssetType::CkUsdc, 50, true, 6);
+        assert_eq!(get_principal_state(&p).unwrap().active_deposits[&key].recorded_value_usd, 150);
+
+        update_3pool_recorded(p, AssetType::CkUsdc, 60, false, 7);
+        assert_eq!(get_principal_state(&p).unwrap().active_deposits[&key].recorded_value_usd, 90);
+
+        // Subtracting past zero drops the record entirely.
+        update_3pool_recorded(p, AssetType::CkUsdc, 1_000, false, 8);
+        assert!(get_principal_state(&p).unwrap().active_deposits.get(&key).is_none());
+    }
+
+    #[test]
+    fn update_3pool_recorded_is_noop_when_unregistered() {
+        init_default(tp(99));
+        update_3pool_recorded(tp(31), AssetType::IcUsd, 100, true, 5);
+        assert!(get_principal_state(&tp(31)).is_none());
+    }
+
+    #[test]
+    fn record_repayment_caps_window_at_season_end() {
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(99)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(1_000),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        let p = tp(32);
+        register(p, 1, QualifyingAction::RepayVault).unwrap();
+
+        record_repayment(p, AssetType::CkUsdc, 500, 100);
+        let st = get_principal_state(&p).unwrap();
+        let ev = &st.repayment_events[0];
+        assert_eq!(ev.asset, AssetType::CkUsdc);
+        assert_eq!(ev.amount_usd, 500);
+        assert_eq!(ev.repaid_at, 100);
+        assert_eq!(ev.window_end, 1_000); // 100 + 90d >> 1000, so capped at season end
+    }
+
+    #[test]
+    fn record_repayment_uses_full_window_within_season() {
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(99)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(u64::MAX),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        let p = tp(33);
+        register(p, 1, QualifyingAction::RepayVault).unwrap();
+        record_repayment(p, AssetType::CkUsdt, 200, 100);
+        let st = get_principal_state(&p).unwrap();
+        assert_eq!(st.repayment_events[0].window_end, 100 + REPAYMENT_WINDOW_NS);
+    }
+
+    // ── Phase 5: open epoch + close accrual ──
+
+    fn open_epoch_at(index: u64) -> OpenEpoch {
+        OpenEpoch {
+            epoch_index: index,
+            epoch_start_ns: 0,
+            epoch_end_ns: 7 * crate::NANOS_PER_DAY,
+            snapshot_a_ns: 1,
+            snapshot_b_ns: 2,
+            a_cursor: None,
+            a_complete: true,
+            b_cursor: None,
+            b_complete: true,
+        }
+    }
+
+    #[test]
+    fn open_epoch_get_set_round_trip() {
+        init_default(tp(99));
+        assert_eq!(get_open_epoch(), None);
+        set_open_epoch(Some(open_epoch_at(3)));
+        assert_eq!(get_open_epoch().unwrap().epoch_index, 3);
+        set_open_epoch(None);
+        assert_eq!(get_open_epoch(), None);
+    }
+
+    #[test]
+    fn run_close_accrual_accrues_balance_and_repayment() {
+        // A long season so the 90-day window is not truncated.
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(99)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(400 * crate::NANOS_PER_DAY),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        let p1 = tp(60);
+        let p2 = tp(61);
+        register(p1, 1, QualifyingAction::MintIcUsd).unwrap();
+        register(p2, 1, QualifyingAction::RepayVault).unwrap();
+
+        // p1: a balance position captured into the snapshot buffer.
+        snapshot_buffer_put(p1, SnapshotWeights { icusd_debt: 100, ..Default::default() });
+        // p2: an open repayment window, no balance position.
+        record_repayment(p2, AssetType::CkUsdc, 1_000 * 100_000_000, 0);
+
+        let week = 7 * crate::NANOS_PER_DAY;
+        let stats = run_close_accrual(0, 0, week, 9_999);
+
+        let repay = 1_000u128 * 100_000_000 * 5 * 7;
+        assert_eq!(get_principal_state(&p1).unwrap().total_points, 700); // 100 over 7 days
+        assert_eq!(get_principal_state(&p2).unwrap().total_points, repay);
+        assert_eq!(get_principal_state(&p1).unwrap().last_epoch_processed, 0);
+        assert_eq!(stats.active_principals, 2);
+        assert_eq!(stats.registered_principals, 2);
+        assert_eq!(stats.points_accrued, 700 + repay);
+        assert_eq!(stats.total_points_all, 700 + repay);
+        assert_eq!(snapshot_buffer_len(), 0); // drained for the next epoch
+    }
+
+    #[test]
+    fn run_close_accrual_prunes_expired_repayment_windows() {
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(99)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(400 * crate::NANOS_PER_DAY),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        let p = tp(65);
+        register(p, 1, QualifyingAction::RepayVault).unwrap();
+        let mut ps = get_principal_state(&p).unwrap();
+        ps.repayment_events = vec![
+            // Expires within epoch 0 (window_end 3d <= epoch end 7d): drop after close.
+            RepaymentEvent { asset: AssetType::CkUsdc, amount_usd: 100, repaid_at: 0, window_end: 3 * crate::NANOS_PER_DAY },
+            // Still open past epoch 0: keep.
+            RepaymentEvent { asset: AssetType::CkUsdc, amount_usd: 100, repaid_at: 0, window_end: 50 * crate::NANOS_PER_DAY },
+        ];
+        put_principal_state(ps);
+
+        let week = 7 * crate::NANOS_PER_DAY;
+        run_close_accrual(0, 0, week, 1);
+
+        let after = get_principal_state(&p).unwrap();
+        assert_eq!(after.repayment_events.len(), 1, "the expired window is pruned");
+        assert_eq!(after.repayment_events[0].window_end, 50 * crate::NANOS_PER_DAY);
+    }
+
+    #[test]
+    fn run_close_accrual_skips_excluded_principals() {
+        let admin = tp(99);
+        init_default(admin);
+        let p = tp(62);
+        register(p, 1, QualifyingAction::MintIcUsd).unwrap();
+        snapshot_buffer_put(p, SnapshotWeights { icusd_debt: 100, ..Default::default() });
+        add_excluded(admin, p).unwrap();
+
+        let week = 7 * crate::NANOS_PER_DAY;
+        let stats = run_close_accrual(0, 0, week, 1);
+        assert_eq!(get_principal_state(&p).unwrap().total_points, 0); // excluded: no accrual
+        assert_eq!(stats.active_principals, 0);
+    }
+
+    #[test]
+    fn snapshot_buffer_merge_min_keeps_smaller_total() {
+        let p = tp(70);
+        snapshot_buffer_put(p, SnapshotWeights { icusd_debt: 100, ..Default::default() }); // A total 100
+        snapshot_buffer_merge_min(p, SnapshotWeights { icusd_debt: 40, ..Default::default() }); // B total 40
+        assert_eq!(snapshot_buffer_get(&p).unwrap().icusd_debt, 40);
+
+        let q = tp(71);
+        snapshot_buffer_put(q, SnapshotWeights { icusd_debt: 30, ..Default::default() }); // A 30
+        snapshot_buffer_merge_min(q, SnapshotWeights { icusd_debt: 90, ..Default::default() }); // B 90
+        assert_eq!(snapshot_buffer_get(&q).unwrap().icusd_debt, 30); // keeps A
+    }
+
+    #[test]
+    fn snapshot_buffer_merge_min_skips_principal_absent_at_a() {
+        let p = tp(72);
+        // No A entry: a B-only principal (registered between snapshots) earns nothing.
+        snapshot_buffer_merge_min(p, SnapshotWeights { icusd_debt: 100, ..Default::default() });
+        assert_eq!(snapshot_buffer_get(&p), None);
+    }
+
+    #[test]
+    fn registered_chunk_after_paginates_in_principal_order() {
+        init_default(tp(99));
+        register(tp(1), 1, QualifyingAction::MintIcUsd).unwrap();
+        register(tp(2), 1, QualifyingAction::MintIcUsd).unwrap();
+        register(tp(3), 1, QualifyingAction::MintIcUsd).unwrap();
+        assert_eq!(registered_chunk_after(None, 2), vec![tp(1), tp(2)]);
+        assert_eq!(registered_chunk_after(Some(tp(2)), 2), vec![tp(3)]);
+        assert_eq!(registered_chunk_after(Some(tp(3)), 2), Vec::<Principal>::new());
+    }
+
+    #[test]
+    fn epoch_guard_is_single_entry() {
+        assert!(try_begin_epoch());
+        assert!(!try_begin_epoch()); // already held
+        end_epoch_guard();
+        assert!(try_begin_epoch());
+    }
+
+    #[test]
+    fn recorded_3pool_composition_reads_active_deposits() {
+        init_default(tp(99));
+        let p = tp(80);
+        register(p, 1, QualifyingAction::Deposit3Pool).unwrap();
+        update_3pool_recorded(p, AssetType::IcUsd, 10, true, 1);
+        update_3pool_recorded(p, AssetType::CkUsdc, 20, true, 1);
+        assert_eq!(recorded_3pool_composition(&p), (10, 20, 0));
+        assert_eq!(recorded_3pool_composition(&tp(123)), (0, 0, 0));
+    }
+
+    #[test]
+    fn revealed_seed_log_appends_and_reads_by_index() {
+        let r = |i: u64| RevealedSeed {
+            epoch_index: i,
+            seed: [i as u8; 32],
+            snapshot_time_a_ns: i,
+            snapshot_time_b_ns: i + 1,
+            revealed_at_ns: i + 2,
+        };
+        append_revealed_seed(r(0));
+        append_revealed_seed(r(1));
+        assert_eq!(revealed_seed_count(), 2);
+        assert_eq!(get_revealed_seed(0).unwrap().epoch_index, 0);
+        assert_eq!(get_revealed_seed(1).unwrap().snapshot_time_a_ns, 1);
+        assert_eq!(get_revealed_seed(2), None);
+    }
+
+    #[test]
+    fn advance_epoch_index_increments() {
+        init_default(tp(99));
+        assert_eq!(current_epoch_index(), 0);
+        advance_epoch_index();
+        advance_epoch_index();
+        assert_eq!(current_epoch_index(), 2);
     }
 }

--- a/src/rumi_points/src/types.rs
+++ b/src/rumi_points/src/types.rs
@@ -183,6 +183,26 @@ pub struct EpochSummary {
     pub snapshot_b_ns: u64,
 }
 
+/// In-flight state of the OPEN weekly epoch, persisted inside `State` so the
+/// periodic driver survives upgrades (resume from here, re-derive nothing). `None`
+/// between epochs and before the season starts. The snapshot cursors are the
+/// resume points for the chunked capture (last-processed principal; `None` means
+/// "not started"). `a_complete` / `b_complete` gate the close on both snapshots
+/// having been captured.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct OpenEpoch {
+    pub epoch_index: u64,
+    pub epoch_start_ns: u64,
+    /// `min(epoch_start + EPOCH_DURATION, season_end)` (the last epoch is partial).
+    pub epoch_end_ns: u64,
+    pub snapshot_a_ns: u64,
+    pub snapshot_b_ns: u64,
+    pub a_cursor: Option<Principal>,
+    pub a_complete: bool,
+    pub b_cursor: Option<Principal>,
+    pub b_complete: bool,
+}
+
 // ── Query view types ────────────────────────────────────────────────────────
 
 /// One row of the public leaderboard (spec Section 10). The canister returns the
@@ -213,6 +233,17 @@ pub struct PointsConfig {
     pub excluded_count: u32,
     pub registered_count: u64,
     pub current_epoch_index: u64,
+    pub snapshot_seed_committed: bool,
+}
+
+/// Epoch-driver status for the ops dashboard (Phase 5).
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct EpochStatus {
+    pub current_epoch_index: u64,
+    pub driver_enabled: bool,
+    pub driver_interval_secs: u64,
+    pub open_epoch: Option<OpenEpoch>,
+    pub revealed_seed_count: u64,
     pub snapshot_seed_committed: bool,
 }
 

--- a/src/rumi_points/src/valuation.rs
+++ b/src/rumi_points/src/valuation.rs
@@ -1,30 +1,148 @@
 //! Asset valuation (spec Section 7 "Asset valuation", implementation plan Phase 5).
 //!
-//! PHASE 5 SCOPE (skeleton only here).
-//!   - ckUSDC, ckUSDT, icUSD, 3USD: valued at $1.00. No peg-aware cap (dropped
-//!     from v1). Face value only.
-//!   - ICP: protocol XRC oracle at epoch time (the same source the backend uses).
-//!   - LP positions: derived from underlying pool reserves at the epoch boundary,
-//!     cached once per snapshot to avoid repeated cross-canister queries.
+//!   - ckUSDC, ckUSDT, icUSD, 3USD: valued at $1.00 face. No peg-aware cap
+//!     (dropped from v1).
+//!   - ICP: protocol XRC oracle rate at snapshot time (the same `last_icp_rate`
+//!     the backend serves via `get_protocol_status`).
+//!   - 3USD/LP for the verification cap (spec Section 5): valued at the 3pool's
+//!     `virtual_price`, so a depositor is not under-credited as pool yield pushes
+//!     the LP above $1.00 face. POSITION values stay at $1.00 face; only the
+//!     verification cap is virtual-price aware.
 //!
-//! The 3USD verification rule (spec Section 5) also lives at this layer in
-//! Phase 4: `active_deposit_value = min(recorded_deposit, verified_3usd)` where
-//! `verified_3usd = wallet + stability_pool + amm_lp_3usd_share`, summed across
-//! the three venues a holder can keep 3USD in.
+//! Canonical fixed-point is `usd_e8s` (`1e8` == $1.00). Native ledger decimals
+//! (pinned 2026-06-02): icUSD 8, 3USD 8, ckUSDC 6, ckUSDT 6, ICP 8. The async
+//! fetchers that pull the three 3USD venues for `verified_3usd` live with the
+//! snapshot driver; this module is the pure valuation math it calls.
 
-#![allow(dead_code)] // Phase 4/5 surface.
+#![allow(dead_code)] // wired by the Phase 5 accrual driver
 
 use crate::types::AssetType;
-use icrc_ledger_types::icrc1::account::Account;
 
-/// USD value (in whole-dollar fixed-point, scaling TBD in Phase 5) of `amount`
-/// units of `asset`. Stables resolve to face value; ICP requires the oracle.
-pub fn value_usd(_asset: AssetType, _amount: u128) -> u128 {
-    unimplemented!("Phase 5: $1 stables, XRC for ICP");
+/// `1e18`, the scale of the 3pool's `virtual_price` (pinned: `vp = D_18dec * 1e8 /
+/// lp_supply_8dec`, so 1 whole LP = `virtual_price / 1e18` USD).
+pub const VIRTUAL_PRICE_SCALE: u128 = 1_000_000_000_000_000_000;
+
+/// Snapshot-wide prices fetched ONCE per snapshot (not per principal) and threaded
+/// through accrual: the ICP/USD oracle rate and the 3pool LP virtual price.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SnapshotPrices {
+    /// USD per 1 whole ICP (`get_protocol_status().last_icp_rate`).
+    pub icp_rate: f64,
+    /// 3pool LP virtual price, `1e18`-scaled (`get_pool_status().virtual_price`).
+    pub virtual_price: u128,
 }
 
-/// Sum of a principal's verified 3USD across wallet + stability pool + AMM LP
-/// share (spec Section 5), used to cap 3pool deposit accrual. Phase 4.
-pub async fn verified_3usd(_account: Account) -> u128 {
-    unimplemented!("Phase 4: wallet + SP + AMM LP 3USD verification");
+/// Face USD value of `native_amount` (in the asset's NATIVE ledger decimals) in
+/// `usd_e8s`. Stables resolve to $1.00 face; ICP uses the oracle rate.
+pub fn value_usd_e8s(asset: AssetType, native_amount: u128, prices: &SnapshotPrices) -> u128 {
+    match asset {
+        // Already 8-decimal; face value is the amount itself.
+        AssetType::IcUsd | AssetType::ThreeUsd => native_amount,
+        // 6-decimal native; scale up to the 8-decimal usd_e8s space.
+        AssetType::CkUsdc | AssetType::CkUsdt => native_amount.saturating_mul(100),
+        // 8-decimal native; value at the oracle rate. `usd_e8s = native_e8s *
+        // rate` because (native/1e8) ICP * rate USD, re-scaled by 1e8, is
+        // native * rate. f64 is deterministic on the IC (the backend serves this
+        // rate as f64); the single multiply is the only float, at the boundary.
+        // A non-finite or negative rate (corrupt oracle) values to 0 rather than
+        // casting Infinity to u128::MAX and dwarfing every other principal.
+        AssetType::Icp => {
+            if !prices.icp_rate.is_finite() || prices.icp_rate <= 0.0 {
+                0
+            } else {
+                (native_amount as f64 * prices.icp_rate).round() as u128
+            }
+        }
+    }
+}
+
+/// USD value (`usd_e8s`) of `lp_e8s` 3USD/LP tokens at `virtual_price`, used only
+/// for the 3USD verification cap. `lp_e8s * virtual_price / 1e18`.
+pub fn value_lp_at_vp(lp_e8s: u128, virtual_price: u128) -> u128 {
+    lp_e8s.saturating_mul(virtual_price) / VIRTUAL_PRICE_SCALE
+}
+
+/// Face USD value of a STABLE asset, no oracle needed (the ingestion path has no
+/// snapshot prices). The 3pool legs and SP/repayment assets are all stables; ICP
+/// is never valued here.
+pub fn value_stable_usd_e8s(asset: AssetType, native_amount: u128) -> u128 {
+    value_usd_e8s(
+        asset,
+        native_amount,
+        &SnapshotPrices { icp_rate: 0.0, virtual_price: 0 },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prices(icp_rate: f64, virtual_price: u128) -> SnapshotPrices {
+        SnapshotPrices { icp_rate, virtual_price }
+    }
+
+    #[test]
+    fn stables_are_face_value_at_eight_decimals() {
+        let p = prices(0.0, VIRTUAL_PRICE_SCALE);
+        // icUSD / 3USD are already 8-decimal: $1.00 -> 1e8, no scaling.
+        assert_eq!(value_usd_e8s(AssetType::IcUsd, 100_000_000, &p), 100_000_000);
+        assert_eq!(value_usd_e8s(AssetType::ThreeUsd, 250_000_000, &p), 250_000_000);
+    }
+
+    #[test]
+    fn ck_stables_scale_six_to_eight_decimals() {
+        let p = prices(0.0, VIRTUAL_PRICE_SCALE);
+        // ckUSDC / ckUSDT are 6-decimal native: $1.00 == 1_000_000 native -> 1e8.
+        assert_eq!(value_usd_e8s(AssetType::CkUsdc, 1_000_000, &p), 100_000_000);
+        assert_eq!(value_usd_e8s(AssetType::CkUsdt, 12_500_000, &p), 1_250_000_000);
+    }
+
+    #[test]
+    fn icp_valued_at_oracle_rate() {
+        // 1 ICP (1e8 e8s) at $5.00 -> $5.00.
+        assert_eq!(
+            value_usd_e8s(AssetType::Icp, 100_000_000, &prices(5.0, 0)),
+            500_000_000
+        );
+        // 2 ICP at $5.50 -> $11.00.
+        assert_eq!(
+            value_usd_e8s(AssetType::Icp, 200_000_000, &prices(5.5, 0)),
+            1_100_000_000
+        );
+    }
+
+    #[test]
+    fn lp_valued_at_virtual_price() {
+        // 1 LP at vp 1.0 -> $1.00.
+        assert_eq!(value_lp_at_vp(100_000_000, VIRTUAL_PRICE_SCALE), 100_000_000);
+        // 1 LP at vp 1.05 -> $1.05 (yield accrued).
+        assert_eq!(
+            value_lp_at_vp(100_000_000, 1_050_000_000_000_000_000),
+            105_000_000
+        );
+        // 2 LP at vp 1.0 -> $2.00.
+        assert_eq!(value_lp_at_vp(200_000_000, VIRTUAL_PRICE_SCALE), 200_000_000);
+    }
+
+    #[test]
+    fn lp_at_zero_virtual_price_is_zero_not_a_panic() {
+        assert_eq!(value_lp_at_vp(100_000_000, 0), 0);
+    }
+
+    #[test]
+    fn icp_non_finite_or_negative_rate_values_zero() {
+        // A corrupt oracle rate must never produce a u128::MAX valuation that would
+        // dwarf every other principal's points.
+        assert_eq!(value_usd_e8s(AssetType::Icp, 100_000_000, &prices(f64::INFINITY, 0)), 0);
+        assert_eq!(value_usd_e8s(AssetType::Icp, 100_000_000, &prices(f64::NAN, 0)), 0);
+        assert_eq!(value_usd_e8s(AssetType::Icp, 100_000_000, &prices(-1.0, 0)), 0);
+    }
+
+    #[test]
+    fn value_stable_helper_matches_face_value_with_decimal_scaling() {
+        assert_eq!(value_stable_usd_e8s(AssetType::IcUsd, 100_000_000), 100_000_000);
+        assert_eq!(value_stable_usd_e8s(AssetType::ThreeUsd, 5), 5);
+        assert_eq!(value_stable_usd_e8s(AssetType::CkUsdc, 1_000_000), 100_000_000);
+        assert_eq!(value_stable_usd_e8s(AssetType::CkUsdt, 2_000_000), 200_000_000);
+    }
 }

--- a/src/rumi_points/tests/pocket_ic_ingest.rs
+++ b/src/rumi_points/tests/pocket_ic_ingest.rs
@@ -15,7 +15,7 @@
 use candid::{CandidType, Decode, Encode, Principal};
 use pocket_ic::{PocketIcBuilder, WasmResult};
 use serde::Deserialize;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 const RUMI_POINTS_WASM: &[u8] =
     include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_points.wasm");
@@ -36,6 +36,36 @@ struct InitArgs {
 enum PointsError {
     Unauthorized,
     Excluded,
+}
+
+// Minimal mirrors for the accrual E2E (decode by field name; width subtyping lets
+// TPrincipalState read just `total_points` from the full record).
+#[derive(CandidType, Deserialize)]
+struct TOpenEpoch {
+    epoch_index: u64,
+    epoch_start_ns: u64,
+    epoch_end_ns: u64,
+    snapshot_a_ns: u64,
+    snapshot_b_ns: u64,
+    a_cursor: Option<Principal>,
+    a_complete: bool,
+    b_cursor: Option<Principal>,
+    b_complete: bool,
+}
+
+#[derive(CandidType, Deserialize)]
+struct TEpochStatus {
+    current_epoch_index: u64,
+    driver_enabled: bool,
+    driver_interval_secs: u64,
+    open_epoch: Option<TOpenEpoch>,
+    revealed_seed_count: u64,
+    snapshot_seed_committed: bool,
+}
+
+#[derive(CandidType, Deserialize)]
+struct TPrincipalState {
+    total_points: candid::Nat,
 }
 
 fn admin() -> Principal {
@@ -183,4 +213,186 @@ fn is_registered(pic: &pocket_ic::PocketIc, rp: Principal, who: Principal) -> bo
         WasmResult::Reply(b) => Decode!(&b, bool).unwrap(),
         WasmResult::Reject(m) => panic!("is_registered rejected: {m}"),
     }
+}
+
+// ── Accrual E2E: the snapshot capture/close path against a mock that answers all
+// four sources' balance queries (the one path unit tests cannot exercise) ──
+
+fn install_mock(pic: &pocket_ic::PocketIc) -> Principal {
+    let mock = pic.create_canister();
+    pic.add_cycles(mock, 4_000_000_000_000);
+    pic.install_canister(mock, MOCK_SOURCE_WASM.to_vec(), Encode!().unwrap(), None);
+    mock
+}
+
+fn install_points(pic: &pocket_ic::PocketIc) -> Principal {
+    let rp = pic.create_canister();
+    pic.add_cycles(rp, 4_000_000_000_000);
+    let init = InitArgs {
+        admin: Some(admin()),
+        excluded_principals: None,
+        season_start_ns: None,
+        season_end_ns: None,
+        snapshot_seed_commit: None, // uncommitted: start_season accepts any seed
+    };
+    pic.install_canister(rp, RUMI_POINTS_WASM.to_vec(), Encode!(&Some(init)).unwrap(), None);
+    rp
+}
+
+fn set_time_ns(pic: &pocket_ic::PocketIc, ns: u64) {
+    pic.set_time(SystemTime::UNIX_EPOCH + Duration::from_nanos(ns));
+}
+
+/// Point all four source tags (backend/3pool/SP/AMM) at the single mock.
+fn set_all_sources(pic: &pocket_ic::PocketIc, rp: Principal, mock: Principal) {
+    for tag in 0u8..4 {
+        admin_ok(pic, rp, "set_source_canister", Encode!(&tag, &mock).unwrap());
+    }
+}
+
+fn set_vault_debt(pic: &pocket_ic::PocketIc, mock: Principal, owner: Principal, debt: u64) {
+    pic.update_call(mock, Principal::anonymous(), "set_vault_debt", Encode!(&owner, &debt).unwrap())
+        .expect("set_vault_debt failed");
+}
+
+fn start_season_ok(pic: &pocket_ic::PocketIc, rp: Principal, seed: [u8; 32]) {
+    let res = pic
+        .update_call(rp, admin(), "start_season", Encode!(&seed.to_vec()).unwrap())
+        .expect("start_season call failed");
+    match res {
+        WasmResult::Reply(b) => {
+            let r: Result<(), String> = Decode!(&b, Result<(), String>).unwrap();
+            assert_eq!(r, Ok(()), "start_season should succeed in-season");
+        }
+        WasmResult::Reject(m) => panic!("start_season rejected: {m}"),
+    }
+}
+
+fn force_tick(pic: &pocket_ic::PocketIc, rp: Principal) {
+    let res = pic
+        .update_call(rp, admin(), "force_epoch_tick", Encode!().unwrap())
+        .expect("force_epoch_tick call failed");
+    match res {
+        WasmResult::Reply(b) => {
+            let r: Result<(), PointsError> = Decode!(&b, Result<(), PointsError>).unwrap();
+            assert_eq!(r, Ok(()), "force_epoch_tick should succeed for admin");
+        }
+        WasmResult::Reject(m) => panic!("force_epoch_tick rejected: {m}"),
+    }
+}
+
+fn epoch_status(pic: &pocket_ic::PocketIc, rp: Principal) -> TEpochStatus {
+    let res = pic
+        .query_call(rp, Principal::anonymous(), "get_epoch_status", Encode!().unwrap())
+        .expect("get_epoch_status call failed");
+    match res {
+        WasmResult::Reply(b) => Decode!(&b, TEpochStatus).unwrap(),
+        WasmResult::Reject(m) => panic!("get_epoch_status rejected: {m}"),
+    }
+}
+
+fn total_points(pic: &pocket_ic::PocketIc, rp: Principal, who: Principal) -> u128 {
+    let res = pic
+        .query_call(rp, Principal::anonymous(), "get_principal_state", Encode!(&who).unwrap())
+        .expect("get_principal_state call failed");
+    let st: Option<TPrincipalState> = match res {
+        WasmResult::Reply(b) => Decode!(&b, Option<TPrincipalState>).unwrap(),
+        WasmResult::Reject(m) => panic!("get_principal_state rejected: {m}"),
+    };
+    st.map(|s| nat_to_u128(&s.total_points)).unwrap_or(0)
+}
+
+fn nat_to_u128(n: &candid::Nat) -> u128 {
+    n.to_string()
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .unwrap()
+}
+
+#[test]
+fn epoch_accrues_points_for_a_held_position() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+    set_time_ns(&pic, rumi_points::DEFAULT_SEASON_START_NS);
+
+    let mock = install_mock(&pic);
+    let rp = install_points(&pic);
+    set_all_sources(&pic, rp, mock);
+
+    let p = Principal::from_slice(&[7; 5]);
+    admin_ok(&pic, rp, "register_test_principal", Encode!(&p).unwrap());
+
+    const DEBT: u64 = 100_000_000; // $1 of icUSD debt (e8s)
+    set_vault_debt(&pic, mock, p, DEBT);
+
+    // Open epoch 0 (uncommitted singleton accepts the seed without verification),
+    // then disable the timer so only force_tick drives the state machine.
+    start_season_ok(&pic, rp, [42u8; 32]);
+    admin_ok(&pic, rp, "set_epoch_driver_enabled", Encode!(&false).unwrap());
+
+    let oe = epoch_status(&pic, rp)
+        .open_epoch
+        .expect("epoch 0 should be open after start_season");
+
+    // Snapshot A.
+    set_time_ns(&pic, oe.snapshot_a_ns);
+    force_tick(&pic, rp);
+    assert!(
+        epoch_status(&pic, rp).open_epoch.unwrap().a_complete,
+        "snapshot A should be captured"
+    );
+
+    // Snapshot B.
+    set_time_ns(&pic, oe.snapshot_b_ns);
+    force_tick(&pic, rp);
+    assert!(
+        epoch_status(&pic, rp).open_epoch.unwrap().b_complete,
+        "snapshot B should be captured"
+    );
+
+    // Close.
+    set_time_ns(&pic, oe.epoch_end_ns);
+    force_tick(&pic, rp);
+    let after = epoch_status(&pic, rp);
+    assert!(after.open_epoch.is_none(), "the epoch should be closed");
+    assert_eq!(after.current_epoch_index, 1, "epoch index advanced");
+
+    // Held $1 of debt through both snapshots over the full week -> debt x 7 days.
+    assert_eq!(total_points(&pic, rp, p), DEBT as u128 * 7);
+}
+
+#[test]
+fn between_snapshot_withdrawal_earns_zero() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+    set_time_ns(&pic, rumi_points::DEFAULT_SEASON_START_NS);
+
+    let mock = install_mock(&pic);
+    let rp = install_points(&pic);
+    set_all_sources(&pic, rp, mock);
+
+    let p = Principal::from_slice(&[7; 5]);
+    admin_ok(&pic, rp, "register_test_principal", Encode!(&p).unwrap());
+
+    set_vault_debt(&pic, mock, p, 100_000_000); // position present at snapshot A
+    start_season_ok(&pic, rp, [42u8; 32]);
+    admin_ok(&pic, rp, "set_epoch_driver_enabled", Encode!(&false).unwrap());
+    let oe = epoch_status(&pic, rp).open_epoch.unwrap();
+
+    set_time_ns(&pic, oe.snapshot_a_ns);
+    force_tick(&pic, rp); // capture A: debt present
+
+    // Withdraw the whole position before snapshot B.
+    set_vault_debt(&pic, mock, p, 0);
+    set_time_ns(&pic, oe.snapshot_b_ns);
+    force_tick(&pic, rp); // capture B: debt gone -> min(D, 0) = 0
+
+    set_time_ns(&pic, oe.epoch_end_ns);
+    force_tick(&pic, rp); // close
+
+    assert_eq!(
+        total_points(&pic, rp, p),
+        0,
+        "the two-snapshot min() closes end-of-epoch sniping"
+    );
 }

--- a/src/rumi_points_e2e_source/src/lib.rs
+++ b/src/rumi_points_e2e_source/src/lib.rs
@@ -12,6 +12,7 @@
 
 use candid::{CandidType, Principal};
 use serde::Deserialize;
+use std::cell::RefCell;
 
 /// The subset of the backend's `EventTypeFilter` that rumi_points sends. We only
 /// need to DECODE it (the mock ignores the filter), and the values rumi_points
@@ -90,4 +91,110 @@ fn get_events_forward_filtered(
             reached_end: true,
         }
     }
+}
+
+// ── Balance-query mocks (Phase 5 accrual E2E) ───────────────────────────────
+// The snapshot capture queries all four sources for a principal's current
+// balances. This single mock answers every one. Only the vault debt is settable
+// (so the test can vary a position between snapshots to exercise the min()); the
+// other venues return empty, isolating the accrual to a single contribution.
+
+thread_local! {
+    /// Test-controlled `(owner, debt_e8s)` returned by `get_vaults`.
+    static VAULT_DEBT: RefCell<Option<(Principal, u64)>> = const { RefCell::new(None) };
+}
+
+/// Superset of the backend `CandidVault` (rumi_points mirrors only `borrowed_icusd_amount`).
+#[derive(CandidType, Deserialize, Clone)]
+struct CandidVault {
+    owner: Principal,
+    vault_id: u64,
+    borrowed_icusd_amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct ProtocolStatus {
+    last_icp_rate: f64,
+    last_icp_timestamp: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct PoolStatus {
+    balances: [u128; 3],
+    lp_total_supply: u128,
+    virtual_price: u128,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct UserStabilityPosition {
+    stablecoin_balances: Vec<(Principal, u64)>,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+struct PoolInfo {
+    pool_id: String,
+    token_a: Principal,
+    token_b: Principal,
+    reserve_a: u128,
+    reserve_b: u128,
+    total_lp_shares: u128,
+}
+
+/// Test control: set the vault debt returned for `owner`.
+#[ic_cdk::update]
+fn set_vault_debt(owner: Principal, debt: u64) {
+    VAULT_DEBT.with(|v| *v.borrow_mut() = Some((owner, debt)));
+}
+
+#[ic_cdk::query]
+fn get_vaults(target: Option<Principal>) -> Vec<CandidVault> {
+    let stored = VAULT_DEBT.with(|v| v.borrow().clone());
+    match (stored, target) {
+        (Some((owner, debt)), Some(t)) if owner == t => vec![CandidVault {
+            owner,
+            vault_id: 1,
+            borrowed_icusd_amount: debt,
+        }],
+        _ => vec![],
+    }
+}
+
+#[ic_cdk::query]
+fn get_protocol_status() -> ProtocolStatus {
+    ProtocolStatus { last_icp_rate: 1.0, last_icp_timestamp: 0 }
+}
+
+#[ic_cdk::query]
+fn get_pool_status() -> PoolStatus {
+    PoolStatus {
+        balances: [0, 0, 0],
+        lp_total_supply: 0,
+        virtual_price: 1_000_000_000_000_000_000, // vp 1.0
+    }
+}
+
+#[ic_cdk::query]
+fn icrc1_balance_of(_account: Account) -> candid::Nat {
+    candid::Nat::from(0u64)
+}
+
+#[ic_cdk::query]
+fn get_user_position(_target: Option<Principal>) -> Option<UserStabilityPosition> {
+    None
+}
+
+#[ic_cdk::query]
+fn get_pools() -> Vec<PoolInfo> {
+    vec![]
+}
+
+#[ic_cdk::query]
+fn get_lp_balance(_pool_id: String, _user: Principal) -> u128 {
+    0
 }


### PR DESCRIPTION
## Summary

Phase 4 (3USD verification) + Phase 5 (weekly accrual engine) for the `rumi_points` airdrop canister. The canister now turns captured activity into points: a weekly epoch driver captures **two randomized intra-epoch snapshots** of every registered principal's balances, takes `min()` (closes end-of-epoch sniping), applies the spec Section-4 multiplier table with virtual-price-aware 3USD verification, accrues dollar-days, and reveals the commit-reveal seed (spike 0.3).

The driver is **OFF by default** (mirrors the poll timer); an operator brings a season live with `start_season(S0)`.

## What's here

- **`accrual.rs`** (new): pure, unit-tested accrual math — multiplier table, matched/unmatched ck-stable split (`2·min` at 5x + `|diff|` at 3x, the dust-gaming fix), 3USD verification factor, `min_by_total` reduction (keeps the smaller-total snapshot whole), period scaling, and the 90-day repayment-window math.
- **`epoch.rs`**: periodic state-machine driver (`next_action`), chunked async snapshot capture with a persisted resume cursor, epoch close, commit-reveal `summary_hash`, and the inter-canister `fetch_*` helpers.
- **`snapshot_seed.rs`**: `derive_snapshot_times` + `SeedManager::start_epoch`/`close_epoch` per spike 0.3 (hash chain verified across 3 epochs).
- **`valuation.rs`**: `usd_e8s` valuation (face value, ck-stable `×100` for 6→8 decimals, ICP via the XRC oracle with a non-finite-rate guard) + virtual-price LP valuation.
- **`events.rs`**: 3pool composition + repayment-window ingestion. `VaultRepay` now carries `repayment_asset` (gated, see below).
- **`state.rs`**: `State` V1→V2 migration (`open_epoch`), plus new stable structures at MemoryIds 11 (snapshot-weights min buffer), 12 (asset-ledger registry), 13 (epoch-driver config). Old V1 blobs decode via `From<StateV1>` — no wipe.
- **`main.rs` / `.did`**: `start_season`, epoch-driver admin endpoints, and the commit-reveal audit queries (`get_revealed_seed`, `get_pending_commit`, `get_epoch_status`).
- **E2E**: two new PocketIC tests — a held position accrues `debt × 7 days`, and a between-snapshot withdrawal earns **0** (the `min()` anti-snipe).

## Gated on upstream

The **5x ckUSDC/ckUSDT repayment window** is fully built and tested but gated on the backend `RepayToVault.repayment_asset: Option<Principal>` field, which is not yet built (separate backend branch). While it's `None`, the window is skipped (logged), not mis-accrued. Flip `source_types::backend::normalize` to read the real field when it ships — no other change here.

## Tests

126 lib unit tests + candid drift + 4 PocketIC E2E (2 ingest + 2 accrual), all green, zero warnings. Built test-first and independently code-reviewed (no critical/high findings; the review's defensive fixes — ICP rate guard, repayment-window pruning, atomic seed-close trap, per-principal source-id caching — are applied).

## Design decisions (confirmed with Rob)

1. **Hybrid architecture**: snapshot-query current balances; event-track only the 3pool per-asset composition (the LP token can't reveal the 1x/3x/5x split) and repayment windows.
2. **Virtual-price-aware 3USD verification** cap (not $1 face) so depositors aren't under-credited as 3USD yield accrues; position values stay $1 face.
3. **Repayment 5x outside the `min()`** (a past repayment can't be sniped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)