### PR TITLE
chore: regenerate stale candid declarations

### DIFF
--- a/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.d.ts
@@ -102,6 +102,11 @@ export interface FeeStats {
   'rebalancing_swap_pct' : number,
   'buckets' : Array<FeeBucket>,
 }
+export interface ForwardLiquidityEventsV2 {
+  'next_start' : bigint,
+  'reached_end' : boolean,
+  'events' : Array<[bigint, LiquidityEventV2]>,
+}
 export interface GetArchivesArgs { 'from' : [] | [Principal] }
 export interface GetArchivesResult { 'archives' : Array<ArchiveInfo> }
 export interface GetBlocksArgs { 'start' : bigint, 'length' : bigint }
@@ -314,6 +319,7 @@ export type ThreePoolError = {
   { 'InsufficientLiquidity' : null } |
   { 'TransferFailed' : { 'token' : string, 'reason' : string } } |
   { 'SlippageExceeded' : null } |
+  { 'ClaimNotFound' : null } |
   { 'PoolEmpty' : null } |
   {
     'InsufficientPoolBalance' : {
@@ -328,6 +334,16 @@ export interface ThreePoolInitArgs {
   'swap_fee_bps' : bigint,
   'initial_a' : bigint,
   'tokens' : Array<TokenConfig>,
+}
+export interface ThreePoolPendingClaim {
+  'id' : bigint,
+  'token_index' : number,
+  'claimant' : Principal,
+  'created_at' : bigint,
+  'ledger' : Principal,
+  'amount' : bigint,
+  'symbol' : string,
+  'reason' : string,
 }
 export interface TokenConfig {
   'decimals' : number,
@@ -422,6 +438,11 @@ export interface _SERVICE {
     { 'Ok' : bigint } |
       { 'Err' : ThreePoolError }
   >,
+  'claim_pending' : ActorMethod<
+    [bigint],
+    { 'Ok' : null } |
+      { 'Err' : ThreePoolError }
+  >,
   'donate' : ActorMethod<
     [number, bigint],
     { 'Ok' : null } |
@@ -458,7 +479,17 @@ export interface _SERVICE {
     [bigint, bigint],
     Array<LiquidityEventV2>
   >,
+  'get_liquidity_events_v2_forward' : ActorMethod<
+    [bigint, bigint],
+    ForwardLiquidityEventsV2
+  >,
   'get_lp_balance' : ActorMethod<[Principal], bigint>,
+  'get_lp_holders' : ActorMethod<[bigint, bigint], Array<[Principal, bigint]>>,
+  'get_pending_claim_count' : ActorMethod<[], bigint>,
+  'get_pending_claims' : ActorMethod<
+    [bigint, bigint],
+    Array<ThreePoolPendingClaim>
+  >,
   'get_pool_health' : ActorMethod<[], PoolHealth>,
   'get_pool_state' : ActorMethod<[], PoolStateView>,
   'get_pool_stats' : ActorMethod<[StatsWindow], PoolStats>,

--- a/src/declarations/rumi_3pool/rumi_3pool.did.js
+++ b/src/declarations/rumi_3pool/rumi_3pool.did.js
@@ -39,6 +39,7 @@ export const idlFactory = ({ IDL }) => {
     'InsufficientLiquidity' : IDL.Null,
     'TransferFailed' : IDL.Record({ 'token' : IDL.Text, 'reason' : IDL.Text }),
     'SlippageExceeded' : IDL.Null,
+    'ClaimNotFound' : IDL.Null,
     'PoolEmpty' : IDL.Null,
     'InsufficientPoolBalance' : IDL.Record({
       'token' : IDL.Text,
@@ -159,6 +160,21 @@ export const idlFactory = ({ IDL }) => {
     'timestamp' : IDL.Nat64,
     'caller' : IDL.Principal,
     'coin_index' : IDL.Opt(IDL.Nat8),
+  });
+  const ForwardLiquidityEventsV2 = IDL.Record({
+    'next_start' : IDL.Nat64,
+    'reached_end' : IDL.Bool,
+    'events' : IDL.Vec(IDL.Tuple(IDL.Nat64, LiquidityEventV2)),
+  });
+  const ThreePoolPendingClaim = IDL.Record({
+    'id' : IDL.Nat64,
+    'token_index' : IDL.Nat8,
+    'claimant' : IDL.Principal,
+    'created_at' : IDL.Nat64,
+    'ledger' : IDL.Principal,
+    'amount' : IDL.Nat,
+    'symbol' : IDL.Text,
+    'reason' : IDL.Text,
   });
   const PoolHealth = IDL.Record({
     'imbalance_trend_1h' : IDL.Int32,
@@ -467,6 +483,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : IDL.Nat, 'Err' : ThreePoolError })],
         ['query'],
       ),
+    'claim_pending' : IDL.Func(
+        [IDL.Nat64],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
+        [],
+      ),
     'donate' : IDL.Func(
         [IDL.Nat8, IDL.Nat],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : ThreePoolError })],
@@ -528,7 +549,23 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(LiquidityEventV2)],
         ['query'],
       ),
+    'get_liquidity_events_v2_forward' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [ForwardLiquidityEventsV2],
+        ['query'],
+      ),
     'get_lp_balance' : IDL.Func([IDL.Principal], [IDL.Nat], ['query']),
+    'get_lp_holders' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat))],
+        ['query'],
+      ),
+    'get_pending_claim_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_pending_claims' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [IDL.Vec(ThreePoolPendingClaim)],
+        ['query'],
+      ),
     'get_pool_health' : IDL.Func([], [PoolHealth], ['query']),
     'get_pool_state' : IDL.Func([], [PoolStateView], ['query']),
     'get_pool_stats' : IDL.Func([StatsWindow], [PoolStats], ['query']),

--- a/src/declarations/rumi_amm/rumi_amm.did.d.ts
+++ b/src/declarations/rumi_amm/rumi_amm.did.d.ts
@@ -58,6 +58,7 @@ export type AmmError = {
   { 'PoolCreationClosed' : null } |
   { 'InvalidInput' : { 'reason' : string } } |
   { 'PoolNotFound' : null } |
+  { 'DuplicateNonce' : null } |
   { 'ZeroAmount' : null } |
   { 'DisproportionateLiquidity' : null } |
   { 'FeeBpsOutOfRange' : null } |
@@ -65,17 +66,18 @@ export type AmmError = {
   { 'InsufficientLpShares' : { 'available' : bigint, 'required' : bigint } } |
   { 'MathOverflow' : null } |
   { 'Unauthorized' : null } |
+  { 'NoLiquidity' : null } |
   { 'PoolAlreadyExists' : null } |
   { 'PoolBusy' : null } |
+  {
+    'InsufficientOnChainBalance' : { 'actual' : bigint, 'expected' : bigint }
+  } |
   { 'InsufficientLiquidity' : null } |
   { 'MaintenanceMode' : null } |
+  { 'BelowMinClaim' : { 'min' : bigint, 'claimable' : bigint } } |
   { 'TransferFailed' : { 'token' : string, 'reason' : string } } |
   { 'ClaimNotFound' : null } |
-  { 'DuplicateNonce' : null } |
-  { 'NoLiquidity' : null } |
-  { 'BelowMinClaim' : { 'claimable' : bigint, 'min' : bigint } } |
-  { 'RewardLedgerTransferFailed' : { 'reason' : string } } |
-  { 'InsufficientOnChainBalance' : { 'expected' : bigint, 'actual' : bigint } };
+  { 'RewardLedgerTransferFailed' : { 'reason' : string } };
 export interface AmmEventsByPrincipalQuery {
   'who' : Principal,
   'pool' : string,

--- a/src/declarations/rumi_amm/rumi_amm.did.js
+++ b/src/declarations/rumi_amm/rumi_amm.did.js
@@ -9,6 +9,7 @@ export const idlFactory = ({ IDL }) => {
     'PoolCreationClosed' : IDL.Null,
     'InvalidInput' : IDL.Record({ 'reason' : IDL.Text }),
     'PoolNotFound' : IDL.Null,
+    'DuplicateNonce' : IDL.Null,
     'ZeroAmount' : IDL.Null,
     'DisproportionateLiquidity' : IDL.Null,
     'FeeBpsOutOfRange' : IDL.Null,
@@ -19,20 +20,19 @@ export const idlFactory = ({ IDL }) => {
     }),
     'MathOverflow' : IDL.Null,
     'Unauthorized' : IDL.Null,
+    'NoLiquidity' : IDL.Null,
     'PoolAlreadyExists' : IDL.Null,
     'PoolBusy' : IDL.Null,
+    'InsufficientOnChainBalance' : IDL.Record({
+      'actual' : IDL.Nat,
+      'expected' : IDL.Nat,
+    }),
     'InsufficientLiquidity' : IDL.Null,
     'MaintenanceMode' : IDL.Null,
+    'BelowMinClaim' : IDL.Record({ 'min' : IDL.Nat, 'claimable' : IDL.Nat }),
     'TransferFailed' : IDL.Record({ 'token' : IDL.Text, 'reason' : IDL.Text }),
     'ClaimNotFound' : IDL.Null,
-    'DuplicateNonce' : IDL.Null,
-    'NoLiquidity' : IDL.Null,
-    'BelowMinClaim' : IDL.Record({ 'claimable' : IDL.Nat, 'min' : IDL.Nat }),
     'RewardLedgerTransferFailed' : IDL.Record({ 'reason' : IDL.Text }),
-    'InsufficientOnChainBalance' : IDL.Record({
-      'expected' : IDL.Nat,
-      'actual' : IDL.Nat,
-    }),
   });
   const CurveType = IDL.Variant({ 'ConstantProduct' : IDL.Null });
   const CreatePoolArgs = IDL.Record({

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -44,9 +44,35 @@ export interface CandidVault {
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
 }
+export interface ChainLiquidatableVault {
+  'sized_repay_e8s' : bigint,
+  'cr_e4' : bigint,
+  'collateral_native' : bigint,
+  'vault_id' : bigint,
+  'chain_id' : number,
+  'liquidation_threshold_e4' : bigint,
+  'effective_debt_e8s' : bigint,
+  'debt_e8s' : bigint,
+}
+export interface ChainLiquidationConfigV1 {
+  'dex' : DexKind,
+  'max_swap_value_e8s' : bigint,
+  'pair' : string,
+  'max_price_age_ns' : bigint,
+  'restore_target_cr_e4' : bigint,
+  'enabled' : boolean,
+  'collateral_token' : string,
+  'factory' : string,
+  'slippage_cap_bps' : number,
+  'router' : string,
+  'settle_stable_token' : string,
+}
 export interface ChainSupplyReconciliation {
   'recorded_supply_e8s' : bigint,
+  'pending_chain_burn_e8s' : bigint,
+  'reserve_backing_e8s' : bigint,
   'gap_e8s' : bigint,
+  'reserve_usdc_native' : bigint,
   'unbacked_excess' : boolean,
   'finalized_block' : bigint,
   'in_flight_mint_e8s' : bigint,
@@ -69,6 +95,7 @@ export interface ChainVaultV1 {
   'opened_at_ns' : bigint,
   'vault_id' : bigint,
   'last_interest_accrual_ns' : bigint,
+  'pending_liquidation' : [] | [PendingLiquidationV1],
   'collateral_chain' : number,
   'mint_recipient' : string,
   'debt_e8s' : bigint,
@@ -161,6 +188,7 @@ export type DeviceSpec = { 'GenericDisplay' : null } |
       'lines_per_page' : number,
     }
   };
+export type DexKind = { 'UniswapV2' : null };
 export interface ErrorInfo { 'description' : string }
 export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   {
@@ -214,6 +242,23 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'chain_id' : number,
       'timestamp' : bigint,
       'tx_hash' : string,
+    }
+  } |
+  {
+    'chain_liquidation_deferred' : {
+      'vault_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'reason' : string,
+    }
+  } |
+  {
+    'chain_reserve_credited' : {
+      'usdc_native' : bigint,
+      'backing_added_e8s' : bigint,
+      'vault_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
     }
   } |
   {
@@ -624,6 +669,15 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'set_icpswap_routing_enabled' : { 'enabled' : boolean } } |
   { 'set_bot_budget' : { 'start_timestamp' : bigint, 'total_e8s' : bigint } } |
   { 'set_rmr_floor' : { 'value' : string } } |
+  {
+    'chain_cfx_claim_settled' : {
+      'claim_id' : bigint,
+      'amount_native' : bigint,
+      'recipient' : string,
+      'chain_id' : number,
+      'timestamp' : bigint,
+    }
+  } |
   { 'set_redemption_fee_floor' : { 'rate' : string } } |
   {
     'set_interest_rate' : {
@@ -683,6 +737,17 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     'set_collateral_borrow_threshold' : {
       'borrow_threshold_ratio' : string,
       'collateral_type' : Principal,
+    }
+  } |
+  {
+    'chain_vault_liquidated' : {
+      'collateral_seized_native' : bigint,
+      'op_id' : bigint,
+      'tier' : LiquidationTier,
+      'vault_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'debt_cleared_e8s' : bigint,
     }
   } |
   {
@@ -820,6 +885,8 @@ export interface InitArg {
 export interface InterestSplitArg { 'bps' : bigint, 'destination' : string }
 export type InterpolationMethod = { 'Linear' : null };
 export interface LineDisplayPage { 'lines' : Array<string> }
+export type LiquidationTier = { 'Bot' : null } |
+  { 'StabilityPool' : null };
 export interface LiquidityStatus {
   'liquidity_provided' : bigint,
   'total_liquidity_provided' : bigint,
@@ -827,12 +894,20 @@ export interface LiquidityStatus {
   'available_liquidity_reward' : bigint,
   'total_available_returns' : bigint,
 }
+export interface ManualPriceInfo { 'set_at_ns' : bigint, 'price_e8' : bigint }
 export type Mode = { 'ReadOnly' : null } |
   { 'GeneralAvailability' : null } |
   { 'Recovery' : null };
 export interface OpenVaultSuccess {
   'block_index' : bigint,
   'vault_id' : bigint,
+}
+export interface PendingLiquidationV1 {
+  'started_at_ns' : bigint,
+  'op_id' : bigint,
+  'tier' : LiquidationTier,
+  'debt_to_clear_e8s' : bigint,
+  'collateral_reserved_native' : bigint,
 }
 export interface PerCollateralRateCurve {
   'markers' : Array<[number, number]>,
@@ -1213,6 +1288,14 @@ export interface _SERVICE {
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
   'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
+  'get_chain_liquidatable_vaults' : ActorMethod<
+    [number],
+    Array<ChainLiquidatableVault>
+  >,
+  'get_chain_liquidation_config' : ActorMethod<
+    [number],
+    [] | [ChainLiquidationConfigV1]
+  >,
   'get_chain_settlement_address' : ActorMethod<[number], Result_2>,
   'get_chain_vault' : ActorMethod<[bigint], [] | [ChainVaultV1]>,
   'get_chains_ecdsa_key_name' : ActorMethod<[], string>,
@@ -1262,8 +1345,14 @@ export interface _SERVICE {
   'get_liquidation_ordering_tolerance_bps' : ActorMethod<[], bigint>,
   'get_liquidation_protocol_share' : ActorMethod<[], number>,
   'get_liquidity_status' : ActorMethod<[Principal], LiquidityStatus>,
+  'get_manual_collateral_price' : ActorMethod<
+    [number, string],
+    [] | [ManualPriceInfo]
+  >,
   'get_min_icusd_amount' : ActorMethod<[], bigint>,
   'get_pending_amm1_donations_count' : ActorMethod<[], bigint>,
+  'get_price_pusher_allowed' : ActorMethod<[], Array<[number, string]>>,
+  'get_price_pusher_principal' : ActorMethod<[], [] | [Principal]>,
   'get_protocol_3usd_reserves' : ActorMethod<[], bigint>,
   'get_protocol_config' : ActorMethod<[], ProtocolConfig>,
   'get_protocol_snapshots' : ActorMethod<
@@ -1314,6 +1403,7 @@ export interface _SERVICE {
     Result_8
   >,
   'icrc28_trusted_origins' : ActorMethod<[], Icrc28TrustedOriginsResponse>,
+  'liquidate_chain_vault' : ActorMethod<[bigint], Result_1>,
   'liquidate_vault' : ActorMethod<[bigint], Result_3>,
   'liquidate_vault_partial' : ActorMethod<[VaultArg], Result_3>,
   'liquidate_vault_partial_with_stable' : ActorMethod<
@@ -1365,6 +1455,10 @@ export interface _SERVICE {
   'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_chain_interest_min_realize_e8s' : ActorMethod<[bigint], Result>,
   'set_chain_interest_tick_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_chain_liquidation_config' : ActorMethod<
+    [number, ChainLiquidationConfigV1],
+    Result
+  >,
   'set_chains_ecdsa_key_name' : ActorMethod<[string], Result>,
   'set_check_vaults_alert_band_bps' : ActorMethod<[bigint], Result>,
   'set_check_vaults_full_sweep_every_n_ticks' : ActorMethod<[bigint], Result>,
@@ -1416,6 +1510,10 @@ export interface _SERVICE {
   'set_min_icusd_amount' : ActorMethod<[bigint], Result>,
   'set_min_xrc_sources_used' : ActorMethod<[number], Result>,
   'set_observer_tick_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_price_pusher_principal' : ActorMethod<
+    [[] | [Principal], Array<[number, string]>],
+    Result
+  >,
   'set_rate_curve_markers' : ActorMethod<
     [[] | [Principal], Array<[number, number]>],
     Result
@@ -1450,6 +1548,7 @@ export interface _SERVICE {
   'set_treasury_principal' : ActorMethod<[Principal], Result>,
   'set_vault_check_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
+  'settle_xrp_claim' : ActorMethod<[bigint, string], Result_2>,
   'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,
   'solana_get_balance' : ActorMethod<[string], Result_1>,
   'solana_get_mint_supply' : ActorMethod<[], Result_1>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -173,12 +173,47 @@ export const idlFactory = ({ IDL }) => {
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
   });
+  const ChainLiquidatableVault = IDL.Record({
+    'sized_repay_e8s' : IDL.Nat,
+    'cr_e4' : IDL.Nat64,
+    'collateral_native' : IDL.Nat,
+    'vault_id' : IDL.Nat64,
+    'chain_id' : IDL.Nat32,
+    'liquidation_threshold_e4' : IDL.Nat64,
+    'effective_debt_e8s' : IDL.Nat,
+    'debt_e8s' : IDL.Nat,
+  });
+  const DexKind = IDL.Variant({ 'UniswapV2' : IDL.Null });
+  const ChainLiquidationConfigV1 = IDL.Record({
+    'dex' : DexKind,
+    'max_swap_value_e8s' : IDL.Nat,
+    'pair' : IDL.Text,
+    'max_price_age_ns' : IDL.Nat64,
+    'restore_target_cr_e4' : IDL.Nat64,
+    'enabled' : IDL.Bool,
+    'collateral_token' : IDL.Text,
+    'factory' : IDL.Text,
+    'slippage_cap_bps' : IDL.Nat16,
+    'router' : IDL.Text,
+    'settle_stable_token' : IDL.Text,
+  });
   const ChainVaultStatus = IDL.Variant({
     'MintPending' : IDL.Null,
     'Open' : IDL.Null,
     'Closed' : IDL.Null,
     'Closing' : IDL.Null,
     'AwaitingDeposit' : IDL.Null,
+  });
+  const LiquidationTier = IDL.Variant({
+    'Bot' : IDL.Null,
+    'StabilityPool' : IDL.Null,
+  });
+  const PendingLiquidationV1 = IDL.Record({
+    'started_at_ns' : IDL.Nat64,
+    'op_id' : IDL.Nat64,
+    'tier' : LiquidationTier,
+    'debt_to_clear_e8s' : IDL.Nat,
+    'collateral_reserved_native' : IDL.Nat,
   });
   const ChainVaultV1 = IDL.Record({
     'status' : ChainVaultStatus,
@@ -191,6 +226,7 @@ export const idlFactory = ({ IDL }) => {
     'opened_at_ns' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
     'last_interest_accrual_ns' : IDL.Nat64,
+    'pending_liquidation' : IDL.Opt(PendingLiquidationV1),
     'collateral_chain' : IDL.Nat32,
     'mint_recipient' : IDL.Text,
     'debt_e8s' : IDL.Nat,
@@ -367,6 +403,19 @@ export const idlFactory = ({ IDL }) => {
       'chain_id' : IDL.Nat32,
       'timestamp' : IDL.Nat64,
       'tx_hash' : IDL.Text,
+    }),
+    'chain_liquidation_deferred' : IDL.Record({
+      'vault_id' : IDL.Nat64,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'reason' : IDL.Text,
+    }),
+    'chain_reserve_credited' : IDL.Record({
+      'usdc_native' : IDL.Nat,
+      'backing_added_e8s' : IDL.Nat,
+      'vault_id' : IDL.Nat64,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
     }),
     'provide_liquidity' : IDL.Record({
       'block_index' : IDL.Nat64,
@@ -691,6 +740,13 @@ export const idlFactory = ({ IDL }) => {
       'total_e8s' : IDL.Nat64,
     }),
     'set_rmr_floor' : IDL.Record({ 'value' : IDL.Text }),
+    'chain_cfx_claim_settled' : IDL.Record({
+      'claim_id' : IDL.Nat64,
+      'amount_native' : IDL.Nat,
+      'recipient' : IDL.Text,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+    }),
     'set_redemption_fee_floor' : IDL.Record({ 'rate' : IDL.Text }),
     'set_interest_rate' : IDL.Record({
       'collateral_type' : IDL.Principal,
@@ -742,6 +798,15 @@ export const idlFactory = ({ IDL }) => {
     'set_collateral_borrow_threshold' : IDL.Record({
       'borrow_threshold_ratio' : IDL.Text,
       'collateral_type' : IDL.Principal,
+    }),
+    'chain_vault_liquidated' : IDL.Record({
+      'collateral_seized_native' : IDL.Nat,
+      'op_id' : IDL.Nat64,
+      'tier' : LiquidationTier,
+      'vault_id' : IDL.Nat64,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'debt_cleared_e8s' : IDL.Nat,
     }),
     'add_collateral_type' : IDL.Record({
       'config' : CollateralConfig,
@@ -805,6 +870,10 @@ export const idlFactory = ({ IDL }) => {
     'liquidity_pool_share' : IDL.Float64,
     'available_liquidity_reward' : IDL.Nat64,
     'total_available_returns' : IDL.Nat64,
+  });
+  const ManualPriceInfo = IDL.Record({
+    'set_at_ns' : IDL.Nat64,
+    'price_e8' : IDL.Nat64,
   });
   const ProtocolConfig = IDL.Record({
     'global_rate_curve' : IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64)),
@@ -1020,7 +1089,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const ChainSupplyReconciliation = IDL.Record({
     'recorded_supply_e8s' : IDL.Nat,
+    'pending_chain_burn_e8s' : IDL.Nat,
+    'reserve_backing_e8s' : IDL.Nat,
     'gap_e8s' : IDL.Int,
+    'reserve_usdc_native' : IDL.Nat,
     'unbacked_excess' : IDL.Bool,
     'finalized_block' : IDL.Nat64,
     'in_flight_mint_e8s' : IDL.Nat,
@@ -1180,6 +1252,16 @@ export const idlFactory = ({ IDL }) => {
         [Result_2],
         [],
       ),
+    'get_chain_liquidatable_vaults' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Vec(ChainLiquidatableVault)],
+        ['query'],
+      ),
+    'get_chain_liquidation_config' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Opt(ChainLiquidationConfigV1)],
+        ['query'],
+      ),
     'get_chain_settlement_address' : IDL.Func([IDL.Nat32], [Result_2], []),
     'get_chain_vault' : IDL.Func(
         [IDL.Nat64],
@@ -1267,8 +1349,23 @@ export const idlFactory = ({ IDL }) => {
         [LiquidityStatus],
         ['query'],
       ),
+    'get_manual_collateral_price' : IDL.Func(
+        [IDL.Nat32, IDL.Text],
+        [IDL.Opt(ManualPriceInfo)],
+        ['query'],
+      ),
     'get_min_icusd_amount' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_pending_amm1_donations_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_price_pusher_allowed' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Text))],
+        ['query'],
+      ),
+    'get_price_pusher_principal' : IDL.Func(
+        [],
+        [IDL.Opt(IDL.Principal)],
+        ['query'],
+      ),
     'get_protocol_3usd_reserves' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_protocol_config' : IDL.Func([], [ProtocolConfig], ['query']),
     'get_protocol_snapshots' : IDL.Func(
@@ -1363,6 +1460,7 @@ export const idlFactory = ({ IDL }) => {
         [Icrc28TrustedOriginsResponse],
         ['query'],
       ),
+    'liquidate_chain_vault' : IDL.Func([IDL.Nat64], [Result_1], []),
     'liquidate_vault' : IDL.Func([IDL.Nat64], [Result_3], []),
     'liquidate_vault_partial' : IDL.Func([VaultArg], [Result_3], []),
     'liquidate_vault_partial_with_stable' : IDL.Func(
@@ -1463,6 +1561,11 @@ export const idlFactory = ({ IDL }) => {
     'set_chain_interest_min_realize_e8s' : IDL.Func([IDL.Nat], [Result], []),
     'set_chain_interest_tick_interval_secs' : IDL.Func(
         [IDL.Nat64],
+        [Result],
+        [],
+      ),
+    'set_chain_liquidation_config' : IDL.Func(
+        [IDL.Nat32, ChainLiquidationConfigV1],
         [Result],
         [],
       ),
@@ -1577,6 +1680,11 @@ export const idlFactory = ({ IDL }) => {
     'set_min_icusd_amount' : IDL.Func([IDL.Nat64], [Result], []),
     'set_min_xrc_sources_used' : IDL.Func([IDL.Nat32], [Result], []),
     'set_observer_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_price_pusher_principal' : IDL.Func(
+        [IDL.Opt(IDL.Principal), IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Text))],
+        [Result],
+        [],
+      ),
     'set_rate_curve_markers' : IDL.Func(
         [IDL.Opt(IDL.Principal), IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64))],
         [Result],
@@ -1622,6 +1730,7 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_vault_check_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
     'set_xrc_fetch_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'settle_xrp_claim' : IDL.Func([IDL.Nat64, IDL.Text], [Result_2], []),
     'solana_bootstrap_nonce' : IDL.Func([IDL.Opt(IDL.Text)], [Result], []),
     'solana_get_balance' : IDL.Func([IDL.Text], [Result_1], []),
     'solana_get_mint_supply' : IDL.Func([], [Result_1], []),

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -72,6 +72,14 @@ export interface LiquidationResult {
   'success' : boolean,
   'collateral_type' : Principal,
 }
+export interface PendingRefund {
+  'id' : bigint,
+  'user' : Principal,
+  'created_at' : bigint,
+  'amount' : bigint,
+  'token_ledger' : Principal,
+  'reason' : string,
+}
 export interface PoolConfiguration {
   'emergency_pause' : boolean,
   'min_deposit_e8s' : bigint,
@@ -130,14 +138,6 @@ export type PoolEventType = {
       'token_ledger' : Principal,
     }
   };
-export interface PendingRefund {
-  'id' : bigint,
-  'user' : Principal,
-  'token_ledger' : Principal,
-  'amount' : bigint,
-  'reason' : string,
-  'created_at' : bigint,
-}
 export interface PoolLiquidationRecord {
   'collateral_price_e8s' : [] | [bigint],
   'stables_consumed' : Array<[Principal, bigint]>,
@@ -150,6 +150,7 @@ export interface PoolLiquidationRecord {
 export type StabilityPoolError = {
     'LedgerTransferFailed' : { 'reason' : string }
   } |
+  { 'RefundClaimNotFound' : null } |
   { 'EmergencyPaused' : null } |
   { 'AlreadyOptedOut' : { 'collateral' : Principal } } |
   { 'TokenNotActive' : { 'ledger' : Principal } } |
@@ -169,8 +170,7 @@ export type StabilityPoolError = {
   { 'SystemBusy' : null } |
   { 'AlreadyOptedIn' : { 'collateral' : Principal } } |
   { 'TokenNotAccepted' : { 'ledger' : Principal } } |
-  { 'InsufficientPoolBalance' : null } |
-  { 'RefundClaimNotFound' : null };
+  { 'InsufficientPoolBalance' : null };
 export interface StabilityPoolInitArgs {
   'protocol_canister_id' : Principal,
   'authorized_admins' : Array<Principal>,
@@ -257,10 +257,7 @@ export interface _SERVICE {
     [[] | [bigint]],
     Array<PoolLiquidationRecord>
   >,
-  'get_pending_refunds' : ActorMethod<
-    [[] | [Principal]],
-    Array<PendingRefund>
-  >,
+  'get_pending_refunds' : ActorMethod<[[] | [Principal]], Array<PendingRefund>>,
   'get_pool_event_count' : ActorMethod<[], bigint>,
   'get_pool_events' : ActorMethod<[bigint, bigint], Array<PoolEvent>>,
   'get_pool_status' : ActorMethod<[], StabilityPoolStatus>,

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -5,6 +5,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const StabilityPoolError = IDL.Variant({
     'LedgerTransferFailed' : IDL.Record({ 'reason' : IDL.Text }),
+    'RefundClaimNotFound' : IDL.Null,
     'EmergencyPaused' : IDL.Null,
     'AlreadyOptedOut' : IDL.Record({ 'collateral' : IDL.Principal }),
     'TokenNotActive' : IDL.Record({ 'ledger' : IDL.Principal }),
@@ -29,15 +30,6 @@ export const idlFactory = ({ IDL }) => {
     'AlreadyOptedIn' : IDL.Record({ 'collateral' : IDL.Principal }),
     'TokenNotAccepted' : IDL.Record({ 'ledger' : IDL.Principal }),
     'InsufficientPoolBalance' : IDL.Null,
-    'RefundClaimNotFound' : IDL.Null,
-  });
-  const PendingRefund = IDL.Record({
-    'id' : IDL.Nat64,
-    'user' : IDL.Principal,
-    'token_ledger' : IDL.Principal,
-    'amount' : IDL.Nat64,
-    'reason' : IDL.Text,
-    'created_at' : IDL.Nat64,
   });
   const LiquidationResult = IDL.Record({
     'error_message' : IDL.Opt(IDL.Text),
@@ -55,6 +47,14 @@ export const idlFactory = ({ IDL }) => {
     'collateral_gained' : IDL.Nat64,
     'timestamp' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
+  });
+  const PendingRefund = IDL.Record({
+    'id' : IDL.Nat64,
+    'user' : IDL.Principal,
+    'created_at' : IDL.Nat64,
+    'amount' : IDL.Nat64,
+    'token_ledger' : IDL.Principal,
+    'reason' : IDL.Text,
   });
   const PoolEventType = IDL.Variant({
     'Withdraw' : IDL.Record({


### PR DESCRIPTION
## What

Running the canonical `scripts/regenerate-declarations.sh` (didc 0.4.0) surfaced that several canisters' committed JS/TS bindings are out of sync with their `.did` sources. This regenerates them so the script is idempotent (`regenerate && git diff` = empty).

Two distinct causes:

### Real drift (stale bindings — substantive)
- **`rumi_protocol_backend`**: `.did` gained the chains-liquidation types (`ChainLiquidationConfigV1`, `PendingLiquidationV1`, `ChainLiquidatableVault`) + `liquidate_chain_vault` / `get_chain_liquidatable_vaults` on 2026-06-20 (`527a4ba`), but the bindings were last regenerated 2026-06-18 (`7b35773`). Purely additive.
- **`rumi_3pool`**: `.did` gained `ClaimNotFound` + pending-claim recovery types (`ThreePoolPendingClaim`, `ForwardLiquidityEventsV2`) + `claim_pending` on 2026-06-07 (`d223ccb`), but bindings last regenerated 2026-05-20 (`43f057a`). Purely additive.

### didc-version canonicalization (no semantic change)
- **`rumi_amm`** + **`rumi_stability_pool`**: `.did` and bindings were committed together, but the committed bindings preserve `.did` *source order* while `didc 0.4.0` emits *canonical (hash) order*. Identical type set, just reordered. **Zero functional impact**: candid fields are hash-identified, and the generated TS types are structural, so field/variant order is irrelevant. Included so the repo aligns to one didc version and the regeneration script stays idempotent.

## Notes
- **No canister code or wasm changes** — frontend artifacts only.
- `rumi_points` is not in the regeneration script's managed set, so it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)