### PR TITLE
test(chains): fix multi_chain_supply_invariant for MultiChainStateV6

### DIFF
--- a/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
+++ b/src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs
@@ -10,7 +10,15 @@
 use rumi_protocol_backend::chains::config::{
     ChainConfigV3, ChainId, ChainStatus, GasStrategy,
 };
-use rumi_protocol_backend::chains::multi_chain_state::MultiChainStateV4;
+// Canonical multi-chain state alias (currently `MultiChainStateV6`). The
+// liquidation-Increment-1 bump added the reserve-backing / pending-chain-burn /
+// sp-attempted scaffolding; `Default` brings those new fields up empty, so the
+// unified RHS (`chain_backing_rhs_e8s` = debt + reserve + pending_burn) reduces
+// to bare `debt` here and the invariant assertions below stay meaningful (the
+// supply helpers all take `&mut MultiChainState`). Using the alias keeps this
+// test pinned to the canonical state across future version bumps, matching the
+// convention in every `chains/` unit test.
+use rumi_protocol_backend::chains::multi_chain_state::MultiChainState;
 use rumi_protocol_backend::chains::supply::{apply_supply_delta, SupplyDelta};
 use rumi_protocol_backend::chains::monad::chain_vault::open_chain_vault_in_state;
 use rumi_protocol_backend::chains::monad::settlement::confirm_mint_in_state;
@@ -38,8 +46,8 @@ fn arb_op() -> impl Strategy<Value = Op> {
     ]
 }
 
-fn seeded_state() -> MultiChainStateV4 {
-    let mut state = MultiChainStateV4::default();
+fn seeded_state() -> MultiChainState {
+    let mut state = MultiChainState::default();
     for id in 1u32..=5u32 {
         state.chain_configs.insert(
             ChainId(id),
@@ -230,7 +238,11 @@ proptest! {
                     if opened {
                         // PRE-mint total is the current total_debt; the helper
                         // adds `amt` internally to derive the post-mint total.
-                        if confirm_mint_in_state(&mut state, cid, next_vault_id, amt, total_debt)
+                        // `now_ns = 0`: this test never harvests interest (it drives
+                        // open -> confirm -> direct-debt burn), so the
+                        // `last_interest_accrual_ns` stamp is inert here. Matches the
+                        // settlement unit tests' convention.
+                        if confirm_mint_in_state(&mut state, cid, next_vault_id, amt, total_debt, 0)
                             .is_ok()
                         {
                             total_debt += amt;


### PR DESCRIPTION
## What

The supply-invariant property test `src/rumi_protocol_backend/tests/multi_chain_supply_invariant.rs` was pinned to the stale `MultiChainStateV4`, but the chains-liquidation Increment 1 work (PR #263, tip of `main`) bumped the canonical multi-chain state to `MultiChainStateV6` (the `MultiChainState` alias). The supply helpers (`apply_supply_delta`) and the open/confirm/burn flow helpers all take `&mut MultiChainState`, so the file no longer compiled — `E0308 expected &mut MultiChainStateV6, found &mut MultiChainStateV4` at every call site.

Because integration tests share a crate-compile, this one file blocked `cargo test -p rumi_protocol_backend` for the whole `tests/` directory (individual files still ran via `--test <name>`). Pre-existing on `main`, unrelated to the native-XRP work.

## Fix (test-only)

- **`MultiChainStateV4` → the canonical `MultiChainState` alias** (= `MultiChainStateV6`) in the import and `seeded_state()`. Matches the convention in every `chains/` unit test and in `supply.rs` itself, and keeps the test pinned to the canonical state across future version bumps. `Default` brings the new V6 fields (`reserve_backing_e8s`, `pending_chain_burn_e8s`, `sp_attempted_chain_vaults`, the liquidation-config maps) up **empty**, so the unified RHS `chain_backing_rhs_e8s = debt + reserve + pending_burn` reduces to bare `debt` here and the `sum == total_debt` assertions stay **exact and non-vacuous**.
- **Added `now_ns = 0` to the `confirm_mint_in_state` call** — a second breakage: the interest-accrual work added a `now_ns` param. This test never harvests interest (it drives open → confirm → direct-debt burn), so the `last_interest_accrual_ns` stamp is inert, matching the settlement unit tests' convention.

Seeding non-zero reserve/pending was deliberately avoided: it would make `apply_supply_delta` reject every op (RHS would exceed the debt-only total the test passes) and the property tests would pass vacuously. The existing `prop_assert!(opened, …)` guards already lock in non-vacuity.

## Verification

- `cargo test -p rumi_protocol_backend --test multi_chain_supply_invariant` → **2/2 proptests pass**.
- `cargo test -p rumi_protocol_backend --no-run` → **0 errors**; all integration-test binaries compile. The whole `tests/` crate is unblocked.
- No production code touched — diff is the single test file (16 insertions / 4 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)