### PR TITLE
fix(chains/evm): Conflux eSpace round-trip fixes (mint gas, idempotent broadcast, custody withdrawal)

### DIFF
--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -1256,6 +1256,18 @@ pub async fn send_raw_transaction(chain: ChainId, raw_tx_hex: &str) -> Result<St
         .map_err(|e| format!("eth_sendRawTransaction parse: {}", e))?;
 
     if let Some(err) = val.get("error") {
+        // IDEMPOTENT-SUCCESS: a broadcast that the node already has is NOT a
+        // failure. The IC executes one HTTPS outcall from MANY replicas, so the
+        // same signed tx is submitted N times; the first lands and the rest get
+        // "already known" / "already exists". Treating that as an error left the
+        // op Queued forever (never Inflight, never confirmed) even though the
+        // mint landed on-chain. The tx hash is a pure function of the signed
+        // bytes, so recover it locally and report success. (A genuine resubmit
+        // of a same-nonce tx is likewise safe — it's the identical tx.)
+        let msg = err.to_string().to_ascii_lowercase();
+        if msg.contains("already known") || msg.contains("already exists") {
+            return crate::chains::evm::tx::raw_tx_hash(raw_tx_hex);
+        }
         return Err(format!("eth_sendRawTransaction RPC error: {}", err));
     }
 

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -319,6 +319,10 @@ fn build_tx_plan(
     prio: u128,
     max_fee: u128,
     contract: Option<&str>,
+    // For NativeWithdrawal only: the value to actually send, already capped so
+    // the custody signer can also pay gas (see `fundable_withdrawal_value`).
+    // `None` (or a Mint op) sends the op's full declared amount.
+    withdrawal_value: Option<u128>,
 ) -> Result<TxPlan, String> {
     match kind {
         SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
@@ -345,11 +349,15 @@ fn build_tx_plan(
             })
         }
         SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
-            // `amount_e18` is wei (1e18 scale) — it goes straight into the
-            // EIP-1559 `value` of a native MON transfer.
+            // `value` is wei (1e18 scale) — it goes straight into the EIP-1559
+            // `value` of a native transfer. The withdrawal is signed by the
+            // vault's own custody address, so `withdrawal_value` is the
+            // gas-netted amount (full `amount_e18` for a partial withdrawal that
+            // leaves a buffer; `custody_balance - gas` for a full close).
+            let value = withdrawal_value.unwrap_or(*amount_e18);
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: *amount_e18 },
+                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
                 nonce,
                 prio,
                 max_fee,
@@ -358,12 +366,59 @@ fn build_tx_plan(
                 fields,
                 vault_id: *vault_id,
                 recipient: recipient.clone(),
-                amount: *amount_e18,
+                amount: value,
                 kind: TxPlanKind::NativeWithdrawal,
             })
         }
         SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
     }
+}
+
+/// Resolve the `(derivation_path, from_address)` that signs an op's tx.
+///
+/// - **Mint** → the per-chain settlement (minter) hot wallet. It only ever pays
+///   icUSD-mint gas (tiny), never user collateral.
+/// - **NativeWithdrawal** → the VAULT'S OWN per-vault custody address, which
+///   holds the deposited collateral. Collateral is paid back out of the same
+///   address it was deposited to — never commingled into the hot wallet — so
+///   there is no custody-sweep dependency. The custody path is re-derived from
+///   the vault's `(chain, owner, vault_id)` exactly as `open_chain_vault` derived
+///   it; the stored `custody_address` is the matching signer address, so no
+///   extra tECDSA derive is needed here.
+async fn resolve_op_signer(
+    chain: ChainId,
+    kind: &SettlementOpKind,
+) -> Result<(Vec<Vec<u8>>, String), String> {
+    match kind {
+        SettlementOpKind::Mint { .. } => tecdsa::cached_settlement_address(chain).await,
+        SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
+            let vid = *vault_id;
+            let info = read_state(|s| {
+                s.multi_chain
+                    .chain_vaults
+                    .get(&vid)
+                    .map(|v| (v.owner, v.custody_address.clone()))
+            });
+            let (owner, custody_addr) =
+                info.ok_or_else(|| format!("withdrawal signer: unknown vault {vid}"))?;
+            // The op's `chain` IS the vault's collateral chain (settlement queues
+            // are keyed by chain), so re-derive the custody path on it.
+            let path = tecdsa::custody_derivation_path(chain, owner, vid);
+            Ok((path, custody_addr))
+        }
+        SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
+    }
+}
+
+/// The native value to actually send for a withdrawal, capped so the custody
+/// signer can ALSO pay its own gas. For a full close the requested amount equals
+/// the entire custody balance, so the worst-case gas (`gas_limit * max_fee`) is
+/// netted out — the withdrawer bears their own gas, as on any native chain, and
+/// a tiny dust (`max_fee - actual_fee`) is left behind. A partial withdrawal
+/// that leaves a buffer sends the full requested amount.
+pub(crate) fn fundable_withdrawal_value(amount_e18: u128, custody_balance: u128, max_fee: u128) -> u128 {
+    let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
+    amount_e18.min(custody_balance.saturating_sub(gas_reserve))
 }
 
 /// Submit path: sign + broadcast a `Queued` op, then mark it `Inflight`.
@@ -448,41 +503,46 @@ async fn submit_op(
         }
     }
 
-    // GAS GATE (Task 11): refuse a new outbound op when the cached settlement
-    // balance is below the hot-wallet floor. FAIL OPEN when the cache is unset
-    // (`None`): an unpopulated cache (fresh chain / observer hasn't run yet)
-    // must NEVER block a legitimate mint. The observer refreshes the cache each
-    // tick (deposit_watch::refresh_hot_wallet_balance).
-    let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
-    if let Some(bal) = cached {
-        if !hardening::hot_wallet_ok(bal) {
-            let now = ic_cdk::api::time();
-            crate::storage::record_event(&crate::event::Event::ChainHotWalletLow {
-                chain_id: chain,
-                balance_e18: bal,
-                threshold_e18: hardening::HOT_WALLET_MIN_E18,
-                timestamp: now,
-            });
-            log!(INFO, "[settlement chain={:?}] hot-wallet balance {} e18 < threshold {} e18; skipping submit of op {} (reads/observer continue)", chain, bal, hardening::HOT_WALLET_MIN_E18, op_id);
-            return;
+    // GAS GATE (Task 11): MINTS ONLY. A mint is paid by the per-chain settlement
+    // hot wallet, so refuse a new mint when the cached settlement balance is
+    // below the hot-wallet floor. FAIL OPEN when the cache is unset (`None`): an
+    // unpopulated cache (fresh chain / observer hasn't run yet) must NEVER block
+    // a legitimate mint. The observer refreshes the cache each tick
+    // (deposit_watch::refresh_hot_wallet_balance). Native WITHDRAWALS are signed
+    // by the vault's own custody address (which holds the collateral) and net
+    // their gas out of the transfer, so the settlement-wallet floor is irrelevant
+    // to them — never gate a withdrawal on it.
+    if matches!(op.kind, SettlementOpKind::Mint { .. }) {
+        let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
+        if let Some(bal) = cached {
+            if !hardening::hot_wallet_ok(bal) {
+                let now = ic_cdk::api::time();
+                crate::storage::record_event(&crate::event::Event::ChainHotWalletLow {
+                    chain_id: chain,
+                    balance_e18: bal,
+                    threshold_e18: hardening::HOT_WALLET_MIN_E18,
+                    timestamp: now,
+                });
+                log!(INFO, "[settlement chain={:?}] hot-wallet balance {} e18 < threshold {} e18; skipping submit of op {} (reads/observer continue)", chain, bal, hardening::HOT_WALLET_MIN_E18, op_id);
+                return;
+            }
         }
     }
 
-    // 1. Resolve the settlement (minter) address via the per-chain cache
-    //    (Task 11 M1): the address is deterministic, so we derive it once per
-    //    chain and reuse it every tick instead of paying a signing-subnet call
-    //    each submit. Returns the derivation PATH too, which the signer needs.
-    let (path, settlement_addr) = match tecdsa::cached_settlement_address(chain).await {
+    // 1. Resolve the signer: mints are signed by the per-chain settlement
+    //    (minter) hot wallet; native withdrawals by the vault's own custody
+    //    address. Returns the derivation PATH too, which the signer needs.
+    let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] cached_settlement_address failed for op {}: {}; will retry", chain, op_id, e);
+            log!(INFO, "[settlement chain={:?}] resolve_op_signer failed for op {}: {}; will retry", chain, op_id, e);
             return;
         }
     };
 
-    // 2. Fetch the nonce ("latest") — we store it on the op so a stuck-tx
-    //    resubmit can replace-by-fee on the SAME nonce.
-    let nonce = match evm_rpc::get_transaction_count(chain, &settlement_addr).await {
+    // 2. Fetch the nonce ("latest") for the SIGNER — we store it on the op so a
+    //    stuck-tx resubmit can replace-by-fee on the SAME nonce.
+    let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
         Ok(n) => n,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry", chain, op_id, e);
@@ -500,9 +560,31 @@ async fn submit_op(
     };
     let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
 
-    // 4. Resolve the contract (mints only) and build the tx plan.
+    // 4. For a native withdrawal, cap the transfer value so the custody signer
+    //    can also pay gas (a full close requests the entire custody balance).
+    //    Read the custody balance ONCE here; the value is recomputed identically
+    //    on a stuck-tx resubmit. Mints don't carry a value, so skip the read.
+    let withdrawal_value = if matches!(op.kind, SettlementOpKind::NativeWithdrawal { .. }) {
+        match evm_rpc::get_balance(chain, &signer_addr).await {
+            Ok(bal) => {
+                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. } = &op.kind {
+                    Some(fundable_withdrawal_value(*amount_e18, bal, max_fee))
+                } else {
+                    None
+                }
+            }
+            Err(e) => {
+                log!(INFO, "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry", chain, op_id, e);
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
+    // 5. Resolve the contract (mints only) and build the tx plan.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, nonce, prio, max_fee, contract.as_deref()) {
+    let plan = match build_tx_plan(chain, &op.kind, nonce, prio, max_fee, contract.as_deref(), withdrawal_value) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry", chain, op_id, e);
@@ -511,8 +593,8 @@ async fn submit_op(
     };
     let TxPlan { fields, vault_id, recipient, amount, kind } = plan;
 
-    // 5. Sign.
-    let raw_hex = match tx::sign_eip1559(&fields, path, &settlement_addr).await {
+    // 6. Sign with the resolved signer (settlement for mints, custody for withdrawals).
+    let raw_hex = match tx::sign_eip1559(&fields, path, &signer_addr).await {
         Ok(h) => h,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry", chain, op_id, e);
@@ -520,7 +602,7 @@ async fn submit_op(
         }
     };
 
-    // 6. Broadcast. A transient send error is logged and retried next tick — we
+    // 7. Broadcast. A transient send error is logged and retried next tick — we
     //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
     //
     //    ON-CHAIN DOUBLE-MINT DEPENDENCY: if send_raw_transaction returns Err but
@@ -543,7 +625,7 @@ async fn submit_op(
         }
     };
 
-    // 7. Mark Inflight + record the tx hash AND the submit nonce. Emit
+    // 8. Mark Inflight + record the tx hash AND the submit nonce. Emit
     //    ChainMintSubmitted for mints.
     let now = ic_cdk::api::time();
     mutate_state(|s| {
@@ -880,8 +962,8 @@ async fn confirm_op(
         }
         SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
             // A confirmed (mined + ok + final) native transfer-out: the
-            // collateral has been paid out from the settlement hot wallet. Mark
-            // the op Succeeded,
+            // collateral has been paid out from the vault's own custody address.
+            // Mark the op Succeeded,
             // then if the vault is `Closing` (a full withdrawal / close) flip it
             // to `Closed` — collateral is gone and (close required) debt is 0, so
             // the vault is fully settled. A partial withdrawal leaves the vault
@@ -945,11 +1027,11 @@ async fn resubmit_if_stuck(
         }
     };
 
-    // Resolve the settlement address via the per-chain cache (Task 11 M1).
-    let (path, settlement_addr) = match tecdsa::cached_settlement_address(chain).await {
+    // Resolve the signer (settlement for mints, vault custody for withdrawals).
+    let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resubmit cached_settlement_address failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            log!(INFO, "[settlement chain={:?}] resubmit resolve_op_signer failed for op {}: {}; leaving Inflight", chain, op_id, e);
             return;
         }
     };
@@ -966,10 +1048,31 @@ async fn resubmit_if_stuck(
     let base_max_fee = base_fee.saturating_mul(2).saturating_add(prio);
     let (bumped_prio, bumped_max) = hardening::bump_gas(prio, base_max_fee);
 
+    // Re-net the withdrawal value at the BUMPED fee so the replacement still
+    // fits within the custody balance (a higher gas reserve sends marginally
+    // less collateral — fine for a replace-by-fee). Mints carry no value.
+    let withdrawal_value = if matches!(op.kind, SettlementOpKind::NativeWithdrawal { .. }) {
+        match evm_rpc::get_balance(chain, &signer_addr).await {
+            Ok(bal) => {
+                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. } = &op.kind {
+                    Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max))
+                } else {
+                    None
+                }
+            }
+            Err(e) => {
+                log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
     // Resolve the contract (mints only) and rebuild the SAME tx at the stored
     // nonce with the bumped fees.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, nonce, bumped_prio, bumped_max, contract.as_deref()) {
+    let plan = match build_tx_plan(chain, &op.kind, nonce, bumped_prio, bumped_max, contract.as_deref(), withdrawal_value) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] resubmit build_tx_plan failed for op {}: {}; leaving Inflight", chain, op_id, e);
@@ -977,8 +1080,8 @@ async fn resubmit_if_stuck(
         }
     };
 
-    // Re-sign on the stored nonce.
-    let raw_hex = match tx::sign_eip1559(&plan.fields, path, &settlement_addr).await {
+    // Re-sign on the stored nonce with the resolved signer.
+    let raw_hex = match tx::sign_eip1559(&plan.fields, path, &signer_addr).await {
         Ok(h) => h,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] resubmit sign_eip1559 failed for op {}: {}; leaving Inflight", chain, op_id, e);

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,4 +1,4 @@
-use super::settlement::{confirm_mint_in_state, select_next_op, OpAction};
+use super::settlement::{confirm_mint_in_state, fundable_withdrawal_value, select_next_op, OpAction};
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
 use crate::chains::multi_chain_state::MultiChainStateV4;
@@ -95,4 +95,30 @@ fn confirm_mint_second_vault_uses_running_total() {
     confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total).expect("confirm 2nd");
     assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
     assert_eq!(s.chain_supplies[&ChainId(10143)], 15_000_000_000);
+}
+
+#[test]
+fn fundable_withdrawal_value_nets_gas_only_when_balance_is_tight() {
+    let amount = 20_000_000_000_000_000_000u128; // 20 native (full close)
+    let max_fee = 40_000_000_000u128; // 40 gwei ceiling
+    let gas_reserve = 21_000u128 * max_fee; // gas_limit * max_fee
+
+    // Full close: custody holds EXACTLY the requested amount -> value is netted
+    // down by the worst-case gas so the tx can still pay for itself.
+    assert_eq!(
+        fundable_withdrawal_value(amount, amount, max_fee),
+        amount - gas_reserve
+    );
+
+    // Partial withdrawal leaving a buffer >= gas: the full requested amount is
+    // sent (custody keeps the rest, which covers gas).
+    let bigger_balance = amount + 1_000_000_000_000_000_000; // 21 native
+    assert_eq!(
+        fundable_withdrawal_value(amount, bigger_balance, max_fee),
+        amount
+    );
+
+    // Degenerate: balance below the gas reserve -> saturates to 0 (never panics
+    // / underflows), so the worker sends a 0-value tx rather than trapping.
+    assert_eq!(fundable_withdrawal_value(amount, gas_reserve / 2, max_fee), 0);
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
@@ -16,7 +16,7 @@
 use alloy_rlp::Encodable;
 
 use super::tx::{
-    assemble_signed_tx, encode_mint_calldata, encode_transfer_calldata, signing_hash,
+    assemble_signed_tx, encode_mint_calldata, encode_transfer_calldata, raw_tx_hash, signing_hash,
     Eip1559Fields,
 };
 
@@ -157,6 +157,42 @@ fn transfer_calldata_encodes_address_and_amount() {
     )
     .expect("valid address");
     assert_eq!(calldata.len(), 4 + 32 * 2);
+}
+
+#[test]
+fn raw_tx_hash_is_keccak_of_signed_bytes_with_or_without_prefix() {
+    use sha3::{Digest, Keccak256};
+    // raw_tx_hash must equal keccak256(decoded bytes), 0x-prefixed lowercase,
+    // and must accept the hex with or without a leading "0x".
+    let raw_bytes = [0x02u8, 0xab, 0xcd, 0xef, 0x10];
+    let expected: [u8; 32] = Keccak256::digest(raw_bytes).into();
+    let expected_hex = format!("0x{}", hex::encode(expected));
+
+    assert_eq!(raw_tx_hash("0x02abcdef10").unwrap(), expected_hex);
+    assert_eq!(raw_tx_hash("02abcdef10").unwrap(), expected_hex);
+    // Malformed hex is an error, never a panic.
+    assert!(raw_tx_hash("0xZZ").is_err());
+}
+
+#[test]
+fn raw_tx_hash_matches_assembled_tx() {
+    use sha3::{Digest, Keccak256};
+    // The hash recovered from a real signed tx's hex must equal keccak256 of
+    // its bytes — i.e. the canonical tx hash the node would assign.
+    let fields = Eip1559Fields {
+        chain_id: 71,
+        nonce: 5,
+        max_priority_fee_per_gas: 1_000_000_000,
+        max_fee_per_gas: 40_000_000_000,
+        gas_limit: 300_000,
+        to: "0xca8dff9e9fa48cbd3ecc43fe798c633afbdf69a3".into(),
+        value: 0,
+        data: vec![0x40, 0xc1, 0x0f, 0x19],
+    };
+    let signed = assemble_signed_tx(&fields, &[0x11u8; 32], &[0x22u8; 32], 0).expect("assemble");
+    let hex_str = format!("0x{}", hex::encode(&signed));
+    let expected: [u8; 32] = Keccak256::digest(&signed).into();
+    assert_eq!(raw_tx_hash(&hex_str).unwrap(), format!("0x{}", hex::encode(expected)));
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/evm/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tx.rs
@@ -77,7 +77,13 @@ pub fn build_eip1559_fields(
                 nonce,
                 max_priority_fee_per_gas: prio,
                 max_fee_per_gas: max_fee,
-                gas_limit: 120_000,
+                // gas_limit is a CEILING (only gas actually used is charged), so a
+                // generous cap is safe across EVM chains. Conflux eSpace meters the
+                // icUSD `mint` at ~177.5k gas (measured via eth_estimateGas) — well
+                // above standard-EVM (~90k) — so the old 120k cap reverted every
+                // mint out-of-gas on eSpace. 300k clears eSpace with headroom and
+                // is still comfortably covered by the settlement hot-wallet float.
+                gas_limit: 300_000,
                 to: contract.to_string(),
                 value: 0,
                 data,
@@ -135,6 +141,21 @@ pub fn encode_transfer_calldata(to: &str, amount: u128) -> Result<Vec<u8>, Strin
 pub fn signing_hash(fields: &Eip1559Fields) -> Result<[u8; 32], String> {
     let payload = rlp_encode_eip1559(fields, None)?;
     Ok(Keccak256::digest(&payload).into())
+}
+
+/// The canonical transaction hash of an already-signed raw EIP-1559 tx:
+/// `keccak256(raw signed bytes)`, returned as a lowercase `"0x…"` 32-byte hex.
+///
+/// Used to recover the tx hash when a broadcast returns an idempotent
+/// "already known" / "already exists" response (the node accepted the tx on a
+/// prior attempt — common when the IC sends the same outcall from multiple
+/// replicas — and replies without echoing the hash). The hash is a pure
+/// function of the signed bytes, so it equals what the node assigned.
+pub fn raw_tx_hash(raw_tx_hex: &str) -> Result<String, String> {
+    let stripped = raw_tx_hex.strip_prefix("0x").unwrap_or(raw_tx_hex);
+    let bytes = hex::decode(stripped).map_err(|e| format!("raw_tx_hash: bad hex: {e}"))?;
+    let hash: [u8; 32] = Keccak256::digest(&bytes).into();
+    Ok(format!("0x{}", hex::encode(hash)))
 }
 
 /// Assemble the final signed EIP-1559 transaction bytes:

--- a/src/rumi_protocol_backend/src/chains/evm/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tx.rs
@@ -62,6 +62,13 @@ pub enum MonadTxKind<'a> {
 /// boundary validation at `set_chain_contract`/`open_chain_vault`/withdraw+close
 /// makes this unreachable in practice, but a malformed address must never trap
 /// the settlement worker after the re-entrancy guard is held).
+/// Intrinsic gas for a plain native-value transfer (no calldata). A native
+/// withdrawal carries no data, so 21_000 is exact on every EVM chain. Exported
+/// so the settlement worker can reserve the worst-case gas
+/// (`gas_limit * max_fee`) out of a full-close withdrawal value with the SAME
+/// number used to build the tx.
+pub const NATIVE_WITHDRAWAL_GAS_LIMIT: u64 = 21_000;
+
 pub fn build_eip1559_fields(
     chain_id: u64,
     kind: MonadTxKind,
@@ -94,7 +101,7 @@ pub fn build_eip1559_fields(
             nonce,
             max_priority_fee_per_gas: prio,
             max_fee_per_gas: max_fee,
-            gas_limit: 21_000,
+            gas_limit: NATIVE_WITHDRAWAL_GAS_LIMIT,
             to: recipient.to_string(),
             value: amount_wei,
             data: vec![],


### PR DESCRIPTION
Three fixes surfaced by running the **first real native-CFX CDP round-trip on Conflux eSpace testnet** (kvg63 staging). The full lifecycle now works end-to-end: deposit 20 CFX → mint 1 icUSD → burn → withdraw ~20 CFX → vault Closed, with the supply invariant exact at every step (0 → 1e8 → 0, gap 0).

These are post-merge commits on top of PR #248 (the M1 rail), rebased onto current `main` (so the PR #250 Monad PocketIC fix is in the base).

## 1. Mint gas ceiling too low for eSpace (`3b9b346`)
`build_eip1559_fields` hardcoded the mint `gas_limit` to 120k, but eSpace meters the icUSD `mint` at ~155k (measured 155,305 on-chain; `eth_estimateGas` ~177k) — well above standard-EVM (~90k). Every mint reverted out-of-gas: the nonce climbed and gas burned while `totalSupply` stayed 0. Raised to 300k (a ceiling — only gas used is charged). Same eSpace-charges-more-gas class as the IcUSD deploy, which needed `--gas-estimate-multiplier 400`.

## 2. `"already known"` broadcast treated as an error (`3b9b346`)
The IC executes one `eth_sendRawTransaction` outcall from many replicas; the first lands the tx and the rest get `{"code":-32603,"message":"already known"}`. We surfaced that as `Err`, so the settlement op stayed `Queued` forever (never `Inflight`, never confirmed) even though the tx landed on-chain. Now treated as idempotent success: recover the canonical tx hash locally via the new `tx::raw_tx_hash` (keccak of the signed bytes). Supersedes the old "re-mint at nonce+1" fallback — the op marks `Inflight`, no second mint.

## 3. Native withdrawals signed from the hot-wallet, not vault custody (`13c01d8`)
Withdrawals were signed by the per-chain settlement (minter) hot-wallet, but deposited collateral lives in each vault's per-vault **custody** address. On a real chain this reverts `insufficient funds for transfer` and only ever worked behind a deferred custody-sweep. Now signed from the vault's own custody address:
- `resolve_op_signer()` — Mint → settlement; NativeWithdrawal → custody path re-derived from the vault's `(chain, owner, vault_id)` (the stored `custody_address` is the matching signer, no extra tECDSA derive).
- `fundable_withdrawal_value()` — caps the transfer at `custody_balance - gas_reserve` so a full close (which requests the entire balance) can still pay its own gas; partial withdrawals send the full amount.
- The hot-wallet floor gate is now mints-only.
- Both `submit_op` and `resubmit_if_stuck` use the resolved signer + netted value.

**This eliminates the deferred custody-sweep mainnet gate** — collateral is never commingled and the hot-wallet only ever funds mint gas.

## Tests
- New unit tests: `raw_tx_hash` (2), `fundable_withdrawal_value` (1). Chains lib **311 green**.
- Conflux end-to-end PocketIC green.
- **Live eSpace testnet round-trip** is the integration proof: mint tx `0xe8c202a5`, burn tx `0xe6c09b2d`, withdrawal tx `0x8f88ab6f` (paid from custody, 20 CFX − gas), vault Closed, `reconcile_chain_supply(71)` recorded == on-chain == 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)