### PR TITLE
feat(chains): runtime-configurable production tECDSA key (key_1) for the EVM rail

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -60,6 +60,7 @@ export type ChainVaultStatus = { 'MintPending' : null } |
   { 'AwaitingDeposit' : null };
 export interface ChainVaultV1 {
   'status' : ChainVaultStatus,
+  'owner_evm' : [] | [string],
   'owner' : Principal,
   'pending_mint_e8s' : bigint,
   'pending_interest_mint_e8s' : bigint,
@@ -907,6 +908,7 @@ export type ProtocolError = { 'GenericError' : string } |
   { 'AlreadyProcessing' : null } |
   { 'NotLowestCR' : null } |
   { 'SupplyInvariantHalted' : null } |
+  { 'EvmAuth' : string } |
   { 'AnonymousCallerNotAllowed' : null } |
   { 'ChainAdmin' : string } |
   { 'AmountTooLow' : { 'minimum_amount' : bigint } } |
@@ -1133,6 +1135,17 @@ export interface VaultDebtCorrection {
   'vault_id' : bigint,
   'correct_borrowed_e8s' : bigint,
 }
+export interface VaultIntent {
+  'action' : number,
+  'owner' : string,
+  'recipient' : string,
+  'collateral_wei' : bigint,
+  'vault_id' : bigint,
+  'chain_id' : bigint,
+  'nonce' : bigint,
+  'deadline_secs' : bigint,
+  'debt_e8s' : bigint,
+}
 export interface VaultRedemption {
   'icusd_redeemed_e8s' : bigint,
   'vault_id' : bigint,
@@ -1163,6 +1176,10 @@ export interface _SERVICE {
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
   'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
+  'borrow_chain_vault_evm' : ActorMethod<
+    [VaultIntent, Uint8Array | number[]],
+    Result
+  >,
   'borrow_from_vault' : ActorMethod<[VaultArg], Result_3>,
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,
   'bot_claim_liquidation' : ActorMethod<[bigint], Result_4>,
@@ -1174,6 +1191,10 @@ export interface _SERVICE {
   'clear_reorg_halt' : ActorMethod<[number], Result>,
   'clear_stuck_operations' : ActorMethod<[[] | [Principal]], Result_1>,
   'close_chain_vault' : ActorMethod<[bigint, string], Result>,
+  'close_chain_vault_evm' : ActorMethod<
+    [VaultIntent, Uint8Array | number[]],
+    Result
+  >,
   'close_solana_vault' : ActorMethod<[bigint, string], Result>,
   'close_vault' : ActorMethod<[bigint], Result_5>,
   'coingecko_transform' : ActorMethod<[TransformArgs], HttpResponse>,
@@ -1194,6 +1215,7 @@ export interface _SERVICE {
   'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
   'get_chain_settlement_address' : ActorMethod<[number], Result_2>,
   'get_chain_vault' : ActorMethod<[bigint], [] | [ChainVaultV1]>,
+  'get_chains_ecdsa_key_name' : ActorMethod<[], string>,
   'get_ckstable_repay_fee' : ActorMethod<[], number>,
   'get_collateral_config' : ActorMethod<[Principal], [] | [CollateralConfig]>,
   'get_collateral_totals' : ActorMethod<[], Array<CollateralTotals>>,
@@ -1300,6 +1322,10 @@ export interface _SERVICE {
   >,
   'list_chain_vaults' : ActorMethod<[number], Array<ChainVaultV1>>,
   'open_chain_vault' : ActorMethod<[number, bigint, bigint, string], Result_1>,
+  'open_chain_vault_evm' : ActorMethod<
+    [VaultIntent, Uint8Array | number[]],
+    Result_1
+  >,
   'open_solana_vault' : ActorMethod<[bigint, bigint, string], Result_9>,
   'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_10>,
   'open_vault_and_borrow' : ActorMethod<
@@ -1339,6 +1365,7 @@ export interface _SERVICE {
   'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_chain_interest_min_realize_e8s' : ActorMethod<[bigint], Result>,
   'set_chain_interest_tick_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_chains_ecdsa_key_name' : ActorMethod<[string], Result>,
   'set_check_vaults_alert_band_bps' : ActorMethod<[bigint], Result>,
   'set_check_vaults_full_sweep_every_n_ticks' : ActorMethod<[bigint], Result>,
   'set_ckstable_repay_fee' : ActorMethod<[number], Result>,
@@ -1445,6 +1472,10 @@ export interface _SERVICE {
   >,
   'withdraw_and_close_vault' : ActorMethod<[bigint], Result_5>,
   'withdraw_chain_collateral' : ActorMethod<[bigint, bigint, string], Result>,
+  'withdraw_chain_collateral_evm' : ActorMethod<
+    [VaultIntent, Uint8Array | number[]],
+    Result
+  >,
   'withdraw_collateral' : ActorMethod<[bigint], Result_1>,
   'withdraw_liquidity' : ActorMethod<[bigint], Result_1>,
   'withdraw_partial_collateral' : ActorMethod<[VaultArg], Result_1>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -95,6 +95,7 @@ export const idlFactory = ({ IDL }) => {
     'AlreadyProcessing' : IDL.Null,
     'NotLowestCR' : IDL.Null,
     'SupplyInvariantHalted' : IDL.Null,
+    'EvmAuth' : IDL.Text,
     'AnonymousCallerNotAllowed' : IDL.Null,
     'ChainAdmin' : IDL.Text,
     'AmountTooLow' : IDL.Record({ 'minimum_amount' : IDL.Nat64 }),
@@ -110,6 +111,17 @@ export const idlFactory = ({ IDL }) => {
     'correct_borrowed_e8s' : IDL.Nat64,
   });
   const Result_2 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ProtocolError });
+  const VaultIntent = IDL.Record({
+    'action' : IDL.Nat8,
+    'owner' : IDL.Text,
+    'recipient' : IDL.Text,
+    'collateral_wei' : IDL.Nat,
+    'vault_id' : IDL.Nat64,
+    'chain_id' : IDL.Nat64,
+    'nonce' : IDL.Nat64,
+    'deadline_secs' : IDL.Nat64,
+    'debt_e8s' : IDL.Nat,
+  });
   const SuccessWithFee = IDL.Record({
     'block_index' : IDL.Nat64,
     'debt_liquidated_e8s' : IDL.Opt(IDL.Nat64),
@@ -170,6 +182,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const ChainVaultV1 = IDL.Record({
     'status' : ChainVaultStatus,
+    'owner_evm' : IDL.Opt(IDL.Text),
     'owner' : IDL.Principal,
     'pending_mint_e8s' : IDL.Nat,
     'pending_interest_mint_e8s' : IDL.Nat,
@@ -1108,6 +1121,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
+    'borrow_chain_vault_evm' : IDL.Func(
+        [VaultIntent, IDL.Vec(IDL.Nat8)],
+        [Result],
+        [],
+      ),
     'borrow_from_vault' : IDL.Func([VaultArg], [Result_3], []),
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_4], []),
@@ -1127,6 +1145,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'close_chain_vault' : IDL.Func([IDL.Nat64, IDL.Text], [Result], []),
+    'close_chain_vault_evm' : IDL.Func(
+        [VaultIntent, IDL.Vec(IDL.Nat8)],
+        [Result],
+        [],
+      ),
     'close_solana_vault' : IDL.Func([IDL.Nat64, IDL.Text], [Result], []),
     'close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'coingecko_transform' : IDL.Func(
@@ -1163,6 +1186,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Opt(ChainVaultV1)],
         ['query'],
       ),
+    'get_chains_ecdsa_key_name' : IDL.Func([], [IDL.Text], ['query']),
     'get_ckstable_repay_fee' : IDL.Func([], [IDL.Float64], ['query']),
     'get_collateral_config' : IDL.Func(
         [IDL.Principal],
@@ -1356,6 +1380,11 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
+    'open_chain_vault_evm' : IDL.Func(
+        [VaultIntent, IDL.Vec(IDL.Nat8)],
+        [Result_1],
+        [],
+      ),
     'open_solana_vault' : IDL.Func(
         [IDL.Nat, IDL.Nat, IDL.Text],
         [Result_9],
@@ -1437,6 +1466,7 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'set_chains_ecdsa_key_name' : IDL.Func([IDL.Text], [Result], []),
     'set_check_vaults_alert_band_bps' : IDL.Func([IDL.Nat64], [Result], []),
     'set_check_vaults_full_sweep_every_n_ticks' : IDL.Func(
         [IDL.Nat64],
@@ -1626,6 +1656,11 @@ export const idlFactory = ({ IDL }) => {
     'withdraw_and_close_vault' : IDL.Func([IDL.Nat64], [Result_5], []),
     'withdraw_chain_collateral' : IDL.Func(
         [IDL.Nat64, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'withdraw_chain_collateral_evm' : IDL.Func(
+        [VaultIntent, IDL.Vec(IDL.Nat8)],
         [Result],
         [],
       ),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -55,6 +55,7 @@ type ChainVaultStatus = variant {
 };
 type ChainVaultV1 = record {
   status : ChainVaultStatus;
+  owner_evm : opt text;
   owner : principal;
   pending_mint_e8s : nat;
   pending_interest_mint_e8s : nat;
@@ -66,7 +67,6 @@ type ChainVaultV1 = record {
   collateral_chain : nat32;
   mint_recipient : text;
   debt_e8s : nat;
-  owner_evm : opt text;
 };
 type CollateralConfig = record {
   last_redemption_time : nat64;
@@ -747,27 +747,12 @@ type ProtocolError = variant {
   AlreadyProcessing;
   NotLowestCR;
   SupplyInvariantHalted;
+  EvmAuth : text;
   AnonymousCallerNotAllowed;
   ChainAdmin : text;
   AmountTooLow : record { minimum_amount : nat64 };
   TransferFromError : record { TransferFromError; nat64 };
   CallerNotOwner;
-  EvmAuth : text;
-};
-
-// M2: an EIP-712 typed-data intent the user signs in their EVM wallet to drive a
-// self-serve foreign-chain vault op. `signature` is the 65-byte (r||s||v) sig.
-// `action`: 0 = Open, 1 = Borrow, 2 = WithdrawCollateral, 3 = Close.
-type VaultIntent = record {
-  action : nat8;
-  chain_id : nat64;
-  owner : text;
-  vault_id : nat64;
-  collateral_wei : nat;
-  debt_e8s : nat;
-  recipient : text;
-  nonce : nat64;
-  deadline_secs : nat64;
 };
 type ProtocolSnapshot = record {
   total_debt : nat64;
@@ -963,6 +948,17 @@ type VaultDebtCorrection = record {
   vault_id : nat64;
   correct_borrowed_e8s : nat64;
 };
+type VaultIntent = record {
+  action : nat8;
+  owner : text;
+  recipient : text;
+  collateral_wei : nat;
+  vault_id : nat64;
+  chain_id : nat64;
+  nonce : nat64;
+  deadline_secs : nat64;
+  debt_e8s : nat;
+};
 type VaultRedemption = record {
   icusd_redeemed_e8s : nat64;
   vault_id : nat64;
@@ -983,6 +979,7 @@ service : (ProtocolArg) -> {
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
   admin_sweep_to_treasury : (text) -> (Result_1);
+  borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);
   bot_claim_liquidation : (nat64) -> (Result_4);
@@ -994,6 +991,7 @@ service : (ProtocolArg) -> {
   clear_reorg_halt : (nat32) -> (Result);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_chain_vault : (nat64, text) -> (Result);
+  close_chain_vault_evm : (VaultIntent, blob) -> (Result);
   close_solana_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
@@ -1014,6 +1012,7 @@ service : (ProtocolArg) -> {
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
+  get_chains_ecdsa_key_name : () -> (text) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
@@ -1097,13 +1096,7 @@ service : (ProtocolArg) -> {
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
-  // M2 EVM-native self-serve: authority is the EIP-712 signature, NOT the IC
-  // caller (anonymous ingress is accepted). The vault is owned by a synthetic
-  // principal derived from the recovered EVM signer. `blob` is the 65-byte sig.
   open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
-  borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
-  withdraw_chain_collateral_evm : (VaultIntent, blob) -> (Result);
-  close_chain_vault_evm : (VaultIntent, blob) -> (Result);
   open_solana_vault : (nat, nat, text) -> (Result_9);
   open_vault : (nat64, opt principal) -> (Result_10);
   open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
@@ -1137,6 +1130,7 @@ service : (ProtocolArg) -> {
   set_chain_contract : (nat32, text) -> (Result);
   set_chain_interest_min_realize_e8s : (nat) -> (Result);
   set_chain_interest_tick_interval_secs : (nat64) -> (Result);
+  set_chains_ecdsa_key_name : (text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
@@ -1219,6 +1213,7 @@ service : (ProtocolArg) -> {
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
   withdraw_chain_collateral : (nat64, nat, text) -> (Result);
+  withdraw_chain_collateral_evm : (VaultIntent, blob) -> (Result);
   withdraw_collateral : (nat64) -> (Result_1);
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);

--- a/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
@@ -14,7 +14,7 @@ use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::PublicKey;
 use sha3::{Digest, Keccak256};
 
-use crate::chains::monad::config::monad_ecdsa_key_name;
+use crate::state::read_state;
 
 /// Derivation path for a per-user collateral custody address.
 /// `[chain_id (LE u32), principal bytes, nonce (LE u64)]`.
@@ -32,7 +32,13 @@ pub fn settlement_derivation_path(chain: ChainId) -> Vec<Vec<u8>> {
 }
 
 fn key_id() -> EcdsaKeyId {
-    EcdsaKeyId { curve: EcdsaCurve::Secp256k1, name: monad_ecdsa_key_name() }
+    // The key name is runtime-configurable (State::chains_ecdsa_key_name): default
+    // `test_key_1` (staging/testnet), `key_1` on a production canister. Only ever
+    // called from async canister paths (derive/sign), so reading State is safe.
+    EcdsaKeyId {
+        curve: EcdsaCurve::Secp256k1,
+        name: read_state(|s| s.chains_ecdsa_key_name.clone()),
+    }
 }
 
 /// Convert a secp256k1 public key (33-byte compressed or 65-byte uncompressed)

--- a/src/rumi_protocol_backend/src/chains/evm/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tx.rs
@@ -19,7 +19,7 @@ use ic_cdk::api::management_canister::ecdsa::{
     sign_with_ecdsa, EcdsaCurve, EcdsaKeyId, SignWithEcdsaArgument,
 };
 
-use crate::chains::monad::config::monad_ecdsa_key_name;
+use crate::state::read_state;
 
 // ─── public types ────────────────────────────────────────────────────────────
 
@@ -235,7 +235,12 @@ pub async fn sign_eip1559(
 ) -> Result<String, String> {
     let hash = signing_hash(fields)?;
 
-    let key_id = EcdsaKeyId { curve: EcdsaCurve::Secp256k1, name: monad_ecdsa_key_name() };
+    // Runtime-configurable key (State::chains_ecdsa_key_name): test_key_1 default,
+    // key_1 on production. sign_eip1559 is async/canister-only, so read_state is safe.
+    let key_id = EcdsaKeyId {
+        curve: EcdsaCurve::Secp256k1,
+        name: read_state(|s| s.chains_ecdsa_key_name.clone()),
+    };
     let arg = SignWithEcdsaArgument {
         message_hash: hash.to_vec(),
         derivation_path,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -5863,6 +5863,51 @@ async fn set_chain_interest_min_realize_e8s(e8s: u128) -> Result<(), ProtocolErr
     Ok(())
 }
 
+/// Pure validation for `set_chains_ecdsa_key_name`: the name must be a supported
+/// IC threshold key (`test_key_1` or `key_1`), and the key may change ONLY while
+/// no chain vault exists — switching the key re-derives every per-vault custody
+/// address, which would orphan already-deposited collateral.
+fn validate_ecdsa_key_change(name: &str, has_chain_vaults: bool) -> Result<(), ProtocolError> {
+    if name != "test_key_1" && name != "key_1" {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "unsupported ecdsa key name '{name}' (expected test_key_1 or key_1)"
+        )));
+    }
+    if has_chain_vaults {
+        return Err(ProtocolError::ChainAdmin(
+            "cannot change the chains ECDSA key while chain vaults exist (it re-derives + orphans every per-vault custody address)".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Set the production tECDSA key name for the EVM chains rail (developer-gated).
+/// Intended for a FRESH production canister: set `key_1` BEFORE registering any
+/// chain, so all custody/settlement/treasury addresses derive from the
+/// production threshold key. Rejected once any chain vault exists (orphan guard).
+/// kvg63 staging keeps the default `test_key_1`.
+#[candid_method(update)]
+#[update]
+fn set_chains_ecdsa_key_name(name: String) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let has_vaults = read_state(|s| !s.multi_chain.chain_vaults.is_empty());
+    validate_ecdsa_key_change(&name, has_vaults)?;
+    mutate_state(|s| s.chains_ecdsa_key_name = name.clone());
+    log!(INFO, "[set_chains_ecdsa_key_name] chains EVM tECDSA key set to {}", name);
+    Ok(())
+}
+
+/// The current chains EVM tECDSA key name (`test_key_1` | `key_1`). Public read
+/// (non-sensitive config; the derived addresses are already public).
+#[candid_method(query)]
+#[query]
+fn get_chains_ecdsa_key_name() -> String {
+    read_state(|s| s.chains_ecdsa_key_name.clone())
+}
+
 /// Task 12: manually trigger one interest harvest for `chain` (developer-gated),
 /// for testing/ops independent of the off-by-default timer. Resolves the
 /// interest-treasury address + APR, enqueues an `InterestMint` for every
@@ -8121,6 +8166,19 @@ mod chain_vault_param_tests {
         assert_eq!(evm_vault_params(ChainId(10143)).unwrap(), ("MON", 13_000)); // Monad preserved
         assert_eq!(evm_vault_params(ChainId(71)).unwrap(), ("CFX", 13_300)); // Conflux = ICP mirror
         assert!(evm_vault_params(ChainId(999)).is_err());
+    }
+
+    #[test]
+    fn ecdsa_key_change_rules() {
+        use super::validate_ecdsa_key_change;
+        // Both supported key names are accepted when no vault exists.
+        assert!(validate_ecdsa_key_change("key_1", false).is_ok());
+        assert!(validate_ecdsa_key_change("test_key_1", false).is_ok());
+        // An unknown key name is rejected (typo/foot-gun guard).
+        assert!(validate_ecdsa_key_change("bogus_key", false).is_err());
+        // Changing the key while chain vaults exist is blocked (would re-derive +
+        // orphan every custody address).
+        assert!(validate_ecdsa_key_change("key_1", true).is_err());
     }
 }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -114,6 +114,12 @@ fn default_observer_tick_interval_secs() -> u64 { 300 }
 fn default_chain_interest_tick_interval_secs() -> u64 { 31_536_000 }
 /// Task 12: 0.01 icUSD dust floor for interest realization.
 fn default_chain_interest_min_realize_e8s() -> u128 { 1_000_000 }
+/// Production tECDSA key name for the EVM chains rail. Default `test_key_1`
+/// (single-sourced from `monad_ecdsa_key_name`); a fresh production canister sets
+/// `key_1` via `set_chains_ecdsa_key_name` before registering any chain.
+fn default_chains_ecdsa_key_name() -> String {
+    crate::chains::monad::config::monad_ecdsa_key_name()
+}
 
 pub fn default_interest_split() -> Vec<InterestRecipient> {
     vec![
@@ -888,6 +894,14 @@ pub struct State {
     /// crosses this.
     #[serde(default = "default_chain_interest_min_realize_e8s")]
     pub chain_interest_min_realize_e8s: u128,
+    /// Production tECDSA key name for the EVM chains rail: `test_key_1` (default,
+    /// staging/testnet) or `key_1` (production). Read by the EVM `key_id()` at
+    /// derive/sign time, so a fresh production canister uses the production
+    /// threshold key with no rebuild. Settable via `set_chains_ecdsa_key_name`
+    /// ONLY while no chain vault exists — changing it re-derives every per-vault
+    /// custody address, which would orphan already-deposited collateral.
+    #[serde(default = "default_chains_ecdsa_key_name")]
+    pub chains_ecdsa_key_name: String,
     pub fee: Ratio,
     pub developer_principal: Principal,
     pub next_available_vault_id: u64,
@@ -1485,6 +1499,7 @@ impl Default for State {
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
             chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
+            chains_ecdsa_key_name: default_chains_ecdsa_key_name(),
             fee: Ratio::from(Decimal::ZERO),
             developer_principal: Principal::anonymous(),
             next_available_vault_id: 1,
@@ -1632,6 +1647,7 @@ impl From<InitArg> for State {
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
             chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
+            chains_ecdsa_key_name: default_chains_ecdsa_key_name(),
             total_collateral_ratio: Ratio::from(Decimal::MAX),
             last_icp_timestamp: None,
             last_icp_rate: None,


### PR DESCRIPTION
The EVM chains rail's tECDSA key name was **hardcoded to `test_key_1`** (`chains/monad/config.rs`), so real CFX would be custodied by a *test* threshold key. This makes it the production key, switchable at runtime.

## Change
- New `State::chains_ecdsa_key_name` (default `test_key_1`, single-sourced from `monad_ecdsa_key_name`, `serde(default)` = CBOR-safe).
- The two EVM `key_id()` sites (`evm/tecdsa.rs` derive, `evm/tx.rs` sign) read it from `State` instead of the const. Both are async/canister-only, so reading `State` is safe (unit tests use a fixed local key and never reach them — `monad_ecdsa_key_name`'s own test stays green).
- `set_chains_ecdsa_key_name(name)` — developer-gated; accepts only `{test_key_1, key_1}`; **rejected once any chain vault exists** (switching the key re-derives every per-vault custody address, which would orphan deposited collateral). `get_chains_ecdsa_key_name()` query.
- TDD: `validate_ecdsa_key_change` pure validator + unit test (RED→GREEN).

## Why runtime, not a Cargo feature
icp-cli has no recipe `features` field / no `icp build --features`, so a compile-time flag is fragile (build-cache gotchas). A runtime, guarded setter fits the one-wasm deploy model: a **fresh production canister sets `key_1` before registering any chain**; kvg63 staging keeps `test_key_1`. No rebuild dance.

## Verification
- 481 backend lib tests green; bin builds clean; `.did` + declarations regenerated; candid compat passes (additive — new methods).
- conflux happy-path + interest-accrual PocketIC e2e green (derive + sign go through the `State` key with the default `test_key_1` — behavior-preserving for staging).

Built on `main` (incl. #251/#252/#253). Not merged/deployed. Chains rail remains testnet/staging-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)