### PR TITLE
chore(conflux-frontend): record staging asset canister id

### DIFF
--- a/.icp/data/mappings/mainnet-staging.ids.json
+++ b/.icp/data/mappings/mainnet-staging.ids.json
@@ -1,3 +1,4 @@
 {
+  "conflux_espace_frontend": "ucdmm-6qaaa-aaaao-bbcpa-cai",
   "rumi_protocol_backend": "kvg63-wiaaa-aaaao-bbabq-cai"
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,4 +1,7 @@
 {
+  "conflux_espace_frontend": {
+    "ic-staging": "ucdmm-6qaaa-aaaao-bbcpa-cai"
+  },
   "icusd_index": {
     "ic": "6niqu-siaaa-aaaap-qrjeq-cai"
   },


### PR DESCRIPTION
Persists the deployed staging asset canister id (`conflux_espace_frontend` = `ucdmm-6qaaa-aaaao-bbcpa-cai`) into `canister_ids.json` (ic-staging) and the icp-cli mapping, so a future `icp deploy conflux_espace_frontend -e mainnet-staging` upgrades the existing canister instead of creating a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)