### PR TITLE
fix(security): backend HIGH hardening pass — close the 6 remaining audit findings

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -861,6 +861,7 @@ type SuccessWithFee = record {
   block_index : nat64;
   fee_amount_paid : nat64;
   collateral_amount_received : opt nat64;
+  debt_liquidated_e8s : opt nat64;
 };
 type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
 type SupplyAuditEntry = record {

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -270,6 +270,13 @@ pub struct SuccessWithFee {
     /// proportional share of the actual collateral received, rather than only
     /// the liquidator bonus (`fee_amount_paid`).
     pub collateral_amount_received: Option<u64>,
+    /// SP-101: the icUSD-denominated debt the backend ACTUALLY cleared (in e8s).
+    /// The partial-liquidation paths cap the requested draw to the vault's
+    /// `max_liquidatable_debt`; the stability pool must debit depositors by this
+    /// realized amount, not the (possibly larger) amount it requested, or the
+    /// tracked aggregate drifts above the pool's real balance. `None` on the
+    /// non-liquidation paths (redeem / borrow). Optional for Candid back-compat.
+    pub debt_liquidated_e8s: Option<u64>,
 }
 
 /// Result from stability pool liquidation (both standard and debt-already-burned paths).

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -3365,6 +3365,10 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 #[update]
 async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> {
     let caller = ic_cdk::caller();
+    // ASYNC-003: serialize per-caller so two concurrent manual recoveries cannot
+    // both pay out the same pending entry (the entry is only removed AFTER the
+    // await below). Defense-in-depth on top of the nonce-dedup fix.
+    let _guard = rumi_protocol_backend::guard::GuardPrincipal::new(caller, "recover_pending_transfer")?;
 
     // Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are
     // keyed by (vault_id, owner). Look up the entry that belongs to the caller.
@@ -3399,10 +3403,16 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
             ));
         }
 
-        let result = management::transfer_collateral(
+        // ASYNC-003: pay with the entry's PERSISTED op_nonce (not a fresh one) so
+        // this manual recovery shares the ledger dedup tuple (created_at_time +
+        // memo) with process_pending_transfer's timer retry. transfer_idempotent
+        // converts the ledger's Duplicate response to Ok, so a concurrent timer
+        // retry and this manual recovery can never double-pay the owner.
+        let result = management::transfer_collateral_with_nonce(
             (transfer.margin - transfer_fee).to_u64(),
             transfer.owner,
             ledger,
+            transfer.op_nonce,
         ).await;
 
         match result {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -155,6 +155,20 @@ async fn validate_freshness_for_vault(vault_id: u64) -> Result<(), ProtocolError
     }
 }
 
+/// Audit ORACLE-001: refresh a collateral's cached price before a debt-increasing
+/// or collateral-decreasing op whose collateral is given directly (the open-*
+/// endpoints). `None` means ICP (the default collateral). `ensure_fresh_price_for`
+/// delegates to `ensure_fresh_price` for ICP, so this is safe to call
+/// unconditionally and mirrors `validate_freshness_for_vault` for the
+/// by-vault-id endpoints. Without it, a non-ICP collateral whose background
+/// fetch has been failing would let the borrower mint against a stale price.
+async fn validate_freshness_for_collateral(
+    collateral_type: Option<Principal>,
+) -> Result<(), ProtocolError> {
+    let ct = collateral_type.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
+    rumi_protocol_backend::xrc::ensure_fresh_price_for(&ct).await
+}
+
 /// Pre-filter to reduce cycle waste from anonymous spam.
 /// Runs on ONE replica without consensus. Can be bypassed by malicious nodes.
 /// NOT a security boundary — all real access control is inside each #[update] method.
@@ -2559,6 +2573,8 @@ async fn open_vault_and_borrow(
 ) -> Result<OpenVaultSuccess, ProtocolError> {
     validate_call().await?;
     validate_mode()?;
+    // ORACLE-001: refresh the (possibly non-ICP) collateral price before minting.
+    validate_freshness_for_collateral(collateral_type).await?;
     check_postcondition(
         rumi_protocol_backend::vault::open_vault_and_borrow(collateral_amount, borrow_amount, collateral_type).await,
     )
@@ -2569,6 +2585,8 @@ async fn open_vault_and_borrow(
 async fn borrow_from_vault(arg: VaultArg) -> Result<SuccessWithFee, ProtocolError> {
     validate_call().await?;
     validate_mode()?;
+    // ORACLE-001: refresh this vault's collateral price before minting more debt.
+    validate_freshness_for_vault(arg.vault_id).await?;
     check_postcondition(rumi_protocol_backend::vault::borrow_from_vault(arg).await)
 }
 
@@ -2612,6 +2630,8 @@ fn get_deposit_account(_collateral_type: Option<Principal>) -> icrc_ledger_types
 async fn open_vault_with_deposit(borrow_amount: u64, collateral_type: Option<Principal>) -> Result<OpenVaultSuccess, ProtocolError> {
     validate_call().await?;
     validate_mode()?;
+    // ORACLE-001: refresh the (possibly non-ICP) collateral price before minting.
+    validate_freshness_for_collateral(collateral_type).await?;
     check_postcondition(rumi_protocol_backend::vault::open_vault_with_deposit(borrow_amount, collateral_type).await)
 }
 
@@ -2636,6 +2656,8 @@ async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
 #[update]
 async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
     validate_call().await?;
+    // ORACLE-001: refresh this vault's collateral price before releasing collateral.
+    validate_freshness_for_vault(vault_id).await?;
     check_postcondition(rumi_protocol_backend::vault::withdraw_collateral(vault_id).await)
 }
 
@@ -2643,6 +2665,8 @@ async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
 #[update]
 async fn withdraw_partial_collateral(arg: rumi_protocol_backend::vault::VaultArg) -> Result<u64, ProtocolError> {
     validate_call().await?;
+    // ORACLE-001: refresh this vault's collateral price before releasing collateral.
+    validate_freshness_for_vault(arg.vault_id).await?;
     check_postcondition(rumi_protocol_backend::vault::withdraw_partial_collateral(arg.vault_id, arg.amount).await)
 }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3744,11 +3744,17 @@ impl State {
     /// Liquidate a vault. Returns the interest share of the debt reduction
     /// so callers can route it to treasury.
     pub fn liquidate_vault(&mut self, vault_id: u64, mode: Mode, collateral_price: UsdIcp) -> ICUSD {
-        let vault = self
-            .vault_id_to_vaults
-            .get(&vault_id)
-            .cloned()
-            .expect("bug: vault not found");
+        // ASYNC-002 defense-in-depth: never trap on a missing vault. The
+        // vault-level `vault::liquidate_vault` now presence-checks and refunds
+        // the liquidator before reaching here, but a concurrent liquidation
+        // could still have removed the vault on any path into this function.
+        // No vault means nothing to liquidate, so return a zero interest share
+        // instead of `.expect`-panicking (which, on the live liquidation path,
+        // would be a trap-after-icUSD-transfer).
+        let vault = match self.vault_id_to_vaults.get(&vault_id).cloned() {
+            Some(v) => v,
+            None => return ICUSD::new(0),
+        };
 
         let ct = vault.collateral_type;
         let vault_collateral_ratio = compute_collateral_ratio(&vault, collateral_price, self);

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -3289,8 +3289,15 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         }
     };
 
-    // Step 4: Update protocol state ATOMICALLY (this is the critical section)
-    let interest_share = mutate_state(|s| {
+    // Step 4: Update protocol state ATOMICALLY (this is the critical section).
+    // ASYNC-002: a concurrent full liquidation may have removed this vault between
+    // our pre-await read and the icUSD pull above. Detect it BEFORE any
+    // irreversible state work and refund the liquidator (None branch below)
+    // instead of trapping inside s.liquidate_vault()'s vault lookup.
+    let interest_share = match mutate_state(|s| {
+        if !s.vault_id_to_vaults.contains_key(&vault_id) {
+            return None;
+        }
         // Execute the liquidation in state first (this must happen)
         // liquidate_vault returns the interest share of the debt reduction
         let interest_share = s.liquidate_vault(vault_id, mode, collateral_price_usd);
@@ -3373,8 +3380,51 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
 
         log!(INFO, "[liquidate_vault] Protocol state updated, {} pending transfers created",
              if !is_recovery_partial && excess_collateral > ICP::new(0) { 2 } else { 1 });
-        interest_share
-    });
+        Some(interest_share)
+    }) {
+        Some(share) => share,
+        None => {
+            // ASYNC-002: the vault was liquidated by a concurrent op while our
+            // icUSD pull was in flight. Refund the liquidator (mirrors the
+            // redeem_reserves durable-refund saga) and return a clean error
+            // instead of trapping with the liquidator's icUSD stuck.
+            guard_principal.fail();
+            log!(INFO,
+                "[liquidate_vault] Vault #{} already liquidated by a concurrent op; refunding {} icUSD to {}",
+                vault_id, debt_amount.to_u64(), caller);
+            let refund_nonce = mutate_state(|s| s.next_op_nonce());
+            match management::transfer_icusd_with_nonce(debt_amount, caller, refund_nonce).await {
+                Ok(refund_block) => {
+                    log!(INFO, "[liquidate_vault] Refunded {} icUSD to {} (block {})",
+                        debt_amount.to_u64(), caller, refund_block);
+                }
+                Err(refund_err) => {
+                    log!(INFO,
+                        "[liquidate_vault] Vault gone AND inline icUSD refund failed for {}: {:?}. \
+                         Enqueueing durable refund (block {}).",
+                        caller, refund_err, icusd_block_index);
+                    mutate_state(|s| {
+                        s.pending_refunds.insert(
+                            icusd_block_index,
+                            crate::state::PendingRefund {
+                                user: caller,
+                                amount_e8s: debt_amount.to_u64(),
+                                retry_count: 0,
+                                op_nonce: refund_nonce,
+                            },
+                        );
+                    });
+                    ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), || {
+                        ic_cdk::spawn(crate::process_pending_transfer())
+                    });
+                }
+            }
+            return Err(ProtocolError::GenericError(format!(
+                "Vault #{} was already liquidated by a concurrent operation; your {} icUSD has been refunded",
+                vault_id, debt_amount.to_u64()
+            )));
+        }
+    };
 
     // Route interest share via N-way split
     crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -172,6 +172,20 @@ pub fn require_vault_not_processing(vault: &Vault) -> Result<(), ProtocolError> 
     }
 }
 
+/// LIQ-101: vault-id wrapper around `require_vault_not_processing` for the
+/// liquidation entry points (manual + SP), which only fetch the vault later in
+/// their amount-computing read_state. If the liquidation bot has already
+/// claimed this vault (`bot_processing` set, with the write-down deferred until
+/// the bot's swap settles), a manual / stability-pool liquidation here would
+/// seize the same collateral a second time. Mirrors the lock every user op
+/// already honors. Absent vault => Ok (a later check surfaces "not found").
+pub fn reject_if_bot_processing(vault_id: u64) -> Result<(), ProtocolError> {
+    match read_state(|s| s.vault_id_to_vaults.get(&vault_id).cloned()) {
+        Some(vault) => require_vault_not_processing(&vault),
+        None => Ok(()),
+    }
+}
+
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct CandidVault {
     pub owner: Principal,
@@ -2223,6 +2237,7 @@ pub async fn repay_and_close_vault(arg: VaultArg) -> Result<RepayAndCloseSuccess
 pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_partial_{}", vault_id))?;
+    reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18. The per-vault CR
     // check below remains the authoritative liquidatability test. See
@@ -2506,6 +2521,7 @@ pub async fn liquidate_vault_partial_with_stable(
 ) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_stable_{}", vault_id))?;
+    reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).
@@ -2856,6 +2872,7 @@ pub async fn liquidate_vault_debt_already_burned(
     }
 
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_debt_burned_{}", vault_id))?;
+    reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault (SP path)
 
     let liquidation_amount: ICUSD = icusd_burned_e8s.into();
 
@@ -3214,6 +3231,7 @@ pub async fn liquidate_vault_debt_already_burned(
 pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_{}", vault_id))?;
+    reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).
@@ -3698,6 +3716,7 @@ pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError>
 pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("partial_liquidate_vault_{}", arg.vault_id))?;
+    reject_if_bot_processing(arg.vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -2349,9 +2349,17 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         // Reduce vault debt and collateral directly
         // Vault loses total_to_seize (liquidator + protocol cut)
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
-            vault.borrowed_icusd_amount -= max_liquidatable_debt;
-            vault.collateral_amount -= total_to_seize.to_u64();
-            vault.accrued_interest -= interest_share;
+            // ASYNC-001: cap each reduction to the CURRENT vault state and
+            // saturating_sub. A concurrent partial liquidation may have reduced
+            // this vault between our pre-await read and now; without the cap the
+            // ICUSD Token::sub would underflow-PANIC and the raw u64 collateral
+            // sub would WRAP, both after the liquidator's icUSD was already pulled.
+            let debt_applied = max_liquidatable_debt.min(vault.borrowed_icusd_amount);
+            let collateral_applied = total_to_seize.to_u64().min(vault.collateral_amount);
+            let interest_applied = interest_share.min(vault.accrued_interest);
+            vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(debt_applied);
+            vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_applied);
+            vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_applied);
         }
 
         // Wave-10 LIQ-008: append the gross debt cleared to the rolling-
@@ -2643,9 +2651,17 @@ pub async fn liquidate_vault_partial_with_stable(
         // Reduce vault debt and collateral directly
         // Vault loses total_to_seize (liquidator + protocol cut)
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
-            vault.borrowed_icusd_amount -= max_liquidatable_debt;
-            vault.collateral_amount -= total_to_seize.to_u64();
-            vault.accrued_interest -= interest_share;
+            // ASYNC-001: cap each reduction to the CURRENT vault state and
+            // saturating_sub. A concurrent partial liquidation may have reduced
+            // this vault between our pre-await read and now; without the cap the
+            // ICUSD Token::sub would underflow-PANIC and the raw u64 collateral
+            // sub would WRAP, both after the liquidator's icUSD was already pulled.
+            let debt_applied = max_liquidatable_debt.min(vault.borrowed_icusd_amount);
+            let collateral_applied = total_to_seize.to_u64().min(vault.collateral_amount);
+            let interest_applied = interest_share.min(vault.accrued_interest);
+            vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(debt_applied);
+            vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_applied);
+            vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_applied);
         }
 
         // Wave-10 LIQ-008: append the gross debt cleared to the rolling-
@@ -3032,9 +3048,17 @@ pub async fn liquidate_vault_debt_already_burned(
         } else { ICUSD::new(0) };
 
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
-            vault.borrowed_icusd_amount -= max_liquidatable_debt;
-            vault.collateral_amount -= total_to_seize.to_u64();
-            vault.accrued_interest -= interest_share;
+            // ASYNC-001: cap each reduction to the CURRENT vault state and
+            // saturating_sub. A concurrent partial liquidation may have reduced
+            // this vault between our pre-await read and now; without the cap the
+            // ICUSD Token::sub would underflow-PANIC and the raw u64 collateral
+            // sub would WRAP, both after the liquidator's icUSD was already pulled.
+            let debt_applied = max_liquidatable_debt.min(vault.borrowed_icusd_amount);
+            let collateral_applied = total_to_seize.to_u64().min(vault.collateral_amount);
+            let interest_applied = interest_share.min(vault.accrued_interest);
+            vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(debt_applied);
+            vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_applied);
+            vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_applied);
         }
 
         // Wave-10 LIQ-008: append the gross debt cleared to the rolling-
@@ -3804,9 +3828,14 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         // Reduce the vault's debt by the liquidator payment amount
         // Vault loses total_to_seize (liquidator + protocol cut)
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&arg.vault_id) {
-            vault.borrowed_icusd_amount -= liquidator_payment;
-            vault.collateral_amount -= total_to_seize.to_u64();
-            vault.accrued_interest -= interest_share;
+            // ASYNC-001: cap each reduction to the CURRENT vault state and
+            // saturating_sub (same race as the other partial-liq paths).
+            let debt_applied = liquidator_payment.min(vault.borrowed_icusd_amount);
+            let collateral_applied = total_to_seize.to_u64().min(vault.collateral_amount);
+            let interest_applied = interest_share.min(vault.accrued_interest);
+            vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(debt_applied);
+            vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_applied);
+            vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_applied);
         }
 
         // Wave-10 LIQ-008: append the gross debt cleared to the rolling-

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -581,6 +581,7 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
                 block_index,
                 fee_amount_paid: fee_amount.to_u64(),
                 collateral_amount_received: None,
+                debt_liquidated_e8s: None, // SP-101
             })
         }
         Err(transfer_from_error) => Err(ProtocolError::TransferFromError(
@@ -978,6 +979,7 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
                 block_index,
                 fee_amount_paid: fee.to_u64(),
                 collateral_amount_received: None,
+                debt_liquidated_e8s: None, // SP-101
             })
         }
         Err(mint_error) => {
@@ -2510,6 +2512,7 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         block_index: icusd_block_index,
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
+        debt_liquidated_e8s: Some(max_liquidatable_debt.to_u64()), // SP-101
     })
 }
 
@@ -2828,6 +2831,7 @@ pub async fn liquidate_vault_partial_with_stable(
         block_index: stable_block_index,
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
+        debt_liquidated_e8s: Some(max_liquidatable_debt.to_u64()), // SP-101
     })
 }
 
@@ -3519,6 +3523,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         block_index: icusd_block_index,
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
+        debt_liquidated_e8s: None, // SP-101
     })
 }
 
@@ -3970,5 +3975,6 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         block_index: icusd_block_index,
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
+        debt_liquidated_e8s: None, // SP-101
     })
 }

--- a/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
@@ -319,3 +319,24 @@ fn async_002_liquidate_vault_presence_checks_and_does_not_trap() {
         vl_body
     );
 }
+
+// ── ASYNC-001 structural fence: the partial-liquidation paths must re-cap to the
+//    current vault state and saturating_sub, never raw -= the pre-await amount. ──
+#[test]
+fn async_001_partial_liq_uses_saturating_recap_not_raw_sub() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let vault_rs = std::fs::read_to_string(root.join("src/vault.rs")).unwrap();
+    assert!(
+        !vault_rs.contains("borrowed_icusd_amount -= max_liquidatable_debt")
+            && !vault_rs.contains("borrowed_icusd_amount -= liquidator_payment"),
+        "partial-liquidation paths must not subtract the pre-await liquidation amount with a raw \
+         -= (ICUSD Token::sub panics on underflow / raw u64 collateral wraps); re-cap to the \
+         current vault state and saturating_sub (audit ASYNC-001)."
+    );
+    assert!(
+        vault_rs.contains("max_liquidatable_debt.min(vault.borrowed_icusd_amount)")
+            && vault_rs.contains("vault.collateral_amount.saturating_sub"),
+        "partial-liquidation paths must re-cap to the current vault state with .min(..) and use \
+         saturating_sub (audit ASYNC-001)."
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
@@ -274,3 +274,48 @@ fn async_003_recover_pending_transfer_reuses_persisted_nonce_and_guards() {
         body
     );
 }
+
+// ── ASYNC-002 structural fence: State::liquidate_vault must not .expect-trap on
+//    a missing vault, and vault::liquidate_vault must presence-check + refund on
+//    the concurrent-liquidation race. ──
+#[test]
+fn async_002_liquidate_vault_presence_checks_and_does_not_trap() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let state_rs = std::fs::read_to_string(root.join("src/state.rs")).unwrap();
+    let vault_rs = std::fs::read_to_string(root.join("src/vault.rs")).unwrap();
+
+    // State::liquidate_vault must not trap on a missing vault.
+    let sl_hdr = "pub fn liquidate_vault(";
+    let sl_start = state_rs.find(sl_hdr).expect("State::liquidate_vault not found");
+    let sl_after = sl_start + sl_hdr.len();
+    let sl_end = ["\n    pub fn ", "\n    fn ", "\n    pub async fn ", "\n    async fn "]
+        .iter()
+        .filter_map(|m| state_rs[sl_after..].find(m).map(|i| sl_after + i))
+        .min()
+        .unwrap_or(state_rs.len());
+    let sl_body = &state_rs[sl_start..sl_end];
+    assert!(
+        !sl_body.contains(".expect(\"bug: vault not found\")"),
+        "State::liquidate_vault must not .expect-trap on a missing vault (audit ASYNC-002); \
+         on the live path that is a trap-after-icUSD-transfer. Return ICUSD::new(0) instead.\n\n{}",
+        sl_body
+    );
+
+    // vault::liquidate_vault must presence-check inside the critical section and
+    // refund the liquidator's icUSD if a concurrent op already removed the vault.
+    let vl_hdr = "pub async fn liquidate_vault(";
+    let vl_start = vault_rs.find(vl_hdr).expect("vault::liquidate_vault not found");
+    let vl_after = vl_start + vl_hdr.len();
+    let vl_end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "]
+        .iter()
+        .filter_map(|m| vault_rs[vl_after..].find(m).map(|i| vl_after + i))
+        .min()
+        .unwrap_or(vault_rs.len());
+    let vl_body = &vault_rs[vl_start..vl_end];
+    assert!(
+        vl_body.contains("contains_key(&vault_id)") && vl_body.contains("transfer_icusd_with_nonce"),
+        "vault::liquidate_vault must presence-check the vault inside the critical section and \
+         refund the liquidator's icUSD on the concurrent-liquidation race (audit ASYNC-002).\n\n{}",
+        vl_body
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_async_001_005_liquidation_race.rs
@@ -242,3 +242,35 @@ fn liquidator_a() -> Principal {
 fn liquidator_b() -> Principal {
     Principal::from_slice(&[2])
 }
+
+// ── ASYNC-003 structural fence: recover_pending_transfer must pay with the
+//    entry's PERSISTED op_nonce (ledger dedup vs the timer retry) and hold a
+//    per-caller guard. FAILS on pre-fix main, PASSES post-fix. ──
+#[test]
+fn async_003_recover_pending_transfer_reuses_persisted_nonce_and_guards() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    let m = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    let hdr = "async fn recover_pending_transfer(";
+    let start = m.find(hdr).expect("recover_pending_transfer not found in main.rs");
+    let after = start + hdr.len();
+    let end = ["\nasync fn ", "\nfn ", "\npub async fn "]
+        .iter()
+        .filter_map(|mk| m[after..].find(mk).map(|i| after + i))
+        .min()
+        .unwrap_or(m.len());
+    let body = &m[start..end];
+    assert!(
+        body.contains("transfer_collateral_with_nonce") && body.contains("op_nonce"),
+        "recover_pending_transfer must pay via transfer_collateral_with_nonce(.., transfer.op_nonce) \
+         so it shares the ledger dedup tuple with process_pending_transfer's timer retry (audit \
+         ASYNC-003); a fresh-nonce transfer_collateral double-pays.\n\n{}",
+        body
+    );
+    assert!(
+        body.contains("GuardPrincipal"),
+        "recover_pending_transfer must hold a GuardPrincipal(caller) so two concurrent manual \
+         recoveries cannot both pay the same entry (audit ASYNC-003).\n\n{}",
+        body
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_liq_101_bot_lock.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_liq_101_bot_lock.rs
@@ -1,0 +1,53 @@
+//! LIQ-101 (audit 2026-06-03-0c3ceb4): every liquidation entry point must honor
+//! the `bot_processing` lock.
+//!
+//! `bot_claim_liquidation` sets `vault.bot_processing` and DEFERS the debt/
+//! collateral write-down until the bot's swap settles. Every user op already
+//! calls `require_vault_not_processing(&vault)?`, but the manual and
+//! stability-pool liquidation paths did not. A manual / SP liquidation against a
+//! bot-claimed vault would seize the same collateral a second time (the recorded
+//! collateral still reflects the pre-claim balance), double-seizing from the
+//! shared pool.
+//!
+//! The fix adds `reject_if_bot_processing(vault_id)?` (a vault-id wrapper around
+//! `require_vault_not_processing`) immediately after the guard in every
+//! liquidation entry, before any icUSD pull or state mutation. This fence reads
+//! `src/vault.rs` and asserts each entry calls it; it FAILS on pre-fix code.
+
+use std::path::PathBuf;
+
+fn vault_fn_body<'a>(src: &'a str, header: &str) -> &'a str {
+    let start = src
+        .find(header)
+        .unwrap_or_else(|| panic!("`{}` not found in vault.rs", header));
+    let after = start + header.len();
+    let end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "]
+        .iter()
+        .filter_map(|m| src[after..].find(m).map(|i| after + i))
+        .min()
+        .unwrap_or(src.len());
+    &src[start..end]
+}
+
+#[test]
+fn liq_101_all_liquidation_entries_reject_bot_processing() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/vault.rs");
+    let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+
+    for header in [
+        "pub async fn liquidate_vault_partial(",
+        "pub async fn liquidate_vault_partial_with_stable(",
+        "pub async fn liquidate_vault_debt_already_burned(",
+        "pub async fn liquidate_vault(",
+        "pub async fn partial_liquidate_vault(",
+    ] {
+        let body = vault_fn_body(&src, header);
+        assert!(
+            body.contains("reject_if_bot_processing"),
+            "liquidation entry `{}` must call reject_if_bot_processing(..)? after its guard so it \
+             cannot double-seize a vault the bot has already claimed (audit LIQ-101).\n\n{}",
+            header, body
+        );
+    }
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_oracle_001_mint_withdraw_freshness.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_oracle_001_mint_withdraw_freshness.rs
@@ -1,0 +1,119 @@
+//! ORACLE-001 (audit 2026-06-03-0c3ceb4): mint/withdraw must gate on a fresh
+//! per-collateral price.
+//!
+//! Audit pass:
+//!   `audit-reports/2026-06-03-0c3ceb4/raw-pass-results/01-oracle-cr-mint.json`
+//!   finding ORACLE-001.
+//!
+//! # The bug
+//!
+//! `validate_call()` only refreshes the ICP price. The prior audit (RED-001 /
+//! LIQ-006) retrofitted a per-collateral freshness gate
+//! (`xrc::ensure_fresh_price_for`) onto the redemption and liquidation paths,
+//! but the debt-increasing / collateral-decreasing endpoints were never
+//! updated. So for a non-ICP collateral whose background price fetch has been
+//! failing, a borrower could mint icUSD (or withdraw collateral) priced against
+//! an arbitrarily stale `last_price` — over-minting against a feed that has
+//! since crashed.
+//!
+//! # The fix these fences pin
+//!
+//! Every such endpoint must refresh the relevant collateral price first:
+//!   * by-vault-id endpoints (`borrow_from_vault`, `withdraw_collateral`,
+//!     `withdraw_partial_collateral`) use `validate_freshness_for_vault`;
+//!   * the open-* endpoints (`open_vault_and_borrow`, `open_vault_with_deposit`)
+//!     take the collateral directly, so they use
+//!     `validate_freshness_for_collateral`.
+//!
+//! Both helpers ultimately call `xrc::ensure_fresh_price_for`. The structural
+//! fences below read `src/main.rs` and assert each endpoint body invokes a
+//! freshness gate; they FAIL on pre-fix main and PASS post-fix.
+
+use std::path::PathBuf;
+
+fn read_main_rs() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+/// Slice a free `async fn` body from its declaration to the next top-level item.
+fn fn_body<'a>(source: &'a str, fn_name: &str) -> &'a str {
+    let header = format!("async fn {}(", fn_name);
+    let start = source
+        .find(&header)
+        .unwrap_or_else(|| panic!("function `{}` not found in main.rs", fn_name));
+    let after = start + header.len();
+    let end = ["\nasync fn ", "\nfn ", "\npub async fn ", "\npub fn "]
+        .iter()
+        .filter_map(|m| source[after..].find(m).map(|i| after + i))
+        .min()
+        .unwrap_or(source.len());
+    &source[start..end]
+}
+
+/// A freshness gate is any of the per-collateral refresh helpers.
+fn gates_freshness(body: &str) -> bool {
+    body.contains("validate_freshness_for_vault")
+        || body.contains("validate_freshness_for_collateral")
+        || body.contains("ensure_fresh_price_for")
+}
+
+#[test]
+fn oracle_001_borrow_from_vault_gates_freshness() {
+    let m = read_main_rs();
+    let body = fn_body(&m, "borrow_from_vault");
+    assert!(
+        gates_freshness(body),
+        "borrow_from_vault must refresh the vault collateral price before minting \
+         (audit ORACLE-001). Use validate_freshness_for_vault(arg.vault_id).await?.\n\n{}",
+        body
+    );
+}
+
+#[test]
+fn oracle_001_open_vault_and_borrow_gates_freshness() {
+    let m = read_main_rs();
+    let body = fn_body(&m, "open_vault_and_borrow");
+    assert!(
+        gates_freshness(body),
+        "open_vault_and_borrow must refresh the collateral price before minting \
+         (audit ORACLE-001).\n\n{}",
+        body
+    );
+}
+
+#[test]
+fn oracle_001_open_vault_with_deposit_gates_freshness() {
+    let m = read_main_rs();
+    let body = fn_body(&m, "open_vault_with_deposit");
+    assert!(
+        gates_freshness(body),
+        "open_vault_with_deposit must refresh the collateral price before minting \
+         (audit ORACLE-001).\n\n{}",
+        body
+    );
+}
+
+#[test]
+fn oracle_001_withdraw_collateral_gates_freshness() {
+    let m = read_main_rs();
+    let body = fn_body(&m, "withdraw_collateral");
+    assert!(
+        gates_freshness(body),
+        "withdraw_collateral must refresh the vault collateral price before \
+         releasing collateral (audit ORACLE-001).\n\n{}",
+        body
+    );
+}
+
+#[test]
+fn oracle_001_withdraw_partial_collateral_gates_freshness() {
+    let m = read_main_rs();
+    let body = fn_body(&m, "withdraw_partial_collateral");
+    assert!(
+        gates_freshness(body),
+        "withdraw_partial_collateral must refresh the vault collateral price \
+         before releasing collateral (audit ORACLE-001).\n\n{}",
+        body
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_sp_101_realized_consumed.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_sp_101_realized_consumed.rs
@@ -1,0 +1,59 @@
+//! SP-101 (audit 2026-06-03-0c3ceb4): the stability pool must debit depositors
+//! by the debt the backend ACTUALLY cleared, not the amount it requested.
+//!
+//! The partial-liquidation backend paths cap the requested draw to the vault's
+//! `max_liquidatable_debt`. The SP, however, recorded `actual_consumed = *amount`
+//! (the requested draw) and `process_liquidation_gains` debited depositors by
+//! that, so on a shallowly-underwater vault the tracked SP aggregate fell by
+//! more than the pool actually spent (permanent depositor value destruction,
+//! worst on the permissionless `execute_liquidation` path).
+//!
+//! Fix: the backend reports the realized debt via a new
+//! `SuccessWithFee.debt_liquidated_e8s`, and the SP debits by it (converting the
+//! icUSD e8s amount to the drawn token's native units for the stable path).
+//!
+//! These fences read both crates' source. NOTE: end-to-end validation (liquidate
+//! a shallow vault and assert the SP aggregate drop == backend cap, and that
+//! icrc1_balance_of(pool) == the tracked aggregate) wants a two-canister PocketIC
+//! test; that is recommended before the (gated) coordinated backend+SP deploy.
+
+use std::path::PathBuf;
+
+#[test]
+fn sp_101_backend_reports_realized_debt() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lib = std::fs::read_to_string(root.join("src/lib.rs")).unwrap();
+    assert!(
+        lib.contains("debt_liquidated_e8s: Option<u64>"),
+        "SuccessWithFee must carry debt_liquidated_e8s: Option<u64> so the SP can debit the \
+         realized amount (audit SP-101)."
+    );
+    let vault = std::fs::read_to_string(root.join("src/vault.rs")).unwrap();
+    let populated = vault
+        .matches("debt_liquidated_e8s: Some(max_liquidatable_debt")
+        .count();
+    assert!(
+        populated >= 2,
+        "the SP-called partial-liquidation paths (liquidate_vault_partial and \
+         liquidate_vault_partial_with_stable) must set debt_liquidated_e8s = \
+         Some(max_liquidatable_debt) (audit SP-101); found {}",
+        populated
+    );
+}
+
+#[test]
+fn sp_101_stability_pool_debits_realized_not_requested() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let sp = std::fs::read_to_string(root.join("../stability_pool/src/liquidation.rs"))
+        .expect("read stability_pool/src/liquidation.rs");
+    assert!(
+        sp.contains("success.debt_liquidated_e8s"),
+        "the SP icUSD/stable liquidation path must debit by success.debt_liquidated_e8s (the \
+         backend's realized, capped amount), not the requested draw (audit SP-101)."
+    );
+    assert!(
+        sp.contains("denormalize_from_e8s"),
+        "the SP must convert the realized icUSD e8s debt to the drawn token's native units for \
+         the non-icUSD (ckUSDT/ckUSDC) path (audit SP-101)."
+    );
+}

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -254,9 +254,20 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 let collateral = success.collateral_amount_received.unwrap_or(success.fee_amount_paid);
                 log!(INFO, "Liquidation succeeded for vault {} with token {}: collateral={}, fee={}",
                     vault_info.vault_id, token_ledger, collateral, success.fee_amount_paid);
-                // Record the consumption; `process_liquidation_gains` will debit
-                // depositor balances exactly once, after this loop.
-                actual_consumed.insert(*token_ledger, *amount);
+                // SP-101: debit by the REALIZED debt the backend actually cleared
+                // (it caps the requested draw to the vault's max_liquidatable_debt),
+                // not the amount we requested, so the tracked aggregate never falls
+                // by more than the pool truly spent. debt_liquidated_e8s is icUSD
+                // e8s; convert to the drawn token's native units on the non-icUSD
+                // path. Falls back to the requested amount if an older backend wasm
+                // does not report it. `process_liquidation_gains` debits depositor
+                // balances exactly once, after this loop.
+                let realized_consumed = match success.debt_liquidated_e8s {
+                    Some(debt_e8) if is_icusd => debt_e8,
+                    Some(debt_e8) => crate::types::denormalize_from_e8s(debt_e8, token_decimals),
+                    None => *amount,
+                };
+                actual_consumed.insert(*token_ledger, realized_consumed);
                 total_collateral_gained += collateral;
                 // Bug 7: one token per vault per round — vault state changed, remaining draws are stale
                 break;

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -143,6 +143,18 @@ pub fn normalize_to_e8s(amount: u64, decimals: u8) -> u64 {
     }
 }
 
+/// Inverse of `normalize_to_e8s`: convert an e8s (8-decimal) amount back to a
+/// token's native decimals. SP-101 uses this to express the backend's realized
+/// icUSD-denominated debt (always e8s) in the drawn stable token's native units
+/// (e.g. ckUSDT/ckUSDC at 6 decimals).
+pub fn denormalize_from_e8s(amount_e8s: u64, decimals: u8) -> u64 {
+    match decimals.cmp(&8) {
+        std::cmp::Ordering::Equal => amount_e8s,
+        std::cmp::Ordering::Less => amount_e8s / 10u64.pow((8 - decimals) as u32),
+        std::cmp::Ordering::Greater => amount_e8s.saturating_mul(10u64.pow((decimals - 8) as u32)),
+    }
+}
+
 /// Convert a 3USD (LP token) amount to its USD value in e8s using virtual price.
 /// `virtual_price` is scaled by 1e18, LP token has 8 decimals.
 /// Result: amount_e8s = lp_amount * virtual_price / 1e18


### PR DESCRIPTION
Closes the **6 remaining HIGH findings** from the backend audit (`audit-reports/2026-06-03-0c3ceb4/`). RED-101 (the 7th) already shipped in #222. Each fix is committed separately, with a structural fence (the pattern that caught RED-101) plus the existing PoC mechanism tests.

| Finding | Fix | Tests |
|---|---|---|
| **ORACLE-001** | Mint/withdraw (`borrow_from_vault`, `open_vault_and_borrow`, `open_vault_with_deposit`, `withdraw_collateral`, `withdraw_partial_collateral`) now gate on a fresh per-collateral price via `validate_freshness_for_vault` / new `validate_freshness_for_collateral`. | 5 fences |
| **ASYNC-001** | All four partial-liq paths re-cap the reduction to the **current** vault state and `saturating_sub` (no ICUSD underflow panic / u64 collateral wrap after the icUSD pull). | fence + 3 mechanism |
| **ASYNC-002** | `vault::liquidate_vault` presence-checks inside the critical section and **refunds** the liquidator's icUSD (durable `pending_refunds` saga) if a concurrent liq won the race; `State::liquidate_vault` returns `0` instead of `.expect`-trapping. | fence + 2 mechanism |
| **ASYNC-003** | `recover_pending_transfer` pays with the entry's **persisted `op_nonce`** (`transfer_collateral_with_nonce`) so it dedups against the timer retry, and holds a per-caller guard. | fence + 2 mechanism |
| **LIQ-101** | All five liquidation entries call `reject_if_bot_processing(vault_id)?` so a manual / SP liquidation can't double-seize a bot-claimed vault. | fence |
| **SP-101** | Backend reports realized debt via `SuccessWithFee.debt_liquidated_e8s`; the stability pool debits by it (decimal-converted), not the requested draw. Cross-canister. | 2 fences |

### Verification
- backend lib **347/0**, stability_pool lib **42/0**, all audit fences green; both canisters compile.

### Important: deploy is gated and coordinated
- **Production base unconfirmed.** Production `tfesu` is an entire multi-chain release behind `main`, and the deployed commit can't be read off-chain (no embedded version, no release tag, `.did` fingerprint inconclusive). These fixes touch only core code (identical on both bases) so they cherry-pick cleanly onto the real prod base **once Rob confirms it**. Do NOT deploy `main` (would ship the gated multi-chain program).
- **SP-101 needs a coordinated `rumi_protocol_backend` + `stability_pool` deploy** (shared `SuccessWithFee` type).
- **Recommended before deploy:** PocketIC concurrency tests for ASYNC-001/002 (stalled-ledger race) and a two-canister SP-101 test (SP aggregate drop == backend cap). Noted in each commit.
- Follow-ups (not protocol-loss): ASYNC-001 over-pull refund delta; SP-101 part (2) `recommended_liquidation_amount` from the cap; ORACLE-002 hard max-age ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)