### PR TITLE
fix(amm): keep Oisy signer popup inside the click gesture window (add-liquidity + claim)

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
   import { walletStore } from '../../stores/wallet';
-  import { ammService, AMM_TOKENS, parseTokenAmount, formatTokenAmount } from '../../services/ammService';
+  import { ammService, AMM_TOKENS, tokenFee, parseTokenAmount, formatTokenAmount } from '../../services/ammService';
   import type { PoolInfo } from '../../services/ammService';
   import { CANISTER_IDS } from '../../config';
   import { ProtocolService } from '../../services/protocol';
@@ -105,6 +105,10 @@
   onMount(() => {
     loadPool();
     refreshAmm1();
+    // Warm the ICRC-1 fee cache so the add-liquidity click handler reads fees
+    // synchronously (Oisy gesture-safety — no live icrc1_fee await before the
+    // first signer consent screen).
+    for (const t of AMM_TOKENS) void tokenFee(t);
   });
 
   async function refreshAmm1() {
@@ -135,7 +139,7 @@
     claiming = true;
     claimMessage = '';
     try {
-      const result = await claimAmm1Rewards();
+      const result = await claimAmm1Rewards(pool?.pool_id);
       if ('claimed_e8s' in result) {
         claimMessage = `Claimed ${(Number(result.claimed_e8s) / 1e8).toFixed(4)} icUSD`;
         pendingE8s = 0n;

--- a/src/vault_frontend/src/lib/services/amm1ApyService.ts
+++ b/src/vault_frontend/src/lib/services/amm1ApyService.ts
@@ -417,14 +417,20 @@ export async function getPendingEarnings(principalText: string): Promise<bigint>
  * Uses the wallet's authenticated agent (Oisy ICRC-25 signer when Oisy
  * is connected, otherwise the standard PNP getActor path).
  */
-export async function claimAmm1Rewards(): Promise<
+export async function claimAmm1Rewards(
+  prefetchedPoolId?: string,
+): Promise<
   { claimed_e8s: bigint } | { error: string }
 > {
   try {
     const wallet = get(walletStore);
     if (!wallet.isConnected) return { error: 'Wallet not connected' };
 
-    const poolId = await getPoolId();
+    // Prefer the caller-supplied pool id (AmmLiquidityPanel already resolved it
+    // in loadPool, pre-click) so the Oisy claim flow never awaits getPoolId()'s
+    // get_pools() query inside the browser gesture window — that would block
+    // the signer popup. Falls back to the cached resolver otherwise.
+    const poolId = prefetchedPoolId ?? await getPoolId();
     const oisyDetected = isOisyWallet();
 
     if (oisyDetected && wallet.principal) {

--- a/src/vault_frontend/src/lib/services/ammService.ts
+++ b/src/vault_frontend/src/lib/services/ammService.ts
@@ -389,10 +389,13 @@ class AmmService {
 
     const oisyDetected = isOisyWallet();
 
-    // Pre-compute approval amounts so the batched signer flow doesn't need
-    // to await mid-batch.
-    const approveA = amountA > 0n ? await approvalAmount(amountA, tokenA) : 0n;
-    const approveB = amountB > 0n ? await approvalAmount(amountB, tokenB) : 0n;
+    // Pre-compute approval amounts from the WARM fee cache (synchronous). For
+    // Oisy, awaiting a live icrc1_fee() here would burn the browser
+    // user-gesture window before the first consent screen and trip the
+    // "Signer window should not be opened outside of click handler" guard.
+    // AmmLiquidityPanel warms the fee cache on mount.
+    const approveA = amountA > 0n ? amountA + tokenFeeCached(tokenA) : 0n;
+    const approveB = amountB > 0n ? amountB + tokenFeeCached(tokenB) : 0n;
 
     if (oisyDetected && wallet.principal) {
       console.log(`[Oisy] Sequential approve(s) + AMM add_liquidity via @icp-sdk/signer v5`);


### PR DESCRIPTION
## Problem

On the **Swap → Liquidity** panel (3USD/ICP AMM1 pool), clicking **Add Liquidity** with an Oisy wallet surfaced:

> Signer window should not be opened outside of click handler

Same class as the 3USD mint bug fixed in #233, but a different flow. The global signer pre-warm from #233 removed the cold-handshake, but this path has its own network `await`s in the click handler:
- `ammService.addLiquidity` did `await approvalAmount(amountA)` + `await approvalAmount(amountB)` — each a live `icrc1_fee()` query — before the first `icrc2_approve`, burning the transient-activation window.
- `claimAmm1Rewards` had the same shape via `await getPoolId()` (a `get_pools()` query).

## Fix (mirrors #233)

- **`ammService.addLiquidity`**: compute approvals with the existing synchronous `tokenFeeCached` (no live-fee await). Fees come from the warm cache.
- **`AmmLiquidityPanel.svelte`**: warm the AMM token fee cache on mount (`tokenFee` for each `AMM_TOKENS`), and pass `pool.pool_id` (already resolved pre-click in `loadPool`) into the claim.
- **`claimAmm1Rewards(prefetchedPoolId?)`**: use the caller-supplied pool id so the claim flow never awaits `getPoolId()` inside the gesture window; falls back to the cached resolver otherwise.

Result: the only `await` before the first signer consent screen is the (pre-warmed) `getOisySignerAgent` — same shape as the working Swap path. AMM swap was already safe (reached via the pre-warmed `SwapInterface`) and is untouched.

## Verification

- `vite build` passes.
- `svelte-check`: 0 errors in the 3 changed files (pre-existing repo errors are in untouched files).
- Unit tests: **98/98 pass**.

Frontend-only; depends on the global pre-warm already shipped in #233.

## Scope

This clears the AMM portion of the systemic audit. Still pending (separate follow-up): vault CDP ops (17 flows), stability-pool deposit, and manual liquidation (3 flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)