### PR TITLE
feat(airdrop): Phase 6 points frontend (/points + leaderboard)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-airdrop-phase6-frontend.md
+++ b/docs/superpowers/plans/2026-06-08-airdrop-phase6-frontend.md
@@ -1,0 +1,966 @@
+# Airdrop Phase 6 Frontend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the public-facing airdrop points UI in `vault_frontend` — a read-only `/points` (My Points status + earn CTA) and `/points/leaderboard`, backed by a new `pointsService.ts`.
+
+**Architecture:** All data comes from public `query` calls on the `rumi_points` canister via an anonymous `HttpAgent` actor (no wallet signing). Correctness-critical logic (points formatting, season-phase, body-state, rank) lives in pure, unit-tested functions in `points.ts`; Svelte 5 components are thin renderers. The section is gated behind `POINTS_ENABLED` (true once the canister id is configured), so it ships dark and lights up at deploy.
+
+**Tech Stack:** SvelteKit (Svelte 5 runes), TypeScript, Tailwind, `@dfinity/agent`, vitest. Mirrors `src/vault_frontend/src/lib/services/explorer/analyticsService.ts`.
+
+**Working directory for all commands:** `src/vault_frontend`. **Branch:** `feat/airdrop-phase6-frontend` (already created).
+
+**Reference types** (from `src/declarations/rumi_points/rumi_points.did.d.ts`):
+- `PublicEpochStatus { open_epoch: [] | [PublicOpenEpoch]; driver_enabled: boolean; current_epoch_index: bigint; ... }`
+- `PointsConfig { registered_count: bigint; season_start_ns: bigint; season_end_ns: bigint; current_epoch_index: bigint; ... }`
+- `PrincipalState { principal: Principal; registered_at_ns: bigint; total_points: bigint; first_qualifying_action: QualifyingAction; active_deposits: Array<[DepositKey, DepositRecord]>; repayment_events: Array<RepaymentEvent>; last_epoch_processed: bigint; }`
+- `LeaderboardEntry { principal: Principal; total_points: bigint; rank: number; estimated_share_bps: number; }`
+- `QualifyingAction = {MintIcUsd:null} | {DepositStabilityPool:null} | {Deposit3Pool:null} | {ProvideAmmLiquidity:null} | {RepayVault:null}`
+- `DepositKey { asset: AssetType; venue: Venue }`, `Venue = {Amm} | {ThreePool} | {Vault} | {StabilityPool}`
+- `_SERVICE.get_principal_state: (Principal) -> ([] | [PrincipalState])`, `get_leaderboard: (number, number) -> Array<LeaderboardEntry>`
+
+---
+
+### Task 1: Pure utilities + tests (`points.ts`)
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/utils/points.ts`
+- Test: `src/vault_frontend/src/lib/utils/points.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/vault_frontend/src/lib/utils/points.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { Principal } from '@dfinity/principal';
+import {
+  formatPoints,
+  qualifyingActionLabel,
+  seasonState,
+  bodyState,
+  deriveRank,
+} from './points';
+import type {
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const P1 = Principal.fromText('aaaaa-aa');
+const P2 = Principal.fromText('2vxsx-fae');
+
+function status(open: boolean, driver: boolean): PublicEpochStatus {
+  return {
+    open_epoch: open
+      ? [{ epoch_index: 0n, epoch_start_ns: 0n, snapshot_a_ns: 0n, snapshot_b_ns: 0n, epoch_end_ns: 0n }]
+      : [],
+    snapshot_seed_committed: true,
+    driver_interval_secs: 604800n,
+    revealed_seed_count: 0n,
+    current_epoch_index: 0n,
+    driver_enabled: driver,
+  };
+}
+function cfg(endNs: bigint): PointsConfig {
+  return {
+    admin: P1,
+    registered_count: 10n,
+    snapshot_seed_committed: true,
+    excluded_count: 9,
+    season_start_ns: 1_780_272_000_000_000_000n,
+    season_end_ns: endNs,
+    current_epoch_index: 0n,
+  };
+}
+
+describe('formatPoints', () => {
+  it('renders usd_e8s-days as USD-days', () => {
+    // $100 held 1 day = 100 * 1e8 * 1 = 1e10 raw -> "100"
+    expect(formatPoints(10_000_000_000n)).toBe('100');
+  });
+  it('keeps two decimals', () => {
+    // 123.45 USD-days = 12_345_000_000 raw
+    expect(formatPoints(12_345_000_000n)).toBe('123.45');
+  });
+  it('groups thousands', () => {
+    expect(formatPoints(1_234_567n * 100_000_000n)).toBe('1,234,567');
+  });
+  it('is zero for empty', () => {
+    expect(formatPoints(0n)).toBe('0');
+  });
+});
+
+describe('qualifyingActionLabel', () => {
+  it('maps each variant', () => {
+    expect(qualifyingActionLabel({ MintIcUsd: null })).toBe('Minted icUSD');
+    expect(qualifyingActionLabel({ DepositStabilityPool: null })).toBe('Deposited to the stability pool');
+    expect(qualifyingActionLabel({ Deposit3Pool: null })).toBe('Added 3pool liquidity');
+    expect(qualifyingActionLabel({ ProvideAmmLiquidity: null })).toBe('Provided AMM liquidity');
+    expect(qualifyingActionLabel({ RepayVault: null })).toBe('Repaid a vault');
+  });
+});
+
+describe('seasonState', () => {
+  const now = 1_784_000_000_000_000_000n;
+  it('unknown when data missing', () => {
+    expect(seasonState(null, null, now)).toBe('unknown');
+  });
+  it('ended when now >= season_end', () => {
+    expect(seasonState(status(false, false), cfg(now), now)).toBe('ended');
+  });
+  it('live when an epoch is open', () => {
+    expect(seasonState(status(true, true), cfg(now + 1n), now)).toBe('live');
+  });
+  it('live when driver enabled between epochs', () => {
+    expect(seasonState(status(false, true), cfg(now + 1n), now)).toBe('live');
+  });
+  it('pre when not started and not ended', () => {
+    expect(seasonState(status(false, false), cfg(now + 1n), now)).toBe('pre');
+  });
+});
+
+describe('bodyState', () => {
+  const ps = { principal: P1, total_points: 1n } as unknown as PrincipalState;
+  it('disconnected', () => {
+    expect(bodyState({ connected: false, excluded: false, state: null })).toBe('disconnected');
+  });
+  it('excluded wins over state', () => {
+    expect(bodyState({ connected: true, excluded: true, state: ps })).toBe('excluded');
+  });
+  it('enrolled when state present', () => {
+    expect(bodyState({ connected: true, excluded: false, state: ps })).toBe('enrolled');
+  });
+  it('not_enrolled when connected without state', () => {
+    expect(bodyState({ connected: true, excluded: false, state: null })).toBe('not_enrolled');
+  });
+});
+
+describe('deriveRank', () => {
+  const rows: LeaderboardEntry[] = [
+    { principal: P1, total_points: 5n, rank: 1, estimated_share_bps: 0 },
+    { principal: P2, total_points: 3n, rank: 2, estimated_share_bps: 0 },
+  ];
+  it('finds a present principal', () => {
+    expect(deriveRank(rows, P2.toText())).toBe(2);
+  });
+  it('null when outside the slice', () => {
+    expect(deriveRank(rows, Principal.fromText('aaaaa-aa').toText())).toBe(1);
+    expect(deriveRank([], P1.toText())).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd src/vault_frontend && npx vitest run src/lib/utils/points.test.ts`
+Expected: FAIL — `Failed to resolve import "./points"` / functions not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/vault_frontend/src/lib/utils/points.ts`:
+```ts
+/**
+ * points.ts — pure helpers for the airdrop points UI. No I/O, fully unit-tested.
+ *
+ * `total_points` from the canister is in usd_e8s-days (USD value x 1e8, held
+ * over time in days). Display divides by 1e8 to get human-readable "USD-days".
+ */
+import type {
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+  QualifyingAction,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const POINTS_FORMATTER = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+/** usd_e8s-days (bigint) -> grouped USD-days string. Reduces via bigint first
+ *  so very large whale values never overflow Number's safe-integer range. */
+export function formatPoints(raw: bigint): string {
+  const hundredthsOfUsdDay = raw / 1_000_000n; // 1e8 / 1e6 = 100
+  const usdDays = Number(hundredthsOfUsdDay) / 100;
+  return POINTS_FORMATTER.format(usdDays);
+}
+
+export function qualifyingActionLabel(a: QualifyingAction): string {
+  if ('MintIcUsd' in a) return 'Minted icUSD';
+  if ('DepositStabilityPool' in a) return 'Deposited to the stability pool';
+  if ('Deposit3Pool' in a) return 'Added 3pool liquidity';
+  if ('ProvideAmmLiquidity' in a) return 'Provided AMM liquidity';
+  if ('RepayVault' in a) return 'Repaid a vault';
+  return 'Qualifying action';
+}
+
+export type SeasonPhase = 'unknown' | 'pre' | 'live' | 'ended';
+
+/** Derive the season banner phase. `nowNs` is the current time in ns. */
+export function seasonState(
+  status: PublicEpochStatus | null,
+  config: PointsConfig | null,
+  nowNs: bigint,
+): SeasonPhase {
+  if (!status || !config) return 'unknown';
+  if (nowNs >= config.season_end_ns) return 'ended';
+  if (status.open_epoch.length > 0 || status.driver_enabled) return 'live';
+  return 'pre';
+}
+
+export type BodyState = 'disconnected' | 'not_enrolled' | 'enrolled' | 'excluded';
+
+export function bodyState(args: {
+  connected: boolean;
+  excluded: boolean;
+  state: PrincipalState | null;
+}): BodyState {
+  if (!args.connected) return 'disconnected';
+  if (args.excluded) return 'excluded';
+  if (args.state) return 'enrolled';
+  return 'not_enrolled';
+}
+
+/** Find a principal's rank in a bounded leaderboard slice; null if absent. */
+export function deriveRank(entries: LeaderboardEntry[], principalText: string): number | null {
+  const hit = entries.find((e) => e.principal.toText() === principalText);
+  return hit ? hit.rank : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd src/vault_frontend && npx vitest run src/lib/utils/points.test.ts`
+Expected: PASS — all describe blocks green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/utils/points.ts src/vault_frontend/src/lib/utils/points.test.ts
+git commit -m "feat(points): pure utils for airdrop points UI (format, season-state, body-state, rank)"
+```
+
+---
+
+### Task 2: Config gate (`config.ts`)
+
+**Files:**
+- Modify: `src/vault_frontend/src/lib/config.ts` (CANISTER_IDS object ends at line 33; add a sibling export after it)
+
+- [ ] **Step 1: Add the canister id placeholder + enable flag**
+
+In `src/vault_frontend/src/lib/config.ts`, inside the `CANISTER_IDS` object (after the `ICPSWAP_ICUSD_ICP_POOL` line, before the closing `} as const;`), add:
+```ts
+  // Rumi Points (airdrop accrual engine). Empty until the canister is reserved
+  // + deployed (trio deploy per src/rumi_points/DEPLOY_RUNBOOK.md); the /points
+  // section stays hidden while this is "".
+  RUMI_POINTS: "",
+```
+Then, immediately after the `} as const;` that closes `CANISTER_IDS` (line 33), add:
+```ts
+/** The /points airdrop section is shown only once the rumi_points canister id
+ *  is configured above. Flip on by filling RUMI_POINTS at deploy time. */
+export const POINTS_ENABLED: boolean = CANISTER_IDS.RUMI_POINTS !== "";
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: completes with no new errors referencing `config.ts` or `POINTS_ENABLED`. (Pre-existing unrelated warnings, if any, are acceptable — compare against a baseline `npm run check` on the untouched file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/config.ts
+git commit -m "feat(points): add RUMI_POINTS canister id slot + POINTS_ENABLED gate"
+```
+
+---
+
+### Task 3: Points service (`pointsService.ts`)
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/services/pointsService.ts`
+
+- [ ] **Step 1: Write the service**
+
+`src/vault_frontend/src/lib/services/pointsService.ts`:
+```ts
+/**
+ * pointsService.ts — anonymous, TTL-cached query functions for the rumi_points
+ * canister. Mirrors analyticsService.ts. All calls are public queries; no wallet.
+ */
+import type { Principal } from '@dfinity/principal';
+import { Actor, HttpAgent } from '@dfinity/agent';
+import { CANISTER_IDS, CONFIG } from '$lib/config';
+import { idlFactory } from '$declarations/rumi_points/rumi_points.did.js';
+import type {
+  _SERVICE as PointsService,
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const TTL = {
+  STATUS: 15_000,
+  CONFIG: 60_000,
+  PRINCIPAL: 15_000,
+  LEADERBOARD: 30_000,
+} as const;
+
+interface CacheEntry<T> {
+  data: T;
+  ts: number;
+}
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string, ttlMs: number): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.ts > ttlMs) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data as T;
+}
+function setCache<T>(key: string, data: T): T {
+  cache.set(key, { data, ts: Date.now() });
+  return data;
+}
+export function invalidatePointsCache(prefix?: string): void {
+  if (!prefix) {
+    cache.clear();
+    return;
+  }
+  for (const key of cache.keys()) if (key.startsWith(prefix)) cache.delete(key);
+}
+
+let _actor: PointsService | null = null;
+function getActor(): PointsService {
+  if (_actor) return _actor;
+  const host = CONFIG.isLocal ? 'http://localhost:4943' : 'https://icp0.io';
+  const agent = new HttpAgent({ host });
+  if (CONFIG.isLocal) {
+    agent.fetchRootKey().catch((e) => console.warn('[pointsService] fetchRootKey failed', e));
+  }
+  _actor = Actor.createActor<PointsService>(idlFactory, {
+    agent,
+    canisterId: CANISTER_IDS.RUMI_POINTS,
+  });
+  return _actor;
+}
+
+export async function getEpochStatus(): Promise<PublicEpochStatus | null> {
+  const key = 'points:status';
+  const cached = getCached<PublicEpochStatus>(key, TTL.STATUS);
+  if (cached) return cached;
+  try {
+    return setCache(key, await getActor().get_epoch_status());
+  } catch (e) {
+    console.error('[pointsService] getEpochStatus failed', e);
+    return null;
+  }
+}
+
+export async function getPointsConfig(): Promise<PointsConfig | null> {
+  const key = 'points:config';
+  const cached = getCached<PointsConfig>(key, TTL.CONFIG);
+  if (cached) return cached;
+  try {
+    return setCache(key, await getActor().get_points_config());
+  } catch (e) {
+    console.error('[pointsService] getPointsConfig failed', e);
+    return null;
+  }
+}
+
+export async function isRegistered(p: Principal): Promise<boolean> {
+  const key = `points:reg:${p.toText()}`;
+  const cached = getCached<boolean>(key, TTL.PRINCIPAL);
+  if (cached !== null) return cached;
+  try {
+    return setCache(key, await getActor().is_registered(p));
+  } catch (e) {
+    console.error('[pointsService] isRegistered failed', e);
+    return false;
+  }
+}
+
+export async function isExcluded(p: Principal): Promise<boolean> {
+  const key = `points:excl:${p.toText()}`;
+  const cached = getCached<boolean>(key, TTL.PRINCIPAL);
+  if (cached !== null) return cached;
+  try {
+    return setCache(key, await getActor().is_excluded(p));
+  } catch (e) {
+    console.error('[pointsService] isExcluded failed', e);
+    return false;
+  }
+}
+
+export async function getPrincipalState(p: Principal): Promise<PrincipalState | null> {
+  const key = `points:state:${p.toText()}`;
+  const cached = getCached<PrincipalState | null>(key, TTL.PRINCIPAL);
+  if (cached !== null) return cached;
+  try {
+    const r = await getActor().get_principal_state(p);
+    return setCache(key, r.length > 0 ? r[0] : null);
+  } catch (e) {
+    console.error('[pointsService] getPrincipalState failed', e);
+    return null;
+  }
+}
+
+export async function getLeaderboard(offset: number, limit: number): Promise<LeaderboardEntry[]> {
+  const key = `points:lb:${offset}:${limit}`;
+  const cached = getCached<LeaderboardEntry[]>(key, TTL.LEADERBOARD);
+  if (cached) return cached;
+  try {
+    return setCache(key, await getActor().get_leaderboard(offset, limit));
+  } catch (e) {
+    console.error('[pointsService] getLeaderboard failed', e);
+    return [];
+  }
+}
+```
+
+> Note: the `isRegistered`/`isExcluded`/`getPrincipalState` caches store `boolean`/`null` values, so the `getCached` "miss" sentinel must be distinguishable. `getCached` returns `null` only on miss; for the boolean getters a cached `false` is stored as `false` and returned via the `!== null` check, and for `getPrincipalState` a cached `null` (real "no state") would look like a miss — acceptable here because a re-query on a still-absent principal is cheap and returns `null` again. Do not "optimize" this into a wrong cache.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no errors referencing `pointsService.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/services/pointsService.ts
+git commit -m "feat(points): anonymous TTL-cached pointsService (mirrors analyticsService)"
+```
+
+---
+
+### Task 4: My-points store (`pointsStore.ts`)
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/stores/pointsStore.ts`
+
+- [ ] **Step 1: Write the store**
+
+`src/vault_frontend/src/lib/stores/pointsStore.ts`:
+```ts
+/**
+ * pointsStore.ts — the connected wallet's points state. Reset/loaded by the
+ * /points page as the principal changes.
+ */
+import { writable } from 'svelte/store';
+import type { Principal } from '@dfinity/principal';
+import type { PrincipalState } from '$declarations/rumi_points/rumi_points.did';
+import { getPrincipalState, isExcluded } from '$lib/services/pointsService';
+
+export interface MyPointsState {
+  loading: boolean;
+  loaded: boolean;
+  state: PrincipalState | null;
+  excluded: boolean;
+  error: boolean;
+}
+
+const initial: MyPointsState = {
+  loading: false,
+  loaded: false,
+  state: null,
+  excluded: false,
+  error: false,
+};
+
+function createMyPointsStore() {
+  const { subscribe, set, update } = writable<MyPointsState>({ ...initial });
+
+  async function load(p: Principal): Promise<void> {
+    update((s) => ({ ...s, loading: true, error: false }));
+    try {
+      const [state, excluded] = await Promise.all([getPrincipalState(p), isExcluded(p)]);
+      set({ loading: false, loaded: true, state, excluded, error: false });
+    } catch (e) {
+      console.error('[pointsStore] load failed', e);
+      set({ ...initial, loaded: true, error: true });
+    }
+  }
+
+  function reset(): void {
+    set({ ...initial });
+  }
+
+  return { subscribe, load, reset };
+}
+
+export const myPointsStore = createMyPointsStore();
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no errors referencing `pointsStore.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/stores/pointsStore.ts
+git commit -m "feat(points): myPointsStore for connected-wallet points state"
+```
+
+---
+
+### Task 5: `SeasonBanner.svelte`
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/points/SeasonBanner.svelte`
+
+- [ ] **Step 1: Write the component**
+
+`src/vault_frontend/src/lib/components/points/SeasonBanner.svelte`:
+```svelte
+<script lang="ts">
+  import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import { seasonState } from '$lib/utils/points';
+
+  interface Props {
+    status: PublicEpochStatus | null;
+    config: PointsConfig | null;
+  }
+  let { status, config }: Props = $props();
+
+  // ms remaining until season end, for a coarse day countdown.
+  const phase = $derived(seasonState(status, config, BigInt(Date.now()) * 1_000_000n));
+  const daysLeft = $derived.by(() => {
+    if (!config) return null;
+    const endMs = Number(config.season_end_ns / 1_000_000n);
+    const d = Math.ceil((endMs - Date.now()) / 86_400_000);
+    return d > 0 ? d : 0;
+  });
+  const epochIndex = $derived(status ? Number(status.current_epoch_index) : 0);
+</script>
+
+<div class="rounded-xl bg-gray-800/30 border border-gray-700/50 px-4 py-3 flex items-center justify-between gap-3">
+  {#if phase === 'live'}
+    <div>
+      <p class="text-sm font-medium text-teal-400">Season 1 is live</p>
+      <p class="text-xs text-gray-400">Epoch {epochIndex}{#if daysLeft !== null} · {daysLeft} day{daysLeft === 1 ? '' : 's'} left{/if}</p>
+    </div>
+  {:else if phase === 'pre'}
+    <div>
+      <p class="text-sm font-medium text-gray-200">Season 1 starts soon</p>
+      <p class="text-xs text-gray-400">Start earning now — your positions are counted once the season opens.</p>
+    </div>
+  {:else if phase === 'ended'}
+    <div>
+      <p class="text-sm font-medium text-gray-200">Season 1 has ended</p>
+      <p class="text-xs text-gray-400">Allocations are being finalized. Claiming is coming soon.</p>
+    </div>
+  {:else}
+    <div>
+      <p class="text-sm font-medium text-gray-300">Airdrop points</p>
+      <p class="text-xs text-gray-500">Loading season status…</p>
+    </div>
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Commit** (component verified by the page typecheck in Task 8)
+
+```bash
+git add src/vault_frontend/src/lib/components/points/SeasonBanner.svelte
+git commit -m "feat(points): SeasonBanner component"
+```
+
+---
+
+### Task 6: `EarnCta.svelte`
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/points/EarnCta.svelte`
+
+- [ ] **Step 1: Write the component**
+
+`src/vault_frontend/src/lib/components/points/EarnCta.svelte`:
+```svelte
+<script lang="ts">
+  interface Props {
+    heading?: string;
+  }
+  let { heading = 'Ways to earn points' }: Props = $props();
+
+  const actions = [
+    { label: 'Mint icUSD', desc: 'Open a vault and borrow icUSD against collateral.', href: '/' },
+    { label: 'Deposit to the stability pool', desc: 'Earn while backstopping liquidations.', href: '/stability-pool' },
+    { label: 'Provide liquidity', desc: 'Add liquidity to the 3pool or AMM.', href: '/liquidity' },
+  ];
+</script>
+
+<div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+  <p class="text-sm font-medium text-gray-200 mb-3">{heading}</p>
+  <ul class="flex flex-col gap-2">
+    {#each actions as a}
+      <li>
+        <a
+          href={a.href}
+          class="flex items-center justify-between gap-3 rounded-lg border border-gray-700/40 bg-gray-900/30 px-3 py-2 hover:border-teal-500/40 transition-colors"
+        >
+          <span>
+            <span class="block text-sm text-gray-100">{a.label}</span>
+            <span class="block text-xs text-gray-500">{a.desc}</span>
+          </span>
+          <span class="text-teal-400 text-sm">→</span>
+        </a>
+      </li>
+    {/each}
+  </ul>
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/points/EarnCta.svelte
+git commit -m "feat(points): EarnCta component with deep-links to qualifying flows"
+```
+
+---
+
+### Task 7: `PointsSummary.svelte`
+
+**Files:**
+- Create: `src/vault_frontend/src/lib/components/points/PointsSummary.svelte`
+
+- [ ] **Step 1: Write the component**
+
+`src/vault_frontend/src/lib/components/points/PointsSummary.svelte`:
+```svelte
+<script lang="ts">
+  import type { PrincipalState, Venue } from '$declarations/rumi_points/rumi_points.did';
+  import { formatPoints, qualifyingActionLabel } from '$lib/utils/points';
+
+  interface Props {
+    state: PrincipalState;
+    rank: number | null;
+  }
+  let { state, rank }: Props = $props();
+
+  function venueLabel(v: Venue): string {
+    if ('Vault' in v) return 'Vault debt';
+    if ('StabilityPool' in v) return 'Stability pool';
+    if ('ThreePool' in v) return '3pool liquidity';
+    if ('Amm' in v) return 'AMM liquidity';
+    return 'Position';
+  }
+  // Distinct venues currently earning, for a short breakdown.
+  const venues = $derived(
+    Array.from(new Set(state.active_deposits.map(([k]) => venueLabel(k.venue)))),
+  );
+  const enrolledDate = $derived(
+    new Date(Number(state.registered_at_ns / 1_000_000n)).toLocaleDateString(),
+  );
+</script>
+
+<div class="flex flex-col gap-4">
+  <div class="grid grid-cols-2 gap-3">
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-xs text-gray-400 uppercase tracking-wider">Your points</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1">{formatPoints(state.total_points)}</p>
+      <p class="text-xs text-gray-500">USD-days</p>
+    </div>
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-xs text-gray-400 uppercase tracking-wider">Rank</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1">{rank !== null ? `#${rank}` : '—'}</p>
+      <p class="text-xs text-gray-500">{rank !== null ? 'on the leaderboard' : 'outside the top ranks'}</p>
+    </div>
+  </div>
+
+  <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+    <p>Enrolled {enrolledDate} · first action: {qualifyingActionLabel(state.first_qualifying_action)}</p>
+    {#if venues.length > 0}
+      <p class="text-xs text-gray-500 mt-2">Currently earning from: {venues.join(', ')}</p>
+    {/if}
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/vault_frontend/src/lib/components/points/PointsSummary.svelte
+git commit -m "feat(points): PointsSummary dashboard card"
+```
+
+---
+
+### Task 8: My Points page (`/points`)
+
+**Files:**
+- Create: `src/vault_frontend/src/routes/points/+page.svelte`
+
+- [ ] **Step 1: Write the page**
+
+`src/vault_frontend/src/routes/points/+page.svelte`:
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { isConnected, principal } from '$lib/stores/wallet';
+  import { myPointsStore } from '$lib/stores/pointsStore';
+  import { getEpochStatus, getPointsConfig, getLeaderboard } from '$lib/services/pointsService';
+  import { bodyState, deriveRank } from '$lib/utils/points';
+  import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import SeasonBanner from '$lib/components/points/SeasonBanner.svelte';
+  import EarnCta from '$lib/components/points/EarnCta.svelte';
+  import PointsSummary from '$lib/components/points/PointsSummary.svelte';
+
+  let status = $state<PublicEpochStatus | null>(null);
+  let config = $state<PointsConfig | null>(null);
+  let rank = $state<number | null>(null);
+
+  onMount(async () => {
+    [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
+  });
+
+  // Load / reset the connected wallet's points as the principal changes.
+  $effect(() => {
+    const p = $principal;
+    if ($isConnected && p) {
+      myPointsStore.load(p);
+      // Best-effort rank from the top slice (no get_my_rank endpoint exists).
+      getLeaderboard(0, 1000).then((rows) => {
+        rank = deriveRank(rows, p.toText());
+      });
+    } else {
+      myPointsStore.reset();
+      rank = null;
+    }
+  });
+
+  const body = $derived(
+    bodyState({
+      connected: $isConnected,
+      excluded: $myPointsStore.excluded,
+      state: $myPointsStore.state,
+    }),
+  );
+</script>
+
+<svelte:head><title>Points · Rumi</title></svelte:head>
+
+<div class="max-w-3xl mx-auto px-4 py-6 flex flex-col gap-4">
+  <h1 class="text-xl font-semibold text-gray-100">Airdrop Points</h1>
+
+  <SeasonBanner {status} {config} />
+
+  {#if $myPointsStore.loading}
+    <div class="flex justify-center py-12">
+      <div class="w-7 h-7 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if body === 'disconnected'}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      Connect your wallet to see your points. Points accrue automatically when you use the protocol.
+    </div>
+    <EarnCta />
+  {:else if body === 'excluded'}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      This address is excluded from the airdrop (protocol-owned).
+    </div>
+  {:else if body === 'enrolled' && $myPointsStore.state}
+    <PointsSummary state={$myPointsStore.state} {rank} />
+    <EarnCta heading="Earn more" />
+  {:else}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      You're not earning points yet. Take a qualifying action to enroll automatically.
+    </div>
+    <EarnCta />
+  {/if}
+</div>
+```
+
+- [ ] **Step 2: Type-check (covers Tasks 5-8 components)**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no errors referencing `routes/points/+page.svelte` or the `points/` components.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/points/+page.svelte
+git commit -m "feat(points): My Points page (status + earn CTA)"
+```
+
+---
+
+### Task 9: Leaderboard page (`/points/leaderboard`)
+
+**Files:**
+- Create: `src/vault_frontend/src/routes/points/leaderboard/+page.svelte`
+
+- [ ] **Step 1: Write the page**
+
+`src/vault_frontend/src/routes/points/leaderboard/+page.svelte`:
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { principal } from '$lib/stores/wallet';
+  import { getLeaderboard, getPointsConfig } from '$lib/services/pointsService';
+  import { formatPoints } from '$lib/utils/points';
+  import { truncatePrincipal } from '$lib/utils/principalHelpers';
+  import type { LeaderboardEntry, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import DataTable from '$lib/components/explorer/DataTable.svelte';
+  import EmptyState from '$lib/components/explorer/EmptyState.svelte';
+
+  const PAGE = 50;
+  let rows = $state<LeaderboardEntry[]>([]);
+  let config = $state<PointsConfig | null>(null);
+  let offset = $state(0);
+  let loading = $state(true);
+
+  const columns = [
+    { key: 'rank', label: 'Rank', align: 'left' as const, width: '15%' },
+    { key: 'principal', label: 'Address', align: 'left' as const },
+    { key: 'total_points', label: 'Points (USD-days)', align: 'right' as const },
+  ];
+
+  async function loadPage(o: number) {
+    loading = true;
+    const [page, cfg] = await Promise.all([getLeaderboard(o, PAGE), config ? Promise.resolve(config) : getPointsConfig()]);
+    rows = page;
+    config = cfg;
+    offset = o;
+    loading = false;
+  }
+  onMount(() => loadPage(0));
+
+  const myText = $derived($principal ? $principal.toText() : null);
+  const participants = $derived(config ? Number(config.registered_count) : null);
+</script>
+
+<svelte:head><title>Leaderboard · Rumi Points</title></svelte:head>
+
+<div class="max-w-4xl mx-auto px-4 py-6 flex flex-col gap-4">
+  <div class="flex items-center justify-between">
+    <h1 class="text-xl font-semibold text-gray-100">Points Leaderboard</h1>
+    {#if participants !== null}
+      <span class="text-xs text-gray-400">{participants.toLocaleString()} participants</span>
+    {/if}
+  </div>
+
+  {#if !loading && rows.length === 0}
+    <EmptyState title="No points yet" message="The leaderboard fills in once accrual begins." icon="chart" />
+  {:else}
+    <DataTable {columns} data={rows} {loading} rowKey={(r) => r.principal.toText()}>
+      {#snippet row(entry: LeaderboardEntry)}
+        <tr class="border-b border-gray-700/30 {myText && entry.principal.toText() === myText ? 'bg-teal-500/10' : ''}">
+          <td class="px-4 py-3 text-gray-300">#{entry.rank}</td>
+          <td class="px-4 py-3">
+            <a href={`/explorer/e/address/${entry.principal.toText()}`} class="text-teal-400 hover:underline font-mono text-xs">
+              {truncatePrincipal(entry.principal.toText())}
+            </a>
+            {#if myText && entry.principal.toText() === myText}<span class="ml-2 text-xs text-teal-400">you</span>{/if}
+          </td>
+          <td class="px-4 py-3 text-right text-gray-100">{formatPoints(entry.total_points)}</td>
+        </tr>
+      {/snippet}
+    </DataTable>
+
+    <div class="flex items-center justify-between">
+      <button
+        class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-gray-300 disabled:opacity-40"
+        disabled={offset === 0 || loading}
+        onclick={() => loadPage(Math.max(0, offset - PAGE))}
+      >Previous</button>
+      <span class="text-xs text-gray-500">Showing {offset + 1}–{offset + rows.length}</span>
+      <button
+        class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-gray-300 disabled:opacity-40"
+        disabled={rows.length < PAGE || loading}
+        onclick={() => loadPage(offset + PAGE)}
+      >Next</button>
+    </div>
+  {/if}
+</div>
+```
+
+> Verified: `src/vault_frontend/src/routes/explorer/e/address/` exists, so `/explorer/e/address/<principal>` is the correct link target.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no errors referencing the leaderboard page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/points/leaderboard/+page.svelte
+git commit -m "feat(points): leaderboard page (rank + truncated address + USD-days)"
+```
+
+---
+
+### Task 10: Navigation link (`+layout.svelte`)
+
+**Files:**
+- Modify: `src/vault_frontend/src/routes/+layout.svelte` (nav block around line 73-80; script block for the import)
+
+- [ ] **Step 1: Import the gate**
+
+In the `<script>` block of `src/vault_frontend/src/routes/+layout.svelte`, add to the existing config import (or as a new import):
+```ts
+  import { POINTS_ENABLED } from '$lib/config';
+```
+
+- [ ] **Step 2: Add the nav link**
+
+In the `<nav class="top-nav">` block, after the Explorer link (line ~80: `<a href="/explorer" ...><span>Explorer</span></a>`), add:
+```svelte
+    {#if POINTS_ENABLED}<a href="/points" class="nav-link" class:active={currentPath.startsWith('/points')}><span>Points</span></a>{/if}
+```
+
+- [ ] **Step 3: Type-check + build**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault_frontend/src/routes/+layout.svelte
+git commit -m "feat(points): gated Points nav link (hidden until canister configured)"
+```
+
+---
+
+### Task 11: Full verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd src/vault_frontend && npm run test`
+Expected: all tests pass, including the new `points.test.ts`.
+
+- [ ] **Step 2: Type-check the whole app**
+
+Run: `cd src/vault_frontend && npm run check`
+Expected: no new errors attributable to the points feature (baseline-compare any pre-existing warnings).
+
+- [ ] **Step 3: Production build**
+
+Run: `cd src/vault_frontend && npm run build`
+Expected: build succeeds. (With `POINTS_ENABLED=false` the routes still compile; they're just unreachable via nav.)
+
+- [ ] **Step 4: Temporary visibility smoke-check (manual, optional)**
+
+Temporarily set `RUMI_POINTS` to any valid-looking canister id in `config.ts`, run `npm run dev`, confirm the `Points` nav item appears and `/points` + `/points/leaderboard` render their empty/disconnected states without runtime errors, then revert the id back to `""`. Do not commit the temporary id.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** routes + nav (Task 2,10), My Points states incl. excluded (Task 8), earn CTA deep-links (Task 6), season banner (Task 5), leaderboard points+rank only / no estimated_share_bps (Task 9 — `estimated_share_bps` is never read), data layer mirror (Task 3), store (Task 4), USD-days formatting (Task 1), bounded rank lookup top-1000 (Task 8), route gating on canister id (Task 2,10). All covered.
+- **No estimated_share_bps** is rendered anywhere (decision 2) — verified in Task 9 markup.
+- **Type consistency:** `formatPoints(bigint)`, `seasonState(status,config,bigint)`, `bodyState({connected,excluded,state})`, `deriveRank(entries,string)` used identically across tasks.
+- **Verified:** explorer address route `/explorer/e/address/<id>` exists (Task 9 link target); `currentPath` is defined in `+layout.svelte:23` (Task 10 nav `class:active`). No open items.

--- a/docs/superpowers/specs/2026-06-08-airdrop-phase6-frontend-design.md
+++ b/docs/superpowers/specs/2026-06-08-airdrop-phase6-frontend-design.md
@@ -1,0 +1,186 @@
+# Airdrop Phase 6 — frontend design
+
+- **Date:** 2026-06-08
+- **Status:** approved (brainstorm), pending spec review
+- **Scope:** Phase 6 of the airdrop. The public-facing UI in `vault_frontend`
+  for the `rumi_points` accrual engine.
+- **Related:** `src/rumi_points/STATUS.md`, `src/rumi_points/DEPLOY_RUNBOOK.md`,
+  the airdrop spec (`docs/specs/rumi-airdrop-spec-v2.md`, local).
+
+## Goal
+
+Give users a public surface to (1) see whether they're earning airdrop points
+and how to start, (2) view their own points and rank, and (3) browse a public
+leaderboard. The `rumi_points` canister (Phases 1-5) is the backend; this phase
+is read-only UI on top of it.
+
+## Key constraint that shapes everything
+
+**The entire feature is read-only.** Every frontend-relevant endpoint is a public
+`query`, and there is **no user-facing register or claim endpoint**:
+
+- Registration is **automatic** — a wallet is enrolled on its first qualifying
+  in-season action (mint icUSD, deposit to the stability pool, add 3pool
+  liquidity), picked up by the canister's poller. `register_test_principal` is
+  admin-only and not used by this UI.
+- Claiming is **out of scope** (Phases 7-8, a separate claim canister).
+
+So the wallet connection only tells us *which* principal to query — there is no
+signing, no PnP authenticated actor, and no on-chain write anywhere in Phase 6.
+
+## Decisions locked (brainstorm)
+
+1. **Enrollment surface = status + earn CTA.** A "My Points" view shows enrollment
+   status; if not enrolled, it explains the qualifying actions and deep-links to
+   the existing flows. No on-chain write.
+2. **Points + rank only.** Do **not** surface `estimated_share_bps` anywhere — it's
+   a fluctuating live estimate and the true allocation is computed later from the
+   frozen ledger. Avoids setting precise airdrop-size expectations.
+3. **New top-level `Points` section** with `/points` (My Points) and
+   `/points/leaderboard`.
+
+## Approach
+
+Mirror the existing explorer/analytics pattern (least new surface area, consistent
+with conventions):
+
+- `src/lib/services/pointsService.ts` — anonymous `HttpAgent` + lazy actor +
+  TTL-cached query functions, modeled on `analyticsService.ts`.
+- Thin Svelte stores for the connected user's points state; reactive refetch on
+  `principal` change (from the existing `walletStore` / `principal` derived store).
+- Reuse `DataTable.svelte` for the leaderboard and the existing card/metric/
+  `EmptyState`/toast patterns for everything else.
+
+*Rejected alternatives:* folding points into the central `appDataStore` (couples
+it into a large shared store — invasive); building bespoke components instead of
+reusing `DataTable` (more control, more divergence).
+
+## Routes & navigation
+
+- New top-level `Points` nav item in `+layout.svelte`.
+- `/points` — My Points (default landing).
+- `/points/leaderboard` — ranked table.
+- The nav item and routes are **gated on `CANISTER_ID_RUMI_POINTS` being
+  configured** (via `config.ts`), so the section stays hidden until the canister
+  is deployed and its id is added to config. No dead links pre-launch.
+
+## My Points page (`/points`)
+
+A **season banner** at the top, driven by `get_epoch_status()`
+(`PublicEpochStatus`):
+
+- No canister id / not deployed → section hidden (see route gating).
+- Deployed, `open_epoch == None` and `!driver_enabled` → "Season 1 starts soon".
+- `open_epoch == Some` → "Season 1 live — Epoch N" + countdown to
+  `season_end_ns` (from `get_points_config`).
+- Now past `season_end_ns` → "Season 1 ended — allocations being finalized;
+  claiming coming soon".
+
+Body states:
+
+| State | Condition | Content |
+|-------|-----------|---------|
+| Disconnected | no wallet | Connect-wallet prompt + short "what is this" + the earn CTA |
+| Connected, not enrolled | `is_registered(p) == false` | "You're not earning yet" + earn CTA |
+| Connected, enrolled | `get_principal_state(p) == Some` | Points dashboard (below) + secondary "earn more" CTA |
+
+**Earn CTA** — a list of qualifying actions, each deep-linking to the existing
+flow:
+- Mint / borrow icUSD → `/`
+- Deposit to the stability pool → `/stability-pool`
+- Provide 3pool / AMM liquidity → `/liquidity`
+
+**Points dashboard** (enrolled), from `PrincipalState`:
+- `total_points` — primary stat, formatted as USD-days (see Formatting).
+- Rank — best-effort (see Rank lookup); always show points even when rank is unknown.
+- Enrolled-since — from `registered_at_ns`.
+- First qualifying action — from `first_qualifying_action`.
+- Earning breakdown — a small list derived from `active_deposits` showing where
+  points are currently accruing (vault debt, SP, 3pool, AMM), so users see which
+  positions count.
+
+Edge: if `is_excluded(p)` (protocol-owned canisters), show a brief "this address
+is excluded" note instead of the dashboard. Normal users never hit this.
+
+## Leaderboard page (`/points/leaderboard`)
+
+- Header stats from `get_points_config()`: total participants
+  (`registered_count`) and the season window.
+- Paginated `DataTable` over `get_leaderboard(offset, limit)`
+  (`vec LeaderboardEntry`): columns **rank**, **principal** (truncated
+  `abcd…wxyz`, with copy + link to the explorer address page), **total points**
+  (USD-days). `estimated_share_bps` is fetched-but-ignored (not rendered).
+- The connected user's row is highlighted when present on the current page.
+- Empty state via `EmptyState.svelte` when there are no entries yet (pre-accrual).
+
+### Rank lookup
+
+There is **no `rank` field on `PrincipalState` and no `get_my_rank` endpoint** —
+`rank` exists only on `LeaderboardEntry`. So a user's rank is derived by locating
+their principal in `get_leaderboard` output. Approach for launch: fetch a bounded
+top slice (e.g. top 1000) and, if the principal appears, show that `rank`;
+otherwise show `total_points` with rank as "unranked / outside top N" rather than
+paging the entire set. This keeps the My Points page to one bounded query and
+avoids unbounded scans. (If precise deep ranks become important, add a dedicated
+canister endpoint later — out of scope here.)
+
+## Data layer
+
+`pointsService.ts` exported functions (all anonymous public queries, TTL-cached):
+
+| Function | Canister method | Notes |
+|----------|-----------------|-------|
+| `getEpochStatus()` | `get_epoch_status` | season banner; short TTL (~15s) |
+| `getPointsConfig()` | `get_points_config` | header stats; medium TTL (~60s) |
+| `isRegistered(p)` | `is_registered` | enrollment gate |
+| `getPrincipalState(p)` | `get_principal_state` | personal dashboard |
+| `isExcluded(p)` | `is_excluded` | excluded-address edge |
+| `getLeaderboard(offset, limit)` | `get_leaderboard` | paginated table |
+
+Stores: a `myPointsStore` (writable) holding `{ registered, state, loading,
+error }`, refetched reactively when `principal` changes; leaderboard fetched
+per-page in the page component (no global store needed).
+
+## Formatting
+
+`total_points` is `nat` in **`usd_e8s`-days** (USD value ×1e8 held over time in
+days). Display = `Number(total_points) / 1e8`, rendered as a grouped number
+labeled "USD-days" (e.g. holding $100 for 1 day → `100` USD-days). Use `bigint`
+math before the divide to avoid precision loss; a shared `formatPoints()` helper
+in `src/lib/utils`.
+
+## Error / empty / loading
+
+- Loading: existing spinner / skeleton pattern; never a blank page.
+- Query failure: non-blocking toast + inline retry; stale cache shown if present.
+- Empty leaderboard / no points yet: `EmptyState.svelte` with copy pointing to
+  the earn CTA.
+
+## Components
+
+- **Reuse:** `DataTable.svelte`, `EmptyState.svelte`, toast store, card/metric
+  styling (`ProtocolVitals`-style), explorer address-link helper, app.css tokens.
+- **New:** `routes/points/+page.svelte`, `routes/points/leaderboard/+page.svelte`,
+  a `SeasonBanner.svelte`, an `EarnCta.svelte`, a `PointsSummary.svelte`
+  (dashboard card), `pointsService.ts`, `myPointsStore`, `formatPoints()`.
+
+## Out of scope (Phase 6)
+
+Claiming (Phases 7-8), `estimated_share_bps` display, any admin/operate controls,
+any on-chain writes, historical per-epoch charts (could reuse `get_epoch_history`
+later).
+
+## Testing
+
+- Unit: `formatPoints()` (e8s-days → USD-days, large values, zero).
+- Component/logic: state selection (disconnected / not-enrolled / enrolled /
+  excluded), season-banner state from `PublicEpochStatus` + `season_end_ns`.
+- Manual against a local replica with a registered test principal
+  (`register_test_principal`) once the canister is deployed locally; verify the
+  three body states, the leaderboard pagination, and the self-row highlight.
+
+## Launch dependency
+
+The section is hidden until `CANISTER_ID_RUMI_POINTS` is configured. It can be
+built and merged now; it goes live when the canister is deployed (trio deploy per
+`DEPLOY_RUNBOOK.md`) and its id is added to `config.ts`.

--- a/src/vault_frontend/src/lib/components/points/EarnCta.svelte
+++ b/src/vault_frontend/src/lib/components/points/EarnCta.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  interface Props {
+    heading?: string;
+  }
+  let { heading = 'Ways to earn points' }: Props = $props();
+
+  const actions = [
+    { label: 'Mint icUSD', desc: 'Open a vault and borrow icUSD against collateral.', href: '/' },
+    { label: 'Deposit to the stability pool', desc: 'Earn while backstopping liquidations.', href: '/stability-pool' },
+    { label: 'Provide liquidity', desc: 'Add liquidity to the 3pool or AMM.', href: '/liquidity' },
+  ];
+</script>
+
+<div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+  <p class="text-sm font-medium text-gray-200 mb-3">{heading}</p>
+  <ul class="flex flex-col gap-2">
+    {#each actions as a}
+      <li>
+        <a
+          href={a.href}
+          class="flex items-center justify-between gap-3 rounded-lg border border-gray-700/40 bg-gray-900/30 px-3 py-2 hover:border-teal-500/40 transition-colors"
+        >
+          <span>
+            <span class="block text-sm text-gray-100">{a.label}</span>
+            <span class="block text-xs text-gray-500">{a.desc}</span>
+          </span>
+          <span class="text-teal-400 text-sm">→</span>
+        </a>
+      </li>
+    {/each}
+  </ul>
+</div>

--- a/src/vault_frontend/src/lib/components/points/PointsSummary.svelte
+++ b/src/vault_frontend/src/lib/components/points/PointsSummary.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { PrincipalState, Venue } from '$declarations/rumi_points/rumi_points.did';
+  import { formatPoints, qualifyingActionLabel } from '$lib/utils/points';
+
+  interface Props {
+    state: PrincipalState;
+    rank: number | null;
+  }
+  let { state, rank }: Props = $props();
+
+  function venueLabel(v: Venue): string {
+    if ('Vault' in v) return 'Vault debt';
+    if ('StabilityPool' in v) return 'Stability pool';
+    if ('ThreePool' in v) return '3pool liquidity';
+    if ('Amm' in v) return 'AMM liquidity';
+    return 'Position';
+  }
+  // Distinct venues currently earning, for a short breakdown.
+  const venues = $derived(
+    Array.from(new Set(state.active_deposits.map(([k]) => venueLabel(k.venue)))),
+  );
+  const enrolledDate = $derived(
+    new Date(Number(state.registered_at_ns / 1_000_000n)).toLocaleDateString(),
+  );
+</script>
+
+<div class="flex flex-col gap-4">
+  <div class="grid grid-cols-2 gap-3">
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-xs text-gray-400 uppercase tracking-wider">Your points</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1">{formatPoints(state.total_points)}</p>
+      <p class="text-xs text-gray-500">USD-days</p>
+    </div>
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-xs text-gray-400 uppercase tracking-wider">Rank</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1">{rank !== null ? `#${rank}` : '—'}</p>
+      <p class="text-xs text-gray-500">{rank !== null ? 'on the leaderboard' : 'outside the top ranks'}</p>
+    </div>
+  </div>
+
+  <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+    <p>Enrolled {enrolledDate} · first action: {qualifyingActionLabel(state.first_qualifying_action)}</p>
+    {#if venues.length > 0}
+      <p class="text-xs text-gray-500 mt-2">Currently earning from: {venues.join(', ')}</p>
+    {/if}
+  </div>
+</div>

--- a/src/vault_frontend/src/lib/components/points/SeasonBanner.svelte
+++ b/src/vault_frontend/src/lib/components/points/SeasonBanner.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import { seasonState } from '$lib/utils/points';
+
+  interface Props {
+    status: PublicEpochStatus | null;
+    config: PointsConfig | null;
+  }
+  let { status, config }: Props = $props();
+
+  // ms remaining until season end, for a coarse day countdown.
+  const phase = $derived(seasonState(status, config, BigInt(Date.now()) * 1_000_000n));
+  const daysLeft = $derived.by(() => {
+    if (!config) return null;
+    const endMs = Number(config.season_end_ns / 1_000_000n);
+    const d = Math.ceil((endMs - Date.now()) / 86_400_000);
+    return d > 0 ? d : 0;
+  });
+  const epochIndex = $derived(status ? Number(status.current_epoch_index) : 0);
+</script>
+
+<div class="rounded-xl bg-gray-800/30 border border-gray-700/50 px-4 py-3 flex items-center justify-between gap-3">
+  {#if phase === 'live'}
+    <div>
+      <p class="text-sm font-medium text-teal-400">Season 1 is live</p>
+      <p class="text-xs text-gray-400">Epoch {epochIndex}{#if daysLeft !== null} · {daysLeft} day{daysLeft === 1 ? '' : 's'} left{/if}</p>
+    </div>
+  {:else if phase === 'pre'}
+    <div>
+      <p class="text-sm font-medium text-gray-200">Season 1 starts soon</p>
+      <p class="text-xs text-gray-400">Start earning now — your positions are counted once the season opens.</p>
+    </div>
+  {:else if phase === 'ended'}
+    <div>
+      <p class="text-sm font-medium text-gray-200">Season 1 has ended</p>
+      <p class="text-xs text-gray-400">Allocations are being finalized. Claiming is coming soon.</p>
+    </div>
+  {:else}
+    <div>
+      <p class="text-sm font-medium text-gray-300">Airdrop points</p>
+      <p class="text-xs text-gray-500">Loading season status…</p>
+    </div>
+  {/if}
+</div>

--- a/src/vault_frontend/src/lib/config.ts
+++ b/src/vault_frontend/src/lib/config.ts
@@ -30,7 +30,15 @@ export const CANISTER_IDS = {
   // ICPswap pools (external DEX for routing)
   ICPSWAP_3USD_ICP_POOL: "mu2zw-6iaaa-aaaar-qb56q-cai",
   ICPSWAP_ICUSD_ICP_POOL: "nqxwe-hiaaa-aaaar-qb5yq-cai",
+  // Rumi Points (airdrop accrual engine). Empty until the canister is reserved
+  // + deployed (trio deploy per src/rumi_points/DEPLOY_RUNBOOK.md); the /points
+  // section stays hidden while this is "".
+  RUMI_POINTS: "",
 } as const;
+
+/** The /points airdrop section is shown only once the rumi_points canister id
+ *  is configured above. Flip on by filling RUMI_POINTS at deploy time. */
+export const POINTS_ENABLED: boolean = CANISTER_IDS.RUMI_POINTS !== "";
 
 // Canister IDs for local development
 export const LOCAL_CANISTER_IDS = {

--- a/src/vault_frontend/src/lib/services/pointsService.ts
+++ b/src/vault_frontend/src/lib/services/pointsService.ts
@@ -1,0 +1,116 @@
+/**
+ * pointsService.ts — anonymous, TTL-cached query functions for the rumi_points
+ * canister. Mirrors analyticsService.ts. All calls are public queries; no wallet.
+ *
+ * Errors are NOT swallowed: the canister-call functions reject on failure so the
+ * UI can distinguish a real failure (show error + retry + toast) from genuinely
+ * empty data (e.g. an unregistered principal -> null). The cache distinguishes a
+ * hit from a miss explicitly, so a cached `null`/`false` is served from cache
+ * (a stored `null` is a real value, not a miss).
+ */
+import type { Principal } from '@dfinity/principal';
+import { Actor, HttpAgent } from '@dfinity/agent';
+import { CANISTER_IDS, CONFIG } from '$lib/config';
+import { idlFactory } from '$declarations/rumi_points/rumi_points.did.js';
+import type {
+  _SERVICE as PointsService,
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const TTL = {
+  STATUS: 15_000,
+  CONFIG: 60_000,
+  PRINCIPAL: 15_000,
+  LEADERBOARD: 30_000,
+} as const;
+
+interface CacheEntry<T> {
+  data: T;
+  ts: number;
+}
+const cache = new Map<string, CacheEntry<unknown>>();
+
+type Cached<T> = { hit: true; value: T } | { hit: false };
+
+function getCached<T>(key: string, ttlMs: number): Cached<T> {
+  const entry = cache.get(key);
+  if (!entry) return { hit: false };
+  if (Date.now() - entry.ts > ttlMs) {
+    cache.delete(key);
+    return { hit: false };
+  }
+  return { hit: true, value: entry.data as T };
+}
+function setCache<T>(key: string, data: T): T {
+  cache.set(key, { data, ts: Date.now() });
+  return data;
+}
+export function invalidatePointsCache(prefix?: string): void {
+  if (!prefix) {
+    cache.clear();
+    return;
+  }
+  for (const key of cache.keys()) if (key.startsWith(prefix)) cache.delete(key);
+}
+
+let _actor: PointsService | null = null;
+function getActor(): PointsService {
+  if (_actor) return _actor;
+  const host = CONFIG.isLocal ? 'http://localhost:4943' : 'https://icp0.io';
+  const agent = new HttpAgent({ host });
+  if (CONFIG.isLocal) {
+    agent.fetchRootKey().catch((e) => console.warn('[pointsService] fetchRootKey failed', e));
+  }
+  _actor = Actor.createActor<PointsService>(idlFactory, {
+    agent,
+    canisterId: CANISTER_IDS.RUMI_POINTS,
+  });
+  return _actor;
+}
+
+export async function getEpochStatus(): Promise<PublicEpochStatus> {
+  const key = 'points:status';
+  const c = getCached<PublicEpochStatus>(key, TTL.STATUS);
+  if (c.hit) return c.value;
+  return setCache(key, await getActor().get_epoch_status());
+}
+
+export async function getPointsConfig(): Promise<PointsConfig> {
+  const key = 'points:config';
+  const c = getCached<PointsConfig>(key, TTL.CONFIG);
+  if (c.hit) return c.value;
+  return setCache(key, await getActor().get_points_config());
+}
+
+export async function isRegistered(p: Principal): Promise<boolean> {
+  const key = `points:reg:${p.toText()}`;
+  const c = getCached<boolean>(key, TTL.PRINCIPAL);
+  if (c.hit) return c.value;
+  return setCache(key, await getActor().is_registered(p));
+}
+
+export async function isExcluded(p: Principal): Promise<boolean> {
+  const key = `points:excl:${p.toText()}`;
+  const c = getCached<boolean>(key, TTL.PRINCIPAL);
+  if (c.hit) return c.value;
+  return setCache(key, await getActor().is_excluded(p));
+}
+
+export async function getPrincipalState(p: Principal): Promise<PrincipalState | null> {
+  const key = `points:state:${p.toText()}`;
+  const c = getCached<PrincipalState | null>(key, TTL.PRINCIPAL);
+  if (c.hit) return c.value;
+  // get_principal_state returns a candid opt: [] | [PrincipalState].
+  const [val] = await getActor().get_principal_state(p);
+  return setCache<PrincipalState | null>(key, val ?? null);
+}
+
+export async function getLeaderboard(offset: number, limit: number): Promise<LeaderboardEntry[]> {
+  const key = `points:lb:${offset}:${limit}`;
+  const c = getCached<LeaderboardEntry[]>(key, TTL.LEADERBOARD);
+  if (c.hit) return c.value;
+  return setCache(key, await getActor().get_leaderboard(offset, limit));
+}

--- a/src/vault_frontend/src/lib/stores/pointsStore.ts
+++ b/src/vault_frontend/src/lib/stores/pointsStore.ts
@@ -1,0 +1,49 @@
+/**
+ * pointsStore.ts — the connected wallet's points state. Reset/loaded by the
+ * /points page as the principal changes.
+ */
+import { writable } from 'svelte/store';
+import type { Principal } from '@dfinity/principal';
+import type { PrincipalState } from '$declarations/rumi_points/rumi_points.did';
+import { getPrincipalState, isExcluded } from '$lib/services/pointsService';
+import { toastStore } from '$lib/stores/toast';
+
+export interface MyPointsState {
+  loading: boolean;
+  loaded: boolean;
+  state: PrincipalState | null;
+  excluded: boolean;
+  error: boolean;
+}
+
+const initial: MyPointsState = {
+  loading: false,
+  loaded: false,
+  state: null,
+  excluded: false,
+  error: false,
+};
+
+function createMyPointsStore() {
+  const { subscribe, set, update } = writable<MyPointsState>({ ...initial });
+
+  async function load(p: Principal): Promise<void> {
+    update((s) => ({ ...s, loading: true, error: false }));
+    try {
+      const [state, excluded] = await Promise.all([getPrincipalState(p), isExcluded(p)]);
+      set({ loading: false, loaded: true, state, excluded, error: false });
+    } catch (e) {
+      console.error('[pointsStore] load failed', e);
+      set({ ...initial, loaded: true, error: true });
+      toastStore.error('Could not load your points. Tap retry.');
+    }
+  }
+
+  function reset(): void {
+    set({ ...initial });
+  }
+
+  return { subscribe, load, reset };
+}
+
+export const myPointsStore = createMyPointsStore();

--- a/src/vault_frontend/src/lib/utils/points.test.ts
+++ b/src/vault_frontend/src/lib/utils/points.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { Principal } from '@dfinity/principal';
+import {
+  formatPoints,
+  qualifyingActionLabel,
+  seasonState,
+  bodyState,
+  deriveRank,
+  hasNextPage,
+} from './points';
+import type {
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const P1 = Principal.fromText('aaaaa-aa');
+const P2 = Principal.fromText('2vxsx-fae');
+
+function status(open: boolean, driver: boolean): PublicEpochStatus {
+  return {
+    open_epoch: open
+      ? [{ epoch_index: 0n, epoch_start_ns: 0n, snapshot_a_ns: 0n, snapshot_b_ns: 0n, epoch_end_ns: 0n }]
+      : [],
+    snapshot_seed_committed: true,
+    driver_interval_secs: 604800n,
+    revealed_seed_count: 0n,
+    current_epoch_index: 0n,
+    driver_enabled: driver,
+  };
+}
+function cfg(endNs: bigint): PointsConfig {
+  return {
+    admin: P1,
+    registered_count: 10n,
+    snapshot_seed_committed: true,
+    excluded_count: 9,
+    season_start_ns: 1_780_272_000_000_000_000n,
+    season_end_ns: endNs,
+    current_epoch_index: 0n,
+  };
+}
+
+describe('formatPoints', () => {
+  it('renders usd_e8s-days as USD-days', () => {
+    // $100 held 1 day = 100 * 1e8 * 1 = 1e10 raw -> "100"
+    expect(formatPoints(10_000_000_000n)).toBe('100');
+  });
+  it('keeps two decimals', () => {
+    // 123.45 USD-days = 12_345_000_000 raw
+    expect(formatPoints(12_345_000_000n)).toBe('123.45');
+  });
+  it('groups thousands', () => {
+    expect(formatPoints(1_234_567n * 100_000_000n)).toBe('1,234,567');
+  });
+  it('is zero for empty', () => {
+    expect(formatPoints(0n)).toBe('0');
+  });
+});
+
+describe('qualifyingActionLabel', () => {
+  it('maps each variant', () => {
+    expect(qualifyingActionLabel({ MintIcUsd: null })).toBe('Minted icUSD');
+    expect(qualifyingActionLabel({ DepositStabilityPool: null })).toBe('Deposited to the stability pool');
+    expect(qualifyingActionLabel({ Deposit3Pool: null })).toBe('Added 3pool liquidity');
+    expect(qualifyingActionLabel({ ProvideAmmLiquidity: null })).toBe('Provided AMM liquidity');
+    expect(qualifyingActionLabel({ RepayVault: null })).toBe('Repaid a vault');
+  });
+});
+
+describe('seasonState', () => {
+  const now = 1_784_000_000_000_000_000n;
+  it('unknown when data missing', () => {
+    expect(seasonState(null, null, now)).toBe('unknown');
+  });
+  it('ended when now >= season_end', () => {
+    expect(seasonState(status(false, false), cfg(now), now)).toBe('ended');
+  });
+  it('live when an epoch is open', () => {
+    expect(seasonState(status(true, true), cfg(now + 1n), now)).toBe('live');
+  });
+  it('live when driver enabled between epochs', () => {
+    expect(seasonState(status(false, true), cfg(now + 1n), now)).toBe('live');
+  });
+  it('pre when not started and not ended', () => {
+    expect(seasonState(status(false, false), cfg(now + 1n), now)).toBe('pre');
+  });
+});
+
+describe('bodyState', () => {
+  const ps = { principal: P1, total_points: 1n } as unknown as PrincipalState;
+  it('disconnected', () => {
+    expect(bodyState({ connected: false, excluded: false, state: null })).toBe('disconnected');
+  });
+  it('excluded wins over state', () => {
+    expect(bodyState({ connected: true, excluded: true, state: ps })).toBe('excluded');
+  });
+  it('enrolled when state present', () => {
+    expect(bodyState({ connected: true, excluded: false, state: ps })).toBe('enrolled');
+  });
+  it('not_enrolled when connected without state', () => {
+    expect(bodyState({ connected: true, excluded: false, state: null })).toBe('not_enrolled');
+  });
+});
+
+describe('deriveRank', () => {
+  const rows: LeaderboardEntry[] = [
+    { principal: P1, total_points: 5n, rank: 1, estimated_share_bps: 0 },
+    { principal: P2, total_points: 3n, rank: 2, estimated_share_bps: 0 },
+  ];
+  it('finds a present principal', () => {
+    expect(deriveRank(rows, P2.toText())).toBe(2);
+  });
+  it('null when principal absent from the slice', () => {
+    const absent = Principal.fromText('rdmx6-jaaaa-aaaaa-aaadq-cai');
+    expect(deriveRank(rows, absent.toText())).toBeNull();
+    expect(deriveRank([], P1.toText())).toBeNull();
+  });
+});
+
+describe('hasNextPage', () => {
+  it('no next on a partial page', () => {
+    expect(hasNextPage(0, 30, 50, 1000)).toBe(false);
+  });
+  it('no next when total reached exactly on a full page', () => {
+    expect(hasNextPage(50, 50, 50, 100)).toBe(false);
+  });
+  it('next when full page and below total', () => {
+    expect(hasNextPage(0, 50, 50, 1000)).toBe(true);
+  });
+  it('full page with unknown total allows next', () => {
+    expect(hasNextPage(0, 50, 50, null)).toBe(true);
+  });
+});

--- a/src/vault_frontend/src/lib/utils/points.ts
+++ b/src/vault_frontend/src/lib/utils/points.ts
@@ -1,0 +1,84 @@
+/**
+ * points.ts — pure helpers for the airdrop points UI. No I/O, fully unit-tested.
+ *
+ * `total_points` from the canister is in usd_e8s-days (USD value x 1e8, held
+ * over time in days). Display divides by 1e8 to get human-readable "USD-days".
+ */
+import type {
+  PublicEpochStatus,
+  PointsConfig,
+  PrincipalState,
+  LeaderboardEntry,
+  QualifyingAction,
+} from '$declarations/rumi_points/rumi_points.did';
+
+const POINTS_FORMATTER = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+/** usd_e8s-days (bigint) -> grouped USD-days string. Reduces via bigint first
+ *  so very large whale values never overflow Number's safe-integer range. */
+export function formatPoints(raw: bigint): string {
+  const hundredthsOfUsdDay = raw / 1_000_000n; // 1e8 / 1e6 = 100
+  const usdDays = Number(hundredthsOfUsdDay) / 100;
+  return POINTS_FORMATTER.format(usdDays);
+}
+
+export function qualifyingActionLabel(a: QualifyingAction): string {
+  if ('MintIcUsd' in a) return 'Minted icUSD';
+  if ('DepositStabilityPool' in a) return 'Deposited to the stability pool';
+  if ('Deposit3Pool' in a) return 'Added 3pool liquidity';
+  if ('ProvideAmmLiquidity' in a) return 'Provided AMM liquidity';
+  if ('RepayVault' in a) return 'Repaid a vault';
+  return 'Qualifying action';
+}
+
+export type SeasonPhase = 'unknown' | 'pre' | 'live' | 'ended';
+
+/** Derive the season banner phase. `nowNs` is the current time in ns. */
+export function seasonState(
+  status: PublicEpochStatus | null,
+  config: PointsConfig | null,
+  nowNs: bigint,
+): SeasonPhase {
+  if (!status || !config) return 'unknown';
+  if (nowNs >= config.season_end_ns) return 'ended';
+  if (status.open_epoch.length > 0 || status.driver_enabled) return 'live';
+  return 'pre';
+}
+
+export type BodyState = 'disconnected' | 'not_enrolled' | 'enrolled' | 'excluded';
+
+export function bodyState(args: {
+  connected: boolean;
+  excluded: boolean;
+  state: PrincipalState | null;
+}): BodyState {
+  if (!args.connected) return 'disconnected';
+  if (args.excluded) return 'excluded';
+  if (args.state) return 'enrolled';
+  return 'not_enrolled';
+}
+
+/** Find a principal's rank in a bounded leaderboard slice; null if absent. */
+export function deriveRank(entries: LeaderboardEntry[], principalText: string): number | null {
+  const hit = entries.find((e) => e.principal.toText() === principalText);
+  return hit ? hit.rank : null;
+}
+
+/**
+ * Whether a Next page exists. A partial page (< pageSize) is always the last
+ * page; with a known total, stop once the current page reaches it. Prevents
+ * paging into an empty trailing page when the last page is exactly pageSize.
+ */
+export function hasNextPage(
+  offset: number,
+  rowsLen: number,
+  pageSize: number,
+  total: number | null,
+): boolean {
+  if (rowsLen < pageSize) return false;
+  if (total !== null && offset + rowsLen >= total) return false;
+  return true;
+}

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import "../app.css";
   import { protocolService } from "../lib/services/protocol";
   import { isDevelopment } from "../lib/config";
+  import { POINTS_ENABLED } from '$lib/config';
   import { developerAccess } from "../lib/stores/developer";
   import ToastContainer from "../lib/components/common/ToastContainer.svelte";
   import { ApiClient } from "../lib/services/protocol/apiClient";
@@ -78,6 +79,7 @@
     {#if isConnected && canViewVaults}<a href="/vaults" class="nav-link" class:active={currentPath.startsWith('/vaults')}><span>Vaults</span></a>{/if}
     {#if isConnected && $permissionStore.isDeveloper}<a href="/treasury" class="nav-link" class:active={currentPath === '/treasury'}><span>Treasury</span></a>{/if}
     <a href="/explorer" class="nav-link" class:active={currentPath.startsWith('/explorer')}><span>Explorer</span></a>
+    {#if POINTS_ENABLED}<a href="/points" class="nav-link" class:active={currentPath.startsWith('/points')}><span>Points</span></a>{/if}
   </nav>
   <div class="top-actions">
     {#if hasLiquidatableVaults}

--- a/src/vault_frontend/src/routes/points/+page.svelte
+++ b/src/vault_frontend/src/routes/points/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { POINTS_ENABLED } from '$lib/config';
+  import { isConnected, principal } from '$lib/stores/wallet';
+  import { myPointsStore } from '$lib/stores/pointsStore';
+  import { getEpochStatus, getPointsConfig, getLeaderboard } from '$lib/services/pointsService';
+  import { bodyState, deriveRank } from '$lib/utils/points';
+  import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import SeasonBanner from '$lib/components/points/SeasonBanner.svelte';
+  import EarnCta from '$lib/components/points/EarnCta.svelte';
+  import PointsSummary from '$lib/components/points/PointsSummary.svelte';
+
+  let status = $state<PublicEpochStatus | null>(null);
+  let config = $state<PointsConfig | null>(null);
+  let rank = $state<number | null>(null);
+
+  onMount(async () => {
+    // Route gate: the section is hidden in nav until the canister is configured;
+    // also block direct-URL access so we never call an unconfigured canister.
+    if (!POINTS_ENABLED) {
+      goto('/');
+      return;
+    }
+    try {
+      [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
+    } catch (e) {
+      // Non-fatal: the banner degrades to its loading/unknown state.
+      console.error('[points] season status load failed', e);
+    }
+  });
+
+  // Load / reset the connected wallet's points as the principal changes.
+  $effect(() => {
+    if (!POINTS_ENABLED) return;
+    const p = $principal;
+    if ($isConnected && p) {
+      myPointsStore.load(p);
+      // Best-effort rank from the top slice (no get_my_rank endpoint exists).
+      getLeaderboard(0, 1000)
+        .then((rows) => {
+          rank = deriveRank(rows, p.toText());
+        })
+        .catch(() => {
+          rank = null;
+        });
+    } else {
+      myPointsStore.reset();
+      rank = null;
+    }
+  });
+
+  function retry() {
+    const p = $principal;
+    if (p) myPointsStore.load(p);
+  }
+
+  const body = $derived(
+    bodyState({
+      connected: $isConnected,
+      excluded: $myPointsStore.excluded,
+      state: $myPointsStore.state,
+    }),
+  );
+</script>
+
+<svelte:head><title>Points · Rumi</title></svelte:head>
+
+<div class="max-w-3xl mx-auto px-4 py-6 flex flex-col gap-4">
+  <h1 class="text-xl font-semibold text-gray-100">Airdrop Points</h1>
+
+  <SeasonBanner {status} {config} />
+
+  {#if $myPointsStore.loading}
+    <div class="flex justify-center py-12">
+      <div class="w-7 h-7 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
+    </div>
+  {:else if $myPointsStore.error}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 flex items-center justify-between gap-3">
+      <span class="text-sm text-gray-300">Couldn't load your points.</span>
+      <button class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-teal-400 hover:border-teal-500/40" onclick={retry}>
+        Retry
+      </button>
+    </div>
+  {:else if body === 'disconnected'}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      Connect your wallet to see your points. Points accrue automatically when you use the protocol.
+    </div>
+    <EarnCta />
+  {:else if body === 'excluded'}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      This address is excluded from the airdrop (protocol-owned).
+    </div>
+  {:else if body === 'enrolled' && $myPointsStore.state}
+    <PointsSummary state={$myPointsStore.state} {rank} />
+    <EarnCta heading="Earn more" />
+  {:else}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
+      You're not earning points yet. Take a qualifying action to enroll automatically.
+    </div>
+    <EarnCta />
+  {/if}
+</div>

--- a/src/vault_frontend/src/routes/points/leaderboard/+page.svelte
+++ b/src/vault_frontend/src/routes/points/leaderboard/+page.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { POINTS_ENABLED } from '$lib/config';
+  import { principal } from '$lib/stores/wallet';
+  import { getLeaderboard, getPointsConfig } from '$lib/services/pointsService';
+  import { formatPoints, hasNextPage } from '$lib/utils/points';
+  import { truncatePrincipal, copyToClipboard } from '$lib/utils/principalHelpers';
+  import { toastStore } from '$lib/stores/toast';
+  import type { LeaderboardEntry, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+  import DataTable from '$lib/components/explorer/DataTable.svelte';
+  import EmptyState from '$lib/components/explorer/EmptyState.svelte';
+
+  const PAGE = 50;
+  let rows = $state<LeaderboardEntry[]>([]);
+  let config = $state<PointsConfig | null>(null);
+  let offset = $state(0);
+  let loading = $state(true);
+  let error = $state(false);
+
+  const columns = [
+    { key: 'rank', label: 'Rank', align: 'left' as const, width: '15%' },
+    { key: 'principal', label: 'Address', align: 'left' as const },
+    { key: 'total_points', label: 'Points (USD-days)', align: 'right' as const },
+  ];
+
+  async function loadPage(o: number) {
+    loading = true;
+    error = false;
+    try {
+      const [page, cfg] = await Promise.all([
+        getLeaderboard(o, PAGE),
+        config ? Promise.resolve(config) : getPointsConfig(),
+      ]);
+      rows = page;
+      config = cfg;
+      offset = o;
+    } catch (e) {
+      console.error('[points] leaderboard load failed', e);
+      error = true;
+      toastStore.error('Could not load the leaderboard.');
+    } finally {
+      loading = false;
+    }
+  }
+  onMount(() => {
+    if (!POINTS_ENABLED) {
+      goto('/');
+      return;
+    }
+    loadPage(0);
+  });
+
+  async function copyAddress(text: string) {
+    if (await copyToClipboard(text)) toastStore.success('Address copied');
+  }
+
+  const myText = $derived($principal ? $principal.toText() : null);
+  const participants = $derived(config ? Number(config.registered_count) : null);
+  const canNext = $derived(!loading && hasNextPage(offset, rows.length, PAGE, participants));
+</script>
+
+<svelte:head><title>Leaderboard · Rumi Points</title></svelte:head>
+
+<div class="max-w-4xl mx-auto px-4 py-6 flex flex-col gap-4">
+  <div class="flex items-center justify-between">
+    <h1 class="text-xl font-semibold text-gray-100">Points Leaderboard</h1>
+    {#if participants !== null}
+      <span class="text-xs text-gray-400">{participants.toLocaleString()} participants</span>
+    {/if}
+  </div>
+
+  {#if error && rows.length === 0}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 flex items-center justify-between gap-3">
+      <span class="text-sm text-gray-300">Couldn't load the leaderboard.</span>
+      <button class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-teal-400 hover:border-teal-500/40" onclick={() => loadPage(offset)}>
+        Retry
+      </button>
+    </div>
+  {:else if !loading && offset === 0 && rows.length === 0}
+    <EmptyState title="No points yet" message="The leaderboard fills in once accrual begins." icon="chart" />
+  {:else}
+    <DataTable {columns} data={rows} {loading} rowKey={(r) => r.principal.toText()}>
+      {#snippet row(entry: LeaderboardEntry)}
+        <tr class="border-b border-gray-700/30 {myText && entry.principal.toText() === myText ? 'bg-teal-500/10' : ''}">
+          <td class="px-4 py-3 text-gray-300">#{entry.rank}</td>
+          <td class="px-4 py-3">
+            <span class="inline-flex items-center gap-2">
+              <a href={`/explorer/e/address/${entry.principal.toText()}`} class="text-teal-400 hover:underline font-mono text-xs">
+                {truncatePrincipal(entry.principal.toText())}
+              </a>
+              <button class="text-gray-500 hover:text-teal-400 text-xs" title="Copy address" aria-label="Copy address" onclick={() => copyAddress(entry.principal.toText())}>⧉</button>
+              {#if myText && entry.principal.toText() === myText}<span class="text-xs text-teal-400">you</span>{/if}
+            </span>
+          </td>
+          <td class="px-4 py-3 text-right text-gray-100">{formatPoints(entry.total_points)}</td>
+        </tr>
+      {/snippet}
+    </DataTable>
+
+    <div class="flex items-center justify-between">
+      <button
+        class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-gray-300 disabled:opacity-40"
+        disabled={offset === 0 || loading}
+        onclick={() => loadPage(Math.max(0, offset - PAGE))}
+      >Previous</button>
+      <span class="text-xs text-gray-500">Showing {rows.length === 0 ? 0 : offset + 1}–{offset + rows.length}</span>
+      <button
+        class="px-3 py-1.5 rounded-lg text-sm border border-gray-700/50 text-gray-300 disabled:opacity-40"
+        disabled={!canNext}
+        onclick={() => loadPage(offset + PAGE)}
+      >Next</button>
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
Public-facing UI for the airdrop points engine (`rumi_points`) in `vault_frontend`. **Read-only** — every call is a public `query`; no wallet signing, no on-chain writes, no claim flow (Phases 7-8).

Spec: `docs/superpowers/specs/2026-06-08-airdrop-phase6-frontend-design.md` · Plan: `docs/superpowers/plans/2026-06-08-airdrop-phase6-frontend.md`

## What it adds
- **`/points` (My Points):** season banner (pre / live / ended), and a body that switches on wallet state — disconnected, not-enrolled, enrolled (points + rank + earning breakdown), or excluded — plus an **Earn CTA** deep-linking to borrow / stability pool / liquidity. Registration is automatic (first qualifying action), so this surface is informational, not a write.
- **`/points/leaderboard`:** rank + truncated address (copy + explorer link) + points (USD-days), self-row highlight, bounded top-1000 rank lookup, paginated.
- **`pointsService.ts`** (anonymous, TTL-cached, mirrors `analyticsService`), **`pointsStore.ts`**, pure **`points.ts`** helpers (+ 20 unit tests), and three components (`SeasonBanner`, `EarnCta`, `PointsSummary`).
- **Gated on `POINTS_ENABLED`:** nav link hidden and routes redirect until `RUMI_POINTS` is set in `config.ts` at deploy. Ships dark, lights up at the trio deploy (see `src/rumi_points/DEPLOY_RUNBOOK.md`).

## Decisions locked (from brainstorm)
- Enrollment surface = status + earn CTA (auto-registration, no register endpoint).
- **Points + rank only** — `estimated_share_bps` is never rendered (fluctuating estimate; real allocation computed later from the frozen ledger).
- New top-level `Points` section.

## Quality pass (workflow-orchestrated + systematic-debugging)
Built via a parallel implementation workflow, then adversarially reviewed (spec / bugs / types) and debugged. Findings fixed: route gating now covers the route components (not just nav); error → toast + inline retry on both pages; leaderboard pagination can no longer strand on an empty trailing page (`hasNextPage` with known total, unit-tested); service cache distinguishes hit/miss so cached `null`/`false` aren't re-queried; candid-opt typing fix; address copy affordance.

## Verification
- `npm run check`: **0 errors in feature files** (the 32 reported errors all pre-exist on `main` in unrelated files — verified by baseline diff).
- `npm run test`: **20 new `points.test.ts` tests pass**; the only failure is the pre-existing `swapRouter.spec.ts` (fails on baseline too).
- `npm run build`: ⚠️ **fails on a PRE-EXISTING, unrelated issue** — `Rollup failed to resolve import "qrcode"` from `WalletConnector.svelte` (`qrcode` is not in `package.json`). **Proven pre-existing**: the baseline build (this branch with the feature stashed) fails identically. Not introduced here; flagged separately. My modules transform cleanly (bundler reaches 311 modules before the `qrcode` failure).

## Launch dependency
Section is hidden until `RUMI_POINTS` is filled in `config.ts` after the canister is reserved + deployed. Buildable/mergeable now; goes live at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)