### PR TITLE
fix(frontend): make points UI resilient to transient query blips

### DIFF
--- a/src/vault_frontend/src/lib/services/pointsService.ts
+++ b/src/vault_frontend/src/lib/services/pointsService.ts
@@ -56,6 +56,28 @@ export function invalidatePointsCache(prefix?: string): void {
   for (const key of cache.keys()) if (key.startsWith(prefix)) cache.delete(key);
 }
 
+/**
+ * Retry a read-only query through transient failures (boundary-node blips,
+ * momentary network drops, transient replica rejections). All points calls are
+ * idempotent queries, so retrying is always safe. Backoff: ~300ms, ~600ms.
+ * Throws the last error once attempts are exhausted, so genuine failures still
+ * surface to the UI (error state + Retry).
+ */
+async function withRetry<T>(fn: () => Promise<T>, attempts = 3, baseDelayMs = 300): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      if (i < attempts - 1) {
+        await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** i));
+      }
+    }
+  }
+  throw lastErr;
+}
+
 let _actor: PointsService | null = null;
 function getActor(): PointsService {
   if (_actor) return _actor;
@@ -75,28 +97,28 @@ export async function getEpochStatus(): Promise<PublicEpochStatus> {
   const key = 'points:status';
   const c = getCached<PublicEpochStatus>(key, TTL.STATUS);
   if (c.hit) return c.value;
-  return setCache(key, await getActor().get_epoch_status());
+  return setCache(key, await withRetry(() => getActor().get_epoch_status()));
 }
 
 export async function getPointsConfig(): Promise<PointsConfig> {
   const key = 'points:config';
   const c = getCached<PointsConfig>(key, TTL.CONFIG);
   if (c.hit) return c.value;
-  return setCache(key, await getActor().get_points_config());
+  return setCache(key, await withRetry(() => getActor().get_points_config()));
 }
 
 export async function isRegistered(p: Principal): Promise<boolean> {
   const key = `points:reg:${p.toText()}`;
   const c = getCached<boolean>(key, TTL.PRINCIPAL);
   if (c.hit) return c.value;
-  return setCache(key, await getActor().is_registered(p));
+  return setCache(key, await withRetry(() => getActor().is_registered(p)));
 }
 
 export async function isExcluded(p: Principal): Promise<boolean> {
   const key = `points:excl:${p.toText()}`;
   const c = getCached<boolean>(key, TTL.PRINCIPAL);
   if (c.hit) return c.value;
-  return setCache(key, await getActor().is_excluded(p));
+  return setCache(key, await withRetry(() => getActor().is_excluded(p)));
 }
 
 export async function getPrincipalState(p: Principal): Promise<PrincipalState | null> {
@@ -104,7 +126,7 @@ export async function getPrincipalState(p: Principal): Promise<PrincipalState | 
   const c = getCached<PrincipalState | null>(key, TTL.PRINCIPAL);
   if (c.hit) return c.value;
   // get_principal_state returns a candid opt: [] | [PrincipalState].
-  const [val] = await getActor().get_principal_state(p);
+  const [val] = await withRetry(() => getActor().get_principal_state(p));
   return setCache<PrincipalState | null>(key, val ?? null);
 }
 
@@ -112,5 +134,5 @@ export async function getLeaderboard(offset: number, limit: number): Promise<Lea
   const key = `points:lb:${offset}:${limit}`;
   const c = getCached<LeaderboardEntry[]>(key, TTL.LEADERBOARD);
   if (c.hit) return c.value;
-  return setCache(key, await getActor().get_leaderboard(offset, limit));
+  return setCache(key, await withRetry(() => getActor().get_leaderboard(offset, limit)));
 }

--- a/src/vault_frontend/src/lib/stores/seasonStore.ts
+++ b/src/vault_frontend/src/lib/stores/seasonStore.ts
@@ -26,8 +26,12 @@ async function ensureLoaded(): Promise<void> {
     const [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
     store.set({ status, config, loaded: true });
   } catch (e) {
-    console.error('[seasonStore] load failed', e);
-    store.set({ status: null, config: null, loaded: true });
+    // Don't latch a transient failure: release the guard so a later trigger
+    // (navigation, another component mounting) retries instead of leaving the
+    // season bar/badges stuck off for the rest of the session. The service
+    // layer already retries each call with backoff before we get here.
+    console.error('[seasonStore] load failed, will retry on next trigger', e);
+    started = false;
   }
 }
 

--- a/src/vault_frontend/src/routes/points/+page.svelte
+++ b/src/vault_frontend/src/routes/points/+page.svelte
@@ -16,19 +16,24 @@
   let rank = $state<number | null>(null);
   let shareBps = $state<number | null>(null);
 
-  onMount(async () => {
+  async function loadSeason() {
+    try {
+      [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
+    } catch (e) {
+      // Non-fatal: the banner degrades to its loading/unknown state. The service
+      // retries with backoff; Retry re-runs this so a transient blip recovers.
+      console.error('[points] season status load failed', e);
+    }
+  }
+
+  onMount(() => {
     // Route gate: the section is hidden in nav until the canister is configured;
     // also block direct-URL access so we never call an unconfigured canister.
     if (!POINTS_ENABLED) {
       goto('/');
       return;
     }
-    try {
-      [status, config] = await Promise.all([getEpochStatus(), getPointsConfig()]);
-    } catch (e) {
-      // Non-fatal: the banner degrades to its loading/unknown state.
-      console.error('[points] season status load failed', e);
-    }
+    loadSeason();
   });
 
   // Load / reset the connected wallet's points as the principal changes.
@@ -56,6 +61,8 @@
   });
 
   function retry() {
+    // Recover both the season banner and the personal points on one tap.
+    if (!status || !config) loadSeason();
     const p = $principal;
     if (p) myPointsStore.load(p);
   }


### PR DESCRIPTION
## Why

A connected user saw *"Could not load your points"* + a season banner stuck on *"Loading season status…"*, while the backend loaded fine for them. Diagnosis: a transient boundary/network blip hitting **only** the points canister at that moment. The canister itself is healthy (Running, ~1.8TC cycles, ~457-day runway) and serves `200`s; the page just handled the blip poorly (the banner had no recovery path and `seasonStore` latched the failure for the whole session).

## Changes (frontend only)
- **`pointsService`**: wrap every read-only query (epoch status, config, principal state, excluded, leaderboard) in **retry-with-backoff** (3 attempts, ~300/600ms). Queries are idempotent, so retrying is safe — a single blip now self-absorbs instead of surfacing an error.
- **`seasonStore`**: stop latching a transient failure — release the load guard so a later trigger (navigation, another component mount) retries, instead of leaving the SeasonBar/badges stuck off for the rest of the session.
- **`/points`**: the Retry button now also re-runs the season-status load, so a blip on that path recovers without a full page reload.

## Testing
129 unit tests pass; production build clean. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)