### PR TITLE
M2: EVM-native self-serve auth for the Conflux/Monad native-collateral CDP rail

### DIFF
--- a/docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-design.md
+++ b/docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-design.md
@@ -1,0 +1,436 @@
+# M2: EVM-native self-serve authentication (Design)
+
+> **Status:** Design / spec. The task-by-task implementation plan is a separate
+> `2026-06-18-conflux-evm-self-serve-auth-plan.md` (produced via
+> superpowers:writing-plans after this design is approved). This document defines
+> *what* we build and *why*; the plan defines *how*, task by task.
+>
+> **Scope banner:** This is the **M2** layer on top of the **M1** native-collateral
+> CDP rail (merged to `main` via PR #248 + #251). M1 proved the full
+> deposit→mint→burn→withdraw loop on Conflux eSpace testnet under **developer-gated**
+> operator control. M2 makes it **self-serve**: a MetaMask user signs an EIP-712
+> intent, the canister verifies the signature and acts, and the vault is owned by a
+> synthetic IC principal derived from the user's EVM address. The IC caller is
+> irrelevant. The `chains/` rail stays **testnet-only and dev-gated to enable** (the
+> `chains/mod.rs` experimental banner stays); M2 adds no mainnet capability.
+
+---
+
+## Goal
+
+Let a user with only an EVM wallet (MetaMask on Conflux eSpace chain 71, or Monad
+chain 10143) open / borrow against / withdraw from / close a native-collateral
+icUSD vault by **signing an EIP-712 intent in their wallet** — without holding an
+IC principal, without an operator driving the call, and without trusting whatever
+relayer or anonymous agent forwards the call to the canister. Authenticity comes
+from the EVM signature, never from the IC caller principal.
+
+## Decisions settled in brainstorming (2026-06-18)
+
+| Fork | Decision | Rationale |
+| --- | --- | --- |
+| Scope | **Backend + tests only** | The frontend (design-doc Component 5) is a separate effort. M2 here is the auth layer + the supporting contract change. |
+| Methods | **open / borrow / withdraw / close** (4 `_evm` methods) | Rob's call: borrow is included even though M1 has no borrow-more path. |
+| Borrow ⇒ contract change | **Bundle the IcUSD.sol mint idempotency redesign into M2** | Borrow-more is a *second* on-chain mint per vault, which the M1 mint-once-per-`vault_id` guard hard-reverts. Idempotency moves to per-*op*. |
+| Auth | **EIP-712 typed-data intent, verified on the canister** | Reuses the backend's existing secp256k1 recovery; no on-chain verifying contract; an untrusted relayer holds no authority. |
+| Ownership | **Synthetic IC principal deterministically derived from the EVM address** | Keeps the entire M1 custody/vault machinery (`owner: Principal`) unchanged. |
+| `mint_recipient` | **Forced `== owner_evm`** (field kept in the struct) | Free-form buys ~zero capability over mint-to-self+transfer and adds an irrecoverable mis-send footgun. Relaxable later without a signature break. |
+| Withdraw/close collateral dest | **Forced `== owner_evm`** | Same no-footgun rule. The user can transfer CFX afterward. |
+| Nonce | **Per-owner monotonic, keyed by the synthetic principal** (so per-(owner,chain)) | One trust assumption shared with ownership; cross-chain replay already blocked by the domain `chainId`. |
+| Anti-spam backstop | **Per-owner cap + TTL-GC of stale `AwaitingDeposit`** (no hard global cap) | A hard global cap with no GC self-DoSes. The GC bounds unfunded state without that failure mode. |
+| State migration | **Additive `#[serde(default)]` fields on the EXISTING structs** (no `V5`/`ChainVaultV2` bump) | `State`/`multi_chain` is ciborium/CBOR (verified in `storage.rs`), so additive serde-default adds are upgrade-safe. Keeps the merge with the concurrent interest-accrual branch purely additive. |
+
+---
+
+## Non-goals (out of scope for this spec)
+
+1. **Frontend** (MetaMask + viem SvelteKit page). Separate effort.
+2. **Mainnet** and everything it gates (production tECDSA keys, independent RPC
+   providers, automated CFX oracle, the chains-rail security review).
+3. **Liquidation** of chain vaults (the next design spec; the rail stays
+   forward-compatible).
+4. **Local BIP32 custody derivation** (the real fix for the per-open tECDSA-derive
+   cycle cost — see §5). Noted as a follow-up; M2 keeps the per-open management call.
+5. **ERC-20 collateral**, stability-pool-from-chain, and the other M1 deferred items.
+
+---
+
+## Verified preconditions (from the merged M1 code on `origin/main`)
+
+- **State is ciborium/CBOR, not Candid.** `storage.rs::save_state_to_stable` /
+  `load_state_from_stable` round-trip the whole `State` through
+  `ciborium::ser/de`. `state.rs` carries dedicated tests proving the
+  serde-default in-place migration. ⇒ Adding `#[serde(default)]` fields to
+  `ChainVaultV1` and `MultiChainStateV4` is upgrade-safe; **no** version-struct
+  bump is needed (and we deliberately avoid one to minimize merge conflict with
+  the concurrent interest-accrual branch, which also edits these structs).
+- **Crypto is all present.** `chains/evm/tx.rs::recover_y_parity` does the k256
+  ecrecover round-trip (`VerifyingKey::recover_from_prehash` + the existing
+  `tecdsa::evm_address_from_pubkey`); `sha3::Keccak256` is imported in `tx.rs` and
+  `tecdsa.rs`. EIP-712 digest + signer recovery is a small new module reusing
+  these — **no new crate**.
+- **Three in-state helpers** (`chains/vault.rs`): `open_chain_vault_in_state`,
+  `withdraw_collateral_in_state`, `close_chain_vault_in_state`. **No `borrow`
+  helper exists** — the M1 rail mints the full declared debt once at
+  deposit-verification.
+- **Dev-gated endpoints are the template** (`main.rs`): `open_chain_vault`
+  (async; tECDSA custody derive), `withdraw_chain_collateral` / `close_chain_vault`
+  (**synchronous** with a hard "must stay sync" invariant — audit FLAG-16: the
+  reserve-at-enqueue must be atomic within one message, no `.await`).
+- **`inspect_message` (main.rs) silently drops anonymous ingress** for every
+  method except two consent-message reads. The 4 `_evm` methods must be added to
+  its accept-list so anonymous callers reach them (it is a cycle-saving
+  pre-filter, **not** a security boundary).
+- **On-chain idempotency** (`foundry/src/IcUSD.sol`): `mint(to, amount, vault_id)`
+  with `mapping(uint64=>bool) minted; require(!minted[vault_id])` — one mint per
+  vault, forever. The settlement queue assigns every op a **unique-per-chain
+  `op_id`** (`settlement_queue.rs`); the confirm path fetches the receipt for the
+  op's **own** `tx_hash`, so multiple Mint events per vault never confuse it.
+
+---
+
+## Component A — EIP-712 intent + signer recovery (`chains/evm/eip712.rs`, new)
+
+The canister is the verifier; there is no on-chain verifying contract.
+
+### Domain (binds chain + deployment)
+
+```
+EIP712Domain(string name, string version, uint256 chainId, address verifyingContract)
+  name              = "Rumi icUSD CDP"
+  version           = "1"
+  chainId           = the collateral chain id (71 Conflux testnet / 10143 Monad)
+  verifyingContract = chain_contracts[chain]   // the deployed IcUSD address
+```
+
+- `chainId` blocks chain 71 ↔ 10143 replay.
+- `verifyingContract` is the IcUSD address, which differs per chain **and** per
+  deployment (staging kvg63 vs mainnet have different IcUSD contracts) ⇒ blocks
+  cross-deployment replay.
+- If `chain_contracts[chain]` is unset, the intent is rejected (no domain to bind).
+
+`domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(name),
+keccak256(version), chainId, verifyingContract))`, where `DOMAIN_TYPEHASH =
+keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`.
+
+### Intent (one struct; `action` discriminates)
+
+```
+VaultIntent(uint8 action, uint64 chainId, address owner, uint64 vaultId,
+            uint256 collateralWei, uint256 debtE8s, address recipient,
+            uint256 nonce, uint256 deadline)
+
+  action: 0 = Open, 1 = Borrow, 2 = WithdrawCollateral, 3 = Close
+```
+
+| action | vaultId | collateralWei | debtE8s | recipient |
+| --- | --- | --- | --- | --- |
+| Open | 0 | declared collateral | initial debt | == owner |
+| Borrow | target | 0 | additional debt | == owner |
+| Withdraw | target | amount to release | 0 | == owner (collateral dest) |
+| Close | target | 0 | 0 | == owner (collateral dest) |
+
+- `recipient` is **enforced `== owner` for every action** in M2 (no mis-send
+  footgun). The field is kept so relaxing to free-form later is a validation
+  change, not a typehash/signature break.
+- `chainId` must equal the domain `chainId` (redundant guard).
+- `now > deadline` ⇒ reject (a signature has a bounded first-use window).
+
+`VAULT_INTENT_TYPEHASH = keccak256("VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)")`.
+`hashStruct = keccak256(abi.encode(TYPEHASH, action, chainId, owner, vaultId, collateralWei, debtE8s, recipient, nonce, deadline))`
+(each field a 32-byte word; `uint*` left-padded big-endian, `address` left-padded to 32 bytes).
+`digest = keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct)`.
+
+### Signer recovery (reuse — no new crate)
+
+```
+recover_evm_address(digest: [u8;32], sig65: [u8;65]) -> Result<String, _>
+  r = sig65[0..32]; s = sig65[32..64]; v = sig65[64]
+  parity = match v { 27|28 => v-27, 0|1 => v, _ => reject }
+  vk = VerifyingKey::recover_from_prehash(digest, Signature::from_scalars(r,s), RecoveryId::new(parity==1,false))
+  return evm_address_from_pubkey(vk.to_encoded_point(false))   // existing helper
+```
+
+This is the same round-trip `tx.rs::recover_y_parity` already performs. Require
+`recovered.to_lowercase() == intent.owner.to_lowercase()`.
+
+---
+
+## Component B — Synthetic principal (vault ownership)
+
+```
+synthetic_owner(chain, evm_addr_20) =
+    Principal::from_slice(
+        keccak256(b"rumi.evm.owner.v1:" ‖ chain.0.to_le_bytes() ‖ evm_addr_20_raw)[0..28]
+        ‖ [0x01]
+    )                                        // 29 bytes total
+```
+
+Properties:
+- **Deterministic** in `(chain, evm_addr)`.
+- **Opaque class** (the trailing `0x01` type tag). A self-authenticating II/wallet
+  principal ends in `0x02` and is 29 bytes, so this principal can **never** equal a
+  real user principal. (It is far longer than any real canister id, and is never
+  used as a caller identity or authenticated against, so a theoretical canister-id
+  collision is harmless.)
+- Used **only** as an internal owner key. Custody stays
+  `custody_derivation_path(chain, synthetic_owner, vault_id)`, so the entire M1 rail
+  is byte-unchanged.
+- The 28-byte keccak truncation gives a 2⁻¹¹² collision bound. The **same**
+  principal keys the nonce map, so ownership and replay share one trust assumption
+  rather than introducing a second.
+
+`evm_addr_20_raw` is the 20 raw address bytes parsed from the recovered hex
+(canonical; avoids hex-case ambiguity).
+
+---
+
+## Component C — Per-owner nonce (replay guard)
+
+New persisted field `evm_owner_nonces: BTreeMap<Principal, u64>` on
+`MultiChainStateV4` (`#[serde(default)]`), **keyed by the synthetic principal**
+(which embeds the chain ⇒ nonces are automatically per-(owner, chain)).
+
+Rule: `expected = evm_owner_nonces.get(&synthetic).copied().unwrap_or(0)`; reject if
+`intent.nonce != expected`; **increment on success**.
+
+### Async-vs-sync nonce handling (saga safety)
+
+Two different spend semantics, each justified by whether there is an `.await`:
+
+- **Sync methods (borrow / withdraw / close) — spend on SUCCESS:** signature
+  recovery is pure compute, so verify → nonce check → op → increment-nonce all run
+  in **one synchronous message**. No `.await`, no race. The increment happens only
+  after the op succeeds, so a failed CR check does not burn a nonce. This preserves
+  the FLAG-16 "withdraw/close must stay synchronous" invariant (the reserve-at-enqueue
+  stays atomic).
+- **Async open — spend on ATTEMPT (pre-await):** the custody derive needs the
+  `vault_id` (the derivation path is `(chain, synthetic, vault_id)`), so `vault_id`
+  must be reserved **before** the await — and for race-safety the nonce is checked +
+  incremented in the **same pre-await `mutate_state`**:
+  1. **Pre-await atomic `mutate_state`:** verify sig + recover owner + deadline
+     (pure), `nonce == expected`, **increment nonce**, per-owner cap, **reserve
+     `vault_id`** from `chain_vault_id_counter`.
+  2. `await derive_evm_address((chain, synthetic, vault_id))`.
+  3. **Post-await `mutate_state`:** insert the vault (owned by `synthetic`, with the
+     reserved `vault_id` + derived custody + `owner_evm`).
+
+  A same-nonce double-submit is rejected at the pre-await nonce check (step 1), so the
+  loser never reaches the derive — no wasted derive, no duplicate vault. The tradeoff:
+  if the derive fails (transient management-canister error), the nonce + vault_id are
+  already spent; the user re-signs with `nonce + 1`. Acceptable — derive failures are
+  rare and a spent counter is harmless.
+
+---
+
+## Component D — Anti-spam / cycle-drain
+
+**Honest stance:** an anonymous-callable open that performs a tECDSA derive is
+inherently cycle-drainable by a Sybil (unlimited throwaway EVM keys), and a
+per-owner cap cannot bound that. M2 bounds **state**, orders cheap checks before the
+expensive derive, and accepts the residual derive-cycle cost as a **testnet** risk.
+
+- **Per-owner cap:** ≤ `MAX_VAULTS_PER_OWNER` (const, 25) non-terminal vaults
+  (`AwaitingDeposit | MintPending | Open | Closing`) per synthetic owner. Checked
+  pre-derive and re-checked in the post-await mutate.
+- **TTL-GC (the backstop):** a timer prunes `AwaitingDeposit` vaults older than
+  `AWAITING_DEPOSIT_TTL_NS` (const, ~24h, via the vault's `opened_at_ns`). Bounds
+  total unfunded state without the self-DoS of a hard global cap. Runs in the
+  existing observer/cleanup tick; pruning an `AwaitingDeposit` vault is safe (no
+  collateral confirmed, no mint enqueued). Funded vaults are never GC'd.
+- **Cheap-before-expensive ordering:** sig recovery + nonce + cap checks all happen
+  before the tECDSA derive in `open_chain_vault_evm`.
+- **The expensive path stays deposit-gated:** `sign_with_ecdsa` + EVM broadcast fire
+  only after a real on-chain deposit is observed at finality (unchanged from M1).
+- **Master switch unchanged:** the `_evm` methods are inert until an admin
+  `register_chain`s + sets a manual price + enables timers (all dev-gated). On a
+  chain that is not registered, every `_evm` method fails fast (`UnknownChain`).
+- **`inspect_message`** must whitelist the 4 `_evm` method names so anonymous
+  ingress reaches them.
+- **Follow-up (the real fix, out of scope):** derive custody addresses **locally**
+  via BIP32 from a cached root tECDSA pubkey, eliminating the per-open management
+  call entirely.
+
+---
+
+## Component E — Borrow + IcUSD.sol per-op idempotency
+
+### Contract (`foundry/src/IcUSD.sol`)
+
+```solidity
+mapping(uint64 => bool) public mintedOps;            // was: minted[vault_id]
+function mint(address to, uint256 amount, uint64 vault_id, uint64 op_id)
+    external onlyRole(MINTER_ROLE)
+{
+    require(!mintedOps[op_id], "op already minted");  // op_id is unique per chain
+    mintedOps[op_id] = true;
+    _mint(to, amount);
+    emit Mint(uint256(vault_id), to, amount);         // EVENT UNCHANGED
+}
+```
+
+- Idempotency moves from per-`vault_id` to per-`op_id` (the settlement queue's
+  unique-per-chain op id). A second mint to the **same vault** (a borrow) with a
+  **different** `op_id` succeeds; a resubmit with the **same** `op_id` still reverts
+  (no double-mint after a transient RPC error).
+- **The `Mint` event is byte-identical**, so the backend log decoder, burn-watch,
+  and confirm paths are untouched. `vault_id` stays load-bearing for the event and
+  for `burn(amount, vault_id)` (repay).
+
+### Backend mint calldata + settlement
+
+- `tx::encode_mint_calldata` → new selector `mint(address,uint256,uint64,uint64)`;
+  append the `op_id` ABI word.
+- Thread the settlement op's `op_id` (already assigned at enqueue) through
+  `build_tx_plan` into the calldata. The genesis (open) mint uses the same per-op
+  guard — consistent.
+
+### `borrow_chain_vault_in_state` (new helper in `chains/vault.rs`)
+
+Mirrors the open helper's structure, parameterized on the same `(address_validator,
+price_symbol)` seams:
+1. Require `status == Open` and `pending_mint_e8s == 0` (no stacked borrows).
+2. CR-check `(collateral_amount_native, debt_e8s + additional_e8s)` ≥ `min_cr_e4`.
+3. Set `pending_mint_e8s = additional_e8s`.
+4. Enqueue a `Mint { recipient, amount_e8s = additional_e8s, vault_id }` op
+   (off-chain dedup key `mint-{chain}-{vault}-{now_ns}`, mirroring the withdraw key).
+
+`confirm_mint_in_state` is unchanged: on the observed mint it moves
+`pending_mint_e8s → debt_e8s` and `apply_supply_delta(+additional)`. The supply
+invariant `sum(chain_supplies) == total_chain_vault_debt` holds across borrow
+(both sides += additional).
+
+### Foundry tests
+
+Update the mint() tests: new selector; **second mint, same vault, different op_id ⇒
+succeeds**; **same op_id ⇒ reverts**. The `Mint`/`Burn` event-pinning tests are
+unchanged (the event did not change).
+
+### Operator step (not done by this change)
+
+Redeploy `IcUSD.sol` to eSpace testnet with the new ABI and re-point
+`set_chain_contract`. Prepped here; run by the operator.
+
+---
+
+## Component F — The four `_evm` methods (`main.rs`, beside the dev-gated ones)
+
+The dev-gated `open_chain_vault` / `withdraw_chain_collateral` / `close_chain_vault`
+**stay** (operator + test use). The new methods accept **anonymous** ingress; all
+authority is the EVM signature.
+
+```
+open_chain_vault_evm(intent, sig65)            -> Result<u64, ProtocolError>   // async
+borrow_chain_vault_evm(intent, sig65)          -> Result<(), ProtocolError>    // sync
+withdraw_chain_collateral_evm(intent, sig65)   -> Result<(), ProtocolError>    // sync
+close_chain_vault_evm(intent, sig65)           -> Result<(), ProtocolError>    // sync
+```
+
+Common verification (a shared helper):
+1. Resolve `chain = intent.chainId`; require it registered and `chain_contracts`
+   set; build the domain.
+2. `digest = eip712_digest(domain, intent)`; `signer = recover_evm_address(digest, sig)`;
+   require `signer == intent.owner`.
+3. Require `intent.chainId == chain` and `now <= intent.deadline`.
+4. `synthetic = synthetic_owner(chain, signer)`.
+5. Nonce check (+increment on success per §C).
+
+Then per method (the Open nonce/`vault_id` ordering follows §C: spend-on-attempt
+pre-await; the sync methods spend-on-success):
+- **Open:** require `recipient == owner`; in the pre-await mutate do the nonce
+  check+increment + per-owner cap + reserve `vault_id`; derive custody from `(chain,
+  synthetic, vault_id)`; then `open_chain_vault_in_state(.. owner = synthetic ..,
+  custody, collateralWei, debtE8s, mint_recipient = owner_evm ..)` with
+  `owner_evm = Some(lowercase signer)` stored on the vault. Returns the `vault_id`.
+- **Borrow:** require `recipient == owner`; load the vault, require `vault.owner ==
+  synthetic` (and `vault.owner_evm == signer`); `borrow_chain_vault_in_state(vault_id,
+  debtE8s, ..)`.
+- **Withdraw:** require `recipient == owner`; ownership check as above;
+  `withdraw_collateral_in_state(vault_id, collateralWei, dest = owner_evm, ..)`.
+- **Close:** ownership check; `close_chain_vault_in_state(vault_id, dest = owner_evm, ..)`.
+
+Ownership authorization = re-recover the signer from the intent and match the stored
+`owner_evm` (lowercased); defense-in-depth, also assert `synthetic == vault.owner`.
+
+---
+
+## Component G — State migration (coordinated with the interest-accrual session)
+
+Two additive `#[serde(default)]` fields on the **existing** structs (no version
+bump):
+- `ChainVaultV1.owner_evm: Option<String>` — `None` for dev/Monad/Solana vaults;
+  `Some(lowercase addr)` for EVM-self-serve vaults.
+- `MultiChainStateV4.evm_owner_nonces: BTreeMap<Principal, u64>`.
+
+The GC needs no stored counter (it scans by `opened_at_ns`, bounded by the
+per-owner cap × owners and the TTL). An **upgrade test** snapshots an M1 state
+(registered chain + vaults + supplies), encodes via the same ciborium path
+`storage.rs` uses, decodes into the new struct, and asserts the vaults/supplies
+survive and the new fields default. If the interest-accrual branch merges first,
+rebase and resolve the (additive) conflicts in these two structs.
+
+---
+
+## Testing strategy (TDD)
+
+- **Unit (Rust):**
+  - EIP-712: a golden `domainSeparator` + `hashStruct` + `digest` vector; a known
+    secp256k1 key signs a known intent and `recover_evm_address` returns the
+    expected address; a tampered field changes the digest / fails recovery.
+  - `synthetic_owner`: determinism; opaque-class (`0x01` tag); never equal to a
+    constructed self-authenticating principal; distinct per chain.
+  - Nonce: monotonic accept; replay reject; per-(owner,chain) isolation.
+  - Per-owner cap: the (N+1)th non-terminal open rejects.
+  - Borrow: CR boundary; `pending != 0` rejects; supply invariant across confirm.
+  - Mint idempotency (Rust calldata): selector + op_id word.
+- **Upgrade (Rust):** the §G round-trip.
+- **PocketIC e2e** (extend `tests/conflux_espace_happy_path_pic.rs`): an
+  **anonymous** caller submits in-test-signed intents → open → deposit → mint →
+  **borrow → mint** → repay (burn) → withdraw → close, asserting synthetic
+  ownership, supply invariant, idempotency, and **replay / wrong-signer rejection**.
+  Run with an **absolute** `POCKET_IC_BIN=$(pwd)/pocket-ic`; rebuild the canister
+  wasm the test `include_bytes!`s after code changes.
+- **Foundry:** the updated mint tests.
+
+Definition of done: the 4 `_evm` methods work end to end; replayed nonce + mismatched
+signature are rejected; recovery + EIP-712 unit-tested with known vectors; the
+upgrade test shows existing vaults migrate cleanly; all chains lib tests + the
+existing conflux/monad PocketIC tests stay green.
+
+---
+
+## Files touched (map)
+
+- **New:** `chains/evm/eip712.rs` (domain/struct hashing + `recover_evm_address` +
+  `synthetic_owner`); `chains/evm/tests_eip712.rs`.
+- **Modify (additive):** `chains/monad/chain_vault.rs` / `chains/vault.rs`
+  (`owner_evm` field; `borrow_chain_vault_in_state`); `chains/multi_chain_state.rs`
+  (`evm_owner_nonces` field); `chains/evm/tx.rs` (mint calldata selector + op_id);
+  `chains/evm/settlement.rs` (thread op_id); `main.rs` (4 `_evm` methods + shared
+  verify helper + `inspect_message` accept-list + the TTL-GC tick);
+  `rumi_protocol_backend.did` (intent record + 4 methods).
+- **Solidity:** `foundry/src/IcUSD.sol` (per-op idempotency + new mint signature) +
+  its Foundry tests.
+- **Tests:** new unit + upgrade suites; extended Conflux PocketIC e2e.
+
+---
+
+## Safety / constraints honored
+
+- **Authority isolation:** the EVM signature is the only authority on `_evm`
+  methods; the IC caller (relayer / anonymous agent) holds none.
+- **Replay:** per-owner monotonic nonce (per-(owner,chain) via the synthetic key) +
+  domain `chainId`/`verifyingContract` binding (cross-chain + cross-deployment) +
+  `deadline`.
+- **Reentrancy / saga:** sync methods have no await; the async open does the
+  authoritative nonce check+increment + vault insert in a single post-await
+  `mutate_state`, with cheap pre-await checks to short-circuit spam.
+- **Cycle-drain:** cheap-before-expensive ordering; deposit-gated mint; per-owner
+  cap + TTL-GC bound state; residual per-open derive cost accepted on testnet with
+  local-derivation as the noted follow-up.
+- **Idempotency:** per-op on-chain guard (`mintedOps[op_id]`); off-chain settlement
+  dedup keys; the supply invariant self-check unchanged.
+- **State-wipe discipline:** additive `#[serde(default)]` fields on ciborium-encoded
+  structs (verified safe), with an upgrade round-trip test.
+- **Testnet + dev-gated to enable:** the `chains/mod.rs` banner stays; no mainnet
+  capability is added.

--- a/docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-plan.md
+++ b/docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-plan.md
@@ -1,0 +1,1029 @@
+# M2 EVM-native Self-Serve Auth — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for each task. Steps use checkbox (`- [ ]`) syntax. Design doc: `docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-design.md`.
+
+**Goal:** Add EIP-712-signed, anonymous-callable `open/borrow/withdraw/close` vault methods to the Conflux/Monad native-collateral CDP rail, with vaults owned by a synthetic principal derived from the EVM signer.
+
+**Architecture:** A new pure `chains/evm/eip712.rs` (domain/struct hashing, k256 ecrecover, synthetic principal) feeds four `_evm` methods in `main.rs` that drive the existing in-state vault helpers owned by the synthetic principal. Borrow adds a per-op `IcUSD.sol` mint-idempotency change. Replay is blocked by a per-owner nonce; state grows by two additive `#[serde(default)]` fields (ciborium-safe). All testnet + dev-gated to enable.
+
+**Tech Stack:** Rust (ic-cdk 0.12, k256 0.13 ecdsa+arithmetic, sha3 0.10, ciborium), Solidity 0.8.24 (Foundry), PocketIC 6.0.0.
+
+**Worktree:** `/Users/robertripley/coding/rumi-protocol-v2/.worktrees/conflux-evm-self-serve-auth` (branch `feat/conflux-evm-self-serve-auth`).
+
+**Test commands:**
+- Unit/lib: `cargo test -p rumi_protocol_backend --lib <filter>`
+- Build wasm (before PocketIC): `cargo build -p rumi_protocol_backend --target wasm32-unknown-unknown --release && cargo build -p monad_rpc_mock --target wasm32-unknown-unknown --release`
+- PocketIC: `POCKET_IC_BIN=$(pwd)/pocket-ic cargo test -p rumi_protocol_backend --test conflux_evm_self_serve_pic`
+- Foundry: `cd foundry && export PATH="$HOME/.foundry/bin:$PATH" && forge test`
+
+---
+
+## File Structure
+
+- **New:** `src/rumi_protocol_backend/src/chains/evm/eip712.rs` — EIP-712 domain/struct hashing, `recover_evm_address`, `synthetic_owner`, `VaultIntent`, `IntentAction`. One responsibility: turn `(intent, sig)` into a verified `(signer_addr, synthetic_principal)` + digest.
+- **New:** `src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs` — unit tests.
+- **New:** `src/rumi_protocol_backend/tests/conflux_evm_self_serve_pic.rs` — PocketIC e2e.
+- **Modify:** `chains/vault.rs` (owner_evm field, `borrow_chain_vault_in_state`, per-owner cap + nonce helpers), `chains/multi_chain_state.rs` (`evm_owner_nonces`), `chains/evm/tx.rs` (mint selector + op_id), `chains/evm/settlement.rs` (thread op_id), `chains/evm/mod.rs` (`pub mod eip712;`), `main.rs` (4 `_evm` methods, verify helper, inspect_message, GC timer), `lib.rs` (`ProtocolError::EvmAuth`), `rumi_protocol_backend.did`.
+- **Modify (Solidity):** `foundry/src/IcUSD.sol`, `foundry/test/IcUSD.t.sol`, `foundry/README.md`, `foundry/DEPLOY.md`, `chains/evm/adapter.rs` (doc prose).
+
+---
+
+## Task 1: EIP-712 module — types, hashing, recovery, synthetic principal
+
+**Files:**
+- Create: `src/rumi_protocol_backend/src/chains/evm/eip712.rs`
+- Create: `src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/evm/mod.rs` (add `pub mod eip712;` and `#[cfg(test)] mod tests_eip712;`)
+
+- [ ] **Step 1.1: Write the module with types + pure functions.**
+
+```rust
+//! EIP-712 typed-data intents for EVM-native self-serve vault auth (M2).
+//!
+//! The canister is the verifier: a user signs a `VaultIntent` in their EVM
+//! wallet, and the canister recomputes the digest, recovers the signer, and
+//! acts. There is NO on-chain verifying contract; the IcUSD contract address
+//! merely binds the EIP-712 domain to a specific chain + deployment so a
+//! signature cannot be replayed across chains (71 vs 10143) or deployments
+//! (staging kvg63 vs mainnet IcUSD addresses differ).
+
+use crate::chains::config::ChainId;
+use candid::{CandidType, Deserialize, Principal};
+use serde::Serialize;
+use sha3::{Digest, Keccak256};
+
+/// Domain name + version, frozen into the EIP-712 domain separator.
+pub const DOMAIN_NAME: &str = "Rumi icUSD CDP";
+pub const DOMAIN_VERSION: &str = "1";
+
+/// The four vault operations a `VaultIntent` can authorize. The numeric value
+/// is the on-wire `uint8 action` field hashed into the struct (do NOT renumber).
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntentAction {
+    Open,               // 0
+    Borrow,             // 1
+    WithdrawCollateral, // 2
+    Close,              // 3
+}
+
+impl IntentAction {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            IntentAction::Open => 0,
+            IntentAction::Borrow => 1,
+            IntentAction::WithdrawCollateral => 2,
+            IntentAction::Close => 3,
+        }
+    }
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(IntentAction::Open),
+            1 => Some(IntentAction::Borrow),
+            2 => Some(IntentAction::WithdrawCollateral),
+            3 => Some(IntentAction::Close),
+            _ => None,
+        }
+    }
+}
+
+/// The signed intent. Candid mirror: `action` is a `nat8`, addresses are
+/// lowercase `0x` `text`, amounts are `nat`, nonce/deadline are `nat64`.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct VaultIntent {
+    pub action: u8,
+    pub chain_id: u64,
+    /// Claimed EVM owner; MUST equal the recovered signer.
+    pub owner: String,
+    pub vault_id: u64,
+    /// Open: declared collateral (wei). Withdraw: amount to release (wei). Else 0.
+    pub collateral_wei: u128,
+    /// Open: initial debt (e8s). Borrow: additional debt (e8s). Else 0.
+    pub debt_e8s: u128,
+    /// Mint recipient (open/borrow) or collateral destination (withdraw/close).
+    /// Enforced `== owner` in M2.
+    pub recipient: String,
+    pub nonce: u64,
+    pub deadline_secs: u64,
+}
+
+/// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
+fn domain_typehash() -> [u8; 32] {
+    Keccak256::digest(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+    )
+    .into()
+}
+
+/// `keccak256("VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)")`
+fn intent_typehash() -> [u8; 32] {
+    Keccak256::digest(
+        b"VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)",
+    )
+    .into()
+}
+
+/// 32-byte big-endian word for a u128 (left-padded).
+fn word_u128(n: u128) -> [u8; 32] {
+    let mut w = [0u8; 32];
+    w[16..].copy_from_slice(&n.to_be_bytes());
+    w
+}
+/// 32-byte big-endian word for a u64.
+fn word_u64(n: u64) -> [u8; 32] {
+    let mut w = [0u8; 32];
+    w[24..].copy_from_slice(&n.to_be_bytes());
+    w
+}
+/// 32-byte word for a 20-byte address (right-aligned). Returns Err on bad hex/len.
+fn word_address(addr: &str) -> Result<[u8; 32], String> {
+    let bytes = parse_addr_20(addr)?;
+    let mut w = [0u8; 32];
+    w[12..].copy_from_slice(&bytes);
+    Ok(w)
+}
+
+/// Parse a `0x`-prefixed 20-byte EVM address into raw bytes (canonical key input).
+pub fn parse_addr_20(addr: &str) -> Result<[u8; 20], String> {
+    let h = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    let v = hex::decode(h).map_err(|e| format!("bad address hex: {e}"))?;
+    v.try_into().map_err(|v: Vec<u8>| format!("address is {} bytes, expected 20", v.len()))
+}
+
+/// `domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak(name), keccak(version), chainId, verifyingContract))`
+pub fn domain_separator(chain_id: u64, verifying_contract: &str) -> Result<[u8; 32], String> {
+    let mut buf = Vec::with_capacity(32 * 5);
+    buf.extend_from_slice(&domain_typehash());
+    buf.extend_from_slice(&<[u8; 32]>::from(Keccak256::digest(DOMAIN_NAME.as_bytes())));
+    buf.extend_from_slice(&<[u8; 32]>::from(Keccak256::digest(DOMAIN_VERSION.as_bytes())));
+    buf.extend_from_slice(&word_u64(chain_id));
+    buf.extend_from_slice(&word_address(verifying_contract)?);
+    Ok(Keccak256::digest(&buf).into())
+}
+
+/// `hashStruct(intent) = keccak256(abi.encode(INTENT_TYPEHASH, ...fields...))`.
+pub fn intent_struct_hash(intent: &VaultIntent) -> Result<[u8; 32], String> {
+    let mut buf = Vec::with_capacity(32 * 10);
+    buf.extend_from_slice(&intent_typehash());
+    buf.extend_from_slice(&word_u64(intent.action as u64));
+    buf.extend_from_slice(&word_u64(intent.chain_id));
+    buf.extend_from_slice(&word_address(&intent.owner)?);
+    buf.extend_from_slice(&word_u64(intent.vault_id));
+    buf.extend_from_slice(&word_u128(intent.collateral_wei));
+    buf.extend_from_slice(&word_u128(intent.debt_e8s));
+    buf.extend_from_slice(&word_address(&intent.recipient)?);
+    buf.extend_from_slice(&word_u64(intent.nonce));
+    buf.extend_from_slice(&word_u64(intent.deadline_secs));
+    Ok(Keccak256::digest(&buf).into())
+}
+
+/// `digest = keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct)`.
+pub fn intent_digest(domain_sep: &[u8; 32], struct_hash: &[u8; 32]) -> [u8; 32] {
+    let mut buf = Vec::with_capacity(2 + 64);
+    buf.push(0x19);
+    buf.push(0x01);
+    buf.extend_from_slice(domain_sep);
+    buf.extend_from_slice(struct_hash);
+    Keccak256::digest(&buf).into()
+}
+
+/// Recover the lowercase `0x` EVM signer address from a 65-byte signature over a
+/// 32-byte prehash digest. Accepts `v ∈ {0,1,27,28}`.
+pub fn recover_evm_address(digest: &[u8; 32], sig65: &[u8]) -> Result<String, String> {
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use super::tecdsa::evm_address_from_pubkey;
+
+    if sig65.len() != 65 {
+        return Err(format!("signature must be 65 bytes, got {}", sig65.len()));
+    }
+    let r: [u8; 32] = sig65[0..32].try_into().unwrap();
+    let s: [u8; 32] = sig65[32..64].try_into().unwrap();
+    let parity = match sig65[64] {
+        0 | 27 => 0u8,
+        1 | 28 => 1u8,
+        v => return Err(format!("bad recovery byte v={v}")),
+    };
+    let sig = Signature::from_scalars(r, s).map_err(|e| format!("bad (r,s): {e}"))?;
+    let rid = RecoveryId::new(parity == 1, false);
+    let vk = VerifyingKey::recover_from_prehash(digest, &sig, rid)
+        .map_err(|e| format!("ecrecover failed: {e}"))?;
+    let pk = vk.to_encoded_point(false).as_bytes().to_vec();
+    evm_address_from_pubkey(&pk)
+}
+
+/// Deterministic opaque-class synthetic owner principal for an EVM address on a
+/// chain. `keccak256("rumi.evm.owner.v1:" ‖ chain_le ‖ addr20)[0..28] ‖ 0x01`.
+/// The trailing `0x01` is the opaque type tag, so this can never equal a
+/// self-authenticating (trailing `0x02`) user principal. Internal owner key only.
+pub fn synthetic_owner(chain: ChainId, evm_addr: &str) -> Result<Principal, String> {
+    let addr20 = parse_addr_20(evm_addr)?;
+    let mut hasher = Keccak256::new();
+    hasher.update(b"rumi.evm.owner.v1:");
+    hasher.update(chain.0.to_le_bytes());
+    hasher.update(addr20);
+    let h: [u8; 32] = hasher.finalize().into();
+    let mut bytes = Vec::with_capacity(29);
+    bytes.extend_from_slice(&h[0..28]);
+    bytes.push(0x01);
+    Ok(Principal::from_slice(&bytes))
+}
+```
+
+- [ ] **Step 1.2: Wire the module** — in `chains/evm/mod.rs` add `pub mod eip712;` near the other `pub mod` lines and `#[cfg(test)] mod tests_eip712;` near the other test modules.
+
+- [ ] **Step 1.3: Write `tests_eip712.rs`** (golden vectors using the fixed-key pattern copied from `chains/evm/tests_tx.rs:336`):
+
+```rust
+use super::eip712::*;
+use crate::chains::config::ChainId;
+use candid::Principal;
+
+/// Fixed secp256k1 key with scalar = 1 → canonical address.
+fn fixed_key_addr() -> (k256::ecdsa::SigningKey, String) {
+    use k256::ecdsa::{SigningKey, VerifyingKey};
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    let mut b = [0u8; 32];
+    b[31] = 1;
+    let sk = SigningKey::from_bytes(&b.into()).unwrap();
+    let vk = VerifyingKey::from(&sk);
+    let pk = vk.to_encoded_point(false).as_bytes().to_vec();
+    let addr = crate::chains::evm::tecdsa::evm_address_from_pubkey(&pk).unwrap();
+    (sk, addr)
+}
+
+fn sign_intent(sk: &k256::ecdsa::SigningKey, digest: &[u8; 32]) -> Vec<u8> {
+    use k256::ecdsa::{signature::hazmat::PrehashSigner, Signature, RecoveryId};
+    let (sig, rid): (Signature, RecoveryId) = sk.sign_prehash_recoverable(digest).unwrap();
+    let mut out = sig.to_bytes().to_vec(); // 64 bytes r||s
+    out.push(27 + u8::from(rid)); // canonical EVM v
+    out
+}
+
+fn sample_intent(owner: &str) -> VaultIntent {
+    VaultIntent {
+        action: IntentAction::Open.as_u8(),
+        chain_id: 71,
+        owner: owner.to_string(),
+        vault_id: 0,
+        collateral_wei: 1_400_000_000_000_000_000_000, // 1400 CFX
+        debt_e8s: 10_000_000_000,                      // 100 icUSD
+        recipient: owner.to_string(),
+        nonce: 0,
+        deadline_secs: 9_999_999_999,
+    }
+}
+
+#[test]
+fn recovers_known_signer() {
+    let (sk, addr) = fixed_key_addr();
+    assert_eq!(addr, "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
+    let contract = "0x00000000000000000000000000000000cf1c0de5";
+    let intent = sample_intent(&addr);
+    let dsep = domain_separator(71, contract).unwrap();
+    let sh = intent_struct_hash(&intent).unwrap();
+    let digest = intent_digest(&dsep, &sh);
+    let sig = sign_intent(&sk, &digest);
+    let recovered = recover_evm_address(&digest, &sig).unwrap();
+    assert_eq!(recovered, addr);
+}
+
+#[test]
+fn wrong_contract_changes_digest() {
+    let (_sk, addr) = fixed_key_addr();
+    let intent = sample_intent(&addr);
+    let a = intent_digest(&domain_separator(71, "0x00000000000000000000000000000000cf1c0de5").unwrap(), &intent_struct_hash(&intent).unwrap());
+    let b = intent_digest(&domain_separator(71, "0x00000000000000000000000000000000deadbeef").unwrap(), &intent_struct_hash(&intent).unwrap());
+    assert_ne!(a, b);
+}
+
+#[test]
+fn wrong_chain_changes_digest() {
+    let (_sk, addr) = fixed_key_addr();
+    let intent = sample_intent(&addr);
+    let sh = intent_struct_hash(&intent).unwrap();
+    let a = intent_digest(&domain_separator(71, "0x00000000000000000000000000000000cf1c0de5").unwrap(), &sh);
+    let b = intent_digest(&domain_separator(10143, "0x00000000000000000000000000000000cf1c0de5").unwrap(), &sh);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn tampered_amount_breaks_recovery_match() {
+    let (sk, addr) = fixed_key_addr();
+    let contract = "0x00000000000000000000000000000000cf1c0de5";
+    let intent = sample_intent(&addr);
+    let digest = intent_digest(&domain_separator(71, contract).unwrap(), &intent_struct_hash(&intent).unwrap());
+    let sig = sign_intent(&sk, &digest);
+    // Recover against a DIFFERENT digest (tampered debt) → different/!=owner addr.
+    let mut tampered = intent.clone();
+    tampered.debt_e8s += 1;
+    let d2 = intent_digest(&domain_separator(71, contract).unwrap(), &intent_struct_hash(&tampered).unwrap());
+    let recovered = recover_evm_address(&d2, &sig).unwrap();
+    assert_ne!(recovered, addr);
+}
+
+#[test]
+fn synthetic_owner_is_opaque_and_deterministic() {
+    let p1 = synthetic_owner(ChainId(71), "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf").unwrap();
+    let p2 = synthetic_owner(ChainId(71), "0x7E5F4552091a69125d5DFcb7b8C2659029395Bdf").unwrap(); // case-insensitive
+    assert_eq!(p1, p2, "address case must not matter");
+    let bytes = p1.as_slice();
+    assert_eq!(bytes.len(), 29);
+    assert_eq!(bytes[28], 0x01, "opaque class tag");
+    // Distinct per chain.
+    let p3 = synthetic_owner(ChainId(10143), "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf").unwrap();
+    assert_ne!(p1, p3);
+    // Never equals a self-authenticating principal (those end in 0x02, len 29).
+    assert_ne!(bytes[28], 0x02);
+}
+```
+
+- [ ] **Step 1.4: Run** `cargo test -p rumi_protocol_backend --lib eip712` → expect all pass.
+- [ ] **Step 1.5: Commit** `feat(chains/evm): EIP-712 intent hashing, ecrecover, synthetic principal`.
+
+---
+
+## Task 2: Additive state fields + ciborium upgrade test
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/vault.rs` (`ChainVaultV1.owner_evm`)
+- Modify: `src/rumi_protocol_backend/src/chains/multi_chain_state.rs` (`MultiChainStateV4.evm_owner_nonces`)
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did` (`ChainVaultV1.owner_evm : opt text`)
+- Test: in `chains/tests_multi_chain_state.rs` (add an upgrade round-trip)
+
+- [ ] **Step 2.1: Add `owner_evm` to `ChainVaultV1`** (chains/vault.rs, after `opened_at_ns`):
+
+```rust
+    pub opened_at_ns: u64,
+    /// EVM owner address (lowercase 0x) for vaults opened via the M2 self-serve
+    /// `_evm` path; `None` for developer-opened / Monad / Solana vaults.
+    /// `#[serde(default)]` keeps pre-M2 ciborium snapshots decoding cleanly
+    /// (State is ciborium-encoded — see storage.rs).
+    #[serde(default)]
+    pub owner_evm: Option<String>,
+```
+
+Then fix every `ChainVaultV1 { ... }` literal that does NOT use `..Default` — there is one in `open_chain_vault_in_state` (chains/vault.rs:247). Add `owner_evm: None,` there (the `_evm` open path will set it after insert, or pass it through — see Task 5). Search the crate for `ChainVaultV1 {` to find all literals (tests included) and add the field.
+
+- [ ] **Step 2.2: Add `evm_owner_nonces` to `MultiChainStateV4`** (multi_chain_state.rs, after `processed_burn_keys`):
+
+```rust
+    #[serde(default)]
+    pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+    /// M2: per-synthetic-owner monotonic nonce for EIP-712 intent replay
+    /// protection. Keyed by `eip712::synthetic_owner(chain, evm_addr)` (which
+    /// embeds the chain → nonces are per-(owner,chain)). `#[serde(default)]`:
+    /// additive, ciborium-safe (no version bump — coordinated with the
+    /// concurrent interest-accrual branch).
+    #[serde(default)]
+    pub evm_owner_nonces: BTreeMap<Principal, u64>,
+```
+
+`Principal` is already imported via `use candid::{CandidType, Deserialize};` — add `Principal` to that import if missing (it currently imports `ChainId` etc.; confirm `candid::Principal` is in scope, else add `use candid::Principal;`).
+
+- [ ] **Step 2.3: Candid** — in `rumi_protocol_backend.did`, add to `ChainVaultV1`:
+
+```candid
+  owner_evm : opt text;
+```
+
+(Do NOT add `evm_owner_nonces` to candid — it is internal state, not exposed.)
+
+- [ ] **Step 2.4: Write the upgrade round-trip test** in `chains/tests_multi_chain_state.rs`:
+
+```rust
+#[test]
+fn pre_m2_snapshot_decodes_with_defaulted_evm_fields() {
+    use crate::chains::multi_chain_state::{MultiChainStateV4};
+    use crate::chains::monad::chain_vault::{ChainVaultV1, ChainVaultStatus};
+    use crate::chains::config::ChainId;
+    use candid::Principal;
+
+    // Build a V4 with one funded vault + a chain supply, encode via ciborium,
+    // then decode into the (post-M2-field) V4 and assert the data survived and
+    // the new fields default.
+    let mut s = MultiChainStateV4::default();
+    s.chain_supplies.insert(ChainId(71), 100_000_000);
+    s.chain_vaults.insert(1, ChainVaultV1 {
+        vault_id: 1,
+        owner: Principal::from_slice(&[1, 2, 3]),
+        collateral_chain: ChainId(71),
+        custody_address: "0xabc".to_string(),
+        collateral_amount_native: 1_000,
+        debt_e8s: 100_000_000,
+        mint_recipient: "0xdef".to_string(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 42,
+        owner_evm: None,
+    });
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&s, &mut buf).unwrap();
+    let back: MultiChainStateV4 = ciborium::de::from_reader(buf.as_slice()).unwrap();
+    assert_eq!(back.chain_supplies.get(&ChainId(71)).copied(), Some(100_000_000));
+    assert_eq!(back.chain_vaults.get(&1).unwrap().debt_e8s, 100_000_000);
+    assert_eq!(back.chain_vaults.get(&1).unwrap().owner_evm, None);
+    assert!(back.evm_owner_nonces.is_empty());
+}
+```
+
+> Note: the design's stronger claim — that a snapshot written BEFORE the new keys existed still decodes — is already proven generically by storage.rs's tests; this test pins the V4-specific shape. To additionally prove the "missing key" path, encode a `ciborium::Value::Map`, strip the `owner_evm`/`evm_owner_nonces` keys, re-encode, and decode (mirroring `state.rs:6504`). Add that as a second test if time permits.
+
+- [ ] **Step 2.5: Run** `cargo test -p rumi_protocol_backend --lib multi_chain_state` → pass.
+- [ ] **Step 2.6: Commit** `feat(chains): additive owner_evm + evm_owner_nonces (serde-default)`.
+
+---
+
+## Task 3: borrow helper + nonce + per-owner cap
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/vault.rs` (`borrow_chain_vault_in_state`, `count_owner_active_vaults`)
+- Modify: `src/rumi_protocol_backend/src/chains/monad/chain_vault.rs` (Monad wrapper for borrow, mirroring open/withdraw/close)
+- Modify: `src/rumi_protocol_backend/src/chains/multi_chain_state.rs` (nonce helper methods)
+- Test: `chains/tests_vault.rs`
+
+- [ ] **Step 3.1: Add nonce helpers to `MultiChainStateV4`** (multi_chain_state.rs `impl MultiChainStateV4`):
+
+```rust
+    /// Expected next nonce for a synthetic owner (0 if never seen).
+    pub fn expected_evm_nonce(&self, owner: &Principal) -> u64 {
+        self.evm_owner_nonces.get(owner).copied().unwrap_or(0)
+    }
+    /// Consume `nonce` for `owner`: succeeds and bumps the counter iff
+    /// `nonce == expected`; else returns the expected value as Err.
+    pub fn consume_evm_nonce(&mut self, owner: &Principal, nonce: u64) -> Result<(), u64> {
+        let expected = self.expected_evm_nonce(owner);
+        if nonce != expected {
+            return Err(expected);
+        }
+        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        Ok(())
+    }
+    /// Count non-terminal vaults (AwaitingDeposit/MintPending/Open/Closing) owned
+    /// by `owner` (anti-spam per-owner cap).
+    pub fn count_owner_active_vaults(&self, owner: &Principal) -> usize {
+        self.chain_vaults
+            .values()
+            .filter(|v| &v.owner == owner)
+            .filter(|v| !matches!(v.status, ChainVaultStatus::Closed))
+            .count()
+    }
+```
+
+(Add `use crate::chains::vault::ChainVaultStatus;` / `use candid::Principal;` to multi_chain_state.rs imports if not present.)
+
+- [ ] **Step 3.2: Add `MAX_VAULTS_PER_OWNER` const + `borrow_chain_vault_in_state`** to chains/vault.rs:
+
+```rust
+/// Anti-spam: max non-terminal vaults a single synthetic owner may hold.
+pub const MAX_VAULTS_PER_OWNER: usize = 25;
+
+/// Reasons `borrow_chain_vault_in_state` can reject.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BorrowError {
+    UnknownVault,
+    /// Vault is not `Open` (only an Open vault has confirmed collateral + debt).
+    WrongStatus { status: ChainVaultStatus },
+    /// A mint is already in flight for this vault (`pending_mint_e8s != 0`).
+    MintInFlight,
+    ZeroDebt,
+    NoPrice,
+    BelowMinCr { cr_e4: u64, min_e4: u64 },
+    QueueError(String),
+    InvalidAddress(String),
+}
+
+/// Borrow additional icUSD against an existing Open vault (a SECOND on-chain
+/// mint, gated by the per-op IcUSD idempotency from Task 4). Sets
+/// `pending_mint_e8s = additional_e8s` and enqueues a `Mint` op; the settlement
+/// confirm moves pending→debt + supply at finality (Design B). The off-chain
+/// idempotency key embeds `now_ns` so it never collides with the genesis open
+/// mint key (`mint-{chain}-{vault}`); the on-chain op_id (assigned at enqueue)
+/// is what the per-op IcUSD guard discriminates on.
+#[allow(clippy::too_many_arguments)]
+pub fn borrow_chain_vault_in_state(
+    state: &mut MultiChainStateV4,
+    vault_id: u64,
+    additional_e8s: u128,
+    recipient: String,
+    address_validator: fn(&str) -> bool,
+    price_symbol: &str,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), BorrowError> {
+    if additional_e8s == 0 {
+        return Err(BorrowError::ZeroDebt);
+    }
+    if !address_validator(&recipient) {
+        return Err(BorrowError::InvalidAddress(recipient));
+    }
+    // Step 1: read-only validation (no mutation on any reject).
+    let (chain, collateral, new_debt) = {
+        let v = state.chain_vaults.get(&vault_id).ok_or(BorrowError::UnknownVault)?;
+        if v.status != ChainVaultStatus::Open {
+            return Err(BorrowError::WrongStatus { status: v.status.clone() });
+        }
+        if v.pending_mint_e8s != 0 {
+            return Err(BorrowError::MintInFlight);
+        }
+        (v.collateral_chain, v.collateral_amount_native, v.debt_e8s.saturating_add(additional_e8s))
+    };
+    let price_e8 = *state
+        .manual_prices
+        .get(&(chain, price_symbol.to_string()))
+        .ok_or(BorrowError::NoPrice)?;
+    let native_decimals = state
+        .chain_configs.get(&chain).map(|c| c.chain_native_decimals).unwrap_or(18);
+    let cr_e4 = collateral_ratio_e4(collateral, native_decimals, price_e8, new_debt);
+    if cr_e4 < min_cr_e4 {
+        return Err(BorrowError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+    }
+    // Step 2: enqueue FIRST (can fail on a dup key). Distinct from the genesis
+    // open key by the now_ns suffix.
+    let op = SettlementOp::new(
+        SettlementOpKind::Mint { recipient, amount_e8s: additional_e8s, vault_id },
+        format!("mint-{}-{}-{}", chain.0, vault_id, now_ns),
+        now_ns,
+    );
+    state.settlement_queues.entry(chain).or_default().enqueue(op)
+        .map_err(|e| BorrowError::QueueError(format!("{e:?}")))?;
+    // Step 3: only after a successful enqueue — reserve the borrow as pending.
+    let v = state.chain_vaults.get_mut(&vault_id).expect("vault present: checked above");
+    v.pending_mint_e8s = additional_e8s;
+    Ok(())
+}
+```
+
+- [ ] **Step 3.3: Add the Monad wrapper** in `chains/monad/chain_vault.rs` (mirroring the open/withdraw/close wrappers, baking `is_valid_evm_address` + `"MON"`):
+
+```rust
+pub fn borrow_chain_vault_in_state(
+    state: &mut MultiChainStateV4,
+    vault_id: u64,
+    additional_e8s: u128,
+    recipient: String,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), crate::chains::vault::BorrowError> {
+    crate::chains::vault::borrow_chain_vault_in_state(
+        state, vault_id, additional_e8s, recipient,
+        crate::chains::monad::tecdsa::is_valid_evm_address, "MON", min_cr_e4, now_ns,
+    )
+}
+```
+
+Also re-export `BorrowError` in the `pub use crate::chains::vault::{...}` line at the top of `chains/monad/chain_vault.rs`.
+
+- [ ] **Step 3.4: Tests** in `chains/tests_vault.rs` — borrow CR boundary (pass at exactly min CR, fail just below), `pending != 0` → `MintInFlight`, non-Open → `WrongStatus`, the supply invariant via `confirm_mint_in_state` after a borrow (mint confirm moves pending→debt and bumps supply by exactly `additional_e8s`), nonce monotonic accept/replay-reject, per-owner cap counts non-terminal only. Use the existing test helpers in that file (registered chain + manual price). Example for the cap:
+
+```rust
+#[test]
+fn per_owner_cap_counts_non_terminal_only() {
+    use crate::chains::multi_chain_state::MultiChainStateV4;
+    use crate::chains::monad::chain_vault::{ChainVaultV1, ChainVaultStatus};
+    use crate::chains::config::ChainId;
+    use candid::Principal;
+    let mut s = MultiChainStateV4::default();
+    let owner = Principal::from_slice(&[9, 9, 9]);
+    let mk = |id: u64, st: ChainVaultStatus| ChainVaultV1 {
+        vault_id: id, owner, collateral_chain: ChainId(71), custody_address: "0x".into(),
+        collateral_amount_native: 0, debt_e8s: 0, mint_recipient: "0x".into(),
+        pending_mint_e8s: 0, status: st, opened_at_ns: 0, owner_evm: None,
+    };
+    s.chain_vaults.insert(1, mk(1, ChainVaultStatus::Open));
+    s.chain_vaults.insert(2, mk(2, ChainVaultStatus::AwaitingDeposit));
+    s.chain_vaults.insert(3, mk(3, ChainVaultStatus::Closed)); // not counted
+    assert_eq!(s.count_owner_active_vaults(&owner), 2);
+}
+```
+
+- [ ] **Step 3.5: Run** `cargo test -p rumi_protocol_backend --lib vault` and `--lib multi_chain_state` → pass.
+- [ ] **Step 3.6: Commit** `feat(chains): borrow_chain_vault_in_state + per-owner nonce/cap helpers`.
+
+---
+
+## Task 4: IcUSD.sol per-op idempotency + calldata + settlement op_id
+
+**Files:**
+- Modify: `foundry/src/IcUSD.sol`, `foundry/test/IcUSD.t.sol`, `foundry/README.md`, `foundry/DEPLOY.md`
+- Modify: `src/rumi_protocol_backend/src/chains/evm/tx.rs` (`encode_mint_calldata`, `MonadTxKind::Mint`, `build_eip1559_fields`)
+- Modify: `src/rumi_protocol_backend/src/chains/evm/settlement.rs` (`build_tx_plan` + 2 call sites thread op_id)
+- Modify: `src/rumi_protocol_backend/src/chains/evm/tests_tx.rs` (calldata length 4+32*3 → 4+32*4)
+- Modify: `src/rumi_protocol_backend/src/chains/evm/adapter.rs` (doc prose `mint(address,uint256,uint64)` → `mint(address,uint256,uint64,uint64)`)
+
+- [ ] **Step 4.1: Compute the new selector** (record it for the Foundry pin):
+
+Run: `cd foundry && export PATH="$HOME/.foundry/bin:$PATH" && cast sig "mint(address,uint256,uint64,uint64)"`
+Record the 4-byte selector hex; it replaces `0x8b3d35ae` in the Foundry ABI-pin test. (If `cast` is unavailable, a Rust scratch test printing `keccak_selector("mint(address,uint256,uint64,uint64)")` works.)
+
+- [ ] **Step 4.2: Edit `foundry/src/IcUSD.sol`** — re-key idempotency to op_id (the Mint EVENT is unchanged):
+
+```solidity
+    /// @dev One mint per settlement op_id (idempotency guard): a canister
+    /// resubmit-after-transient-RPC-error must not double-mint on-chain. Per-OP
+    /// (not per-vault) so a vault can be minted to more than once (borrow).
+    mapping(uint64 => bool) public mintedOps;
+
+    // ...
+
+    /// @notice Mint icUSD. Only the canister settlement address (MINTER_ROLE).
+    /// `op_id` is the backend settlement queue's unique-per-chain op id; reverts
+    /// if it was already minted (idempotency). `vault_id` stays the debt key for
+    /// the Mint event + burn(repay).
+    function mint(address to, uint256 amount, uint64 vault_id, uint64 op_id) external onlyRole(MINTER_ROLE) {
+        require(!mintedOps[op_id], "op already minted");
+        mintedOps[op_id] = true;
+        _mint(to, amount);
+        emit Mint(uint256(vault_id), to, amount);
+    }
+```
+
+- [ ] **Step 4.3: Update `foundry/test/IcUSD.t.sol`** — add the 4th arg to every `icusd.mint(...)` call; replace `test_mint_same_vault_id_twice_reverts` with per-op semantics + a new "same vault, different op_id succeeds" test; fix the selector literal:
+
+```solidity
+    // Same op_id reverts (idempotency); different op_id (even same vault) succeeds.
+    function test_mint_same_op_id_twice_reverts() public {
+        vm.startPrank(minter);
+        icusd.mint(alice, 100, 7, 1000);
+        assertTrue(icusd.mintedOps(1000));
+        vm.expectRevert(bytes("op already minted"));
+        icusd.mint(alice, 50, 7, 1000); // same op_id -> revert
+        vm.stopPrank();
+        assertEq(icusd.totalSupply(), 100);
+    }
+
+    function test_borrow_same_vault_new_op_id_succeeds() public {
+        vm.startPrank(minter);
+        icusd.mint(alice, 100, 7, 1000); // genesis
+        icusd.mint(alice, 50, 7, 1001);  // borrow: same vault, new op_id
+        vm.stopPrank();
+        assertEq(icusd.totalSupply(), 150);
+        assertEq(icusd.balanceOf(alice), 150);
+    }
+```
+
+In `test_abi_pinned_to_backend_constants`, change line 100 to the new signature + recomputed selector from Step 4.1:
+
+```solidity
+        assertEq(bytes4(keccak256("mint(address,uint256,uint64,uint64)")), bytes4(0x<NEW_SELECTOR>), "mint selector drift");
+```
+
+The Mint/Burn topic0 pins stay (event unchanged). Update the other mint call sites (lines ~32, 49, 54, 65, 73, 74, 117, 127, 142, 151, 173) to pass a 4th arg (any distinct op id; reuse the vault_id or a literal). Delete/replace the old `test_mint_same_vault_id_twice_reverts`.
+
+- [ ] **Step 4.4: Run Foundry** `cd foundry && export PATH="$HOME/.foundry/bin:$PATH" && forge test` → pass (install deps first if `lib/` missing per README).
+
+- [ ] **Step 4.5: Edit `tx.rs`** — `MonadTxKind::Mint` gains `op_id`, `encode_mint_calldata` gains `op_id` + a 4th word + new selector string, `build_eip1559_fields` threads it:
+
+```rust
+    Mint { contract: &'a str, recipient: &'a str, amount_e8s: u128, vault_id: u64, op_id: u64 },
+```
+```rust
+pub fn encode_mint_calldata(to: &str, amount_e8s: u128, vault_id: u64, op_id: u64) -> Result<Vec<u8>, String> {
+    let selector = keccak_selector("mint(address,uint256,uint64,uint64)");
+    let mut out = Vec::with_capacity(4 + 128);
+    out.extend_from_slice(&selector);
+    out.extend_from_slice(&abi_word_address(to)?);
+    out.extend_from_slice(&abi_word_u128(amount_e8s));
+    out.extend_from_slice(&abi_word_u128(vault_id as u128));
+    out.extend_from_slice(&abi_word_u128(op_id as u128));
+    Ok(out)
+}
+```
+In `build_eip1559_fields`, the `MonadTxKind::Mint` arm destructures `op_id` and passes it: `encode_mint_calldata(recipient, amount_e8s, vault_id, op_id)`.
+
+- [ ] **Step 4.6: Edit `settlement.rs`** — `build_tx_plan` gains an `op_id: u64` param; the `Mint` arm sets `MonadTxKind::Mint { ..., op_id }`; both call sites (`submit_op` ~line 587 and the resubmit path ~line 1075) pass the `op_id` they already hold. (The `op_id` is the function param in `submit_op(chain, op_id, op)` and in the resubmit fn.)
+
+- [ ] **Step 4.7: Fix `tests_tx.rs`** — `mint_calldata_has_correct_selector`: `encode_mint_calldata(addr, amount, vault_id, op_id)` and assert `calldata.len() == 4 + 32 * 4`. Add a positive assertion that the 4th word equals the op_id.
+
+- [ ] **Step 4.8: Update doc prose** in `adapter.rs:12,165`, `foundry/README.md:12-13,19-20`, `foundry/DEPLOY.md` (mint signature + per-op idempotency wording).
+
+- [ ] **Step 4.9: Run** `cargo test -p rumi_protocol_backend --lib tx` and `--lib settlement` → pass.
+- [ ] **Step 4.10: Commit** `feat(chains/evm,foundry): per-op mint idempotency (op_id) for borrow`.
+
+---
+
+## Task 5: the 4 `_evm` methods + verify helper + inspect_message + error
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/lib.rs` (`ProtocolError::EvmAuth(String)`)
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did` (`EvmAuth : text`, `VaultIntent` record, 4 methods)
+- Modify: `src/rumi_protocol_backend/src/main.rs` (verify helper, 4 methods, inspect_message)
+
+- [ ] **Step 5.1: Add the error variant** (lib.rs, append AFTER `ChainAdmin(String)`):
+
+```rust
+    /// M2 EVM-native self-serve auth failure (bad signature, signer != owner,
+    /// nonce replay, expired deadline, recipient != owner, per-owner cap, etc.).
+    EvmAuth(String),
+```
+And the candid `variant` (append): `EvmAuth : text;`.
+
+- [ ] **Step 5.2: Add the shared verify helper + the 4 methods** to main.rs (near the dev-gated chain endpoints, ~line 1015). Use the verbatim integration points:
+  - `evm_vault_params(chain)` → `(symbol, min_cr)`.
+  - `chain_contracts` read for the domain's verifyingContract.
+  - `eip712::{VaultIntent, IntentAction, domain_separator, intent_struct_hash, intent_digest, recover_evm_address, synthetic_owner}`.
+  - `chain_vault_id_counter`, `custody_derivation_path`, `derive_evm_address`, the in-state `open/borrow/withdraw/close` helpers.
+
+```rust
+/// Verified, authenticated intent context shared by all four `_evm` methods.
+struct VerifiedIntent {
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    owner_evm: String,            // lowercase recovered signer
+    synthetic: candid::Principal, // vault owner key
+    symbol: &'static str,
+    min_cr: u64,
+}
+
+/// Recompute the EIP-712 digest, recover the signer, enforce signer==owner,
+/// chain match, deadline, and recipient==owner. Does NOT touch the nonce
+/// (each method consumes it atomically with its state change). Pure (no await).
+fn verify_intent(
+    intent: &rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    sig: &[u8],
+    expected_action: rumi_protocol_backend::chains::evm::eip712::IntentAction,
+) -> Result<VerifiedIntent, ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712 as e712;
+    let chain = rumi_protocol_backend::chains::config::ChainId(intent.chain_id as u32);
+    // Action must match the endpoint.
+    if e712::IntentAction::from_u8(intent.action) != Some(expected_action) {
+        return Err(ProtocolError::EvmAuth("intent action mismatch".into()));
+    }
+    let (symbol, min_cr) = evm_vault_params(chain)?;
+    // Domain bound to the deployed IcUSD contract for this chain.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned())
+        .ok_or_else(|| ProtocolError::EvmAuth(format!("no contract for chain {}", chain.0)))?;
+    // Deadline (seconds).
+    let now_secs = ic_cdk::api::time() / 1_000_000_000;
+    if now_secs > intent.deadline_secs {
+        return Err(ProtocolError::EvmAuth("intent expired".into()));
+    }
+    // Recompute digest + recover signer.
+    let dsep = e712::domain_separator(intent.chain_id, &contract)
+        .map_err(|e| ProtocolError::EvmAuth(format!("domain: {e}")))?;
+    let sh = e712::intent_struct_hash(intent)
+        .map_err(|e| ProtocolError::EvmAuth(format!("struct hash: {e}")))?;
+    let digest = e712::intent_digest(&dsep, &sh);
+    let signer = e712::recover_evm_address(&digest, sig)
+        .map_err(|e| ProtocolError::EvmAuth(format!("recover: {e}")))?;
+    if !signer.eq_ignore_ascii_case(&intent.owner) {
+        return Err(ProtocolError::EvmAuth("signer != owner".into()));
+    }
+    // M2: recipient forced == owner for every action.
+    if !intent.recipient.eq_ignore_ascii_case(&intent.owner) {
+        return Err(ProtocolError::EvmAuth("recipient must equal owner".into()));
+    }
+    let synthetic = e712::synthetic_owner(chain, &signer)
+        .map_err(|e| ProtocolError::EvmAuth(format!("synthetic: {e}")))?;
+    Ok(VerifiedIntent { chain, owner_evm: signer.to_lowercase(), synthetic, symbol, min_cr })
+}
+```
+
+`open_chain_vault_evm` (async; nonce + cap + vault_id reserved PRE-await, derive, then insert):
+
+```rust
+#[candid_method(update)]
+#[update]
+async fn open_chain_vault_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<u64, ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent(&intent, &signature, IntentAction::Open)?;
+    // Pre-await atomic: consume nonce, enforce cap, reserve vault_id. (Spend on
+    // attempt — race-safe around the tECDSA derive; a same-nonce double-submit
+    // is rejected here so the loser never pays for a derive.)
+    let vault_id = mutate_state(|s| {
+        s.multi_chain.consume_evm_nonce(&v.synthetic, intent.nonce)
+            .map_err(|exp| ProtocolError::EvmAuth(format!("bad nonce: got {}, expected {}", intent.nonce, exp)))?;
+        if s.multi_chain.count_owner_active_vaults(&v.synthetic)
+            >= rumi_protocol_backend::chains::vault::MAX_VAULTS_PER_OWNER {
+            return Err(ProtocolError::EvmAuth("per-owner vault cap reached".into()));
+        }
+        s.chain_vault_id_counter += 1;
+        Ok(s.chain_vault_id_counter)
+    })?;
+    let path = rumi_protocol_backend::chains::evm::tecdsa::custody_derivation_path(v.chain, v.synthetic, vault_id);
+    let (_pk, custody) = rumi_protocol_backend::chains::evm::tecdsa::derive_evm_address(path)
+        .await
+        .map_err(|e| ProtocolError::EvmAuth(format!("derive: {e}")))?;
+    let now = ic_cdk::api::time();
+    let owner_evm = v.owner_evm.clone();
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::vault::open_chain_vault_in_state(
+            &mut s.multi_chain, v.chain, v.synthetic, custody,
+            intent.collateral_wei, intent.debt_e8s, v.owner_evm.clone(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol, v.min_cr, now, vault_id,
+        ).map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        // Stamp the EVM owner on the freshly-inserted vault.
+        if let Some(vault) = s.multi_chain.chain_vaults.get_mut(&vault_id) {
+            vault.owner_evm = Some(owner_evm.clone());
+        }
+        Ok(vault_id)
+    })
+}
+```
+
+> Decision: rather than thread `owner_evm` through `open_chain_vault_in_state`'s signature (which Monad/Solana also call), the `_evm` method stamps `owner_evm` on the inserted vault immediately after. Keeps the shared helper's signature stable. (`mint_recipient` is passed as `owner_evm` since recipient==owner.)
+
+`borrow_chain_vault_evm` / `withdraw_chain_collateral_evm` / `close_chain_vault_evm` (sync; spend-on-success). Each loads the vault, asserts `vault.owner == synthetic` AND `vault.owner_evm == Some(owner_evm)`, then in ONE `mutate_state`: do the op, and only on Ok consume the nonce:
+
+```rust
+#[candid_method(update)]
+#[update]
+fn borrow_chain_vault_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent(&intent, &signature, IntentAction::Borrow)?;
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        // Authorize: vault owned by this synthetic + EVM owner matches.
+        let ok = s.multi_chain.chain_vaults.get(&intent.vault_id)
+            .map(|vault| vault.owner == v.synthetic
+                && vault.owner_evm.as_deref().map(|a| a.eq_ignore_ascii_case(&v.owner_evm)).unwrap_or(false))
+            .unwrap_or(false);
+        if !ok { return Err(ProtocolError::EvmAuth("not vault owner".into())); }
+        // Nonce check FIRST (read-only), perform op, then bump nonce on success.
+        let expected = s.multi_chain.expected_evm_nonce(&v.synthetic);
+        if intent.nonce != expected {
+            return Err(ProtocolError::EvmAuth(format!("bad nonce: got {}, expected {}", intent.nonce, expected)));
+        }
+        rumi_protocol_backend::chains::vault::borrow_chain_vault_in_state(
+            &mut s.multi_chain, intent.vault_id, intent.debt_e8s, v.owner_evm.clone(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol, v.min_cr, now,
+        ).map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        s.multi_chain.evm_owner_nonces.insert(v.synthetic, expected.saturating_add(1));
+        Ok(())
+    })
+}
+```
+
+Withdraw and close are identical in shape, calling `withdraw_collateral_in_state(vault_id, intent.collateral_wei, dest = owner_evm, ...)` and `close_chain_vault_in_state(vault_id, dest = owner_evm, ...)` respectively, with the same owner-auth + nonce-on-success pattern and `IntentAction::WithdrawCollateral` / `IntentAction::Close`.
+
+- [ ] **Step 5.3: inspect_message accept-list** — add the 4 method names so anonymous ingress reaches them (main.rs:180):
+
+```rust
+        "icrc21_canister_call_consent_message" | "icrc10_supported_standards"
+        | "open_chain_vault_evm" | "borrow_chain_vault_evm"
+        | "withdraw_chain_collateral_evm" | "close_chain_vault_evm" => {
+            ic_cdk::api::call::accept_message();
+        }
+```
+
+- [ ] **Step 5.4: Candid** — add to `rumi_protocol_backend.did`: the `VaultIntent` record (snake_case mirror), the `EvmAuth : text` variant in `ProtocolError`, and the 4 methods:
+
+```candid
+type VaultIntent = record {
+  action : nat8;
+  chain_id : nat64;
+  owner : text;
+  vault_id : nat64;
+  collateral_wei : nat;
+  debt_e8s : nat;
+  recipient : text;
+  nonce : nat64;
+  deadline_secs : nat64;
+};
+```
+```candid
+  open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
+  borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
+  withdraw_chain_collateral_evm : (VaultIntent, blob) -> (Result);
+  close_chain_vault_evm : (VaultIntent, blob) -> (Result);
+```
+
+(`blob` is candid for `Vec<u8>`. `Result_1` = `Ok : nat64`, `Result` = `Ok` unit, both already defined.)
+
+- [ ] **Step 5.5: Run** `cargo build -p rumi_protocol_backend` and `cargo test -p rumi_protocol_backend --lib` → compile + lib green.
+- [ ] **Step 5.6: Commit** `feat(backend): EVM-signed open/borrow/withdraw/close + inspect_message + EvmAuth`.
+
+---
+
+## Task 6: TTL-GC timer for stale AwaitingDeposit vaults
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/vault.rs` (pure `prune_stale_awaiting_deposit` + const)
+- Modify: `src/rumi_protocol_backend/src/main.rs` (`register_chain_vault_gc_timer` + hook into `setup_timers`)
+- Test: `chains/tests_vault.rs`
+
+- [ ] **Step 6.1: Add the pure prune fn + TTL const** to chains/vault.rs:
+
+```rust
+/// TTL for an unfunded vault before the GC reaps it (24h in ns).
+pub const AWAITING_DEPOSIT_TTL_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
+
+/// Remove `AwaitingDeposit` vaults whose `opened_at_ns` is older than the TTL.
+/// Returns the number pruned. Pure (in-state) — safe: an `AwaitingDeposit`
+/// vault has no confirmed debt, no enqueued mint, and contributes nothing to
+/// `chain_supplies`, so removal cannot break the supply invariant.
+pub fn prune_stale_awaiting_deposit(state: &mut MultiChainStateV4, now_ns: u64, ttl_ns: u64) -> usize {
+    let stale: Vec<u64> = state.chain_vaults.iter()
+        .filter(|(_, v)| v.status == ChainVaultStatus::AwaitingDeposit
+            && now_ns.saturating_sub(v.opened_at_ns) > ttl_ns)
+        .map(|(&id, _)| id)
+        .collect();
+    for id in &stale {
+        state.chain_vaults.remove(id);
+    }
+    stale.len()
+}
+```
+
+- [ ] **Step 6.2: Add the timer** in main.rs (model on `register_observer_timer`), ticking every 1h:
+
+```rust
+fn register_chain_vault_gc_timer() {
+    ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(3600), || {
+        let now = ic_cdk::api::time();
+        let pruned = mutate_state(|s| {
+            rumi_protocol_backend::chains::vault::prune_stale_awaiting_deposit(
+                &mut s.multi_chain, now,
+                rumi_protocol_backend::chains::vault::AWAITING_DEPOSIT_TTL_NS,
+            )
+        });
+        if pruned > 0 {
+            log!(INFO, "[chain_vault_gc] pruned {} stale AwaitingDeposit vaults", pruned);
+        }
+    });
+}
+```
+
+Call `register_chain_vault_gc_timer();` at the end of `setup_timers()` (main.rs ~line 439), next to `register_observer_timer()`.
+
+- [ ] **Step 6.3: Test** in `chains/tests_vault.rs`: a vault older than TTL in AwaitingDeposit is pruned; a young one stays; an Open vault older than TTL is NOT pruned.
+- [ ] **Step 6.4: Run** `cargo test -p rumi_protocol_backend --lib vault` → pass.
+- [ ] **Step 6.5: Commit** `feat(chains): TTL-GC for stale AwaitingDeposit chain vaults`.
+
+---
+
+## Task 7: PocketIC e2e — anonymous EVM-signed flow
+
+**Files:**
+- Create: `src/rumi_protocol_backend/tests/conflux_evm_self_serve_pic.rs`
+
+This mirrors `conflux_espace_happy_path_pic.rs` but drives the `_evm` methods as an **anonymous** caller with in-test-signed intents. Reuse that file's harness verbatim (copy `boot`, `update_dev`, `query_unit`, `get_vault`, `advance_and_tick`, `assert_supply`, `word_u128`, `word_addr`, `push_mint_log`, `push_burn_log`, the mock-control calls, `ProtocolInitArg`, the topic0 consts).
+
+- [ ] **Step 7.1: Add EIP-712 signing helpers in the test** (fixed key, sign digest, build sig65), recomputing the digest exactly as the canister does:
+
+```rust
+fn signer() -> (k256::ecdsa::SigningKey, String) { /* scalar=1 → 0x7e5f...95bdf, as Task 1 */ }
+
+fn eip712_digest(chain_id: u64, contract: &str, intent: &VaultIntentWire) -> [u8;32] {
+    // Re-implement domain_separator + intent_struct_hash + intent_digest with
+    // keccak (sha3) over the SAME field order as chains/evm/eip712.rs, OR import
+    // the lib functions directly (the backend crate is a dep of the test).
+}
+```
+
+> Simplest: the test depends on `rumi_protocol_backend` as a lib, so call `rumi_protocol_backend::chains::evm::eip712::{domain_separator, intent_struct_hash, intent_digest, VaultIntent}` directly — no re-implementation. Build the `VaultIntent`, compute the digest with the lib, sign with k256, append `27 + v`.
+
+- [ ] **Step 7.2: Drive the full flow** as `Principal::anonymous()`:
+  1. `boot()` + register chain (dev) + `set_chain_contract(71, CONTRACT)` + manual price + seed cursor + `set_burn_watch_poll_enabled` (all dev), exactly as the happy-path test.
+  2. Probe `get_chain_settlement_address(71)`; if tECDSA unavailable on this PocketIC build, assert the gated subset and return (mirror the happy-path guard).
+  3. Sign an **Open** intent (nonce 0, collateral 1400 CFX, debt 100e8, owner=recipient=signer); `update_call(backend, anonymous, "open_chain_vault_evm", Encode!(&intent, &sig))` → `Ok(vault_id)`. Assert the vault's `owner` is the synthetic principal (`eip712::synthetic_owner(ChainId(71), &signer_addr)`) and `owner_evm == Some(signer_lower)`.
+  4. Deposit (`set_balance(custody, collateral)`) + ticks → MintPending; relocate receipt + `push_mint_log` → Open, supply 100e8. The on-chain mint log carries the vault's `mint_recipient` (== signer); the settlement op carries op_id (the mock doesn't check the calldata, so no contract change is exercised here — the per-op idempotency is exercised by Foundry).
+  5. Sign a **Borrow** intent (nonce 1, debt 50e8); submit anonymous → Ok. Ticks + relocate a SECOND mint receipt (`0xcfxmint2`) + `push_mint_log(vault, recipient, 50e8, "0xcfxmint2", cursor)` → debt 150e8, supply 150e8.
+  6. **Repay** by `push_burn_log` 150e8 → debt 0, supply 0.
+  7. Sign a **Withdraw**/**Close** intent (nonce 2) dest=owner; submit anonymous → Ok; ticks + receipt → Closed.
+  8. **Replay rejection:** re-submit the Open intent (nonce 0) → `Err(EvmAuth("bad nonce..."))`. **Wrong-signer rejection:** flip a byte in the signature → `Err(EvmAuth("signer != owner"))` (or recover error). **Anonymous-reaches-method:** the fact that the anonymous calls above returned `Ok`/typed `Err` (not a transport reject) proves the inspect_message accept-list works.
+
+- [ ] **Step 7.3: Build wasms + run:**
+```
+cargo build -p rumi_protocol_backend --target wasm32-unknown-unknown --release
+cargo build -p monad_rpc_mock --target wasm32-unknown-unknown --release
+POCKET_IC_BIN=$(pwd)/pocket-ic cargo test -p rumi_protocol_backend --test conflux_evm_self_serve_pic -- --nocapture
+```
+Expect: full flow passes; replay + wrong-signer rejected.
+
+- [ ] **Step 7.4: Commit** `test(chains/evm): PocketIC EVM-signed self-serve e2e + replay rejection`.
+
+---
+
+## Task 8: Regression sweep, review, verification
+
+- [ ] **Step 8.1: Full lib suite** `cargo test -p rumi_protocol_backend --lib` → all green (incl. the prior 361 + new).
+- [ ] **Step 8.2: Existing chain PocketIC tests stay green** — rebuild wasms, then run the conflux + monad happy-path + burn-idempotency + supply-gate suites with the absolute `POCKET_IC_BIN`. These exercise the genesis mint through the NEW per-op calldata path (the mock ignores calldata, so they validate no regression in the queue/confirm threading).
+- [ ] **Step 8.3: Foundry** `cd foundry && forge test` → green.
+- [ ] **Step 8.4: Candid sync** — regenerate/inspect the `.did` matches the new methods (the build emits candid via `candid_method`; confirm no drift).
+- [ ] **Step 8.5: Adversarial review** (see plan §Review) — parallel canister-security / silent-failure / audit pass on the diff; fix findings.
+- [ ] **Step 8.6: Commit** any review fixes; push the branch; open the PR to `main` (surface the diff). **Do NOT merge or deploy without Rob's explicit authorization.**
+
+---
+
+## Spec coverage check
+
+- EIP-712 domain binding (chain + contract) → Task 1 (`domain_separator`) + Task 5 (`verify_intent` reads `chain_contracts`). ✓
+- Signer recovery reusing existing machinery → Task 1 (`recover_evm_address`). ✓
+- Synthetic principal (opaque, collision-resistant, ≠ II) → Task 1 + tests. ✓
+- Per-owner monotonic nonce (per-(owner,chain)) → Task 3 helpers + Task 5 (async spend-on-attempt, sync spend-on-success). ✓
+- Synthetic ownership of the op via existing in-state helpers → Task 5. ✓
+- `owner_evm` stored → Task 2 + Task 5 stamp. ✓
+- Anti-spam: per-owner cap + deposit-gated mint + TTL-GC + cheap-before-derive → Task 3 (cap), Task 6 (GC), Task 5 (ordering). ✓
+- Borrow + per-op IcUSD idempotency → Task 3 + Task 4. ✓
+- `recipient == owner` enforced → Task 5 (`verify_intent`). ✓
+- inspect_message accept-list → Task 5.3. ✓
+- Additive serde-default migration + upgrade test → Task 2. ✓
+- Unit vectors (recovery + EIP-712) + PocketIC e2e + replay rejection → Task 1, Task 7. ✓
+- Existing tests stay green → Task 8. ✓

--- a/foundry/README.md
+++ b/foundry/README.md
@@ -9,15 +9,17 @@ minter (`MINTER_ROLE`); any holder may `burn` to repay their vault.
 `IcUSD.sol` is pinned to the backend's Monad adapter
 (`src/rumi_protocol_backend/src/chains/monad/`):
 
-- `mint(address to, uint256 amount, uint64 vault_id)` matches the selector built
-  by `tx::encode_mint_calldata` (`keccak256("mint(address,uint256,uint64)")[:4]`).
+- `mint(address to, uint256 amount, uint64 vault_id, uint64 op_id)` matches the
+  selector built by `tx::encode_mint_calldata` (`keccak256("mint(address,uint256,uint64,uint64)")[:4]` == `0x31239e64`).
 - `Mint(uint256,address,uint256)` / `Burn(uint256,address,uint256)` topic0 hashes
   match `MINT_EVENT_TOPIC0` / `BURN_EVENT_TOPIC0` in `evm_rpc.rs`. `vault_id` and
   `recipient`/`burner` are `indexed` so the observer reads them from
   `topics[1]`/`topics[2]` and `amount` from `data` (see `MintLog`/`BurnLog`).
 - 8 decimals so 1 base unit == 1 e8s (1:1 with the ICP-side e8s accounting).
-- `mapping(uint64 => bool) minted` is a per-`vault_id` idempotency guard: a
-  canister resubmit-after-transient-RPC-error cannot double-mint.
+- `mapping(uint64 => bool) mintedOps` is a per-`op_id` idempotency guard (was
+  per-`vault_id`): a canister resubmit-after-transient-RPC-error cannot
+  double-mint, while a borrow (a second mint to the same vault under a NEW
+  op_id) is allowed.
 
 ## Dependencies
 

--- a/foundry/src/IcUSD.sol
+++ b/foundry/src/IcUSD.sol
@@ -23,7 +23,17 @@ contract IcUSD is ERC20, AccessControl {
     /// resubmit-after-transient-RPC-error must not double-mint on-chain. Keyed
     /// per-OP (not per-vault) so a vault can be minted to more than once across
     /// distinct ops (borrow). `op_id` is the Rumi settlement queue's
-    /// unique-per-chain op id.
+    /// unique-per-chain op id, assigned monotonically from the queue tail.
+    ///
+    /// OPERATOR NOTE (M2 review finding I): `op_id` uniqueness vs this contract
+    /// relies on the backend's settlement-queue tail only ever increasing for a
+    /// given (chain, IcUSD contract). Resetting backend chain state to a lower
+    /// tail — `delete_chain` + re-register, or restoring an older state snapshot —
+    /// while keeping the SAME deployed IcUSD contract would replay op_ids that are
+    /// already `mintedOps[op_id] == true`, so every post-reset mint would revert
+    /// ("op already minted"). Re-registering an EVM chain against the same IcUSD
+    /// contract is therefore UNSUPPORTED: deploy a fresh IcUSD if the backend
+    /// chain state is ever reset.
     mapping(uint64 => bool) public mintedOps;
 
     constructor(address admin, address minter) ERC20("Rumi icUSD", "icUSD") {

--- a/foundry/src/IcUSD.sol
+++ b/foundry/src/IcUSD.sol
@@ -19,9 +19,12 @@ contract IcUSD is ERC20, AccessControl {
     event Mint(uint256 indexed vault_id, address indexed recipient, uint256 amount);
     event Burn(uint256 indexed vault_id, address indexed burner, uint256 amount);
 
-    /// @dev One mint per Rumi vault_id (idempotency guard): a canister
-    /// resubmit-after-transient-RPC-error must not double-mint on-chain.
-    mapping(uint64 => bool) public minted;
+    /// @dev One mint per settlement op_id (idempotency guard): a canister
+    /// resubmit-after-transient-RPC-error must not double-mint on-chain. Keyed
+    /// per-OP (not per-vault) so a vault can be minted to more than once across
+    /// distinct ops (borrow). `op_id` is the Rumi settlement queue's
+    /// unique-per-chain op id.
+    mapping(uint64 => bool) public mintedOps;
 
     constructor(address admin, address minter) ERC20("Rumi icUSD", "icUSD") {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -33,10 +36,14 @@ contract IcUSD is ERC20, AccessControl {
     }
 
     /// @notice Mint icUSD. Only the canister settlement address (MINTER_ROLE).
-    /// Reverts if `vault_id` was already minted (idempotency).
-    function mint(address to, uint256 amount, uint64 vault_id) external onlyRole(MINTER_ROLE) {
-        require(!minted[vault_id], "vault already minted");
-        minted[vault_id] = true;
+    /// `op_id` is the settlement op's unique id; reverts if it was already minted
+    /// (per-op idempotency). `vault_id` stays the debt key carried in the `Mint`
+    /// event and used by `burn` (repay), so a vault can be minted to more than
+    /// once via distinct `op_id`s (borrow). The `Mint` event is UNCHANGED so the
+    /// backend log decoder (`MintLog`) is unaffected.
+    function mint(address to, uint256 amount, uint64 vault_id, uint64 op_id) external onlyRole(MINTER_ROLE) {
+        require(!mintedOps[op_id], "op already minted");
+        mintedOps[op_id] = true;
         _mint(to, amount);
         emit Mint(uint256(vault_id), to, amount);
     }

--- a/foundry/test/IcUSD.t.sol
+++ b/foundry/test/IcUSD.t.sol
@@ -29,7 +29,7 @@ contract IcUSDTest is Test {
         vm.expectEmit(true, true, false, true); // check vault_id(topic1), recipient(topic2), data(amount)
         emit Mint(42, alice, 10_000_000_000);
         vm.prank(minter);
-        icusd.mint(alice, 10_000_000_000, 42);
+        icusd.mint(alice, 10_000_000_000, 42, 42);
         assertEq(icusd.balanceOf(alice), 10_000_000_000);
         assertEq(icusd.totalSupply(), 10_000_000_000);
     }
@@ -46,12 +46,12 @@ contract IcUSDTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, minterRole)
         );
-        icusd.mint(alice, 1, 1);
+        icusd.mint(alice, 1, 1, 1);
     }
 
     function test_anyone_can_burn_their_balance_and_emits_event() public {
         vm.prank(minter);
-        icusd.mint(alice, 10_000_000_000, 7);
+        icusd.mint(alice, 10_000_000_000, 7, 7);
         vm.expectEmit(true, true, false, true);
         emit Burn(7, alice, 4_000_000_000);
         vm.prank(alice);
@@ -62,7 +62,7 @@ contract IcUSDTest is Test {
 
     function test_burn_exceeding_balance_reverts() public {
         vm.prank(minter);
-        icusd.mint(alice, 100, 1);
+        icusd.mint(alice, 100, 1, 1);
         vm.prank(alice);
         vm.expectRevert(); // ERC20InsufficientBalance (OZ v5 custom error)
         icusd.burn(101, 1);
@@ -70,8 +70,8 @@ contract IcUSDTest is Test {
 
     function test_total_supply_tracks_mint_minus_burn() public {
         vm.startPrank(minter);
-        icusd.mint(alice, 1_000, 1);
-        icusd.mint(bob, 2_000, 2);
+        icusd.mint(alice, 1_000, 1, 1);
+        icusd.mint(bob, 2_000, 2, 2);
         vm.stopPrank();
         assertEq(icusd.totalSupply(), 3_000);
         vm.prank(bob);
@@ -79,15 +79,28 @@ contract IcUSDTest is Test {
         assertEq(icusd.totalSupply(), 2_500);
     }
 
-    // --- Task-20 addition 1: per-vault_id mint idempotency guard ---
-    function test_mint_same_vault_id_twice_reverts() public {
+    // --- M2: per-OP-id mint idempotency guard (was per-vault) ---
+    // A resubmit of the SAME settlement op (same op_id) must not double-mint,
+    // while a SECOND mint to the same vault under a NEW op_id (borrow) succeeds.
+    function test_mint_same_op_id_twice_reverts() public {
         vm.startPrank(minter);
-        icusd.mint(alice, 100, 7);
-        assertTrue(icusd.minted(7));
-        vm.expectRevert(bytes("vault already minted"));
-        icusd.mint(alice, 50, 7); // same vault_id -> revert (idempotency: no on-chain double-mint)
+        icusd.mint(alice, 100, 7, 1000);
+        assertTrue(icusd.mintedOps(1000));
+        vm.expectRevert(bytes("op already minted"));
+        icusd.mint(alice, 50, 7, 1000); // same op_id -> revert (resubmit can't double-mint)
         vm.stopPrank();
         assertEq(icusd.totalSupply(), 100); // second mint did not happen
+    }
+
+    function test_borrow_same_vault_new_op_id_succeeds() public {
+        vm.startPrank(minter);
+        icusd.mint(alice, 100, 7, 1000); // genesis mint for vault 7
+        icusd.mint(alice, 50, 7, 1001);  // borrow: same vault, NEW op_id -> succeeds
+        vm.stopPrank();
+        assertEq(icusd.totalSupply(), 150);
+        assertEq(icusd.balanceOf(alice), 150);
+        assertTrue(icusd.mintedOps(1000));
+        assertTrue(icusd.mintedOps(1001));
     }
 
     // --- Task-20 addition 2: ABI PINNING to the backend's constants ---
@@ -96,8 +109,8 @@ contract IcUSDTest is Test {
     // evm_rpc.rs). If anyone changes an event/mint signature, this test fails,
     // catching a contract<->canister ABI drift before it ships.
     function test_abi_pinned_to_backend_constants() public pure {
-        // mint(address,uint256,uint64) selector == tx::encode_mint_calldata's selector
-        assertEq(bytes4(keccak256("mint(address,uint256,uint64)")), bytes4(0x8b3d35ae), "mint selector drift");
+        // mint(address,uint256,uint64,uint64) selector == tx::encode_mint_calldata's selector
+        assertEq(bytes4(keccak256("mint(address,uint256,uint64,uint64)")), bytes4(0x31239e64), "mint selector drift");
         // Mint/Burn event topic0 == MINT_EVENT_TOPIC0 / BURN_EVENT_TOPIC0 in evm_rpc.rs
         assertEq(
             keccak256("Mint(uint256,address,uint256)"),
@@ -114,7 +127,7 @@ contract IcUSDTest is Test {
     function testFuzz_mint_then_full_burn_nets_zero(uint96 amount, uint64 vaultId) public {
         vm.assume(amount > 0);
         vm.prank(minter);
-        icusd.mint(alice, amount, vaultId);
+        icusd.mint(alice, amount, vaultId, vaultId);
         vm.prank(alice);
         icusd.burn(amount, vaultId);
         assertEq(icusd.balanceOf(alice), 0);
@@ -123,7 +136,7 @@ contract IcUSDTest is Test {
 
     function test_standard_erc20_transfer_approve() public {
         vm.prank(minter);
-        icusd.mint(alice, 1_000, 1);
+        icusd.mint(alice, 1_000, 1, 1);
         vm.prank(alice);
         icusd.transfer(bob, 400);
         assertEq(icusd.balanceOf(bob), 400);
@@ -139,7 +152,7 @@ contract IcUSDTest is Test {
         vm.prank(admin);
         icusd.grantRole(minterRole, alice);
         vm.prank(alice);
-        icusd.mint(bob, 500, 100);
+        icusd.mint(bob, 500, 100, 100);
         assertEq(icusd.balanceOf(bob), 500);
         // admin revokes -> alice can no longer mint
         vm.prank(admin);
@@ -148,7 +161,7 @@ contract IcUSDTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, alice, minterRole)
         );
-        icusd.mint(bob, 1, 101);
+        icusd.mint(bob, 1, 101, 101);
     }
 
     function test_non_admin_cannot_grant_minter() public {
@@ -170,7 +183,7 @@ contract IcUSDTest is Test {
     function test_mint_log_topic_layout_matches_decoder() public {
         vm.recordLogs();
         vm.prank(minter);
-        icusd.mint(alice, 10_000_000_000, 42);
+        icusd.mint(alice, 10_000_000_000, 42, 42);
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
         bytes32 mintTopic0 = keccak256("Mint(uint256,address,uint256)");

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -743,6 +743,22 @@ type ProtocolError = variant {
   AmountTooLow : record { minimum_amount : nat64 };
   TransferFromError : record { TransferFromError; nat64 };
   CallerNotOwner;
+  EvmAuth : text;
+};
+
+// M2: an EIP-712 typed-data intent the user signs in their EVM wallet to drive a
+// self-serve foreign-chain vault op. `signature` is the 65-byte (r||s||v) sig.
+// `action`: 0 = Open, 1 = Borrow, 2 = WithdrawCollateral, 3 = Close.
+type VaultIntent = record {
+  action : nat8;
+  chain_id : nat64;
+  owner : text;
+  vault_id : nat64;
+  collateral_wei : nat;
+  debt_e8s : nat;
+  recipient : text;
+  nonce : nat64;
+  deadline_secs : nat64;
 };
 type ProtocolSnapshot = record {
   total_debt : nat64;
@@ -1072,6 +1088,13 @@ service : (ProtocolArg) -> {
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
+  // M2 EVM-native self-serve: authority is the EIP-712 signature, NOT the IC
+  // caller (anonymous ingress is accepted). The vault is owned by a synthetic
+  // principal derived from the recovered EVM signer. `blob` is the 65-byte sig.
+  open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
+  borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
+  withdraw_chain_collateral_evm : (VaultIntent, blob) -> (Result);
+  close_chain_vault_evm : (VaultIntent, blob) -> (Result);
   open_solana_vault : (nat, nat, text) -> (Result_9);
   open_vault : (nat64, opt principal) -> (Result_10);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -64,6 +64,7 @@ type ChainVaultV1 = record {
   collateral_chain : nat32;
   mint_recipient : text;
   debt_e8s : nat;
+  owner_evm : opt text;
 };
 type CustodyKind = variant { IcrcLedger; NativeXrp };
 type XrpVaultOpenInfo = record { vault_id : nat64; custody_address : text };

--- a/src/rumi_protocol_backend/src/chains/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/adapter.rs
@@ -56,6 +56,11 @@ pub struct MintInstruction {
     pub amount_e8s: u128,
     pub vault_id: u64,
     pub idempotency_key: String,
+    /// Settlement queue op id — the EVM `mint(...,uint64 op_id)` per-op
+    /// idempotency discriminator. Ignored by chains (e.g. Solana) whose
+    /// idempotency is durable-nonce based. `#[serde(default)]` keeps it additive.
+    #[serde(default)]
+    pub op_id: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]

--- a/src/rumi_protocol_backend/src/chains/evm/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/adapter.rs
@@ -9,7 +9,7 @@
 //! transactions; broadcasting is handled by the settlement worker (Task 13).
 //!
 //! ## Phase scope
-//! - `sign_mint`: builds + signs the `mint(address,uint256,uint64)` call on the
+//! - `sign_mint`: builds + signs the `mint(address,uint256,uint64,uint64)` call on the
 //!   icUSD EVM contract.
 //! - `sign_withdrawal`: builds + signs a native MON transfer to the recipient.
 //! - `sign_burn`: reserved; Phase 1b burns are user-initiated on-chain.
@@ -162,7 +162,7 @@ impl ChainAdapter for MonadAdapter {
         })
     }
 
-    /// Build and sign a `mint(address,uint256,uint64)` call on the icUSD contract.
+    /// Build and sign a `mint(address,uint256,uint64,uint64)` call on the icUSD contract.
     ///
     /// gas_limit = 120_000 — generous for a typical ERC-20-style mint call,
     /// covers the vault-id event emission and any SSTORE on first-mint paths.
@@ -200,6 +200,7 @@ impl ChainAdapter for MonadAdapter {
                 recipient: &instr.recipient,
                 amount_e8s: instr.amount_e8s,
                 vault_id: instr.vault_id,
+                op_id: instr.op_id,
             },
             nonce,
             prio,

--- a/src/rumi_protocol_backend/src/chains/evm/eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/eip712.rs
@@ -156,7 +156,6 @@ pub fn intent_digest(domain_sep: &[u8; 32], struct_hash: &[u8; 32]) -> [u8; 32] 
 pub fn recover_evm_address(digest: &[u8; 32], sig65: &[u8]) -> Result<String, String> {
     use super::tecdsa::evm_address_from_pubkey;
     use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
-    use k256::elliptic_curve::sec1::ToEncodedPoint;
 
     if sig65.len() != 65 {
         return Err(format!("signature must be 65 bytes, got {}", sig65.len()));

--- a/src/rumi_protocol_backend/src/chains/evm/eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/eip712.rs
@@ -175,6 +175,60 @@ pub fn recover_evm_address(digest: &[u8; 32], sig65: &[u8]) -> Result<String, St
     evm_address_from_pubkey(&pk)
 }
 
+/// Why a pure `verify_intent` rejected the request. The `main.rs` wrapper maps
+/// each to `ProtocolError::EvmAuth`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifyError {
+    /// `intent.action` does not match the endpoint's expected action.
+    ActionMismatch,
+    /// `now_secs > intent.deadline_secs`.
+    Expired,
+    /// Domain/struct hashing or ecrecover failed (carries the detail).
+    Recover(String),
+    /// The recovered signer is not `intent.owner`.
+    SignerMismatch,
+    /// `intent.recipient != intent.owner` (M2 forces recipient == owner).
+    RecipientNotOwner,
+}
+
+/// Pure verification of a signed intent — NO IC state or time access (caller
+/// supplies `verifying_contract` and `now_secs`), so it is fully unit-testable.
+///
+/// Recomputes the EIP-712 digest, recovers the signer, and enforces: action
+/// matches the endpoint, deadline not passed, recovered signer == `owner`,
+/// `recipient == owner` (M2). On success returns
+/// `(owner_evm_lowercase, synthetic_owner_principal)`. The IC caller is never
+/// consulted — authenticity is the EVM signature alone.
+pub fn verify_intent(
+    intent: &VaultIntent,
+    sig: &[u8],
+    expected_action: IntentAction,
+    verifying_contract: &str,
+    now_secs: u64,
+) -> Result<(String, Principal), VerifyError> {
+    if IntentAction::from_u8(intent.action) != Some(expected_action) {
+        return Err(VerifyError::ActionMismatch);
+    }
+    if now_secs > intent.deadline_secs {
+        return Err(VerifyError::Expired);
+    }
+    let dsep = domain_separator(intent.chain_id, verifying_contract).map_err(VerifyError::Recover)?;
+    let sh = intent_struct_hash(intent).map_err(VerifyError::Recover)?;
+    let digest = intent_digest(&dsep, &sh);
+    let signer = recover_evm_address(&digest, sig).map_err(VerifyError::Recover)?;
+    if !signer.eq_ignore_ascii_case(&intent.owner) {
+        return Err(VerifyError::SignerMismatch);
+    }
+    // M2: the recipient (mint dest for open/borrow, collateral dest for
+    // withdraw/close) is forced to equal the owner — no mis-send footgun.
+    if !intent.recipient.eq_ignore_ascii_case(&intent.owner) {
+        return Err(VerifyError::RecipientNotOwner);
+    }
+    let synthetic =
+        synthetic_owner(ChainId(intent.chain_id as u32), &signer).map_err(VerifyError::Recover)?;
+    Ok((signer.to_lowercase(), synthetic))
+}
+
 /// Deterministic opaque-class synthetic owner principal for an EVM address on a
 /// chain. `keccak256("rumi.evm.owner.v1:" ‖ chain_le ‖ addr20)[0..28] ‖ 0x01`.
 /// The trailing `0x01` is the opaque type tag, so this can never equal a

--- a/src/rumi_protocol_backend/src/chains/evm/eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/eip712.rs
@@ -115,6 +115,20 @@ pub fn parse_addr_20(addr: &str) -> Result<[u8; 20], String> {
 }
 
 /// `domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak(name), keccak(version), chainId, verifyingContract))`
+///
+/// CROSS-DEPLOYMENT REPLAY (M2 review finding H — operational assumption): the
+/// domain binds to the chain (`chainId`) and the deployed IcUSD contract
+/// (`verifyingContract`), NOT to the IC backend canister id. Two Rumi backend
+/// deployments (e.g. staging vs mainnet) are therefore distinguished ONLY by
+/// pointing at DISTINCT IcUSD contract addresses. This holds in practice — each
+/// deployment deploys its own IcUSD and registers it via `set_chain_contract` —
+/// but it is an operational requirement, not an in-protocol guarantee: if two
+/// deployments ever shared the same IcUSD address on the same chain, a signed
+/// intent could replay across them. A stronger binding (an EIP-712 `salt` set to
+/// the backend canister id) is a mainnet-hardening follow-up; it is deferred here
+/// because it would couple the frontend signer to the canister id and is
+/// unnecessary on the testnet rail where the contract-per-deployment assumption
+/// is naturally satisfied.
 pub fn domain_separator(chain_id: u64, verifying_contract: &str) -> Result<[u8; 32], String> {
     let mut buf = Vec::with_capacity(32 * 5);
     buf.extend_from_slice(&domain_typehash());
@@ -208,6 +222,14 @@ pub fn verify_intent(
 ) -> Result<(String, Principal), VerifyError> {
     if IntentAction::from_u8(intent.action) != Some(expected_action) {
         return Err(VerifyError::ActionMismatch);
+    }
+    // The intent's `chain_id` is hashed into the digest as a u64, but `ChainId`
+    // is a u32; the caller truncates `intent.chain_id as u32` for config lookup
+    // and synthetic-owner derivation. Reject any value that would not round-trip
+    // through u32 so the digest-bound chain can never diverge from the resolved
+    // chain (M2 review finding D — latent on chains 71/10143, guarded anyway).
+    if intent.chain_id > u32::MAX as u64 {
+        return Err(VerifyError::Recover("chain_id exceeds u32 range".into()));
     }
     if now_secs > intent.deadline_secs {
         return Err(VerifyError::Expired);

--- a/src/rumi_protocol_backend/src/chains/evm/eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/eip712.rs
@@ -1,0 +1,195 @@
+//! EIP-712 typed-data intents for EVM-native self-serve vault auth (M2).
+//!
+//! The canister is the verifier: a user signs a `VaultIntent` in their EVM
+//! wallet, and the canister recomputes the digest, recovers the signer, and
+//! acts. There is NO on-chain verifying contract; the IcUSD contract address
+//! merely binds the EIP-712 domain to a specific chain + deployment so a
+//! signature cannot be replayed across chains (71 vs 10143) or deployments
+//! (staging kvg63 vs mainnet IcUSD addresses differ). The signer principal is
+//! NEVER the IC caller — authenticity is the EVM signature alone.
+
+use crate::chains::config::ChainId;
+use candid::{CandidType, Deserialize, Principal};
+use serde::Serialize;
+use sha3::{Digest, Keccak256};
+
+/// Domain name + version, frozen into the EIP-712 domain separator.
+pub const DOMAIN_NAME: &str = "Rumi icUSD CDP";
+pub const DOMAIN_VERSION: &str = "1";
+
+/// The four vault operations a `VaultIntent` can authorize. The numeric value is
+/// the on-wire `uint8 action` field hashed into the struct (do NOT renumber).
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntentAction {
+    Open,               // 0
+    Borrow,             // 1
+    WithdrawCollateral, // 2
+    Close,              // 3
+}
+
+impl IntentAction {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            IntentAction::Open => 0,
+            IntentAction::Borrow => 1,
+            IntentAction::WithdrawCollateral => 2,
+            IntentAction::Close => 3,
+        }
+    }
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(IntentAction::Open),
+            1 => Some(IntentAction::Borrow),
+            2 => Some(IntentAction::WithdrawCollateral),
+            3 => Some(IntentAction::Close),
+            _ => None,
+        }
+    }
+}
+
+/// The signed intent. Candid mirror: `action` is a `nat8`, addresses are
+/// lowercase `0x` `text`, amounts `nat`, nonce/deadline `nat64`.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct VaultIntent {
+    pub action: u8,
+    pub chain_id: u64,
+    /// Claimed EVM owner; MUST equal the recovered signer.
+    pub owner: String,
+    pub vault_id: u64,
+    /// Open: declared collateral (wei). Withdraw: amount to release (wei). Else 0.
+    pub collateral_wei: u128,
+    /// Open: initial debt (e8s). Borrow: additional debt (e8s). Else 0.
+    pub debt_e8s: u128,
+    /// Mint recipient (open/borrow) or collateral destination (withdraw/close).
+    /// Enforced `== owner` in M2.
+    pub recipient: String,
+    pub nonce: u64,
+    pub deadline_secs: u64,
+}
+
+/// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
+pub fn domain_typehash() -> [u8; 32] {
+    Keccak256::digest(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+    )
+    .into()
+}
+
+/// `keccak256("VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)")`
+pub fn intent_typehash() -> [u8; 32] {
+    Keccak256::digest(
+        b"VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)",
+    )
+    .into()
+}
+
+/// 32-byte big-endian word for a u128 (left-padded). Identical to the uint256
+/// ABI encoding of the same value.
+fn word_u128(n: u128) -> [u8; 32] {
+    let mut w = [0u8; 32];
+    w[16..].copy_from_slice(&n.to_be_bytes());
+    w
+}
+
+/// 32-byte big-endian word for a u64. Identical to the uint8/uint64/uint256 ABI
+/// encoding of the same value (all widen to one 32-byte word).
+fn word_u64(n: u64) -> [u8; 32] {
+    let mut w = [0u8; 32];
+    w[24..].copy_from_slice(&n.to_be_bytes());
+    w
+}
+
+/// 32-byte word for a 20-byte address (right-aligned). Err on bad hex/length.
+fn word_address(addr: &str) -> Result<[u8; 32], String> {
+    let bytes = parse_addr_20(addr)?;
+    let mut w = [0u8; 32];
+    w[12..].copy_from_slice(&bytes);
+    Ok(w)
+}
+
+/// Parse a `0x`-prefixed 20-byte EVM address into raw bytes (canonical key input).
+pub fn parse_addr_20(addr: &str) -> Result<[u8; 20], String> {
+    let h = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    let v = hex::decode(h).map_err(|e| format!("bad address hex: {e}"))?;
+    v.try_into().map_err(|v: Vec<u8>| format!("address is {} bytes, expected 20", v.len()))
+}
+
+/// `domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak(name), keccak(version), chainId, verifyingContract))`
+pub fn domain_separator(chain_id: u64, verifying_contract: &str) -> Result<[u8; 32], String> {
+    let mut buf = Vec::with_capacity(32 * 5);
+    buf.extend_from_slice(&domain_typehash());
+    buf.extend_from_slice(&<[u8; 32]>::from(Keccak256::digest(DOMAIN_NAME.as_bytes())));
+    buf.extend_from_slice(&<[u8; 32]>::from(Keccak256::digest(DOMAIN_VERSION.as_bytes())));
+    buf.extend_from_slice(&word_u64(chain_id));
+    buf.extend_from_slice(&word_address(verifying_contract)?);
+    Ok(Keccak256::digest(&buf).into())
+}
+
+/// `hashStruct(intent) = keccak256(abi.encode(INTENT_TYPEHASH, ...fields...))`.
+pub fn intent_struct_hash(intent: &VaultIntent) -> Result<[u8; 32], String> {
+    let mut buf = Vec::with_capacity(32 * 10);
+    buf.extend_from_slice(&intent_typehash());
+    buf.extend_from_slice(&word_u64(intent.action as u64));
+    buf.extend_from_slice(&word_u64(intent.chain_id));
+    buf.extend_from_slice(&word_address(&intent.owner)?);
+    buf.extend_from_slice(&word_u64(intent.vault_id));
+    buf.extend_from_slice(&word_u128(intent.collateral_wei));
+    buf.extend_from_slice(&word_u128(intent.debt_e8s));
+    buf.extend_from_slice(&word_address(&intent.recipient)?);
+    buf.extend_from_slice(&word_u64(intent.nonce));
+    buf.extend_from_slice(&word_u64(intent.deadline_secs));
+    Ok(Keccak256::digest(&buf).into())
+}
+
+/// `digest = keccak256(0x19 ‖ 0x01 ‖ domainSeparator ‖ hashStruct)`.
+pub fn intent_digest(domain_sep: &[u8; 32], struct_hash: &[u8; 32]) -> [u8; 32] {
+    let mut buf = Vec::with_capacity(2 + 64);
+    buf.push(0x19);
+    buf.push(0x01);
+    buf.extend_from_slice(domain_sep);
+    buf.extend_from_slice(struct_hash);
+    Keccak256::digest(&buf).into()
+}
+
+/// Recover the lowercase `0x` EVM signer address from a 65-byte signature over a
+/// 32-byte prehash digest. Accepts `v ∈ {0,1,27,28}`.
+pub fn recover_evm_address(digest: &[u8; 32], sig65: &[u8]) -> Result<String, String> {
+    use super::tecdsa::evm_address_from_pubkey;
+    use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+
+    if sig65.len() != 65 {
+        return Err(format!("signature must be 65 bytes, got {}", sig65.len()));
+    }
+    let r: [u8; 32] = sig65[0..32].try_into().unwrap();
+    let s: [u8; 32] = sig65[32..64].try_into().unwrap();
+    let parity = match sig65[64] {
+        0 | 27 => 0u8,
+        1 | 28 => 1u8,
+        v => return Err(format!("bad recovery byte v={v}")),
+    };
+    let sig = Signature::from_scalars(r, s).map_err(|e| format!("bad (r,s): {e}"))?;
+    let rid = RecoveryId::new(parity == 1, false);
+    let vk = VerifyingKey::recover_from_prehash(digest, &sig, rid)
+        .map_err(|e| format!("ecrecover failed: {e}"))?;
+    let pk = vk.to_encoded_point(false).as_bytes().to_vec();
+    evm_address_from_pubkey(&pk)
+}
+
+/// Deterministic opaque-class synthetic owner principal for an EVM address on a
+/// chain. `keccak256("rumi.evm.owner.v1:" ‖ chain_le ‖ addr20)[0..28] ‖ 0x01`.
+/// The trailing `0x01` is the opaque type tag, so this can never equal a
+/// self-authenticating (trailing `0x02`) user principal. Internal owner key only
+/// — it is never used as a caller identity nor authenticated against.
+pub fn synthetic_owner(chain: ChainId, evm_addr: &str) -> Result<Principal, String> {
+    let addr20 = parse_addr_20(evm_addr)?;
+    let mut hasher = Keccak256::new();
+    hasher.update(b"rumi.evm.owner.v1:");
+    hasher.update(chain.0.to_le_bytes());
+    hasher.update(addr20);
+    let h: [u8; 32] = hasher.finalize().into();
+    let mut bytes = Vec::with_capacity(29);
+    bytes.extend_from_slice(&h[0..28]);
+    bytes.push(0x01);
+    Ok(Principal::from_slice(&bytes))
+}

--- a/src/rumi_protocol_backend/src/chains/evm/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/mod.rs
@@ -4,6 +4,7 @@
 pub mod adapter;
 pub mod burn_proof;
 pub mod deposit_watch;
+pub mod eip712;
 pub mod evm_rpc;
 pub mod hardening;
 pub mod settlement;
@@ -20,6 +21,9 @@ mod tests_burn_proof;
 
 #[cfg(test)]
 mod tests_deposit_watch;
+
+#[cfg(test)]
+mod tests_eip712;
 
 #[cfg(test)]
 mod tests_evm_rpc;

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -868,25 +868,26 @@ async fn confirm_op(
                 }
             };
 
-            // Find the Mint log for this vault, preferring the one whose tx hash
-            // matches this op's submission (case-insensitive).
-            // `log_index` is threaded through from get_logs but not needed here
-            // (the settlement path selects by vault_id + tx_hash, not by log
-            // identity — each mint op maps to exactly one Mint event).
+            // Find THIS op's Mint log by EXACT tx-hash match (case-insensitive).
+            //
+            // M2 review finding B: the per-op IcUSD idempotency (`mintedOps[op_id]`,
+            // replacing `minted[vault_id]`) means a vault can be minted to more
+            // than once (borrow), so there can be MULTIPLE `Mint(vault_id, …)` logs
+            // for the same vault — possibly in the same block. The old fallback
+            // ("first vault-id match when no tx-hash match") could therefore bind
+            // an arbitrary same-vault mint's amount to THIS op. Require the exact
+            // tx-hash match: this op submitted exactly one tx (`tx_hash`), and that
+            // tx emitted exactly the `Mint` for this op. If no log's tx hash matches
+            // (transient RPC view), leave the op Inflight and retry next tick.
             let mut matched: Option<(u128, String)> = None;
             for (topics, data, log_tx, log_block, _log_index) in &logs {
+                if !log_tx.eq_ignore_ascii_case(&tx_hash) {
+                    continue;
+                }
                 match evm_rpc::decode_mint_log(topics, data, log_tx, *log_block) {
                     Ok(m) if m.vault_id == vault_id => {
-                        let exact = log_tx.eq_ignore_ascii_case(&tx_hash);
-                        // Prefer an exact tx-hash match; otherwise take the first
-                        // vault-id match as a fallback (safe: IcUSD.mint reverts a
-                        // repeat vault_id, so at most one Mint log per vault exists).
-                        if exact {
-                            matched = Some((m.amount_e8s, m.recipient));
-                            break;
-                        } else if matched.is_none() {
-                            matched = Some((m.amount_e8s, m.recipient));
-                        }
+                        matched = Some((m.amount_e8s, m.recipient));
+                        break;
                     }
                     Ok(_) => {}
                     Err(e) => {

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -315,6 +315,7 @@ struct TxPlan {
 fn build_tx_plan(
     chain: ChainId,
     kind: &SettlementOpKind,
+    op_id: u64,
     nonce: u64,
     prio: u128,
     max_fee: u128,
@@ -328,6 +329,8 @@ fn build_tx_plan(
         SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
             let contract = contract.ok_or_else(|| "icUSD contract not set".to_string())?;
             // Delegate the per-op-kind field shape to the single source of truth.
+            // `op_id` is the on-chain per-op idempotency key (so a resubmit of THIS
+            // op can't double-mint, while a borrow's distinct op_id can).
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
                 tx::MonadTxKind::Mint {
@@ -335,6 +338,7 @@ fn build_tx_plan(
                     recipient,
                     amount_e8s: *amount_e8s,
                     vault_id: *vault_id,
+                    op_id,
                 },
                 nonce,
                 prio,
@@ -584,7 +588,7 @@ async fn submit_op(
 
     // 5. Resolve the contract (mints only) and build the tx plan.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, nonce, prio, max_fee, contract.as_deref(), withdrawal_value) {
+    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, prio, max_fee, contract.as_deref(), withdrawal_value) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry", chain, op_id, e);
@@ -1072,7 +1076,7 @@ async fn resubmit_if_stuck(
     // Resolve the contract (mints only) and rebuild the SAME tx at the stored
     // nonce with the bumped fees.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, nonce, bumped_prio, bumped_max, contract.as_deref(), withdrawal_value) {
+    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, bumped_prio, bumped_max, contract.as_deref(), withdrawal_value) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] resubmit build_tx_plan failed for op {}: {}; leaving Inflight", chain, op_id, e);

--- a/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
@@ -24,7 +24,7 @@ fn state_with_open_vault(debt: u128) -> MultiChainStateV4 {
             mint_recipient: "0xr".into(),
             pending_mint_e8s: 0,
             status: ChainVaultStatus::Open,
-            opened_at_ns: 0,
+            opened_at_ns: 0, owner_evm: None,
         },
     );
     s

--- a/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
@@ -13,7 +13,7 @@ fn seeded() -> MultiChainStateV4 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xcustody".into(), collateral_amount_native: 0, debt_e8s: 0,
         mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
+        status: ChainVaultStatus::Open, opened_at_ns: 0, owner_evm: None,
     });
     s
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
@@ -1,0 +1,154 @@
+//! Unit tests for the EIP-712 self-serve auth primitives.
+//!
+//! The golden values below were produced by INDEPENDENT tools, so these tests
+//! prove the Rust implementation matches the EIP-712 standard a real EVM wallet
+//! (ethers/viem/MetaMask) uses — not merely self-consistency:
+//!   - typehashes:   `cast keccak "<type string>"`
+//!   - digest + sig: python `eth_account.Account` over the typed-data with the
+//!     scalar=1 private key (`0x00..01`, address 0x7e5f…95bdf).
+
+use super::eip712::*;
+use crate::chains::config::ChainId;
+
+const GOLDEN_OWNER: &str = "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf";
+const GOLDEN_CONTRACT: &str = "0x00000000000000000000000000000000cf1c0de5";
+const GOLDEN_DIGEST: &str = "0x76fe467010b364bc9ed7caf7153a42bdc924e1cb7bf223d8182d9537717b9adc";
+const GOLDEN_SIG65: &str = "0x06f8ac987a3a020f6e25dbfc7634ebfd95f10ab9d657a2dcd91323506381f8b65e4a53a93ee2d35887b616a4c0efccdd6406b9c93fdfcdcf0b7cbe20c3b2127a1c";
+
+fn hexb(s: &str) -> Vec<u8> {
+    hex::decode(s.strip_prefix("0x").unwrap_or(s)).unwrap()
+}
+
+/// The exact intent the golden vector was generated for.
+fn golden_intent() -> VaultIntent {
+    VaultIntent {
+        action: IntentAction::Open.as_u8(),
+        chain_id: 71,
+        owner: GOLDEN_OWNER.to_string(),
+        vault_id: 0,
+        collateral_wei: 1_400_000_000_000_000_000_000, // 1400 CFX
+        debt_e8s: 10_000_000_000,                      // 100 icUSD
+        recipient: GOLDEN_OWNER.to_string(),
+        nonce: 0,
+        deadline_secs: 9_999_999_999,
+    }
+}
+
+#[test]
+fn domain_typehash_matches_cast_keccak() {
+    // cast keccak "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    assert_eq!(
+        format!("0x{}", hex::encode(domain_typehash())),
+        "0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f"
+    );
+}
+
+#[test]
+fn intent_typehash_matches_cast_keccak() {
+    // cast keccak "VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256 deadline)"
+    assert_eq!(
+        format!("0x{}", hex::encode(intent_typehash())),
+        "0x07f73e19bcdb683434be07c61e7b96781a58480279d7eb147175fb3bc38182f5"
+    );
+}
+
+#[test]
+fn digest_matches_eth_account_golden() {
+    let dsep = domain_separator(71, GOLDEN_CONTRACT).unwrap();
+    let sh = intent_struct_hash(&golden_intent()).unwrap();
+    let digest = intent_digest(&dsep, &sh);
+    assert_eq!(format!("0x{}", hex::encode(digest)), GOLDEN_DIGEST);
+}
+
+#[test]
+fn recovers_eth_account_golden_signature() {
+    let digest: [u8; 32] = hexb(GOLDEN_DIGEST).try_into().unwrap();
+    let recovered = recover_evm_address(&digest, &hexb(GOLDEN_SIG65)).unwrap();
+    assert_eq!(recovered, GOLDEN_OWNER);
+}
+
+#[test]
+fn round_trip_sign_and_recover_with_k256() {
+    use k256::ecdsa::{signature::hazmat::PrehashSigner, RecoveryId, Signature, SigningKey, VerifyingKey};
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    let mut b = [0u8; 32];
+    b[31] = 1;
+    let sk = SigningKey::from_bytes(&b.into()).unwrap();
+    let addr = crate::chains::evm::tecdsa::evm_address_from_pubkey(
+        &VerifyingKey::from(&sk).to_encoded_point(false).as_bytes().to_vec(),
+    )
+    .unwrap();
+    let dsep = domain_separator(71, GOLDEN_CONTRACT).unwrap();
+    let intent = golden_intent();
+    let digest = intent_digest(&dsep, &intent_struct_hash(&intent).unwrap());
+    let (sig, rid): (Signature, RecoveryId) = sk.sign_prehash_recoverable(&digest).unwrap();
+    let mut sig65 = sig.to_bytes().to_vec();
+    sig65.push(27 + u8::from(rid));
+    assert_eq!(recover_evm_address(&digest, &sig65).unwrap(), addr);
+}
+
+#[test]
+fn wrong_contract_changes_digest() {
+    let intent = golden_intent();
+    let sh = intent_struct_hash(&intent).unwrap();
+    let a = intent_digest(&domain_separator(71, GOLDEN_CONTRACT).unwrap(), &sh);
+    let b = intent_digest(
+        &domain_separator(71, "0x00000000000000000000000000000000deadbeef").unwrap(),
+        &sh,
+    );
+    assert_ne!(a, b);
+}
+
+#[test]
+fn wrong_chain_changes_digest() {
+    let sh = intent_struct_hash(&golden_intent()).unwrap();
+    let a = intent_digest(&domain_separator(71, GOLDEN_CONTRACT).unwrap(), &sh);
+    let b = intent_digest(&domain_separator(10143, GOLDEN_CONTRACT).unwrap(), &sh);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn tampered_field_breaks_owner_match() {
+    use k256::ecdsa::{signature::hazmat::PrehashSigner, RecoveryId, Signature, SigningKey};
+    let mut b = [0u8; 32];
+    b[31] = 1;
+    let sk = SigningKey::from_bytes(&b.into()).unwrap();
+    let intent = golden_intent();
+    let digest = intent_digest(
+        &domain_separator(71, GOLDEN_CONTRACT).unwrap(),
+        &intent_struct_hash(&intent).unwrap(),
+    );
+    let (sig, rid): (Signature, RecoveryId) = sk.sign_prehash_recoverable(&digest).unwrap();
+    let mut sig65 = sig.to_bytes().to_vec();
+    sig65.push(27 + u8::from(rid));
+    // Recover against a DIFFERENT digest (tampered debt) → not the owner.
+    let mut tampered = intent.clone();
+    tampered.debt_e8s += 1;
+    let d2 = intent_digest(
+        &domain_separator(71, GOLDEN_CONTRACT).unwrap(),
+        &intent_struct_hash(&tampered).unwrap(),
+    );
+    assert_ne!(recover_evm_address(&d2, &sig65).unwrap(), GOLDEN_OWNER);
+}
+
+#[test]
+fn bad_recovery_byte_rejected() {
+    let digest: [u8; 32] = hexb(GOLDEN_DIGEST).try_into().unwrap();
+    let mut sig = hexb(GOLDEN_SIG65);
+    sig[64] = 42; // invalid v
+    assert!(recover_evm_address(&digest, &sig).is_err());
+}
+
+#[test]
+fn synthetic_owner_is_opaque_deterministic_and_distinct() {
+    let p1 = synthetic_owner(ChainId(71), GOLDEN_OWNER).unwrap();
+    // Case-insensitive: a checksummed address yields the same principal.
+    let p2 = synthetic_owner(ChainId(71), "0x7E5F4552091a69125d5DFcb7b8C2659029395Bdf").unwrap();
+    assert_eq!(p1, p2);
+    let bytes = p1.as_slice();
+    assert_eq!(bytes.len(), 29);
+    assert_eq!(bytes[28], 0x01, "opaque class tag");
+    assert_ne!(bytes[28], 0x02, "must never be a self-authenticating principal");
+    // Distinct per chain (same address on Monad differs).
+    assert_ne!(p1, synthetic_owner(ChainId(10143), GOLDEN_OWNER).unwrap());
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
@@ -239,3 +239,16 @@ fn verify_intent_rejects_tampered_intent() {
         Err(VerifyError::SignerMismatch)
     );
 }
+
+#[test]
+fn verify_intent_rejects_chain_id_above_u32() {
+    // chain_id is hashed as u64 but resolved as u32; a value > u32::MAX must be
+    // rejected so the digest-bound chain cannot diverge from the resolved chain.
+    let mut intent = golden_intent();
+    intent.chain_id = (u32::MAX as u64) + 1;
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    assert!(matches!(
+        verify_intent(&intent, &sig, IntentAction::Open, GOLDEN_CONTRACT, 1000),
+        Err(VerifyError::Recover(_))
+    ));
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_eip712.rs
@@ -152,3 +152,90 @@ fn synthetic_owner_is_opaque_deterministic_and_distinct() {
     // Distinct per chain (same address on Monad differs).
     assert_ne!(p1, synthetic_owner(ChainId(10143), GOLDEN_OWNER).unwrap());
 }
+
+// ─── pure verify_intent (the rejection paths) ─────────────────────────────────
+
+/// Sign `intent` for `contract` with the fixed scalar=1 key → 65-byte sig.
+fn sign_for(intent: &VaultIntent, contract: &str) -> Vec<u8> {
+    use k256::ecdsa::{signature::hazmat::PrehashSigner, RecoveryId, Signature, SigningKey};
+    let mut b = [0u8; 32];
+    b[31] = 1;
+    let sk = SigningKey::from_bytes(&b.into()).unwrap();
+    let digest = intent_digest(
+        &domain_separator(intent.chain_id, contract).unwrap(),
+        &intent_struct_hash(intent).unwrap(),
+    );
+    let (sig, rid): (Signature, RecoveryId) = sk.sign_prehash_recoverable(&digest).unwrap();
+    let mut out = sig.to_bytes().to_vec();
+    out.push(27 + u8::from(rid));
+    out
+}
+
+#[test]
+fn verify_intent_happy_path_returns_owner_and_synthetic() {
+    let intent = golden_intent();
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    let (owner, synthetic) =
+        verify_intent(&intent, &sig, IntentAction::Open, GOLDEN_CONTRACT, 1000).unwrap();
+    assert_eq!(owner, GOLDEN_OWNER);
+    assert_eq!(synthetic, synthetic_owner(ChainId(71), GOLDEN_OWNER).unwrap());
+}
+
+#[test]
+fn verify_intent_rejects_action_mismatch() {
+    let intent = golden_intent(); // action = Open
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    // Endpoint expects Borrow, intent is Open.
+    assert_eq!(
+        verify_intent(&intent, &sig, IntentAction::Borrow, GOLDEN_CONTRACT, 1000),
+        Err(VerifyError::ActionMismatch)
+    );
+}
+
+#[test]
+fn verify_intent_rejects_expired_deadline() {
+    let mut intent = golden_intent();
+    intent.deadline_secs = 500;
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    assert_eq!(
+        verify_intent(&intent, &sig, IntentAction::Open, GOLDEN_CONTRACT, 501),
+        Err(VerifyError::Expired)
+    );
+}
+
+#[test]
+fn verify_intent_rejects_wrong_signer() {
+    // A signature over a DIFFERENT contract recovers a signer that won't match
+    // the intent's owner once we verify against the real contract domain.
+    let intent = golden_intent();
+    let sig = sign_for(&intent, "0x00000000000000000000000000000000deadbeef");
+    assert_eq!(
+        verify_intent(&intent, &sig, IntentAction::Open, GOLDEN_CONTRACT, 1000),
+        Err(VerifyError::SignerMismatch)
+    );
+}
+
+#[test]
+fn verify_intent_rejects_recipient_not_owner() {
+    let mut intent = golden_intent();
+    intent.recipient = "0x00000000000000000000000000000000deadbeef".into();
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    assert_eq!(
+        verify_intent(&intent, &sig, IntentAction::Open, GOLDEN_CONTRACT, 1000),
+        Err(VerifyError::RecipientNotOwner)
+    );
+}
+
+#[test]
+fn verify_intent_rejects_tampered_intent() {
+    // Sign the original, then tamper the debt — the recovered signer no longer
+    // matches owner (the signature is over the un-tampered digest).
+    let intent = golden_intent();
+    let sig = sign_for(&intent, GOLDEN_CONTRACT);
+    let mut tampered = intent.clone();
+    tampered.debt_e8s += 1;
+    assert_eq!(
+        verify_intent(&tampered, &sig, IntentAction::Open, GOLDEN_CONTRACT, 1000),
+        Err(VerifyError::SignerMismatch)
+    );
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -10,7 +10,7 @@ fn vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending: u128) {
         vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
         mint_recipient: "0xr".into(), pending_mint_e8s: pending,
-        status: ChainVaultStatus::MintPending, opened_at_ns: 0,
+        status: ChainVaultStatus::MintPending, opened_at_ns: 0, owner_evm: None,
     });
 }
 
@@ -88,7 +88,7 @@ fn confirm_mint_second_vault_uses_running_total() {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 10_000_000_000,
         mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
+        status: ChainVaultStatus::Open, opened_at_ns: 0, owner_evm: None,
     });
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8

--- a/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
@@ -141,12 +141,17 @@ fn minimal_bytes_for(mut n: usize) -> Vec<u8> {
 
 #[test]
 fn mint_calldata_has_correct_selector() {
-    // mint(address,uint256,uint64): 4-byte selector + 3*32-byte args = 100 bytes.
+    // mint(address,uint256,uint64,uint64): 4-byte selector + 4*32-byte args = 132 bytes.
     let calldata =
-        encode_mint_calldata("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 10_000_000_000, 42)
+        encode_mint_calldata("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 10_000_000_000, 42, 1234)
             .expect("valid address");
-    assert_eq!(calldata.len(), 4 + 32 * 3);
-    assert_ne!(&calldata[0..4], &[0u8; 4]);
+    assert_eq!(calldata.len(), 4 + 32 * 4);
+    // Selector for "mint(address,uint256,uint64,uint64)" (cast sig).
+    assert_eq!(&calldata[0..4], &[0x31, 0x23, 0x9e, 0x64]);
+    // 4th ABI word (bytes 100..132) carries the op_id (left-padded big-endian).
+    let mut expected_op = [0u8; 32];
+    expected_op[24..].copy_from_slice(&1234u64.to_be_bytes());
+    assert_eq!(&calldata[4 + 32 * 3..], &expected_op);
 }
 
 #[test]
@@ -525,7 +530,7 @@ fn signing_hash_returns_err_on_malformed_to() {
 /// `encode_mint_calldata` surfaces `Err` on a malformed recipient (no panic).
 #[test]
 fn encode_mint_calldata_returns_err_on_malformed_address() {
-    let result = encode_mint_calldata("0xbadhex!", 1_000_000, 1);
+    let result = encode_mint_calldata("0xbadhex!", 1_000_000, 1, 1);
     assert!(result.is_err(), "expected Err for bad hex recipient, got Ok");
 }
 

--- a/src/rumi_protocol_backend/src/chains/evm/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tx.rs
@@ -39,8 +39,11 @@ pub struct Eip1559Fields {
 /// The per-op-kind shape of a Monad settlement transaction (what varies between
 /// a mint and a native withdrawal: `to`, `value`, calldata, gas_limit).
 pub enum MonadTxKind<'a> {
-    /// `mint(address,uint256,uint64)` on the icUSD EVM contract.
-    Mint { contract: &'a str, recipient: &'a str, amount_e8s: u128, vault_id: u64 },
+    /// `mint(address,uint256,uint64,uint64)` on the icUSD EVM contract. `op_id`
+    /// is the settlement queue's unique-per-chain op id and is the on-chain
+    /// idempotency discriminator (per-op, not per-vault), so a vault can be
+    /// minted to more than once (borrow).
+    Mint { contract: &'a str, recipient: &'a str, amount_e8s: u128, vault_id: u64, op_id: u64 },
     /// A native MON transfer (`amount_wei` carried in the EIP-1559 `value`).
     NativeWithdrawal { recipient: &'a str, amount_wei: u128 },
 }
@@ -77,8 +80,8 @@ pub fn build_eip1559_fields(
     max_fee: u128,
 ) -> Result<Eip1559Fields, String> {
     match kind {
-        MonadTxKind::Mint { contract, recipient, amount_e8s, vault_id } => {
-            let data = encode_mint_calldata(recipient, amount_e8s, vault_id)?;
+        MonadTxKind::Mint { contract, recipient, amount_e8s, vault_id, op_id } => {
+            let data = encode_mint_calldata(recipient, amount_e8s, vault_id, op_id)?;
             Ok(Eip1559Fields {
                 chain_id,
                 nonce,
@@ -111,18 +114,27 @@ pub fn build_eip1559_fields(
 
 // ─── calldata helpers ─────────────────────────────────────────────────────────
 
-/// Build calldata for `mint(address,uint256,uint64)`.
-/// Signature string: `"mint(address,uint256,uint64)"`.
-/// Layout: 4-byte selector || word(address) || word(amount) || word(vault_id).
+/// Build calldata for `mint(address,uint256,uint64,uint64)`.
+/// Signature string: `"mint(address,uint256,uint64,uint64)"` (selector 0x31239e64).
+/// Layout: 4-byte selector || word(address) || word(amount) || word(vault_id) ||
+/// word(op_id). `op_id` is the settlement queue's unique-per-chain op id and is
+/// the on-chain per-op idempotency key (so a vault can be minted to more than
+/// once — borrow). `vault_id` stays the debt key for the `Mint` event + repay.
 ///
 /// Returns `Err` if `to` is not a valid 20-byte hex address.
-pub fn encode_mint_calldata(to: &str, amount_e8s: u128, vault_id: u64) -> Result<Vec<u8>, String> {
-    let selector = keccak_selector("mint(address,uint256,uint64)");
-    let mut out = Vec::with_capacity(4 + 96);
+pub fn encode_mint_calldata(
+    to: &str,
+    amount_e8s: u128,
+    vault_id: u64,
+    op_id: u64,
+) -> Result<Vec<u8>, String> {
+    let selector = keccak_selector("mint(address,uint256,uint64,uint64)");
+    let mut out = Vec::with_capacity(4 + 128);
     out.extend_from_slice(&selector);
     out.extend_from_slice(&abi_word_address(to)?);
     out.extend_from_slice(&abi_word_u128(amount_e8s));
     out.extend_from_slice(&abi_word_u128(vault_id as u128));
+    out.extend_from_slice(&abi_word_u128(op_id as u128));
     Ok(out)
 }
 

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -27,8 +27,8 @@ use candid::Principal;
 // `super::chain_vault::{...}` resolves through these, so nothing downstream
 // changes.
 pub use crate::chains::vault::{
-    collateral_ratio_e4, verify_deposit_and_enqueue_mint_in_state, ChainVaultStatus, ChainVaultV1,
-    OpenVaultError, WithdrawError,
+    collateral_ratio_e4, verify_deposit_and_enqueue_mint_in_state, BorrowError, ChainVaultStatus,
+    ChainVaultV1, OpenVaultError, WithdrawError,
 };
 
 /// Minimum collateral ratio (e4: 13000 == 130.00%) required to open a Monad
@@ -87,6 +87,29 @@ pub fn withdraw_collateral_in_state(
         vault_id,
         amount_e18,
         dest_address,
+        crate::chains::monad::tecdsa::is_valid_evm_address,
+        "MON",
+        min_cr_e4,
+        now_ns,
+    )
+}
+
+/// Borrow more icUSD against an Open Monad vault. Thin wrapper over
+/// `crate::chains::vault::borrow_chain_vault_in_state` with the Monad EVM address
+/// validator and the `"MON"` price key baked in.
+pub fn borrow_chain_vault_in_state(
+    state: &mut MultiChainStateV4,
+    vault_id: u64,
+    additional_e8s: u128,
+    recipient: String,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), BorrowError> {
+    crate::chains::vault::borrow_chain_vault_in_state(
+        state,
+        vault_id,
+        additional_e8s,
+        recipient,
         crate::chains::monad::tecdsa::is_valid_evm_address,
         "MON",
         min_cr_e4,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
@@ -33,7 +33,7 @@ fn chain_vault_round_trips_via_candid() {
         mint_recipient: "0xrecipient".into(),
         pending_mint_e8s: 10_000_000_000, // 100 icUSD pending
         status: ChainVaultStatus::MintPending,
-        opened_at_ns: 1_700_000_000_000_000_000,
+        opened_at_ns: 1_700_000_000_000_000_000, owner_evm: None,
     };
     let bytes = Encode!(&v).expect("encode");
     let back: ChainVaultV1 = Decode!(&bytes, ChainVaultV1).expect("decode");
@@ -53,7 +53,7 @@ fn chain_vault_round_trips_via_cbor() {
         mint_recipient: "0xb".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
-        opened_at_ns: 0,
+        opened_at_ns: 0, owner_evm: None,
     };
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&v, &mut buf).expect("cbor encode");

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -283,6 +283,32 @@ impl MultiChainStateV4 {
     pub fn total_chain_vault_debt_e8s(&self) -> u128 {
         self.chain_vaults.values().map(|v| v.debt_e8s).sum()
     }
+
+    /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).
+    pub fn expected_evm_nonce(&self, owner: &Principal) -> u64 {
+        self.evm_owner_nonces.get(owner).copied().unwrap_or(0)
+    }
+
+    /// M2: consume `nonce` for `owner`. Succeeds and bumps the counter iff
+    /// `nonce == expected`; else returns the expected value as `Err` (no mutation).
+    pub fn consume_evm_nonce(&mut self, owner: &Principal, nonce: u64) -> Result<(), u64> {
+        let expected = self.expected_evm_nonce(owner);
+        if nonce != expected {
+            return Err(expected);
+        }
+        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        Ok(())
+    }
+
+    /// M2 anti-spam: count NON-terminal vaults (everything but `Closed`) owned by
+    /// `owner` — the per-owner open cap.
+    pub fn count_owner_active_vaults(&self, owner: &Principal) -> usize {
+        use crate::chains::vault::ChainVaultStatus;
+        self.chain_vaults
+            .values()
+            .filter(|v| &v.owner == owner && v.status != ChainVaultStatus::Closed)
+            .count()
+    }
 }
 
 pub type MultiChainState = MultiChainStateV4;

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -32,7 +32,7 @@
 use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
 use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -264,6 +264,13 @@ pub struct MultiChainStateV4 {
     pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
     #[serde(default)]
     pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+    /// M2: per-synthetic-owner monotonic nonce for EIP-712 intent replay
+    /// protection. Keyed by `eip712::synthetic_owner(chain, evm_addr)` (which
+    /// embeds the chain → nonces are per-(owner,chain)). `#[serde(default)]`:
+    /// additive, ciborium-safe (no version-struct bump — coordinated with the
+    /// concurrent interest-accrual branch so both changes stay purely additive).
+    #[serde(default)]
+    pub evm_owner_nonces: BTreeMap<Principal, u64>,
 }
 
 impl MultiChainStateV4 {

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -246,6 +246,7 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
                 amount_e8s: *amount_e8s,
                 vault_id: *vault_id,
                 idempotency_key: op.idempotency_key.clone(),
+                op_id: op.op_id,
             };
             match adapter.sign_mint(instr).await {
                 Ok(signed) => (

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -41,7 +41,7 @@ fn solana_vault_pending(s: &mut MultiChainStateV4, vault_id: u64, pending_e8s: u
             mint_recipient: "So11111111111111111111111111111111111111112".into(),
             pending_mint_e8s: pending_e8s,
             status: ChainVaultStatus::MintPending,
-            opened_at_ns: 0,
+            opened_at_ns: 0, owner_evm: None,
         },
     );
 }
@@ -99,7 +99,7 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
             mint_recipient: "So11111111111111111111111111111111111111112".into(),
             pending_mint_e8s: 0,
             status: ChainVaultStatus::Open,
-            opened_at_ns: 0,
+            opened_at_ns: 0, owner_evm: None,
         },
     );
     solana_vault_pending(&mut s, 2, 5_000_000_000);

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -46,7 +46,7 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
         mint_recipient: "0x0000000000000000000000000000000000000000".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::AwaitingDeposit,
-        opened_at_ns: 0,
+        opened_at_ns: 0, owner_evm: None,
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state.rs
@@ -41,3 +41,66 @@ fn round_trips_via_cbor() {
     let back: MultiChainStateV1 = ciborium::de::from_reader(buf.as_slice()).expect("cbor decode");
     assert_eq!(back.chain_supplies.get(&ChainId(11)), Some(&1234u128));
 }
+
+// ── M2: additive owner_evm + evm_owner_nonces serde-default migration ──────────
+
+/// Recursively drop the M2 keys from a CBOR value, simulating a snapshot written
+/// before they existed (at any nesting level: top-level `evm_owner_nonces`, and
+/// `owner_evm` inside each `chain_vaults` vault map).
+fn strip_m2_keys(v: ciborium::Value) -> ciborium::Value {
+    use ciborium::Value;
+    match v {
+        Value::Map(entries) => Value::Map(
+            entries
+                .into_iter()
+                .filter(|(k, _)| !matches!(k, Value::Text(s) if s == "evm_owner_nonces" || s == "owner_evm"))
+                .map(|(k, val)| (k, strip_m2_keys(val)))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(strip_m2_keys).collect()),
+        other => other,
+    }
+}
+
+#[test]
+fn pre_m2_snapshot_decodes_with_defaulted_evm_fields() {
+    use super::config::ChainId;
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::multi_chain_state::MultiChainStateV4;
+    use candid::Principal;
+
+    let mut s = MultiChainStateV4::default();
+    s.chain_supplies.insert(ChainId(71), 100_000_000);
+    s.evm_owner_nonces.insert(Principal::from_slice(&[7, 7, 7]), 3);
+    s.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::from_slice(&[1, 2, 3]),
+            collateral_chain: ChainId(71),
+            custody_address: "0xabc".into(),
+            collateral_amount_native: 1_000,
+            debt_e8s: 100_000_000,
+            mint_recipient: "0xdef".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 42,
+            owner_evm: Some("0xfeed".into()),
+        },
+    );
+
+    // Encode current shape, strip the M2 keys (→ a pre-M2 snapshot), re-encode.
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&s, &mut buf).unwrap();
+    let val: ciborium::Value = ciborium::de::from_reader(buf.as_slice()).unwrap();
+    let mut pre_m2 = Vec::new();
+    ciborium::ser::into_writer(&strip_m2_keys(val), &mut pre_m2).unwrap();
+
+    // The pre-M2 bytes MUST decode into the current struct (proves serde-default).
+    let back: MultiChainStateV4 = ciborium::de::from_reader(pre_m2.as_slice()).unwrap();
+    assert_eq!(back.chain_supplies.get(&ChainId(71)).copied(), Some(100_000_000));
+    let v = back.chain_vaults.get(&1).expect("vault survived");
+    assert_eq!(v.debt_e8s, 100_000_000);
+    assert_eq!(v.owner_evm, None, "stripped owner_evm must default to None");
+    assert!(back.evm_owner_nonces.is_empty(), "stripped evm_owner_nonces must default to empty");
+}

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -167,7 +167,7 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
         mint_recipient: "0xrecipient".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
-        opened_at_ns: 99,
+        opened_at_ns: 99, owner_evm: None,
     });
     v2.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v2.last_observed_block.insert(ChainId(10143), 35_136_248);
@@ -240,7 +240,7 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
         mint_recipient: "0xrecipient".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
-        opened_at_ns: 99,
+        opened_at_ns: 99, owner_evm: None,
     });
     v3.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v3.last_observed_block.insert(ChainId(10143), 35_136_248);
@@ -287,7 +287,7 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         mint_recipient: "0xr".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
-        opened_at_ns: 0,
+        opened_at_ns: 0, owner_evm: None,
     });
     s.chain_vaults.insert(2, ChainVaultV1 {
         vault_id: 2,
@@ -299,7 +299,7 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         mint_recipient: "0xr".into(),
         pending_mint_e8s: 0,
         status: ChainVaultStatus::Open,
-        opened_at_ns: 0,
+        opened_at_ns: 0, owner_evm: None,
     });
     assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -29,7 +29,7 @@ fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u12
         mint_recipient: "0xrecipient".into(),
         pending_mint_e8s: pending,
         status,
-        opened_at_ns: 0,
+        opened_at_ns: 0, owner_evm: None,
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -252,7 +252,9 @@ use super::vault::{prune_stale_awaiting_deposit, AWAITING_DEPOSIT_TTL_NS};
 #[test]
 fn gc_prunes_only_stale_awaiting_deposit() {
     use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-    let mut s = MultiChainStateV4::default();
+    // setup() registers CHAIN (status Registered), so its observer is "active"
+    // and the GC is allowed to reap stale unfunded vaults on it (finding F).
+    let mut s = setup(PRICE_150_USD_E8);
     let mk = |id: u64, st: ChainVaultStatus, opened: u64| ChainVaultV1 {
         vault_id: id, owner: Principal::anonymous(), collateral_chain: CHAIN,
         custody_address: "c".into(), collateral_amount_native: 0, debt_e8s: 0,
@@ -275,4 +277,67 @@ fn gc_prunes_only_stale_awaiting_deposit() {
     assert!(s.chain_vaults.contains_key(&2), "young AwaitingDeposit kept");
     assert!(s.chain_vaults.contains_key(&3), "Open kept");
     assert!(s.chain_vaults.contains_key(&4), "MintPending kept");
+}
+
+#[test]
+fn gc_skips_stale_vaults_when_observer_inactive() {
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    let now = 100 * AWAITING_DEPOSIT_TTL_NS;
+    let stale = |id: u64| ChainVaultV1 {
+        vault_id: id, owner: Principal::anonymous(), collateral_chain: CHAIN,
+        custody_address: "c".into(), collateral_amount_native: 0, debt_e8s: 0,
+        mint_recipient: "r".into(), pending_mint_e8s: 0,
+        status: ChainVaultStatus::AwaitingDeposit,
+        opened_at_ns: now - AWAITING_DEPOSIT_TTL_NS - 1, owner_evm: None,
+    };
+    // (a) Chain not registered at all -> no observer -> not reaped (would strand
+    //     a funded-but-unobserved deposit).
+    let mut s = MultiChainStateV4::default();
+    s.chain_vaults.insert(1, stale(1));
+    assert_eq!(prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS), 0);
+    assert!(s.chain_vaults.contains_key(&1), "unregistered-chain vault kept");
+    // (b) Chain registered but reorg-halted -> observer halted -> not reaped.
+    let mut s = setup(PRICE_150_USD_E8);
+    s.reorg_halted.insert(CHAIN, true);
+    s.chain_vaults.insert(1, stale(1));
+    assert_eq!(prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS), 0);
+    assert!(s.chain_vaults.contains_key(&1), "reorg-halted-chain vault kept");
+}
+
+// ─── M2 review finding A: collateral release blocked while a borrow mint pends ─
+
+use super::vault::{close_chain_vault_in_state, withdraw_collateral_in_state, WithdrawError};
+
+#[test]
+fn withdraw_and_close_reject_while_borrow_mint_in_flight() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // Open vault, 100 SOL collateral, debt 100e8; borrow 50 more (pending=50e8).
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1).unwrap();
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 50_00000000);
+    // Withdraw must reject — releasing collateral now would undercollateralize
+    // once the borrow mint confirms (debt would jump 100e8 -> 150e8).
+    assert_eq!(
+        withdraw_collateral_in_state(&mut s, 7, 1, "good-address".into(), only_good, "SOL", 13_000, 2),
+        Err(WithdrawError::MintInFlight)
+    );
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 1, "no withdraw enqueued");
+}
+
+#[test]
+fn close_rejects_while_borrow_mint_in_flight_even_if_debt_zero() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // A repaid (debt 0) but still-Open vault that borrows: debt stays 0, pending=50e8.
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 0);
+    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1).unwrap();
+    // Close (debt==0) must NOT release collateral while the borrow mint pends.
+    assert_eq!(
+        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        Err(WithdrawError::MintInFlight)
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().status,
+        super::monad::chain_vault::ChainVaultStatus::Open,
+        "vault not closed"
+    );
 }

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -244,3 +244,35 @@ fn per_owner_cap_counts_non_terminal_only() {
     insert_open_vault(&mut s, Principal::anonymous(), 4, 0, 0);
     assert_eq!(s.count_owner_active_vaults(&owner), 2);
 }
+
+// ─── M2: stale AwaitingDeposit GC ─────────────────────────────────────────────
+
+use super::vault::{prune_stale_awaiting_deposit, AWAITING_DEPOSIT_TTL_NS};
+
+#[test]
+fn gc_prunes_only_stale_awaiting_deposit() {
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    let mut s = MultiChainStateV4::default();
+    let mk = |id: u64, st: ChainVaultStatus, opened: u64| ChainVaultV1 {
+        vault_id: id, owner: Principal::anonymous(), collateral_chain: CHAIN,
+        custody_address: "c".into(), collateral_amount_native: 0, debt_e8s: 0,
+        mint_recipient: "r".into(), pending_mint_e8s: 0, status: st, opened_at_ns: opened,
+        owner_evm: None,
+    };
+    let now = 100 * AWAITING_DEPOSIT_TTL_NS;
+    // 1: stale AwaitingDeposit (older than TTL) -> pruned.
+    s.chain_vaults.insert(1, mk(1, ChainVaultStatus::AwaitingDeposit, now - AWAITING_DEPOSIT_TTL_NS - 1));
+    // 2: young AwaitingDeposit (within TTL) -> kept.
+    s.chain_vaults.insert(2, mk(2, ChainVaultStatus::AwaitingDeposit, now - 1));
+    // 3: old Open vault -> kept (only AwaitingDeposit is GC'd; a funded vault is safe).
+    s.chain_vaults.insert(3, mk(3, ChainVaultStatus::Open, 0));
+    // 4: old MintPending -> kept (a mint is in flight; not unfunded).
+    s.chain_vaults.insert(4, mk(4, ChainVaultStatus::MintPending, 0));
+
+    let pruned = prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS);
+    assert_eq!(pruned, 1);
+    assert!(!s.chain_vaults.contains_key(&1), "stale AwaitingDeposit pruned");
+    assert!(s.chain_vaults.contains_key(&2), "young AwaitingDeposit kept");
+    assert!(s.chain_vaults.contains_key(&3), "Open kept");
+    assert!(s.chain_vaults.contains_key(&4), "MintPending kept");
+}

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -131,3 +131,116 @@ fn open_no_price_when_symbol_key_absent() {
     assert!(matches!(res, Err(OpenVaultError::NoPrice)), "got {res:?}");
     assert!(s.chain_vaults.is_empty());
 }
+
+// ─── M2: borrow + nonce + per-owner cap ───────────────────────────────────────
+
+use super::vault::{borrow_chain_vault_in_state, BorrowError};
+use super::evm::settlement::confirm_mint_in_state;
+
+/// Insert an Open vault (confirmed collateral + debt, no mint in flight) owned by
+/// `owner`, and seed the chain supply to match its debt so the invariant holds.
+fn insert_open_vault(s: &mut MultiChainStateV4, owner: Principal, vault_id: u64, collateral: u128, debt: u128) {
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    s.chain_vaults.insert(vault_id, ChainVaultV1 {
+        vault_id, owner, collateral_chain: CHAIN, custody_address: "custody".into(),
+        collateral_amount_native: collateral, debt_e8s: debt, mint_recipient: "good-address".into(),
+        pending_mint_e8s: 0, status: ChainVaultStatus::Open, opened_at_ns: 0,
+        owner_evm: Some("0xowner".into()),
+    });
+    *s.chain_supplies.entry(CHAIN).or_default() += debt;
+}
+
+#[test]
+fn borrow_open_vault_enqueues_mint_and_reserves_pending() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // 100 SOL ($15000) collateral, 100 icUSD debt; borrow 50 more → CR fine.
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1);
+    assert_eq!(r, Ok(()));
+    let v = s.chain_vaults.get(&7).unwrap();
+    assert_eq!(v.pending_mint_e8s, 50_00000000, "borrow reserves the additional as pending");
+    assert_eq!(v.debt_e8s, 100_00000000, "confirmed debt unchanged until mint observed");
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 1, "one Mint op enqueued");
+}
+
+#[test]
+fn borrow_then_confirm_preserves_supply_invariant() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1).unwrap();
+    let pre = s.total_chain_vault_debt_e8s();
+    confirm_mint_in_state(&mut s, CHAIN, 7, 50_00000000, pre).expect("confirm");
+    let v = s.chain_vaults.get(&7).unwrap();
+    assert_eq!(v.debt_e8s, 150_00000000, "pending moved into confirmed debt");
+    assert_eq!(v.pending_mint_e8s, 0);
+    assert_eq!(s.chain_supplies.get(&CHAIN).copied().unwrap(), 150_00000000, "supply == total debt");
+    assert_eq!(s.chain_supplies.get(&CHAIN).copied().unwrap(), s.total_chain_vault_debt_e8s());
+}
+
+#[test]
+fn borrow_rejects_when_mint_in_flight() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    s.chain_vaults.get_mut(&7).unwrap().pending_mint_e8s = 1; // a mint already pending
+    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1);
+    assert_eq!(r, Err(BorrowError::MintInFlight));
+}
+
+#[test]
+fn borrow_rejects_non_open_vault() {
+    use super::monad::chain_vault::ChainVaultStatus;
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::AwaitingDeposit;
+    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1);
+    assert_eq!(r, Err(BorrowError::WrongStatus { status: ChainVaultStatus::AwaitingDeposit }));
+}
+
+#[test]
+fn borrow_rejects_below_min_cr() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // 1 SOL ($150) collateral, 100 icUSD debt (CR 150%); borrow 50 more → new debt
+    // 150 icUSD, CR = 150/150 = 100% < 130% → reject.
+    insert_open_vault(&mut s, Principal::anonymous(), 7, ONE_SOL, 100_00000000);
+    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 1);
+    assert!(matches!(r, Err(BorrowError::BelowMinCr { .. })), "got {r:?}");
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0, "no mutation on reject");
+}
+
+#[test]
+fn borrow_rejects_zero_debt_and_bad_recipient() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    assert_eq!(borrow_chain_vault_in_state(&mut s, 7, 0, "good-address".into(), only_good, "SOL", 13_000, 1), Err(BorrowError::ZeroDebt));
+    assert_eq!(borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "bad".into(), only_good, "SOL", 13_000, 1), Err(BorrowError::InvalidAddress("bad".into())));
+}
+
+#[test]
+fn nonce_consume_is_monotonic_and_rejects_replay() {
+    let mut s = MultiChainStateV4::default();
+    let owner = Principal::from_slice(&[5, 5, 5]);
+    assert_eq!(s.expected_evm_nonce(&owner), 0);
+    assert_eq!(s.consume_evm_nonce(&owner, 0), Ok(()));
+    assert_eq!(s.expected_evm_nonce(&owner), 1);
+    assert_eq!(s.consume_evm_nonce(&owner, 0), Err(1), "replay of nonce 0 rejected");
+    assert_eq!(s.consume_evm_nonce(&owner, 5), Err(1), "out-of-order rejected");
+    assert_eq!(s.consume_evm_nonce(&owner, 1), Ok(()));
+    // A different owner has an independent sequence.
+    let other = Principal::from_slice(&[6, 6, 6]);
+    assert_eq!(s.consume_evm_nonce(&other, 0), Ok(()));
+}
+
+#[test]
+fn per_owner_cap_counts_non_terminal_only() {
+    use super::monad::chain_vault::ChainVaultStatus;
+    let mut s = MultiChainStateV4::default();
+    let owner = Principal::from_slice(&[9, 9, 9]);
+    insert_open_vault(&mut s, owner, 1, 0, 0);
+    insert_open_vault(&mut s, owner, 2, 0, 0);
+    s.chain_vaults.get_mut(&2).unwrap().status = ChainVaultStatus::AwaitingDeposit;
+    insert_open_vault(&mut s, owner, 3, 0, 0);
+    s.chain_vaults.get_mut(&3).unwrap().status = ChainVaultStatus::Closed; // terminal, not counted
+    // A different owner's vault is not counted.
+    insert_open_vault(&mut s, Principal::anonymous(), 4, 0, 0);
+    assert_eq!(s.count_owner_active_vaults(&owner), 2);
+}

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -136,6 +136,12 @@ pub enum WithdrawError {
     /// phantom collateral), and a `MintPending` vault has a mint in flight
     /// against its collateral. Carries the offending status.
     WrongStatus { status: ChainVaultStatus },
+    /// A borrow mint is in flight for this Open vault (`pending_mint_e8s != 0`).
+    /// The CR check would run against the STALE confirmed `debt_e8s` (which does
+    /// not yet include the pending borrow), so releasing collateral now could
+    /// leave the vault below `min_cr_e4` once the borrow mint confirms. Reject
+    /// until the mint settles (mirrors `BorrowError::MintInFlight`). M2 review-A.
+    MintInFlight,
 }
 
 /// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
@@ -420,6 +426,14 @@ pub fn withdraw_collateral_in_state(
         if v.status != ChainVaultStatus::Open {
             return Err(WithdrawError::WrongStatus { status: v.status.clone() });
         }
+        // A borrow mint in flight means the CR check below would run against the
+        // stale confirmed debt (pending borrow not yet folded in); releasing
+        // collateral now could undercollateralize the vault once the mint
+        // confirms. Reject until it settles (the settlement queue is sequential,
+        // so this clears quickly). M2 review finding A.
+        if v.pending_mint_e8s != 0 {
+            return Err(WithdrawError::MintInFlight);
+        }
         if amount_e18 > v.collateral_amount_native {
             return Err(WithdrawError::InsufficientCollateral);
         }
@@ -526,6 +540,15 @@ pub fn close_chain_vault_in_state(
             .ok_or(WithdrawError::UnknownVault)?;
         if v.debt_e8s != 0 {
             return Err(WithdrawError::HasDebt);
+        }
+        // A repaid (debt 0) but still-Open vault CAN have a borrow mint in flight
+        // (pending_mint_e8s != 0). Closing it now would release all collateral,
+        // then the borrow mint confirms and leaves debt with no backing. Reject
+        // BEFORE the degenerate short-circuit below. M2 review finding A. (The
+        // delegate's withdraw path also guards this, but the zero-collateral
+        // short-circuit bypasses the delegate, so the check must live here too.)
+        if v.pending_mint_e8s != 0 {
+            return Err(WithdrawError::MintInFlight);
         }
         (v.collateral_amount_native, v.status.clone())
     };
@@ -670,16 +693,29 @@ pub const AWAITING_DEPOSIT_TTL_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
 /// funded vault to `MintPending` within its tick (seconds–minutes) long before
 /// the 24h TTL, so a real deposit is never stranded. This is the anti-spam
 /// backstop: it bounds total unfunded state without the self-DoS of a hard cap.
+///
+/// M2 review finding F: a vault is reaped ONLY if its chain's observer is
+/// currently running — `status == Registered` AND not `reorg_halted`. If the
+/// observer is halted or the chain is disabled, a funded-but-not-yet-observed
+/// deposit could otherwise be stranded by the GC. A vault on an
+/// inactive-observer chain is left until the observer resumes (then it either
+/// flips to `MintPending` if funded, or ages out on a later GC tick once active).
 pub fn prune_stale_awaiting_deposit(
     state: &mut MultiChainStateV4,
     now_ns: u64,
     ttl_ns: u64,
 ) -> usize {
+    use crate::chains::config::ChainStatus;
     let stale: Vec<u64> = state
         .chain_vaults
         .iter()
         .filter(|(_, v)| {
-            v.status == ChainVaultStatus::AwaitingDeposit
+            let observer_active = matches!(
+                state.chain_configs.get(&v.collateral_chain).map(|c| c.status),
+                Some(ChainStatus::Registered)
+            ) && !state.reorg_halted.get(&v.collateral_chain).copied().unwrap_or(false);
+            observer_active
+                && v.status == ChainVaultStatus::AwaitingDeposit
                 && now_ns.saturating_sub(v.opened_at_ns) > ttl_ns
         })
         .map(|(&id, _)| id)

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -554,3 +554,104 @@ pub fn close_chain_vault_in_state(
         now_ns,
     )
 }
+
+// ─── M2: borrow + anti-spam ───────────────────────────────────────────────────
+
+/// Anti-spam: max non-terminal vaults a single synthetic owner may hold.
+pub const MAX_VAULTS_PER_OWNER: usize = 25;
+
+/// Reasons `borrow_chain_vault_in_state` can reject. No mutation on any error.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BorrowError {
+    UnknownVault,
+    /// Vault is not `Open` (only an Open vault has confirmed collateral + debt).
+    WrongStatus { status: ChainVaultStatus },
+    /// A mint is already in flight for this vault (`pending_mint_e8s != 0`).
+    MintInFlight,
+    ZeroDebt,
+    NoPrice,
+    BelowMinCr { cr_e4: u64, min_e4: u64 },
+    QueueError(String),
+    InvalidAddress(String),
+}
+
+/// Borrow additional icUSD against an existing `Open` vault — a SECOND on-chain
+/// mint, gated by the per-op `IcUSD` idempotency (the mint op carries the
+/// settlement queue's unique-per-chain `op_id`). Sets `pending_mint_e8s =
+/// additional_e8s` and enqueues a `Mint` op; the settlement confirm moves
+/// pending→debt + chain supply at finality (Design B). The off-chain idempotency
+/// key embeds `now_ns` so it never collides with the genesis open mint key
+/// (`mint-{chain}-{vault}`).
+///
+/// `address_validator` / `price_symbol` are the same per-chain seams as the open
+/// helper. Rejections (no mutation on any path): `additional == 0` → `ZeroDebt`;
+/// malformed `recipient` → `InvalidAddress`; absent/non-Open vault →
+/// `UnknownVault`/`WrongStatus`; an in-flight mint → `MintInFlight`; no price →
+/// `NoPrice`; post-borrow CR `< min_cr_e4` → `BelowMinCr`.
+#[allow(clippy::too_many_arguments)]
+pub fn borrow_chain_vault_in_state(
+    state: &mut MultiChainStateV4,
+    vault_id: u64,
+    additional_e8s: u128,
+    recipient: String,
+    address_validator: fn(&str) -> bool,
+    price_symbol: &str,
+    min_cr_e4: u64,
+    now_ns: u64,
+) -> Result<(), BorrowError> {
+    if additional_e8s == 0 {
+        return Err(BorrowError::ZeroDebt);
+    }
+    if !address_validator(&recipient) {
+        return Err(BorrowError::InvalidAddress(recipient));
+    }
+    // Step 1: read-only validation — no mutation on any rejection path.
+    let (chain, collateral, new_debt) = {
+        let v = state.chain_vaults.get(&vault_id).ok_or(BorrowError::UnknownVault)?;
+        // Only an Open vault has confirmed, on-chain-deposited collateral AND
+        // confirmed debt to borrow against.
+        if v.status != ChainVaultStatus::Open {
+            return Err(BorrowError::WrongStatus { status: v.status.clone() });
+        }
+        // No stacked borrows: a non-zero pending means a mint is already in flight
+        // for this vault, and the settlement queue is sequential per chain.
+        if v.pending_mint_e8s != 0 {
+            return Err(BorrowError::MintInFlight);
+        }
+        (
+            v.collateral_chain,
+            v.collateral_amount_native,
+            v.debt_e8s.saturating_add(additional_e8s),
+        )
+    };
+    let price_e8 = *state
+        .manual_prices
+        .get(&(chain, price_symbol.to_string()))
+        .ok_or(BorrowError::NoPrice)?;
+    let native_decimals = state
+        .chain_configs
+        .get(&chain)
+        .map(|c| c.chain_native_decimals)
+        .unwrap_or(18);
+    let cr_e4 = collateral_ratio_e4(collateral, native_decimals, price_e8, new_debt);
+    if cr_e4 < min_cr_e4 {
+        return Err(BorrowError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+    }
+    // Step 2: enqueue FIRST (can fail on a duplicate key). The `now_ns` suffix
+    // keeps this key distinct from the genesis open mint (`mint-{chain}-{vault}`).
+    let op = SettlementOp::new(
+        SettlementOpKind::Mint { recipient, amount_e8s: additional_e8s, vault_id },
+        format!("mint-{}-{}-{}", chain.0, vault_id, now_ns),
+        now_ns,
+    );
+    state
+        .settlement_queues
+        .entry(chain)
+        .or_default()
+        .enqueue(op)
+        .map_err(|e| BorrowError::QueueError(format!("{e:?}")))?;
+    // Step 3: only after a successful enqueue — reserve the borrow as pending.
+    let v = state.chain_vaults.get_mut(&vault_id).expect("vault present: checked above");
+    v.pending_mint_e8s = additional_e8s;
+    Ok(())
+}

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -655,3 +655,37 @@ pub fn borrow_chain_vault_in_state(
     v.pending_mint_e8s = additional_e8s;
     Ok(())
 }
+
+// ─── M2: stale AwaitingDeposit GC (anti-spam backstop) ────────────────────────
+
+/// TTL for an unfunded vault before the GC reaps it (24h in ns).
+pub const AWAITING_DEPOSIT_TTL_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
+
+/// Remove `AwaitingDeposit` vaults whose `opened_at_ns` is older than `ttl_ns`.
+/// Returns the number pruned.
+///
+/// Safe: an `AwaitingDeposit` vault has NO confirmed debt, NO enqueued mint, and
+/// contributes nothing to `chain_supplies`, so removing it cannot break the
+/// supply invariant. Only unfunded vaults are reaped — the observer flips a
+/// funded vault to `MintPending` within its tick (seconds–minutes) long before
+/// the 24h TTL, so a real deposit is never stranded. This is the anti-spam
+/// backstop: it bounds total unfunded state without the self-DoS of a hard cap.
+pub fn prune_stale_awaiting_deposit(
+    state: &mut MultiChainStateV4,
+    now_ns: u64,
+    ttl_ns: u64,
+) -> usize {
+    let stale: Vec<u64> = state
+        .chain_vaults
+        .iter()
+        .filter(|(_, v)| {
+            v.status == ChainVaultStatus::AwaitingDeposit
+                && now_ns.saturating_sub(v.opened_at_ns) > ttl_ns
+        })
+        .map(|(&id, _)| id)
+        .collect();
+    for id in &stale {
+        state.chain_vaults.remove(id);
+    }
+    stale.len()
+}

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -70,6 +70,13 @@ pub struct ChainVaultV1 {
     pub pending_mint_e8s: u128,
     pub status: ChainVaultStatus,
     pub opened_at_ns: u64,
+    /// EVM owner address (lowercase `0x`) for vaults opened via the M2 self-serve
+    /// `_evm` path; `None` for developer-opened / Monad / Solana vaults. Used to
+    /// authorize borrow/withdraw/close by re-recovering the EIP-712 signer.
+    /// `#[serde(default)]` keeps pre-M2 ciborium snapshots decoding cleanly
+    /// (State is ciborium-encoded — see storage.rs).
+    #[serde(default)]
+    pub owner_evm: Option<String>,
 }
 
 /// Reasons `open_chain_vault_in_state` / `verify_deposit_and_enqueue_mint_in_state`
@@ -257,7 +264,7 @@ pub fn open_chain_vault_in_state(
             // the custody-address balance covers the declared collateral.
             pending_mint_e8s: debt_e8s,
             status: ChainVaultStatus::AwaitingDeposit,
-            opened_at_ns: now_ns,
+            opened_at_ns: now_ns, owner_evm: None,
         },
     );
     // No mint enqueued - that happens in verify_deposit_and_enqueue_mint_in_state.

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -665,6 +665,12 @@ pub enum ProtocolError {
     /// structured `ChainAdminError` enum lives in `chains::config` and is
     /// stringified here so the Candid surface stays append-only.
     ChainAdmin(String),
+    /// M2 EVM-native self-serve auth failure (bad signature, recovered signer !=
+    /// owner, nonce replay, expired deadline, recipient != owner, per-owner cap,
+    /// unknown/unregistered chain, custody-derive failure, or an underlying vault
+    /// rejection). Wraps a developer-facing message. Appended AFTER `ChainAdmin`
+    /// so historical on-chain events keep decoding (append-only Candid surface).
+    EvmAuth(String),
 }
 
 impl From<GuardError> for ProtocolError {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -447,6 +447,28 @@ fn setup_timers() {
     // from double-processing an op.
     register_settlement_timer();
     register_observer_timer();
+    register_chain_vault_gc_timer();
+}
+
+/// M2 anti-spam backstop: hourly GC of stale `AwaitingDeposit` chain vaults
+/// (unfunded opens older than the TTL). Bounds total unfunded state from
+/// anonymous `open_chain_vault_evm` spam without the self-DoS of a hard cap.
+/// Pruning an `AwaitingDeposit` vault is supply-invariant-safe (no confirmed
+/// debt / enqueued mint). Re-registered every upgrade via `setup_timers`.
+fn register_chain_vault_gc_timer() {
+    ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(3600), || {
+        let now = ic_cdk::api::time();
+        let pruned = mutate_state(|s| {
+            rumi_protocol_backend::chains::vault::prune_stale_awaiting_deposit(
+                &mut s.multi_chain,
+                now,
+                rumi_protocol_backend::chains::vault::AWAITING_DEPOSIT_TTL_NS,
+            )
+        });
+        if pruned > 0 {
+            log!(INFO, "[chain_vault_gc] pruned {} stale AwaitingDeposit vaults", pruned);
+        }
+    });
 }
 
 fn capture_protocol_snapshot() {

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1144,12 +1144,20 @@ fn withdraw_chain_collateral(
     }
     let now = ic_cdk::api::time();
     mutate_state(|s| {
-        let chain = s
+        let vault = s
             .multi_chain
             .chain_vaults
             .get(&vault_id)
-            .map(|v| v.collateral_chain)
             .ok_or_else(|| ProtocolError::ChainAdmin("unknown vault".into()))?;
+        // M2 review finding E: an EVM-owned (self-serve) vault may ONLY be driven
+        // by its EVM signer via the `_evm` methods — the operator must not be able
+        // to move a user's collateral. Refuse the dev path for such vaults.
+        if vault.owner_evm.is_some() {
+            return Err(ProtocolError::ChainAdmin(
+                "vault is EVM-owned; use the signed _evm endpoint".into(),
+            ));
+        }
+        let chain = vault.collateral_chain;
         let (symbol, min_cr) = evm_vault_params(chain)?;
         rumi_protocol_backend::chains::vault::withdraw_collateral_in_state(
             &mut s.multi_chain,
@@ -1183,12 +1191,20 @@ fn close_chain_vault(vault_id: u64, dest_address: String) -> Result<(), Protocol
     }
     let now = ic_cdk::api::time();
     mutate_state(|s| {
-        let chain = s
+        let vault = s
             .multi_chain
             .chain_vaults
             .get(&vault_id)
-            .map(|v| v.collateral_chain)
             .ok_or_else(|| ProtocolError::ChainAdmin("unknown vault".into()))?;
+        // M2 review finding E: an EVM-owned (self-serve) vault may ONLY be driven
+        // by its EVM signer via the `_evm` methods — the operator must not be able
+        // to move a user's collateral. Refuse the dev path for such vaults.
+        if vault.owner_evm.is_some() {
+            return Err(ProtocolError::ChainAdmin(
+                "vault is EVM-owned; use the signed _evm endpoint".into(),
+            ));
+        }
+        let chain = vault.collateral_chain;
         let (symbol, min_cr) = evm_vault_params(chain)?;
         rumi_protocol_backend::chains::vault::close_chain_vault_in_state(
             &mut s.multi_chain,
@@ -1312,6 +1328,18 @@ async fn open_chain_vault_evm(
     let now = ic_cdk::api::time();
     let owner_evm = v.owner_evm.clone();
     mutate_state(|s| {
+        // Re-check the per-owner cap on the AUTHORITATIVE map before inserting
+        // (M2 review finding C). The pre-await check can be raced: several opens
+        // for the same owner (distinct nonces) all pass their pre-await count
+        // while their vaults are still mid-derive and not yet inserted. Without
+        // this re-check, a pipelined burst could blow past MAX_VAULTS_PER_OWNER.
+        // The loser forfeits its (already-spent) nonce — consistent with the
+        // async open's spend-on-attempt semantics.
+        if s.multi_chain.count_owner_active_vaults(&v.synthetic)
+            >= rumi_protocol_backend::chains::vault::MAX_VAULTS_PER_OWNER
+        {
+            return Err(ProtocolError::EvmAuth("per-owner vault cap reached".into()));
+        }
         rumi_protocol_backend::chains::vault::open_chain_vault_in_state(
             &mut s.multi_chain,
             v.chain,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -182,6 +182,16 @@ fn inspect_message() {
         "icrc21_canister_call_consent_message" | "icrc10_supported_standards" => {
             ic_cdk::api::call::accept_message();
         }
+        // M2 EVM-native self-serve: authority is the EIP-712 signature, so the IC
+        // caller is irrelevant and ANONYMOUS ingress MUST be accepted (a relayer or
+        // a wallet's anonymous agent forwards the signed intent). The in-method
+        // signature verification + per-owner nonce/cap are the real boundary; this
+        // accept just lets the message reach the method body. inspect_message is a
+        // single-replica pre-filter, never a security boundary.
+        "open_chain_vault_evm" | "borrow_chain_vault_evm" | "withdraw_chain_collateral_evm"
+        | "close_chain_vault_evm" => {
+            ic_cdk::api::call::accept_message();
+        }
         // Everything else requires a non-anonymous caller
         _ => {
             if caller != Principal::anonymous() {
@@ -1168,6 +1178,258 @@ fn close_chain_vault(vault_id: u64, dest_address: String) -> Result<(), Protocol
             now,
         )
         .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
+    })
+}
+
+// ─── M2: EVM-native self-serve vault endpoints (EIP-712 signed, anonymous) ────
+//
+// Authority is the EVM signature, NEVER the IC caller (anonymous ingress is
+// accepted; see inspect_message). The vault is owned by a synthetic principal
+// derived from the recovered signer. The dev-gated endpoints above stay for
+// operator/test use; these are the self-serve variants.
+
+/// Verified, authenticated intent context shared by all four `_evm` methods.
+struct VerifiedIntent {
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    /// Lowercase `0x` recovered signer; the authoritative EVM owner.
+    owner_evm: String,
+    /// Vault owner key = `synthetic_owner(chain, signer)`.
+    synthetic: candid::Principal,
+    symbol: &'static str,
+    min_cr: u64,
+}
+
+/// Resolve per-chain params + the deployed IcUSD contract (for the EIP-712
+/// domain) + the current time, then delegate to the pure
+/// `eip712::verify_intent`. Maps every failure to `ProtocolError::EvmAuth`. No
+/// `.await` (callable from the synchronous methods).
+fn verify_intent_ctx(
+    intent: &rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: &[u8],
+    expected_action: rumi_protocol_backend::chains::evm::eip712::IntentAction,
+) -> Result<VerifiedIntent, ProtocolError> {
+    let chain = rumi_protocol_backend::chains::config::ChainId(intent.chain_id as u32);
+    // Resolve symbol + min CR (fails fast for a non-EVM / unregistered chain).
+    let (symbol, min_cr) = evm_vault_params(chain)
+        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+    // The deployed IcUSD address binds the EIP-712 domain to this chain+deployment.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned())
+        .ok_or_else(|| ProtocolError::EvmAuth(format!("no contract set for chain {}", chain.0)))?;
+    let now_secs = ic_cdk::api::time() / 1_000_000_000;
+    let (owner_evm, synthetic) = rumi_protocol_backend::chains::evm::eip712::verify_intent(
+        intent,
+        signature,
+        expected_action,
+        &contract,
+        now_secs,
+    )
+    .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+    Ok(VerifiedIntent { chain, owner_evm, synthetic, symbol, min_cr })
+}
+
+/// Authorize a borrow/withdraw/close `_evm` op against an existing vault: the
+/// vault must be owned by `synthetic` AND carry a matching `owner_evm`. Read-only.
+fn evm_owns_vault(s: &State, vault_id: u64, v: &VerifiedIntent) -> bool {
+    s.multi_chain
+        .chain_vaults
+        .get(&vault_id)
+        .map(|vault| {
+            vault.owner == v.synthetic
+                && vault
+                    .owner_evm
+                    .as_deref()
+                    .map(|a| a.eq_ignore_ascii_case(&v.owner_evm))
+                    .unwrap_or(false)
+        })
+        .unwrap_or(false)
+}
+
+/// EVM-signed `Open` (async — derives the per-vault custody address via tECDSA).
+///
+/// Saga/TOCTOU: the nonce is consumed + the per-owner cap checked + the vault id
+/// reserved in ONE pre-await `mutate_state` (spend-on-attempt), so a same-nonce
+/// double-submit is rejected before the costly derive and no duplicate vault can
+/// be created. A failed derive leaves the nonce spent — the user re-signs with
+/// `nonce + 1` (a spent counter is harmless; no funds move on this path).
+#[candid_method(update)]
+#[update]
+async fn open_chain_vault_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<u64, ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent_ctx(&intent, &signature, IntentAction::Open)?;
+    // Pre-await atomic: consume nonce, enforce per-owner cap, reserve vault id.
+    let vault_id = mutate_state(|s| {
+        s.multi_chain
+            .consume_evm_nonce(&v.synthetic, intent.nonce)
+            .map_err(|expected| {
+                ProtocolError::EvmAuth(format!(
+                    "bad nonce: got {}, expected {}",
+                    intent.nonce, expected
+                ))
+            })?;
+        if s.multi_chain.count_owner_active_vaults(&v.synthetic)
+            >= rumi_protocol_backend::chains::vault::MAX_VAULTS_PER_OWNER
+        {
+            return Err(ProtocolError::EvmAuth("per-owner vault cap reached".into()));
+        }
+        s.chain_vault_id_counter += 1;
+        Ok(s.chain_vault_id_counter)
+    })?;
+    // tECDSA derive of the per-vault custody address, keyed by the synthetic owner.
+    let path = rumi_protocol_backend::chains::evm::tecdsa::custody_derivation_path(
+        v.chain,
+        v.synthetic,
+        vault_id,
+    );
+    let (_pubkey, custody) =
+        rumi_protocol_backend::chains::evm::tecdsa::derive_evm_address(path)
+            .await
+            .map_err(|e| ProtocolError::EvmAuth(format!("derive: {e}")))?;
+    let now = ic_cdk::api::time();
+    let owner_evm = v.owner_evm.clone();
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::vault::open_chain_vault_in_state(
+            &mut s.multi_chain,
+            v.chain,
+            v.synthetic,
+            custody,
+            intent.collateral_wei,
+            intent.debt_e8s,
+            owner_evm.clone(), // mint_recipient == owner (recipient forced == owner)
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol,
+            v.min_cr,
+            now,
+            vault_id,
+        )
+        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        // Stamp the EVM owner so borrow/withdraw/close can re-authorize.
+        if let Some(vault) = s.multi_chain.chain_vaults.get_mut(&vault_id) {
+            vault.owner_evm = Some(owner_evm.clone());
+        }
+        Ok(vault_id)
+    })
+}
+
+/// EVM-signed `Borrow` (synchronous — no `.await`, so the nonce check + op +
+/// nonce bump are atomic in one message; preserves the FLAG-16 sync invariant).
+/// Spend-on-success: a failed op does not burn the nonce.
+#[candid_method(update)]
+#[update]
+fn borrow_chain_vault_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent_ctx(&intent, &signature, IntentAction::Borrow)?;
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        if !evm_owns_vault(s, intent.vault_id, &v) {
+            return Err(ProtocolError::EvmAuth("not the vault owner".into()));
+        }
+        let expected = s.multi_chain.expected_evm_nonce(&v.synthetic);
+        if intent.nonce != expected {
+            return Err(ProtocolError::EvmAuth(format!(
+                "bad nonce: got {}, expected {}",
+                intent.nonce, expected
+            )));
+        }
+        rumi_protocol_backend::chains::vault::borrow_chain_vault_in_state(
+            &mut s.multi_chain,
+            intent.vault_id,
+            intent.debt_e8s,
+            v.owner_evm.clone(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol,
+            v.min_cr,
+            now,
+        )
+        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        s.multi_chain
+            .evm_owner_nonces
+            .insert(v.synthetic, expected.saturating_add(1));
+        Ok(())
+    })
+}
+
+/// EVM-signed `WithdrawCollateral` (synchronous; spend-on-success). The released
+/// collateral goes to `owner_evm` (recipient forced == owner).
+#[candid_method(update)]
+#[update]
+fn withdraw_chain_collateral_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent_ctx(&intent, &signature, IntentAction::WithdrawCollateral)?;
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        if !evm_owns_vault(s, intent.vault_id, &v) {
+            return Err(ProtocolError::EvmAuth("not the vault owner".into()));
+        }
+        let expected = s.multi_chain.expected_evm_nonce(&v.synthetic);
+        if intent.nonce != expected {
+            return Err(ProtocolError::EvmAuth(format!(
+                "bad nonce: got {}, expected {}",
+                intent.nonce, expected
+            )));
+        }
+        rumi_protocol_backend::chains::vault::withdraw_collateral_in_state(
+            &mut s.multi_chain,
+            intent.vault_id,
+            intent.collateral_wei,
+            v.owner_evm.clone(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol,
+            v.min_cr,
+            now,
+        )
+        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        s.multi_chain
+            .evm_owner_nonces
+            .insert(v.synthetic, expected.saturating_add(1));
+        Ok(())
+    })
+}
+
+/// EVM-signed `Close` (synchronous; spend-on-success). Requires `debt_e8s == 0`
+/// (repay first by burning icUSD on-chain); returns all collateral to `owner_evm`.
+#[candid_method(update)]
+#[update]
+fn close_chain_vault_evm(
+    intent: rumi_protocol_backend::chains::evm::eip712::VaultIntent,
+    signature: Vec<u8>,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::chains::evm::eip712::IntentAction;
+    let v = verify_intent_ctx(&intent, &signature, IntentAction::Close)?;
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        if !evm_owns_vault(s, intent.vault_id, &v) {
+            return Err(ProtocolError::EvmAuth("not the vault owner".into()));
+        }
+        let expected = s.multi_chain.expected_evm_nonce(&v.synthetic);
+        if intent.nonce != expected {
+            return Err(ProtocolError::EvmAuth(format!(
+                "bad nonce: got {}, expected {}",
+                intent.nonce, expected
+            )));
+        }
+        rumi_protocol_backend::chains::vault::close_chain_vault_in_state(
+            &mut s.multi_chain,
+            intent.vault_id,
+            v.owner_evm.clone(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+            v.symbol,
+            v.min_cr,
+            now,
+        )
+        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+        s.multi_chain
+            .evm_owner_nonces
+            .insert(v.synthetic, expected.saturating_add(1));
+        Ok(())
     })
 }
 

--- a/src/rumi_protocol_backend/src/storage.rs
+++ b/src/rumi_protocol_backend/src/storage.rs
@@ -399,7 +399,7 @@ mod state_snapshot_tests {
                 mint_recipient: "0xabc0000000000000000000000000000000000002".into(),
                 pending_mint_e8s: 0,
                 status: ChainVaultStatus::Open,
-                opened_at_ns: 42,
+                opened_at_ns: 42, owner_evm: None,
             },
         );
 

--- a/src/rumi_protocol_backend/tests/conflux_espace_happy_path_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_espace_happy_path_pic.rs
@@ -125,6 +125,7 @@ struct ChainVaultV1 {
     pending_mint_e8s: candid::Nat,
     status: ChainVaultStatus,
     opened_at_ns: u64,
+    owner_evm: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -146,6 +147,9 @@ struct SupplyAuditWire {
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum ProtocolError {
     ChainAdmin(String),
+    /// M2 self-serve rejection (bad nonce, wrong signer, etc.). The `_evm`
+    /// methods return this; mirrored so the rejection-path asserts decode.
+    EvmAuth(String),
 }
 
 // ─── Wasm loaders ────────────────────────────────────────────────────────────
@@ -692,4 +696,254 @@ fn push_burn_log(
         "push_log",
         Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
     );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// M2: EVM-native self-serve (EIP-712 signed, ANONYMOUS caller) end-to-end.
+//
+// Proves the full self-serve loop with the IC caller = Principal::anonymous():
+//   open_chain_vault_evm -> deposit -> mint -> borrow_chain_vault_evm -> mint
+//   -> repay (burn) -> close_chain_vault_evm -> Closed
+// plus replay-nonce + wrong-signer rejection. The vault is owned by the
+// synthetic principal derived from the recovered EVM signer; the anonymous calls
+// reaching the method body proves the inspect_message accept-list works.
+// ════════════════════════════════════════════════════════════════════════════
+
+use rumi_protocol_backend::chains::evm::eip712::{
+    domain_separator, intent_digest, intent_struct_hash, synthetic_owner, IntentAction, VaultIntent,
+};
+
+const EVM_CONTRACT: &str = "0x00000000000000000000000000000000cf1c0de5";
+
+/// The fixed scalar=1 secp256k1 signer + its canonical EVM address.
+fn evm_signer() -> (k256::ecdsa::SigningKey, String) {
+    use k256::ecdsa::{SigningKey, VerifyingKey};
+    let mut b = [0u8; 32];
+    b[31] = 1;
+    let sk = SigningKey::from_bytes(&b.into()).unwrap();
+    let pk = VerifyingKey::from(&sk).to_encoded_point(false).as_bytes().to_vec();
+    let addr = rumi_protocol_backend::chains::evm::tecdsa::evm_address_from_pubkey(&pk).unwrap();
+    (sk, addr)
+}
+
+fn make_intent(
+    action: IntentAction,
+    owner: &str,
+    vault_id: u64,
+    collateral_wei: u128,
+    debt_e8s: u128,
+    nonce: u64,
+) -> VaultIntent {
+    VaultIntent {
+        action: action.as_u8(),
+        chain_id: CONFLUX_CHAIN_ID as u64,
+        owner: owner.to_string(),
+        vault_id,
+        collateral_wei,
+        debt_e8s,
+        recipient: owner.to_string(), // M2: recipient forced == owner
+        nonce,
+        deadline_secs: 9_999_999_999,
+    }
+}
+
+/// Sign an intent for `EVM_CONTRACT` with the fixed key → 65-byte r||s||v sig.
+fn sign(sk: &k256::ecdsa::SigningKey, intent: &VaultIntent) -> Vec<u8> {
+    use k256::ecdsa::{RecoveryId, Signature};
+    let digest = intent_digest(
+        &domain_separator(intent.chain_id, EVM_CONTRACT).unwrap(),
+        &intent_struct_hash(intent).unwrap(),
+    );
+    let (sig, rid): (Signature, RecoveryId) = sk.sign_prehash_recoverable(&digest).unwrap();
+    let mut out = sig.to_bytes().to_vec();
+    out.push(27 + u8::from(rid));
+    out
+}
+
+/// dev-gated register + config for Conflux (steps shared with the happy path).
+fn configure_conflux(pic: &PocketIc, backend: Principal, mock: Principal, seed: u64) {
+    decode_result(
+        update_dev(pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+    update_any(pic, mock, "set_getlogs_max_range", Encode!(&1000u64).unwrap());
+    update_any(pic, mock, "set_espace_receipt_fields", Encode!(&true).unwrap());
+    let reg = RegisterChainArg {
+        chain_id: ChainId(CONFLUX_CHAIN_ID),
+        display_name: "ConfluxESpaceTestnet".to_string(),
+        rpc_endpoints: vec!["https://evmtestnet.confluxrpc.com".to_string()],
+        finality_depth: CONFLUX_FINALITY_DEPTH as u32,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 1, max_fee_gwei_ceiling: 100 },
+        chain_native_decimals: 18,
+        min_quorum_providers: Some(1),
+    };
+    decode_result(update_dev(pic, backend, "register_chain", Encode!(&reg).unwrap()), "register_chain")
+        .expect("register_chain");
+    decode_result(
+        update_dev(pic, backend, "set_chain_contract", Encode!(&ChainId(CONFLUX_CHAIN_ID), &EVM_CONTRACT.to_string()).unwrap()),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+    decode_result(
+        update_dev(pic, backend, "set_manual_collateral_price", Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &15_000_000u64).unwrap()),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+    decode_result(
+        update_dev(pic, backend, "set_last_observed_block", Encode!(&ChainId(CONFLUX_CHAIN_ID), &seed).unwrap()),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+    decode_result(
+        update_dev(pic, backend, "set_burn_watch_poll_enabled", Encode!(&ChainId(CONFLUX_CHAIN_ID), &true).unwrap()),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
+}
+
+/// Submit a signed intent as the ANONYMOUS caller; decode `Result<u64, _>`.
+fn open_evm(pic: &PocketIc, backend: Principal, intent: &VaultIntent, sig: &[u8]) -> Result<u64, ProtocolError> {
+    match pic
+        .update_call(backend, Principal::anonymous(), "open_chain_vault_evm", Encode!(intent, &sig.to_vec()).unwrap())
+        .expect("open_chain_vault_evm call")
+    {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>).expect("decode open_evm"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault_evm rejected at transport (inspect_message?): {msg}"),
+    }
+}
+
+/// Submit a signed borrow/withdraw/close intent as ANONYMOUS; decode `Result<(), _>`.
+fn unit_evm(pic: &PocketIc, backend: Principal, method: &str, intent: &VaultIntent, sig: &[u8]) -> Result<(), ProtocolError> {
+    match pic
+        .update_call(backend, Principal::anonymous(), method, Encode!(intent, &sig.to_vec()).unwrap())
+        .unwrap_or_else(|e| panic!("{method} call failed: {e}"))
+    {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>).unwrap_or_else(|e| panic!("decode {method}: {e}")),
+        WasmResult::Reject(msg) => panic!("{method} rejected at transport (inspect_message?): {msg}"),
+    }
+}
+
+#[test]
+fn conflux_evm_self_serve_full_flow_and_rejections() {
+    let (pic, backend, mock) = boot();
+    let seed: u64 = 1_000_000;
+    configure_conflux(&pic, backend, mock, seed);
+    assert_supply(&pic, backend, 0, "after config");
+
+    let (sk, owner) = evm_signer();
+    let synthetic = synthetic_owner(
+        rumi_protocol_backend::chains::config::ChainId(CONFLUX_CHAIN_ID),
+        &owner,
+    )
+    .unwrap();
+
+    // Block plan + settlement broadcast hash.
+    let cursor1 = seed + SCAN_WINDOW;
+    let head1 = cursor1 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head1, &head1).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xevmmint1".to_string()).unwrap());
+
+    // ECDSA probe — gated subset if PocketIC can't provision test_key_1.
+    let settlement_addr = match update_dev(&pic, backend, "get_chain_settlement_address", Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap()) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            _ => None,
+        },
+        WasmResult::Reject(_) => None,
+    };
+    let settlement_addr = match settlement_addr {
+        Some(a) => a,
+        None => {
+            eprintln!("[evm self-serve] ECDSA unavailable; running gated subset (config + invariant 0)");
+            // Even gated, a signed open must FAIL only at the derive (not auth):
+            // verify the signature path is reached (returns an EvmAuth derive err).
+            let intent = make_intent(IntentAction::Open, &owner, 0, 1_400 * E18, 100 * E8, 0);
+            let sig = sign(&sk, &intent);
+            assert!(matches!(open_evm(&pic, backend, &intent, &sig), Err(ProtocolError::EvmAuth(_))));
+            assert_supply(&pic, backend, 0, "gated final");
+            return;
+        }
+    };
+    update_any(&pic, mock, "set_balance", Encode!(&settlement_addr, &candid::Nat::from(1_000_000u128 * E18)).unwrap());
+
+    // ── OPEN (anonymous, EIP-712 signed, nonce 0) ────────────────────────────
+    let collateral = 1_400u128 * E18; // $210 backing
+    let open_intent = make_intent(IntentAction::Open, &owner, 0, collateral, 100 * E8, 0);
+    let open_sig = sign(&sk, &open_intent);
+    let vault_id = open_evm(&pic, backend, &open_intent, &open_sig).expect("open_evm Ok");
+    let v = get_vault(&pic, backend, vault_id).expect("vault after open");
+    assert_eq!(v.owner, synthetic, "vault owned by the synthetic principal");
+    assert_eq!(v.owner_evm.as_deref(), Some(owner.to_lowercase().as_str()), "owner_evm stamped");
+    assert_eq!(v.status, ChainVaultStatus::AwaitingDeposit);
+    assert_eq!(v.mint_recipient, owner.to_lowercase(), "mint recipient == owner");
+    let custody = v.custody_address.clone();
+    assert_supply(&pic, backend, 0, "after open_evm");
+
+    // ── deposit -> MintPending -> mint confirm (Open, supply 100e8) ──────────
+    update_any(&pic, mock, "set_balance", Encode!(&custody, &candid::Nat::from(collateral)).unwrap());
+    advance_and_tick(&pic, 2);
+    assert_eq!(get_vault(&pic, backend, vault_id).unwrap().status, ChainVaultStatus::MintPending);
+    advance_and_tick(&pic, 1); // submit
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xevmmint1".to_string(), &true, &cursor1).unwrap());
+    push_mint_log(&pic, mock, vault_id, &owner, 100 * E8, "0xevmmint1", cursor1);
+    advance_and_tick(&pic, 4); // confirm
+    assert_eq!(get_vault(&pic, backend, vault_id).unwrap().status, ChainVaultStatus::Open);
+    assert_supply(&pic, backend, 100 * E8, "after mint confirm");
+
+    // ── BORROW (anonymous, nonce 1, +50e8) -> mint2 confirm (supply 150e8) ───
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xevmmint2".to_string()).unwrap());
+    let borrow_intent = make_intent(IntentAction::Borrow, &owner, vault_id, 0, 50 * E8, 1);
+    let borrow_sig = sign(&sk, &borrow_intent);
+    unit_evm(&pic, backend, "borrow_chain_vault_evm", &borrow_intent, &borrow_sig).expect("borrow_evm Ok");
+    advance_and_tick(&pic, 1); // submit mint2
+    // The settlement finality gate is `receipt_block <= observer cursor`; after
+    // mint1 the cursor sits at cursor1, so the borrow mint receipt+log must land
+    // at cursor1 too. This also puts a SECOND Mint log for this vault at cursor1,
+    // exercising the per-op confirm's exact-tx-hash match (the M2 change that lets
+    // a vault be minted to more than once).
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xevmmint2".to_string(), &true, &cursor1).unwrap());
+    push_mint_log(&pic, mock, vault_id, &owner, 50 * E8, "0xevmmint2", cursor1);
+    advance_and_tick(&pic, 4); // confirm mint2
+    let v = get_vault(&pic, backend, vault_id).unwrap();
+    assert_eq!(v.debt_e8s, candid::Nat::from(150 * E8), "borrow confirmed => debt 150e8");
+    assert_supply(&pic, backend, 150 * E8, "after borrow mint confirm");
+
+    // ── REPAY (burn full 150e8 on chain) -> debt 0, supply 0 ─────────────────
+    let cursor2 = cursor1 + SCAN_WINDOW;
+    let head2 = cursor2 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head2, &head2).unwrap());
+    push_burn_log(&pic, mock, vault_id, &owner, 150 * E8, "0xevmburn1", cursor1 + 500);
+    advance_and_tick(&pic, 3);
+    assert_eq!(get_vault(&pic, backend, vault_id).unwrap().debt_e8s, candid::Nat::from(0u32), "repaid => debt 0");
+    assert_supply(&pic, backend, 0, "after repay");
+
+    // ── CLOSE (anonymous, nonce 2) -> Closing -> Closed ──────────────────────
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xevmwd1".to_string()).unwrap());
+    let close_intent = make_intent(IntentAction::Close, &owner, vault_id, 0, 0, 2);
+    let close_sig = sign(&sk, &close_intent);
+    unit_evm(&pic, backend, "close_chain_vault_evm", &close_intent, &close_sig).expect("close_evm Ok");
+    assert_eq!(get_vault(&pic, backend, vault_id).unwrap().status, ChainVaultStatus::Closing, "close => Closing");
+    advance_and_tick(&pic, 1); // submit withdrawal
+    update_any(&pic, mock, "set_receipt", Encode!(&"0xevmwd1".to_string(), &true, &cursor2).unwrap());
+    advance_and_tick(&pic, 4); // confirm
+    assert_eq!(get_vault(&pic, backend, vault_id).unwrap().status, ChainVaultStatus::Closed, "close confirmed => Closed");
+    assert_supply(&pic, backend, 0, "final (Closed)");
+
+    // ── REJECTIONS ───────────────────────────────────────────────────────────
+    // 1. Replay the original OPEN intent (nonce 0, already consumed) → bad nonce.
+    match open_evm(&pic, backend, &open_intent, &open_sig) {
+        Err(ProtocolError::EvmAuth(m)) => assert!(m.contains("nonce"), "expected nonce error, got {m}"),
+        other => panic!("replayed open should fail with EvmAuth(nonce), got {other:?}"),
+    }
+    // 2. Wrong signer: a fresh OPEN intent (nonce 3) with a corrupted signature.
+    let fresh = make_intent(IntentAction::Open, &owner, 0, collateral, 100 * E8, 3);
+    let mut bad_sig = sign(&sk, &fresh);
+    bad_sig[10] ^= 0xff; // corrupt r → recovers a different (or no) signer
+    match open_evm(&pic, backend, &fresh, &bad_sig) {
+        Err(ProtocolError::EvmAuth(_)) => {}
+        other => panic!("corrupted-signature open should fail with EvmAuth, got {other:?}"),
+    }
+
+    eprintln!("[evm self-serve] FULL PASS: anonymous EIP-712 open/borrow/repay/close + replay/wrong-signer rejection on chain 71");
 }


### PR DESCRIPTION
## What

Adds the **M2 EVM-native self-serve auth** layer on top of the merged M1 native-collateral CDP rail (PR #248/#251). A MetaMask user signs an **EIP-712 intent**; the canister verifies the signature and drives the vault op, with the vault owned by a **synthetic IC principal** derived from the recovered EVM address. The IC caller is irrelevant — anonymous ingress is accepted and authority is the EVM signature alone. **Testnet-only + dev-gated to enable** (the `chains/mod.rs` experimental banner stays).

Backend + tests only (no frontend, per scope).

## How it works

- **EIP-712 intent** (`chains/evm/eip712.rs`, new): domain binds `chainId` + the deployed IcUSD contract; `VaultIntent(action, chainId, owner, vaultId, collateralWei, debtE8s, recipient, nonce, deadline)`. Signer recovery reuses the existing k256 ecrecover + `evm_address_from_pubkey` — no new crate. Validated against an **independent `eth_account` golden vector** + `cast keccak` typehashes, so a real wallet signature verifies.
- **Synthetic principal**: `keccak("rumi.evm.owner.v1:" ‖ chain_le ‖ addr20)[..28] ‖ 0x01` — opaque-class (`0x01` tag), can never equal a self-authenticating II principal; used only as an internal owner key.
- **4 anonymous methods**: `open_chain_vault_evm` (async; tECDSA custody derive), `borrow/withdraw/close_chain_vault_evm` (sync). `recipient` forced `== owner`. Whitelisted in `inspect_message`.
- **Replay**: per-synthetic-owner monotonic nonce — spend-on-attempt for the async open (TOCTOU-safe around the derive), spend-on-success for the sync methods (preserves the FLAG-16 sync invariant).
- **Borrow** required moving `IcUSD.sol` mint idempotency from per-`vault_id` to **per-`op_id`** (`mintedOps[op_id]`); the `Mint` event is byte-identical so the log decoder is untouched. New `mint(address,uint256,uint64,uint64)` selector `0x31239e64`; settlement threads the queue's `op_id`.
- **Anti-spam**: per-owner vault cap (25) + 24h TTL-GC of stale `AwaitingDeposit` (skips inactive-observer chains) + deposit-gated mint + cheap-checks-before-derive.
- **State**: additive `#[serde(default)]` `owner_evm` (on `ChainVaultV1`) + `evm_owner_nonces` (on `MultiChainStateV4`) — ciborium/CBOR, so upgrade-safe with **no version-struct bump** (keeps the merge with the concurrent interest-accrual branch additive). An upgrade test strips the M2 keys from a CBOR snapshot and proves it still decodes.

## Adversarial review

Ran a 6-lens adversarial review (each finding independently refuted). Fixed in the final commit:
- **A (HIGH):** withdraw/close now reject while a borrow mint is in flight (would otherwise release collateral against stale debt and undercollateralize on confirm).
- **B (MED):** settlement confirm requires an **exact tx-hash** Mint-log match (the old vault-id fallback is unsafe now that a vault can have multiple Mint logs).
- **C/D/E/F:** post-await cap re-check; `chain_id > u32::MAX` guard; dev-path refuses EVM-owned vaults; TTL-GC skips halted/disabled chains.
- Documented: cross-deployment replay assumption (distinct IcUSD per deploy) + the re-register `op_id`-reset operator note.

## Test evidence

- **Backend lib: 463 passed** (EIP-712 golden vectors, recovery, synthetic principal, nonce/cap, borrow + supply invariant, upgrade migration, GC, the review fixes).
- **Candid drift guard: green** (`.did` == generated interface).
- **Foundry: 14 passed** (per-op idempotency + ABI pins).
- **PocketIC e2e (anonymous, in-test EIP-712 signed):** open → deposit → mint → **borrow → mint** → repay (burn) → close → Closed, asserting synthetic ownership, the supply invariant (0→100e8→150e8→0), and **replay-nonce + corrupted-signature rejection**. The borrow's second Mint log per vault exercises the exact-tx-hash match.
- **Regression:** all existing chain PocketIC suites green (monad/conflux happy-path, burn-idempotency, getlogs-chunking, supply-gate, burn-proof, solana-m2-sign, observer-consensus, multi-chain-supply).

## Operator follow-up (not in this PR)

Redeploy `IcUSD.sol` (new ABI) to eSpace testnet + re-point `set_chain_contract`. The rail stays dev-gated to enable.

Design + plan: `docs/superpowers/plans/2026-06-18-conflux-evm-self-serve-auth-{design,plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)