### PR TITLE
audit(chains): pre-mainnet security review + gated launch runbook

### DIFF
--- a/audit-reports/2026-06-18-39a07cd/coverage-crosscheck.md
+++ b/audit-reports/2026-06-18-39a07cd/coverage-crosscheck.md
@@ -1,0 +1,29 @@
+# Coverage cross-check (Step 5) — grep-authoritative
+
+Anchor 39a07cd. Method: exact-symbol enumeration (zero false negatives), each item mapped to the pass that covered it. No code-graph reliance.
+
+## 1. State-mutating chain entry points (main.rs) — all covered
+register_chain, set_chain_config, open_chain_vault, withdraw_chain_collateral, close_chain_vault,
+get_chain_settlement_address, get_chain_vault, set_chain_contract, set_manual_collateral_price,
+set_evm_rpc_principal, clear_invariant_halt, clear_reorg_halt, set_last_observed_block,
+set_burn_watch_poll_enabled, set_chain_interest_tick_interval_secs, set_chain_interest_min_realize_e8s,
+harvest_chain_interest, get_chain_interest_treasury_address.
+-> covered by: auth-dos (all), mint-doublemint (open), withdraw-custody (withdraw/close),
+   interest-accrual (harvest/set_chain_interest_*/get_treasury), rpc-finality-reorg (set_manual_price/
+   set_last_observed_block/clear_reorg/set_chain_contract), tecdsa-keys (get_*_address), supply-invariant (clear_invariant_halt).
+NO entry-point coverage gap.
+
+## 2. Re-entrancy / guard sites — all covered (async-races pass)
+SETTLEMENT_INFLIGHT (evm/settlement.rs), OBSERVER_INFLIGHT (evm + solana deposit_watch),
+SOLANA_SETTLEMENT_INFLIGHT (solana/settlement.rs), inflight_should_acquire/INFLIGHT_STALE_NS (hardening.rs).
+The async-races pass examined the guard acquire/Drop/self-heal; the withdraw-custody pass examined the per-op CAS.
+
+## 3. Supply-mutation / mint / burn / transfer sites — all covered (supply-invariant + mint + withdraw passes)
+70 references across: supply.rs (apply_supply_delta, check_invariant), evm/settlement.rs (confirm_mint_in_state,
+confirm_interest_mint_in_state, debt_e8s +=), evm/deposit_watch.rs + evm/burn_proof.rs (apply_burn_to_state),
+vault.rs (open/withdraw/close debt+collateral), multi_chain_state.rs (totals helpers), solana/settlement.rs.
+Each file audited by the supply-invariant pass; the two confirm fns + apply_burn additionally by mint + withdraw passes.
+
+## Result
+No uncovered economic entry point, guard site, or value-transfer site. The multi-site root cause F-05
+names both its sites (confirm_interest_mint_in_state + the close shortcut).

--- a/audit-reports/2026-06-18-39a07cd/findings.json
+++ b/audit-reports/2026-06-18-39a07cd/findings.json
@@ -1,0 +1,42 @@
+{
+  "anchor": "39a07cd1c3fcfbb0acedc975d4ba4ced2d25f71d",
+  "date": "2026-06-18",
+  "scope": "Conflux/Monad chains rail (src/rumi_protocol_backend/src/chains/ + foundry/src/IcUSD.sol)",
+  "summary": { "candidates_raised": 11, "confirmed_real": 4, "false_positives": 5, "informational_defense_in_depth": 1, "regressions_from_pr252": 0 },
+  "verdict": "GO for gated eSpace-mainnet soft-launch with conditions; no real bug in PR #252",
+  "findings": [
+    { "id": "F-01", "severity": "HIGH", "category": "cdp-domain", "subcategory": "oracle-integrity",
+      "title": "Manual price oracle has no staleness or sanity bounds",
+      "locations": ["chains/vault.rs:collateral_ratio_e4 + open/withdraw CR", "chains/multi_chain_state.rs:manual_prices", "main.rs:set_manual_collateral_price"],
+      "in_pr252": false, "prior_status": "PRE-EXISTING",
+      "exploit": "stale price -> vault opened over-MCR is undercollateralized at true price; zero/low price freezes vaults",
+      "mitigation_gated_launch": "dev-gated opens + small debt ceiling + active price monitoring", "owner": "chains rail (M2 session)" },
+    { "id": "F-02", "severity": "MEDIUM", "category": "ic-platform", "subcategory": "finality-reorg",
+      "title": "processed_burn_keys unbounded growth during deep-reorg/stalled-cursor",
+      "locations": ["chains/evm/deposit_watch.rs:advance_cursor_and_prune"],
+      "in_pr252": false, "prior_status": "PRE-EXISTING (documented in code)", "theoretical": true, "owner": "chains rail" },
+    { "id": "F-03", "severity": "LOW", "category": "cdp-domain", "subcategory": "oracle-integrity",
+      "title": "set_manual_collateral_price lacks bounds/delta/timelock", "locations": ["main.rs:set_manual_collateral_price"],
+      "in_pr252": false, "prior_status": "PRE-EXISTING", "note": "admin-gated, reversible; folds into F-01" },
+    { "id": "F-04", "severity": "LOW", "category": "ic-platform", "subcategory": "quorum",
+      "title": "RPC provider concentration (Confura-only); mainnet needs independent providers",
+      "locations": ["chains/evm/conflux/config.rs", "chains/evm/evm_rpc.rs"],
+      "in_pr252": false, "prior_status": "KNOWN MAINNET GATE", "note": "min_quorum=1 still requires strict-majority=2-of-3; risk is single operator" },
+    { "id": "F-05", "severity": "INFORMATIONAL", "category": "cdp-domain", "subcategory": "debt-interest-defense-in-depth",
+      "title": "confirm_interest_mint_in_state has no local status guard (currently unreachable to exploit)",
+      "locations": ["chains/evm/settlement.rs:confirm_interest_mint_in_state", "chains/vault.rs:close_chain_vault_in_state zero-collateral shortcut"],
+      "in_pr252": true, "prior_status": "NEW", "exploitable": false,
+      "reachability": "(Open, collateral==0) is unreachable: open requires collateral>0; partial withdraw stays CR-checked>0; full withdraw sets Closing; withdraw blocked while pending_interest>0",
+      "recommendation": "add status!=Open guard to confirm_interest_mint_in_state + pending_interest==0 to the close shortcut (cheap defense-in-depth)", "owner": "M2 session" },
+    { "id": "F-06", "severity": "LOW", "category": "cdp-domain", "subcategory": "cr-math",
+      "title": "Withdrawal CR validated at enqueue, not at settlement confirm", "locations": ["chains/vault.rs:withdraw_collateral_in_state"],
+      "in_pr252": false, "prior_status": "PRE-EXISTING", "theoretical": true, "note": "requires admin price-move on own op; folds into F-01" }
+  ],
+  "false_positives": [
+    { "title": "Interest harvest vs settlement confirm pre_total race", "why": "no .await between read_state(pre_total) and mutate_state(confirm); IC atomic between awaits" },
+    { "title": "Double add-back on reverted NativeWithdrawal", "why": "per-op CAS (still-Inflight?) inside the single mutate_state" },
+    { "title": "Reused vault IDs carry stale last_interest_accrual_ns", "why": "monotonic counter (never reused) + on-chain minted[vault_id] guard" },
+    { "title": "Interest rounding/resubmit double-count", "why": "pending_interest_mint_e8s!=0 harvest filter + resubmit reuses stored op.amount_e8s" },
+    { "title": "min_quorum=1 => 1-of-N reads", "why": "required agreement = max(1, strict_majority=2) = 2; reclassified as F-04 operator concentration" }
+  ]
+}

--- a/audit-reports/2026-06-18-39a07cd/methodology.md
+++ b/audit-reports/2026-06-18-39a07cd/methodology.md
@@ -1,0 +1,15 @@
+# Methodology
+
+- **Harness:** audit-icp-cdp. **Anchor:** 39a07cd (clean). **Mode:** first chains-rail-focused audit (differential context: 2026-06-03 cross-chain first pass).
+- **Passes (10, read-only Explore agents):** supply-invariant, mint/double-mint, withdraw/custody, interest-accrual,
+  async-races, rpc-finality-reorg, stable/upgrade, auth/cycle-DoS, tECDSA-keys, IcUSD.sol(Solidity).
+- **Rule packs loaded:** ic-rules.md (§1 async races, §2 inter-canister failure, §3 stable/upgrade, §4 cycle DoS,
+  §5 caller auth, §6 controller-vs-admin), cdp-checklist.md (§1 oracle, §2 CR math, §6 debt/interest).
+  ICP-native passes that DON'T apply (SP accounting, redemption/peg, ICP liquidation) were dropped — out of scope.
+- **Verification:** every medium+ candidate independently re-verified by a skeptical agent (default false_positive).
+  A verifier conflict on the interest-on-closed-vault concern (F-05) was resolved manually by reading
+  vault.rs:424-452 (withdraw guard) + 555-594 (close shortcut) — exploit precondition (Open, collateral==0) proven unreachable.
+- **Coverage:** grep-authoritative enumeration (see coverage-crosscheck.md), not code-graph.
+- **Key IC-semantics calibration applied repeatedly:** a read_state immediately followed by a mutate_state (no .await
+  between) is atomic on the IC; cross-message interleaving only at awaits. This collapsed 1 recurring false positive
+  (the pre_total "race").

--- a/audit-reports/2026-06-18-39a07cd/report.md
+++ b/audit-reports/2026-06-18-39a07cd/report.md
@@ -1,0 +1,67 @@
+# Security Audit — Conflux/Monad native-collateral chains rail
+
+**Anchor:** `origin/main` @ `39a07cd1c3fcfbb0acedc975d4ba4ced2d25f71d` (PR #251 Conflux rail + PR #252 Option-B interest accrual).
+**Date:** 2026-06-18. **Auditor:** automated harness (audit-icp-cdp), 10 specialist passes + adversarial verification + manual reachability resolution. **Dirty files:** none.
+**Purpose:** pre-mainnet gate for a **gated eSpace-mainnet soft-launch** (chain 1030, small debt ceiling, dev/allowlist-gated opens, manual liquidation + monitoring).
+
+## Bottom line
+
+**GO for the gated soft-launch, with conditions (below). NO confirmed real bug in the interest-accrual work (PR #252); no regression.** Every finding the harness raised against the new interest path was verified to be a **false positive** (IC message atomicity + the existing in-code guards). The substantive findings are **pre-existing chains-rail properties that are already on the documented mainnet-gate list** — chiefly the manual price oracle. They are mitigated, not eliminated, by the gated-launch controls.
+
+11 candidate findings → after adversarial verification + manual resolution of a verifier conflict:
+- **1 HIGH** (pre-existing): manual price oracle has no staleness/bounds.
+- **1 MEDIUM** (pre-existing, theoretical): burn-watch idempotency map can grow unbounded during a deep reorg + stalled cursor.
+- **2 LOW** (pre-existing): price-set endpoint lacks bounds/delta/timelock; RPC provider concentration.
+- **1 INFORMATIONAL** (new code, defense-in-depth): `confirm_interest_mint_in_state` has no local status guard (currently unreachable to exploit).
+- **5 verified FALSE POSITIVES** (documented below so a re-audit doesn't re-raise them).
+
+## Findings (severity order)
+
+### F-01 — HIGH — Manual price oracle: no staleness or bounds → undercollateralization / freeze
+- **Category:** CDP-domain / oracle integrity. **Status vs prior audit:** pre-existing (the chains rail has always used `manual_prices` with no freshness). **In PR #252?** No — unrelated to interest accrual.
+- **Locations:** `chains/vault.rs:collateral_ratio_e4` + the open/withdraw CR checks; `chains/multi_chain_state.rs` `manual_prices: BTreeMap<(ChainId,String),u64>` (no timestamp); `main.rs:set_manual_collateral_price` (only rejects `price_e8==0`).
+- **Mechanism:** CR = `collateral_native * price_e8 / 10^dec / debt_e8s * 10_000`. `price_e8` is an admin-set scalar with **no timestamp, staleness check, or sanity bound**. If the CFX market moves and the admin doesn't refresh, a vault that opened over-MCR at the stale price is silently undercollateralized at the true price; a `price_e8` driven to a low value freezes all open/withdraw (BelowMinCr) for vaults with debt.
+- **Why HIGH not CRITICAL:** requires admin negligence or a market event, not a single attacker-controlled input. For the **gated soft-launch** the blast radius is bounded by dev-gated opens + a small debt ceiling, so it is **mitigated** (see conditions). For a **public launch** it is a hard gate.
+- **Recommendation (mainnet):** store `(price_e8, updated_at_ns)` per `(chain,symbol)`; reject CR-relevant ops when `now - updated_at > MAX_PRICE_AGE`; emit a `PriceSet` event for off-chain staleness alerting; move to an automated oracle (XRC already carries CFX via 6/9 sources; or Pyth/Chainlink on EVM) before removing the caps. **Owner:** chains rail (coordinate with the `feat/conflux-evm-self-serve-auth` session; not edited here).
+
+### F-02 — MEDIUM — `processed_burn_keys` can grow unbounded during a deep reorg + stalled cursor
+- **Category:** IC-platform / oracle-finality. **Status:** pre-existing (the code's own docstring flags "revisit for deeper finality / higher vault counts"). **In PR #252?** No.
+- **Location:** `chains/evm/deposit_watch.rs:advance_cursor_and_prune` (~865-891).
+- **Mechanism:** the burn-watch idempotency set is pruned only when the cursor advances (`finalized > last_observed`). With Conflux `finality_depth=100`, a deep reorg that regresses/stalls the finalized block below the cursor — or a reorg-halt awaiting operator `clear_reorg_halt` — stops pruning while new burns keep being recorded, so the `BTreeMap<u64,BTreeSet<String>>` grows. Theoretical (needs reorg/halt + prolonged stall + many burns); no fund loss or invariant breach.
+- **Recommendation:** add block-count/time-based eviction independent of cursor advance (e.g. retain only the last N blocks' keys; the on-chain `minted[vault_id]` guard backstops a re-applied burn). Monitor map size. **Owner:** chains rail.
+
+### F-03 — LOW — `set_manual_collateral_price` lacks bounds / delta / timelock
+- **Category:** CDP-domain / oracle. **Status:** pre-existing. Developer-gated, reversible, fully observable. A fat-finger or compromised dev key can set a nonsensical price (the only check is `> 0`). Per the audit brief, admin-only = LOW. **Recommendation:** %-band-vs-previous check, price history, optional timelock for mainnet. Folds into F-01's oracle work.
+
+### F-04 — LOW — RPC provider concentration (Confura-only); mainnet needs independent providers
+- **Category:** IC-platform / quorum. **Status:** known mainnet gate. NOTE the harness's "min_quorum=1 means 1-of-N" claim was a **false positive**: required agreement is `max(floor=1, strict_majority=2) = 2`, so reads still need 2-of-3 agreement. The real risk is that all three eSpace endpoints are one operator (Confura), so it is a 1-of-1 *trust* model. Fine for testnet; **mainnet requires ≥3 independent providers** (already on the gate list).
+
+### F-05 — INFORMATIONAL — `confirm_interest_mint_in_state` relies on upstream invariants (no local status guard)
+- **Category:** CDP-domain / debt-interest. **In PR #252?** Yes (new code). **Verdict: currently UNREACHABLE to exploit — defense-in-depth only.**
+- **The concern (two verifiers conflicted; resolved manually):** `confirm_interest_mint_in_state` (settlement.rs:147) has no `status == Open` check, and `close_chain_vault_in_state`'s zero-collateral shortcut (vault.rs:575) stamps `Closed` without the `InterestRealizationPending` guard. **But the exploit precondition `(Open, collateral == 0)` is unreachable:** open requires collateral > 0 (CR), partial withdraws stay CR-checked > 0, and a full withdraw sets status to **`Closing`** (not Open) — and any withdraw is blocked while `pending_interest_mint_e8s > 0` (vault.rs:444). So a pending-interest vault can never reach `Closed` before its interest mint confirms. Verified by reading vault.rs:424-452 + 555-594.
+- **Why still worth a cheap fix:** the safety currently rests on an *upstream* invariant (the close shortcut never coinciding with a pending-interest, collateral-0, Open vault). A future change to the close shortcut, the withdraw guard, or a new collateral-0-Open path would silently let interest credit a Closed vault. **Recommendation (cheap, defense-in-depth):** add `if vault.status != Open { return Err(...); }` to `confirm_interest_mint_in_state` (leave the op Inflight / mark Failed), and add `pending_interest_mint_e8s == 0` to the close shortcut guard. **Owner:** whoever next edits chains/ (the M2 session) — not edited here.
+
+### F-06 — LOW (theoretical) — Withdrawal CR validated at enqueue, not at settlement confirm
+- **Category:** CDP-domain / CR math. **Status:** pre-existing. Between a withdraw enqueue and its on-chain confirm, an admin could move the manual price, so the withdrawal was validated against a now-stale price. Requires admin action on their own op (admin-gated → LOW/theoretical). Re-checking CR at confirm (or snapshotting the price on the op) would harden it. Subsumed by F-01's oracle work.
+
+## Verified FALSE POSITIVES (recorded so a re-audit collapses them)
+1. **"Interest harvest vs settlement confirm race on pre_total"** (settlement.rs:1127) — the `read_state(pre_total)` is immediately followed by `mutate_state(confirm)` with **no `.await` between**; IC messages run atomically between awaits, so no observer-burn or cross-chain settlement can interleave. (Raised twice — also in the prior code review. Pattern is confusing; see F-05's note — moving the read inside the mutate would stop the recurring false alarm.)
+2. **Double add-back on reverted NativeWithdrawal** (settlement.rs:867) — the per-op CAS (`still Inflight?`) inside the single `mutate_state` makes the second tick a no-op.
+3. **Reused vault IDs carry stale `last_interest_accrual_ns`** — `chain_vault_id_counter` is monotonic (never reused; ~1.8e19 opens to overflow) and the on-chain `minted[vault_id]` guard would block a reused-id mint regardless.
+4. **Interest accrual rounding / resubmit double-count** — the `pending_interest_mint_e8s != 0` harvest filter (interest.rs:72) blocks re-harvest while a mint is in flight; resubmit re-uses the stored `op.amount_e8s`, not a fresh accrual.
+5. **min_quorum=1 ⇒ 1-of-N reads** — required agreement is `max(1, strict_majority)=2`; reclassified as F-04 (operator concentration).
+
+## Methodology + coverage
+See `methodology.md` and `coverage-crosscheck.md`. 10 read-only specialist passes (Explore agents) over `chains/` + `IcUSD.sol`; every medium+ candidate independently re-verified; the supply-invariant / mint / withdraw / interest passes cross-checked against the grep-authoritative enumeration of all 18 chain entry points, the settlement/observer guard sites, and the 70 supply-mutation sites (no entry-point coverage gap).
+
+## Limitations
+- Read-only review of the **chains rail only**; the ICP-native engine, the M2 self-serve auth (`feat/conflux-evm-self-serve-auth`), and chains liquidation (not built) are out of scope.
+- Manual prices, single-operator RPC, and deferred automated liquidation are accepted properties of a *gated, capped, dev-gated* soft-launch; they are **hard gates for a public launch**.
+- No live-chain (real reorg / real oracle manipulation) testing; F-01/F-02 reproductions are documented, not executed as PoC tests.
+
+## Gated-soft-launch conditions (the audit's go-with-conditions)
+1. **Keep opens dev/allowlist-gated + a small `debt_ceiling_e8s`** on chain 1030 — caps the blast radius of F-01.
+2. **Active CFX price discipline:** a refresh cadence + off-chain staleness/large-move alerting (mitigates F-01/F-03/F-06 until the staleness check / automated oracle lands).
+3. **Manual-liquidation playbook ready** (automated liquidation is deferred).
+4. **Coordinate the F-05 defense-in-depth one-liner** with the chains/M2 session (cheap, not blocking).
+5. **Before lifting the caps to a public launch:** F-01 (oracle staleness/automation), F-04 (independent RPC providers), F-02 (burn-key eviction).

--- a/audit-reports/2026-06-18-39a07cd/scope.md
+++ b/audit-reports/2026-06-18-39a07cd/scope.md
@@ -1,0 +1,38 @@
+# Audit scope — Conflux/Monad chains rail
+
+**Anchor:** `origin/main` @ `39a07cd1c3fcfbb0acedc975d4ba4ced2d25f71d` (branch `main`).
+Includes PR #251 (Conflux eSpace rail) + PR #252 (Option-B interest accrual).
+**Audit branch:** `audit/conflux-chains-rail` (worktree, read-only over `chains/`).
+**Date:** 2026-06-18. **Dirty files:** none (clean checkout of the anchor).
+
+## Why this audit
+Pre-mainnet gate for a **gated eSpace-mainnet soft-launch** of the native-CFX CDP:
+chain 1030, small debt ceiling, dev/allowlist-gated, manual liquidation + monitoring.
+This is the "security review of the revived chains rail" mainnet gate.
+
+## In scope
+- `src/rumi_protocol_backend/src/chains/` (~12,343 non-test LoC): `vault.rs`, `supply.rs`,
+  `multi_chain_state.rs`, `settlement_queue.rs`, `config.rs`, `admin.rs`, `recovery.rs`,
+  `interest.rs`, `evm/*` (adapter, deposit_watch, settlement, tecdsa, evm_rpc, hardening,
+  burn_proof, tx, conflux/, monad/), `solana/*` + `xrp/*` (shared-helper blast radius only).
+- `foundry/src/IcUSD.sol` (51 LoC) + `foundry/test/IcUSD.t.sol`.
+- The NEW Option-B interest path end-to-end (harvest → InterestMint → confirm), the synthetic
+  `mint_id` disjointness, the per-chain tECDSA interest-treasury.
+
+## Out of scope (explicit)
+- ICP-native CDP engine (vaults/SP/redemption/liquidation) — separately audited (2026-06-09 @e49ed10).
+- Chains **liquidation** — deferred/not built; soft-launch uses manual liquidation + caps.
+- **M2 EVM-native self-serve auth** (`feat/conflux-evm-self-serve-auth`) — concurrent session, owns the
+  chains source; reviewed separately. This audit does not edit chains source.
+- SP cross-chain deposit; automated CFX oracle (soft-launch uses admin manual_prices + monitoring).
+
+## Methodology
+10 parallel read-only specialist passes (Explore agents) → adversarial verification of every
+medium+ finding → grep-authoritative coverage cross-check → calibrated report.
+Passes: supply-invariant, mint/double-mint, withdraw/custody, interest-accrual, async-races,
+rpc-finality-reorg, stable/upgrade, auth/cycle-DoS, tECDSA-keys, IcUSD.sol.
+Differential vs the 2026-06-03 cross-chain audit (Solana+Monad first pass).
+
+## Hard invariant under test
+`sum(multi_chain.chain_supplies) == sum(chain_vaults[*].debt_e8s)` — enforced by
+`apply_supply_delta` + Timer-B `check_invariant` + `reconcile_chain_supply`.

--- a/docs/plans/2026-06-18-conflux-gated-mainnet-launch-runbook.md
+++ b/docs/plans/2026-06-18-conflux-gated-mainnet-launch-runbook.md
@@ -1,0 +1,131 @@
+# Conflux gated eSpace-mainnet soft-launch — operator runbook
+
+Status: DRAFT for Rob. Local doc (docs/ gitignored). Anchor: `main`@`39a07cd` (PR #251 rail + #252 interest).
+Posture: the 2026-06-18 chains-rail audit said **GO for a gated soft-launch with conditions** (`audit-reports/2026-06-18-39a07cd/`).
+Goal: real CFX on **eSpace mainnet (chain 1030)**, tightly capped + dev-gated, manual risk management.
+
+---
+
+## ⚠️ Read first — three hard truths that shape every step
+
+1. **There is NO liquidation on the chains rail yet** (deferred to its own spec). So an undercollateralized chain vault cannot be liquidated — there is no recovery path for bad debt. The ONLY protections are: conservative LTV, tiny caps, monitoring, and the fact that **`open_chain_vault` is developer-gated** (only you open vaults). → **Keep the launch dev-gated. Do NOT wire M2 self-serve (user-opened vaults) to mainnet until liquidation exists.** With dev-only opens you are managing your own positions; that is the safe shape of this soft-launch.
+
+2. **The debt ceiling is NOT code-enforced** (`debt_ceiling_e8s` is carried in `ChainCollateralConfig` but the open path consumes only `min_cr_e4`). So the "small cap" is **operational** — it is you opening few small vaults, not a guardrail. Treat the cap as a discipline, not a safety net.
+
+3. **The ECDSA key is hardcoded to `test_key_1`** (`chains/monad/config.rs::monad_ecdsa_key_name`). Real CFX would be custodied by tECDSA `test_key_1`. Moving to production `key_1` is a **code change** (M2's area) + redeploy + a full re-derivation of every custody/settlement/interest-treasury address + an IcUSD.sol redeploy with the new minter. See Decision 0.
+
+---
+
+## Decision 0 (REQUIRED — your call): which ECDSA key
+| | `test_key_1` (current) | `key_1` (production) |
+|---|---|---|
+| Code change | none | edit `monad_ecdsa_key_name()` → `"key_1"` (chains source = M2 session) + redeploy |
+| Addresses | already derived (testnet-proven) | ALL custody/settlement/treasury addresses change → IcUSD.sol must be redeployed with the new minter |
+| Risk for real CFX | `test_key_1` is a real threshold key but designated "test" (weaker operational guarantees) | production-grade |
+| Speed | fast (interim) | slower (code + coordination + key availability on the subnet) |
+
+**Recommendation:** for an *initial, tiny, short-duration* gated launch (a few CFX, you-only), `test_key_1` is the fast path and is consistent with "soft-launch". **Migrate to `key_1` before holding non-trivial value or lifting caps.** If you want real value from day one, do `key_1` first (it is a hard pre-req, not optional, for meaningful TVL).
+
+## Decision 1 (your call): which canister
+- **kvg63 staging** (already runs the rail + interest, `test_key_1`): fastest. Adding chain 1030 here puts real eSpace-mainnet CFX on the staging canister. Fine for a tiny dev-only soft-launch; keep it small.
+- **Production `tfesu`** (`key_1`): mixes the chains rail's real-CFX custody into the live ICP-CDP canister. Bigger blast radius; only after Decision 0 = `key_1` + a fresh audit pass of the combined surface. **Not recommended for the soft-launch.**
+- **New production-keyed canister** for the chains rail: cleanest separation for scale; more setup.
+
+**Recommendation:** kvg63 for the initial gated launch; a dedicated production-keyed canister when you go to `key_1`/scale.
+
+---
+
+## Pre-launch checklist (audit's go-with-conditions)
+- [ ] Decision 0 (key) + Decision 1 (canister) made.
+- [ ] **≥2 independent mainnet RPC providers** secured (NOWNodes / BlockPi / Validation Cloud) — NOT all Confura (audit F-04). Register with `min_quorum_providers ≥ 2`.
+- [ ] CFX price-monitoring + auto-refresh running (audit F-01 — see §"Price monitoring" below). **This is the single most important condition** because the oracle is manual.
+- [ ] Tiny initial cap agreed (e.g. ≤ a few hundred USD of debt total) and a written discipline that you (the only opener) won't exceed it.
+- [ ] Monitoring dashboard live: `reconcile_chain_supply(1030)` gap = 0, `invariant_halted`/`reorg_halted` false, hot-wallet balance, `processed_burn_keys` size (audit F-02).
+- [ ] Deployer key funded with real CFX for the IcUSD.sol deploy gas (~1.65M gas; eSpace meters high).
+- [ ] (Optional, cheap) the F-05 defense-in-depth one-liner coordinated with the M2 session.
+
+---
+
+## Operator sequence (templates — fill the placeholders; use `--identity rumi_identity`)
+
+> If Decision 0 = `key_1`: FIRST land the `monad_ecdsa_key_name()` → `"key_1"` change (M2 session) + redeploy the backend, because every address below changes with the key.
+
+**1. Get the canister's chain-1030 settlement (minter) address** (this is what IcUSD.sol's MINTER_ROLE must be):
+```
+icp canister call <CANISTER> get_chain_settlement_address '(1030 : nat32)' -e <ENV> --identity rumi_identity
+# -> 0x<minter>   (per-chain, key-dependent; derived from settlement_derivation_path(1030))
+```
+
+**2. Deploy IcUSD.sol to eSpace MAINNET** (Foundry; mirrors the testnet deploy, see `foundry/DEPLOY.md`):
+```
+cd foundry
+export CANISTER_SETTLEMENT_ADDR=0x<minter from step 1>
+export DEPLOYER_PK=<funded eSpace-mainnet deployer key>
+forge script script/DeployIcUSD.s.sol \
+  --rpc-url https://evm.confluxrpc.com \
+  --broadcast --gas-estimate-multiplier 400      # eSpace meters ~1.65M gas vs forge's ~1.16M estimate (testnet gotcha)
+# -> IcUSD deployed at 0x<icusd_mainnet>; admin == minter == the canister settlement addr
+```
+
+**3. Register chain 1030** (mainnet params; independent RPCs; deeper finality):
+```
+icp canister call <CANISTER> register_chain '(record {
+  chain_id = 1030 : nat32;
+  display_name = "ConfluxESpaceMainnet";
+  rpc_endpoints = vec { "https://<provider1>"; "https://<provider2>"; "https://<provider3>" };
+  finality_depth = 400 : nat32;          # mainnet PoW reorg depth (security-review param; testnet used 100)
+  gas_strategy = variant { EvmEip1559 = record { max_priority_fee_gwei = 1 : nat64; max_fee_gwei_ceiling = 200 : nat64 } };
+  chain_native_decimals = 18 : nat8;
+  min_quorum_providers = opt (2 : nat32);   # >=2 INDEPENDENT providers (audit F-04)
+})' -e <ENV> --identity rumi_identity
+```
+
+**4. Point the chain at the IcUSD contract + set the CFX price + seed the cursor:**
+```
+icp canister call <CANISTER> set_chain_contract '(1030 : nat32, "0x<icusd_mainnet>")' -e <ENV> --identity rumi_identity
+icp canister call <CANISTER> set_manual_collateral_price '(1030 : nat32, "CFX", <price_e8> : nat64)' -e <ENV> --identity rumi_identity   # e.g. $0.15 -> 15_000_000
+icp canister call <CANISTER> set_last_observed_block '(1030 : nat32, <current_eSpace_head - 1024> : nat64)' -e <ENV> --identity rumi_identity  # snappy burn detection
+```
+
+**5. Turn the timers on** (currently floored to ~1yr/off on staging):
+```
+icp canister call <CANISTER> set_observer_tick_interval_secs '(60 : nat64)' -e <ENV> --identity rumi_identity
+icp canister call <CANISTER> set_settlement_tick_interval_secs '(60 : nat64)' -e <ENV> --identity rumi_identity
+# Interest: leave the harvest timer OFF; realize manually via harvest_chain_interest(1030) when desired,
+# OR set_chain_interest_tick_interval_secs to a long cadence. Watch cycle burn (outcall freq x reservation).
+```
+
+**6. Smoke test (you-only, tiny):** open one small vault → deposit a few CFX → confirm mint → burn → withdraw → Closed, asserting `reconcile_chain_supply(1030)` gap = 0 at each step (same flow proven on testnet). THEN open the (still small) real positions.
+
+**7. Cycles:** top kvg63/the launch canister well above the freeze threshold — outcalls fail (and silently halt the observer) before freezing. `icp cycles mint ... && icp canister top-up ...`.
+
+---
+
+## Price monitoring (audit F-01 — the most important condition)
+
+The oracle is a manual `set_manual_collateral_price` scalar with **no on-chain timestamp or staleness check**. A stale/unrefreshed price is the highest real risk. Mitigation = an **off-chain monitor** (a small cron/script or an IC canister timer; NOT chains source — I can build it):
+- Poll real CFX/USD from **≥2 sources** (e.g. Coingecko + Binance) every N minutes; take the median.
+- Compare to the on-chain price (query the canister); **auto-call `set_manual_collateral_price`** when |market − on-chain| > X% (e.g. 2%), and ALWAYS at least every Y minutes (since there's no on-chain age, the monitor owns freshness).
+- Recompute every chain-1030 vault's *true* CR at the live price; **alert** if any vault < a warning band (e.g. 1.6×) so you can act before it goes underwater (no liquidation exists — your action is to ask the owner to add collateral / repay, or close your own vault).
+- Alert on monitor downtime (a dead monitor = a frozen oracle).
+
+---
+
+## Live monitoring + manual risk playbook
+- **Invariant:** `reconcile_chain_supply(1030)` gap must stay 0; `get_supply_audit` total == Σ vault debt. Alert on any drift, on `invariant_halted`, on `reorg_halted` (clear via `clear_reorg_halt` after verifying), on hot-wallet low.
+- **F-02:** watch `processed_burn_keys` size; a prolonged reorg/halt grows it. Restart-from-snapshot is the escape hatch.
+- **Risk (no liquidation):** keep LTV conservative; you are the only opener, so keep every vault well over-collateralized and be ready to repay/close it yourself. This is the substitute for liquidation.
+
+---
+
+## Go / no-go gate for the gated launch
+GO when: Decisions 0/1 made · ≥2 independent RPCs · price monitor+auto-refresh live · tiny cap + discipline · invariant dashboard live · smoke test green · cycles topped. The audit does NOT otherwise block it.
+
+## Before lifting the caps to a PUBLIC launch (the remaining gates)
+1. **Liquidation** built (the #1 gap — no public launch without it).
+2. **Production `key_1`** (Decision 0) on a dedicated canister.
+3. **Automated/timestamped oracle** (audit F-01) — replace the manual price + monitor with on-chain staleness or XRC/Pyth.
+4. **≥3 independent RPC providers** + `min_quorum ≥ 3` (audit F-04).
+5. **`processed_burn_keys` eviction** (audit F-02) + the F-05 confirm-status guard.
+6. **Debt-ceiling enforcement** in the open path (currently unused) before user-opened (M2) vaults.
+7. **M2 self-serve UX** (other session) + a fresh audit of the combined surface.

--- a/docs/plans/2026-06-18-conflux-gated-mainnet-launch-runbook.md
+++ b/docs/plans/2026-06-18-conflux-gated-mainnet-launch-runbook.md
@@ -12,19 +12,19 @@ Goal: real CFX on **eSpace mainnet (chain 1030)**, tightly capped + dev-gated, m
 
 2. **The debt ceiling is NOT code-enforced** (`debt_ceiling_e8s` is carried in `ChainCollateralConfig` but the open path consumes only `min_cr_e4`). So the "small cap" is **operational** — it is you opening few small vaults, not a guardrail. Treat the cap as a discipline, not a safety net.
 
-3. **The ECDSA key is hardcoded to `test_key_1`** (`chains/monad/config.rs::monad_ecdsa_key_name`). Real CFX would be custodied by tECDSA `test_key_1`. Moving to production `key_1` is a **code change** (M2's area) + redeploy + a full re-derivation of every custody/settlement/interest-treasury address + an IcUSD.sol redeploy with the new minter. See Decision 0.
+3. **The ECDSA key is now a runtime setter (PR #254 — was hardcoded `test_key_1`).** `set_chains_ecdsa_key_name("key_1")` flips the EVM rail to the production threshold key — **no code change/rebuild**. BUT switching re-derives every custody/settlement/interest-treasury address, so it is **rejected once any chain vault exists**: set `key_1` on a FRESH canister BEFORE registering any chain, then deploy IcUSD.sol pointed at the new `key_1`-derived minter. kvg63 staging keeps `test_key_1`. See Decision 0.
 
 ---
 
 ## Decision 0 (REQUIRED — your call): which ECDSA key
-| | `test_key_1` (current) | `key_1` (production) |
+PR #254 made this a **runtime setter** — no code change either way.
+| | `test_key_1` (default) | `key_1` (production) |
 |---|---|---|
-| Code change | none | edit `monad_ecdsa_key_name()` → `"key_1"` (chains source = M2 session) + redeploy |
-| Addresses | already derived (testnet-proven) | ALL custody/settlement/treasury addresses change → IcUSD.sol must be redeployed with the new minter |
-| Risk for real CFX | `test_key_1` is a real threshold key but designated "test" (weaker operational guarantees) | production-grade |
-| Speed | fast (interim) | slower (code + coordination + key availability on the subnet) |
+| How | nothing (default) | `set_chains_ecdsa_key_name("key_1")` on a fresh canister, before any chain is registered |
+| Addresses | testnet-proven | all custody/settlement/treasury addresses derive from `key_1` → deploy IcUSD.sol pointed at the new minter |
+| Risk for real CFX | a real threshold key but designated "test" (weaker operational guarantees) | production-grade |
 
-**Recommendation:** for an *initial, tiny, short-duration* gated launch (a few CFX, you-only), `test_key_1` is the fast path and is consistent with "soft-launch". **Migrate to `key_1` before holding non-trivial value or lifting caps.** If you want real value from day one, do `key_1` first (it is a hard pre-req, not optional, for meaningful TVL).
+**Recommendation: use `key_1` for anything holding real CFX you'd be sad to lose** (the setter makes it cheap now). `test_key_1` only for a throwaway dust-only smoke test. Either way the key MUST be set before the first vault (the setter refuses once vaults exist — orphan guard).
 
 ## Decision 1 (your call): which canister
 - **kvg63 staging** (already runs the rail + interest, `test_key_1`): fastest. Adding chain 1030 here puts real eSpace-mainnet CFX on the staging canister. Fine for a tiny dev-only soft-launch; keep it small.
@@ -48,7 +48,11 @@ Goal: real CFX on **eSpace mainnet (chain 1030)**, tightly capped + dev-gated, m
 
 ## Operator sequence (templates — fill the placeholders; use `--identity rumi_identity`)
 
-> If Decision 0 = `key_1`: FIRST land the `monad_ecdsa_key_name()` → `"key_1"` change (M2 session) + redeploy the backend, because every address below changes with the key.
+**0. (If Decision 0 = `key_1`) set the production key FIRST**, on the fresh canister, before any chain is registered (it refuses once a vault exists — and every address below derives from it):
+```
+icp canister call <CANISTER> set_chains_ecdsa_key_name '("key_1")' -e <ENV> --identity rumi_identity
+icp canister call <CANISTER> get_chains_ecdsa_key_name '()' -e <ENV>   # verify -> "key_1"
+```
 
 **1. Get the canister's chain-1030 settlement (minter) address** (this is what IcUSD.sol's MINTER_ROLE must be):
 ```


### PR DESCRIPTION
## What

Docs-only (6 files, no code): the pre-mainnet security review of the Conflux/Monad EVM rail @`39a07cd` plus a gated eSpace-mainnet soft-launch runbook.

- `audit-reports/2026-06-18-39a07cd/` — report, findings.json, scope, methodology, coverage-crosscheck
- `docs/plans/2026-06-18-conflux-gated-mainnet-launch-runbook.md` (marked **DRAFT for Rob** — review before relying on it)

## Verdict

**GO for a gated soft-launch** (dev-gated, your-hands-only, tiny caps, no public self-serve). 11 candidates → 4 confirmed + 1 informational + 5 false positives. No real bug in the PR #252 interest accrual; no regression.

| ID | Sev | Gates what |
|----|-----|-----------|
| F-01 | HIGH | Manual price oracle has no staleness/sanity bound. Mitigated for the gated launch by the off-chain CFX price monitor (PR #255); **hard gate for a public launch.** |
| F-02 | MED | `processed_burn_keys` unbounded growth under deep reorg + stalled cursor. Public-launch gate; no fund loss. |
| F-04 | LOW | RPC provider concentration (all Confura). Public launch needs ≥3 independent providers. |
| F-05 | INFO | New (PR #252) missing-status-guard; proven unreachable. Cheap defense-in-depth one-liner recommended. |

## The hard truths (why this stays gated)

- **No liquidation / bad-debt recovery on the chains rail.** The launch MUST stay dev-gated; the M2 self-serve frontend must NOT be wired to mainnet until liquidation exists.
- **Debt ceiling is not code-enforced** — `debt_ceiling_e8s` is carried but the open path only checks `min_cr`. The "small cap" is operational discipline, not a guardrail.

These (plus an automated/timestamped oracle, ≥3 RPCs, `processed_burn_keys` eviction, and a fresh audit of the combined surface) are the gates before lifting caps to a public launch.

## Notes

XC-001 (the parked chains-recovery finding) is neither closed nor re-raised here. The runbook is a draft for your review — the operator decisions it can't make (ECDSA key `test_key_1` vs `key_1`; which canister) are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)