### PR TITLE
fix(backend): heal collateral_to_vault_ids stale ids + fix close_vault endpoint

### DIFF
--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -1433,6 +1433,13 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
                     vault.collateral_amount = vault.collateral_amount.saturating_sub(total_collateral_seized);
                     vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_share);
                 }
+                // Shared drain rule (see state::cleanup_if_drained): every
+                // runtime path that records PartialLiquidateVault removes the
+                // vault when the liquidation emptied it, so replay must apply
+                // the identical rule — otherwise replayed state keeps shell
+                // vaults and stale secondary-index ids that live state does
+                // not have.
+                state.cleanup_if_drained(vault_id);
                 // Track 3USD reserves from stability pool liquidations
                 if let Some(reserves_e8s) = three_usd_reserves_e8s {
                     state.protocol_3usd_reserves += reserves_e8s;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -659,14 +659,7 @@ fn post_upgrade(arg: ProtocolArg) {
             .map(|(id, _)| *id)
             .collect();
         for vault_id in &empty_vault_ids {
-            if let Some(vault) = s.vault_id_to_vaults.remove(vault_id) {
-                if let Some(ids) = s.principal_to_vault_ids.get_mut(&vault.owner) {
-                    ids.retain(|id| id != vault_id);
-                    if ids.is_empty() {
-                        s.principal_to_vault_ids.remove(&vault.owner);
-                    }
-                }
-            }
+            s.remove_vault_and_unindex(*vault_id);
         }
         if !empty_vault_ids.is_empty() {
             log!(INFO, "[upgrade]: cleaned up {} empty vaults: {:?}", empty_vault_ids.len(), empty_vault_ids);
@@ -691,6 +684,26 @@ fn post_upgrade(arg: ProtocolArg) {
         INFO,
         "[upgrade]: Wave-8b LIQ-002 migration rebuilt vault_cr_index for {} vault(s)",
         reindexed,
+    );
+
+    // Converge the remaining secondary vault indexes with the primary map.
+    // collateral_to_vault_ids accumulated stale ids in the persisted snapshot
+    // (mainnet 2026-06-11: 185 indexed ids vs 82 open vaults) because close
+    // paths never unindexed; the runtime fix stops new drift and this sweep
+    // heals what the snapshot still carries. Idempotent — a no-op once
+    // consistent.
+    let (stale_ids, missing_ids, empty_principals) = mutate_state(|s| {
+        let (stale, missing) = s.rebuild_collateral_index();
+        let empties = s.prune_empty_principal_entries();
+        (stale, missing, empties)
+    });
+    log!(
+        INFO,
+        "[upgrade]: vault-index sweep: dropped {} stale collateral-index id(s), \
+         re-added {} missing id(s), pruned {} empty principal entr(y/ies)",
+        stale_ids,
+        missing_ids,
+        empty_principals,
     );
 
     let end = ic_cdk::api::instruction_counter();
@@ -3781,10 +3794,13 @@ async fn bot_confirm_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
 
         s.bot_total_debt_covered_e8s += claim.debt_amount;
         s.bot_claims.remove(&vault_id);
-        // Wave-8b LIQ-002: bot-confirmed liquidation reduced debt+collateral
-        // → re-key the CR index entry. (No removal: bot path never drains to
-        // zero in a single confirm.)
-        s.reindex_vault_cr(vault_id);
+        // Shared drain rule (see state::cleanup_if_drained): a bot confirm
+        // normally only reduces debt+collateral (re-key the CR entry), but if
+        // the write-down emptied the vault it must be removed like every
+        // other PartialLiquidateVault path, or replay diverges.
+        if s.cleanup_if_drained(vault_id) {
+            log!(INFO, "[bot_confirm_liquidation] Vault #{} fully liquidated — removed", vault_id);
+        }
     });
 
     log!(INFO, "[bot_confirm_liquidation] Confirmed liquidation for vault #{}: debt={}, collateral={}",

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -2990,6 +2990,98 @@ impl State {
         }
     }
 
+    /// Single canonical vault-removal path: drops the vault from the primary
+    /// map AND every secondary index (per-principal, per-collateral,
+    /// sorted-troves CR), pruning empty per-principal sets.
+    ///
+    /// Every code path that deletes a vault MUST go through here. Bypassing
+    /// it is how `collateral_to_vault_ids` accumulated ~103 stale ids on
+    /// mainnet (measured 2026-06-11: 185 indexed vs 82 open vaults) — the
+    /// unindex helper existed but no close path called it.
+    ///
+    /// Tolerates missing secondary-index entries instead of trapping so a
+    /// historically inconsistent state heals on removal rather than bricking
+    /// event replay.
+    pub fn remove_vault_and_unindex(&mut self, vault_id: u64) -> Option<Vault> {
+        let vault = self.vault_id_to_vaults.remove(&vault_id)?;
+        if let Some(vault_ids) = self.principal_to_vault_ids.get_mut(&vault.owner) {
+            vault_ids.remove(&vault_id);
+            if vault_ids.is_empty() {
+                self.principal_to_vault_ids.remove(&vault.owner);
+            }
+        }
+        self.unindex_vault_by_collateral(&vault.collateral_type, vault_id);
+        self.unindex_vault_cr(vault_id);
+        Some(vault)
+    }
+
+    /// Shared drain rule for every partial-liquidation path: a vault left
+    /// with zero debt AND zero collateral is removed (primary map + all
+    /// secondary indexes) and `true` is returned; otherwise the vault's CR
+    /// index entry is re-keyed and `false` is returned.
+    ///
+    /// All five runtime recorders of `PartialLiquidateVault` and the event's
+    /// replay handler must call this same helper — if any path applies a
+    /// different rule, replayed state diverges from live state.
+    pub fn cleanup_if_drained(&mut self, vault_id: u64) -> bool {
+        let drained = self
+            .vault_id_to_vaults
+            .get(&vault_id)
+            .is_some_and(|v| v.borrowed_icusd_amount.0 == 0 && v.collateral_amount == 0);
+        if drained {
+            self.remove_vault_and_unindex(vault_id);
+        } else {
+            // Wave-8b LIQ-002: the partial deduction changed debt/collateral;
+            // re-key the CR index entry (self-cleaning if the vault is gone).
+            self.reindex_vault_cr(vault_id);
+        }
+        drained
+    }
+
+    /// Converge `collateral_to_vault_ids` to exactly the vaults present in
+    /// `vault_id_to_vaults`. Returns `(stale_removed, missing_added)`.
+    ///
+    /// Idempotent, O(N log N) over open vaults. Run by post_upgrade so an
+    /// index that drifted in the persisted snapshot (mainnet 2026-06-11:
+    /// ~103 stale ids from close paths that never unindexed) heals on the
+    /// next deploy without a reinstall.
+    pub fn rebuild_collateral_index(&mut self) -> (usize, usize) {
+        let mut fresh: BTreeMap<CollateralType, BTreeSet<u64>> = BTreeMap::new();
+        for (id, vault) in &self.vault_id_to_vaults {
+            fresh.entry(vault.collateral_type).or_default().insert(*id);
+        }
+
+        let in_index = |index: &BTreeMap<CollateralType, BTreeSet<u64>>,
+                        ct: &CollateralType,
+                        id: &u64| index.get(ct).is_some_and(|ids| ids.contains(id));
+        let stale_removed = self
+            .collateral_to_vault_ids
+            .iter()
+            .flat_map(|(ct, ids)| ids.iter().map(move |id| (ct, id)))
+            .filter(|(ct, id)| !in_index(&fresh, ct, id))
+            .count();
+        let missing_added = fresh
+            .iter()
+            .flat_map(|(ct, ids)| ids.iter().map(move |id| (ct, id)))
+            .filter(|(ct, id)| !in_index(&self.collateral_to_vault_ids, ct, id))
+            .count();
+
+        self.collateral_to_vault_ids = fresh;
+        (stale_removed, missing_added)
+    }
+
+    /// Drop per-principal vault-id sets that are empty. Returns how many
+    /// entries were pruned.
+    ///
+    /// Close paths now prune the owner's entry when their last vault goes,
+    /// but snapshots taken before that change still carry empty sets; this
+    /// converges them so live state matches what event replay produces.
+    pub fn prune_empty_principal_entries(&mut self) -> usize {
+        let before = self.principal_to_vault_ids.len();
+        self.principal_to_vault_ids.retain(|_, ids| !ids.is_empty());
+        before - self.principal_to_vault_ids.len()
+    }
+
     // ---- Wave-8b LIQ-002: sorted-troves CR index ---------------------------
 
     /// Convert a CR ratio into the integer key used by `vault_cr_index`.
@@ -3362,17 +3454,25 @@ impl State {
     pub fn open_vault(&mut self, vault: Vault) {
         let vault_id = vault.vault_id;
         let collateral_type = vault.collateral_type;
-        // If this vault_id already exists with a different owner (e.g. duplicate
-        // OpenVault events in the log), remove the stale index entry so
-        // principal_to_vault_ids stays consistent with vault_id_to_vaults.
-        if let Some(old_vault) = self.vault_id_to_vaults.get(&vault_id) {
-            if old_vault.owner != vault.owner {
-                if let Some(old_ids) = self.principal_to_vault_ids.get_mut(&old_vault.owner) {
+        // If this vault_id already exists with a different owner or collateral
+        // type (e.g. duplicate OpenVault events in the log), remove the stale
+        // index entries so the secondary indexes stay consistent with
+        // vault_id_to_vaults.
+        if let Some((old_owner, old_ct)) = self
+            .vault_id_to_vaults
+            .get(&vault_id)
+            .map(|v| (v.owner, v.collateral_type))
+        {
+            if old_owner != vault.owner {
+                if let Some(old_ids) = self.principal_to_vault_ids.get_mut(&old_owner) {
                     old_ids.remove(&vault_id);
                     if old_ids.is_empty() {
-                        self.principal_to_vault_ids.remove(&old_vault.owner);
+                        self.principal_to_vault_ids.remove(&old_owner);
                     }
                 }
+            }
+            if old_ct != collateral_type {
+                self.unindex_vault_by_collateral(&old_ct, vault_id);
             }
         }
         self.vault_id_to_vaults.insert(vault_id, vault.clone());
@@ -3393,22 +3493,13 @@ impl State {
     }
 
     pub fn close_vault(&mut self, vault_id: u64) {
-        if let Some(vault) = self.vault_id_to_vaults.remove(&vault_id) {
-            let owner = vault.owner;
-            // NOTE: We intentionally do NOT create a pending_margin_transfer here.
-            // CloseVault requires collateral=0, and WithdrawAndCloseVault already
-            // transferred collateral directly before calling this. Inserting a
-            // pending entry would be phantom — never cleared by a MarginTransfer event.
-            // Legitimate pending transfers (liquidator rewards) are created directly
-            // by the liquidation code in vault.rs.
-            if let Some(vault_ids) = self.principal_to_vault_ids.get_mut(&owner) {
-                vault_ids.remove(&vault_id);
-            } else {
-                ic_cdk::trap("BUG: tried to close vault with no owner");
-            }
-            // Wave-8b LIQ-002: drop from the sorted-troves CR index.
-            self.unindex_vault_cr(vault_id);
-        } else {
+        // NOTE: We intentionally do NOT create a pending_margin_transfer here.
+        // CloseVault requires collateral=0, and WithdrawAndCloseVault already
+        // transferred collateral directly before calling this. Inserting a
+        // pending entry would be phantom — never cleared by a MarginTransfer event.
+        // Legitimate pending transfers (liquidator rewards) are created directly
+        // by the liquidation code in vault.rs.
+        if self.remove_vault_and_unindex(vault_id).is_none() {
             ic_cdk::trap("BUG: tried to close unknown vault");
         }
     }
@@ -3868,14 +3959,7 @@ impl State {
             // Full liquidation — removes vault entirely
             // All remaining accrued_interest is interest revenue
             let interest_share = vault.accrued_interest;
-            if let Some(vault) = self.vault_id_to_vaults.remove(&vault_id) {
-                if let Some(vault_ids) = self.principal_to_vault_ids.get_mut(&vault.owner) {
-                    vault_ids.remove(&vault_id);
-                }
-            }
-            // Wave-8b LIQ-002: full liquidation removes the vault entirely;
-            // drop its index entry too.
-            self.unindex_vault_cr(vault_id);
+            self.remove_vault_and_unindex(vault_id);
             interest_share
         }
     }
@@ -3897,20 +3981,13 @@ impl State {
                 Vacant(_) => panic!("bug: vault not found"),
             }
         }
-        if let Some(vault) = self.vault_id_to_vaults.remove(&vault_id) {
-            let owner = vault.owner;
-            if let Some(vault_ids) = self.principal_to_vault_ids.get_mut(&owner) {
-                vault_ids.remove(&vault_id);
-            }
-        }
-        // Wave-8b LIQ-002: re-key every vault that received a share, then drop
-        // the source vault from the index. `redistribute_vault` is currently
-        // only reachable from event replay (no #[update] wires it), but the
-        // index contract holds for any caller.
+        self.remove_vault_and_unindex(vault_id);
+        // Wave-8b LIQ-002: re-key every vault that received a share.
+        // `redistribute_vault` is currently only reachable from event replay
+        // (no #[update] wires it), but the index contract holds for any caller.
         for tid in touched_ids {
             self.reindex_vault_cr(tid);
         }
-        self.unindex_vault_cr(vault_id);
     }
     
     /// Water-filling redemption: spread redemptions across vaults to equalize CR.
@@ -4259,6 +4336,11 @@ impl State {
             "principal_to_vault_ids does not match"
         );
         ensure_eq!(
+            self.collateral_to_vault_ids,
+            other.collateral_to_vault_ids,
+            "collateral_to_vault_ids does not match"
+        );
+        ensure_eq!(
             self.xrc_principal,
             other.xrc_principal,
             "xrc_principal does not match"
@@ -4307,6 +4389,39 @@ impl State {
             for vault_id in vault_ids {
                 if self.vault_id_to_vaults.get(vault_id).is_none() {
                     panic!("Not all vault ids are in the id -> Vault map.")
+                }
+            }
+        }
+
+        // The collateral index must mirror vault_id_to_vaults exactly. Stale
+        // ids inflate per-collateral vault counts and cost every index
+        // consumer dead lookups (mainnet 2026-06-11: 185 indexed ids vs 82
+        // open vaults). Size equality plus every-entry-valid implies each
+        // open vault is indexed exactly once under its own collateral type.
+        let indexed_total: usize = self
+            .collateral_to_vault_ids
+            .values()
+            .map(|ids| ids.len())
+            .sum();
+        ensure_eq!(
+            indexed_total,
+            self.vault_id_to_vaults.len(),
+            "collateral_to_vault_ids size does not match open vault count"
+        );
+        for (ct, ids) in &self.collateral_to_vault_ids {
+            for vault_id in ids {
+                match self.vault_id_to_vaults.get(vault_id) {
+                    Some(vault) => ensure_eq!(
+                        vault.collateral_type,
+                        *ct,
+                        "vault {} is indexed under the wrong collateral type",
+                        vault_id
+                    ),
+                    None => ensure!(
+                        false,
+                        "stale vault id {} in collateral_to_vault_ids",
+                        vault_id
+                    ),
                 }
             }
         }

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -1822,27 +1822,14 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
     mutate_state(|s| {
         // Make sure vault exists before attempting to remove
         if s.vault_id_to_vaults.contains_key(&vault_id) {
-            // Remove from vault_id_to_vaults map
-            s.vault_id_to_vaults.remove(&vault_id);
-
-            // Wave-8b LIQ-002: drop from the sorted-troves CR index. The
-            // dedicated `state::close_vault` already does this; this path
-            // does the removal inline (without going through `close_vault`)
-            // to skip the trap branches, so we mirror the unindex here.
-            s.unindex_vault_cr(vault_id);
-
-            // Remove from principal_to_vault_ids map
-            if let Some(vault_ids) = s.principal_to_vault_ids.get_mut(&vault.owner) {
-                vault_ids.remove(&vault_id);
-                // If this was the user's last vault, remove the principal entry
-                if vault_ids.is_empty() {
-                    s.principal_to_vault_ids.remove(&vault.owner);
-                }
-            }
-
-            // Record the close vault event
+            // The vault must still exist when record_close_vault runs:
+            // state::close_vault inside it performs the removal (primary map
+            // + every secondary index) and traps on an unknown vault. An
+            // earlier version removed the vault inline here first, so the
+            // recorder's close always hit that trap and rolled the whole
+            // call back — the endpoint could never succeed.
             crate::event::record_close_vault(s, vault_id, None);
-            
+
             // Complete the close request
             s.complete_close_vault_request();
             
@@ -2674,29 +2661,10 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
             },
         );
 
-        // Clean up fully liquidated vaults (zero debt and zero collateral)
-        let mut removed = false;
-        if let Some(vault) = s.vault_id_to_vaults.get(&vault_id) {
-            if vault.borrowed_icusd_amount.0 == 0 && vault.collateral_amount == 0 {
-                let owner = vault.owner;
-                s.vault_id_to_vaults.remove(&vault_id);
-                if let Some(ids) = s.principal_to_vault_ids.get_mut(&owner) {
-                    ids.retain(|id| *id != vault_id);
-                    if ids.is_empty() {
-                        s.principal_to_vault_ids.remove(&owner);
-                    }
-                }
-                log!(INFO, "[liquidate_vault_partial] Vault #{} fully liquidated — removed", vault_id);
-                removed = true;
-            }
-        }
-
-        // Wave-8b LIQ-002: re-key after the partial deduction, or unindex if
-        // the vault was drained to zero and removed above.
-        if removed {
-            s.unindex_vault_cr(vault_id);
-        } else {
-            s.reindex_vault_cr(vault_id);
+        // Shared drain rule (see state::cleanup_if_drained): remove the vault
+        // if this liquidation emptied it, else re-key its CR index entry.
+        if s.cleanup_if_drained(vault_id) {
+            log!(INFO, "[liquidate_vault_partial] Vault #{} fully liquidated — removed", vault_id);
         }
 
         log!(INFO, "[liquidate_vault_partial] Partial liquidation completed, {} pending transfers created", 1);
@@ -2989,12 +2957,11 @@ pub async fn liquidate_vault_partial_with_stable(
             },
         );
 
-        // Wave-8b LIQ-002: re-key the index entry after the partial deduction.
-        // (`liquidate_vault_partial_with_stable` does not currently include
-        // the zero-debt-zero-collateral cleanup branch its sibling has, so a
-        // simple reindex is sufficient. If a future cleanup branch is added
-        // here, mirror the unindex path from `liquidate_vault_partial`.)
-        s.reindex_vault_cr(vault_id);
+        // Shared drain rule (see state::cleanup_if_drained): remove the vault
+        // if this liquidation emptied it, else re-key its CR index entry.
+        if s.cleanup_if_drained(vault_id) {
+            log!(INFO, "[liquidate_vault_stable] Vault #{} fully liquidated — removed", vault_id);
+        }
 
         log!(INFO, "[liquidate_vault_stable] Partial liquidation completed, pending transfer created");
         interest_share
@@ -3404,32 +3371,13 @@ pub async fn liquidate_vault_debt_already_burned(
             },
         );
 
-        // Clean up fully liquidated vaults (zero debt and zero collateral)
-        let mut removed = false;
-        if let Some(vault) = s.vault_id_to_vaults.get(&vault_id) {
-            if vault.borrowed_icusd_amount.0 == 0 && vault.collateral_amount == 0 {
-                let owner = vault.owner;
-                s.vault_id_to_vaults.remove(&vault_id);
-                if let Some(ids) = s.principal_to_vault_ids.get_mut(&owner) {
-                    ids.retain(|id| *id != vault_id);
-                    if ids.is_empty() {
-                        s.principal_to_vault_ids.remove(&owner);
-                    }
-                }
-                log!(INFO, "[liquidate_vault_debt_burned] Vault #{} fully liquidated — removed", vault_id);
-                removed = true;
-            }
-        }
-
-        // Wave-8b LIQ-002: re-key after partial deduction, or unindex if
-        // drained. The band gate that originally consumed this index was
-        // deactivated 2026-05-18, but `check_vaults`' at-risk-band sharding
-        // (Wave-9c DOS-005) still relies on accurate CR keys, so the index
-        // must stay current.
-        if removed {
-            s.unindex_vault_cr(vault_id);
-        } else {
-            s.reindex_vault_cr(vault_id);
+        // Shared drain rule (see state::cleanup_if_drained): remove the vault
+        // if this liquidation emptied it, else re-key its CR index entry.
+        // The band gate that originally consumed the CR index was deactivated
+        // 2026-05-18, but `check_vaults`' at-risk-band sharding (Wave-9c
+        // DOS-005) still relies on accurate CR keys.
+        if s.cleanup_if_drained(vault_id) {
+            log!(INFO, "[liquidate_vault_debt_burned] Vault #{} fully liquidated — removed", vault_id);
         }
 
         interest_share
@@ -4231,10 +4179,11 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
             },
         );
 
-        // Wave-8b LIQ-002: re-key after the partial deduction. This endpoint
-        // doesn't include a zero-debt-zero-collateral cleanup branch (unlike
-        // `liquidate_vault_partial`), so a simple reindex is correct.
-        s.reindex_vault_cr(arg.vault_id);
+        // Shared drain rule (see state::cleanup_if_drained): remove the vault
+        // if this liquidation emptied it, else re-key its CR index entry.
+        if s.cleanup_if_drained(arg.vault_id) {
+            log!(INFO, "[partial_liquidate_vault] Vault #{} fully liquidated — removed", arg.vault_id);
+        }
 
         log!(INFO, "[partial_liquidate_vault] Protocol state updated, pending transfer created");
         interest_share

--- a/src/rumi_protocol_backend/tests/collateral_index_consistency.rs
+++ b/src/rumi_protocol_backend/tests/collateral_index_consistency.rs
@@ -1,0 +1,544 @@
+//! Regression fence: `collateral_to_vault_ids` must shrink when vaults close.
+//!
+//! Measured on mainnet 2026-06-11: summing `ids.len()` across
+//! `get_collateral_totals()` gave ~185 indexed ids while `get_vault_count()`
+//! returned 82 open vaults. Root cause: `unindex_vault_by_collateral` existed
+//! (state.rs) but had zero callers — every vault-removal path leaked its id:
+//!
+//!   * `State::close_vault` (runtime withdraw_and_close / repay_and_close +
+//!     replay of CloseVault / WithdrawAndCloseVault / VaultWithdrawnAndClosed)
+//!   * `State::liquidate_vault` full-liquidation branch (runtime + replay)
+//!   * `State::redistribute_vault` (replay)
+//!   * vault.rs partial-liquidation drain cleanups (runtime only)
+//!   * main.rs post_upgrade empty-vault cleanup
+//!
+//! Impact was display-only (consumers `filter_map` over the primary map, so
+//! stale ids were skipped in sums) but `get_collateral_totals().vault_count`,
+//! the dashboard, and `get_protocol_status` reported inflated counts, and
+//! every index consumer paid O(stale) wasted lookups.
+//!
+//! Layers in this file:
+//!  1. State-level: each close path un-indexes, both for the collateral index
+//!     and the principal index (empty per-owner sets must be pruned so replay
+//!     and runtime converge on identical maps).
+//!  2. Replay-level: replaying a log that opens and closes vaults yields an
+//!     index identical to the one live operation produces, including the
+//!     drain-to-zero partial-liquidation removal that previously only
+//!     happened at runtime.
+//!  3. Healing: `rebuild_collateral_index` converges a corrupted index back
+//!     to the primary map (run by post_upgrade so mainnet heals on deploy).
+
+use candid::Principal;
+
+use rumi_protocol_backend::event::{replay, Event};
+use rumi_protocol_backend::numeric::{ICUSD, ICP, UsdIcp};
+use rumi_protocol_backend::state::{Mode, State};
+use rumi_protocol_backend::vault::Vault;
+use rumi_protocol_backend::InitArg;
+use rust_decimal_macros::dec;
+
+fn icp_ledger() -> Principal {
+    Principal::from_slice(&[10])
+}
+
+fn init_arg() -> InitArg {
+    InitArg {
+        xrc_principal: Principal::anonymous(),
+        icusd_ledger_principal: Principal::anonymous(),
+        icp_ledger_principal: icp_ledger(),
+        fee_e8s: 0,
+        developer_principal: Principal::anonymous(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    }
+}
+
+fn fresh_state_with_price(price: f64) -> State {
+    let mut state = State::from(init_arg());
+    let icp = state.icp_collateral_type();
+    if let Some(config) = state.collateral_configs.get_mut(&icp) {
+        config.last_price = Some(price);
+    }
+    state
+}
+
+fn owner() -> Principal {
+    Principal::from_slice(&[42])
+}
+
+fn make_vault(vault_id: u64, collateral_e8s: u64, borrowed_icusd_e8s: u64) -> Vault {
+    Vault {
+        owner: owner(),
+        vault_id,
+        collateral_amount: collateral_e8s,
+        borrowed_icusd_amount: ICUSD::new(borrowed_icusd_e8s),
+        collateral_type: icp_ledger(),
+        last_accrual_time: 0,
+        accrued_interest: ICUSD::new(0),
+        bot_processing: false,
+    }
+}
+
+/// Ids indexed under a collateral type (empty if the entry was pruned).
+fn indexed_ids(state: &State, ct: &Principal) -> Vec<u64> {
+    state
+        .collateral_to_vault_ids
+        .get(ct)
+        .map(|ids| ids.iter().copied().collect())
+        .unwrap_or_default()
+}
+
+/// The exact two-direction consistency contract between the collateral index
+/// and the primary vault map.
+fn assert_index_matches_vaults(state: &State, context: &str) {
+    let indexed_total: usize = state
+        .collateral_to_vault_ids
+        .values()
+        .map(|ids| ids.len())
+        .sum();
+    assert_eq!(
+        indexed_total,
+        state.vault_id_to_vaults.len(),
+        "{context}: indexed id count must equal open vault count",
+    );
+    for (ct, ids) in &state.collateral_to_vault_ids {
+        for id in ids {
+            let vault = state
+                .vault_id_to_vaults
+                .get(id)
+                .unwrap_or_else(|| panic!("{context}: indexed id {id} has no vault"));
+            assert_eq!(
+                &vault.collateral_type, ct,
+                "{context}: vault {id} indexed under wrong collateral type",
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Layer 1 — state-level close paths
+// ============================================================================
+
+#[test]
+fn close_vault_removes_id_from_collateral_index() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    state.open_vault(make_vault(1, 0, 0));
+    state.open_vault(make_vault(2, 0, 0));
+    assert_eq!(indexed_ids(&state, &icp), vec![1, 2]);
+
+    state.close_vault(1);
+    assert_eq!(
+        indexed_ids(&state, &icp),
+        vec![2],
+        "closing vault 1 must drop it from collateral_to_vault_ids",
+    );
+
+    state.close_vault(2);
+    assert!(
+        indexed_ids(&state, &icp).is_empty(),
+        "closing the last vault must leave no indexed ids",
+    );
+    assert_index_matches_vaults(&state, "after closing all vaults");
+}
+
+#[test]
+fn close_vault_prunes_empty_principal_entry() {
+    let mut state = fresh_state_with_price(5.0);
+    state.open_vault(make_vault(1, 0, 0));
+    state.close_vault(1);
+    assert!(
+        state.principal_to_vault_ids.get(&owner()).is_none(),
+        "closing the owner's last vault must prune the empty principal entry \
+         (the runtime close path prunes it; replay must match)",
+    );
+}
+
+#[test]
+fn full_liquidation_removes_id_from_collateral_index() {
+    // GeneralAvailability mode always takes the full-liquidation branch,
+    // which removes the vault from the primary map entirely.
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    // 1 ICP collateral @ $5 vs 10 icUSD debt → deeply underwater.
+    state.open_vault(make_vault(1, 100_000_000, 1_000_000_000));
+    state.open_vault(make_vault(2, 10_000_000_000, 1_000_000_000));
+
+    let price = UsdIcp::from(dec!(5.0));
+    state.liquidate_vault(1, Mode::GeneralAvailability, price);
+
+    assert!(
+        !state.vault_id_to_vaults.contains_key(&1),
+        "sanity: full liquidation removes the vault",
+    );
+    assert_eq!(
+        indexed_ids(&state, &icp),
+        vec![2],
+        "full liquidation must drop the vault from collateral_to_vault_ids",
+    );
+    assert_index_matches_vaults(&state, "after full liquidation");
+}
+
+#[test]
+fn full_liquidation_prunes_empty_principal_entry() {
+    let mut state = fresh_state_with_price(5.0);
+    state.open_vault(make_vault(1, 100_000_000, 1_000_000_000));
+
+    let price = UsdIcp::from(dec!(5.0));
+    state.liquidate_vault(1, Mode::GeneralAvailability, price);
+
+    assert!(
+        state.principal_to_vault_ids.get(&owner()).is_none(),
+        "full liquidation of the owner's last vault must prune the empty principal entry",
+    );
+}
+
+#[test]
+fn redistribute_vault_removes_id_from_collateral_index() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    state.open_vault(make_vault(1, 100_000_000, 1_000_000_000));
+    state.open_vault(make_vault(2, 10_000_000_000, 1_000_000_000));
+
+    state.redistribute_vault(1);
+
+    assert!(
+        !state.vault_id_to_vaults.contains_key(&1),
+        "sanity: redistribution removes the source vault",
+    );
+    assert_eq!(
+        indexed_ids(&state, &icp),
+        vec![2],
+        "redistribution must drop the source vault from collateral_to_vault_ids",
+    );
+    assert_index_matches_vaults(&state, "after redistribution");
+}
+
+#[test]
+fn open_vault_duplicate_id_with_new_collateral_type_reindexes() {
+    // Defensive: a duplicate OpenVault event for an existing id must not leave
+    // the id indexed under the old collateral type.
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    let other_ct = Principal::from_slice(&[77]);
+
+    state.open_vault(make_vault(1, 0, 0));
+    assert_eq!(indexed_ids(&state, &icp), vec![1]);
+
+    let mut moved = make_vault(1, 0, 0);
+    moved.collateral_type = other_ct;
+    state.open_vault(moved);
+
+    assert!(
+        indexed_ids(&state, &icp).is_empty(),
+        "re-opening vault 1 under a new collateral type must unindex the old type",
+    );
+    assert_eq!(indexed_ids(&state, &other_ct), vec![1]);
+    assert_index_matches_vaults(&state, "after duplicate open with new type");
+}
+
+// ============================================================================
+// Layer 2 — replay-exactness
+// ============================================================================
+
+#[test]
+fn replay_close_vault_keeps_collateral_index_exact() {
+    let events = vec![
+        Event::Init(init_arg()),
+        Event::OpenVault {
+            vault: make_vault(1, 0, 0),
+            block_index: 1,
+            timestamp: None,
+        },
+        Event::OpenVault {
+            vault: make_vault(2, 0, 0),
+            block_index: 2,
+            timestamp: None,
+        },
+        Event::CloseVault {
+            vault_id: 1,
+            block_index: None,
+            timestamp: None,
+        },
+    ];
+
+    let state = replay(events.into_iter()).expect("replay must succeed");
+
+    assert_eq!(
+        indexed_ids(&state, &state.icp_collateral_type()),
+        vec![2],
+        "replayed CloseVault must unindex exactly like the live path",
+    );
+    assert_index_matches_vaults(&state, "after replayed close");
+}
+
+#[test]
+fn replay_partial_liquidation_drain_removes_vault_and_index() {
+    // Runtime behavior (vault.rs liquidate_vault_partial / _debt_burned):
+    // a partial liquidation that drains the vault to zero debt AND zero
+    // collateral removes the vault and prunes the owner's entry. Replay must
+    // mirror that rule or replayed state diverges from live state (shell
+    // vaults + stale index ids — exactly what post_upgrade's one-time
+    // empty-vault cleanup had to patch over on mainnet).
+    let events = vec![
+        Event::Init(init_arg()),
+        Event::OpenVault {
+            vault: make_vault(1, 100_000_000, 50_000_000),
+            block_index: 1,
+            timestamp: None,
+        },
+        Event::PartialLiquidateVault {
+            vault_id: 1,
+            liquidator_payment: ICUSD::new(50_000_000),
+            icp_to_liquidator: ICP::new(100_000_000),
+            liquidator: None,
+            icp_rate: Some(UsdIcp::from(dec!(5.0))),
+            protocol_fee_collateral: None,
+            timestamp: None,
+            three_usd_reserves_e8s: None,
+        },
+    ];
+
+    let state = replay(events.into_iter()).expect("replay must succeed");
+
+    assert!(
+        !state.vault_id_to_vaults.contains_key(&1),
+        "replay must remove a vault drained to zero debt and zero collateral, \
+         mirroring the runtime partial-liquidation cleanup",
+    );
+    assert!(
+        indexed_ids(&state, &state.icp_collateral_type()).is_empty(),
+        "drained vault must not linger in collateral_to_vault_ids after replay",
+    );
+    assert!(
+        state.principal_to_vault_ids.get(&owner()).is_none(),
+        "drained vault's owner entry must be pruned after replay",
+    );
+}
+
+#[test]
+fn replay_partial_liquidation_keeps_surviving_vault_indexed() {
+    // The drain-removal rule must NOT fire when anything remains in the vault.
+    let events = vec![
+        Event::Init(init_arg()),
+        Event::OpenVault {
+            vault: make_vault(1, 100_000_000, 50_000_000),
+            block_index: 1,
+            timestamp: None,
+        },
+        Event::PartialLiquidateVault {
+            vault_id: 1,
+            liquidator_payment: ICUSD::new(20_000_000),
+            icp_to_liquidator: ICP::new(40_000_000),
+            liquidator: None,
+            icp_rate: Some(UsdIcp::from(dec!(5.0))),
+            protocol_fee_collateral: None,
+            timestamp: None,
+            three_usd_reserves_e8s: None,
+        },
+    ];
+
+    let state = replay(events.into_iter()).expect("replay must succeed");
+
+    assert!(
+        state.vault_id_to_vaults.contains_key(&1),
+        "partially liquidated vault with remaining balances must survive replay",
+    );
+    assert_eq!(
+        indexed_ids(&state, &state.icp_collateral_type()),
+        vec![1],
+        "surviving vault must stay indexed",
+    );
+}
+
+// ============================================================================
+// Layer 3 — healing sweep (run by post_upgrade) and invariants
+// ============================================================================
+
+#[test]
+fn rebuild_collateral_index_heals_corrupted_index() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    let bogus_ct = Principal::from_slice(&[88]);
+    state.open_vault(make_vault(1, 0, 0));
+    state.open_vault(make_vault(2, 0, 0));
+    state.open_vault(make_vault(3, 0, 0));
+
+    // Corrupt the index the way mainnet drifted: a stale id whose vault is
+    // gone, a duplicate entry under a wrong collateral type, and a missing
+    // entry for a live vault.
+    state
+        .collateral_to_vault_ids
+        .get_mut(&icp)
+        .unwrap()
+        .insert(99);
+    state
+        .collateral_to_vault_ids
+        .entry(bogus_ct)
+        .or_default()
+        .insert(2);
+    state
+        .collateral_to_vault_ids
+        .get_mut(&icp)
+        .unwrap()
+        .remove(&3);
+
+    let (stale_removed, missing_added) = state.rebuild_collateral_index();
+
+    assert_eq!(stale_removed, 2, "stale id 99 + wrong-type duplicate of 2");
+    assert_eq!(missing_added, 1, "vault 3 was missing from the index");
+    assert_eq!(indexed_ids(&state, &icp), vec![1, 2, 3]);
+    assert!(state.collateral_to_vault_ids.get(&bogus_ct).is_none());
+    assert_index_matches_vaults(&state, "after rebuild");
+}
+
+#[test]
+fn rebuild_collateral_index_is_idempotent_on_consistent_state() {
+    let mut state = fresh_state_with_price(5.0);
+    state.open_vault(make_vault(1, 0, 0));
+    state.open_vault(make_vault(2, 0, 0));
+
+    let (stale_removed, missing_added) = state.rebuild_collateral_index();
+
+    assert_eq!((stale_removed, missing_added), (0, 0));
+    assert_index_matches_vaults(&state, "after no-op rebuild");
+}
+
+#[test]
+fn prune_empty_principal_entries_removes_only_empty_sets() {
+    let mut state = fresh_state_with_price(5.0);
+    state.open_vault(make_vault(1, 0, 0));
+    // Historical close paths left empty sets behind; simulate one.
+    let ghost = Principal::from_slice(&[9, 9]);
+    state
+        .principal_to_vault_ids
+        .insert(ghost, std::collections::BTreeSet::new());
+
+    let pruned = state.prune_empty_principal_entries();
+
+    assert_eq!(pruned, 1);
+    assert!(state.principal_to_vault_ids.get(&ghost).is_none());
+    assert_eq!(
+        state
+            .principal_to_vault_ids
+            .get(&owner())
+            .map(|ids| ids.len()),
+        Some(1),
+        "live owner entry must survive the prune",
+    );
+}
+
+#[test]
+fn cleanup_if_drained_removes_zero_zero_vault() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    state.open_vault(make_vault(1, 0, 0));
+    state.open_vault(make_vault(2, 100_000_000, 50_000_000));
+
+    assert!(
+        state.cleanup_if_drained(1),
+        "a zero-debt zero-collateral vault must be reported drained",
+    );
+    assert!(!state.vault_id_to_vaults.contains_key(&1));
+    assert_eq!(indexed_ids(&state, &icp), vec![2]);
+    assert_index_matches_vaults(&state, "after drain cleanup");
+}
+
+#[test]
+fn cleanup_if_drained_keeps_vault_with_remaining_balances() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    // Zero debt but collateral remains (post-repay, pre-withdraw) — NOT drained.
+    state.open_vault(make_vault(1, 100_000_000, 0));
+    // Zero collateral but debt remains (underwater write-down) — NOT drained.
+    state.open_vault(make_vault(2, 0, 50_000_000));
+
+    assert!(!state.cleanup_if_drained(1));
+    assert!(!state.cleanup_if_drained(2));
+    assert!(!state.cleanup_if_drained(99), "missing vault is not drained");
+    assert_eq!(indexed_ids(&state, &icp), vec![1, 2]);
+}
+
+#[test]
+fn check_invariants_accepts_consistent_state() {
+    let mut state = fresh_state_with_price(5.0);
+    state.open_vault(make_vault(1, 0, 0));
+    state.open_vault(make_vault(2, 0, 0));
+    assert!(state.check_invariants().is_ok());
+}
+
+#[test]
+fn check_invariants_rejects_stale_collateral_index_id() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    state.open_vault(make_vault(1, 0, 0));
+    state
+        .collateral_to_vault_ids
+        .get_mut(&icp)
+        .unwrap()
+        .insert(99);
+
+    assert!(
+        state.check_invariants().is_err(),
+        "an indexed id with no live vault must fail the invariant check",
+    );
+}
+
+#[test]
+fn check_invariants_rejects_unindexed_vault() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    state.open_vault(make_vault(1, 0, 0));
+    state
+        .collateral_to_vault_ids
+        .get_mut(&icp)
+        .unwrap()
+        .remove(&1);
+
+    assert!(
+        state.check_invariants().is_err(),
+        "a live vault missing from the collateral index must fail the invariant check",
+    );
+}
+
+#[test]
+fn check_invariants_rejects_wrong_collateral_type_entry() {
+    let mut state = fresh_state_with_price(5.0);
+    let icp = state.icp_collateral_type();
+    let bogus_ct = Principal::from_slice(&[88]);
+    state.open_vault(make_vault(1, 0, 0));
+    state
+        .collateral_to_vault_ids
+        .get_mut(&icp)
+        .unwrap()
+        .remove(&1);
+    state
+        .collateral_to_vault_ids
+        .entry(bogus_ct)
+        .or_default()
+        .insert(1);
+
+    assert!(
+        state.check_invariants().is_err(),
+        "a vault indexed under the wrong collateral type must fail the invariant check",
+    );
+}
+
+#[test]
+fn semantic_eq_catches_collateral_index_divergence() {
+    let mut a = fresh_state_with_price(5.0);
+    let mut b = fresh_state_with_price(5.0);
+    a.open_vault(make_vault(1, 0, 0));
+    b.open_vault(make_vault(1, 0, 0));
+    assert!(a.check_semantically_eq(&b).is_ok());
+
+    let icp = b.icp_collateral_type();
+    b.collateral_to_vault_ids.get_mut(&icp).unwrap().insert(99);
+
+    assert!(
+        a.check_semantically_eq(&b).is_err(),
+        "self_check must flag a replayed/live collateral-index mismatch",
+    );
+}

--- a/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
+++ b/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
@@ -11,7 +11,7 @@ use icrc_ledger_types::icrc2::approve::ApproveArgs;
 // Import necessary types from the codebase
 use rumi_protocol_backend::{
     vault::{OpenVaultSuccess, CandidVault, VaultArg},
-    ProtocolError, SuccessWithFee, Fees, GetEventsArg, LiquidityStatus,
+    CollateralTotals, ProtocolError, SuccessWithFee, Fees, GetEventsArg, LiquidityStatus,
     AddCollateralArg, StabilityPoolLiquidationResult,
 };
 use rumi_protocol_backend::event::Event;
@@ -1499,16 +1499,18 @@ fn test_add_margin_to_vault() {
     log("🎉 TEST PASSED: test_add_margin_to_vault");
 }
 
-// Test for closing a vault after repaying all debt.
+// Test for closing a vault after repaying all debt and withdrawing all
+// collateral (a June-2025 protocol change requires collateral to be
+// withdrawn before close).
 //
-// Pre-existing test failure: a June-2025 protocol change requires vault
-// collateral to be withdrawn before close. This test does not withdraw and
-// fails with "Cannot close vault with remaining collateral. Withdraw collateral
-// first." Marked #[ignore] so the pre-deploy hook can run pocket_ic_tests
-// cleanly. Tracked for follow-up: insert a withdraw_partial_collateral step
-// after the repayment and re-enable.
+// Also a regression fence for two bugs fixed 2026-06-11:
+//  * the endpoint double-removed the vault (inline in vault.rs, then again
+//    via record_close_vault -> state::close_vault) so every bare close_vault
+//    call hit the "tried to close unknown vault" trap and rolled back;
+//  * close paths never removed the vault id from collateral_to_vault_ids,
+//    inflating get_collateral_totals().vault_count (mainnet: 185 indexed ids
+//    vs 82 open vaults).
 #[test]
-#[ignore = "pre-existing: needs collateral-withdraw step before close per Jun-2025 protocol change"]
 fn test_close_vault() {
     log("🧪 TEST STARTING: test_close_vault");
     
@@ -1595,7 +1597,30 @@ fn test_close_vault() {
     // Step 6: Verify vault has no debt
     let vault_after_repay = get_vault(&pic, protocol_id, test_user, vault_id);
     assert_eq!(vault_after_repay.borrowed_icusd_amount, 0, "Vault should have no debt after full repayment");
-    
+
+    // Step 6.5: Withdraw all collateral — close_vault requires an empty vault
+    log("💸 Withdrawing all collateral before close");
+    let encoded_withdraw_args = match encode_args((vault_id,)) {
+        Ok(bytes) => bytes,
+        Err(e) => panic!("Failed to encode withdraw_collateral args: {}", e),
+    };
+    match pic.update_call(
+        protocol_id,
+        test_user,
+        "withdraw_collateral",
+        encoded_withdraw_args
+    ) {
+        Ok(WasmResult::Reply(bytes)) => {
+            match decode_one::<Result<u64, ProtocolError>>(&bytes) {
+                Ok(Ok(block_index)) => log(&format!("✅ Collateral withdrawn, block index: {}", block_index)),
+                Ok(Err(e)) => panic!("Error in withdraw_collateral result: {:?}", e),
+                Err(e) => panic!("Failed to decode withdraw_collateral response: {}", e),
+            }
+        },
+        Ok(WasmResult::Reject(error)) => panic!("Canister rejected withdraw_collateral call: {}", error),
+        Err(e) => panic!("Failed to call withdraw_collateral: {}", e),
+    };
+
     // Step 7: Close the vault
     log("🔒 Closing vault");
     let encoded_close_vault_args = match encode_args((vault_id,)) {
@@ -1661,14 +1686,36 @@ fn test_close_vault() {
         WasmResult::Reject(error) => panic!("Canister rejected get_vaults call: {}", error),
     };
     
-    // Either the vault should be gone or it should have 0 margin and 0 borrowing
-    for vault in &vaults {
-        if vault.vault_id == vault_id {
-            assert_eq!(vault.icp_margin_amount, 0, "Closed vault should have 0 margin");
-            assert_eq!(vault.borrowed_icusd_amount, 0, "Closed vault should have 0 borrowed amount");
-        }
-    }
-    
+    assert!(
+        vaults.iter().all(|v| v.vault_id != vault_id),
+        "Closed vault must be removed, not left as a zero-balance shell",
+    );
+
+    // Step 10: The collateral index must not retain the closed vault's id.
+    // get_collateral_totals counts straight off collateral_to_vault_ids —
+    // this is the count that drifted to 185-vs-82 on mainnet.
+    let totals_result = match pic.query_call(
+        protocol_id,
+        test_user,
+        "get_collateral_totals",
+        encode_args(()).unwrap()
+    ) {
+        Ok(result) => result,
+        Err(e) => panic!("Failed to call get_collateral_totals: {}", e),
+    };
+    let totals: Vec<CollateralTotals> = match totals_result {
+        WasmResult::Reply(bytes) => match decode_one(&bytes) {
+            Ok(decoded) => decoded,
+            Err(e) => panic!("Failed to decode collateral totals: {}", e),
+        },
+        WasmResult::Reject(error) => panic!("Canister rejected get_collateral_totals call: {}", error),
+    };
+    let indexed_vaults: u64 = totals.iter().map(|t| t.vault_count).sum();
+    assert_eq!(
+        indexed_vaults, 0,
+        "collateral_to_vault_ids must not retain ids for closed vaults",
+    );
+
     log("🎉 TEST PASSED: test_close_vault");
 }
 
@@ -2297,15 +2344,12 @@ fn test_borrow_against_cketh_vault() {
     log("🎉 TEST PASSED: test_borrow_against_cketh_vault");
 }
 
-/// Full lifecycle: open ckETH vault -> borrow -> repay -> close.
-/// Verifies all state transitions and that collateral is returned on close.
-//
-// Pre-existing test failure (same root cause as test_close_vault above): the
-// June-2025 close-vault change requires collateral to be withdrawn first.
-// Marked #[ignore] for the pre-deploy hook. Tracked for follow-up: insert a
-// withdraw_partial_collateral step before close_vault and re-enable.
+/// Full lifecycle: open ckETH vault -> borrow -> repay -> withdraw -> close.
+/// Verifies all state transitions, that collateral is returned on withdraw
+/// (the June-2025 close-vault change requires an emptied vault), and that
+/// the closed vault leaves no id behind in collateral_to_vault_ids — for a
+/// non-ICP index bucket.
 #[test]
-#[ignore = "pre-existing: needs collateral-withdraw step before close per Jun-2025 protocol change"]
 fn test_cketh_vault_full_lifecycle() {
     log("🧪 TEST STARTING: test_cketh_vault_full_lifecycle");
     let (pic, protocol_id, _icp_ledger_id, icusd_ledger_id, cketh_ledger_id) =
@@ -2389,10 +2433,32 @@ fn test_cketh_vault_full_lifecycle() {
     let vault = get_vault(&pic, protocol_id, test_user, vault_id);
     assert_eq!(vault.borrowed_icusd_amount, 0, "Vault debt should be zero after full repayment");
 
-    // --- Step 4: Close vault ---
-    // Record ckETH balance before close
+    // --- Step 3.5: Withdraw all collateral (close requires an empty vault) ---
     let cketh_before = get_icp_balance(&pic, cketh_ledger_id, test_user);
 
+    let encoded_withdraw = encode_args((vault_id,)).unwrap();
+    let withdraw_result = pic
+        .update_call(protocol_id, test_user, "withdraw_collateral", encoded_withdraw)
+        .expect("Failed to call withdraw_collateral");
+    match withdraw_result {
+        WasmResult::Reply(bytes) => {
+            let res: Result<u64, ProtocolError> =
+                decode_one(&bytes).expect("Failed to decode withdraw_collateral response");
+            let block_index = res.expect("withdraw_collateral returned error");
+            log(&format!("📌 Step 3.5: Collateral withdrawn, block_index: {}", block_index));
+        }
+        WasmResult::Reject(msg) => panic!("withdraw_collateral rejected: {}", msg),
+    }
+
+    // Check that ckETH was returned by the withdrawal
+    let cketh_after = get_icp_balance(&pic, cketh_ledger_id, test_user);
+    log(&format!("💰 ckETH balance before withdraw: {}, after: {}", cketh_before, cketh_after));
+    assert!(
+        cketh_after > cketh_before,
+        "ckETH balance should increase after withdrawing collateral"
+    );
+
+    // --- Step 4: Close vault ---
     let encoded_close = encode_args((vault_id,)).unwrap();
     let close_result = pic
         .update_call(protocol_id, test_user, "close_vault", encoded_close)
@@ -2412,12 +2478,22 @@ fn test_cketh_vault_full_lifecycle() {
         WasmResult::Reject(msg) => panic!("close_vault rejected: {}", msg),
     }
 
-    // Check that ckETH was returned
-    let cketh_after = get_icp_balance(&pic, cketh_ledger_id, test_user);
-    log(&format!("💰 ckETH balance before close: {}, after close: {}", cketh_before, cketh_after));
-    assert!(
-        cketh_after > cketh_before,
-        "ckETH balance should increase after closing vault (collateral returned)"
+    // --- Step 5: The ckETH index bucket must not retain the closed vault ---
+    let totals_result = pic
+        .query_call(protocol_id, test_user, "get_collateral_totals", encode_args(()).unwrap())
+        .expect("Failed to call get_collateral_totals");
+    let totals: Vec<CollateralTotals> = match totals_result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("Failed to decode collateral totals"),
+        WasmResult::Reject(msg) => panic!("get_collateral_totals rejected: {}", msg),
+    };
+    let cketh_indexed = totals
+        .iter()
+        .find(|t| t.collateral_type == cketh_ledger_id)
+        .map(|t| t.vault_count)
+        .unwrap_or(0);
+    assert_eq!(
+        cketh_indexed, 0,
+        "ckETH collateral index must not retain ids for closed vaults"
     );
 
     log("🎉 TEST PASSED: test_cketh_vault_full_lifecycle");


### PR DESCRIPTION
## Summary

`collateral_to_vault_ids` (the `BTreeMap<CollateralType, BTreeSet<u64>>` secondary index) retained ids for closed vaults because `unindex_vault_by_collateral` had **zero callers**. Measured on mainnet 2026-06-11: **185 ids** summed across `get_collateral_totals()` vs **82 open vaults** (`get_vault_count()`) — ~103 stale.

Impact today is **display-only** (every consumer except the counters does `filter_map(|id| self.vault_id_to_vaults.get(id))`, so stale ids contribute 0 to value sums), but `get_collateral_totals().vault_count`, `dashboard.rs`, and `get_protocol_status` reported inflated counts, and every index consumer paid O(stale) wasted lookups.

Investigating turned up **two more bugs** in the same removal machinery. Each fix was written test-first (TDD) — the test failed for the right reason against the pre-fix code, then passed.

## The three bugs

1. **Index leak at all 7 vault-removal sites.** Introduce `State::remove_vault_and_unindex` as the single canonical removal path (primary map + principal-set prune + collateral unindex + CR unindex). `close_vault`, the full-liquidation branch of `liquidate_vault`, `redistribute_vault`, the `vault.rs` close endpoint, the two partial-liq drain cleanups, and the `post_upgrade` empty-vault sweep all route through it.

2. **The bare `close_vault` endpoint never worked.** `vault.rs` removed the vault inline, then `record_close_vault` → `state::close_vault` trapped `"BUG: tried to close unknown vault"` and rolled the whole call back. Proven in PocketIC against the pre-fix wasm (exact trap), green after the fix. Frontend close flows use `withdraw_and_close` / `repay_and_close`, which route through `state::close_vault` directly, so users never hit the broken bare endpoint.

3. **Event replay diverged from runtime.** A partial liquidation that drained a vault to zero debt + zero collateral removed it at runtime (2 of the 5 `PartialLiquidateVault` recorders), but `replay()` never did, and the other 3 recorders left shells at runtime too. Introduce `State::cleanup_if_drained` as the shared drain rule used by **all 5** recorders (`vault.rs` ×3, `main.rs` `bot_confirm_liquidation`) **and** the replay handler, so live and replayed state stay byte-identical.

## Healing + enforcement

- **`post_upgrade` sweep** (idempotent): `rebuild_collateral_index()` + `prune_empty_principal_entries()` converge the index to the primary map and log dropped/added counts. **Mainnet heals on the next backend deploy — no reinstall.** Expect ~103 dropped stale ids in the upgrade log.
- **`check_invariants`** now enforces index == map in both directions (every indexed id has a live vault of that type; every open vault is indexed exactly once).
- **`check_semantically_eq`** compares the index, so `self_check` builds enforce replay-exactness.

## Tests

- New `tests/collateral_index_consistency.rs` — 19 state/replay/sweep unit tests (every close path un-indexes; replay matches runtime including the drain rule; the heal sweep converges a corrupted index and is idempotent; invariant + semantic-eq rejection cases).
- Un-ignored PocketIC `test_close_vault` and `test_cketh_vault_full_lifecycle` — added the withdraw-collateral step the June-2025 close change requires; both now assert `get_collateral_totals().vault_count` drops to 0 after close, for an ICP **and** a non-ICP (ckETH) bucket.

**Green:** lib 370 · index 19 · full pre-deploy PocketIC set (`pocket_ic_tests`/`pocket_ic_3usd`/`integration_test`/`pocket_ic_analytics`) · BK-001/002 interleave · LIQ-003.

## Notes

- Backend hygiene fix with **no UI dependency** — the explorer frontend already stopped trusting this count client-side (PR #240 counts open vaults client-side).
- **Never reinstall the backend** — the heal sweep is in `post_upgrade`, so an upgrade deploy fixes mainnet state in place.
- Out of scope (separate chip): two pre-existing non-compiling test targets on `main` (`tests/tests.rs` missing `bot_processing`; `tests/multi_chain_supply_invariant.rs` on `MultiChainStateV3` vs `V4`) — neither is in the pre-deploy hook's test set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)