### PR TITLE
feat(chains): Conflux/Monad CDP interest accrual (Task 12, Option B)

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -44,6 +44,15 @@ export interface CandidVault {
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
 }
+export interface ChainSupplyReconciliation {
+  'recorded_supply_e8s' : bigint,
+  'gap_e8s' : bigint,
+  'unbacked_excess' : boolean,
+  'finalized_block' : bigint,
+  'in_flight_mint_e8s' : bigint,
+  'chain_id' : number,
+  'onchain_total_supply_e8s' : bigint,
+}
 export type ChainVaultStatus = { 'MintPending' : null } |
   { 'Open' : null } |
   { 'Closed' : null } |
@@ -53,10 +62,12 @@ export interface ChainVaultV1 {
   'status' : ChainVaultStatus,
   'owner' : Principal,
   'pending_mint_e8s' : bigint,
+  'pending_interest_mint_e8s' : bigint,
   'custody_address' : string,
   'collateral_amount_e18' : bigint,
   'opened_at_ns' : bigint,
   'vault_id' : bigint,
+  'last_interest_accrual_ns' : bigint,
   'collateral_chain' : number,
   'mint_recipient' : string,
   'debt_e8s' : bigint,
@@ -79,6 +90,7 @@ export interface CollateralConfig {
   'redemption_tier' : number,
   'redemption_fee_floor' : Uint8Array | number[],
   'borrow_threshold_ratio' : Uint8Array | number[],
+  'custody_kind' : [] | [CustodyKind],
   'ledger_fee' : bigint,
   'recovery_target_cr' : Uint8Array | number[],
   'current_base_rate' : Uint8Array | number[],
@@ -137,6 +149,8 @@ export interface ConsentMessageSpec {
   'metadata' : ConsentMessageMetadata,
   'device_spec' : [] | [DeviceSpec],
 }
+export type CustodyKind = { 'IcrcLedger' : null } |
+  { 'NativeXrp' : null };
 export type DeficitSource = { 'Liquidation' : { 'vault_id' : bigint } } |
   { 'Redemption' : { 'redeemer' : Principal } };
 export type DeviceSpec = { 'GenericDisplay' : null } |
@@ -400,6 +414,17 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'set_reserve_redemptions_enabled' : { 'enabled' : boolean } } |
   { 'set_min_icusd_amount' : { 'amount' : string } } |
   { 'set_borrowing_fee_curve' : { 'markers' : string } } |
+  {
+    'chain_interest_minted' : {
+      'mint_id' : bigint,
+      'vault_id' : bigint,
+      'block_number' : bigint,
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'tx_hash' : string,
+    }
+  } |
   { 'set_interest_pool_share' : { 'share' : string } } |
   { 'set_liquidation_protocol_share' : { 'share' : string } } |
   {
@@ -726,6 +751,11 @@ export interface EventsByPrincipalPagedResponse {
 export type FeeSource = { 'BorrowingFee' : null } |
   { 'RedemptionFee' : null };
 export interface Fees { 'redemption_fee' : number, 'borrowing_fee' : number }
+export interface ForwardFilteredEventsResponse {
+  'next_start' : bigint,
+  'reached_end' : boolean,
+  'events' : Array<[bigint, Event]>,
+}
 export type GasStrategy = { 'NotApplicable' : null } |
   { 'SolanaPriorityFee' : { 'lamports_per_cu_ceiling' : bigint } } |
   {
@@ -939,6 +969,7 @@ export interface RegisterChainArg {
   'chain_native_decimals' : number,
   'display_name' : string,
   'chain_id' : number,
+  'min_quorum_providers' : [] | [number],
 }
 export interface RepayAndCloseSuccess {
   'collateral_return_block_index' : [] | [bigint],
@@ -960,15 +991,23 @@ export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
   { 'Err' : ProtocolError };
-export type Result_10 = { 'Ok' : boolean } |
+export type Result_10 = { 'Ok' : OpenVaultSuccess } |
   { 'Err' : ProtocolError };
-export type Result_11 = { 'Ok' : ReserveRedemptionResult } |
+export type Result_11 = { 'Ok' : XrpVaultOpenInfo } |
   { 'Err' : ProtocolError };
-export type Result_12 = { 'Ok' : RepayAndCloseSuccess } |
+export type Result_12 = { 'Ok' : ChainSupplyReconciliation } |
   { 'Err' : ProtocolError };
-export type Result_13 = { 'Ok' : StabilityPoolLiquidationResult } |
+export type Result_13 = { 'Ok' : boolean } |
   { 'Err' : ProtocolError };
-export type Result_14 = { 'Ok' : number } |
+export type Result_14 = { 'Ok' : ReserveRedemptionResult } |
+  { 'Err' : ProtocolError };
+export type Result_15 = { 'Ok' : RepayAndCloseSuccess } |
+  { 'Err' : ProtocolError };
+export type Result_16 = { 'Ok' : Uint8Array | number[] } |
+  { 'Err' : ProtocolError };
+export type Result_17 = { 'Ok' : StabilityPoolLiquidationResult } |
+  { 'Err' : ProtocolError };
+export type Result_18 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_2 = { 'Ok' : string } |
   { 'Err' : ProtocolError };
@@ -984,7 +1023,7 @@ export type Result_7 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_8 = { 'Ok' : ConsentInfo } |
   { 'Err' : Icrc21Error };
-export type Result_9 = { 'Ok' : OpenVaultSuccess } |
+export type Result_9 = { 'Ok' : ChainVaultV1 } |
   { 'Err' : ProtocolError };
 export type SpProofLedger = { 'IcusdBurn' : null } |
   { 'ThreePoolTransfer' : null };
@@ -1013,7 +1052,9 @@ export type StableTokenType = { 'CKUSDC' : null } |
 export interface StandardRecord { 'url' : string, 'name' : string }
 export interface SuccessWithFee {
   'block_index' : bigint,
+  'debt_liquidated_e8s' : [] | [bigint],
   'fee_amount_paid' : bigint,
+  'stable_pulled_e6s' : [] | [bigint],
   'collateral_amount_received' : [] | [bigint],
 }
 export interface SupplyAudit {
@@ -1065,6 +1106,7 @@ export interface UpdateChainConfigArg {
   'gas_strategy' : [] | [GasStrategy],
   'finality_depth' : [] | [number],
   'display_name' : [] | [string],
+  'min_quorum_providers' : [] | [[] | [number]],
 }
 export interface UpgradeArg {
   'mode' : [] | [Mode],
@@ -1102,6 +1144,10 @@ export interface VaultsPageResponse {
 }
 export type XrcAssetClass = { 'Cryptocurrency' : null } |
   { 'FiatCurrency' : null };
+export interface XrpVaultOpenInfo {
+  'custody_address' : string,
+  'vault_id' : bigint,
+}
 export interface _SERVICE {
   'add_collateral_token' : ActorMethod<[AddCollateralArg], Result>,
   'add_margin_to_vault' : ActorMethod<[VaultArg], Result_1>,
@@ -1121,14 +1167,17 @@ export interface _SERVICE {
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,
   'bot_claim_liquidation' : ActorMethod<[bigint], Result_4>,
   'bot_confirm_liquidation' : ActorMethod<[bigint], Result>,
+  'chain_has_active_settlement_op' : ActorMethod<[number], boolean>,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
   'clear_invariant_halt' : ActorMethod<[], Result>,
   'clear_liquidation_breaker' : ActorMethod<[], Result>,
   'clear_reorg_halt' : ActorMethod<[number], Result>,
   'clear_stuck_operations' : ActorMethod<[[] | [Principal]], Result_1>,
   'close_chain_vault' : ActorMethod<[bigint, string], Result>,
+  'close_solana_vault' : ActorMethod<[bigint, string], Result>,
   'close_vault' : ActorMethod<[bigint], Result_5>,
   'coingecko_transform' : ActorMethod<[TransformArgs], HttpResponse>,
+  'confirm_xrp_deposit' : ActorMethod<[bigint], Result_1>,
   'delete_chain' : ActorMethod<[number], Result>,
   'disable_chain' : ActorMethod<[number], Result>,
   'enter_recovery_mode' : ActorMethod<[], Result>,
@@ -1142,6 +1191,7 @@ export interface _SERVICE {
   'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
+  'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
   'get_chain_settlement_address' : ActorMethod<[number], Result_2>,
   'get_chain_vault' : ActorMethod<[bigint], [] | [ChainVaultV1]>,
   'get_ckstable_repay_fee' : ActorMethod<[], number>,
@@ -1166,6 +1216,10 @@ export interface _SERVICE {
   'get_events_filtered' : ActorMethod<
     [GetEventsArg],
     GetEventsFilteredResponse
+  >,
+  'get_events_forward_filtered' : ActorMethod<
+    [bigint, bigint, [] | [Array<EventTypeFilter>]],
+    ForwardFilteredEventsResponse
   >,
   'get_fees' : ActorMethod<[bigint], Fees>,
   'get_fees_for_collateral' : ActorMethod<[Principal, bigint], Fees>,
@@ -1230,6 +1284,7 @@ export interface _SERVICE {
   'get_vault_interest_rate' : ActorMethod<[bigint], Result_7>,
   'get_vaults' : ActorMethod<[[] | [Principal]], Array<CandidVault>>,
   'get_vaults_page' : ActorMethod<[bigint, bigint], VaultsPageResponse>,
+  'harvest_chain_interest' : ActorMethod<[number], Result_1>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,
   'icrc10_supported_standards' : ActorMethod<[], Array<StandardRecord>>,
   'icrc21_canister_call_consent_message' : ActorMethod<
@@ -1245,24 +1300,32 @@ export interface _SERVICE {
   >,
   'list_chain_vaults' : ActorMethod<[number], Array<ChainVaultV1>>,
   'open_chain_vault' : ActorMethod<[number, bigint, bigint, string], Result_1>,
-  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
+  'open_solana_vault' : ActorMethod<[bigint, bigint, string], Result_9>,
+  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_10>,
   'open_vault_and_borrow' : ActorMethod<
     [bigint, bigint, [] | [Principal]],
-    Result_9
+    Result_10
   >,
-  'open_vault_with_deposit' : ActorMethod<[bigint, [] | [Principal]], Result_9>,
+  'open_vault_with_deposit' : ActorMethod<
+    [bigint, [] | [Principal]],
+    Result_10
+  >,
+  'open_xrp_vault' : ActorMethod<[], Result_11>,
   'partial_liquidate_vault' : ActorMethod<[VaultArg], Result_3>,
   'partial_repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'provide_liquidity' : ActorMethod<[bigint], Result_1>,
-  'recover_pending_transfer' : ActorMethod<[bigint], Result_10>,
+  'reconcile_chain_supply' : ActorMethod<[number], Result_12>,
+  'recover_pending_transfer' : ActorMethod<[bigint], Result_13>,
+  'recover_stuck_chain_vault' : ActorMethod<[number, bigint], Result>,
   'redeem_collateral' : ActorMethod<[Principal, bigint], Result_3>,
   'redeem_icp' : ActorMethod<[bigint], Result_3>,
-  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_11>,
+  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_14>,
   'register_chain' : ActorMethod<[RegisterChainArg], Result>,
-  'repay_and_close_vault' : ActorMethod<[VaultArg], Result_12>,
+  'repay_and_close_vault' : ActorMethod<[VaultArg], Result_15>,
   'repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'repay_to_vault_with_stable' : ActorMethod<[VaultArgWithToken], Result_1>,
   'reset_bot_budget' : ActorMethod<[bigint], Result>,
+  'resolve_stuck_settlement_op' : ActorMethod<[number, bigint], Result>,
   'set_amm1_canister' : ActorMethod<[Principal], Result>,
   'set_amm1_pool_id' : ActorMethod<[string], Result>,
   'set_borrowing_fee' : ActorMethod<[number], Result>,
@@ -1274,6 +1337,8 @@ export interface _SERVICE {
   'set_burn_watch_poll_enabled' : ActorMethod<[number, boolean], Result>,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
   'set_chain_contract' : ActorMethod<[number, string], Result>,
+  'set_chain_interest_min_realize_e8s' : ActorMethod<[bigint], Result>,
+  'set_chain_interest_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_check_vaults_alert_band_bps' : ActorMethod<[bigint], Result>,
   'set_check_vaults_full_sweep_every_n_ticks' : ActorMethod<[bigint], Result>,
   'set_ckstable_repay_fee' : ActorMethod<[number], Result>,
@@ -1345,6 +1410,8 @@ export interface _SERVICE {
   'set_rmr_floor' : ActorMethod<[number], Result>,
   'set_rmr_floor_cr' : ActorMethod<[number], Result>,
   'set_settlement_tick_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_sol_rpc_principal' : ActorMethod<[Principal], Result>,
+  'set_solana_workers_enabled' : ActorMethod<[boolean], Result>,
   'set_sp_writedown_disabled' : ActorMethod<[boolean], Result>,
   'set_stability_pool_principal' : ActorMethod<[Principal], Result>,
   'set_stable_ledger_principal' : ActorMethod<
@@ -1356,16 +1423,21 @@ export interface _SERVICE {
   'set_treasury_principal' : ActorMethod<[Principal], Result>,
   'set_vault_check_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
-  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_13>,
+  'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,
+  'solana_get_balance' : ActorMethod<[string], Result_1>,
+  'solana_get_mint_supply' : ActorMethod<[], Result_1>,
+  'solana_settlement_address' : ActorMethod<[], Result_2>,
+  'solana_sign_test_transfer' : ActorMethod<[string, bigint], Result_16>,
+  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_17>,
   'stability_pool_liquidate_debt_burned' : ActorMethod<
     [bigint, bigint, SpWritedownProof],
-    Result_13
+    Result_17
   >,
   'stability_pool_liquidate_with_reserves' : ActorMethod<
     [bigint, bigint, bigint, Principal],
-    Result_13
+    Result_17
   >,
-  'submit_burn_proof' : ActorMethod<[number, string], Result_14>,
+  'submit_burn_proof' : ActorMethod<[number, string], Result_18>,
   'unfreeze_protocol' : ActorMethod<[], Result>,
   'update_collateral_config' : ActorMethod<
     [Principal, CollateralConfig],
@@ -1376,6 +1448,14 @@ export interface _SERVICE {
   'withdraw_collateral' : ActorMethod<[bigint], Result_1>,
   'withdraw_liquidity' : ActorMethod<[bigint], Result_1>,
   'withdraw_partial_collateral' : ActorMethod<[VaultArg], Result_1>,
+  'withdraw_solana_collateral' : ActorMethod<[bigint, bigint, string], Result>,
+  'xrp_balance' : ActorMethod<[string], Result_1>,
+  'xrp_custody_address' : ActorMethod<[Principal, bigint], Result_2>,
+  'xrp_settlement_address' : ActorMethod<[], Result_2>,
+  'xrp_transform_account' : ActorMethod<[TransformArgs], HttpResponse>,
+  'xrp_transform_server' : ActorMethod<[TransformArgs], HttpResponse>,
+  'xrp_transform_submit' : ActorMethod<[TransformArgs], HttpResponse>,
+  'xrp_transform_tx' : ActorMethod<[TransformArgs], HttpResponse>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -112,7 +112,9 @@ export const idlFactory = ({ IDL }) => {
   const Result_2 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ProtocolError });
   const SuccessWithFee = IDL.Record({
     'block_index' : IDL.Nat64,
+    'debt_liquidated_e8s' : IDL.Opt(IDL.Nat64),
     'fee_amount_paid' : IDL.Nat64,
+    'stable_pulled_e6s' : IDL.Opt(IDL.Nat64),
     'collateral_amount_received' : IDL.Opt(IDL.Nat64),
   });
   const Result_3 = IDL.Variant({
@@ -170,10 +172,12 @@ export const idlFactory = ({ IDL }) => {
     'status' : ChainVaultStatus,
     'owner' : IDL.Principal,
     'pending_mint_e8s' : IDL.Nat,
+    'pending_interest_mint_e8s' : IDL.Nat,
     'custody_address' : IDL.Text,
     'collateral_amount_e18' : IDL.Nat,
     'opened_at_ns' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
+    'last_interest_accrual_ns' : IDL.Nat64,
     'collateral_chain' : IDL.Nat32,
     'mint_recipient' : IDL.Text,
     'debt_e8s' : IDL.Nat,
@@ -194,6 +198,10 @@ export const idlFactory = ({ IDL }) => {
     'method' : InterpolationMethod,
     'markers' : IDL.Vec(RateMarker),
   });
+  const CustodyKind = IDL.Variant({
+    'IcrcLedger' : IDL.Null,
+    'NativeXrp' : IDL.Null,
+  });
   const CollateralConfig = IDL.Record({
     'last_redemption_time' : IDL.Nat64,
     'status' : CollateralStatus,
@@ -212,6 +220,7 @@ export const idlFactory = ({ IDL }) => {
     'redemption_tier' : IDL.Nat8,
     'redemption_fee_floor' : IDL.Vec(IDL.Nat8),
     'borrow_threshold_ratio' : IDL.Vec(IDL.Nat8),
+    'custody_kind' : IDL.Opt(CustodyKind),
     'ledger_fee' : IDL.Nat64,
     'recovery_target_cr' : IDL.Vec(IDL.Nat8),
     'current_base_rate' : IDL.Vec(IDL.Nat8),
@@ -495,6 +504,15 @@ export const idlFactory = ({ IDL }) => {
     'set_reserve_redemptions_enabled' : IDL.Record({ 'enabled' : IDL.Bool }),
     'set_min_icusd_amount' : IDL.Record({ 'amount' : IDL.Text }),
     'set_borrowing_fee_curve' : IDL.Record({ 'markers' : IDL.Text }),
+    'chain_interest_minted' : IDL.Record({
+      'mint_id' : IDL.Nat64,
+      'vault_id' : IDL.Nat64,
+      'block_number' : IDL.Nat64,
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'tx_hash' : IDL.Text,
+    }),
     'set_interest_pool_share' : IDL.Record({ 'share' : IDL.Text }),
     'set_liquidation_protocol_share' : IDL.Record({ 'share' : IDL.Text }),
     'update_collateral_config' : IDL.Record({
@@ -750,6 +768,11 @@ export const idlFactory = ({ IDL }) => {
     'total' : IDL.Nat64,
     'events' : IDL.Vec(IDL.Tuple(IDL.Nat64, Event)),
   });
+  const ForwardFilteredEventsResponse = IDL.Record({
+    'next_start' : IDL.Nat64,
+    'reached_end' : IDL.Bool,
+    'events' : IDL.Vec(IDL.Tuple(IDL.Nat64, Event)),
+  });
   const Fees = IDL.Record({
     'redemption_fee' : IDL.Float64,
     'borrowing_fee' : IDL.Float64,
@@ -965,15 +988,37 @@ export const idlFactory = ({ IDL }) => {
     'amount' : IDL.Nat64,
     'token_type' : StableTokenType,
   });
+  const Result_9 = IDL.Variant({ 'Ok' : ChainVaultV1, 'Err' : ProtocolError });
   const OpenVaultSuccess = IDL.Record({
     'block_index' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
   });
-  const Result_9 = IDL.Variant({
+  const Result_10 = IDL.Variant({
     'Ok' : OpenVaultSuccess,
     'Err' : ProtocolError,
   });
-  const Result_10 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
+  const XrpVaultOpenInfo = IDL.Record({
+    'custody_address' : IDL.Text,
+    'vault_id' : IDL.Nat64,
+  });
+  const Result_11 = IDL.Variant({
+    'Ok' : XrpVaultOpenInfo,
+    'Err' : ProtocolError,
+  });
+  const ChainSupplyReconciliation = IDL.Record({
+    'recorded_supply_e8s' : IDL.Nat,
+    'gap_e8s' : IDL.Int,
+    'unbacked_excess' : IDL.Bool,
+    'finalized_block' : IDL.Nat64,
+    'in_flight_mint_e8s' : IDL.Nat,
+    'chain_id' : IDL.Nat32,
+    'onchain_total_supply_e8s' : IDL.Nat,
+  });
+  const Result_12 = IDL.Variant({
+    'Ok' : ChainSupplyReconciliation,
+    'Err' : ProtocolError,
+  });
+  const Result_13 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
   const ReserveRedemptionResult = IDL.Record({
     'icusd_block_index' : IDL.Nat64,
     'stable_token_used' : IDL.Principal,
@@ -981,7 +1026,7 @@ export const idlFactory = ({ IDL }) => {
     'fee_amount' : IDL.Nat64,
     'stable_amount_sent' : IDL.Nat64,
   });
-  const Result_11 = IDL.Variant({
+  const Result_14 = IDL.Variant({
     'Ok' : ReserveRedemptionResult,
     'Err' : ProtocolError,
   });
@@ -1001,12 +1046,13 @@ export const idlFactory = ({ IDL }) => {
     'chain_native_decimals' : IDL.Nat8,
     'display_name' : IDL.Text,
     'chain_id' : IDL.Nat32,
+    'min_quorum_providers' : IDL.Opt(IDL.Nat32),
   });
   const RepayAndCloseSuccess = IDL.Record({
     'collateral_return_block_index' : IDL.Opt(IDL.Nat64),
     'repay_block_index' : IDL.Nat64,
   });
-  const Result_12 = IDL.Variant({
+  const Result_15 = IDL.Variant({
     'Ok' : RepayAndCloseSuccess,
     'Err' : ProtocolError,
   });
@@ -1015,6 +1061,11 @@ export const idlFactory = ({ IDL }) => {
     'gas_strategy' : IDL.Opt(GasStrategy),
     'finality_depth' : IDL.Opt(IDL.Nat32),
     'display_name' : IDL.Opt(IDL.Text),
+    'min_quorum_providers' : IDL.Opt(IDL.Opt(IDL.Nat32)),
+  });
+  const Result_16 = IDL.Variant({
+    'Ok' : IDL.Vec(IDL.Nat8),
+    'Err' : ProtocolError,
   });
   const StabilityPoolLiquidationResult = IDL.Record({
     'fee' : IDL.Nat64,
@@ -1026,7 +1077,7 @@ export const idlFactory = ({ IDL }) => {
     'collateral_type' : IDL.Text,
     'collateral_received' : IDL.Nat64,
   });
-  const Result_13 = IDL.Variant({
+  const Result_17 = IDL.Variant({
     'Ok' : StabilityPoolLiquidationResult,
     'Err' : ProtocolError,
   });
@@ -1035,7 +1086,7 @@ export const idlFactory = ({ IDL }) => {
     'ledger_kind' : SpProofLedger,
     'vault_id_memo' : IDL.Nat64,
   });
-  const Result_14 = IDL.Variant({ 'Ok' : IDL.Nat32, 'Err' : ProtocolError });
+  const Result_18 = IDL.Variant({ 'Ok' : IDL.Nat32, 'Err' : ProtocolError });
   return IDL.Service({
     'add_collateral_token' : IDL.Func([AddCollateralArg], [Result], []),
     'add_margin_to_vault' : IDL.Func([VaultArg], [Result_1], []),
@@ -1061,6 +1112,11 @@ export const idlFactory = ({ IDL }) => {
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_4], []),
     'bot_confirm_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
+    'chain_has_active_settlement_op' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Bool],
+        ['query'],
+      ),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
     'clear_invariant_halt' : IDL.Func([], [Result], []),
     'clear_liquidation_breaker' : IDL.Func([], [Result], []),
@@ -1071,12 +1127,14 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'close_chain_vault' : IDL.Func([IDL.Nat64, IDL.Text], [Result], []),
+    'close_solana_vault' : IDL.Func([IDL.Nat64, IDL.Text], [Result], []),
     'close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'coingecko_transform' : IDL.Func(
         [TransformArgs],
         [HttpResponse],
         ['query'],
       ),
+    'confirm_xrp_deposit' : IDL.Func([IDL.Nat64], [Result_1], []),
     'delete_chain' : IDL.Func([IDL.Nat32], [Result], []),
     'disable_chain' : IDL.Func([IDL.Nat32], [Result], []),
     'enter_recovery_mode' : IDL.Func([], [Result], []),
@@ -1094,6 +1152,11 @@ export const idlFactory = ({ IDL }) => {
     'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_cr_tolerance_bps' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
+    'get_chain_interest_treasury_address' : IDL.Func(
+        [IDL.Nat32],
+        [Result_2],
+        [],
+      ),
     'get_chain_settlement_address' : IDL.Func([IDL.Nat32], [Result_2], []),
     'get_chain_vault' : IDL.Func(
         [IDL.Nat64],
@@ -1141,6 +1204,11 @@ export const idlFactory = ({ IDL }) => {
     'get_events_filtered' : IDL.Func(
         [GetEventsArg],
         [GetEventsFilteredResponse],
+        ['query'],
+      ),
+    'get_events_forward_filtered' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64, IDL.Opt(IDL.Vec(EventTypeFilter))],
+        [ForwardFilteredEventsResponse],
         ['query'],
       ),
     'get_fees' : IDL.Func([IDL.Nat64], [Fees], ['query']),
@@ -1254,6 +1322,7 @@ export const idlFactory = ({ IDL }) => {
         [VaultsPageResponse],
         ['query'],
       ),
+    'harvest_chain_interest' : IDL.Func([IDL.Nat32], [Result_1], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse_1], ['query']),
     'icrc10_supported_standards' : IDL.Func(
         [],
@@ -1287,34 +1356,46 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
+    'open_solana_vault' : IDL.Func(
+        [IDL.Nat, IDL.Nat, IDL.Text],
+        [Result_9],
+        [],
+      ),
     'open_vault' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_9],
+        [Result_10],
         [],
       ),
     'open_vault_and_borrow' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_9],
+        [Result_10],
         [],
       ),
     'open_vault_with_deposit' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_9],
+        [Result_10],
         [],
       ),
+    'open_xrp_vault' : IDL.Func([], [Result_11], []),
     'partial_liquidate_vault' : IDL.Func([VaultArg], [Result_3], []),
     'partial_repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'provide_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
-    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_10], []),
+    'reconcile_chain_supply' : IDL.Func([IDL.Nat32], [Result_12], []),
+    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_13], []),
+    'recover_stuck_chain_vault' : IDL.Func(
+        [IDL.Nat32, IDL.Nat64],
+        [Result],
+        [],
+      ),
     'redeem_collateral' : IDL.Func([IDL.Principal, IDL.Nat64], [Result_3], []),
     'redeem_icp' : IDL.Func([IDL.Nat64], [Result_3], []),
     'redeem_reserves' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_11],
+        [Result_14],
         [],
       ),
     'register_chain' : IDL.Func([RegisterChainArg], [Result], []),
-    'repay_and_close_vault' : IDL.Func([VaultArg], [Result_12], []),
+    'repay_and_close_vault' : IDL.Func([VaultArg], [Result_15], []),
     'repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'repay_to_vault_with_stable' : IDL.Func(
         [VaultArgWithToken],
@@ -1322,6 +1403,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'reset_bot_budget' : IDL.Func([IDL.Nat64], [Result], []),
+    'resolve_stuck_settlement_op' : IDL.Func(
+        [IDL.Nat32, IDL.Nat64],
+        [Result],
+        [],
+      ),
     'set_amm1_canister' : IDL.Func([IDL.Principal], [Result], []),
     'set_amm1_pool_id' : IDL.Func([IDL.Text], [Result], []),
     'set_borrowing_fee' : IDL.Func([IDL.Float64], [Result], []),
@@ -1345,6 +1431,12 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'set_chain_contract' : IDL.Func([IDL.Nat32, IDL.Text], [Result], []),
+    'set_chain_interest_min_realize_e8s' : IDL.Func([IDL.Nat], [Result], []),
+    'set_chain_interest_tick_interval_secs' : IDL.Func(
+        [IDL.Nat64],
+        [Result],
+        [],
+      ),
     'set_check_vaults_alert_band_bps' : IDL.Func([IDL.Nat64], [Result], []),
     'set_check_vaults_full_sweep_every_n_ticks' : IDL.Func(
         [IDL.Nat64],
@@ -1482,6 +1574,8 @@ export const idlFactory = ({ IDL }) => {
     'set_rmr_floor' : IDL.Func([IDL.Float64], [Result], []),
     'set_rmr_floor_cr' : IDL.Func([IDL.Float64], [Result], []),
     'set_settlement_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_sol_rpc_principal' : IDL.Func([IDL.Principal], [Result], []),
+    'set_solana_workers_enabled' : IDL.Func([IDL.Bool], [Result], []),
     'set_sp_writedown_disabled' : IDL.Func([IDL.Bool], [Result], []),
     'set_stability_pool_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_stable_ledger_principal' : IDL.Func(
@@ -1498,22 +1592,31 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_vault_check_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
     'set_xrc_fetch_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'solana_bootstrap_nonce' : IDL.Func([IDL.Opt(IDL.Text)], [Result], []),
+    'solana_get_balance' : IDL.Func([IDL.Text], [Result_1], []),
+    'solana_get_mint_supply' : IDL.Func([], [Result_1], []),
+    'solana_settlement_address' : IDL.Func([], [Result_2], []),
+    'solana_sign_test_transfer' : IDL.Func(
+        [IDL.Text, IDL.Nat64],
+        [Result_16],
+        [],
+      ),
     'stability_pool_liquidate' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
-        [Result_13],
+        [Result_17],
         [],
       ),
     'stability_pool_liquidate_debt_burned' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, SpWritedownProof],
-        [Result_13],
+        [Result_17],
         [],
       ),
     'stability_pool_liquidate_with_reserves' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, IDL.Nat64, IDL.Principal],
-        [Result_13],
+        [Result_17],
         [],
       ),
-    'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_14], []),
+    'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_18], []),
     'unfreeze_protocol' : IDL.Func([], [Result], []),
     'update_collateral_config' : IDL.Func(
         [IDL.Principal, CollateralConfig],
@@ -1529,6 +1632,34 @@ export const idlFactory = ({ IDL }) => {
     'withdraw_collateral' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
     'withdraw_partial_collateral' : IDL.Func([VaultArg], [Result_1], []),
+    'withdraw_solana_collateral' : IDL.Func(
+        [IDL.Nat64, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'xrp_balance' : IDL.Func([IDL.Text], [Result_1], []),
+    'xrp_custody_address' : IDL.Func(
+        [IDL.Principal, IDL.Nat64],
+        [Result_2],
+        [],
+      ),
+    'xrp_settlement_address' : IDL.Func([], [Result_2], []),
+    'xrp_transform_account' : IDL.Func(
+        [TransformArgs],
+        [HttpResponse],
+        ['query'],
+      ),
+    'xrp_transform_server' : IDL.Func(
+        [TransformArgs],
+        [HttpResponse],
+        ['query'],
+      ),
+    'xrp_transform_submit' : IDL.Func(
+        [TransformArgs],
+        [HttpResponse],
+        ['query'],
+      ),
+    'xrp_transform_tx' : IDL.Func([TransformArgs], [HttpResponse], ['query']),
   });
 };
 export const init = ({ IDL }) => {

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -57,17 +57,16 @@ type ChainVaultV1 = record {
   status : ChainVaultStatus;
   owner : principal;
   pending_mint_e8s : nat;
+  pending_interest_mint_e8s : nat;
   custody_address : text;
   collateral_amount_e18 : nat;
   opened_at_ns : nat64;
   vault_id : nat64;
+  last_interest_accrual_ns : nat64;
   collateral_chain : nat32;
   mint_recipient : text;
   debt_e8s : nat;
 };
-type CustodyKind = variant { IcrcLedger; NativeXrp };
-type XrpVaultOpenInfo = record { vault_id : nat64; custody_address : text };
-type XrpVaultOpenResult = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
 type CollateralConfig = record {
   last_redemption_time : nat64;
   status : CollateralStatus;
@@ -86,6 +85,7 @@ type CollateralConfig = record {
   redemption_tier : nat8;
   redemption_fee_floor : blob;
   borrow_threshold_ratio : blob;
+  custody_kind : opt CustodyKind;
   ledger_fee : nat64;
   recovery_target_cr : blob;
   current_base_rate : blob;
@@ -96,7 +96,6 @@ type CollateralConfig = record {
   borrowing_fee : blob;
   interest_rate_apr : blob;
   liquidation_ratio : blob;
-  custody_kind : opt CustodyKind;
 };
 type CollateralInterestInfo = record {
   total_debt_e8s : nat64;
@@ -141,6 +140,7 @@ type ConsentMessageSpec = record {
   metadata : ConsentMessageMetadata;
   device_spec : opt DeviceSpec;
 };
+type CustodyKind = variant { IcrcLedger; NativeXrp };
 type DeficitSource = variant {
   Liquidation : record { vault_id : nat64 };
   Redemption : record { redeemer : principal };
@@ -339,6 +339,15 @@ type Event = variant {
   set_reserve_redemptions_enabled : record { enabled : bool };
   set_min_icusd_amount : record { amount : text };
   set_borrowing_fee_curve : record { markers : text };
+  chain_interest_minted : record {
+    mint_id : nat64;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   set_interest_pool_share : record { share : text };
   set_liquidation_protocol_share : record { share : text };
   update_collateral_config : record {
@@ -797,8 +806,6 @@ type RegisterChainArg = record {
   chain_native_decimals : nat8;
   display_name : text;
   chain_id : nat32;
-  // M-05: optional per-chain quorum-provider floor override. Omit (or null) to
-  // use the default floor (3 distinct providers).
   min_quorum_providers : opt nat32;
 };
 type RepayAndCloseSuccess = record {
@@ -820,19 +827,20 @@ type ReserveRedemptionResult = record {
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
 type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_11 = variant {
+type Result_11 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
+type Result_12 = variant {
   Ok : ChainSupplyReconciliation;
   Err : ProtocolError;
 };
-type Result_12 = variant { Ok : bool; Err : ProtocolError };
-type Result_13 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_14 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_15 = variant { Ok : blob; Err : ProtocolError };
-type Result_16 = variant {
+type Result_13 = variant { Ok : bool; Err : ProtocolError };
+type Result_14 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_15 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_16 = variant { Ok : blob; Err : ProtocolError };
+type Result_17 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_17 = variant { Ok : nat32; Err : ProtocolError };
+type Result_18 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
@@ -866,10 +874,10 @@ type StableTokenType = variant { CKUSDC; CKUSDT };
 type StandardRecord = record { url : text; name : text };
 type SuccessWithFee = record {
   block_index : nat64;
-  fee_amount_paid : nat64;
-  collateral_amount_received : opt nat64;
   debt_liquidated_e8s : opt nat64;
+  fee_amount_paid : nat64;
   stable_pulled_e6s : opt nat64;
+  collateral_amount_received : opt nat64;
 };
 type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
 type SupplyAuditEntry = record {
@@ -914,9 +922,6 @@ type UpdateChainConfigArg = record {
   gas_strategy : opt GasStrategy;
   finality_depth : opt nat32;
   display_name : opt text;
-  // M-05: set/clear the per-chain quorum-provider floor override. Outer opt
-  // absent/null => leave unchanged; opt (null) => clear back to the default;
-  // opt (opt N) => set the floor to N (must be >= 1).
   min_quorum_providers : opt opt nat32;
 };
 type UpgradeArg = record { mode : opt Mode; description : opt text };
@@ -951,6 +956,7 @@ type VaultsPageResponse = record {
   next_start_id : opt nat64;
 };
 type XrcAssetClass = variant { Cryptocurrency; FiatCurrency };
+type XrpVaultOpenInfo = record { custody_address : text; vault_id : nat64 };
 service : (ProtocolArg) -> {
   add_collateral_token : (AddCollateralArg) -> (Result);
   add_margin_to_vault : (VaultArg) -> (Result_1);
@@ -974,6 +980,7 @@ service : (ProtocolArg) -> {
   close_solana_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
+  confirm_xrp_deposit : (nat64) -> (Result_1);
   delete_chain : (nat32) -> (Result);
   disable_chain : (nat32) -> (Result);
   enter_recovery_mode : () -> (Result);
@@ -987,6 +994,7 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_ckstable_repay_fee : () -> (float64) query;
@@ -1062,6 +1070,7 @@ service : (ProtocolArg) -> {
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
+  harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
   icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
@@ -1075,17 +1084,18 @@ service : (ProtocolArg) -> {
   open_vault : (nat64, opt principal) -> (Result_10);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
   open_vault_with_deposit : (nat64, opt principal) -> (Result_10);
+  open_xrp_vault : () -> (Result_11);
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  reconcile_chain_supply : (nat32) -> (Result_11);
-  recover_pending_transfer : (nat64) -> (Result_12);
+  reconcile_chain_supply : (nat32) -> (Result_12);
+  recover_pending_transfer : (nat64) -> (Result_13);
   recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_13);
+  redeem_reserves : (nat64, opt principal) -> (Result_14);
   register_chain : (RegisterChainArg) -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_14);
+  repay_and_close_vault : (VaultArg) -> (Result_15);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
@@ -1101,6 +1111,8 @@ service : (ProtocolArg) -> {
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
+  set_chain_interest_min_realize_e8s : (nat) -> (Result);
+  set_chain_interest_tick_interval_secs : (nat64) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
@@ -1170,15 +1182,15 @@ service : (ProtocolArg) -> {
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
   solana_settlement_address : () -> (Result_2);
-  solana_sign_test_transfer : (text, nat64) -> (Result_15);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_16);
+  solana_sign_test_transfer : (text, nat64) -> (Result_16);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_17);
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_16,
+      Result_17,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_16,
+      Result_17,
     );
-  submit_burn_proof : (nat32, text) -> (Result_17);
+  submit_burn_proof : (nat32, text) -> (Result_18);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
@@ -1194,6 +1206,4 @@ service : (ProtocolArg) -> {
   xrp_transform_server : (TransformArgs) -> (HttpResponse) query;
   xrp_transform_submit : (TransformArgs) -> (HttpResponse) query;
   xrp_transform_tx : (TransformArgs) -> (HttpResponse) query;
-  open_xrp_vault : () -> (XrpVaultOpenResult);
-  confirm_xrp_deposit : (nat64) -> (Result_1);
 }

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -101,6 +101,7 @@ pub fn confirm_mint_in_state(
     vault_id: u64,
     observed_e8s: u128,
     pre_mint_total_debt: u128,
+    now_ns: u64,
 ) -> Result<(), String> {
     // Step 1: validate (read-only — no mutation on failure).
     {
@@ -130,6 +131,10 @@ pub fn confirm_mint_in_state(
     v.debt_e8s = v.debt_e8s.saturating_add(observed_e8s);
     v.pending_mint_e8s = 0;
     v.status = ChainVaultStatus::Open;
+    // Task 12: the vault's debt is now live, so interest starts accruing from
+    // here. Stamp the accrual window start (a fresh vault decoded with 0 would
+    // otherwise bill interest from the unix epoch on its first harvest).
+    v.last_interest_accrual_ns = now_ns;
     Ok(())
 }
 
@@ -138,7 +143,7 @@ pub fn confirm_mint_in_state(
 /// advance `last_interest_accrual_ns` to the harvest snapshot, and clear the
 /// pending. `observed_e8s` (from the on-chain Mint log) must equal the vault's
 /// `pending_interest_mint_e8s`. `pre_total` is the PRE-mint
-/// `total_chain_vault_debt_e8s()`. STUB — real body in GREEN.
+/// `total_chain_vault_debt_e8s()`.
 pub fn confirm_interest_mint_in_state(
     state: &mut MultiChainStateV4,
     chain: ChainId,
@@ -1022,7 +1027,7 @@ async fn confirm_op(
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
 
             let result = mutate_state(|s| {
-                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, observed_e8s, pre_total)
+                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, observed_e8s, pre_total, now)
             });
 
             match result {

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -133,6 +133,54 @@ pub fn confirm_mint_in_state(
     Ok(())
 }
 
+/// Task 12 (Option B): confirm an on-chain interest mint — grow the REAL vault's
+/// `debt_e8s` and the chain supply by `observed_e8s` TOGETHER (invariant exact),
+/// advance `last_interest_accrual_ns` to the harvest snapshot, and clear the
+/// pending. `observed_e8s` (from the on-chain Mint log) must equal the vault's
+/// `pending_interest_mint_e8s`. `pre_total` is the PRE-mint
+/// `total_chain_vault_debt_e8s()`. STUB — real body in GREEN.
+pub fn confirm_interest_mint_in_state(
+    state: &mut MultiChainStateV4,
+    chain: ChainId,
+    vault_id: u64,
+    observed_e8s: u128,
+    accrual_through_ns: u64,
+    pre_total: u128,
+) -> Result<(), String> {
+    // Step 1: validate (read-only — no mutation on failure).
+    {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or_else(|| format!("confirm_interest_mint: unknown vault {vault_id}"))?;
+        if v.pending_interest_mint_e8s != observed_e8s {
+            return Err(format!(
+                "confirm_interest_mint: observed {} != pending {}",
+                observed_e8s, v.pending_interest_mint_e8s
+            ));
+        }
+    }
+
+    // Step 2: supply delta. Debt and supply grow together by exactly the minted
+    // amount, so the foreign-chain invariant stays exact. Rejects (no mutation)
+    // on divergence/halt.
+    let post_total = pre_total.saturating_add(observed_e8s);
+    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_total)
+        .map_err(|e| format!("{e:?}"))?;
+
+    // Step 3: only reached when the supply delta succeeded. Realize the interest
+    // into debt and advance the accrual window to the harvest snapshot time (NOT
+    // confirm time), so the harvest->confirm sliver accrues next round.
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.debt_e8s = v.debt_e8s.saturating_add(observed_e8s);
+    v.pending_interest_mint_e8s = 0;
+    v.last_interest_accrual_ns = accrual_through_ns;
+    Ok(())
+}
+
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
 
 /// Timer D entry point: run one settlement cycle for every registered+enabled
@@ -284,6 +332,9 @@ pub async fn run_settlement(chain: ChainId) {
 enum TxPlanKind {
     Mint,
     NativeWithdrawal,
+    /// Task 12: an interest-realization mint (to the treasury). Submit-path logs
+    /// it; the authoritative record is `ChainInterestMinted` on confirm.
+    InterestMint,
 }
 
 /// Per-op-kind tx shape mirroring `MonadAdapter`'s choices, so the submit and
@@ -370,6 +421,34 @@ fn build_tx_plan(
                 kind: TxPlanKind::NativeWithdrawal,
             })
         }
+        SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, recipient, .. } => {
+            // Task 12: identical IcUSD.mint calldata to a normal Mint, but the
+            // on-chain `vault_id` arg is the SYNTHETIC `mint_id` (the real vault
+            // already minted once at open and IcUSD.mint reverts a repeat id),
+            // and the calldata `to:` is the interest-treasury `recipient`. Signed
+            // by the minter (resolve_op_signer). The `TxPlan.vault_id` carries the
+            // REAL vault for event attribution.
+            let contract = contract.ok_or_else(|| "icUSD contract not set".to_string())?;
+            let fields = tx::build_eip1559_fields(
+                chain.0 as u64,
+                tx::MonadTxKind::Mint {
+                    contract,
+                    recipient,
+                    amount_e8s: *amount_e8s,
+                    vault_id: *mint_id,
+                },
+                nonce,
+                prio,
+                max_fee,
+            )?;
+            Ok(TxPlan {
+                fields,
+                vault_id: *vault_id,
+                recipient: recipient.clone(),
+                amount: *amount_e8s,
+                kind: TxPlanKind::InterestMint,
+            })
+        }
         SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
     }
 }
@@ -391,6 +470,8 @@ async fn resolve_op_signer(
 ) -> Result<(Vec<Vec<u8>>, String), String> {
     match kind {
         SettlementOpKind::Mint { .. } => tecdsa::cached_settlement_address(chain).await,
+        // Task 12: interest mints are signed by the minter, same as a vault mint.
+        SettlementOpKind::InterestMint { .. } => tecdsa::cached_settlement_address(chain).await,
         SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
             let vid = *vault_id;
             let info = read_state(|s| {
@@ -512,7 +593,10 @@ async fn submit_op(
     // by the vault's own custody address (which holds the collateral) and net
     // their gas out of the transfer, so the settlement-wallet floor is irrelevant
     // to them — never gate a withdrawal on it.
-    if matches!(op.kind, SettlementOpKind::Mint { .. }) {
+    // Task 12: interest mints are ALSO paid by the settlement hot wallet, so they
+    // are gated on its balance too (a vault open mint and an interest mint cost
+    // the same gas).
+    if matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }) {
         let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
         if let Some(bal) = cached {
             if !hardening::hot_wallet_ok(bal) {
@@ -663,6 +747,11 @@ async fn submit_op(
             });
             log!(INFO, "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}", chain, op_id, vault_id, amount, tx_hash);
         }
+        TxPlanKind::InterestMint => {
+            // Submit-path log only; the authoritative event is ChainInterestMinted
+            // on confirm (after the on-chain mint is observed at finality).
+            log!(INFO, "[settlement chain={:?}] interest mint submitted: op={} vault={} amount_e8s={} treasury={} tx={}", chain, op_id, vault_id, amount, recipient, tx_hash);
+        }
     }
 }
 
@@ -799,6 +888,15 @@ async fn confirm_op(
                         if v.status == ChainVaultStatus::Closing {
                             v.status = ChainVaultStatus::Open;
                         }
+                    }
+                }
+                SettlementOpKind::InterestMint { vault_id, .. } => {
+                    // Task 12: no debt/supply was credited (the mint reverted), so
+                    // just clear the reservation. last_interest_accrual_ns is left
+                    // unchanged, so the same window is retried at the next harvest
+                    // (no double-charge, no loss).
+                    if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
+                        v.pending_interest_mint_e8s = 0;
                     }
                 }
                 SettlementOpKind::Burn { .. } => {}
@@ -957,6 +1055,99 @@ async fn confirm_op(
                     // (divergence/halt/amount mismatch), NOT a tx failure. Leave
                     // the op Inflight for retry; do NOT mark it Failed.
                     log!(INFO, "[settlement chain={:?}] confirm_mint_in_state FAILED for op {} vault {}: {}; left Inflight", chain, op_id, vault_id, e);
+                }
+            }
+        }
+        SettlementOpKind::InterestMint { vault_id, mint_id, accrual_through_ns, recipient, .. } => {
+            // Task 12: same Mint-log read as a vault mint, but matched by the
+            // SYNTHETIC `mint_id` and recipient-verified against the interest
+            // treasury. On confirm, debt + supply grow together for the REAL vault.
+            let vault_id = *vault_id;
+            let mint_id = *mint_id;
+            let accrual_through_ns = *accrual_through_ns;
+            let intended_recipient = recipient.clone();
+
+            let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+            let contract = match contract {
+                Some(c) => c,
+                None => {
+                    log!(INFO, "[settlement chain={:?}] no contract configured; cannot confirm interest mint op {}", chain, op_id);
+                    return;
+                }
+            };
+
+            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+                Ok(l) => l,
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] get_logs(interest mint) failed confirming op {}: {}; will retry", chain, op_id, e);
+                    return;
+                }
+            };
+
+            let mut matched: Option<(u128, String)> = None;
+            for (topics, data, log_tx, log_block, _log_index) in &logs {
+                match evm_rpc::decode_mint_log(topics, data, log_tx, *log_block) {
+                    Ok(m) if m.vault_id == mint_id => {
+                        let exact = log_tx.eq_ignore_ascii_case(&tx_hash);
+                        if exact {
+                            matched = Some((m.amount_e8s, m.recipient));
+                            break;
+                        } else if matched.is_none() {
+                            matched = Some((m.amount_e8s, m.recipient));
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log!(INFO, "[settlement chain={:?}] decode_mint_log failed confirming interest op {}: {}", chain, op_id, e);
+                    }
+                }
+            }
+
+            let (observed_e8s, observed_recipient) = match matched {
+                Some(pair) => pair,
+                None => {
+                    log!(INFO, "[settlement chain={:?}] no interest Mint log for mint_id {} in block {} confirming op {}; will retry", chain, mint_id, block_number, op_id);
+                    return;
+                }
+            };
+
+            // The interest mint MUST land at the per-chain interest-treasury
+            // address (the recipient stored on the op). A mismatch is a real
+            // divergence: leave Inflight, do NOT credit.
+            if !intended_recipient.eq_ignore_ascii_case(&observed_recipient) {
+                log!(INFO, "[settlement chain={:?}] interest-mint recipient mismatch op {} mint_id {}: on-chain {} != treasury {}; left Inflight (NOT credited)", chain, op_id, mint_id, observed_recipient, intended_recipient);
+                return;
+            }
+
+            let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
+            let result = mutate_state(|s| {
+                confirm_interest_mint_in_state(
+                    &mut s.multi_chain, chain, vault_id, observed_e8s, accrual_through_ns, pre_total,
+                )
+            });
+
+            match result {
+                Ok(()) => {
+                    mutate_state(|s| {
+                        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                            if let Some(o) = q.pending.get_mut(&op_id) {
+                                o.mark_succeeded(tx_hash.clone(), now);
+                            }
+                        }
+                    });
+                    crate::storage::record_event(&crate::event::Event::ChainInterestMinted {
+                        chain_id: chain,
+                        vault_id,
+                        mint_id,
+                        amount_e8s: observed_e8s,
+                        tx_hash: tx_hash.clone(),
+                        block_number,
+                        timestamp: now,
+                    });
+                    log!(INFO, "[settlement chain={:?}] interest mint confirmed: op={} vault={} mint_id={} amount_e8s={} block={} tx={}", chain, op_id, vault_id, mint_id, observed_e8s, block_number, tx_hash);
+                }
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] confirm_interest_mint_in_state FAILED for op {} vault {}: {}; left Inflight", chain, op_id, vault_id, e);
                 }
             }
         }

--- a/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
@@ -108,3 +108,38 @@ pub async fn cached_settlement_address(chain: ChainId) -> Result<(Vec<Vec<u8>>, 
     });
     Ok((path, addr))
 }
+
+// ─── Interest-treasury address (Task 12) ───────────────────────────────────────
+
+/// Derivation path for the per-chain interest-treasury (revenue) address.
+/// Distinct from the settlement (minter) path so realized interest revenue is
+/// held separately from the operational hot wallet while staying
+/// canister-controlled (it can later be swept via the same custody-withdrawal
+/// machinery).
+pub fn interest_treasury_derivation_path(chain: ChainId) -> Vec<Vec<u8>> {
+    vec![chain.0.to_le_bytes().to_vec(), b"interest-treasury".to_vec()]
+}
+
+thread_local! {
+    static INTEREST_TREASURY_ADDR_CACHE: std::cell::RefCell<std::collections::BTreeMap<ChainId, String>> =
+        const { std::cell::RefCell::new(std::collections::BTreeMap::new()) };
+}
+
+/// Cached per-chain interest-treasury address (Task 12). Mirrors
+/// `cached_settlement_address`: derives + caches on first use (deterministic, no
+/// nonce). The minter (settlement) address SIGNS interest mints; this address is
+/// only the `to:` recipient that receives the minted interest revenue. Returns
+/// (path, address).
+pub async fn cached_interest_treasury_address(
+    chain: ChainId,
+) -> Result<(Vec<Vec<u8>>, String), String> {
+    let path = interest_treasury_derivation_path(chain);
+    if let Some(addr) = INTEREST_TREASURY_ADDR_CACHE.with(|c| c.borrow().get(&chain).cloned()) {
+        return Ok((path, addr));
+    }
+    let (_pubkey, addr) = derive_evm_address(path.clone()).await?;
+    INTEREST_TREASURY_ADDR_CACHE.with(|c| {
+        c.borrow_mut().insert(chain, addr.clone());
+    });
+    Ok((path, addr))
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
@@ -25,6 +25,8 @@ fn state_with_open_vault(debt: u128) -> MultiChainStateV4 {
             pending_mint_e8s: 0,
             status: ChainVaultStatus::Open,
             opened_at_ns: 0,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
         },
     );
     s

--- a/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
@@ -14,6 +14,8 @@ fn seeded() -> MultiChainStateV4 {
         custody_address: "0xcustody".into(), collateral_amount_native: 0, debt_e8s: 0,
         mint_recipient: "0xr".into(), pending_mint_e8s: 0,
         status: ChainVaultStatus::Open, opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     s
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,4 +1,7 @@
-use super::settlement::{confirm_mint_in_state, fundable_withdrawal_value, select_next_op, OpAction};
+use super::settlement::{
+    confirm_interest_mint_in_state, confirm_mint_in_state, fundable_withdrawal_value,
+    select_next_op, OpAction,
+};
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
 use crate::chains::multi_chain_state::MultiChainStateV4;
@@ -59,6 +62,54 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
     assert!(matches!(s.chain_vaults[&1].status, ChainVaultStatus::Open));
     assert_eq!(s.chain_supplies[&ChainId(10143)], 10_000_000_000);
+}
+
+/// An Open vault with confirmed `debt` and an interest mint of `pending` in
+/// flight (`last_interest_accrual_ns = 1_000`).
+fn vault_interest_pending(s: &mut MultiChainStateV4, vault_id: u64, debt: u128, pending: u128) {
+    s.chain_vaults.insert(vault_id, ChainVaultV1 {
+        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(71),
+        custody_address: "0xc".into(), collateral_amount_native: 1_400_000_000_000_000_000_000,
+        debt_e8s: debt, mint_recipient: "0xr".into(), pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open, opened_at_ns: 0,
+        last_interest_accrual_ns: 1_000,
+        pending_interest_mint_e8s: pending,
+    });
+}
+
+#[test]
+fn confirm_interest_mint_grows_debt_and_supply_equally() {
+    let mut s = MultiChainStateV4::default();
+    s.chain_supplies.insert(ChainId(71), 100 * 100_000_000); // 100 icUSD principal minted
+    vault_interest_pending(&mut s, 1, 100 * 100_000_000, 2 * 100_000_000); // 2 icUSD pending
+    let pre = s.total_chain_vault_debt_e8s(); // 100e8
+    confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 2 * 100_000_000, 5_000, pre)
+        .expect("confirm");
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 102 * 100_000_000, "debt += interest");
+    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0, "pending cleared");
+    assert_eq!(
+        s.chain_vaults[&1].last_interest_accrual_ns, 5_000,
+        "accrual window advanced to the harvest snapshot time"
+    );
+    assert_eq!(
+        s.chain_supplies[&ChainId(71)],
+        102 * 100_000_000,
+        "supply grows equally -> invariant gap stays 0"
+    );
+}
+
+#[test]
+fn confirm_interest_mint_rejects_amount_mismatch_no_mutation() {
+    let mut s = MultiChainStateV4::default();
+    s.chain_supplies.insert(ChainId(71), 100 * 100_000_000);
+    vault_interest_pending(&mut s, 1, 100 * 100_000_000, 2 * 100_000_000);
+    let pre = s.total_chain_vault_debt_e8s();
+    let err = confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 3 * 100_000_000, 5_000, pre)
+        .unwrap_err();
+    assert!(err.contains("observed"), "mismatch error mentions observed/pending: {err}");
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100 * 100_000_000, "debt untouched on reject");
+    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 2 * 100_000_000, "pending untouched");
+    assert_eq!(s.chain_supplies[&ChainId(71)], 100 * 100_000_000, "supply untouched");
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -11,6 +11,8 @@ fn vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending: u128) {
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
         mint_recipient: "0xr".into(), pending_mint_e8s: pending,
         status: ChainVaultStatus::MintPending, opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
 }
 
@@ -89,6 +91,8 @@ fn confirm_mint_second_vault_uses_running_total() {
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 10_000_000_000,
         mint_recipient: "0xr".into(), pending_mint_e8s: 0,
         status: ChainVaultStatus::Open, opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -57,11 +57,15 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
     // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
     // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
-    confirm_mint_in_state(&mut s, ChainId(10143), 1, 10_000_000_000, 0).expect("confirm");
+    confirm_mint_in_state(&mut s, ChainId(10143), 1, 10_000_000_000, 0, 7_777).expect("confirm");
     assert_eq!(s.chain_vaults[&1].debt_e8s, 10_000_000_000);
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
     assert!(matches!(s.chain_vaults[&1].status, ChainVaultStatus::Open));
     assert_eq!(s.chain_supplies[&ChainId(10143)], 10_000_000_000);
+    assert_eq!(
+        s.chain_vaults[&1].last_interest_accrual_ns, 7_777,
+        "interest accrual window is stamped when the vault goes Open at mint-confirm"
+    );
 }
 
 /// An Open vault with confirmed `debt` and an interest mint of `pending` in
@@ -118,7 +122,7 @@ fn confirm_mint_rejects_amount_mismatch() {
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000);
     // Observed amount differs from pending: reject (caught before any supply mutation), do not mutate.
-    let res = confirm_mint_in_state(&mut s, ChainId(10143), 1, 9_999_999_999, 0);
+    let res = confirm_mint_in_state(&mut s, ChainId(10143), 1, 9_999_999_999, 0, 0);
     assert!(res.is_err());
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 10_000_000_000);
     assert_eq!(s.chain_supplies[&ChainId(10143)], 0);
@@ -128,7 +132,7 @@ fn confirm_mint_rejects_amount_mismatch() {
 fn confirm_mint_unknown_vault_rejected() {
     let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(ChainId(10143), 0);
-    assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0).is_err());
+    assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0, 0).is_err());
 }
 
 #[test]
@@ -147,7 +151,7 @@ fn confirm_mint_second_vault_uses_running_total() {
     });
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
-    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total).expect("confirm 2nd");
+    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0).expect("confirm 2nd");
     assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
     assert_eq!(s.chain_supplies[&ChainId(10143)], 15_000_000_000);
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_tecdsa.rs
@@ -1,9 +1,26 @@
 use super::tecdsa::{
-    custody_derivation_path, evm_address_from_pubkey, is_valid_evm_address,
-    settlement_derivation_path,
+    custody_derivation_path, evm_address_from_pubkey, interest_treasury_derivation_path,
+    is_valid_evm_address, settlement_derivation_path,
 };
 use crate::chains::config::ChainId;
 use candid::Principal;
+
+// Task 12: the interest-treasury path is deterministic, distinct from the
+// settlement path, and uses the `b"interest-treasury"` label, so revenue lands
+// at a separate canister-controlled address per chain.
+#[test]
+fn interest_treasury_path_is_distinct_and_labeled() {
+    let chain = ChainId(71);
+    assert_eq!(
+        interest_treasury_derivation_path(chain),
+        vec![chain.0.to_le_bytes().to_vec(), b"interest-treasury".to_vec()]
+    );
+    assert_ne!(
+        interest_treasury_derivation_path(chain),
+        settlement_derivation_path(chain),
+        "interest treasury must not collide with the minter address"
+    );
+}
 
 #[test]
 fn evm_address_from_known_uncompressed_pubkey() {

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -104,8 +104,18 @@ pub fn harvest_chain_interest_in_state(
                 enqueued.push(op_id);
             }
             // Duplicate idempotency key (a fresh mint_id makes this unreachable);
-            // skip and retry at the next harvest. No reservation made.
-            Err(_) => {}
+            // skip and retry at the next harvest. No reservation made. Log it —
+            // if it ever fires, something is wrong (mirrors accrue_single_vault's
+            // overflow-defer log).
+            Err(e) => {
+                ic_canister_log::log!(
+                    crate::logs::INFO,
+                    "[harvest chain={:?}] InterestMint enqueue failed for vault {} (unexpected with a fresh mint_id): {:?}; no reservation made",
+                    chain,
+                    vault_id,
+                    e
+                );
+            }
         }
     }
     enqueued

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -37,6 +37,80 @@ pub fn accrued_chain_interest_e8s(debt_e8s: u128, apr_bps: u64, elapsed_ns: u64)
     new_debt.saturating_sub(debt_e8s)
 }
 
+use crate::chains::config::ChainId;
+use crate::chains::multi_chain_state::MultiChainStateV4;
+use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
+use crate::chains::vault::ChainVaultStatus;
+
+/// Enqueue an `InterestMint` for every `Open`, debt-bearing vault on `chain`
+/// whose accrued interest clears `threshold_e8s` and has no interest mint
+/// already in flight. Sets `pending_interest_mint_e8s` (Design-B reserve); does
+/// NOT touch `debt_e8s`, supply, or `last_interest_accrual_ns` — the confirm
+/// path realizes those once the on-chain mint lands. `alloc_mint_id` yields
+/// FRESH globally-unique ids (from `chain_vault_id_counter`) so the on-chain
+/// `IcUSD.mint` never collides with a real vault id or a prior interest mint.
+/// `treasury_recipient` is the per-chain interest-treasury address (resolved by
+/// the async caller). Returns the op_ids enqueued.
+pub fn harvest_chain_interest_in_state(
+    state: &mut MultiChainStateV4,
+    chain: ChainId,
+    apr_bps: u64,
+    threshold_e8s: u128,
+    treasury_recipient: &str,
+    now_ns: u64,
+    mut alloc_mint_id: impl FnMut() -> u64,
+) -> Vec<u64> {
+    // Phase 1: pick eligible vaults + locked-in amounts (immutable scan, so the
+    // mint-id allocator + enqueue can borrow `state` mutably in phase 2).
+    let eligible: Vec<(u64, u128)> = state
+        .chain_vaults
+        .values()
+        .filter(|v| {
+            v.collateral_chain == chain
+                && v.status == ChainVaultStatus::Open
+                && v.debt_e8s > 0
+                && v.pending_interest_mint_e8s == 0
+        })
+        .filter_map(|v| {
+            let accrued = accrued_chain_interest_e8s(
+                v.debt_e8s,
+                apr_bps,
+                now_ns.saturating_sub(v.last_interest_accrual_ns),
+            );
+            (accrued > 0 && accrued >= threshold_e8s).then_some((v.vault_id, accrued))
+        })
+        .collect();
+
+    // Phase 2: enqueue an InterestMint + reserve the pending amount for each.
+    let mut enqueued = Vec::new();
+    for (vault_id, amount) in eligible {
+        let mint_id = alloc_mint_id();
+        let op = SettlementOp::new(
+            SettlementOpKind::InterestMint {
+                vault_id,
+                mint_id,
+                amount_e8s: amount,
+                accrual_through_ns: now_ns,
+                recipient: treasury_recipient.to_string(),
+            },
+            format!("interest-{}-{}", chain.0, mint_id),
+            now_ns,
+        );
+        match state.settlement_queues.entry(chain).or_default().enqueue(op) {
+            Ok(op_id) => {
+                if let Some(v) = state.chain_vaults.get_mut(&vault_id) {
+                    v.pending_interest_mint_e8s = amount;
+                }
+                enqueued.push(op_id);
+            }
+            // Duplicate idempotency key (a fresh mint_id makes this unreachable);
+            // skip and retry at the next harvest. No reservation made.
+            Err(_) => {}
+        }
+    }
+    enqueued
+}
+
 #[cfg(test)]
 mod tests {
     use super::accrued_chain_interest_e8s;
@@ -78,5 +152,115 @@ mod tests {
     fn overflow_defers_to_zero_not_panic() {
         // u128::MAX exceeds Decimal's range -> defer (0), never panic.
         assert_eq!(accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR), 0);
+    }
+
+    // ─── harvest_chain_interest_in_state ────────────────────────────────────
+    use super::harvest_chain_interest_in_state;
+    use crate::chains::config::ChainId;
+    use crate::chains::multi_chain_state::MultiChainStateV4;
+    use crate::chains::settlement_queue::SettlementOpKind;
+    use crate::chains::vault::{ChainVaultStatus, ChainVaultV1};
+    use candid::Principal;
+
+    const CHAIN: ChainId = ChainId(71);
+    const TREASURY: &str = "0x00000000000000000000000000000000000c0ffe";
+
+    fn open_vault(
+        s: &mut MultiChainStateV4,
+        vault_id: u64,
+        debt_e8s: u128,
+        last_accrual_ns: u64,
+        pending_interest: u128,
+        status: ChainVaultStatus,
+    ) {
+        s.chain_vaults.insert(
+            vault_id,
+            ChainVaultV1 {
+                vault_id,
+                owner: Principal::anonymous(),
+                collateral_chain: CHAIN,
+                custody_address: "0xc".into(),
+                collateral_amount_native: 1_400 * 1_000_000_000_000_000_000,
+                debt_e8s,
+                mint_recipient: "0xr".into(),
+                pending_mint_e8s: 0,
+                status,
+                opened_at_ns: 0,
+                last_interest_accrual_ns: last_accrual_ns,
+                pending_interest_mint_e8s: pending_interest,
+            },
+        );
+    }
+
+    #[test]
+    fn harvest_enqueues_one_interest_mint_per_eligible_vault() {
+        let mut s = MultiChainStateV4::default();
+        open_vault(&mut s, 1, 100 * E8, /*last accrual a year ago*/ 0, 0, ChainVaultStatus::Open);
+        let now = NANOS_PER_YEAR;
+        let mut next = 1000u64;
+        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
+            next += 1;
+            next
+        });
+        assert_eq!(ops.len(), 1, "one eligible vault -> one op");
+        let v = &s.chain_vaults[&1];
+        assert_eq!(v.pending_interest_mint_e8s, 2 * E8, "reserved 2% of 100 for a year");
+        assert_eq!(v.debt_e8s, 100 * E8, "debt untouched until confirm");
+        assert_eq!(v.last_interest_accrual_ns, 0, "accrual window not advanced at harvest");
+        let q = &s.settlement_queues[&CHAIN];
+        let op = q.pending.values().next().expect("op enqueued");
+        match &op.kind {
+            SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, accrual_through_ns, recipient } => {
+                assert_eq!(*vault_id, 1);
+                assert_eq!(*mint_id, 1001, "id from the allocator");
+                assert_eq!(*amount_e8s, 2 * E8);
+                assert_eq!(*accrual_through_ns, now);
+                assert_eq!(recipient, TREASURY);
+            }
+            other => panic!("expected InterestMint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn harvest_skips_below_threshold() {
+        let mut s = MultiChainStateV4::default();
+        // 1ns elapsed on 100 icUSD -> 1 e8s accrued, below a 1e6 threshold.
+        open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
+        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
+        assert!(ops.is_empty(), "below-threshold accrual is not realized");
+        assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0);
+    }
+
+    #[test]
+    fn harvest_skips_in_flight_non_open_and_zero_debt() {
+        let mut s = MultiChainStateV4::default();
+        open_vault(&mut s, 1, 100 * E8, 0, /*in flight*/ 50_000_000, ChainVaultStatus::Open);
+        open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::MintPending); // not Open
+        open_vault(&mut s, 3, 0, 0, 0, ChainVaultStatus::Open); // zero debt
+        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || 99);
+        assert!(ops.is_empty(), "in-flight / non-Open / zero-debt vaults are all skipped");
+    }
+
+    #[test]
+    fn harvest_allocates_disjoint_mint_ids_for_multiple_vaults() {
+        let mut s = MultiChainStateV4::default();
+        open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
+        open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::Open);
+        let mut next = 5000u64;
+        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || {
+            next += 1;
+            next
+        });
+        assert_eq!(ops.len(), 2);
+        let mint_ids: Vec<u64> = s.settlement_queues[&CHAIN]
+            .pending
+            .values()
+            .filter_map(|o| match &o.kind {
+                SettlementOpKind::InterestMint { mint_id, .. } => Some(*mint_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(mint_ids.len(), 2);
+        assert_ne!(mint_ids[0], mint_ids[1], "mint ids are disjoint");
     }
 }

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -1,0 +1,82 @@
+//! Chain-vault interest accrual math + harvest (Phase 1b Task 12, Option B).
+//!
+//! Mirrors the ICP-native `State::accrue_single_vault` factor formula
+//! (`new_debt = ceil(debt * (1 + rate * elapsed / NANOS_PER_YEAR))`, round UP =
+//! protocol favor, overflow => defer) but for foreign-chain vaults whose debt is
+//! denominated in e8s `u128`. Unlike ICP, accrued interest is NOT folded into
+//! `debt_e8s` here (that would break the chain supply invariant); it is only
+//! realized when the on-chain interest mint confirms (see `evm/settlement.rs`).
+
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+use rust_decimal::Decimal;
+
+use crate::numeric::NANOS_PER_YEAR;
+
+/// Interest (e8s) accrued on `debt_e8s` at `apr_bps` (fraction x 10^-4; 200 =
+/// 2.00% APR) over `elapsed_ns` nanoseconds. Rounds UP (protocol favor). Returns
+/// 0 on zero debt / zero elapsed / zero rate, and DEFERS (returns 0, never
+/// panics) on any Decimal overflow — mirroring ICP's overflow-defer.
+pub fn accrued_chain_interest_e8s(debt_e8s: u128, apr_bps: u64, elapsed_ns: u64) -> u128 {
+    if debt_e8s == 0 || apr_bps == 0 || elapsed_ns == 0 {
+        return 0;
+    }
+    // Defer (not panic) if debt cannot be represented as a Decimal.
+    let debt = match Decimal::from_u128(debt_e8s) {
+        Some(d) => d,
+        None => return 0,
+    };
+    let rate = Decimal::from(apr_bps) / Decimal::from(10_000u64);
+    let factor =
+        Decimal::ONE + rate * Decimal::from(elapsed_ns) / Decimal::from(NANOS_PER_YEAR);
+    // new_debt = ceil(debt * factor); the accrued interest is the delta. Defer
+    // on a Decimal->u128 overflow (unreachable at real debt scales).
+    let new_debt = match (debt * factor).ceil().to_u128() {
+        Some(n) => n,
+        None => return 0,
+    };
+    new_debt.saturating_sub(debt_e8s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::accrued_chain_interest_e8s;
+    const E8: u128 = 100_000_000;
+    const NANOS_PER_YEAR: u64 = 365 * 24 * 60 * 60 * 1_000_000_000;
+
+    #[test]
+    fn two_percent_full_year_on_100_icusd_is_2_icusd() {
+        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR), 2 * E8);
+    }
+
+    #[test]
+    fn half_year_is_half_the_interest() {
+        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR / 2), E8);
+    }
+
+    #[test]
+    fn rounds_up_protocol_favor() {
+        // A 1ns window on 100 icUSD yields a sub-e8s interest that must ceil to 1.
+        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, 1), 1);
+    }
+
+    #[test]
+    fn zero_debt_zero_interest() {
+        assert_eq!(accrued_chain_interest_e8s(0, 200, NANOS_PER_YEAR), 0);
+    }
+
+    #[test]
+    fn zero_elapsed_zero_interest() {
+        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, 0), 0);
+    }
+
+    #[test]
+    fn zero_bps_zero_interest() {
+        assert_eq!(accrued_chain_interest_e8s(100 * E8, 0, NANOS_PER_YEAR), 0);
+    }
+
+    #[test]
+    fn overflow_defers_to_zero_not_panic() {
+        // u128::MAX exceeds Decimal's range -> defer (0), never panic.
+        assert_eq!(accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR), 0);
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -34,6 +34,7 @@ pub mod adapter;
 pub mod admin;
 pub mod collateral_config;
 pub mod config;
+pub mod interest;
 pub mod multi_chain_state;
 pub mod recovery;
 pub mod settlement_queue;

--- a/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
@@ -34,6 +34,8 @@ fn chain_vault_round_trips_via_candid() {
         pending_mint_e8s: 10_000_000_000, // 100 icUSD pending
         status: ChainVaultStatus::MintPending,
         opened_at_ns: 1_700_000_000_000_000_000,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     };
     let bytes = Encode!(&v).expect("encode");
     let back: ChainVaultV1 = Decode!(&bytes, ChainVaultV1).expect("decode");
@@ -54,6 +56,8 @@ fn chain_vault_round_trips_via_cbor() {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
         opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     };
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&v, &mut buf).expect("cbor encode");

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -90,6 +90,61 @@ fn open_and_fund(
     v.status = ChainVaultStatus::Open;
 }
 
+/// One year in ns (matches `numeric::NANOS_PER_YEAR`).
+const NANOS_PER_YEAR: u64 = 365 * 24 * 60 * 60 * 1_000_000_000;
+
+// Task 12: a withdrawal is rejected while an interest mint is in flight for the
+// vault (`pending_interest_mint_e8s > 0`), so a full close cannot confirm after
+// the collateral leaves and credit unbacked interest debt to a Closed vault.
+#[test]
+fn withdraw_blocked_while_interest_mint_in_flight() {
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 5 * ONE_MON_E18, 100_0000_0000); // 5 MON, debt 100 icUSD
+    s.chain_vaults.get_mut(&7).unwrap().pending_interest_mint_e8s = 50_000_000; // in flight
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        ONE_MON_E18,
+        "0x000000000000000000000000000000000000dead".into(),
+        MIN_CR_E4,
+        555,
+    );
+    assert!(
+        matches!(res, Err(WithdrawError::InterestRealizationPending)),
+        "withdraw must be blocked while an interest mint is in flight, got {res:?}"
+    );
+}
+
+// Task 12: the post-withdrawal CR check counts accrued-but-unrealized interest.
+// 2 MON ($200) backing 100 icUSD; withdrawing 0.69 MON leaves 1.31 MON ($131) =
+// 131% on principal (>=130%), but a year of 2% interest makes effective debt
+// 102 icUSD => 128.4% (<130%). The IDENTICAL withdrawal with no elapsed interest
+// succeeds, isolating the interest as the cause.
+#[test]
+fn withdraw_cr_counts_accrued_interest() {
+    let now = 10 * NANOS_PER_YEAR;
+    let withdraw_amt = 690_000_000_000_000_000u128; // 0.69 MON
+    let debt = 100_0000_0000u128; // 100 icUSD
+    let dest = "0x000000000000000000000000000000000000dead".to_string();
+
+    // (a) a full year of accrued interest -> BelowMinCr.
+    let mut s = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s, 7, 2 * ONE_MON_E18, debt);
+    s.chain_vaults.get_mut(&7).unwrap().last_interest_accrual_ns = now - NANOS_PER_YEAR;
+    let res = withdraw_collateral_in_state(&mut s, 7, withdraw_amt, dest.clone(), MIN_CR_E4, now);
+    assert!(
+        matches!(res, Err(WithdrawError::BelowMinCr { .. })),
+        "accrued interest must raise effective debt for the CR check, got {res:?}"
+    );
+
+    // (b) the SAME vault + withdrawal with zero elapsed interest -> succeeds.
+    let mut s2 = setup(PRICE_100_USD_E8);
+    open_and_fund(&mut s2, 7, 2 * ONE_MON_E18, debt);
+    s2.chain_vaults.get_mut(&7).unwrap().last_interest_accrual_ns = now; // elapsed 0
+    let res2 = withdraw_collateral_in_state(&mut s2, 7, withdraw_amt, dest, MIN_CR_E4, now);
+    assert!(res2.is_ok(), "same withdrawal succeeds without accrued interest: {res2:?}");
+}
+
 // 1. full withdraw of a debt-free vault closes it (Closing) + enqueues one
 //    NativeWithdrawal carrying the real vault_id and the e18 amount.
 #[test]

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -127,6 +127,14 @@ pub fn apply_resolve_reversal_in_state(
                     }
                 }
             }
+            SettlementOpKind::InterestMint { vault_id, .. } => {
+                if let Some(v) = state.chain_vaults.get_mut(vault_id) {
+                    // Task 12: clear the orphaned interest reservation; nothing was
+                    // minted/credited. last_interest_accrual_ns is left unchanged so
+                    // the window is retried at the next harvest (no double-charge).
+                    v.pending_interest_mint_e8s = 0;
+                }
+            }
             SettlementOpKind::Burn { .. } => {}
         }
     }

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -23,6 +23,24 @@ pub enum SettlementOpKind {
     /// which was never enqueued anywhere and carried the wrong unit + no id).
     NativeWithdrawal { recipient: String, amount_e18: u128, vault_id: u64 },
     Burn { amount_e8s: u128 },
+    /// Task 12 (Option B): realize accrued interest by minting `amount_e8s`
+    /// icUSD to the per-chain interest-treasury address. `mint_id` is a FRESH,
+    /// globally-unique id (from `chain_vault_id_counter`) used as the on-chain
+    /// `IcUSD.mint` vault_id arg + the Mint-log match key — the REAL vault
+    /// already minted once at open and `IcUSD.mint` reverts a repeat vault_id.
+    /// `vault_id` is the REAL vault the interest is charged to; the confirm path
+    /// grows ITS `debt_e8s` and advances its `last_interest_accrual_ns` to
+    /// `accrual_through_ns` (the harvest snapshot time). `recipient` is the
+    /// per-chain interest-treasury address (resolved once at harvest time), used
+    /// as the `IcUSD.mint` `to:` and recipient-verified on confirm. EVM-only in
+    /// Phase 1b.
+    InterestMint {
+        vault_id: u64,
+        mint_id: u64,
+        amount_e8s: u128,
+        accrual_through_ns: u64,
+        recipient: String,
+    },
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
@@ -142,14 +160,16 @@ impl SettlementQueueV1 {
         })
     }
 
-    /// True iff the queue has a NON-terminal `Mint` op (`Queued` or `Inflight`).
-    /// Distinct from `has_active_op` (which also counts `NativeWithdrawal`):
-    /// only a `Mint` changes on-chain icUSD `totalSupply`, so only a live mint
-    /// can mask a burn from the observer's supply-equality backstop
-    /// (`backstop_should_scan`). Terminal (`Succeeded`/`Failed`) ops never count.
+    /// True iff the queue has a NON-terminal supply-increasing mint op (`Mint`
+    /// or, Task 12, `InterestMint`) in `Queued`/`Inflight`. Distinct from
+    /// `has_active_op` (which also counts `NativeWithdrawal`): only a mint changes
+    /// on-chain icUSD `totalSupply`, so only a live mint can mask a burn from the
+    /// observer's supply-equality backstop (`backstop_should_scan`). An interest
+    /// mint also raises `totalSupply`, so it counts too. Terminal
+    /// (`Succeeded`/`Failed`) ops never count.
     pub fn has_active_mint_op(&self) -> bool {
         self.pending.values().any(|op| {
-            matches!(op.kind, SettlementOpKind::Mint { .. })
+            matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. })
                 && matches!(
                     op.status,
                     SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -463,7 +463,7 @@ fn confirm_succeeded(
                 if !still_inflight {
                     return MintConfirm::AlreadyHandled;
                 }
-                match confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total) {
+                match confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total, now) {
                     Ok(()) => {
                         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                             if let Some(o) = q.pending.get_mut(&op_id) {

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -178,10 +178,12 @@ pub async fn run_settlement(chain: ChainId) {
 /// re-sign. See the module doc for the durable-nonce idempotency rationale.
 async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // A Burn op is never signable in M2 - burns are user-initiated on-chain. Fail
-    // it up front (no RPC), mirroring Monad.
-    if matches!(op.kind, SettlementOpKind::Burn { .. }) {
+    // it up front (no RPC), mirroring Monad. Task 12: an InterestMint can never be
+    // enqueued on a Solana queue (interest harvest is EVM-only), but fail it
+    // defensively too so a stray op can never wedge the worker.
+    if matches!(op.kind, SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. }) {
         let now = ic_cdk::api::time();
-        let reason = "burn not signable in M2 (burns are user-initiated on-chain)".to_string();
+        let reason = "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
         mutate_state(|s| {
             if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                 if let Some(o) = q.pending.get_mut(&op_id) {
@@ -277,7 +279,7 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
                 Err(e) => return handle_adapter_error(chain, op_id, "sign_withdrawal", e),
             }
         }
-        SettlementOpKind::Burn { .. } => {
+        SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. } => {
             // Unreachable: handled (marked Failed) at the top of this fn.
             return;
         }
@@ -518,10 +520,10 @@ fn confirm_succeeded(
             });
             log!(INFO, "[solana settlement chain={:?}] withdrawal op {} vault {} confirmed slot={} sig={} (Closing->Closed if applicable)", chain, op_id, vid, slot, signature);
         }
-        SettlementOpKind::Burn { .. } => {
-            // Unreachable: a Burn op is marked Failed on the submit path and never
-            // goes Inflight. Log defensively rather than panic.
-            log!(INFO, "[solana settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
+        SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. } => {
+            // Unreachable: Burn/InterestMint ops are marked Failed on the submit
+            // path and never go Inflight. Log defensively rather than panic.
+            log!(INFO, "[solana settlement chain={:?}] inflight non-signable op {} reached confirm path unexpectedly", chain, op_id);
         }
     }
 }
@@ -575,7 +577,7 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
                     }
                 }
             }
-            SettlementOpKind::Burn { .. } => {}
+            SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. } => {}
         }
         if let Some(o) = s
             .multi_chain
@@ -602,7 +604,7 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
             SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
                 log!(INFO, "[solana settlement chain={:?}] withdrawal op {} vault {} reverted on-chain (sig {}); marked Failed, restored {} lamports of reserved collateral", chain, op_id, vault_id, signature, amount_e18);
             }
-            SettlementOpKind::Burn { .. } => {}
+            SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. } => {}
         }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -54,7 +54,7 @@ fn solana_confirm_mint_moves_pending_to_debt_and_increments_supply() {
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending (e8s)
                                                      // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
-    confirm_mint_in_state(&mut s, SOL, 1, 10_000_000_000, 0).expect("confirm");
+    confirm_mint_in_state(&mut s, SOL, 1, 10_000_000_000, 0, 0).expect("confirm");
     assert_eq!(s.chain_vaults[&1].debt_e8s, 10_000_000_000);
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
     assert!(matches!(s.chain_vaults[&1].status, ChainVaultStatus::Open));
@@ -67,7 +67,7 @@ fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000);
     // Observed != pending: reject before any supply mutation; nothing changes.
-    let res = confirm_mint_in_state(&mut s, SOL, 1, 9_999_999_999, 0);
+    let res = confirm_mint_in_state(&mut s, SOL, 1, 9_999_999_999, 0, 0);
     assert!(res.is_err());
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 10_000_000_000);
     assert_eq!(s.chain_vaults[&1].debt_e8s, 0);
@@ -79,7 +79,7 @@ fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
 fn solana_confirm_mint_unknown_vault_rejected() {
     let mut s = MultiChainStateV4::default();
     s.chain_supplies.insert(SOL, 0);
-    assert!(confirm_mint_in_state(&mut s, SOL, 999, 1, 0).is_err());
+    assert!(confirm_mint_in_state(&mut s, SOL, 999, 1, 0, 0).is_err());
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
     );
     solana_vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
-    confirm_mint_in_state(&mut s, SOL, 2, 5_000_000_000, pre_total).expect("confirm 2nd");
+    confirm_mint_in_state(&mut s, SOL, 2, 5_000_000_000, pre_total, 0).expect("confirm 2nd");
     assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
     assert_eq!(s.chain_supplies[&SOL], 15_000_000_000);
 }

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -42,6 +42,8 @@ fn solana_vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending_e8s: u
             pending_mint_e8s: pending_e8s,
             status: ChainVaultStatus::MintPending,
             opened_at_ns: 0,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
         },
     );
 }
@@ -100,6 +102,8 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
             pending_mint_e8s: 0,
             status: ChainVaultStatus::Open,
             opened_at_ns: 0,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
         },
     );
     solana_vault_pending(&mut s, 2, 5_000_000_000);

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -118,3 +118,18 @@ pub fn check_invariant(
     }
     Ok(())
 }
+
+/// Phase 1b Task 12 migration: stamp `last_interest_accrual_ns = now_ns` for any
+/// chain vault that decoded with 0 (an existing vault from a snapshot written
+/// before the interest fields existed), so the first harvest does not bill
+/// interest from the unix epoch. New vaults are stamped to `now` at mint-confirm
+/// (`confirm_mint_in_state`) and never decode as 0, so this only ever touches
+/// pre-feature vaults. Idempotent (re-running is a no-op once stamped). Called
+/// from `post_upgrade` after `restore_state`.
+pub fn stamp_chain_interest_accrual_start(state: &mut MultiChainStateV4, now_ns: u64) {
+    for v in state.chain_vaults.values_mut() {
+        if v.last_interest_accrual_ns == 0 {
+            v.last_interest_accrual_ns = now_ns;
+        }
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -47,6 +47,8 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::AwaitingDeposit,
         opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -311,3 +311,66 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
     });
     assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
 }
+
+// Task 12: a ChainVaultV1 snapshot written BEFORE the interest fields existed
+// (no `last_interest_accrual_ns` / `pending_interest_mint_e8s` keys) MUST decode
+// into the current ChainVaultV1 with those fields defaulting to 0, NOT error
+// (which on a real canister wipes multi_chain state via the replay fallback).
+// Then the post_upgrade stamp repairs the 0 so the first harvest doesn't bill
+// from the unix epoch.
+#[test]
+fn legacy_chain_vault_decodes_interest_fields_defaulted_then_stamped() {
+    use super::vault::{ChainVaultStatus, ChainVaultV1};
+    use candid::Principal;
+    use serde::Serialize;
+
+    // The exact pre-Task-12 ChainVaultV1 shape (same field names + serde rename).
+    #[derive(Serialize)]
+    struct LegacyChainVault {
+        vault_id: u64,
+        owner: Principal,
+        collateral_chain: ChainId,
+        custody_address: String,
+        #[serde(rename = "collateral_amount_e18")]
+        collateral_amount_native: u128,
+        debt_e8s: u128,
+        mint_recipient: String,
+        pending_mint_e8s: u128,
+        status: ChainVaultStatus,
+        opened_at_ns: u64,
+    }
+    let legacy = LegacyChainVault {
+        vault_id: 7,
+        owner: Principal::anonymous(),
+        collateral_chain: ChainId(71),
+        custody_address: "0xcustody".into(),
+        collateral_amount_native: 1_234,
+        debt_e8s: 555,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 99,
+    };
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&legacy, &mut buf).expect("encode legacy vault");
+    let decoded: ChainVaultV1 = ciborium::de::from_reader(buf.as_slice())
+        .expect("legacy ChainVaultV1 MUST decode into the new shape (no state wipe)");
+
+    // Pre-existing fields preserved exactly:
+    assert_eq!(decoded.vault_id, 7);
+    assert_eq!(decoded.debt_e8s, 555);
+    assert_eq!(decoded.collateral_amount_native, 1_234);
+    assert_eq!(decoded.opened_at_ns, 99);
+    assert_eq!(decoded.status, ChainVaultStatus::Open);
+    // New interest fields defaulted to 0:
+    assert_eq!(decoded.last_interest_accrual_ns, 0);
+    assert_eq!(decoded.pending_interest_mint_e8s, 0);
+
+    // The post_upgrade stamp repairs the 0 last_interest_accrual_ns.
+    let mut s = MultiChainState::default();
+    s.chain_vaults.insert(7, decoded);
+    super::supply::stamp_chain_interest_accrual_start(&mut s, 1_700_000_000_000_000_000);
+    assert_eq!(s.chain_vaults[&7].last_interest_accrual_ns, 1_700_000_000_000_000_000);
+    assert_eq!(s.chain_vaults[&7].debt_e8s, 555, "stamp does not touch debt");
+}

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -168,6 +168,8 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
         opened_at_ns: 99,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     v2.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v2.last_observed_block.insert(ChainId(10143), 35_136_248);
@@ -241,6 +243,8 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
         opened_at_ns: 99,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     v3.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v3.last_observed_block.insert(ChainId(10143), 35_136_248);
@@ -288,6 +292,8 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
         opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     s.chain_vaults.insert(2, ChainVaultV1 {
         vault_id: 2,
@@ -300,6 +306,8 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
         opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     });
     assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -30,6 +30,8 @@ fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u12
         pending_mint_e8s: pending,
         status,
         opened_at_ns: 0,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -102,3 +102,35 @@ fn divergence_from_total_debt_is_rejected() {
     assert!(matches!(res, Err(SupplyInvariantError::Divergence { .. })));
     assert_eq!(s.chain_supplies[&ChainId(101)], 100);
 }
+
+// Task 12: the post_upgrade migration stamp sets last_interest_accrual_ns = now
+// for any vault that decoded with 0 (an existing vault from a pre-field
+// snapshot), and leaves already-stamped vaults alone. Idempotent.
+#[test]
+fn stamp_sets_accrual_start_only_for_unstamped_vaults() {
+    use super::vault::{ChainVaultStatus, ChainVaultV1};
+    use candid::Principal;
+    let mk = |id: u64, last: u64| ChainVaultV1 {
+        vault_id: id,
+        owner: Principal::anonymous(),
+        collateral_chain: ChainId(71),
+        custody_address: "0xc".into(),
+        collateral_amount_native: 0,
+        debt_e8s: 100,
+        mint_recipient: "0xr".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 0,
+        last_interest_accrual_ns: last,
+        pending_interest_mint_e8s: 0,
+    };
+    let mut s = MultiChainStateV4::default();
+    s.chain_vaults.insert(1, mk(1, 0)); // unstamped (pre-field snapshot)
+    s.chain_vaults.insert(2, mk(2, 5)); // already stamped
+    super::supply::stamp_chain_interest_accrual_start(&mut s, 12_345);
+    assert_eq!(s.chain_vaults[&1].last_interest_accrual_ns, 12_345, "unstamped vault gets now");
+    assert_eq!(s.chain_vaults[&2].last_interest_accrual_ns, 5, "already-stamped untouched");
+    // Idempotent: a second run does not re-stamp the now-stamped vault.
+    super::supply::stamp_chain_interest_accrual_start(&mut s, 99_999);
+    assert_eq!(s.chain_vaults[&1].last_interest_accrual_ns, 12_345, "idempotent");
+}

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -70,6 +70,21 @@ pub struct ChainVaultV1 {
     pub pending_mint_e8s: u128,
     pub status: ChainVaultStatus,
     pub opened_at_ns: u64,
+    /// Phase 1b Task 12 (interest accrual). Start of the current accrual window
+    /// (ns). Set when the vault becomes Open (mint confirm); advanced to the
+    /// harvest snapshot time when an interest mint confirms. `#[serde(default)]`
+    /// = 0 for a vault decoded from a pre-field snapshot; `post_upgrade` then
+    /// stamps it to the upgrade time (a 0 would otherwise bill ~56yr of interest
+    /// on the first harvest). Added in-place per the repo's reorg-fields
+    /// precedent (phase-1b struct, never mainnet-persisted; serde-default is the
+    /// state-wipe safety).
+    #[serde(default)]
+    pub last_interest_accrual_ns: u64,
+    /// Interest amount locked in at harvest, awaiting its on-chain mint
+    /// confirmation (Design-B pending pattern, mirrors `pending_mint_e8s`).
+    /// `> 0` ⇒ one interest realization is in flight for this vault.
+    #[serde(default)]
+    pub pending_interest_mint_e8s: u128,
 }
 
 /// Reasons `open_chain_vault_in_state` / `verify_deposit_and_enqueue_mint_in_state`
@@ -258,6 +273,10 @@ pub fn open_chain_vault_in_state(
             pending_mint_e8s: debt_e8s,
             status: ChainVaultStatus::AwaitingDeposit,
             opened_at_ns: now_ns,
+            // Interest accrues only once the vault is Open with confirmed debt;
+            // stamped to `now` at mint-confirm (Task 7). Open-time = 0 (debt 0).
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
         },
     );
     // No mint enqueued - that happens in verify_deposit_and_enqueue_mint_in_state.

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -144,6 +144,12 @@ pub enum WithdrawError {
     /// phantom collateral), and a `MintPending` vault has a mint in flight
     /// against its collateral. Carries the offending status.
     WrongStatus { status: ChainVaultStatus },
+    /// An interest mint is in flight (`pending_interest_mint_e8s > 0`):
+    /// collateral cannot leave until it confirms. Otherwise a full close could
+    /// confirm AFTER the collateral is withdrawn and credit the realized
+    /// interest as unbacked debt on a Closed vault (Task 12). The window is a
+    /// few settlement ticks; the next harvest/confirm clears it.
+    InterestRealizationPending,
 }
 
 /// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
@@ -415,7 +421,7 @@ pub fn withdraw_collateral_in_state(
     now_ns: u64,
 ) -> Result<(), WithdrawError> {
     // Step 1: read-only validation. No mutation on any rejection path.
-    let (chain, remaining, debt_e8s) = {
+    let (chain, remaining, debt_e8s, last_accrual_ns) = {
         let v = state
             .chain_vaults
             .get(&vault_id)
@@ -432,11 +438,17 @@ pub fn withdraw_collateral_in_state(
         if v.status != ChainVaultStatus::Open {
             return Err(WithdrawError::WrongStatus { status: v.status.clone() });
         }
+        // Task 12: refuse collateral-out while an interest mint is in flight.
+        // The mint could confirm AFTER the collateral leaves and credit the
+        // realized interest as unbacked debt on a (then-Closing/Closed) vault.
+        if v.pending_interest_mint_e8s > 0 {
+            return Err(WithdrawError::InterestRealizationPending);
+        }
         if amount_e18 > v.collateral_amount_native {
             return Err(WithdrawError::InsufficientCollateral);
         }
         let remaining = v.collateral_amount_native - amount_e18;
-        (v.collateral_chain, remaining, v.debt_e8s)
+        (v.collateral_chain, remaining, v.debt_e8s, v.last_interest_accrual_ns)
     };
 
     // Price is needed for the post-withdrawal CR check (only when debt remains).
@@ -451,8 +463,22 @@ pub fn withdraw_collateral_in_state(
         .unwrap_or(18);
 
     // A debt-free vault is trivially over-collateralized; skip the CR check.
+    // Task 12: the CR check counts accrued-but-unrealized interest, so interest
+    // can correctly push a vault toward min CR. apr_bps is self-resolved from the
+    // vault's chain config (0 for a chain without a collateral config -> no
+    // interest, behavior-preserving for non-CDP chains). This is a read-side
+    // adjustment only; no mint happens here.
     if debt_e8s > 0 {
-        let cr_e4 = collateral_ratio_e4(remaining, native_decimals, price_e8, debt_e8s);
+        let apr_bps = crate::chains::collateral_config::chain_collateral_config(chain)
+            .map(|c| c.interest_apr_bps)
+            .unwrap_or(0);
+        let accrued = crate::chains::interest::accrued_chain_interest_e8s(
+            debt_e8s,
+            apr_bps,
+            now_ns.saturating_sub(last_accrual_ns),
+        );
+        let effective_debt = debt_e8s.saturating_add(accrued);
+        let cr_e4 = collateral_ratio_e4(remaining, native_decimals, price_e8, effective_debt);
         if cr_e4 < min_cr_e4 {
             return Err(WithdrawError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
         }

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -881,6 +881,19 @@ pub enum Event {
         threshold_e18: u128,
         timestamp: u64,
     },
+    /// Task 12 (Option B): an interest mint confirmed on-chain. `mint_id` is the
+    /// synthetic on-chain mint id; `vault_id` is the REAL vault whose `debt_e8s`
+    /// grew by `amount_e8s` (matched by the chain supply growing equally).
+    #[serde(rename = "chain_interest_minted")]
+    ChainInterestMinted {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        mint_id: u64,
+        amount_e8s: u128,
+        tx_hash: String,
+        block_number: u64,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -1001,6 +1014,7 @@ impl Event {
             | Event::ChainMintSubmitted { vault_id, .. }
             | Event::ChainMintConfirmed { vault_id, .. }
             | Event::ChainBurnObserved { vault_id, .. }
+            | Event::ChainInterestMinted { vault_id, .. }
             | Event::WithdrawalSigned { vault_id, .. } => vault_id == filter_vault_id,
             // Phase 1b: protocol-wide or op-scoped events, not vault-specific.
             Event::ChainSettlementFailed { .. }
@@ -2022,6 +2036,7 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             | Event::ChainMintSubmitted { .. }
             | Event::ChainMintConfirmed { .. }
             | Event::ChainBurnObserved { .. }
+            | Event::ChainInterestMinted { .. }
             | Event::WithdrawalSigned { .. }
             | Event::ChainSettlementFailed { .. }
             | Event::ChainReorgDetected { .. }

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -591,6 +591,17 @@ fn post_upgrade(arg: ProtocolArg) {
         log!(INFO, "[upgrade]: migrated {} vaults: set last_accrual_time to {}", migrated, now);
     }
 
+    // Task 12: mirror the above for FOREIGN-CHAIN vaults — stamp
+    // last_interest_accrual_ns for any that decoded with 0 (a vault from a
+    // pre-interest-field snapshot), so the first interest harvest does not bill
+    // from the unix epoch. New vaults are stamped at mint-confirm; idempotent.
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::supply::stamp_chain_interest_accrual_start(
+            &mut s.multi_chain,
+            now,
+        );
+    });
+
     // Safety net: if bot is configured but allowlist is empty, default to ICP
     mutate_state(|s| {
         if s.liquidation_bot_principal.is_some() && s.bot_allowed_collateral_types.is_empty() {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -5535,6 +5535,23 @@ async fn set_chain_interest_tick_interval_secs(secs: u64) -> Result<(), Protocol
     Ok(())
 }
 
+/// Task 12: tune the interest-realization dust floor (e8s) — accrued interest
+/// below this is not minted (its gas would dwarf the interest). Default 0.01
+/// icUSD. Developer-gated.
+#[candid_method(update)]
+#[update]
+async fn set_chain_interest_min_realize_e8s(e8s: u128) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set the chain interest dust floor".to_string(),
+        ));
+    }
+    mutate_state(|s| s.chain_interest_min_realize_e8s = e8s);
+    log!(INFO, "[set_chain_interest_min_realize_e8s] interest dust floor set to {} e8s", e8s);
+    Ok(())
+}
+
 /// Task 12: manually trigger one interest harvest for `chain` (developer-gated),
 /// for testing/ops independent of the off-by-default timer. Resolves the
 /// interest-treasury address + APR, enqueues an `InterestMint` for every

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -209,6 +209,9 @@ thread_local! {
         const { std::cell::Cell::new(None) };
     static OBSERVER_TIMER_ID: std::cell::Cell<Option<ic_cdk_timers::TimerId>> =
         const { std::cell::Cell::new(None) };
+    // Task 12: foreign-chain interest harvest. Same transient lifecycle.
+    static CHAIN_INTEREST_TIMER_ID: std::cell::Cell<Option<ic_cdk_timers::TimerId>> =
+        const { std::cell::Cell::new(None) };
 }
 
 fn register_xrc_fetch_timer() {
@@ -345,6 +348,92 @@ fn register_settlement_timer() {
     });
 }
 
+/// Task 12: interest harvest fan-out — for each registered EVM chain, resolve its
+/// interest-treasury recipient + APR and enqueue `InterestMint` ops for every
+/// eligible vault. The settlement worker (Timer D) then mints/confirms them.
+/// Interest accrual is EVM-only in Phase 1b (Solana has no on-chain mint path
+/// here), so Solana is skipped. No-op in ReadOnly mode. No state borrow is held
+/// across the treasury-address derive `.await`.
+async fn run_all_chain_interest_harvests() {
+    if read_state(|s| s.mode == Mode::ReadOnly) {
+        return;
+    }
+    let (chains, _solana_enabled) = registered_chains_and_solana_flag();
+    let now = ic_cdk::api::time();
+    for chain in chains {
+        if chain == SOLANA_CHAIN_ID {
+            continue; // interest accrual is EVM-only in Phase 1b
+        }
+        if let Err(e) = harvest_one_chain_interest(chain, now).await {
+            log!(INFO, "[interest harvest chain={:?}] skipped: {}", chain, e);
+        }
+    }
+}
+
+/// Harvest interest for one EVM chain: resolve `apr_bps` + the interest-treasury
+/// address (async, cached), then run the in-state harvest. Interest-mint ids are
+/// drawn from the SAME `chain_vault_id_counter` as vault opens (guaranteeing
+/// global disjointness from real vault ids and prior interest mints): read the
+/// counter, hand the harvest a fresh-id closure over a LOCAL copy, write the
+/// advanced value back — all inside one `mutate_state`, so the closure never
+/// reborrows `s`.
+async fn harvest_one_chain_interest(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    now: u64,
+) -> Result<u64, String> {
+    let apr_bps =
+        match rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain) {
+            Some(c) if c.interest_apr_bps > 0 => c.interest_apr_bps,
+            Some(_) => return Ok(0), // a configured 0-rate chain accrues nothing
+            None => return Err(format!("no collateral config for chain {}", chain.0)),
+        };
+    let treasury =
+        rumi_protocol_backend::chains::evm::tecdsa::cached_interest_treasury_address(chain)
+            .await
+            .map(|(_path, addr)| addr)
+            .map_err(|e| format!("interest-treasury address derive failed: {e}"))?;
+    let threshold = read_state(|s| s.chain_interest_min_realize_e8s);
+    let enqueued = mutate_state(|s| {
+        let mut k = s.chain_vault_id_counter;
+        let ops = rumi_protocol_backend::chains::interest::harvest_chain_interest_in_state(
+            &mut s.multi_chain,
+            chain,
+            apr_bps,
+            threshold,
+            &treasury,
+            now,
+            || {
+                k += 1;
+                k
+            },
+        );
+        s.chain_vault_id_counter = k;
+        ops.len() as u64
+    });
+    if enqueued > 0 {
+        log!(INFO, "[interest harvest chain={:?}] enqueued {} interest mint(s) to treasury {}", chain, enqueued, treasury);
+    }
+    Ok(enqueued)
+}
+
+/// Task 12: register the interest-harvest timer. Clears + re-registers in place
+/// so the setter can re-tune live. FLOOR: a 0 interval is forced to the 1-year
+/// default (never a busy-loop), mirroring the settlement/observer timers.
+fn register_chain_interest_timer() {
+    let secs = read_state(|s| s.chain_interest_tick_interval_secs);
+    let secs = if secs == 0 { 31_536_000 } else { secs };
+    CHAIN_INTEREST_TIMER_ID.with(|cell| {
+        if let Some(old) = cell.get() {
+            ic_cdk_timers::clear_timer(old);
+        }
+        let new_id = ic_cdk_timers::set_timer_interval(
+            std::time::Duration::from_secs(secs),
+            || ic_cdk::spawn(run_all_chain_interest_harvests()),
+        );
+        cell.set(Some(new_id));
+    });
+}
+
 /// Phase 1b Task 15: register the inbound observer fan-out. Same
 /// clear-and-re-register-in-place + 0-floor protection as the settlement timer.
 fn register_observer_timer() {
@@ -437,6 +526,12 @@ fn setup_timers() {
     // from double-processing an op.
     register_settlement_timer();
     register_observer_timer();
+
+    // Task 12: foreign-chain interest harvest. Defaults to a ~1-year interval
+    // (effectively OFF) so realization is deliberate; tunable via
+    // `set_chain_interest_tick_interval_secs`. No-op when no EVM chain is
+    // registered, so it is safe to register on staging before any chain exists.
+    register_chain_interest_timer();
 }
 
 fn capture_protocol_snapshot() {
@@ -5415,6 +5510,68 @@ async fn set_settlement_tick_interval_secs(secs: u64) -> Result<(), ProtocolErro
     register_settlement_timer();
     log!(INFO, "[set_settlement_tick_interval_secs] Timer D interval set to {}s", secs);
     Ok(())
+}
+
+/// Task 12: tune the foreign-chain interest-harvest interval (seconds). Default
+/// ~1 year (effectively OFF). Re-registers the timer in place. Rejects `secs ==
+/// 0` (the register fn also floors a 0 to the 1-year default). Developer-gated.
+#[candid_method(update)]
+#[update]
+async fn set_chain_interest_tick_interval_secs(secs: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set the chain interest tick interval".to_string(),
+        ));
+    }
+    if secs == 0 {
+        return Err(ProtocolError::GenericError(
+            "Chain interest tick interval must be > 0".to_string(),
+        ));
+    }
+    mutate_state(|s| s.chain_interest_tick_interval_secs = secs);
+    register_chain_interest_timer();
+    log!(INFO, "[set_chain_interest_tick_interval_secs] interest harvest interval set to {}s", secs);
+    Ok(())
+}
+
+/// Task 12: manually trigger one interest harvest for `chain` (developer-gated),
+/// for testing/ops independent of the off-by-default timer. Resolves the
+/// interest-treasury address + APR, enqueues an `InterestMint` for every
+/// eligible vault, and returns the number enqueued. The settlement worker then
+/// mints/confirms them on-chain.
+#[candid_method(update)]
+#[update]
+async fn harvest_chain_interest(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<u64, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let now = ic_cdk::api::time();
+    harvest_one_chain_interest(chain, now)
+        .await
+        .map_err(ProtocolError::ChainAdmin)
+}
+
+/// Task 12: derive the per-chain interest-treasury (revenue) address — the
+/// tECDSA-derived EVM address that receives minted interest, distinct from the
+/// settlement (minter) address. Developer-gated (derivation costs cycles + a
+/// signing-subnet call). Used by ops + tests to learn where revenue accrues.
+#[candid_method(update)]
+#[update]
+async fn get_chain_interest_treasury_address(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<String, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    rumi_protocol_backend::chains::evm::tecdsa::cached_interest_treasury_address(chain)
+        .await
+        .map(|(_path, addr)| addr)
+        .map_err(|e| ProtocolError::ChainAdmin(format!("derive: {e}")))
 }
 
 /// Phase 1b Task 15: tune the Monad inbound observer fan-out interval in

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -109,6 +109,11 @@ fn default_vault_check_tick_interval_secs() -> u64 { 300 }
 /// developer-gated setters tune the live cadence without an upgrade.
 fn default_settlement_tick_interval_secs() -> u64 { 300 }
 fn default_observer_tick_interval_secs() -> u64 { 300 }
+/// Task 12: ~1 year (365 days) — effectively OFF by default (realization is
+/// deliberate, not an always-on heartbeat).
+fn default_chain_interest_tick_interval_secs() -> u64 { 31_536_000 }
+/// Task 12: 0.01 icUSD dust floor for interest realization.
+fn default_chain_interest_min_realize_e8s() -> u128 { 1_000_000 }
 
 pub fn default_interest_split() -> Vec<InterestRecipient> {
     vec![
@@ -868,6 +873,21 @@ pub struct State {
     /// `set_observer_tick_interval_secs`. Same 0-floor protection as above.
     #[serde(default = "default_observer_tick_interval_secs")]
     pub observer_tick_interval_secs: u64,
+    /// Task 12: cadence (seconds) for the foreign-chain interest harvest
+    /// (`main::run_all_chain_interest_harvests`). Defaults to ~1 year, i.e.
+    /// effectively OFF on staging — interest realization mints on-chain (gas +
+    /// cycles), so it is deliberate, not an always-on heartbeat. Tunable via
+    /// `set_chain_interest_tick_interval_secs`; the register fn floors a 0 to the
+    /// 1-year default so a missing serde-default never busy-loops. (Accrual for
+    /// CR is lazy-on-read; only realization rides this timer.)
+    #[serde(default = "default_chain_interest_tick_interval_secs")]
+    pub chain_interest_tick_interval_secs: u64,
+    /// Task 12: dust floor (e8s) below which accrued interest is NOT realized, to
+    /// avoid sub-cent on-chain mints whose gas dwarfs the interest. Default 0.01
+    /// icUSD. The accrued interest keeps accumulating (in the CR read) until it
+    /// crosses this.
+    #[serde(default = "default_chain_interest_min_realize_e8s")]
+    pub chain_interest_min_realize_e8s: u128,
     pub fee: Ratio,
     pub developer_principal: Principal,
     pub next_available_vault_id: u64,
@@ -1463,6 +1483,8 @@ impl Default for State {
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
             settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
+            chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
+            chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
             fee: Ratio::from(Decimal::ZERO),
             developer_principal: Principal::anonymous(),
             next_available_vault_id: 1,
@@ -1608,6 +1630,8 @@ impl From<InitArg> for State {
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
             settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
+            chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
+            chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
             total_collateral_ratio: Ratio::from(Decimal::MAX),
             last_icp_timestamp: None,
             last_icp_rate: None,

--- a/src/rumi_protocol_backend/src/storage.rs
+++ b/src/rumi_protocol_backend/src/storage.rs
@@ -400,6 +400,8 @@ mod state_snapshot_tests {
                 pending_mint_e8s: 0,
                 status: ChainVaultStatus::Open,
                 opened_at_ns: 42,
+                last_interest_accrual_ns: 0,
+                pending_interest_mint_e8s: 0,
             },
         );
 

--- a/src/rumi_protocol_backend/tests/conflux_interest_accrual_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_interest_accrual_pic.rs
@@ -1,0 +1,430 @@
+//! Conflux eSpace (chain 71) end-to-end INTEREST-ACCRUAL integration test
+//! (Task 12, Option B), against the scripted mock EVM RPC canister.
+//!
+//! Mirrors `conflux_espace_happy_path_pic.rs` through open -> deposit -> mint,
+//! then exercises the interest path:
+//!
+//!   open -> deposit -> mint (debt 100e8, supply 100e8)
+//!     -> advance ~60d, harvest_chain_interest  => InterestMint enqueued, vault
+//!        reserves pending_interest_mint_e8s (debt/supply UNCHANGED)
+//!     -> settlement mints the interest to the per-chain interest-treasury and
+//!        confirms                               => debt 100e8+I, supply 100e8+I
+//!     -> burn (100e8 + I) on chain              => debt 0, supply 0
+//!     -> withdraw all collateral                => Closing -> Closed, supply 0
+//!
+//! The POINT: after the interest mint confirms, the vault's `debt_e8s` and the
+//! chain supply grow by EXACTLY the same amount, so the supply invariant
+//! (get_global_icusd_supply() == sum(chain vault debt)) gap stays 0. This is
+//! what makes Option B correct where Option C would drive supply below debt.
+//!
+//! Like the happy path, this boots with an II subnet so PocketIC can provision
+//! `test_key_1`, PROBES ECDSA, and runs the GATED subset (register/config +
+//! invariant-at-0) on an ECDSA-less build, auto-upgrading to the full path on an
+//! ECDSA-capable build.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types ──────────────────────────────────────────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 { max_priority_fee_gwei: u64, max_fee_gwei_ceiling: u64 },
+    EvmLegacy { gas_price_gwei_ceiling: u64 },
+    SolanaPriorityFee { lamports_per_cu_ceiling: u64 },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+    min_quorum_providers: Option<u32>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+/// Mirror of the backend `ChainVaultV1` WIRE shape, INCLUDING the two Task-12
+/// interest fields (decode tolerates them because the backend now returns them).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+    last_interest_accrual_ns: u64,
+    pending_interest_mint_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+    GenericError(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CONFLUX_CHAIN_ID: u32 = 71;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+const BURN_EVENT_TOPIC0: &str =
+    "0xe1b6e34006e9871307436c226f232f9c5e7690c1d2c4f4adda4f607a75a9beca";
+const CONFLUX_FINALITY_DEPTH: u64 = 100;
+const SCAN_WINDOW: u64 = 1024;
+
+// ─── Call helpers ─────────────────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    match pic
+        .query_call(cid, Principal::anonymous(), method, encode_one(()).unwrap())
+        .expect("query call")
+    {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+fn u128_of(n: &candid::Nat) -> u128 {
+    // candid::Nat's Display uses `_` thousands separators; strip before parse.
+    n.to_string().replace('_', "").parse::<u128>().expect("nat fits u128")
+}
+
+// ─── Boot ─────────────────────────────────────────────────────────────────────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").unwrap();
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(backend_id, backend_wasm(), encode_args((init,)).unwrap(), None);
+    pic.install_canister(mock_id, mock_wasm(), Encode!().unwrap(), None);
+    for _ in 0..5 {
+        pic.tick();
+    }
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+    // The mock has no XRC, so every ICP price fetch fails; 3 consecutive failures
+    // trip the oracle circuit breaker into ReadOnly (which halts the settlement
+    // worker). This test runs longer than the happy path, so slow the XRC fetch
+    // timer to ~never — only the one immediate startup fetch fails (counter=1).
+    let _ = update_dev(&pic, backend_id, "set_xrc_fetch_interval_secs", Encode!(&1_000_000_000u64).unwrap());
+    (pic, backend_id, mock_id)
+}
+
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+fn assert_supply(pic: &PocketIc, cid: Principal, expected_e8s: u128, step: &str) {
+    let global: candid::Nat = query_unit(pic, cid, "get_global_icusd_supply");
+    assert_eq!(global, candid::Nat::from(expected_e8s), "[{step}] get_global_icusd_supply mismatch");
+    let audit: SupplyAuditWire = query_unit(pic, cid, "get_supply_audit");
+    assert_eq!(audit.total_e8s, candid::Nat::from(expected_e8s), "[{step}] supply_audit.total mismatch");
+    let sum: candid::Nat = audit
+        .per_chain
+        .iter()
+        .fold(candid::Nat::from(0u32), |acc, e| acc + e.supply_e8s.clone());
+    assert_eq!(audit.total_e8s, sum, "[{step}] audit total != sum(per_chain)");
+    if let Some(c) = audit.per_chain.iter().find(|e| e.chain_id == CONFLUX_CHAIN_ID) {
+        assert_eq!(c.supply_e8s, candid::Nat::from(expected_e8s), "[{step}] Conflux per-chain supply mismatch");
+    }
+}
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+fn word_addr(addr: &str) -> String {
+    let raw = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    match pic
+        .query_call(backend, Principal::anonymous(), "get_chain_vault", Encode!(&vault_id).unwrap())
+        .expect("get_chain_vault query")
+    {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {msg}"),
+    }
+}
+
+fn push_mint_log(pic: &PocketIc, mock: Principal, vault_id: u64, recipient: &str, amount_e8s: u128, tx_hash: &str, block: u64) {
+    let topics = vec![MINT_EVENT_TOPIC0.to_string(), word_u128(vault_id as u128), word_addr(recipient)];
+    update_any(pic, mock, "push_log", Encode!(&topics, &word_u128(amount_e8s), &tx_hash.to_string(), &block).unwrap());
+}
+fn push_burn_log(pic: &PocketIc, mock: Principal, vault_id: u64, burner: &str, amount_e8s: u128, tx_hash: &str, block: u64) {
+    let topics = vec![BURN_EVENT_TOPIC0.to_string(), word_u128(vault_id as u128), word_addr(burner)];
+    update_any(pic, mock, "push_log", Encode!(&topics, &word_u128(amount_e8s), &tx_hash.to_string(), &block).unwrap());
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn conflux_interest_accrual_supply_invariant() {
+    let (pic, backend, mock) = boot();
+
+    decode_result(update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()), "set_evm_rpc_principal").unwrap();
+    update_any(&pic, mock, "set_getlogs_max_range", Encode!(&1000u64).unwrap());
+    update_any(&pic, mock, "set_espace_receipt_fields", Encode!(&true).unwrap());
+
+    let reg = RegisterChainArg {
+        chain_id: ChainId(CONFLUX_CHAIN_ID),
+        display_name: "ConfluxESpaceTestnet".to_string(),
+        rpc_endpoints: vec!["https://evmtestnet.confluxrpc.com".to_string()],
+        finality_depth: CONFLUX_FINALITY_DEPTH as u32,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 1, max_fee_gwei_ceiling: 100 },
+        chain_native_decimals: 18,
+        min_quorum_providers: Some(1),
+    };
+    decode_result(update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()), "register_chain").unwrap();
+    decode_result(
+        update_dev(&pic, backend, "set_chain_contract", Encode!(&ChainId(CONFLUX_CHAIN_ID), &"0x00000000000000000000000000000000cf1c0de5".to_string()).unwrap()),
+        "set_chain_contract",
+    ).unwrap();
+    decode_result(
+        update_dev(&pic, backend, "set_manual_collateral_price", Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &15_000_000u64).unwrap()),
+        "set_manual_collateral_price",
+    ).unwrap();
+    let seed: u64 = 1_000_000;
+    decode_result(update_dev(&pic, backend, "set_last_observed_block", Encode!(&ChainId(CONFLUX_CHAIN_ID), &seed).unwrap()), "set_last_observed_block").unwrap();
+    decode_result(update_dev(&pic, backend, "set_burn_watch_poll_enabled", Encode!(&ChainId(CONFLUX_CHAIN_ID), &true).unwrap()), "set_burn_watch_poll_enabled").unwrap();
+
+    assert_supply(&pic, backend, 0, "after register/config");
+
+    let cursor1 = seed + SCAN_WINDOW;
+    let head1 = cursor1 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head1, &head1).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxmint1".to_string()).unwrap());
+
+    // ECDSA probe (decides full vs gated).
+    let settlement_addr = match update_dev(&pic, backend, "get_chain_settlement_address", Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap()) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    };
+    let _settlement_addr = match settlement_addr {
+        Some(addr) => addr,
+        None => {
+            eprintln!("[conflux interest] ECDSA UNAVAILABLE; running GATED subset");
+            assert_supply(&pic, backend, 0, "gated: invariant at 0");
+            return;
+        }
+    };
+    eprintln!("[conflux interest] ECDSA AVAILABLE; running FULL interest path");
+
+    // Fund the settlement (hot wallet) address so the mint gas gate passes.
+    update_any(&pic, mock, "set_balance", Encode!(&_settlement_addr, &candid::Nat::from(1_000_000u128 * E18)).unwrap());
+
+    // ── open -> deposit -> mint (debt 100e8, supply 100e8) ───────────────────
+    let collateral_e18 = 1_400u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic, backend, "open_chain_vault",
+        Encode!(&ChainId(CONFLUX_CHAIN_ID), &candid::Nat::from(collateral_e18), &candid::Nat::from(debt_e8s), &recipient).unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>).unwrap().expect("open ok"),
+        WasmResult::Reject(m) => panic!("open_chain_vault rejected: {m}"),
+    };
+    let custody = get_vault(&pic, backend, vault_id).unwrap().custody_address;
+    update_any(&pic, mock, "set_balance", Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap());
+    advance_and_tick(&pic, 2); // observer -> MintPending + enqueue mint
+
+    advance_and_tick(&pic, 1); // settlement submit
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xcfxmint1".to_string(), &true, &cursor1).unwrap());
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xcfxmint1", cursor1);
+    advance_and_tick(&pic, 4); // settlement confirm
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after mint");
+    assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+    assert_eq!(u128_of(&v.debt_e8s), 100 * E8);
+    assert!(v.last_interest_accrual_ns > 0, "accrual window stamped at mint-confirm");
+    assert_supply(&pic, backend, 100 * E8, "after mint confirm");
+
+    // ── Interest: harvest, mint interest to treasury, confirm ────────────────
+    // Lower the dust floor to 1 e8s so the small elapsed since mint-confirm
+    // produces a realizable (positive) interest WITHOUT a large clock jump (a
+    // big advance_time confuses PocketIC's overdue-timer handling). The interest
+    // MAGNITUDE is unit-tested in chains::interest; this test proves the
+    // end-to-end supply invariant, which holds for any positive interest.
+    decode_result(update_dev(&pic, backend, "set_chain_interest_min_realize_e8s", Encode!(&1u128).unwrap()), "set_chain_interest_min_realize_e8s").unwrap();
+    advance_and_tick(&pic, 2); // accrue a little interest since mint-confirm
+
+    let treasury: String = match update_dev(&pic, backend, "get_chain_interest_treasury_address", Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap()) {
+        WasmResult::Reply(b) => Decode!(&b, Result<String, ProtocolError>).unwrap().expect("treasury addr"),
+        WasmResult::Reject(m) => panic!("get_chain_interest_treasury_address rejected: {m}"),
+    };
+    assert_ne!(treasury.to_lowercase(), _settlement_addr.to_lowercase(), "treasury != minter address");
+
+    // Pre-arm the interest-mint broadcast hash, then harvest.
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxint1".to_string()).unwrap());
+    let n: u64 = match update_dev(&pic, backend, "harvest_chain_interest", Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap()) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>).unwrap().expect("harvest ok"),
+        WasmResult::Reject(m) => panic!("harvest_chain_interest rejected: {m}"),
+    };
+    assert_eq!(n, 1, "one eligible vault => one interest mint enqueued");
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after harvest");
+    let interest = u128_of(&v.pending_interest_mint_e8s);
+    assert!(interest > 0, "accrued interest is positive: got {interest}");
+    assert_eq!(u128_of(&v.debt_e8s), 100 * E8, "debt unchanged until interest mint confirms");
+    assert_supply(&pic, backend, 100 * E8, "after harvest (reserved, not yet minted)");
+
+    // Synthetic on-chain mint id = chain_vault_id_counter after harvest. One vault
+    // opened (vault_id == counter == 1); the harvest allocated counter+1.
+    let interest_mint_id = vault_id + 1;
+
+    advance_and_tick(&pic, 1); // settlement submit interest mint
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xcfxint1".to_string(), &true, &cursor1).unwrap());
+    push_mint_log(&pic, mock, interest_mint_id, &treasury, interest, "0xcfxint1", cursor1);
+    advance_and_tick(&pic, 4); // settlement confirm interest mint
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after interest confirm");
+    assert_eq!(u128_of(&v.pending_interest_mint_e8s), 0, "pending interest cleared on confirm");
+    let debt_with_interest = 100 * E8 + interest;
+    assert_eq!(u128_of(&v.debt_e8s), debt_with_interest, "debt grew by the minted interest");
+    // THE invariant: debt and supply grew together -> gap stays 0.
+    assert_supply(&pic, backend, debt_with_interest, "after interest mint (debt+supply grew together)");
+
+    // ── burn principal + interest => debt 0, supply 0 ─────────────────────────
+    let cursor2 = cursor1 + SCAN_WINDOW;
+    let head2 = cursor2 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head2, &head2).unwrap());
+    push_burn_log(&pic, mock, vault_id, &recipient, debt_with_interest, "0xcfxburn1", cursor1 + 500);
+    advance_and_tick(&pic, 3);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after burn");
+    assert_eq!(u128_of(&v.debt_e8s), 0, "principal+interest fully burned => debt 0");
+    assert_supply(&pic, backend, 0, "after burn principal+interest");
+
+    // ── withdraw all collateral => Closing -> Closed ──────────────────────────
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxwd1".to_string()).unwrap());
+    decode_result(
+        update_dev(&pic, backend, "withdraw_chain_collateral", Encode!(&vault_id, &candid::Nat::from(collateral_e18), &"0x000000000000000000000000000000000000dead".to_string()).unwrap()),
+        "withdraw_chain_collateral",
+    ).unwrap();
+    let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw enqueue");
+    assert_eq!(v.status, ChainVaultStatus::Closing, "withdraw all => Closing");
+
+    advance_and_tick(&pic, 1);
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xcfxwd1".to_string(), &true, &cursor2).unwrap());
+    advance_and_tick(&pic, 4);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after withdraw confirm");
+    assert_eq!(v.status, ChainVaultStatus::Closed, "withdraw confirmed => Closed");
+    assert_supply(&pic, backend, 0, "final (Closed)");
+
+    eprintln!("[conflux interest] FULL interest path PASSED: supply invariant held 0 -> 100e8 -> 100e8+I -> 0 across open/mint/HARVEST/interest-mint/burn/withdraw; debt and supply grew together by I={interest} e8s");
+}


### PR DESCRIPTION
Accrues the 2% APR (`interest_apr_bps = 200`) carried by chain-vault collateral configs, **Option-B style**: interest is realized by minting it on-chain to a per-chain treasury **and** growing the vault's `debt_e8s` by the same amount, so the hard invariant `sum(chain_supplies) == sum(chain_vaults[*].debt_e8s)` stays exact (Option C would drive supply below principal debt).

## How it works
- **Lazy accrual for CR on read** (`effective_debt = debt + accrued_since(last_accrual)` in the withdraw CR check); **realization (the on-chain mint) on an off-by-default timer** (`chain_interest_tick_interval_secs`, default ~1yr) plus an admin `harvest_chain_interest(chain)`. No always-on heartbeat.
- Harvest reserves `pending_interest_mint_e8s` and enqueues a new `SettlementOpKind::InterestMint` (Design-B pending pattern, mirrors `pending_mint_e8s`). The existing EVM settlement worker mints it via the **same `IcUSD.mint` path** and confirms via `confirm_interest_mint_in_state`, which does `apply_supply_delta(Increase)` + `debt_e8s += amount` **atomically** (debt and supply grow together, gap 0), advances `last_interest_accrual_ns` to the harvest snapshot, and clears the reservation.
- `IcUSD.mint` is one-shot per `vault_id`, so each interest mint draws a **fresh synthetic `mint_id` from the global `chain_vault_id_counter`** (monotonic ⇒ disjoint from every real vault id and prior interest mint), used as the on-chain vault_id arg + Mint-log match key. **No Solidity change / no redeploy.**
- Interest treasury = a **dedicated per-chain tECDSA-derived address** (new `b"interest-treasury"` derivation path) — clean revenue/ops separation, still canister-controlled. Minter signs; treasury is the `to:`.
- Withdraw/close is blocked while an interest mint is in flight (`WithdrawError::InterestRealizationPending`) so a full close can't confirm after collateral leaves and credit unbacked debt.

## Migration
Two `#[serde(default)]` fields added **in-place to `ChainVaultV1`** (+ two config scalars on `state::State`), per the repo's own reorg-fields precedent (phase-1b struct, never mainnet-persisted; serde-default on CBOR is the wipe-safety) — no `ChainVaultV2`/`MultiChainStateV5` bump, no helper/alias churn. A `post_upgrade` sweep stamps `last_interest_accrual_ns = now` for any vault decoded with 0 (else the first harvest would bill from the epoch); new vaults are stamped at mint-confirm. Migration is unit-tested (legacy-CBOR-decode + stamp).

## Known characteristic (documented, accepted)
Burning principal between harvests forgives that window's unrealized interest (the async rail can't realize synchronously on a user-initiated on-chain burn the way ICP does on repay). Bounded by harvest cadence; an `owed_interest` accumulator could close it later.

## Verification
- backend lib **451 passed / 0 failed**; `chains::` **329** (311 baseline + 18 new); `collateral_config` asserts `interest_apr_bps == 200`
- PocketIC: new **conflux interest e2e** (asserts debt+supply grow together / gap 0 through open→mint→harvest→interest-mint→burn→withdraw→Closed), plus **conflux happy** + **monad happy** (shared EVM rail intact)
- candid `.did` + declarations regenerated; compat check passes
- Adversarial multi-agent review: 0 real bugs (one "confirmed" HIGH was a false positive — no `.await` between the `read_state(pre_total)` and `mutate_state`, so it's atomic on the IC, mirroring the audited `confirm_mint_in_state` pattern).

New developer-gated endpoints: `harvest_chain_interest`, `set_chain_interest_tick_interval_secs`, `set_chain_interest_min_realize_e8s`, `get_chain_interest_treasury_address`. New event `ChainInterestMinted`.

Not merged/deployed. Chains rail remains testnet/staging-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)