### PR TITLE
fix(amm,3pool): outbound transfers pay amount-fee so reserves track real holdings

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -356,7 +356,9 @@ canisters:
   #
   # The dummy admin value below is the management canister (aaaaa-aa). The
   # wasm decodes this into an AmmInitArgs that post_upgrade never touches; the
-  # live admin (mi66c-...) is preserved by the stable-memory load path along
+  # live admin (fd7h3-mgmok-dmojz-awmxl-k7eqn-37mcv-jjkxp-parnt-ehngl-l2z3m-kae,
+  # i.e. the rumi_identity icp-cli identity; verified 2026-06-08 from the AMM
+  # admin event log) is preserved by the stable-memory load path along
   # with the pool registry, LP balances, swap event log, liquidity event log,
   # admin event log, and rewards accumulator state.
   #

--- a/src/declarations/rumi_amm/rumi_amm.did
+++ b/src/declarations/rumi_amm/rumi_amm.did
@@ -175,6 +175,11 @@ type AmmError = variant {
   MaintenanceMode;
   ClaimNotFound;
   PoolBusy;
+  DuplicateNonce;
+  NoLiquidity;
+  BelowMinClaim : record { claimable : nat; min : nat };
+  RewardLedgerTransferFailed : record { reason : text };
+  InsufficientOnChainBalance : record { expected : nat; actual : nat };
   InvalidInput : record { reason : text };
 };
 

--- a/src/declarations/rumi_amm/rumi_amm.did.d.ts
+++ b/src/declarations/rumi_amm/rumi_amm.did.d.ts
@@ -70,7 +70,12 @@ export type AmmError = {
   { 'InsufficientLiquidity' : null } |
   { 'MaintenanceMode' : null } |
   { 'TransferFailed' : { 'token' : string, 'reason' : string } } |
-  { 'ClaimNotFound' : null };
+  { 'ClaimNotFound' : null } |
+  { 'DuplicateNonce' : null } |
+  { 'NoLiquidity' : null } |
+  { 'BelowMinClaim' : { 'claimable' : bigint, 'min' : bigint } } |
+  { 'RewardLedgerTransferFailed' : { 'reason' : string } } |
+  { 'InsufficientOnChainBalance' : { 'expected' : bigint, 'actual' : bigint } };
 export interface AmmEventsByPrincipalQuery {
   'who' : Principal,
   'pool' : string,

--- a/src/declarations/rumi_amm/rumi_amm.did.js
+++ b/src/declarations/rumi_amm/rumi_amm.did.js
@@ -25,6 +25,14 @@ export const idlFactory = ({ IDL }) => {
     'MaintenanceMode' : IDL.Null,
     'TransferFailed' : IDL.Record({ 'token' : IDL.Text, 'reason' : IDL.Text }),
     'ClaimNotFound' : IDL.Null,
+    'DuplicateNonce' : IDL.Null,
+    'NoLiquidity' : IDL.Null,
+    'BelowMinClaim' : IDL.Record({ 'claimable' : IDL.Nat, 'min' : IDL.Nat }),
+    'RewardLedgerTransferFailed' : IDL.Record({ 'reason' : IDL.Text }),
+    'InsufficientOnChainBalance' : IDL.Record({
+      'expected' : IDL.Nat,
+      'actual' : IDL.Nat,
+    }),
   });
   const CurveType = IDL.Variant({ 'ConstantProduct' : IDL.Null });
   const CreatePoolArgs = IDL.Record({

--- a/src/rumi_3pool/src/lib.rs
+++ b/src/rumi_3pool/src/lib.rs
@@ -443,8 +443,11 @@ pub async fn swap(i: u8, j: u8, dx: u128, min_dy: u128) -> Result<u128, ThreePoo
     let output = outcome.output_native;
     let fee = outcome.fee_native;
 
-    // 6. Slippage check
-    if output < min_dy {
+    // 6. Slippage check against the NET amount the taker receives. The output
+    //    transfer pays `output - ledger_fee`, so check net so `min_dy` is a true
+    //    minimum received. Fee lookup is cached (the output transfer reuses it).
+    let net_output = output.saturating_sub(crate::transfers::ledger_fee(token_j_ledger).await);
+    if net_output < min_dy {
         return Err(ThreePoolError::SlippageExceeded);
     }
 
@@ -717,9 +720,19 @@ pub async fn remove_liquidity(
     // 3. Calculate withdrawal amounts
     let amounts = calc_remove_liquidity(lp_burn, &balances, lp_total_supply);
 
-    // 4. Check each amount >= min_amounts
+    // 4. Check each NET amount (after the per-leg ledger fee) >= min_amounts.
+    //    transfer_to_user pays `amount - ledger_fee`, so check net so min_amounts
+    //    are true minimums received. Fee lookups are cached (transfers reuse them).
+    let token_ledgers = read_state(|s| {
+        [
+            s.config.tokens[0].ledger_id,
+            s.config.tokens[1].ledger_id,
+            s.config.tokens[2].ledger_id,
+        ]
+    });
     for k in 0..3 {
-        if amounts[k] < min_arr[k] {
+        let net_k = amounts[k].saturating_sub(crate::transfers::ledger_fee(token_ledgers[k]).await);
+        if net_k < min_arr[k] {
             return Err(ThreePoolError::SlippageExceeded);
         }
     }
@@ -859,8 +872,11 @@ pub async fn remove_one_coin(
     let amount = roc_outcome.amount_native;
     let fee = roc_outcome.fee_native;
 
-    // 4. Slippage check
-    if amount < min_amount {
+    // 4. Slippage check against the NET amount the taker receives (the output
+    //    transfer pays `amount - ledger_fee`), so `min_amount` is a true minimum.
+    let out_ledger = read_state(|s| s.config.tokens[idx].ledger_id);
+    let net_amount = amount.saturating_sub(crate::transfers::ledger_fee(out_ledger).await);
+    if net_amount < min_amount {
         return Err(ThreePoolError::SlippageExceeded);
     }
 

--- a/src/rumi_3pool/src/transfers.rs
+++ b/src/rumi_3pool/src/transfers.rs
@@ -9,6 +9,36 @@ use candid::Principal;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
 use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// Standard ICRC-1 transfer fee (native units), used as a conservative fallback
+/// when a ledger's `icrc1_fee` query cannot be reached. Erring high keeps the
+/// pool solvent (we send slightly less) rather than risking an over-send.
+const DEFAULT_LEDGER_FEE: u128 = 10_000;
+
+thread_local! {
+    /// Per-ledger transfer-fee cache, populated lazily from `icrc1_fee` on the
+    /// first outbound transfer to a ledger. Heap-only (not persisted), so it is
+    /// simply re-warmed after an upgrade.
+    static LEDGER_FEES: RefCell<HashMap<Principal, u128>> = RefCell::new(HashMap::new());
+}
+
+/// Fetch a ledger's transfer fee, caching the result per ledger. On query
+/// failure, falls back to the standard ICRC-1 fee (the solvency-safe direction).
+pub async fn ledger_fee(ledger: Principal) -> u128 {
+    if let Some(fee) = LEDGER_FEES.with(|c| c.borrow().get(&ledger).copied()) {
+        return fee;
+    }
+    let result: Result<(candid::Nat,), _> =
+        ic_cdk::call(ledger, "icrc1_fee", ()).await;
+    let fee: u128 = match result {
+        Ok((f,)) => f.0.try_into().unwrap_or(DEFAULT_LEDGER_FEE),
+        Err(_) => DEFAULT_LEDGER_FEE,
+    };
+    LEDGER_FEES.with(|c| c.borrow_mut().insert(ledger, fee));
+    fee
+}
 
 /// Transfer tokens FROM a user TO this canister (requires prior ICRC-2 approval).
 pub async fn transfer_from_user(
@@ -53,18 +83,34 @@ pub async fn transfer_from_user(
 }
 
 /// Transfer tokens FROM this canister TO a user.
+///
+/// The ICRC-1 ledger debits `sent + fee` from this canister but credits the
+/// recipient only `sent`. Callers debit the pool balance by the full `amount`,
+/// so to keep tracked balances in step with the real on-chain holdings we send
+/// `amount - fee`: the canister balance then drops by exactly `amount` and the
+/// recipient (taker/withdrawer) bears the fee. This lets a 100% withdrawal drain
+/// cleanly instead of drifting balances above real holdings (one fee per
+/// transfer) and eventually failing the last withdrawal with InsufficientFunds.
 pub async fn transfer_to_user(
     ledger: Principal,
     to: Principal,
     amount: u128,
 ) -> Result<(), String> {
+    let fee = ledger_fee(ledger).await;
+    if amount <= fee {
+        // Nothing transferable once the ledger fee is covered. The caller has
+        // already debited `amount` from the pool balance, so leaving this dust
+        // keeps tracked balances <= real holdings (solvency-safe).
+        return Ok(());
+    }
+    let send = amount - fee;
     let args = TransferArg {
         from_subaccount: None,
         to: Account {
             owner: to,
             subaccount: None,
         },
-        amount: candid::Nat::from(amount),
+        amount: candid::Nat::from(send),
         fee: None,
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),

--- a/src/rumi_amm/rumi_amm.did
+++ b/src/rumi_amm/rumi_amm.did
@@ -175,6 +175,11 @@ type AmmError = variant {
   MaintenanceMode;
   ClaimNotFound;
   PoolBusy;
+  DuplicateNonce;
+  NoLiquidity;
+  BelowMinClaim : record { claimable : nat; min : nat };
+  RewardLedgerTransferFailed : record { reason : text };
+  InsufficientOnChainBalance : record { expected : nat; actual : nat };
   InvalidInput : record { reason : text };
 };
 

--- a/src/rumi_amm/src/lib.rs
+++ b/src/rumi_amm/src/lib.rs
@@ -868,15 +868,15 @@ async fn swap(
     let (amount_out, total_fee, protocol_fee) =
         compute_swap(reserve_in, reserve_out, amount_in, fee_bps, protocol_fee_bps)?;
 
-    // `min_amount_out` is the minimum GROSS pool output. Per the fee model in
-    // transfer_to_user, the taker receives `amount_out - ledger_fee` (the taker
-    // bears the flat ICRC-1 transfer fee, which the frontend accounts for when
-    // setting `min_amount_out`). The slippage check is about pool price, not the
-    // fixed ledger fee, so it is evaluated on the gross output.
-    if amount_out < min_amount_out {
+    // Enforce slippage against the NET amount the taker receives. transfer_to_user
+    // pays `amount_out - ledger_fee`, so checking the gross output could let the
+    // taker receive up to one ledger fee less than `min_amount_out`. The fee
+    // lookup is cached (the transfer below reuses it), so this adds no real cost.
+    let net_out = amount_out.saturating_sub(crate::transfers::ledger_fee(ledger_out).await);
+    if net_out < min_amount_out {
         return Err(AmmError::InsufficientOutput {
             expected_min: min_amount_out,
-            actual: amount_out,
+            actual: net_out,
         });
     }
 
@@ -1157,13 +1157,15 @@ async fn remove_liquidity(
 
     let (amount_a, amount_b) = compute_remove_liquidity(lp_shares, reserve_a, reserve_b, total_shares)?;
 
-    // `min_amount_a/b` are GROSS pool outputs; the withdrawer bears the flat
-    // ICRC-1 transfer fee on each leg (transfer_to_user pays `amount - fee`),
-    // which the frontend accounts for. Same rationale as the swap path.
-    if amount_a < min_amount_a || amount_b < min_amount_b {
+    // Enforce slippage against the NET amounts the withdrawer receives (each leg
+    // pays `amount - ledger_fee`), so min_amount_a/b are true minimums received.
+    // Fee lookups are cached (the transfers below reuse them).
+    let net_a = amount_a.saturating_sub(crate::transfers::ledger_fee(token_a).await);
+    let net_b = amount_b.saturating_sub(crate::transfers::ledger_fee(token_b).await);
+    if net_a < min_amount_a || net_b < min_amount_b {
         return Err(AmmError::InsufficientOutput {
             expected_min: min_amount_a.max(min_amount_b),
-            actual: amount_a.min(amount_b),
+            actual: net_a.min(net_b),
         });
     }
 

--- a/src/rumi_amm/src/lib.rs
+++ b/src/rumi_amm/src/lib.rs
@@ -868,6 +868,11 @@ async fn swap(
     let (amount_out, total_fee, protocol_fee) =
         compute_swap(reserve_in, reserve_out, amount_in, fee_bps, protocol_fee_bps)?;
 
+    // `min_amount_out` is the minimum GROSS pool output. Per the fee model in
+    // transfer_to_user, the taker receives `amount_out - ledger_fee` (the taker
+    // bears the flat ICRC-1 transfer fee, which the frontend accounts for when
+    // setting `min_amount_out`). The slippage check is about pool price, not the
+    // fixed ledger fee, so it is evaluated on the gross output.
     if amount_out < min_amount_out {
         return Err(AmmError::InsufficientOutput {
             expected_min: min_amount_out,
@@ -1152,6 +1157,9 @@ async fn remove_liquidity(
 
     let (amount_a, amount_b) = compute_remove_liquidity(lp_shares, reserve_a, reserve_b, total_shares)?;
 
+    // `min_amount_a/b` are GROSS pool outputs; the withdrawer bears the flat
+    // ICRC-1 transfer fee on each leg (transfer_to_user pays `amount - fee`),
+    // which the frontend accounts for. Same rationale as the swap path.
     if amount_a < min_amount_a || amount_b < min_amount_b {
         return Err(AmmError::InsufficientOutput {
             expected_min: min_amount_a.max(min_amount_b),

--- a/src/rumi_amm/src/transfers.rs
+++ b/src/rumi_amm/src/transfers.rs
@@ -5,6 +5,36 @@ use candid::Principal;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
 use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// Standard ICRC-1 transfer fee (e8s), used as a conservative fallback when a
+/// ledger's `icrc1_fee` query cannot be reached. Erring high keeps the pool
+/// solvent (we send slightly less) rather than risking an over-send.
+const DEFAULT_LEDGER_FEE_E8S: u128 = 10_000;
+
+thread_local! {
+    /// Per-ledger transfer-fee cache, populated lazily from `icrc1_fee` on the
+    /// first outbound transfer to a ledger. Heap-only (not persisted), so it is
+    /// simply re-warmed after an upgrade.
+    static LEDGER_FEES: RefCell<HashMap<Principal, u128>> = RefCell::new(HashMap::new());
+}
+
+/// Fetch a ledger's transfer fee, caching the result per ledger. On query
+/// failure, falls back to the standard ICRC-1 fee (the solvency-safe direction).
+pub async fn ledger_fee(ledger: Principal) -> u128 {
+    if let Some(fee) = LEDGER_FEES.with(|c| c.borrow().get(&ledger).copied()) {
+        return fee;
+    }
+    let result: Result<(candid::Nat,), _> =
+        ic_cdk::call(ledger, "icrc1_fee", ()).await;
+    let fee: u128 = match result {
+        Ok((f,)) => f.0.try_into().unwrap_or(DEFAULT_LEDGER_FEE_E8S),
+        Err(_) => DEFAULT_LEDGER_FEE_E8S,
+    };
+    LEDGER_FEES.with(|c| c.borrow_mut().insert(ledger, fee));
+    fee
+}
 
 /// Transfer tokens FROM a user TO a pool's subaccount (requires prior ICRC-2 approval).
 pub async fn transfer_from_user(
@@ -56,25 +86,36 @@ pub async fn transfer_from_user(
 
 /// Transfer tokens FROM a pool's subaccount TO a user.
 ///
-/// NOTE: The ICRC-1 ledger deducts its transfer fee from the `amount` sent,
-/// so the user receives `amount - ledger_fee`. The reserve bookkeeping in
-/// lib.rs uses the full `amount`, meaning the canister accumulates a small
-/// surplus (one ledger fee per outbound transfer). This surplus stays in the
-/// subaccount and accrues to the protocol — it's safe (protocol has MORE
-/// tokens than reserves track, not fewer).
+/// The ICRC-1 ledger debits `sent + fee` from the source subaccount but credits
+/// the recipient only `sent`. Callers debit their reserve by the full `amount`,
+/// so to keep the tracked reserve exactly in step with the on-chain subaccount
+/// balance we send `amount - fee`: the subaccount then drops by exactly `amount`
+/// and the recipient (taker/withdrawer) bears the fee, as is standard. This is
+/// what lets a 100% withdrawal drain cleanly instead of stranding the final
+/// ledger-fee's worth of tokens. (Historically this sent the full `amount`,
+/// which drifted reserves above the real balance by one fee per transfer and
+/// eventually broke the last withdrawal with InsufficientFunds.)
 pub async fn transfer_to_user(
     ledger: Principal,
     from_subaccount: [u8; 32],
     to: Principal,
     amount: u128,
 ) -> Result<u64, String> {
+    let fee = ledger_fee(ledger).await;
+    if amount <= fee {
+        // Nothing is transferable once the ledger fee is covered. The caller
+        // has already debited `amount` from its reserve, so leaving this dust
+        // in the subaccount keeps reserves <= the real balance (solvency-safe).
+        return Ok(0);
+    }
+    let send = amount - fee;
     let args = TransferArg {
         from_subaccount: Some(from_subaccount),
         to: Account {
             owner: to,
             subaccount: None,
         },
-        amount: candid::Nat::from(amount),
+        amount: candid::Nat::from(send),
         fee: None,
         memo: None,
         // Set created_at_time for ledger-side deduplication.

--- a/src/rumi_amm/tests/failure_injection_tests.rs
+++ b/src/rumi_amm/tests/failure_injection_tests.rs
@@ -822,3 +822,57 @@ fn full_withdrawal_succeeds_after_fee_drift() {
     assert!(pool_after.reserve_b <= floor,
         "reserve_b should drain to the locked minimum, got {}", pool_after.reserve_b);
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// Test: slippage (`min_amount_out`) is enforced against the NET amount the
+// taker actually receives (gross output minus the ledger fee), not the gross
+// pool output. Otherwise a taker could receive one ledger fee less than the
+// minimum they demanded.
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn swap_slippage_enforced_on_net_received() {
+    // Pool 1: observe a swap's gross output and confirm the taker receives it
+    // net of exactly one ledger fee.
+    let env = setup_flaky();
+    set_fee(&env, env.token_a_id, 10_000);
+    set_fee(&env, env.token_b_id, 10_000);
+    let pool_id = create_pool(&env);
+    add_initial_liquidity(&env, &pool_id, 100_000_00000000);
+    let pool = get_pool_info(&env, &pool_id).unwrap();
+    let swap_in: u128 = 1_000_00000000;
+
+    let bal_before = get_flaky_balance(&env, pool.token_b, env.user, None);
+    let swap_result = env.pic
+        .update_call(env.amm_id, env.user, "swap",
+            encode_args((pool_id.clone(), pool.token_a, swap_in, 0u128)).unwrap())
+        .expect("swap call failed");
+    let gross_out: u128 = {
+        let res: SwapResult = decode_ok(swap_result);
+        res.amount_out
+    };
+    let bal_after = get_flaky_balance(&env, pool.token_b, env.user, None);
+    assert_eq!(bal_after - bal_before, gross_out - 10_000,
+        "taker should receive the gross output minus exactly one ledger fee");
+
+    // Pool 2: identical reserves. Demanding min_amount_out == the gross output
+    // must be rejected, because the taker would actually receive gross - fee,
+    // below the requested minimum.
+    let env2 = setup_flaky();
+    set_fee(&env2, env2.token_a_id, 10_000);
+    set_fee(&env2, env2.token_b_id, 10_000);
+    let pool_id2 = create_pool(&env2);
+    add_initial_liquidity(&env2, &pool_id2, 100_000_00000000);
+    let pool2 = get_pool_info(&env2, &pool_id2).unwrap();
+
+    let result2 = env2.pic
+        .update_call(env2.amm_id, env2.user, "swap",
+            encode_args((pool_id2.clone(), pool2.token_a, swap_in, gross_out)).unwrap())
+        .expect("swap call failed");
+    let res2: Result<SwapResult, AmmError> = match result2 {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode swap result failed"),
+        WasmResult::Reject(msg) => panic!("swap rejected: {}", msg),
+    };
+    assert!(matches!(res2, Err(AmmError::InsufficientOutput { .. })),
+        "swap demanding min == gross output must reject (taker receives net < min), got {:?}", res2);
+}

--- a/src/rumi_amm/tests/failure_injection_tests.rs
+++ b/src/rumi_amm/tests/failure_injection_tests.rs
@@ -734,3 +734,91 @@ fn test_add_liquidity_real_ledger_unapproved_token_b() {
     assert_eq!(pool_before.reserve_a, pool_after.reserve_a, "reserve_a unchanged");
     assert_eq!(pool_before.reserve_b, pool_after.reserve_b, "reserve_b unchanged");
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// Test: fee-accounting drift — a 100% withdrawal after fee-charging activity
+// must still drain the pool cleanly.
+//
+// Reproduces the 2026-06-08 production incident: every outbound icrc1_transfer
+// costs `amount + fee` on the ledger, but the pool debited its reserves by only
+// `amount`. Over many transfers the tracked reserve drifts ABOVE the real
+// subaccount balance, so claiming the full reserve on a 100% withdrawal fails
+// with InsufficientFunds and strands the funds in a pending claim.
+// ════════════════════════════════════════════════════════════════════════
+
+fn set_fee(env: &FlakyTestEnv, ledger_id: Principal, fee: u128) {
+    env.pic
+        .update_call(ledger_id, Principal::anonymous(), "set_fee", encode_one(Nat::from(fee)).unwrap())
+        .expect("set_fee failed");
+}
+
+fn swap_exact(env: &FlakyTestEnv, pool_id: &str, token_in: Principal, amount_in: u128) {
+    let result = env.pic
+        .update_call(env.amm_id, env.user, "swap",
+            encode_args((pool_id.to_string(), token_in, amount_in, 0u128)).unwrap())
+        .expect("swap call failed");
+    let _: SwapResult = decode_ok(result);
+}
+
+fn pending_claims(env: &FlakyTestEnv) -> Vec<PendingClaim> {
+    let result = env.pic
+        .query_call(env.amm_id, Principal::anonymous(), "get_pending_claims", encode_one(()).unwrap())
+        .expect("get_pending_claims failed");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode pending claims failed"),
+        WasmResult::Reject(msg) => panic!("get_pending_claims rejected: {}", msg),
+    }
+}
+
+#[test]
+fn full_withdrawal_succeeds_after_fee_drift() {
+    let env = setup_flaky();
+    // Give both ledgers a real, nonzero transfer fee so each outbound transfer costs one fee.
+    set_fee(&env, env.token_a_id, 10_000);
+    set_fee(&env, env.token_b_id, 10_000);
+
+    let pool_id = create_pool(&env);
+    let liq: u128 = 100_000_00000000;
+    add_initial_liquidity(&env, &pool_id, liq);
+
+    // Generate drift: each swap pays out one token and leaks one ledger fee on the
+    // output side that the pool never debited from its reserves.
+    let pool = get_pool_info(&env, &pool_id).unwrap();
+    for _ in 0..5 {
+        swap_exact(&env, &pool_id, pool.token_a, 1_000_00000000);
+        swap_exact(&env, &pool_id, pool.token_b, 1_000_00000000);
+    }
+
+    // The sole LP withdraws 100%. This must succeed and drain the pool — the LP
+    // bears the unavoidable per-transfer ledger fee, nothing gets stranded.
+    let lp = get_user_lp_balance(&env, &pool_id);
+    let result = env.pic
+        .update_call(env.amm_id, env.user, "remove_liquidity",
+            encode_args((pool_id.clone(), lp, 0u128, 0u128)).unwrap())
+        .expect("remove_liquidity call failed");
+    let (amount_a, amount_b) = match result {
+        WasmResult::Reply(bytes) => {
+            let res: Result<(Nat, Nat), AmmError> =
+                decode_one(&bytes).expect("decode remove_liquidity failed");
+            res.expect("100% withdrawal must succeed after fee drift (was: InsufficientFunds)")
+        }
+        WasmResult::Reject(msg) => panic!("remove_liquidity rejected: {}", msg),
+    };
+
+    // The LP actually receives both tokens (net of one ledger fee each).
+    assert!(amount_a > Nat::from(0u64) && amount_b > Nat::from(0u64),
+        "LP must receive both tokens, got ({}, {})", amount_a, amount_b);
+
+    // No funds stranded in a pending claim — this is where the bug stranded them.
+    assert!(pending_claims(&env).is_empty(),
+        "100% withdrawal must not strand funds in a pending claim");
+
+    // Pool drained down to (at most) the permanently-locked minimum-liquidity
+    // floor (~1000 units), not the full reserve.
+    let pool_after = get_pool_info(&env, &pool_id).unwrap();
+    let floor = Nat::from(10_000u64);
+    assert!(pool_after.reserve_a <= floor,
+        "reserve_a should drain to the locked minimum, got {}", pool_after.reserve_a);
+    assert!(pool_after.reserve_b <= floor,
+        "reserve_b should drain to the locked minimum, got {}", pool_after.reserve_b);
+}

--- a/src/vault_frontend/src/lib/services/amm1ApyService.ts
+++ b/src/vault_frontend/src/lib/services/amm1ApyService.ts
@@ -197,6 +197,11 @@ const rewardsIdlFactory = ({ IDL }: { IDL: typeof import('@dfinity/candid').IDL 
     MaintenanceMode: IDL.Null,
     ClaimNotFound: IDL.Null,
     PoolBusy: IDL.Null,
+    DuplicateNonce: IDL.Null,
+    NoLiquidity: IDL.Null,
+    BelowMinClaim: IDL.Record({ claimable: IDL.Nat, min: IDL.Nat }),
+    RewardLedgerTransferFailed: IDL.Record({ reason: IDL.Text }),
+    InsufficientOnChainBalance: IDL.Record({ expected: IDL.Nat, actual: IDL.Nat }),
   });
   return IDL.Service({
     get_amm_reward_series: IDL.Func(
@@ -465,6 +470,14 @@ function formatClaimError(err: any): string {
     return 'AMM is in maintenance mode — claims are temporarily disabled';
   if ('PoolBusy' in err)
     return 'Pool is busy with another transaction. Please try again in a moment.';
+  if ('RewardLedgerTransferFailed' in err)
+    return `Reward transfer failed (your earnings are safe, please retry): ${err.RewardLedgerTransferFailed.reason}`;
+  if ('BelowMinClaim' in err)
+    return `Below the minimum claim amount (${Number(err.BelowMinClaim.min) / 1e8} icUSD).`;
+  if ('InsufficientOnChainBalance' in err)
+    return 'Reward account is being topped up — please retry shortly.';
+  if ('NoLiquidity' in err) return 'No liquidity in this pool.';
+  if ('DuplicateNonce' in err) return 'Duplicate request — already processed.';
   return 'Unknown AMM error';
 }
 


### PR DESCRIPTION
## Problem

Both AMM canisters (`rumi_amm`, `rumi_3pool`) had a fee-accounting bug: every outbound `icrc1_transfer` costs `amount + fee` on the ledger, but the pool debited its tracked reserves/balances by only `amount`. Over many transfers the tracked reserves drifted **above** real on-chain holdings by one ledger fee each. A 100% withdrawal then tried to pay the full tracked reserve and failed with `InsufficientFunds`, stranding the funds in a pending claim.

Production incident 2026-06-08: a 100% withdrawal from the live 3USD/ICP `rumi_amm` pool failed; 694.15 ICP was stranded in a pending claim and recovered out-of-band (top up the ~0.0023 ICP fee deficit, then `claim_pending`).

## Fix

`transfer_to_user` (the single outbound helper in each canister) now looks up the ledger fee — cached per ledger via `icrc1_fee`, heap-only so upgrade-safe — and sends `amount - fee`. The balance then drops by exactly `amount` and stays in step with reserves; the taker/withdrawer bears the fee (standard). A 100% withdrawal drains cleanly to the locked minimum-liquidity floor.

| Commit | What |
|---|---|
| `9ef65f0` | rumi_amm core fix + reproducing PocketIC test. Full suite green (74). |
| `6ccb564` | rumi_3pool same fix (centralized in its outbound helper). Full suite green (135). |
| `f7d3d0b` | Declare 5 new AmmError variants in .did + declarations + frontend IDL. Fixes `Cannot find field hash _4064741376_` (= `RewardLedgerTransferFailed`). |
| `d3d7570` | Correct stale `mi66c` admin comment (live admin is `fd7h3` = rumi_identity, verified from the event log). |
| `4fbc8b1` | **Net-check**: slippage now enforced against the *net* amount received in both canisters (swap / remove / remove_one_coin), so `min_*` are true minimums received. |

## Measured / decided this round

- **3pool drift measured → solvent.** Real holdings exceed obligations on all three tokens (+0.197 icUSD, +0.397 ckUSDT, +0.348 ckUSDC). No remediation needed. Note: mainnet is running the **pre-PR-228 3pool wasm** (no pending-claims yet), so this fix rides out with the next 3pool deploy.
- **Reward path intentionally unchanged.** `transfer_reward_icusd` keeps paying the claimant the full reward with the fee from the protocol-funded reward subaccount — the documented design (see `amm1_earnings_pro_rata`). Separate pot from reserves.

## Deploy notes (NOT deployed — gated on review + your authorization)

- No new persisted state in this PR → no AmmStateV migration / upgrade incompatibility from these changes.
- The next `rumi_3pool` deploy is a larger jump (this PR + the already-merged PR-228 pending-claims + AmmState work). Use the dummy `ThreePoolInitArgs` on upgrade (per deploy runbook).
- `ledger_fee` cache is heap-only → re-warmed lazily after each upgrade (first swap/remove per ledger pays one `icrc1_fee` query).
- Frontend declaration changes need a frontend redeploy to surface better error messages live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)