### PR TITLE
feat(conflux-frontend): standalone eSpace self-serve CDP UI

### DIFF
--- a/docs/superpowers/plans/2026-06-19-conflux-espace-frontend-design.md
+++ b/docs/superpowers/plans/2026-06-19-conflux-espace-frontend-design.md
@@ -1,0 +1,88 @@
+# Conflux eSpace self-serve frontend (Design)
+
+> Standalone MetaMask + viem UI for the M2 EVM-native self-serve CDP rail. The
+> backend ([[2026-06-18-conflux-evm-self-serve-auth-design]]) is merged + deployed
+> to mainnet-staging (kvg63) and the full open→deposit→4-arg-mint→Open round-trip
+> is proven on real eSpace. This is the user-facing surface that was deferred from
+> that scope. Testnet/staging-only.
+
+## Goal
+
+Let a user with only MetaMask on Conflux eSpace testnet (chain 71) open / borrow
+against / repay / withdraw / close a native-CFX icUSD vault by signing EIP-712
+intents — no IC principal, no II login. The vault is owned by the synthetic
+principal the backend derives from the EVM signer; the IC caller is anonymous.
+
+## Decisions (settled 2026-06-19)
+
+| Fork | Decision |
+| --- | --- |
+| Location/stack | **Standalone Vite + Svelte SPA** at `src/conflux_espace_frontend/` (isolated from the production `vault_frontend`, which points at prod `tfesu` and has no EVM deps). |
+| Scope | **Full lifecycle**: open / borrow / withdraw / close / repay(burn) + status polling. |
+| Target | Staging backend `kvg63-wiaaa-aaaao-bbabq-cai`; IcUSD `0xBD02222D388BC43095A4758C3e977d5dF8f68f7a`; Conflux eSpace testnet chain 71; eSpace RPC `https://evmtestnet.confluxrpc.com`. |
+| Signing | MetaMask (primary) via viem `signTypedData`; an **optional dev-key signer** (viem `privateKeyToAccount`) for demo/verification without MetaMask. |
+
+## Architecture
+
+A single-page Svelte app. Two integrations, each a small focused module:
+
+- **`config.ts`** — the staging canister id, IcUSD address, chain id 71, eSpace RPC,
+  the EIP-712 domain (`name: "Rumi icUSD CDP"`, `version: "1"`, `chainId: 71`,
+  `verifyingContract: <IcUSD>`), and the ICP-mirrored CR params (min CR 1.33).
+- **`eip712.ts`** — builds the `VaultIntent` typed-data and signs it (viem
+  `signTypedData` for MetaMask, or `account.signTypedData` for the dev key),
+  returning the 65-byte `r‖s‖v` signature as a `Uint8Array` for the canister blob.
+  MUST be byte-identical to the backend's `chains/evm/eip712.rs` (same domain,
+  same `VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,
+  uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,uint256
+  deadline)` struct). `recipient` is forced `== owner`.
+- **`backend.ts`** — an anonymous `@dfinity/agent` actor (host `https://icp0.io`,
+  canister `kvg63`) built from the tracked `src/declarations/rumi_protocol_backend`
+  idlFactory, with typed wrappers: `openVaultEvm`, `borrowVaultEvm`,
+  `withdrawCollateralEvm`, `closeVaultEvm`, `getChainVault`. The `_evm` calls take
+  `(VaultIntent, blob)`.
+- **`evm.ts`** — viem `walletClient` (MetaMask) + `publicClient` (eSpace RPC):
+  connect + add/switch to chain 71, send the native CFX deposit, call
+  `IcUSD.burn(amount, vaultId)` to repay, and read `balanceOf` / CFX balance.
+
+UI: `App.svelte` orchestrates; small components for Connect, the Open form
+(enter icUSD debt → required CFX computed from min CR + a CFX price input),
+VaultCard (status + the lifecycle action buttons), and a deposit-instructions
+panel (custody address + "send X CFX").
+
+## Data flow (open + mint)
+
+1. Connect MetaMask → ensure chain 71.
+2. User enters debt (e.g. 0.2 icUSD); UI shows required CFX = debt × minCR / price.
+3. Read the per-owner nonce from the vault list (or start at 0); build the Open
+   `VaultIntent` (collateralWei, debtE8s, recipient = owner); `signTypedData`.
+4. `open_chain_vault_evm(intent, sig)` → `vault_id`; poll `get_chain_vault` →
+   show the custody address.
+5. User clicks "Send X CFX" → viem `sendTransaction` to custody.
+6. Poll status `AwaitingDeposit → MintPending → Open`; icUSD `balanceOf` updates.
+7. Borrow / Withdraw / Close = sign the matching intent (nonce += 1 each). Repay =
+   `IcUSD.burn(amount, vaultId)` then the burn-watch decrements debt.
+
+## Error handling
+
+- Wrong network → prompt to switch to chain 71.
+- Canister `Err(EvmAuth ...)` → surface the message (bad nonce, expired, etc.).
+- A failed CR check (`BelowMinCr`) → show required-vs-provided.
+- All amounts validated client-side before signing (debt ≥ min, CR ≥ 1.33).
+
+## Testing / verification
+
+- **Vitest unit (the critical gate):** `eip712.ts` builds the typed-data and
+  `hashTypedData` MUST equal the backend golden digest
+  `0x76fe467010b364bc9ed7caf7153a42bdc924e1cb7bf223d8182d9537717b9adc` for the
+  same intent, and signing with the scalar=1 key recovers
+  `0x7e5f4552091a69125d5dfcb7b8c2659029395bdf`. This proves frontend↔backend
+  EIP-712 parity. Plus the CR/required-CFX math.
+- **Build green** (`npm run build`) and **dev server renders** (verified via the
+  preview tools — the wallet/signing path is exercised by the dev-key signer,
+  the same path the staging round-trip proved).
+
+## Out of scope
+
+Production deployment (asset canister), Monad chain, multi-wallet, i18n. This is
+the testnet demo surface; the chains rail stays experimental/parked.

--- a/src/conflux_espace_frontend/.gitignore
+++ b/src/conflux_espace_frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+*.tsbuildinfo

--- a/src/conflux_espace_frontend/index.html
+++ b/src/conflux_espace_frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rumi · icUSD on Conflux eSpace</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/src/conflux_espace_frontend/package-lock.json
+++ b/src/conflux_espace_frontend/package-lock.json
@@ -1,0 +1,2314 @@
+{
+  "name": "conflux_espace_frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conflux_espace_frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/principal": "^2.3.0",
+        "viem": "^2.22.0"
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^4.0.4",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.22.6",
+        "svelte-check": "^4.1.4",
+        "typescript": "^5.7.3",
+        "vite": "^5.4.11",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@dfinity/agent": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.1.tgz",
+      "integrity": "sha512-IczFFOUDGfMTdQ83yiCvGtvHr1IIB80lWBP0ZYRLogs6NVt8t6HYcMlu1sgT+9VivhT7iwX4pktPFxxOkO3COw==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/agent instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.3.1",
+        "base64-arraybuffer": "^0.2.0",
+        "borc": "^2.1.1",
+        "buffer": "^6.0.3",
+        "simple-cbor": "^0.4.1"
+      },
+      "peerDependencies": {
+        "@dfinity/candid": "^2.4.1",
+        "@dfinity/principal": "^2.4.1"
+      }
+    },
+    "node_modules/@dfinity/candid": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.1.tgz",
+      "integrity": "sha512-kOaIKfhR2PYN8vD4M0Pc4s/7wb1nKjlTJUw+5E9jh26T03fITIZmaafIuwlX+wmdxwIT9Xoy7PlsxOEpzv203A==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/candid instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@dfinity/principal": "^2.4.1"
+      }
+    },
+    "node_modules/@dfinity/principal": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.1.tgz",
+      "integrity": "sha512-Cz6XQVOwq0TXDBClPbcidDd4SqK1lfr1/Kn34ruDD13xVQ4iaP1iCntzS9O97+vGpY/6jwDtKd32Gn5YJ9BQNw==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/principal instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
+      "integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
+      "integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
+        "debug": "^4.3.7",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.12",
+        "vitefu": "^1.0.3"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0-next.96 || ^5.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
+      "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0",
+        "svelte": "^5.0.0-next.96 || ^5.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/borc/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.11.tgz",
+      "integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "license": "MIT",
+      "dependencies": {
+        "delimit-stream": "0.1.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
+      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.11",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
+      "integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "0.1.1",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/conflux_espace_frontend/package.json
+++ b/src/conflux_espace_frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "conflux_espace_frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Standalone MetaMask + viem UI for the Rumi M2 EVM-native self-serve CDP rail on Conflux eSpace testnet (chain 71). Testnet/staging-only.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.4",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.22.6",
+    "svelte-check": "^4.1.4",
+    "typescript": "^5.7.3",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.8"
+  },
+  "dependencies": {
+    "@dfinity/agent": "^2.3.0",
+    "@dfinity/candid": "^2.3.0",
+    "@dfinity/principal": "^2.3.0",
+    "viem": "^2.22.0"
+  }
+}

--- a/src/conflux_espace_frontend/src/App.svelte
+++ b/src/conflux_espace_frontend/src/App.svelte
@@ -3,8 +3,8 @@
   import { backend, errText, type ChainVault } from "./backend";
   import { signIntent, toCandidIntent, type VaultIntentInput } from "./eip712";
   import {
-    connectMetaMask, connectDevKey, hasMetaMask, sendDeposit, icusdBalance, cfxBalance,
-    fmtCfx, fmtIcusd, parseEther, type Wallet,
+    connectMetaMask, connectDevKey, hasMetaMask, sendDeposit, burnIcusd, icusdBalance, cfxBalance,
+    fmtCfx, fmtIcusd, parseEther, toE8s, txUrl, type Wallet,
   } from "./evm";
   import VaultCard from "./VaultCard.svelte";
 
@@ -34,7 +34,7 @@
     return s === "AwaitingDeposit" || s === "MintPending" || s === "Closing";
   }));
 
-  const debtE8s = $derived(BigInt(Math.round((parseFloat(debtInput) || 0) * 1e8)));
+  const debtE8s = $derived(toE8s(debtInput));
   const requiredCfxWei = $derived.by(() => {
     const d = parseFloat(debtInput) || 0;
     const p = parseFloat(cfxPrice) || 0;
@@ -86,7 +86,10 @@
       if ("Ok" in res) { nonce += 1n; return res; }
       const msg = errText(res.Err);
       const m = msg.match(/expected (\d+)/);
-      if (m && attempt === 0) { nonce = BigInt(m[1]); continue; } // sync + retry once
+      if (m) {
+        nonce = BigInt(m[1]); // keep the local nonce fresh for the next action
+        if (attempt === 0) continue; // retry once with the corrected nonce
+      }
       return res;
     }
     return { Err: { GenericError: "nonce sync failed" } };
@@ -113,13 +116,11 @@
     try {
       if (kind === "deposit") {
         busy = "Confirm the CFX deposit in your wallet…";
-        const { txUrl } = await import("./evm");
         const hash = await sendDeposit(w, vault.custody_address as `0x${string}`, vault.collateral_amount_e18);
         ok = `Deposit sent (${hash.slice(0, 12)}…) — watch the status flip to Open.`;
         console.log("deposit tx", txUrl(hash));
       } else if (kind === "repay") {
         busy = "Confirm the on-chain burn in your wallet…";
-        const { burnIcusd } = await import("./evm");
         const amt = amountE8s ?? vault.debt_e8s;
         await burnIcusd(w, amt, vault.vault_id);
         ok = `Repaid ${fmtIcusd(amt)} icUSD on-chain — the observer will decrement the vault debt.`;

--- a/src/conflux_espace_frontend/src/App.svelte
+++ b/src/conflux_espace_frontend/src/App.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { ACTION, MIN_CR, MIN_DEBT_E8S, ICUSD_CONTRACT, BACKEND_CANISTER_ID } from "./config";
+  import { backend, errText, type ChainVault } from "./backend";
+  import { signIntent, toCandidIntent, type VaultIntentInput } from "./eip712";
+  import {
+    connectMetaMask, connectDevKey, hasMetaMask, sendDeposit, icusdBalance, cfxBalance,
+    fmtCfx, fmtIcusd, parseEther, type Wallet,
+  } from "./evm";
+  import VaultCard from "./VaultCard.svelte";
+
+  let wallet = $state<Wallet | null>(null);
+  let vaults = $state<ChainVault[]>([]);
+  let cfx = $state(0n);
+  let icusd = $state(0n);
+  let nonce = $state(0n); // next per-owner nonce; auto-synced on a bad-nonce reject
+
+  let busy = $state<string | null>(null);
+  let err = $state<string | null>(null);
+  let ok = $state<string | null>(null);
+
+  // open form
+  let debtInput = $state("0.2");
+  let cfxPrice = $state("0.15"); // UX hint only — the real CR check is server-side
+  let showDevKey = $state(false);
+  let devKey = $state("0x" + "00".repeat(31) + "01"); // scalar=1 demo key
+
+  const owned = $derived(
+    wallet
+      ? vaults.filter((v) => v.owner_evm.length && v.owner_evm[0]!.toLowerCase() === wallet!.address.toLowerCase())
+      : []
+  );
+  const pendingExists = $derived(owned.some((v) => {
+    const s = Object.keys(v.status)[0];
+    return s === "AwaitingDeposit" || s === "MintPending" || s === "Closing";
+  }));
+
+  const debtE8s = $derived(BigInt(Math.round((parseFloat(debtInput) || 0) * 1e8)));
+  const requiredCfxWei = $derived.by(() => {
+    const d = parseFloat(debtInput) || 0;
+    const p = parseFloat(cfxPrice) || 0;
+    if (d <= 0 || p <= 0) return 0n;
+    const cfxNeeded = (d * MIN_CR / p) * 1.02; // +2% buffer over the floor
+    return parseEther(cfxNeeded.toFixed(6));
+  });
+
+  function reset() { err = null; ok = null; }
+
+  async function refresh() {
+    if (!wallet) return;
+    try {
+      const be = await backend();
+      vaults = await be.list_chain_vaults(71);
+      cfx = await cfxBalance(wallet.address);
+      icusd = await icusdBalance(wallet.address);
+    } catch (e: any) { err = `Refresh failed: ${e?.message ?? e}`; }
+  }
+
+  async function connectMM() {
+    reset(); busy = "Connecting…";
+    try { wallet = await connectMetaMask(); await refresh(); }
+    catch (e: any) { err = e?.message ?? String(e); }
+    finally { busy = null; }
+  }
+  async function connectDev() {
+    reset(); busy = "Loading dev key…";
+    try { wallet = connectDevKey(devKey.trim()); await refresh(); }
+    catch (e: any) { err = `Bad key: ${e?.message ?? e}`; }
+    finally { busy = null; }
+  }
+  function disconnect() { wallet = null; vaults = []; reset(); }
+
+  /** Sign + submit an intent, auto-syncing the per-owner nonce on a bad-nonce reject. */
+  async function submit(
+    action: number, vaultId: bigint, collateralWei: bigint, debt: bigint,
+    call: (be: Awaited<ReturnType<typeof backend>>, i: any, sig: Uint8Array) => Promise<{ Ok?: unknown; Err?: any }>
+  ): Promise<{ Ok?: unknown; Err?: any }> {
+    const be = await backend();
+    const w = wallet!;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const input: VaultIntentInput = {
+        action, owner: w.address, vaultId, collateralWei, debtE8s: debt,
+        nonce, deadlineSecs: BigInt(Math.floor(Date.now() / 1000) + 3600),
+      };
+      const sig = await signIntent(w.client, w.account as any, input);
+      const res = await call(be, toCandidIntent(input), sig);
+      if ("Ok" in res) { nonce += 1n; return res; }
+      const msg = errText(res.Err);
+      const m = msg.match(/expected (\d+)/);
+      if (m && attempt === 0) { nonce = BigInt(m[1]); continue; } // sync + retry once
+      return res;
+    }
+    return { Err: { GenericError: "nonce sync failed" } };
+  }
+
+  async function doOpen() {
+    reset();
+    if (debtE8s < MIN_DEBT_E8S) { err = `Minimum debt is ${fmtIcusd(MIN_DEBT_E8S)} icUSD`; return; }
+    if (requiredCfxWei <= 0n) { err = "Enter a debt and CFX price"; return; }
+    busy = "Sign the Open intent in your wallet…";
+    try {
+      const res = await submit(ACTION.Open, 0n, requiredCfxWei, debtE8s,
+        (be, i, sig) => be.open_chain_vault_evm(i, sig));
+      if ("Ok" in res) { ok = `Vault #${res.Ok} opened — send the CFX deposit below.`; await refresh(); }
+      else err = errText(res.Err);
+    } catch (e: any) { err = e?.message ?? String(e); }
+    finally { busy = null; }
+  }
+
+  // actions invoked by VaultCard
+  async function onAction(kind: string, vault: ChainVault, amountE8s?: bigint) {
+    reset();
+    const w = wallet!;
+    try {
+      if (kind === "deposit") {
+        busy = "Confirm the CFX deposit in your wallet…";
+        const { txUrl } = await import("./evm");
+        const hash = await sendDeposit(w, vault.custody_address as `0x${string}`, vault.collateral_amount_e18);
+        ok = `Deposit sent (${hash.slice(0, 12)}…) — watch the status flip to Open.`;
+        console.log("deposit tx", txUrl(hash));
+      } else if (kind === "repay") {
+        busy = "Confirm the on-chain burn in your wallet…";
+        const { burnIcusd } = await import("./evm");
+        const amt = amountE8s ?? vault.debt_e8s;
+        await burnIcusd(w, amt, vault.vault_id);
+        ok = `Repaid ${fmtIcusd(amt)} icUSD on-chain — the observer will decrement the vault debt.`;
+      } else if (kind === "borrow") {
+        busy = "Sign the Borrow intent…";
+        const res = await submit(ACTION.Borrow, vault.vault_id, 0n, amountE8s ?? 0n,
+          (be, i, sig) => be.borrow_chain_vault_evm(i, sig));
+        if ("Ok" in res) ok = "Borrow signed — the mint will land shortly."; else err = errText(res.Err);
+      } else if (kind === "withdraw") {
+        busy = "Sign the Withdraw intent…";
+        const res = await submit(ACTION.WithdrawCollateral, vault.vault_id, amountE8s ?? 0n, 0n,
+          (be, i, sig) => be.withdraw_chain_collateral_evm(i, sig));
+        if ("Ok" in res) ok = "Withdraw signed."; else err = errText(res.Err);
+      } else if (kind === "close") {
+        busy = "Sign the Close intent…";
+        const res = await submit(ACTION.Close, vault.vault_id, 0n, 0n,
+          (be, i, sig) => be.close_chain_vault_evm(i, sig));
+        if ("Ok" in res) ok = "Close signed — collateral returns to your wallet."; else err = errText(res.Err);
+      }
+      await refresh();
+    } catch (e: any) { err = e?.message ?? String(e); }
+    finally { busy = null; }
+  }
+
+  // poll while anything is in flight
+  $effect(() => {
+    if (!wallet || !pendingExists) return;
+    const id = setInterval(refresh, 8000);
+    return () => clearInterval(id);
+  });
+</script>
+
+<div class="wrap">
+  <header class="top">
+    <div class="brand">
+      <div class="logo">R</div>
+      <div>
+        <h1>icUSD on Conflux eSpace</h1>
+        <div class="sub">Self-serve CDP · sign with your EVM wallet</div>
+      </div>
+    </div>
+    <span class="badge testnet">eSpace testnet · chain 71 · staging</span>
+  </header>
+
+  {#if !wallet}
+    <div class="card">
+      <h2>Connect</h2>
+      <p class="hint">Open a CFX-collateralized icUSD vault by signing an EIP-712 intent — no IC login.
+        Your wallet is the only identity; the canister verifies the signature.</p>
+      <div class="row">
+        <button class="primary" onclick={connectMM} disabled={!!busy || !hasMetaMask()}>
+          {hasMetaMask() ? "Connect MetaMask" : "MetaMask not detected"}
+        </button>
+        <button class="ghost sm" onclick={() => (showDevKey = !showDevKey)}>{showDevKey ? "Hide" : "Use a dev key"}</button>
+      </div>
+      {#if showDevKey}
+        <div class="divider"></div>
+        <label for="devkey">Private key (testnet only — for the no-wallet demo path)</label>
+        <div class="field"><div class="row">
+          <input id="devkey" class="mono" bind:value={devKey} spellcheck="false" />
+          <button onclick={connectDev} disabled={!!busy}>Load</button>
+        </div></div>
+        <p class="hint">Pre-filled with the scalar=1 demo key (<span class="mono">0x7e5f…95bdf</span>) — the same one the staging round-trip used.</p>
+      {/if}
+    </div>
+  {:else}
+    <div class="card">
+      <div class="row spread">
+        <h2>Wallet</h2>
+        <button class="ghost sm" onclick={disconnect}>Disconnect</button>
+      </div>
+      <div class="kv"><span class="k">Address</span><span class="v mono">{wallet.address}</span></div>
+      <div class="kv"><span class="k">CFX</span><span class="v">{fmtCfx(cfx)}</span></div>
+      <div class="kv"><span class="k">icUSD</span><span class="v">{fmtIcusd(icusd)}</span></div>
+      <div class="kv"><span class="k">Signer</span><span class="v">{wallet.kind === "metamask" ? "MetaMask" : "dev key"}</span></div>
+    </div>
+
+    <div class="card">
+      <h2>Open a vault</h2>
+      <p class="hint">Enter the icUSD you want to mint. Required CFX is the {Math.round(MIN_CR * 100)}% min-CR
+        floor (+2% buffer) at your price — the real CR check runs on the canister.</p>
+      <div class="row">
+        <div class="field" style="flex:1">
+          <label for="debt">icUSD debt</label>
+          <input id="debt" type="number" min="0.1" step="0.1" bind:value={debtInput} />
+        </div>
+        <div class="field" style="flex:1">
+          <label for="cfxprice">CFX price (USD, hint)</label>
+          <input id="cfxprice" type="number" min="0" step="0.01" bind:value={cfxPrice} />
+        </div>
+      </div>
+      <div class="kv"><span class="k">Required CFX (≈)</span><span class="v">{fmtCfx(requiredCfxWei)}</span></div>
+      <div class="row" style="margin-top:14px">
+        <button class="primary" onclick={doOpen} disabled={!!busy}>Sign & open</button>
+      </div>
+    </div>
+
+    {#each owned as v (v.vault_id)}
+      <VaultCard vault={v} busy={busy} {onAction} />
+    {/each}
+    {#if owned.length === 0}
+      <div class="card"><p class="hint" style="margin:0">No vaults yet for this address. Open one above.</p></div>
+    {/if}
+  {/if}
+
+  {#if busy}<div class="notice info"><span class="spin"></span>{busy}</div>{/if}
+  {#if err}<div class="notice err">{err}</div>{/if}
+  {#if ok}<div class="notice ok">{ok}</div>{/if}
+
+  <div class="foot">
+    Backend <span class="mono">{BACKEND_CANISTER_ID}</span> (staging) · IcUSD <span class="mono">{ICUSD_CONTRACT.slice(0, 10)}…</span><br />
+    Testnet only. The chains rail is experimental — not on production.
+  </div>
+</div>

--- a/src/conflux_espace_frontend/src/VaultCard.svelte
+++ b/src/conflux_espace_frontend/src/VaultCard.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { statusName, type ChainVault } from "./backend";
+  import { fmtCfx, fmtIcusd, parseEther } from "./evm";
+
+  let { vault, busy, onAction }: {
+    vault: ChainVault;
+    busy: string | null;
+    onAction: (kind: string, vault: ChainVault, amount?: bigint) => void;
+  } = $props();
+
+  const status = $derived(statusName(vault.status));
+  const custody = $derived(vault.custody_address);
+
+  let borrowAmt = $state("0.1");
+  let repayAmt = $state("");
+  let withdrawAmt = $state("");
+
+  const toE8s = (s: string) => BigInt(Math.round((parseFloat(s) || 0) * 1e8));
+
+  function copy() { navigator.clipboard?.writeText(custody); }
+</script>
+
+<div class="card">
+  <div class="row spread">
+    <h2>Vault #{vault.vault_id}</h2>
+    <span class="pill {status}">{status}</span>
+  </div>
+
+  <div class="kv"><span class="k">Debt</span><span class="v">{fmtIcusd(vault.debt_e8s)} icUSD</span></div>
+  <div class="kv"><span class="k">Collateral</span><span class="v">{fmtCfx(vault.collateral_amount_e18)} CFX</span></div>
+  {#if vault.pending_mint_e8s > 0n}
+    <div class="kv"><span class="k">Pending mint</span><span class="v">{fmtIcusd(vault.pending_mint_e8s)} icUSD</span></div>
+  {/if}
+  <div class="kv"><span class="k">Custody</span>
+    <span class="v mono copy" role="button" tabindex="0" onclick={copy} onkeydown={copy} title="copy">{custody.slice(0, 14)}…{custody.slice(-6)}</span>
+  </div>
+
+  {#if status === "AwaitingDeposit"}
+    <div class="notice info" style="margin-top:14px">
+      Send <b>{fmtCfx(vault.collateral_amount_e18)} CFX</b> to the custody address, then it mints automatically.
+    </div>
+    <div class="row" style="margin-top:12px">
+      <button class="primary" disabled={!!busy} onclick={() => onAction("deposit", vault)}>
+        Send {fmtCfx(vault.collateral_amount_e18)} CFX
+      </button>
+      <span class="muted" style="font-size:12px">(or send manually from any wallet)</span>
+    </div>
+  {:else if status === "MintPending"}
+    <div class="notice info" style="margin-top:14px"><span class="spin"></span>Deposit detected — minting at finality (eSpace ~ a few min).</div>
+  {:else if status === "Open"}
+    <div class="divider"></div>
+    <div class="field">
+      <label for="borrow-{vault.vault_id}">Borrow more icUSD</label>
+      <div class="row">
+        <input id="borrow-{vault.vault_id}" type="number" min="0" step="0.1" bind:value={borrowAmt} style="flex:1" />
+        <button disabled={!!busy} onclick={() => onAction("borrow", vault, toE8s(borrowAmt))}>Borrow</button>
+      </div>
+    </div>
+    <div class="field">
+      <label for="repay-{vault.vault_id}">Repay icUSD (on-chain burn)</label>
+      <div class="row">
+        <input id="repay-{vault.vault_id}" type="number" min="0" step="0.1" placeholder={fmtIcusd(vault.debt_e8s)} bind:value={repayAmt} style="flex:1" />
+        <button disabled={!!busy || vault.debt_e8s === 0n}
+          onclick={() => onAction("repay", vault, repayAmt ? toE8s(repayAmt) : vault.debt_e8s)}>Repay</button>
+      </div>
+    </div>
+    <div class="field">
+      <label for="withdraw-{vault.vault_id}">Withdraw CFX collateral</label>
+      <div class="row">
+        <input id="withdraw-{vault.vault_id}" type="number" min="0" step="0.1" bind:value={withdrawAmt} style="flex:1" />
+        <button disabled={!!busy || !withdrawAmt}
+          onclick={() => onAction("withdraw", vault, parseEther((parseFloat(withdrawAmt) || 0).toFixed(6)))}>Withdraw</button>
+      </div>
+    </div>
+    <div class="row">
+      <button class="danger" disabled={!!busy || vault.debt_e8s !== 0n}
+        onclick={() => onAction("close", vault)}>Close vault (repay first)</button>
+    </div>
+  {:else}
+    <div class="notice info" style="margin-top:14px">Vault is {status.toLowerCase()}.</div>
+  {/if}
+</div>

--- a/src/conflux_espace_frontend/src/VaultCard.svelte
+++ b/src/conflux_espace_frontend/src/VaultCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { statusName, type ChainVault } from "./backend";
-  import { fmtCfx, fmtIcusd, parseEther } from "./evm";
+  import { fmtCfx, fmtIcusd, toE8s, toWei } from "./evm";
 
   let { vault, busy, onAction }: {
     vault: ChainVault;
@@ -14,8 +14,6 @@
   let borrowAmt = $state("0.1");
   let repayAmt = $state("");
   let withdrawAmt = $state("");
-
-  const toE8s = (s: string) => BigInt(Math.round((parseFloat(s) || 0) * 1e8));
 
   function copy() { navigator.clipboard?.writeText(custody); }
 </script>
@@ -53,14 +51,14 @@
       <label for="borrow-{vault.vault_id}">Borrow more icUSD</label>
       <div class="row">
         <input id="borrow-{vault.vault_id}" type="number" min="0" step="0.1" bind:value={borrowAmt} style="flex:1" />
-        <button disabled={!!busy} onclick={() => onAction("borrow", vault, toE8s(borrowAmt))}>Borrow</button>
+        <button disabled={!!busy || toE8s(borrowAmt) === 0n} onclick={() => onAction("borrow", vault, toE8s(borrowAmt))}>Borrow</button>
       </div>
     </div>
     <div class="field">
       <label for="repay-{vault.vault_id}">Repay icUSD (on-chain burn)</label>
       <div class="row">
         <input id="repay-{vault.vault_id}" type="number" min="0" step="0.1" placeholder={fmtIcusd(vault.debt_e8s)} bind:value={repayAmt} style="flex:1" />
-        <button disabled={!!busy || vault.debt_e8s === 0n}
+        <button disabled={!!busy || vault.debt_e8s === 0n || (repayAmt !== "" && toE8s(repayAmt) === 0n)}
           onclick={() => onAction("repay", vault, repayAmt ? toE8s(repayAmt) : vault.debt_e8s)}>Repay</button>
       </div>
     </div>
@@ -68,8 +66,8 @@
       <label for="withdraw-{vault.vault_id}">Withdraw CFX collateral</label>
       <div class="row">
         <input id="withdraw-{vault.vault_id}" type="number" min="0" step="0.1" bind:value={withdrawAmt} style="flex:1" />
-        <button disabled={!!busy || !withdrawAmt}
-          onclick={() => onAction("withdraw", vault, parseEther((parseFloat(withdrawAmt) || 0).toFixed(6)))}>Withdraw</button>
+        <button disabled={!!busy || toWei(withdrawAmt) === 0n}
+          onclick={() => onAction("withdraw", vault, toWei(withdrawAmt))}>Withdraw</button>
       </div>
     </div>
     <div class="row">

--- a/src/conflux_espace_frontend/src/backend.ts
+++ b/src/conflux_espace_frontend/src/backend.ts
@@ -93,6 +93,8 @@ export type ChainVault = {
     | { Closed: null };
   opened_at_ns: bigint;
   owner_evm: [] | [string];
+  last_interest_accrual_ns: bigint;
+  pending_interest_mint_e8s: bigint;
 };
 
 type Res<T> = { Ok: T } | { Err: Record<string, unknown> };

--- a/src/conflux_espace_frontend/src/backend.ts
+++ b/src/conflux_espace_frontend/src/backend.ts
@@ -1,0 +1,130 @@
+// Anonymous @dfinity/agent actor for the Rumi backend on mainnet-staging (kvg63).
+// Authority is the EVM signature carried in each intent, NOT the IC caller, so an
+// anonymous agent is exactly right. A minimal hand-rolled IDL (the tracked
+// declarations predate the _evm methods) — covers only what the UI calls.
+
+import { Actor, HttpAgent } from "@dfinity/agent";
+import { IDL } from "@dfinity/candid";
+import type { Principal } from "@dfinity/principal";
+import { BACKEND_CANISTER_ID, IC_HOST } from "./config";
+
+export const idlFactory: IDL.InterfaceFactory = ({ IDL }) => {
+  const VaultIntent = IDL.Record({
+    action: IDL.Nat8,
+    chain_id: IDL.Nat64,
+    owner: IDL.Text,
+    vault_id: IDL.Nat64,
+    collateral_wei: IDL.Nat,
+    debt_e8s: IDL.Nat,
+    recipient: IDL.Text,
+    nonce: IDL.Nat64,
+    deadline_secs: IDL.Nat64,
+  });
+  // The _evm methods only ever return Ok | EvmAuth; ChainAdmin/GenericError
+  // included defensively so an unexpected variant still decodes with a message.
+  const ProtocolError = IDL.Variant({
+    EvmAuth: IDL.Text,
+    ChainAdmin: IDL.Text,
+    GenericError: IDL.Text,
+    TemporarilyUnavailable: IDL.Text,
+    AnonymousCallerNotAllowed: IDL.Null,
+  });
+  const ChainVaultStatus = IDL.Variant({
+    AwaitingDeposit: IDL.Null,
+    MintPending: IDL.Null,
+    Open: IDL.Null,
+    Closing: IDL.Null,
+    Closed: IDL.Null,
+  });
+  const ChainVaultV1 = IDL.Record({
+    vault_id: IDL.Nat64,
+    owner: IDL.Principal,
+    collateral_chain: IDL.Nat32,
+    custody_address: IDL.Text,
+    collateral_amount_e18: IDL.Nat,
+    debt_e8s: IDL.Nat,
+    mint_recipient: IDL.Text,
+    pending_mint_e8s: IDL.Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: IDL.Nat64,
+    owner_evm: IDL.Opt(IDL.Text),
+    last_interest_accrual_ns: IDL.Nat64,
+    pending_interest_mint_e8s: IDL.Nat,
+  });
+  const ResNat64 = IDL.Variant({ Ok: IDL.Nat64, Err: ProtocolError });
+  const ResUnit = IDL.Variant({ Ok: IDL.Null, Err: ProtocolError });
+  const blob = IDL.Vec(IDL.Nat8);
+  return IDL.Service({
+    open_chain_vault_evm: IDL.Func([VaultIntent, blob], [ResNat64], []),
+    borrow_chain_vault_evm: IDL.Func([VaultIntent, blob], [ResUnit], []),
+    withdraw_chain_collateral_evm: IDL.Func([VaultIntent, blob], [ResUnit], []),
+    close_chain_vault_evm: IDL.Func([VaultIntent, blob], [ResUnit], []),
+    get_chain_vault: IDL.Func([IDL.Nat64], [IDL.Opt(ChainVaultV1)], ["query"]),
+    list_chain_vaults: IDL.Func([IDL.Nat32], [IDL.Vec(ChainVaultV1)], ["query"]),
+  });
+};
+
+export type CandidIntent = {
+  action: number;
+  chain_id: bigint;
+  owner: string;
+  vault_id: bigint;
+  collateral_wei: bigint;
+  debt_e8s: bigint;
+  recipient: string;
+  nonce: bigint;
+  deadline_secs: bigint;
+};
+
+export type ChainVault = {
+  vault_id: bigint;
+  owner: Principal;
+  collateral_chain: number;
+  custody_address: string;
+  collateral_amount_e18: bigint;
+  debt_e8s: bigint;
+  mint_recipient: string;
+  pending_mint_e8s: bigint;
+  status:
+    | { AwaitingDeposit: null }
+    | { MintPending: null }
+    | { Open: null }
+    | { Closing: null }
+    | { Closed: null };
+  opened_at_ns: bigint;
+  owner_evm: [] | [string];
+};
+
+type Res<T> = { Ok: T } | { Err: Record<string, unknown> };
+
+export interface Backend {
+  open_chain_vault_evm(i: CandidIntent, sig: Uint8Array): Promise<Res<bigint>>;
+  borrow_chain_vault_evm(i: CandidIntent, sig: Uint8Array): Promise<Res<null>>;
+  withdraw_chain_collateral_evm(i: CandidIntent, sig: Uint8Array): Promise<Res<null>>;
+  close_chain_vault_evm(i: CandidIntent, sig: Uint8Array): Promise<Res<null>>;
+  get_chain_vault(vaultId: bigint): Promise<[] | [ChainVault]>;
+  list_chain_vaults(chainId: number): Promise<ChainVault[]>;
+}
+
+let _actor: Backend | null = null;
+
+export async function backend(): Promise<Backend> {
+  if (_actor) return _actor;
+  const agent = await HttpAgent.create({ host: IC_HOST });
+  // Mainnet root key is hardcoded into the agent — NEVER fetchRootKey here.
+  _actor = Actor.createActor<Backend>(idlFactory, {
+    agent,
+    canisterId: BACKEND_CANISTER_ID,
+  });
+  return _actor;
+}
+
+/** Pull a human message out of a `Result.Err` variant (EvmAuth/ChainAdmin/…). */
+export function errText(err: Record<string, unknown>): string {
+  const [k, v] = Object.entries(err)[0] ?? ["Error", ""];
+  return typeof v === "string" && v.length ? `${k}: ${v}` : k;
+}
+
+export function statusName(s: ChainVault["status"]): string {
+  return Object.keys(s)[0] ?? "Unknown";
+}

--- a/src/conflux_espace_frontend/src/config.ts
+++ b/src/conflux_espace_frontend/src/config.ts
@@ -1,0 +1,76 @@
+import { defineChain } from "viem";
+
+// ── Targets (staging only — the chains rail is experimental/testnet) ───────────
+
+/** Rumi backend on mainnet-STAGING (kvg63). NOT production tfesu. */
+export const BACKEND_CANISTER_ID = "kvg63-wiaaa-aaaao-bbabq-cai";
+/** IC HTTP gateway. Anonymous agent — the EVM signature is the only auth. */
+export const IC_HOST = "https://icp0.io";
+
+/** Conflux eSpace testnet. */
+export const CHAIN_ID = 71;
+export const ESPACE_RPC = "https://evmtestnet.confluxrpc.com";
+export const ESPACE_EXPLORER = "https://evmtestnet.confluxscan.org";
+
+/** Deployed IcUSD ERC-20 (the M2 per-op-idempotency 4-arg-mint build). */
+export const ICUSD_CONTRACT =
+  "0xBD02222D388BC43095A4758C3e977d5dF8f68f7a" as const;
+
+/** EIP-712 domain — MUST match the backend's `chains/evm/eip712.rs` exactly. */
+export const EIP712_DOMAIN = {
+  name: "Rumi icUSD CDP",
+  version: "1",
+  chainId: CHAIN_ID,
+  verifyingContract: ICUSD_CONTRACT,
+} as const;
+
+// ── CDP params (mirror the backend's ICP-mirrored CFX collateral config) ───────
+
+/** Minimum collateral ratio (1.33 = 133%). */
+export const MIN_CR = 1.33;
+/** Minimum vault debt: 0.1 icUSD (e8s). */
+export const MIN_DEBT_E8S = 10_000_000n;
+/** icUSD / CFX decimals. */
+export const ICUSD_DECIMALS = 8; // 1 base unit == 1 e8s
+export const CFX_DECIMALS = 18;
+
+// ── viem chain ─────────────────────────────────────────────────────────────────
+
+export const confluxESpaceTestnet = defineChain({
+  id: CHAIN_ID,
+  name: "Conflux eSpace Testnet",
+  nativeCurrency: { name: "Conflux", symbol: "CFX", decimals: CFX_DECIMALS },
+  rpcUrls: { default: { http: [ESPACE_RPC] } },
+  blockExplorers: { default: { name: "ConfluxScan", url: ESPACE_EXPLORER } },
+  testnet: true,
+});
+
+// ── Intent action discriminants (must match IntentAction in the backend) ───────
+
+export const ACTION = {
+  Open: 0,
+  Borrow: 1,
+  WithdrawCollateral: 2,
+  Close: 3,
+} as const;
+
+/** Minimal ABI for the bits of IcUSD.sol the UI touches. */
+export const ICUSD_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "burn",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "amount", type: "uint256" },
+      { name: "target_vault_id", type: "uint64" },
+    ],
+    outputs: [],
+  },
+] as const;

--- a/src/conflux_espace_frontend/src/eip712.test.ts
+++ b/src/conflux_espace_frontend/src/eip712.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+import { recoverTypedDataAddress } from "viem";
+import { intentDigest, typedData, signIntent, type VaultIntentInput } from "./eip712";
+import { ACTION } from "./config";
+
+// The SAME golden vector the backend pins in chains/evm/tests_eip712.rs:
+//   - signer = scalar=1 key → address 0x7e5f…95bdf
+//   - domain verifyingContract = 0x…cf1c0de5 (the backend's test contract)
+//   - intent: Open, 1400 CFX collateral, 100 icUSD debt, nonce 0
+//   - digest + signature produced by python eth_account (independent of viem)
+const GOLDEN_OWNER = "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf";
+const GOLDEN_CONTRACT = "0x00000000000000000000000000000000cf1c0de5";
+const GOLDEN_DIGEST = "0x76fe467010b364bc9ed7caf7153a42bdc924e1cb7bf223d8182d9537717b9adc";
+const GOLDEN_SIG =
+  "0x06f8ac987a3a020f6e25dbfc7634ebfd95f10ab9d657a2dcd91323506381f8b65e4a53a93ee2d35887b616a4c0efccdd6406b9c93fdfcdcf0b7cbe20c3b2127a1c";
+
+const goldenIntent: VaultIntentInput = {
+  action: ACTION.Open,
+  owner: GOLDEN_OWNER as `0x${string}`,
+  vaultId: 0n,
+  collateralWei: 1_400n * 10n ** 18n,
+  debtE8s: 10_000_000_000n,
+  nonce: 0n,
+  deadlineSecs: 9_999_999_999n,
+};
+
+describe("EIP-712 frontend ↔ backend parity", () => {
+  it("hashTypedData equals the backend's golden digest", () => {
+    expect(intentDigest(goldenIntent, GOLDEN_CONTRACT as `0x${string}`)).toBe(GOLDEN_DIGEST);
+  });
+
+  it("the backend's golden signature recovers to the owner against our typed-data", async () => {
+    const recovered = await recoverTypedDataAddress({
+      ...typedData(goldenIntent, GOLDEN_CONTRACT as `0x${string}`),
+      signature: GOLDEN_SIG as `0x${string}`,
+    });
+    expect(recovered.toLowerCase()).toBe(GOLDEN_OWNER);
+  });
+
+  it("signing with the scalar=1 key round-trips to the owner (the dev-key path)", async () => {
+    const pk = ("0x" + "00".repeat(31) + "01") as `0x${string}`;
+    const account = privateKeyToAccount(pk);
+    expect(account.address.toLowerCase()).toBe(GOLDEN_OWNER);
+    const sig = await signIntent(account, account, goldenIntent); // uses live-contract domain
+    expect(sig.length).toBe(65); // r‖s‖v
+    const recovered = await recoverTypedDataAddress({
+      ...typedData(goldenIntent), // live IcUSD domain
+      signature: ("0x" + Buffer.from(sig).toString("hex")) as `0x${string}`,
+    });
+    expect(recovered.toLowerCase()).toBe(GOLDEN_OWNER);
+  });
+});

--- a/src/conflux_espace_frontend/src/eip712.ts
+++ b/src/conflux_espace_frontend/src/eip712.ts
@@ -3,7 +3,7 @@
 // `eip712.test.ts` golden-vector test pins this against the backend's own vector.
 
 import { hashTypedData, hexToBytes, type Account, type TypedDataDomain } from "viem";
-import { CHAIN_ID, EIP712_DOMAIN, ICUSD_CONTRACT } from "./config";
+import { CHAIN_ID, EIP712_DOMAIN } from "./config";
 
 /** Inputs a caller provides; `recipient` is always forced to `owner` (M2 rule). */
 export interface VaultIntentInput {
@@ -34,20 +34,17 @@ export const VAULT_INTENT_TYPES = {
   ],
 } as const;
 
+// `EIP712_DOMAIN` is the single source of truth for name/version/chainId/
+// verifyingContract; only the parity test overrides verifyingContract.
 function domainFor(verifyingContract: `0x${string}`): TypedDataDomain {
-  return {
-    name: EIP712_DOMAIN.name,
-    version: EIP712_DOMAIN.version,
-    chainId: CHAIN_ID,
-    verifyingContract,
-  };
+  return { ...EIP712_DOMAIN, verifyingContract };
 }
 
 /** The full typed-data object viem signs/hashes. `verifyingContract` defaults to
  *  the live IcUSD; the parity test overrides it to reproduce the backend vector. */
 export function typedData(
   i: VaultIntentInput,
-  verifyingContract: `0x${string}` = ICUSD_CONTRACT
+  verifyingContract: `0x${string}` = EIP712_DOMAIN.verifyingContract
 ) {
   return {
     domain: domainFor(verifyingContract),

--- a/src/conflux_espace_frontend/src/eip712.ts
+++ b/src/conflux_espace_frontend/src/eip712.ts
@@ -1,0 +1,106 @@
+// EIP-712 VaultIntent typed-data. MUST be byte-identical to the backend's
+// chains/evm/eip712.rs (same domain, same struct, same field order/types). The
+// `eip712.test.ts` golden-vector test pins this against the backend's own vector.
+
+import { hashTypedData, hexToBytes, type Account, type TypedDataDomain } from "viem";
+import { CHAIN_ID, EIP712_DOMAIN, ICUSD_CONTRACT } from "./config";
+
+/** Inputs a caller provides; `recipient` is always forced to `owner` (M2 rule). */
+export interface VaultIntentInput {
+  action: number; // ACTION.* (uint8)
+  owner: `0x${string}`;
+  vaultId: bigint;
+  collateralWei: bigint;
+  debtE8s: bigint;
+  nonce: bigint;
+  deadlineSecs: bigint;
+}
+
+// Field order + types MUST match the backend type string:
+// VaultIntent(uint8 action,uint64 chainId,address owner,uint64 vaultId,
+//   uint256 collateralWei,uint256 debtE8s,address recipient,uint256 nonce,
+//   uint256 deadline)
+export const VAULT_INTENT_TYPES = {
+  VaultIntent: [
+    { name: "action", type: "uint8" },
+    { name: "chainId", type: "uint64" },
+    { name: "owner", type: "address" },
+    { name: "vaultId", type: "uint64" },
+    { name: "collateralWei", type: "uint256" },
+    { name: "debtE8s", type: "uint256" },
+    { name: "recipient", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+
+function domainFor(verifyingContract: `0x${string}`): TypedDataDomain {
+  return {
+    name: EIP712_DOMAIN.name,
+    version: EIP712_DOMAIN.version,
+    chainId: CHAIN_ID,
+    verifyingContract,
+  };
+}
+
+/** The full typed-data object viem signs/hashes. `verifyingContract` defaults to
+ *  the live IcUSD; the parity test overrides it to reproduce the backend vector. */
+export function typedData(
+  i: VaultIntentInput,
+  verifyingContract: `0x${string}` = ICUSD_CONTRACT
+) {
+  return {
+    domain: domainFor(verifyingContract),
+    types: VAULT_INTENT_TYPES,
+    primaryType: "VaultIntent" as const,
+    message: {
+      action: i.action,
+      chainId: BigInt(CHAIN_ID),
+      owner: i.owner,
+      vaultId: i.vaultId,
+      collateralWei: i.collateralWei,
+      debtE8s: i.debtE8s,
+      recipient: i.owner, // recipient == owner
+      nonce: i.nonce,
+      deadline: i.deadlineSecs,
+    },
+  };
+}
+
+/** keccak256(0x1901 ‖ domainSep ‖ structHash) — the digest the backend recovers. */
+export function intentDigest(
+  i: VaultIntentInput,
+  verifyingContract?: `0x${string}`
+): `0x${string}` {
+  return hashTypedData(typedData(i, verifyingContract));
+}
+
+type TypedDataSigner = { signTypedData: (args: any) => Promise<`0x${string}`> };
+
+/** Sign with a viem account (MetaMask `walletClient`, or a dev-key `Account`).
+ *  Returns the 65-byte r‖s‖v signature ready for the canister `blob` argument. */
+export async function signIntent(
+  signer: TypedDataSigner,
+  account: Account | `0x${string}`,
+  i: VaultIntentInput
+): Promise<Uint8Array> {
+  const sigHex = await signer.signTypedData({ account, ...typedData(i) });
+  return hexToBytes(sigHex);
+}
+
+/** The Candid `VaultIntent` record. owner/recipient lowercased to match the
+ *  backend's recovered (lowercase) address; nat fields stay bigint. */
+export function toCandidIntent(i: VaultIntentInput) {
+  const owner = i.owner.toLowerCase();
+  return {
+    action: i.action,
+    chain_id: BigInt(CHAIN_ID),
+    owner,
+    vault_id: i.vaultId,
+    collateral_wei: i.collateralWei,
+    debt_e8s: i.debtE8s,
+    recipient: owner,
+    nonce: i.nonce,
+    deadline_secs: i.deadlineSecs,
+  };
+}

--- a/src/conflux_espace_frontend/src/evm.ts
+++ b/src/conflux_espace_frontend/src/evm.ts
@@ -1,0 +1,114 @@
+// viem integration: MetaMask (primary) or an in-browser dev-key signer (the path
+// the staging round-trip used), the CFX deposit, the IcUSD.burn repay, and reads.
+
+import {
+  createPublicClient,
+  createWalletClient,
+  custom,
+  http,
+  parseEther,
+  formatEther,
+  formatUnits,
+  type Address,
+  type Hex,
+  type WalletClient,
+} from "viem";
+import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
+import {
+  CHAIN_ID,
+  ESPACE_EXPLORER,
+  ESPACE_RPC,
+  ICUSD_ABI,
+  ICUSD_CONTRACT,
+  ICUSD_DECIMALS,
+  confluxESpaceTestnet,
+} from "./config";
+
+export const publicClient = createPublicClient({
+  chain: confluxESpaceTestnet,
+  transport: http(ESPACE_RPC),
+});
+
+export interface Wallet {
+  address: Address;
+  kind: "metamask" | "devkey";
+  client: WalletClient;
+  account: Address | PrivateKeyAccount;
+}
+
+export function hasMetaMask(): boolean {
+  return typeof (window as any).ethereum !== "undefined";
+}
+
+export async function connectMetaMask(): Promise<Wallet> {
+  const eth = (window as any).ethereum;
+  if (!eth) throw new Error("No injected wallet. Install MetaMask, or use the dev-key signer below.");
+  const client = createWalletClient({ chain: confluxESpaceTestnet, transport: custom(eth) });
+  const [address] = await client.requestAddresses();
+  await ensureChain(client, eth);
+  return { address, kind: "metamask", client, account: address };
+}
+
+export function connectDevKey(pk: string): Wallet {
+  const hex = (pk.startsWith("0x") ? pk : `0x${pk}`) as Hex;
+  const account = privateKeyToAccount(hex);
+  const client = createWalletClient({ account, chain: confluxESpaceTestnet, transport: http(ESPACE_RPC) });
+  return { address: account.address, kind: "devkey", client, account };
+}
+
+async function ensureChain(client: WalletClient, eth: any) {
+  try {
+    await client.switchChain({ id: CHAIN_ID });
+  } catch (e: any) {
+    if (e?.code === 4902 || /Unrecognized|add this chain/i.test(String(e?.message ?? ""))) {
+      await eth.request({
+        method: "wallet_addEthereumChain",
+        params: [
+          {
+            chainId: "0x47", // 71
+            chainName: "Conflux eSpace Testnet",
+            nativeCurrency: { name: "Conflux", symbol: "CFX", decimals: 18 },
+            rpcUrls: [ESPACE_RPC],
+            blockExplorerUrls: [ESPACE_EXPLORER],
+          },
+        ],
+      });
+    } else {
+      throw e;
+    }
+  }
+}
+
+const txArgs = (w: Wallet) => ({ account: w.account as any, chain: confluxESpaceTestnet });
+
+export async function sendDeposit(w: Wallet, custody: Address, amountWei: bigint): Promise<Hex> {
+  return w.client.sendTransaction({ ...txArgs(w), to: custody, value: amountWei });
+}
+
+export async function burnIcusd(w: Wallet, amountE8s: bigint, vaultId: bigint): Promise<Hex> {
+  return w.client.writeContract({
+    ...txArgs(w),
+    address: ICUSD_CONTRACT,
+    abi: ICUSD_ABI,
+    functionName: "burn",
+    args: [amountE8s, vaultId],
+  });
+}
+
+export async function icusdBalance(addr: Address): Promise<bigint> {
+  return (await publicClient.readContract({
+    address: ICUSD_CONTRACT,
+    abi: ICUSD_ABI,
+    functionName: "balanceOf",
+    args: [addr],
+  })) as bigint;
+}
+
+export async function cfxBalance(addr: Address): Promise<bigint> {
+  return publicClient.getBalance({ address: addr });
+}
+
+export const fmtCfx = (wei: bigint) => Number(formatEther(wei)).toLocaleString(undefined, { maximumFractionDigits: 4 });
+export const fmtIcusd = (e8s: bigint) => Number(formatUnits(e8s, ICUSD_DECIMALS)).toLocaleString(undefined, { maximumFractionDigits: 4 });
+export const txUrl = (hash: string) => `${ESPACE_EXPLORER}/tx/${hash}`;
+export { parseEther };

--- a/src/conflux_espace_frontend/src/evm.ts
+++ b/src/conflux_espace_frontend/src/evm.ts
@@ -7,6 +7,7 @@ import {
   custom,
   http,
   parseEther,
+  parseUnits,
   formatEther,
   formatUnits,
   type Address,
@@ -106,6 +107,19 @@ export async function icusdBalance(addr: Address): Promise<bigint> {
 
 export async function cfxBalance(addr: Address): Promise<bigint> {
   return publicClient.getBalance({ address: addr });
+}
+
+// Decimal-string -> base units via integer parsing (no float precision loss).
+// Returns 0n for empty/invalid/non-positive input so callers can gate on `=== 0n`.
+export function toE8s(s: string): bigint {
+  const n = parseFloat(s);
+  if (!Number.isFinite(n) || n <= 0) return 0n;
+  try { return parseUnits(s as `${number}`, ICUSD_DECIMALS); } catch { return 0n; }
+}
+export function toWei(s: string): bigint {
+  const n = parseFloat(s);
+  if (!Number.isFinite(n) || n <= 0) return 0n;
+  try { return parseEther(s as `${number}`); } catch { return 0n; }
 }
 
 export const fmtCfx = (wei: bigint) => Number(formatEther(wei)).toLocaleString(undefined, { maximumFractionDigits: 4 });

--- a/src/conflux_espace_frontend/src/main.ts
+++ b/src/conflux_espace_frontend/src/main.ts
@@ -1,0 +1,7 @@
+import { mount } from "svelte";
+import "./styles.css";
+import App from "./App.svelte";
+
+const app = mount(App, { target: document.getElementById("app")! });
+
+export default app;

--- a/src/conflux_espace_frontend/src/styles.css
+++ b/src/conflux_espace_frontend/src/styles.css
@@ -1,0 +1,101 @@
+:root {
+  --bg: #0b0d12;
+  --panel: #141821;
+  --panel-2: #1b202b;
+  --border: #262d3a;
+  --text: #e6e9ef;
+  --muted: #8b94a7;
+  --accent: #7c5cff;
+  --accent-2: #00d2b8;
+  --danger: #ff5d6c;
+  --ok: #2ecc71;
+  --warn: #f5a623;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: radial-gradient(1200px 600px at 70% -10%, #1a1430 0%, var(--bg) 55%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.wrap { max-width: 760px; margin: 0 auto; padding: 32px 20px 80px; }
+
+header.top { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 28px; }
+.brand { display: flex; align-items: center; gap: 12px; }
+.brand .logo {
+  width: 36px; height: 36px; border-radius: 10px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  display: grid; place-items: center; font-weight: 800; color: #0b0d12;
+}
+.brand h1 { font-size: 17px; margin: 0; font-weight: 700; }
+.brand .sub { color: var(--muted); font-size: 12px; }
+
+.badge {
+  font-size: 11px; padding: 4px 9px; border-radius: 999px;
+  border: 1px solid var(--border); color: var(--muted); background: var(--panel);
+}
+.badge.testnet { color: var(--warn); border-color: #3a2f17; background: #1c160a; }
+
+.card {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: 16px; padding: 22px; margin-bottom: 18px;
+}
+.card h2 { margin: 0 0 4px; font-size: 15px; }
+.card .hint { color: var(--muted); font-size: 13px; margin: 0 0 16px; line-height: 1.5; }
+
+.row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.spread { justify-content: space-between; }
+
+label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+input, select {
+  width: 100%; background: var(--panel-2); border: 1px solid var(--border);
+  color: var(--text); border-radius: 10px; padding: 11px 12px; font-size: 14px;
+  outline: none;
+}
+input:focus { border-color: var(--accent); }
+.field { margin-bottom: 14px; }
+.field .row input { flex: 1; }
+
+button {
+  border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
+  border-radius: 10px; padding: 11px 16px; font-size: 14px; font-weight: 600;
+  cursor: pointer; transition: transform .04s ease, background .15s ease;
+}
+button:hover:not(:disabled) { background: #232a38; }
+button:active:not(:disabled) { transform: translateY(1px); }
+button:disabled { opacity: .45; cursor: not-allowed; }
+button.primary { background: linear-gradient(135deg, var(--accent), #6248d8); border-color: transparent; color: white; }
+button.primary:hover:not(:disabled) { filter: brightness(1.08); }
+button.ghost { background: transparent; }
+button.danger { border-color: #3a1f24; color: var(--danger); background: #1d1216; }
+button.sm { padding: 7px 11px; font-size: 12px; }
+
+.kv { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px dashed var(--border); font-size: 13px; }
+.kv:last-child { border-bottom: none; }
+.kv .k { color: var(--muted); }
+.kv .v { font-variant-numeric: tabular-nums; font-weight: 600; }
+.mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; }
+
+.pill { font-size: 11px; padding: 3px 9px; border-radius: 999px; font-weight: 700; letter-spacing: .02em; }
+.pill.AwaitingDeposit { background: #1c160a; color: var(--warn); }
+.pill.MintPending { background: #11202a; color: var(--accent-2); }
+.pill.Open { background: #0f2417; color: var(--ok); }
+.pill.Closing, .pill.Closed { background: #20151a; color: var(--muted); }
+
+.notice { border-radius: 10px; padding: 12px 14px; font-size: 13px; line-height: 1.5; margin-top: 14px; }
+.notice.err { background: #20151a; border: 1px solid #3a1f24; color: #ffb4bc; }
+.notice.ok { background: #0f2417; border: 1px solid #16341f; color: #b7f0cb; }
+.notice.info { background: #11202a; border: 1px solid #1a3140; color: #bfeae3; }
+
+.spin { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin .7s linear infinite; vertical-align: -2px; margin-right: 7px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.copy { cursor: pointer; color: var(--accent-2); }
+.muted { color: var(--muted); }
+.divider { height: 1px; background: var(--border); margin: 16px 0; }
+a { color: var(--accent-2); }
+.foot { text-align: center; color: var(--muted); font-size: 12px; margin-top: 28px; line-height: 1.6; }

--- a/src/conflux_espace_frontend/svelte.config.js
+++ b/src/conflux_espace_frontend/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/src/conflux_espace_frontend/tsconfig.json
+++ b/src/conflux_espace_frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "strict": true,
+    "verbatimModuleSyntax": false,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "vite.config.ts"]
+}

--- a/src/conflux_espace_frontend/vite.config.ts
+++ b/src/conflux_espace_frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+// Standalone SPA. `global`/`process` shims keep @dfinity/agent happy in the
+// browser. Vitest runs in node (jsdom not needed — the unit tests are pure logic).
+export default defineConfig({
+  plugins: [svelte()],
+  define: {
+    global: "globalThis",
+    "process.env": {},
+  },
+  server: { port: 5180 },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## What

A standalone **Vite + Svelte 5** SPA (`src/conflux_espace_frontend/`) for the EVM-native self-serve CDP rail on Conflux eSpace testnet (chain 71). Users open and manage a CFX-collateralized icUSD vault by signing an **EIP-712 `VaultIntent`** with MetaMask (or an in-browser dev-key signer); the canister verifies the signature, so the IC caller is anonymous and the EVM wallet is the only identity.

This is the frontend half of M2. The backend (the four `_evm` methods, EIP-712 verifier, synthetic-principal auth, 4-arg-mint idempotency) already merged and deployed to mainnet-staging via #253.

## Scope

Only **2 logical changes** vs `main` (the big stat you may see locally is a stale local `main`):
- the design doc (`docs/superpowers/plans/2026-06-19-conflux-espace-frontend-design.md`)
- the new `src/conflux_espace_frontend/` app

Nothing in the backend or other frontends is touched.

## How it works

- **`eip712.ts`** — typed-data construction + signing. `EIP712_DOMAIN` is the single source of truth for the domain. Validated against the backend's own golden vector (digest `0x76fe46…`, scalar=1 round-trip) by 3 Vitest tests, so a real wallet signature is provably what the canister verifies.
- **`backend.ts`** — anonymous `@dfinity/agent` actor with a hand-rolled IDL for the `_evm` methods (the tracked declarations predate them). **Never** calls `fetchRootKey` on mainnet.
- **`evm.ts`** — viem public client + wallet, CFX deposit, `IcUSD.burn` repay, balance reads, and integer-precise `toE8s`/`toWei` parsers.
- **`App.svelte` + `VaultCard.svelte`** — full lifecycle (open / borrow / withdraw / close / on-chain repay), per-owner nonce auto-sync on a bad-nonce reject, an 8s poll while anything is in flight, and status-gated action buttons.

## Review

Ran an adversarial 5-lens review (secrets, EIP-712 parity, amount-unit correctness, IDL/candid parity, Svelte/build hygiene) with every finding independently verified before trusting it. **The security core — EIP-712 type/domain/digest parity and the signature v-byte encoding — was confirmed correct.** The 9 confirmed findings were all LOW/INFO polish and are fixed in `f5fbf81` (single-source domain, guarded amount parsing, consistent imports, type-completeness, sturdier nonce resync).

One item is deferred because it needs a backend endpoint (out of scope for a frontend PR): prefetching the per-owner nonce on connect, so a returning owner's first action doesn't reject-then-re-sign. It self-heals today; documented in the fix commit.

## Verification

- `vitest` 3/3, `svelte-check` 0 errors / 0 warnings, `npm run build` clean.
- Drove the dev-key path against **live mainnet-staging (kvg63)**: it renders the real `Vault #3` (Open, 10 CFX, 0.2 icUSD debt) and the 0.2 icUSD balance from the staging round-trip, with correctly-gated lifecycle buttons.

## Notes

- Testnet only; the chains rail is experimental and not on production `tfesu`.
- MetaMask is the production signer; the dev-key signer is a testnet convenience (pre-filled with the public scalar=1 demo key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)