### PR TITLE
fix(redemption): gate redeem_icp on ReadOnly mode (RED-101)

### DIFF
--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -665,6 +665,27 @@ impl From<GuardError> for ProtocolError {
     }
 }
 
+impl ProtocolError {
+    /// The exact `TemporarilyUnavailable` rejection returned whenever the
+    /// protocol is latched `Mode::ReadOnly` (insolvency: total collateral ratio
+    /// below 100%, or the deficit account over its configured threshold).
+    ///
+    /// Single source of truth so the Candid entry-layer gate
+    /// (`main.rs::validate_mode`) and the shared vault-module redemption gates
+    /// (`vault::redeem_collateral` / `vault::redeem_reserves`) return a
+    /// byte-identical error. Audit RED-101 (regression of RED-003) showed that a
+    /// second entry point (`redeem_icp`) silently bypassed the entry-layer-only
+    /// gate; gating inside the vault module closes any present/future redemption
+    /// surface by construction, and this constructor keeps every layer's message
+    /// in lockstep.
+    pub fn read_only_mode() -> Self {
+        ProtocolError::TemporarilyUnavailable(
+            "protocol temporarly unavailable, please wait for an upgrade or for total collateral ratio to go above 100%"
+                .to_string(),
+        )
+    }
+}
+
 /// Candid-compatible struct matching the stability pool's and bot's `LiquidatableVaultInfo`.
 /// Defined inline to avoid a crate dependency between backend and pool/bot.
 #[derive(CandidType, Clone, Debug, Deserialize)]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -109,11 +109,10 @@ async fn validate_call() -> Result<(), ProtocolError> {
 
 fn validate_mode() -> Result<(), ProtocolError> {
     match read_state(|s| s.mode) {
-        Mode::ReadOnly => {
-            Err(ProtocolError::TemporarilyUnavailable(
-                "protocol temporarly unavailable, please wait for an upgrade or for total collateral ratio to go above 100%".to_string(),
-            ))
-        }
+        // Shared constructor keeps this entry-layer gate byte-identical to the
+        // vault-module gates in vault::redeem_collateral / redeem_reserves
+        // (audit RED-101).
+        Mode::ReadOnly => Err(ProtocolError::read_only_mode()),
         Mode::GeneralAvailability => Ok(()),
         Mode::Recovery => Ok(())
     }
@@ -2207,6 +2206,12 @@ fn get_vault_count() -> u64 {
 #[update]
 async fn redeem_icp(icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
     validate_call().await?;
+    // Wave-9 RED-003 / RED-101: gate the ICP redemption path on protocol mode,
+    // matching redeem_collateral. This endpoint was the RED-003 fix's blind spot
+    // (it reaches the same collateral-seizing path via vault::redeem_icp ->
+    // vault::redeem_collateral). Defense in depth alongside the shared
+    // vault-module gate now in vault::redeem_collateral.
+    validate_mode()?;
     check_postcondition(rumi_protocol_backend::vault::redeem_icp(icusd_amount).await)
 }
 

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -207,6 +207,15 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
     let caller = ic_cdk::api::caller();
     let _guard_principal = GuardPrincipal::new(caller, "redeem_reserves")?;
 
+    // RED-101 / RED-003: gate on protocol mode here too. The endpoint keeps its
+    // own validate_mode() (defense in depth), but the spillover branch below
+    // calls record_redemption_on_vaults DIRECTLY (it does not route through
+    // redeem_collateral), so the redeem_collateral gate does not cover it. Gate
+    // at this entry point so the reserve path is covered by construction as well.
+    if read_state(|s| s.mode) == Mode::ReadOnly {
+        return Err(ProtocolError::read_only_mode());
+    }
+
     let icusd_amount: ICUSD = icusd_amount_raw.into();
 
     if icusd_amount < read_state(|s| s.min_icusd_amount) {
@@ -467,6 +476,19 @@ pub async fn redeem_icp(icusd_amount: u64) -> Result<SuccessWithFee, ProtocolErr
 pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let _guard_principal = GuardPrincipal::new(caller, "redeem_collateral")?;
+
+    // RED-101 / RED-003: gate redemption on protocol mode at the shared internal
+    // entry point, not just at the Candid endpoints. ReadOnly auto-latches on
+    // insolvency (total collateral ratio < 100%, or the deficit account over its
+    // threshold); redeeming then extracts collateral at oracle face value from an
+    // already-insolvent protocol, deepening the bad-debt position. Placed after
+    // the guard and before any icUSD is pulled so every redemption surface
+    // (redeem_icp, redeem_collateral) is covered by construction. The Wave-9
+    // fix lived only in main.rs::validate_mode and the redeem_icp endpoint
+    // bypassed it. Same error as that gate via the shared constructor.
+    if read_state(|s| s.mode) == Mode::ReadOnly {
+        return Err(ProtocolError::read_only_mode());
+    }
 
     let icusd_amount: ICUSD = _icusd_amount.into();
 

--- a/src/rumi_protocol_backend/tests/audit_pocs_liq_005_deficit_account_pic.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_liq_005_deficit_account_pic.rs
@@ -930,3 +930,141 @@ fn liq_005_pic_upgrade_preserves_deficit_state() {
         "deficit_readonly_threshold_e8s lost on upgrade"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit RED-101 (2026-06-03-0c3ceb4): behavioral fence for the redeem_icp
+// ReadOnly bypass. Lives here because this file already owns a proven
+// deficit-threshold ReadOnly-latch fixture; the structural fences live in
+// `audit_pocs_red_003_readonly_redemption.rs`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Call `redeem_icp(icusd_e8s)` as the test user and decode the result.
+fn redeem_icp_call(f: &Fixture, icusd_e8s: u64) -> Result<SuccessWithFee, ProtocolError> {
+    let result = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.test_user,
+            "redeem_icp",
+            encode_args((icusd_e8s,)).unwrap(),
+        )
+        .expect("redeem_icp call failed at transport level");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode redeem_icp result"),
+        WasmResult::Reject(m) => panic!("redeem_icp rejected at canister level: {}", m),
+    }
+}
+
+/// Call `redeem_collateral(collateral_type, icusd_e8s)` as the test user.
+fn redeem_collateral_call(
+    f: &Fixture,
+    collateral_type: Principal,
+    icusd_e8s: u64,
+) -> Result<SuccessWithFee, ProtocolError> {
+    let result = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.test_user,
+            "redeem_collateral",
+            encode_args((collateral_type, icusd_e8s)).unwrap(),
+        )
+        .expect("redeem_collateral call failed at transport level");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode redeem_collateral result"),
+        WasmResult::Reject(m) => panic!("redeem_collateral rejected at canister level: {}", m),
+    }
+}
+
+/// Assert a redemption result is specifically the `Mode::ReadOnly` rejection
+/// that `validate_mode()` / the vault-module gate return, not some other
+/// `TemporarilyUnavailable` (e.g. a missing price) and not a different error.
+/// Keying on the ReadOnly-specific message text prevents a false pass.
+fn assert_readonly_rejection(result: &Result<SuccessWithFee, ProtocolError>, ctx: &str) {
+    match result {
+        Err(ProtocolError::TemporarilyUnavailable(msg))
+            if msg.contains("total collateral ratio to go above 100%") => {}
+        other => panic!(
+            "{ctx}: expected Err(TemporarilyUnavailable(<ReadOnly message>)), got {:?}",
+            other
+        ),
+    }
+}
+
+/// Audit RED-101: while the protocol is latched `Mode::ReadOnly`, the
+/// `redeem_icp` endpoint must reject. The Wave-9 RED-003 fix gated
+/// `redeem_collateral` / `redeem_reserves` but MISSED the ICP convenience
+/// path (`redeem_icp` -> `vault::redeem_icp` -> `vault::redeem_collateral`).
+/// ICP is the tier-1, highest-TVL collateral and the first asset returned by
+/// `get_collateral_types_by_redemption_priority`, so this is the primary
+/// redemption path the gate was meant to close.
+///
+/// The `redeem_collateral` control already carries the RED-003 gate, so it
+/// rejects on BOTH the pre- and post-fix wasm, proving the ReadOnly latch is
+/// real and observable, and isolating the `redeem_icp` gap. The `redeem_icp`
+/// assertion is the regression fence: it FAILS on the pre-fix wasm (redeem_icp
+/// bypasses the gate) and PASSES once the shared vault-module gate plus the
+/// endpoint defense-in-depth land.
+#[test]
+fn red_101_pic_redeem_icp_rejects_in_readonly() {
+    let f = setup_fixture();
+
+    // ── Latch ReadOnly via the deficit threshold (same path as
+    //    `liq_005_pic_readonly_latch_at_threshold`). ──
+    let _ = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.developer,
+            "set_deficit_readonly_threshold_e8s",
+            encode_args((1_000_000_000u64,)).unwrap(), // 10 icUSD
+        )
+        .expect("set_deficit_readonly_threshold_e8s");
+    drop_icp_price(&f, 10_000_000); // $0.10 → vault deeply underwater
+    icrc2_approve_call(
+        &f.pic,
+        f.icusd_ledger,
+        f.test_user,
+        f.protocol_id,
+        100_000_000_000u128,
+    );
+    let _ = f
+        .pic
+        .update_call(
+            f.protocol_id,
+            f.test_user,
+            "liquidate_vault",
+            encode_args((f.vault_id,)).unwrap(),
+        )
+        .expect("liquidate_vault failed");
+
+    // Precondition: the protocol is genuinely latched ReadOnly.
+    let status = protocol_status(&f.pic, f.protocol_id);
+    assert_eq!(
+        status.mode,
+        ProtocolMode::ReadOnly,
+        "fixture precondition: expected mode=ReadOnly after the deficit crossed \
+         its threshold; got {:?}",
+        status.mode
+    );
+
+    // Amount above any min and large enough that, on the pre-fix wasm,
+    // redeem_icp would proceed into the icUSD-pull path rather than reject.
+    // Irrelevant on the fixed path: the gate fires before any icUSD is pulled.
+    let redeem_e8s = 5_000_000_000u64; // 50 icUSD
+
+    // Control: redeem_collateral(ICP, …) already carries the RED-003 gate, so
+    // it rejects with ReadOnly on both the pre- and post-fix wasm.
+    let control = redeem_collateral_call(&f, f.icp_ledger, redeem_e8s);
+    assert_readonly_rejection(
+        &control,
+        "redeem_collateral(ICP) must reject in ReadOnly (RED-003 control)",
+    );
+
+    // RED-101: redeem_icp must reject identically. Fails on the pre-fix wasm.
+    let icp = redeem_icp_call(&f, redeem_e8s);
+    assert_readonly_rejection(
+        &icp,
+        "redeem_icp must reject in ReadOnly (RED-101 regression of RED-003)",
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_red_003_readonly_redemption.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_red_003_readonly_redemption.rs
@@ -31,6 +31,32 @@
 //!      `redeem_collateral` and `redeem_reserves` MUST contain a
 //!      `validate_mode()?` call after the fix lands. The structural
 //!      fence will FAIL on pre-fix main and PASS post-fix.
+//!
+//! # RED-101 regression (audit 2026-06-03-0c3ceb4): the ICP path was open
+//!
+//! The Wave-9 fix gated only the two #[update] endpoints above. The
+//! sibling endpoint `redeem_icp` (main.rs) called only `validate_call()`
+//! and then `vault::redeem_icp`, a thin wrapper over
+//! `vault::redeem_collateral`, and NEITHER performed a `Mode::ReadOnly`
+//! check. ICP is the tier-1, highest-TVL collateral and the first asset
+//! returned by `get_collateral_types_by_redemption_priority`, so the
+//! primary redemption path the gate was meant to close was the one still
+//! open: a holder could redeem ICP at oracle face value while the protocol
+//! was latched ReadOnly (insolvent), deepening the bad-debt position.
+//!
+//! The root-cause fix moves the gate into the shared vault-module entry
+//! points so every present/future redemption surface is covered by
+//! construction: `vault::redeem_collateral` AND `vault::redeem_reserves`
+//! reject in `Mode::ReadOnly` at the top (after the per-caller guard,
+//! before any icUSD is pulled), returning the same `TemporarilyUnavailable`
+//! that `main.rs::validate_mode()` produces. The endpoint-level
+//! `validate_mode()?` checks are kept as defense-in-depth, including a new
+//! one on `redeem_icp`. The `red_101_*` structural fences below pin all of
+//! it. A behavioral end-to-end fence lives in
+//! `audit_pocs_liq_005_deficit_account_pic.rs`
+//! (`red_101_pic_redeem_icp_rejects_in_readonly`), which reuses that file's
+//! deficit-threshold ReadOnly-latch fixture to call `redeem_icp` on a live
+//! canister latched ReadOnly and assert it rejects.
 
 use rumi_protocol_backend::state::{Mode, State};
 use std::path::PathBuf;
@@ -41,6 +67,16 @@ use std::path::PathBuf;
 /// is robust to test invocation from any working directory.
 fn read_main_rs() -> String {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+/// Reads `src/vault.rs` for the vault-module structural assertions. The
+/// shared redemption gate lives here (not just at the Candid entry layer),
+/// so RED-101's fences read this file directly. Same `CARGO_MANIFEST_DIR`
+/// anchoring as `read_main_rs`.
+fn read_vault_rs() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/vault.rs");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
 }
@@ -67,6 +103,26 @@ fn function_body_slice<'a>(source: &'a str, fn_name: &str) -> &'a str {
         (None, Some(f)) => f,
         (None, None) => source.len(),
     };
+    &source[start..end]
+}
+
+/// Slice the body of a `pub async fn` named `fn_name` in `vault.rs`, from its
+/// declaration up to the next column-0 item. `vault.rs` declares free items at
+/// column 0 as `pub async fn` / `pub fn` / `async fn` / `fn`; nested helpers
+/// are indented, so anchoring the end on a newline-prefixed column-0 item
+/// header isolates exactly one function body. (The `main.rs` slicer keys off
+/// bare `async fn`, which would over-run a `pub async fn` boundary here.)
+fn vault_function_body_slice<'a>(source: &'a str, fn_name: &str) -> &'a str {
+    let header = format!("pub async fn {}(", fn_name);
+    let start = source
+        .find(&header)
+        .unwrap_or_else(|| panic!("function `{}` not found in vault.rs", fn_name));
+    let after_header = start + header.len();
+    let end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "]
+        .iter()
+        .filter_map(|marker| source[after_header..].find(marker).map(|i| after_header + i))
+        .min()
+        .unwrap_or(source.len());
     &source[start..end]
 }
 
@@ -111,6 +167,64 @@ fn red_003_main_rs_redeem_reserves_calls_validate_mode() {
          to gate reserve redemption on protocol mode (audit RED-003). \
          Reserve-redemption spillover walks the same vault cr-index as \
          redeem_collateral, so the same gate applies.\n\nInspected body:\n{}",
+        body,
+    );
+}
+
+// ── RED-101 (2026-06-03-0c3ceb4): close the redeem_icp ReadOnly bypass ──────
+//
+// These fences extend the RED-003 ones to the ICP redemption path that the
+// per-endpoint Wave-9 fix missed. They cover both the new defense-in-depth
+// endpoint check AND the root-cause vault-module gate.
+
+#[test]
+fn red_101_main_rs_redeem_icp_calls_validate_mode() {
+    let main_rs = read_main_rs();
+    let body = function_body_slice(&main_rs, "redeem_icp");
+    assert!(
+        body.contains("validate_mode()?"),
+        "main.rs::redeem_icp endpoint must call `validate_mode()?` immediately \
+         after `validate_call().await?`, matching redeem_collateral (audit \
+         RED-101, regression of RED-003). redeem_icp is a distinct #[update] \
+         surface that reaches the same collateral-seizing path \
+         (vault::redeem_icp -> vault::redeem_collateral -> \
+         record_redemption_on_vaults); without this gate a redeemer can \
+         extract ICP at face value while the protocol is latched \
+         ReadOnly.\n\nInspected body:\n{}",
+        body,
+    );
+}
+
+#[test]
+fn red_101_vault_redeem_collateral_gates_readonly() {
+    let vault_rs = read_vault_rs();
+    let body = vault_function_body_slice(&vault_rs, "redeem_collateral");
+    assert!(
+        body.contains("Mode::ReadOnly"),
+        "vault::redeem_collateral must reject when `state.mode == Mode::ReadOnly` \
+         at the shared internal entry point (after the per-caller guard, before \
+         pulling icUSD) so every redemption surface (redeem_icp, \
+         redeem_collateral) is gated by construction (audit RED-101). The \
+         per-endpoint validate_mode() in main.rs lives in the Candid entry layer; \
+         gating here closes any entry point (present or future) that forgets \
+         it.\n\nInspected body:\n{}",
+        body,
+    );
+}
+
+#[test]
+fn red_101_vault_redeem_reserves_gates_readonly() {
+    let vault_rs = read_vault_rs();
+    let body = vault_function_body_slice(&vault_rs, "redeem_reserves");
+    assert!(
+        body.contains("Mode::ReadOnly"),
+        "vault::redeem_reserves must also reject when `state.mode == Mode::ReadOnly` \
+         at the vault-module boundary. Its spillover branch calls \
+         record_redemption_on_vaults DIRECTLY (it does not route through \
+         redeem_collateral), so the redeem_collateral gate does not cover it. \
+         Keep the endpoint-level validate_mode() AND gate here so the reserve \
+         path is covered by construction too (audit RED-101).\n\nInspected \
+         body:\n{}",
         body,
     );
 }


### PR DESCRIPTION
## RED-101 (HIGH) — regression of RED-003

Audit `2026-06-03-0c3ceb4` finding **RED-101**: the `redeem_icp` endpoint bypassed the Wave-9 RED-003 ReadOnly mode gate.

`validate_mode()` was added to the `redeem_collateral` and `redeem_reserves` endpoints, but the sibling `redeem_icp` endpoint called only `validate_call()` then `vault::redeem_icp` → `vault::redeem_collateral`, with **no `Mode::ReadOnly` check anywhere on that path**. ICP is the tier-1, highest-TVL collateral and the first redemption-priority asset, so the primary path the gate was meant to close stayed open: a holder could redeem ICP at oracle face value while the protocol was latched ReadOnly (insolvent), deepening the bad-debt position.

## Fix (root cause + defense in depth)

Moves the gate into the **shared vault-module entry points** so every present/future redemption surface is covered by construction, rather than patching one endpoint:

- **`lib.rs`** — new `ProtocolError::read_only_mode()`, a single source of truth so the entry-layer gate and the vault-module gates return a **byte-identical** error. (Message drift across copies is exactly what let RED-003 regress.)
- **`vault::redeem_collateral`** — rejects in `Mode::ReadOnly` after the guard, before any icUSD is pulled. Covers both `redeem_icp` and `redeem_collateral`.
- **`vault::redeem_reserves`** — gated too; its spillover branch calls `record_redemption_on_vaults` directly (not via `redeem_collateral`), so it needs its own gate.
- **`main.rs::redeem_icp`** — adds `validate_mode()?` (defense in depth, matching `redeem_collateral`).
- **`main.rs::validate_mode`** — routed through the shared constructor (behavior identical).

`redeem_reserves` **keeps** its endpoint `validate_mode()` — confirmed it cannot rely on the `redeem_collateral` gate.

## Tests (TDD: watched each fail, then pass)

- **3 structural fences** in `audit_pocs_red_003_readonly_redemption.rs` — the `redeem_icp` endpoint has `validate_mode()?`, and both vault functions gate on `Mode::ReadOnly`.
- **1 behavioral PocketIC fence** `red_101_pic_redeem_icp_rejects_in_readonly` in `audit_pocs_liq_005_deficit_account_pic.rs`, reusing the deficit-threshold ReadOnly-latch fixture. The pre-fix RED proved the bypass (`redeem_icp` reached `transfer_icusd_from`); a `redeem_collateral` control assertion passes pre- and post-fix, proving the latch is real and isolating the `redeem_icp` gap.

## Verification

| Check | Result |
|---|---|
| `cargo test --lib` | 347 passed, 0 failed |
| RED-003 PoC (structural) | 6/6 |
| LIQ-005 PIC (behavioral + 4 originals) | 5/5 |
| RED-001 / RED-002 redemption PoCs | 5/5, 5/5 |
| wasm rebuild | clean |

**Not deployed.** Scoped to RED-101 only — unrelated in-flight cross-chain audit changes are intentionally excluded from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)