### PR TITLE
Launch deploy: rumi_points airdrop hardening + 2026-06-05 CDP security audit (cross-chain parked)

### DIFF
--- a/src/declarations/rumi_3pool/rumi_3pool.did
+++ b/src/declarations/rumi_3pool/rumi_3pool.did
@@ -47,6 +47,18 @@ type ThreePoolError = variant {
   InsufficientLpBalance : record { required : nat; available : nat };
   BurnFailed : record { token : text; reason : text };
   PoolLocked;
+  ClaimNotFound;
+};
+
+type ThreePoolPendingClaim = record {
+  id : nat64;
+  claimant : principal;
+  token_index : nat8;
+  ledger : principal;
+  symbol : text;
+  amount : nat;
+  reason : text;
+  created_at : nat64;
 };
 
 type SwapEvent = record {
@@ -118,6 +130,12 @@ type LiquidityEventV2 = record {
   pool_balances_after : vec nat;
   virtual_price_after : nat;
   migrated : bool;
+};
+
+type ForwardLiquidityEventsV2 = record {
+  events : vec record { nat64; LiquidityEventV2 };
+  next_start : nat64;
+  reached_end : bool;
 };
 
 type QuoteSwapResult = record {
@@ -476,6 +494,10 @@ service : (ThreePoolInitArgs) -> {
   get_pool_status : () -> (PoolStatus) query;
   get_lp_balance : (principal) -> (nat) query;
   get_all_lp_holders : () -> (vec record { principal; nat }) query;
+  get_lp_holders : (nat64, nat64) -> (vec record { principal; nat }) query;
+  claim_pending : (nat64) -> (variant { Ok; Err : ThreePoolError });
+  get_pending_claims : (nat64, nat64) -> (vec ThreePoolPendingClaim) query;
+  get_pending_claim_count : () -> (nat64) query;
   calc_swap : (nat8, nat8, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_add_liquidity_query : (vec nat, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_remove_liquidity_query : (nat) -> (variant { Ok : vec nat; Err : ThreePoolError }) query;
@@ -507,6 +529,7 @@ service : (ThreePoolInitArgs) -> {
   get_swap_events_v2 : (nat64, nat64) -> (vec SwapEventV2) query;
   get_swap_fees_over_window : (nat32) -> (nat) query;
   get_liquidity_events_v2 : (nat64, nat64) -> (vec LiquidityEventV2) query;
+  get_liquidity_events_v2_forward : (nat64, nat64) -> (ForwardLiquidityEventsV2) query;
   get_liquidity_event_count_v2 : () -> (nat64) query;
 
   // Explorer endpoints (E1-E14)

--- a/src/declarations/rumi_points/index.d.ts
+++ b/src/declarations/rumi_points/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './rumi_points.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const rumi_points: ActorSubclass<_SERVICE>;

--- a/src/declarations/rumi_points/index.js
+++ b/src/declarations/rumi_points/index.js
@@ -1,0 +1,42 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./rumi_points.did.js";
+export { idlFactory } from "./rumi_points.did.js";
+
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_RUMI_POINTS;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const rumi_points = canisterId ? createActor(canisterId) : undefined;

--- a/src/declarations/rumi_points/rumi_points.did
+++ b/src/declarations/rumi_points/rumi_points.did
@@ -1,0 +1,155 @@
+type AssetType = variant { Icp; IcUsd; CkUsdc; CkUsdt; ThreeUsd };
+type DepositKey = record { asset : AssetType; venue : Venue };
+type DepositRecord = record {
+  asset : AssetType;
+  venue : Venue;
+  last_verified_at : nat64;
+  deposited_at : nat64;
+  recorded_value_usd : nat;
+};
+type EpochStatus = record {
+  open_epoch : opt OpenEpoch;
+  snapshot_seed_committed : bool;
+  driver_interval_secs : nat64;
+  revealed_seed_count : nat64;
+  current_epoch_index : nat64;
+  driver_enabled : bool;
+};
+type EpochSummary = record {
+  epoch_index : nat64;
+  points_accrued_this_epoch : nat;
+  epoch_start_ns : nat64;
+  registered_principals : nat64;
+  active_principals : nat64;
+  total_points_all : nat;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+  epoch_end_ns : nat64;
+};
+type IngestStatus = record {
+  registered_count : nat64;
+  poll_interval_secs : nat64;
+  poll_enabled : bool;
+  sources : vec SourceStatus;
+};
+type InitArgs = record {
+  admin : opt principal;
+  excluded_principals : opt vec principal;
+  snapshot_seed_commit : opt blob;
+  season_start_ns : opt nat64;
+  season_end_ns : opt nat64;
+};
+type LeaderboardEntry = record {
+  "principal" : principal;
+  total_points : nat;
+  rank : nat32;
+  estimated_share_bps : nat32;
+};
+type OpenEpoch = record {
+  close_active : nat64;
+  close_cursor : opt principal;
+  epoch_index : nat64;
+  epoch_start_ns : nat64;
+  a_cursor : opt principal;
+  b_complete : bool;
+  b_cursor : opt principal;
+  close_started : bool;
+  a_complete : bool;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+  close_points_accrued : nat;
+  epoch_end_ns : nat64;
+};
+type PointsConfig = record {
+  admin : principal;
+  registered_count : nat64;
+  snapshot_seed_committed : bool;
+  excluded_count : nat32;
+  season_start_ns : nat64;
+  season_end_ns : nat64;
+  current_epoch_index : nat64;
+};
+type PointsError = variant { Unauthorized; Excluded };
+type PrincipalState = record {
+  "principal" : principal;
+  registered_at_ns : nat64;
+  total_points : nat;
+  repayment_events : vec RepaymentEvent;
+  first_qualifying_action : QualifyingAction;
+  active_deposits : vec record { DepositKey; DepositRecord };
+  last_epoch_processed : nat64;
+};
+type PublicEpochStatus = record {
+  open_epoch : opt PublicOpenEpoch;
+  snapshot_seed_committed : bool;
+  driver_interval_secs : nat64;
+  revealed_seed_count : nat64;
+  current_epoch_index : nat64;
+  driver_enabled : bool;
+};
+type PublicOpenEpoch = record {
+  epoch_index : nat64;
+  epoch_start_ns : nat64;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+  epoch_end_ns : nat64;
+};
+type QualifyingAction = variant {
+  ProvideAmmLiquidity;
+  MintIcUsd;
+  Deposit3Pool;
+  DepositStabilityPool;
+  RepayVault;
+};
+type RegistrationInfo = record {
+  "principal" : principal;
+  registered_at_ns : nat64;
+  first_qualifying_action : QualifyingAction;
+};
+type RepaymentEvent = record {
+  asset : AssetType;
+  repaid_at : nat64;
+  amount_usd : nat;
+  window_end : nat64;
+};
+type Result = variant { Ok; Err : PointsError };
+type Result_1 = variant { Ok; Err : text };
+type Result_2 = variant { Ok : nat64; Err : PointsError };
+type RevealedSeed = record {
+  revealed_at_ns : nat64;
+  epoch_index : nat64;
+  seed : blob;
+  snapshot_time_a_ns : nat64;
+  snapshot_time_b_ns : nat64;
+};
+type SourceStatus = record { tag : nat8; cursor : nat64; canister : principal };
+type Venue = variant { Amm; ThreePool; Vault; StabilityPool };
+service : (opt InitArgs) -> {
+  add_excluded_principal : (principal) -> (Result);
+  force_epoch_tick : () -> (Result);
+  get_asset_ledgers : () -> (vec record { nat8; principal }) query;
+  get_epoch_history : (nat32, nat32) -> (vec EpochSummary) query;
+  get_epoch_status : () -> (PublicEpochStatus) query;
+  get_epoch_status_admin : () -> (EpochStatus) query;
+  get_excluded_principals : () -> (vec principal) query;
+  get_ingest_status : () -> (IngestStatus) query;
+  get_leaderboard : (nat32, nat32) -> (vec LeaderboardEntry) query;
+  get_pending_commit : () -> (blob) query;
+  get_points_config : () -> (PointsConfig) query;
+  get_principal_state : (principal) -> (opt PrincipalState) query;
+  get_registration_info : (principal) -> (opt RegistrationInfo) query;
+  get_revealed_seed : (nat64) -> (opt RevealedSeed) query;
+  is_excluded : (principal) -> (bool) query;
+  is_registered : (principal) -> (bool) query;
+  register_test_principal : (principal) -> (Result);
+  remove_excluded_principal : (principal) -> (Result);
+  set_asset_ledger : (nat8, principal) -> (Result);
+  set_epoch_driver_enabled : (bool) -> (Result);
+  set_epoch_driver_interval_secs : (nat64) -> (Result);
+  set_excluded_principals : (vec principal) -> (Result);
+  set_poll_enabled : (bool) -> (Result);
+  set_poll_interval_secs : (nat64) -> (Result);
+  set_source_canister : (nat8, principal) -> (Result);
+  start_season : (blob) -> (Result_1);
+  trigger_poll : () -> (Result_2);
+}

--- a/src/declarations/rumi_points/rumi_points.did.d.ts
+++ b/src/declarations/rumi_points/rumi_points.did.d.ts
@@ -1,0 +1,174 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+
+export type AssetType = { 'Icp' : null } |
+  { 'IcUsd' : null } |
+  { 'CkUsdc' : null } |
+  { 'CkUsdt' : null } |
+  { 'ThreeUsd' : null };
+export interface DepositKey { 'asset' : AssetType, 'venue' : Venue }
+export interface DepositRecord {
+  'asset' : AssetType,
+  'venue' : Venue,
+  'last_verified_at' : bigint,
+  'deposited_at' : bigint,
+  'recorded_value_usd' : bigint,
+}
+export interface EpochStatus {
+  'open_epoch' : [] | [OpenEpoch],
+  'snapshot_seed_committed' : boolean,
+  'driver_interval_secs' : bigint,
+  'revealed_seed_count' : bigint,
+  'current_epoch_index' : bigint,
+  'driver_enabled' : boolean,
+}
+export interface EpochSummary {
+  'epoch_index' : bigint,
+  'points_accrued_this_epoch' : bigint,
+  'epoch_start_ns' : bigint,
+  'registered_principals' : bigint,
+  'active_principals' : bigint,
+  'total_points_all' : bigint,
+  'snapshot_a_ns' : bigint,
+  'snapshot_b_ns' : bigint,
+  'epoch_end_ns' : bigint,
+}
+export interface IngestStatus {
+  'registered_count' : bigint,
+  'poll_interval_secs' : bigint,
+  'poll_enabled' : boolean,
+  'sources' : Array<SourceStatus>,
+}
+export interface InitArgs {
+  'admin' : [] | [Principal],
+  'excluded_principals' : [] | [Array<Principal>],
+  'snapshot_seed_commit' : [] | [Uint8Array | number[]],
+  'season_start_ns' : [] | [bigint],
+  'season_end_ns' : [] | [bigint],
+}
+export interface LeaderboardEntry {
+  'principal' : Principal,
+  'total_points' : bigint,
+  'rank' : number,
+  'estimated_share_bps' : number,
+}
+export interface OpenEpoch {
+  'close_active' : bigint,
+  'close_cursor' : [] | [Principal],
+  'epoch_index' : bigint,
+  'epoch_start_ns' : bigint,
+  'a_cursor' : [] | [Principal],
+  'b_complete' : boolean,
+  'b_cursor' : [] | [Principal],
+  'close_started' : boolean,
+  'a_complete' : boolean,
+  'snapshot_a_ns' : bigint,
+  'snapshot_b_ns' : bigint,
+  'close_points_accrued' : bigint,
+  'epoch_end_ns' : bigint,
+}
+export interface PointsConfig {
+  'admin' : Principal,
+  'registered_count' : bigint,
+  'snapshot_seed_committed' : boolean,
+  'excluded_count' : number,
+  'season_start_ns' : bigint,
+  'season_end_ns' : bigint,
+  'current_epoch_index' : bigint,
+}
+export type PointsError = { 'Unauthorized' : null } |
+  { 'Excluded' : null };
+export interface PrincipalState {
+  'principal' : Principal,
+  'registered_at_ns' : bigint,
+  'total_points' : bigint,
+  'repayment_events' : Array<RepaymentEvent>,
+  'first_qualifying_action' : QualifyingAction,
+  'active_deposits' : Array<[DepositKey, DepositRecord]>,
+  'last_epoch_processed' : bigint,
+}
+export interface PublicEpochStatus {
+  'open_epoch' : [] | [PublicOpenEpoch],
+  'snapshot_seed_committed' : boolean,
+  'driver_interval_secs' : bigint,
+  'revealed_seed_count' : bigint,
+  'current_epoch_index' : bigint,
+  'driver_enabled' : boolean,
+}
+export interface PublicOpenEpoch {
+  'epoch_index' : bigint,
+  'epoch_start_ns' : bigint,
+  'snapshot_a_ns' : bigint,
+  'snapshot_b_ns' : bigint,
+  'epoch_end_ns' : bigint,
+}
+export type QualifyingAction = { 'ProvideAmmLiquidity' : null } |
+  { 'MintIcUsd' : null } |
+  { 'Deposit3Pool' : null } |
+  { 'DepositStabilityPool' : null } |
+  { 'RepayVault' : null };
+export interface RegistrationInfo {
+  'principal' : Principal,
+  'registered_at_ns' : bigint,
+  'first_qualifying_action' : QualifyingAction,
+}
+export interface RepaymentEvent {
+  'asset' : AssetType,
+  'repaid_at' : bigint,
+  'amount_usd' : bigint,
+  'window_end' : bigint,
+}
+export type Result = { 'Ok' : null } |
+  { 'Err' : PointsError };
+export type Result_1 = { 'Ok' : null } |
+  { 'Err' : string };
+export type Result_2 = { 'Ok' : bigint } |
+  { 'Err' : PointsError };
+export interface RevealedSeed {
+  'revealed_at_ns' : bigint,
+  'epoch_index' : bigint,
+  'seed' : Uint8Array | number[],
+  'snapshot_time_a_ns' : bigint,
+  'snapshot_time_b_ns' : bigint,
+}
+export interface SourceStatus {
+  'tag' : number,
+  'cursor' : bigint,
+  'canister' : Principal,
+}
+export type Venue = { 'Amm' : null } |
+  { 'ThreePool' : null } |
+  { 'Vault' : null } |
+  { 'StabilityPool' : null };
+export interface _SERVICE {
+  'add_excluded_principal' : ActorMethod<[Principal], Result>,
+  'force_epoch_tick' : ActorMethod<[], Result>,
+  'get_asset_ledgers' : ActorMethod<[], Array<[number, Principal]>>,
+  'get_epoch_history' : ActorMethod<[number, number], Array<EpochSummary>>,
+  'get_epoch_status' : ActorMethod<[], PublicEpochStatus>,
+  'get_epoch_status_admin' : ActorMethod<[], EpochStatus>,
+  'get_excluded_principals' : ActorMethod<[], Array<Principal>>,
+  'get_ingest_status' : ActorMethod<[], IngestStatus>,
+  'get_leaderboard' : ActorMethod<[number, number], Array<LeaderboardEntry>>,
+  'get_pending_commit' : ActorMethod<[], Uint8Array | number[]>,
+  'get_points_config' : ActorMethod<[], PointsConfig>,
+  'get_principal_state' : ActorMethod<[Principal], [] | [PrincipalState]>,
+  'get_registration_info' : ActorMethod<[Principal], [] | [RegistrationInfo]>,
+  'get_revealed_seed' : ActorMethod<[bigint], [] | [RevealedSeed]>,
+  'is_excluded' : ActorMethod<[Principal], boolean>,
+  'is_registered' : ActorMethod<[Principal], boolean>,
+  'register_test_principal' : ActorMethod<[Principal], Result>,
+  'remove_excluded_principal' : ActorMethod<[Principal], Result>,
+  'set_asset_ledger' : ActorMethod<[number, Principal], Result>,
+  'set_epoch_driver_enabled' : ActorMethod<[boolean], Result>,
+  'set_epoch_driver_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_excluded_principals' : ActorMethod<[Array<Principal>], Result>,
+  'set_poll_enabled' : ActorMethod<[boolean], Result>,
+  'set_poll_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_source_canister' : ActorMethod<[number, Principal], Result>,
+  'start_season' : ActorMethod<[Uint8Array | number[]], Result_1>,
+  'trigger_poll' : ActorMethod<[], Result_2>,
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/rumi_points/rumi_points.did.js
+++ b/src/declarations/rumi_points/rumi_points.did.js
@@ -1,0 +1,217 @@
+export const idlFactory = ({ IDL }) => {
+  const InitArgs = IDL.Record({
+    'admin' : IDL.Opt(IDL.Principal),
+    'excluded_principals' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'snapshot_seed_commit' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'season_start_ns' : IDL.Opt(IDL.Nat64),
+    'season_end_ns' : IDL.Opt(IDL.Nat64),
+  });
+  const PointsError = IDL.Variant({
+    'Unauthorized' : IDL.Null,
+    'Excluded' : IDL.Null,
+  });
+  const Result = IDL.Variant({ 'Ok' : IDL.Null, 'Err' : PointsError });
+  const EpochSummary = IDL.Record({
+    'epoch_index' : IDL.Nat64,
+    'points_accrued_this_epoch' : IDL.Nat,
+    'epoch_start_ns' : IDL.Nat64,
+    'registered_principals' : IDL.Nat64,
+    'active_principals' : IDL.Nat64,
+    'total_points_all' : IDL.Nat,
+    'snapshot_a_ns' : IDL.Nat64,
+    'snapshot_b_ns' : IDL.Nat64,
+    'epoch_end_ns' : IDL.Nat64,
+  });
+  const PublicOpenEpoch = IDL.Record({
+    'epoch_index' : IDL.Nat64,
+    'epoch_start_ns' : IDL.Nat64,
+    'snapshot_a_ns' : IDL.Nat64,
+    'snapshot_b_ns' : IDL.Nat64,
+    'epoch_end_ns' : IDL.Nat64,
+  });
+  const PublicEpochStatus = IDL.Record({
+    'open_epoch' : IDL.Opt(PublicOpenEpoch),
+    'snapshot_seed_committed' : IDL.Bool,
+    'driver_interval_secs' : IDL.Nat64,
+    'revealed_seed_count' : IDL.Nat64,
+    'current_epoch_index' : IDL.Nat64,
+    'driver_enabled' : IDL.Bool,
+  });
+  const OpenEpoch = IDL.Record({
+    'close_active' : IDL.Nat64,
+    'close_cursor' : IDL.Opt(IDL.Principal),
+    'epoch_index' : IDL.Nat64,
+    'epoch_start_ns' : IDL.Nat64,
+    'a_cursor' : IDL.Opt(IDL.Principal),
+    'b_complete' : IDL.Bool,
+    'b_cursor' : IDL.Opt(IDL.Principal),
+    'close_started' : IDL.Bool,
+    'a_complete' : IDL.Bool,
+    'snapshot_a_ns' : IDL.Nat64,
+    'snapshot_b_ns' : IDL.Nat64,
+    'close_points_accrued' : IDL.Nat,
+    'epoch_end_ns' : IDL.Nat64,
+  });
+  const EpochStatus = IDL.Record({
+    'open_epoch' : IDL.Opt(OpenEpoch),
+    'snapshot_seed_committed' : IDL.Bool,
+    'driver_interval_secs' : IDL.Nat64,
+    'revealed_seed_count' : IDL.Nat64,
+    'current_epoch_index' : IDL.Nat64,
+    'driver_enabled' : IDL.Bool,
+  });
+  const SourceStatus = IDL.Record({
+    'tag' : IDL.Nat8,
+    'cursor' : IDL.Nat64,
+    'canister' : IDL.Principal,
+  });
+  const IngestStatus = IDL.Record({
+    'registered_count' : IDL.Nat64,
+    'poll_interval_secs' : IDL.Nat64,
+    'poll_enabled' : IDL.Bool,
+    'sources' : IDL.Vec(SourceStatus),
+  });
+  const LeaderboardEntry = IDL.Record({
+    'principal' : IDL.Principal,
+    'total_points' : IDL.Nat,
+    'rank' : IDL.Nat32,
+    'estimated_share_bps' : IDL.Nat32,
+  });
+  const PointsConfig = IDL.Record({
+    'admin' : IDL.Principal,
+    'registered_count' : IDL.Nat64,
+    'snapshot_seed_committed' : IDL.Bool,
+    'excluded_count' : IDL.Nat32,
+    'season_start_ns' : IDL.Nat64,
+    'season_end_ns' : IDL.Nat64,
+    'current_epoch_index' : IDL.Nat64,
+  });
+  const AssetType = IDL.Variant({
+    'Icp' : IDL.Null,
+    'IcUsd' : IDL.Null,
+    'CkUsdc' : IDL.Null,
+    'CkUsdt' : IDL.Null,
+    'ThreeUsd' : IDL.Null,
+  });
+  const RepaymentEvent = IDL.Record({
+    'asset' : AssetType,
+    'repaid_at' : IDL.Nat64,
+    'amount_usd' : IDL.Nat,
+    'window_end' : IDL.Nat64,
+  });
+  const QualifyingAction = IDL.Variant({
+    'ProvideAmmLiquidity' : IDL.Null,
+    'MintIcUsd' : IDL.Null,
+    'Deposit3Pool' : IDL.Null,
+    'DepositStabilityPool' : IDL.Null,
+    'RepayVault' : IDL.Null,
+  });
+  const Venue = IDL.Variant({
+    'Amm' : IDL.Null,
+    'ThreePool' : IDL.Null,
+    'Vault' : IDL.Null,
+    'StabilityPool' : IDL.Null,
+  });
+  const DepositKey = IDL.Record({ 'asset' : AssetType, 'venue' : Venue });
+  const DepositRecord = IDL.Record({
+    'asset' : AssetType,
+    'venue' : Venue,
+    'last_verified_at' : IDL.Nat64,
+    'deposited_at' : IDL.Nat64,
+    'recorded_value_usd' : IDL.Nat,
+  });
+  const PrincipalState = IDL.Record({
+    'principal' : IDL.Principal,
+    'registered_at_ns' : IDL.Nat64,
+    'total_points' : IDL.Nat,
+    'repayment_events' : IDL.Vec(RepaymentEvent),
+    'first_qualifying_action' : QualifyingAction,
+    'active_deposits' : IDL.Vec(IDL.Tuple(DepositKey, DepositRecord)),
+    'last_epoch_processed' : IDL.Nat64,
+  });
+  const RegistrationInfo = IDL.Record({
+    'principal' : IDL.Principal,
+    'registered_at_ns' : IDL.Nat64,
+    'first_qualifying_action' : QualifyingAction,
+  });
+  const RevealedSeed = IDL.Record({
+    'revealed_at_ns' : IDL.Nat64,
+    'epoch_index' : IDL.Nat64,
+    'seed' : IDL.Vec(IDL.Nat8),
+    'snapshot_time_a_ns' : IDL.Nat64,
+    'snapshot_time_b_ns' : IDL.Nat64,
+  });
+  const Result_1 = IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text });
+  const Result_2 = IDL.Variant({ 'Ok' : IDL.Nat64, 'Err' : PointsError });
+  return IDL.Service({
+    'add_excluded_principal' : IDL.Func([IDL.Principal], [Result], []),
+    'force_epoch_tick' : IDL.Func([], [Result], []),
+    'get_asset_ledgers' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat8, IDL.Principal))],
+        ['query'],
+      ),
+    'get_epoch_history' : IDL.Func(
+        [IDL.Nat32, IDL.Nat32],
+        [IDL.Vec(EpochSummary)],
+        ['query'],
+      ),
+    'get_epoch_status' : IDL.Func([], [PublicEpochStatus], ['query']),
+    'get_epoch_status_admin' : IDL.Func([], [EpochStatus], ['query']),
+    'get_excluded_principals' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Principal)],
+        ['query'],
+      ),
+    'get_ingest_status' : IDL.Func([], [IngestStatus], ['query']),
+    'get_leaderboard' : IDL.Func(
+        [IDL.Nat32, IDL.Nat32],
+        [IDL.Vec(LeaderboardEntry)],
+        ['query'],
+      ),
+    'get_pending_commit' : IDL.Func([], [IDL.Vec(IDL.Nat8)], ['query']),
+    'get_points_config' : IDL.Func([], [PointsConfig], ['query']),
+    'get_principal_state' : IDL.Func(
+        [IDL.Principal],
+        [IDL.Opt(PrincipalState)],
+        ['query'],
+      ),
+    'get_registration_info' : IDL.Func(
+        [IDL.Principal],
+        [IDL.Opt(RegistrationInfo)],
+        ['query'],
+      ),
+    'get_revealed_seed' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Opt(RevealedSeed)],
+        ['query'],
+      ),
+    'is_excluded' : IDL.Func([IDL.Principal], [IDL.Bool], ['query']),
+    'is_registered' : IDL.Func([IDL.Principal], [IDL.Bool], ['query']),
+    'register_test_principal' : IDL.Func([IDL.Principal], [Result], []),
+    'remove_excluded_principal' : IDL.Func([IDL.Principal], [Result], []),
+    'set_asset_ledger' : IDL.Func([IDL.Nat8, IDL.Principal], [Result], []),
+    'set_epoch_driver_enabled' : IDL.Func([IDL.Bool], [Result], []),
+    'set_epoch_driver_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_excluded_principals' : IDL.Func(
+        [IDL.Vec(IDL.Principal)],
+        [Result],
+        [],
+      ),
+    'set_poll_enabled' : IDL.Func([IDL.Bool], [Result], []),
+    'set_poll_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_source_canister' : IDL.Func([IDL.Nat8, IDL.Principal], [Result], []),
+    'start_season' : IDL.Func([IDL.Vec(IDL.Nat8)], [Result_1], []),
+    'trigger_poll' : IDL.Func([], [Result_2], []),
+  });
+};
+export const init = ({ IDL }) => {
+  const InitArgs = IDL.Record({
+    'admin' : IDL.Opt(IDL.Principal),
+    'excluded_principals' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'snapshot_seed_commit' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'season_start_ns' : IDL.Opt(IDL.Nat64),
+    'season_end_ns' : IDL.Opt(IDL.Nat64),
+  });
+  return [IDL.Opt(InitArgs)];
+};

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -840,6 +840,8 @@ type SuccessWithFee = record {
   block_index : nat64;
   fee_amount_paid : nat64;
   collateral_amount_received : opt nat64;
+  debt_liquidated_e8s : opt nat64;
+  stable_pulled_e6s : opt nat64;
 };
 type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
 type SupplyAuditEntry = record {

--- a/src/rumi_3pool/rumi_3pool.did
+++ b/src/rumi_3pool/rumi_3pool.did
@@ -47,6 +47,18 @@ type ThreePoolError = variant {
   InsufficientLpBalance : record { required : nat; available : nat };
   BurnFailed : record { token : text; reason : text };
   PoolLocked;
+  ClaimNotFound;
+};
+
+type ThreePoolPendingClaim = record {
+  id : nat64;
+  claimant : principal;
+  token_index : nat8;
+  ledger : principal;
+  symbol : text;
+  amount : nat;
+  reason : text;
+  created_at : nat64;
 };
 
 type SwapEvent = record {
@@ -482,6 +494,10 @@ service : (ThreePoolInitArgs) -> {
   get_pool_status : () -> (PoolStatus) query;
   get_lp_balance : (principal) -> (nat) query;
   get_all_lp_holders : () -> (vec record { principal; nat }) query;
+  get_lp_holders : (nat64, nat64) -> (vec record { principal; nat }) query;
+  claim_pending : (nat64) -> (variant { Ok; Err : ThreePoolError });
+  get_pending_claims : (nat64, nat64) -> (vec ThreePoolPendingClaim) query;
+  get_pending_claim_count : () -> (nat64) query;
   calc_swap : (nat8, nat8, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_add_liquidity_query : (vec nat, nat) -> (variant { Ok : nat; Err : ThreePoolError }) query;
   calc_remove_liquidity_query : (nat) -> (variant { Ok : vec nat; Err : ThreePoolError }) query;

--- a/src/rumi_3pool/src/admin.rs
+++ b/src/rumi_3pool/src/admin.rs
@@ -116,6 +116,12 @@ pub fn stop_ramp_a(caller: Principal, now: u64) -> Result<(), ThreePoolError> {
 
 /// Withdraw accumulated admin fees, transferring them to the admin.
 pub async fn withdraw_admin_fees(caller: Principal) -> Result<[u128; 3], ThreePoolError> {
+    // Serialize against concurrent withdrawals and against the swap/liquidity
+    // paths that mutate `admin_fees`. Without this, two concurrent admin calls
+    // both read the same non-zero `fees`, both zero it, and both transfer — a
+    // double payout of accrued fees. Audit 2026-06-05 (3P-04).
+    let _pool_guard = crate::pool_guard::PoolGuard::new()?;
+
     let (admin, fees, tokens) = read_state(|s| {
         (s.config.admin, s.admin_fees, s.config.tokens.clone())
     });
@@ -124,26 +130,38 @@ pub async fn withdraw_admin_fees(caller: Principal) -> Result<[u128; 3], ThreePo
         return Err(ThreePoolError::Unauthorized);
     }
 
-    // Zero out fees first (deduct-before-transfer)
+    // Zero out fees first (deduct-before-transfer).
     mutate_state(|s| {
         s.admin_fees = [0; 3];
     });
 
-    // Transfer each non-zero fee to admin
+    // Transfer each non-zero fee to admin. If a transfer fails, restore that
+    // token's fee (the tokens are still in the pool's account) and continue
+    // with the rest — never bail mid-loop and silently strand the un-sent
+    // fees by leaving them zeroed. Audit 2026-06-05 (3P-04).
+    let mut withdrawn = [0u128; 3];
     for k in 0..3 {
         if fees[k] > 0 {
-            transfer_to_user(tokens[k].ledger_id, admin, fees[k])
-                .await
-                .map_err(|reason| ThreePoolError::TransferFailed {
-                    token: tokens[k].symbol.clone(),
-                    reason,
-                })?;
+            match transfer_to_user(tokens[k].ledger_id, admin, fees[k]).await {
+                Ok(()) => {
+                    withdrawn[k] = fees[k];
+                }
+                Err(reason) => {
+                    mutate_state(|s| {
+                        s.admin_fees[k] = s.admin_fees[k].saturating_add(fees[k]);
+                    });
+                    ic_cdk::println!(
+                        "[withdraw_admin_fees] token {} transfer failed: {}; fee restored",
+                        tokens[k].symbol, reason
+                    );
+                }
+            }
         }
     }
 
-    record_admin_event(caller, ThreePoolAdminAction::WithdrawAdminFees { amounts: fees });
+    record_admin_event(caller, ThreePoolAdminAction::WithdrawAdminFees { amounts: withdrawn });
 
-    Ok(fees)
+    Ok(withdrawn)
 }
 
 /// Pause or unpause the pool.

--- a/src/rumi_3pool/src/icrc3.rs
+++ b/src/rumi_3pool/src/icrc3.rs
@@ -183,13 +183,26 @@ pub fn encode_block_with_phash(block: &Icrc3Block, phash: Option<&[u8; 32]>) -> 
 
 // ─── Query implementations ───
 
+/// Maximum number of blocks returned across all `GetBlocksArgs` ranges in a
+/// single `icrc3_get_blocks` call. Without this, a caller could pass many
+/// ranges (or repeat `{0, log_length}`) and force an unbounded reply plus a
+/// per-block SHA-256 over the whole log. The ic-icrc1-index-ng paginates well
+/// below this, so it is invisible to honest callers. Audit 2026-06-05 (SAT-006).
+pub const MAX_GET_BLOCKS_RESPONSE: u64 = 2_000;
+
 pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
     let log_length = crate::storage::blocks::len();
 
     let mut result_blocks = Vec::new();
+    let mut remaining = MAX_GET_BLOCKS_RESPONSE;
     for arg in &args {
+        if remaining == 0 {
+            break;
+        }
         let start = nat_to_u64(&arg.start);
-        let length = nat_to_u64(&arg.length);
+        // Cap this range's length to the global response budget so the total
+        // number of blocks (and SHA-256 hashes) stays bounded across all args.
+        let length = nat_to_u64(&arg.length).min(remaining);
 
         if start >= log_length {
             continue;
@@ -219,6 +232,7 @@ pub fn icrc3_get_blocks(args: Vec<GetBlocksArgs>) -> GetBlocksResult {
         // hashing happens once per returned block, replacing the old
         // O(end) chain rebuild.
         let blocks = crate::storage::blocks::range(start, end - start);
+        remaining = remaining.saturating_sub(blocks.len() as u64);
         for block in &blocks {
             let encoded = encode_block_with_phash(block, prev_hash.as_ref());
             // Compute the running hash so the next iteration has its parent.

--- a/src/rumi_3pool/src/icrc_token.rs
+++ b/src/rumi_3pool/src/icrc_token.rs
@@ -117,12 +117,14 @@ pub fn icrc1_transfer(caller: Principal, args: TransferArg) -> Result<Nat, Trans
         });
     }
 
-    if caller == to_principal {
-        return Err(TransferError::GenericError {
-            error_code: Nat::from(4u64),
-            message: "cannot transfer to self".to_string(),
-        });
-    }
+    // NOTE (audit 2026-06-05, SAT-007): a previous over-broad guard rejected
+    // every transfer where `caller == to.owner`, which broke legitimate wallet
+    // flows (notably the "3USD send with Internet Identity" bug) whenever a
+    // wallet routed a send to the same owning principal under a different
+    // subaccount. Because balances are keyed by owner principal only, a
+    // same-owner transfer is a self-cancelling no-op on the balance (debit then
+    // credit the same key, net zero), so allowing it is safe and matches the
+    // ICP/ICRC-1 ledger convention of permitting self-transfers.
 
     mutate_state(|s| {
         let from_balance = crate::storage::lp_balance_get(&caller);

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -308,6 +308,93 @@ fn get_current_a() -> u64 {
     })
 }
 
+// ─── Pending-claim recovery (audit 2026-06-05, 3P-01/02/03) ───
+
+/// Upper bound on outstanding pending claims. A claim is only created when a
+/// ledger transfer (and, for swap/add, its refund) fails, which is not caller-
+/// controllable, so this is a memory-safety bound rather than an anti-DoS one.
+const MAX_PENDING_CLAIMS: u64 = 10_000;
+
+/// Record tokens the pool owes `claimant` after a failed payout/refund so the
+/// funds can be recovered via `claim_pending` instead of being stranded.
+fn record_pending_claim(
+    claimant: Principal,
+    token_index: u8,
+    ledger: Principal,
+    symbol: &str,
+    amount: u128,
+    reason: &str,
+) -> u64 {
+    // Bound memory. Dropping the oldest claim is itself a (logged) value loss,
+    // but reaching the cap requires thousands of genuine ledger failures.
+    if storage::pending_claims::len() >= MAX_PENDING_CLAIMS {
+        if let Some(oldest) = storage::pending_claims::list(0, 1).into_iter().next() {
+            log!(INFO, "WARN: pending_claims at capacity; dropping oldest claim #{}", oldest.id);
+            storage::pending_claims::remove(oldest.id);
+        }
+    }
+    let id = storage::pending_claims::next_id();
+    log!(INFO, "Pending claim #{} recorded: {} owes {} of token {} ({}): {}",
+        id, claimant, amount, token_index, symbol, reason);
+    storage::pending_claims::insert(crate::types::ThreePoolPendingClaim {
+        id,
+        claimant,
+        token_index,
+        ledger,
+        symbol: symbol.to_string(),
+        amount,
+        reason: reason.to_string(),
+        created_at: ic_cdk::api::time() / 1_000_000_000,
+    });
+    id
+}
+
+/// Recover tokens the pool owes after a failed payout/refund. The original
+/// claimant or the pool admin may call this. The claim is removed BEFORE the
+/// async transfer (prevents two concurrent calls both paying out) and re-
+/// inserted if the transfer fails. Audit 2026-06-05 (3P-01/02/03).
+#[update]
+pub async fn claim_pending(claim_id: u64) -> Result<(), ThreePoolError> {
+    let caller = ic_cdk::api::caller();
+
+    // Remove first (atomic) to prevent double-claim across the await.
+    let claim = storage::pending_claims::remove(claim_id)
+        .ok_or(ThreePoolError::ClaimNotFound)?;
+
+    let admin = read_state(|s| s.config.admin);
+    if caller != claim.claimant && caller != admin {
+        // Not authorized — re-insert before returning so the claim is not lost.
+        storage::pending_claims::insert(claim);
+        return Err(ThreePoolError::Unauthorized);
+    }
+
+    match transfer_to_user(claim.ledger, claim.claimant, claim.amount).await {
+        Ok(()) => {
+            log!(INFO, "Pending claim #{} resolved: {} received {} of {}",
+                claim_id, claim.claimant, claim.amount, claim.symbol);
+            Ok(())
+        }
+        Err(reason) => {
+            // Transfer failed — re-insert so the user can retry.
+            let symbol = claim.symbol.clone();
+            storage::pending_claims::insert(claim);
+            Err(ThreePoolError::TransferFailed { token: symbol, reason })
+        }
+    }
+}
+
+/// View outstanding pending claims (bounded page; `limit` capped at 1000).
+#[query]
+pub fn get_pending_claims(offset: u64, limit: u64) -> Vec<crate::types::ThreePoolPendingClaim> {
+    storage::pending_claims::list(offset, limit.min(1000))
+}
+
+/// Count of outstanding pending claims.
+#[query]
+pub fn get_pending_claim_count() -> u64 {
+    storage::pending_claims::len()
+}
+
 // ─── Swap ───
 
 #[update]
@@ -324,6 +411,14 @@ pub async fn swap(i: u8, j: u8, dx: u128, min_dy: u128) -> Result<u128, ThreePoo
 
     let i_idx = i as usize;
     let j_idx = j as usize;
+
+    // Validate coin indices BEFORE indexing `s.config.tokens[..]` below.
+    // Otherwise an out-of-range i/j panics on the array index (clean rollback
+    // but an ugly trap) instead of returning a typed InvalidCoinIndex error.
+    // Audit 2026-06-05 (3PT-001).
+    if i_idx >= 3 || j_idx >= 3 || i_idx == j_idx {
+        return Err(ThreePoolError::InvalidCoinIndex);
+    }
 
     // 3. Compute current A and precision_muls
     let amp = get_current_a();
@@ -360,17 +455,36 @@ pub async fn swap(i: u8, j: u8, dx: u128, min_dy: u128) -> Result<u128, ThreePoo
     transfer_from_user(token_i_ledger, caller, dx)
         .await
         .map_err(|reason| ThreePoolError::TransferFailed {
-            token: token_i_symbol,
+            token: token_i_symbol.clone(),
             reason,
         })?;
 
-    // 8. Transfer output token from pool to user
-    transfer_to_user(token_j_ledger, caller, output)
-        .await
-        .map_err(|reason| ThreePoolError::TransferFailed {
+    // 8. Transfer output token from pool to user.
+    //
+    // The input was just pulled into the pool's account, but `s.balances` is
+    // NOT credited until step 8 below (after both transfers succeed). So if the
+    // output transfer fails here, the pulled input would be stranded in the pool
+    // with no accounting and no recourse for the user. Refund the input; if the
+    // refund itself fails, record a pending claim so the user can recover it via
+    // `claim_pending`. Audit 2026-06-05 (3P-01): mirrors rumi_amm's swap path.
+    if let Err(reason) = transfer_to_user(token_j_ledger, caller, output).await {
+        if let Err(refund_err) = transfer_to_user(token_i_ledger, caller, dx).await {
+            record_pending_claim(
+                caller,
+                i,
+                token_i_ledger,
+                &token_i_symbol,
+                dx,
+                &format!(
+                    "swap output transfer failed ({reason}), then input refund failed ({refund_err})"
+                ),
+            );
+        }
+        return Err(ThreePoolError::TransferFailed {
             token: token_j_symbol,
             reason,
-        })?;
+        });
+    }
 
     // 8. Update state
     //
@@ -465,19 +579,51 @@ pub async fn add_liquidity(amounts: Vec<u128>, min_lp: u128) -> Result<u128, Thr
         return Err(ThreePoolError::SlippageExceeded);
     }
 
-    // 8. Transfer each non-zero amount from user to pool
+    // 8. Transfer each non-zero amount from user to pool.
+    //
+    // `s.balances` is not credited until after the whole loop succeeds (step 8
+    // below). If a transfer fails mid-loop, the amounts already pulled (indices
+    // < k) are stranded in the pool with no accounting. Refund each already-
+    // pulled amount; if a refund itself fails, record a pending claim so the
+    // user can recover it via `claim_pending`. Audit 2026-06-05 (3P-03).
     let caller = ic_cdk::api::caller();
+    let token_meta: [(Principal, String); 3] = read_state(|s| {
+        [
+            (s.config.tokens[0].ledger_id, s.config.tokens[0].symbol.clone()),
+            (s.config.tokens[1].ledger_id, s.config.tokens[1].symbol.clone()),
+            (s.config.tokens[2].ledger_id, s.config.tokens[2].symbol.clone()),
+        ]
+    });
     for k in 0..3 {
         if amounts_arr[k] > 0 {
-            let (ledger, symbol) = read_state(|s| {
-                (s.config.tokens[k].ledger_id, s.config.tokens[k].symbol.clone())
-            });
-            transfer_from_user(ledger, caller, amounts_arr[k])
-                .await
-                .map_err(|reason| ThreePoolError::TransferFailed {
-                    token: symbol,
+            let (ledger, symbol) = &token_meta[k];
+            if let Err(reason) = transfer_from_user(*ledger, caller, amounts_arr[k]).await {
+                // Refund everything already pulled (indices 0..k).
+                for r in 0..k {
+                    if amounts_arr[r] > 0 {
+                        let (r_ledger, r_symbol) = &token_meta[r];
+                        if let Err(refund_err) =
+                            transfer_to_user(*r_ledger, caller, amounts_arr[r]).await
+                        {
+                            record_pending_claim(
+                                caller,
+                                r as u8,
+                                *r_ledger,
+                                r_symbol,
+                                amounts_arr[r],
+                                &format!(
+                                    "add_liquidity aborted after token {k} pull failed; \
+                                     refund of token {r} also failed ({refund_err})"
+                                ),
+                            );
+                        }
+                    }
+                }
+                return Err(ThreePoolError::TransferFailed {
+                    token: symbol.clone(),
                     reason,
-                })?;
+                });
+            }
         }
     }
 
@@ -594,18 +740,37 @@ pub async fn remove_liquidity(
         });
     });
 
-    // 6. Transfer each non-zero amount to user
+    // 6. Transfer each non-zero amount to user.
+    //
+    // LP and balances were already deducted in step 5 (deduct-before-transfer),
+    // so the user is owed these tokens unconditionally. If a transfer fails,
+    // record a pending claim for the un-sent amount and CONTINUE with the other
+    // tokens — never bail mid-loop and strand the remaining payouts. The user
+    // recovers any failed leg via `claim_pending`. Audit 2026-06-05 (3P-02).
+    let token_meta: [(Principal, String); 3] = read_state(|s| {
+        [
+            (s.config.tokens[0].ledger_id, s.config.tokens[0].symbol.clone()),
+            (s.config.tokens[1].ledger_id, s.config.tokens[1].symbol.clone()),
+            (s.config.tokens[2].ledger_id, s.config.tokens[2].symbol.clone()),
+        ]
+    });
+    let mut first_failure: Option<(String, String)> = None;
     for k in 0..3 {
         if amounts[k] > 0 {
-            let (ledger, symbol) = read_state(|s| {
-                (s.config.tokens[k].ledger_id, s.config.tokens[k].symbol.clone())
-            });
-            transfer_to_user(ledger, caller, amounts[k])
-                .await
-                .map_err(|reason| ThreePoolError::TransferFailed {
-                    token: symbol,
-                    reason,
-                })?;
+            let (ledger, symbol) = &token_meta[k];
+            if let Err(reason) = transfer_to_user(*ledger, caller, amounts[k]).await {
+                record_pending_claim(
+                    caller,
+                    k as u8,
+                    *ledger,
+                    symbol,
+                    amounts[k],
+                    &format!("remove_liquidity payout of token {k} failed ({reason})"),
+                );
+                if first_failure.is_none() {
+                    first_failure = Some((symbol.clone(), reason));
+                }
+            }
         }
     }
 
@@ -637,6 +802,12 @@ pub async fn remove_liquidity(
     });
 
     log!(INFO, "RemoveLiquidity: {} LP -> {:?} for {}", lp_burn, amounts, caller);
+
+    // Surface a partial-payout failure to the caller (claims persist for
+    // recovery). The LP burn and any successful legs are already committed.
+    if let Some((token, reason)) = first_failure {
+        return Err(ThreePoolError::TransferFailed { token, reason });
+    }
 
     Ok(amounts.to_vec())
 }
@@ -714,17 +885,27 @@ pub async fn remove_one_coin(
         });
     });
 
-    // 6. Transfer to user
+    // 6. Transfer to user.
+    //
+    // LP and balance were already deducted in step 5, so the user is owed
+    // `amount` unconditionally. If the transfer fails, record a pending claim
+    // so the user recovers it via `claim_pending` rather than losing it (the
+    // tokens physically remain in the pool). Audit 2026-06-05 (3P-02).
     let (ledger, symbol) = read_state(|s| {
         (s.config.tokens[idx].ledger_id, s.config.tokens[idx].symbol.clone())
     });
 
-    transfer_to_user(ledger, caller, amount)
-        .await
-        .map_err(|reason| ThreePoolError::TransferFailed {
-            token: symbol,
-            reason,
-        })?;
+    if let Err(reason) = transfer_to_user(ledger, caller, amount).await {
+        record_pending_claim(
+            caller,
+            coin_index,
+            ledger,
+            &symbol,
+            amount,
+            &format!("remove_one_coin payout of token {idx} failed ({reason})"),
+        );
+        return Err(ThreePoolError::TransferFailed { token: symbol, reason });
+    }
 
     // Record liquidity event v2 (dynamic-fee schema).
     mutate_state(|s| {
@@ -945,7 +1126,16 @@ pub fn get_lp_balance(user: Principal) -> u128 {
     storage::lp_balance_get(&user)
 }
 
-/// Returns all LP holders and their balances, sorted by balance descending.
+/// Maximum holders returned by `get_all_lp_holders` / `get_lp_holders`.
+/// 3USD is freely transferable with a zero fee, so an attacker could spread
+/// dust across many principals to inflate the holder set; this bounds the
+/// reply size. Use `get_lp_holders(offset, limit)` to page beyond the top.
+/// Audit 2026-06-05 (SAT-008).
+pub const MAX_HOLDERS_RETURNED: usize = 10_000;
+
+/// Returns LP holders and balances, sorted by balance descending, bounded to
+/// the top `MAX_HOLDERS_RETURNED`. Use `get_lp_holders` to page through the
+/// full set if it ever exceeds the cap.
 #[query]
 pub fn get_all_lp_holders() -> Vec<(Principal, u128)> {
     let mut holders: Vec<(Principal, u128)> = storage::lp_balance_iter()
@@ -953,7 +1143,25 @@ pub fn get_all_lp_holders() -> Vec<(Principal, u128)> {
         .filter(|(_, b)| *b > 0)
         .collect();
     holders.sort_by(|a, b| b.1.cmp(&a.1));
+    holders.truncate(MAX_HOLDERS_RETURNED);
     holders
+}
+
+/// Paginated LP holders, sorted by balance descending. `limit` is capped at
+/// `MAX_HOLDERS_RETURNED`. Audit 2026-06-05 (SAT-008).
+#[query]
+pub fn get_lp_holders(offset: u64, limit: u64) -> Vec<(Principal, u128)> {
+    let mut holders: Vec<(Principal, u128)> = storage::lp_balance_iter()
+        .into_iter()
+        .filter(|(_, b)| *b > 0)
+        .collect();
+    holders.sort_by(|a, b| b.1.cmp(&a.1));
+    let limit = (limit as usize).min(MAX_HOLDERS_RETURNED);
+    holders
+        .into_iter()
+        .skip(offset as usize)
+        .take(limit)
+        .collect()
 }
 
 #[query]

--- a/src/rumi_3pool/src/storage.rs
+++ b/src/rumi_3pool/src/storage.rs
@@ -27,6 +27,8 @@
 //   16,17   icrc3_blocks log
 //   18,19   icrc3_block_hashes log      — cumulative hash chain cache (parallel
 //                                         to blocks log; entry i == hash of block i)
+//   20      pending_claims              — BTreeMap<u64, ThreePoolPendingClaim>
+//   21      next_claim_id cell          — monotonic u64 claim id counter
 //
 // Migration semantics: the first `post_upgrade` after the Phase A deploy runs
 // a one-shot drain (see `storage::migration`). All subsequent upgrades just
@@ -47,7 +49,7 @@ use std::cell::RefCell;
 
 use crate::types::{
     Icrc3Block, LiquidityEventV1, LiquidityEventV2, LpAllowance, PoolConfig, SwapEventV1,
-    SwapEventV2, ThreePoolAdminEvent, VirtualPriceSnapshot,
+    SwapEventV2, ThreePoolAdminEvent, ThreePoolPendingClaim, VirtualPriceSnapshot,
 };
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
@@ -74,6 +76,8 @@ const MEM_BLOCKS_INDEX: MemoryId = MemoryId::new(16);
 const MEM_BLOCKS_DATA: MemoryId = MemoryId::new(17);
 const MEM_BLOCK_HASHES_INDEX: MemoryId = MemoryId::new(18);
 const MEM_BLOCK_HASHES_DATA: MemoryId = MemoryId::new(19);
+const MEM_PENDING_CLAIMS: MemoryId = MemoryId::new(20);
+const MEM_NEXT_CLAIM_ID: MemoryId = MemoryId::new(21);
 
 // ─── SlimState ───────────────────────────────────────────────────────────────
 //
@@ -299,6 +303,7 @@ impl_storable_candid_unbounded!(ThreePoolAdminEvent);
 impl_storable_candid_unbounded!(VirtualPriceSnapshot);
 impl_storable_candid_unbounded!(Icrc3Block);
 impl_storable_candid_unbounded!(LpAllowance);
+impl_storable_candid_unbounded!(ThreePoolPendingClaim);
 
 // ─── MemoryManager + stable structures (thread-local) ────────────────────────
 //
@@ -396,6 +401,18 @@ thread_local! {
             )
             .expect("init block_hashes log"),
         );
+
+    // Pending claims: tokens the pool owes a user after a failed payout/refund.
+    // Keyed by monotonic claim id (StorableU128 holding a u64-range value).
+    // Lives in its own memory region so it is fully upgrade-safe — adding it
+    // touches neither SlimState nor any existing structure. Audit 2026-06-05.
+    pub(crate) static PENDING_CLAIMS: RefCell<StableBTreeMap<StorableU128, ThreePoolPendingClaim, Memory>> =
+        RefCell::new(StableBTreeMap::init(MM.with(|m| m.borrow().get(MEM_PENDING_CLAIMS))));
+
+    pub(crate) static NEXT_CLAIM_ID: RefCell<StableCell<StorableU128, Memory>> = RefCell::new(
+        StableCell::init(MM.with(|m| m.borrow().get(MEM_NEXT_CLAIM_ID)), StorableU128(0))
+            .expect("init next_claim_id cell"),
+    );
 }
 
 // ─── Public API: SlimState cell ──────────────────────────────────────────────
@@ -548,6 +565,58 @@ log_api!(admin_ev, ADMIN_EV_LOG, ThreePoolAdminEvent);
 log_api!(vp_snap, VP_SNAP_LOG, VirtualPriceSnapshot);
 log_api!(blocks, BLOCKS_LOG, Icrc3Block);
 log_api!(block_hashes, BLOCK_HASHES_LOG, StorableHash);
+
+// ─── Public API: pending_claims ──────────────────────────────────────────────
+//
+// Recovery records for tokens the pool owes a user after a failed payout or
+// refund. Insert on failure; remove on successful `claim_pending`. Audit
+// 2026-06-05 (3P-01/02/03): mirrors `rumi_amm`'s pending-claim recovery.
+
+pub mod pending_claims {
+    use super::*;
+
+    /// Allocate the next monotonic claim id and persist the bumped counter.
+    pub fn next_id() -> u64 {
+        NEXT_CLAIM_ID.with(|c| {
+            let cur = c.borrow().get().0;
+            let next = cur.saturating_add(1);
+            c.borrow_mut()
+                .set(StorableU128(next))
+                .expect("set next_claim_id");
+            cur as u64
+        })
+    }
+
+    /// Insert a pending claim under its id.
+    pub fn insert(claim: ThreePoolPendingClaim) {
+        PENDING_CLAIMS.with(|m| {
+            m.borrow_mut()
+                .insert(StorableU128(claim.id as u128), claim);
+        });
+    }
+
+    /// Remove and return the claim with `id`, if present.
+    pub fn remove(id: u64) -> Option<ThreePoolPendingClaim> {
+        PENDING_CLAIMS.with(|m| m.borrow_mut().remove(&StorableU128(id as u128)))
+    }
+
+    /// Number of outstanding pending claims.
+    pub fn len() -> u64 {
+        PENDING_CLAIMS.with(|m| m.borrow().len())
+    }
+
+    /// List a bounded page of pending claims ordered by id.
+    pub fn list(offset: u64, limit: u64) -> Vec<ThreePoolPendingClaim> {
+        PENDING_CLAIMS.with(|m| {
+            m.borrow()
+                .iter()
+                .skip(offset as usize)
+                .take(limit as usize)
+                .map(|(_, v)| v)
+                .collect()
+        })
+    }
+}
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
@@ -857,6 +926,45 @@ mod tests {
         let bytes = sp.to_bytes();
         let back = StorablePrincipal::from_bytes(bytes);
         assert_eq!(back.0, p);
+    }
+
+    #[test]
+    fn pending_claims_roundtrip_and_recovery_api() {
+        // Audit 2026-06-05 (3P-01/02/03): the pending-claim recovery store must
+        // allocate monotonic ids, insert/remove/list, and survive read-back.
+        use crate::types::ThreePoolPendingClaim;
+        let claimant = Principal::from_text("2vxsx-fae").unwrap();
+        let ledger = Principal::anonymous();
+
+        let id0 = pending_claims::next_id();
+        let id1 = pending_claims::next_id();
+        assert_eq!(id1, id0 + 1, "ids must be monotonic");
+
+        let claim = ThreePoolPendingClaim {
+            id: id0,
+            claimant,
+            token_index: 1,
+            ledger,
+            symbol: "ckUSDT".to_string(),
+            amount: 5_000_000,
+            reason: "remove_liquidity payout failed".to_string(),
+            created_at: 123,
+        };
+        pending_claims::insert(claim.clone());
+        let before = pending_claims::len();
+        assert!(before >= 1);
+
+        let listed = pending_claims::list(0, 100);
+        assert!(listed.iter().any(|c| c.id == id0 && c.amount == 5_000_000 && c.token_index == 1));
+
+        // Removing returns the stored claim and shrinks the set.
+        let removed = pending_claims::remove(id0).expect("claim must be present");
+        assert_eq!(removed.amount, 5_000_000);
+        assert_eq!(removed.ledger, ledger);
+        assert_eq!(pending_claims::len(), before - 1);
+
+        // Removing a missing id is a clean None (claim_pending -> ClaimNotFound).
+        assert!(pending_claims::remove(id0).is_none());
     }
 
     #[test]

--- a/src/rumi_3pool/src/types.rs
+++ b/src/rumi_3pool/src/types.rs
@@ -405,6 +405,37 @@ pub enum ThreePoolError {
     /// should retry. Audit fence B-01 (Wave 14a): prevents two concurrent
     /// callers from pricing against the same pre-state across an `await`.
     PoolLocked,
+    /// No pending claim exists with the requested id (already resolved, or
+    /// never recorded). Audit 2026-06-05 (3P-01/02/03): pending-claim recovery.
+    ClaimNotFound,
+}
+
+/// A record of tokens the pool owes a user after a value-moving operation
+/// pulled or debited their funds but a subsequent ledger transfer failed.
+///
+/// Created when `swap` / `add_liquidity` / `remove_liquidity` / `remove_one_coin`
+/// cannot complete a payout or refund. The owed tokens physically remain in the
+/// pool's account; the claim lets the user (or admin) recover them later via
+/// `claim_pending`, instead of the funds being silently stranded. Mirrors the
+/// `rumi_amm::PendingClaim` recovery mechanism. Audit 2026-06-05 (3P-01/02/03).
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+pub struct ThreePoolPendingClaim {
+    pub id: u64,
+    /// The principal owed the tokens.
+    pub claimant: Principal,
+    /// Which of the pool's three tokens is owed (0, 1, or 2).
+    pub token_index: u8,
+    /// The ledger of the owed token, resolved at record time so a later
+    /// config change cannot redirect the payout.
+    pub ledger: Principal,
+    /// Display symbol of the owed token at record time.
+    pub symbol: String,
+    /// Amount owed in the token's native decimals.
+    pub amount: u128,
+    /// Human-readable reason the claim was recorded.
+    pub reason: String,
+    /// Unix seconds at which the claim was recorded.
+    pub created_at: u64,
 }
 
 // ─── Authorized Redeem-and-Burn Types ───

--- a/src/rumi_3pool/tests/audit_pocs_3p_recovery_and_token.rs
+++ b/src/rumi_3pool/tests/audit_pocs_3p_recovery_and_token.rs
@@ -1,0 +1,92 @@
+//! 3pool audit fences (2026-06-05-d67e100):
+//!
+//! 3P-01/02/03 (SAT-001/002): swap / add_liquidity / remove_liquidity /
+//!   remove_one_coin pulled or debited user funds, then on a failed ledger
+//!   transfer returned early with NO refund and NO recovery record — stranding
+//!   the funds (the rumi_amm handles this; the 3pool did not). The fix refunds
+//!   or records a pending claim on every failure path, recoverable via
+//!   `claim_pending`.
+//!
+//! SAT-007: the 3USD token rejected EVERY same-owner transfer
+//!   (`caller == to.owner`), breaking the "send 3USD with Internet Identity"
+//!   flow. Balances are keyed by owner only, so a same-owner transfer is a
+//!   net-zero no-op; the over-broad guard is removed.
+//!
+//! SAT-006: `icrc3_get_blocks` capped each range to the log length but not the
+//!   total across an unbounded `args` vector; the fix bounds the total response.
+//!
+//! These are source-level fences (the behavioral paths need a failing-ledger
+//! PocketIC harness; see report for the end-to-end repro). They FAIL on pre-fix
+//! source.
+
+use std::path::PathBuf;
+
+fn read(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+fn fn_body<'a>(src: &'a str, header: &'a str) -> &'a str {
+    let start = src.find(header).unwrap_or_else(|| panic!("`{}` not found", header));
+    let after = start + header.len();
+    let end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn ", "\n#[update]", "\n#[query]"]
+        .iter()
+        .filter_map(|m| src[after..].find(m).map(|i| after + i))
+        .min()
+        .unwrap_or(src.len());
+    &src[start..end]
+}
+
+#[test]
+fn p3_recovery_value_moving_paths_record_pending_claim() {
+    let src = read("src/lib.rs");
+    for header in [
+        "pub async fn swap(",
+        "pub async fn add_liquidity(",
+        "pub async fn remove_liquidity(",
+        "pub async fn remove_one_coin(",
+    ] {
+        let body = fn_body(&src, header);
+        assert!(
+            body.contains("record_pending_claim"),
+            "3pool entry `{}` must refund or record_pending_claim on a failed transfer so user \
+             funds are recoverable, not stranded (audit 3P-01/02/03).",
+            header
+        );
+    }
+    // The recovery endpoint and its query must exist.
+    assert!(src.contains("pub async fn claim_pending("), "claim_pending recovery endpoint missing");
+    assert!(src.contains("pub fn get_pending_claims("), "get_pending_claims query missing");
+}
+
+#[test]
+fn p3_withdraw_admin_fees_holds_pool_guard() {
+    // 3P-04: concurrent admin withdrawals could double-pay accrued fees.
+    let src = read("src/admin.rs");
+    let body = fn_body(&src, "pub async fn withdraw_admin_fees(");
+    assert!(
+        body.contains("PoolGuard::new"),
+        "withdraw_admin_fees must hold the PoolGuard so concurrent calls cannot double-pay fees \
+         (audit 3P-04)."
+    );
+}
+
+#[test]
+fn sat_007_3usd_allows_same_owner_transfer() {
+    // The over-broad "cannot transfer to self" rejection must be gone.
+    let src = read("src/icrc_token.rs");
+    assert!(
+        !src.contains("cannot transfer to self"),
+        "3USD must not reject same-owner transfers (the Internet Identity send bug); balances are \
+         owner-keyed so a same-owner transfer is a safe net-zero no-op (audit SAT-007)."
+    );
+}
+
+#[test]
+fn sat_006_icrc3_get_blocks_is_bounded() {
+    let src = read("src/icrc3.rs");
+    assert!(
+        src.contains("MAX_GET_BLOCKS_RESPONSE"),
+        "icrc3_get_blocks must cap the total blocks returned across all args (audit SAT-006)."
+    );
+}

--- a/src/rumi_amm/src/state.rs
+++ b/src/rumi_amm/src/state.rs
@@ -266,7 +266,47 @@ pub fn save_to_stable_memory() {
     });
 }
 
-/// V4 state shape (current on-chain: has pending_claims but no swap_events).
+/// V5 state shape — a frozen snapshot of `AmmState` AS OF the 2026-06-05 audit
+/// (SAT-004 fix). It mirrors every field of the live `AmmState` at this commit.
+///
+/// WHY THIS EXISTS: the live `AmmState` carries ~13 fields beyond V4
+/// (`swap_events`, `liquidity_events`, `admin_events`, `holder_snapshots`,
+/// `reward_events`, `claim_events`, `protocol_backend_principal`,
+/// `tvl_samples`, and their id counters). Before V5, the newest snapshot in
+/// the fallback chain was V4. So the next time anyone added a NON-`Option`
+/// field to `AmmState`, the on-chain bytes would fail `Decode!(_, AmmState)`
+/// and fall through to V4, silently resetting `protocol_backend_principal`
+/// (halting reward distribution) and dropping all post-V4 state WITHOUT a
+/// trap — the exact 2026-05-18 state-wipe incident class (UPG-002).
+///
+/// MAINTENANCE RULE: whenever you add a non-`Option` field to `AmmState`,
+/// FIRST add a new `AmmStateVN` that snapshots the *previous* shape (a copy of
+/// this struct) and wire it into `try_decode_state` ahead of V4. Keep this V5
+/// struct frozen — never edit it to track `AmmState`.
+#[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+struct AmmStateV5 {
+    pub admin: Principal,
+    pub pools: BTreeMap<PoolId, Pool>,
+    pub pool_creation_open: bool,
+    pub maintenance_mode: bool,
+    pub pending_claims: Vec<PendingClaim>,
+    pub next_claim_id: u64,
+    pub swap_events: Vec<AmmSwapEvent>,
+    pub next_swap_event_id: u64,
+    pub liquidity_events: Vec<AmmLiquidityEvent>,
+    pub next_liquidity_event_id: u64,
+    pub admin_events: Vec<AmmAdminEvent>,
+    pub next_admin_event_id: u64,
+    pub holder_snapshots: Vec<HolderSnapshot>,
+    pub reward_events: Vec<AmmRewardEvent>,
+    pub next_reward_event_id: u64,
+    pub claim_events: Vec<AmmClaimEvent>,
+    pub next_claim_event_id: u64,
+    pub protocol_backend_principal: Option<Principal>,
+    pub tvl_samples: Vec<TvlSample>,
+}
+
+/// V4 state shape (has pending_claims but no swap_events).
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
 struct AmmStateV4 {
     pub admin: Principal,
@@ -306,6 +346,32 @@ struct AmmStateV1 {
 pub fn try_decode_state(bytes: &[u8]) -> Option<AmmState> {
     if let Ok(state) = Decode!(bytes, AmmState) {
         return Some(state);
+    }
+    // V5: the frozen snapshot of the current shape. This is what protects a
+    // future non-Option field addition from silently falling through to V4 and
+    // wiping post-V4 state (SAT-004). It maps 1:1 onto AmmState today.
+    if let Ok(v5) = Decode!(bytes, AmmStateV5) {
+        return Some(AmmState {
+            admin: v5.admin,
+            pools: v5.pools,
+            pool_creation_open: v5.pool_creation_open,
+            maintenance_mode: v5.maintenance_mode,
+            pending_claims: v5.pending_claims,
+            next_claim_id: v5.next_claim_id,
+            swap_events: v5.swap_events,
+            next_swap_event_id: v5.next_swap_event_id,
+            liquidity_events: v5.liquidity_events,
+            next_liquidity_event_id: v5.next_liquidity_event_id,
+            admin_events: v5.admin_events,
+            next_admin_event_id: v5.next_admin_event_id,
+            holder_snapshots: v5.holder_snapshots,
+            reward_events: v5.reward_events,
+            next_reward_event_id: v5.next_reward_event_id,
+            claim_events: v5.claim_events,
+            next_claim_event_id: v5.next_claim_event_id,
+            protocol_backend_principal: v5.protocol_backend_principal,
+            tvl_samples: v5.tvl_samples,
+        });
     }
     if let Ok(v4) = Decode!(bytes, AmmStateV4) {
         return Some(AmmState {
@@ -404,12 +470,18 @@ pub fn try_decode_state(bytes: &[u8]) -> Option<AmmState> {
 
 /// Restore state from stable memory (called from post_upgrade).
 ///
-/// UPG-002 fix: rather than trapping on decode failure (which bricks the
-/// canister until a hotfix wasm ships), walk the V-current..V1 fallback chain
-/// via `try_decode_state`. If every known version fails, log a CRITICAL
-/// diagnostic with the snapshot length and a short hex preview, then fall
-/// back to empty state. AMM positions are reconstructable from underlying
-/// ledger balances, so empty fallback is a defensible last resort here.
+/// Walk the V-current..V1 fallback chain via `try_decode_state`. If a known
+/// version decodes, restore it.
+///
+/// If EVERY known version fails, TRAP (audit 2026-06-05). The previous behavior
+/// fell back to empty state on the theory that "AMM positions are
+/// reconstructable from underlying ledger balances" — but that is false: pool
+/// `reserve_a/reserve_b` are pure internal accounting (never re-synced from
+/// `icrc1_balance_of`) and the per-LP reward state (`acc_reward_per_share`,
+/// `lp_rewards`, `pending_claims`) cannot be reconstructed at all. A silent
+/// wipe of live pools is exactly the 2026-05-18 incident class. Trapping keeps
+/// the canister on its old wasm with state intact until a fix ships, matching
+/// the backend (UPG-001) and the other satellites.
 pub fn load_from_stable_memory() {
     let mut len_bytes = [0u8; 8];
     ic_cdk::api::stable::stable64_read(0, &mut len_bytes);
@@ -435,12 +507,16 @@ pub fn load_from_stable_memory() {
     log!(
         INFO,
         "CRITICAL UPG-002: AMM snapshot decode failed for all known schema versions \
-         (current, V4, V3, V2, V1). snapshot_len={} bytes, first_{}_bytes_hex={}. \
-         Falling back to empty state. AMM positions can be reconstructed from \
-         underlying ledger balances; admin must re-set via admin endpoints.",
+         (current, V5, V4, V3, V2, V1). snapshot_len={} bytes, first_{}_bytes_hex={}. \
+         Trapping to preserve on-chain state (old wasm + stable memory stay intact) \
+         rather than wiping live pools and reward state. Ship a wasm with a matching \
+         AmmStateVN snapshot to recover.",
         bytes.len(),
         preview_len,
         preview_hex
     );
-    replace_state(AmmState::default());
+    ic_cdk::trap(
+        "AMM post_upgrade: stable state did not decode under any known schema version \
+         (current, V5, V4, V3, V2, V1); refusing to wipe live pools — see CRITICAL log",
+    );
 }

--- a/src/rumi_amm/tests/audit_pocs_upg_002_decode_fallback.rs
+++ b/src/rumi_amm/tests/audit_pocs_upg_002_decode_fallback.rs
@@ -9,17 +9,27 @@
 //! bricks the canister.
 //!
 //! The fix extracts the version-walking logic into `try_decode_state`, which
-//! returns `None` if every known version fails. The caller (`load_from_stable_memory`)
-//! then logs a CRITICAL diagnostic and falls back to `AmmState::default()`. AMM
-//! positions are reconstructable from underlying ledger balances, so empty
-//! fallback is a defensible last resort here (versus stability_pool, where
-//! empty fallback zeroes depositor positions and is therefore the absolute
-//! last resort).
+//! returns `None` if every known version fails.
+//!
+//! UPDATE (audit 2026-06-05, SAT-004): the caller `load_from_stable_memory` now
+//! TRAPS when every known version fails, instead of wiping to
+//! `AmmState::default()`. The old "AMM positions are reconstructable from ledger
+//! balances" justification was false — pool reserves are internal-only
+//! accounting and the per-LP reward state cannot be reconstructed. A silent
+//! wipe of live pools is the 2026-05-18 incident class. `try_decode_state` still
+//! returns `None` on undecodable input (the unit-testable contract below); only
+//! the caller's reaction changed from wipe to trap.
+//!
+//! Also added: `AmmStateV5`, a frozen snapshot of the current shape, so the next
+//! non-Option field added to `AmmState` decodes via V5 instead of silently
+//! falling through to V4 (which would drop `protocol_backend_principal` and all
+//! post-V4 state).
 //!
 //! These unit tests exercise `try_decode_state` directly:
 //! 1. Valid encoded state decodes round-trip.
 //! 2. Corrupt bytes return None (no trap, no panic).
 //! 3. Truncated and empty bytes return None.
+//! 4. A fully-populated current state round-trips with post-V4 fields intact.
 
 use candid::Encode;
 use rumi_amm::state::{try_decode_state, AmmState};
@@ -68,4 +78,35 @@ fn upg_002_empty_bytes_return_none_no_trap() {
         decoded.is_none(),
         "UPG-002: empty bytes must return None, not panic or trap",
     );
+}
+
+#[test]
+fn sat_004_populated_state_preserves_post_v4_fields() {
+    // SAT-004: the fields the live AmmState carries beyond V4
+    // (protocol_backend_principal, event logs + counters, tvl_samples) must
+    // survive an upgrade round-trip. Before the AmmStateV5 snapshot, the next
+    // non-Option field added to AmmState would route the decode to V4 and
+    // silently reset protocol_backend_principal to None (halting reward
+    // distribution) and drop all post-V4 state. This pins the round-trip for
+    // the current shape so a broken/ reordered decode is caught.
+    let mut state = AmmState::default();
+    let backend = candid::Principal::from_text("aaaaa-aa").unwrap();
+    state.protocol_backend_principal = Some(backend);
+    state.next_swap_event_id = 42;
+    state.next_claim_id = 7;
+
+    let bytes = Encode!(&state).expect("encode populated AmmState");
+    let decoded = try_decode_state(&bytes).expect("populated state must decode");
+
+    assert_eq!(
+        decoded.protocol_backend_principal,
+        Some(backend),
+        "SAT-004: protocol_backend_principal must survive decode, else reward \
+         distribution halts after upgrade",
+    );
+    assert_eq!(
+        decoded.next_swap_event_id, 42,
+        "SAT-004: post-V4 counters must survive the decode",
+    );
+    assert_eq!(decoded.next_claim_id, 7);
 }

--- a/src/rumi_analytics/Cargo.toml
+++ b/src/rumi_analytics/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-candid = "0.10.6"
+candid = { version = "0.10.6", features = ["value"] }
 ic-cdk = "0.12.0"
 ic-cdk-timers = "0.10.0"
 ic-cdk-macros = "0.8.3"

--- a/src/rumi_analytics/src/sources/backend.rs
+++ b/src/rumi_analytics/src/sources/backend.rs
@@ -510,6 +510,100 @@ impl BackendEvent {
     }
 }
 
+/// Decode a raw Candid response blob from `get_events` into a `(decoded,
+/// total_fetched)` pair using per-element decoding.
+///
+/// `cursor_start` is the absolute event index of the first element in this
+/// batch; it is used only for log messages.
+///
+/// Exposed as `pub(crate)` so unit tests can drive it without a live IC
+/// runtime.  The async `get_events_resilient` wrapper is the only production
+/// call-site.
+pub(crate) fn decode_events_resilient(
+    raw_bytes: &[u8],
+    cursor_start: u64,
+) -> Result<(Vec<BackendEvent>, u64), String> {
+    // Decode the response as generic IDLArgs so that unknown variant hashes
+    // do not abort the parse.  The response is a 1-tuple whose single arg is
+    // a vec of variants.
+    let idl_args = candid::IDLArgs::from_bytes(raw_bytes)
+        .map_err(|e| format!("get_events IDLArgs parse: {}", e))?;
+
+    let elements: Vec<candid::IDLValue> = match idl_args.args.into_iter().next() {
+        Some(candid::IDLValue::Vec(v)) => v,
+        Some(other) => {
+            return Err(format!(
+                "get_events: expected Vec, got {:?}",
+                std::mem::discriminant(&other)
+            ))
+        }
+        None => return Err("get_events: empty response tuple".to_string()),
+    };
+
+    let total_fetched = elements.len() as u64;
+    let mut decoded = Vec::with_capacity(elements.len());
+
+    for (idx, elem) in elements.into_iter().enumerate() {
+        let abs_idx = cursor_start + idx as u64;
+        // Re-encode the individual element as a 1-arg IDL blob so that the
+        // standard typed decoder can consume it.
+        let elem_bytes = match candid::IDLArgs::new(&[elem]).to_bytes() {
+            Ok(b) => b,
+            Err(e) => {
+                ic_cdk::println!(
+                    "[tail_backend] event idx={} re-encode failed (skipping): {}",
+                    abs_idx,
+                    e
+                );
+                continue;
+            }
+        };
+        match candid::decode_one::<BackendEvent>(&elem_bytes) {
+            Ok(event) => decoded.push(event),
+            Err(e) => {
+                ic_cdk::println!(
+                    "[tail_backend] event idx={} unknown/undecodable variant (skipping): {}",
+                    abs_idx,
+                    e
+                );
+            }
+        }
+    }
+
+    Ok((decoded, total_fetched))
+}
+
+/// Fetch a batch of backend events and decode each element individually.
+///
+/// Returns `(decoded, total_fetched)` where:
+/// - `decoded` is the list of events that could be decoded as a known
+///   `BackendEvent` variant; elements that fail to decode are skipped.
+/// - `total_fetched` is the number of elements the backend actually returned
+///   in the batch, including any that were skipped due to unknown/undecodable
+///   variants.
+///
+/// The caller MUST advance the cursor by `total_fetched` (not just
+/// `decoded.len()`) so that undecodable events are not re-fetched on the
+/// next tick. A single unknown variant in the middle of a batch no longer
+/// poisons the entire batch.
+pub async fn get_events_resilient(
+    backend: Principal,
+    start: u64,
+    length: u64,
+) -> Result<(Vec<BackendEvent>, u64), String> {
+    let arg = GetEventsArg { start, length };
+    let arg_bytes = candid::encode_one(&arg)
+        .map_err(|e| format!("get_events_resilient encode: {}", e))?;
+
+    let raw_bytes = ic_cdk::api::call::call_raw(backend, "get_events", arg_bytes, 0)
+        .await
+        .map_err(|(code, msg)| format!("get_events: {:?} {}", code, msg))?;
+
+    decode_events_resilient(&raw_bytes, start)
+}
+
+/// Legacy typed fetch — kept for reference; prefer `get_events_resilient`.
+#[allow(dead_code)]
 pub async fn get_events(
     backend: Principal,
     start: u64,
@@ -527,4 +621,122 @@ pub async fn get_event_count(backend: Principal) -> Result<u64, String> {
         .await
         .map_err(|(code, msg)| format!("get_event_count: {:?} {}", code, msg))?;
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::CandidType;
+
+    /// A superset of `BackendEvent` used on the "sender side" in tests.
+    ///
+    /// This mirrors how the real backend works: the backend may add new variants
+    /// that the analytics mirror does not yet know about.  We encode a batch
+    /// using this extended enum and then verify that `decode_events_resilient`
+    /// (which uses `BackendEvent` as the target type) handles the unknown
+    /// variants gracefully.
+    ///
+    /// IMPORTANT: All variants that should decode successfully as `BackendEvent`
+    /// must carry the same `#[serde(rename = "...")]` tag as they do in
+    /// `BackendEvent`. Unknown variants use any name not in `BackendEvent`.
+    #[derive(CandidType, Deserialize, Clone, Debug)]
+    enum BackendEventExtended {
+        // Known variants (same serde rename as BackendEvent)
+        #[serde(rename = "price_update")]
+        PriceUpdate {},
+        #[serde(rename = "init")]
+        Init {},
+        // Unknown variant — not present in the analytics BackendEvent mirror.
+        // This simulates a future backend variant that analytics hasn't added yet.
+        #[serde(rename = "new_future_backend_event_v999")]
+        NewFutureBackendEventV999 {},
+    }
+
+    /// Encode a batch as a raw Candid response blob `(Vec<BackendEventExtended>,)`.
+    ///
+    /// This produces bytes in exactly the shape the backend would send: a
+    /// 1-tuple whose first (and only) element is a vec of variant values,
+    /// each encoded with the full candid type table including all variant
+    /// hashes.  The type table is derived from `BackendEventExtended`, so the
+    /// unknown variant's hash IS present in the wire format — analytics'
+    /// `decode_events_resilient` must skip it without aborting the batch.
+    fn encode_batch(events: Vec<BackendEventExtended>) -> Vec<u8> {
+        candid::encode_one(events).expect("encode_batch: failed to encode")
+    }
+
+    /// (a) A batch containing ONLY known variants decodes fully without error.
+    #[test]
+    fn all_known_variants_decode_fully() {
+        let raw = encode_batch(vec![
+            BackendEventExtended::PriceUpdate {},
+            BackendEventExtended::Init {},
+        ]);
+        let (decoded, total) = decode_events_resilient(&raw, 0).expect("should not error");
+        assert_eq!(total, 2, "total_fetched must equal elements in batch");
+        assert_eq!(decoded.len(), 2, "all known events must be decoded");
+    }
+
+    /// (b) A batch with one unknown variant in the middle does not fail the
+    ///     whole batch: known events on either side are still decoded.
+    /// (c) The cursor-advance count (total_fetched) equals the full batch size,
+    ///     not just the number of successfully decoded events, so the tailer
+    ///     always makes forward progress even when new backend variants appear.
+    #[test]
+    fn unknown_variant_skipped_known_events_preserved_cursor_advances() {
+        // Three-element batch: known | unknown | known
+        let raw = encode_batch(vec![
+            BackendEventExtended::PriceUpdate {},
+            BackendEventExtended::NewFutureBackendEventV999 {},
+            BackendEventExtended::Init {},
+        ]);
+        let (decoded, total) =
+            decode_events_resilient(&raw, 100).expect("should not error on mixed batch");
+
+        // (c) cursor advance count = full batch size (3), not decoded count (2)
+        assert_eq!(
+            total, 3,
+            "total_fetched must include the skipped unknown event so cursor always advances"
+        );
+
+        // (b) the two known events on either side of the unknown are preserved
+        assert_eq!(
+            decoded.len(),
+            2,
+            "known events on either side of unknown variant must be decoded"
+        );
+
+        // Verify the known events decode to the expected variants
+        assert!(
+            matches!(decoded[0], BackendEvent::PriceUpdate {}),
+            "first event must decode as PriceUpdate"
+        );
+        assert!(
+            matches!(decoded[1], BackendEvent::Init {}),
+            "third event must decode as Init"
+        );
+    }
+
+    /// A batch consisting entirely of unknown variants: decoded list is empty
+    /// but total_fetched still equals the batch size so the cursor advances.
+    #[test]
+    fn all_unknown_variants_cursor_still_advances() {
+        let raw = encode_batch(vec![
+            BackendEventExtended::NewFutureBackendEventV999 {},
+            BackendEventExtended::NewFutureBackendEventV999 {},
+        ]);
+        let (decoded, total) =
+            decode_events_resilient(&raw, 0).expect("should not error on all-unknown batch");
+        assert_eq!(total, 2, "total_fetched must equal batch size even when all are unknown");
+        assert_eq!(decoded.len(), 0, "no events should be decoded when all are unknown");
+    }
+
+    /// An empty batch is valid: both counts are 0 and no error is returned.
+    #[test]
+    fn empty_batch_is_valid() {
+        let raw = encode_batch(vec![]);
+        let (decoded, total) =
+            decode_events_resilient(&raw, 0).expect("should not error on empty batch");
+        assert_eq!(total, 0);
+        assert_eq!(decoded.len(), 0);
+    }
 }

--- a/src/rumi_analytics/src/tailing/backend_events.rs
+++ b/src/rumi_analytics/src/tailing/backend_events.rs
@@ -30,27 +30,33 @@ pub async fn run() {
     if count <= cursor { return; }
 
     let fetch_len = (count - cursor).min(BATCH_SIZE);
-    let events = match sources::backend::get_events(backend, cursor, fetch_len).await {
-        Ok(e) => e,
-        Err(e) => {
-            ic_cdk::println!("[tail_backend] get_events failed: {}", e);
-            state::mutate_state(|s| {
-                s.error_counters.backend += 1;
-                update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
-            });
-            return;
-        }
-    };
+    // Use the resilient per-element decoder so that a single unknown or
+    // undecodable variant does not poison the whole batch.  The cursor is
+    // advanced by `total_fetched` (all elements the backend returned),
+    // regardless of how many were actually decoded, so the tailer always
+    // makes forward progress even when the backend ships a new variant that
+    // analytics does not yet mirror.
+    let (events, total_fetched) =
+        match sources::backend::get_events_resilient(backend, cursor, fetch_len).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                ic_cdk::println!("[tail_backend] get_events failed: {}", e);
+                state::mutate_state(|s| {
+                    s.error_counters.backend += 1;
+                    update_cursor_error(s, cursors::CURSOR_ID_BACKEND_EVENTS, e);
+                });
+                return;
+            }
+        };
 
-    let mut processed = 0u64;
     for (i, event) in events.iter().enumerate() {
         let event_id = cursor + i as u64;
         route_backend_event(event_id, event);
-        processed += 1;
     }
 
-    if processed > 0 {
-        cursors::backend_events::set(cursor + processed);
+    // Advance by total_fetched so unknown-variant events are not re-fetched.
+    if total_fetched > 0 {
+        cursors::backend_events::set(cursor + total_fetched);
         state::mutate_state(|s| {
             update_cursor_success(s, cursors::CURSOR_ID_BACKEND_EVENTS, ic_cdk::api::time());
         });

--- a/src/rumi_points/DEPLOY_RUNBOOK.md
+++ b/src/rumi_points/DEPLOY_RUNBOOK.md
@@ -1,0 +1,176 @@
+# rumi_points — airdrop launch runbook
+
+Authoritative sequence for the **full public launch** of the airdrop points
+engine. Maps to launch items 1-5. Companion to `STATUS.md` (what the canister
+does) — this file is *how to ship it*.
+
+> Conventions: `DFX="$HOME/Library/Application Support/org.dfinity.dfx/bin/dfx"`,
+> `export DFX_WARNING=-mainnet_plaintext_identity`, and **always**
+> `--identity rumi_identity` for mainnet. NEVER reinstall a stateful canister —
+> upgrades only. `rumi_points` itself is a *fresh install* (new canister).
+
+---
+
+## 0. Status at time of writing (2026-06-07)
+
+| Item | State |
+|------|-------|
+| 1. POINTS-001/002 hardening | ✅ committed + verified (146 lib / 7 PocketIC / candid), PR #228 open, **awaiting merge OK** |
+| 2. Reserve mainnet canister id | ⛔ not done — Rob's action (irreversible) |
+| 3. Deploy trio (points + backend + 3pool) | ⛔ blocked — see the blocker below |
+| 4. Operate (commit H0 / poll / start_season) | ⛔ blocked on 3; needs secret seed `S0` from Rob |
+| 5. Phase 6 frontend | ⛔ not built; declarations generated (this pass) |
+
+## ⚠️ THE deploy blocker (verified 2026-06-07)
+
+The poller reads two **source endpoints that are NOT live on mainnet**. Verified
+by direct query call:
+
+```
+$DFX canister --network ic --identity rumi_identity call \
+  tfesu-vyaaa-aaaap-qrd7a-cai get_events_forward_filtered '(0:nat64,1:nat64,null)' --query
+  -> CanisterError: Canister has no query method 'get_events_forward_filtered'
+
+$DFX canister --network ic --identity rumi_identity call \
+  fohh4-yyaaa-aaaap-qtkpa-cai get_liquidity_events_v2_forward '(0:nat64,1:nat64)' --query
+  -> CanisterError: Canister has no query method 'get_liquidity_events_v2_forward'
+```
+
+Both endpoints are **committed on `main`** but the deployed mainnet wasms predate
+them. So the launch is genuinely a **trio deploy**: install `rumi_points` AND
+upgrade `rumi_protocol_backend` AND upgrade `rumi_3pool`.
+
+**Consequence — the airdrop deploy rides with / follows the 2026-06-05 audit.**
+There are ~37 uncommitted backend + ~8 uncommitted 3pool audit changes in the
+working tree (incl. LIVE backend HIGHs per the audit memory). Deploying the
+backend/3pool forward endpoints from bare `main` would ship a backend WITHOUT
+those audit fixes and burn a backend upgrade. Correct order: **land the
+2026-06-05 audit first**, then one combined upgrade carries audit fixes + the
+forward endpoints, and `rumi_points` installs alongside.
+
+---
+
+## Gates that are Rob's (cannot proceed without)
+
+1. **Merge PR #228** (item 1).
+2. **Reserve the mainnet canister id** for `rumi_points` (item 2) — irreversible,
+   spends ICP/cycles on `rumi_identity`. Add to `canister_ids.json` + `mainnet-live`.
+3. **Deploy authorization** (item 3) — and the audit landing first (above).
+4. **The secret 32-byte season seed `S0`** (item 4) — Rob generates and holds it
+   (commit-reveal; the canister must not generate its own secret). `H0 = sha256(S0)`
+   is committed at install; `S0` is revealed via `start_season(S0)`.
+
+---
+
+## Pre-flight facts
+
+- **Wasm exceeds the 2 MiB ingress limit.** Release wasm is **2.43 MB**
+  (2,429,258 B) > 2,097,152 B. Must `ic-wasm shrink` + `gzip` before install
+  (gzips to ~606 KB). Same treatment as `rumi_analytics`.
+- **H0 is set at install** via `InitArgs.snapshot_seed_commit` (opt blob). If left
+  `None` it defaults to all-zeros → `is_committed()` is false → `start_season`
+  rejects with `NotCommitted` (the F3 security fix). **You must pass H0 at install.**
+- **`excluded_principals` REPLACES, not merges.** `None` applies the built-in
+  9-canister protocol-owned seed; passing a vec overrides it entirely.
+- **Source/asset config is mainnet-seeded automatically** at init (no override
+  needed on mainnet; `set_source_canister`/`set_asset_ledger` are for local/test).
+- **Default season window:** `2026-06-01 00:00 UTC → 2026-08-31 23:59 UTC` (91 days).
+  Already started; fine (poll backfills from cursor 0). Confirm or override via
+  `season_start_ns`/`season_end_ns`.
+
+```
+InitArgs = record {
+  admin                : opt principal;   // defaults to deploying identity
+  excluded_principals  : opt vec principal; // None = 9-canister seed (REPLACES)
+  snapshot_seed_commit : opt blob;        // H0 = sha256(S0) — REQUIRED to start a season
+  season_start_ns      : opt nat64;       // default 2026-06-01
+  season_end_ns        : opt nat64;       // default 2026-08-31
+}
+```
+
+---
+
+## Deploy sequence
+
+**A. Land the 2026-06-05 audit** (prerequisite; separate work) so `main` carries
+audit fixes + the committed forward endpoints.
+
+**B. Merge PR #228** (item 1) into the deploy `main`.
+
+**C. Reserve the canister id** (Rob):
+```
+$DFX canister --network ic --identity rumi_identity create rumi_points
+# add the returned id to canister_ids.json and the mainnet-live list
+```
+
+**D. Generate the seed** (Rob, offline, keep S0 secret):
+```
+S0 = 32 random bytes            # keep secret, store safely
+H0 = sha256(S0)                 # the commitment passed at install
+```
+
+**E. Build + shrink + gzip + install `rumi_points`:**
+```
+cargo build --release --target wasm32-unknown-unknown -p rumi_points
+ic-wasm target/wasm32-unknown-unknown/release/rumi_points.wasm -o /tmp/rumi_points.shrunk.wasm shrink
+gzip -c /tmp/rumi_points.shrunk.wasm > /tmp/rumi_points.wasm.gz
+# install with InitArgs carrying H0 + the chosen season window:
+$DFX canister --network ic --identity rumi_identity install rumi_points \
+  --wasm /tmp/rumi_points.wasm.gz \
+  --argument '(opt record { snapshot_seed_commit = opt blob "<H0>"; season_start_ns = null; season_end_ns = null; admin = null; excluded_principals = null })'
+```
+
+**F. Upgrade backend** (forward endpoints) — Upgrade variant + description:
+```
+$DFX deploy rumi_protocol_backend --network ic --identity rumi_identity \
+  --argument '(variant { Upgrade = record { mode = null; description = opt "Add airdrop source-forward read endpoints (+ 2026-06-05 audit)" } })'
+```
+
+**G. Upgrade 3pool** (forward endpoint) — dummy ThreePoolInitArgs required on upgrade:
+```
+$DFX deploy rumi_3pool --network ic --identity rumi_identity --argument '(<dummy ThreePoolInitArgs>)'
+```
+
+**H. Verify the trio:** re-run the two query calls from the blocker section — both
+must now return data instead of "no query method".
+
+> The pre-deploy hook (`.claude/hooks/pre-deploy-test.sh`) runs the full suite
+> (incl. the POCKET_IC_BIN E2E) before any mainnet deploy.
+
+---
+
+## Operate sequence (item 4)
+
+1. Confirm config: `get_source_canisters`, `get_asset_ledgers` (mainnet-seeded);
+   `get_pending_commit` should equal H0.
+2. `set_poll_enabled(true)` — start ingestion.
+3. Let the poll timer run (or `trigger_poll`); confirm registrations via
+   `get_ingest_status` and `leaderboard`.
+4. `start_season(<S0 as blob>)` — opens epoch 0, enables the epoch driver,
+   begins the commit-reveal chain.
+5. Monitor: public `get_epoch_status`; admin-only `get_epoch_status_admin` for
+   cursor/progress; `get_revealed_seed(i)` for the audit chain. `force_epoch_tick`
+   is manual step / ops recovery.
+
+---
+
+## Frontend (item 5)
+
+- Declarations generated at `src/declarations/rumi_points/` (this pass).
+- `index.js` resolves the id from `process.env.CANISTER_ID_RUMI_POINTS` — auto-set
+  once the id is in `canister_ids.json` (step C).
+- Surfaces to build: enrollment (confetti), personal status, leaderboard.
+
+---
+
+## Known non-blockers
+
+- **5x ckUSDC/ckUSDT repayment window** is gated on the upstream backend
+  `RepayToVault.repayment_asset` field (confirmed still NOT built 2026-06-07).
+  Season 1 launches without it; the window is skipped + logged. Flip
+  `source_types::backend::normalize` to read the real field when it ships — no
+  other change here.
+- **Capture stall counter** (STATUS follow-up): a permanently-unreachable source
+  safely stalls the epoch (never closes); visible via `get_epoch_status_admin`,
+  recoverable via `add_excluded` / `force_epoch_tick`. Surfacing a stall count is
+  a nicety, not a blocker.

--- a/src/rumi_points/rumi_points.did
+++ b/src/rumi_points/rumi_points.did
@@ -46,14 +46,18 @@ type LeaderboardEntry = record {
   estimated_share_bps : nat32;
 };
 type OpenEpoch = record {
+  close_active : nat64;
+  close_cursor : opt principal;
   epoch_index : nat64;
   epoch_start_ns : nat64;
   a_cursor : opt principal;
   b_complete : bool;
   b_cursor : opt principal;
+  close_started : bool;
   a_complete : bool;
   snapshot_a_ns : nat64;
   snapshot_b_ns : nat64;
+  close_points_accrued : nat;
   epoch_end_ns : nat64;
 };
 type PointsConfig = record {
@@ -74,6 +78,21 @@ type PrincipalState = record {
   first_qualifying_action : QualifyingAction;
   active_deposits : vec record { DepositKey; DepositRecord };
   last_epoch_processed : nat64;
+};
+type PublicEpochStatus = record {
+  open_epoch : opt PublicOpenEpoch;
+  snapshot_seed_committed : bool;
+  driver_interval_secs : nat64;
+  revealed_seed_count : nat64;
+  current_epoch_index : nat64;
+  driver_enabled : bool;
+};
+type PublicOpenEpoch = record {
+  epoch_index : nat64;
+  epoch_start_ns : nat64;
+  snapshot_a_ns : nat64;
+  snapshot_b_ns : nat64;
+  epoch_end_ns : nat64;
 };
 type QualifyingAction = variant {
   ProvideAmmLiquidity;
@@ -110,7 +129,8 @@ service : (opt InitArgs) -> {
   force_epoch_tick : () -> (Result);
   get_asset_ledgers : () -> (vec record { nat8; principal }) query;
   get_epoch_history : (nat32, nat32) -> (vec EpochSummary) query;
-  get_epoch_status : () -> (EpochStatus) query;
+  get_epoch_status : () -> (PublicEpochStatus) query;
+  get_epoch_status_admin : () -> (EpochStatus) query;
   get_excluded_principals : () -> (vec principal) query;
   get_ingest_status : () -> (IngestStatus) query;
   get_leaderboard : (nat32, nat32) -> (vec LeaderboardEntry) query;

--- a/src/rumi_points/src/epoch.rs
+++ b/src/rumi_points/src/epoch.rs
@@ -245,6 +245,10 @@ fn open_new_epoch(index: u64, seed_arg: Option<[u8; 32]>, _now: u64) -> Result<(
         a_complete: false,
         b_cursor: None,
         b_complete: false,
+        close_started: false,
+        close_cursor: None,
+        close_points_accrued: 0,
+        close_active: 0,
     }));
     Ok(())
 }
@@ -297,7 +301,15 @@ async fn capture(which: Snapshot) {
         Snapshot::A => open.a_cursor,
         Snapshot::B => open.b_cursor,
     };
-    let chunk = state::registered_chunk_after(cursor, CAPTURE_CHUNK);
+    // Capture in a seed-derived, unpredictable order (POINTS-001 defense-in-depth):
+    // an attacker who cannot predict when their principal is captured cannot time a
+    // flash deposit to land just before their snapshot chunk. The order is stable
+    // for the epoch (the cursor resumes correctly). Fall back to principal order
+    // only if no seed is available (should not happen once an epoch is open).
+    let chunk = match state::current_epoch_seed() {
+        Some(seed) => state::registered_chunk_after_shuffled(&seed, cursor, CAPTURE_CHUNK),
+        None => state::registered_chunk_after(cursor, CAPTURE_CHUNK),
+    };
     let mut last_captured: Option<Principal> = None;
     let mut hit_error = false;
     for p in &chunk {
@@ -340,15 +352,33 @@ async fn capture(which: Snapshot) {
     state::set_open_epoch(Some(open));
 }
 
-// ── Epoch close ──
+// ── Epoch close (chunked, POINTS-002) ──
 
+/// One `Close` step. The close is CHUNKED: each call processes a bounded batch of
+/// principals (`run_close_accrual_chunk`) and persists the resume cursor + running
+/// totals into the open epoch. Only once the whole registered set has been closed
+/// (`CloseStep::Done`) does it finalize: reveal the seed, append the summary,
+/// advance the epoch index, and clear the open epoch. While batches remain it
+/// returns early, leaving the epoch open at `DriverAction::Close` so the next tick
+/// resumes. This keeps each message well under the 5B-instruction limit and makes
+/// the close re-entrant-safe (the single-tick `EPOCH_IN_PROGRESS` guard already
+/// serializes ticks) and idempotent (the cursor advances exactly-once per
+/// principal, so a re-run never double-credits).
 fn close_current_epoch(now: u64) {
+    let stats = match state::run_close_accrual_chunk(now) {
+        // Still principals left to close: persist progress (already done inside the
+        // chunk) and return. The epoch stays open; `next_action` returns `Close`
+        // again next tick and we resume from the persisted cursor.
+        state::CloseStep::More => return,
+        state::CloseStep::Done(stats) => stats,
+    };
+    // Re-read the open epoch (the chunk persisted the final cursor/totals into it).
     let open = match state::get_open_epoch() {
         Some(o) => o,
+        // Defensive: the close finished but the epoch vanished (e.g. a concurrent
+        // forced close). Nothing left to finalize.
         None => return,
     };
-    let stats =
-        state::run_close_accrual(open.epoch_index, open.epoch_start_ns, open.epoch_end_ns, now);
     let summary = EpochSummary {
         epoch_index: open.epoch_index,
         epoch_start_ns: open.epoch_start_ns,
@@ -613,6 +643,10 @@ mod tests {
             a_complete,
             b_cursor: None,
             b_complete,
+            close_started: false,
+            close_cursor: None,
+            close_points_accrued: 0,
+            close_active: 0,
         }
     }
 

--- a/src/rumi_points/src/main.rs
+++ b/src/rumi_points/src/main.rs
@@ -9,7 +9,7 @@ use ic_canister_log::{declare_log_buffer, log};
 use rumi_points::snapshot_seed::RevealedSeed;
 use rumi_points::types::{
     EpochStatus, EpochSummary, IngestStatus, InitArgs, LeaderboardEntry, PointsConfig, PointsError,
-    PrincipalState, RegistrationInfo, SourceStatus,
+    PrincipalState, PublicEpochStatus, RegistrationInfo, SourceStatus,
 };
 use rumi_points::{epoch, poll, state};
 
@@ -239,8 +239,24 @@ fn get_asset_ledgers() -> Vec<(u8, Principal)> {
     state::asset_ledgers()
 }
 
+/// PUBLIC epoch status (POINTS-001). Returns the open epoch's bounds + snapshot
+/// times only; the in-flight capture/close cursors and completion flags are
+/// withheld so a not-yet-captured principal cannot watch the cursor and time a
+/// flash deposit to beat the `min(A,B)` anti-snipe defense. Admins use
+/// `get_epoch_status_admin` for the full progress view.
 #[ic_cdk::query]
-fn get_epoch_status() -> EpochStatus {
+fn get_epoch_status() -> PublicEpochStatus {
+    state::public_epoch_status()
+}
+
+/// ADMIN-ONLY full epoch status, including the capture/close cursors and
+/// completion flags (POINTS-001). Traps for non-admin callers so the cursor
+/// progress is never disclosed publicly.
+#[ic_cdk::query]
+fn get_epoch_status_admin() -> EpochStatus {
+    if !state::is_admin(ic_cdk::caller()) {
+        ic_cdk::trap("unauthorized: get_epoch_status_admin is admin-only");
+    }
     state::epoch_status()
 }
 

--- a/src/rumi_points/src/state.rs
+++ b/src/rumi_points/src/state.rs
@@ -52,8 +52,8 @@ use crate::accrual::{self, SnapshotWeights};
 use crate::snapshot_seed::{RevealedSeed, SnapshotSeedSingleton};
 use crate::types::{
     AssetType, DepositKey, DepositRecord, EpochStatus, EpochSummary, InitArgs, LeaderboardEntry,
-    OpenEpoch, PointEntry, PointSource, PointsConfig, PointsError, PrincipalState, QualifyingAction,
-    RegistrationInfo, RepaymentEvent, Venue,
+    OpenEpoch, PointEntry, PointSource, PointsConfig, PointsError, PrincipalState, PublicEpochStatus,
+    PublicOpenEpoch, QualifyingAction, RegistrationInfo, RepaymentEvent, Venue,
 };
 
 // ── Memory ids (never reuse) ────────────────────────────────────────────────
@@ -174,6 +174,75 @@ pub struct StateV1 {
     pub snapshot_seed: SnapshotSeedSingleton,
 }
 
+/// FROZEN V2 shape of the open epoch (pre-POINTS-002, before the chunked-close
+/// fields). Old `StoredState::V2` blobs whose `open_epoch` is `Some` decode into
+/// this; it migrates forward to the current `OpenEpoch` with the `close_*` fields
+/// defaulted (a mid-epoch upgrade that lands before the close simply re-runs the
+/// close from the start, which is idempotent). NEVER change these fields.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct OpenEpochV2 {
+    pub epoch_index: u64,
+    pub epoch_start_ns: u64,
+    pub epoch_end_ns: u64,
+    pub snapshot_a_ns: u64,
+    pub snapshot_b_ns: u64,
+    pub a_cursor: Option<Principal>,
+    pub a_complete: bool,
+    pub b_cursor: Option<Principal>,
+    pub b_complete: bool,
+}
+
+impl From<OpenEpochV2> for OpenEpoch {
+    fn from(v: OpenEpochV2) -> Self {
+        OpenEpoch {
+            epoch_index: v.epoch_index,
+            epoch_start_ns: v.epoch_start_ns,
+            epoch_end_ns: v.epoch_end_ns,
+            snapshot_a_ns: v.snapshot_a_ns,
+            snapshot_b_ns: v.snapshot_b_ns,
+            a_cursor: v.a_cursor,
+            a_complete: v.a_complete,
+            b_cursor: v.b_cursor,
+            b_complete: v.b_complete,
+            // The chunked close had not started in the V2 layout. Default to a
+            // fresh (not-started) close; if the upgrade lands after both snapshots,
+            // the close re-runs from the start, which is idempotent.
+            close_started: false,
+            close_cursor: None,
+            close_points_accrued: 0,
+            close_active: 0,
+        }
+    }
+}
+
+/// FROZEN V2 shape of `State` (pre-POINTS-002). Identical to today's `State`
+/// except `open_epoch` carries the frozen `OpenEpochV2` (no chunked-close fields).
+/// Old `{"V2": ...}` blob bytes decode into this, then migrate forward.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct StateV2 {
+    pub admin: Principal,
+    pub excluded_principals: BTreeSet<Principal>,
+    pub season_start_ns: u64,
+    pub season_end_ns: u64,
+    pub current_epoch_index: u64,
+    pub snapshot_seed: SnapshotSeedSingleton,
+    pub open_epoch: Option<OpenEpochV2>,
+}
+
+impl From<StateV2> for State {
+    fn from(v: StateV2) -> Self {
+        State {
+            admin: v.admin,
+            excluded_principals: v.excluded_principals,
+            season_start_ns: v.season_start_ns,
+            season_end_ns: v.season_end_ns,
+            current_epoch_index: v.current_epoch_index,
+            snapshot_seed: v.snapshot_seed,
+            open_epoch: v.open_epoch.map(Into::into),
+        }
+    }
+}
+
 /// Singleton config (admin, excluded set, season window, epoch counter, in-flight
 /// seed, open-epoch driver state). Held on the heap during execution and
 /// serialized to the `STATE_BLOB` region on `pre_upgrade`, mirroring the backend.
@@ -208,14 +277,16 @@ impl From<StateV1> for State {
 #[derive(Serialize, Deserialize)]
 pub enum StoredState {
     V1(StateV1),
-    V2(State),
+    V2(StateV2),
+    V3(State),
 }
 
 impl StoredState {
     fn into_current(self) -> State {
         match self {
             StoredState::V1(old) => old.into(),
-            StoredState::V2(s) => s,
+            StoredState::V2(old) => old.into(),
+            StoredState::V3(s) => s,
         }
     }
 }
@@ -530,9 +601,17 @@ pub fn register_test_principal(
     Ok(())
 }
 
+/// Max rows `get_leaderboard` will return in one call (PTS-001). A caller passing
+/// an unbounded `limit` is clamped to this, bounding the response size and the
+/// per-call materialization. Pagination via `offset` reaches the full board.
+pub const MAX_LEADERBOARD_LIMIT: u32 = 1_000;
+
 /// Ranked leaderboard (desc by points, principal as tiebreak), paginated, with
-/// each entry's estimated share of the 5% pool in basis points.
+/// each entry's estimated share of the 5% pool in basis points. `limit` is clamped
+/// to `MAX_LEADERBOARD_LIMIT` (PTS-001) so an unbounded request cannot force a
+/// giant response.
 pub fn leaderboard(offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
+    let limit = limit.min(MAX_LEADERBOARD_LIMIT);
     let mut all: Vec<(Principal, u128)> = PRINCIPALS.with(|m| {
         m.borrow()
             .iter()
@@ -541,7 +620,7 @@ pub fn leaderboard(offset: u32, limit: u32) -> Vec<LeaderboardEntry> {
     });
     // Highest points first; principal id as a stable tiebreak.
     all.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-    // Saturating, consistent with `run_close_accrual` (a non-saturating `.sum()`
+    // Saturating, consistent with the close accrual (a non-saturating `.sum()`
     // would panic in debug on the astronomically unlikely u128 overflow).
     let total_points_all: u128 = all
         .iter()
@@ -583,12 +662,13 @@ pub fn epoch_history(offset: u64, limit: u64) -> Vec<EpochSummary> {
     })
 }
 
-/// Serialize the heap `State` (as `StoredState::V1`) to the singleton blob with
-/// the 8-byte little-endian length prefix. Called from `#[pre_upgrade]`.
+/// Serialize the heap `State` (as the current `StoredState` version) to the
+/// singleton blob with the 8-byte little-endian length prefix. Called from
+/// `#[pre_upgrade]`.
 pub fn save_state_to_stable() {
     let bytes = with_state(|s| {
         let mut buf = Vec::new();
-        ciborium::ser::into_writer(&StoredState::V2(s.clone()), &mut buf)
+        ciborium::ser::into_writer(&StoredState::V3(s.clone()), &mut buf)
             .expect("failed to serialize State to CBOR");
         buf
     });
@@ -733,13 +813,32 @@ pub fn points_config() -> PointsConfig {
     })
 }
 
-/// Epoch-driver status for the ops dashboard (Phase 5).
+/// FULL epoch-driver status, INCLUDING the in-flight capture/close cursors.
+/// ADMIN-ONLY: the cursors must not be public (POINTS-001). Surfaced via the
+/// admin-gated `get_epoch_status_admin` endpoint.
 pub fn epoch_status() -> EpochStatus {
     with_state(|s| EpochStatus {
         current_epoch_index: s.current_epoch_index,
         driver_enabled: epoch_driver_enabled(),
         driver_interval_secs: epoch_driver_interval_secs(),
         open_epoch: s.open_epoch.clone(),
+        revealed_seed_count: revealed_seed_count(),
+        snapshot_seed_committed: s.snapshot_seed.is_committed(),
+    })
+}
+
+/// PUBLIC epoch-driver status for the ops dashboard (POINTS-001). Same as
+/// `epoch_status` but the open epoch is reduced to its public window: the bounds
+/// and snapshot times, with the capture/close cursors and completion flags
+/// OMITTED. Exposing how far the capture has progressed would let a not-yet-
+/// captured principal time a flash deposit to land in a snapshot it has not been
+/// captured into yet, beating the `min(A,B)` anti-snipe defense.
+pub fn public_epoch_status() -> PublicEpochStatus {
+    with_state(|s| PublicEpochStatus {
+        current_epoch_index: s.current_epoch_index,
+        driver_enabled: epoch_driver_enabled(),
+        driver_interval_secs: epoch_driver_interval_secs(),
+        open_epoch: s.open_epoch.clone().map(PublicOpenEpoch::from),
         revealed_seed_count: revealed_seed_count(),
         snapshot_seed_committed: s.snapshot_seed.is_committed(),
     })
@@ -899,15 +998,39 @@ pub fn snapshot_buffer_len() -> u64 {
     SNAPSHOT_BUFFER.with(|b| b.borrow().len())
 }
 
-/// Empty the buffer (called at epoch close, before the next epoch opens).
-pub fn snapshot_buffer_clear() {
+/// Max snapshot-buffer entries removed per `snapshot_buffer_clear_chunk` call
+/// (PTS-002). Bounds the per-message work so clearing a season-scale buffer cannot
+/// blow the instruction limit in a single sweep (which would compound POINTS-002).
+pub const SNAPSHOT_BUFFER_CLEAR_CHUNK: u64 = 200;
+
+/// Remove up to `SNAPSHOT_BUFFER_CLEAR_CHUNK` entries from the buffer. Returns
+/// `true` once the buffer is EMPTY (nothing left to clear), `false` if more
+/// remain. Bounded per call (PTS-002) so a large buffer is drained across several
+/// messages instead of one O(N) sweep that risks the 5B-instruction trap.
+pub fn snapshot_buffer_clear_chunk() -> bool {
     SNAPSHOT_BUFFER.with(|b| {
         let mut map = b.borrow_mut();
-        let keys: Vec<StorablePrincipal> = map.iter().map(|(k, _)| k).collect();
-        for k in keys {
-            map.remove(&k);
+        let keys: Vec<StorablePrincipal> = map
+            .iter()
+            .map(|(k, _)| k)
+            .take(SNAPSHOT_BUFFER_CLEAR_CHUNK as usize)
+            .collect();
+        for k in &keys {
+            map.remove(k);
         }
-    });
+        map.is_empty()
+    })
+}
+
+/// Empty the buffer fully, in bounded chunks (PTS-002). Used on paths where the
+/// buffer is small (e.g. opening a fresh epoch, where the prior close already
+/// drained it) or in tests. The loop is bounded by the buffer size; each iteration
+/// removes a full chunk (or finishes), so it terminates in
+/// `ceil(len / SNAPSHOT_BUFFER_CLEAR_CHUNK)` steps. The CLOSE path does NOT call
+/// this in one shot; it drains the buffer incrementally as it accrues each
+/// principal and mops up stragglers across ticks (see `run_close_accrual_chunk`).
+pub fn snapshot_buffer_clear() {
+    while !snapshot_buffer_clear_chunk() {}
 }
 
 // ── Phase 5: asset-ledger registry (MemoryId 12) ────────────────────────────
@@ -1081,7 +1204,7 @@ pub fn season_bounds() -> (u64, u64) {
 }
 
 /// Aggregate result of an epoch close, used to build the `EpochSummary`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CloseStats {
     pub total_points_all: u128,
     pub points_accrued: u128,
@@ -1089,22 +1212,61 @@ pub struct CloseStats {
     pub registered_principals: u64,
 }
 
-/// Close-time accrual over every registered principal: scale each one's min-
-/// snapshot weights over the epoch period, add repayment-window points, write the
-/// per-source `PointEntry` rows, and bump `total_points`. Excluded principals are
-/// skipped (spec Section 11). Clears the snapshot buffer at the end.
-pub fn run_close_accrual(
-    epoch_index: u64,
-    epoch_start: u64,
-    epoch_end_capped: u64,
-    now_ns: u64,
-) -> CloseStats {
-    // Snapshot the principal set first (cannot mutate PRINCIPALS while iterating).
-    let principals: Vec<Principal> =
-        PRINCIPALS.with(|m| m.borrow().iter().map(|(k, _)| k.0).collect());
-    let mut points_accrued = 0u128;
-    let mut active = 0u64;
-    for p in &principals {
+/// One step of the chunked epoch close (POINTS-002). Either more batches remain or
+/// the close finished.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CloseStep {
+    /// A batch was processed; the close cursor advanced. The open epoch's
+    /// `close_*` fields have been persisted. Call again next tick to continue.
+    More,
+    /// Every registered principal has been closed exactly once; the snapshot
+    /// buffer was cleared. `CloseStats` is the finalized aggregate for the
+    /// `EpochSummary`. The driver now does the seed close + summary + index bump.
+    Done(CloseStats),
+}
+
+/// Principals closed per chunked-close tick. Each principal does up to ~8 stable
+/// `PointEntry` appends plus a `PrincipalState` rewrite, so the whole close over N
+/// principals is O(N) stable writes and at a few thousand principals an UNCHUNKED
+/// close blows the 5B-instruction limit, traps, and (since it never advanced the
+/// epoch index) re-traps on every retry -> permanent accrual stall. Bounding the
+/// batch keeps each close message well under budget; the cursor in `OpenEpoch`
+/// resumes between ticks. Conservative relative to CAPTURE_CHUNK because the close
+/// does more per-principal work (writes, not just reads).
+pub const CLOSE_CHUNK: u64 = 50;
+
+/// Process ONE batch of the chunked epoch close. Reads the resume cursor and
+/// running totals from the open epoch, accrues up to `CLOSE_CHUNK` registered
+/// principals STRICTLY AFTER the cursor, and persists the advanced cursor + totals
+/// back into the open epoch. Returns `CloseStep::More` while batches remain, or
+/// `CloseStep::Done(stats)` once the registered set is exhausted (also clearing the
+/// snapshot buffer).
+///
+/// Exactly-once guarantee: principals are processed in stable key order and the
+/// cursor always advances to the last-processed principal, so a resumed batch
+/// starts strictly after it. No principal is ever accrued twice across batches,
+/// even if a tick traps after persisting the cursor (the cursor is persisted in
+/// the SAME synchronous message as the accrual writes; there is no await between
+/// them, so they commit or roll back together).
+///
+/// Idempotent restart: if the open epoch is reloaded after an upgrade with
+/// `close_started == false`, the close simply begins again from the start; a
+/// partially-closed epoch keeps its cursor and resumes.
+pub fn run_close_accrual_chunk(now_ns: u64) -> CloseStep {
+    let mut open = match get_open_epoch() {
+        Some(o) => o,
+        // No open epoch: nothing to close. Report a trivially-finished close so the
+        // driver's finalize path is a no-op-safe call.
+        None => return CloseStep::Done(CloseStats::default()),
+    };
+    let epoch_index = open.epoch_index;
+    let epoch_start = open.epoch_start_ns;
+    let epoch_end_capped = open.epoch_end_ns;
+
+    let batch = registered_chunk_after(open.close_cursor, CLOSE_CHUNK);
+    let mut last_closed = open.close_cursor;
+    for p in &batch {
+        last_closed = Some(*p);
         if is_excluded(p) {
             continue; // excluded principals never accrue (spec Section 11)
         }
@@ -1113,6 +1275,10 @@ pub fn run_close_accrual(
             None => continue,
         };
         let min_weights = snapshot_buffer_get(p).unwrap_or_default();
+        // Consume this principal's buffer entry as we close it, so the buffer is
+        // drained incrementally across the close batches instead of in one O(N)
+        // sweep at the end (PTS-002, which would compound POINTS-002's budget).
+        snapshot_buffer_remove(p);
         let (entries, delta) =
             accrual::accrue_principal(min_weights, &ps.repayment_events, epoch_start, epoch_end_capped);
         for (source, pts) in entries {
@@ -1126,26 +1292,63 @@ pub fn run_close_accrual(
         }
         if delta > 0 {
             ps.total_points = ps.total_points.saturating_add(delta);
-            active += 1;
+            open.close_active = open.close_active.saturating_add(1);
         }
         ps.last_epoch_processed = epoch_index;
         // Drop repayment windows that can no longer overlap any future epoch, so
         // the per-principal vec stays bounded (no unbounded growth in the value).
         ps.repayment_events.retain(|r| r.window_end > epoch_end_capped);
         put_principal_state(ps);
-        points_accrued = points_accrued.saturating_add(delta);
+        open.close_points_accrued = open.close_points_accrued.saturating_add(delta);
     }
-    snapshot_buffer_clear();
+
+    open.close_started = true;
+    open.close_cursor = last_closed;
+    // A short batch (fewer than CLOSE_CHUNK) means the registered set is exhausted.
+    let accrual_done = (batch.len() as u64) < CLOSE_CHUNK;
+    set_open_epoch(Some(open.clone()));
+
+    if !accrual_done {
+        return CloseStep::More;
+    }
+
+    // Accrual is done. Mop up any buffer stragglers (entries for principals that
+    // were captured then deregistered, so the per-principal loop above never
+    // visited them) in BOUNDED chunks (PTS-002). Stay in `More` until the buffer is
+    // empty so the final mop-up never becomes a single unbounded sweep.
+    if !snapshot_buffer_clear_chunk() {
+        return CloseStep::More;
+    }
+
+    // Buffer drained and accrual complete: compute the season-wide total for the
+    // summary and finalize.
     let total_points_all = PRINCIPALS.with(|m| {
         m.borrow()
             .iter()
             .fold(0u128, |acc, (_, v)| acc.saturating_add(v.into_current().total_points))
     });
-    CloseStats {
+    let registered_principals = registered_count();
+    CloseStep::Done(CloseStats {
         total_points_all,
-        points_accrued,
-        active_principals: active,
-        registered_principals: principals.len() as u64,
+        points_accrued: open.close_points_accrued,
+        active_principals: open.close_active,
+        registered_principals,
+    })
+}
+
+/// Drive the chunked close to completion in a loop, returning the finalized
+/// `CloseStats`. Requires an open epoch (the close reads its bounds + cursor).
+/// Used by tests and by any caller that wants the whole close in one synchronous
+/// pass (the production driver instead spreads it across ticks via
+/// `run_close_accrual_chunk`). The loop is bounded: each iteration advances the
+/// cursor past at least `CLOSE_CHUNK` principals (or finishes), so it terminates
+/// in `ceil(registered / CLOSE_CHUNK)` steps.
+#[cfg(test)]
+pub fn run_close_accrual_to_completion(now_ns: u64) -> CloseStats {
+    loop {
+        if let CloseStep::Done(stats) = run_close_accrual_chunk(now_ns) {
+            return stats;
+        }
     }
 }
 
@@ -1158,8 +1361,11 @@ pub fn snapshot_buffer_merge_min(p: Principal, weights: SnapshotWeights) {
     }
 }
 
-/// The next chunk of registered principals (sorted) strictly after `cursor`
-/// (`None` = from the start), up to `limit`. Drives the chunked snapshot capture.
+/// The next chunk of registered principals (in stable principal order) strictly
+/// after `cursor` (`None` = from the start), up to `limit`. Drives the chunked
+/// epoch CLOSE, where order is irrelevant (every principal is processed exactly
+/// once). The CAPTURE uses `registered_chunk_after_shuffled` instead, so the
+/// capture order is unpredictable (POINTS-001 defense-in-depth).
 pub fn registered_chunk_after(cursor: Option<Principal>, limit: u64) -> Vec<Principal> {
     PRINCIPALS.with(|m| {
         let map = m.borrow();
@@ -1169,6 +1375,56 @@ pub fn registered_chunk_after(cursor: Option<Principal>, limit: u64) -> Vec<Prin
             None => keys.take(limit as usize).collect(),
         }
     })
+}
+
+/// A seed-derived, epoch-stable order key for a principal: `sha256(seed || p)`.
+/// The capture iterates principals in order of this key, so the order is fixed for
+/// the epoch (resumable by cursor) yet unpredictable to anyone who does not know
+/// the epoch's secret seed (revealed only at close). This is the POINTS-001
+/// defense-in-depth: an attacker cannot predict WHEN their principal is captured,
+/// so they cannot reliably flash-inflate their balance just before their snapshot.
+pub fn capture_order_key(seed: &[u8; 32], p: &Principal) -> [u8; 32] {
+    crate::snapshot_seed::sha256(&[seed, p.as_slice()])
+}
+
+/// The next chunk of registered principals for the CAPTURE, ordered by the
+/// seed-derived `capture_order_key`, strictly after `cursor` in that order
+/// (`None` = from the start), up to `limit` (POINTS-001). The order is stable for
+/// the epoch (so the cursor resumes correctly) but unpredictable without the seed.
+/// A principal registered mid-epoch that sorts before the cursor is skipped at this
+/// snapshot (its min(A,B) is then 0) exactly as in the principal-ordered path.
+pub fn registered_chunk_after_shuffled(
+    seed: &[u8; 32],
+    cursor: Option<Principal>,
+    limit: u64,
+) -> Vec<Principal> {
+    // Materialize (order_key, principal) for all registered principals, sort by the
+    // order key, then take `limit` strictly after the cursor's key. O(N log N) per
+    // chunk; acceptable at Season-1 scale (the capture is the accepted bottleneck)
+    // and bounded because the registered set is bounded by real registrations.
+    let mut keyed: Vec<([u8; 32], Principal)> = PRINCIPALS.with(|m| {
+        m.borrow()
+            .iter()
+            .map(|(k, _)| (capture_order_key(seed, &k.0), k.0))
+            .collect()
+    });
+    keyed.sort_unstable();
+    let cursor_key = cursor.map(|c| capture_order_key(seed, &c));
+    keyed
+        .into_iter()
+        .filter(|(key, _)| match &cursor_key {
+            Some(ck) => key > ck,
+            None => true,
+        })
+        .map(|(_, p)| p)
+        .take(limit as usize)
+        .collect()
+}
+
+/// The open epoch's secret seed (the seed driving THIS epoch's capture order and
+/// snapshot times). `None` if no epoch is open or the seed is somehow unset.
+pub fn current_epoch_seed() -> Option<[u8; 32]> {
+    with_state(|s| s.snapshot_seed.current_seed)
 }
 
 /// Acquire the single-tick epoch-driver guard (pairs with `end_epoch_guard`).
@@ -1518,7 +1774,46 @@ mod tests {
     }
 
     #[test]
-    fn state_v2_blob_round_trips_with_open_epoch() {
+    fn state_v2_blob_migrates_to_v3_defaulting_close_fields() {
+        // A pre-POINTS-002 V2 blob: open epoch in the frozen OpenEpochV2 shape (no
+        // chunked-close fields). It must decode and migrate forward, defaulting the
+        // close_* fields so a mid-epoch upgrade does not wipe the open epoch.
+        let v2 = StateV2 {
+            admin: tp(1),
+            excluded_principals: [tp(2)].into_iter().collect(),
+            season_start_ns: 0,
+            season_end_ns: 0,
+            current_epoch_index: 5,
+            snapshot_seed: SnapshotSeedSingleton::default(),
+            open_epoch: Some(OpenEpochV2 {
+                epoch_index: 5,
+                epoch_start_ns: 10,
+                epoch_end_ns: 20,
+                snapshot_a_ns: 12,
+                snapshot_b_ns: 18,
+                a_cursor: Some(tp(9)),
+                a_complete: true,
+                b_cursor: None,
+                b_complete: false,
+            }),
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&StoredState::V2(v2.clone()), &mut bytes).unwrap();
+
+        let migrated = decode_stored_state(&bytes).expect("V2 blob must decode and migrate");
+        let oe = migrated.open_epoch.expect("open epoch survives migration");
+        assert_eq!(oe.epoch_index, 5);
+        assert_eq!(oe.a_cursor, Some(tp(9)));
+        assert!(oe.a_complete);
+        // The new chunked-close fields default to a fresh (not-started) close.
+        assert!(!oe.close_started);
+        assert_eq!(oe.close_cursor, None);
+        assert_eq!(oe.close_points_accrued, 0);
+        assert_eq!(oe.close_active, 0);
+    }
+
+    #[test]
+    fn state_v3_blob_round_trips_with_open_epoch() {
         let state = State {
             admin: tp(1),
             excluded_principals: BTreeSet::new(),
@@ -1536,10 +1831,14 @@ mod tests {
                 a_complete: true,
                 b_cursor: None,
                 b_complete: false,
+                close_started: true,
+                close_cursor: Some(tp(4)),
+                close_points_accrued: 123,
+                close_active: 2,
             }),
         };
         let mut bytes = Vec::new();
-        ciborium::ser::into_writer(&StoredState::V2(state.clone()), &mut bytes).unwrap();
+        ciborium::ser::into_writer(&StoredState::V3(state.clone()), &mut bytes).unwrap();
         assert_eq!(decode_stored_state(&bytes), Some(state));
     }
 
@@ -1749,16 +2048,26 @@ mod tests {
     // ── Phase 5: open epoch + close accrual ──
 
     fn open_epoch_at(index: u64) -> OpenEpoch {
+        open_epoch_bounds(index, 0, 7 * crate::NANOS_PER_DAY)
+    }
+
+    /// An open epoch (both snapshots complete, close not started) with explicit
+    /// bounds, for driving the chunked close in tests.
+    fn open_epoch_bounds(index: u64, start: u64, end: u64) -> OpenEpoch {
         OpenEpoch {
             epoch_index: index,
-            epoch_start_ns: 0,
-            epoch_end_ns: 7 * crate::NANOS_PER_DAY,
+            epoch_start_ns: start,
+            epoch_end_ns: end,
             snapshot_a_ns: 1,
             snapshot_b_ns: 2,
             a_cursor: None,
             a_complete: true,
             b_cursor: None,
             b_complete: true,
+            close_started: false,
+            close_cursor: None,
+            close_points_accrued: 0,
+            close_active: 0,
         }
     }
 
@@ -1795,7 +2104,8 @@ mod tests {
         record_repayment(p2, AssetType::CkUsdc, 1_000 * 100_000_000, 0);
 
         let week = 7 * crate::NANOS_PER_DAY;
-        let stats = run_close_accrual(0, 0, week, 9_999);
+        set_open_epoch(Some(open_epoch_bounds(0, 0, week)));
+        let stats = run_close_accrual_to_completion(9_999);
 
         let repay = 1_000u128 * 100_000_000 * 5 * 7;
         assert_eq!(get_principal_state(&p1).unwrap().total_points, 700); // 100 over 7 days
@@ -1831,7 +2141,8 @@ mod tests {
         put_principal_state(ps);
 
         let week = 7 * crate::NANOS_PER_DAY;
-        run_close_accrual(0, 0, week, 1);
+        set_open_epoch(Some(open_epoch_bounds(0, 0, week)));
+        run_close_accrual_to_completion(1);
 
         let after = get_principal_state(&p).unwrap();
         assert_eq!(after.repayment_events.len(), 1, "the expired window is pruned");
@@ -1848,7 +2159,8 @@ mod tests {
         add_excluded(admin, p).unwrap();
 
         let week = 7 * crate::NANOS_PER_DAY;
-        let stats = run_close_accrual(0, 0, week, 1);
+        set_open_epoch(Some(open_epoch_bounds(0, 0, week)));
+        let stats = run_close_accrual_to_completion(1);
         assert_eq!(get_principal_state(&p).unwrap().total_points, 0); // excluded: no accrual
         assert_eq!(stats.active_principals, 0);
     }
@@ -1928,5 +2240,294 @@ mod tests {
         advance_epoch_index();
         advance_epoch_index();
         assert_eq!(current_epoch_index(), 2);
+    }
+
+    // ── POINTS-002: the chunked epoch close ──
+
+    /// Register `n` principals, each with $1 of icUSD debt captured for the epoch.
+    fn seed_principals_with_debt(n: u8) {
+        for i in 1..=n {
+            let p = tp(i);
+            register(p, 1, QualifyingAction::MintIcUsd).unwrap();
+            snapshot_buffer_put(p, SnapshotWeights { icusd_debt: 100, ..Default::default() });
+        }
+    }
+
+    #[test]
+    fn chunked_close_credits_every_principal_exactly_once_over_many_batches() {
+        // POINTS-002: a close over MORE than CLOSE_CHUNK principals must span
+        // several `More` ticks, then one `Done`, and credit each principal exactly
+        // once (no double-credit across resumed batches, no skipped principal).
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(200)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(400 * crate::NANOS_PER_DAY),
+                excluded_principals: Some(vec![]), // no protocol-owned exclusions
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        // 2.5 batches' worth so we exercise More -> More -> Done with a short tail.
+        let n: u8 = (CLOSE_CHUNK as u8) * 2 + (CLOSE_CHUNK as u8) / 2;
+        seed_principals_with_debt(n);
+
+        let week = 7 * crate::NANOS_PER_DAY;
+        set_open_epoch(Some(open_epoch_bounds(0, 0, week)));
+
+        // Drive the close one batch at a time, counting the ticks.
+        let mut more_ticks = 0u32;
+        let stats = loop {
+            match run_close_accrual_chunk(1) {
+                CloseStep::More => {
+                    more_ticks += 1;
+                    assert!(
+                        get_open_epoch().is_some(),
+                        "the epoch stays OPEN while the close is mid-flight"
+                    );
+                    assert!(more_ticks < 100, "close must terminate, not loop forever");
+                }
+                CloseStep::Done(s) => break s,
+            }
+        };
+
+        // It took multiple batches (the whole point of chunking).
+        assert!(more_ticks >= 2, "expected several More ticks, got {more_ticks}");
+        // Each principal accrued exactly $1 over 7 days, exactly once.
+        for i in 1..=n {
+            assert_eq!(
+                get_principal_state(&tp(i)).unwrap().total_points,
+                700,
+                "principal {i} must be credited exactly once (100 debt x 7 days)"
+            );
+            assert_eq!(get_principal_state(&tp(i)).unwrap().last_epoch_processed, 0);
+        }
+        assert_eq!(stats.active_principals, n as u64);
+        assert_eq!(stats.registered_principals, n as u64);
+        assert_eq!(stats.points_accrued, 700 * n as u128);
+        assert_eq!(stats.total_points_all, 700 * n as u128);
+        // PTS-002: the snapshot buffer is fully drained by close completion.
+        assert_eq!(snapshot_buffer_len(), 0, "buffer drained across the chunked close");
+    }
+
+    #[test]
+    fn chunked_close_does_not_double_credit_when_a_batch_is_replayed() {
+        // POINTS-002 exactly-once: re-running the SAME first batch (simulating a
+        // retry after a trap that rolled back the cursor advance) must not credit a
+        // principal twice. Because the cursor advances in the same synchronous
+        // message as the accrual, a real trap rolls both back together; here we
+        // assert the weaker property that a partial close followed by completion
+        // still credits each principal exactly once.
+        init_state(
+            Some(InitArgs {
+                admin: Some(tp(200)),
+                season_start_ns: Some(0),
+                season_end_ns: Some(400 * crate::NANOS_PER_DAY),
+                excluded_principals: Some(vec![]),
+                ..Default::default()
+            }),
+            Principal::anonymous(),
+        );
+        let n: u8 = (CLOSE_CHUNK as u8) + 5; // one full batch + a short tail
+        seed_principals_with_debt(n);
+
+        let week = 7 * crate::NANOS_PER_DAY;
+        set_open_epoch(Some(open_epoch_bounds(0, 0, week)));
+
+        // Process exactly the first batch.
+        assert_eq!(run_close_accrual_chunk(1), CloseStep::More);
+        let after_first = get_open_epoch().unwrap();
+        assert!(after_first.close_started);
+        assert!(after_first.close_cursor.is_some(), "cursor advanced past batch 1");
+
+        // Finish the close.
+        let stats = run_close_accrual_to_completion(1);
+
+        // Every principal is credited exactly once despite the multi-step close.
+        for i in 1..=n {
+            assert_eq!(get_principal_state(&tp(i)).unwrap().total_points, 700);
+        }
+        assert_eq!(stats.points_accrued, 700 * n as u128);
+        assert_eq!(stats.active_principals, n as u64);
+    }
+
+    #[test]
+    fn chunked_close_on_no_open_epoch_is_a_noop_done() {
+        init_default(tp(99));
+        assert_eq!(get_open_epoch(), None);
+        assert_eq!(run_close_accrual_chunk(1), CloseStep::Done(CloseStats::default()));
+    }
+
+    // ── PTS-002: bounded snapshot-buffer clear ──
+
+    #[test]
+    fn snapshot_buffer_clear_chunk_is_bounded_and_eventually_empties() {
+        // Put more than one chunk's worth of entries; one chunk call leaves some.
+        let n = SNAPSHOT_BUFFER_CLEAR_CHUNK + 50;
+        for i in 0..n {
+            // Distinct principals from a 4-byte counter so keys differ.
+            let bytes = (i as u32).to_be_bytes();
+            snapshot_buffer_put(Principal::from_slice(&bytes), SnapshotWeights::default());
+        }
+        assert_eq!(snapshot_buffer_len(), n);
+
+        // One bounded chunk removes at most SNAPSHOT_BUFFER_CLEAR_CHUNK and is not
+        // yet empty.
+        let emptied = snapshot_buffer_clear_chunk();
+        assert!(!emptied, "first chunk should not empty a >1-chunk buffer");
+        assert_eq!(snapshot_buffer_len(), n - SNAPSHOT_BUFFER_CLEAR_CHUNK);
+
+        // The convenience full-clear finishes the rest in bounded chunks.
+        snapshot_buffer_clear();
+        assert_eq!(snapshot_buffer_len(), 0);
+        assert!(snapshot_buffer_clear_chunk(), "clearing an empty buffer reports empty");
+    }
+
+    // ── PTS-001: bounded leaderboard ──
+
+    #[test]
+    fn leaderboard_clamps_limit_to_max() {
+        // Seed a handful of principals; a giant `limit` must clamp to
+        // MAX_LEADERBOARD_LIMIT (we cannot seed a million, so assert the clamp via
+        // a small max by checking the returned len never exceeds the registered
+        // count and that an absurd limit does not panic / over-return).
+        let mk = |p: Principal, pts: u128| PrincipalState {
+            principal: p,
+            total_points: pts,
+            active_deposits: BTreeMap::new(),
+            repayment_events: Vec::new(),
+            last_epoch_processed: 0,
+            registered_at_ns: 1,
+            first_qualifying_action: QualifyingAction::MintIcUsd,
+        };
+        for i in 1..=5u8 {
+            put_principal_state(mk(tp(i), i as u128 * 10));
+        }
+        // An unbounded limit returns at most the registered set (5), and the call
+        // is bounded by MAX_LEADERBOARD_LIMIT regardless.
+        let board = leaderboard(0, u32::MAX);
+        assert_eq!(board.len(), 5);
+        assert!(MAX_LEADERBOARD_LIMIT >= board.len() as u32);
+    }
+
+    #[test]
+    fn leaderboard_limit_clamp_caps_returned_rows() {
+        // White-box: with MORE registered principals than the cap, a request for
+        // u32::MAX rows returns at most MAX_LEADERBOARD_LIMIT. We shrink the proof
+        // to the cap by registering cap+overflow synthetic principals would be huge,
+        // so instead assert the clamp arithmetic directly: limit.min(MAX) is what
+        // the function applies.
+        let mk = |p: Principal| PrincipalState {
+            principal: p,
+            total_points: 1,
+            active_deposits: BTreeMap::new(),
+            repayment_events: Vec::new(),
+            last_epoch_processed: 0,
+            registered_at_ns: 1,
+            first_qualifying_action: QualifyingAction::MintIcUsd,
+        };
+        // Register a few; request a tiny clamp via the public arg path.
+        for i in 0..3u32 {
+            put_principal_state(mk(Principal::from_slice(&i.to_be_bytes())));
+        }
+        // A limit ABOVE the cap is clamped; a limit BELOW the cap is honored.
+        assert_eq!(leaderboard(0, 2).len(), 2, "small limit honored");
+        assert!(
+            leaderboard(0, u32::MAX).len() <= MAX_LEADERBOARD_LIMIT as usize,
+            "unbounded limit clamped to MAX_LEADERBOARD_LIMIT"
+        );
+    }
+
+    // ── POINTS-001: public epoch status omits cursors; capture order is shuffled ──
+
+    #[test]
+    fn public_epoch_status_omits_capture_and_close_cursors() {
+        init_default(tp(99));
+        set_open_epoch(Some(OpenEpoch {
+            epoch_index: 2,
+            epoch_start_ns: 10,
+            epoch_end_ns: 20,
+            snapshot_a_ns: 12,
+            snapshot_b_ns: 18,
+            a_cursor: Some(tp(7)),
+            a_complete: true,
+            b_cursor: Some(tp(3)),
+            b_complete: false,
+            close_started: true,
+            close_cursor: Some(tp(5)),
+            close_points_accrued: 99,
+            close_active: 1,
+        }));
+        // The full (admin) status carries the cursors.
+        let full = epoch_status();
+        let foe = full.open_epoch.unwrap();
+        assert_eq!(foe.a_cursor, Some(tp(7)));
+        assert!(foe.a_complete);
+        // The public status reduces the open epoch to bounds + snapshot times only.
+        let pub_status = public_epoch_status();
+        let poe = pub_status.open_epoch.unwrap();
+        assert_eq!(poe.epoch_index, 2);
+        assert_eq!(poe.epoch_start_ns, 10);
+        assert_eq!(poe.epoch_end_ns, 20);
+        assert_eq!(poe.snapshot_a_ns, 12);
+        assert_eq!(poe.snapshot_b_ns, 18);
+        // PublicOpenEpoch has NO cursor/complete fields at all (compile-time), so
+        // there is nothing for an attacker to read; assert the public/full views
+        // agree on the non-sensitive window.
+        assert_eq!(poe.epoch_index, foe.epoch_index);
+        assert_eq!(poe.snapshot_a_ns, foe.snapshot_a_ns);
+    }
+
+    #[test]
+    fn shuffled_capture_order_is_seed_dependent_and_covers_all_exactly_once() {
+        // POINTS-001 defense-in-depth: the capture order is a seed-derived
+        // permutation, NOT principal order, and a different seed yields a different
+        // order — so an attacker cannot predict when their principal is captured.
+        init_default(tp(99));
+        for i in 1..=10u8 {
+            register(tp(i), 1, QualifyingAction::MintIcUsd).unwrap();
+        }
+        let seed_a = [1u8; 32];
+        let seed_b = [2u8; 32];
+
+        let order_a = registered_chunk_after_shuffled(&seed_a, None, 100);
+        let order_b = registered_chunk_after_shuffled(&seed_b, None, 100);
+        let principal_order = registered_chunk_after(None, 100);
+
+        // Same membership (all 10), regardless of order.
+        assert_eq!(order_a.len(), 10);
+        let mut sorted_a = order_a.clone();
+        sorted_a.sort();
+        assert_eq!(sorted_a, principal_order, "shuffle covers exactly the same set");
+
+        // The shuffled order differs from principal order, and two seeds differ
+        // from each other (unpredictability).
+        assert_ne!(order_a, principal_order, "capture order is not principal order");
+        assert_ne!(order_a, order_b, "different seeds produce different capture orders");
+    }
+
+    #[test]
+    fn shuffled_capture_cursor_resumes_without_gaps_or_repeats() {
+        // Paginating the shuffled order by cursor must visit every principal exactly
+        // once across pages (the resume invariant the chunked capture relies on).
+        init_default(tp(99));
+        for i in 1..=12u8 {
+            register(tp(i), 1, QualifyingAction::MintIcUsd).unwrap();
+        }
+        let seed = [7u8; 32];
+        let full = registered_chunk_after_shuffled(&seed, None, 100);
+
+        // Walk in pages of 5, threading the cursor (last principal of each page).
+        let mut paged: Vec<Principal> = Vec::new();
+        let mut cursor: Option<Principal> = None;
+        loop {
+            let page = registered_chunk_after_shuffled(&seed, cursor, 5);
+            if page.is_empty() {
+                break;
+            }
+            cursor = page.last().copied();
+            paged.extend(page);
+        }
+        assert_eq!(paged, full, "cursor-paged shuffle equals the full shuffle, once each");
     }
 }

--- a/src/rumi_points/src/types.rs
+++ b/src/rumi_points/src/types.rs
@@ -189,6 +189,15 @@ pub struct EpochSummary {
 /// resume points for the chunked capture (last-processed principal; `None` means
 /// "not started"). `a_complete` / `b_complete` gate the close on both snapshots
 /// having been captured.
+///
+/// The `close_*` fields drive the chunked epoch CLOSE (POINTS-002): the close is
+/// no longer a single atomic O(N principals x sources) pass (which can exceed the
+/// 5B-instruction limit and trap, never advancing the epoch index -> permanent
+/// accrual stall). Instead it processes a bounded batch of principals per tick,
+/// persisting the resume cursor and the running totals here, and only finalizes
+/// (seed close + summary + index advance) once the cursor reaches the end. The
+/// cursor advances strictly past each closed principal, so none is double-credited
+/// across resumed batches.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct OpenEpoch {
     pub epoch_index: u64,
@@ -201,6 +210,19 @@ pub struct OpenEpoch {
     pub a_complete: bool,
     pub b_cursor: Option<Principal>,
     pub b_complete: bool,
+    /// Whether the chunked close pass has begun. Distinguishes "close not started"
+    /// (`false`) from "close in progress with no principal yet closed"
+    /// (`true`, `close_cursor == None`).
+    pub close_started: bool,
+    /// Resume point for the chunked close: the last principal whose accrual was
+    /// committed. `None` = none closed yet. The next batch processes principals
+    /// strictly AFTER this, guaranteeing exactly-once close per principal.
+    pub close_cursor: Option<Principal>,
+    /// Running sum of points accrued across all close batches so far (for the
+    /// `EpochSummary` written at finalization).
+    pub close_points_accrued: u128,
+    /// Running count of principals that accrued > 0 across all close batches.
+    pub close_active: u64,
 }
 
 // ── Query view types ────────────────────────────────────────────────────────
@@ -236,7 +258,12 @@ pub struct PointsConfig {
     pub snapshot_seed_committed: bool,
 }
 
-/// Epoch-driver status for the ops dashboard (Phase 5).
+/// FULL epoch-driver status, including the in-flight capture/close cursors. This
+/// is ADMIN-ONLY (`get_epoch_status_admin`): exposing `a_cursor`/`b_cursor`/
+/// `a_complete`/`b_complete` to the public lets a not-yet-captured principal watch
+/// the capture cursor and flash-inflate its balance right before its snapshot
+/// chunk, defeating the `min(A,B)` anti-snipe defense (POINTS-001). The public
+/// `get_epoch_status` returns `PublicEpochStatus` instead.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct EpochStatus {
     pub current_epoch_index: u64,
@@ -245,6 +272,49 @@ pub struct EpochStatus {
     pub open_epoch: Option<OpenEpoch>,
     pub revealed_seed_count: u64,
     pub snapshot_seed_committed: bool,
+}
+
+/// PUBLIC epoch-driver status for the ops dashboard (POINTS-001). Mirrors
+/// `EpochStatus` but the open epoch is reduced to its non-sensitive window
+/// (bounds + snapshot times), with the in-flight capture/close cursors and
+/// completion flags OMITTED so an attacker cannot time a flash deposit to a
+/// snapshot it has not yet been captured into.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct PublicEpochStatus {
+    pub current_epoch_index: u64,
+    pub driver_enabled: bool,
+    pub driver_interval_secs: u64,
+    /// The open epoch's public window (no capture/close progress). `None` between
+    /// epochs and before the season starts.
+    pub open_epoch: Option<PublicOpenEpoch>,
+    pub revealed_seed_count: u64,
+    pub snapshot_seed_committed: bool,
+}
+
+/// Public view of the open epoch: its bounds and snapshot times only. The snapshot
+/// times are NOT secret once the epoch is open (they were committed via the
+/// commit-reveal seed and a user cannot retroactively change them); what must stay
+/// hidden is HOW FAR the capture/close has progressed, so the cursors and
+/// completion flags are not exposed.
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PublicOpenEpoch {
+    pub epoch_index: u64,
+    pub epoch_start_ns: u64,
+    pub epoch_end_ns: u64,
+    pub snapshot_a_ns: u64,
+    pub snapshot_b_ns: u64,
+}
+
+impl From<OpenEpoch> for PublicOpenEpoch {
+    fn from(o: OpenEpoch) -> Self {
+        PublicOpenEpoch {
+            epoch_index: o.epoch_index,
+            epoch_start_ns: o.epoch_start_ns,
+            epoch_end_ns: o.epoch_end_ns,
+            snapshot_a_ns: o.snapshot_a_ns,
+            snapshot_b_ns: o.snapshot_b_ns,
+        }
+    }
 }
 
 /// One source's ingestion state (Phase 2 ops observability).

--- a/src/rumi_points/tests/pocket_ic_ingest.rs
+++ b/src/rumi_points/tests/pocket_ic_ingest.rs
@@ -40,6 +40,10 @@ enum PointsError {
 
 // Minimal mirrors for the accrual E2E (decode by field name; width subtyping lets
 // TPrincipalState read just `total_points` from the full record).
+// Full (admin) open-epoch view: includes the capture/close cursors and completion
+// flags, read via the admin-only `get_epoch_status_admin` (POINTS-001 moved these
+// off the public `get_epoch_status`). Width subtyping lets this decode the full
+// record while ignoring the close_* fields the tests do not assert on.
 #[derive(CandidType, Deserialize)]
 struct TOpenEpoch {
     epoch_index: u64,
@@ -59,6 +63,27 @@ struct TEpochStatus {
     driver_enabled: bool,
     driver_interval_secs: u64,
     open_epoch: Option<TOpenEpoch>,
+    revealed_seed_count: u64,
+    snapshot_seed_committed: bool,
+}
+
+// Public open-epoch view: bounds + snapshot times only, NO capture/close cursors
+// (POINTS-001). This is what the anonymous `get_epoch_status` returns.
+#[derive(CandidType, Deserialize)]
+struct TPublicOpenEpoch {
+    epoch_index: u64,
+    epoch_start_ns: u64,
+    epoch_end_ns: u64,
+    snapshot_a_ns: u64,
+    snapshot_b_ns: u64,
+}
+
+#[derive(CandidType, Deserialize)]
+struct TPublicEpochStatus {
+    current_epoch_index: u64,
+    driver_enabled: bool,
+    driver_interval_secs: u64,
+    open_epoch: Option<TPublicOpenEpoch>,
     revealed_seed_count: u64,
     snapshot_seed_committed: bool,
 }
@@ -292,12 +317,26 @@ fn force_tick(pic: &pocket_ic::PocketIc, rp: Principal) {
     }
 }
 
+/// Full epoch status with capture/close progress, via the ADMIN-only
+/// `get_epoch_status_admin` (POINTS-001 keeps the cursors off the public query).
 fn epoch_status(pic: &pocket_ic::PocketIc, rp: Principal) -> TEpochStatus {
+    let res = pic
+        .query_call(rp, admin(), "get_epoch_status_admin", Encode!().unwrap())
+        .expect("get_epoch_status_admin call failed");
+    match res {
+        WasmResult::Reply(b) => Decode!(&b, TEpochStatus).unwrap(),
+        WasmResult::Reject(m) => panic!("get_epoch_status_admin rejected: {m}"),
+    }
+}
+
+/// Public epoch status (anonymous caller), via `get_epoch_status`. Used to assert
+/// the cursors are NOT exposed (POINTS-001).
+fn public_epoch_status(pic: &pocket_ic::PocketIc, rp: Principal) -> TPublicEpochStatus {
     let res = pic
         .query_call(rp, Principal::anonymous(), "get_epoch_status", Encode!().unwrap())
         .expect("get_epoch_status call failed");
     match res {
-        WasmResult::Reply(b) => Decode!(&b, TEpochStatus).unwrap(),
+        WasmResult::Reply(b) => Decode!(&b, TPublicEpochStatus).unwrap(),
         WasmResult::Reject(m) => panic!("get_epoch_status rejected: {m}"),
     }
 }
@@ -461,4 +500,144 @@ fn transient_fetch_error_does_not_zero_a_held_position() {
         DEBT as u128 * 7,
         "a recovered transient error yields full credit, not a min()-locked zero"
     );
+}
+
+/// POINTS-001: the PUBLIC `get_epoch_status` must NOT expose the capture/close
+/// cursors (an attacker watching the cursor could time a flash deposit to beat the
+/// `min(A,B)` anti-snipe defense). The full cursor view is admin-only.
+#[test]
+fn public_epoch_status_hides_cursors_and_admin_view_is_gated() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+    set_time_ns(&pic, rumi_points::DEFAULT_SEASON_START_NS);
+
+    let mock = install_mock(&pic);
+    let rp = install_points(&pic);
+    set_all_sources(&pic, rp, mock);
+
+    let p = Principal::from_slice(&[7; 5]);
+    admin_ok(&pic, rp, "register_test_principal", Encode!(&p).unwrap());
+    set_vault_debt(&pic, mock, p, 100_000_000);
+    start_season_ok(&pic, rp, SEASON_SEED);
+    admin_ok(&pic, rp, "set_epoch_driver_enabled", Encode!(&false).unwrap());
+
+    // Capture A so the admin view has a non-trivial cursor to expose.
+    let oe = epoch_status(&pic, rp).open_epoch.unwrap();
+    set_time_ns(&pic, oe.snapshot_a_ns);
+    force_tick(&pic, rp);
+
+    // The PUBLIC query (anonymous caller) decodes into PublicEpochStatus, whose
+    // open epoch has bounds + snapshot times but NO cursor/complete fields. The
+    // decode itself proves the wire shape carries no cursors.
+    let pub_status = public_epoch_status(&pic, rp);
+    let poe = pub_status.open_epoch.expect("epoch 0 is open");
+    assert_eq!(poe.epoch_index, 0);
+    assert_eq!(poe.snapshot_a_ns, oe.snapshot_a_ns);
+    assert_eq!(poe.snapshot_b_ns, oe.snapshot_b_ns);
+
+    // The ADMIN query is admin-gated: an anonymous caller is rejected (trap).
+    let denied = pic.query_call(
+        rp,
+        Principal::anonymous(),
+        "get_epoch_status_admin",
+        Encode!().unwrap(),
+    );
+    match denied {
+        Err(_) => {} // rejected at the call layer
+        Ok(WasmResult::Reject(_)) => {} // trapped: unauthorized
+        Ok(WasmResult::Reply(_)) => {
+            panic!("get_epoch_status_admin must reject a non-admin caller")
+        }
+    }
+
+    // The admin CAN read the full view (with cursors).
+    let admin_view = epoch_status(&pic, rp);
+    assert!(
+        admin_view.open_epoch.unwrap().a_complete,
+        "admin view still exposes capture progress"
+    );
+}
+
+/// POINTS-002: an epoch close that spans MANY principals (more than one close
+/// chunk) must complete through the live driver without trapping, advancing the
+/// epoch index and crediting every held position exactly once. Pre-fix this was a
+/// single unchunked O(N) message that could exceed the instruction limit and trap,
+/// stalling accrual permanently. We register well over CLOSE_CHUNK principals and
+/// drive the state machine to completion.
+#[test]
+fn chunked_close_completes_over_many_principals_end_to_end() {
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+    set_time_ns(&pic, rumi_points::DEFAULT_SEASON_START_NS);
+
+    let mock = install_mock(&pic);
+    let rp = install_points(&pic);
+    set_all_sources(&pic, rp, mock);
+
+    // Register many principals (> 2 close chunks of 50) so the close MUST span
+    // several batches. The mock tracks one held position; that principal must be
+    // credited exactly once, and every other registered principal must still be
+    // processed for the close to finalize (no permanent stall).
+    const N: u32 = 130;
+    const DEBT: u64 = 100_000_000; // $1
+    let who = |i: u32| Principal::from_slice(&i.to_be_bytes());
+    for i in 0..N {
+        admin_ok(&pic, rp, "register_test_principal", Encode!(&who(i)).unwrap());
+    }
+    // One held principal (the mock returns debt for a single owner). Pick one near
+    // the end so it is processed in a LATE close batch, exercising resume.
+    let held = who(N - 3);
+    set_vault_debt(&pic, mock, held, DEBT);
+
+    start_season_ok(&pic, rp, SEASON_SEED);
+    admin_ok(&pic, rp, "set_epoch_driver_enabled", Encode!(&false).unwrap());
+    let oe = epoch_status(&pic, rp).open_epoch.unwrap();
+
+    // Drive snapshot A to completion (capture is chunked at 100/principals tick).
+    set_time_ns(&pic, oe.snapshot_a_ns);
+    for _ in 0..10 {
+        if epoch_status(&pic, rp).open_epoch.unwrap().a_complete {
+            break;
+        }
+        force_tick(&pic, rp);
+    }
+    assert!(epoch_status(&pic, rp).open_epoch.unwrap().a_complete, "snapshot A completes");
+
+    // Drive snapshot B to completion.
+    set_time_ns(&pic, oe.snapshot_b_ns);
+    for _ in 0..10 {
+        if epoch_status(&pic, rp).open_epoch.unwrap().b_complete {
+            break;
+        }
+        force_tick(&pic, rp);
+    }
+    assert!(epoch_status(&pic, rp).open_epoch.unwrap().b_complete, "snapshot B completes");
+
+    // Drive the CHUNKED close to completion. It spans several ticks (130 principals
+    // / 50 per close chunk = 3 batches); each tick stays in the open state until
+    // the cursor reaches the end.
+    set_time_ns(&pic, oe.epoch_end_ns);
+    let mut closed = false;
+    for _ in 0..20 {
+        force_tick(&pic, rp);
+        if epoch_status(&pic, rp).open_epoch.is_none() {
+            closed = true;
+            break;
+        }
+    }
+    assert!(closed, "the chunked close must finish (no permanent stall)");
+
+    let after = epoch_status(&pic, rp);
+    assert!(after.open_epoch.is_none(), "epoch closed");
+    assert_eq!(after.current_epoch_index, 1, "epoch index advanced exactly once");
+
+    // The held principal is credited EXACTLY once: $1 of debt over the full week.
+    // (Pre-fix, the unchunked close over 130 principals could trap before reaching
+    // this principal's batch and never advance the index.)
+    assert_eq!(
+        total_points(&pic, rp, held),
+        DEBT as u128 * 7,
+        "the held principal is credited exactly once across the chunked close"
+    );
+    // A no-debt principal accrued nothing but was still processed (the close had to
+    // iterate all 130 principals to finalize, so this is implied by closure).
+    assert_eq!(total_points(&pic, rp, who(0)), 0);
 }

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -793,6 +793,9 @@ type RegisterChainArg = record {
   chain_native_decimals : nat8;
   display_name : text;
   chain_id : nat32;
+  // M-05: optional per-chain quorum-provider floor override. Omit (or null) to
+  // use the default floor (3 distinct providers).
+  min_quorum_providers : opt nat32;
 };
 type RepayAndCloseSuccess = record {
   collateral_return_block_index : opt nat64;
@@ -862,6 +865,7 @@ type SuccessWithFee = record {
   fee_amount_paid : nat64;
   collateral_amount_received : opt nat64;
   debt_liquidated_e8s : opt nat64;
+  stable_pulled_e6s : opt nat64;
 };
 type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
 type SupplyAuditEntry = record {
@@ -906,6 +910,10 @@ type UpdateChainConfigArg = record {
   gas_strategy : opt GasStrategy;
   finality_depth : opt nat32;
   display_name : opt text;
+  // M-05: set/clear the per-chain quorum-provider floor override. Outer opt
+  // absent/null => leave unchanged; opt (null) => clear back to the default;
+  // opt (opt N) => set the floor to N (must be >= 1).
+  min_quorum_providers : opt opt nat32;
 };
 type UpgradeArg = record { mode : opt Mode; description : opt text };
 type Vault = record {

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -4,10 +4,10 @@
 //! state-shape rules without spinning up PocketIC.
 
 use super::config::{
-    ChainAdminError, ChainConfigV2, ChainId, ChainStatus, GasStrategy, RegisterChainArg,
+    ChainAdminError, ChainConfigV3, ChainId, ChainStatus, GasStrategy, RegisterChainArg,
     UpdateChainConfigArg,
 };
-use super::multi_chain_state::MultiChainStateV3;
+use super::multi_chain_state::MultiChainStateV4;
 use super::settlement_queue::SettlementQueueV1;
 
 /// EVM chains need >= 1 confirmation before a block is treated as final. A
@@ -19,14 +19,37 @@ fn is_evm(gas: &GasStrategy) -> bool {
     matches!(gas, GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. })
 }
 
+/// Audit M-04 (QUORUM-1): de-duplicate `rpc_endpoints` by URL, preserving the
+/// first occurrence's order. The EVM-RPC quorum (`call_evm_rpc`) tallies
+/// agreement by DISTINCT provider; if the same URL appears twice it would be
+/// queried (and could vote) twice, letting ONE provider satisfy a >1 quorum on
+/// its own. Deduping at registration/config time guarantees the persisted list
+/// already contains only distinct providers, so the runtime tally is honest.
+/// Comparison is exact-string (operators must supply canonical URLs); this never
+/// drops a genuinely distinct endpoint.
+fn dedup_endpoints(endpoints: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::with_capacity(endpoints.len());
+    for url in endpoints {
+        if seen.insert(url.clone()) {
+            out.push(url);
+        }
+    }
+    out
+}
+
 pub fn register_chain_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     arg: RegisterChainArg,
     now_ns: u64,
-) -> Result<ChainConfigV2, ChainAdminError> {
-    if arg.rpc_endpoints.is_empty() {
+) -> Result<ChainConfigV3, ChainAdminError> {
+    // M-04 (QUORUM-1): collapse duplicate URLs BEFORE the non-empty check, so a
+    // list of nothing but repeats (which would give a false sense of quorum) is
+    // rejected as effectively empty.
+    let rpc_endpoints = dedup_endpoints(arg.rpc_endpoints);
+    if rpc_endpoints.is_empty() {
         return Err(ChainAdminError::InvalidConfig(
-            "rpc_endpoints must contain at least one URL".into(),
+            "rpc_endpoints must contain at least one (distinct) URL".into(),
         ));
     }
     // Validate the native-asset decimals. This feeds `collateral_ratio_e4`
@@ -47,13 +70,21 @@ pub fn register_chain_in_state(
             "finality_depth must be >= 1 for EVM chains (0 treats any mined block as final)".into(),
         ));
     }
+    // M-05 (QUORUM-2): a per-chain override of 0 distinct providers is nonsense
+    // (it would disable the fail-closed floor); require >= 1. `None` means "use
+    // DEFAULT_MIN_QUORUM_PROVIDERS".
+    if let Some(0) = arg.min_quorum_providers {
+        return Err(ChainAdminError::InvalidConfig(
+            "min_quorum_providers must be >= 1 (omit/null for the default floor)".into(),
+        ));
+    }
     if state.chain_configs.contains_key(&arg.chain_id) {
         return Err(ChainAdminError::ChainAlreadyRegistered(arg.chain_id));
     }
-    let cfg = ChainConfigV2 {
+    let cfg = ChainConfigV3 {
         chain_id: arg.chain_id,
         display_name: arg.display_name,
-        rpc_endpoints: arg.rpc_endpoints,
+        rpc_endpoints,
         finality_depth: arg.finality_depth,
         gas_strategy: arg.gas_strategy,
         chain_native_decimals: arg.chain_native_decimals,
@@ -62,6 +93,8 @@ pub fn register_chain_in_state(
         // Phase 1c: notify-then-verify is the default; the continuous poll-scan
         // starts OFF and is enabled per-chain only via set_burn_watch_poll_enabled.
         burn_watch_poll_enabled: false,
+        // M-05 (QUORUM-2): per-chain quorum-provider floor override (None => default).
+        min_quorum_providers: arg.min_quorum_providers,
     };
     state.chain_configs.insert(arg.chain_id, cfg.clone());
     state.chain_supplies.insert(arg.chain_id, 0);
@@ -70,7 +103,7 @@ pub fn register_chain_in_state(
 }
 
 pub fn disable_chain_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     let cfg = state
@@ -88,7 +121,7 @@ pub fn disable_chain_in_state(
 /// would be a silent state leak). All-or-nothing: every rejection path returns
 /// before the first mutation, so a refused delete leaves the chain fully intact.
 pub fn delete_chain_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     if !state.chain_configs.contains_key(&chain_id) {
@@ -122,7 +155,7 @@ pub fn delete_chain_in_state(
 }
 
 pub fn update_chain_config_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain_id: ChainId,
     update: UpdateChainConfigArg,
 ) -> Result<(), ChainAdminError> {
@@ -135,9 +168,16 @@ pub fn update_chain_config_in_state(
     // (all-or-nothing). rpc_endpoints must stay non-empty, and an EVM chain must
     // keep finality_depth >= 1 even if only one of (gas_strategy, finality_depth)
     // is being changed.
-    if let Some(eps) = &update.rpc_endpoints {
+    //
+    // M-04 (QUORUM-1): dedup the supplied endpoints FIRST, then check non-empty
+    // against the deduped list (a list of nothing but repeats is effectively
+    // empty and must be rejected). The deduped list is what gets persisted.
+    let deduped_endpoints = update.rpc_endpoints.map(dedup_endpoints);
+    if let Some(eps) = &deduped_endpoints {
         if eps.is_empty() {
-            return Err(ChainAdminError::InvalidConfig("rpc_endpoints cannot be empty".into()));
+            return Err(ChainAdminError::InvalidConfig(
+                "rpc_endpoints cannot be empty (after de-duplication)".into(),
+            ));
         }
     }
     let effective_finality = update.finality_depth.unwrap_or(cfg.finality_depth);
@@ -150,11 +190,18 @@ pub fn update_chain_config_in_state(
             "finality_depth must be >= 1 for EVM chains (0 treats any mined block as final)".into(),
         ));
     }
+    // M-05 (QUORUM-2): if the override is being SET (Some(Some(n))), it must be
+    // >= 1. Some(None) clears it back to the default; None leaves it unchanged.
+    if let Some(Some(0)) = update.min_quorum_providers {
+        return Err(ChainAdminError::InvalidConfig(
+            "min_quorum_providers must be >= 1 (pass opt null to clear to the default)".into(),
+        ));
+    }
 
     if let Some(name) = update.display_name {
         cfg.display_name = name;
     }
-    if let Some(eps) = update.rpc_endpoints {
+    if let Some(eps) = deduped_endpoints {
         cfg.rpc_endpoints = eps;
     }
     if let Some(d) = update.finality_depth {
@@ -162,6 +209,11 @@ pub fn update_chain_config_in_state(
     }
     if let Some(g) = update.gas_strategy {
         cfg.gas_strategy = g;
+    }
+    // M-05 (QUORUM-2): outer Some => caller addressed the field. Inner Some(n)
+    // sets the override; inner None clears it back to the default.
+    if let Some(override_value) = update.min_quorum_providers {
+        cfg.min_quorum_providers = override_value;
     }
     Ok(())
 }

--- a/src/rumi_protocol_backend/src/chains/config.rs
+++ b/src/rumi_protocol_backend/src/chains/config.rs
@@ -1,10 +1,11 @@
 //! Per-chain configuration record.
 //!
 //! Versioned-snapshot pattern (see spec Section 3): the active shape is
-//! `ChainConfigV1`. Adding a field = bump to `ChainConfigV2`, register a
-//! migration in `crate::chains::supply::migrate_multi_chain_state`, and
-//! rebind `pub type ChainConfig = ChainConfigV2;`. Never modify V1 in
-//! place once it has shipped.
+//! `ChainConfigV3`. Adding a field = bump to the next `ChainConfigV(N+1)`
+//! (carry every prior field verbatim, decorate the new one with
+//! `#[serde(default)]`), rebind `pub type ChainConfig = ...;`, and bump the
+//! enclosing `MultiChainState` so its `chain_configs` value type follows. Never
+//! modify a shipped version in place once it has been persisted.
 
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
@@ -91,8 +92,64 @@ pub struct ChainConfigV2 {
     pub burn_watch_poll_enabled: bool,
 }
 
+/// Phase 1d snapshot (audit M-05, QUORUM-2). Carries every `ChainConfigV2`
+/// field verbatim (so a V2-shaped CBOR sub-map maps each by name straight
+/// across) and adds the per-chain quorum-provider floor override.
+///
+/// `min_quorum_providers` carries `#[serde(default)]` so a `ChainConfigV2` CBOR
+/// sub-map (which lacks this key entirely) decodes into `ChainConfigV3` without
+/// error, defaulting the override to `None` (= use `DEFAULT_MIN_QUORUM_PROVIDERS`).
+/// State persists via ciborium (CBOR + serde), which fills a missing key from
+/// `#[serde(default)]` rather than failing — the SAME mechanism that made the
+/// V1->V2 add-a-field decode safe (proven by `tests_config`). It is NOT a Candid
+/// `Decode!` of a fixed record, so the added serde-default field cannot trip the
+/// AMM-style state-wipe fallback (2026-05-18 incident).
+///
+/// Add the NEXT field by bumping to `ChainConfigV4` (keep V3 verbatim), adding
+/// `#[serde(default)]` on the new field, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
+pub struct ChainConfigV3 {
+    // carried verbatim from V2 — always present in any valid snapshot
+    pub chain_id: ChainId,
+    pub display_name: String,
+    pub rpc_endpoints: Vec<String>,
+    pub finality_depth: u32,
+    pub gas_strategy: GasStrategy,
+    pub chain_native_decimals: u8,
+    pub registered_at_ns: u64,
+    pub status: ChainStatus,
+    #[serde(default)]
+    pub burn_watch_poll_enabled: bool,
+    /// Audit M-05 (QUORUM-2): per-chain override for the minimum number of
+    /// DISTINCT RPC providers that must agree before a financial read
+    /// (balance / supply / block / receipt) is credited on an EVM chain.
+    /// `None` (default) => use `DEFAULT_MIN_QUORUM_PROVIDERS` (3). A value of
+    /// `Some(n)` lowers/raises the floor for a chain whose viable independent
+    /// provider count differs (must be >= 1). Solana chains do NOT consult this
+    /// (the SOL-RPC canister enforces its own consensus). New in V3 —
+    /// `#[serde(default)]` lets a V2 CBOR sub-map decode cleanly to `None`.
+    #[serde(default)]
+    pub min_quorum_providers: Option<u32>,
+}
+
 /// Active alias. Rebind to a later version when a field is added.
-pub type ChainConfig = ChainConfigV2;
+pub type ChainConfig = ChainConfigV3;
+
+/// Default minimum number of DISTINCT RPC providers that must agree on a
+/// financial read before an EVM chain credits it (audit M-05 / QUORUM-2). A
+/// deployment MUST configure at least this many independent endpoints to run the
+/// observer / settlement workers (or perform a financial read); below the floor
+/// the read FAILS CLOSED. Override per chain via
+/// `ChainConfigV3::min_quorum_providers`.
+pub const DEFAULT_MIN_QUORUM_PROVIDERS: u32 = 3;
+
+/// The effective quorum-provider floor for a config: its override when set
+/// (clamped to >= 1), else `DEFAULT_MIN_QUORUM_PROVIDERS`.
+pub fn effective_min_quorum_providers(cfg: &ChainConfigV3) -> u32 {
+    cfg.min_quorum_providers
+        .map(|n| n.max(1))
+        .unwrap_or(DEFAULT_MIN_QUORUM_PROVIDERS)
+}
 
 /// Caller-supplied registration payload. Distinct from the persisted
 /// `ChainConfigV1` so the admin endpoint can fill `registered_at_ns` and
@@ -105,6 +162,11 @@ pub struct RegisterChainArg {
     pub finality_depth: u32,
     pub gas_strategy: GasStrategy,
     pub chain_native_decimals: u8,
+    /// Audit M-05 (QUORUM-2): optional per-chain quorum-provider floor override.
+    /// `None`/omitted => use `DEFAULT_MIN_QUORUM_PROVIDERS` (3 distinct
+    /// providers). Candid: `opt nat32`.
+    #[serde(default)]
+    pub min_quorum_providers: Option<u32>,
 }
 
 /// Operator-supplied update payload. Every field is optional; omitted
@@ -115,6 +177,12 @@ pub struct UpdateChainConfigArg {
     pub rpc_endpoints: Option<Vec<String>>,
     pub finality_depth: Option<u32>,
     pub gas_strategy: Option<GasStrategy>,
+    /// Audit M-05 (QUORUM-2): set/clear the per-chain quorum-provider floor.
+    /// Candid `opt opt nat32`: outer `None` (absent) => leave unchanged; outer
+    /// `Some(None)` => clear back to the default; outer `Some(Some(n))` => set
+    /// the floor to `n` (clamped to >= 1 at apply time).
+    #[serde(default)]
+    pub min_quorum_providers: Option<Option<u32>>,
 }
 
 /// Reasons a `register_chain`/`set_chain_config` call can be rejected.

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -1,3 +1,22 @@
+//! ⚠️ EXPERIMENTAL — NOT WIRED UP FOR PRODUCTION. LEAVE ALONE / REVISIT LATER. ⚠️
+//!
+//! The entire `chains/` tree (Monad + Solana cross-chain CDP) is experimental
+//! and intentionally dormant: the observer/settlement timers are OFF by default,
+//! every cross-chain write endpoint is developer-gated, and the chains run on
+//! testnet/devnet only. It is NOT part of the production ICP-native protocol.
+//!
+//! The 2026-06-05 security audit (`audit-reports/2026-06-05-d67e100/`) added the
+//! M-04..M-09 quorum / finality / recovery remediations here (endpoint dedup,
+//! `min_quorum_providers` fail-closed floor, quorumed finality probe, finality-
+//! aware deposit cursor, on-chain re-verify in resolve/recover). That work
+//! compiles and the backend lib tests pass, BUT it has NOT been exhaustively
+//! reviewed, the candid `.did` sync for the new surface is unverified, and the
+//! sub-agent that wrote it was stopped before finishing additional tests.
+//!
+//! DO NOT enable any cross-chain feature (timers, real providers, mainnet) or
+//! treat this code as production-ready without a deliberate, careful human
+//! review pass first. It is preserved here on purpose — parked, not abandoned.
+//!
 //! Multi-chain scaffolding (Phase 1a).
 //!
 //! This module tree carries the chain-agnostic abstractions used by every
@@ -15,6 +34,7 @@ pub mod adapter;
 pub mod admin;
 pub mod config;
 pub mod multi_chain_state;
+pub mod recovery;
 pub mod settlement_queue;
 pub mod supply;
 pub mod vault;
@@ -23,7 +43,9 @@ pub mod solana;
 
 pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};
-pub use multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
+pub use multi_chain_state::{
+    MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
+};
 pub use settlement_queue::{SettlementOp, SettlementQueueV1};
 pub use supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
 
@@ -47,6 +69,9 @@ mod tests_supply;
 
 #[cfg(test)]
 mod tests_admin;
+
+#[cfg(test)]
+mod tests_recovery;
 
 #[cfg(test)]
 mod tests_self_check;

--- a/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/burn_proof.rs
@@ -5,7 +5,7 @@ use crate::chains::monad::evm_rpc::{
     decode_burn_log, get_transaction_receipt_with_logs, is_block_final, BurnLog,
     TxReceiptWithLogs, BURN_EVENT_TOPIC0,
 };
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use ic_canister_log::log;
@@ -29,7 +29,7 @@ use ic_canister_log::log;
 /// apply+record commit in one message slice) — a retry re-skips them and
 /// re-attempts the halting burn. This matches the audited poll-path C-1 semantics.
 pub fn apply_receipt_burns_to_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     _chain: ChainId,
     contract: &str,
     tx_hash: &str,

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -19,7 +19,7 @@
 //! Keeps the Monad-only `MONAD_MIN_CR_E4` constant local.
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use candid::Principal;
 
 // Re-export the chain-agnostic types + un-parameterized helpers. Every existing
@@ -43,7 +43,7 @@ pub const MONAD_MIN_CR_E4: u64 = 13_000;
 /// surface are identical to the pre-hoist Monad helper.
 #[allow(clippy::too_many_arguments)]
 pub fn open_chain_vault_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain: ChainId,
     owner: Principal,
     custody_address: String,
@@ -75,7 +75,7 @@ pub fn open_chain_vault_in_state(
 /// address validator and the `"MON"` price key baked in. Signature, behavior,
 /// and error surface are identical to the pre-hoist Monad helper.
 pub fn withdraw_collateral_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     amount_e18: u128,
     dest_address: String,
@@ -99,7 +99,7 @@ pub fn withdraw_collateral_in_state(
 /// validator and the `"MON"` price key baked in. Signature, behavior, and error
 /// surface are identical to the pre-hoist Monad helper.
 pub fn close_chain_vault_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     dest_address: String,
     min_cr_e4: u64,

--- a/src/rumi_protocol_backend/src/chains/monad/config.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/config.rs
@@ -46,5 +46,12 @@ pub fn monad_default_register_arg() -> RegisterChainArg {
             max_fee_gwei_ceiling: 500,
         },
         chain_native_decimals: MON_NATIVE_DECIMALS,
+        // M-05 (QUORUM-2): use the default floor (DEFAULT_MIN_QUORUM_PROVIDERS =
+        // 3 distinct providers). NOTE: `monad_rpc_endpoints()` ships only ONE URL
+        // today, which is BELOW the floor — the observer/settlement workers fail
+        // closed until the operator adds >= 2 more independent endpoints via
+        // `set_chain_config` before un-gating permissionless mainnet. This is the
+        // intended fail-closed posture, not a regression.
+        min_quorum_providers: None,
     }
 }

--- a/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/deposit_watch.rs
@@ -42,7 +42,7 @@
 use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
@@ -118,7 +118,7 @@ pub fn backstop_should_scan(
 /// of a u128 collateral balance is not a realistic failure mode but we guard
 /// it anyway). Returns `Err` if the vault is not found.
 pub fn credit_deposit_to_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     amount_e18: u128,
 ) -> Result<(), String> {
@@ -168,7 +168,7 @@ pub fn credit_deposit_to_state(
 /// burner==owner constraint if griefing (uninvited debt repayment) becomes a
 /// concern; for Phase 1b it is accepted.
 pub fn apply_burn_to_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     burn: &super::evm_rpc::BurnLog,
     total_debt_e8s: u128,
 ) -> Result<(), BurnApplyError> {
@@ -878,7 +878,7 @@ pub async fn run_observer(chain: ChainId) {
 /// vaults make a tick outliving MAX_BLOCK_SCAN_WINDOW blocks unreachable in
 /// practice). Revisit for deeper finality / higher vault counts where a self-heal
 /// reclaim could race the prune.
-pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV3, chain: ChainId, finalized: u64) {
+pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV4, chain: ChainId, finalized: u64) {
     state.last_observed_block.insert(chain, finalized);
     let stale: Vec<u64> = state
         .processed_burn_keys

--- a/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/evm_rpc.rs
@@ -34,7 +34,7 @@
 
 use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
-use crate::chains::config::ChainId;
+use crate::chains::config::{effective_min_quorum_providers, ChainId};
 use crate::state::read_state;
 use crate::logs::{DEBUG, INFO};
 
@@ -132,13 +132,24 @@ pub struct RpcApi {
     pub headers: Option<Vec<EvmRpcHttpHeader>>,
 }
 
-/// Minimal `RpcService` — only the `Custom` variant is needed for Monad
-/// (all other variants address built-in chains by name).
+/// `RpcService` — we only ever ENCODE `Custom` (Monad is always a custom
+/// provider), but the multi-provider `eth_getBlockByNumber` (M-06) can return an
+/// `Inconsistent` result whose per-provider vector is keyed by `RpcService`. To
+/// avoid a Candid decode TRAP (the FLAG-9 caveat) we mirror the FULL variant set
+/// from the live .did. The built-in provider arms (which we never send, so never
+/// expect on the wire, but might appear if the canister echoes a default
+/// provider) carry `candid::Reserved` payloads — they decode without inspecting
+/// their contents, exactly the idiom the Solana `sol_rpc` mirror uses. Only the
+/// `Custom` arm carries a real `RpcApi` (the one we ever read back).
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum RpcService {
+    Provider(u64),
     Custom(RpcApi),
-    // Other built-in variants exist in the .did but are unused here.
-    // Candid decoding is flexible: we only need to encode Custom.
+    EthMainnet(candid::Reserved),
+    EthSepolia(candid::Reserved),
+    ArbitrumOne(candid::Reserved),
+    BaseMainnet(candid::Reserved),
+    OptimismMainnet(candid::Reserved),
 }
 
 /// Mirrors the live .did `JsonRpcError` record.
@@ -311,20 +322,15 @@ pub enum GetBlockByNumberResult {
     Err(RpcError),
 }
 
-/// `MultiGetBlockByNumberResult` from the live .did.  We only ever send ONE
-/// `Custom` provider, so the canister always returns `Consistent`;
-/// `Inconsistent` is never on the wire and never decoded in practice (it
-/// references the singular `RpcService`, which is fine since we never decode
-/// that arm).
+/// `MultiGetBlockByNumberResult` from the live .did.
 ///
-/// NOTE (Phase 1b / M-1): `RpcService` above mirrors only the `Custom` variant.
-/// If multi-provider support is ever introduced (e.g. a second `Custom` URL or
-/// a built-in `EthMainnet`-style arm), the EVM RPC canister MAY return an
-/// `Inconsistent` result containing a non-`Custom` `RpcService` variant, which
-/// would TRAP on Candid decode because this enum lacks those arms. Acceptable
-/// for Phase 1b (Monad is always addressed via a single `Custom` provider);
-/// revisit by mirroring the full `RpcService` variant set if multi-provider is
-/// introduced.
+/// M-06 (QUORUM-3): the finalized-height probe now passes ALL distinct
+/// configured providers (not just the first), so on disagreement the canister
+/// returns `Inconsistent` carrying a per-provider vector keyed by `RpcService`.
+/// We decode and TALLY that vector by distinct provider rather than trapping.
+/// The FLAG-9 caveat (a non-`Custom` provider variant in that vector would
+/// previously trap the decode) is handled by mirroring the full `RpcService`
+/// variant set above (built-in arms carry `candid::Reserved`).
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum MultiGetBlockByNumberResult {
     Consistent(GetBlockByNumberResult),
@@ -567,47 +573,79 @@ fn response_consensus_key(text: &str) -> serde_json::Value {
     }
 }
 
+/// Read a chain's DISTINCT configured RPC endpoints and its effective
+/// quorum-provider floor (audit M-04/M-05). The endpoints are already deduped at
+/// registration/config time (`chains::admin::dedup_endpoints`); we dedup again
+/// here defensively so a hand-poked state cannot smuggle a repeat past the
+/// distinct-provider tally. Returns `(distinct_endpoints, floor)`.
+fn endpoints_and_floor(chain: ChainId) -> (Vec<String>, u32) {
+    read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| {
+                let mut seen = std::collections::BTreeSet::new();
+                let distinct: Vec<String> = c
+                    .rpc_endpoints
+                    .iter()
+                    .filter(|u| seen.insert((*u).clone()))
+                    .cloned()
+                    .collect();
+                (distinct, effective_min_quorum_providers(c))
+            })
+            .unwrap_or_else(|| (Vec::new(), crate::chains::config::DEFAULT_MIN_QUORUM_PROVIDERS))
+    })
+}
+
 /// Send a raw JSON-RPC READ to the EVM RPC canister with MULTI-PROVIDER QUORUM
-/// (audit FLAG-1). Queries EVERY configured endpoint and requires a STRICT
-/// MAJORITY of the configured providers to return the same semantic result
-/// before returning it, so a single malicious / compromised / lagging provider
-/// cannot fabricate a balance, block, supply, or receipt the canister credits.
+/// (audit FLAG-1 + M-04/M-05). Queries EVERY DISTINCT configured endpoint and
+/// requires at least the chain's quorum-provider FLOOR of DISTINCT providers to
+/// return the same semantic result before returning it, so a single malicious /
+/// compromised / lagging provider cannot fabricate a balance, block, supply, or
+/// receipt the canister credits.
 ///
-/// With ONE configured endpoint this degrades to a single-provider read (no
-/// cross-provider quorum is possible). The deployment MUST configure >= 3
-/// independent endpoints to get real 2-of-3 protection (an ops action; see the
-/// pre-permissionless checklist). On no-quorum or all-fail this returns Err so
-/// the caller never credits / advances on disagreement.
+/// FAIL-CLOSED FLOOR (M-05, QUORUM-2): if the chain has FEWER distinct configured
+/// endpoints than its floor (`DEFAULT_MIN_QUORUM_PROVIDERS` = 3 unless
+/// overridden), the read is REFUSED outright — no single- or sub-floor-provider
+/// financial read is ever credited. A deployment MUST configure >= floor
+/// independent endpoints (an ops action) before the observer / settlement
+/// workers can read. This is the runtime gate that makes the quorum non-dormant.
+///
+/// DISTINCT-PROVIDER TALLY (M-04, QUORUM-1): agreement is counted by DISTINCT
+/// provider URL, never by list slot or raw response count, so a duplicated
+/// endpoint (already deduped at config time, deduped again here) can never vote
+/// twice toward the quorum. The winning value must be returned by
+/// `max(floor, strict_majority_of_distinct)` distinct providers.
+///
+/// On below-floor, no-quorum, or all-fail this returns Err so the caller never
+/// credits / advances on disagreement.
 ///
 /// READS ONLY. `eth_sendRawTransaction` is a write and uses
 /// `call_evm_rpc_broadcast` (first-Ok: a broadcast lands if ANY provider accepts
 /// it; requiring agreement would wrongly drop a tx that only some providers saw).
 async fn call_evm_rpc(chain: ChainId, json_payload: &str) -> Result<String, String> {
-    let endpoints: Vec<String> = read_state(|s| {
-        s.multi_chain
-            .chain_configs
-            .get(&chain)
-            .map(|c| c.rpc_endpoints.clone())
-            .unwrap_or_default()
-    });
+    let (endpoints, floor) = endpoints_and_floor(chain);
     if endpoints.is_empty() {
         return Err(format!("no RPC endpoints configured for chain {:?}", chain));
     }
+    // M-05 (QUORUM-2): fail closed below the distinct-provider floor. With fewer
+    // than `floor` distinct providers there is no way to reach the required
+    // cross-provider agreement, so a financial read must never be credited.
+    if (endpoints.len() as u32) < floor {
+        return Err(format!(
+            "RPC quorum floor not met for chain {:?}: {} distinct provider(s) configured, need >= {} (configure more endpoints; financial reads fail closed below the floor)",
+            chain, endpoints.len(), floor
+        ));
+    }
     let canister = evm_rpc_principal();
 
-    // Single provider: no cross-provider quorum is possible.
-    if endpoints.len() == 1 {
-        log!(DEBUG, "[evm_rpc] single-provider read for chain {:?} (configure >= 3 endpoints for quorum)", chain);
-        return single_call(canister, &endpoints[0], json_payload).await;
-    }
-
-    // Multi-provider: collect every Ok response, then require a strict majority
-    // of the CONFIGURED providers to agree on the semantic result.
-    let mut oks: Vec<String> = Vec::new();
+    // Collect every Ok response PAIRED with its provider URL, so the tally counts
+    // DISTINCT providers (M-04), not list slots or raw response multiplicity.
+    let mut oks: Vec<(String, String)> = Vec::new(); // (url, response_text)
     let mut last_err = String::new();
     for url in &endpoints {
         match single_call(canister, url, json_payload).await {
-            Ok(text) => oks.push(text),
+            Ok(text) => oks.push((url.clone(), text)),
             Err(e) => {
                 log!(DEBUG, "[evm_rpc] provider read error via {}: {}", url, e);
                 last_err = e;
@@ -617,22 +655,41 @@ async fn call_evm_rpc(chain: ChainId, json_payload: &str) -> Result<String, Stri
     if oks.is_empty() {
         return Err(format!("all {} providers failed; last: {}", endpoints.len(), last_err));
     }
-    let needed = endpoints.len() / 2 + 1; // strict majority of the full provider set
-    let keys: Vec<serde_json::Value> = oks.iter().map(|t| response_consensus_key(t)).collect();
+
+    // Group by semantic consensus key; for each key count the number of DISTINCT
+    // provider URLs that returned it (endpoints are deduped, so each URL appears
+    // at most once in `oks`, but we count distinctly to be explicit and robust).
+    let keyed: Vec<(String, serde_json::Value)> = oks
+        .iter()
+        .map(|(url, text)| (url.clone(), response_consensus_key(text)))
+        .collect();
     let mut best_idx = 0usize;
     let mut best_count = 0usize;
-    for i in 0..keys.len() {
-        let count = keys.iter().filter(|k| **k == keys[i]).count();
+    for i in 0..keyed.len() {
+        let mut providers_for_key = std::collections::BTreeSet::new();
+        for (url, key) in &keyed {
+            if *key == keyed[i].1 {
+                providers_for_key.insert(url.clone());
+            }
+        }
+        let count = providers_for_key.len();
         if count > best_count {
             best_count = count;
             best_idx = i;
         }
     }
+
+    // Required distinct agreement: at least the floor AND a strict majority of the
+    // DISTINCT configured providers (the floor is the audit's primary guard; the
+    // majority preserves the original FLAG-1 protection for larger provider sets).
+    let majority = endpoints.len() / 2 + 1;
+    let needed = (floor as usize).max(majority);
     if best_count >= needed {
-        Ok(oks[best_idx].clone())
+        // Return the winning provider's response text (the consensus value).
+        Ok(oks[best_idx].1.clone())
     } else {
         Err(format!(
-            "RPC quorum not reached for chain {:?}: best agreement {}/{} (need {})",
+            "RPC quorum not reached for chain {:?}: best distinct-provider agreement {}/{} (need {})",
             chain, best_count, endpoints.len(), needed
         ))
     }
@@ -687,27 +744,44 @@ fn next_rpc_id() -> u64 {
 /// returning Ok(Some(...)). Investigate the RPC endpoint and the EVM RPC
 /// canister's cycle balance if you see this repeating.
 async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, String> {
-    // Read the chain's configured endpoints (same source as `call_evm_rpc`).
-    // The typed method needs a single Custom provider; use the first endpoint.
-    let endpoints: Vec<String> = read_state(|s| {
-        s.multi_chain
-            .chain_configs
-            .get(&chain)
-            .map(|c| c.rpc_endpoints.clone())
-            .unwrap_or_default()
-    });
-    let first = endpoints
-        .first()
-        .ok_or_else(|| format!("no RPC endpoints configured for chain {:?}", chain))?
-        .clone();
+    // M-06 (QUORUM-3): route the finality/block-existence probe through the SAME
+    // multi-provider quorum the balance/supply reads use, instead of trusting a
+    // single `endpoints.first()`. Pass ALL distinct configured providers and ask
+    // the EVM-RPC canister for `Threshold` consensus at our floor; below the
+    // floor we fail closed (same as `call_evm_rpc`).
+    let (endpoints, floor) = endpoints_and_floor(chain);
+    if endpoints.is_empty() {
+        return Err(format!("no RPC endpoints configured for chain {:?}", chain));
+    }
+    if (endpoints.len() as u32) < floor {
+        return Err(format!(
+            "RPC quorum floor not met for chain {:?}: {} distinct provider(s) configured, need >= {} (block probe fails closed below the floor)",
+            chain, endpoints.len(), floor
+        ));
+    }
 
+    let services: Vec<RpcApi> = endpoints
+        .iter()
+        .map(|url| RpcApi {
+            url: url.clone(),
+            headers: None,
+        })
+        .collect();
+    let total_providers = services.len() as u8;
     let rpc_services = RpcServices::Custom {
         chain_id: chain.0 as u64,
-        services: vec![RpcApi {
-            url: first,
-            headers: None,
-        }],
+        services,
     };
+    // Ask the canister to enforce a Threshold of `floor`-of-`total` providers.
+    // The canister returns `Consistent` only when at least `min` providers agree;
+    // otherwise `Inconsistent`, which we tally ourselves as a defense-in-depth.
+    let rpc_config = Some(RpcConfig {
+        response_size_estimate: None,
+        response_consensus: Some(ConsensusStrategy::Threshold {
+            total: Some(total_providers),
+            min: floor.min(u8::MAX as u32) as u8,
+        }),
+    });
 
     let canister = evm_rpc_principal();
     let result: Result<(MultiGetBlockByNumberResult,), _> =
@@ -716,7 +790,7 @@ async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, 
             "eth_getBlockByNumber",
             (
                 rpc_services,
-                Option::<RpcConfig>::None,
+                rpc_config,
                 BlockTag::Number(candid::Nat::from(n)),
             ),
             EVM_RPC_CALL_CYCLES,
@@ -734,7 +808,7 @@ async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, 
         Ok((MultiGetBlockByNumberResult::Consistent(GetBlockByNumberResult::Err(rpc_err)),)) => {
             // Block-not-found is the common benign case (chain hasn't reached
             // block n yet). HOWEVER a rate-limit, TooFewCycles, or IcError also
-            // maps here — both collapse to Ok(None) so the cursor does not advance.
+            // maps here — all collapse to Ok(None) so the cursor does not advance.
             // A single occurrence is harmless; a PERSISTENT stream means a real
             // provider / consensus problem and the cursor is stalled. See the
             // helper's doc comment for the monitoring note.
@@ -747,8 +821,47 @@ async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, 
             );
             Ok(None)
         }
-        Ok((MultiGetBlockByNumberResult::Inconsistent(_),)) => {
-            Err("unexpected inconsistent eth_getBlockByNumber result".to_string())
+        Ok((MultiGetBlockByNumberResult::Inconsistent(per_provider),)) => {
+            // Providers disagreed below the canister's threshold. Tally the
+            // per-provider results ourselves by DISTINCT block number: only if at
+            // least `floor` distinct providers report the SAME block number do we
+            // treat the block as confirmed-existing. Otherwise we cannot confirm
+            // it this tick (return Ok(None) → the cursor does NOT advance, which
+            // is the fail-closed behavior — a block we cannot agree exists must
+            // never advance the finalized cursor).
+            use std::collections::BTreeMap;
+            let mut votes: BTreeMap<u64, std::collections::BTreeSet<String>> = BTreeMap::new();
+            let mut undecodable = 0usize;
+            for (svc, res) in &per_provider {
+                if let GetBlockByNumberResult::Ok(block) = res {
+                    match u64::try_from(block.number.0.clone()) {
+                        Ok(num) => {
+                            // Key the voter by a stable provider identity. Custom
+                            // providers carry their URL; built-in arms (which we
+                            // never send) fall back to a debug label so they still
+                            // count as one distinct voter rather than trapping.
+                            let voter = match svc {
+                                RpcService::Custom(api) => api.url.clone(),
+                                other => format!("{:?}", other),
+                            };
+                            votes.entry(num).or_default().insert(voter);
+                        }
+                        Err(_) => undecodable += 1,
+                    }
+                }
+            }
+            let best = votes.iter().max_by_key(|(_, set)| set.len());
+            match best {
+                Some((num, set)) if (set.len() as u32) >= floor => Ok(Some(*num)),
+                _ => {
+                    log!(
+                        INFO,
+                        "[evm_rpc] eth_getBlockByNumber(Number({})) chain={:?} Inconsistent: no block number reached {} distinct-provider agreement ({} undecodable); cursor will not advance this tick",
+                        n, chain, floor, undecodable
+                    );
+                    Ok(None)
+                }
+            }
         }
         Err((code, msg)) => Err(format!(
             "eth_getBlockByNumber call error ({:?}): {}",
@@ -773,6 +886,19 @@ async fn eth_get_block_number_at(chain: ChainId, n: u64) -> Result<Option<u64>, 
 ///
 /// `last_observed == 0` means the burn-watch cursor is unseeded; the caller
 /// (`run_observer`) skips burn-watch entirely in that case (no genesis crawl).
+///
+/// M-07 (FINAL-1): the cursor advances to `candidate` ONLY when `candidate`
+/// satisfies `is_block_final(candidate, finality_depth)` — i.e. block
+/// `candidate + finality_depth` also exists, so `candidate` is buried under at
+/// least `finality_depth` confirmations. The prior code advanced on mere block
+/// EXISTENCE (`is_block_final` was never applied here, unlike `burn_proof.rs`),
+/// so the "finalized" cursor it returned could include a still-reorg-able block.
+/// Both the burn-watch scan and the settlement mint-confirm gate treat this
+/// returned value as final, so advancing it on an unfinalized block let a burn /
+/// mint-confirm act on a block that could still reorg out. Now both the probe
+/// AND the finality bury-check route through the multi-provider quorum
+/// (`eth_get_block_number_at`), so a single lagging provider can neither
+/// fabricate nor prematurely finalize the cursor.
 pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
     let last_observed = read_state(|s| {
         s.multi_chain
@@ -781,10 +907,21 @@ pub async fn fetch_block_numbers(chain: ChainId) -> Result<(u64, u64), String> {
             .copied()
             .unwrap_or(0)
     });
+    let finality_depth = read_state(|s| {
+        s.multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.finality_depth as u64)
+    })
+    .unwrap_or(1);
     let candidate = last_observed.saturating_add(MAX_BLOCK_SCAN_WINDOW);
-    match eth_get_block_number_at(chain, candidate).await? {
-        Some(_) => Ok((candidate, candidate)), // block exists & final → advance window
-        None => Ok((last_observed, last_observed)), // not advanced enough yet → nothing new
+    // Advance only when `candidate` is buried under >= finality_depth blocks
+    // (M-07). `is_block_final` itself probes `candidate + finality_depth` through
+    // the quorum path, so existence of the candidate alone is no longer enough.
+    if is_block_final(chain, candidate, finality_depth).await? {
+        Ok((candidate, candidate)) // candidate exists AND is final → advance window
+    } else {
+        Ok((last_observed, last_observed)) // not final yet → nothing new this tick
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/monad/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/settlement.rs
@@ -38,7 +38,7 @@ use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
@@ -96,7 +96,7 @@ pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
 /// 3. Only after (2) succeeds: move `pending_mint_e8s` -> `debt_e8s`, set
 ///    status `Open`.
 pub fn confirm_mint_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain: ChainId,
     vault_id: u64,
     observed_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_burn_proof.rs
@@ -2,15 +2,15 @@ use crate::chains::config::ChainId;
 use crate::chains::monad::burn_proof::apply_receipt_burns_to_state;
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::monad::evm_rpc::{TxReceiptWithLogs, BURN_EVENT_TOPIC0};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use candid::Principal;
 
 fn word(v: u128) -> String {
     format!("0x{:064x}", v)
 }
 
-fn state_with_open_vault(debt: u128) -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn state_with_open_vault(debt: u128) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), debt);
     s.chain_vaults.insert(
         1,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_deposit_watch.rs
@@ -1,13 +1,13 @@
 use super::deposit_watch::{advance_cursor_and_prune, apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::monad::evm_rpc::BurnLog;
 use crate::chains::supply::SupplyInvariantError;
 use candid::Principal;
 
-fn seeded() -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn seeded() -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -16,7 +16,7 @@ use super::chain_vault::{
     ChainVaultStatus, OpenVaultError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -31,8 +31,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 /// Register chain 10143 and set its manual MON price. Mirrors what the live
 /// register_chain endpoint + a manual price override do (chain_supplies and
 /// settlement_queues are seeded by register_chain_in_state).
-fn setup(price_e8: u64) -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn setup(price_e8: u64) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -43,6 +43,7 @@ fn setup(price_e8: u64) -> MultiChainStateV3 {
             max_fee_gwei_ceiling: 500,
         },
         chain_native_decimals: 18,
+        min_quorum_providers: None,
     };
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     s.manual_prices.insert((CHAIN, "MON".into()), price_e8);
@@ -246,7 +247,7 @@ fn verify_unknown_vault_errors() {
 // 8. open rejects an unregistered chain
 #[test]
 fn open_rejects_unknown_chain() {
-    let mut s = MultiChainStateV3::default(); // no chain registered
+    let mut s = MultiChainStateV4::default(); // no chain registered
     let res = open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
         "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
@@ -305,7 +306,7 @@ fn open_rejects_invalid_recipient() {
 // 9. open rejects when no MON price is configured
 #[test]
 fn open_rejects_when_no_price() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     // Register the chain but DON'T set a MON price.
     let arg = RegisterChainArg {
         chain_id: CHAIN,
@@ -314,6 +315,7 @@ fn open_rejects_when_no_price() {
         finality_depth: 1,
         gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
         chain_native_decimals: 18,
+        min_quorum_providers: None,
     };
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     let res = open_chain_vault_in_state(

--- a/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_settlement.rs
@@ -1,11 +1,11 @@
 use super::settlement::{confirm_mint_in_state, select_next_op, OpAction};
 use super::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
 
-fn vault_pending(s: &mut MultiChainStateV3, vault_id: u64, pending: u128) {
+fn vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending: u128) {
     s.chain_vaults.insert(vault_id, ChainVaultV1 {
         vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
@@ -47,7 +47,7 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
 
 #[test]
 fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
     // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
@@ -61,7 +61,7 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
 
 #[test]
 fn confirm_mint_rejects_amount_mismatch() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000);
     // Observed amount differs from pending: reject (caught before any supply mutation), do not mutate.
@@ -73,7 +73,7 @@ fn confirm_mint_rejects_amount_mismatch() {
 
 #[test]
 fn confirm_mint_unknown_vault_rejected() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0).is_err());
 }
@@ -82,7 +82,7 @@ fn confirm_mint_unknown_vault_rejected() {
 fn confirm_mint_second_vault_uses_running_total() {
     // Two vaults: first already confirmed (debt 100e8, supply 100e8). Confirming the
     // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -22,7 +22,7 @@ use super::chain_vault::{
     ChainVaultStatus, WithdrawError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -35,8 +35,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 const MIN_CR_E4: u64 = 13_000;
 
 /// Register chain 10143 and set its manual MON price (mirrors `tests_open_vault`).
-fn setup(price_e8: u64) -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn setup(price_e8: u64) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -47,6 +47,7 @@ fn setup(price_e8: u64) -> MultiChainStateV3 {
             max_fee_gwei_ceiling: 500,
         },
         chain_native_decimals: 18,
+        min_quorum_providers: None,
     };
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     s.manual_prices.insert((CHAIN, "MON".into()), price_e8);
@@ -62,7 +63,7 @@ fn owner() -> Principal {
 /// open helper records `pending_mint_e8s` and `debt_e8s == 0`; we set the
 /// fields directly here to skip the deposit-watch + settlement round trip.)
 fn open_and_fund(
-    s: &mut MultiChainStateV3,
+    s: &mut MultiChainStateV4,
     vault_id: u64,
     collateral_e18: u128,
     debt_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -29,7 +29,7 @@
 //! See spec Section 3 ("State wipe on upgrade") and the 2026-05-18 AMM
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
 
-use super::config::{ChainConfigV1, ChainConfigV2, ChainId};
+use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
 use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
 use candid::{CandidType, Deserialize};
@@ -217,4 +217,65 @@ impl MultiChainStateV3 {
     }
 }
 
-pub type MultiChainState = MultiChainStateV3;
+/// Phase 1d snapshot (audit M-05, QUORUM-2). Identical to `MultiChainStateV3`
+/// in every field EXCEPT `chain_configs`, whose value type bumps from
+/// `ChainConfigV2` to `ChainConfigV3` (the latter adds the
+/// `min_quorum_providers` per-chain quorum floor). This is a NON-BREAKING
+/// reshape under ciborium, exactly like the V2->V3 `ChainConfigV1->V2` bump:
+///
+///  - The ten outer fields are byte-for-byte identical to V3 and map across by
+///    name (the four originals are always present; the V2-added maps keep their
+///    `#[serde(default)]`).
+///  - `chain_configs` is a CBOR map `{ChainId -> {field-map}}`. On decode each
+///    inner field-map decodes as a `ChainConfigV3`; the new
+///    `min_quorum_providers` key is absent in any V3-written sub-map and is
+///    supplied by its field-level `#[serde(default)]` (=> `None`). So a live
+///    `MultiChainStateV3` CBOR snapshot decodes into `MultiChainStateV4`
+///    without error and without wiping any chain/vault/supply state.
+///
+/// Because the decode is in-place, NO explicit migration call is needed in
+/// `post_upgrade`; `migrate_multi_chain_state` in `supply.rs` remains the
+/// dormant template for the next BREAKING bump.
+///
+/// Add the NEXT field by bumping to `MultiChainStateV5` (keep V4 verbatim),
+/// `#[serde(default)]` on the new field, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct MultiChainStateV4 {
+    /// Bumped value type vs V3 (`ChainConfigV2` -> `ChainConfigV3`). Always
+    /// present in any valid snapshot; the nested `ChainConfigV3` add-a-field is
+    /// what carries the `#[serde(default)]` (see `ChainConfigV3`).
+    pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
+    pub chain_supplies: BTreeMap<ChainId, u128>,
+    pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+    pub invariant_halted: bool,
+    #[serde(default)]
+    pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+    #[serde(default)]
+    pub chain_contracts: BTreeMap<ChainId, String>,
+    #[serde(default)]
+    pub manual_prices: BTreeMap<(ChainId, String), u64>,
+    #[serde(default)]
+    pub last_observed_block: BTreeMap<ChainId, u64>,
+    #[serde(default)]
+    pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+    #[serde(default)]
+    pub reorg_halted: BTreeMap<ChainId, bool>,
+    #[serde(default)]
+    pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+    #[serde(default)]
+    pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+}
+
+impl MultiChainStateV4 {
+    pub fn total_supply_all_chains_e8s(&self) -> u128 {
+        self.chain_supplies.values().copied().sum()
+    }
+
+    /// Sum of confirmed debt across all foreign-chain vaults (e8s). See the
+    /// V2 doc — same foreign-chain-only invariant.
+    pub fn total_chain_vault_debt_e8s(&self) -> u128 {
+        self.chain_vaults.values().map(|v| v.debt_e8s).sum()
+    }
+}
+
+pub type MultiChainState = MultiChainStateV4;

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -1,0 +1,391 @@
+//! On-chain-verified recovery for wedged settlement ops and stuck chain vaults
+//! (audit M-08 / RECOV-01 and M-09 / RECOV-02).
+//!
+//! Both recovery endpoints (`resolve_stuck_settlement_op`,
+//! `recover_stuck_chain_vault`) reverse or release protocol accounting on what
+//! used to be PURE operator assertion. That is dangerous: reversing a Mint op
+//! whose tx actually landed leaves icUSD minted with no recorded debt (an
+//! unbacked mint), and flipping a `MintPending` vault to `Open` releases its
+//! collateral — so if the mint really landed the user keeps both the on-chain
+//! icUSD AND the collateral.
+//!
+//! This module re-reads the relevant on-chain state through the SAME
+//! multi-provider EVM-RPC quorum the observer/settlement use (so a single
+//! lagging/lying provider cannot spoof the check) and REFUSES the reversal /
+//! release when on-chain state shows the op landed (or cannot be shown NOT to
+//! have landed). The `#[update]` handlers in `main.rs` are thin async wrappers
+//! over these helpers (the wrappers keep the developer-only auth check + the
+//! event/log emission); all the verification + state-machine logic lives here so
+//! it is unit-testable without PocketIC.
+//!
+//! Borrow discipline mirrors the settlement worker: snapshot under `read_state`,
+//! `.await` the RPC, then commit under `mutate_state`; no state borrow is held
+//! across an `.await`.
+
+use crate::chains::config::ChainId;
+use crate::chains::monad::chain_vault::ChainVaultStatus;
+use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
+use crate::state::{mutate_state, read_state};
+
+/// Why a verified recovery was refused. The `#[update]` wrappers map this to a
+/// `ProtocolError::ChainAdmin(String)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveryError {
+    /// The chain id is not registered.
+    UnknownChain(ChainId),
+    /// The op id does not exist on the chain's settlement queue.
+    UnknownOp(u64),
+    /// The op is not `Inflight` (nothing to resolve).
+    NotInflight(String),
+    /// The vault id is unknown.
+    UnknownVault(u64),
+    /// The vault is not on the supplied chain.
+    WrongChain { vault_id: u64, chain: ChainId },
+    /// The vault is not a recoverable stuck mint (wrong status / nonzero pending).
+    NotRecoverable(String),
+    /// A live (Queued/Inflight) mint op still exists for the vault.
+    LiveMintOp(u64),
+    /// An EVM-RPC quorum read failed; recovery is refused (fail-closed) because
+    /// we could not confirm the op did NOT land.
+    VerificationUnavailable(String),
+    /// On-chain state shows the op DID land — reversing/releasing would create an
+    /// unbacked mint or double-release collateral. Refused.
+    OnChainLanded(String),
+}
+
+impl std::fmt::Display for RecoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+// ─── M-08: resolve a stuck settlement op, on-chain-verified ───────────────────
+
+/// Read the op, confirm it is `Inflight`, and capture its `last_tx_hash` (the
+/// only datum the async re-verification needs; the per-kind reversal re-reads the
+/// kind fresh from state under the commit borrow). Returns the tx hash, or
+/// `Ok(None)` if the op never broadcast a tx (so it cannot have landed).
+fn snapshot_inflight_op_tx(chain: ChainId, op_id: u64) -> Result<Option<String>, RecoveryError> {
+    read_state(|s| {
+        let q = s
+            .multi_chain
+            .settlement_queues
+            .get(&chain)
+            .ok_or(RecoveryError::UnknownChain(chain))?;
+        let op = q.pending.get(&op_id).ok_or(RecoveryError::UnknownOp(op_id))?;
+        if !matches!(op.status, SettlementOpStatus::Inflight { .. }) {
+            return Err(RecoveryError::NotInflight(format!(
+                "op {op_id} status {:?}",
+                op.status
+            )));
+        }
+        Ok(op.last_tx_hash.clone())
+    })
+}
+
+/// Pure reversal applied AFTER on-chain verification clears the op as not-landed.
+/// Mirrors the confirm-reverted path exactly, guarded on the op still being
+/// `Inflight` (compare-and-swap) so a concurrent confirm cannot double-apply.
+/// Returns `true` iff this call performed the reversal (the op was still
+/// Inflight).
+pub fn apply_resolve_reversal_in_state(
+    state: &mut crate::chains::multi_chain_state::MultiChainStateV4,
+    chain: ChainId,
+    op_id: u64,
+    now: u64,
+) -> bool {
+    let still_inflight = state
+        .settlement_queues
+        .get(&chain)
+        .and_then(|q| q.pending.get(&op_id))
+        .map(|o| matches!(o.status, SettlementOpStatus::Inflight { .. }))
+        .unwrap_or(false);
+    if !still_inflight {
+        return false;
+    }
+    // Clone the kind out so we can mutate vaults and the op without overlapping
+    // borrows.
+    let kind = state
+        .settlement_queues
+        .get(&chain)
+        .and_then(|q| q.pending.get(&op_id))
+        .map(|o| o.kind.clone());
+    if let Some(kind) = kind {
+        match &kind {
+            SettlementOpKind::Mint { vault_id, .. } => {
+                if let Some(v) = state.chain_vaults.get_mut(vault_id) {
+                    // Design B: no debt counted; clear pending, leave MintPending.
+                    v.pending_mint_e8s = 0;
+                }
+            }
+            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                if let Some(v) = state.chain_vaults.get_mut(vault_id) {
+                    v.collateral_amount_native =
+                        v.collateral_amount_native.saturating_add(*amount_e18);
+                    if v.status == ChainVaultStatus::Closing {
+                        v.status = ChainVaultStatus::Open;
+                    }
+                }
+            }
+            SettlementOpKind::Burn { .. } => {}
+        }
+    }
+    if let Some(o) = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+    {
+        o.mark_failed("manually resolved (stuck Inflight, on-chain-verified not landed)".to_string(), now);
+    }
+    true
+}
+
+/// M-08 (RECOV-01): resolve a stuck `Inflight` settlement op, but ONLY after
+/// re-reading its on-chain tx receipt through the EVM-RPC quorum and confirming
+/// the tx did NOT land.
+///
+/// Policy (fail-closed):
+///  - Receipt shows the tx SUCCEEDED → the op LANDED → REFUSE
+///    (`OnChainLanded`). Reversing a landed Mint = unbacked mint; reversing a
+///    landed NativeWithdrawal = double-credited collateral.
+///  - Receipt shows the tx REVERTED → safe to reverse (the on-chain effect did
+///    not happen) → apply the reversal.
+///  - Receipt is PENDING/UNKNOWN (`None`) → the tx is not mined, so its effect
+///    has NOT landed; reversing only marks the op Failed + clears a Mint's
+///    pending (it does NOT release collateral — the vault stays MintPending, and
+///    M-09's separate verified check gates the eventual collateral release).
+///    Allowed, but logged.
+///  - No `last_tx_hash` recorded → the op never broadcast a tx (it cannot have
+///    landed) → safe to reverse.
+///  - The quorum read itself ERRORS → REFUSE (`VerificationUnavailable`): we
+///    must not reverse on an unverifiable state.
+///
+/// Returns `Ok(true)` if the reversal was applied, `Ok(false)` if the op was no
+/// longer Inflight by commit time (a concurrent confirm won the CAS).
+pub async fn resolve_stuck_settlement_op_verified(
+    chain: ChainId,
+    op_id: u64,
+) -> Result<bool, RecoveryError> {
+    let last_tx_hash = snapshot_inflight_op_tx(chain, op_id)?;
+
+    // Re-verify on-chain unless there is simply no tx to check.
+    if let Some(tx_hash) = &last_tx_hash {
+        match crate::chains::monad::evm_rpc::get_transaction_receipt(chain, tx_hash).await {
+            Ok(Some((true, block))) => {
+                return Err(RecoveryError::OnChainLanded(format!(
+                    "op {op_id} tx {tx_hash} succeeded on-chain at block {block}; refusing to reverse (would create an unbacked mint / double-release collateral)"
+                )));
+            }
+            Ok(Some((false, _block))) => {
+                // Reverted on-chain — the effect did not happen; safe to reverse.
+            }
+            Ok(None) => {
+                // Pending / unknown: not mined, so not landed. Allowed (clears
+                // accounting only; collateral release is gated separately by M-09).
+            }
+            Err(e) => {
+                return Err(RecoveryError::VerificationUnavailable(format!(
+                    "could not read receipt for op {op_id} tx {tx_hash} via quorum: {e}"
+                )));
+            }
+        }
+    }
+
+    let now = ic_cdk::api::time();
+    let did_reverse =
+        mutate_state(|s| apply_resolve_reversal_in_state(&mut s.multi_chain, chain, op_id, now));
+    Ok(did_reverse)
+}
+
+// ─── M-09: recover a stuck chain vault, on-chain-verified ─────────────────────
+
+/// Pure pre-checks for `recover_stuck_chain_vault` (no on-chain read, operates on
+/// a borrowed state so it is unit-testable). On success returns the tx hashes of
+/// any TERMINAL Mint ops for this vault (so the async path can re-verify each did
+/// not actually succeed on-chain). Mirrors the pre-fix endpoint's guards: vault
+/// exists, is on `chain`, is `MintPending` with `pending_mint_e8s == 0`, and has
+/// NO live (Queued/Inflight) Mint op.
+pub fn precheck_recover_vault_in_state(
+    state: &crate::chains::multi_chain_state::MultiChainStateV4,
+    chain: ChainId,
+    vault_id: u64,
+) -> Result<Vec<String>, RecoveryError> {
+    let v = state
+        .chain_vaults
+        .get(&vault_id)
+        .ok_or(RecoveryError::UnknownVault(vault_id))?;
+    if v.collateral_chain != chain {
+        return Err(RecoveryError::WrongChain { vault_id, chain });
+    }
+    if v.status != ChainVaultStatus::MintPending || v.pending_mint_e8s != 0 {
+        return Err(RecoveryError::NotRecoverable(format!(
+            "vault {vault_id} status {:?}, pending_mint_e8s {}",
+            v.status, v.pending_mint_e8s
+        )));
+    }
+    let queue = state.settlement_queues.get(&chain);
+    let has_live_mint = queue
+        .map(|q| {
+            q.pending.values().any(|op| {
+                matches!(&op.kind, SettlementOpKind::Mint { vault_id: vid, .. } if *vid == vault_id)
+                    && matches!(
+                        op.status,
+                        SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                    )
+            })
+        })
+        .unwrap_or(false);
+    if has_live_mint {
+        return Err(RecoveryError::LiveMintOp(vault_id));
+    }
+    // Collect tx hashes of TERMINAL Mint ops for this vault, so the async path can
+    // re-verify none of them actually succeeded on-chain (a Failed/Succeeded op
+    // may carry a `last_tx_hash` that did land).
+    let tx_hashes: Vec<String> = queue
+        .map(|q| {
+            q.pending
+                .values()
+                .filter_map(|op| match &op.kind {
+                    SettlementOpKind::Mint { vault_id: vid, .. } if *vid == vault_id => {
+                        op.last_tx_hash.clone()
+                    }
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(tx_hashes)
+}
+
+/// `read_state` wrapper over `precheck_recover_vault_in_state` for the async path.
+pub fn precheck_recover_vault(
+    chain: ChainId,
+    vault_id: u64,
+) -> Result<Vec<String>, RecoveryError> {
+    read_state(|s| precheck_recover_vault_in_state(&s.multi_chain, chain, vault_id))
+}
+
+/// Apply the MintPending->Open transition AFTER on-chain verification. Re-checks
+/// the guards inside the same `mutate_state` (defense against a state change
+/// between the precheck snapshot and commit). Returns `Ok(())` on success.
+pub fn apply_recover_vault_in_state(
+    state: &mut crate::chains::multi_chain_state::MultiChainStateV4,
+    chain: ChainId,
+    vault_id: u64,
+) -> Result<(), RecoveryError> {
+    // Re-check live mint op (could have been enqueued between precheck and now).
+    let has_live_mint = state
+        .settlement_queues
+        .get(&chain)
+        .map(|q| {
+            q.pending.values().any(|op| {
+                matches!(&op.kind, SettlementOpKind::Mint { vault_id: vid, .. } if *vid == vault_id)
+                    && matches!(
+                        op.status,
+                        SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                    )
+            })
+        })
+        .unwrap_or(false);
+    if has_live_mint {
+        return Err(RecoveryError::LiveMintOp(vault_id));
+    }
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .ok_or(RecoveryError::UnknownVault(vault_id))?;
+    if v.collateral_chain != chain {
+        return Err(RecoveryError::WrongChain { vault_id, chain });
+    }
+    if v.status != ChainVaultStatus::MintPending || v.pending_mint_e8s != 0 {
+        return Err(RecoveryError::NotRecoverable(format!(
+            "vault {vault_id} status {:?}, pending_mint_e8s {} (changed since precheck)",
+            v.status, v.pending_mint_e8s
+        )));
+    }
+    v.status = ChainVaultStatus::Open;
+    Ok(())
+}
+
+/// M-09 (RECOV-02): recover a `MintPending` vault to `Open` (releasing its
+/// collateral via the existing close/withdraw paths) ONLY after re-verifying
+/// on-chain that the mint did NOT actually land.
+///
+/// `recover_stuck_chain_vault` previously trusted `pending_mint_e8s == 0`, a
+/// value the (then-unverified) `resolve_stuck_settlement_op` could set even when
+/// the mint had landed. After M-08 hardens that path, this adds an INDEPENDENT
+/// on-chain re-check so a vault whose mint really landed can never be flipped to
+/// Open:
+///
+///  1. For every TERMINAL Mint op recorded for this vault, re-read its tx
+///     receipt through the quorum. Any one that SUCCEEDED → REFUSE
+///     (`OnChainLanded`): the mint landed, releasing collateral would let the
+///     user keep both the on-chain icUSD and the collateral.
+///  2. Defensive supply re-check: read the icUSD `totalSupply()` on this chain
+///     at the finalized cursor (consensus-safe) and compare to the recorded
+///     `chain_supplies` plus any in-flight mints. If on-chain supply EXCEEDS
+///     recorded + in-flight (the unbacked-mint signature), REFUSE — even if no
+///     terminal op tx hash pointed at it, a mint may have landed.
+///  3. Only when both checks pass: flip MintPending->Open.
+///
+/// Any quorum read error is fail-closed (`VerificationUnavailable`).
+pub async fn recover_stuck_chain_vault_verified(
+    chain: ChainId,
+    vault_id: u64,
+) -> Result<(), RecoveryError> {
+    let mint_tx_hashes = precheck_recover_vault(chain, vault_id)?;
+
+    // (1) Re-verify each terminal Mint op's tx did not succeed on-chain.
+    for tx_hash in &mint_tx_hashes {
+        match crate::chains::monad::evm_rpc::get_transaction_receipt(chain, tx_hash).await {
+            Ok(Some((true, block))) => {
+                return Err(RecoveryError::OnChainLanded(format!(
+                    "vault {vault_id} mint tx {tx_hash} succeeded on-chain at block {block}; refusing to release collateral"
+                )));
+            }
+            Ok(Some((false, _))) | Ok(None) => { /* reverted or not mined — fine */ }
+            Err(e) => {
+                return Err(RecoveryError::VerificationUnavailable(format!(
+                    "could not read mint receipt for vault {vault_id} tx {tx_hash} via quorum: {e}"
+                )));
+            }
+        }
+    }
+
+    // (2) Defensive on-chain supply re-check (catches a landed mint with no
+    // recorded tx hash). Skipped only when there is no contract or no finalized
+    // cursor yet (then there can be no confirmed on-chain mint to find).
+    let (contract, cursor, recorded_supply, in_flight_mint) = read_state(|s| {
+        let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
+        let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+        let recorded_supply = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+        let in_flight_mint: u128 = s
+            .multi_chain
+            .chain_vaults
+            .values()
+            .filter(|v| v.collateral_chain == chain)
+            .map(|v| v.pending_mint_e8s)
+            .sum();
+        (contract, cursor, recorded_supply, in_flight_mint)
+    });
+    if let (Some(contract), true) = (contract, cursor > 0) {
+        match crate::chains::monad::evm_rpc::erc20_total_supply_at(chain, &contract, cursor).await {
+            Ok(onchain_supply) => {
+                if onchain_supply > recorded_supply.saturating_add(in_flight_mint) {
+                    return Err(RecoveryError::OnChainLanded(format!(
+                        "vault {vault_id}: on-chain icUSD supply {} exceeds recorded {} + in-flight {} at block {}; a mint may have landed — refusing to release collateral",
+                        onchain_supply, recorded_supply, in_flight_mint, cursor
+                    )));
+                }
+            }
+            Err(e) => {
+                return Err(RecoveryError::VerificationUnavailable(format!(
+                    "could not read on-chain totalSupply for vault {vault_id} via quorum: {e}"
+                )));
+            }
+        }
+    }
+
+    // (3) Verified clear — flip MintPending->Open under a fresh borrow.
+    mutate_state(|s| apply_recover_vault_in_state(&mut s.multi_chain, chain, vault_id))
+}

--- a/src/rumi_protocol_backend/src/chains/solana/config.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/config.rs
@@ -49,5 +49,9 @@ pub fn solana_default_register_arg() -> RegisterChainArg {
             lamports_per_cu_ceiling: 10_000,
         },
         chain_native_decimals: SOL_NATIVE_DECIMALS,
+        // M-05 (QUORUM-2): not consulted for Solana — the SOL-RPC canister
+        // enforces its own Equality/Threshold consensus and rejects
+        // `Inconsistent` responses. Kept `None` for shape completeness.
+        min_quorum_providers: None,
     }
 }

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -51,7 +51,7 @@ use crate::Mode;
 // Reuse the chain-agnostic pure helpers from the Monad settlement module (the
 // FIFO one-in-flight selector and the supply-invariant mint-confirm). These are
 // chain-independent: `select_next_op` scans a `SettlementQueueV1` and
-// `confirm_mint_in_state` operates on `MultiChainStateV3`, neither of which is
+// `confirm_mint_in_state` operates on `MultiChainStateV4`, neither of which is
 // Monad-specific.
 use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
 

--- a/src/rumi_protocol_backend/src/chains/solana/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_deposit_watch.rs
@@ -19,7 +19,7 @@ use super::config::SOLANA_CHAIN_ID;
 use super::deposit_watch::supply_drop_detected;
 use super::ted25519::{is_valid_solana_address, solana_address_from_pubkey};
 use crate::chains::config::{GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
 use crate::chains::vault::{
     open_chain_vault_in_state, verify_deposit_and_enqueue_mint_in_state, ChainVaultStatus,
@@ -43,8 +43,8 @@ fn valid_solana_address(byte: u8) -> String {
 /// Register Solana (chain 501) with 9-decimal native units and a manual `"SOL"`
 /// price, then open an `AwaitingDeposit` vault (id 7) declaring `declared_lamports`
 /// collateral and `HUNDRED_ICUSD_E8S` debt. Returns the seeded state.
-fn seeded_awaiting_deposit(declared_lamports: u128) -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn seeded_awaiting_deposit(declared_lamports: u128) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     let arg = RegisterChainArg {
         chain_id: SOLANA_CHAIN_ID,
         display_name: "SolanaDevnet".into(),
@@ -56,6 +56,7 @@ fn seeded_awaiting_deposit(declared_lamports: u128) -> MultiChainStateV3 {
             lamports_per_cu_ceiling: 10_000,
         },
         chain_native_decimals: 9,
+        min_quorum_providers: None,
     };
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     s.manual_prices

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -5,7 +5,7 @@
 //! RPC + signing-subnet round trip); here we cover only the pure pieces:
 //!
 //! - the REUSE of the chain-agnostic `confirm_mint_in_state` / `select_next_op`
-//!   helpers on a SOLANA-flavored `MultiChainStateV3` (a Solana mint confirm
+//!   helpers on a SOLANA-flavored `MultiChainStateV4` (a Solana mint confirm
 //!   moves pending -> debt, increments `chain_supplies`, and flips the vault to
 //!   `Open` - identical invariant to Monad, exercised here against the Solana
 //!   chain id so the reuse is proven, not assumed);
@@ -14,7 +14,7 @@
 
 use crate::chains::config::ChainId;
 use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::{
     SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
 };
@@ -28,7 +28,7 @@ const SOL: ChainId = ChainId(501);
 /// Insert a Solana `MintPending` vault with the given pending mint amount.
 /// `collateral_amount_native` is in lamports (Solana's 9-decimal base unit); a
 /// confirm does not read it, but we set a realistic value for clarity.
-fn solana_vault_pending(s: &mut MultiChainStateV3, vault_id: u64, pending_e8s: u128) {
+fn solana_vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending_e8s: u128) {
     s.chain_vaults.insert(
         vault_id,
         ChainVaultV1 {
@@ -48,7 +48,7 @@ fn solana_vault_pending(s: &mut MultiChainStateV3, vault_id: u64, pending_e8s: u
 
 #[test]
 fn solana_confirm_mint_moves_pending_to_debt_and_increments_supply() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending (e8s)
                                                      // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
@@ -61,7 +61,7 @@ fn solana_confirm_mint_moves_pending_to_debt_and_increments_supply() {
 
 #[test]
 fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000);
     // Observed != pending: reject before any supply mutation; nothing changes.
@@ -75,7 +75,7 @@ fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
 
 #[test]
 fn solana_confirm_mint_unknown_vault_rejected() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(SOL, 0);
     assert!(confirm_mint_in_state(&mut s, SOL, 999, 1, 0).is_err());
 }
@@ -85,7 +85,7 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
     // Two Solana vaults: the first already confirmed (debt 100e8, supply 100e8);
     // confirming the second (pending 50e8) must pass PRE-mint total = 100e8, and
     // the helper computes the post-mint total 150e8 internally.
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(SOL, 10_000_000_000);
     s.chain_vaults.insert(
         1,

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,7 +12,7 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
+use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainStateV4};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
@@ -63,7 +63,7 @@ pub enum SupplyInvariantError {
 /// authoritative `total_debt_e8s` snapshot taken at the same logical
 /// moment; we reject any apply that would leave sum != total_debt.
 pub fn apply_supply_delta(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain: ChainId,
     delta: SupplyDelta,
     total_debt_e8s: u128,
@@ -109,7 +109,7 @@ pub fn apply_supply_delta(
 /// On `Err`, the caller flips `state.invariant_halted = true` and emits
 /// an event.
 pub fn check_invariant(
-    state: &MultiChainStateV3,
+    state: &MultiChainStateV4,
     total_debt_e8s: u128,
 ) -> Result<(), SupplyInvariantError> {
     let sum: u128 = state.chain_supplies.values().copied().sum();

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -2,9 +2,12 @@
 //! flow (caller check, event recording, traps) is exercised in PocketIC under
 //! Task 12.
 
-use super::config::{ChainAdminError, ChainConfigV2, ChainId, ChainStatus, GasStrategy, RegisterChainArg, UpdateChainConfigArg};
+use super::config::{
+    effective_min_quorum_providers, ChainAdminError, ChainConfigV3, ChainId, ChainStatus,
+    GasStrategy, RegisterChainArg, UpdateChainConfigArg, DEFAULT_MIN_QUORUM_PROVIDERS,
+};
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-use super::multi_chain_state::MultiChainStateV3;
+use super::multi_chain_state::MultiChainStateV4;
 use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
 use candid::Principal;
 
@@ -16,6 +19,7 @@ fn arg() -> RegisterChainArg {
         finality_depth: 1,
         gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
         chain_native_decimals: 18,
+        min_quorum_providers: None,
     }
 }
 
@@ -27,6 +31,7 @@ fn config_arg_999() -> RegisterChainArg {
         finality_depth: 1,
         gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
         chain_native_decimals: 18,
+        min_quorum_providers: None,
     }
 }
 
@@ -47,7 +52,7 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
 
 #[test]
 fn register_chain_inserts_config_and_zero_supply() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     register_chain_in_state(&mut s, arg(), 1_700_000_000_000_000_000).expect("register");
     assert!(s.chain_configs.contains_key(&ChainId(101)));
     assert_eq!(s.chain_supplies[&ChainId(101)], 0);
@@ -56,13 +61,15 @@ fn register_chain_inserts_config_and_zero_supply() {
     assert!(matches!(cfg.status, ChainStatus::Registered));
     // Phase 1c default: a freshly registered chain has the emergency poll-scan OFF.
     assert!(!cfg.burn_watch_poll_enabled);
-    // Note: not unused -- `ChainConfigV2` is brought into scope to assert the type alias.
-    let _: &ChainConfigV2 = cfg;
+    // Note: not unused -- `ChainConfigV3` is brought into scope to assert the type alias.
+    let _: &ChainConfigV3 = cfg;
+    // Phase 1d default: the per-chain quorum-provider floor override is unset (None).
+    assert_eq!(cfg.min_quorum_providers, None);
 }
 
 #[test]
 fn register_chain_rejects_duplicates() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
     assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
@@ -70,7 +77,7 @@ fn register_chain_rejects_duplicates() {
 
 #[test]
 fn register_chain_rejects_empty_rpc_endpoints() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let mut a = arg();
     a.rpc_endpoints = vec![];
     let err = register_chain_in_state(&mut s, a, 0).expect_err("empty endpoints");
@@ -79,7 +86,7 @@ fn register_chain_rejects_empty_rpc_endpoints() {
 
 #[test]
 fn register_chain_rejects_out_of_range_decimals() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     // 0 would make the CR native-scale 1 (collateral treated as whole units),
     // inflating every CR check and admitting under-collateralized opens.
     let mut zero = arg();
@@ -104,7 +111,7 @@ fn register_chain_rejects_out_of_range_decimals() {
 
 #[test]
 fn register_chain_enforces_evm_finality_floor() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     // EVM chain with finality_depth 0 is rejected.
     let mut a = arg(); // EvmEip1559 gas strategy
     a.finality_depth = 0;
@@ -125,7 +132,7 @@ fn register_chain_enforces_evm_finality_floor() {
 
 #[test]
 fn disable_chain_flips_status_and_preserves_supply() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
@@ -135,7 +142,7 @@ fn disable_chain_flips_status_and_preserves_supply() {
 
 #[test]
 fn set_chain_config_updates_supplied_fields_only() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     let original_name = s.chain_configs[&ChainId(101)].display_name.clone();
     let update = UpdateChainConfigArg {
@@ -143,6 +150,7 @@ fn set_chain_config_updates_supplied_fields_only() {
         rpc_endpoints: Some(vec!["https://new.example".into()]),
         finality_depth: Some(5),
         gas_strategy: None,
+        min_quorum_providers: None,
     };
     update_chain_config_in_state(&mut s, ChainId(101), update).expect("update");
     assert_eq!(s.chain_configs[&ChainId(101)].display_name, original_name);
@@ -152,7 +160,7 @@ fn set_chain_config_updates_supplied_fields_only() {
 
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let err = update_chain_config_in_state(
         &mut s,
         ChainId(404),
@@ -163,7 +171,7 @@ fn set_chain_config_rejects_unknown_chain() {
 
 #[test]
 fn delete_chain_removes_zero_supply_chain() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     // Populate EVERY per-chain map so the purge can be observed.
@@ -193,7 +201,7 @@ fn delete_chain_removes_zero_supply_chain() {
 
 #[test]
 fn delete_chain_refuses_when_supply_nonzero() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_supplies.insert(c, 1);
@@ -206,7 +214,7 @@ fn delete_chain_refuses_when_supply_nonzero() {
 
 #[test]
 fn delete_chain_refuses_when_open_vaults_reference_it() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_vaults.insert(1, dummy_vault(1, c));
@@ -219,7 +227,7 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
 
 #[test]
 fn delete_chain_unknown_is_rejected() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_config.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_config.rs
@@ -1,6 +1,8 @@
 //! ChainConfig encode/decode + version-alias invariants.
 
-use super::config::{ChainConfig, ChainConfigV1, ChainConfigV2, ChainId, ChainStatus, GasStrategy};
+use super::config::{
+    ChainConfig, ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId, ChainStatus, GasStrategy,
+};
 use candid::{Decode, Encode};
 
 #[test]
@@ -42,11 +44,11 @@ fn chain_config_round_trips_via_candid() {
 }
 
 #[test]
-fn chain_config_alias_matches_v2() {
-    // Phase 1c rebound `ChainConfig` from V1 to V2 (added the
-    // `burn_watch_poll_enabled` poll-scan flag). `ChainConfig` is the active
-    // version pointer; the next field add bumps it to V3.
-    fn _check(_x: ChainConfig) -> ChainConfigV2 { _x }
+fn chain_config_alias_matches_v3() {
+    // Phase 1d rebound `ChainConfig` from V2 to V3 (added the M-05
+    // `min_quorum_providers` quorum-provider floor override). `ChainConfig` is
+    // the active version pointer; the next field add bumps it to V4.
+    fn _check(_x: ChainConfig) -> ChainConfigV3 { _x }
 }
 
 #[test]
@@ -120,4 +122,48 @@ fn v2_config_round_trips_with_poll_flag_set() {
         ciborium::de::from_reader(buf.as_slice()).expect("V2 config round-trips");
     assert!(back.burn_watch_poll_enabled);
     assert_eq!(back.finality_depth, 3);
+}
+
+#[test]
+fn v2_cbor_sub_map_decodes_into_v3_defaulting_the_quorum_floor() {
+    // STATE-WIPE REGRESSION (audit M-05 / Phase 1d). On the live staging
+    // canister `chain_configs` VALUES were written as `ChainConfigV2` field-maps
+    // (no `min_quorum_providers` key). After this upgrade those same bytes must
+    // decode into `ChainConfigV3` with every V2 field preserved and the new
+    // `min_quorum_providers` defaulted to `None` via its field-level
+    // `#[serde(default)]`. State persists via ciborium (serde), NOT a Candid
+    // `Decode!` of a fixed record, so a missing key fills from the default
+    // rather than failing — this is what prevents the AMM-style state-wipe
+    // (2026-05-18). Dropping the `#[serde(default)]` would error "missing field"
+    // here and silently wipe multi_chain state on the real canister.
+    let v2 = ChainConfigV2 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".to_string(),
+        rpc_endpoints: vec!["https://rpc".to_string()],
+        finality_depth: 3,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 500,
+        },
+        chain_native_decimals: 18,
+        registered_at_ns: 7,
+        status: ChainStatus::Registered,
+        burn_watch_poll_enabled: true,
+    };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v2, &mut buf).expect("cbor encode V2 config");
+    let v3: ChainConfigV3 = ciborium::de::from_reader(buf.as_slice())
+        .expect("V2 config sub-map MUST decode into V3 without wiping state");
+
+    // Every V2 field preserved verbatim:
+    assert_eq!(v3.chain_id, ChainId(10143));
+    assert_eq!(v3.display_name, "MonadTestnet");
+    assert_eq!(v3.rpc_endpoints, vec!["https://rpc".to_string()]);
+    assert_eq!(v3.finality_depth, 3);
+    assert_eq!(v3.chain_native_decimals, 18);
+    assert_eq!(v3.registered_at_ns, 7);
+    assert!(matches!(v3.status, ChainStatus::Registered));
+    assert!(v3.burn_watch_poll_enabled);
+    // The new quorum-floor override defaults to None (=> DEFAULT_MIN_QUORUM_PROVIDERS).
+    assert_eq!(v3.min_quorum_providers, None);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,4 +1,6 @@
-use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3};
+use super::multi_chain_state::{
+    MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
+};
 use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
 
@@ -118,8 +120,8 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
 }
 
 #[test]
-fn active_alias_points_at_v3() {
-    fn _check(x: MultiChainState) -> MultiChainStateV3 { x }
+fn active_alias_points_at_v4() {
+    fn _check(x: MultiChainState) -> MultiChainStateV4 { x }
 }
 
 #[test]
@@ -193,6 +195,80 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
     // Total debt still reconciles (no state wipe).
     assert_eq!(v3.total_chain_vault_debt_e8s(), 50_000_000);
     assert_eq!(v3.total_supply_all_chains_e8s(), 50_000_000);
+}
+
+#[test]
+fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
+    // STATE-WIPE REGRESSION (audit M-05 / Phase 1d). The live staging canister
+    // persists a `MultiChainStateV3` whose `chain_configs` values are
+    // `ChainConfigV2` field-maps. This upgrade rebinds `MultiChainState` to V4
+    // (whose `chain_configs` value type is `ChainConfigV3`). A populated V3 CBOR
+    // snapshot MUST decode into V4 with:
+    //   - the ten outer fields carried across by name, and
+    //   - each nested config decoding from `ChainConfigV2` into `ChainConfigV3`
+    //     with `min_quorum_providers` supplied by its `#[serde(default)]`.
+    // This is the exact ciborium decode path `load_state_from_stable()` runs on
+    // upgrade. Without the nested `#[serde(default)]` the decode would fail with
+    // "missing field `min_quorum_providers`", silently wiping multi_chain state
+    // on the real canister. (Vault 1 with real debt/supply lives here.)
+    use super::config::{ChainConfigV2, ChainStatus, GasStrategy};
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::settlement_queue::SettlementQueueV1;
+    use std::collections::BTreeSet;
+
+    let mut v3 = MultiChainStateV3::default();
+    v3.chain_configs.insert(ChainId(10143), ChainConfigV2 {
+        chain_id: ChainId(10143),
+        display_name: "MonadTestnet".into(),
+        rpc_endpoints: vec!["https://rpc".into()],
+        finality_depth: 3,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
+        chain_native_decimals: 18,
+        registered_at_ns: 123,
+        status: ChainStatus::Registered,
+        burn_watch_poll_enabled: true,
+    });
+    v3.chain_supplies.insert(ChainId(10143), 50_000_000);
+    v3.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
+    v3.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: ChainId(10143),
+        custody_address: "0xcustody".into(),
+        collateral_amount_native: 1_000_000_000_000_000_000,
+        debt_e8s: 50_000_000,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 99,
+    });
+    v3.chain_contracts.insert(ChainId(10143), "0xicusd".into());
+    v3.last_observed_block.insert(ChainId(10143), 35_136_248);
+    v3.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+
+    // Encode as V3 (the bytes the live canister wrote), decode as V4 (new shape).
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v3, &mut buf).expect("cbor encode V3");
+    let v4: MultiChainStateV4 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V3 snapshot MUST decode into V4");
+
+    // Outer state preserved:
+    assert_eq!(v4.chain_supplies.get(&ChainId(10143)), Some(&50_000_000u128));
+    assert_eq!(v4.chain_vaults.len(), 1);
+    assert_eq!(v4.chain_vaults[&1].debt_e8s, 50_000_000);
+    assert_eq!(v4.chain_contracts.get(&ChainId(10143)), Some(&"0xicusd".to_string()));
+    assert_eq!(v4.last_observed_block.get(&ChainId(10143)), Some(&35_136_248u64));
+    assert!(v4.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
+    // Nested config migrated V2 -> V3: V2 fields preserved, new override defaulted None.
+    let cfg = v4.chain_configs.get(&ChainId(10143)).expect("config preserved");
+    assert_eq!(cfg.finality_depth, 3);
+    assert_eq!(cfg.display_name, "MonadTestnet");
+    assert!(matches!(cfg.status, ChainStatus::Registered));
+    assert!(cfg.burn_watch_poll_enabled, "V2 poll flag carried across");
+    assert_eq!(cfg.min_quorum_providers, None, "new quorum floor defaults to None");
+    // Total debt still reconciles (no state wipe).
+    assert_eq!(v4.total_chain_vault_debt_e8s(), 50_000_000);
+    assert_eq!(v4.total_supply_all_chains_e8s(), 50_000_000);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -1,0 +1,203 @@
+//! Pure-state tests for the on-chain-verified recovery helpers (audit M-08 /
+//! RECOV-01 and M-09 / RECOV-02). The async verification orchestrators
+//! (`resolve_stuck_settlement_op_verified`, `recover_stuck_chain_vault_verified`)
+//! make EVM-RPC quorum calls and are covered by PocketIC; here we exercise the
+//! pure reversal + precheck + transition helpers they delegate to, plus the
+//! state-machine guards that prevent releasing collateral / reversing a landed
+//! mint.
+
+use super::config::ChainId;
+use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+use super::multi_chain_state::MultiChainStateV4;
+use super::recovery::{
+    apply_recover_vault_in_state, apply_resolve_reversal_in_state,
+    precheck_recover_vault_in_state, RecoveryError,
+};
+use super::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
+use candid::Principal;
+
+const CHAIN: ChainId = ChainId(10143);
+
+fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u128) -> ChainVaultV1 {
+    ChainVaultV1 {
+        vault_id,
+        owner: Principal::anonymous(),
+        collateral_chain: CHAIN,
+        custody_address: "0xcustody".into(),
+        collateral_amount_native: collateral,
+        debt_e8s: 0,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: pending,
+        status,
+        opened_at_ns: 0,
+    }
+}
+
+fn inflight_op(op_id: u64, kind: SettlementOpKind, tx: Option<&str>) -> SettlementOp {
+    let mut op = SettlementOp::new(kind, format!("key-{op_id}"), 0);
+    op.op_id = op_id;
+    op.status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    op.last_tx_hash = tx.map(|s| s.to_string());
+    op
+}
+
+fn state_with_op(op: SettlementOp) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
+    let mut q = super::settlement_queue::SettlementQueueV1::default();
+    let id = op.op_id;
+    q.pending.insert(id, op);
+    q.tail = id + 1;
+    s.settlement_queues.insert(CHAIN, q);
+    s
+}
+
+// ── M-08: apply_resolve_reversal_in_state ─────────────────────────────────────
+
+#[test]
+fn resolve_reversal_mint_clears_pending_and_marks_failed() {
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        Some("0xtx"),
+    ));
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 5, 0));
+
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    assert!(did, "first reversal applies");
+    // Pending cleared, status stays MintPending (Design B: no debt was counted).
+    assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
+    assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::MintPending);
+    // Op marked Failed.
+    assert!(matches!(
+        s.settlement_queues[&CHAIN].pending[&0].status,
+        SettlementOpStatus::Failed { .. }
+    ));
+}
+
+#[test]
+fn resolve_reversal_withdrawal_restores_collateral_and_reopens() {
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        Some("0xtx"),
+    ));
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    assert!(did);
+    // Reserved collateral added back; Closing -> Open.
+    assert_eq!(s.chain_vaults[&1].collateral_amount_native, 1_000);
+    assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::Open);
+}
+
+#[test]
+fn resolve_reversal_is_idempotent_cas() {
+    // A second reversal (op already Failed) is a no-op and does NOT double-credit
+    // the withdrawal collateral (the CAS guard prevents 2x amount_e18).
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        Some("0xtx"),
+    ));
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+
+    assert!(apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100));
+    let second = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 200);
+    assert!(!second, "second reversal is a no-op (op no longer Inflight)");
+    assert_eq!(
+        s.chain_vaults[&1].collateral_amount_native, 1_000,
+        "collateral credited exactly once"
+    );
+}
+
+// ── M-09: precheck + transition ───────────────────────────────────────────────
+
+#[test]
+fn precheck_recover_returns_terminal_mint_tx_hashes() {
+    // A terminal (Failed) Mint op for the vault carries a tx hash the async path
+    // must re-verify on-chain.
+    let mut s = MultiChainStateV4::default();
+    let mut q = super::settlement_queue::SettlementQueueV1::default();
+    let mut op = inflight_op(
+        0,
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        Some("0xmint_tx"),
+    );
+    op.status = SettlementOpStatus::Failed { reason: "x".into(), failed_ns: 1 };
+    q.pending.insert(0, op);
+    q.tail = 1;
+    s.settlement_queues.insert(CHAIN, q);
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+
+    let hashes = precheck_recover_vault_in_state(&s, CHAIN, 1).expect("precheck ok");
+    assert_eq!(hashes, vec!["0xmint_tx".to_string()]);
+}
+
+#[test]
+fn precheck_recover_rejects_live_mint_op() {
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        Some("0xtx"),
+    )); // Inflight == live
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    let err = precheck_recover_vault_in_state(&s, CHAIN, 1).expect_err("live mint");
+    assert!(matches!(err, RecoveryError::LiveMintOp(1)));
+}
+
+#[test]
+fn precheck_recover_rejects_nonzero_pending_or_wrong_status() {
+    let mut s = MultiChainStateV4::default();
+    // Nonzero pending => not recoverable.
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
+    assert!(matches!(
+        precheck_recover_vault_in_state(&s, CHAIN, 1),
+        Err(RecoveryError::NotRecoverable(_))
+    ));
+    // Wrong status (Open) => not recoverable.
+    s.chain_vaults.insert(2, vault(2, ChainVaultStatus::Open, 0, 9));
+    assert!(matches!(
+        precheck_recover_vault_in_state(&s, CHAIN, 2),
+        Err(RecoveryError::NotRecoverable(_))
+    ));
+}
+
+#[test]
+fn precheck_recover_rejects_wrong_chain_and_unknown() {
+    let mut s = MultiChainStateV4::default();
+    let mut v = vault(1, ChainVaultStatus::MintPending, 0, 9);
+    v.collateral_chain = ChainId(999);
+    s.chain_vaults.insert(1, v);
+    assert!(matches!(
+        precheck_recover_vault_in_state(&s, CHAIN, 1),
+        Err(RecoveryError::WrongChain { vault_id: 1, .. })
+    ));
+    assert!(matches!(
+        precheck_recover_vault_in_state(&s, CHAIN, 42),
+        Err(RecoveryError::UnknownVault(42))
+    ));
+}
+
+#[test]
+fn apply_recover_vault_flips_mintpending_to_open() {
+    let mut s = MultiChainStateV4::default();
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    apply_recover_vault_in_state(&mut s, CHAIN, 1).expect("recover");
+    assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::Open);
+}
+
+#[test]
+fn apply_recover_vault_rechecks_guards_at_commit() {
+    // A live mint op enqueued between precheck and commit must block the flip
+    // (defense-in-depth re-check inside apply_recover_vault_in_state).
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        Some("0xtx"),
+    ));
+    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    let err = apply_recover_vault_in_state(&mut s, CHAIN, 1).expect_err("live mint at commit");
+    assert!(matches!(err, RecoveryError::LiveMintOp(1)));
+    // Vault NOT flipped.
+    assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::MintPending);
+}

--- a/src/rumi_protocol_backend/src/chains/tests_self_check.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_self_check.rs
@@ -2,12 +2,12 @@
 //! self-check flips the halt flag and Mode and stops mutating supplies.
 
 use super::config::ChainId;
-use super::multi_chain_state::MultiChainStateV3;
+use super::multi_chain_state::MultiChainStateV4;
 use super::supply::check_invariant;
 
 #[test]
 fn check_invariant_passes_when_sum_equals_total_debt() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     assert!(check_invariant(&s, 300).is_ok());
@@ -15,7 +15,7 @@ fn check_invariant_passes_when_sum_equals_total_debt() {
 
 #[test]
 fn check_invariant_fails_on_drift() {
-    let mut s = MultiChainStateV3::default();
+    let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     let err = check_invariant(&s, 299).expect_err("drift must be caught");
@@ -24,6 +24,6 @@ fn check_invariant_fails_on_drift() {
 
 #[test]
 fn empty_state_passes_when_total_debt_is_zero() {
-    let s = MultiChainStateV3::default();
+    let s = MultiChainStateV4::default();
     assert!(check_invariant(&s, 0).is_ok());
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,12 +1,12 @@
 use super::supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
-use super::config::{ChainConfigV2, ChainId, ChainStatus, GasStrategy};
-use super::multi_chain_state::MultiChainStateV3;
+use super::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
+use super::multi_chain_state::MultiChainStateV4;
 
-fn fixture_state() -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn fixture_state() -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     s.chain_configs.insert(
         ChainId(101),
-        ChainConfigV2 {
+        ChainConfigV3 {
             chain_id: ChainId(101),
             display_name: "TestChain".into(),
             rpc_endpoints: vec![],
@@ -16,6 +16,7 @@ fn fixture_state() -> MultiChainStateV3 {
             registered_at_ns: 0,
             status: ChainStatus::Registered,
             burn_watch_poll_enabled: false,
+            min_quorum_providers: None,
         },
     );
     s.chain_supplies.insert(ChainId(101), 0);

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -12,7 +12,7 @@
 //! this file only asserts the parameterization itself.
 
 use super::config::{ChainId, GasStrategy, RegisterChainArg};
-use super::multi_chain_state::MultiChainStateV3;
+use super::multi_chain_state::MultiChainStateV4;
 use super::vault::{open_chain_vault_in_state, OpenVaultError};
 use candid::Principal;
 
@@ -33,8 +33,8 @@ fn only_good(addr: &str) -> bool {
 
 /// Register chain 501 with 9-decimal native units and set its manual `"SOL"`
 /// price. Mirrors what register_chain + a manual price override do.
-fn setup(price_e8: u64) -> MultiChainStateV3 {
-    let mut s = MultiChainStateV3::default();
+fn setup(price_e8: u64) -> MultiChainStateV4 {
+    let mut s = MultiChainStateV4::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "SolanaDevnet".into(),
@@ -46,6 +46,7 @@ fn setup(price_e8: u64) -> MultiChainStateV3 {
             lamports_per_cu_ceiling: 10_000,
         },
         chain_native_decimals: 9,
+        min_quorum_providers: None,
     };
     crate::chains::admin::register_chain_in_state(&mut s, arg, 0).expect("register chain");
     s.manual_prices.insert((CHAIN, "SOL".into()), price_e8);

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -30,7 +30,7 @@
 //! observed at finality (settlement worker, Task 10).
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV3;
+use crate::chains::multi_chain_state::MultiChainStateV4;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
@@ -192,7 +192,7 @@ pub fn collateral_ratio_e4(
 /// - declared CR `< min_cr_e4` -> `BelowMinCr`
 #[allow(clippy::too_many_arguments)]
 pub fn open_chain_vault_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     chain: ChainId,
     owner: Principal,
     custody_address: String,
@@ -283,7 +283,7 @@ pub fn open_chain_vault_in_state(
 /// rejected enqueue leaves the vault `AwaitingDeposit` and the queue unchanged,
 /// and the next deposit-watch tick retries cleanly.
 pub fn verify_deposit_and_enqueue_mint_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     observed_balance_e18: u128,
     now_ns: u64,
@@ -386,7 +386,7 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
 /// So a rejected enqueue leaves the vault and its collateral untouched.
 #[allow(clippy::too_many_arguments)]
 pub fn withdraw_collateral_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     amount_e18: u128,
     dest_address: String,
@@ -502,7 +502,7 @@ pub fn withdraw_collateral_in_state(
 /// (A non-Open zero-collateral vault is NOT short-circuited - it falls through
 /// to the delegate's gate and rejects with `WrongStatus`.)
 pub fn close_chain_vault_in_state(
-    state: &mut MultiChainStateV3,
+    state: &mut MultiChainStateV4,
     vault_id: u64,
     dest_address: String,
     address_validator: fn(&str) -> bool,

--- a/src/rumi_protocol_backend/src/guard.rs
+++ b/src/rumi_protocol_backend/src/guard.rs
@@ -163,6 +163,209 @@ impl Drop for GuardPrincipal {
     }
 }
 
+thread_local! {
+    /// Vault ids with a liquidation currently in flight. Transient (heap):
+    /// in-flight liquidations never span a canister upgrade, and ic-cdk's
+    /// `call_on_cleanup` runs this guard's `Drop` even when a post-`await`
+    /// continuation traps, so the entry is always released. Same pattern the
+    /// 3pool/amm `PoolGuard`s use.
+    static LIQUIDATING_VAULTS: std::cell::RefCell<std::collections::HashSet<u64>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Per-vault liquidation lock. Serializes EVERY liquidator (any caller — two
+/// humans, the stability pool, a human + the SP) on a single vault across the
+/// snapshot -> pull-icUSD -> re-cap -> collateral-payout sequence.
+///
+/// BK-001/002 (audit 2026-06-05): `GuardPrincipal` keys on the CALLER, so two
+/// different liquidators racing the same vault both pass it. Each snapshots the
+/// vault's full collateral before its `await`; the post-`await` re-cap
+/// (ASYNC-001) prevents the vault-accounting underflow/wrap, but the collateral
+/// PAYOUT (`pending_margin_transfers`) still uses the stale per-caller snapshot,
+/// so the loser is paid the full pre-state collateral out of the SHARED
+/// collateral pool — draining other vaults' backing. Keying the lock on
+/// `vault_id` (not the caller) makes the whole sequence atomic per vault and
+/// closes the economic over-seize the re-cap alone left open.
+#[must_use]
+pub struct VaultLiquidationGuard(u64);
+
+impl VaultLiquidationGuard {
+    /// Acquire the liquidation lock for `vault_id`. Returns
+    /// `TemporarilyUnavailable` if another liquidation of the same vault is in
+    /// flight; the caller should back off (the stability pool, per project
+    /// rule, must NOT retry — it falls through to manual, which is correct).
+    pub fn new(vault_id: u64) -> Result<Self, crate::ProtocolError> {
+        LIQUIDATING_VAULTS.with(|set| {
+            let mut set = set.borrow_mut();
+            if set.contains(&vault_id) {
+                return Err(crate::ProtocolError::TemporarilyUnavailable(format!(
+                    "Vault #{vault_id} is already being liquidated; retry shortly"
+                )));
+            }
+            set.insert(vault_id);
+            Ok(Self(vault_id))
+        })
+    }
+}
+
+impl Drop for VaultLiquidationGuard {
+    fn drop(&mut self) {
+        LIQUIDATING_VAULTS.with(|set| {
+            set.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
+thread_local! {
+    /// In-flight borrow reservations per collateral type (icUSD e8s). A borrow
+    /// checks the debt ceiling / global mint cap, then mints icUSD across an
+    /// `await`, then records the debt. Concurrent borrows from DIFFERENT owners
+    /// both pass the pre-await check against the same committed aggregate and
+    /// both mint, blowing past the cap (BK-003). This map bridges the gap: a
+    /// borrow reserves its amount here (counted by every concurrent borrow's
+    /// cap check) before minting, and releases on Drop. Transient/heap; ic-cdk
+    /// `call_on_cleanup` drops the guard on continuation-trap, so reservations
+    /// never leak.
+    static BORROW_RESERVATIONS: std::cell::RefCell<std::collections::HashMap<Principal, u64>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Atomically check-and-reserve borrow headroom against in-flight reservations.
+///
+/// BK-003 (audit 2026-06-05): enforces the per-collateral debt ceiling and the
+/// global icUSD mint cap across the mint `await`, so two distinct owners cannot
+/// each pass the pre-await check and jointly exceed the cap.
+#[must_use]
+pub struct BorrowReservationGuard {
+    collateral: Principal,
+    amount: u64,
+}
+
+impl BorrowReservationGuard {
+    /// Reserve `amount` for `collateral` iff, counting all in-flight
+    /// reservations, the per-collateral ceiling and the global mint cap both
+    /// still hold. The committed aggregates (`current_collateral_debt`,
+    /// `current_global_borrowed`) are read by the caller and passed in. Returns
+    /// `Err` (no reservation taken) when a concurrent in-flight borrow has
+    /// already consumed the headroom.
+    pub fn try_reserve(
+        collateral: Principal,
+        amount: u64,
+        current_collateral_debt: u64,
+        debt_ceiling: u64,
+        current_global_borrowed: u64,
+        global_cap: u64,
+    ) -> Result<Self, String> {
+        BORROW_RESERVATIONS.with(|r| {
+            let mut map = r.borrow_mut();
+            let coll_reserved: u64 = map.get(&collateral).copied().unwrap_or(0);
+            let total_reserved: u64 = map.values().copied().sum();
+
+            if current_collateral_debt
+                .saturating_add(coll_reserved)
+                .saturating_add(amount)
+                > debt_ceiling
+            {
+                return Err(format!(
+                    "Borrow would exceed debt ceiling incl in-flight ({} + {} + {} > {})",
+                    current_collateral_debt, coll_reserved, amount, debt_ceiling
+                ));
+            }
+            if current_global_borrowed
+                .saturating_add(total_reserved)
+                .saturating_add(amount)
+                > global_cap
+            {
+                return Err(format!(
+                    "Borrow would exceed global icUSD mint cap incl in-flight ({} + {} + {} > {})",
+                    current_global_borrowed, total_reserved, amount, global_cap
+                ));
+            }
+
+            *map.entry(collateral).or_insert(0) += amount;
+            Ok(Self { collateral, amount })
+        })
+    }
+}
+
+impl Drop for BorrowReservationGuard {
+    fn drop(&mut self) {
+        BORROW_RESERVATIONS.with(|r| {
+            let mut map = r.borrow_mut();
+            if let Some(v) = map.get_mut(&self.collateral) {
+                *v = v.saturating_sub(self.amount);
+                if *v == 0 {
+                    map.remove(&self.collateral);
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod vault_liquidation_guard_tests {
+    use super::*;
+
+    #[test]
+    fn vault_liquidation_guard_is_exclusive_per_vault() {
+        // BK-001/002 fence: the lock is per-vault, not per-caller.
+        let g1 = VaultLiquidationGuard::new(42).expect("first acquire for vault 42");
+        // A second liquidator (any caller) racing the SAME vault is rejected.
+        assert!(
+            VaultLiquidationGuard::new(42).is_err(),
+            "second concurrent liquidation of vault 42 must be rejected",
+        );
+        // A different vault is independent and acquires concurrently.
+        let g2 = VaultLiquidationGuard::new(43).expect("different vault acquires independently");
+        drop(g1);
+        // Once vault 42's liquidation finishes (guard dropped), it can be re-acquired.
+        let _g3 = VaultLiquidationGuard::new(42).expect("re-acquire vault 42 after release");
+        drop(g2);
+    }
+
+    #[test]
+    fn borrow_reservation_enforces_ceiling_across_concurrent_inflight() {
+        // BK-003 fence: a second in-flight borrow that would push committed debt
+        // + in-flight reservations over the ceiling is rejected, even though the
+        // committed aggregate alone still has headroom.
+        let coll = Principal::from_slice(&[7]);
+        let ceiling = 1_000u64;
+        let global = u64::MAX;
+
+        // Committed debt 600, ceiling 1000. First borrow of 300 reserves -> 900 headroom used.
+        let g1 = BorrowReservationGuard::try_reserve(coll, 300, 600, ceiling, 600, global)
+            .expect("first in-flight borrow fits (600+0+300<=1000)");
+        // Second concurrent borrow of 300 sees committed 600 + reserved 300 + 300 = 1200 > 1000 -> rejected.
+        assert!(
+            BorrowReservationGuard::try_reserve(coll, 300, 600, ceiling, 600, global).is_err(),
+            "second concurrent borrow must be rejected once in-flight reservations are counted",
+        );
+        // A smaller second borrow that fits (600+300+100=1000) is allowed.
+        let _g2 = BorrowReservationGuard::try_reserve(coll, 100, 600, ceiling, 600, global)
+            .expect("second borrow of 100 fits exactly at the ceiling");
+        drop(g1);
+        // After the first releases, headroom frees up again.
+        let _g3 = BorrowReservationGuard::try_reserve(coll, 300, 600, ceiling, 600, global)
+            .expect("headroom freed after first reservation dropped");
+    }
+
+    #[test]
+    fn borrow_reservation_enforces_global_cap() {
+        // Different collaterals still share the global mint cap.
+        let c1 = Principal::from_slice(&[1]);
+        let c2 = Principal::from_slice(&[2]);
+        let big_ceiling = u64::MAX;
+        let global = 1_000u64;
+        let g1 = BorrowReservationGuard::try_reserve(c1, 700, 0, big_ceiling, 0, global)
+            .expect("first global reservation fits");
+        assert!(
+            BorrowReservationGuard::try_reserve(c2, 400, 0, big_ceiling, 0, global).is_err(),
+            "second collateral's borrow must respect the shared global cap (0+700+400>1000)",
+        );
+        drop(g1);
+    }
+}
+
 #[must_use]
 pub struct TimerLogicGuard(());
 

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -277,6 +277,15 @@ pub struct SuccessWithFee {
     /// tracked aggregate drifts above the pool's real balance. `None` on the
     /// non-liquidation paths (redeem / borrow). Optional for Candid back-compat.
     pub debt_liquidated_e8s: Option<u64>,
+    /// SP-110 (audit 2026-06-05): on the ckUSDT/ckUSDC liquidation path the
+    /// backend pulls `base + repay-fee surcharge` stable from the caller, but
+    /// `debt_liquidated_e8s` only reflects the base debt. The stability pool
+    /// must debit depositors by the TOTAL stable pulled (this field, in the
+    /// stable token's e6 native units), or the repay-fee surcharge leaves the
+    /// pool un-debited and the tracked aggregate drifts above the real ledger
+    /// balance. `Some` only on the ckStable path; `None` elsewhere. Optional for
+    /// Candid back-compat.
+    pub stable_pulled_e6s: Option<u64>,
 }
 
 /// Result from stability pool liquidation (both standard and debt-already-burned paths).

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1647,62 +1647,23 @@ fn delete_chain(
 /// Mint op left.
 #[candid_method(update)]
 #[update]
-fn recover_stuck_chain_vault(
+async fn recover_stuck_chain_vault(
     chain: rumi_protocol_backend::chains::config::ChainId,
     vault_id: u64,
 ) -> Result<(), ProtocolError> {
-    use rumi_protocol_backend::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
-    use rumi_protocol_backend::chains::vault::ChainVaultStatus;
+    // M-09 (RECOV-02): this used to flip MintPending->Open on the unverified
+    // `pending_mint_e8s == 0` alone. It now delegates to the chains recovery
+    // module, which RE-VERIFIES on-chain (via the EVM-RPC quorum) that the mint
+    // did NOT actually land before releasing collateral. Async because the
+    // verification makes inter-canister RPC calls.
     let caller = ic_cdk::caller();
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    mutate_state(|s| {
-        let v = s
-            .multi_chain
-            .chain_vaults
-            .get(&vault_id)
-            .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain vault {vault_id}")))?;
-        if v.collateral_chain != chain {
-            return Err(ProtocolError::ChainAdmin(format!(
-                "vault {vault_id} is not on chain {:?}",
-                chain
-            )));
-        }
-        if v.status != ChainVaultStatus::MintPending || v.pending_mint_e8s != 0 {
-            return Err(ProtocolError::ChainAdmin(format!(
-                "vault {vault_id} is not a recoverable stuck mint (status {:?}, pending_mint_e8s {})",
-                v.status, v.pending_mint_e8s
-            )));
-        }
-        let has_live_mint = s
-            .multi_chain
-            .settlement_queues
-            .get(&chain)
-            .map(|q| {
-                q.pending.values().any(|op| {
-                    matches!(&op.kind, SettlementOpKind::Mint { vault_id: vid, .. } if *vid == vault_id)
-                        && matches!(
-                            op.status,
-                            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
-                        )
-                })
-            })
-            .unwrap_or(false);
-        if has_live_mint {
-            return Err(ProtocolError::ChainAdmin(format!(
-                "vault {vault_id} still has a live mint op; wait for it to reach a terminal state"
-            )));
-        }
-        let v = s
-            .multi_chain
-            .chain_vaults
-            .get_mut(&vault_id)
-            .expect("vault present: checked above");
-        v.status = ChainVaultStatus::Open;
-        Ok(())
-    })?;
-    log!(INFO, "[recover_stuck_chain_vault] chain={:?} vault={} MintPending->Open (collateral now recoverable via close/withdraw)", chain, vault_id);
+    rumi_protocol_backend::chains::recovery::recover_stuck_chain_vault_verified(chain, vault_id)
+        .await
+        .map_err(|e| ProtocolError::ChainAdmin(format!("{e}")))?;
+    log!(INFO, "[recover_stuck_chain_vault] chain={:?} vault={} MintPending->Open (on-chain-verified mint did NOT land; collateral now recoverable via close/withdraw)", chain, vault_id);
     Ok(())
 }
 
@@ -1720,65 +1681,29 @@ fn recover_stuck_chain_vault(
 /// is currently `Inflight`.
 #[candid_method(update)]
 #[update]
-fn resolve_stuck_settlement_op(
+async fn resolve_stuck_settlement_op(
     chain: rumi_protocol_backend::chains::config::ChainId,
     op_id: u64,
 ) -> Result<(), ProtocolError> {
-    use rumi_protocol_backend::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
-    use rumi_protocol_backend::chains::vault::ChainVaultStatus;
+    // M-08 (RECOV-01): this used to reverse the op on pure operator assertion
+    // (no `.await`, no on-chain re-read). It now delegates to the chains recovery
+    // module, which RE-READS the op's tx receipt through the EVM-RPC quorum and
+    // REFUSES the reversal if the tx actually landed (reversing a landed Mint
+    // would leave an unbacked mint). Async because the verification makes
+    // inter-canister RPC calls.
     let caller = ic_cdk::caller();
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    let now = ic_cdk::api::time();
-    mutate_state(|s| {
-        // Snapshot the op kind and confirm it is Inflight (CAS).
-        let kind = {
-            let q = s
-                .multi_chain
-                .settlement_queues
-                .get(&chain)
-                .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain {:?}", chain)))?;
-            let op = q.pending.get(&op_id).ok_or_else(|| {
-                ProtocolError::ChainAdmin(format!("unknown op {op_id} on chain {:?}", chain))
-            })?;
-            if !matches!(op.status, SettlementOpStatus::Inflight { .. }) {
-                return Err(ProtocolError::ChainAdmin(format!(
-                    "op {op_id} is not Inflight (status {:?}); nothing to resolve",
-                    op.status
-                )));
-            }
-            op.kind.clone()
-        };
-        // Per-kind reversal, mirroring confirm_reverted.
-        match &kind {
-            SettlementOpKind::Mint { vault_id, .. } => {
-                if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
-                    v.pending_mint_e8s = 0; // Design B: no debt counted; leave status MintPending.
-                }
-            }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
-                if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
-                    v.collateral_amount_native =
-                        v.collateral_amount_native.saturating_add(*amount_e18);
-                    if v.status == ChainVaultStatus::Closing {
-                        v.status = ChainVaultStatus::Open;
-                    }
-                }
-            }
-            SettlementOpKind::Burn { .. } => {}
-        }
-        if let Some(o) = s
-            .multi_chain
-            .settlement_queues
-            .get_mut(&chain)
-            .and_then(|q| q.pending.get_mut(&op_id))
-        {
-            o.mark_failed("manually resolved (stuck Inflight)".to_string(), now);
-        }
-        Ok(())
-    })?;
-    log!(INFO, "[resolve_stuck_settlement_op] chain={:?} op={} marked Failed + reversed (operator-confirmed not landed)", chain, op_id);
+    let did_reverse =
+        rumi_protocol_backend::chains::recovery::resolve_stuck_settlement_op_verified(chain, op_id)
+            .await
+            .map_err(|e| ProtocolError::ChainAdmin(format!("{e}")))?;
+    if did_reverse {
+        log!(INFO, "[resolve_stuck_settlement_op] chain={:?} op={} marked Failed + reversed (on-chain-verified NOT landed)", chain, op_id);
+    } else {
+        log!(INFO, "[resolve_stuck_settlement_op] chain={:?} op={} no longer Inflight at commit (concurrent confirm); no-op", chain, op_id);
+    }
     Ok(())
 }
 
@@ -2943,7 +2868,30 @@ async fn stability_pool_liquidate_with_reserves(
     match rumi_protocol_backend::vault::liquidate_vault_debt_already_burned(
         vault_id, icusd_debt_covered_e8s, caller, Some(three_usd_amount_e8s), proof,
     ).await {
-        Ok(success) => Ok(success),
+        Ok(success) => {
+            // VER-002 (audit 2026-06-05): the full `three_usd_amount_e8s` was
+            // pulled above, but the writedown is capped to the vault's current
+            // debt, so `success.liquidated_debt` can be < `icusd_debt_covered_e8s`
+            // (e.g. the vault shrank between the SP's read and now). Refund the
+            // PROPORTIONAL excess 3USD so only the realized portion leaves the
+            // SP. The SP records the same realized portion (floor formula) as
+            // consumed, so its tracked aggregate and ledger balance both net to
+            // exactly `realized_3usd` with no drift.
+            if icusd_debt_covered_e8s > 0 && success.liquidated_debt < icusd_debt_covered_e8s {
+                let realized_3usd = (three_usd_amount_e8s as u128)
+                    .saturating_mul(success.liquidated_debt as u128)
+                    / (icusd_debt_covered_e8s as u128);
+                let excess = three_usd_amount_e8s.saturating_sub(realized_3usd as u64);
+                if excess > 0 {
+                    log!(INFO,
+                        "[stability_pool_liquidate_with_reserves] vault #{}: writedown capped \
+                         ({} of {} icUSD realized); refunding {} excess 3USD to SP",
+                        vault_id, success.liquidated_debt, icusd_debt_covered_e8s, excess);
+                    refund_3usd_to_stability_pool(three_usd_ledger, caller, excess, vault_id).await;
+                }
+            }
+            Ok(success)
+        }
         Err(liq_error) => {
             refund_3usd_to_stability_pool(
                 three_usd_ledger, caller, three_usd_amount_e8s, vault_id,
@@ -3634,6 +3582,14 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
             "Caller is not the registered liquidation bot canister".to_string(),
         ));
     }
+
+    // BK-001/002: hold the per-vault liquidation lock across the claim so the
+    // bot's collateral-seizing claim cannot interleave with an in-flight manual
+    // or SP liquidation of the same vault (which would otherwise both seize from
+    // the shared collateral pool). The persistent `bot_processing` flag set
+    // below covers the longer claim->confirm window; this guard covers the claim
+    // message itself. Released on return (incl. continuation-trap via cleanup).
+    let _vault_liq_guard = rumi_protocol_backend::guard::VaultLiquidationGuard::new(vault_id)?;
 
     // Check no existing claim on this vault
     let existing_claim = read_state(|s| s.bot_claims.contains_key(&vault_id));

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -2,7 +2,7 @@ use crate::event::{
     record_add_margin_to_vault, record_borrow_from_vault, record_open_vault,
     record_redemption_on_vaults, record_repayed_to_vault,
 };
-use crate::guard::GuardPrincipal;
+use crate::guard::{GuardPrincipal, VaultLiquidationGuard};
 use crate::GuardError;
 use crate::logs::INFO;
 use crate::management::{mint_icusd, transfer_collateral, transfer_collateral_from, transfer_icusd_from, transfer_stable_from};
@@ -582,6 +582,7 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
                 fee_amount_paid: fee_amount.to_u64(),
                 collateral_amount_received: None,
                 debt_liquidated_e8s: None, // SP-101
+                stable_pulled_e6s: None, // SP-110
             })
         }
         Err(transfer_from_error) => Err(ProtocolError::TransferFromError(
@@ -902,28 +903,32 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
         return Err(ProtocolError::CallerNotOwner);
     }
 
-    // Check debt ceiling
+    // Check debt ceiling + global mint cap AND reserve the headroom atomically.
+    //
+    // BK-003 (audit 2026-06-05): these caps are checked here but the debt is not
+    // recorded until after the `mint_icusd().await` below. Two borrows from
+    // DIFFERENT owners both pass this check against the same committed aggregate,
+    // both mint, and jointly exceed the cap (the per-caller GuardPrincipal does
+    // not serialize distinct owners against the aggregate). The reservation guard
+    // counts every in-flight borrow in the check and is held across the mint, so
+    // a concurrent borrow sees this one's reserved amount. Released on Drop
+    // (return or continuation-trap via ic-cdk cleanup).
     let current_debt = read_state(|s| s.total_debt_for_collateral(&vault.collateral_type));
     let debt_ceiling = read_state(|s| {
         s.get_collateral_config(&vault.collateral_type)
             .map(|c| c.debt_ceiling)
             .unwrap_or(u64::MAX)
     });
-    if current_debt.to_u64() + amount.to_u64() > debt_ceiling {
-        return Err(ProtocolError::GenericError(format!(
-            "Borrow would exceed debt ceiling ({} + {} > {})",
-            current_debt.to_u64(), amount.to_u64(), debt_ceiling
-        )));
-    }
-
-    // Check global icUSD mint cap
     let (global_cap, total_borrowed) = read_state(|s| (s.global_icusd_mint_cap, s.total_borrowed_icusd_amount()));
-    if total_borrowed.to_u64() + amount.to_u64() > global_cap {
-        return Err(ProtocolError::GenericError(format!(
-            "Borrow would exceed global icUSD mint cap ({} + {} > {})",
-            total_borrowed.to_u64(), amount.to_u64(), global_cap
-        )));
-    }
+    let _borrow_reservation = crate::guard::BorrowReservationGuard::try_reserve(
+        vault.collateral_type,
+        amount.to_u64(),
+        current_debt.to_u64(),
+        debt_ceiling,
+        total_borrowed.to_u64(),
+        global_cap,
+    )
+    .map_err(ProtocolError::GenericError)?;
 
     let collateral_value = crate::numeric::collateral_usd_value(vault.collateral_amount, collateral_price, config_decimals);
     let min_ratio = read_state(|s| {
@@ -980,6 +985,7 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
                 fee_amount_paid: fee.to_u64(),
                 collateral_amount_received: None,
                 debt_liquidated_e8s: None, // SP-101
+                stable_pulled_e6s: None, // SP-110
             })
         }
         Err(mint_error) => {
@@ -2240,6 +2246,9 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_partial_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
+    // BK-001/002: per-vault lock so two different callers can't race this vault
+    // and both be paid the full pre-state collateral from the shared pool.
+    let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?;
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18. The per-vault CR
     // check below remains the authoritative liquidatability test. See
@@ -2513,6 +2522,7 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: Some(max_liquidatable_debt.to_u64()), // SP-101
+        stable_pulled_e6s: None, // SP-110 (icUSD path: no stable surcharge)
     })
 }
 
@@ -2525,6 +2535,7 @@ pub async fn liquidate_vault_partial_with_stable(
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_stable_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
+    let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?; // BK-001/002 per-vault lock
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).
@@ -2832,6 +2843,7 @@ pub async fn liquidate_vault_partial_with_stable(
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: Some(max_liquidatable_debt.to_u64()), // SP-101
+        stable_pulled_e6s: Some(total_pull_e6s), // SP-110: base + repay-fee surcharge
     })
 }
 
@@ -2877,6 +2889,7 @@ pub async fn liquidate_vault_debt_already_burned(
 
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_debt_burned_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault (SP path)
+    let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?; // BK-001/002 per-vault lock
 
     let liquidation_amount: ICUSD = icusd_burned_e8s.into();
 
@@ -3236,6 +3249,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
+    let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?; // BK-001/002 per-vault lock
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).
@@ -3524,6 +3538,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: None, // SP-101
+        stable_pulled_e6s: None, // SP-110
     })
 }
 
@@ -3722,6 +3737,7 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, &format!("partial_liquidate_vault_{}", arg.vault_id))?;
     reject_if_bot_processing(arg.vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
+    let _vault_liq_guard = VaultLiquidationGuard::new(arg.vault_id)?; // BK-001/002 per-vault lock
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18 (see
     // `liquidate_vault_partial` above for rationale).
@@ -3976,5 +3992,6 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: None, // SP-101
+        stable_pulled_e6s: None, // SP-110
     })
 }

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -446,17 +446,35 @@ pub async fn ensure_fresh_price_for(
             crate::management::fetch_collateral_price(*collateral_type).await;
         }
 
-        // Verify we have a price now
-        let has_price = read_state(|s| {
-            s.get_collateral_config(collateral_type)
-                .and_then(|c| c.last_price)
-                .is_some()
+        // Fail CLOSED if, after the (best-effort) refresh, the cached price is
+        // missing OR still older than the hard staleness ceiling.
+        //
+        // ORACLE-001 / VER-001 (audit 2026-06-05): this previously checked only
+        // `last_price.is_some()`. `fetch_collateral_price` is best-effort — on a
+        // down feed (XRC source-count rejection, LST canister error, CoinGecko
+        // failure) it returns WITHOUT updating the cache. So a stale cached
+        // `last_price` passed the gate, letting mint/withdraw originate against
+        // an arbitrarily old non-ICP price. We now enforce the same 10-minute
+        // hard ceiling the ICP path applies via `check_price_not_too_old`. nICP
+        // (LstWrapped) inherits the underlying ICP timestamp (see
+        // `fetch_collateral_price`), so this also correctly rejects an nICP
+        // price derived from a stale ICP rate.
+        const MAX_NON_ICP_PRICE_AGE_NANOS: u64 = 10 * 60 * 1_000_000_000;
+        let now = ic_cdk::api::time();
+        let fresh = read_state(|s| match s.get_collateral_config(collateral_type) {
+            Some(c) => match (c.last_price, c.last_price_timestamp) {
+                (Some(price), Some(ts)) if price.is_finite() && price > 0.0 => {
+                    now.saturating_sub(ts) <= MAX_NON_ICP_PRICE_AGE_NANOS
+                }
+                _ => false,
+            },
+            None => false,
         });
-        if has_price {
+        if fresh {
             Ok(())
         } else {
-            Err(crate::ProtocolError::GenericError(format!(
-                "No price available for collateral {}",
+            Err(crate::ProtocolError::TemporarilyUnavailable(format!(
+                "No fresh price available for collateral {} (stale or missing after on-demand refresh)",
                 collateral_type
             )))
         }

--- a/src/rumi_protocol_backend/tests/audit_pocs_bk_001_002_concurrent_liquidation_pic.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_bk_001_002_concurrent_liquidation_pic.rs
@@ -1,0 +1,490 @@
+//! BK-001 / BK-002 PocketIC fence (Layer 3 — canister boundary, audit 2026-06-05).
+//!
+//! The per-vault `VaultLiquidationGuard` closes the cross-caller liquidation
+//! over-seize. `GuardPrincipal` keys on the CALLER, so before the fix two
+//! different liquidators racing the SAME vault both passed the guard, both
+//! snapshotted the vault's full collateral pre-`await`, and both were paid that
+//! full collateral out of the SHARED collateral pool — draining OTHER vaults'
+//! backing. The ASYNC-001 re-cap fixed the vault accounting but NOT the payout.
+//!
+//! This fixture seeds the pool with TWO vaults of equal collateral and fires
+//! two concurrent `liquidate_vault_partial` calls (from two different
+//! principals) at ONE of them via `submit_call` (both ingress messages are
+//! queued before either executes, so they interleave). The economic invariant
+//! is then checked: the total collateral paid out across both attempts must not
+//! exceed the targeted vault's collateral. On the pre-fix wasm both liquidators
+//! are paid ~the full vault collateral (sum ~= 2x), draining the bystander
+//! vault's backing; with the per-vault guard at most one full payout occurs.
+//!
+//! Fixture mirrors `audit_pocs_liq_005_deficit_account_pic.rs`.
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::{Duration, SystemTime};
+
+use rumi_protocol_backend::ProtocolError;
+
+// ─── Local mirrors of ICRC-1 Candid types ───
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct FeatureFlags {
+    icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct InitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct MetadataValue {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+    #[serde(rename = "Nat")]
+    nat: Option<Nat>,
+    #[serde(rename = "Int")]
+    int: Option<i64>,
+    #[serde(rename = "Blob")]
+    blob: Option<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum LedgerArg {
+    #[serde(rename = "Init")]
+    Init(InitArgs),
+    #[serde(rename = "Upgrade")]
+    Upgrade(Option<()>),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ApproveArgs {
+    from_subaccount: Option<[u8; 32]>,
+    spender: Account,
+    amount: Nat,
+    expected_allowance: Option<Nat>,
+    expires_at: Option<u64>,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ApproveError {
+    BadFee { expected_fee: Nat },
+    InsufficientFunds { balance: Nat },
+    AllowanceChanged { current_allowance: Nat },
+    Expired { ledger_time: u64 },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+// ─── Backend types (mirrored locally; extra Candid fields are ignored) ───
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArgVariant {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct VaultArg {
+    vault_id: u64,
+    amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct OpenVaultSuccess {
+    vault_id: u64,
+    block_index: u64,
+}
+
+// Minimal mirror — Candid ignores the other CandidVault fields on decode.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct LiquidatableVault {
+    vault_id: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SuccessWithFee {
+    block_index: u64,
+    fee_amount_paid: u64,
+    collateral_amount_received: Option<u64>,
+}
+
+// ─── WASM fixtures ───
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn protocol_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn xrc_wasm() -> Vec<u8> {
+    include_bytes!("../../xrc_demo/xrc/xrc.wasm").to_vec()
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+struct MockXRC {
+    rates: Vec<(String, u64)>,
+}
+
+fn prepare_mock_xrc() -> Vec<u8> {
+    let mock = MockXRC {
+        rates: vec![("ICP/USD".to_string(), 1_000_000_000)], // $10.00 (e8s)
+    };
+    encode_one(mock).expect("encode mock XRC init")
+}
+
+// ─── Helpers ───
+
+fn account(owner: Principal) -> Account {
+    Account {
+        owner,
+        subaccount: None,
+    }
+}
+
+fn deploy_icrc1_ledger(
+    pic: &PocketIc,
+    minting_account: Account,
+    transfer_fee: u64,
+    initial_balances: Vec<(Account, Nat)>,
+    name: &str,
+    symbol: &str,
+    controller: Principal,
+) -> Principal {
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = InitArgs {
+        minting_account,
+        fee_collector_account: None,
+        transfer_fee: Nat::from(transfer_fee),
+        decimals: Some(8),
+        max_memo_length: Some(64),
+        token_name: name.into(),
+        token_symbol: symbol.into(),
+        metadata: vec![],
+        initial_balances,
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: controller,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).expect("encode ledger init"),
+        None,
+    );
+    ledger_id
+}
+
+fn icrc2_approve_call(
+    pic: &PocketIc,
+    ledger: Principal,
+    sender: Principal,
+    spender: Principal,
+    amount: u128,
+) {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: account(spender),
+        amount: Nat::from(amount),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    let result = pic
+        .update_call(ledger, sender, "icrc2_approve", encode_one(args).unwrap())
+        .expect("icrc2_approve call failed");
+    let parsed: Result<Nat, ApproveError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode icrc2_approve"),
+        WasmResult::Reject(m) => panic!("icrc2_approve rejected: {}", m),
+    };
+    parsed.expect("approve returned error");
+}
+
+fn xrc_set_rate(pic: &PocketIc, xrc: Principal, sender: Principal, base: &str, quote: &str, rate_e8s: u64) {
+    let result = pic
+        .update_call(
+            xrc,
+            sender,
+            "set_exchange_rate",
+            encode_args((base.to_string(), quote.to_string(), rate_e8s)).unwrap(),
+        )
+        .expect("set_exchange_rate call failed");
+    if let WasmResult::Reject(m) = result {
+        panic!("set_exchange_rate rejected: {}", m);
+    }
+}
+
+fn open_and_borrow(
+    pic: &PocketIc,
+    protocol_id: Principal,
+    icp_ledger: Principal,
+    user: Principal,
+    collateral_e8s: u64,
+    borrow_e8s: u64,
+) -> u64 {
+    icrc2_approve_call(pic, icp_ledger, user, protocol_id, collateral_e8s as u128);
+    let open_result = pic
+        .update_call(
+            protocol_id,
+            user,
+            "open_vault",
+            encode_args((collateral_e8s, None::<Principal>)).unwrap(),
+        )
+        .expect("open_vault failed");
+    let vault_id = match open_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<OpenVaultSuccess, ProtocolError> = decode_one(&bytes).expect("decode open_vault");
+            r.expect("open_vault returned error").vault_id
+        }
+        WasmResult::Reject(msg) => panic!("open_vault rejected: {}", msg),
+    };
+    let borrow_result = pic
+        .update_call(
+            protocol_id,
+            user,
+            "borrow_from_vault",
+            encode_args((VaultArg { vault_id, amount: borrow_e8s },)).unwrap(),
+        )
+        .expect("borrow_from_vault failed");
+    match borrow_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<SuccessWithFee, ProtocolError> = decode_one(&bytes).expect("decode borrow");
+            r.expect("borrow_from_vault returned error");
+        }
+        WasmResult::Reject(msg) => panic!("borrow rejected: {}", msg),
+    }
+    vault_id
+}
+
+// ─── Test ───
+
+/// BK-001/002: two concurrent `liquidate_vault_partial` calls (distinct callers)
+/// against ONE vault must not pay out more collateral than that vault holds.
+#[test]
+fn bk_001_002_concurrent_liquidation_does_not_over_seize() {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+
+    let user_a = Principal::self_authenticating(b"bk_001_user_a");
+    let user_b = Principal::self_authenticating(b"bk_001_user_b");
+    let developer = Principal::self_authenticating(b"bk_001_developer");
+    let treasury = Principal::self_authenticating(b"bk_001_treasury");
+
+    let protocol_id = pic.create_canister();
+    pic.add_cycles(protocol_id, 2_000_000_000_000);
+    pic.set_controllers(protocol_id, None, vec![Principal::anonymous(), developer])
+        .expect("set_controllers failed");
+
+    let icp_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        10_000,
+        vec![
+            (account(user_a), Nat::from(1_000_000_000_000u64)),
+            (account(user_b), Nat::from(1_000_000_000_000u64)),
+        ],
+        "Internet Computer Protocol",
+        "ICP",
+        developer,
+    );
+    let icusd_ledger = deploy_icrc1_ledger(&pic, account(protocol_id), 0, vec![], "icUSD", "icUSD", developer);
+
+    let xrc_id = pic.create_canister();
+    pic.add_cycles(xrc_id, 1_000_000_000_000);
+    pic.install_canister(xrc_id, xrc_wasm(), prepare_mock_xrc(), None);
+
+    pic.set_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1_711_324_800));
+
+    let init = ProtocolArgVariant::Init(ProtocolInitArg {
+        fee_e8s: 10_000,
+        icp_ledger_principal: icp_ledger,
+        xrc_principal: xrc_id,
+        icusd_ledger_principal: icusd_ledger,
+        developer_principal: developer,
+    });
+    pic.install_canister(protocol_id, protocol_wasm(), encode_args((init,)).expect("encode init"), None);
+    pic.advance_time(Duration::from_secs(1));
+    for _ in 0..10 {
+        pic.tick();
+    }
+
+    // Disable dynamic fee/interest curves so both users get their full 100 icUSD.
+    for (method, payload) in [
+        ("set_borrowing_fee_curve", encode_args((None::<String>,)).unwrap()),
+        ("set_borrowing_fee", encode_args((0.0f64,)).unwrap()),
+        ("set_treasury_principal", encode_args((treasury,)).unwrap()),
+    ] {
+        pic.update_call(protocol_id, developer, method, payload).expect(method);
+    }
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_rate_curve_markers",
+        encode_args((None::<Principal>, vec![(1.5f64, 1.0f64), (3.0f64, 1.0f64)])).unwrap(),
+    )
+    .expect("set_rate_curve_markers");
+    pic.update_call(protocol_id, developer, "set_interest_rate", encode_args((icp_ledger, 0.0f64)).unwrap())
+        .expect("set_interest_rate");
+
+    // Vault A (target) and Vault B (bystander), each 50 ICP collateral / 100 icUSD debt.
+    // The pool now holds 100 ICP; vault B's 50 ICP is the "other vault" backing
+    // that a cross-caller over-seize on A would drain.
+    let collateral_e8s = 5_000_000_000u64; // 50 ICP
+    let borrow_e8s = 10_000_000_000u64; // 100 icUSD
+    let vault_a = open_and_borrow(&pic, protocol_id, icp_ledger, user_a, collateral_e8s, borrow_e8s);
+    let _vault_b = open_and_borrow(&pic, protocol_id, icp_ledger, user_b, collateral_e8s, borrow_e8s);
+
+    // Both users approve the protocol to pull their icUSD for liquidation payment.
+    icrc2_approve_call(&pic, icusd_ledger, user_a, protocol_id, 100_000_000_000u128);
+    icrc2_approve_call(&pic, icusd_ledger, user_b, protocol_id, 100_000_000_000u128);
+
+    // Drop ICP to $0.10 so vault A is deeply underwater (≈$5 backing $100 debt):
+    // a single partial liquidation seizes ≈ all 50 ICP of A. Then tick until the
+    // protocol's CACHED price has propagated and vault A actually shows up as
+    // liquidatable — otherwise one racer could be rejected by a stale ($10)
+    // price rather than by the per-vault guard, which would make this test pass
+    // even on the buggy wasm.
+    xrc_set_rate(&pic, xrc_id, developer, "ICP", "USD", 10_000_000);
+    let mut liquidatable = false;
+    for _ in 0..12 {
+        pic.advance_time(Duration::from_secs(310));
+        for _ in 0..6 {
+            pic.tick();
+        }
+        let result = pic
+            .query_call(protocol_id, Principal::anonymous(), "get_liquidatable_vaults", encode_args(()).unwrap())
+            .expect("get_liquidatable_vaults");
+        if let WasmResult::Reply(b) = result {
+            if let Ok(vaults) = decode_one::<Vec<LiquidatableVault>>(&b) {
+                if vaults.iter().any(|v| v.vault_id == vault_a) {
+                    liquidatable = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        liquidatable,
+        "fixture precondition: vault A must be liquidatable (cached price propagated to $0.10) \
+         before the race so both racers see it liquidatable"
+    );
+
+    // Race: submit BOTH liquidations before either executes, so the two ingress
+    // messages interleave. user_a and user_b are distinct callers, so the
+    // per-CALLER GuardPrincipal does not serialize them — only the per-VAULT
+    // VaultLiquidationGuard does.
+    let arg = encode_args((VaultArg { vault_id: vault_a, amount: borrow_e8s },)).unwrap();
+    let msg_a = pic
+        .submit_call(protocol_id, user_a, "liquidate_vault_partial", arg.clone())
+        .expect("submit liquidation A");
+    let msg_b = pic
+        .submit_call(protocol_id, user_b, "liquidate_vault_partial", arg)
+        .expect("submit liquidation B");
+
+    let decode = |res: WasmResult| -> Result<SuccessWithFee, ProtocolError> {
+        match res {
+            WasmResult::Reply(b) => decode_one(&b).expect("decode liquidation result"),
+            WasmResult::Reject(m) => panic!("liquidation rejected at canister level: {}", m),
+        }
+    };
+    let res_a = decode(pic.await_call(msg_a).expect("await A"));
+    let res_b = decode(pic.await_call(msg_b).expect("await B"));
+
+    let seized = |r: &Result<SuccessWithFee, ProtocolError>| -> u64 {
+        match r {
+            Ok(s) => s.collateral_amount_received.unwrap_or(0),
+            Err(_) => 0,
+        }
+    };
+    let total_seized = seized(&res_a) + seized(&res_b);
+
+    // At least one liquidation must have succeeded (the fix must not break liquidation).
+    assert!(
+        res_a.is_ok() || res_b.is_ok(),
+        "expected at least one liquidation to succeed; A={:?} B={:?}",
+        res_a,
+        res_b
+    );
+
+    // EXACTLY ONE may succeed: two liquidators racing one (fully-underwater) vault
+    // cannot both be paid. Pre-fix, the per-CALLER guard let both through and both
+    // were paid the stale full collateral; with the per-VAULT guard the loser is
+    // rejected (or finds the vault already gone).
+    assert!(
+        res_a.is_ok() ^ res_b.is_ok(),
+        "BK-001/002: exactly one of the two concurrent liquidations must succeed; A={:?} B={:?}",
+        res_a,
+        res_b
+    );
+
+    // THE INVARIANT: total collateral paid to liquidators must not exceed the
+    // targeted vault's collateral. Pre-fix, both callers were paid ~50 ICP from
+    // the shared pool (sum ≈ 2x), draining the bystander vault's backing.
+    assert!(
+        total_seized <= collateral_e8s,
+        "BK-001/002 over-seize: total collateral paid {} exceeds vault A's collateral {} \
+         (A={:?}, B={:?})",
+        total_seized,
+        collateral_e8s,
+        res_a,
+        res_b
+    );
+}

--- a/src/rumi_protocol_backend/tests/audit_pocs_bk_001_002_per_vault_lock.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_bk_001_002_per_vault_lock.rs
@@ -1,0 +1,76 @@
+//! BK-001 / BK-002 (audit 2026-06-05-d67e100): every collateral-seizing
+//! liquidation entry point must hold a PER-VAULT liquidation lock, not just the
+//! per-CALLER `GuardPrincipal`.
+//!
+//! Root cause: `GuardPrincipal::new(caller, "..._{vault_id}")` keys on the
+//! CALLER principal (the vault id only decorates the operation-name string), so
+//! two different liquidators (two humans, or the stability pool + a human)
+//! racing the SAME vault both pass the guard. Each snapshots the vault's full
+//! collateral before its `await`; the ASYNC-001 re-cap fixed the vault-
+//! accounting underflow/wrap, but the collateral PAYOUT
+//! (`pending_margin_transfers.insert(.. margin: collateral_to_liquidator ..)`)
+//! still uses the STALE per-caller snapshot. The loser is therefore paid the
+//! full pre-state collateral out of the SHARED collateral pool (`from_subaccount:
+//! None`), draining other vaults' backing — an economic over-seize / insolvency
+//! vector the re-cap alone did not close.
+//!
+//! Fix: a `VaultLiquidationGuard` keyed on `vault_id` (transient thread-local,
+//! released on return and on continuation-trap via ic-cdk cleanup), acquired in
+//! all five manual/SP liquidation entry points AND in `bot_claim_liquidation`.
+//!
+//! Two fences below:
+//!   1. Source fence: each liquidation entry acquires `VaultLiquidationGuard`.
+//!   2. Behavioral fence: the guard is exclusive per vault and independent
+//!      across vaults (re-exports the in-crate unit test invariant).
+
+use std::path::PathBuf;
+
+fn fn_body<'a>(src: &'a str, header: &str) -> &'a str {
+    let start = src
+        .find(header)
+        .unwrap_or_else(|| panic!("`{}` not found", header));
+    let after = start + header.len();
+    let end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "]
+        .iter()
+        .filter_map(|m| src[after..].find(m).map(|i| after + i))
+        .min()
+        .unwrap_or(src.len());
+    &src[start..end]
+}
+
+#[test]
+fn bk_001_002_manual_sp_entries_hold_per_vault_guard() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/vault.rs");
+    let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+
+    for header in [
+        "pub async fn liquidate_vault_partial(",
+        "pub async fn liquidate_vault_partial_with_stable(",
+        "pub async fn liquidate_vault_debt_already_burned(",
+        "pub async fn liquidate_vault(",
+        "pub async fn partial_liquidate_vault(",
+    ] {
+        let body = fn_body(&src, header);
+        assert!(
+            body.contains("VaultLiquidationGuard::new"),
+            "liquidation entry `{}` must acquire VaultLiquidationGuard::new(vault_id)? so two \
+             different callers cannot race the same vault and both be paid the full pre-state \
+             collateral from the shared pool (audit BK-001/002).",
+            header
+        );
+    }
+}
+
+#[test]
+fn bk_001_002_bot_claim_holds_per_vault_guard() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    let body = fn_body(&src, "async fn bot_claim_liquidation(");
+    assert!(
+        body.contains("VaultLiquidationGuard::new"),
+        "bot_claim_liquidation must also acquire the per-vault liquidation guard so a bot claim \
+         cannot interleave with an in-flight manual/SP liquidation of the same vault (BK-001/002)."
+    );
+}

--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -12,6 +12,10 @@ use crate::state::{read_state, mutate_state};
 
 /// Deposit a stablecoin into the pool. User must have pre-approved the pool canister.
 pub async fn deposit(token_ledger: Principal, amount: u64) -> Result<(), StabilityPoolError> {
+    // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
     let caller = ic_cdk::api::caller();
 
     // Validate token is accepted
@@ -94,6 +98,12 @@ pub async fn deposit(token_ledger: Principal, amount: u64) -> Result<(), Stabili
 /// 2. Transfer tokens to user
 /// 3. If transfer fails, rollback the deduction
 pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), StabilityPoolError> {
+    // SP-102: refuse balance-mutating ops while a liquidation is apportioning,
+    // so a withdraw cannot land between a liquidation's snapshot and its burn
+    // apportionment and escape the depositor's share of the loss.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
     let caller = ic_cdk::api::caller();
 
     if read_state(|s| s.configuration.emergency_pause) {
@@ -184,6 +194,10 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
 /// 2. Transfer collateral to user
 /// 3. If transfer fails, rollback the deduction
 pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, StabilityPoolError> {
+    // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
     let caller = ic_cdk::api::caller();
 
     if read_state(|s| s.configuration.emergency_pause) {
@@ -302,6 +316,10 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
 
 /// Claim all nonzero collateral gains across all collateral types.
 pub async fn claim_all_collateral() -> Result<BTreeMap<Principal, u64>, StabilityPoolError> {
+    // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
     let caller = ic_cdk::api::caller();
 
     if read_state(|s| s.configuration.emergency_pause) {
@@ -339,6 +357,10 @@ pub async fn deposit_as_3usd(
     token_ledger: Principal,
     amount: u64,
 ) -> Result<u64, StabilityPoolError> {
+    // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
     let caller = ic_cdk::api::caller();
 
     let config = read_state(|s| s.get_stablecoin_config(&token_ledger).cloned())

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -9,6 +9,7 @@ pub mod state;
 pub mod deposits;
 pub mod liquidation;
 pub mod logs;
+pub mod pool_guard;
 
 use crate::types::*;
 use crate::state::{mutate_state, read_state};

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -9,6 +9,13 @@ use crate::logs::INFO;
 use crate::types::*;
 use crate::state::{read_state, mutate_state};
 
+/// Conservative fallback for a collateral ledger's transfer fee, used only when
+/// the live `icrc1_fee` query fails (SP-104). Set to the common ICRC fee
+/// (10_000 e8s, as on ICP/ckBTC-class ledgers). Over-estimating the fee
+/// under-credits depositors slightly (solvency-safe) rather than over-crediting
+/// them as a fee=0 fallback would. The next successful liquidation reconciles.
+const FALLBACK_COLLATERAL_FEE_E8S: u64 = 10_000;
+
 /// Called by the backend when it detects liquidatable vaults (push model).
 /// Processes each vault sequentially, consuming stablecoins and distributing collateral.
 pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> Vec<LiquidationResult> {
@@ -16,6 +23,19 @@ pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> V
         log!(INFO, "Pool is paused — ignoring {} liquidatable vaults", vaults.len());
         return vec![];
     }
+
+    // SP-102: hold the per-pool liquidation lock across the whole batch so
+    // deposit/withdraw/claim cannot land between a vault's snapshot and its
+    // burn apportionment (which would let a withdrawer escape their share).
+    // If another liquidation is already running, skip this batch (no retry —
+    // the backend re-notifies on its next tick).
+    let _liq_guard = match crate::pool_guard::SpLiquidationGuard::new() {
+        Ok(g) => g,
+        Err(_) => {
+            log!(INFO, "notify_liquidatable_vaults: a liquidation is already in flight; skipping this batch");
+            return vec![];
+        }
+    };
 
     log!(INFO, "Received push notification: {} liquidatable vaults", vaults.len());
 
@@ -59,9 +79,19 @@ pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> V
     results
 }
 
-/// Public fallback: anyone can call this to trigger a liquidation for a specific vault.
-/// Per-caller guard is enforced at the lib.rs level.
+/// Public fallback: anyone (except the anonymous principal) can call this to
+/// trigger a liquidation for a specific vault.
+///
+/// SP-111 (audit 2026-06-05): the previous comment claimed a per-caller guard
+/// was enforced at the lib.rs level — there was none. Concurrency is now
+/// serialized by the per-pool `SpLiquidationGuard` acquired below (SP-102), and
+/// the anonymous principal is rejected here to keep the permissionless trigger
+/// from being driven by unauthenticated cycle-griefing callers.
 pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, StabilityPoolError> {
+    if ic_cdk::api::caller() == Principal::anonymous() {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+
     if read_state(|s| s.configuration.emergency_pause) {
         return Err(StabilityPoolError::EmergencyPaused);
     }
@@ -69,6 +99,10 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
     if read_state(|s| s.in_flight_liquidations.contains(&vault_id)) {
         return Err(StabilityPoolError::SystemBusy);
     }
+
+    // SP-102: hold the per-pool liquidation lock across snapshot -> await ->
+    // apportion so deposit/withdraw/claim cannot race the apportionment.
+    let _liq_guard = crate::pool_guard::SpLiquidationGuard::new()?;
 
     // Fetch vault info from backend
     let protocol_id = read_state(|s| s.protocol_canister_id);
@@ -254,18 +288,23 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 let collateral = success.collateral_amount_received.unwrap_or(success.fee_amount_paid);
                 log!(INFO, "Liquidation succeeded for vault {} with token {}: collateral={}, fee={}",
                     vault_info.vault_id, token_ledger, collateral, success.fee_amount_paid);
-                // SP-101: debit by the REALIZED debt the backend actually cleared
-                // (it caps the requested draw to the vault's max_liquidatable_debt),
-                // not the amount we requested, so the tracked aggregate never falls
-                // by more than the pool truly spent. debt_liquidated_e8s is icUSD
-                // e8s; convert to the drawn token's native units on the non-icUSD
-                // path. Falls back to the requested amount if an older backend wasm
-                // does not report it. `process_liquidation_gains` debits depositor
-                // balances exactly once, after this loop.
-                let realized_consumed = match success.debt_liquidated_e8s {
-                    Some(debt_e8) if is_icusd => debt_e8,
-                    Some(debt_e8) => crate::types::denormalize_from_e8s(debt_e8, token_decimals),
-                    None => *amount,
+                // SP-101 / SP-110: debit by what the backend ACTUALLY pulled from
+                // the pool, not the amount we requested, so the tracked aggregate
+                // never drifts from the real ledger balance. `process_liquidation_gains`
+                // debits depositor balances exactly once, after this loop.
+                //   - icUSD path: the backend pulled exactly the realized debt
+                //     (`debt_liquidated_e8s`), no surcharge.
+                //   - ckStable path: the backend pulled `base + repay-fee surcharge`
+                //     (`stable_pulled_e6s`). Using only the base-debt conversion
+                //     left the surcharge un-debited and the aggregate above the
+                //     ledger (SP-110). Prefer the exact `stable_pulled_e6s`; fall
+                //     back to the base conversion for an older backend wasm.
+                let realized_consumed = match (success.debt_liquidated_e8s, is_icusd) {
+                    (Some(debt_e8), true) => debt_e8,
+                    (Some(debt_e8), false) => success
+                        .stable_pulled_e6s
+                        .unwrap_or_else(|| crate::types::denormalize_from_e8s(debt_e8, token_decimals)),
+                    (None, _) => *amount,
                 };
                 actual_consumed.insert(*token_ledger, realized_consumed);
                 total_collateral_gained += collateral;
@@ -359,10 +398,24 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
 
         match liq_result {
             Ok((Ok(success),)) => {
-                actual_consumed.insert(*token_ledger, *amount);
+                // VER-002 (audit 2026-06-05): the backend caps the writedown to
+                // the vault's current debt and refunds the proportional excess
+                // 3USD (see stability_pool_liquidate_with_reserves). Record only
+                // the REALIZED 3USD using the SAME floor formula the backend
+                // refund uses, so the SP's tracked aggregate and its ledger
+                // balance both net to exactly the realized amount (no drift).
+                // `icusd_equiv_e8s` here equals the `icusd_debt_covered_e8s` the
+                // backend received, so the two formulas are identical.
+                let realized_3usd = if icusd_equiv_e8s > 0 && success.liquidated_debt < icusd_equiv_e8s {
+                    ((*amount as u128).saturating_mul(success.liquidated_debt as u128)
+                        / icusd_equiv_e8s as u128) as u64
+                } else {
+                    *amount
+                };
+                actual_consumed.insert(*token_ledger, realized_3usd);
                 total_collateral_gained += success.collateral_received;
-                log!(INFO, "3USD reserves liquidation succeeded for vault {}: {} collateral, {} 3USD consumed",
-                    vault_info.vault_id, success.collateral_received, amount);
+                log!(INFO, "3USD reserves liquidation succeeded for vault {}: {} collateral, {} 3USD consumed (requested {})",
+                    vault_info.vault_id, success.collateral_received, realized_3usd, amount);
                 break; // one token per vault per round
             }
             Ok((Err(e),)) => {
@@ -411,7 +464,16 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 let fee: u128 = fee_nat.0.try_into().unwrap_or(0);
                 fee as u64
             },
-            Err(_) => 0,
+            Err(e) => {
+                // SP-104 (audit 2026-06-05): do NOT fall back to fee=0. The actual
+                // payout transfer deducts the real ledger fee, so crediting the full
+                // gross over-credits depositors and leaves the pool short by one fee.
+                // Use a conservative fallback so we under- rather than over-credit
+                // (solvency-safe); the next successful interaction reconciles.
+                log!(INFO, "icrc1_fee query failed for collateral {}: {:?}; using conservative fallback {} e8s",
+                    vault_info.collateral_type, e, FALLBACK_COLLATERAL_FEE_E8S);
+                FALLBACK_COLLATERAL_FEE_E8S
+            },
         };
         let net_collateral = total_collateral_gained.saturating_sub(collateral_fee);
 

--- a/src/stability_pool/src/pool_guard.rs
+++ b/src/stability_pool/src/pool_guard.rs
@@ -1,0 +1,78 @@
+//! Per-pool reentrancy guard for the stability pool's liquidation path.
+//!
+//! SP-102 (audit 2026-06-05): a liquidation snapshots depositor balances,
+//! `await`s the backend (which pulls the consumed stables), then re-reads the
+//! LIVE depositor set to apportion the burn and collateral gains. `deposit` /
+//! `withdraw` / `claim_*` run across that await window, so a withdraw that lands
+//! mid-liquidation escapes its share of the burn while the remaining depositors
+//! over-absorb, and the tracked aggregate can end up above the real ledger
+//! balance. This guard serializes the liquidation against the balance-mutating
+//! user ops: the liquidation holds it across its await; `deposit` / `withdraw` /
+//! `claim_*` reject with `SystemBusy` while it is held.
+//!
+//! Thread-local + RAII: ic-cdk's `call_on_cleanup` drops the guard (releasing
+//! the lock) even when a post-`await` continuation traps, so the pool never
+//! wedges. Same pattern as `rumi_3pool::PoolGuard`.
+//!
+//! This is a CONCURRENCY guard, not a liquidation retry. A rejected concurrent
+//! liquidation simply does not run this round and falls through to the next
+//! notification / manual handling; the SP never auto-retries a liquidation
+//! (project rule).
+
+use crate::types::StabilityPoolError;
+use std::cell::RefCell;
+
+thread_local! {
+    static LIQUIDATION_ACTIVE: RefCell<bool> = const { RefCell::new(false) };
+}
+
+#[must_use]
+pub struct SpLiquidationGuard;
+
+impl SpLiquidationGuard {
+    /// Acquire the exclusive liquidation lock. Returns `SystemBusy` if another
+    /// liquidation is already in flight (no auto-retry — the caller or the next
+    /// notification round handles it).
+    pub fn new() -> Result<Self, StabilityPoolError> {
+        LIQUIDATION_ACTIVE.with(|f| {
+            let mut held = f.borrow_mut();
+            if *held {
+                return Err(StabilityPoolError::SystemBusy);
+            }
+            *held = true;
+            Ok(Self)
+        })
+    }
+}
+
+impl Drop for SpLiquidationGuard {
+    fn drop(&mut self) {
+        LIQUIDATION_ACTIVE.with(|f| *f.borrow_mut() = false);
+    }
+}
+
+/// True while a liquidation holds the lock. `deposit` / `withdraw` / `claim_*`
+/// reject (with `SystemBusy`) when this is true, so they cannot race the
+/// liquidation's snapshot -> await -> apportion sequence.
+pub fn liquidation_in_progress() -> bool {
+    LIQUIDATION_ACTIVE.with(|f| *f.borrow())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sp_liquidation_guard_is_exclusive_and_blocks_ops() {
+        assert!(!liquidation_in_progress());
+        let g = SpLiquidationGuard::new().expect("first acquire");
+        assert!(liquidation_in_progress(), "deposit/withdraw/claim see the lock as held");
+        assert!(
+            SpLiquidationGuard::new().is_err(),
+            "a second concurrent liquidation must be rejected (SystemBusy)",
+        );
+        drop(g);
+        assert!(!liquidation_in_progress(), "lock released on drop");
+        let _g2 = SpLiquidationGuard::new().expect("re-acquire after release");
+    }
+}

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1013,11 +1013,15 @@ pub fn try_decode_state(bytes: &[u8]) -> Option<StabilityPoolState> {
 /// UPG-001 fix: rather than trapping on decode failure (which bricks the
 /// canister until a hotfix wasm with a compatible decoder is shipped), walk
 /// the known-version fallback chain via `try_decode_state`. If every known
-/// version fails, log a CRITICAL diagnostic with the snapshot length and a
-/// short hex preview, then fall back to empty state. The empty fallback is a
-/// last resort: it zeroes depositor positions. Operators should treat it as a
-/// recoverable incident (rebuild from event history if possible) rather than
-/// a routine outcome.
+/// version fails, TRAP (audit 2026-06-05, UPG-101).
+///
+/// The previous behavior wiped to empty state, which ZEROES every depositor's
+/// position — the most destructive possible outcome for a stability pool and
+/// exactly the 2026-05-18 silent-state-wipe incident class. Trapping instead
+/// keeps the canister on its old wasm with stable memory intact, so an operator
+/// can ship a wasm with a matching `StabilityPoolStateVN` snapshot and recover
+/// every position. This matches the backend (UPG-001) and the other satellites,
+/// which all trap-not-wipe on an undecodable snapshot.
 pub fn load_from_stable_memory() {
     let mut len_bytes = [0u8; 8];
     ic_cdk::api::stable::stable64_read(0, &mut len_bytes);
@@ -1042,15 +1046,19 @@ pub fn load_from_stable_memory() {
         .collect();
     log!(
         INFO,
-        "CRITICAL UPG-001: stability pool snapshot decode failed for all known schema versions. \
-         snapshot_len={} bytes, first_{}_bytes_hex={}. \
-         Falling back to empty state. Depositor positions are reset; operator must \
-         restore from event history or admin endpoints.",
+        "CRITICAL UPG-001/UPG-101: stability pool snapshot decode failed for all known schema \
+         versions. snapshot_len={} bytes, first_{}_bytes_hex={}. \
+         Trapping to preserve on-chain state (old wasm + stable memory stay intact) rather than \
+         wiping every depositor position. Ship a wasm with a matching StabilityPoolStateVN \
+         snapshot to recover.",
         bytes.len(),
         preview_len,
         preview_hex
     );
-    replace_state(StabilityPoolState::default());
+    ic_cdk::trap(
+        "stability_pool post_upgrade: stable state did not decode under any known schema version; \
+         refusing to wipe depositor positions — see CRITICAL log",
+    );
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/src/stability_pool/tests/audit_pocs_sp_reentrancy_and_realized.rs
+++ b/src/stability_pool/tests/audit_pocs_sp_reentrancy_and_realized.rs
@@ -1,0 +1,101 @@
+//! Stability-pool audit fences (2026-06-05-d67e100):
+//!
+//! SP-102: a liquidation snapshots depositor balances, awaits the backend, then
+//!   apportions the burn against the LIVE set. deposit/withdraw/claim ran across
+//!   that window, letting a withdrawer escape their share. The fix is a per-pool
+//!   reentrancy guard (`SpLiquidationGuard`): the liquidation holds it across the
+//!   await; deposit/withdraw/claim reject (`SystemBusy`) while it is held.
+//!
+//! VER-002 / SP-110: the SP recorded the REQUESTED draw (3USD path) and only the
+//!   base ckStable debt (ckStable path) as consumed, ignoring the realized
+//!   amount the backend actually pulled (the 3USD writedown is capped + excess
+//!   refunded; the ckStable pull includes a repay-fee surcharge). The fix records
+//!   the realized amount (`liquidated_debt` / `stable_pulled_e6s`).
+//!
+//! SP-104: a failed `icrc1_fee` query fell back to fee=0, over-crediting gains.
+//!   The fix uses a conservative fallback so we under- rather than over-credit.
+//!
+//! Source fences (the end-to-end paths need a PocketIC + failing-ledger harness;
+//! see the report). They FAIL on pre-fix source.
+
+use std::path::PathBuf;
+
+fn read(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+fn fn_body<'a>(src: &'a str, header: &'a str) -> &'a str {
+    let start = src.find(header).unwrap_or_else(|| panic!("`{}` not found", header));
+    let after = start + header.len();
+    let end = ["\npub async fn ", "\npub fn ", "\nasync fn ", "\nfn "]
+        .iter()
+        .filter_map(|m| src[after..].find(m).map(|i| after + i))
+        .min()
+        .unwrap_or(src.len());
+    &src[start..end]
+}
+
+#[test]
+fn sp_102_liquidation_entries_hold_reentrancy_guard() {
+    let src = read("src/liquidation.rs");
+    for header in [
+        "pub async fn notify_liquidatable_vaults(",
+        "pub async fn execute_liquidation(",
+    ] {
+        let body = fn_body(&src, header);
+        assert!(
+            body.contains("SpLiquidationGuard::new"),
+            "liquidation entry `{}` must hold the per-pool SpLiquidationGuard across its await \
+             so deposit/withdraw/claim cannot race the burn apportionment (audit SP-102).",
+            header
+        );
+    }
+}
+
+#[test]
+fn sp_102_balance_ops_reject_during_liquidation() {
+    let src = read("src/deposits.rs");
+    for header in [
+        "pub async fn deposit(",
+        "pub async fn withdraw(",
+        "pub async fn claim_collateral(",
+        "pub async fn claim_all_collateral(",
+        "pub async fn deposit_as_3usd(",
+    ] {
+        let body = fn_body(&src, header);
+        assert!(
+            body.contains("liquidation_in_progress"),
+            "balance-mutating entry `{}` must reject while a liquidation is apportioning \
+             (audit SP-102).",
+            header
+        );
+    }
+}
+
+#[test]
+fn ver_002_sp_110_records_realized_not_requested() {
+    let src = read("src/liquidation.rs");
+    // 3USD path (VER-002): must derive consumption from the realized liquidated_debt.
+    assert!(
+        src.contains("success.liquidated_debt < icusd_equiv_e8s"),
+        "the 3USD reserves path must record the REALIZED 3USD (from liquidated_debt), \
+         not the requested draw (audit VER-002).",
+    );
+    // ckStable path (SP-110): must use the backend's actual stable pulled.
+    assert!(
+        src.contains("stable_pulled_e6s"),
+        "the ckStable path must debit the TOTAL stable pulled (base + repay-fee surcharge) \
+         via stable_pulled_e6s (audit SP-110).",
+    );
+}
+
+#[test]
+fn sp_104_fee_query_failure_does_not_fall_back_to_zero() {
+    let src = read("src/liquidation.rs");
+    assert!(
+        src.contains("FALLBACK_COLLATERAL_FEE_E8S"),
+        "a failed icrc1_fee query must use a conservative non-zero fallback, not fee=0 \
+         (which over-credits gains) (audit SP-104).",
+    );
+}

--- a/src/stability_pool/tests/audit_pocs_upg_001_decode_fallback.rs
+++ b/src/stability_pool/tests/audit_pocs_upg_001_decode_fallback.rs
@@ -23,10 +23,13 @@
 //! 2. Corrupt bytes return None (no trap, no panic).
 //! 3. Empty bytes return None.
 //!
-//! The end-to-end "post_upgrade does not trap on corruption" path is exercised
-//! indirectly: `load_from_stable_memory` calls `try_decode_state` and falls back
-//! to `StabilityPoolState::default()` when None is returned. As long as
-//! `try_decode_state` is total (never panics), `load_from_stable_memory` is total.
+//! UPDATE (audit 2026-06-05, UPG-101): `load_from_stable_memory` now TRAPS when
+//! `try_decode_state` returns None, instead of falling back to
+//! `StabilityPoolState::default()`. Wiping to default zeroes every depositor
+//! position (the 2026-05-18 incident class); trapping preserves stable memory
+//! so an operator can ship a wasm with a matching `StabilityPoolStateVN`
+//! snapshot and recover. `try_decode_state` itself is unchanged and still total
+//! (returns None, never panics) — the contract these tests pin.
 
 use candid::Encode;
 use stability_pool::state::{try_decode_state, StabilityPoolState};


### PR DESCRIPTION
Launch-deploy branch. Per `DEPLOY_RUNBOOK.md`, the airdrop launch upgrades backend + 3pool, so the **2026-06-05 CDP security audit rides with this deploy**. This PR therefore bundles three things:

1. `rumi_points` airdrop launch hardening (POINTS-001/002, PTS-001/002).
2. The deploy runbook + generated `rumi_points` declarations.
3. The full **2026-06-05 CDP security audit** remediations (report: `audit-reports/2026-06-05-d67e100/`).

---

## ⚠️ Experimental cross-chain — PARKED, do not wire up

The `chains/` (Monad + Solana) tree is **experimental and intentionally dormant** (timers off, dev-gated, testnet/devnet). The audit's M-04..M-09 quorum/finality/recovery remediations were added there, but that work was produced by a sub-agent that was stopped before finishing, is **not exhaustively reviewed**, and its candid `.did` sync is **unverified**. It compiles and the backend lib tests pass, but **do not enable any cross-chain feature without a deliberate human review pass**. It is preserved on purpose (parked, not abandoned). See the banner at the top of `src/rumi_protocol_backend/src/chains/mod.rs`. This does **not** gate the ICP-native deploy.

---

## Security audit fixes (ICP-native — review/deploy targets)

**HIGH**
- **BK-001/002** — per-vault `VaultLiquidationGuard`: two liquidators racing one vault could both be paid the stale full collateral from the shared pool (the per-caller guard didn't serialize distinct callers; the ASYNC re-cap fixed accounting but not the payout). Proven end-to-end by a PocketIC interleave test (`tests/audit_pocs_bk_001_002_concurrent_liquidation_pic.rs`).
- **BK-003** — `BorrowReservationGuard`: per-collateral debt-ceiling / global mint-cap checked pre-await then minted; concurrent borrowers from distinct owners could jointly exceed the cap. Now atomically checked-and-reserved across the mint await.
- **VER-001 (ORACLE-001)** — non-ICP collateral could mint/withdraw against a stale price when the feed was down; now enforces a 10-min staleness ceiling, fail-closed.

**rumi_3pool (focus area)** — pending-claim recovery for swap/add/remove/remove_one_coin (+ `claim_pending`); 3USD same-owner transfer fix (the Internet-Identity send bug); `icrc3_get_blocks` cap; `withdraw_admin_fees` guard + restore-on-failure; swap coin-index validation; bounded LP-holder pagination.

**rumi_amm (focus area)** — `AmmStateV5` snapshot + trap-on-undecodable (closes the silent state-wipe footgun that next non-Option field add would trigger).

**stability_pool** — VER-002/SP-110 realized-debit (backend refunds excess 3USD on a capped writedown; SP records realized 3USD + ckStable repay-fee surcharge via new back-compat `SuccessWithFee.stable_pulled_e6s`); SP-102 per-pool reentrancy guard; SP-104 conservative fee fallback; SP-111.

**rumi_analytics** — M-18 resilient per-element `get_events` decode (unknown variants skipped, cursor advances), ending the recurring cycle drain.

**SP-103 (stability-pool sandwich): accepted-by-design** (owner decision) — honest depositors earn interest continuously while a sandwicher forgoes it for a ~1-minute window; left documented, not fixed.

**Reclassified (not bugs under IC guaranteed-response):** AMM swap/claim and treasury `created_at_time` "double-pay" candidates — the reduce-before-transfer + restore-on-reject patterns are safe; defense-in-depth only.

## rumi_points launch hardening

- **POINTS-002** — chunked epoch close with a resume cursor (`close_started`/`close_cursor`/`close_points_accrued`/`close_active` on `OpenEpoch`), exactly-once across resumed batches; state migrated V2 → V3 (versioned snapshot, no wipe). Fixes the permanent accrual stall when the atomic close exceeded the instruction limit.
- **POINTS-001** — `get_epoch_status` no longer leaks capture cursors (split into public `PublicEpochStatus` + admin-gated `get_epoch_status_admin`), restoring the `min(A,B)` anti-snipe defense; seed-shuffled capture order as defense-in-depth.
- **PTS-001/002** — bounded leaderboard scan + chunked snapshot-buffer clear.

## Verification

All lib tests green: backend **361**, stability_pool 43, rumi_points 146, rumi_analytics 115, rumi_3pool 107, rumi_amm 39. Plus the BK-001/002 PocketIC interleave test and source-fence PoCs for the 3pool/SP/backend fixes.

## Notes

- **Not merged** — for review. Do not merge/deploy without explicit sign-off (regular merge commit, never squash).
- A PocketIC interleave test proves BK-001/002; a fixture gotcha is documented in the test (protocol is the ICP minting account → assert on reported `collateral_amount_received`, not the pool ledger balance).
- The cross-chain `chains/` changes are the one part that needs a careful human read before it's trusted; everything else is reviewed and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
