### PR TITLE
feat(conflux-frontend): host as a staging asset canister

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -675,6 +675,23 @@ canisters:
           - cp -R src/rumi_homepage/assets/.well-known src/rumi_homepage/dist/.well-known
           - cp -f src/rumi_homepage/assets/favicon.ico src/rumi_homepage/dist/favicon.ico
 
+  # Conflux eSpace self-serve CDP UI (experimental, testnet-only, staging-backend).
+  # Standalone Vite SPA — NOT in the npm root workspaces, so it builds in its own
+  # dir with its own lockfile (`npm ci && npm run build` -> dist/). The single
+  # tracked .ic-assets.json is copied into dist for the CSP (IC boundary + eSpace
+  # testnet RPC) and the SPA index.html fallback. Scoped to mainnet-staging ONLY
+  # (see the env block below) so this experimental rail never rides a production
+  # frontend. Deploy individually: `icp deploy conflux_espace_frontend -e mainnet-staging`.
+  - name: conflux_espace_frontend
+    recipe:
+      type: "@dfinity/asset-canister@v2.1.0"
+      configuration:
+        dir: src/conflux_espace_frontend/dist
+        build:
+          - bash -c 'cd src/conflux_espace_frontend && npm ci && npm run build'
+          - cp src/conflux_espace_frontend/.ic-assets.json src/conflux_espace_frontend/dist/.ic-assets.json
+          - rm -f src/conflux_espace_frontend/dist/.DS_Store
+
 networks:
   - name: local
     mode: managed
@@ -887,6 +904,7 @@ environments:
     network: ic
     canisters:
       - rumi_protocol_backend
+      - conflux_espace_frontend
     init_args:
       # The staging canister was first installed with the full Init variant during
       # Phase 1a (icusd_ledger_principal = `aaaaa-aa` so any accidental icUSD mint

--- a/src/conflux_espace_frontend/.ic-assets.json
+++ b/src/conflux_espace_frontend/.ic-assets.json
@@ -1,0 +1,12 @@
+[
+    {
+        "match": "**/*",
+        "security_policy": "standard",
+        "headers": {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Content-Security-Policy": "default-src 'self';script-src 'self' 'wasm-unsafe-eval';worker-src 'self' blob:;connect-src 'self' blob: https://icp0.io https://*.icp0.io https://icp-api.io https://ic0.app https://*.ic0.app https://evmtestnet.confluxrpc.com;img-src 'self' data:;style-src 'self' 'unsafe-inline';style-src-elem 'self' 'unsafe-inline';font-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'self';form-action 'self';upgrade-insecure-requests;",
+            "Permissions-Policy": "clipboard-write=(self)"
+        },
+        "allow_raw_access": true
+    }
+]


### PR DESCRIPTION
## What

Gives the just-merged `src/conflux_espace_frontend` (PR #257) a deployable home: a dedicated `@dfinity/asset-canister` **scoped to `mainnet-staging` only** (network `ic`, alongside the staging backend kvg63). The experimental, testnet-only rail never rides a production frontend.

- **`icp.yaml`** — new `conflux_espace_frontend` canister. It is **not** in the npm root workspaces, so it builds standalone (`cd src/conflux_espace_frontend && npm ci && npm run build` → `dist/`), then copies the tracked `.ic-assets.json` in. Added to the `mainnet-staging` env canisters list.
- **`.ic-assets.json`** — SPA fallback + a CSP mirroring the proven `vault_frontend` policy, trimmed to this app's origins: the IC boundary (`icp0.io`/`*.icp0.io`/`icp-api.io`/`ic0.app`) plus the eSpace testnet RPC (`evmtestnet.confluxrpc.com`); `clipboard-write` for the copy-custody button.

## Verification

Ran the exact build recipe: `dist/` contains `index.html`, `assets/`, and exactly one asset-config file (avoids the icp-cli two-config gather error). YAML parses; canister appears in the staging env only.

## Follow-up (not in this PR)

Actual deploy needs canister creation (cycles) on `mainnet-staging`: `icp deploy conflux_espace_frontend -e mainnet-staging --identity rumi_identity`. Reachable at the free `https://<canister-id>.icp0.io` — no custom domain until the rail graduates from experimental. **The deployed CSP should be smoke-tested** (an update-call signature path exercises the agent's certificate verification, which the local dev server doesn't enforce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)