### PR TITLE
fix(chains): cross-chain (Solana+Monad) security audit remediation

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,15 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainSupplyReconciliation = record {
+  recorded_supply_e8s : nat;
+  gap_e8s : int;
+  unbacked_excess : bool;
+  finalized_block : nat64;
+  in_flight_mint_e8s : nat;
+  chain_id : nat32;
+  onchain_total_supply_e8s : nat;
+};
 type ChainVaultStatus = variant {
   MintPending;
   Open;
@@ -804,15 +813,19 @@ type ReserveRedemptionResult = record {
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
 type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_11 = variant { Ok : bool; Err : ProtocolError };
-type Result_12 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_13 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_14 = variant { Ok : blob; Err : ProtocolError };
-type Result_15 = variant {
+type Result_11 = variant {
+  Ok : ChainSupplyReconciliation;
+  Err : ProtocolError;
+};
+type Result_12 = variant { Ok : bool; Err : ProtocolError };
+type Result_13 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_14 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_15 = variant { Ok : blob; Err : ProtocolError };
+type Result_16 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_16 = variant { Ok : nat32; Err : ProtocolError };
+type Result_17 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
@@ -1052,15 +1065,18 @@ service : (ProtocolArg) -> {
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  recover_pending_transfer : (nat64) -> (Result_11);
+  reconcile_chain_supply : (nat32) -> (Result_11);
+  recover_pending_transfer : (nat64) -> (Result_12);
+  recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_12);
+  redeem_reserves : (nat64, opt principal) -> (Result_13);
   register_chain : (RegisterChainArg) -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_13);
+  repay_and_close_vault : (VaultArg) -> (Result_14);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
+  resolve_stuck_settlement_op : (nat32, nat64) -> (Result);
   set_amm1_canister : (principal) -> (Result);
   set_amm1_pool_id : (text) -> (Result);
   set_borrowing_fee : (float64) -> (Result);
@@ -1141,15 +1157,15 @@ service : (ProtocolArg) -> {
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
   solana_settlement_address : () -> (Result_2);
-  solana_sign_test_transfer : (text, nat64) -> (Result_14);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_15);
+  solana_sign_test_transfer : (text, nat64) -> (Result_15);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_16);
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_15,
+      Result_16,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_15,
+      Result_16,
     );
-  submit_burn_proof : (nat32, text) -> (Result_16);
+  submit_burn_proof : (nat32, text) -> (Result_17);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -4,11 +4,20 @@
 //! state-shape rules without spinning up PocketIC.
 
 use super::config::{
-    ChainAdminError, ChainConfigV2, ChainId, ChainStatus, RegisterChainArg,
+    ChainAdminError, ChainConfigV2, ChainId, ChainStatus, GasStrategy, RegisterChainArg,
     UpdateChainConfigArg,
 };
 use super::multi_chain_state::MultiChainStateV3;
 use super::settlement_queue::SettlementQueueV1;
+
+/// EVM chains need >= 1 confirmation before a block is treated as final. A
+/// `finality_depth` of 0 makes `is_block_final(block, 0)` true for any mined
+/// block, defeating reorg safety on the burn/settlement-confirm paths. Solana
+/// (which reads at the `finalized` commitment) legitimately uses 0, so the floor
+/// applies only to EVM gas strategies.
+fn is_evm(gas: &GasStrategy) -> bool {
+    matches!(gas, GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. })
+}
 
 pub fn register_chain_in_state(
     state: &mut MultiChainStateV3,
@@ -18,6 +27,24 @@ pub fn register_chain_in_state(
     if arg.rpc_endpoints.is_empty() {
         return Err(ChainAdminError::InvalidConfig(
             "rpc_endpoints must contain at least one URL".into(),
+        ));
+    }
+    // Validate the native-asset decimals. This feeds `collateral_ratio_e4`
+    // (10^chain_native_decimals is the divisor that converts native base units
+    // to whole units); a wrong value silently mis-scales every CR check for the
+    // chain. `0` makes the scale 1 (collateral treated as whole units, CR
+    // inflated ~1e9-1e18x -> under-collateralized opens accepted); an absurdly
+    // large value underflows CR to 0 (fails-closed). Expected: 18 for EVM, 9 for
+    // Solana. Reject anything outside a sane band at registration.
+    if arg.chain_native_decimals == 0 || arg.chain_native_decimals > 36 {
+        return Err(ChainAdminError::InvalidConfig(format!(
+            "chain_native_decimals {} out of range (expected 1..=36; 18 for EVM, 9 for Solana)",
+            arg.chain_native_decimals
+        )));
+    }
+    if is_evm(&arg.gas_strategy) && arg.finality_depth == 0 {
+        return Err(ChainAdminError::InvalidConfig(
+            "finality_depth must be >= 1 for EVM chains (0 treats any mined block as final)".into(),
         ));
     }
     if state.chain_configs.contains_key(&arg.chain_id) {
@@ -103,13 +130,31 @@ pub fn update_chain_config_in_state(
         .chain_configs
         .get_mut(&chain_id)
         .ok_or(ChainAdminError::ChainNotRegistered(chain_id))?;
+
+    // Validate the FULL post-update config before mutating anything
+    // (all-or-nothing). rpc_endpoints must stay non-empty, and an EVM chain must
+    // keep finality_depth >= 1 even if only one of (gas_strategy, finality_depth)
+    // is being changed.
+    if let Some(eps) = &update.rpc_endpoints {
+        if eps.is_empty() {
+            return Err(ChainAdminError::InvalidConfig("rpc_endpoints cannot be empty".into()));
+        }
+    }
+    let effective_finality = update.finality_depth.unwrap_or(cfg.finality_depth);
+    let effective_is_evm = match &update.gas_strategy {
+        Some(g) => is_evm(g),
+        None => is_evm(&cfg.gas_strategy),
+    };
+    if effective_is_evm && effective_finality == 0 {
+        return Err(ChainAdminError::InvalidConfig(
+            "finality_depth must be >= 1 for EVM chains (0 treats any mined block as final)".into(),
+        ));
+    }
+
     if let Some(name) = update.display_name {
         cfg.display_name = name;
     }
     if let Some(eps) = update.rpc_endpoints {
-        if eps.is_empty() {
-            return Err(ChainAdminError::InvalidConfig("rpc_endpoints cannot be empty".into()));
-        }
         cfg.rpc_endpoints = eps;
     }
     if let Some(d) = update.finality_depth {

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -661,6 +661,23 @@ pub async fn run_observer(chain: ChainId) {
         } else {
             match erc20_total_supply_at(chain, &contract, finalized).await {
                 Ok(onchain_supply) => {
+                    // FLAG-2 positive-divergence alarm: `has_inflight_mint` is
+                    // false in this arm, so an on-chain supply ABOVE recorded is
+                    // unexplained — the unbacked-mint signature (a mint that
+                    // landed but was never credited, or an out-of-band mint). The
+                    // pre-existing backstop only reacts to a DROP (a burn); this
+                    // catches the EXCESS direction. Alarm loudly but do NOT
+                    // auto-halt: this single-provider read can be transiently
+                    // wrong (FLAG-1), so the operator reconciles (reconcile_chain_supply)
+                    // and halts via existing controls rather than a flaky read
+                    // freezing the chain.
+                    if onchain_supply > recorded_supply {
+                        log!(
+                            INFO,
+                            "[observer chain={:?}] SUPPLY DIVERGENCE ALARM: onchain totalSupply {} EXCEEDS recorded {} by {} with no mint in flight (possible unbacked mint); run reconcile_chain_supply",
+                            chain, onchain_supply, recorded_supply, onchain_supply.saturating_sub(recorded_supply)
+                        );
+                    }
                     let scan = backstop_should_scan(onchain_supply, recorded_supply, has_inflight_mint);
                     if scan {
                         log!(

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -525,10 +525,63 @@ fn evm_rpc_principal() -> Principal {
         })
 }
 
-/// Send a raw JSON-RPC payload to the EVM RPC canister using the `request`
-/// escape-hatch method.  Tries each of the chain's configured RPC endpoints in
-/// order and returns the first successful `Ok` inner text.  On all-fail returns
-/// the last error string.
+/// Issue ONE JSON-RPC `request` to a single endpoint. Returns the inner response
+/// text on success, or an error string (provider error or IC call error).
+async fn single_call(canister: Principal, url: &str, json_payload: &str) -> Result<String, String> {
+    let rpc_service = RpcService::Custom(RpcApi {
+        url: url.to_string(),
+        headers: None,
+    });
+    let result: Result<(RequestResult,), _> = ic_cdk::api::call::call_with_payment128(
+        canister,
+        "request",
+        (rpc_service, json_payload.to_string(), EVM_RPC_MAX_RESPONSE_BYTES),
+        EVM_RPC_CALL_CYCLES,
+    )
+    .await;
+    match result {
+        Ok((RequestResult::Ok(text),)) => Ok(text),
+        Ok((RequestResult::Err(rpc_err),)) => Err(format!("RPC error from {}: {:?}", url, rpc_err)),
+        Err((code, msg)) => Err(format!("call error to {} ({:?}): {}", url, code, msg)),
+    }
+}
+
+/// The consensus key of a JSON-RPC response: its semantic `result` value, or its
+/// `error` value if there is no result. `serde_json::Value` equality is
+/// whitespace- and key-order-independent, so two providers that returned the
+/// same logical result agree even when their JSON formatting (or the volatile
+/// `id` field) differs. An unparseable / shape-less response groups only with
+/// itself, so it can never be mistaken for agreement.
+fn response_consensus_key(text: &str) -> serde_json::Value {
+    match serde_json::from_str::<serde_json::Value>(text) {
+        Ok(v) => {
+            if let Some(r) = v.get("result") {
+                r.clone()
+            } else if let Some(e) = v.get("error") {
+                serde_json::json!({ "__error": e })
+            } else {
+                serde_json::json!({ "__raw": text })
+            }
+        }
+        Err(_) => serde_json::json!({ "__raw": text }),
+    }
+}
+
+/// Send a raw JSON-RPC READ to the EVM RPC canister with MULTI-PROVIDER QUORUM
+/// (audit FLAG-1). Queries EVERY configured endpoint and requires a STRICT
+/// MAJORITY of the configured providers to return the same semantic result
+/// before returning it, so a single malicious / compromised / lagging provider
+/// cannot fabricate a balance, block, supply, or receipt the canister credits.
+///
+/// With ONE configured endpoint this degrades to a single-provider read (no
+/// cross-provider quorum is possible). The deployment MUST configure >= 3
+/// independent endpoints to get real 2-of-3 protection (an ops action; see the
+/// pre-permissionless checklist). On no-quorum or all-fail this returns Err so
+/// the caller never credits / advances on disagreement.
+///
+/// READS ONLY. `eth_sendRawTransaction` is a write and uses
+/// `call_evm_rpc_broadcast` (first-Ok: a broadcast lands if ANY provider accepts
+/// it; requiring agreement would wrongly drop a tx that only some providers saw).
 async fn call_evm_rpc(chain: ChainId, json_payload: &str) -> Result<String, String> {
     let endpoints: Vec<String> = read_state(|s| {
         s.multi_chain
@@ -537,45 +590,76 @@ async fn call_evm_rpc(chain: ChainId, json_payload: &str) -> Result<String, Stri
             .map(|c| c.rpc_endpoints.clone())
             .unwrap_or_default()
     });
-
     if endpoints.is_empty() {
         return Err(format!("no RPC endpoints configured for chain {:?}", chain));
     }
-
     let canister = evm_rpc_principal();
+
+    // Single provider: no cross-provider quorum is possible.
+    if endpoints.len() == 1 {
+        log!(DEBUG, "[evm_rpc] single-provider read for chain {:?} (configure >= 3 endpoints for quorum)", chain);
+        return single_call(canister, &endpoints[0], json_payload).await;
+    }
+
+    // Multi-provider: collect every Ok response, then require a strict majority
+    // of the CONFIGURED providers to agree on the semantic result.
+    let mut oks: Vec<String> = Vec::new();
     let mut last_err = String::new();
-
     for url in &endpoints {
-        let rpc_service = RpcService::Custom(RpcApi {
-            url: url.clone(),
-            headers: None,
-        });
-
-        let result: Result<(RequestResult,), _> =
-            ic_cdk::api::call::call_with_payment128(
-                canister,
-                "request",
-                (rpc_service, json_payload.to_string(), EVM_RPC_MAX_RESPONSE_BYTES),
-                EVM_RPC_CALL_CYCLES,
-            )
-            .await;
-
-        match result {
-            Ok((RequestResult::Ok(text),)) => {
-                log!(DEBUG, "[evm_rpc] call ok via {}", url);
-                return Ok(text);
-            }
-            Ok((RequestResult::Err(rpc_err),)) => {
-                last_err = format!("RPC error from {}: {:?}", url, rpc_err);
-                log!(DEBUG, "[evm_rpc] provider error via {}: {:?}", url, rpc_err);
-            }
-            Err((code, msg)) => {
-                last_err = format!("call error to {} ({:?}): {}", url, code, msg);
-                log!(DEBUG, "[evm_rpc] call error via {}: {:?} {}", url, code, msg);
+        match single_call(canister, url, json_payload).await {
+            Ok(text) => oks.push(text),
+            Err(e) => {
+                log!(DEBUG, "[evm_rpc] provider read error via {}: {}", url, e);
+                last_err = e;
             }
         }
     }
+    if oks.is_empty() {
+        return Err(format!("all {} providers failed; last: {}", endpoints.len(), last_err));
+    }
+    let needed = endpoints.len() / 2 + 1; // strict majority of the full provider set
+    let keys: Vec<serde_json::Value> = oks.iter().map(|t| response_consensus_key(t)).collect();
+    let mut best_idx = 0usize;
+    let mut best_count = 0usize;
+    for i in 0..keys.len() {
+        let count = keys.iter().filter(|k| **k == keys[i]).count();
+        if count > best_count {
+            best_count = count;
+            best_idx = i;
+        }
+    }
+    if best_count >= needed {
+        Ok(oks[best_idx].clone())
+    } else {
+        Err(format!(
+            "RPC quorum not reached for chain {:?}: best agreement {}/{} (need {})",
+            chain, best_count, endpoints.len(), needed
+        ))
+    }
+}
 
+/// Broadcast a raw JSON-RPC WRITE (`eth_sendRawTransaction`). Returns the first
+/// provider's Ok — a broadcast propagates if ANY provider accepts it, so quorum
+/// is the wrong model for a write. On all-fail returns the last error.
+async fn call_evm_rpc_broadcast(chain: ChainId, json_payload: &str) -> Result<String, String> {
+    let endpoints: Vec<String> = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.rpc_endpoints.clone())
+            .unwrap_or_default()
+    });
+    if endpoints.is_empty() {
+        return Err(format!("no RPC endpoints configured for chain {:?}", chain));
+    }
+    let canister = evm_rpc_principal();
+    let mut last_err = String::new();
+    for url in &endpoints {
+        match single_call(canister, url, json_payload).await {
+            Ok(text) => return Ok(text),
+            Err(e) => last_err = e,
+        }
+    }
     Err(last_err)
 }
 
@@ -725,6 +809,33 @@ pub async fn get_balance(chain: ChainId, address: &str) -> Result<u128, String> 
     let hex = val["result"]
         .as_str()
         .ok_or_else(|| format!("eth_getBalance: missing result in {:?}", text))?;
+    parse_hex_quantity(hex)
+}
+
+/// Returns the native balance (in wei) of `address` at a SPECIFIC block number.
+/// Like `erc20_total_supply_at`, a fixed block number is byte-identical across
+/// the EVM RPC canister's replicas (so HTTPS-outcall consensus is reached) AND,
+/// when the number is a finalized block, the read is reorg-safe. The settlement
+/// worker uses this to RE-VERIFY a deposit at finality before broadcasting an
+/// irreversible mint: deposit DETECTION runs on the volatile `"latest"` balance
+/// for liveness (the Gate-4 design), but the mint must only fire against a
+/// deposit that is buried and cannot reorg away.
+pub async fn get_balance_at_block(chain: ChainId, address: &str, block: u64) -> Result<u128, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_getBalance","params":[{:?},"0x{:x}"],"id":{}}}"#,
+        address,
+        block,
+        next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("eth_getBalance(at block) parse: {}", e))?;
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_getBalance(at block) RPC error: {}", err));
+    }
+    let hex = val["result"]
+        .as_str()
+        .ok_or_else(|| format!("eth_getBalance(at block): missing result in {:?}", text))?;
     parse_hex_quantity(hex)
 }
 
@@ -993,7 +1104,8 @@ pub async fn send_raw_transaction(chain: ChainId, raw_tx_hex: &str) -> Result<St
         raw_tx_hex,
         next_rpc_id()
     );
-    let text = call_evm_rpc(chain, &payload).await?;
+    // A broadcast is a write: first-Ok, not quorum (see call_evm_rpc_broadcast).
+    let text = call_evm_rpc_broadcast(chain, &payload).await?;
     let val: serde_json::Value = serde_json::from_str(&text)
         .map_err(|e| format!("eth_sendRawTransaction parse: {}", e))?;
 

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -399,6 +399,55 @@ async fn submit_op(
         return;
     }
 
+    // DEPOSIT FINALITY GATE (Mint ops only): the deposit-watch flips a vault to
+    // MintPending on a `"latest"` (chain-tip, depth-0) custody balance for
+    // liveness (the Gate-4 design keeps DETECTION robust to block-height read
+    // failures). But an icUSD mint is irreversible, so before BROADCASTING the
+    // mint we RE-VERIFY the custody balance still covers the declared collateral
+    // at the observer's finalized cursor (`last_observed_block`, which the
+    // observer advances only to confirmed-final blocks — the same value the mint
+    // CONFIRM path treats as final). If the deposit cannot be shown final yet
+    // (cursor unseeded, balance not yet reflected at the cursor, or the read
+    // fails) we DEFER: leave the op Queued and retry next tick. This is
+    // fail-closed — a deposit that reorgs out after the tip observation can never
+    // back a mint. (Withdrawals/Burns are unaffected.)
+    if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
+        let vid = *vault_id;
+        let (cursor, vinfo) = read_state(|s| {
+            let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+            let v = s
+                .multi_chain
+                .chain_vaults
+                .get(&vid)
+                .map(|v| (v.custody_address.clone(), v.collateral_amount_native));
+            (cursor, v)
+        });
+        let (custody, declared) = match vinfo {
+            Some(p) => p,
+            None => {
+                log!(INFO, "[settlement chain={:?}] mint op {}: unknown vault {}; will retry", chain, op_id, vid);
+                return;
+            }
+        };
+        if cursor == 0 {
+            log!(INFO, "[settlement chain={:?}] mint op {} vault {}: finalized cursor unseeded; cannot verify deposit finality — call set_last_observed_block(chain, <current tip>) to enable mints", chain, op_id, vid);
+            return;
+        }
+        match evm_rpc::get_balance_at_block(chain, &custody, cursor).await {
+            Ok(final_balance) if final_balance >= declared => {
+                log!(INFO, "[settlement chain={:?}] mint op {} vault {}: deposit verified final ({} >= declared {} at block {})", chain, op_id, vid, final_balance, declared, cursor);
+            }
+            Ok(final_balance) => {
+                log!(INFO, "[settlement chain={:?}] mint op {} vault {}: deposit not yet final (finalized balance {} < declared {} at block {}); deferring broadcast", chain, op_id, vid, final_balance, declared, cursor);
+                return;
+            }
+            Err(e) => {
+                log!(INFO, "[settlement chain={:?}] mint op {} vault {}: get_balance_at_block failed ({}); deferring broadcast", chain, op_id, vid, e);
+                return;
+            }
+        }
+    }
+
     // GAS GATE (Task 11): refuse a new outbound op when the cached settlement
     // balance is below the hot-wallet floor. FAIL OPEN when the cache is unset
     // (`None`): an unpopulated cache (fresh chain / observer hasn't run yet)
@@ -738,18 +787,19 @@ async fn confirm_op(
             // `log_index` is threaded through from get_logs but not needed here
             // (the settlement path selects by vault_id + tx_hash, not by log
             // identity — each mint op maps to exactly one Mint event).
-            let mut matched: Option<u128> = None;
+            let mut matched: Option<(u128, String)> = None;
             for (topics, data, log_tx, log_block, _log_index) in &logs {
                 match evm_rpc::decode_mint_log(topics, data, log_tx, *log_block) {
                     Ok(m) if m.vault_id == vault_id => {
                         let exact = log_tx.eq_ignore_ascii_case(&tx_hash);
                         // Prefer an exact tx-hash match; otherwise take the first
-                        // vault-id match as a fallback.
+                        // vault-id match as a fallback (safe: IcUSD.mint reverts a
+                        // repeat vault_id, so at most one Mint log per vault exists).
                         if exact {
-                            matched = Some(m.amount_e8s);
+                            matched = Some((m.amount_e8s, m.recipient));
                             break;
                         } else if matched.is_none() {
-                            matched = Some(m.amount_e8s);
+                            matched = Some((m.amount_e8s, m.recipient));
                         }
                     }
                     Ok(_) => {}
@@ -759,13 +809,32 @@ async fn confirm_op(
                 }
             }
 
-            let observed_e8s = match matched {
-                Some(a) => a,
+            let (observed_e8s, observed_recipient) = match matched {
+                Some(pair) => pair,
                 None => {
                     log!(INFO, "[settlement chain={:?}] no Mint log for vault {} in block {} confirming op {}; will retry", chain, vault_id, block_number, op_id);
                     return;
                 }
             };
+
+            // Verify the on-chain Mint recipient matches the vault's intended
+            // `mint_recipient` (case-insensitive). The supply invariant is
+            // recipient-agnostic, so without this check a mint to the WRONG
+            // address would still balance and be marked Succeeded. A mismatch is a
+            // real divergence: leave the op Inflight and do NOT credit.
+            let intended_recipient =
+                read_state(|s| s.multi_chain.chain_vaults.get(&vault_id).map(|v| v.mint_recipient.clone()));
+            match intended_recipient {
+                Some(intended) if intended.eq_ignore_ascii_case(&observed_recipient) => {}
+                Some(intended) => {
+                    log!(INFO, "[settlement chain={:?}] mint-confirm recipient mismatch op {} vault {}: on-chain {} != intended {}; left Inflight (NOT credited)", chain, op_id, vault_id, observed_recipient, intended);
+                    return;
+                }
+                None => {
+                    log!(INFO, "[settlement chain={:?}] mint-confirm: unknown vault {} for op {}; left Inflight", chain, vault_id, op_id);
+                    return;
+                }
+            }
 
             // PRE-mint total: sum of foreign-chain vault debt BEFORE this mint
             // counts (this vault's debt_e8s is still 0 under Design B). NEVER

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -438,18 +438,43 @@ fn confirm_succeeded(
             // `confirm_mint_in_state` re-validates it equals the vault's
             // `pending_mint_e8s` before crediting.
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
-            let result = mutate_state(|s| {
-                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total)
-            });
-            match result {
-                Ok(()) => {
-                    mutate_state(|s| {
+            // CAS: credit + mark Succeeded in ONE mutate_state, gated on the op
+            // still being Inflight. Mirrors the Monad reverted-path CAS so two
+            // overlapping ticks (possible under the 10-min stale-guard reclaim)
+            // cannot both credit: the first flips the op to Succeeded, the second
+            // sees it non-Inflight and no-ops. `confirm_mint_in_state`'s
+            // pending==observed check is the backstop; this makes the guard
+            // explicit and symmetric with `confirm_reverted`.
+            enum MintConfirm {
+                Credited,
+                AlreadyHandled,
+                Failed(String),
+            }
+            let outcome = mutate_state(|s| {
+                let still_inflight = s
+                    .multi_chain
+                    .settlement_queues
+                    .get(&chain)
+                    .and_then(|q| q.pending.get(&op_id))
+                    .map(|o| matches!(o.status, SettlementOpStatus::Inflight { .. }))
+                    .unwrap_or(false);
+                if !still_inflight {
+                    return MintConfirm::AlreadyHandled;
+                }
+                match confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total) {
+                    Ok(()) => {
                         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                             if let Some(o) = q.pending.get_mut(&op_id) {
                                 o.mark_succeeded(signature.to_string(), now);
                             }
                         }
-                    });
+                        MintConfirm::Credited
+                    }
+                    Err(e) => MintConfirm::Failed(e),
+                }
+            });
+            match outcome {
+                MintConfirm::Credited => {
                     crate::storage::record_event(&crate::event::Event::ChainMintConfirmed {
                         chain_id: chain,
                         vault_id,
@@ -461,7 +486,10 @@ fn confirm_succeeded(
                     });
                     log!(INFO, "[solana settlement chain={:?}] mint confirmed: op={} vault={} amount_e8s={} slot={} sig={}", chain, op_id, vault_id, amount_e8s, slot, signature);
                 }
-                Err(e) => {
+                MintConfirm::AlreadyHandled => {
+                    log!(INFO, "[solana settlement chain={:?}] op {} already finalized by a concurrent tick; skipping double-credit", chain, op_id);
+                }
+                MintConfirm::Failed(e) => {
                     // A confirm failure here is a protocol-level condition
                     // (divergence/halt/amount mismatch), NOT a tx failure. Leave
                     // the op Inflight for retry; do NOT mark it Failed.

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -78,6 +78,52 @@ fn register_chain_rejects_empty_rpc_endpoints() {
 }
 
 #[test]
+fn register_chain_rejects_out_of_range_decimals() {
+    let mut s = MultiChainStateV3::default();
+    // 0 would make the CR native-scale 1 (collateral treated as whole units),
+    // inflating every CR check and admitting under-collateralized opens.
+    let mut zero = arg();
+    zero.chain_native_decimals = 0;
+    let err = register_chain_in_state(&mut s, zero, 0).expect_err("zero decimals");
+    assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
+    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+
+    // Absurdly large decimals are also rejected.
+    let mut huge = arg();
+    huge.chain_native_decimals = 200;
+    let err = register_chain_in_state(&mut s, huge, 0).expect_err("huge decimals");
+    assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
+
+    // The valid EVM (18) and Solana (9) values still register.
+    let mut sol = arg();
+    sol.chain_id = ChainId(102);
+    sol.chain_native_decimals = 9;
+    register_chain_in_state(&mut s, sol, 0).expect("9 decimals (Solana) ok");
+    assert_eq!(s.chain_configs[&ChainId(102)].chain_native_decimals, 9);
+}
+
+#[test]
+fn register_chain_enforces_evm_finality_floor() {
+    let mut s = MultiChainStateV3::default();
+    // EVM chain with finality_depth 0 is rejected.
+    let mut a = arg(); // EvmEip1559 gas strategy
+    a.finality_depth = 0;
+    let err = register_chain_in_state(&mut s, a, 0).expect_err("evm finality 0");
+    assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
+    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+
+    // A Solana-style chain (non-EVM gas) MAY use finality_depth 0 (reads at the
+    // `finalized` commitment).
+    let mut sol = arg();
+    sol.chain_id = ChainId(202);
+    sol.chain_native_decimals = 9;
+    sol.gas_strategy = GasStrategy::SolanaPriorityFee { lamports_per_cu_ceiling: 10_000 };
+    sol.finality_depth = 0;
+    register_chain_in_state(&mut s, sol, 0).expect("solana finality 0 ok");
+    assert_eq!(s.chain_configs[&ChainId(202)].finality_depth, 0);
+}
+
+#[test]
 fn disable_chain_flips_status_and_preserves_supply() {
     let mut s = MultiChainStateV3::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1038,6 +1038,12 @@ async fn open_chain_vault(
 /// observer decrements `debt_e8s` + chain supply. This path moves only
 /// collateral. Synchronous — `dest_address` is supplied by the caller, so no
 /// tECDSA derive is needed; signing happens later in Timer D. Developer-gated.
+///
+/// CONCURRENCY INVARIANT (audit FLAG-16): this MUST stay synchronous. Its
+/// safety against double-withdraw rests on the reserve-at-enqueue happening
+/// atomically within this single message (no `GuardPrincipal` is taken, unlike
+/// the ICP-native vault ops). Adding ANY `.await` here re-opens a read->await->
+/// write race; if you must, acquire a per-vault `GuardPrincipal` first.
 #[candid_method(update)]
 #[update]
 fn withdraw_chain_collateral(
@@ -1070,6 +1076,8 @@ fn withdraw_chain_collateral(
 /// Monad), then withdraws the FULL remaining collateral to `dest_address`
 /// (vault -> `Closing`, then `Closed` on the transfer's confirmation).
 /// Synchronous + developer-gated (mirrors `withdraw_chain_collateral`).
+/// CONCURRENCY INVARIANT (audit FLAG-16): keep synchronous — see
+/// `withdraw_chain_collateral`; adding an `.await` needs a per-vault guard.
 #[candid_method(update)]
 #[update]
 fn close_chain_vault(vault_id: u64, dest_address: String) -> Result<(), ProtocolError> {
@@ -1169,6 +1177,9 @@ async fn open_solana_vault(
 
 /// Withdraw Solana collateral (mirrors `withdraw_chain_collateral`).
 ///
+/// CONCURRENCY INVARIANT (audit FLAG-16): keep synchronous — see
+/// `withdraw_chain_collateral`; adding an `.await` needs a per-vault guard.
+///
 /// CR-checks the REMAINING collateral against `SOLANA_MIN_CR_E4` (debt-free
 /// vaults skip the check), RESERVES the withdrawn lamports, and enqueues a
 /// `NativeWithdrawal` op for the Task-8 settlement worker to sign + broadcast. A
@@ -1210,7 +1221,8 @@ fn withdraw_solana_collateral(
 /// Requires the vault's `debt_e8s == 0` (repay first by burning icUSD on
 /// Solana), then withdraws the FULL remaining collateral to `dest_address`
 /// (vault -> `Closing`, then `Closed` on the transfer's confirmation).
-/// Synchronous + developer-gated.
+/// Synchronous + developer-gated. CONCURRENCY INVARIANT (audit FLAG-16): keep
+/// synchronous — see `withdraw_chain_collateral`; an `.await` needs a guard.
 #[candid_method(update)]
 #[update]
 fn close_solana_vault(vault_id: u64, dest_address: String) -> Result<(), ProtocolError> {
@@ -1365,6 +1377,13 @@ fn set_manual_collateral_price(
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
+    // Reject a zero price. A 0 price drives `collateral_ratio_e4` to 0, which
+    // fails-closed (every open/withdraw with debt rejects with BelowMinCr), so
+    // it cannot mint under-collateralized — but it is never a legitimate value
+    // and silently freezes the chain's vaults. Catch the fat-finger explicitly.
+    if price_e8 == 0 {
+        return Err(ProtocolError::ChainAdmin("price_e8 must be greater than 0".into()));
+    }
     mutate_state(|s| {
         s.multi_chain.manual_prices.insert((chain, symbol.clone()), price_e8);
     });
@@ -1399,11 +1418,29 @@ fn clear_invariant_halt() -> Result<(), ProtocolError> {
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    mutate_state(|s| {
-        s.multi_chain.invariant_halted = false;
+    // Refuse to clear into a still-diverged state. The halt exists because the
+    // Timer-B self-check found `sum(chain_supplies) != total_chain_vault_debt`;
+    // clearing it blind would re-enable cross-chain supply mutation on top of a
+    // known-bad invariant. Re-verify against live state and only clear when the
+    // internal invariant actually holds again (the operator is still expected to
+    // have reconciled against on-chain reality first).
+    let result = mutate_state(|s| {
+        let total_debt = s.multi_chain.total_chain_vault_debt_e8s();
+        match rumi_protocol_backend::chains::supply::check_invariant(&s.multi_chain, total_debt) {
+            Ok(()) => {
+                s.multi_chain.invariant_halted = false;
+                Ok(())
+            }
+            Err(e) => Err(ProtocolError::ChainAdmin(format!(
+                "refusing to clear invariant halt: supply invariant still diverged ({e:?}); \
+                 reconcile chain_supplies vs vault debt first"
+            ))),
+        }
     });
-    log!(INFO, "[clear_invariant_halt] global invariant halt cleared");
-    Ok(())
+    if result.is_ok() {
+        log!(INFO, "[clear_invariant_halt] global invariant halt cleared (invariant re-verified)");
+    }
+    result
 }
 
 /// Clear a chain's reorg circuit breaker. Resets BOTH `reorg_halted` AND the
@@ -1477,8 +1514,15 @@ fn get_last_observed_block(
 /// frontend, per plan Task 7) can poll-and-retry until the receipt is final.
 ///
 /// FUTURE ROBUSTNESS (flagged per Rob 2026-05-31): v1 liveness depends on the
-/// submitter (the dApp). Harden later with a relayer or an incentivized
-/// permissionless submitter; add a per-caller rate-limit when that lands.
+/// submitter (the dApp). Proper DoS protection (this is a permissionless
+/// endpoint that spends a ~2B-cycle `eth_getTransactionReceipt` outcall per
+/// call) needs the deferred relayer / incentivized-submitter design (audit
+/// FLAG-7). A naive per-caller wall-clock rate-limit was rejected: it both fails
+/// against principal rotation AND wrongly throttles legitimate back-to-back
+/// submissions (e.g. two distinct burns in the same second). The endpoint does
+/// reject the anonymous principal as basic hygiene (ingress anonymous is also
+/// dropped by `inspect_message`; this is belt-and-suspenders, and covers any
+/// future non-ingress entry that skips that hook).
 #[candid_method(update)]
 #[update]
 async fn submit_burn_proof(
@@ -1488,6 +1532,13 @@ async fn submit_burn_proof(
     use rumi_protocol_backend::chains::monad::burn_proof::{
         verify_and_apply_burn_proof, BurnProofError,
     };
+
+    if ic_cdk::caller() == candid::Principal::anonymous() {
+        return Err(ProtocolError::ChainAdmin(
+            "anonymous caller not allowed for submit_burn_proof".into(),
+        ));
+    }
+
     match verify_and_apply_burn_proof(chain_id, &tx_hash).await {
         Ok(n) => {
             if n > 0 {
@@ -1567,6 +1618,249 @@ fn delete_chain(
         }
         Err(e) => Err(ProtocolError::ChainAdmin(format!("{e:?}"))),
     }
+}
+
+/// Developer-gated recovery for a foreign-chain vault wedged in `MintPending`
+/// after its mint permanently reverted (audit FLAG-4). When a mint reverts at
+/// finality the worker clears `pending_mint_e8s` but leaves the vault
+/// `MintPending`; there is no transition out (withdraw/close require `Open`, and
+/// the mint can never re-confirm with `pending == 0`), so the deposited
+/// collateral would be locked forever. This transitions a genuinely-stuck vault
+/// back to `Open` (debt is 0 under Design B — the mint was never confirmed) so
+/// the existing dev-gated `close_chain_vault` / `withdraw_chain_collateral` can
+/// return the collateral. Rejects unless the vault is on `chain`, is
+/// `MintPending`, has `pending_mint_e8s == 0`, and has NO live (Queued/Inflight)
+/// Mint op left.
+#[candid_method(update)]
+#[update]
+fn recover_stuck_chain_vault(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    vault_id: u64,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
+    use rumi_protocol_backend::chains::vault::ChainVaultStatus;
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    mutate_state(|s| {
+        let v = s
+            .multi_chain
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain vault {vault_id}")))?;
+        if v.collateral_chain != chain {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "vault {vault_id} is not on chain {:?}",
+                chain
+            )));
+        }
+        if v.status != ChainVaultStatus::MintPending || v.pending_mint_e8s != 0 {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "vault {vault_id} is not a recoverable stuck mint (status {:?}, pending_mint_e8s {})",
+                v.status, v.pending_mint_e8s
+            )));
+        }
+        let has_live_mint = s
+            .multi_chain
+            .settlement_queues
+            .get(&chain)
+            .map(|q| {
+                q.pending.values().any(|op| {
+                    matches!(&op.kind, SettlementOpKind::Mint { vault_id: vid, .. } if *vid == vault_id)
+                        && matches!(
+                            op.status,
+                            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                        )
+                })
+            })
+            .unwrap_or(false);
+        if has_live_mint {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "vault {vault_id} still has a live mint op; wait for it to reach a terminal state"
+            )));
+        }
+        let v = s
+            .multi_chain
+            .chain_vaults
+            .get_mut(&vault_id)
+            .expect("vault present: checked above");
+        v.status = ChainVaultStatus::Open;
+        Ok(())
+    })?;
+    log!(INFO, "[recover_stuck_chain_vault] chain={:?} vault={} MintPending->Open (collateral now recoverable via close/withdraw)", chain, vault_id);
+    Ok(())
+}
+
+/// Developer-gated resolution for a settlement op wedged `Inflight` (audit
+/// FLAG-10). `select_next_op` is strictly one-in-flight per chain, so an op whose
+/// tx never confirms blocks EVERY later op for that chain (the Solana path has no
+/// automatic same-bytes rebroadcast yet). This marks the op `Failed` and applies
+/// the SAME per-kind reversal as the confirm-reverted path (clear a Mint's
+/// `pending_mint_e8s`; restore a NativeWithdrawal's reserved collateral and flip
+/// `Closing -> Open`) so the queue can advance.
+///
+/// DANGER: the operator MUST first verify on-chain that the op's tx did NOT land.
+/// Marking a Mint `Failed` after its tx actually minted on-chain would leave
+/// icUSD minted with no recorded debt (an unbacked mint). Rejects unless the op
+/// is currently `Inflight`.
+#[candid_method(update)]
+#[update]
+fn resolve_stuck_settlement_op(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    op_id: u64,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
+    use rumi_protocol_backend::chains::vault::ChainVaultStatus;
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        // Snapshot the op kind and confirm it is Inflight (CAS).
+        let kind = {
+            let q = s
+                .multi_chain
+                .settlement_queues
+                .get(&chain)
+                .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain {:?}", chain)))?;
+            let op = q.pending.get(&op_id).ok_or_else(|| {
+                ProtocolError::ChainAdmin(format!("unknown op {op_id} on chain {:?}", chain))
+            })?;
+            if !matches!(op.status, SettlementOpStatus::Inflight { .. }) {
+                return Err(ProtocolError::ChainAdmin(format!(
+                    "op {op_id} is not Inflight (status {:?}); nothing to resolve",
+                    op.status
+                )));
+            }
+            op.kind.clone()
+        };
+        // Per-kind reversal, mirroring confirm_reverted.
+        match &kind {
+            SettlementOpKind::Mint { vault_id, .. } => {
+                if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
+                    v.pending_mint_e8s = 0; // Design B: no debt counted; leave status MintPending.
+                }
+            }
+            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
+                    v.collateral_amount_native =
+                        v.collateral_amount_native.saturating_add(*amount_e18);
+                    if v.status == ChainVaultStatus::Closing {
+                        v.status = ChainVaultStatus::Open;
+                    }
+                }
+            }
+            SettlementOpKind::Burn { .. } => {}
+        }
+        if let Some(o) = s
+            .multi_chain
+            .settlement_queues
+            .get_mut(&chain)
+            .and_then(|q| q.pending.get_mut(&op_id))
+        {
+            o.mark_failed("manually resolved (stuck Inflight)".to_string(), now);
+        }
+        Ok(())
+    })?;
+    log!(INFO, "[resolve_stuck_settlement_op] chain={:?} op={} marked Failed + reversed (operator-confirmed not landed)", chain, op_id);
+    Ok(())
+}
+
+/// On-demand reconciliation report for a chain (audit FLAG-2). Compares the real
+/// on-chain icUSD `totalSupply()` (read at the finalized cursor, consensus-safe
+/// specific block) against the canister's recorded `chain_supplies` plus any
+/// in-flight mints.
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ChainSupplyReconciliation {
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub finalized_block: u64,
+    pub onchain_total_supply_e8s: u128,
+    pub recorded_supply_e8s: u128,
+    pub in_flight_mint_e8s: u128,
+    /// True iff on-chain supply exceeds recorded + in-flight mints: the
+    /// unbacked-mint signature that the periodic self-check (two internal mirror
+    /// fields) structurally cannot detect.
+    pub unbacked_excess: bool,
+    /// Signed gap = onchain - recorded. Positive => excess (possible unbacked
+    /// mint); negative => deficit (an unsubmitted burn the backstop handles).
+    pub gap_e8s: i128,
+}
+
+/// Developer-gated, on-demand supply reconciliation against the chain (audit
+/// FLAG-2). The Timer-B self-check only compares two INTERNAL mirror fields
+/// (`sum(chain_supplies)` vs `total_chain_vault_debt`), which are kept in
+/// lockstep and so cannot reveal canister-vs-chain drift. This reads the real
+/// on-chain `totalSupply()` at the finalized cursor and reports the gap, so an
+/// unbacked mint (on-chain supply ABOVE recorded, with no in-flight mint) is
+/// detectable even when recorded debt is 0 (which the observer's per-tick alarm
+/// skips on its no-debt fast path).
+#[candid_method(update)]
+#[update]
+async fn reconcile_chain_supply(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<ChainSupplyReconciliation, ProtocolError> {
+    use rumi_protocol_backend::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let (contract, recorded, in_flight, cursor) = read_state(|s| {
+        let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
+        let recorded = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+        let in_flight = s
+            .multi_chain
+            .settlement_queues
+            .get(&chain)
+            .map(|q| {
+                q.pending
+                    .values()
+                    .filter_map(|op| match &op.kind {
+                        SettlementOpKind::Mint { amount_e8s, .. }
+                            if matches!(
+                                op.status,
+                                SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                            ) =>
+                        {
+                            Some(*amount_e8s)
+                        }
+                        _ => None,
+                    })
+                    .sum::<u128>()
+            })
+            .unwrap_or(0);
+        let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+        (contract, recorded, in_flight, cursor)
+    });
+    let contract = contract.ok_or_else(|| {
+        ProtocolError::ChainAdmin(format!("no icUSD contract configured for chain {:?}", chain))
+    })?;
+    if cursor == 0 {
+        return Err(ProtocolError::ChainAdmin(
+            "finalized cursor unseeded; call set_last_observed_block(chain, <tip>) first".into(),
+        ));
+    }
+    let onchain =
+        rumi_protocol_backend::chains::monad::evm_rpc::erc20_total_supply_at(chain, &contract, cursor)
+            .await
+            .map_err(|e| {
+                ProtocolError::TemporarilyUnavailable(format!("totalSupply read failed; retry: {e}"))
+            })?;
+    let gap_e8s = onchain as i128 - recorded as i128;
+    let unbacked_excess = onchain > recorded.saturating_add(in_flight);
+    if unbacked_excess {
+        log!(INFO, "[reconcile_chain_supply] chain={:?} UNBACKED EXCESS: onchain {} > recorded {} + in_flight {} (block {})", chain, onchain, recorded, in_flight, cursor);
+    }
+    Ok(ChainSupplyReconciliation {
+        chain_id: chain,
+        finalized_block: cursor,
+        onchain_total_supply_e8s: onchain,
+        recorded_supply_e8s: recorded,
+        in_flight_mint_e8s: in_flight,
+        unbacked_excess,
+        gap_e8s,
+    })
 }
 
 #[candid_method(query)]

--- a/src/rumi_protocol_backend/src/storage.rs
+++ b/src/rumi_protocol_backend/src/storage.rs
@@ -222,38 +222,75 @@ pub fn save_state_to_stable(state: &crate::state::State) {
     });
 }
 
-/// Attempts to restore State from stable memory. Returns None if no state was saved.
+/// Attempts to restore State from stable memory.
+///
+/// Returns `None` ONLY when no snapshot has ever been written (the genuine
+/// first-upgrade / no-state case), where `post_upgrade` legitimately rebuilds
+/// from the event log.
+///
+/// If a snapshot IS present but cannot be restored (corrupt length prefix or a
+/// ciborium decode failure, e.g. a `State` schema change the versioned in-place
+/// decode could not absorb) this **traps** instead of returning `None`. Silently
+/// falling back to event replay would be catastrophic: every `chains::` event
+/// (`DepositObserved`, `ChainMintConfirmed`, `ChainBurnObserved`, ...) is a
+/// replay NO-OP (see `event.rs`), so a replay-rebuilt `State` comes back with an
+/// EMPTY `multi_chain` while ICP-native state is reconstructed. That wipes every
+/// foreign-chain vault, supply, and settlement queue while real icUSD stays
+/// minted on Monad/Solana, breaking `sum(chain_supplies) == total_debt` with no
+/// recovery (the 2026-05-18 AMM state-wipe class, with a worse blast radius).
+/// Trapping keeps the canister on the OLD wasm with stable memory intact, so the
+/// operator can fix the schema and retry — a bricked-pending-fix upgrade is
+/// strictly safer than a silent balance wipe.
 pub fn load_state_from_stable() -> Option<crate::state::State> {
     MEMORY_MANAGER.with(|m| {
         let mem = m.borrow().get(STATE_MEMORY_ID);
         if mem.size() == 0 {
-            return None; // No state memory allocated yet
+            return None; // No state memory allocated yet (genuine first upgrade).
         }
         let mut len_bytes = [0u8; 8];
         mem.read(0, &mut len_bytes);
         let len = u64::from_le_bytes(len_bytes);
         if len == 0 {
-            return None; // No state saved yet
+            return None; // No state saved yet (genuine first upgrade).
         }
-        // Sanity check: length must fit within allocated memory (minus 8-byte prefix)
+        // A snapshot IS present from here on. Any failure below is corruption of
+        // a real snapshot, NOT a missing one — trap, never silently fall back to
+        // event replay (which would wipe `multi_chain`; see the fn doc comment).
         let mem_bytes = mem.size() * WASM_PAGE_SIZE;
         if len > mem_bytes.saturating_sub(8) {
-            ic_cdk::println!(
-                "[upgrade]: corrupt state length {} exceeds memory size {}",
+            ic_cdk::trap(&corrupt_snapshot_trap_msg(&format!(
+                "length prefix {} exceeds allocated state memory {} bytes",
                 len, mem_bytes
-            );
-            return None; // Fall back to event replay
+            )));
         }
         let mut buf = vec![0u8; len as usize];
         mem.read(8, &mut buf);
-        match ciborium::de::from_reader::<crate::state::State, _>(buf.as_slice()) {
+        match decode_state_body(&buf) {
             Ok(state) => Some(state),
-            Err(e) => {
-                ic_cdk::println!("[upgrade]: failed to deserialize state from stable memory: {:?}", e);
-                None // Fall back to event replay
-            }
+            Err(e) => ic_cdk::trap(&corrupt_snapshot_trap_msg(&e)),
         }
     })
+}
+
+/// Pure ciborium decode of a `State` snapshot body (the bytes AFTER the 8-byte
+/// length prefix). Extracted from `load_state_from_stable` so the healthy
+/// round-trip and the corrupt-input rejection are unit-testable without
+/// thread-local stable memory.
+pub fn decode_state_body(buf: &[u8]) -> Result<crate::state::State, String> {
+    ciborium::de::from_reader::<crate::state::State, _>(buf)
+        .map_err(|e| format!("ciborium decode failed: {e:?}"))
+}
+
+/// The trap message used when a present `State` snapshot cannot be restored.
+/// See `load_state_from_stable` for why this is a trap, not a replay fallback.
+fn corrupt_snapshot_trap_msg(detail: &str) -> String {
+    format!(
+        "[upgrade] ABORT: a State snapshot is present but could not be restored ({detail}). \
+         Refusing to fall back to event replay: chain events are replay no-ops, so replay \
+         would WIPE all foreign-chain vaults, supplies, and settlement queues (2026-05-18 \
+         AMM state-wipe class). The canister stays on the OLD wasm with stable memory intact; \
+         fix the State schema and retry the upgrade."
+    )
 }
 
 // ── Protocol Snapshots ─────────────────────────────────────────────────────
@@ -310,5 +347,99 @@ impl Iterator for SnapshotIterator {
     fn nth(&mut self, n: usize) -> Option<crate::ProtocolSnapshot> {
         self.pos = self.pos.saturating_add(n as u64);
         self.next()
+    }
+}
+
+#[cfg(test)]
+mod state_snapshot_tests {
+    //! Guards for the upgrade snapshot decode path. `load_state_from_stable`
+    //! traps on a present-but-undecodable snapshot rather than silently
+    //! replaying events (which would wipe `multi_chain`). These tests exercise
+    //! the pure `decode_state_body` half so the healthy round-trip and the
+    //! corrupt-input rejection are covered without a wasm/PocketIC harness.
+    use super::*;
+    use crate::chains::config::ChainId;
+    use crate::chains::vault::{ChainVaultStatus, ChainVaultV1};
+    use candid::Principal;
+
+    fn encode_state(state: &crate::state::State) -> Vec<u8> {
+        // Mirror `save_state_to_stable`'s encoder exactly.
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(state, &mut buf).expect("encode State to CBOR");
+        buf
+    }
+
+    #[test]
+    fn default_state_round_trips() {
+        let state = crate::state::State::default();
+        let bytes = encode_state(&state);
+        let decoded = decode_state_body(&bytes).expect("default State must decode");
+        assert_eq!(decoded.multi_chain.chain_supplies.len(), 0);
+    }
+
+    #[test]
+    fn populated_multi_chain_survives_round_trip() {
+        // The guard the audit asked for: a populated `multi_chain` sub-tree (a
+        // foreign-chain vault + its supply) must survive the exact ciborium
+        // encode/decode the upgrade path uses, so a future `State` field that
+        // breaks CBOR decode fails HERE in CI rather than wiping vaults on a
+        // live upgrade.
+        let mut state = crate::state::State::default();
+        let chain = ChainId(10143);
+        state.multi_chain.chain_supplies.insert(chain, 5_000_000_000);
+        state.multi_chain.chain_vaults.insert(
+            1,
+            ChainVaultV1 {
+                vault_id: 1,
+                owner: Principal::anonymous(),
+                collateral_chain: chain,
+                custody_address: "0xabc0000000000000000000000000000000000001".into(),
+                collateral_amount_native: 1_000_000_000_000_000_000,
+                debt_e8s: 5_000_000_000,
+                mint_recipient: "0xabc0000000000000000000000000000000000002".into(),
+                pending_mint_e8s: 0,
+                status: ChainVaultStatus::Open,
+                opened_at_ns: 42,
+            },
+        );
+
+        let bytes = encode_state(&state);
+        let decoded = decode_state_body(&bytes).expect("populated State must decode");
+
+        assert_eq!(
+            decoded.multi_chain.chain_supplies.get(&chain),
+            Some(&5_000_000_000)
+        );
+        let v = decoded
+            .multi_chain
+            .chain_vaults
+            .get(&1)
+            .expect("vault survives round-trip");
+        assert_eq!(v.debt_e8s, 5_000_000_000);
+        assert_eq!(v.status, ChainVaultStatus::Open);
+        // The whole-State invariant the trap protects: chain supply == vault debt.
+        assert_eq!(
+            decoded.multi_chain.total_supply_all_chains_e8s(),
+            decoded.multi_chain.total_chain_vault_debt_e8s()
+        );
+    }
+
+    #[test]
+    fn corrupt_bytes_are_rejected_not_silently_wiped() {
+        // The real path turns this Err into a trap, never a silent replay/wipe.
+        assert!(
+            decode_state_body(b"\xff\x00not-a-valid-state-snapshot\xde\xad").is_err(),
+            "corrupt bytes must fail to decode"
+        );
+    }
+
+    #[test]
+    fn truncated_snapshot_is_rejected() {
+        let bytes = encode_state(&crate::state::State::default());
+        let truncated = &bytes[..bytes.len() / 2];
+        assert!(
+            decode_state_body(truncated).is_err(),
+            "a truncated snapshot must fail to decode (not silently wipe)"
+        );
     }
 }


### PR DESCRIPTION
## Cross-chain (Solana + Monad) security audit remediation

First dedicated security audit of the cross-chain integration (`src/chains/`), run via the `audit-icp-cdp` harness (8 specialist sub-agents + manual verification) at commit `b8c772f`. This PR lands the 15 mechanically-fixable findings.

### Verification
- Lib unit suite: **347 pass**, 0 fail
- Candid `.did` regenerated, compatibility test green
- **Entire chains PocketIC suite green on a fresh wasm** (11 Monad + Solana test files)
- No new compiler warnings

### Fixed (15)
**Correctness / safety**
- State-wipe defense: `load_state_from_stable` traps on a present-but-undecodable snapshot instead of silently replaying (which wipes `multi_chain`). Touches the canister-wide `post_upgrade` path.
- Deposit-finality gate: Monad mint will not broadcast until the deposit is final at the cursor (detection stays at the tip; fail-closed).
- Mint-confirm verifies the on-chain recipient.
- Multi-provider RPC quorum for reads; first-Ok broadcast for the send write.
- Supply-divergence alarm + `reconcile_chain_supply` endpoint.
- Solana `confirm_succeeded` CAS guard.

**Recovery / hardening**
- `recover_stuck_chain_vault`, `resolve_stuck_settlement_op` (dev-gated).
- `clear_invariant_halt` re-verify; EVM finality-depth floor; manual-price/decimals validation; `submit_burn_proof` anonymous rejection; concurrency-invariant comments.

### Deferred (design / feature decisions, see audit report)
Custody-to-settlement sweep, foreign-collateral oracle + liquidation, bounded idempotency set, withdrawal request-id, feature-gating the test signer, Solana on-chain amount decode.

### Notes
- `submit_burn_proof` per-caller rate-limit was tried and reverted (it throttled legitimate back-to-back submissions and is weak vs principal rotation; proper DoS protection is folded into the deferred relayer design).
- Frontend declarations (`src/declarations/`) need `dfx generate` before any frontend deploy (3 new dev-only endpoints).
- The `post_upgrade` change warrants a careful review before the next mainnet deploy; the pre-deploy hook reruns the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
