### PR TITLE
Increment 1 — MultiChainStateV6 + unified supply invariant (accounting scaffolding, no execution)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-chains-liquidation-increment-1.md
+++ b/docs/superpowers/plans/2026-06-19-chains-liquidation-increment-1.md
@@ -1,0 +1,107 @@
+# Chains Liquidation — Increment 1: MultiChainStateV6 + Unified Supply Invariant
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`. This increment touches the protocol's most safety-critical code (state migration + the supply invariant). The first task de-risks the state-wipe; do NOT proceed to the invariant rewrite until the V5→V6 round-trip test is green.
+
+**Goal:** Bump the persisted multi-chain root to `MultiChainStateV6` (reserve + pending-burn + liquidation-config + sp-attempted state, plus a `pending_liquidation` vault marker) and generalize the supply invariant to `sum(chain_supplies) == debt + reserve_backing + pending_chain_burn` — purely the accounting + config scaffolding, NO liquidation execution. Ships behind the existing dev-gating; the new terms are all 0 until Increment 2+ uses them, so it is behavior-preserving.
+
+**Architecture:** Follow the documented additive-reshape recipe (`multi_chain_state.rs:8-30`): keep `MultiChainStateV5` byte-verbatim, add `MultiChainStateV6` with the V5 fields + new `#[serde(default)]` fields, move the impl to V6, rebind `pub type MultiChainState = MultiChainStateV6`. `State.multi_chain` already uses the alias, so the only signature churn is the ~40 functions that hard-code `&mut MultiChainStateV5` → rename to the alias `MultiChainState` so this is the LAST time a bump needs a rename.
+
+**Tech stack:** Rust, ciborium/CBOR persisted state, the chains module, `cargo test` (unit + the V5→V6 CBOR round-trip + the conflux PocketIC regression).
+
+**HIGH review findings folded in (from the spec Appendix A):**
+- **#1 (interest conservation):** the invariant counts REALIZED supply vs `debt_e8s`. `pending_interest_mint_e8s` is NOT yet in `chain_supplies` (it mints on confirm), so it must NOT appear on the invariant RHS. The reserve/burn terms only ever move ALREADY-realized debt. A unit test must assert the invariant holds for a vault carrying non-zero `pending_interest_mint_e8s`.
+- **#2 (apply_supply_delta false-halt):** the current strict-equality self-check is `sum(supplies) == sum(debt)`. Generalizing to a 3-term RHS, the reserve-shift helper must move debt→reserve in ONE atomic mutation so the equality holds at every checkpoint; `apply_supply_delta` keeps rejecting a delta that would break the (generalized) equality. Add the reserve/burn terms to BOTH the periodic self-check and `apply_supply_delta`'s check in the SAME commit so neither sees a half-updated RHS.
+
+---
+
+### Task 1: MultiChainStateV6 bump + V5→V6 round-trip safety test (DE-RISK THE WIPE FIRST)
+
+**Files:** `chains/multi_chain_state.rs`, `chains/tests_multi_chain_state_v2.rs`, and a per-file alias rename across the ~25 files listed by `grep -rln MultiChainStateV5 src`.
+
+- [ ] **Step 1: Add the V6 struct.** In `multi_chain_state.rs`, after the V5 struct, add `MultiChainStateV6` = every V5 field verbatim (the 4 base fields undecorated; the 11 existing `#[serde(default)]` fields) PLUS, each `#[serde(default)]`:
+```rust
+/// Bot-path (PSM) reserve backing per chain (e8s): icUSD value backed by
+/// bot-held stable, NOT by an open vault. Part of the unified invariant RHS.
+pub reserve_backing_e8s: BTreeMap<ChainId, u128>,
+/// Bot-held settle-stable (USDC) per chain in native base units (18-dec on
+/// eSpace), pending the manual bridge to cUSDT reserves. Informational/audit.
+pub reserve_usdc_native: BTreeMap<ChainId, u128>,
+/// SP-path debt mid-burn per chain (e8s): the SP has absorbed it (icUSD will
+/// burn on-chain) but the burn is not yet confirmed. Part of the invariant RHS.
+pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
+/// Vaults whose bot liquidation failed and were escalated to the SP exactly
+/// once (the no-retry guard; once present, never re-attempted by the SP).
+pub sp_attempted_chain_vaults: BTreeSet<u64>,
+```
+(The `chain_liquidation_configs` map + its `ChainLiquidationConfigV1` type are added to V6 in Task 4 — still pre-deploy, so the same V6 struct, no V7.)
+
+- [ ] **Step 2: Move the impl + rebind the alias.** Change `impl MultiChainStateV5` → `impl MultiChainStateV6` (the helper methods now live on V6), and `pub type MultiChainState = MultiChainStateV5;` → `= MultiChainStateV6;`. Update the in-file `manual_price_tests` to construct `MultiChainStateV6::default()`.
+
+- [ ] **Step 3: Alias-rename the function signatures.** For every NON-definition file that references `MultiChainStateV5` (all of `grep -rln MultiChainStateV5 src` except `multi_chain_state.rs` and the version-specific round-trip tests in `tests_multi_chain_state_v2.rs`), replace `MultiChainStateV5` → `MultiChainState`. In `supply.rs`, the historical `migrate_multi_chain_state(v1: MultiChainStateV1) -> MultiChainStateV2` template stays version-explicit; only the live function signatures (`&mut MultiChainStateV5` → `&mut MultiChainState`) change.
+
+- [ ] **Step 4: Write the V5→V6 round-trip test.** In `tests_multi_chain_state_v2.rs`, mirroring `v3_cbor_snapshot_decodes_into_v4_without_wiping_state`:
+```rust
+#[test]
+fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
+    // Build a populated V5, encode to CBOR, decode as V6: every carried field
+    // survives and the four new V6 fields come up empty (NOT a wipe).
+    let mut v5 = MultiChainStateV5::default();
+    v5.chain_supplies.insert(ChainId(1030), 100 * E8);
+    // ... seed a vault, a contract, a manual price, a nonce ...
+    let mut buf = Vec::new();
+    ciborium::into_writer(&v5, &mut buf).unwrap();
+    let v6: MultiChainStateV6 = ciborium::from_reader(&buf[..]).unwrap();
+    assert_eq!(v6.chain_supplies, v5.chain_supplies, "carried field survived");
+    assert!(v6.reserve_backing_e8s.is_empty(), "new field defaulted, not wiped");
+    assert!(v6.pending_chain_burn_e8s.is_empty());
+    assert!(v6.sp_attempted_chain_vaults.is_empty());
+}
+```
+
+- [ ] **Step 5: Build + test.** `cargo build -p rumi_protocol_backend` (compiler verifies every renamed signature), then `cargo test -p rumi_protocol_backend --lib chains::tests_multi_chain_state` — the round-trip test MUST pass before continuing. Commit: `feat(chains): MultiChainStateV6 (reserve + pending-burn + sp-attempted)`.
+
+---
+
+### Task 2: The `pending_liquidation` vault marker (no new status)
+
+**Files:** `chains/monad/chain_vault.rs` (the `ChainVaultV1` struct), `chains/vault.rs` (the owner-write guards).
+
+- [ ] **Step 1:** Add to `ChainVaultV1`, `#[serde(default)]`: `pub pending_liquidation: Option<PendingLiquidationV1>,` and define `PendingLiquidationV1 { op_id: u64, debt_to_clear_e8s: u128, collateral_reserved_native: u128, tier: LiquidationTier, started_at_ns: u64 }` + `enum LiquidationTier { Bot, StabilityPool }`. (Resolved spec §3.1: a marker, NOT a new `ChainVaultStatus` variant, so no `match` exhaustiveness churn and the existing pending-marker write-guards apply.)
+- [ ] **Step 2:** Add `LiquidationInFlight` rejection arms to `WithdrawError`/`BorrowError`/`OpenVaultError` as appropriate, and reject owner write-ops while `pending_liquidation.is_some()` (mirrors the `MintInFlight` guard). Tests: a vault with a `pending_liquidation` marker rejects borrow/withdraw/close. Update the `ChainVaultV1` literal-construction sites in tests (the compiler lists them) to add `pending_liquidation: None`.
+- [ ] **Step 3:** Build + test + commit `feat(chains): pending_liquidation vault marker + write guards`.
+
+---
+
+### Task 3: The unified supply invariant + apply_supply_delta (HIGH #1, #2)
+
+**Files:** `chains/supply.rs` (`reconcile_chain_supply` / the self-check / `apply_supply_delta`).
+
+- [ ] **Step 1: Generalize the invariant helper.** Add `pub fn chain_backing_rhs_e8s(state, chain) -> u128` = `sum(vault.debt_e8s for chain) + reserve_backing_e8s[chain] + pending_chain_burn_e8s[chain]`. The invariant is `chain_supplies[chain] == chain_backing_rhs_e8s(chain)`. With all-zero reserve/burn it reduces to the existing `supply == debt`, so it is behavior-preserving.
+- [ ] **Step 2: Write the failing tests FIRST:** (a) invariant holds with non-zero `reserve_backing_e8s` (supply unchanged, debt down by X, reserve up by X); (b) invariant holds with non-zero `pending_chain_burn_e8s` (supply still == old, debt down, pending-burn up — pre-confirm); (c) **HIGH #1:** invariant holds for a vault carrying non-zero `pending_interest_mint_e8s` (it is NOT on the RHS — only realized `debt_e8s` is); (d) **HIGH #2:** `apply_supply_delta` rejects a delta that would break the GENERALIZED equality, and accepts one that preserves it.
+- [ ] **Step 3:** Update `reconcile_chain_supply`, the periodic self-check, AND `apply_supply_delta`'s equality check to the 3-term RHS in the SAME commit (so no checkpoint sees a half-updated RHS — HIGH #2). Run; make green. Commit `feat(chains): unified supply invariant (debt + reserve + pending-burn)`.
+
+---
+
+### Task 4: `apply_debt_to_reserve_shift` + the liquidation config (getter/setter)
+
+**Files:** `chains/supply.rs`, NEW `chains/liquidation_config.rs`, `chains/multi_chain_state.rs` (add `chain_liquidation_configs` to V6), `main.rs` (admin endpoints).
+
+- [ ] **Step 1:** `pub fn apply_debt_to_reserve_shift(state, chain, vault_id, cleared_e8s, stable_native)` — atomically: `vault.debt_e8s -= cleared`, `reserve_backing_e8s[chain] += cleared`, `reserve_usdc_native[chain] += stable_native`, leaving `chain_supplies` UNCHANGED (no burn). Asserts the invariant holds after. NO liquidation caller yet — exercised by a unit test proving a reserve shift keeps the invariant balanced (the Increment-2 bot path will call it).
+- [ ] **Step 2:** `chains/liquidation_config.rs`: `ChainLiquidationConfigV1 { dex: DexKind, router, factory, pair, collateral_token, settle_stable_token, slippage_cap_bps, restore_target_cr_e4, enabled: bool }` + `enum DexKind { UniswapV2 }`. Add `chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>` to `MultiChainStateV6` (`#[serde(default)]`). Dev-gated `set_chain_liquidation_config` / `get_chain_liquidation_config` in `main.rs`. Tests + the V6 round-trip test extended to seed + assert the config survives.
+- [ ] **Step 3:** Build + test + commit.
+
+---
+
+### Task 5: Event variants + verify + PR
+
+- [ ] **Step 1:** Add the forward-looking event variants (`ChainVaultLiquidated`, `ChainReserveCredited`, `ChainCfxClaimSettled`, `ChainLiquidationDeferred`) to the chains `Event` enum (unused until Increment 2; additive, like the config was in Increment 0). Confirm the candid round-trip test for the event enum still passes.
+- [ ] **Step 2: Full verify.** `cargo test -p rumi_protocol_backend --lib` (incl. the V5→V6 round-trip) + `--bin` + the conflux + interest PocketIC suites (`POCKET_IC_BIN=…`). Rebuild the wasm first (PocketIC `include_bytes!`s it).
+- [ ] **Step 3: PR** against `main`: "Increment 1 — MultiChainStateV6 + unified supply invariant (accounting scaffolding, no execution)". Note the V5→V6 round-trip proof, the all-zero behavior-preservation, and that the deploy is a state-preserving upgrade (the new fields default empty on the live kvg63 snapshot).
+
+---
+
+## Self-review
+- **Spec coverage:** implements spec §3 (state + versioning), §5 (unified invariant), the §3.1 marker resolution, and the §8 config seam (getter/setter only). Execution (sizing, the swap, the SP) is Increments 2-4, untouched here.
+- **Wipe safety:** the V5→V6 round-trip test (Task 1 Step 4) is the gate; nothing proceeds until it passes. Every new persisted field/struct carries `#[serde(default)]`; the four base fields stay undecorated.
+- **Behavior preservation:** all new RHS terms are 0 until Increment 2, so the generalized invariant equals the old `supply == debt` on the live snapshot — the staging upgrade changes no behavior.
+- **HIGH findings:** #1 (pending_interest excluded from RHS) and #2 (3-term RHS updated atomically in self-check + apply_supply_delta together) are pinned by Task 3 Step 2 tests (c) and (d).

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -39,7 +39,10 @@ type CandidVault = record {
 };
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
+  pending_chain_burn_e8s : nat;
+  reserve_backing_e8s : nat;
   gap_e8s : int;
+  reserve_usdc_native : nat;
   unbacked_excess : bool;
   finalized_block : nat64;
   in_flight_mint_e8s : nat;

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,17 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainLiquidationConfigV1 = record {
+  dex : DexKind;
+  pair : text;
+  restore_target_cr_e4 : nat64;
+  enabled : bool;
+  collateral_token : text;
+  factory : text;
+  slippage_cap_bps : nat16;
+  router : text;
+  settle_stable_token : text;
+};
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
   pending_chain_burn_e8s : nat;
@@ -154,6 +165,7 @@ type DeviceSpec = variant {
   GenericDisplay;
   LineDisplay : record { characters_per_line : nat16; lines_per_page : nat16 };
 };
+type DexKind = variant { UniswapV2 };
 type ErrorInfo = record { description : text };
 type Event = variant {
   set_borrowing_fee : record { rate : text };
@@ -1023,6 +1035,9 @@ service : (ProtocolArg) -> {
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
+  get_chain_liquidation_config : (nat32) -> (
+      opt ChainLiquidationConfigV1,
+    ) query;
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_chains_ecdsa_key_name : () -> (text) query;
@@ -1146,6 +1161,7 @@ service : (ProtocolArg) -> {
   set_chain_contract : (nat32, text) -> (Result);
   set_chain_interest_min_realize_e8s : (nat) -> (Result);
   set_chain_interest_tick_interval_secs : (nat64) -> (Result);
+  set_chain_liquidation_config : (nat32, ChainLiquidationConfigV1) -> (Result);
   set_chains_ecdsa_key_name : (text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -64,6 +64,7 @@ type ChainVaultV1 = record {
   opened_at_ns : nat64;
   vault_id : nat64;
   last_interest_accrual_ns : nat64;
+  pending_liquidation : opt PendingLiquidationV1;
   collateral_chain : nat32;
   mint_recipient : text;
   debt_e8s : nat;
@@ -666,6 +667,7 @@ type InitArg = record {
 type InterestSplitArg = record { bps : nat64; destination : text };
 type InterpolationMethod = variant { Linear };
 type LineDisplayPage = record { lines : vec text };
+type LiquidationTier = variant { Bot; StabilityPool };
 type LiquidityStatus = record {
   liquidity_provided : nat64;
   total_liquidity_provided : nat64;
@@ -676,6 +678,13 @@ type LiquidityStatus = record {
 type ManualPriceInfo = record { set_at_ns : nat64; price_e8 : nat64 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type PendingLiquidationV1 = record {
+  started_at_ns : nat64;
+  op_id : nat64;
+  tier : LiquidationTier;
+  debt_to_clear_e8s : nat;
+  collateral_reserved_native : nat;
+};
 type PerCollateralRateCurve = record {
   markers : vec record { float64; float64 };
   base_rate : float64;

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -210,6 +210,19 @@ type Event = variant {
     timestamp : nat64;
     tx_hash : text;
   };
+  chain_liquidation_deferred : record {
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    reason : text;
+  };
+  chain_reserve_credited : record {
+    usdc_native : nat;
+    backing_added_e8s : nat;
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -510,6 +523,13 @@ type Event = variant {
   set_icpswap_routing_enabled : record { enabled : bool };
   set_bot_budget : record { start_timestamp : nat64; total_e8s : nat64 };
   set_rmr_floor : record { value : text };
+  chain_cfx_claim_settled : record {
+    claim_id : nat64;
+    amount_native : nat;
+    recipient : text;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   set_redemption_fee_floor : record { rate : text };
   set_interest_rate : record {
     collateral_type : principal;
@@ -556,6 +576,15 @@ type Event = variant {
   set_collateral_borrow_threshold : record {
     borrow_threshold_ratio : text;
     collateral_type : principal;
+  };
+  chain_vault_liquidated : record {
+    collateral_seized_native : nat;
+    op_id : nat64;
+    tier : LiquidationTier;
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    debt_cleared_e8s : nat;
   };
   add_collateral_type : record {
     config : CollateralConfig;

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -7,7 +7,7 @@ use super::config::{
     ChainAdminError, ChainConfigV3, ChainId, ChainStatus, GasStrategy, RegisterChainArg,
     UpdateChainConfigArg,
 };
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 use super::settlement_queue::SettlementQueueV1;
 
 /// EVM chains need >= 1 confirmation before a block is treated as final. A
@@ -39,7 +39,7 @@ fn dedup_endpoints(endpoints: Vec<String>) -> Vec<String> {
 }
 
 pub fn register_chain_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     arg: RegisterChainArg,
     now_ns: u64,
 ) -> Result<ChainConfigV3, ChainAdminError> {
@@ -103,7 +103,7 @@ pub fn register_chain_in_state(
 }
 
 pub fn disable_chain_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     let cfg = state
@@ -121,7 +121,7 @@ pub fn disable_chain_in_state(
 /// would be a silent state leak). All-or-nothing: every rejection path returns
 /// before the first mutation, so a refused delete leaves the chain fully intact.
 pub fn delete_chain_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain_id: ChainId,
 ) -> Result<(), ChainAdminError> {
     if !state.chain_configs.contains_key(&chain_id) {
@@ -157,7 +157,7 @@ pub fn delete_chain_in_state(
 }
 
 pub fn update_chain_config_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain_id: ChainId,
     update: UpdateChainConfigArg,
 ) -> Result<(), ChainAdminError> {

--- a/src/rumi_protocol_backend/src/chains/evm/burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/burn_proof.rs
@@ -5,7 +5,7 @@ use crate::chains::monad::evm_rpc::{
     decode_burn_log, get_transaction_receipt_with_logs, is_block_final, BurnLog,
     TxReceiptWithLogs, BURN_EVENT_TOPIC0,
 };
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use ic_canister_log::log;
@@ -29,7 +29,7 @@ use ic_canister_log::log;
 /// apply+record commit in one message slice) — a retry re-skips them and
 /// re-attempts the halting burn. This matches the audited poll-path C-1 semantics.
 pub fn apply_receipt_burns_to_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     _chain: ChainId,
     contract: &str,
     tx_hash: &str,

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -42,7 +42,7 @@
 use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
@@ -118,7 +118,7 @@ pub fn backstop_should_scan(
 /// of a u128 collateral balance is not a realistic failure mode but we guard
 /// it anyway). Returns `Err` if the vault is not found.
 pub fn credit_deposit_to_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     amount_e18: u128,
 ) -> Result<(), String> {
@@ -168,7 +168,7 @@ pub fn credit_deposit_to_state(
 /// burner==owner constraint if griefing (uninvited debt repayment) becomes a
 /// concern; for Phase 1b it is accepted.
 pub fn apply_burn_to_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     burn: &super::evm_rpc::BurnLog,
     total_debt_e8s: u128,
 ) -> Result<(), BurnApplyError> {
@@ -878,7 +878,7 @@ pub async fn run_observer(chain: ChainId) {
 /// vaults make a tick outliving MAX_BLOCK_SCAN_WINDOW blocks unreachable in
 /// practice). Revisit for deeper finality / higher vault counts where a self-heal
 /// reclaim could race the prune.
-pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainStateV5, chain: ChainId, finalized: u64) {
+pub(crate) fn advance_cursor_and_prune(state: &mut MultiChainState, chain: ChainId, finalized: u64) {
     state.last_observed_block.insert(chain, finalized);
     let stale: Vec<u64> = state
         .processed_burn_keys

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -38,7 +38,7 @@ use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
@@ -96,7 +96,7 @@ pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
 /// 3. Only after (2) succeeds: move `pending_mint_e8s` -> `debt_e8s`, set
 ///    status `Open`.
 pub fn confirm_mint_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     vault_id: u64,
     observed_e8s: u128,
@@ -145,7 +145,7 @@ pub fn confirm_mint_in_state(
 /// `pending_interest_mint_e8s`. `pre_total` is the PRE-mint
 /// `total_chain_vault_debt_e8s()`.
 pub fn confirm_interest_mint_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     vault_id: u64,
     observed_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
@@ -28,7 +28,7 @@ fn state_with_open_vault(debt: u128) -> MultiChainState {
             owner_evm: None,
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-        },
+            pending_liquidation: None,        },
     );
     s
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
@@ -2,15 +2,15 @@ use crate::chains::config::ChainId;
 use crate::chains::monad::burn_proof::apply_receipt_burns_to_state;
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::monad::evm_rpc::{TxReceiptWithLogs, BURN_EVENT_TOPIC0};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use candid::Principal;
 
 fn word(v: u128) -> String {
     format!("0x{:064x}", v)
 }
 
-fn state_with_open_vault(debt: u128) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn state_with_open_vault(debt: u128) -> MultiChainState {
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), debt);
     s.chain_vaults.insert(
         1,

--- a/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
@@ -1,13 +1,13 @@
 use super::deposit_watch::{advance_cursor_and_prune, apply_burn_to_state, credit_deposit_to_state, BurnApplyError};
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::monad::evm_rpc::BurnLog;
 use crate::chains::supply::SupplyInvariantError;
 use candid::Principal;
 
-fn seeded() -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn seeded() -> MultiChainState {
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
@@ -17,7 +17,7 @@ fn seeded() -> MultiChainState {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     s
 }
 

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -17,7 +17,7 @@ fn vault_pending(s: &mut MultiChainState, vault_id: u64, pending: u128) {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn vault_interest_pending(s: &mut MultiChainState, vault_id: u64, debt: u128, pe
     owner_evm: None,
         last_interest_accrual_ns: 1_000,
         pending_interest_mint_e8s: pending,
-    });
+        pending_liquidation: None,    });
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn confirm_mint_second_vault_uses_running_total() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
     confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0).expect("confirm 2nd");

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -4,11 +4,11 @@ use super::settlement::{
 };
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
 
-fn vault_pending(s: &mut MultiChainStateV5, vault_id: u64, pending: u128) {
+fn vault_pending(s: &mut MultiChainState, vault_id: u64, pending: u128) {
     s.chain_vaults.insert(vault_id, ChainVaultV1 {
         vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
         custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
@@ -53,7 +53,7 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
 
 #[test]
 fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
     // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
@@ -71,7 +71,7 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
 
 /// An Open vault with confirmed `debt` and an interest mint of `pending` in
 /// flight (`last_interest_accrual_ns = 1_000`).
-fn vault_interest_pending(s: &mut MultiChainStateV5, vault_id: u64, debt: u128, pending: u128) {
+fn vault_interest_pending(s: &mut MultiChainState, vault_id: u64, debt: u128, pending: u128) {
     s.chain_vaults.insert(vault_id, ChainVaultV1 {
         vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(71),
         custody_address: "0xc".into(), collateral_amount_native: 1_400_000_000_000_000_000_000,
@@ -85,7 +85,7 @@ fn vault_interest_pending(s: &mut MultiChainStateV5, vault_id: u64, debt: u128, 
 
 #[test]
 fn confirm_interest_mint_grows_debt_and_supply_equally() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(71), 100 * 100_000_000); // 100 icUSD principal minted
     vault_interest_pending(&mut s, 1, 100 * 100_000_000, 2 * 100_000_000); // 2 icUSD pending
     let pre = s.total_chain_vault_debt_e8s(); // 100e8
@@ -106,7 +106,7 @@ fn confirm_interest_mint_grows_debt_and_supply_equally() {
 
 #[test]
 fn confirm_interest_mint_rejects_amount_mismatch_no_mutation() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(71), 100 * 100_000_000);
     vault_interest_pending(&mut s, 1, 100 * 100_000_000, 2 * 100_000_000);
     let pre = s.total_chain_vault_debt_e8s();
@@ -120,7 +120,7 @@ fn confirm_interest_mint_rejects_amount_mismatch_no_mutation() {
 
 #[test]
 fn confirm_mint_rejects_amount_mismatch() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000);
     // Observed amount differs from pending: reject (caught before any supply mutation), do not mutate.
@@ -132,7 +132,7 @@ fn confirm_mint_rejects_amount_mismatch() {
 
 #[test]
 fn confirm_mint_unknown_vault_rejected() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     assert!(confirm_mint_in_state(&mut s, ChainId(10143), 999, 1, 0, 0).is_err());
 }
@@ -141,7 +141,7 @@ fn confirm_mint_unknown_vault_rejected() {
 fn confirm_mint_second_vault_uses_running_total() {
     // Two vaults: first already confirmed (debt 100e8, supply 100e8). Confirming the
     // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
     s.chain_vaults.insert(1, ChainVaultV1 {
         vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -38,7 +38,7 @@ pub fn accrued_chain_interest_e8s(debt_e8s: u128, apr_bps: u64, elapsed_ns: u64)
 }
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
 use crate::chains::vault::ChainVaultStatus;
 
@@ -52,7 +52,7 @@ use crate::chains::vault::ChainVaultStatus;
 /// `treasury_recipient` is the per-chain interest-treasury address (resolved by
 /// the async caller). Returns the op_ids enqueued.
 pub fn harvest_chain_interest_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     apr_bps: u64,
     threshold_e8s: u128,
@@ -167,7 +167,7 @@ mod tests {
     // ─── harvest_chain_interest_in_state ────────────────────────────────────
     use super::harvest_chain_interest_in_state;
     use crate::chains::config::ChainId;
-    use crate::chains::multi_chain_state::MultiChainStateV5;
+    use crate::chains::multi_chain_state::MultiChainState;
     use crate::chains::settlement_queue::SettlementOpKind;
     use crate::chains::vault::{ChainVaultStatus, ChainVaultV1};
     use candid::Principal;
@@ -176,7 +176,7 @@ mod tests {
     const TREASURY: &str = "0x00000000000000000000000000000000000c0ffe";
 
     fn open_vault(
-        s: &mut MultiChainStateV5,
+        s: &mut MultiChainState,
         vault_id: u64,
         debt_e8s: u128,
         last_accrual_ns: u64,
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn harvest_enqueues_one_interest_mint_per_eligible_vault() {
-        let mut s = MultiChainStateV5::default();
+        let mut s = MultiChainState::default();
         open_vault(&mut s, 1, 100 * E8, /*last accrual a year ago*/ 0, 0, ChainVaultStatus::Open);
         let now = NANOS_PER_YEAR;
         let mut next = 1000u64;
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn harvest_skips_below_threshold() {
-        let mut s = MultiChainStateV5::default();
+        let mut s = MultiChainState::default();
         // 1ns elapsed on 100 icUSD -> 1 e8s accrued, below a 1e6 threshold.
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
         let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn harvest_skips_in_flight_non_open_and_zero_debt() {
-        let mut s = MultiChainStateV5::default();
+        let mut s = MultiChainState::default();
         open_vault(&mut s, 1, 100 * E8, 0, /*in flight*/ 50_000_000, ChainVaultStatus::Open);
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::MintPending); // not Open
         open_vault(&mut s, 3, 0, 0, 0, ChainVaultStatus::Open); // zero debt
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn harvest_allocates_disjoint_mint_ids_for_multiple_vaults() {
-        let mut s = MultiChainStateV5::default();
+        let mut s = MultiChainState::default();
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::Open);
         let mut next = 5000u64;

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -199,7 +199,7 @@ mod tests {
                 owner_evm: None,
                 last_interest_accrual_ns: last_accrual_ns,
                 pending_interest_mint_e8s: pending_interest,
-            },
+                pending_liquidation: None,            },
         );
     }
 

--- a/src/rumi_protocol_backend/src/chains/liquidation_config.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation_config.rs
@@ -1,0 +1,179 @@
+//! Per-chain, operator-settable liquidation config (spec 8, Tier B).
+//!
+//! Chain-agnostic by construction: the liquidation ENGINE is generic; the only
+//! per-chain knobs are the DEX wiring (which UniswapV2-family pool to sell the
+//! seized collateral into) + the risk knobs. A new EVM chain plugs in as a config
+//! ROW (`set_chain_liquidation_config`), not as code. The same DEX family (any
+//! UniswapV2 fork, e.g. Swappi on Conflux eSpace) reuses `DexKind::UniswapV2`
+//! verbatim.
+//!
+//! Versioned-snapshot pattern (see spec Section 3): the active shape is
+//! `ChainLiquidationConfigV1`. Adding a field = bump to V2 (carry every prior
+//! field verbatim, decorate the new one with `#[serde(default)]`). The enclosing
+//! `MultiChainStateV6.chain_liquidation_configs` map is `#[serde(default)]`, so a
+//! pre-config snapshot decodes with an empty map (state-wipe safe). Inert until
+//! Increment 2+ reads it; Increment 1 only ships the getter/setter scaffolding.
+
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
+/// The DEX family used to liquidate a chain's collateral. Only the UniswapV2
+/// constant-product family ships first (Swappi/Conflux); the engine's swap
+/// encoder + quote reader are keyed off this so a new family is a new arm, not a
+/// rewrite.
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DexKind {
+    /// UniswapV2 constant-product AMM (and forks: Swappi, etc.).
+    UniswapV2,
+}
+
+/// Per-chain liquidation config (operator-set, dev-gated). Holds the DEX wiring
+/// + the two risk knobs the bot path needs. Addresses are chain-native hex
+/// strings (validated by the engine's address validator at swap-build time, not
+/// here). `enabled` is the per-chain kill switch: even with the whole chains rail
+/// dev-gated, an operator must explicitly flip this on before any liquidation
+/// swap can run for the chain.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ChainLiquidationConfigV1 {
+    /// Which DEX family to route the collateral->stable swap through.
+    pub dex: DexKind,
+    /// The DEX router contract (the swap entrypoint, e.g. Swappi router). Distinct
+    /// from `factory` — the spec calls out that the liquidity facts only give the
+    /// factory, and the router address is a required separate input.
+    pub router: String,
+    /// The DEX factory contract (used for the set-time pair sanity check in a
+    /// later increment).
+    pub factory: String,
+    /// The collateral/stable pair (pool) contract the swap reads reserves from.
+    pub pair: String,
+    /// The collateral token sold (wrapped native gas asset, e.g. WCFX).
+    pub collateral_token: String,
+    /// The settle-stable token received and held as reserve (e.g. USDC).
+    pub settle_stable_token: String,
+    /// Max acceptable slippage on the swap, in basis points (<= 10_000).
+    pub slippage_cap_bps: u16,
+    /// The collateral ratio (e4: 15_500 == 155.00%) the partial liquidation sizes
+    /// the vault back up to.
+    pub restore_target_cr_e4: u64,
+    /// Per-chain kill switch. `false` => no liquidation swap runs for this chain
+    /// even if the rest of the rail is enabled.
+    pub enabled: bool,
+}
+
+/// Reasons `set_chain_liquidation_config` rejects a config (no state mutation on
+/// any error).
+#[derive(Debug, PartialEq, Eq)]
+pub enum LiquidationConfigError {
+    /// `slippage_cap_bps` exceeds 100% (10_000 bps).
+    SlippageCapTooHigh { slippage_cap_bps: u16 },
+    /// `restore_target_cr_e4` is not above 100% (a target at/below par cannot
+    /// restore a vault).
+    RestoreTargetTooLow { restore_target_cr_e4: u64 },
+    /// An `enabled` config left a required address empty (the swap could never
+    /// build). Disabled configs may carry placeholder/empty addresses.
+    MissingAddress(&'static str),
+}
+
+impl ChainLiquidationConfigV1 {
+    /// Validate operator-supplied invariants before persisting. Disabled configs
+    /// are allowed to be partially filled (an operator stages the wiring, then
+    /// flips `enabled`); an enabled config must have every address present.
+    pub fn validate(&self) -> Result<(), LiquidationConfigError> {
+        if self.slippage_cap_bps > 10_000 {
+            return Err(LiquidationConfigError::SlippageCapTooHigh {
+                slippage_cap_bps: self.slippage_cap_bps,
+            });
+        }
+        if self.restore_target_cr_e4 <= 10_000 {
+            return Err(LiquidationConfigError::RestoreTargetTooLow {
+                restore_target_cr_e4: self.restore_target_cr_e4,
+            });
+        }
+        if self.enabled {
+            if self.router.is_empty() {
+                return Err(LiquidationConfigError::MissingAddress("router"));
+            }
+            if self.factory.is_empty() {
+                return Err(LiquidationConfigError::MissingAddress("factory"));
+            }
+            if self.pair.is_empty() {
+                return Err(LiquidationConfigError::MissingAddress("pair"));
+            }
+            if self.collateral_token.is_empty() {
+                return Err(LiquidationConfigError::MissingAddress("collateral_token"));
+            }
+            if self.settle_stable_token.is_empty() {
+                return Err(LiquidationConfigError::MissingAddress("settle_stable_token"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_cfg() -> ChainLiquidationConfigV1 {
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0xrouter".into(),
+            factory: "0xfactory".into(),
+            pair: "0xpair".into(),
+            collateral_token: "0xwcfx".into(),
+            settle_stable_token: "0xusdc".into(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn valid_enabled_config_passes() {
+        assert_eq!(enabled_cfg().validate(), Ok(()));
+    }
+
+    #[test]
+    fn slippage_above_100pct_rejected() {
+        let mut c = enabled_cfg();
+        c.slippage_cap_bps = 10_001;
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::SlippageCapTooHigh { slippage_cap_bps: 10_001 })
+        );
+    }
+
+    #[test]
+    fn restore_target_at_or_below_par_rejected() {
+        let mut c = enabled_cfg();
+        c.restore_target_cr_e4 = 10_000;
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::RestoreTargetTooLow { restore_target_cr_e4: 10_000 })
+        );
+    }
+
+    #[test]
+    fn enabled_config_with_empty_address_rejected() {
+        let mut c = enabled_cfg();
+        c.pair = String::new();
+        assert_eq!(c.validate(), Err(LiquidationConfigError::MissingAddress("pair")));
+    }
+
+    #[test]
+    fn disabled_config_may_have_empty_addresses() {
+        // An operator can stage a config (addresses TBD) while it is disabled.
+        let c = ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: String::new(),
+            factory: String::new(),
+            pair: String::new(),
+            collateral_token: String::new(),
+            settle_stable_token: String::new(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: false,
+        };
+        assert_eq!(c.validate(), Ok(()));
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -49,7 +49,7 @@ pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};
 pub use multi_chain_state::{
     MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
-    MultiChainStateV5,
+    MultiChainStateV5, MultiChainStateV6,
 };
 pub use settlement_queue::{SettlementOp, SettlementQueueV1};
 pub use supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};

--- a/src/rumi_protocol_backend/src/chains/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/mod.rs
@@ -35,6 +35,7 @@ pub mod admin;
 pub mod collateral_config;
 pub mod config;
 pub mod interest;
+pub mod liquidation_config;
 pub mod multi_chain_state;
 pub mod recovery;
 pub mod settlement_queue;
@@ -47,6 +48,7 @@ pub mod xrp;
 
 pub use adapter::ChainAdapter;
 pub use config::{ChainConfig, ChainId, ChainStatus};
+pub use liquidation_config::{ChainLiquidationConfigV1, DexKind, LiquidationConfigError};
 pub use multi_chain_state::{
     MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
     MultiChainStateV5, MultiChainStateV6,

--- a/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/chain_vault.rs
@@ -19,7 +19,7 @@
 //! Keeps the Monad-only `MONAD_MIN_CR_E4` constant local.
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use candid::Principal;
 
 // Re-export the chain-agnostic types + un-parameterized helpers. Every existing
@@ -43,7 +43,7 @@ pub const MONAD_MIN_CR_E4: u64 = 13_000;
 /// surface are identical to the pre-hoist Monad helper.
 #[allow(clippy::too_many_arguments)]
 pub fn open_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     owner: Principal,
     custody_address: String,
@@ -80,7 +80,7 @@ pub fn open_chain_vault_in_state(
 /// address validator and the `"MON"` price key baked in. Signature, behavior,
 /// and error surface are identical to the pre-hoist Monad helper.
 pub fn withdraw_collateral_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     amount_e18: u128,
     dest_address: String,
@@ -103,7 +103,7 @@ pub fn withdraw_collateral_in_state(
 /// `crate::chains::vault::borrow_chain_vault_in_state` with the Monad EVM address
 /// validator and the `"MON"` price key baked in.
 pub fn borrow_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     additional_e8s: u128,
     recipient: String,
@@ -130,7 +130,7 @@ pub fn borrow_chain_vault_in_state(
 /// validator and the `"MON"` price key baked in. Signature, behavior, and error
 /// surface are identical to the pre-hoist Monad helper.
 pub fn close_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     dest_address: String,
     min_cr_e4: u64,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_chain_vault.rs
@@ -37,7 +37,7 @@ fn chain_vault_round_trips_via_candid() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    };
+        pending_liquidation: None,    };
     let bytes = Encode!(&v).expect("encode");
     let back: ChainVaultV1 = Decode!(&bytes, ChainVaultV1).expect("decode");
     assert_eq!(back.vault_id, 42);
@@ -60,7 +60,7 @@ fn chain_vault_round_trips_via_cbor() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    };
+        pending_liquidation: None,    };
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&v, &mut buf).expect("cbor encode");
     let back: ChainVaultV1 = ciborium::de::from_reader(buf.as_slice()).expect("cbor decode");

--- a/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_open_vault.rs
@@ -16,7 +16,7 @@ use super::chain_vault::{
     ChainVaultStatus, OpenVaultError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -31,8 +31,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 /// Register chain 10143 and set its manual MON price. Mirrors what the live
 /// register_chain endpoint + a manual price override do (chain_supplies and
 /// settlement_queues are seeded by register_chain_in_state).
-fn setup(price_e8: u64) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn setup(price_e8: u64) -> MultiChainState {
+    let mut s = MultiChainState::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -247,7 +247,7 @@ fn verify_unknown_vault_errors() {
 // 8. open rejects an unregistered chain
 #[test]
 fn open_rejects_unknown_chain() {
-    let mut s = MultiChainStateV5::default(); // no chain registered
+    let mut s = MultiChainState::default(); // no chain registered
     let res = open_chain_vault_in_state(
         &mut s, CHAIN, owner(), "0xcustody".into(), 100 * ONE_MON_E18, 100_00000000,
         "0x000000000000000000000000000000000000c0de".into(), 13000, 0, 7,
@@ -306,7 +306,7 @@ fn open_rejects_invalid_recipient() {
 // 9. open rejects when no MON price is configured
 #[test]
 fn open_rejects_when_no_price() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     // Register the chain but DON'T set a MON price.
     let arg = RegisterChainArg {
         chain_id: CHAIN,

--- a/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
+++ b/src/rumi_protocol_backend/src/chains/monad/tests_withdraw.rs
@@ -22,7 +22,7 @@ use super::chain_vault::{
     ChainVaultStatus, WithdrawError,
 };
 use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::SettlementOpKind;
 use candid::Principal;
 
@@ -35,8 +35,8 @@ const ONE_MON_E18: u128 = 1_000_000_000_000_000_000;
 const MIN_CR_E4: u64 = 13_000;
 
 /// Register chain 10143 and set its manual MON price (mirrors `tests_open_vault`).
-fn setup(price_e8: u64) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn setup(price_e8: u64) -> MultiChainState {
+    let mut s = MultiChainState::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "MonadTestnet".into(),
@@ -63,7 +63,7 @@ fn owner() -> Principal {
 /// open helper records `pending_mint_e8s` and `debt_e8s == 0`; we set the
 /// fields directly here to skip the deposit-watch + settlement round trip.)
 fn open_and_fund(
-    s: &mut MultiChainStateV5,
+    s: &mut MultiChainState,
     vault_id: u64,
     collateral_e18: u128,
     debt_e8s: u128,

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -30,6 +30,7 @@
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
 
 use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
+use super::liquidation_config::ChainLiquidationConfigV1;
 use super::monad::chain_vault::ChainVaultV1;
 use super::settlement_queue::SettlementQueueV1;
 use candid::{CandidType, Deserialize, Principal};
@@ -508,6 +509,14 @@ pub struct MultiChainStateV6 {
     /// harmless (worst case a vault waits one extra tick for manual).
     #[serde(default)]
     pub sp_attempted_chain_vaults: BTreeSet<u64>,
+    /// Per-chain, operator-settable liquidation config (spec 8): the DEX wiring +
+    /// risk knobs the bot path reads, keyed by chain. Added directly to V6 (not a
+    /// V7) because V6 has not yet been persisted to any live canister — same
+    /// pre-deploy rationale as the reorg fields were added directly to V2.
+    /// `#[serde(default)]` is mandatory state-wipe defense regardless. Inert until
+    /// Increment 2+ reads it; Increment 1 ships only the getter/setter.
+    #[serde(default)]
+    pub chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>,
 }
 
 impl MultiChainStateV6 {

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -423,7 +423,150 @@ impl MultiChainStateV5 {
     }
 }
 
-pub type MultiChainState = MultiChainStateV5;
+/// Chains-liquidation Increment 1 snapshot. Carries every `MultiChainStateV5`
+/// field verbatim, plus the liquidation-engine accounting scaffolding: per-chain
+/// reserve backing (bot/PSM path), the physical USDC custody mirror, per-chain
+/// pending SP burn (pre-eSpace-burn), and the one-shot SP-attempted set. This is
+/// a NON-BREAKING reshape under ciborium, exactly like every prior bump:
+///
+///  - The fifteen V5 fields are byte-for-byte identical and map across by name
+///    (the four originals are always present; every V2+-added map keeps its
+///    `#[serde(default)]`).
+///  - The four new V6 fields each carry `#[serde(default)]`, so a live
+///    `MultiChainStateV5` CBOR snapshot (which lacks these keys entirely) decodes
+///    into V6 with them defaulting to empty — NOT a state wipe. Proven by
+///    `tests_multi_chain_state_v2::v5_cbor_snapshot_decodes_into_v6_without_wiping_state`.
+///
+/// All four new fields are 0/empty until Increment 2 wires the liquidation
+/// engine, so the unified supply invariant (debt + reserve + pending-burn)
+/// reduces to the old `supply == debt` on the live snapshot — the upgrade is
+/// behavior-preserving.
+///
+/// Because the decode is in-place, NO explicit `post_upgrade` migration call is
+/// needed; `migrate_multi_chain_state` in `supply.rs` remains the dormant
+/// template for the next BREAKING bump.
+///
+/// Add the NEXT field by bumping to `MultiChainStateV7` (keep V6 verbatim),
+/// `#[serde(default)]` on the new field, and rebinding the alias below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
+pub struct MultiChainStateV6 {
+    pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
+    pub chain_supplies: BTreeMap<ChainId, u128>,
+    pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+    pub invariant_halted: bool,
+    #[serde(default)]
+    pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+    #[serde(default)]
+    pub chain_contracts: BTreeMap<ChainId, String>,
+    #[serde(default)]
+    pub manual_prices: BTreeMap<(ChainId, String), u64>,
+    #[serde(default)]
+    pub last_observed_block: BTreeMap<ChainId, u64>,
+    #[serde(default)]
+    pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+    #[serde(default)]
+    pub reorg_halted: BTreeMap<ChainId, bool>,
+    #[serde(default)]
+    pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+    #[serde(default)]
+    pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+    /// M2: per-synthetic-owner monotonic nonce for EIP-712 intent replay
+    /// protection (carried verbatim from V5).
+    #[serde(default)]
+    pub evm_owner_nonces: BTreeMap<Principal, u64>,
+    /// Audit F-01: wall-clock ns of the last manual-price write per
+    /// `(chain, symbol)` (carried verbatim from V5).
+    #[serde(default)]
+    pub manual_price_set_at_ns: BTreeMap<(ChainId, String), u64>,
+    // --- New in V6: chains-liquidation accounting scaffolding (Increment 1) ---
+    /// Bot-path (PSM) reserve backing per chain (e8s): icUSD value whose backing
+    /// shifted CFX->USDC, no longer an open vault's debt but not yet burned.
+    /// RHS term-2 of the unified supply invariant. Grows on bot-liquidation
+    /// confirm; shrinks ONLY when a human bridges + the foreign icUSD is burned.
+    /// Empty until Increment 2 wires the bot liquidation path. `#[serde(default)]`
+    /// is mandatory state-wipe defense (a V5 snapshot lacks this key).
+    #[serde(default)]
+    pub reserve_backing_e8s: BTreeMap<ChainId, u128>,
+    /// Physical settle-stable (USDC) the reserve address holds, per chain, in
+    /// native base units (18-dec on eSpace), pending the manual bridge to cUSDT
+    /// reserves. Bookkeeping of the ASSET, distinct from the icUSD-denominated
+    /// backing; the gap reveals realized slippage / penalty surplus. NOT on the
+    /// invariant RHS. Empty until Increment 2.
+    #[serde(default)]
+    pub reserve_usdc_native: BTreeMap<ChainId, u128>,
+    /// SP-path debt mid-burn per chain (e8s): the SP has absorbed it (icUSD
+    /// burned IC-side) but the matching eSpace burn is not yet confirmed. RHS
+    /// term-3 of the unified supply invariant. Moves to a `chain_supplies`
+    /// decrement when the eSpace Burn op confirms. Empty until Increment 4.
+    #[serde(default)]
+    pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
+    /// Chains analog of the ICP `sp_attempted_vaults`: vaults whose bot
+    /// liquidation failed and were escalated to the SP exactly once (the
+    /// no-retry guard; once present, never re-attempted by the SP). Empty until
+    /// Increment 4. Rides V6 because it is in the persisted root, but it is
+    /// transient routing state (reset on resolution); surviving an upgrade is
+    /// harmless (worst case a vault waits one extra tick for manual).
+    #[serde(default)]
+    pub sp_attempted_chain_vaults: BTreeSet<u64>,
+}
+
+impl MultiChainStateV6 {
+    pub fn total_supply_all_chains_e8s(&self) -> u128 {
+        self.chain_supplies.values().copied().sum()
+    }
+
+    /// Sum of confirmed debt across all foreign-chain vaults (e8s). See the
+    /// V2 doc — same foreign-chain-only invariant.
+    pub fn total_chain_vault_debt_e8s(&self) -> u128 {
+        self.chain_vaults.values().map(|v| v.debt_e8s).sum()
+    }
+
+    /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).
+    pub fn expected_evm_nonce(&self, owner: &Principal) -> u64 {
+        self.evm_owner_nonces.get(owner).copied().unwrap_or(0)
+    }
+
+    /// M2: consume `nonce` for `owner`. Succeeds and bumps the counter iff
+    /// `nonce == expected`; else returns the expected value as `Err` (no mutation).
+    pub fn consume_evm_nonce(&mut self, owner: &Principal, nonce: u64) -> Result<(), u64> {
+        let expected = self.expected_evm_nonce(owner);
+        if nonce != expected {
+            return Err(expected);
+        }
+        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        Ok(())
+    }
+
+    /// M2 anti-spam: count NON-terminal vaults (everything but `Closed`) owned by
+    /// `owner` — the per-owner open cap.
+    pub fn count_owner_active_vaults(&self, owner: &Principal) -> usize {
+        use crate::chains::vault::ChainVaultStatus;
+        self.chain_vaults
+            .values()
+            .filter(|v| &v.owner == owner && v.status != ChainVaultStatus::Closed)
+            .count()
+    }
+
+    /// Write a manual collateral price for `(chain, symbol)` and stamp the
+    /// wall-clock time of the write. Both maps are updated together so the
+    /// getter can never see a price without its freshness timestamp.
+    pub fn set_manual_price(&mut self, chain: ChainId, symbol: String, price_e8: u64, now_ns: u64) {
+        self.manual_prices.insert((chain, symbol.clone()), price_e8);
+        self.manual_price_set_at_ns.insert((chain, symbol), now_ns);
+    }
+
+    /// Read the manual collateral price for `(chain, symbol)` as
+    /// `(price_e8, set_at_ns)`. Returns `None` if no price is set. `set_at_ns` is
+    /// `0` for a price set before the V5 upgrade (timestamp not yet recorded).
+    pub fn get_manual_price(&self, chain: ChainId, symbol: &str) -> Option<(u64, u64)> {
+        let key = (chain, symbol.to_string());
+        let price = *self.manual_prices.get(&key)?;
+        let set_at = self.manual_price_set_at_ns.get(&key).copied().unwrap_or(0);
+        Some((price, set_at))
+    }
+}
+
+pub type MultiChainState = MultiChainStateV6;
 
 #[cfg(test)]
 mod manual_price_tests {
@@ -433,20 +576,20 @@ mod manual_price_tests {
 
     #[test]
     fn set_manual_price_stores_price_and_timestamp() {
-        let mut mc = MultiChainStateV5::default();
+        let mut mc = MultiChainState::default();
         mc.set_manual_price(CFX, "CFX".to_string(), 15_000_000, 1234);
         assert_eq!(mc.get_manual_price(CFX, "CFX"), Some((15_000_000, 1234)));
     }
 
     #[test]
     fn get_manual_price_none_when_unset() {
-        let mc = MultiChainStateV5::default();
+        let mc = MultiChainState::default();
         assert_eq!(mc.get_manual_price(CFX, "CFX"), None);
     }
 
     #[test]
     fn set_manual_price_overwrites_price_and_timestamp() {
-        let mut mc = MultiChainStateV5::default();
+        let mut mc = MultiChainState::default();
         mc.set_manual_price(CFX, "CFX".to_string(), 15_000_000, 1000);
         mc.set_manual_price(CFX, "CFX".to_string(), 16_000_000, 2000);
         assert_eq!(mc.get_manual_price(CFX, "CFX"), Some((16_000_000, 2000)));
@@ -456,7 +599,7 @@ mod manual_price_tests {
     fn get_manual_price_reports_zero_timestamp_for_pre_v5_price() {
         // A price written before V5 lives in `manual_prices` with NO entry in
         // `manual_price_set_at_ns`. The getter must report set_at_ns = 0, not None.
-        let mut mc = MultiChainStateV5::default();
+        let mut mc = MultiChainState::default();
         mc.manual_prices.insert((CFX, "CFX".to_string()), 15_000_000);
         assert_eq!(mc.get_manual_price(CFX, "CFX"), Some((15_000_000, 0)));
     }

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -515,10 +515,27 @@ impl MultiChainStateV6 {
         self.chain_supplies.values().copied().sum()
     }
 
-    /// Sum of confirmed debt across all foreign-chain vaults (e8s). See the
-    /// V2 doc — same foreign-chain-only invariant.
+    /// Sum of confirmed debt across all foreign-chain vaults (e8s). RHS term-1 of
+    /// the unified supply invariant (spec 5.2). NOTE: counts only REALIZED
+    /// `debt_e8s`, so `pending_interest_mint_e8s` (accrued-but-unconfirmed
+    /// interest) is deliberately excluded — it mints new supply only on confirm
+    /// and is not yet in `chain_supplies` (finding #1).
     pub fn total_chain_vault_debt_e8s(&self) -> u128 {
         self.chain_vaults.values().map(|v| v.debt_e8s).sum()
+    }
+
+    /// RHS term-2 of the unified supply invariant (spec 3.3, 5.2): total icUSD
+    /// whose backing shifted CFX->USDC reserve (bot/PSM path), summed across
+    /// chains. 0 until Increment 2 wires the bot liquidation path.
+    pub fn total_reserve_backing_e8s(&self) -> u128 {
+        self.reserve_backing_e8s.values().copied().sum()
+    }
+
+    /// RHS term-3 of the unified supply invariant (spec 3.3, 5.2): total icUSD the
+    /// SP burned IC-side but whose matching eSpace burn is not yet confirmed,
+    /// summed across chains. 0 until Increment 4 wires the SP path.
+    pub fn total_pending_chain_burn_e8s(&self) -> u128 {
+        self.pending_chain_burn_e8s.values().copied().sum()
     }
 
     /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -89,7 +89,7 @@ fn snapshot_inflight_op_tx(chain: ChainId, op_id: u64) -> Result<Option<String>,
 /// Returns `true` iff this call performed the reversal (the op was still
 /// Inflight).
 pub fn apply_resolve_reversal_in_state(
-    state: &mut crate::chains::multi_chain_state::MultiChainStateV5,
+    state: &mut crate::chains::multi_chain_state::MultiChainState,
     chain: ChainId,
     op_id: u64,
     now: u64,
@@ -214,7 +214,7 @@ pub async fn resolve_stuck_settlement_op_verified(
 /// exists, is on `chain`, is `MintPending` with `pending_mint_e8s == 0`, and has
 /// NO live (Queued/Inflight) Mint op.
 pub fn precheck_recover_vault_in_state(
-    state: &crate::chains::multi_chain_state::MultiChainStateV5,
+    state: &crate::chains::multi_chain_state::MultiChainState,
     chain: ChainId,
     vault_id: u64,
 ) -> Result<Vec<String>, RecoveryError> {
@@ -277,7 +277,7 @@ pub fn precheck_recover_vault(
 /// the guards inside the same `mutate_state` (defense against a state change
 /// between the precheck snapshot and commit). Returns `Ok(())` on success.
 pub fn apply_recover_vault_in_state(
-    state: &mut crate::chains::multi_chain_state::MultiChainStateV5,
+    state: &mut crate::chains::multi_chain_state::MultiChainState,
     chain: ChainId,
     vault_id: u64,
 ) -> Result<(), RecoveryError> {

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -51,7 +51,7 @@ use crate::Mode;
 // Reuse the chain-agnostic pure helpers from the Monad settlement module (the
 // FIFO one-in-flight selector and the supply-invariant mint-confirm). These are
 // chain-independent: `select_next_op` scans a `SettlementQueueV1` and
-// `confirm_mint_in_state` operates on `MultiChainStateV5`, neither of which is
+// `confirm_mint_in_state` operates on `MultiChainState`, neither of which is
 // Monad-specific.
 use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
 

--- a/src/rumi_protocol_backend/src/chains/solana/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_deposit_watch.rs
@@ -19,7 +19,7 @@ use super::config::SOLANA_CHAIN_ID;
 use super::deposit_watch::supply_drop_detected;
 use super::ted25519::{is_valid_solana_address, solana_address_from_pubkey};
 use crate::chains::config::{GasStrategy, RegisterChainArg};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus};
 use crate::chains::vault::{
     open_chain_vault_in_state, verify_deposit_and_enqueue_mint_in_state, ChainVaultStatus,
@@ -43,8 +43,8 @@ fn valid_solana_address(byte: u8) -> String {
 /// Register Solana (chain 501) with 9-decimal native units and a manual `"SOL"`
 /// price, then open an `AwaitingDeposit` vault (id 7) declaring `declared_lamports`
 /// collateral and `HUNDRED_ICUSD_E8S` debt. Returns the seeded state.
-fn seeded_awaiting_deposit(declared_lamports: u128) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn seeded_awaiting_deposit(declared_lamports: u128) -> MultiChainState {
+    let mut s = MultiChainState::default();
     let arg = RegisterChainArg {
         chain_id: SOLANA_CHAIN_ID,
         display_name: "SolanaDevnet".into(),

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -5,7 +5,7 @@
 //! RPC + signing-subnet round trip); here we cover only the pure pieces:
 //!
 //! - the REUSE of the chain-agnostic `confirm_mint_in_state` / `select_next_op`
-//!   helpers on a SOLANA-flavored `MultiChainStateV5` (a Solana mint confirm
+//!   helpers on a SOLANA-flavored `MultiChainState` (a Solana mint confirm
 //!   moves pending -> debt, increments `chain_supplies`, and flips the vault to
 //!   `Open` - identical invariant to Monad, exercised here against the Solana
 //!   chain id so the reuse is proven, not assumed);
@@ -14,7 +14,7 @@
 
 use crate::chains::config::ChainId;
 use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{
     SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
 };
@@ -28,7 +28,7 @@ const SOL: ChainId = ChainId(501);
 /// Insert a Solana `MintPending` vault with the given pending mint amount.
 /// `collateral_amount_native` is in lamports (Solana's 9-decimal base unit); a
 /// confirm does not read it, but we set a realistic value for clarity.
-fn solana_vault_pending(s: &mut MultiChainStateV5, vault_id: u64, pending_e8s: u128) {
+fn solana_vault_pending(s: &mut MultiChainState, vault_id: u64, pending_e8s: u128) {
     s.chain_vaults.insert(
         vault_id,
         ChainVaultV1 {
@@ -51,7 +51,7 @@ fn solana_vault_pending(s: &mut MultiChainStateV5, vault_id: u64, pending_e8s: u
 
 #[test]
 fn solana_confirm_mint_moves_pending_to_debt_and_increments_supply() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending (e8s)
                                                      // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
@@ -64,7 +64,7 @@ fn solana_confirm_mint_moves_pending_to_debt_and_increments_supply() {
 
 #[test]
 fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(SOL, 0);
     solana_vault_pending(&mut s, 1, 10_000_000_000);
     // Observed != pending: reject before any supply mutation; nothing changes.
@@ -78,7 +78,7 @@ fn solana_confirm_mint_rejects_amount_mismatch_no_mutation() {
 
 #[test]
 fn solana_confirm_mint_unknown_vault_rejected() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(SOL, 0);
     assert!(confirm_mint_in_state(&mut s, SOL, 999, 1, 0, 0).is_err());
 }
@@ -88,7 +88,7 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
     // Two Solana vaults: the first already confirmed (debt 100e8, supply 100e8);
     // confirming the second (pending 50e8) must pass PRE-mint total = 100e8, and
     // the helper computes the post-mint total 150e8 internally.
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(SOL, 10_000_000_000);
     s.chain_vaults.insert(
         1,

--- a/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/tests_settlement.rs
@@ -45,7 +45,7 @@ fn solana_vault_pending(s: &mut MultiChainState, vault_id: u64, pending_e8s: u12
             owner_evm: None,
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-        },
+            pending_liquidation: None,        },
     );
 }
 
@@ -106,7 +106,7 @@ fn solana_confirm_mint_second_vault_uses_running_total() {
             owner_evm: None,
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-        },
+            pending_liquidation: None,        },
     );
     solana_vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -55,13 +55,45 @@ pub enum SupplyDelta {
 pub enum SupplyInvariantError {
     UnknownChain(ChainId),
     Underflow { chain: ChainId, current: u128, attempted_decrease: u128 },
+    /// `sum(chain_supplies)` did not equal the unified-invariant RHS. `total_debt`
+    /// carries that full RHS (debt + reserve_backing + pending_chain_burn — spec
+    /// 5.2), NOT the bare debt; the field name is kept for wire stability. With
+    /// all-zero reserve/pending (Increment 1) the RHS equals bare debt, so the
+    /// reported pair is byte-identical to the pre-Increment-1 behavior.
     Divergence { sum_after: u128, total_debt: u128 },
     HaltedAfterSelfCheckFailure,
 }
 
-/// Single-entry mutation path for `chain_supplies`. Caller passes the
-/// authoritative `total_debt_e8s` snapshot taken at the same logical
-/// moment; we reject any apply that would leave sum != total_debt.
+/// The unified supply-invariant right-hand side (spec 5.2): every circulating
+/// foreign icUSD is backed by EITHER an open vault's collateral (the
+/// `total_debt_e8s` term the caller passes), OR protocol-held USDC reserve
+/// (`total_reserve_backing_e8s`), OR an IC-side SP burn awaiting its eSpace burn
+/// (`total_pending_chain_burn_e8s`).
+///
+/// The caller passes the debt total it already computes (it owns the debt
+/// mutation); the reserve + pending-burn terms are read from `state` HERE, so a
+/// caller can never forget a term and FALSE-HALT the chain (finding #24). This is
+/// the SINGLE source of truth for the RHS — `apply_supply_delta` and
+/// `check_invariant` (hence the Timer-B self-check AND `clear_invariant_halt`) all
+/// route through it, so the consumers can never disagree (findings #2, #7).
+///
+/// Deliberately NOT terms: `reserve_usdc_native` tracks the physical USDC asset,
+/// not icUSD-denominated backing (spec 3.2, 5.6); `pending_interest_mint_e8s`
+/// mints new supply only on confirm and is excluded from
+/// `total_chain_vault_debt_e8s` (finding #1). With all-zero reserve/pending
+/// (Increment 1) this reduces to the old `supply == debt`, so it is
+/// behavior-preserving.
+pub fn chain_backing_rhs_e8s(state: &MultiChainState, total_debt_e8s: u128) -> u128 {
+    total_debt_e8s
+        .saturating_add(state.total_reserve_backing_e8s())
+        .saturating_add(state.total_pending_chain_burn_e8s())
+}
+
+/// Single-entry mutation path for `chain_supplies`. The caller passes the
+/// authoritative `total_debt_e8s` snapshot taken at the same logical moment; we
+/// reject any apply that would leave `sum(chain_supplies)` != the unified RHS
+/// (`chain_backing_rhs_e8s` = debt + reserve + pending-burn). No mutation on
+/// rejection.
 pub fn apply_supply_delta(
     state: &mut MultiChainState,
     chain: ChainId,
@@ -96,25 +128,37 @@ pub fn apply_supply_delta(
         .iter()
         .map(|(&id, &v)| if id == chain { new } else { v })
         .sum();
-    if sum_after != total_debt_e8s {
-        return Err(SupplyInvariantError::Divergence { sum_after, total_debt: total_debt_e8s });
+    // Compare against the unified RHS (debt + reserve + pending-burn), read from
+    // the SAME `state` so the check can never use a stale reserve/pending snapshot
+    // (finding #2). With all-zero reserve/pending this is `sum_after != total_debt`.
+    let rhs = chain_backing_rhs_e8s(state, total_debt_e8s);
+    if sum_after != rhs {
+        return Err(SupplyInvariantError::Divergence { sum_after, total_debt: rhs });
     }
 
     state.chain_supplies.insert(chain, new);
     Ok(())
 }
 
-/// Phase 1a periodic self-check (called from Timer B in Task 11).
-/// Returns `Ok(())` when sum == total_debt and `Err(...)` otherwise.
-/// On `Err`, the caller flips `state.invariant_halted = true` and emits
-/// an event.
+/// Periodic self-check (called from the Timer-B self-check AND from
+/// `clear_invariant_halt`). Returns `Ok(())` when `sum(chain_supplies)` equals the
+/// unified RHS (`chain_backing_rhs_e8s` = debt + reserve + pending-burn) and
+/// `Err(...)` otherwise. On `Err`, the Timer-B caller flips
+/// `state.invariant_halted = true` and flips to ReadOnly.
+///
+/// Both callers pass only `total_chain_vault_debt_e8s()`; the reserve + pending
+/// terms are added here, so the Timer-B self-check and `clear_invariant_halt` both
+/// pick up the generalized RHS WITHOUT any caller change — a bot liquidation that
+/// shifts debt->reserve no longer FALSE-HALTs the chain, and the un-halt path can
+/// succeed against the unified RHS (findings #2, #7).
 pub fn check_invariant(
     state: &MultiChainState,
     total_debt_e8s: u128,
 ) -> Result<(), SupplyInvariantError> {
     let sum: u128 = state.chain_supplies.values().copied().sum();
-    if sum != total_debt_e8s {
-        return Err(SupplyInvariantError::Divergence { sum_after: sum, total_debt: total_debt_e8s });
+    let rhs = chain_backing_rhs_e8s(state, total_debt_e8s);
+    if sum != rhs {
+        return Err(SupplyInvariantError::Divergence { sum_after: sum, total_debt: rhs });
     }
     Ok(())
 }

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,7 +12,7 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainStateV5};
+use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainState};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
@@ -63,7 +63,7 @@ pub enum SupplyInvariantError {
 /// authoritative `total_debt_e8s` snapshot taken at the same logical
 /// moment; we reject any apply that would leave sum != total_debt.
 pub fn apply_supply_delta(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     delta: SupplyDelta,
     total_debt_e8s: u128,
@@ -109,7 +109,7 @@ pub fn apply_supply_delta(
 /// On `Err`, the caller flips `state.invariant_halted = true` and emits
 /// an event.
 pub fn check_invariant(
-    state: &MultiChainStateV5,
+    state: &MultiChainState,
     total_debt_e8s: u128,
 ) -> Result<(), SupplyInvariantError> {
     let sum: u128 = state.chain_supplies.values().copied().sum();
@@ -126,7 +126,7 @@ pub fn check_invariant(
 /// (`confirm_mint_in_state`) and never decode as 0, so this only ever touches
 /// pre-feature vaults. Idempotent (re-running is a no-op once stamped). Called
 /// from `post_upgrade` after `restore_state`.
-pub fn stamp_chain_interest_accrual_start(state: &mut MultiChainStateV5, now_ns: u64) {
+pub fn stamp_chain_interest_accrual_start(state: &mut MultiChainState, now_ns: u64) {
     for v in state.chain_vaults.values_mut() {
         if v.last_interest_accrual_ns == 0 {
             v.last_interest_accrual_ns = now_ns;

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -163,6 +163,90 @@ pub fn check_invariant(
     Ok(())
 }
 
+/// Reasons `apply_debt_to_reserve_shift` rejects (no state mutation on any error).
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReserveShiftError {
+    /// The invariant self-check has halted the rail; do not move backing.
+    Halted,
+    /// No such chain vault.
+    UnknownVault(u64),
+    /// The vault's `collateral_chain` does not match the requested `chain`.
+    WrongChain { vault_chain: ChainId, requested: ChainId },
+    /// `cleared_e8s` exceeds the vault's live `debt_e8s` (would over-credit the
+    /// reserve term relative to debt actually retired).
+    ClearExceedsDebt { cleared_e8s: u128, vault_debt_e8s: u128 },
+    /// The post-move unified invariant would not hold. The move conserves
+    /// debt+reserve, so this only fires if the invariant was ALREADY diverged
+    /// before the call (defensive; no mutation).
+    InvariantBroken { sum_supplies: u128, rhs: u128 },
+}
+
+/// Bot/PSM Phase-2 accounting (spec 4.9, 5.3): atomically move `cleared_e8s` of a
+/// vault's debt into the chain's reserve backing (NO icUSD burn — `chain_supplies`
+/// is UNCHANGED) and record the realized `stable_native` USDC. This is the single
+/// gate for the reserve term. It conserves `debt + reserve`, so the unified
+/// invariant is preserved BY CONSTRUCTION; the pre-apply check is a defensive
+/// assert that catches pre-existing drift (no mutation on rejection).
+///
+/// NO caller until Increment 2 (the bot confirm path); Increment 1 ships it +
+/// proves a reserve shift keeps the invariant balanced.
+pub fn apply_debt_to_reserve_shift(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    vault_id: u64,
+    cleared_e8s: u128,
+    stable_native: u128,
+) -> Result<(), ReserveShiftError> {
+    if state.invariant_halted {
+        return Err(ReserveShiftError::Halted);
+    }
+    // Validate (read-only — no mutation on any rejection path).
+    let vault_debt = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(ReserveShiftError::UnknownVault(vault_id))?;
+        if v.collateral_chain != chain {
+            return Err(ReserveShiftError::WrongChain {
+                vault_chain: v.collateral_chain,
+                requested: chain,
+            });
+        }
+        v.debt_e8s
+    };
+    if cleared_e8s > vault_debt {
+        return Err(ReserveShiftError::ClearExceedsDebt {
+            cleared_e8s,
+            vault_debt_e8s: vault_debt,
+        });
+    }
+
+    // Pre-validate the post-move unified invariant WITHOUT mutating, so a
+    // divergence (only possible if the invariant was ALREADY broken before the
+    // call — the move conserves debt+reserve) leaves state untouched. chain_supplies
+    // is unchanged; debt drops by cleared_e8s and reserve_backing rises by the same,
+    // so the RHS is invariant. reserve_usdc_native is NOT an RHS term (spec 3.2/5.6).
+    let sum_supplies = state.total_supply_all_chains_e8s();
+    let post_debt_total = state.total_chain_vault_debt_e8s().saturating_sub(cleared_e8s);
+    let post_reserve_total = state.total_reserve_backing_e8s().saturating_add(cleared_e8s);
+    let post_rhs = post_debt_total
+        .saturating_add(post_reserve_total)
+        .saturating_add(state.total_pending_chain_burn_e8s());
+    if sum_supplies != post_rhs {
+        return Err(ReserveShiftError::InvariantBroken { sum_supplies, rhs: post_rhs });
+    }
+
+    // Apply atomically (every reject above happened before any mutation).
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.debt_e8s -= cleared_e8s;
+    *state.reserve_backing_e8s.entry(chain).or_default() += cleared_e8s;
+    *state.reserve_usdc_native.entry(chain).or_default() += stable_native;
+    Ok(())
+}
+
 /// Phase 1b Task 12 migration: stamp `last_interest_accrual_ns = now_ns` for any
 /// chain vault that decoded with 0 (an existing vault from a snapshot written
 /// before the interest fields existed), so the first harvest does not bill

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -50,7 +50,7 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    }
+        pending_liquidation: None,    }
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -7,7 +7,7 @@ use super::config::{
     GasStrategy, RegisterChainArg, UpdateChainConfigArg, DEFAULT_MIN_QUORUM_PROVIDERS,
 };
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
 use candid::Principal;
 
@@ -55,7 +55,7 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
 
 #[test]
 fn register_chain_inserts_config_and_zero_supply() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 1_700_000_000_000_000_000).expect("register");
     assert!(s.chain_configs.contains_key(&ChainId(101)));
     assert_eq!(s.chain_supplies[&ChainId(101)], 0);
@@ -72,7 +72,7 @@ fn register_chain_inserts_config_and_zero_supply() {
 
 #[test]
 fn register_chain_rejects_duplicates() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
     assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
@@ -80,7 +80,7 @@ fn register_chain_rejects_duplicates() {
 
 #[test]
 fn register_chain_rejects_empty_rpc_endpoints() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let mut a = arg();
     a.rpc_endpoints = vec![];
     let err = register_chain_in_state(&mut s, a, 0).expect_err("empty endpoints");
@@ -89,7 +89,7 @@ fn register_chain_rejects_empty_rpc_endpoints() {
 
 #[test]
 fn register_chain_rejects_out_of_range_decimals() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     // 0 would make the CR native-scale 1 (collateral treated as whole units),
     // inflating every CR check and admitting under-collateralized opens.
     let mut zero = arg();
@@ -114,7 +114,7 @@ fn register_chain_rejects_out_of_range_decimals() {
 
 #[test]
 fn register_chain_enforces_evm_finality_floor() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     // EVM chain with finality_depth 0 is rejected.
     let mut a = arg(); // EvmEip1559 gas strategy
     a.finality_depth = 0;
@@ -135,7 +135,7 @@ fn register_chain_enforces_evm_finality_floor() {
 
 #[test]
 fn disable_chain_flips_status_and_preserves_supply() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
@@ -145,7 +145,7 @@ fn disable_chain_flips_status_and_preserves_supply() {
 
 #[test]
 fn set_chain_config_updates_supplied_fields_only() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     let original_name = s.chain_configs[&ChainId(101)].display_name.clone();
     let update = UpdateChainConfigArg {
@@ -163,7 +163,7 @@ fn set_chain_config_updates_supplied_fields_only() {
 
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let err = update_chain_config_in_state(
         &mut s,
         ChainId(404),
@@ -174,7 +174,7 @@ fn set_chain_config_rejects_unknown_chain() {
 
 #[test]
 fn delete_chain_removes_zero_supply_chain() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     // Populate EVERY per-chain map so the purge can be observed.
@@ -211,7 +211,7 @@ fn delete_chain_removes_zero_supply_chain() {
 
 #[test]
 fn delete_chain_refuses_when_supply_nonzero() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_supplies.insert(c, 1);
@@ -224,7 +224,7 @@ fn delete_chain_refuses_when_supply_nonzero() {
 
 #[test]
 fn delete_chain_refuses_when_open_vaults_reference_it() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let c = ChainId(999);
     register_chain_in_state(&mut s, config_arg_999(), 0).expect("register");
     s.chain_vaults.insert(1, dummy_vault(1, c));
@@ -237,7 +237,7 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
 
 #[test]
 fn delete_chain_unknown_is_rejected() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state.rs
@@ -87,7 +87,7 @@ fn pre_m2_snapshot_decodes_with_defaulted_evm_fields() {
             opened_at_ns: 42,
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-            owner_evm: Some("0xfeed".into()),
+            pending_liquidation: None,            owner_evm: Some("0xfeed".into()),
         },
     );
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -380,6 +380,56 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
 }
 
 #[test]
+fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
+    // STATE-WIPE defense (the forward direction): once V6 is live, a V6 snapshot
+    // carrying the new liquidation-engine fields (reserve maps, pending-burn,
+    // sp-attempted set, the liquidation config) MUST survive an encode->decode
+    // round-trip with every value intact. This is the path a V6->V6 upgrade runs.
+    use super::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+    use std::collections::BTreeSet;
+
+    const CFX: ChainId = ChainId(1030);
+
+    let mut v6 = MultiChainStateV6::default();
+    v6.chain_supplies.insert(CFX, 100);
+    v6.reserve_backing_e8s.insert(CFX, 40);
+    v6.reserve_usdc_native.insert(CFX, 45_000_000_000_000_000_000);
+    v6.pending_chain_burn_e8s.insert(CFX, 15);
+    v6.sp_attempted_chain_vaults.insert(7);
+    v6.sp_attempted_chain_vaults.insert(9);
+    v6.chain_liquidation_configs.insert(CFX, ChainLiquidationConfigV1 {
+        dex: DexKind::UniswapV2,
+        router: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
+        factory: "0xe2a6f7c0ce4d5d300f97aa7e125455f5cd3342f5".into(),
+        pair: "0xpair".into(),
+        collateral_token: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
+        settle_stable_token: "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372".into(),
+        slippage_cap_bps: 250,
+        restore_target_cr_e4: 15_500,
+        enabled: true,
+    });
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v6, &mut buf).expect("cbor encode V6");
+    let decoded: MultiChainStateV6 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V6 snapshot round-trips");
+
+    assert_eq!(decoded.reserve_backing_e8s.get(&CFX), Some(&40));
+    assert_eq!(decoded.reserve_usdc_native.get(&CFX), Some(&45_000_000_000_000_000_000));
+    assert_eq!(decoded.pending_chain_burn_e8s.get(&CFX), Some(&15));
+    assert_eq!(decoded.sp_attempted_chain_vaults, BTreeSet::from([7, 9]));
+    let cfg = decoded.chain_liquidation_configs.get(&CFX).expect("config survived");
+    assert_eq!(cfg.dex, DexKind::UniswapV2);
+    assert_eq!(cfg.slippage_cap_bps, 250);
+    assert_eq!(cfg.restore_target_cr_e4, 15_500);
+    assert!(cfg.enabled);
+    assert_eq!(cfg.settle_stable_token, "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372");
+    // The aggregate accessors reflect the round-tripped reserve/pending terms.
+    assert_eq!(decoded.total_reserve_backing_e8s(), 40);
+    assert_eq!(decoded.total_pending_chain_burn_e8s(), 15);
+}
+
+#[test]
 fn chain_vault_debt_total_sums_only_chain_vaults() {
     use super::monad::chain_vault::{ChainVaultV1, ChainVaultStatus};
 

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,6 +1,6 @@
 use super::multi_chain_state::{
     MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
-    MultiChainStateV5,
+    MultiChainStateV5, MultiChainStateV6,
 };
 use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
@@ -121,8 +121,8 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
 }
 
 #[test]
-fn active_alias_points_at_v5() {
-    fn _check(x: MultiChainState) -> MultiChainStateV5 { x }
+fn active_alias_points_at_v6() {
+    fn _check(x: MultiChainState) -> MultiChainStateV6 { x }
 }
 
 #[test]
@@ -276,6 +276,107 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
     // Total debt still reconciles (no state wipe).
     assert_eq!(v4.total_chain_vault_debt_e8s(), 50_000_000);
     assert_eq!(v4.total_supply_all_chains_e8s(), 50_000_000);
+}
+
+#[test]
+fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
+    // STATE-WIPE REGRESSION (chains-liquidation Increment 1). The live staging
+    // canister (kvg63) persists a `MultiChainStateV5`. This increment rebinds the
+    // `MultiChainState` alias to V6, which adds four NEW maps/sets
+    // (reserve_backing_e8s, reserve_usdc_native, pending_chain_burn_e8s,
+    // sp_attempted_chain_vaults). A populated V5 CBOR snapshot MUST decode into V6
+    // with:
+    //   - every carried field preserved (the four originals + every V2+-added map
+    //     incl. the V4 nonces and the V5 price timestamps), and
+    //   - each new V6 field supplied by its `#[serde(default)]` => empty.
+    // This is the exact ciborium decode path `load_state_from_stable()` runs on
+    // upgrade. WITHOUT field-level `#[serde(default)]` on the new V6 fields this
+    // decode fails with "missing field `reserve_backing_e8s`", which on the real
+    // canister silently WIPES multi_chain state via the event-replay fallback
+    // (the 2026-05-18 AMM incident class). Real Vault state lives on kvg63, so a
+    // wipe here would destroy live vaults/supply/contracts.
+    use super::config::{ChainConfigV3, ChainStatus, GasStrategy};
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::settlement_queue::SettlementQueueV1;
+    use std::collections::BTreeSet;
+
+    const CFX: ChainId = ChainId(1030);
+
+    let mut v5 = MultiChainStateV5::default();
+    v5.chain_configs.insert(CFX, ChainConfigV3 {
+        chain_id: CFX,
+        display_name: "ConfluxESpace".into(),
+        rpc_endpoints: vec!["https://evm.confluxrpc.com".into()],
+        finality_depth: 5,
+        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 1, max_fee_gwei_ceiling: 200 },
+        chain_native_decimals: 18,
+        registered_at_ns: 123,
+        status: ChainStatus::Registered,
+        burn_watch_poll_enabled: true,
+        min_quorum_providers: Some(3),
+    });
+    v5.chain_supplies.insert(CFX, 100 * 100_000_000); // 100 icUSD in e8s
+    v5.settlement_queues.insert(CFX, SettlementQueueV1::default());
+    v5.invariant_halted = false;
+    v5.chain_vaults.insert(3, ChainVaultV1 {
+        vault_id: 3,
+        owner: candid::Principal::anonymous(),
+        collateral_chain: CFX,
+        custody_address: "0xcustody".into(),
+        collateral_amount_native: 1_000_000_000_000_000_000,
+        debt_e8s: 100 * 100_000_000,
+        mint_recipient: "0xrecipient".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 99,
+        owner_evm: Some("0xowner".into()),
+        last_interest_accrual_ns: 1_700_000_000_000_000_000,
+        pending_interest_mint_e8s: 0,
+    });
+    v5.chain_contracts.insert(CFX, "0xicusd".into());
+    v5.last_observed_block.insert(CFX, 35_136_248);
+    v5.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+    v5.evm_owner_nonces.insert(candid::Principal::anonymous(), 7);
+    // Stamp a manual price + its freshness timestamp (the V5-added side-channel).
+    v5.set_manual_price(CFX, "CFX".to_string(), 4_800_000, 1_700_000_000_000_000_001);
+
+    // Encode as V5 (the bytes the live canister wrote), decode as V6 (new shape).
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v5, &mut buf).expect("cbor encode V5");
+    let v6: MultiChainStateV6 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V5 snapshot MUST decode into V6");
+
+    // --- Every carried field survived (NOT wiped) ---
+    assert_eq!(v6.chain_supplies, v5.chain_supplies, "chain_supplies carried");
+    assert_eq!(v6.chain_supplies.get(&CFX), Some(&(100 * 100_000_000u128)));
+    assert_eq!(v6.chain_vaults.len(), 1);
+    assert_eq!(v6.chain_vaults[&3].debt_e8s, 100 * 100_000_000);
+    assert_eq!(v6.chain_vaults[&3].owner_evm, Some("0xowner".to_string()));
+    assert_eq!(v6.chain_vaults[&3].last_interest_accrual_ns, 1_700_000_000_000_000_000);
+    assert_eq!(v6.chain_contracts.get(&CFX), Some(&"0xicusd".to_string()));
+    assert_eq!(v6.last_observed_block.get(&CFX), Some(&35_136_248u64));
+    assert!(v6.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
+    assert_eq!(v6.expected_evm_nonce(&candid::Principal::anonymous()), 7, "nonce carried");
+    assert_eq!(
+        v6.get_manual_price(CFX, "CFX"),
+        Some((4_800_000, 1_700_000_000_000_000_001)),
+        "manual price + freshness timestamp carried"
+    );
+    let cfg = v6.chain_configs.get(&CFX).expect("config preserved");
+    assert_eq!(cfg.finality_depth, 5);
+    assert!(cfg.burn_watch_poll_enabled);
+    assert_eq!(cfg.min_quorum_providers, Some(3));
+
+    // --- The four NEW V6 fields defaulted EMPTY (state-wipe defense, not a wipe) ---
+    assert!(v6.reserve_backing_e8s.is_empty(), "new field defaulted empty, not wiped");
+    assert!(v6.reserve_usdc_native.is_empty());
+    assert!(v6.pending_chain_burn_e8s.is_empty());
+    assert!(v6.sp_attempted_chain_vaults.is_empty());
+
+    // Total debt still reconciles with supply (the invariant is intact post-decode;
+    // with all-zero reserve/pending the generalized RHS reduces to bare debt).
+    assert_eq!(v6.total_chain_vault_debt_e8s(), 100 * 100_000_000);
+    assert_eq!(v6.total_supply_all_chains_e8s(), 100 * 100_000_000);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -172,7 +172,7 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     v2.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v2.last_observed_block.insert(ChainId(10143), 35_136_248);
     v2.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
@@ -248,7 +248,7 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     v3.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v3.last_observed_block.insert(ChainId(10143), 35_136_248);
     v3.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
@@ -332,7 +332,7 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
         owner_evm: Some("0xowner".into()),
         last_interest_accrual_ns: 1_700_000_000_000_000_000,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     v5.chain_contracts.insert(CFX, "0xicusd".into());
     v5.last_observed_block.insert(CFX, 35_136_248);
     v5.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
@@ -399,7 +399,7 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     s.chain_vaults.insert(2, ChainVaultV1 {
         vault_id: 2,
         owner: candid::Principal::anonymous(),
@@ -414,7 +414,7 @@ fn chain_vault_debt_total_sums_only_chain_vaults() {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    });
+        pending_liquidation: None,    });
     assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -8,7 +8,7 @@
 
 use super::config::ChainId;
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 use super::recovery::{
     apply_recover_vault_in_state, apply_resolve_reversal_in_state,
     precheck_recover_vault_in_state, RecoveryError,
@@ -44,8 +44,8 @@ fn inflight_op(op_id: u64, kind: SettlementOpKind, tx: Option<&str>) -> Settleme
     op
 }
 
-fn state_with_op(op: SettlementOp) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn state_with_op(op: SettlementOp) -> MultiChainState {
+    let mut s = MultiChainState::default();
     let mut q = super::settlement_queue::SettlementQueueV1::default();
     let id = op.op_id;
     q.pending.insert(id, op);
@@ -119,7 +119,7 @@ fn resolve_reversal_is_idempotent_cas() {
 fn precheck_recover_returns_terminal_mint_tx_hashes() {
     // A terminal (Failed) Mint op for the vault carries a tx hash the async path
     // must re-verify on-chain.
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let mut q = super::settlement_queue::SettlementQueueV1::default();
     let mut op = inflight_op(
         0,
@@ -150,7 +150,7 @@ fn precheck_recover_rejects_live_mint_op() {
 
 #[test]
 fn precheck_recover_rejects_nonzero_pending_or_wrong_status() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     // Nonzero pending => not recoverable.
     s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
     assert!(matches!(
@@ -167,7 +167,7 @@ fn precheck_recover_rejects_nonzero_pending_or_wrong_status() {
 
 #[test]
 fn precheck_recover_rejects_wrong_chain_and_unknown() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let mut v = vault(1, ChainVaultStatus::MintPending, 0, 9);
     v.collateral_chain = ChainId(999);
     s.chain_vaults.insert(1, v);
@@ -183,7 +183,7 @@ fn precheck_recover_rejects_wrong_chain_and_unknown() {
 
 #[test]
 fn apply_recover_vault_flips_mintpending_to_open() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     apply_recover_vault_in_state(&mut s, CHAIN, 1).expect("recover");
     assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::Open);

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -33,7 +33,7 @@ fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u12
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    }
+        pending_liquidation: None,    }
 }
 
 fn inflight_op(op_id: u64, kind: SettlementOpKind, tx: Option<&str>) -> SettlementOp {

--- a/src/rumi_protocol_backend/src/chains/tests_self_check.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_self_check.rs
@@ -2,12 +2,12 @@
 //! self-check flips the halt flag and Mode and stops mutating supplies.
 
 use super::config::ChainId;
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 use super::supply::check_invariant;
 
 #[test]
 fn check_invariant_passes_when_sum_equals_total_debt() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     assert!(check_invariant(&s, 300).is_ok());
@@ -15,7 +15,7 @@ fn check_invariant_passes_when_sum_equals_total_debt() {
 
 #[test]
 fn check_invariant_fails_on_drift() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(1), 100);
     s.chain_supplies.insert(ChainId(2), 200);
     let err = check_invariant(&s, 299).expect_err("drift must be caught");
@@ -24,6 +24,6 @@ fn check_invariant_fails_on_drift() {
 
 #[test]
 fn empty_state_passes_when_total_debt_is_zero() {
-    let s = MultiChainStateV5::default();
+    let s = MultiChainState::default();
     assert!(check_invariant(&s, 0).is_ok());
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,4 +1,4 @@
-use super::supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
+use super::supply::{apply_supply_delta, check_invariant, SupplyDelta, SupplyInvariantError};
 use super::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
 use super::multi_chain_state::MultiChainState;
 
@@ -134,4 +134,109 @@ fn stamp_sets_accrual_start_only_for_unstamped_vaults() {
     // Idempotent: a second run does not re-stamp the now-stamped vault.
     super::supply::stamp_chain_interest_accrual_start(&mut s, 99_999);
     assert_eq!(s.chain_vaults[&1].last_interest_accrual_ns, 12_345, "idempotent");
+}
+
+// ─── Increment 1 / Task 3: unified supply invariant (debt + reserve + pending-burn)
+//
+// spec 5.2: sum(chain_supplies) == total_chain_vault_debt_e8s()
+//                                + total_reserve_backing_e8s()      (bot/PSM path)
+//                                + total_pending_chain_burn_e8s()   (SP path, pre-burn)
+// With all-zero reserve/pending (Increment 1) this reduces to the old
+// `supply == debt`, so it is behavior-preserving on the live snapshot.
+
+const CHAIN: ChainId = ChainId(101);
+
+/// An Open vault on CHAIN with the given realized debt and pending interest.
+fn vault_with(debt_e8s: u128, pending_interest_e8s: u128) -> super::vault::ChainVaultV1 {
+    use super::vault::ChainVaultStatus;
+    use candid::Principal;
+    super::vault::ChainVaultV1 {
+        vault_id: 1,
+        owner: Principal::anonymous(),
+        collateral_chain: CHAIN,
+        custody_address: "0xc".into(),
+        collateral_amount_native: 0,
+        debt_e8s,
+        mint_recipient: "0xr".into(),
+        pending_mint_e8s: 0,
+        status: ChainVaultStatus::Open,
+        opened_at_ns: 0,
+        owner_evm: None,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: pending_interest_e8s,
+        pending_liquidation: None,
+    }
+}
+
+// (a) The reserve term is part of the RHS: when the bot shifts debt -> reserve,
+// chain_supplies stays put while debt drops, and the invariant still holds. The
+// OLD bare-debt check would FALSE-HALT here (sum 100 != debt 70).
+#[test]
+fn invariant_holds_with_nonzero_reserve_backing() {
+    let mut s = fixture_state();
+    s.chain_supplies.insert(CHAIN, 100); // 100 icUSD circulating
+    s.reserve_backing_e8s.insert(CHAIN, 30); // 30 backed by bot-held USDC reserve
+    // debt component = 70; generalized RHS = 70 + 30 + 0 = 100 == supply.
+    assert_eq!(check_invariant(&s, 70), Ok(()));
+}
+
+// (b) The pending-burn term is part of the RHS: the SP burns IC-side first and
+// moves the amount into pending_chain_burn_e8s; chain_supplies drops only when the
+// eSpace burn confirms. The invariant must hold during that window.
+#[test]
+fn invariant_holds_with_nonzero_pending_chain_burn() {
+    let mut s = fixture_state();
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 30);
+    assert_eq!(check_invariant(&s, 70), Ok(()));
+}
+
+// (c) HIGH #1: pending_interest_mint_e8s mints NEW foreign icUSD only when it
+// CONFIRMS, so it is NOT yet in chain_supplies and must NOT appear on the RHS.
+// Here a vault carries 70 realized debt + 50 pending interest, and 30 of debt has
+// shifted to bot reserve, so supply = 100 (= 70 + 30). The 50 pending interest is
+// excluded from BOTH total_chain_vault_debt_e8s() and the RHS.
+#[test]
+fn invariant_excludes_pending_interest_mint_from_rhs() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 50));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    let debt = s.total_chain_vault_debt_e8s();
+    assert_eq!(debt, 70, "total debt counts only realized debt_e8s, excludes pending interest");
+    // RHS = 70 + 30 + 0 = 100 == supply. If the 50 pending interest leaked onto the
+    // RHS it would be 150 != 100 and this would FALSE-HALT.
+    assert_eq!(check_invariant(&s, debt), Ok(()));
+}
+
+// (d) HIGH #2: apply_supply_delta enforces the GENERALIZED equality — it accepts a
+// delta that preserves sum == debt + reserve + pending_burn and rejects (no
+// mutation) one that breaks it.
+#[test]
+fn apply_supply_delta_enforces_generalized_rhs() {
+    let mut s = fixture_state();
+    // Balanced start: supply 100 == debt 70 + reserve 30.
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    // A mint of +10 with debt now 80: 110 == 80 + 30 -> accept.
+    assert_eq!(apply_supply_delta(&mut s, CHAIN, SupplyDelta::Increase(10), 80), Ok(()));
+    assert_eq!(s.chain_supplies[&CHAIN], 110);
+    // A delta that breaks the generalized equality is rejected, no mutation:
+    // +5 while still claiming debt 80 -> 115 != 80 + 30 = 110 -> Divergence.
+    assert_eq!(
+        apply_supply_delta(&mut s, CHAIN, SupplyDelta::Increase(5), 80),
+        Err(SupplyInvariantError::Divergence { sum_after: 115, total_debt: 110 })
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], 110, "no mutation on rejection");
+}
+
+// Behavior preservation: with all-zero reserve/pending the generalized RHS is
+// byte-identical to the old `supply == debt` (this is what makes the staging
+// upgrade a no-op behaviorally).
+#[test]
+fn invariant_reduces_to_bare_debt_when_reserve_and_pending_zero() {
+    let mut s = fixture_state();
+    s.chain_supplies.insert(CHAIN, 70);
+    assert_eq!(check_invariant(&s, 70), Ok(()));
+    assert_eq!(check_invariant(&s, 71), Err(SupplyInvariantError::Divergence { sum_after: 70, total_debt: 71 }));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -124,7 +124,7 @@ fn stamp_sets_accrual_start_only_for_unstamped_vaults() {
         owner_evm: None,
         last_interest_accrual_ns: last,
         pending_interest_mint_e8s: 0,
-    };
+        pending_liquidation: None,    };
     let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, mk(1, 0)); // unstamped (pre-field snapshot)
     s.chain_vaults.insert(2, mk(2, 5)); // already stamped

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -240,3 +240,71 @@ fn invariant_reduces_to_bare_debt_when_reserve_and_pending_zero() {
     assert_eq!(check_invariant(&s, 70), Ok(()));
     assert_eq!(check_invariant(&s, 71), Err(SupplyInvariantError::Divergence { sum_after: 70, total_debt: 71 }));
 }
+
+// ─── Increment 1 / Task 4: apply_debt_to_reserve_shift (the reserve-term gate) ───
+
+use super::supply::{apply_debt_to_reserve_shift, ReserveShiftError};
+
+// The bot path moves debt -> reserve WITHOUT burning icUSD: chain_supplies stays
+// put, debt drops, reserve rises by the same amount, and the unified invariant
+// stays balanced by construction.
+#[test]
+fn reserve_shift_moves_debt_to_reserve_and_preserves_invariant() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    // pre: 100 == 100 (debt) + 0 (reserve) + 0 (pending)
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+
+    // Bot clears 40 of debt into reserve, realizing 45_000000000000000000 wei USDC
+    // (incl. the 12% penalty surplus over the 40 cleared).
+    apply_debt_to_reserve_shift(&mut s, CHAIN, 1, 40, 45_000_000_000_000_000_000)
+        .expect("reserve shift");
+
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 60, "vault debt reduced by cleared amount");
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], 40, "reserve_backing credited the cleared debt");
+    assert_eq!(
+        s.reserve_usdc_native[&CHAIN], 45_000_000_000_000_000_000,
+        "realized USDC recorded (NOT on the invariant RHS)"
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], 100, "chain_supplies UNCHANGED (no burn)");
+    // post: 100 == 60 (debt) + 40 (reserve) + 0 (pending) -> invariant still holds
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn reserve_shift_rejects_clearing_more_than_debt() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    assert_eq!(
+        apply_debt_to_reserve_shift(&mut s, CHAIN, 1, 150, 1),
+        Err(ReserveShiftError::ClearExceedsDebt { cleared_e8s: 150, vault_debt_e8s: 100 })
+    );
+    // No mutation on rejection.
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100);
+    assert!(s.reserve_backing_e8s.get(&CHAIN).copied().unwrap_or(0) == 0);
+    assert!(s.reserve_usdc_native.get(&CHAIN).copied().unwrap_or(0) == 0);
+}
+
+#[test]
+fn reserve_shift_rejects_unknown_vault() {
+    let mut s = fixture_state();
+    assert_eq!(
+        apply_debt_to_reserve_shift(&mut s, CHAIN, 99, 10, 10),
+        Err(ReserveShiftError::UnknownVault(99))
+    );
+}
+
+#[test]
+fn reserve_shift_blocked_while_invariant_halted() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.invariant_halted = true;
+    assert_eq!(
+        apply_debt_to_reserve_shift(&mut s, CHAIN, 1, 40, 1),
+        Err(ReserveShiftError::Halted)
+    );
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation while halted");
+}

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,9 +1,9 @@
 use super::supply::{apply_supply_delta, SupplyDelta, SupplyInvariantError};
 use super::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 
-fn fixture_state() -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn fixture_state() -> MultiChainState {
+    let mut s = MultiChainState::default();
     s.chain_configs.insert(
         ChainId(101),
         ChainConfigV3 {
@@ -125,7 +125,7 @@ fn stamp_sets_accrual_start_only_for_unstamped_vaults() {
         last_interest_accrual_ns: last,
         pending_interest_mint_e8s: 0,
     };
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, mk(1, 0)); // unstamped (pre-field snapshot)
     s.chain_vaults.insert(2, mk(2, 5)); // already stamped
     super::supply::stamp_chain_interest_accrual_start(&mut s, 12_345);

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -12,7 +12,7 @@
 //! this file only asserts the parameterization itself.
 
 use super::config::{ChainId, GasStrategy, RegisterChainArg};
-use super::multi_chain_state::MultiChainStateV5;
+use super::multi_chain_state::MultiChainState;
 use super::vault::{open_chain_vault_in_state, OpenVaultError};
 use candid::Principal;
 
@@ -33,8 +33,8 @@ fn only_good(addr: &str) -> bool {
 
 /// Register chain 501 with 9-decimal native units and set its manual `"SOL"`
 /// price. Mirrors what register_chain + a manual price override do.
-fn setup(price_e8: u64) -> MultiChainStateV5 {
-    let mut s = MultiChainStateV5::default();
+fn setup(price_e8: u64) -> MultiChainState {
+    let mut s = MultiChainState::default();
     let arg = RegisterChainArg {
         chain_id: CHAIN,
         display_name: "SolanaDevnet".into(),
@@ -145,7 +145,7 @@ use super::evm::settlement::confirm_mint_in_state;
 
 /// Insert an Open vault (confirmed collateral + debt, no mint in flight) owned by
 /// `owner`, and seed the chain supply to match its debt so the invariant holds.
-fn insert_open_vault(s: &mut MultiChainStateV5, owner: Principal, vault_id: u64, collateral: u128, debt: u128) {
+fn insert_open_vault(s: &mut MultiChainState, owner: Principal, vault_id: u64, collateral: u128, debt: u128) {
     use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
     s.chain_vaults.insert(vault_id, ChainVaultV1 {
         vault_id, owner, collateral_chain: CHAIN, custody_address: "custody".into(),
@@ -288,7 +288,7 @@ fn borrow_rejects_when_over_debt_ceiling() {
 
 #[test]
 fn nonce_consume_is_monotonic_and_rejects_replay() {
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let owner = Principal::from_slice(&[5, 5, 5]);
     assert_eq!(s.expected_evm_nonce(&owner), 0);
     assert_eq!(s.consume_evm_nonce(&owner, 0), Ok(()));
@@ -304,7 +304,7 @@ fn nonce_consume_is_monotonic_and_rejects_replay() {
 #[test]
 fn per_owner_cap_counts_non_terminal_only() {
     use super::monad::chain_vault::ChainVaultStatus;
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     let owner = Principal::from_slice(&[9, 9, 9]);
     insert_open_vault(&mut s, owner, 1, 0, 0);
     insert_open_vault(&mut s, owner, 2, 0, 0);
@@ -367,7 +367,7 @@ fn gc_skips_stale_vaults_when_observer_inactive() {
     };
     // (a) Chain not registered at all -> no observer -> not reaped (would strand
     //     a funded-but-unobserved deposit).
-    let mut s = MultiChainStateV5::default();
+    let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, stale(1));
     assert_eq!(prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS), 0);
     assert!(s.chain_vaults.contains_key(&1), "unregistered-chain vault kept");

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -153,7 +153,7 @@ fn insert_open_vault(s: &mut MultiChainState, owner: Principal, vault_id: u64, c
         pending_mint_e8s: 0, status: ChainVaultStatus::Open, opened_at_ns: 0,
     last_interest_accrual_ns: 0,
     pending_interest_mint_e8s: 0,
-        owner_evm: Some("0xowner".into()),
+    pending_liquidation: None,        owner_evm: Some("0xowner".into()),
     });
     *s.chain_supplies.entry(CHAIN).or_default() += debt;
 }
@@ -332,7 +332,7 @@ fn gc_prunes_only_stale_awaiting_deposit() {
         mint_recipient: "r".into(), pending_mint_e8s: 0, status: st, opened_at_ns: opened,
     last_interest_accrual_ns: 0,
     pending_interest_mint_e8s: 0,
-        owner_evm: None,
+    pending_liquidation: None,        owner_evm: None,
     };
     let now = 100 * AWAITING_DEPOSIT_TTL_NS;
     // 1: stale AwaitingDeposit (older than TTL) -> pruned.
@@ -364,7 +364,7 @@ fn gc_skips_stale_vaults_when_observer_inactive() {
         opened_at_ns: now - AWAITING_DEPOSIT_TTL_NS - 1, owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-    };
+        pending_liquidation: None,    };
     // (a) Chain not registered at all -> no observer -> not reaped (would strand
     //     a funded-but-unobserved deposit).
     let mut s = MultiChainState::default();
@@ -414,5 +414,90 @@ fn close_rejects_while_borrow_mint_in_flight_even_if_debt_zero() {
         s.chain_vaults.get(&7).unwrap().status,
         super::monad::chain_vault::ChainVaultStatus::Open,
         "vault not closed"
+    );
+}
+
+// ─── Increment 1 / Task 2: pending_liquidation marker write-guards (spec 3.1) ───
+
+use super::vault::{LiquidationTier, PendingLiquidationV1};
+
+/// A Bot-tier liquidation marker for the owner-write-guard tests.
+fn liq_marker() -> PendingLiquidationV1 {
+    PendingLiquidationV1 {
+        op_id: 1,
+        debt_to_clear_e8s: 10_00000000,
+        collateral_reserved_native: ONE_SOL,
+        tier: LiquidationTier::Bot,
+        started_at_ns: 100,
+    }
+}
+
+#[test]
+fn withdraw_rejected_while_liquidation_in_flight() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    // A liquidation is mid-flight: the vault's collateral is reserved/handed to a
+    // tier. An owner withdraw (even a tiny, CR-safe 1-lamport one) must be rejected
+    // so the collateral cannot be double-spent against an in-flight swap/burn.
+    s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
+    assert_eq!(
+        withdraw_collateral_in_state(&mut s, 7, 1, "good-address".into(), only_good, "SOL", 13_000, 2),
+        Err(WithdrawError::LiquidationInFlight)
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().collateral_amount_native,
+        100 * ONE_SOL,
+        "collateral untouched on rejection"
+    );
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0, "no withdraw enqueued");
+}
+
+#[test]
+fn borrow_rejected_while_liquidation_in_flight() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
+    assert_eq!(
+        borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 2),
+        Err(BorrowError::LiquidationInFlight)
+    );
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0, "no borrow reserved on rejection");
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0, "no mint enqueued");
+}
+
+#[test]
+fn close_rejected_while_liquidation_in_flight_via_withdraw_delegate() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // debt 0 but collateral > 0: close delegates to withdraw, which must reject on
+    // the marker (the non-degenerate path).
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 0);
+    s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
+    assert_eq!(
+        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        Err(WithdrawError::LiquidationInFlight)
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().status,
+        super::monad::chain_vault::ChainVaultStatus::Open,
+        "vault not closed while liquidation in flight"
+    );
+}
+
+#[test]
+fn close_rejected_while_liquidation_in_flight_degenerate_zero_collateral() {
+    let mut s = setup(PRICE_150_USD_E8);
+    // debt 0, collateral 0, Open: close normally short-circuits straight to Closed.
+    // The marker must block even that degenerate path — the short-circuit bypasses
+    // the withdraw delegate, so the guard must live in close's OWN block.
+    insert_open_vault(&mut s, Principal::anonymous(), 7, 0, 0);
+    s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
+    assert_eq!(
+        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        Err(WithdrawError::LiquidationInFlight)
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().status,
+        super::monad::chain_vault::ChainVaultStatus::Open,
+        "vault not closed while liquidation in flight"
     );
 }

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -92,6 +92,56 @@ pub struct ChainVaultV1 {
     /// `> 0` ⇒ one interest realization is in flight for this vault.
     #[serde(default)]
     pub pending_interest_mint_e8s: u128,
+    /// Chains-liquidation marker (spec 3.1): `Some(..)` while a liquidation is
+    /// mid-flight for this vault. A MARKER, deliberately NOT a new
+    /// `ChainVaultStatus` variant — the vault stays `Open` throughout, so no
+    /// `match ChainVaultStatus` site needs a new arm and the existing owner-write
+    /// guards key off this exactly as they do off `pending_mint_e8s`. Set by
+    /// `begin_liquidation_in_state` (Increment 2), cleared on confirm/revert.
+    /// While `Some`, owner write-ops (withdraw/borrow/close) reject with
+    /// `LiquidationInFlight`. `#[serde(default)]` = `None` for a vault decoded
+    /// from a pre-field snapshot (mandatory state-wipe defense). Empty until
+    /// Increment 2 wires the engine.
+    #[serde(default)]
+    pub pending_liquidation: Option<PendingLiquidationV1>,
+}
+
+/// Which liquidation tier reserved a vault's collateral (spec 3.1, 6). The tier
+/// matters because the bot path (PSM swap) and the SP path reserve/clear
+/// collateral differently; it is recorded on the marker so the confirm/escalation
+/// logic (Increments 2-4) knows which path owns the in-flight liquidation.
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiquidationTier {
+    /// Tier 1: canister-as-bot PSM swap (seized CFX -> USDC reserve, no icUSD burn).
+    Bot,
+    /// Tier 2: ICP Stability Pool fallback (burns icUSD, absorbs the chain debt).
+    StabilityPool,
+}
+
+/// Per-vault liquidation-in-flight marker (spec 3.1). Mirrors the existing
+/// Design-B pending markers (`pending_mint_e8s`, `pending_interest_mint_e8s`):
+/// "this much is mid-settlement and may revert." Carries enough to resolve the
+/// in-flight op on confirm and to restore the reserved collateral on revert.
+/// Inert until Increment 2 populates it; defined here so the V6 root + the
+/// owner-write guards are ready and a single bump covers the whole engine.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct PendingLiquidationV1 {
+    /// Settlement-queue op id of the liquidation op (the bot swap, or the SP
+    /// eSpace burn). Phase 2 confirm matches on this id (and tolerates the op
+    /// already being pruned — finding #5: the marker, not the op, is the source
+    /// of truth for routing/settlement).
+    pub op_id: u64,
+    /// Debt (e8s) this liquidation is sized to retire.
+    pub debt_to_clear_e8s: u128,
+    /// Collateral (native base units, e.g. CFX wei) decremented from
+    /// `collateral_amount_native` and handed to the tier; restored under CAS on
+    /// revert.
+    pub collateral_reserved_native: u128,
+    /// Which tier owns this in-flight liquidation.
+    pub tier: LiquidationTier,
+    /// Wall-clock ns the liquidation was begun (for the bot-timeout / aged-marker
+    /// alarms in later increments).
+    pub started_at_ns: u64,
 }
 
 /// Reasons `open_chain_vault_in_state` / `verify_deposit_and_enqueue_mint_in_state`
@@ -169,6 +219,12 @@ pub enum WithdrawError {
     /// interest as unbacked debt on a Closed vault (Task 12). The window is a
     /// few settlement ticks; the next harvest/confirm clears it.
     InterestRealizationPending,
+    /// A liquidation is in flight for this vault (`pending_liquidation.is_some()`).
+    /// The vault's collateral is reserved/handed to the liquidation tier; an owner
+    /// withdraw or close while a swap/burn may still settle could double-spend the
+    /// collateral or under-collateralize the residual debt. Reject until the
+    /// marker clears (mirrors `MintInFlight`). Spec 3.1.
+    LiquidationInFlight,
 }
 
 /// Compute the collateral ratio (e4: 25000 == 250.00%) for a foreign-chain vault.
@@ -340,7 +396,7 @@ pub fn open_chain_vault_in_state(
             // stamped to `now` at mint-confirm (Task 7). Open-time = 0 (debt 0).
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-        },
+            pending_liquidation: None,        },
     );
     // No mint enqueued - that happens in verify_deposit_and_enqueue_mint_in_state.
     Ok(())
@@ -509,6 +565,13 @@ pub fn withdraw_collateral_in_state(
         if v.pending_interest_mint_e8s > 0 {
             return Err(WithdrawError::InterestRealizationPending);
         }
+        // Increment 1 (spec 3.1): a liquidation is in flight — the vault's
+        // collateral is reserved/handed to a tier and a swap/burn may still
+        // settle. Releasing collateral now could double-spend it or strand the
+        // residual debt. Reject until the marker clears (mirrors MintInFlight).
+        if v.pending_liquidation.is_some() {
+            return Err(WithdrawError::LiquidationInFlight);
+        }
         if amount_e18 > v.collateral_amount_native {
             return Err(WithdrawError::InsufficientCollateral);
         }
@@ -639,6 +702,13 @@ pub fn close_chain_vault_in_state(
         if v.pending_mint_e8s != 0 {
             return Err(WithdrawError::MintInFlight);
         }
+        // Increment 1 (spec 3.1): block close while a liquidation is in flight.
+        // The degenerate zero-collateral short-circuit below bypasses the withdraw
+        // delegate, so the marker guard must live here too (same rationale as the
+        // pending_mint guard above). The delegate path inherits the withdraw guard.
+        if v.pending_liquidation.is_some() {
+            return Err(WithdrawError::LiquidationInFlight);
+        }
         (v.collateral_amount_native, v.status.clone())
     };
 
@@ -690,6 +760,11 @@ pub enum BorrowError {
     /// The borrow would push the chain's total outstanding+in-flight debt over
     /// the configured `debt_ceiling_e8s`.
     DebtCeilingExceeded { would_be_e8s: u128, ceiling_e8s: u128 },
+    /// A liquidation is in flight for this vault (`pending_liquidation.is_some()`).
+    /// Borrowing more against collateral that is reserved/handed to a liquidation
+    /// tier could leave the post-confirm vault under-collateralized. Reject until
+    /// the marker clears (mirrors `MintInFlight`). Spec 3.1.
+    LiquidationInFlight,
 }
 
 /// Borrow additional icUSD against an existing `Open` vault — a SECOND on-chain
@@ -736,6 +811,12 @@ pub fn borrow_chain_vault_in_state(
         // for this vault, and the settlement queue is sequential per chain.
         if v.pending_mint_e8s != 0 {
             return Err(BorrowError::MintInFlight);
+        }
+        // Increment 1 (spec 3.1): no new borrow while a liquidation is in flight —
+        // the collateral is reserved/handed to a tier, so borrowing more against it
+        // could leave the post-confirm vault under-collateralized.
+        if v.pending_liquidation.is_some() {
+            return Err(BorrowError::LiquidationInFlight);
         }
         (
             v.collateral_chain,

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -30,7 +30,7 @@
 //! observed at finality (settlement worker, Task 10).
 
 use crate::chains::config::ChainId;
-use crate::chains::multi_chain_state::MultiChainStateV5;
+use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
@@ -210,7 +210,7 @@ pub fn collateral_ratio_e4(
 /// this total over the configured cap. Counts `pending_mint_e8s` and
 /// `pending_interest_mint_e8s` so concurrent in-flight opens/borrows cannot
 /// collectively breach the ceiling. Saturating throughout.
-pub fn total_chain_debt_including_pending_e8s(state: &MultiChainStateV5, chain: ChainId) -> u128 {
+pub fn total_chain_debt_including_pending_e8s(state: &MultiChainState, chain: ChainId) -> u128 {
     state
         .chain_vaults
         .values()
@@ -249,7 +249,7 @@ pub fn total_chain_debt_including_pending_e8s(state: &MultiChainStateV5, chain: 
 /// - declared CR `< min_cr_e4` -> `BelowMinCr`
 #[allow(clippy::too_many_arguments)]
 pub fn open_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     chain: ChainId,
     owner: Principal,
     custody_address: String,
@@ -365,7 +365,7 @@ pub fn open_chain_vault_in_state(
 /// rejected enqueue leaves the vault `AwaitingDeposit` and the queue unchanged,
 /// and the next deposit-watch tick retries cleanly.
 pub fn verify_deposit_and_enqueue_mint_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     observed_balance_e18: u128,
     now_ns: u64,
@@ -468,7 +468,7 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
 /// So a rejected enqueue leaves the vault and its collateral untouched.
 #[allow(clippy::too_many_arguments)]
 pub fn withdraw_collateral_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     amount_e18: u128,
     dest_address: String,
@@ -612,7 +612,7 @@ pub fn withdraw_collateral_in_state(
 /// (A non-Open zero-collateral vault is NOT short-circuited - it falls through
 /// to the delegate's gate and rejects with `WrongStatus`.)
 pub fn close_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     dest_address: String,
     address_validator: fn(&str) -> bool,
@@ -707,7 +707,7 @@ pub enum BorrowError {
 /// `NoPrice`; post-borrow CR `< min_cr_e4` → `BelowMinCr`.
 #[allow(clippy::too_many_arguments)]
 pub fn borrow_chain_vault_in_state(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     vault_id: u64,
     additional_e8s: u128,
     recipient: String,
@@ -813,7 +813,7 @@ pub const AWAITING_DEPOSIT_TTL_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
 /// inactive-observer chain is left until the observer resumes (then it either
 /// flips to `MintPending` if funded, or ages out on a later GC tick once active).
 pub fn prune_stale_awaiting_deposit(
-    state: &mut MultiChainStateV5,
+    state: &mut MultiChainState,
     now_ns: u64,
     ttl_ns: u64,
 ) -> usize {

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -894,6 +894,55 @@ pub enum Event {
         block_number: u64,
         timestamp: u64,
     },
+    // ── Chains-liquidation engine (Increment 1: defined, NOT yet emitted) ──
+    // Forward-looking variants for the liquidation cascade. Additive to the
+    // append-only event candid surface; emitted starting Increment 2 (bot path)
+    // / Increment 4 (SP path). Defined now so the V6 bump + the event surface land
+    // together and a single deploy covers the engine.
+    /// Increment 2+: a bot (PSM) partial liquidation confirmed — `debt_cleared_e8s`
+    /// of the vault's debt was retired into reserve (no icUSD burn) and
+    /// `collateral_seized_native` was sold. Pairs with `ChainReserveCredited`.
+    #[serde(rename = "chain_vault_liquidated")]
+    ChainVaultLiquidated {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        op_id: u64,
+        debt_cleared_e8s: u128,
+        collateral_seized_native: u128,
+        tier: crate::chains::vault::LiquidationTier,
+        timestamp: u64,
+    },
+    /// Increment 2+: reserve backing credited for a chain after a bot swap settled
+    /// (`backing_added_e8s` moved debt->reserve; `usdc_native` realized USDC
+    /// recorded). The accounting side of `ChainVaultLiquidated`.
+    #[serde(rename = "chain_reserve_credited")]
+    ChainReserveCredited {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        backing_added_e8s: u128,
+        usdc_native: u128,
+        timestamp: u64,
+    },
+    /// Increment 4+: an SP depositor's CFX claim was settled (paid to their EVM
+    /// address) for a chain-vault liquidation. Claim-scoped, not vault-scoped.
+    #[serde(rename = "chain_cfx_claim_settled")]
+    ChainCfxClaimSettled {
+        chain_id: crate::chains::config::ChainId,
+        claim_id: u64,
+        recipient: String,
+        amount_native: u128,
+        timestamp: u64,
+    },
+    /// Increment 2+: a vault was liquidatable but liquidation was DEFERRED this
+    /// tick (stale price, halted chain, DEX depth too thin, etc.). Carries the
+    /// reason so the operator can see why a vault is stuck at a tier.
+    #[serde(rename = "chain_liquidation_deferred")]
+    ChainLiquidationDeferred {
+        chain_id: crate::chains::config::ChainId,
+        vault_id: u64,
+        reason: String,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -1015,10 +1064,16 @@ impl Event {
             | Event::ChainMintConfirmed { vault_id, .. }
             | Event::ChainBurnObserved { vault_id, .. }
             | Event::ChainInterestMinted { vault_id, .. }
+            // Increment 1: chains-liquidation events that name a vault.
+            | Event::ChainVaultLiquidated { vault_id, .. }
+            | Event::ChainReserveCredited { vault_id, .. }
+            | Event::ChainLiquidationDeferred { vault_id, .. }
             | Event::WithdrawalSigned { vault_id, .. } => vault_id == filter_vault_id,
             // Phase 1b: protocol-wide or op-scoped events, not vault-specific.
             Event::ChainSettlementFailed { .. }
             | Event::ChainReorgDetected { .. }
+            // Increment 1: an SP CFX claim is claim-scoped, not vault-scoped.
+            | Event::ChainCfxClaimSettled { .. }
             | Event::ChainHotWalletLow { .. } => false,
         }
     }
@@ -2040,6 +2095,13 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             | Event::WithdrawalSigned { .. }
             | Event::ChainSettlementFailed { .. }
             | Event::ChainReorgDetected { .. }
+            // Increment 1: chains-liquidation events are observability-only; the
+            // reserve/debt/supply mutations happen live in the bot/SP confirm
+            // paths (Increments 2-4), not on replay.
+            | Event::ChainVaultLiquidated { .. }
+            | Event::ChainReserveCredited { .. }
+            | Event::ChainCfxClaimSettled { .. }
+            | Event::ChainLiquidationDeferred { .. }
             | Event::ChainHotWalletLow { .. } => {},
         }
     }

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2292,6 +2292,17 @@ pub struct ChainSupplyReconciliation {
     /// Signed gap = onchain - recorded. Positive => excess (possible unbacked
     /// mint); negative => deficit (an unsubmitted burn the backstop handles).
     pub gap_e8s: i128,
+    /// INFORMATIONAL breakdown of the unified supply invariant's RHS for this
+    /// chain (spec 5.4, findings #17/#20/#29). These are backing RECLASSIFICATION,
+    /// NOT on-chain supply, so they MUST NOT enter `unbacked_excess` (which is the
+    /// on-chain-vs-recorded truth check) — adding them there would mask a real
+    /// unbacked mint. They are surfaced purely so the operator sees the
+    /// debt/reserve/pending-burn split. 0 until Increment 2+ populates them.
+    pub reserve_backing_e8s: u128,
+    pub pending_chain_burn_e8s: u128,
+    /// Physical USDC the reserve address holds for this chain (native base units,
+    /// 18-dec on eSpace). Bookkeeping of the ASSET; informational only.
+    pub reserve_usdc_native: u128,
 }
 
 /// Developer-gated, on-demand supply reconciliation against the chain (audit
@@ -2312,33 +2323,39 @@ async fn reconcile_chain_supply(
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    let (contract, recorded, in_flight, cursor) = read_state(|s| {
-        let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
-        let recorded = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
-        let in_flight = s
-            .multi_chain
-            .settlement_queues
-            .get(&chain)
-            .map(|q| {
-                q.pending
-                    .values()
-                    .filter_map(|op| match &op.kind {
-                        SettlementOpKind::Mint { amount_e8s, .. }
-                            if matches!(
-                                op.status,
-                                SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
-                            ) =>
-                        {
-                            Some(*amount_e8s)
-                        }
-                        _ => None,
-                    })
-                    .sum::<u128>()
-            })
-            .unwrap_or(0);
-        let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
-        (contract, recorded, in_flight, cursor)
-    });
+    let (contract, recorded, in_flight, cursor, reserve_backing, pending_burn, reserve_usdc) =
+        read_state(|s| {
+            let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
+            let recorded = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+            let in_flight = s
+                .multi_chain
+                .settlement_queues
+                .get(&chain)
+                .map(|q| {
+                    q.pending
+                        .values()
+                        .filter_map(|op| match &op.kind {
+                            SettlementOpKind::Mint { amount_e8s, .. }
+                                if matches!(
+                                    op.status,
+                                    SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                                ) =>
+                            {
+                                Some(*amount_e8s)
+                            }
+                            _ => None,
+                        })
+                        .sum::<u128>()
+                })
+                .unwrap_or(0);
+            let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+            // Informational RHS breakdown for this chain (NOT part of the
+            // unbacked_excess check — findings #17/#20/#29).
+            let reserve_backing = s.multi_chain.reserve_backing_e8s.get(&chain).copied().unwrap_or(0);
+            let pending_burn = s.multi_chain.pending_chain_burn_e8s.get(&chain).copied().unwrap_or(0);
+            let reserve_usdc = s.multi_chain.reserve_usdc_native.get(&chain).copied().unwrap_or(0);
+            (contract, recorded, in_flight, cursor, reserve_backing, pending_burn, reserve_usdc)
+        });
     let contract = contract.ok_or_else(|| {
         ProtocolError::ChainAdmin(format!("no icUSD contract configured for chain {:?}", chain))
     })?;
@@ -2354,6 +2371,11 @@ async fn reconcile_chain_supply(
                 ProtocolError::TemporarilyUnavailable(format!("totalSupply read failed; retry: {e}"))
             })?;
     let gap_e8s = onchain as i128 - recorded as i128;
+    // The unbacked-excess test compares on-chain totalSupply against recorded
+    // chain_supplies (+ in-flight mints) ONLY. reserve_backing / pending_chain_burn
+    // are internal backing reclassification that never change on-chain totalSupply,
+    // so they MUST stay out of this inequality or they would mask a real unbacked
+    // mint (findings #17/#20/#29). They are reported below as informational fields.
     let unbacked_excess = onchain > recorded.saturating_add(in_flight);
     if unbacked_excess {
         log!(INFO, "[reconcile_chain_supply] chain={:?} UNBACKED EXCESS: onchain {} > recorded {} + in_flight {} (block {})", chain, onchain, recorded, in_flight, cursor);
@@ -2366,6 +2388,9 @@ async fn reconcile_chain_supply(
         in_flight_mint_e8s: in_flight,
         unbacked_excess,
         gap_e8s,
+        reserve_backing_e8s: reserve_backing,
+        pending_chain_burn_e8s: pending_burn,
+        reserve_usdc_native: reserve_usdc,
     })
 }
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1861,6 +1861,48 @@ fn set_chain_contract(
     Ok(())
 }
 
+/// Set (or replace) the per-chain liquidation config (spec 8, Tier B): the DEX
+/// wiring + risk knobs the bot path will read. Developer-gated. The config is
+/// validated (slippage cap <= 100%, restore target > par, required addresses
+/// present when `enabled`) before persisting; a rejected config mutates nothing.
+/// Inert until Increment 2+ reads it (Increment 1 ships only this scaffolding).
+#[candid_method(update)]
+#[update]
+fn set_chain_liquidation_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    config
+        .validate()
+        .map_err(|e| ProtocolError::ChainAdmin(format!("invalid liquidation config: {e:?}")))?;
+    mutate_state(|s| {
+        s.multi_chain.chain_liquidation_configs.insert(chain, config.clone());
+    });
+    log!(
+        INFO,
+        "[set_chain_liquidation_config] chain={:?} dex={:?} enabled={}",
+        chain,
+        config.dex,
+        config.enabled
+    );
+    Ok(())
+}
+
+/// Return the per-chain liquidation config, or None if unset. Public read-only
+/// query (mirrors `get_chain_vault`); the config is operator DEX wiring + risk
+/// knobs, no secrets.
+#[candid_method(query)]
+#[query]
+fn get_chain_liquidation_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Option<rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1> {
+    read_state(|s| s.multi_chain.chain_liquidation_configs.get(&chain).cloned())
+}
+
 /// Manual-price readout for `(chain, symbol)`: the USD e8 price plus the
 /// wall-clock nanosecond timestamp of the last write (audit F-01 freshness).
 /// `set_at_ns == 0` means the price was set before the V5 upgrade (timestamp

--- a/src/rumi_protocol_backend/src/storage.rs
+++ b/src/rumi_protocol_backend/src/storage.rs
@@ -403,7 +403,7 @@ mod state_snapshot_tests {
                 owner_evm: None,
                 last_interest_accrual_ns: 0,
                 pending_interest_mint_e8s: 0,
-            },
+                pending_liquidation: None,            },
         );
 
         let bytes = encode_state(&state);


### PR DESCRIPTION
## Increment 1 — MultiChainStateV6 + unified supply invariant

Second increment of the chains-rail liquidation engine. **Pure accounting + config scaffolding — NO liquidation execution** (that is Increments 2-4). Every new RHS term is `0` until Increment 2 wires the engine, so the live invariant equals the old `supply == debt`; the staging upgrade is behavior-preserving.

Executes `docs/superpowers/plans/2026-06-19-chains-liquidation-increment-1.md` task-by-task, folding in the HIGH (and relevant MED) findings from the design spec's Appendix A.

### What's in it
1. **MultiChainStateV6** — additive-reshape bump (V5 kept byte-verbatim; four new `#[serde(default)]` maps/sets: `reserve_backing_e8s`, `reserve_usdc_native`, `pending_chain_burn_e8s`, `sp_attempted_chain_vaults`; plus `chain_liquidation_configs`). The ~40 hard-coded `&mut MultiChainStateV5` signatures were alias-renamed to `MultiChainState` so this is the last bump needing a rename (finding #15).
2. **`pending_liquidation` vault marker** (spec 3.1) — a marker, NOT a new `ChainVaultStatus` variant; owner write-ops (withdraw/borrow/close) reject with a new `LiquidationInFlight` arm.
3. **Unified supply invariant** — `sum(chain_supplies) == debt + reserve_backing + pending_chain_burn` (spec 5.2), via one `chain_backing_rhs_e8s` helper that both `check_invariant` and `apply_supply_delta` route through.
4. **`apply_debt_to_reserve_shift`** — the single gate for the reserve term (conserves debt+reserve; no caller until Increment 2).
5. **`ChainLiquidationConfigV1`** + `DexKind` + dev-gated `set` / public `get` endpoints.
6. **Four forward-looking event variants** (`ChainVaultLiquidated`, `ChainReserveCredited`, `ChainCfxClaimSettled`, `ChainLiquidationDeferred`) — defined, not yet emitted.

### State-wipe safety (the #1 risk)
- `v5_cbor_snapshot_decodes_into_v6_without_wiping_state` proves a populated V5 snapshot decodes into V6 with every carried field intact and the new fields defaulting empty. **The guard was verified to catch a regression**: dropping `#[serde(default)]` makes the decode fail with `missing field reserve_backing_e8s` (the 2026-05-18 AMM state-wipe signature).
- A V6→V6 round-trip proves the new fields (incl. the liquidation config) persist forward.
- The live kvg63 snapshot is V5; the upgrade decodes it into V6 with the new fields empty — a state-preserving upgrade.

### HIGH findings handled (spec Appendix A)
- **#1** `pending_interest_mint_e8s` is excluded from the RHS (it mints supply only on confirm; excluded from `total_chain_vault_debt_e8s`). Pinned by a test.
- **#2 / #7 / #24** the 3-term RHS lives in ONE helper computed from `state`, so callers cannot forget a term and false-halt. **Both** `check_invariant` callers — the Timer-B self-check AND `clear_invariant_halt` — inherit the generalized RHS with no edit. (The plan's four-consumer list omitted `clear_invariant_halt`; internal-compute covers it for free, so the operator's un-halt path can succeed after a bot liquidation.)
- **#15** the V5-signature blast radius (alias rename, so the next bump is one line).
- **#33 / #38** chains events ride the append-only top-level `event.rs` (no `chains/event.rs`); every `.did` change is additive and the candid compatibility test stays green.

### Deliberate divergence from the plan (flagged)
The plan's Task 3 says "update `reconcile_chain_supply` to the 3-term RHS," but findings **#17/#20/#29** (verified against code) show reserve must NOT enter reconcile's `unbacked_excess` check — that is a *different* invariant (on-chain `totalSupply` vs recorded `chain_supplies`), and adding reserve there would **mask a real unbacked mint**. So `unbacked_excess` arithmetic is **unchanged**; the three terms are surfaced as **informational breakdown fields** on `ChainSupplyReconciliation` only, with a comment pinning the decision. `reserve_usdc_native` is likewise NOT an RHS term (it tracks the physical USDC asset, not icUSD backing — spec 3.2/5.6).

### Verification
- `cargo test -p rumi_protocol_backend --lib`: **520 passed**
- `--bin`: **4 passed** (incl. `check_candid_interface_compatibility`)
- `conflux_espace_happy_path_pic`: **2 passed**; `conflux_interest_accrual_pic`: **1 passed** (wasm rebuilt first)
- TDD throughout: every marker-guard, invariant, reserve-shift, and config test was written first and watched fail for the right reason, then made green.

### Not in scope (Increments 2-4)
Liquidation execution: sizing/detection, the tECDSA Swappi swap, the SP fallback + CFX claim path. `apply_debt_to_reserve_shift`, the config, the marker, and the events have **no callers** yet.

### Commits
- `MultiChainStateV6 (reserve + pending-burn + sp-attempted)`
- `pending_liquidation vault marker + write guards`
- `unified supply invariant (debt + reserve + pending-burn)`
- `apply_debt_to_reserve_shift + liquidation config`
- `forward-looking liquidation event variants`

**Deploy note:** a state-preserving upgrade (new fields default empty on the live V5 kvg63 snapshot). NOT deployed — this PR stops at review per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
