### PR TITLE
fix(docs,nav): interest-split reactivity, swap routing accuracy, Airdrop→Points rename

### DIFF
--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -91,7 +91,7 @@
     {#if isConnected && canViewVaults}<a href="/vaults" class="nav-link" class:active={currentPath.startsWith('/vaults')}><span>Vaults</span></a>{/if}
     {#if isConnected && $permissionStore.isDeveloper}<a href="/treasury" class="nav-link" class:active={currentPath === '/treasury'}><span>Treasury</span></a>{/if}
     <a href="/explorer" class="nav-link" class:active={currentPath.startsWith('/explorer')}><span>Explorer</span></a>
-    {#if POINTS_ENABLED}<a href="/points" class="nav-link nav-airdrop" class:active={currentPath.startsWith('/points')} title="Earn airdrop points"><span class="airdrop-pill">✨ Airdrop</span></a>{/if}
+    {#if POINTS_ENABLED}<a href="/points" class="nav-link nav-airdrop" class:active={currentPath.startsWith('/points')} title="View your points"><span class="airdrop-pill">✨ Points</span></a>{/if}
   </nav>
   <div class="top-actions">
     {#if hasLiquidatableVaults}
@@ -139,7 +139,7 @@
   <a href="/3usd" class="mob-item" class:active={currentPath === '/3usd'}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v12M9 9.5C9 8.12 10.34 7 12 7s3 1.12 3 2.5c0 1.93-3 2.5-3 4.5M12 17h.01"/></svg><span>3USD</span></a>
   <a href="/vaults" class="mob-item" class:active={currentPath.startsWith('/vaults')}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg><span>Vaults</span></a>
   <a href="/explorer" class="mob-item" class:active={currentPath.startsWith('/explorer')}><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg><span>Explorer</span></a>
-  {#if POINTS_ENABLED}<a href="/points" class="mob-item mob-airdrop" class:active={currentPath.startsWith('/points')}><svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2l2.2 5.8L20 10l-5.8 2.2L12 18l-2.2-5.8L4 10l5.8-2.2z"/></svg><span>Airdrop</span></a>{/if}
+  {#if POINTS_ENABLED}<a href="/points" class="mob-item mob-airdrop" class:active={currentPath.startsWith('/points')}><svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2l2.2 5.8L20 10l-5.8 2.2L12 18l-2.2-5.8L4 10l5.8-2.2z"/></svg><span>Points</span></a>{/if}
 </nav>
 {#if isDevelopment && showDebug}<div class="fixed bottom-4 right-4 z-50"><div class="flex flex-col gap-2"><PriceDebug /><WalletDebug /></div></div>{/if}
 <style>

--- a/src/vault_frontend/src/routes/docs/before-you-borrow/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/before-you-borrow/+page.svelte
@@ -12,10 +12,13 @@
   let borrowingFeeCurve: [number, number][] = [];
   let interestSplit: InterestSplitEntryDTO[] = [];
 
-  function splitPct(dest: string): string {
+  // Reactive so the template re-renders once interestSplit loads in onMount.
+  // A plain function isn't tracked by Svelte (the template only references
+  // splitPct, not interestSplit), so it would stay on the placeholder forever.
+  $: splitPct = (dest: string): string => {
     const entry = interestSplit.find(s => s.destination === dest);
     return entry ? (Number(entry.bps) / 100).toFixed(0) + '%' : '—';
-  }
+  };
   $: collateralSymbols = collaterals.map(c => c.symbol).join(', ') || 'ICP';
 
   onMount(async () => {

--- a/src/vault_frontend/src/routes/docs/parameters/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/parameters/+page.svelte
@@ -46,10 +46,13 @@
   import type { InterestSplitEntryDTO } from '$lib/services/types';
   let interestSplit: InterestSplitEntryDTO[] = [];
 
-  function splitPct(dest: string): string {
+  // Reactive so template re-renders once interestSplit loads (a plain function
+  // isn't tracked by Svelte). The page already gates on `loaded`, but keeping
+  // this reactive future-proofs any splitPct call moved outside that gate.
+  $: splitPct = (dest: string): string => {
     const entry = interestSplit.find(s => s.destination === dest);
     return entry ? (Number(entry.bps) / 100).toFixed(0) + '%' : '—';
-  }
+  };
 
   function destLabel(dest: string): string {
     switch (dest) {

--- a/src/vault_frontend/src/routes/docs/stability-pool/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/stability-pool/+page.svelte
@@ -7,10 +7,13 @@
   let interestSplit: InterestSplitEntryDTO[] = [];
   let liqProtocolPct = '3';
 
-  function splitPct(dest: string): string {
+  // Reactive so the template re-renders once interestSplit loads in onMount.
+  // A plain function isn't tracked by Svelte (the template only references
+  // splitPct, not interestSplit), so it would stay on the placeholder forever.
+  $: splitPct = (dest: string): string => {
     const entry = interestSplit.find(s => s.destination === dest);
     return entry ? (Number(entry.bps) / 100).toFixed(0) + '%' : '—';
-  }
+  };
 
   onMount(async () => {
     try {

--- a/src/vault_frontend/src/routes/docs/swap/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/swap/+page.svelte
@@ -5,10 +5,13 @@
 
   let interestSplit: InterestSplitEntryDTO[] = [];
 
-  function splitPct(dest: string): string {
+  // Reactive so the template re-renders once interestSplit loads in onMount.
+  // A plain function isn't tracked by Svelte (the template only references
+  // splitPct, not interestSplit), so it would stay on the placeholder forever.
+  $: splitPct = (dest: string): string => {
     const entry = interestSplit.find(s => s.destination === dest);
     return entry ? (Number(entry.bps) / 100).toFixed(0) + '%' : '—';
-  }
+  };
 
   onMount(async () => {
     try {
@@ -27,14 +30,13 @@
 
   <section class="doc-section">
     <h2 class="doc-heading">What the Swap Page Does</h2>
-    <p>The <a href="/swap" class="doc-link">Swap</a> page is a router over Rumi's own liquidity. Depending on the pair you pick, it routes through the <a href="/docs/three-pool" class="doc-link">3pool</a> (stablecoins), Rumi's pair AMM (3USD/ICP), or both in sequence. For the 3USD/ICP and icUSD/ICP legs it also quotes the corresponding ICPSwap pool and uses whichever venue pays out more.</p>
+    <p>The <a href="/swap" class="doc-link">Swap</a> page is a router over Rumi's own liquidity. Depending on the pair you pick, it routes through the <a href="/docs/three-pool" class="doc-link">3pool</a> (stablecoins), Rumi's pair AMM (3USD/ICP), or both in sequence.</p>
     <ul class="doc-list">
       <li><strong>Stablecoin ↔ stablecoin</strong> (icUSD, ckUSDT, ckUSDC): single swap through the 3pool.</li>
       <li><strong>Stablecoin → 3USD</strong>: a one-sided 3pool deposit (mints 3USD).</li>
       <li><strong>3USD → stablecoin</strong>: a single-token 3pool withdrawal (burns 3USD).</li>
-      <li><strong>3USD ↔ ICP</strong>: Rumi's AMM or ICPSwap's 3USD/ICP pool, whichever quotes better.</li>
-      <li><strong>ICP ↔ stablecoin</strong>: two hops through 3USD (AMM leg plus 3pool leg).</li>
-      <li><strong>icUSD ↔ ICP</strong>: routed directly through ICPSwap's icUSD/ICP pool when that beats the two-hop route.</li>
+      <li><strong>3USD ↔ ICP</strong>: a single swap through Rumi's pair AMM.</li>
+      <li><strong>ICP ↔ stablecoin</strong> (including icUSD ↔ ICP): two hops through 3USD (the AMM leg plus the 3pool leg).</li>
     </ul>
     <p>Quotes shown in the UI are net amounts: every outbound transfer pays the output token's ledger fee, and your minimum-output (slippage) bound is enforced against the net amount you actually receive. The default slippage tolerance is 0.5% and you can adjust it per trade.</p>
   </section>
@@ -59,7 +61,6 @@
     <h2 class="doc-heading">Risks</h2>
     <p><strong>Impermanent loss:</strong> unlike the stablecoin 3pool, the 3USD/ICP pair holds a volatile asset. If the ICP price moves significantly after you deposit, the value of your LP position can underperform simply holding the two assets. Fee and reward income may not cover the difference.</p>
     <p><strong>Smart contract risk:</strong> the AMM is its own canister with its own code. It is covered by the protocol's recurring security reviews (reports at <a href="https://rumiprotocol.com/security" class="doc-link" target="_blank" rel="noopener">rumiprotocol.com/security</a>), but it has not been audited by a traditional human-led security firm. See the <a href="/docs/beta" class="doc-link">beta disclaimer</a>.</p>
-    <p><strong>External venue risk:</strong> routes that touch ICPSwap depend on ICPSwap's own contracts and liquidity, which Rumi does not control.</p>
   </section>
 </article>
 

--- a/src/vault_frontend/src/routes/docs/three-pool/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/three-pool/+page.svelte
@@ -6,10 +6,13 @@
 
   let interestSplit: InterestSplitEntryDTO[] = [];
 
-  function splitPct(dest: string): string {
+  // Reactive so the template re-renders once interestSplit loads in onMount.
+  // A plain function isn't tracked by Svelte (the template only references
+  // splitPct, not interestSplit), so it would stay on the placeholder forever.
+  $: splitPct = (dest: string): string => {
     const entry = interestSplit.find(s => s.destination === dest);
     return entry ? (Number(entry.bps) / 100).toFixed(0) + '%' : '—';
-  }
+  };
 
   // Pool state
   let tokenSymbols: string[] = [];


### PR DESCRIPTION
## Bugs fixed

**1. Interest-split percentages stuck on the `—` placeholder** (reported on `/docs/stability-pool`, then `/docs/three-pool`, then the new `/docs/swap` LP-earnings line).

Svelte reactivity, not the data path — the backend returns `interest_split` in `get_protocol_status` (with a `get_interest_split` fallback) and the declarations are current. `splitPct()` was a plain function, so `{splitPct('stability_pool')}` statically references only `splitPct`, not `interestSplit`. Svelte evaluates it once at init (while `interestSplit` is `[]` → `—`) and never re-runs it after `onMount` loads the data. Pages gated behind `{#if loaded}` (parameters, redemptions) looked fine; ungated prose stayed on `—`.

Fix: convert `splitPct` to a reactive `$: splitPct = (dest) => …` on all five docs pages that define it (stability-pool, before-you-borrow, three-pool, parameters, swap). Same pattern `/docs/redemptions` already uses.

**2. `/docs/swap` overstated ICPSwap.** ICPSwap routing is admin-gated and **off by default** (`swapRouter._icpswapEnabled = false`), and the ICPSwap 3USD/ICP pool no longer exists. The page no longer presents ICPSwap as a co-equal venue: 3USD↔ICP is a single swap through Rumi's pair AMM, and ICP↔stablecoin (incl. icUSD↔ICP) is the two-hop 3USD route through Rumi liquidity. Removed the ICPSwap "external venue risk" bullet.

## Requested change

**3. Renamed the nav pill `✨ Airdrop` → `✨ Points`** (desktop + mobile), keeping the gradient/glow formatting. Matches the "Points" convention common across DeFi. CSS class names left unchanged as styling hooks.

## Verification
- `npm ci` + `npm run build --workspace=vault_frontend` passes.

Frontend-only; deploy is a vault_frontend asset deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)