### PR TITLE
ops(cfx-monitor): service scaffolding for continuous hosting

### DIFF
--- a/monitoring/cfx-price-monitor/ops/SERVICE.md
+++ b/monitoring/cfx-price-monitor/ops/SERVICE.md
@@ -1,0 +1,88 @@
+# Running the CFX price monitor as a service
+
+The monitor is the interim mitigation for audit **F-01**: the chains-rail CFX
+oracle is a manual price with no on-chain staleness check, and there is no
+liquidation on the rail, so a stale price is the highest risk. **A dead monitor =
+a frozen oracle.** Host it accordingly.
+
+> **Pick an always-on host.** A laptop is the wrong home — sleep, lid-close, and
+> Wi-Fi drops are exactly the failure the monitor exists to prevent. Use a small
+> always-on Linux VM/server (systemd, below) or a Mac that never sleeps (launchd).
+
+This dir ships three things:
+- `run.sh` — supervisor-agnostic wrapper (sets PATH + config, execs the daemon)
+- `cfx-monitor.service` — **systemd** unit (recommended host)
+- `com.rumi.cfx-monitor.plist` — macOS **launchd** LaunchAgent
+
+---
+
+## 1. Prerequisites
+- Node.js 20+ on the host.
+- This repo checked out; in `monitoring/cfx-price-monitor/` run `npm ci`.
+- The backend deployed with the F-01 endpoints (`get_manual_collateral_price`,
+  `set_price_pusher_principal`, `get_price_pusher_allowed`).
+
+## 2. Create + register the scoped price-pusher (one time)
+The daemon authenticates as a **narrowly-scoped** principal that can ONLY set the
+manual price, and ONLY for its allow-listed `(chain, symbol)` pairs. Never give it
+the developer key.
+
+```sh
+# a) generate a dedicated key (plaintext so a headless service can read the PEM)
+dfx identity new cfx-pusher --storage-mode plaintext
+PUSHER=$(dfx identity get-principal --identity cfx-pusher)
+
+# b) register it (as the DEVELOPER), scoped to the chain+symbol it may set.
+#    staging = chain 71 ("CFX"); eSpace mainnet = chain 1030.
+icp canister call rumi_protocol_backend set_price_pusher_principal \
+  "(opt principal \"$PUSHER\", vec { record { 71 : nat32; \"CFX\" } })" \
+  --environment mainnet-staging --identity rumi_identity
+
+# c) export the PEM to a secure, persistent path (chmod 600), NOT /tmp
+#    (dfx blocks plaintext identities on mainnet without this warning suppressed)
+DFX_WARNING=-mainnet_plaintext_identity dfx identity export cfx-pusher > cfx-pusher.pem
+chmod 600 cfx-pusher.pem
+```
+
+Verify: `icp canister call rumi_protocol_backend get_price_pusher_allowed '()' -e mainnet-staging`
+should show your `(chain, symbol)`. The daemon's startup also warns if its identity
+isn't the registered pusher.
+
+## 3. Configure
+All config is via env vars (see [`../.env.example`](../.env.example) for the full
+list + defaults). The minimum: `CANISTER_ID`, `IDENTITY_PEM`, `CHAIN_ID`, `SYMBOL`,
+`COINGECKO_ID`. Set `SLACK_WEBHOOK_URL` to get alerts in Slack (otherwise they go to
+the log as structured JSON).
+
+## 4a. Install on Linux (systemd — recommended)
+Edit the `__PLACEHOLDER__`s in `cfx-monitor.service`, then follow the comment block
+at its top. Watch it: `journalctl -u cfx-monitor -f`. Stop: `systemctl disable --now cfx-monitor`.
+
+## 4b. Install on macOS (launchd)
+Edit the `__PLACEHOLDER__`s in `com.rumi.cfx-monitor.plist` (absolute paths only),
+then follow the comment block at its top. `KeepAlive` restarts it if it ever exits;
+`RunAtLoad` starts it at login. Stop: `launchctl unload ~/Library/LaunchAgents/com.rumi.cfx-monitor.plist`.
+
+## 5. What "healthy" looks like
+Each cycle logs one `"message":"tick"` line:
+```json
+{"message":"tick","ok":true,"refreshed":false,"marketE8":"4874000","usedSources":["coingecko","kraken","okx"],"alerts":0,"sourceFailures":0}
+```
+- `ok:true` every cycle (a run of `ok:false` trips the downtime watchdog → a `monitor_downtime` alert).
+- `refreshed:true` when it pushed a new price (drift > `DRIFT_BPS` or age > `MAX_AGE_SEC`).
+- `alerts:0` — non-zero means a vault is under the CR warn band, sources disagreed, a write failed, etc. (search the log for `"level":"critical"`).
+
+## 6. Staging vs eSpace-mainnet
+| | staging | eSpace mainnet |
+|---|---|---|
+| `CANISTER_ID` | `kvg63-wiaaa-aaaao-bbabq-cai` | the mainnet-1030 launch canister |
+| `CHAIN_ID` | `71` | `1030` |
+| pusher scope | `record {71;"CFX"}` | `record {1030;"CFX"}` |
+
+## 7. Security notes
+- The pusher key can ONLY set prices for its allow-listed `(chain, symbol)` — not
+  open/close vaults, not any other endpoint. Blast radius if the host is compromised
+  is "set the CFX price", which the backend also rejects at `0`.
+- Rotate or revoke instantly from the developer key:
+  `set_price_pusher_principal(opt principal "<new>", vec {…})` or `(null, vec {})`.
+- Keep the PEM `chmod 600`, owned by the service user, off shared/tmp paths.

--- a/monitoring/cfx-price-monitor/ops/cfx-monitor.service
+++ b/monitoring/cfx-price-monitor/ops/cfx-monitor.service
@@ -1,0 +1,47 @@
+# systemd unit for the CFX price monitor (audit F-01 oracle keeper).
+# This is the RECOMMENDED host: a small always-on Linux VM/server.
+#
+# Install (replace every __PLACEHOLDER__ first):
+#   sudo useradd --system --no-create-home --shell /usr/sbin/nologin cfxmon
+#   sudo install -d -o cfxmon -g cfxmon -m 700 /etc/cfx-monitor
+#   sudo install -o cfxmon -g cfxmon -m 600 cfx-pusher.pem /etc/cfx-monitor/cfx-pusher.pem
+#   # check out this repo to /opt/cfx-price-monitor and run `npm ci` in the daemon dir
+#   sudo cp cfx-monitor.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable --now cfx-monitor
+#   journalctl -u cfx-monitor -f          # watch ticks
+#
+[Unit]
+Description=Rumi CFX price monitor (audit F-01 oracle keeper)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=cfxmon
+Group=cfxmon
+WorkingDirectory=/opt/cfx-price-monitor/monitoring/cfx-price-monitor
+# Ensure `npm`/`node` are on PATH for the service (adjust to your install).
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/env npm start
+# A dead monitor is a frozen oracle: always restart.
+Restart=always
+RestartSec=10
+
+# --- config (override target/canister/key here) ---
+Environment=CANISTER_ID=__CANISTER_ID__
+Environment=IDENTITY_PEM=/etc/cfx-monitor/cfx-pusher.pem
+Environment=CHAIN_ID=__CHAIN_ID__
+Environment=SYMBOL=CFX
+Environment=COINGECKO_ID=conflux-token
+# Environment=SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# Environment=POLL_SEC=60
+
+# --- hardening ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadOnlyPaths=/etc/cfx-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/monitoring/cfx-price-monitor/ops/com.rumi.cfx-monitor.plist
+++ b/monitoring/cfx-price-monitor/ops/com.rumi.cfx-monitor.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  macOS launchd LaunchAgent for the CFX price monitor (audit F-01 oracle keeper).
+  A laptop is NOT a good host for an oracle keeper (sleep/lid/Wi-Fi drops = a
+  frozen oracle). Prefer an always-on host + the systemd unit. Use this only for
+  a desktop/Mac-mini that stays awake and online.
+
+  Install (replace every __PLACEHOLDER__ first):
+    cp com.rumi.cfx-monitor.plist ~/Library/LaunchAgents/
+    launchctl load  ~/Library/LaunchAgents/com.rumi.cfx-monitor.plist   # start + enable
+    launchctl list | grep com.rumi.cfx-monitor                          # verify
+    tail -f __LOG_DIR__/cfx-monitor.log                                 # watch ticks
+  Stop / disable:
+    launchctl unload ~/Library/LaunchAgents/com.rumi.cfx-monitor.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.rumi.cfx-monitor</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>__APP_DIR__/monitoring/cfx-price-monitor/ops/run.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>NODE_BIN_DIR</key>  <string>__NODE_BIN_DIR__</string>
+    <key>APP_DIR</key>       <string>__APP_DIR__/monitoring/cfx-price-monitor</string>
+    <key>CANISTER_ID</key>   <string>__CANISTER_ID__</string>
+    <key>IDENTITY_PEM</key>  <string>__IDENTITY_PEM__</string>
+    <key>CHAIN_ID</key>      <string>__CHAIN_ID__</string>
+    <key>SYMBOL</key>        <string>CFX</string>
+    <key>COINGECKO_ID</key>  <string>conflux-token</string>
+    <!-- <key>SLACK_WEBHOOK_URL</key> <string>https://hooks.slack.com/services/...</string> -->
+  </dict>
+
+  <!-- start at login + restart if it ever exits (a dead monitor = a frozen oracle) -->
+  <key>RunAtLoad</key> <true/>
+  <key>KeepAlive</key> <true/>
+  <key>ThrottleInterval</key> <integer>10</integer>
+
+  <key>StandardOutPath</key>  <string>__LOG_DIR__/cfx-monitor.log</string>
+  <key>StandardErrorPath</key> <string>__LOG_DIR__/cfx-monitor.err.log</string>
+</dict>
+</plist>

--- a/monitoring/cfx-price-monitor/ops/run.sh
+++ b/monitoring/cfx-price-monitor/ops/run.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Run the CFX price monitor under a process supervisor (launchd, systemd, pm2,
+# Docker, ...). Supervisors run with a minimal environment, so this wrapper sets
+# PATH + the daemon's config, then execs the daemon. Override any value via the
+# supervisor's own env block instead of editing this file.
+#
+# See SERVICE.md for the full setup (pusher identity, PEM, install).
+set -eu
+
+# --- node on PATH ---------------------------------------------------------
+# NODE_BIN_DIR must contain `node` and `npm`. Find it with:
+#   dirname "$(command -v node)"
+# nvm users: point this at the ACTIVE version's bin (nvm is not on a fixed path).
+NODE_BIN_DIR="${NODE_BIN_DIR:-/usr/local/bin}"
+export PATH="$NODE_BIN_DIR:$PATH"
+
+# --- where the daemon lives -----------------------------------------------
+# A checkout of this repo's monitoring/cfx-price-monitor with `npm ci` already run.
+APP_DIR="${APP_DIR:-$HOME/cfx-price-monitor/monitoring/cfx-price-monitor}"
+cd "$APP_DIR"
+
+# --- required config ------------------------------------------------------
+# CANISTER_ID : the backend canister. Staging kvg63-wiaaa-aaaao-bbabq-cai (chain 71),
+#               or the eventual mainnet-1030 launch canister.
+# IDENTITY_PEM: path to the SCOPED price-pusher key (chmod 600). NOT the developer key.
+: "${CANISTER_ID:?set CANISTER_ID}"
+: "${IDENTITY_PEM:?set IDENTITY_PEM (path to the scoped price-pusher PEM)}"
+export CANISTER_ID IDENTITY_PEM
+
+# --- target (defaults to Conflux eSpace mainnet) --------------------------
+export CHAIN_ID="${CHAIN_ID:-1030}"        # 1030 = eSpace mainnet, 71 = eSpace testnet (staging)
+export SYMBOL="${SYMBOL:-CFX}"
+export COINGECKO_ID="${COINGECKO_ID:-conflux-token}"
+
+# --- optional: alerting + threshold overrides (see .env.example) ----------
+# export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+# export POLL_SEC=60 DRIFT_BPS=200 MAX_AGE_SEC=300 CALL_TIMEOUT_SEC=15
+
+exec npm start


### PR DESCRIPTION
Ready-to-run service scaffolding for the CFX price monitor (audit F-01), under `monitoring/cfx-price-monitor/ops/`:

- `cfx-monitor.service` — systemd unit (recommended: a small always-on Linux VM/server; includes hardening + auto-restart)
- `com.rumi.cfx-monitor.plist` — macOS launchd LaunchAgent (KeepAlive + RunAtLoad)
- `run.sh` — supervisor-agnostic wrapper (sets PATH + config, execs the daemon)
- `SERVICE.md` — scoped-pusher setup, secure PEM handling, install/operate, staging-vs-eSpace-mainnet, key rotation

No secrets, no service installed, no mainnet write — just the artifacts to host the monitor properly. A laptop is deliberately called out as the wrong host (a dead monitor = a frozen oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)