### PR TITLE
fix(vault_frontend): add missing qrcode dependency (unblocks production build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6211,6 +6211,7 @@
         "dexie": "^4.0.11",
         "dotenv": "^16.4.7",
         "lightweight-charts": "^5.1.0",
+        "qrcode": "^1.5.4",
         "vite-plugin-environment": "^1.1.3"
       },
       "devDependencies": {
@@ -6220,6 +6221,7 @@
         "@sveltejs/kit": "^2.19.0",
         "@sveltejs/package": "^2.3.7",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
+        "@types/qrcode": "^1.5.6",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.7.0",
         "eslint-config-prettier": "^9.1.0",

--- a/src/vault_frontend/package.json
+++ b/src/vault_frontend/package.json
@@ -29,6 +29,7 @@
 		"@sveltejs/kit": "^2.19.0",
 		"@sveltejs/package": "^2.3.7",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@types/qrcode": "^1.5.6",
 		"autoprefixer": "^10.4.20",
 		"eslint": "^9.7.0",
 		"eslint-config-prettier": "^9.1.0",
@@ -67,6 +68,7 @@
 		"dexie": "^4.0.11",
 		"dotenv": "^16.4.7",
 		"lightweight-charts": "^5.1.0",
+		"qrcode": "^1.5.4",
 		"vite-plugin-environment": "^1.1.3"
 	}
 }


### PR DESCRIPTION
## Problem

`npm run build` in `src/vault_frontend` fails on `main`, blocking every frontend asset deploy:

```
[vite]: Rollup failed to resolve import "qrcode" from
"src/vault_frontend/src/lib/components/wallet/WalletConnector.svelte"
```

Pre-existing on `main`, unrelated to the airdrop points work.

## Root cause

`WalletConnector.svelte` imports `qrcode` (line 17) and uses it in the wallet **Receive** view (`QRCode.toDataURL(...)`, line 437) to render the deposit-address QR code. This is a real, wanted feature, but `qrcode` was missing from `package.json` `dependencies`. The resolved `qrcode` entries were still pinned in `package-lock.json` from a prior install, so the `package.json` reference had simply been dropped at some point.

## Fix

- Re-add `qrcode@^1.5.4` to `dependencies`.
- Add `@types/qrcode@^1.5.6` to `devDependencies` (the import lives in a `lang="ts"` Svelte file).

No `@rollup/rollup-darwin-*` added. Two files changed: `src/vault_frontend/package.json` and the root `package-lock.json` (+4 lines total).

## Verification

- `cd src/vault_frontend && npm run build` → **exit 0**, adapter-static wrote `dist/`.
- `npm ls qrcode @types/qrcode` → clean, resolved for root and the `vault_frontend` workspace.
- The ~32 pre-existing `svelte-check` errors and the 1 failing `swapRouter.spec.ts` test are separate longstanding issues and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)