### PR TITLE
feat(frontend): highlight airdrop point-earning across the app

### DIFF
--- a/src/vault_frontend/src/lib/components/points/EarnCta.svelte
+++ b/src/vault_frontend/src/lib/components/points/EarnCta.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
+  import MultiplierBadge from './MultiplierBadge.svelte';
+
   interface Props {
     heading?: string;
   }
   let { heading = 'Ways to earn points' }: Props = $props();
 
+  // Curated, sorted high → low. Each venue shows its best available multiplier.
   const actions = [
-    { label: 'Mint icUSD', desc: 'Open a vault and borrow icUSD against collateral.', href: '/' },
-    { label: 'Deposit to the stability pool', desc: 'Earn while backstopping liquidations.', href: '/stability-pool' },
-    { label: 'Provide liquidity', desc: 'Add liquidity to the 3pool or AMM.', href: '/liquidity' },
+    { label: 'Provide 3pool liquidity', desc: 'Pair ckUSDC + ckUSDT for the highest boost.', href: '/3usd', mult: 5 },
+    { label: 'Deposit 3USD to the stability pool', desc: 'Backstop liquidations and earn double.', href: '/stability-pool', mult: 2 },
+    { label: 'Add 3USD/ICP to the AMM', desc: 'Provide liquidity to the Rumi AMM.', href: '/swap', mult: 2 },
+    { label: 'Mint icUSD', desc: 'Borrow against ICP, ckBTC, or ckXAUT collateral.', href: '/', mult: 1 },
   ];
 </script>
 
@@ -18,13 +22,13 @@
       <li>
         <a
           href={a.href}
-          class="flex items-center justify-between gap-3 rounded-lg border border-gray-700/40 bg-gray-900/30 px-3 py-2 hover:border-teal-500/40 transition-colors"
+          class="flex items-center justify-between gap-3 rounded-lg border border-gray-700/40 bg-gray-900/30 px-3 py-2 hover:border-emerald-500/40 transition-colors"
         >
-          <span>
+          <span class="min-w-0">
             <span class="block text-sm text-gray-100">{a.label}</span>
             <span class="block text-xs text-gray-500">{a.desc}</span>
           </span>
-          <span class="text-teal-400 text-sm">→</span>
+          <MultiplierBadge multiplier={a.mult} size="md" />
         </a>
       </li>
     {/each}

--- a/src/vault_frontend/src/lib/components/points/MultiplierBadge.svelte
+++ b/src/vault_frontend/src/lib/components/points/MultiplierBadge.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  /**
+   * MultiplierBadge — the green airdrop multiplier pill used across every
+   * point-earning surface. Reads nothing; the caller supplies the multiplier from
+   * pointsRules so the badge can never disagree with the canister.
+   */
+  interface Props {
+    multiplier: number;
+    variant?: 'compact' | 'full';
+    size?: 'sm' | 'md';
+    comingSoon?: boolean;
+    /** Override the text after the icon (e.g. "up to 5× points"). */
+    label?: string;
+  }
+  let { multiplier, variant = 'compact', size = 'sm', comingSoon = false, label }: Props = $props();
+
+  const pad = $derived(size === 'md' ? 'px-2.5 py-1 text-sm' : 'px-2 py-0.5 text-xs');
+  const tone = $derived(
+    comingSoon
+      ? 'bg-gray-500/15 text-gray-400 border-gray-500/25'
+      : 'bg-emerald-400/15 text-emerald-300 border-emerald-400/35',
+  );
+  const text = $derived(
+    label ??
+      (variant === 'full'
+        ? comingSoon
+          ? `${multiplier}× points soon`
+          : `Earn ${multiplier}× points`
+        : `${multiplier}×`),
+  );
+</script>
+
+<span
+  class="inline-flex items-center gap-1 rounded-full border font-medium whitespace-nowrap tabular-nums {pad} {tone}"
+  title={comingSoon ? 'Coming soon' : `Earns ${multiplier}× airdrop points`}
+>
+  {#if !comingSoon}
+    <svg viewBox="0 0 24 24" width="11" height="11" fill="currentColor" aria-hidden="true" style="flex-shrink:0">
+      <path d="M13 2L4.5 13.5H11l-1 8.5L19.5 10H13z" />
+    </svg>
+  {/if}
+  {text}
+</span>

--- a/src/vault_frontend/src/lib/components/points/PointsCallout.svelte
+++ b/src/vault_frontend/src/lib/components/points/PointsCallout.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  /**
+   * PointsCallout — the inline green callout shown on deposit forms to tell the
+   * user what multiplier their current inputs earn, plus an optional hint (e.g.
+   * the 3USD-holding rule or a nudge toward a higher tier).
+   */
+  interface Props {
+    headline: string;
+    hint?: string;
+    tone?: 'earning' | 'info' | 'warning';
+  }
+  let { headline, hint, tone = 'earning' }: Props = $props();
+
+  const styles: Record<string, string> = {
+    earning: 'bg-emerald-400/10 border-emerald-400/30 text-emerald-300',
+    info: 'bg-gray-500/10 border-gray-500/25 text-gray-200',
+    warning: 'bg-amber-400/10 border-amber-400/30 text-amber-200',
+  };
+</script>
+
+<div class="flex items-start gap-2.5 rounded-lg border px-3 py-2.5 {styles[tone]}">
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true" style="flex-shrink:0;margin-top:1px">
+    <path d="M13 2L4.5 13.5H11l-1 8.5L19.5 10H13z" />
+  </svg>
+  <div class="min-w-0">
+    <p class="text-sm font-medium leading-tight">{headline}</p>
+    {#if hint}<p class="text-xs text-gray-400 mt-0.5 leading-snug">{hint}</p>{/if}
+  </div>
+</div>

--- a/src/vault_frontend/src/lib/components/points/PointsSummary.svelte
+++ b/src/vault_frontend/src/lib/components/points/PointsSummary.svelte
@@ -1,23 +1,57 @@
 <script lang="ts">
-  import type { PrincipalState, Venue } from '$declarations/rumi_points/rumi_points.did';
+  import type {
+    PrincipalState,
+    Venue,
+    AssetType,
+  } from '$declarations/rumi_points/rumi_points.did';
   import { formatPoints, qualifyingActionLabel } from '$lib/utils/points';
+  import { depositMultiplierLabel, formatSharePct, type EarnVenue } from '$lib/utils/pointsRules';
+  import MultiplierBadge from './MultiplierBadge.svelte';
 
   interface Props {
     state: PrincipalState;
     rank: number | null;
+    shareBps?: number | null;
   }
-  let { state, rank }: Props = $props();
+  let { state, rank, shareBps = null }: Props = $props();
 
-  function venueLabel(v: Venue): string {
-    if ('Vault' in v) return 'Vault debt';
-    if ('StabilityPool' in v) return 'Stability pool';
-    if ('ThreePool' in v) return '3pool liquidity';
-    if ('Amm' in v) return 'AMM liquidity';
-    return 'Position';
+  function venueKey(v: Venue): EarnVenue {
+    if ('Vault' in v) return 'vault';
+    if ('StabilityPool' in v) return 'stabilityPool';
+    if ('ThreePool' in v) return 'threePool';
+    return 'amm';
   }
-  // Distinct venues currently earning, for a short breakdown.
-  const venues = $derived(
-    Array.from(new Set(state.active_deposits.map(([k]) => venueLabel(k.venue)))),
+  function venueLabel(v: EarnVenue): string {
+    return v === 'vault' ? 'Vault debt'
+      : v === 'stabilityPool' ? 'Stability pool'
+      : v === 'threePool' ? '3pool liquidity'
+      : 'AMM liquidity';
+  }
+  function assetSymbol(a: AssetType): string {
+    if ('IcUsd' in a) return 'icUSD';
+    if ('CkUsdc' in a) return 'ckUSDC';
+    if ('CkUsdt' in a) return 'ckUSDT';
+    if ('ThreeUsd' in a) return '3USD';
+    if ('Icp' in a) return 'ICP';
+    return '';
+  }
+  // recorded_value_usd is usd_e8s (USD * 1e8). Reduce via bigint to stay exact.
+  function usd(raw: bigint): string {
+    const cents = raw / 1_000_000n; // 1e8 / 1e6 = 100 → hundredths of a dollar
+    return `$${(Number(cents) / 100).toLocaleString('en-US', { maximumFractionDigits: 2 })}`;
+  }
+
+  const positions = $derived(
+    state.active_deposits.map(([key, rec]) => {
+      const v = venueKey(key.venue);
+      const sym = assetSymbol(key.asset);
+      return {
+        venue: venueLabel(v),
+        symbol: sym,
+        mult: depositMultiplierLabel(v, sym),
+        value: usd(rec.recorded_value_usd),
+      };
+    }),
   );
   const enrolledDate = $derived(
     new Date(Number(state.registered_at_ns / 1_000_000n)).toLocaleDateString(),
@@ -25,23 +59,42 @@
 </script>
 
 <div class="flex flex-col gap-4">
-  <div class="grid grid-cols-2 gap-3">
+  <div class="grid grid-cols-3 gap-3">
     <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
       <p class="text-xs text-gray-400 uppercase tracking-wider">Your points</p>
-      <p class="text-2xl font-semibold text-gray-100 mt-1">{formatPoints(state.total_points)}</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1 tabular-nums">{formatPoints(state.total_points)}</p>
       <p class="text-xs text-gray-500">USD-days</p>
     </div>
     <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
       <p class="text-xs text-gray-400 uppercase tracking-wider">Rank</p>
-      <p class="text-2xl font-semibold text-gray-100 mt-1">{rank !== null ? `#${rank}` : '—'}</p>
+      <p class="text-2xl font-semibold text-gray-100 mt-1 tabular-nums">{rank !== null ? `#${rank}` : '—'}</p>
       <p class="text-xs text-gray-500">{rank !== null ? 'on the leaderboard' : 'outside the top ranks'}</p>
+    </div>
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-xs text-gray-400 uppercase tracking-wider">Est. share</p>
+      <p class="text-2xl font-semibold text-emerald-300 mt-1 tabular-nums">{shareBps !== null ? formatSharePct(shareBps) : '—'}</p>
+      <p class="text-xs text-gray-500">of the Season 1 pool</p>
     </div>
   </div>
 
+  {#if positions.length > 0}
+    <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4">
+      <p class="text-sm font-medium text-gray-200 mb-3">Where you're earning</p>
+      <ul class="flex flex-col gap-2">
+        {#each positions as p}
+          <li class="flex items-center justify-between gap-3 rounded-lg border border-gray-700/40 bg-gray-900/30 px-3 py-2">
+            <span class="min-w-0">
+              <span class="block text-sm text-gray-100">{p.venue}</span>
+              <span class="block text-xs text-gray-500">{p.symbol} · {p.value}</span>
+            </span>
+            <MultiplierBadge multiplier={0} label={p.mult} />
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
   <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">
     <p>Enrolled {enrolledDate} · first action: {qualifyingActionLabel(state.first_qualifying_action)}</p>
-    {#if venues.length > 0}
-      <p class="text-xs text-gray-500 mt-2">Currently earning from: {venues.join(', ')}</p>
-    {/if}
   </div>
 </div>

--- a/src/vault_frontend/src/lib/components/points/SeasonBar.svelte
+++ b/src/vault_frontend/src/lib/components/points/SeasonBar.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  /**
+   * SeasonBar — a slim, persistent airdrop bar shown at the top of every page's
+   * content (the layout hides it on /points* to avoid duplicating the dashboard).
+   * It adapts to the season phase and the connected wallet's enrollment so the
+   * airdrop is impossible to miss while walking the app. Display-only; loads
+   * cached public queries plus the shared myPointsStore.
+   */
+  import { onMount } from 'svelte';
+  import { POINTS_ENABLED } from '$lib/config';
+  import { isConnected, principal } from '$lib/stores/wallet';
+  import { myPointsStore } from '$lib/stores/pointsStore';
+  import { seasonStore, seasonPhase } from '$lib/stores/seasonStore';
+  import { formatPoints, bodyState } from '$lib/utils/points';
+  import { MAX_MULTIPLIER } from '$lib/utils/pointsRules';
+
+  let loadedFor = $state<string | null>(null);
+
+  onMount(() => {
+    seasonStore.ensureLoaded();
+  });
+
+  // Load the connected principal's points once per principal (service is cached;
+  // shared with the /points page). Reloads on wallet switch.
+  $effect(() => {
+    if (!POINTS_ENABLED) return;
+    const p = $principal;
+    if ($isConnected && p) {
+      const t = p.toText();
+      if (loadedFor !== t) {
+        loadedFor = t;
+        myPointsStore.load(p);
+      }
+    } else if (loadedFor !== null) {
+      loadedFor = null;
+    }
+  });
+
+  const phase = $derived($seasonPhase);
+  const body = $derived(
+    bodyState({ connected: $isConnected, excluded: $myPointsStore.excluded, state: $myPointsStore.state }),
+  );
+  const pts = $derived($myPointsStore.state ? formatPoints($myPointsStore.state.total_points) : null);
+</script>
+
+{#if POINTS_ENABLED && phase !== 'unknown' && body !== 'excluded'}
+  <a class="season-bar" href="/points" aria-label="Airdrop points">
+    <span class="sb-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M12 2l2.2 6.2L20.5 10l-6.3 1.8L12 18l-1.8-6.2L4 10l6.2-1.8z" /></svg>
+    </span>
+    <span class="sb-tag">Season 1</span>
+    <span class="sb-sep" aria-hidden="true">·</span>
+
+    {#if phase === 'pre'}
+      <span class="sb-msg">Airdrop starts soon — get positioned to earn up to {MAX_MULTIPLIER}×</span>
+      <span class="sb-cta">See how →</span>
+    {:else if phase === 'ended'}
+      <span class="sb-msg">Season 1 has ended — allocations are being finalized</span>
+      <span class="sb-cta">View →</span>
+    {:else if body === 'enrolled' && pts !== null}
+      <span class="sb-msg">You're earning — <strong class="sb-pts">{pts}</strong> points so far</span>
+      <span class="sb-cta">View →</span>
+    {:else if body === 'not_enrolled' && $myPointsStore.loaded}
+      <span class="sb-msg">You're not earning yet — take any qualifying action to enroll</span>
+      <span class="sb-cta">See how →</span>
+    {:else}
+      <span class="sb-msg">The airdrop is live — earn up to {MAX_MULTIPLIER}× points just by using Rumi</span>
+      <span class="sb-cta">{$isConnected ? 'View →' : 'Connect to earn →'}</span>
+    {/if}
+  </a>
+{/if}
+
+<style>
+  .season-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4375rem 0.875rem;
+    margin-bottom: 1.25rem;
+    border-radius: 0.625rem;
+    border: 1px solid rgba(52, 211, 153, 0.28);
+    background: rgba(52, 211, 153, 0.06);
+    text-decoration: none;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .season-bar:hover {
+    border-color: rgba(52, 211, 153, 0.5);
+    background: rgba(52, 211, 153, 0.1);
+  }
+  .sb-icon { display: inline-flex; color: #34d399; flex-shrink: 0; }
+  .sb-tag { color: #6ee7b7; font-weight: 700; letter-spacing: 0.01em; flex-shrink: 0; }
+  .sb-sep { color: var(--rumi-text-muted); flex-shrink: 0; }
+  .sb-msg {
+    color: var(--rumi-text-secondary);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sb-pts { color: var(--rumi-text-primary); font-weight: 700; }
+  .sb-cta { color: #6ee7b7; font-weight: 600; flex-shrink: 0; white-space: nowrap; }
+
+  @media (max-width: 768px) {
+    .season-bar { font-size: 0.75rem; padding: 0.375rem 0.625rem; margin-bottom: 0.875rem; }
+  }
+</style>

--- a/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import { Principal } from '@dfinity/principal';
   import { walletStore } from '../../stores/wallet';
   import { stabilityPoolService, formatTokenAmount, parseTokenAmount } from '../../services/stabilityPoolService';
@@ -7,6 +7,13 @@
   import type { PoolStatus, StablecoinConfig, UserPosition } from '../../services/stabilityPoolService';
   import { CANISTER_IDS } from '../../config';
   import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
+  import PointsCallout from '../points/PointsCallout.svelte';
+  import { spMultiplier } from '$lib/utils/pointsRules';
+  import { seasonStore, earningActive } from '$lib/stores/seasonStore';
+
+  onMount(() => { seasonStore.ensureLoaded(); });
+
+  $: spMult = spMultiplier(selectedToken?.symbol);
 
   export let poolStatus: PoolStatus | null = null;
   export let userPosition: UserPosition | null = null;
@@ -243,6 +250,15 @@
         </div>
       {/if}
     </div>
+
+    {#if activeTab === 'deposit' && $earningActive && selectedToken}
+      <div style="margin-bottom:0.75rem">
+        <PointsCallout
+          headline={`Earning ${spMult}× points on your ${selectedToken.symbol} deposit`}
+          hint={spMult === 1 ? 'Deposit 3USD here instead to earn 2× points.' : undefined}
+        />
+      </div>
+    {/if}
 
     <!-- Submit -->
     <button

--- a/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
@@ -16,6 +16,10 @@
     type Amm1EffectiveApy,
   } from '../../services/amm1ApyService';
   import { getThreePoolApy } from '../../services/threePoolApyService';
+  import PointsCallout from '../points/PointsCallout.svelte';
+  import { seasonStore, earningActive } from '$lib/stores/seasonStore';
+
+  onMount(() => { seasonStore.ensureLoaded(); });
 
   const dispatch = createEventDispatcher();
 
@@ -439,6 +443,11 @@
         </div>
       {:else if priceLoading}
         <div class="price-info">Loading prices...</div>
+      {/if}
+      {#if $earningActive}
+        <div style="margin-bottom:0.75rem">
+          <PointsCallout headline="Earning 2× points on your 3USD/ICP liquidity" />
+        </div>
       {/if}
       <button class="submit-btn" on:click={handleAdd} disabled={addLoading}>
         {#if addLoading}

--- a/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/LiquidityInterface.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import { walletStore } from '../../stores/wallet';
   import {
     threePoolService,
@@ -11,6 +11,21 @@
   import { formatStableTokenDisplay } from '../../utils/format';
   import { isOisyLandedSentinel } from '../../services/protocol/oisyResilience';
   import { isOisyWallet } from '../../services/protocol/walletOperations';
+  import PointsCallout from '../points/PointsCallout.svelte';
+  import { compute3poolMultiplier, threePoolHeadline } from '$lib/utils/pointsRules';
+  import { seasonStore, earningActive } from '$lib/stores/seasonStore';
+
+  onMount(() => { seasonStore.ensureLoaded(); });
+
+  // POOL_TOKENS order is [icUSD, ckUSDT, ckUSDC]. Live multiplier mirrors accrual.rs.
+  $: addMultiplier = compute3poolMultiplier({
+    icusd: parseFloat(addAmounts[0]) || 0,
+    ckusdt: parseFloat(addAmounts[1]) || 0,
+    ckusdc: parseFloat(addAmounts[2]) || 0,
+  });
+  $: addPointsHint =
+    (addMultiplier.nudge ? `${addMultiplier.nudge}. ` : '') +
+    'Keep the 3USD you mint (in your wallet, the stability pool, or the AMM) to keep these points.';
 
   function poolLedgerRef(index: number) {
     const t = POOL_TOKENS[index];
@@ -439,6 +454,12 @@
         {/if}
       </div>
     </div>
+
+    {#if $earningActive && addMultiplier.headline > 0}
+      <div style="margin-bottom:0.75rem">
+        <PointsCallout headline={threePoolHeadline(addMultiplier)} hint={addPointsHint} />
+      </div>
+    {/if}
 
     <button
       class="submit-btn"

--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -14,6 +14,8 @@
   import { toastStore } from '../../stores/toast';
   import { isOisyWallet } from '../../services/protocol/walletOperations';
   import { ApiClient } from '../../services/protocol/apiClient';
+  import MultiplierBadge from '../points/MultiplierBadge.svelte';
+  import { seasonStore, earningActive } from '$lib/stores/seasonStore';
 
   export let vault: Vault;
   export let icpPrice: number = 0;
@@ -232,6 +234,7 @@
   let recoveryMultiplier: number = 1;
   let ckstableRepayFee = 0; // Protocol repay fee rate for ckStables (e.g., 0.01 = 1%)
   onMount(async () => {
+    seasonStore.ensureLoaded();
     // Fetch per-vault dynamic rate eagerly so collapsed card shows actual APR
     ApiClient.getVaultInterestRate(vault.vaultId).then(rate => {
       if (rate !== null) dynamicInterestRate = rate;
@@ -953,7 +956,7 @@
 
             {:else if activeAction === 'borrow'}
               <div class="input-header">
-                <span class="input-label">Borrow icUSD</span>
+                <span class="input-label">Borrow icUSD {#if $earningActive}<MultiplierBadge multiplier={1} />{/if}</span>
                 {#if maxBorrowable > 0}
                   <button class="max-text" on:click={setMaxBorrow}>Max: {floorTo(maxBorrowable, 4)}</button>
                 {/if}
@@ -987,7 +990,7 @@
 
             {:else if activeAction === 'repay'}
               <div class="input-header">
-                <span class="input-label">Repay Debt</span>
+                <span class="input-label">Repay Debt {#if $earningActive}<MultiplierBadge multiplier={5} comingSoon label="5× soon" />{/if}</span>
                 {#if maxRepayable > 0}
                   <button class="max-text" on:click={setMaxRepay}>Max: {floorTo(maxRepayable, 4)}</button>
                 {/if}

--- a/src/vault_frontend/src/lib/stores/seasonStore.ts
+++ b/src/vault_frontend/src/lib/stores/seasonStore.ts
@@ -1,0 +1,43 @@
+/**
+ * seasonStore.ts — one shared, lazily-loaded copy of the airdrop season status so
+ * every "earn Nx points" badge can gate on the live season phase without each
+ * component issuing its own query. Call `ensureLoaded()` from any component that
+ * shows earning UI; the underlying queries are cached and loaded at most once.
+ */
+import { writable, derived } from 'svelte/store';
+import { POINTS_ENABLED } from '$lib/config';
+import { getEpochStatus, getPointsConfig } from '$lib/services/pointsService';
+import { seasonState, type SeasonPhase } from '$lib/utils/points';
+import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
+
+interface SeasonData {
+  status: PublicEpochStatus | null;
+  config: PointsConfig | null;
+  loaded: boolean;
+}
+
+const store = writable<SeasonData>({ status: null, config: null, loaded: false });
+let started = false;
+
+async function ensureLoaded(): Promise<void> {
+  if (started || !POINTS_ENABLED) return;
+  started = true;
+  try {
+    const [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
+    store.set({ status, config, loaded: true });
+  } catch (e) {
+    console.error('[seasonStore] load failed', e);
+    store.set({ status: null, config: null, loaded: true });
+  }
+}
+
+export const seasonStore = { subscribe: store.subscribe, ensureLoaded };
+
+export const seasonPhase = derived(
+  store,
+  ($s): SeasonPhase => seasonState($s.status, $s.config, BigInt(Date.now()) * 1_000_000n),
+);
+
+/** Whether to show "earn Nx points" badges — true during the live season and the
+ *  pre-season run-up (positions are counted once the season opens). */
+export const earningActive = derived(seasonPhase, ($p) => $p === 'live' || $p === 'pre');

--- a/src/vault_frontend/src/lib/utils/pointsRules.test.ts
+++ b/src/vault_frontend/src/lib/utils/pointsRules.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compute3poolMultiplier,
+  threePoolHeadline,
+  spMultiplier,
+  depositMultiplierLabel,
+  formatSharePct,
+} from './pointsRules';
+
+describe('compute3poolMultiplier — mirrors accrual.rs snapshot_weights', () => {
+  it('equal ckUSDC/ckUSDT pair is fully matched at 5x', () => {
+    const m = compute3poolMultiplier({ ckusdc: 100, ckusdt: 100 });
+    expect(m.matchedUsd).toBe(200); // 2*min(100,100)
+    expect(m.unmatchedUsd).toBe(0);
+    expect(m.headline).toBe(5);
+    expect(m.effective).toBe(5);
+  });
+
+  it('matched portion accrues 5x, remainder accrues 3x', () => {
+    // 100 ckUSDC + 40 ckUSDT: matched = 2*40 = 80 @5x; unmatched = 60 @3x
+    const m = compute3poolMultiplier({ ckusdc: 100, ckusdt: 40 });
+    expect(m.matchedUsd).toBe(80);
+    expect(m.unmatchedUsd).toBe(60);
+    expect(m.headline).toBe(5);
+    // weighted = 80*5 + 60*3 = 580; deposited = 140 → 4.14 → 4.1
+    expect(m.effective).toBe(4.1);
+  });
+
+  it('dust pairing does NOT flip the whole position to 5x blended', () => {
+    // 50000 ckUSDC + 1 ckUSDT: only $2 is matched; the rest stays at 3x.
+    const m = compute3poolMultiplier({ ckusdc: 50000, ckusdt: 1 });
+    expect(m.matchedUsd).toBe(2);
+    expect(m.unmatchedUsd).toBe(49999);
+    // blended must be ~3x, nowhere near 5x
+    expect(m.effective).toBeLessThan(3.1);
+    expect(m.effective).toBeGreaterThan(2.9);
+    // the form headline must not scream a flat 5x
+    expect(threePoolHeadline(m)).not.toContain('Earning 5× — matched');
+  });
+
+  it('single-sided ckUSDC earns 3x with a nudge to reach 5x', () => {
+    const m = compute3poolMultiplier({ ckusdc: 100 });
+    expect(m.matchedUsd).toBe(0);
+    expect(m.headline).toBe(3);
+    expect(m.effective).toBe(3);
+    expect(m.nudge).toBe('Add ckUSDT to reach 5×');
+  });
+
+  it('icUSD-only liquidity earns 1x', () => {
+    const m = compute3poolMultiplier({ icusd: 100 });
+    expect(m.headline).toBe(1);
+    expect(m.effective).toBe(1);
+    expect(threePoolHeadline(m)).toContain('1×');
+  });
+
+  it('empty input earns nothing', () => {
+    const m = compute3poolMultiplier({});
+    expect(m.headline).toBe(0);
+    expect(m.effective).toBe(0);
+  });
+
+  it('clamps negative inputs to zero', () => {
+    const m = compute3poolMultiplier({ ckusdc: -50, ckusdt: 50 });
+    expect(m.matchedUsd).toBe(0);
+    expect(m.unmatchedUsd).toBe(50);
+    expect(m.headline).toBe(3);
+  });
+});
+
+describe('spMultiplier', () => {
+  it('3USD earns 2x', () => {
+    expect(spMultiplier('3USD')).toBe(2);
+    expect(spMultiplier('threeusd')).toBe(2);
+  });
+  it('icUSD and others earn 1x', () => {
+    expect(spMultiplier('icUSD')).toBe(1);
+    expect(spMultiplier('ckUSDC')).toBe(1);
+    expect(spMultiplier(null)).toBe(1);
+  });
+});
+
+describe('depositMultiplierLabel', () => {
+  it('labels per venue/asset', () => {
+    expect(depositMultiplierLabel('threePool', 'ckUSDC')).toBe('3–5×');
+    expect(depositMultiplierLabel('threePool', 'icUSD')).toBe('1×');
+    expect(depositMultiplierLabel('stabilityPool', '3USD')).toBe('2×');
+    expect(depositMultiplierLabel('stabilityPool', 'icUSD')).toBe('1×');
+    expect(depositMultiplierLabel('amm', 'ICP')).toBe('2×');
+    expect(depositMultiplierLabel('vault', 'icUSD')).toBe('1×');
+  });
+});
+
+describe('formatSharePct', () => {
+  it('converts bps of the pool to a percentage', () => {
+    expect(formatSharePct(250)).toBe('2.50%');
+    expect(formatSharePct(10000)).toBe('100.00%');
+  });
+  it('returns a dash for non-positive/non-finite', () => {
+    expect(formatSharePct(0)).toBe('—');
+    expect(formatSharePct(NaN)).toBe('—');
+  });
+});

--- a/src/vault_frontend/src/lib/utils/pointsRules.ts
+++ b/src/vault_frontend/src/lib/utils/pointsRules.ts
@@ -1,0 +1,129 @@
+/**
+ * pointsRules.ts — the single source of truth for Season 1 airdrop multipliers,
+ * mirrored from the rumi_points canister (accrual.rs / airdrop spec v2). Pure and
+ * unit-tested. Every badge, callout, and table in the UI reads from here so the
+ * app and the docs can never disagree.
+ *
+ * All amounts here are USD-equivalent: icUSD, ckUSDC, ckUSDT and 3USD all peg to
+ * ~$1, so the entered token amount is its own USD value for multiplier purposes.
+ */
+
+export const SEASON_LABEL = 'Season 1';
+export const MAX_MULTIPLIER = 5;
+
+/** The repay-with-ckUSDC/ckUSDT 5x window is blocked on an upstream backend field
+ *  (RepayToVault.repayment_asset). Advertise it as "coming soon" until it ships;
+ *  do not imply it is live. */
+export const REPAY_BOOST_COMING_SOON = true;
+export const REPAY_BOOST_MULTIPLIER = 5;
+
+export type EarnVenue = 'vault' | 'stabilityPool' | 'threePool' | 'amm';
+
+export interface EarnRule {
+  key: string;
+  label: string;
+  venue: EarnVenue;
+  multiplier: number;
+  href: string;
+}
+
+/** The public multiplier table, ordered high → low for "ways to earn" lists. */
+export const EARN_RULES: EarnRule[] = [
+  { key: 'ck-matched', label: 'ckUSDC + ckUSDT matched pair in the 3pool', venue: 'threePool', multiplier: 5, href: '/3usd' },
+  { key: 'ck-unmatched', label: 'ckUSDC or ckUSDT in the 3pool', venue: 'threePool', multiplier: 3, href: '/3usd' },
+  { key: 'sp-3usd', label: '3USD in the stability pool', venue: 'stabilityPool', multiplier: 2, href: '/stability-pool' },
+  { key: 'amm', label: '3USD/ICP liquidity in the AMM', venue: 'amm', multiplier: 2, href: '/swap' },
+  { key: 'vault', label: 'icUSD borrowed against a vault', venue: 'vault', multiplier: 1, href: '/' },
+  { key: 'icusd-3pool', label: 'icUSD in the 3pool', venue: 'threePool', multiplier: 1, href: '/3usd' },
+  { key: 'sp-icusd', label: 'icUSD in the stability pool', venue: 'stabilityPool', multiplier: 1, href: '/stability-pool' },
+];
+
+/** Stability-pool deposit multiplier by token symbol (case-insensitive). */
+export function spMultiplier(symbol: string | null | undefined): number {
+  if (!symbol) return 1;
+  const s = symbol.toLowerCase();
+  if (s === '3usd' || s === 'threeusd') return 2;
+  return 1; // icUSD (and any other stable) in the SP earns 1x
+}
+
+export interface ThreePoolMultiplier {
+  /** Highest active tier: 5 (any matched), 3 (single-sided ck), 1 (icUSD only), 0 (empty). */
+  headline: number;
+  /** Blended effective multiplier = weighted / deposited, rounded to 1 dp. */
+  effective: number;
+  matchedUsd: number; // 2*min(usdc,usdt) — dollars earning 5x
+  unmatchedUsd: number; // |usdc-usdt| — dollars earning 3x
+  icusdUsd: number; // icUSD dollars earning 1x
+  /** A short nudge toward a higher tier, or null. */
+  nudge: string | null;
+}
+
+/**
+ * Mirror of accrual.rs snapshot_weights for the 3pool:
+ *   matched   = 2*min(usdc,usdt)  @ 5x
+ *   unmatched = |usdc - usdt|     @ 3x
+ *   icusd     =  icusd            @ 1x
+ * Inputs are USD-equivalent token amounts (>= 0). A token-dust amount of the
+ * opposite coin does NOT flip the whole position to 5x — only the matched portion
+ * does (the v1 dust-gaming exploit is closed in the canister), so the blended
+ * `effective` stays honest.
+ */
+export function compute3poolMultiplier(input: {
+  icusd?: number;
+  ckusdc?: number;
+  ckusdt?: number;
+}): ThreePoolMultiplier {
+  const icusd = Math.max(0, input.icusd ?? 0);
+  const usdc = Math.max(0, input.ckusdc ?? 0);
+  const usdt = Math.max(0, input.ckusdt ?? 0);
+
+  const matchedUsd = 2 * Math.min(usdc, usdt);
+  const unmatchedUsd = Math.abs(usdc - usdt);
+  const icusdUsd = icusd;
+
+  const deposited = icusd + usdc + usdt;
+  const weighted = icusdUsd * 1 + matchedUsd * 5 + unmatchedUsd * 3;
+
+  let headline = 0;
+  if (matchedUsd > 0) headline = 5;
+  else if (unmatchedUsd > 0) headline = 3;
+  else if (icusdUsd > 0) headline = 1;
+
+  const effective = deposited > 0 ? Math.round((weighted / deposited) * 10) / 10 : 0;
+
+  let nudge: string | null = null;
+  if (matchedUsd === 0 && unmatchedUsd > 0) {
+    const missing = usdc === 0 ? 'ckUSDC' : 'ckUSDT';
+    nudge = `Add ${missing} to reach 5×`;
+  } else if (matchedUsd > 0 && unmatchedUsd > 0) {
+    nudge = 'Balance the pair so all of it earns 5×';
+  }
+
+  return { headline, effective, matchedUsd, unmatchedUsd, icusdUsd, nudge };
+}
+
+/** Human headline for the 3pool callout given a computed multiplier. */
+export function threePoolHeadline(m: ThreePoolMultiplier): string {
+  if (m.headline === 5 && m.unmatchedUsd === 0 && m.icusdUsd === 0) {
+    return 'Earning 5× — matched ckUSDC + ckUSDT pair';
+  }
+  if (m.headline === 5) return `Earning up to 5× · ≈${m.effective}× blended`;
+  if (m.headline === 3) return 'Earning 3× on single-sided ckUSDC/ckUSDT';
+  if (m.headline === 1) return 'Earning 1× on icUSD liquidity';
+  return 'Add liquidity to start earning points';
+}
+
+/** Multiplier label for a (venue, assetSymbol) active deposit on the dashboard. */
+export function depositMultiplierLabel(venue: EarnVenue, assetSymbol: string): string {
+  const s = assetSymbol.toLowerCase();
+  if (venue === 'threePool') return s.includes('ckusd') ? '3–5×' : '1×';
+  if (venue === 'stabilityPool') return spMultiplier(assetSymbol) === 2 ? '2×' : '1×';
+  if (venue === 'amm') return '2×';
+  return '1×'; // vault
+}
+
+/** Format LeaderboardEntry.estimated_share_bps (bps of the Season 1 pool) as a %. */
+export function formatSharePct(bps: number): string {
+  if (!Number.isFinite(bps) || bps <= 0) return '—';
+  return `${(bps / 100).toFixed(2)}%`;
+}

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   import { POINTS_ENABLED } from '$lib/config';
   import { developerAccess } from "../lib/stores/developer";
   import ToastContainer from "../lib/components/common/ToastContainer.svelte";
+  import SeasonBar from "$lib/components/points/SeasonBar.svelte";
   import { ApiClient } from "../lib/services/protocol/apiClient";
   import { initIcpswapRoutingFlag } from "../lib/services/swapRouter";
   import { stabilityPoolService } from "../lib/services/stabilityPoolService";
@@ -113,7 +114,7 @@
 </header>
 <PositionStrip />
 <ToastContainer />
-<main class="main-content"><slot /></main>
+<main class="main-content">{#if POINTS_ENABLED && !currentPath.startsWith('/points')}<SeasonBar />{/if}<slot /></main>
 <footer class="app-footer">
   <div class="footer-inner">
     <div class="footer-links">

--- a/src/vault_frontend/src/routes/+page.svelte
+++ b/src/vault_frontend/src/routes/+page.svelte
@@ -12,6 +12,8 @@
   import { collateralStore, activeCollateralTypes } from '$lib/stores/collateralStore';
   import { CANISTER_IDS } from '$lib/config';
   import ProtocolStats from '$lib/components/dashboard/ProtocolStats.svelte';
+  import MultiplierBadge from '$lib/components/points/MultiplierBadge.svelte';
+  import { seasonStore, earningActive } from '$lib/stores/seasonStore';
 
   let collateralAmount = 1;
   let icusdAmount = 5;
@@ -171,6 +173,7 @@
   onMount(() => {
     loadProtocolData();
     refreshPrice();
+    seasonStore.ensureLoaded();
     // Ensure collateral configs are loaded (provides per-asset CR, fees, etc.)
     collateralStore.fetchSupportedCollateral();
     priceRefreshInterval = setInterval(refreshPrice, 30000);
@@ -333,6 +336,13 @@
             {#if errorMessage}<div class="msg-error">{errorMessage}</div>{/if}
             {#if successMessage}<div class="msg-success">{successMessage}</div>{/if}
 
+            {#if $earningActive}
+              <div class="points-hint">
+                <MultiplierBadge multiplier={1} variant="full" />
+                <span>on the icUSD you mint, while the vault is open</span>
+              </div>
+            {/if}
+
             <button
               class="btn-primary cta-button"
               on:click={createVault}
@@ -485,6 +495,12 @@
 
   /* CTA */
   .cta-button { width: 100%; padding: 0.75rem; }
+
+  /* Airdrop points hint above the CTA */
+  .points-hint {
+    display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+    font-size: 0.75rem; color: var(--rumi-text-muted);
+  }
 
   /* Dev gate */
   .dev-gate { text-align: center; padding: 2rem 1rem; }

--- a/src/vault_frontend/src/routes/docs/points/+page.svelte
+++ b/src/vault_frontend/src/routes/docs/points/+page.svelte
@@ -29,11 +29,13 @@
           <tr><td>icUSD in the stability pool</td><td class="mult">1x</td></tr>
           <tr><td>3USD in the stability pool</td><td class="mult">2x</td></tr>
           <tr><td>3USD/ICP liquidity in the Rumi AMM</td><td class="mult">2x</td></tr>
+          <tr><td>Repay a vault with ckUSDC or ckUSDT <span class="soon">coming soon</span></td><td class="mult">5x</td></tr>
         </tbody>
       </table>
     </div>
     <p>Multipliers stack <strong>across activities</strong>: borrowing against a vault, depositing in the 3pool, and depositing in the stability pool all earn independently at the same time. They do not stack within a single activity.</p>
     <p>For the matched-pair rate, the matched portion is twice the smaller of your ckUSDC and ckUSDT deposits at 5x; whatever is left over on the larger side earns the unmatched 3x rate. Adding a token-sized amount of one coin does not flip your whole position to 5x.</p>
+    <p>The <strong>5x repayment boost</strong> rewards repaying vault debt with ckUSDC or ckUSDT: the repaid amount earns for a 90-day window (capped at season end). It is not live yet and will be enabled in an upcoming backend release.</p>
   </section>
 
   <section class="doc-section">
@@ -86,4 +88,10 @@
   }
   .doc-table tbody tr:last-child td { border-bottom: none; }
   .mult { color: var(--rumi-action); font-weight: 600; font-variant-numeric: tabular-nums; }
+  .soon {
+    display: inline-block; margin-left: 0.375rem; padding: 0.0625rem 0.375rem;
+    font-size: 0.625rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--rumi-text-muted); background: rgba(120,120,140,0.12);
+    border: 1px solid var(--rumi-border); border-radius: 999px; vertical-align: middle;
+  }
 </style>

--- a/src/vault_frontend/src/routes/points/+page.svelte
+++ b/src/vault_frontend/src/routes/points/+page.svelte
@@ -5,7 +5,7 @@
   import { isConnected, principal } from '$lib/stores/wallet';
   import { myPointsStore } from '$lib/stores/pointsStore';
   import { getEpochStatus, getPointsConfig, getLeaderboard } from '$lib/services/pointsService';
-  import { bodyState, deriveRank } from '$lib/utils/points';
+  import { bodyState } from '$lib/utils/points';
   import type { PublicEpochStatus, PointsConfig } from '$declarations/rumi_points/rumi_points.did';
   import SeasonBanner from '$lib/components/points/SeasonBanner.svelte';
   import EarnCta from '$lib/components/points/EarnCta.svelte';
@@ -14,6 +14,7 @@
   let status = $state<PublicEpochStatus | null>(null);
   let config = $state<PointsConfig | null>(null);
   let rank = $state<number | null>(null);
+  let shareBps = $state<number | null>(null);
 
   onMount(async () => {
     // Route gate: the section is hidden in nav until the canister is configured;
@@ -36,17 +37,21 @@
     const p = $principal;
     if ($isConnected && p) {
       myPointsStore.load(p);
-      // Best-effort rank from the top slice (no get_my_rank endpoint exists).
+      // Best-effort rank + estimated share from the top slice (no get_my_rank endpoint).
       getLeaderboard(0, 1000)
         .then((rows) => {
-          rank = deriveRank(rows, p.toText());
+          const me = rows.find((e) => e.principal.toText() === p.toText());
+          rank = me ? me.rank : null;
+          shareBps = me ? me.estimated_share_bps : null;
         })
         .catch(() => {
           rank = null;
+          shareBps = null;
         });
     } else {
       myPointsStore.reset();
       rank = null;
+      shareBps = null;
     }
   });
 
@@ -92,7 +97,7 @@
       This address is excluded from the airdrop (protocol-owned).
     </div>
   {:else if body === 'enrolled' && $myPointsStore.state}
-    <PointsSummary state={$myPointsStore.state} {rank} />
+    <PointsSummary state={$myPointsStore.state} {rank} {shareBps} />
     <EarnCta heading="Earn more" />
   {:else}
     <div class="rounded-xl bg-gray-800/30 border border-gray-700/50 p-4 text-sm text-gray-300">


### PR DESCRIPTION
## What

Make Season 1 point-earning obvious everywhere a user takes an action, the way most points-farming DeFi protocols do it. Previously the only points surfaces were the nav pill, `/points`, and `/docs/points`, so a user walking the app had no idea what was earning them points.

## Building blocks
- `lib/utils/pointsRules.ts` (+ test): single source of truth for the multiplier table and `compute3poolMultiplier()`, mirrored from the rumi_points canister `accrual.rs` (matched 5×, unmatched 3×, dust-case stays honest, icUSD 1×). 12 unit tests.
- `MultiplierBadge` / `PointsCallout`: reusable green multiplier pill + inline form callout.
- `SeasonBar`: slim persistent airdrop bar at the top of every page (hidden on `/points`), adapts to season phase + enrollment.
- `stores/seasonStore.ts`: one shared, lazily-loaded season status so earning badges gate on the live phase (auto-hide after season end) without each component querying.

## Surfaces wired (display-only — no awaits between click and signer, so Oisy gesture rules are untouched)
Borrow CTA (1×), VaultCard borrow (1×) / repay (5× coming soon), stability-pool deposit (dynamic 1×/2×), 3pool add (live 1×/3×/5× callout + the 3USD-holding hint), AMM add (2×), refreshed `EarnCta` (badged, sorted, dead `/liquidity` link fixed).

## Page revamps
`/points` dashboard gains estimated pool share + a per-venue "where you're earning" breakdown from `active_deposits`; `/docs/points` adds the 5× repay boost row (marked coming soon — blocked on backend `RepayToVault.repayment_asset`).

## Safety / testing
All gated behind `POINTS_ENABLED`. 129 unit tests pass; production build clean; zero new `svelte-check` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)