### PR TITLE
Chains liquidation Increment 3 — Tier-1 bot swap execution (tECDSA Swappi swap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7296,6 +7296,7 @@ dependencies = [
  "candid_parser",
  "ciborium",
  "ed25519-dalek",
+ "ethnum",
  "flate2",
  "futures",
  "hex",

--- a/src/monad_rpc_mock/src/lib.rs
+++ b/src/monad_rpc_mock/src/lib.rs
@@ -294,6 +294,10 @@ struct Script {
     /// eSpace receipt fields `gasFee`/`burntGasFee` so the decoder's tolerance of
     /// those (non-Monad) fields is exercised. Toggled by `set_espace_receipt_fields`.
     espace_receipt_fields: bool,
+    /// Per-selector canned `eth_call` results (selector hex "0x........" lowercased
+    /// -> the full 0x result blob). Lets a swap test script getReserves / token0 /
+    /// balanceOf returns. Set via `set_eth_call_response`.
+    eth_call_responses: HashMap<String, String>,
 }
 
 thread_local! {
@@ -630,14 +634,26 @@ fn request(_service: RpcService, json_payload: String, _max_response_bytes: u64)
                 )
             }
             "eth_call" => {
-                // params = [{to, data}, "0x<block>"]. The observer's supply gate
-                // calls totalSupply() (selector 0x18160ddd) at a specific block.
-                // Return the scripted total_supply as a left-padded 32-byte word
-                // (the ABI encoding of a uint256), exactly as a real node would.
-                format!(
-                    r#"{{"jsonrpc":"2.0","id":{},"result":"0x{:064x}"}}"#,
-                    id, script.total_supply
-                )
+                // params = [{to, data}, "0x<block>"]. Dispatch by the 4-byte
+                // selector in `data`: a test can script per-selector returns (e.g.
+                // getReserves 0x0902f1ac, token0 0x0dfe1681, balanceOf 0x70a08231)
+                // via `set_eth_call_response`. Fall back to the scripted
+                // total_supply (selector 0x18160ddd) for the observer supply gate.
+                let selector = params
+                    .get(0)
+                    .and_then(|v| v.get("data"))
+                    .and_then(|v| v.as_str())
+                    .map(|d| d.chars().take(10).collect::<String>().to_lowercase())
+                    .unwrap_or_default();
+                if let Some(ret) = script.eth_call_responses.get(&selector) {
+                    format!(r#"{{"jsonrpc":"2.0","id":{},"result":{:?}}}"#, id, ret)
+                } else {
+                    // Default: the ABI-encoded uint256 totalSupply.
+                    format!(
+                        r#"{{"jsonrpc":"2.0","id":{},"result":"0x{:064x}"}}"#,
+                        id, script.total_supply
+                    )
+                }
             }
             other => {
                 // Unknown method: a JSON-RPC error so an unexpected wrapper call
@@ -787,6 +803,19 @@ fn clear_logs() {
 #[ic_cdk_macros::update]
 fn set_total_supply(value: u128) {
     SCRIPT.with(|s| s.borrow_mut().total_supply = value);
+}
+
+/// Script a per-selector `eth_call` result. `selector` is the 4-byte selector hex
+/// ("0x0902f1ac" etc.); `return_data` is the full 0x ABI-encoded result blob the
+/// mock returns for any `eth_call` whose `data` starts with that selector. Lets a
+/// swap test canned-respond getReserves / token0 / balanceOf.
+#[ic_cdk_macros::update]
+fn set_eth_call_response(selector: String, return_data: String) {
+    SCRIPT.with(|s| {
+        s.borrow_mut()
+            .eth_call_responses
+            .insert(selector.to_lowercase(), return_data);
+    });
 }
 
 /// Set the max `eth_getLogs` block range (`toBlock - fromBlock`) the mock

--- a/src/rumi_protocol_backend/Cargo.toml
+++ b/src/rumi_protocol_backend/Cargo.toml
@@ -41,6 +41,9 @@ icrc-ledger-types = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc2787
 icrc-ledger-client-cdk = { git = "https://github.com/Rumi-Protocol/ic", rev = "fc278709" }
 rust_decimal = "1.32.0"
 rust_decimal_macros = "1.32"
+# 256-bit ints for the UniswapV2 swap math: amount_in * reserve_out overflows
+# u128 at 18-decimal token magnitudes (~1e48). Already in the dep tree.
+ethnum = "1.5"
 serde_bytes = "0.11"
 serde_json = "1.0.96"
 num-traits = "0.2"

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1084,6 +1084,7 @@ service : (ProtocolArg) -> {
   get_chain_liquidation_config : (nat32) -> (
       opt ChainLiquidationConfigV1,
     ) query;
+  get_chain_reserve_address : (nat32) -> (Result_2);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_chains_ecdsa_key_name : () -> (text) query;

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -52,13 +52,17 @@ type ChainLiquidationConfigV1 = record {
   max_swap_value_e8s : nat;
   pair : text;
   max_price_age_ns : nat64;
+  fee_bps : nat16;
   restore_target_cr_e4 : nat64;
+  max_dex_oracle_divergence_bps : nat32;
   enabled : bool;
   collateral_token : text;
+  settle_stable_decimals : nat8;
   factory : text;
   slippage_cap_bps : nat16;
   router : text;
   settle_stable_token : text;
+  deadline_secs : nat64;
 };
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;

--- a/src/rumi_protocol_backend/src/chains/collateral_config.rs
+++ b/src/rumi_protocol_backend/src/chains/collateral_config.rs
@@ -62,6 +62,16 @@ pub fn chain_collateral_config(chain: ChainId) -> Option<ChainCollateralConfig> 
             debt_ceiling_e8s: Some(500 * 100_000_000),
             ..ICP_MIRROR
         }),
+        // Conflux eSpace MAINNET (chain 1030): same risk profile as testnet 71.
+        // This is where real Swappi DEX liquidity lives (the swap's real target);
+        // adding the row makes the rail 1030-ready (Inc 3, finding #23). Tests +
+        // the staging deploy stay on 71; onboarding 1030 is the operator's enable
+        // step (liquidation config row + manual price + mainnet-fork dry-run).
+        1030 => Some(ChainCollateralConfig {
+            min_cr_e4: 15_000,
+            debt_ceiling_e8s: Some(500 * 100_000_000),
+            ..ICP_MIRROR
+        }),
         // Monad testnet: preserve its historical 130% open threshold
         // (behavior-preserving); other params ICP-mirrored but inert for Monad.
         10143 => Some(ChainCollateralConfig {
@@ -99,10 +109,20 @@ mod tests {
     }
 
     #[test]
+    fn conflux_mainnet_1030_mirrors_71() {
+        let c = chain_collateral_config(ChainId(1030)).expect("conflux mainnet known");
+        assert_eq!(c.min_cr_e4, 15_000);
+        assert_eq!(c.liquidation_threshold_e4, 13_300);
+        assert_eq!(c.recovery_target_cr_e4, 15_500);
+        assert_eq!(c.liquidation_penalty_bps, 1_200);
+        assert_eq!(c.debt_ceiling_e8s, Some(500 * 100_000_000));
+    }
+
+    #[test]
     fn liquidation_threshold_below_open_gate_per_chain() {
         // The liquidation trigger MUST be strictly below the open/borrow gate so a
         // freshly-opened vault at exactly the open CR is never instantly liquidatable.
-        for chain in [ChainId(71), ChainId(10143)] {
+        for chain in [ChainId(71), ChainId(1030), ChainId(10143)] {
             let c = chain_collateral_config(chain).expect("known chain");
             assert!(
                 c.liquidation_threshold_e4 < c.min_cr_e4,

--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -116,6 +116,19 @@ pub const BURN_EVENT_TOPIC0: &str =
 pub const MINT_EVENT_TOPIC0: &str =
     "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
 
+/// keccak256("Transfer(address,address,uint256)") — the canonical ERC-20
+/// Transfer event topic0. Used by the liquidation-swap confirm to read the
+/// REALIZED settle-stable output (the `Transfer(_, reserve, amount)` log).
+pub const TRANSFER_EVENT_TOPIC0: &str =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/// `getReserves()[:4]` selector (UniswapV2 pair).
+pub const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
+/// `token0()[:4]` selector (UniswapV2 pair).
+pub const TOKEN0_SELECTOR: &str = "0x0dfe1681";
+/// `balanceOf(address)[:4]` selector (ERC-20).
+pub const BALANCE_OF_SELECTOR: &str = "0x70a08231";
+
 /// `keccak256("totalSupply()")[:4]`, the ERC-20 `totalSupply()` selector.
 /// `IcUSD.sol` uses 8 decimals, so the returned value is e8s (1:1 with the
 /// ICP-side `chain_supplies` accounting, no scaling needed).
@@ -512,6 +525,60 @@ impl MintLog {
             block_number,
         })
     }
+}
+
+/// A decoded ERC-20 `Transfer(from, to, amount)` log. The liquidation-swap
+/// confirm reads the `Transfer(_, reserve_recipient, amount)` log to learn the
+/// REALIZED settle-stable output (spec §4.8 — never trust min-out as the actual
+/// amount). `to` and `amount` are the indexed recipient + the data value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferLog {
+    /// Recipient address (0x-prefixed, lowercase) from the indexed `to` topic.
+    pub to: String,
+    /// Transferred amount (native base units of the token).
+    pub amount: u128,
+}
+
+impl TransferLog {
+    /// Decode from `[Transfer topic0, from(indexed), to(indexed)]` + `data=amount`.
+    pub fn from_raw(topics: &[String], data: &str) -> Result<Self, String> {
+        if topics.len() < 3 {
+            return Err(format!("TransferLog: expected >=3 topics, got {}", topics.len()));
+        }
+        if !topics[0].eq_ignore_ascii_case(TRANSFER_EVENT_TOPIC0) {
+            return Err(format!("TransferLog: wrong topic0: {}", topics[0]));
+        }
+        let to = {
+            let raw = topics[2]
+                .strip_prefix("0x")
+                .or_else(|| topics[2].strip_prefix("0X"))
+                .unwrap_or(&topics[2]);
+            let addr_hex = if raw.len() >= 40 { &raw[raw.len() - 40..] } else { raw };
+            format!("0x{}", addr_hex.to_lowercase())
+        };
+        let amount = parse_hex_quantity(data)?;
+        Ok(TransferLog { to, amount })
+    }
+}
+
+/// Split a UniswapV2 `getReserves()` return `(uint112 reserve0, uint112
+/// reserve1, uint32)` into `(reserve0, reserve1)`. Each uint112 occupies a
+/// 32-byte ABI word, but only the low 28 hex chars (112 bits) are significant —
+/// we parse the full words to be safe (the high bits are zero for a uint112).
+pub fn parse_two_uint112(result_hex: &str) -> Result<(u128, u128), String> {
+    let hex = result_hex
+        .strip_prefix("0x")
+        .or_else(|| result_hex.strip_prefix("0X"))
+        .ok_or_else(|| format!("getReserves result missing 0x prefix: {:?}", result_hex))?;
+    // Two full 32-byte words for the two uint112 reserves = 128 hex chars.
+    if hex.len() < 128 {
+        return Err(format!("getReserves result too short: {:?}", result_hex));
+    }
+    let r0 = u128::from_str_radix(&hex[0..64], 16)
+        .map_err(|e| format!("getReserves reserve0 parse: {}", e))?;
+    let r1 = u128::from_str_radix(&hex[64..128], 16)
+        .map_err(|e| format!("getReserves reserve1 parse: {}", e))?;
+    Ok((r0, r1))
 }
 
 /// Convenience free fn delegating to `MintLog::from_raw`.
@@ -1012,6 +1079,60 @@ pub async fn erc20_total_supply_at(
         .as_str()
         .ok_or_else(|| format!("eth_call(totalSupply): missing result in {:?}", text))?;
     parse_eth_call_u128(hex)
+}
+
+/// Read a generic `eth_call` result hex at a PINNED finalized block (finding
+/// #13: a "latest" read returns different bytes per provider and fails the
+/// multi-provider quorum; pinning a finalized number is byte-identical across
+/// replicas). Shared by the DEX reads below.
+async fn eth_call_at_block(chain: ChainId, to: &str, data: &str, block: u64) -> Result<String, String> {
+    let payload = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"to":{:?},"data":{:?}}},"0x{:x}"],"id":{}}}"#,
+        to, data, block, next_rpc_id()
+    );
+    let text = call_evm_rpc(chain, &payload).await?;
+    let val: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("eth_call parse: {}", e))?;
+    if let Some(err) = val.get("error") {
+        return Err(format!("eth_call RPC error: {}", err));
+    }
+    val["result"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("eth_call: missing result in {:?}", text))
+}
+
+/// UniswapV2 `getReserves()` at a pinned finalized block -> `(reserve0,
+/// reserve1)` (finding #13). The reserve ordering follows the pair's `token0()`,
+/// which the caller reads separately and orients against.
+pub async fn get_reserves(chain: ChainId, pair: &str, block: u64) -> Result<(u128, u128), String> {
+    let hex = eth_call_at_block(chain, pair, GET_RESERVES_SELECTOR, block).await?;
+    parse_two_uint112(&hex)
+}
+
+/// UniswapV2 `token0()` at a pinned block -> the pair's token0 address
+/// (0x-prefixed, lowercase). V2 pairs sort tokens by address, so the reserve
+/// ordering MUST be read, never assumed.
+pub async fn get_pair_token0(chain: ChainId, pair: &str, block: u64) -> Result<String, String> {
+    let hex = eth_call_at_block(chain, pair, TOKEN0_SELECTOR, block).await?;
+    let raw = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(&hex);
+    if raw.len() < 40 {
+        return Err(format!("token0: result too short: {:?}", hex));
+    }
+    Ok(format!("0x{}", raw[raw.len() - 40..].to_lowercase()))
+}
+
+/// ERC-20 `balanceOf(addr)` at a pinned block (native base units). Used to
+/// reconcile the reserve address's on-chain stable custody.
+pub async fn erc20_balance_of(chain: ChainId, token: &str, addr: &str, block: u64) -> Result<u128, String> {
+    let a = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    if a.len() != 40 || hex::decode(a).is_err() {
+        return Err(format!("erc20_balance_of: invalid address {:?}", addr));
+    }
+    // selector + 32-byte left-padded address arg.
+    let data = format!("{}{:0>64}", BALANCE_OF_SELECTOR, a.to_lowercase());
+    let hex = eth_call_at_block(chain, token, &data, block).await?;
+    parse_eth_call_u128(&hex)
 }
 
 /// Returns the transaction count (nonce) of `address` at the latest block.

--- a/src/rumi_protocol_backend/src/chains/evm/hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/hardening.rs
@@ -23,6 +23,30 @@ pub fn on_not_mined_tick(tries: u32, finality_depth: u32, has_submit_nonce: bool
     (new_tries, resubmit)
 }
 
+/// Default extra margin (secs) added to a swap's on-chain `deadline_secs` before
+/// the IC gives up on a never-mined LiquidationSwap. MUST exceed chain finality so
+/// a mined-then-reverted swap (deadline expiry) is observed on-chain BEFORE the IC
+/// timeout fires — else the SP could absorb debt the swap later settles (spec §4.8
+/// double-spend). 10 minutes is comfortably > eSpace finality.
+pub const SWAP_CONFIRM_FINALITY_MARGIN_SECS: u64 = 600;
+
+/// Net-new confirm-timeout for the LiquidationSwap kind (findings #12/#22): a
+/// never-mined swap (dropped from the mempool, no receipt ever) must transition
+/// to `Failed` so it cannot wedge the vault marker + reserved collateral forever
+/// (swaps are EXCLUDED from replace-by-fee, so without this they sit Inflight
+/// indefinitely). Returns true once `now - inflight_since > deadline + margin`.
+pub fn swap_confirm_timed_out(
+    inflight_since_ns: u64,
+    now_ns: u64,
+    deadline_secs: u64,
+    finality_margin_secs: u64,
+) -> bool {
+    let timeout_ns = deadline_secs
+        .saturating_add(finality_margin_secs)
+        .saturating_mul(1_000_000_000);
+    now_ns.saturating_sub(inflight_since_ns) > timeout_ns
+}
+
 /// Consecutive observer ticks a finalized-block regression must persist before
 /// it is treated as a real reorg (vs a transient single-provider RPC lag).
 /// fetch_block_numbers is un-quorumed (one provider at a time), so a single

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -193,6 +193,95 @@ pub fn confirm_interest_mint_in_state(
     Ok(())
 }
 
+/// Phase 2 of the bot liquidation (spec §4.9): USDC is in hand — move
+/// `debt_e8s -> reserve_backing_e8s` (the ONLY invariant move; `chain_supplies`
+/// is NOT touched, no icUSD burned). Modeled on `confirm_interest_mint_in_state`:
+/// read-only validate -> single guarded mutation -> clear marker + emit events.
+///
+/// `realized_usdc_native` is the REAL output decoded from the on-chain Transfer
+/// log (never min-out). `actual_cleared = min(debt_to_clear, live_debt,
+/// realized_usd)` (findings #16/#1/#19): reserve_backing is NEVER credited more
+/// than the realized USD value, and any shortfall is recorded as per-chain bad
+/// debt. The marker (not the op) is the source of truth (finding #5): only
+/// `pending_liquidation.op_id == op_id` is required (a pruned op is tolerated).
+///
+/// State-only (no events / no `ic_cdk::api::time`), so it is unit-testable; the
+/// CALLER (`confirm_op`) emits `ChainVaultLiquidated` + `ChainReserveCredited`
+/// from the returned data (matching `confirm_interest_mint_in_state`'s split).
+pub fn apply_liquidation_settlement_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    vault_id: u64,
+    op_id: u64,
+    realized_usdc_native: u128,
+    settle_decimals: u8,
+) -> Result<LiquidationSettlement, String> {
+    use crate::chains::monad::chain_vault::ChainVaultStatus;
+
+    // Step 1: validate (read-only — no mutation on failure). Capture sizing.
+    let (debt_to_clear, collateral_reserved, live_debt, tier) = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or_else(|| format!("apply_liquidation_settlement: unknown vault {vault_id}"))?;
+        let m = v
+            .pending_liquidation
+            .as_ref()
+            .ok_or_else(|| format!("apply_liquidation_settlement: vault {vault_id} has no liquidation marker"))?;
+        if m.op_id != op_id {
+            return Err(format!(
+                "apply_liquidation_settlement: marker op {} != confirming op {}",
+                m.op_id, op_id
+            ));
+        }
+        (m.debt_to_clear_e8s, m.collateral_reserved_native, v.debt_e8s, m.tier)
+    };
+
+    // Step 2: clamp — reserve_backing NEVER exceeds the realized USD value, nor the
+    // live debt (a concurrent burn is already blocked by the marker, so live_debt
+    // == debt_at_phase1; the min is belt-and-suspenders).
+    let realized_usd_e8 = crate::chains::liquidation::stable_native_to_e8s(realized_usdc_native, settle_decimals);
+    let actual_cleared = debt_to_clear.min(live_debt).min(realized_usd_e8);
+
+    // Step 3: the single guarded invariant move (debt -> reserve; supply untouched).
+    // apply_debt_to_reserve_shift re-validates the unified invariant + caps at debt.
+    crate::chains::supply::apply_debt_to_reserve_shift(state, chain, vault_id, actual_cleared, realized_usdc_native)
+        .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
+
+    // Step 4: record any shortfall as per-chain bad debt (never silent).
+    if debt_to_clear > actual_cleared {
+        *state.chain_bad_debt_e8s.entry(chain).or_default() += debt_to_clear - actual_cleared;
+    }
+
+    // Step 5: clear the marker + routing record; close the vault if fully drained.
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.pending_liquidation = None;
+    if v.debt_e8s == 0 && v.collateral_amount_native == 0 {
+        v.status = ChainVaultStatus::Closed;
+    }
+    state.bot_pending_chain_vaults.remove(&vault_id);
+
+    Ok(LiquidationSettlement {
+        actual_cleared,
+        collateral_seized_native: collateral_reserved,
+        tier,
+        realized_usdc_native,
+    })
+}
+
+/// Result of `apply_liquidation_settlement_in_state` — the data `confirm_op`
+/// needs to emit the `ChainVaultLiquidated` + `ChainReserveCredited` events.
+#[derive(Clone, Copy, Debug)]
+pub struct LiquidationSettlement {
+    pub actual_cleared: u128,
+    pub collateral_seized_native: u128,
+    pub tier: crate::chains::vault::LiquidationTier,
+    pub realized_usdc_native: u128,
+}
+
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
 
 /// Timer D entry point: run one settlement cycle for every registered+enabled

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -71,13 +71,8 @@ pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
     }
     for (&id, op) in q.pending.iter() {
         if matches!(op.status, SettlementOpStatus::Queued) {
-            // Increment 2: LiquidationSwap ops are enqueued but INERT (the swap
-            // submit path is Increment 3). Skip them so they neither execute nor
-            // head-of-line-block user ops. Increment 3 removes this guard and
-            // wires the submit/confirm/revert arms.
-            if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
-                continue;
-            }
+            // Increment 3: LiquidationSwap ops are now actionable (submit_op routes
+            // them through the dedicated swap path). The Inc-2 skip is removed.
             return Some((id, OpAction::Submit));
         }
     }
@@ -600,8 +595,21 @@ async fn resolve_op_signer(
             Ok((path, custody_addr))
         }
         SettlementOpKind::Burn { .. } => Err("burn not signable in Phase 1b".to_string()),
-        SettlementOpKind::LiquidationSwap { .. } => {
-            Err("liquidation swap signing is Increment 3".to_string())
+        SettlementOpKind::LiquidationSwap { vault_id, .. } => {
+            // The swap is signed by the vault's OWN custody address — it holds the
+            // CFX paid as the swap `value` (never commingled to the hot wallet),
+            // exactly like a NativeWithdrawal.
+            let vid = *vault_id;
+            let info = read_state(|s| {
+                s.multi_chain
+                    .chain_vaults
+                    .get(&vid)
+                    .map(|v| (v.owner, v.custody_address.clone()))
+            });
+            let (owner, custody_addr) =
+                info.ok_or_else(|| format!("swap signer: unknown vault {vid}"))?;
+            let path = tecdsa::custody_derivation_path(chain, owner, vid);
+            Ok((path, custody_addr))
         }
     }
 }
@@ -615,6 +623,15 @@ async fn resolve_op_signer(
 pub(crate) fn fundable_withdrawal_value(amount_e18: u128, custody_balance: u128, max_fee: u128) -> u128 {
     let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
     amount_e18.min(custody_balance.saturating_sub(gas_reserve))
+}
+
+/// The native CFX to swap (carried as the EIP-1559 `value`), capped so the
+/// custody signer can ALSO pay the swap gas (spec §4.8). Mirrors
+/// `fundable_withdrawal_value` but reserves the larger swap gas budget. If this
+/// goes to 0 the caller must NOT submit (escalate).
+pub(crate) fn fundable_swap_value(collateral_in: u128, custody_balance: u128, max_fee: u128) -> u128 {
+    let gas_reserve = (tx::LIQUIDATION_SWAP_GAS_LIMIT as u128).saturating_mul(max_fee);
+    collateral_in.min(custody_balance.saturating_sub(gas_reserve))
 }
 
 /// Submit path: sign + broadcast a `Queued` op, then mark it `Inflight`.
@@ -647,6 +664,14 @@ async fn submit_op(
             timestamp: now,
         });
         log!(INFO, "[settlement chain={:?}] op {} is a Burn; marked Failed (burns are user-initiated in Phase 1b)", chain, op_id);
+        return;
+    }
+
+    // A LiquidationSwap has its own self-contained submit flow (live DEX reads,
+    // JIT min-out + oracle gate, fundable-value gas net, fail-closed escalation)
+    // — route it to the dedicated path instead of the generic mint/withdrawal one.
+    if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
+        submit_liquidation_swap(chain, op_id, op).await;
         return;
     }
 
@@ -870,6 +895,211 @@ async fn submit_op(
     }
 }
 
+/// Fail a LiquidationSwap and escalate (spec §4.8 failure matrix, finding #10):
+/// mark the op `Failed`, restore the reserved collateral under a marker-CAS,
+/// clear the `pending_liquidation` marker, and mark the vault `sp_attempted` so
+/// detection does NOT re-route it to the bot (no retry loop). The Tier-2 SP
+/// consumer of `sp_attempted_chain_vaults` lands in Increment 4; until then the
+/// vault falls to Tier-3 manual. Emits the existing `ChainSettlementFailed` (no
+/// new Event variant). Used by both the submit do-not-swap branches and the
+/// confirm revert/timeout branches. Idempotent via the op_id marker-CAS.
+fn escalate_failed_swap(chain: ChainId, op_id: u64, vault_id: u64, reason: String) {
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+            if let Some(o) = q.pending.get_mut(&op_id) {
+                o.mark_failed(reason.clone(), now);
+            }
+        }
+        // Restore reserved collateral + clear the marker ONLY if THIS op still owns
+        // it (a concurrent confirm or a post-upgrade re-run cannot double-restore).
+        if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vault_id) {
+            let owns = v.pending_liquidation.as_ref().map_or(false, |m| m.op_id == op_id);
+            if owns {
+                let reserved = v.pending_liquidation.as_ref().map(|m| m.collateral_reserved_native).unwrap_or(0);
+                v.collateral_amount_native = v.collateral_amount_native.saturating_add(reserved);
+                v.pending_liquidation = None;
+            }
+        }
+        s.multi_chain.bot_pending_chain_vaults.remove(&vault_id);
+        // The bot gave up; do not re-route to the bot. (Inc 4 SP consumes this.)
+        s.multi_chain.sp_attempted_chain_vaults.insert(vault_id);
+    });
+    crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+        chain_id: chain,
+        op_id,
+        reason: reason.clone(),
+        timestamp: now,
+    });
+    log!(INFO, "[settlement chain={:?}] liquidation swap op {} vault {} FAILED -> escalated: {}", chain, op_id, vault_id, reason);
+}
+
+/// Dedicated submit path for a `LiquidationSwap` op (spec §4.8). Reads live DEX
+/// reserves PINNED to a finalized block (finding #13), computes a just-in-time
+/// `amount_out_min` (constant-product + slippage haircut) gated by the oracle
+/// cross-check, nets gas via `fundable_swap_value`, signs with the vault's custody
+/// key, and broadcasts to the router with native CFX in `value` and the USDC `to`
+/// = the tECDSA reserve address. FAIL-CLOSED: a bad DEX quote (reserves err/zero,
+/// min-out 0, oracle divergence, custody can't cover gas) escalates; a transient
+/// infra blip (block/nonce/fee/balance/sign/send) leaves the op Queued to retry.
+async fn submit_liquidation_swap(
+    chain: ChainId,
+    op_id: u64,
+    op: crate::chains::settlement_queue::SettlementOp,
+) {
+    use crate::chains::liquidation as liq;
+
+    // Op fields.
+    let (vault_id, collateral_in, router, pair, path0, path1, deadline_secs) = match &op.kind {
+        SettlementOpKind::LiquidationSwap {
+            vault_id, collateral_in_native, router, pair, path, deadline_secs, ..
+        } => {
+            if path.len() < 2 {
+                escalate_failed_swap(chain, op_id, *vault_id, "swap path malformed".into());
+                return;
+            }
+            (*vault_id, *collateral_in_native, router.clone(), pair.clone(), path[0].clone(), path[1].clone(), *deadline_secs)
+        }
+        _ => return, // unreachable: caller matched LiquidationSwap
+    };
+
+    let now = ic_cdk::api::time();
+    // Sync snapshot: liq-config knobs + fresh price + native decimals. A missing
+    // config/price/symbol is fail-closed (escalate) — the rail should not be
+    // enabled without them.
+    let snap = read_state(|s| {
+        let cfg = s.multi_chain.chain_liquidation_configs.get(&chain)?;
+        let native_decimals =
+            s.multi_chain.chain_configs.get(&chain).map(|c| c.chain_native_decimals).unwrap_or(18);
+        let symbol = crate::chains::evm::evm_chain_config(chain).map(|c| c.native_symbol)?;
+        let price = liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, cfg.max_price_age_ns).ok()?;
+        Some((cfg.fee_bps, cfg.slippage_cap_bps, cfg.max_dex_oracle_divergence_bps, cfg.settle_stable_decimals, native_decimals, price))
+    });
+    let (fee_bps, slippage_bps, divergence_bps, settle_decimals, native_decimals, price_e8) = match snap {
+        Some(t) => t,
+        None => {
+            escalate_failed_swap(chain, op_id, vault_id, "swap config/price unavailable".into());
+            return;
+        }
+    };
+
+    // Custody signer (holds the CFX) + the derived reserve `to`.
+    let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
+        Ok(p) => p,
+        Err(e) => {
+            escalate_failed_swap(chain, op_id, vault_id, format!("swap signer: {e}"));
+            return;
+        }
+    };
+    let reserve_to = match tecdsa::cached_reserve_address(chain).await {
+        Ok((_p, a)) => a,
+        Err(e) => {
+            escalate_failed_swap(chain, op_id, vault_id, format!("reserve address derive: {e}"));
+            return;
+        }
+    };
+
+    // Finalized block for the consensus-safe reserves read (transient -> retry).
+    let finalized = match evm_rpc::fetch_block_numbers(chain).await {
+        Ok((_l, f)) => f,
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] swap op {}: fetch_block_numbers failed ({}); will retry", chain, op_id, e);
+            return;
+        }
+    };
+    // token0 + reserves (fail-CLOSED per spec §4.8: a DEX-quote read error escalates).
+    let token0 = match evm_rpc::get_pair_token0(chain, &pair, finalized).await {
+        Ok(a) => a,
+        Err(e) => {
+            escalate_failed_swap(chain, op_id, vault_id, format!("token0 read: {e}"));
+            return;
+        }
+    };
+    let (r0, r1) = match evm_rpc::get_reserves(chain, &pair, finalized).await {
+        Ok(r) => r,
+        Err(e) => {
+            escalate_failed_swap(chain, op_id, vault_id, format!("getReserves read: {e}"));
+            return;
+        }
+    };
+    let (reserve_in, reserve_out) = if token0.eq_ignore_ascii_case(&path0) { (r0, r1) } else { (r1, r0) };
+
+    // Infra reads (transient -> retry, do NOT escalate on a blip).
+    let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
+        Ok(n) => n,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: nonce read failed ({}); will retry", chain, op_id, e); return; }
+    };
+    let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
+        Ok(p) => p,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: fetch_fees failed ({}); will retry", chain, op_id, e); return; }
+    };
+    let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
+    let custody_balance = match evm_rpc::get_balance(chain, &signer_addr).await {
+        Ok(b) => b,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: get_balance failed ({}); will retry", chain, op_id, e); return; }
+    };
+
+    // Gas net + JIT min-out + oracle cross-check — all fail-CLOSED (escalate).
+    let fundable = fundable_swap_value(collateral_in, custody_balance, max_fee);
+    if fundable == 0 {
+        escalate_failed_swap(chain, op_id, vault_id, "custody cannot cover swap gas".into());
+        return;
+    }
+    let (expected_out, min_out) = liq::compute_amount_out_min(fundable, reserve_in, reserve_out, fee_bps, slippage_bps);
+    if min_out == 0 {
+        escalate_failed_swap(chain, op_id, vault_id, "min-out 0 (reserves zero/too thin)".into());
+        return;
+    }
+    let oracle_value_e8 = liq::collateral_value_e8s(fundable, native_decimals, price_e8);
+    if !liq::oracle_corroborated(expected_out, settle_decimals, oracle_value_e8, divergence_bps) {
+        escalate_failed_swap(chain, op_id, vault_id, "pool price diverges from oracle (thin/manipulated)".into());
+        return;
+    }
+
+    // Build + sign + broadcast. The on-chain deadline = now + horizon.
+    let deadline = now / 1_000_000_000 + deadline_secs;
+    let fields = match tx::build_eip1559_fields(
+        chain.0 as u64,
+        tx::MonadTxKind::Swap {
+            router: &router,
+            amount_in: fundable,
+            amount_out_min: min_out,
+            path: [&path0, &path1],
+            to: &reserve_to,
+            deadline,
+        },
+        nonce,
+        prio,
+        max_fee,
+    ) {
+        Ok(f) => f,
+        Err(e) => {
+            // A malformed address is a config bug, not transient -> escalate.
+            escalate_failed_swap(chain, op_id, vault_id, format!("build swap tx: {e}"));
+            return;
+        }
+    };
+    let raw = match tx::sign_eip1559(&fields, path, &signer_addr).await {
+        Ok(h) => h,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: sign failed ({}); will retry", chain, op_id, e); return; }
+    };
+    let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw).await {
+        Ok(h) => h,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed ({}); will retry", chain, op_id, e); return; }
+    };
+
+    mutate_state(|s| {
+        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+            if let Some(o) = q.pending.get_mut(&op_id) {
+                o.mark_inflight(now);
+                o.last_tx_hash = Some(tx_hash.clone());
+                o.submit_nonce = Some(nonce);
+            }
+        }
+    });
+    log!(INFO, "[settlement chain={:?}] liquidation swap submitted: op={} vault={} amount_in={} min_out={} to_reserve={} tx={}", chain, op_id, vault_id, fundable, min_out, reserve_to, tx_hash);
+}
+
 /// Confirm path: check an `Inflight` op's receipt and finalize on success.
 async fn confirm_op(
     chain: ChainId,
@@ -898,6 +1128,39 @@ async fn confirm_op(
     let (status_ok, block_number) = match receipt {
         Some(pair) => pair,
         None => {
+            // LiquidationSwap: NEVER replace-by-fee (spec §4.8). A never-mined swap
+            // instead TIMES OUT -> Failed -> escalate (findings #12/#22), so it can
+            // never wedge the vault marker + reserved collateral. The timeout
+            // (deadline + finality margin) exceeds chain finality, so a
+            // mined-then-reverted swap is caught by the revert branch first.
+            if let SettlementOpKind::LiquidationSwap { vault_id, deadline_secs, .. } = &op.kind {
+                let last_attempt = match &op.status {
+                    SettlementOpStatus::Inflight { last_attempt_ns, .. } => *last_attempt_ns,
+                    _ => return,
+                };
+                let now = ic_cdk::api::time();
+                if hardening::swap_confirm_timed_out(
+                    last_attempt,
+                    now,
+                    *deadline_secs,
+                    hardening::SWAP_CONFIRM_FINALITY_MARGIN_SECS,
+                ) {
+                    escalate_failed_swap(chain, op_id, *vault_id, "swap confirm timeout (never mined)".into());
+                    return;
+                }
+                // Not timed out yet: advance tries for visibility, never resubmit.
+                mutate_state(|s| {
+                    if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                        if let Some(o) = q.pending.get_mut(&op_id) {
+                            if let SettlementOpStatus::Inflight { tries, .. } = &mut o.status {
+                                *tries = tries.saturating_add(1);
+                            }
+                        }
+                    }
+                });
+                return;
+            }
+
             // Not mined yet. ADVANCE `tries` on EVERY not-mined tick (the prior
             // code only advanced on submit / successful-resubmit, so `is_stuck`
             // (>= 2) was unreachable and replace-by-fee never fired). The pure
@@ -975,6 +1238,14 @@ async fn confirm_op(
     //    re-entrancy guard is deferred to Task 15; this per-op CAS is the local
     //    defense-in-depth.
     if !status_ok {
+        // A reverted LiquidationSwap (deadline expiry / min-out unmet on-chain):
+        // restore the reserved collateral + clear the marker + escalate via the
+        // shared helper (the generic CAS below can't call it from inside its own
+        // mutate_state). The helper's marker-CAS prevents a double-restore.
+        if let SettlementOpKind::LiquidationSwap { vault_id, .. } = &op.kind {
+            escalate_failed_swap(chain, op_id, *vault_id, "swap reverted on-chain".into());
+            return;
+        }
         let reason = "tx reverted".to_string();
         let did_revert = mutate_state(|s| {
             // CAS: only the first tick to observe this op Inflight does the work.
@@ -1301,11 +1572,86 @@ async fn confirm_op(
             // never goes Inflight. Log defensively rather than panic.
             log!(INFO, "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
         }
-        SettlementOpKind::LiquidationSwap { .. } => {
-            // Unreachable in Increment 2: select_next_op skips LiquidationSwap so
-            // it never goes Inflight. Increment 3 wires the real confirm (Transfer
-            // decode -> reserve shift) here. Log defensively rather than panic.
-            log!(INFO, "[settlement chain={:?}] LiquidationSwap op {} reached confirm unexpectedly (Increment 3 wiring missing)", chain, op_id);
+        SettlementOpKind::LiquidationSwap { vault_id, path, .. } => {
+            // Mined + ok + final: read the REALIZED settle-stable output from the
+            // `Transfer(_, reserve, amount)` log (never trust min-out), then move
+            // debt -> reserve via Phase 2 (spec §4.8/§4.9).
+            let vault_id = *vault_id;
+            let settle_stable = path.get(1).cloned().unwrap_or_default(); // path[1] = settle stable token
+            let reserve_to = match tecdsa::cached_reserve_address(chain).await {
+                Ok((_p, a)) => a,
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] swap confirm op {}: reserve address derive failed ({}); will retry", chain, op_id, e);
+                    return;
+                }
+            };
+            let settle_decimals = read_state(|s| {
+                s.multi_chain.chain_liquidation_configs.get(&chain).map(|c| c.settle_stable_decimals)
+            })
+            .unwrap_or(18);
+
+            let logs = match evm_rpc::get_logs(chain, &settle_stable, evm_rpc::TRANSFER_EVENT_TOPIC0, block_number, block_number).await {
+                Ok(l) => l,
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] swap confirm op {}: get_logs(Transfer) failed ({}); will retry", chain, op_id, e);
+                    return;
+                }
+            };
+            let mut realized: Option<u128> = None;
+            for (topics, data, _log_tx, _log_block, _log_index) in &logs {
+                if let Ok(t) = evm_rpc::TransferLog::from_raw(topics, data) {
+                    if t.to.eq_ignore_ascii_case(&reserve_to) {
+                        realized = Some(t.amount);
+                        break;
+                    }
+                }
+            }
+            let realized_usdc = match realized {
+                Some(a) => a,
+                None => {
+                    // Receipt is OK but no Transfer-to-reserve is visible yet (a
+                    // transient RPC view). Leave Inflight + retry; the confirm-
+                    // timeout backstops a permanently-missing log.
+                    log!(INFO, "[settlement chain={:?}] swap confirm op {}: no USDC Transfer to reserve {} in block {}; will retry", chain, op_id, reserve_to, block_number);
+                    return;
+                }
+            };
+
+            // Phase 2 (state-only): clamp + move debt -> reserve; events emitted here.
+            let settled = mutate_state(|s| {
+                apply_liquidation_settlement_in_state(&mut s.multi_chain, chain, vault_id, op_id, realized_usdc, settle_decimals)
+            });
+            match settled {
+                Ok(res) => {
+                    mutate_state(|s| {
+                        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                            if let Some(o) = q.pending.get_mut(&op_id) {
+                                o.mark_succeeded(tx_hash.clone(), now);
+                            }
+                        }
+                    });
+                    crate::storage::record_event(&crate::event::Event::ChainVaultLiquidated {
+                        chain_id: chain,
+                        vault_id,
+                        op_id,
+                        debt_cleared_e8s: res.actual_cleared,
+                        collateral_seized_native: res.collateral_seized_native,
+                        tier: res.tier,
+                        timestamp: now,
+                    });
+                    crate::storage::record_event(&crate::event::Event::ChainReserveCredited {
+                        chain_id: chain,
+                        vault_id,
+                        backing_added_e8s: res.actual_cleared,
+                        usdc_native: res.realized_usdc_native,
+                        timestamp: now,
+                    });
+                    log!(INFO, "[settlement chain={:?}] liquidation swap confirmed: op={} vault={} cleared_e8s={} realized_usdc={} block={} tx={}", chain, op_id, vault_id, res.actual_cleared, realized_usdc, block_number, tx_hash);
+                }
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] apply_liquidation_settlement FAILED op {} vault {}: {}; left Inflight", chain, op_id, vault_id, e);
+                }
+            }
         }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tecdsa.rs
@@ -149,3 +149,34 @@ pub async fn cached_interest_treasury_address(
     });
     Ok((path, addr))
 }
+
+// ─── Liquidation-reserve address (Increment 3, spec §4.8) ───────────────────────
+
+/// Derivation path for the per-chain liquidation-RESERVE (PSM sink) address.
+/// Distinct from settlement/interest/custody paths. Bot-liquidation swaps settle
+/// their USDC output here; the bridge sweeps FROM it (out of scope). The vault's
+/// OWN custody key signs the swap (it holds the CFX); this is only the `to:`.
+pub fn reserve_derivation_path(chain: ChainId) -> Vec<Vec<u8>> {
+    vec![chain.0.to_le_bytes().to_vec(), b"liquidation-reserve".to_vec()]
+}
+
+thread_local! {
+    static RESERVE_ADDR_CACHE: std::cell::RefCell<std::collections::BTreeMap<ChainId, String>> =
+        const { std::cell::RefCell::new(std::collections::BTreeMap::new()) };
+}
+
+/// Cached per-chain liquidation-reserve address (spec §4.8). Mirrors
+/// `cached_settlement_address`: deterministic (no nonce), derives + caches on
+/// first use. Resolved at swap submit (the USDC `to:`) and at confirm (to match
+/// the realized `Transfer(_, reserve, amount)` log). Returns (path, address).
+pub async fn cached_reserve_address(chain: ChainId) -> Result<(Vec<Vec<u8>>, String), String> {
+    let path = reserve_derivation_path(chain);
+    if let Some(addr) = RESERVE_ADDR_CACHE.with(|c| c.borrow().get(&chain).cloned()) {
+        return Ok((path, addr));
+    }
+    let (_pubkey, addr) = derive_evm_address(path.clone()).await?;
+    RESERVE_ADDR_CACHE.with(|c| {
+        c.borrow_mut().insert(chain, addr.clone());
+    });
+    Ok((path, addr))
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
@@ -350,3 +350,34 @@ fn parse_eth_call_u128_decodes_padded_word() {
     let too_big = format!("0x{}", "f".repeat(64));
     assert!(parse_eth_call_u128(&too_big).is_err());
 }
+
+// ─── Increment 3 / Task 4: DEX getReserves parse + Transfer-log decode ───
+#[test]
+fn parse_two_uint112_splits_getreserves() {
+    use super::evm_rpc::parse_two_uint112;
+    // ABI return (uint112, uint112, uint32) = THREE full 32-byte words (each value
+    // left-padded), 192 hex chars. parse reads word0 + word1.
+    let hex = format!("0x{:064x}{:064x}{:064x}", 1_000_000u128, 90_900u128, 12_345u128);
+    assert_eq!(parse_two_uint112(&hex).unwrap(), (1_000_000, 90_900));
+    // Too-short result fails closed.
+    assert!(parse_two_uint112("0x1234").is_err());
+}
+
+#[test]
+fn transfer_log_decodes_to_and_amount() {
+    use super::evm_rpc::{TransferLog, TRANSFER_EVENT_TOPIC0};
+    let to = "0x000000000000000000000000000000000000c0de";
+    let topics = vec![
+        TRANSFER_EVENT_TOPIC0.to_string(),
+        format!("0x{:064x}", 1u128), // from (indexed, padded)
+        format!("0x000000000000000000000000{}", to.trim_start_matches("0x")), // to (indexed, padded)
+    ];
+    let data = format!("0x{:064x}", 5_000_000u128);
+    let t = TransferLog::from_raw(&topics, &data).unwrap();
+    assert_eq!(t.to.to_lowercase(), to.to_lowercase());
+    assert_eq!(t.amount, 5_000_000);
+    // Wrong topic0 -> Err.
+    let mut bad = topics.clone();
+    bad[0] = format!("0x{}", "0".repeat(64));
+    assert!(TransferLog::from_raw(&bad, &data).is_err());
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_hardening.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_hardening.rs
@@ -96,3 +96,15 @@ fn inflight_acquire_future_timestamp_treated_as_fresh() {
     let future_timestamp = now_ns + 999_999_999_999; // well beyond now
     assert!(!inflight_should_acquire(Some(future_timestamp), now_ns, INFLIGHT_STALE_NS));
 }
+
+// ─── Increment 3 / Task 8: swap confirm-timeout (findings #12/#22) ───
+#[test]
+fn swap_confirm_timed_out_after_deadline_plus_finality() {
+    use super::hardening::swap_confirm_timed_out;
+    let t0 = 1_000_000_000u64;
+    // Within deadline(180)+margin(600)=780s -> not timed out.
+    assert!(!swap_confirm_timed_out(t0, t0 + 100 * 1_000_000_000, 180, 600));
+    assert!(!swap_confirm_timed_out(t0, t0 + 780 * 1_000_000_000, 180, 600)); // exactly at edge: not yet (>)
+    // One ns past the window -> timed out.
+    assert!(swap_confirm_timed_out(t0, t0 + 780 * 1_000_000_000 + 1, 180, 600));
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -184,3 +184,109 @@ fn fundable_withdrawal_value_nets_gas_only_when_balance_is_tight() {
     // / underflows), so the worker sends a 0-value tx rather than trapping.
     assert_eq!(fundable_withdrawal_value(amount, gas_reserve / 2, max_fee), 0);
 }
+
+// ─── Increment 3 / Task 7: apply_liquidation_settlement_in_state (Phase 2) ───
+mod phase2_tests {
+    use super::super::settlement::apply_liquidation_settlement_in_state;
+    use crate::chains::config::ChainId;
+    use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use crate::chains::multi_chain_state::MultiChainState;
+    use crate::chains::vault::{LiquidationTier, PendingLiquidationV1};
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(71);
+    const E8: u128 = 100_000_000;
+    const E18: u128 = 1_000_000_000_000_000_000;
+
+    /// Insert an Open vault mid-liquidation (collateral already reserved in Phase 1)
+    /// with a Bot marker, and seed chain_supplies so the unified invariant holds.
+    fn marked(
+        s: &mut MultiChainState,
+        vault_id: u64,
+        debt_e8s: u128,
+        collateral_remaining: u128,
+        debt_to_clear: u128,
+        collateral_reserved: u128,
+    ) {
+        s.chain_vaults.insert(
+            vault_id,
+            ChainVaultV1 {
+                vault_id,
+                owner: Principal::anonymous(),
+                collateral_chain: CFX,
+                custody_address: "0xc".into(),
+                collateral_amount_native: collateral_remaining,
+                debt_e8s,
+                mint_recipient: "0xr".into(),
+                pending_mint_e8s: 0,
+                status: ChainVaultStatus::Open,
+                opened_at_ns: 0,
+                owner_evm: None,
+                last_interest_accrual_ns: 0,
+                pending_interest_mint_e8s: 0,
+                pending_liquidation: Some(PendingLiquidationV1 {
+                    op_id: 9,
+                    debt_to_clear_e8s: debt_to_clear,
+                    collateral_reserved_native: collateral_reserved,
+                    tier: LiquidationTier::Bot,
+                    started_at_ns: 0,
+                }),
+            },
+        );
+        *s.chain_supplies.entry(CFX).or_default() += debt_e8s;
+        s.bot_pending_chain_vaults.insert(vault_id, 0);
+    }
+
+    #[test]
+    fn shifts_debt_to_reserve_supply_unchanged() {
+        let mut s = MultiChainState::default();
+        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        // realized 75 USDC (18-dec) -> 75e8 >= debt_to_clear 67e8.
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18).expect("phase2 ok");
+        let v = s.chain_vaults.get(&7).unwrap();
+        assert_eq!(v.debt_e8s, 33 * E8, "debt -= actual_cleared");
+        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 67 * E8, "backing += actual_cleared");
+        assert_eq!(*s.reserve_usdc_native.get(&CFX).unwrap(), 75 * E18, "usdc += realized");
+        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply UNCHANGED (PSM)");
+        assert!(v.pending_liquidation.is_none(), "marker cleared");
+        assert!(s.chain_bad_debt_e8s.get(&CFX).is_none(), "no shortfall");
+        // Unified invariant: supply == debt + reserve + pending_burn.
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+        );
+    }
+
+    #[test]
+    fn shortfall_clamps_and_records_bad_debt() {
+        let mut s = MultiChainState::default();
+        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        // realized only 60 USDC -> 60e8 < debt_to_clear 67e8.
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18).expect("phase2 ok");
+        assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 40 * E8);
+        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 60 * E8, "backing capped at realized USD");
+        assert_eq!(*s.chain_bad_debt_e8s.get(&CFX).unwrap(), 7 * E8, "shortfall recorded");
+        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply unchanged");
+    }
+
+    #[test]
+    fn closes_vault_when_drained() {
+        let mut s = MultiChainState::default();
+        // collateral fully reserved in Phase 1 (remaining 0); clearing all debt drains it.
+        marked(&mut s, 7, 100 * E8, 0, 100 * E8, 1_400 * E18);
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 112 * E18, 18).expect("phase2 ok");
+        let v = s.chain_vaults.get(&7).unwrap();
+        assert_eq!(v.debt_e8s, 0);
+        assert_eq!(v.status, ChainVaultStatus::Closed, "drained vault closes");
+    }
+
+    #[test]
+    fn rejects_op_mismatch_no_mutation() {
+        let mut s = MultiChainState::default();
+        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        // confirming op 99 != marker op 9.
+        assert!(apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18).is_err());
+        assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 100 * E8, "no mutation on reject");
+        assert!(s.reserve_backing_e8s.get(&CFX).is_none());
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_tecdsa.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_tecdsa.rs
@@ -90,3 +90,18 @@ fn is_valid_evm_address_accepts_well_formed_and_rejects_malformed() {
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
 }
+
+// ─── Increment 3 / Task 5: liquidation-reserve derivation path ───
+#[test]
+fn reserve_path_distinct_from_settlement_and_treasury() {
+    use super::tecdsa::{interest_treasury_derivation_path, reserve_derivation_path, settlement_derivation_path};
+    use crate::chains::config::ChainId;
+    let c = ChainId(71);
+    let reserve = reserve_derivation_path(c);
+    assert_ne!(reserve, settlement_derivation_path(c), "reserve path must differ from settlement");
+    assert_ne!(reserve, interest_treasury_derivation_path(c), "reserve path must differ from treasury");
+    // The label component is the distinguishing element.
+    assert_eq!(reserve[1], b"liquidation-reserve".to_vec());
+    // Per-chain: a different chain yields a different path.
+    assert_ne!(reserve_derivation_path(ChainId(1030)), reserve);
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_tx.rs
@@ -540,3 +540,44 @@ fn encode_transfer_calldata_returns_err_on_malformed_address() {
     let result = encode_transfer_calldata("0xbadhex!", 1_000_000);
     assert!(result.is_err(), "expected Err for bad hex recipient, got Ok");
 }
+
+// ─── Increment 3 / Task 3: dynamic address[] swap calldata encoder ───
+#[test]
+fn swap_exact_eth_for_tokens_calldata_matches_reference() {
+    // Reference = swapExactETHForTokens(uint256,address[],address,uint256), selector
+    // 0x7ff36ab5; head = [amountOutMin, path-offset=0x80, to, deadline]; tail =
+    // [path.len=2, path[0], path[1]]. amountOutMin=1000, to=0x..c0de, deadline=180,
+    // path=[WCFX, USDC]. (Hand-derived per the UniswapV2 ABI; matches `cast calldata`.)
+    let path = [
+        "0x14b2d3bc65e74dae1030eafd8ac30c533c976a9b",
+        "0x6963efed0ab40f6c3d7bda44a05dcf1437c44372",
+    ];
+    let data = super::tx::encode_swap_exact_eth_for_tokens_calldata(
+        1000,
+        &path,
+        "0x000000000000000000000000000000000000c0de",
+        180,
+    )
+    .expect("valid addresses encode");
+    let hex_out = format!("0x{}", hex::encode(&data));
+    let expected = "0x7ff36ab5\
+00000000000000000000000000000000000000000000000000000000000003e8\
+0000000000000000000000000000000000000000000000000000000000000080\
+000000000000000000000000000000000000000000000000000000000000c0de\
+00000000000000000000000000000000000000000000000000000000000000b4\
+0000000000000000000000000000000000000000000000000000000000000002\
+00000000000000000000000014b2d3bc65e74dae1030eafd8ac30c533c976a9b\
+0000000000000000000000006963efed0ab40f6c3d7bda44a05dcf1437c44372";
+    assert_eq!(hex_out, expected.replace('\n', ""));
+    // 4-byte selector + 7 words = 4 + 224 = 228 bytes.
+    assert_eq!(data.len(), 4 + 7 * 32);
+}
+
+#[test]
+fn swap_calldata_rejects_malformed_address() {
+    let path = ["0xnothex", "0x6963efed0ab40f6c3d7bda44a05dcf1437c44372"];
+    assert!(
+        super::tx::encode_swap_exact_eth_for_tokens_calldata(1, &path, "0x000000000000000000000000000000000000c0de", 1).is_err(),
+        "malformed path address must Err, never panic"
+    );
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tx.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tx.rs
@@ -46,6 +46,17 @@ pub enum MonadTxKind<'a> {
     Mint { contract: &'a str, recipient: &'a str, amount_e8s: u128, vault_id: u64, op_id: u64 },
     /// A native MON transfer (`amount_wei` carried in the EIP-1559 `value`).
     NativeWithdrawal { recipient: &'a str, amount_wei: u128 },
+    /// UniswapV2 `swapExactETHForTokens`: native collateral carried in the
+    /// EIP-1559 `value`, sold for the settle-stable to `to` (the reserve address).
+    /// `path = [wrapped_collateral, settle_stable]`. Bot-liquidation swap (spec §4.8).
+    Swap {
+        router: &'a str,
+        amount_in: u128,
+        amount_out_min: u128,
+        path: [&'a str; 2],
+        to: &'a str,
+        deadline: u64,
+    },
 }
 
 /// Single source of truth for the per-op-kind EIP-1559 field shape (gas_limit,
@@ -109,6 +120,20 @@ pub fn build_eip1559_fields(
             value: amount_wei,
             data: vec![],
         }),
+        MonadTxKind::Swap { router, amount_in, amount_out_min, path, to, deadline } => {
+            let data = encode_swap_exact_eth_for_tokens_calldata(amount_out_min, &path, to, deadline)?;
+            Ok(Eip1559Fields {
+                chain_id,
+                nonce,
+                max_priority_fee_per_gas: prio,
+                max_fee_per_gas: max_fee,
+                gas_limit: LIQUIDATION_SWAP_GAS_LIMIT,
+                to: router.to_string(),
+                // Native CFX carried in `value`; the router wraps to WCFX internally.
+                value: amount_in,
+                data,
+            })
+        }
     }
 }
 
@@ -389,6 +414,46 @@ fn abi_word_u128(n: u128) -> [u8; 32] {
     let mut word = [0u8; 32];
     word[16..].copy_from_slice(&n.to_be_bytes());
     word
+}
+
+/// Gas ceiling for a UniswapV2 `swapExactETHForTokens` (wrap + swap + transfer +
+/// pair update). 250k per spec §4.8 — a CEILING (only used gas is charged), so a
+/// generous cap is safe. MEASURE on eSpace mainnet before enabling; the icUSD
+/// mint already meters ~177.5k, so a swap may want more headroom.
+pub const LIQUIDATION_SWAP_GAS_LIMIT: u64 = 250_000;
+
+/// ABI-encode `swapExactETHForTokens(uint256 amountOutMin, address[] path,
+/// address to, uint256 deadline)` (spec §4.8). The ONLY dynamic-type ABI encode
+/// in the codebase — pinned byte-for-byte by
+/// `swap_exact_eth_for_tokens_calldata_matches_reference`. Layout: 4-byte
+/// selector + head[amountOutMin, path-offset=0x80, to, deadline] +
+/// tail[path.len=2, path[0], path[1]]. Returns `Err` on any malformed address
+/// (defense-in-depth; never panics the settlement worker).
+///
+/// CRITICAL (spec §4.8/#31): the selector assumes the canonical UniswapV2
+/// signature (0x7ff36ab5). The operator MUST confirm the DEPLOYED Swappi router's
+/// signature before enabling — a wrong selector reverts every swap.
+pub fn encode_swap_exact_eth_for_tokens_calldata(
+    amount_out_min: u128,
+    path: &[&str; 2],
+    to: &str,
+    deadline: u64,
+) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(4 + 7 * 32);
+    out.extend_from_slice(&keccak_selector(
+        "swapExactETHForTokens(uint256,address[],address,uint256)",
+    ));
+    // head (4 words): amountOutMin, offset to `path` (0x80 = 4 words past the head
+    // start), to, deadline.
+    out.extend_from_slice(&abi_word_u128(amount_out_min));
+    out.extend_from_slice(&abi_word_u128(0x80));
+    out.extend_from_slice(&abi_word_address(to)?);
+    out.extend_from_slice(&abi_word_u128(deadline as u128));
+    // tail: dynamic `path` = length (2) then the two addresses.
+    out.extend_from_slice(&abi_word_u128(2));
+    out.extend_from_slice(&abi_word_address(path[0])?);
+    out.extend_from_slice(&abi_word_address(path[1])?);
+    Ok(out)
 }
 
 /// Parse a "0x…" hex address into 20 bytes.

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -301,6 +301,57 @@ pub fn detect_and_route_chain_liquidations_in_state(
     routed
 }
 
+// ─── Increment 3: swap min-out + oracle cross-check (spec §4.8) ───
+
+/// UniswapV2 constant-product output with fee, plus the slippage haircut (spec
+/// §4.8). Returns `(expected_out, amount_out_min)` in the OUT token's native base
+/// units. Returns `(0, 0)` on any zero/degenerate input (the caller fail-closes:
+/// no swap without a satisfiable min-out).
+pub fn compute_amount_out_min(
+    amount_in: u128,
+    reserve_in: u128,
+    reserve_out: u128,
+    fee_bps: u16,
+    slippage_bps: u16,
+) -> (u128, u128) {
+    if amount_in == 0 || reserve_in == 0 || reserve_out == 0 || fee_bps as u32 >= 10_000 {
+        return (0, 0);
+    }
+    let amount_in_with_fee = amount_in.saturating_mul(10_000u128.saturating_sub(fee_bps as u128));
+    let numerator = amount_in_with_fee.saturating_mul(reserve_out);
+    let denominator = reserve_in.saturating_mul(10_000).saturating_add(amount_in_with_fee);
+    if denominator == 0 {
+        return (0, 0);
+    }
+    let expected_out = numerator / denominator;
+    let min_out = expected_out.saturating_mul(10_000u128.saturating_sub(slippage_bps as u128)) / 10_000;
+    (expected_out, min_out)
+}
+
+/// USD value (e8s) of `native` units of a `decimals`-decimal stable token.
+pub fn stable_native_to_e8s(native: u128, decimals: u8) -> u128 {
+    let scale = 10u128.saturating_pow(decimals as u32);
+    if scale == 0 {
+        return 0;
+    }
+    native.saturating_mul(100_000_000) / scale
+}
+
+/// The DEX-depth oracle cross-check (spec §4.8): the pool's expected stable-out
+/// must be at least `(1 - divergence)` of the oracle-implied USD value of the
+/// seized collateral. Fail-closed (false) on a thin/manipulated pool.
+pub fn oracle_corroborated(
+    expected_out_native: u128,
+    settle_decimals: u8,
+    oracle_value_e8: u128,
+    max_divergence_bps: u32,
+) -> bool {
+    let expected_out_e8 = stable_native_to_e8s(expected_out_native, settle_decimals);
+    let floor =
+        oracle_value_e8.saturating_mul(10_000u128.saturating_sub(max_divergence_bps as u128)) / 10_000;
+    expected_out_e8 >= floor
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -579,5 +630,45 @@ mod tests {
         s.bot_pending_chain_vaults.insert(7, 10);
         prune_recovered_chain_routing_state(&mut s, ChainId(71), "CFX", 13_300, 5_000);
         assert!(s.bot_pending_chain_vaults.contains_key(&7), "still-liquidatable vault NOT cleared");
+    }
+
+    // ─── Increment 3 / Task 2: pure swap min-out + oracle cross-check ───
+    const E18: u128 = 1_000_000_000_000_000_000;
+    const E8: u128 = 100_000_000;
+
+    #[test]
+    fn amount_out_min_v2_constant_product_with_fee_and_haircut() {
+        let (expected, min_out) = compute_amount_out_min(
+            2_000u128 * E18,
+            1_000_000u128 * E18,
+            90_900u128 * E18,
+            25,
+            250,
+        );
+        assert!(expected > 0 && min_out > 0 && min_out < expected);
+        // min_out is exactly the 2.5% haircut of expected.
+        assert_eq!(min_out, expected.saturating_mul(9_750) / 10_000);
+    }
+
+    #[test]
+    fn amount_out_min_zero_when_reserves_zero() {
+        assert_eq!(compute_amount_out_min(1, 0, 100, 25, 250), (0, 0));
+        assert_eq!(compute_amount_out_min(1, 100, 0, 25, 250), (0, 0));
+        assert_eq!(compute_amount_out_min(0, 100, 100, 25, 250), (0, 0));
+    }
+
+    #[test]
+    fn oracle_cross_check_rejects_thin_pool() {
+        // expected_out 95 USDC (18-dec) vs oracle-implied 100 USD: exactly 5% below.
+        let oracle_value_e8 = 100 * E8;
+        let expected_out_native = 95u128 * E18;
+        assert!(oracle_corroborated(expected_out_native, 18, oracle_value_e8, 500)); // at the edge: OK
+        assert!(!oracle_corroborated(expected_out_native, 18, oracle_value_e8, 499)); // one bp tighter: reject
+    }
+
+    #[test]
+    fn stable_native_to_e8s_scales_by_decimals() {
+        assert_eq!(stable_native_to_e8s(50u128 * E18, 18), 50 * E8); // 18-dec USDC -> e8s
+        assert_eq!(stable_native_to_e8s(50u128 * 1_000_000, 6), 50 * E8); // 6-dec -> e8s
     }
 }

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -461,6 +461,10 @@ mod tests {
                 enabled: true,
                 max_swap_value_e8s: 2_000 * 100_000_000,
                 max_price_age_ns: 1_800_000_000_000,
+                max_dex_oracle_divergence_bps: 500,
+                fee_bps: 25,
+                settle_stable_decimals: 18,
+                deadline_secs: 180,
             },
         );
     }

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -264,6 +264,11 @@ pub fn detect_and_route_chain_liquidations_in_state(
             || v.pending_mint_e8s != 0
             || v.pending_interest_mint_e8s != 0
             || v.pending_liquidation.is_some()
+            // The bot already failed/gave up on this vault (escalated) — do NOT
+            // re-route it to the bot (no retry loop, finding #10). It falls to
+            // Tier-3 manual / the Tier-2 SP (Increment 4). The prune clears this
+            // once the vault recovers above the liquidation threshold.
+            || state.sp_attempted_chain_vaults.contains(&vid)
         {
             continue;
         }
@@ -603,6 +608,21 @@ mod tests {
         seed_cfg_unchecked(&mut s);
         s.chain_liquidation_configs.get_mut(&ChainId(71)).unwrap().enabled = false;
         assert_eq!(detect_and_route_chain_liquidations_in_state(&mut s, ChainId(71), "CFX", 13_300, 2_000, 3), 0);
+        assert!(s.chain_vaults.get(&1).unwrap().pending_liquidation.is_none());
+    }
+
+    #[test]
+    fn detect_skips_bot_failed_sp_attempted_vaults() {
+        // Finding #10: a vault the bot already failed (sp_attempted) is NOT
+        // re-routed to the bot (no retry loop), even while still liquidatable.
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        s.manual_prices.insert((ChainId(71), "CFX".into()), 8_000_000);
+        s.manual_price_set_at_ns.insert((ChainId(71), "CFX".into()), 1_000);
+        insert_vault_liq(&mut s, 1, 1_400, 100, ChainVaultStatus::Open); // underwater
+        s.sp_attempted_chain_vaults.insert(1);
+        let routed = detect_and_route_chain_liquidations_in_state(&mut s, ChainId(71), "CFX", 13_300, 2_000, 10);
+        assert_eq!(routed, 0, "bot-failed vault not re-routed");
         assert!(s.chain_vaults.get(&1).unwrap().pending_liquidation.is_none());
     }
 

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -319,17 +319,45 @@ pub fn compute_amount_out_min(
     fee_bps: u16,
     slippage_bps: u16,
 ) -> (u128, u128) {
+    use ethnum::U256;
     if amount_in == 0 || reserve_in == 0 || reserve_out == 0 || fee_bps as u32 >= 10_000 {
         return (0, 0);
     }
-    let amount_in_with_fee = amount_in.saturating_mul(10_000u128.saturating_sub(fee_bps as u128));
-    let numerator = amount_in_with_fee.saturating_mul(reserve_out);
-    let denominator = reserve_in.saturating_mul(10_000).saturating_add(amount_in_with_fee);
-    if denominator == 0 {
-        return (0, 0);
-    }
-    let expected_out = numerator / denominator;
-    let min_out = expected_out.saturating_mul(10_000u128.saturating_sub(slippage_bps as u128)) / 10_000;
+    // MUST use 256-bit intermediates: `amount_in_with_fee * reserve_out` overflows
+    // u128 at 18-decimal token magnitudes (~1e25 * 1e23 = 1e48 >> u128 max 3.4e38).
+    // All ops checked -> fail-closed (0,0) on any overflow, never wrap/panic.
+    let fee_mult = U256::from(10_000u32 - fee_bps as u32);
+    let amount_in_with_fee = match U256::from(amount_in).checked_mul(fee_mult) {
+        Some(v) => v,
+        None => return (0, 0),
+    };
+    let numerator = match amount_in_with_fee.checked_mul(U256::from(reserve_out)) {
+        Some(v) => v,
+        None => return (0, 0),
+    };
+    let denominator = match U256::from(reserve_in)
+        .checked_mul(U256::from(10_000u32))
+        .and_then(|x| x.checked_add(amount_in_with_fee))
+    {
+        Some(d) if d != 0 => d,
+        _ => return (0, 0),
+    };
+    let expected_u256 = numerator / denominator;
+    // `expected_out < reserve_out <= u128::MAX` for a real swap, so it fits u128;
+    // guard anyway (fail-closed) rather than truncate.
+    let expected_out = match u128::try_from(expected_u256) {
+        Ok(v) => v,
+        Err(_) => return (0, 0),
+    };
+    let slip_mult = U256::from(10_000u32 - slippage_bps.min(10_000) as u32);
+    let min_out = match U256::from(expected_out)
+        .checked_mul(slip_mult)
+        .map(|x| x / U256::from(10_000u32))
+        .and_then(|x| u128::try_from(x).ok())
+    {
+        Some(v) => v,
+        None => return (0, 0),
+    };
     (expected_out, min_out)
 }
 
@@ -665,7 +693,15 @@ mod tests {
             25,
             250,
         );
-        assert!(expected > 0 && min_out > 0 && min_out < expected);
+        // ABSOLUTE value, not just relations: pool price ~0.0909 USDC/CFX, so
+        // selling 2000 CFX yields ~181 USDC (18-dec) minus fee + small impact.
+        // This catches the u128-overflow bug (saturating_mul gave a garbage ~3.4e10).
+        assert!(
+            expected > 175 * E18 && expected < 182 * E18,
+            "expected_out {} not in the ~181e18 sane band (u256 math must not overflow)",
+            expected
+        );
+        assert!(min_out > 0 && min_out < expected);
         // min_out is exactly the 2.5% haircut of expected.
         assert_eq!(min_out, expected.saturating_mul(9_750) / 10_000);
     }

--- a/src/rumi_protocol_backend/src/chains/liquidation_config.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation_config.rs
@@ -70,6 +70,23 @@ pub struct ChainLiquidationConfigV1 {
     /// push interval (start ~30 min).
     #[serde(default)]
     pub max_price_age_ns: u64,
+    /// Pool-vs-oracle divergence ceiling (bps) for the submit-time cross-check
+    /// (spec §4.8): if the pool prices collateral more than this below oracle, the
+    /// pool is thin/manipulated -> do NOT swap, escalate. Also half of the #16
+    /// penalty-cushion invariant (`penalty > slippage + divergence`).
+    #[serde(default)]
+    pub max_dex_oracle_divergence_bps: u32,
+    /// The DEX swap fee in bps (Swappi UniswapV2 = 25 = 0.25%); used by the
+    /// constant-product min-out (spec §4.8). CONFIRM against the live router.
+    #[serde(default)]
+    pub fee_bps: u16,
+    /// Decimals of `settle_stable_token` (18 on eSpace; a future chain may be 6).
+    /// Used at the realized-USD <-> e8s boundary. NOT a constant (spec §8).
+    #[serde(default)]
+    pub settle_stable_decimals: u8,
+    /// On-chain swap deadline horizon (secs, ~180). The tx deadline = now + this.
+    #[serde(default)]
+    pub deadline_secs: u64,
 }
 
 /// Reasons `set_chain_liquidation_config` rejects a config (no state mutation on
@@ -90,6 +107,12 @@ pub enum LiquidationConfigError {
     /// An `enabled` config left the price-staleness ceiling at 0 (spec §4.3):
     /// every fresh-price check would fail closed. Disabled configs may carry 0.
     ZeroPriceAge,
+    /// An `enabled` config has `settle_stable_decimals` of 0 or > 36 (spec §8): the
+    /// realized-USD <-> e8s conversion would be wrong. Disabled configs may carry 0.
+    BadSettleDecimals,
+    /// An `enabled` config left the swap `deadline_secs` at 0 (spec §4.8): a swap
+    /// with a zero deadline reverts immediately. Disabled configs may carry 0.
+    ZeroDeadline,
 }
 
 impl ChainLiquidationConfigV1 {
@@ -129,6 +152,12 @@ impl ChainLiquidationConfigV1 {
             if self.max_price_age_ns == 0 {
                 return Err(LiquidationConfigError::ZeroPriceAge);
             }
+            if self.settle_stable_decimals == 0 || self.settle_stable_decimals > 36 {
+                return Err(LiquidationConfigError::BadSettleDecimals);
+            }
+            if self.deadline_secs == 0 {
+                return Err(LiquidationConfigError::ZeroDeadline);
+            }
         }
         Ok(())
     }
@@ -151,7 +180,34 @@ mod tests {
             enabled: true,
             max_swap_value_e8s: 2_000 * 100_000_000,
             max_price_age_ns: 1_800_000_000_000,
+            max_dex_oracle_divergence_bps: 500,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
         }
+    }
+
+    #[test]
+    fn config_carries_inc3_swap_fields() {
+        let c = enabled_cfg();
+        assert!(c.max_dex_oracle_divergence_bps > 0);
+        assert!(c.fee_bps > 0);
+        assert_eq!(c.settle_stable_decimals, 18);
+        assert!(c.deadline_secs > 0);
+    }
+
+    #[test]
+    fn enabled_config_rejects_zero_settle_decimals() {
+        let mut c = enabled_cfg();
+        c.settle_stable_decimals = 0;
+        assert_eq!(c.validate(), Err(LiquidationConfigError::BadSettleDecimals));
+    }
+
+    #[test]
+    fn enabled_config_rejects_zero_deadline() {
+        let mut c = enabled_cfg();
+        c.deadline_secs = 0;
+        assert_eq!(c.validate(), Err(LiquidationConfigError::ZeroDeadline));
     }
 
     #[test]
@@ -222,6 +278,10 @@ mod tests {
             enabled: false,
             max_swap_value_e8s: 0,
             max_price_age_ns: 0,
+            max_dex_oracle_divergence_bps: 0,
+            fee_bps: 0,
+            settle_stable_decimals: 0,
+            deadline_secs: 0,
         };
         assert_eq!(c.validate(), Ok(()));
     }

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -525,6 +525,15 @@ pub struct MultiChainStateV6 {
     /// same rationale as the maps above); `#[serde(default)]` is mandatory.
     #[serde(default)]
     pub bot_pending_chain_vaults: BTreeMap<u64, u64>,
+    /// Per-chain realized bad debt (e8s): when a bot swap's realized USDC valued
+    /// in USD is LESS than the debt it was sized to clear, the shortfall
+    /// (debt_to_clear - actual_cleared) is recorded here — reserve_backing is
+    /// NEVER credited more than the realized value (findings #16/#1). Strict
+    /// min-out makes this unreachable on the happy path; the counter exists so a
+    /// structural under-cover is visible, not silent. Added directly to V6
+    /// (pre-deploy); `#[serde(default)]` mandatory.
+    #[serde(default)]
+    pub chain_bad_debt_e8s: BTreeMap<ChainId, u128>,
 }
 
 impl MultiChainStateV6 {

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -409,6 +409,10 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
         enabled: true,
         max_swap_value_e8s: 2_000 * 100_000_000,
         max_price_age_ns: 1_800_000_000_000,
+        max_dex_oracle_divergence_bps: 500,
+        fee_bps: 25,
+        settle_stable_decimals: 18,
+        deadline_secs: 180,
     });
 
     let mut buf = Vec::new();
@@ -428,6 +432,10 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     assert_eq!(cfg.settle_stable_token, "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372");
     assert_eq!(cfg.max_swap_value_e8s, 2_000 * 100_000_000);
     assert_eq!(cfg.max_price_age_ns, 1_800_000_000_000);
+    assert_eq!(cfg.max_dex_oracle_divergence_bps, 500);
+    assert_eq!(cfg.fee_bps, 25);
+    assert_eq!(cfg.settle_stable_decimals, 18);
+    assert_eq!(cfg.deadline_secs, 180);
     // The aggregate accessors reflect the round-tripped reserve/pending terms.
     assert_eq!(decoded.total_reserve_backing_e8s(), 40);
     assert_eq!(decoded.total_pending_chain_burn_e8s(), 15);

--- a/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
@@ -142,12 +142,13 @@ fn has_active_mint_op_true_only_for_live_mint() {
     assert!(!q.has_active_mint_op(), "succeeded mint does not count");
 }
 
-// ─── Increment 2 / Task 5: inert LiquidationSwap op (enqueue-only until Inc 3) ───
+// ─── Increment 3: LiquidationSwap is now actionable (select_next_op no longer skips) ───
 #[test]
-fn liquidation_swap_op_is_skipped_by_select_next_op_until_inc3() {
+fn liquidation_swap_op_is_selectable_in_inc3() {
     use super::evm::settlement::select_next_op;
     let mut q = SettlementQueueV1::default();
-    // Enqueue an inert LiquidationSwap, then a normal Mint after it.
+    // The lowest-op_id Queued op is selected for Submit. A LiquidationSwap enqueued
+    // first is now picked (Inc 2 skipped it; Inc 3 routes it to the swap submit path).
     q.enqueue(SettlementOp::new(
         SettlementOpKind::LiquidationSwap {
             vault_id: 7,
@@ -164,17 +165,11 @@ fn liquidation_swap_op_is_skipped_by_select_next_op_until_inc3() {
         1,
     ))
     .unwrap();
-    q.enqueue(SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xm".into(), amount_e8s: 5, vault_id: 7 },
-        "mint-71-7-2".into(),
-        2,
-    ))
-    .unwrap();
-    // The swap is skipped; the Mint is selected for Submit (no head-of-line block).
-    let (id, _action) = select_next_op(&q).expect("an actionable op");
+    let (id, action) = select_next_op(&q).expect("an actionable op");
     let selected = q.pending.get(&id).unwrap();
     assert!(
-        matches!(selected.kind, SettlementOpKind::Mint { .. }),
-        "swap must be skipped in Inc 2"
+        matches!(selected.kind, SettlementOpKind::LiquidationSwap { .. }),
+        "swap is now selectable in Inc 3"
     );
+    assert!(matches!(action, super::evm::settlement::OpAction::Submit));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -536,6 +536,10 @@ mod begin_liquidation_tests {
                 enabled,
                 max_swap_value_e8s,
                 max_price_age_ns: 1_800_000_000_000,
+                max_dex_oracle_divergence_bps: 500,
+                fee_bps: 25,
+                settle_stable_decimals: 18,
+                deadline_secs: 180,
             },
         );
     }

--- a/src/rumi_protocol_backend/src/guard.rs
+++ b/src/rumi_protocol_backend/src/guard.rs
@@ -237,6 +237,51 @@ impl Drop for VaultLiquidationGuard {
 }
 
 thread_local! {
+    /// Foreign-CHAIN vault ids with a liquidation in flight across an `await`
+    /// (the bot swap: begin -> submit -> confirm). Separate id-space from the
+    /// ICP `LIQUIDATING_VAULTS` (chain vault ids live in
+    /// `MultiChainState.chain_vaults`, keyed independently). Transient/heap;
+    /// ic-cdk `call_on_cleanup` drops the guard even on a post-`await`
+    /// continuation trap, so the lock is always released. The DURABLE lock is the
+    /// persisted `pending_liquidation` marker (spec §10); this heap guard just
+    /// serializes the async swap against concurrent triggers within one canister.
+    static CHAIN_LIQUIDATING_VAULTS: std::cell::RefCell<std::collections::HashSet<u64>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Per-vault lock for a foreign-chain liquidation held across the async swap
+/// (spec §10). Mirrors `VaultLiquidationGuard` but on the chain vault id-space.
+#[must_use]
+pub struct ChainVaultLiquidationGuard(u64);
+
+impl ChainVaultLiquidationGuard {
+    /// Acquire the chain-liquidation lock for `vault_id`. Returns
+    /// `TemporarilyUnavailable` if another liquidation on the same chain vault is
+    /// in flight (the caller must NOT retry — per the no-retry rule it falls
+    /// through to the next tier/manual).
+    pub fn new(vault_id: u64) -> Result<Self, crate::ProtocolError> {
+        CHAIN_LIQUIDATING_VAULTS.with(|set| {
+            let mut set = set.borrow_mut();
+            if set.contains(&vault_id) {
+                return Err(crate::ProtocolError::TemporarilyUnavailable(format!(
+                    "Another liquidation on chain vault #{vault_id} is in flight; retry shortly"
+                )));
+            }
+            set.insert(vault_id);
+            Ok(Self(vault_id))
+        })
+    }
+}
+
+impl Drop for ChainVaultLiquidationGuard {
+    fn drop(&mut self) {
+        CHAIN_LIQUIDATING_VAULTS.with(|set| {
+            set.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
+thread_local! {
     /// In-flight borrow reservations per collateral type (icUSD e8s). A borrow
     /// checks the debt ceiling / global mint cap, then mints icUSD across an
     /// `await`, then records the debt. Concurrent borrows from DIFFERENT owners
@@ -341,6 +386,19 @@ mod vault_liquidation_guard_tests {
         // Once vault 42's liquidation finishes (guard dropped), it can be re-acquired.
         let _g3 = VaultLiquidationGuard::new(42).expect("re-acquire vault 42 after release");
         drop(g2);
+    }
+
+    #[test]
+    fn chain_vault_liquidation_guard_is_exclusive_and_independent_of_icp() {
+        let g1 = ChainVaultLiquidationGuard::new(7).expect("first acquire chain vault 7");
+        assert!(
+            ChainVaultLiquidationGuard::new(7).is_err(),
+            "second concurrent chain liquidation of vault 7 must be rejected",
+        );
+        // Separate id-space from the ICP guard: the same id locks independently.
+        let _icp = VaultLiquidationGuard::new(7).expect("ICP guard for id 7 is independent");
+        drop(g1);
+        let _g2 = ChainVaultLiquidationGuard::new(7).expect("re-acquire chain vault 7 after release");
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -6279,6 +6279,25 @@ async fn get_chain_interest_treasury_address(
         .map_err(|e| ProtocolError::ChainAdmin(format!("derive: {e}")))
 }
 
+/// Increment 3: derive the per-chain liquidation-RESERVE address — the
+/// tECDSA-derived EVM address bot-liquidation swaps settle USDC into (the PSM
+/// sink). Developer-gated. The operator uses this to FIND + FUND the reserve
+/// address and to verify books==custody before bridging (spec §4.8/§5.5).
+#[candid_method(update)]
+#[update]
+async fn get_chain_reserve_address(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<String, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    rumi_protocol_backend::chains::evm::tecdsa::cached_reserve_address(chain)
+        .await
+        .map(|(_path, addr)| addr)
+        .map_err(|e| ProtocolError::ChainAdmin(format!("derive reserve: {e}")))
+}
+
 /// Phase 1b Task 15: tune the Monad inbound observer fan-out interval in
 /// seconds. Default 30. Re-registers in place.
 ///

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1879,19 +1879,21 @@ fn set_chain_liquidation_config(
     config
         .validate()
         .map_err(|e| ProtocolError::ChainAdmin(format!("invalid liquidation config: {e:?}")))?;
-    // Finding #16: the penalty cushion MUST exceed the slippage budget, or a swap
-    // can structurally deliver less stable than the debt it clears (under-cover).
-    // (The max_dex_oracle_divergence_bps term joins this invariant in Increment 3.)
+    // Finding #16: the penalty cushion MUST exceed the slippage + oracle-divergence
+    // budget, or a swap can structurally deliver less stable than the debt it
+    // clears (under-cover). Increment 3 adds the max_dex_oracle_divergence_bps term.
     if config.enabled {
         let penalty_bps = rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)
             .map(|c| c.liquidation_penalty_bps)
             .ok_or_else(|| {
                 ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
             })?;
-        if (config.slippage_cap_bps as u64) >= penalty_bps {
+        let budget_bps =
+            (config.slippage_cap_bps as u64).saturating_add(config.max_dex_oracle_divergence_bps as u64);
+        if budget_bps >= penalty_bps {
             return Err(ProtocolError::ChainAdmin(format!(
-                "slippage_cap_bps {} must be < liquidation_penalty_bps {} (penalty cushion)",
-                config.slippage_cap_bps, penalty_bps
+                "slippage_cap_bps {} + max_dex_oracle_divergence_bps {} must be < liquidation_penalty_bps {} (penalty cushion, finding #16)",
+                config.slippage_cap_bps, config.max_dex_oracle_divergence_bps, penalty_bps
             )));
         }
     }

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
@@ -151,6 +151,12 @@ struct ChainLiquidationConfigV1 {
     enabled: bool,
     max_swap_value_e8s: candid::Nat,
     max_price_age_ns: u64,
+    // Increment 3 fields (the backend struct gained these; the mirror MUST match
+    // or set_chain_liquidation_config fails to decode).
+    max_dex_oracle_divergence_bps: u32,
+    fee_bps: u16,
+    settle_stable_decimals: u8,
+    deadline_secs: u64,
 }
 
 /// Mirror of `main::ChainLiquidatableVault` (the discovery query row).
@@ -376,6 +382,10 @@ fn enabled_liq_config() -> ChainLiquidationConfigV1 {
         enabled: true,
         max_swap_value_e8s: candid::Nat::from(2_000u128 * E8),
         max_price_age_ns: 1_800_000_000_000, // 30 min
+        max_dex_oracle_divergence_bps: 500,
+        fee_bps: 25,
+        settle_stable_decimals: 18,
+        deadline_secs: 180,
     }
 }
 
@@ -598,6 +608,14 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
     assert!(v.pending_liquidation.is_none(), "healthy vault has no liquidation marker");
     assert_supply(&pic, backend, 100 * E8, "after mint");
 
+    // Inc 3: the LiquidationSwap op is now ACTIONABLE (the settlement worker would
+    // submit it). This test is about DETECTION only (the swap submit/confirm is the
+    // conflux_liquidation_swap_pic suite), so idle the settlement timer now (after
+    // the mint confirmed) — the swap op stays Queued and the `pending_liquidation`
+    // marker persists for the detection assertions below. The observer (detection)
+    // timer keeps firing.
+    let _ = update_dev(&pic, backend, "set_settlement_tick_interval_secs", Encode!(&31_536_000u64).unwrap());
+
     // ── Enable the liquidation config (master switch on) ─────────────────────
     decode_result(
         update_dev(
@@ -715,6 +733,13 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
     // (no marker set), and the discovery query fails closed (empty).
     // ════════════════════════════════════════════════════════════════════════
 
+    // Re-enable the settlement timer (it was idled above to keep vault 1's marker
+    // for the detection assertions, which are now done). Vault 2 needs settlement
+    // to mint. Vault 1's Queued swap will now submit + escalate (no DEX reads in
+    // this detection-only test -> getReserves read fails -> Failed, not Inflight),
+    // which is harmless here (vault 1's assertions already ran).
+    let _ = update_dev(&pic, backend, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
     // Refresh the price (re-stamp set_at_ns to "now") so the second vault can OPEN
     // at a healthy CR, then later go underwater while its price ages out.
     decode_result(
@@ -823,11 +848,17 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
         get_vault(&pic, backend, vault2_id).unwrap().pending_liquidation.is_none(),
         "stale price => detection deferred; vault2 NOT marked"
     );
-    // The first vault's marker is untouched; supply still unchanged by detection.
+    // Inc 3: once settlement was re-enabled (for vault 2's mint), vault 1's Queued
+    // swap submitted and ESCALATED (this detection-only test sets no DEX reads, so
+    // getReserves fails -> Failed, collateral restored, marker cleared, sp_attempted).
+    // Detection does NOT re-mark it (sp_attempted exclusion, finding #10). The full
+    // swap-success path is the conflux_liquidation_swap_pic suite.
     assert!(
-        get_vault(&pic, backend, vault_id).unwrap().pending_liquidation.is_some(),
-        "vault 1's marker survives the stale-price tick"
+        get_vault(&pic, backend, vault_id).unwrap().pending_liquidation.is_none(),
+        "vault 1 escalated (no DEX reads) and is not re-marked"
     );
+    // Supply is UNCHANGED throughout: escalation restores collateral, never touches
+    // debt/supply; detection never moves supply.
     assert_supply(&pic, backend, 200 * E8, "after stale-price tick (supply unchanged)");
 
     eprintln!("[liquidation-detection] FULL detection path PASSED: enabled-config-gated observer scan marked an underwater vault (Bot tier, collateral reserved, debt+supply unchanged), the discovery query lists pre-mark / excludes post-mark, the dev gate rejects an anonymous trigger, and a stale price defers detection (no marker, empty query) on chain 71.");

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
@@ -1,0 +1,909 @@
+//! Conflux eSpace testnet (chain 71) Increment-3 Tier-1 bot LIQUIDATION SWAP
+//! end-to-end integration test against the scripted mock EVM RPC canister.
+//!
+//! This is the integration PROOF that the Increment-3 bot SWAP executes the full
+//! two-phase liquidation against the EVM-RPC mock:
+//!
+//!   1. DETECTION (Increment 2, reused verbatim): the observer tick marks an
+//!      underwater Open vault with a `pending_liquidation` (Bot tier) marker,
+//!      reserving its collateral and enqueueing a `LiquidationSwap` op. Debt +
+//!      `chain_supplies` are UNCHANGED at trigger (Design B).
+//!   2. SWAP SUBMIT (Increment 3): the settlement worker reads the DEX
+//!      token0/getReserves at the finalized block, computes a JIT min-out gated by
+//!      the oracle cross-check, nets gas via `fundable_swap_value`, signs with the
+//!      vault's custody key, and broadcasts a `swapExactETHForTokens` to the
+//!      router (CFX in `value`, USDC `to` = the tECDSA reserve address). The op
+//!      goes Inflight.
+//!   3. SWAP CONFIRM (Increment 3): once the receipt is mined + final, the worker
+//!      reads the REALIZED USDC output from the `Transfer(_, reserve, amount)` log
+//!      (never min-out) and moves `debt_e8s -> reserve_backing_e8s` (the ONLY
+//!      invariant move — NO icUSD burned, this is a PSM). The vault drains fully
+//!      to debt 0 and Closes; `chain_supplies` is UNCHANGED.
+//!
+//! The reserve is BACKING, not unbacked supply (findings #17/#20/#29):
+//! `reconcile_chain_supply` reports `reserve_backing_e8s` + `reserve_usdc_native`
+//! as informational RHS terms and `unbacked_excess == false` (on-chain totalSupply
+//! still == recorded chain supply).
+//!
+//! Harness (boot, register_chain, deposit->mint->Open sequence, ECDSA-gating,
+//! supply invariant, candid mirrors) is COPIED from
+//! `conflux_liquidation_detection_pic.rs`. As in that test, the flow PROBES ECDSA
+//! via `get_chain_settlement_address`; if ECDSA is unavailable in this PocketIC
+//! build it runs a GATED subset (which still proves the new config fields decode +
+//! the reserve/settlement address endpoints signal ECDSA-unavailable) and returns
+//! early. The swap is NEVER faked.
+
+use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::time::Duration;
+
+// ─── Locally-mirrored backend types (shapes mirror src/.../*.rs exactly) ─────
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+    treasury_principal: Option<Principal>,
+    stability_pool_principal: Option<Principal>,
+    ckusdt_ledger_principal: Option<Principal>,
+    ckusdc_ledger_principal: Option<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArg {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+struct ChainId(u32);
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum GasStrategy {
+    EvmEip1559 {
+        max_priority_fee_gwei: u64,
+        max_fee_gwei_ceiling: u64,
+    },
+    EvmLegacy {
+        gas_price_gwei_ceiling: u64,
+    },
+    SolanaPriorityFee {
+        lamports_per_cu_ceiling: u64,
+    },
+    NotApplicable,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct RegisterChainArg {
+    chain_id: ChainId,
+    display_name: String,
+    rpc_endpoints: Vec<String>,
+    finality_depth: u32,
+    gas_strategy: GasStrategy,
+    chain_native_decimals: u8,
+    min_quorum_providers: Option<u32>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum ChainVaultStatus {
+    AwaitingDeposit,
+    MintPending,
+    Open,
+    Closing,
+    Closed,
+}
+
+// ─── Liquidation mirrors ──────────────────────────────────────────────────────
+
+/// Mirror of `chains::vault::LiquidationTier`.
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+enum LiquidationTier {
+    Bot,
+    StabilityPool,
+}
+
+/// Mirror of `chains::vault::PendingLiquidationV1` (the in-flight marker).
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct PendingLiquidationV1 {
+    op_id: u64,
+    debt_to_clear_e8s: candid::Nat,
+    collateral_reserved_native: candid::Nat,
+    tier: LiquidationTier,
+    started_at_ns: u64,
+}
+
+/// Mirror of `chains::vault::ChainVaultV1`, EXTENDED with `pending_liquidation`.
+/// Candid records decode by field name and ignore extra wire fields, so the
+/// happy-path subset of fields + the marker field is sufficient. NOTE: the wire
+/// field for the native collateral amount is `collateral_amount_e18`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainVaultV1 {
+    vault_id: u64,
+    owner: Principal,
+    collateral_chain: ChainId,
+    custody_address: String,
+    collateral_amount_e18: candid::Nat,
+    debt_e8s: candid::Nat,
+    mint_recipient: String,
+    pending_mint_e8s: candid::Nat,
+    status: ChainVaultStatus,
+    opened_at_ns: u64,
+    owner_evm: Option<String>,
+    pending_liquidation: Option<PendingLiquidationV1>,
+}
+
+/// Mirror of `chains::liquidation_config::DexKind`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum DexKind {
+    UniswapV2,
+}
+
+/// Mirror of `chains::liquidation_config::ChainLiquidationConfigV1`, INCLUDING the
+/// Increment-2 fields (`max_swap_value_e8s`, `max_price_age_ns`) AND the four
+/// Increment-3 fields (`max_dex_oracle_divergence_bps`, `fee_bps`,
+/// `settle_stable_decimals`, `deadline_secs`). Field set + types verified against
+/// `rumi_protocol_backend.did`'s `type ChainLiquidationConfigV1`.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainLiquidationConfigV1 {
+    dex: DexKind,
+    router: String,
+    factory: String,
+    pair: String,
+    collateral_token: String,
+    settle_stable_token: String,
+    slippage_cap_bps: u16,
+    restore_target_cr_e4: u64,
+    enabled: bool,
+    max_swap_value_e8s: candid::Nat,
+    max_price_age_ns: u64,
+    // ── Increment 3 ──
+    max_dex_oracle_divergence_bps: u32,
+    fee_bps: u16,
+    settle_stable_decimals: u8,
+    deadline_secs: u64,
+}
+
+/// Mirror of `main::ChainSupplyReconciliation`. Field set + types verified against
+/// `rumi_protocol_backend.did`'s `type ChainSupplyReconciliation` (10 fields). The
+/// swap assertions only read `reserve_backing_e8s` / `reserve_usdc_native` /
+/// `unbacked_excess`, but the full field set is mirrored so candid decodes.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainSupplyReconciliation {
+    chain_id: ChainId,
+    finalized_block: u64,
+    onchain_total_supply_e8s: candid::Nat,
+    recorded_supply_e8s: candid::Nat,
+    in_flight_mint_e8s: candid::Nat,
+    unbacked_excess: bool,
+    gap_e8s: candid::Int,
+    reserve_backing_e8s: candid::Nat,
+    pending_chain_burn_e8s: candid::Nat,
+    reserve_usdc_native: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditEntryWire {
+    chain_id: u32,
+    display_name: String,
+    supply_e8s: candid::Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SupplyAuditWire {
+    total_e8s: candid::Nat,
+    per_chain: Vec<SupplyAuditEntryWire>,
+}
+
+/// Minimal mirror of `ProtocolError`: the chain endpoints here only ever return
+/// `ChainAdmin(text)` or (on ECDSA-derive failures) the same. Any other variant
+/// fails the Candid decode loudly (the correct signal that something unexpected
+/// happened). `TemporarilyUnavailable`/`EvmAuth` are included for completeness so
+/// a transient reconcile error decodes rather than mis-tags.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolError {
+    ChainAdmin(String),
+    EvmAuth(String),
+    TemporarilyUnavailable(String),
+}
+
+// ─── Wasm loaders ────────────────────────────────────────────────────────────
+
+fn backend_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn mock_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CONFLUX_CHAIN_ID: u32 = 71;
+const E18: u128 = 1_000_000_000_000_000_000;
+const E8: u128 = 100_000_000;
+/// keccak256("Mint(uint256,address,uint256)"), must match evm_rpc.rs.
+const MINT_EVENT_TOPIC0: &str =
+    "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+/// keccak256("Transfer(address,address,uint256)"), must match evm_rpc.rs.
+const TRANSFER_TOPIC0: &str =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+/// UniswapV2 pair `token0()` selector (must match evm_rpc.rs `TOKEN0_SELECTOR`).
+const TOKEN0_SELECTOR: &str = "0x0dfe1681";
+/// UniswapV2 pair `getReserves()` selector (must match `GET_RESERVES_SELECTOR`).
+const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
+
+/// Conflux register arg's `finality_depth` (mirrors conflux_testnet_register_arg()).
+const CONFLUX_FINALITY_DEPTH: u64 = 100;
+/// Observer block-scan window (`MAX_BLOCK_SCAN_WINDOW`).
+const SCAN_WINDOW: u64 = 1024;
+
+/// The specific DEX wiring addresses (valid 42-char 0x). The collateral_token and
+/// settle_stable_token are REUSED below for the canned DEX reads + the Transfer
+/// log contract, so they must be byte-identical everywhere.
+const DEX_ROUTER: &str = "0x1111111111111111111111111111111111111111";
+const DEX_FACTORY: &str = "0x2222222222222222222222222222222222222222";
+const DEX_PAIR: &str = "0x3333333333333333333333333333333333333333";
+/// WCFX (the collateral token + path[0]).
+const WCFX: &str = "0x14b2d3bc65e74dae1030eafd8ac30c533c976a9b";
+/// USDC (the settle stable token + path[1]); 18-dec on eSpace.
+const USDC: &str = "0x6963efed0ab40f6c3d7bda44a05dcf1437c44372";
+
+// ─── PocketIC call helpers ───────────────────────────────────────────────────
+
+fn dev() -> Principal {
+    Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
+}
+
+fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
+where
+    T: CandidType + for<'a> Deserialize<'a>,
+{
+    let reply = pic
+        .query_call(
+            cid,
+            Principal::anonymous(),
+            method,
+            encode_one(()).expect("encode unit"),
+        )
+        .expect("query call");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, T).expect("decode reply"),
+        WasmResult::Reject(msg) => panic!("query {} rejected: {}", method, msg),
+    }
+}
+
+fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, dev(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+    pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn decode_result(reply: WasmResult, method: &str) -> Result<(), ProtocolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), ProtocolError>)
+            .unwrap_or_else(|e| panic!("decode {} Result: {}", method, e)),
+        WasmResult::Reject(msg) => panic!("{} rejected: {}", method, msg),
+    }
+}
+
+// ─── Boot: II subnet (for tECDSA) + application subnet (backend + mock) ───────
+
+fn boot() -> (PocketIc, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: mgmt,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: None,
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+
+    // Pin observer + settlement cadence to 30s (code default is 300s).
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
+    (pic, backend_id, mock_id)
+}
+
+/// Tick the canister timers across `windows` 35s windows so the observer (Timer
+/// A) and settlement (Timer D) timers fire and their async futures run.
+fn advance_and_tick(pic: &PocketIc, windows: u32) {
+    for _ in 0..windows {
+        pic.advance_time(Duration::from_secs(35));
+        for _ in 0..10 {
+            pic.tick();
+        }
+    }
+}
+
+// ─── Supply-invariant assertion (PSM: a liquidation swap does NOT move supply) ─
+
+fn assert_supply(pic: &PocketIc, cid: Principal, expected_e8s: u128, step: &str) {
+    let global: candid::Nat = query_unit(pic, cid, "get_global_icusd_supply");
+    assert_eq!(
+        global,
+        candid::Nat::from(expected_e8s),
+        "[{step}] get_global_icusd_supply mismatch"
+    );
+
+    let audit: SupplyAuditWire = query_unit(pic, cid, "get_supply_audit");
+    assert_eq!(
+        audit.total_e8s,
+        candid::Nat::from(expected_e8s),
+        "[{step}] supply_audit.total mismatch"
+    );
+    let sum: candid::Nat = audit
+        .per_chain
+        .iter()
+        .fold(candid::Nat::from(0u32), |acc, e| acc + e.supply_e8s.clone());
+    assert_eq!(audit.total_e8s, sum, "[{step}] audit total != sum(per_chain)");
+
+    if let Some(conflux) = audit.per_chain.iter().find(|e| e.chain_id == CONFLUX_CHAIN_ID) {
+        assert_eq!(
+            conflux.supply_e8s,
+            candid::Nat::from(expected_e8s),
+            "[{step}] Conflux per-chain supply mismatch"
+        );
+    }
+}
+
+// ─── 32-byte ABI word encoding for log topics / data / eth_call returns ───────
+
+fn word_u128(v: u128) -> String {
+    format!("0x{:064x}", v)
+}
+
+fn word_addr(addr: &str) -> String {
+    let raw = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    format!("0x{:0>64}", raw.to_lowercase())
+}
+
+// ─── liquidation config builder (ENABLED, with the Increment-3 fields) ────────
+
+/// The ENABLED Conflux liquidation config used throughout this test. Uses the
+/// SPECIFIC WCFX/USDC token addresses (reused for the canned DEX reads + the
+/// realized Transfer log). 18-dec USDC, 0.25% pool fee, 2.5% slippage cap, 5%
+/// oracle-divergence ceiling, 155% restore target, $2k depth cap, 30-min
+/// staleness ceiling, 180s on-chain deadline.
+fn enabled_liq_config() -> ChainLiquidationConfigV1 {
+    ChainLiquidationConfigV1 {
+        dex: DexKind::UniswapV2,
+        router: DEX_ROUTER.to_string(),
+        factory: DEX_FACTORY.to_string(),
+        pair: DEX_PAIR.to_string(),
+        collateral_token: WCFX.to_string(),
+        settle_stable_token: USDC.to_string(),
+        slippage_cap_bps: 250,
+        restore_target_cr_e4: 15_500,
+        enabled: true,
+        max_swap_value_e8s: candid::Nat::from(2_000u128 * E8),
+        max_price_age_ns: 1_800_000_000_000, // 30 min
+        max_dex_oracle_divergence_bps: 500,
+        fee_bps: 25,
+        settle_stable_decimals: 18,
+        deadline_secs: 180,
+    }
+}
+
+// ─── The test ────────────────────────────────────────────────────────────────
+
+#[test]
+fn conflux_liquidation_swap_executes_and_credits_reserve() {
+    let (pic, backend, mock) = boot();
+
+    // ── Step 1: point the backend's EVM wrapper at the mock + Conflux quirks ──
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+    update_any(&pic, mock, "set_getlogs_max_range", Encode!(&1000u64).unwrap());
+    update_any(&pic, mock, "set_espace_receipt_fields", Encode!(&true).unwrap());
+
+    // ── Step 2: register Conflux + contract + manual CFX price ($0.15) ───────
+    let reg = RegisterChainArg {
+        chain_id: ChainId(CONFLUX_CHAIN_ID),
+        display_name: "ConfluxESpaceTestnet".to_string(),
+        rpc_endpoints: vec!["https://evmtestnet.confluxrpc.com".to_string()],
+        finality_depth: CONFLUX_FINALITY_DEPTH as u32,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 1,
+            max_fee_gwei_ceiling: 100,
+        },
+        chain_native_decimals: 18,
+        min_quorum_providers: Some(1),
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"0x00000000000000000000000000000000cf1c0de5".to_string())
+                .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+
+    // $0.15 / CFX in e8 => 15_000_000. Healthy price for the open.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &15_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    // ── Seed the burn-watch cursor + enable poll-scan (harness parity) ───────
+    let seed: u64 = 1_000_000;
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &seed).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
+
+    assert_supply(&pic, backend, 0, "after register/config");
+
+    // ── Block plan (finality_depth = 100) ────────────────────────────────────
+    // The mint receipt + log AND the swap receipt + Transfer log all land at the
+    // SAME finalized cursor (cursor1), the deepest block the observer + settlement
+    // finality gate treat as final.
+    let cursor1 = seed + SCAN_WINDOW;
+    let head1 = cursor1 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head1, &head1).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxmint1".to_string()).unwrap());
+
+    // ── ECDSA probe: decide full vs gated ────────────────────────────────────
+    let settlement_addr = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            Ok(Err(e)) => {
+                eprintln!("[swap] ECDSA UNAVAILABLE (get_chain_settlement_address returned Err: {e:?}); running GATED subset");
+                None
+            }
+            Err(decode_err) => {
+                eprintln!("[swap] get_chain_settlement_address decode error ({decode_err}); running GATED subset");
+                None
+            }
+        },
+        WasmResult::Reject(msg) => {
+            eprintln!("[swap] ECDSA UNAVAILABLE (get_chain_settlement_address rejected: {msg}); running GATED subset");
+            None
+        }
+    };
+
+    let settlement_addr = match settlement_addr {
+        Some(addr) => {
+            eprintln!("[swap] ECDSA AVAILABLE; settlement address = {addr}; running FULL swap path");
+            addr
+        }
+        None => {
+            // ── GATED subset: the new config (incl. the 4 Increment-3 fields)
+            // decodes + round-trips, and the reserve/settlement address endpoints
+            // correctly signal ECDSA-unavailable. We do NOT fake the swap.
+            decode_result(
+                update_dev(
+                    &pic,
+                    backend,
+                    "set_chain_liquidation_config",
+                    Encode!(&ChainId(CONFLUX_CHAIN_ID), &enabled_liq_config()).unwrap(),
+                ),
+                "set_chain_liquidation_config",
+            )
+            .expect("gated: set_chain_liquidation_config (proves the 4 Inc-3 fields decode)");
+
+            let cfg = get_liq_config(&pic, backend).expect("gated: config round-trips");
+            assert_eq!(cfg.max_dex_oracle_divergence_bps, 500, "gated: divergence bps round-trips");
+            assert_eq!(cfg.fee_bps, 25, "gated: fee_bps round-trips");
+            assert_eq!(cfg.settle_stable_decimals, 18, "gated: settle decimals round-trips");
+            assert_eq!(cfg.deadline_secs, 180, "gated: deadline_secs round-trips");
+            assert_eq!(cfg.collateral_token, WCFX, "gated: collateral_token round-trips");
+            assert_eq!(cfg.settle_stable_token, USDC, "gated: settle_stable_token round-trips");
+            assert!(cfg.enabled, "gated: enabled round-trips");
+
+            // The reserve-address endpoint must ALSO signal ECDSA-unavailable.
+            match get_reserve_address(&pic, backend) {
+                Err(_) => { /* expected: ECDSA off */ }
+                Ok(a) => panic!("gated: reserve address returned Ok({a}) but settlement ECDSA was unavailable"),
+            }
+
+            assert_supply(&pic, backend, 0, "gated: ECDSA unavailable, invariant at 0");
+            eprintln!("[swap] ECDSA unavailable; ran gated subset (Inc-3 config decodes; reserve/settlement signal ECDSA-off)");
+            return;
+        }
+    };
+
+    // ════════════════════════════════════════════════════════════════════════
+    // FULL SWAP PATH (ECDSA available)
+    // ════════════════════════════════════════════════════════════════════════
+
+    // Fund the settlement (hot-wallet) address so the mint submit-path gas gate passes.
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000_000u128 * E18)).unwrap(),
+    );
+
+    // ── Step 1: Open a vault (1400 CFX @ $0.15 = $210 backing 100 icUSD = 210% CR) ──
+    let collateral_e18 = 1_400u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(CONFLUX_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault exists after open");
+    assert_eq!(v.status, ChainVaultStatus::AwaitingDeposit, "open => AwaitingDeposit");
+    let custody = v.custody_address.clone();
+    assert_supply(&pic, backend, 0, "after open (AwaitingDeposit)");
+
+    // ── deposit -> MintPending -> mint confirm (Open, supply 100e8) ──────────
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(&pic, 2);
+    assert_eq!(
+        get_vault(&pic, backend, vault_id).unwrap().status,
+        ChainVaultStatus::MintPending,
+        "deposit verified => MintPending"
+    );
+
+    advance_and_tick(&pic, 1); // submit mint (Queued -> Inflight)
+    update_any(
+        &pic,
+        mock,
+        "set_receipt",
+        Encode!(&"0xcfxmint1".to_string(), &true, &cursor1).unwrap(),
+    );
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xcfxmint1", cursor1);
+    advance_and_tick(&pic, 4); // confirm mint
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after mint confirm");
+    assert_eq!(v.status, ChainVaultStatus::Open, "mint confirmed => Open");
+    assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "mint confirmed => debt 100e8");
+    assert!(v.pending_liquidation.is_none(), "healthy vault has no liquidation marker");
+    assert_supply(&pic, backend, 100 * E8, "after mint");
+
+    // ── Step 2: learn the reserve address (the swap's USDC `to` + Transfer match) ──
+    // Derived from the tECDSA reserve key — independent of any vault state, so it is
+    // resolved up front (before detection) and reused to seed the canned reads.
+    let reserve = match get_reserve_address(&pic, backend) {
+        Ok(a) => a.to_lowercase(),
+        Err(e) => {
+            // ECDSA derived the SETTLEMENT address above but not the RESERVE
+            // address: we are in the gated regime after all. Bail honestly.
+            eprintln!("[swap] reserve address derive Err ({e:?}) despite settlement ECDSA; running gated subset");
+            return;
+        }
+    };
+    eprintln!("[swap] reserve address = {reserve}");
+
+    // ── Step 3: seed everything the swap SUBMIT reads, BEFORE detection ───────
+    // The settlement worker can pick up the freshly-enqueued LiquidationSwap op on
+    // the very next tick after detection marks it (both timers fire in the same
+    // advance_and_tick window). If the DEX reads / custody balance / send-hash are
+    // not in place by then, the swap fail-closes (escalates) and clears the marker.
+    // So seed them all FIRST, then drop the price to trigger detection.
+
+    // 3a. Fund custody so the swap is fundable (>= 1400 CFX collateral + gas).
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(2_000u128 * E18)).unwrap(),
+    );
+    // 3b. token0() == collateral_token (WCFX), ABI-encoded as a single 32-byte word.
+    update_any(
+        &pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&TOKEN0_SELECTOR.to_string(), &word_addr(WCFX)).unwrap(),
+    );
+    // 3c. getReserves() -> (reserve0, reserve1, ts). token0 == WCFX so reserve0 =
+    // WCFX reserve, reserve1 = USDC reserve. A DEEP pool priced at $0.08/CFX so the
+    // oracle cross-check passes: 1e24 WCFX vs 8e22 USDC (8e22/1e24 = 0.08).
+    let reserve0_wcfx = 1_000_000u128 * E18; // 1e24
+    let reserve1_usdc = 80_000u128 * E18; // 8e22
+    let getreserves_blob = format!(
+        "0x{:064x}{:064x}{:064x}",
+        reserve0_wcfx, reserve1_usdc, 0u128
+    );
+    update_any(
+        &pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_RESERVES_SELECTOR.to_string(), &getreserves_blob).unwrap(),
+    );
+    // 3d. The hash the swap broadcast returns (so the confirm can match it).
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxswap1".to_string()).unwrap());
+
+    // ── Step 4: enable the liquidation config + drop the price to $0.08 ──────
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_liquidation_config",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &enabled_liq_config()).unwrap(),
+        ),
+        "set_chain_liquidation_config",
+    )
+    .expect("set_chain_liquidation_config Ok");
+
+    // $0.08 / CFX => 1400 * 0.08 = $112 vs 100 debt => CR ~112% < 133%.
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &8_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price (drop)",
+    )
+    .expect("set_manual_collateral_price (drop)");
+
+    // ── Step 5: observer tick marks the vault (Bot tier; collateral reserved) +
+    // the settlement worker SUBMITS the swap (DEX reads + JIT min-out + oracle
+    // gate, all seeded above) -> the op goes Inflight, the marker persists. ─────
+    advance_and_tick(&pic, 3);
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after detection + swap submit");
+    let marker = v
+        .pending_liquidation
+        .clone()
+        .expect("detection set a pending_liquidation marker (NOT escalated: the swap broadcast)");
+    assert_eq!(marker.tier, LiquidationTier::Bot, "Tier-1 bot liquidation");
+    assert!(
+        marker.debt_to_clear_e8s > candid::Nat::from(0u32),
+        "marker sized to clear a non-zero debt"
+    );
+    // The full $112 of collateral covers the full $100 debt at the 1.12x bonus, so
+    // the entire 1400 CFX is reserved and the vault's remaining collateral is 0.
+    assert_eq!(
+        v.collateral_amount_e18,
+        candid::Nat::from(0u32),
+        "all collateral reserved (full liquidation): remaining collateral == 0"
+    );
+    assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "debt UNCHANGED at trigger (Design B)");
+    assert_eq!(v.status, ChainVaultStatus::Open, "vault stays Open under the marker");
+    assert_supply(&pic, backend, 100 * E8, "after detection + swap submit (supply unchanged)");
+
+    // ── Step 6: provide the realized-USDC Transfer log + receipt at the cursor ─
+    // The confirm reads the receipt (mined+final) then queries eth_getLogs on the
+    // USDC token for TRANSFER_TOPIC0 at [cursor1, cursor1]. The mock's get_logs
+    // filters by topic0 + block range (NOT contract address), so a push_log with
+    // the Transfer topic0 + the reserve `to` topic at cursor1 is returned.
+    update_any(
+        &pic,
+        mock,
+        "set_receipt",
+        Encode!(&"0xcfxswap1".to_string(), &true, &cursor1).unwrap(),
+    );
+    // realized = 110 USDC (18-dec) > the 100 icUSD debt; from(any), to(reserve).
+    let realized_usdc_native = 110u128 * E18;
+    let transfer_topics = vec![
+        TRANSFER_TOPIC0.to_string(),
+        word_addr("0x000000000000000000000000000000000000babe"), // from (any)
+        word_addr(&reserve),                                     // to == reserve
+    ];
+    update_any(
+        &pic,
+        mock,
+        "push_log",
+        Encode!(
+            &transfer_topics,
+            &word_u128(realized_usdc_native),
+            &"0xcfxswap1".to_string(),
+            &cursor1
+        )
+        .unwrap(),
+    );
+    advance_and_tick(&pic, 4); // confirm the swap (Phase 2: debt -> reserve)
+
+    // ════════════════════════════════════════════════════════════════════════
+    // HAPPY-PATH ASSERTIONS
+    // ════════════════════════════════════════════════════════════════════════
+    let v = get_vault(&pic, backend, vault_id).expect("vault after swap confirm");
+    assert_eq!(v.debt_e8s, candid::Nat::from(0u32), "swap cleared the full debt => debt_e8s 0");
+    assert_eq!(
+        v.status,
+        ChainVaultStatus::Closed,
+        "fully drained (debt 0 + collateral 0) => Closed"
+    );
+    assert!(
+        v.pending_liquidation.is_none(),
+        "swap settled => pending_liquidation marker cleared"
+    );
+
+    // PSM: NO icUSD burned. chain_supplies is UNCHANGED across the whole swap.
+    assert_supply(&pic, backend, 100 * E8, "after swap confirm (PSM: supply unchanged)");
+
+    // Reserve credited: reconcile reads on-chain totalSupply (== recorded => no
+    // unbacked excess) and reports the reserve backing + physical USDC.
+    update_any(&pic, mock, "set_total_supply", Encode!(&(100u128 * E8)).unwrap());
+    let recon = reconcile_chain_supply(&pic, backend).expect("reconcile_chain_supply Ok");
+    assert_eq!(
+        recon.reserve_backing_e8s,
+        candid::Nat::from(100u128 * E8),
+        "reserve_backing_e8s == the cleared debt (100e8)"
+    );
+    assert_eq!(
+        recon.reserve_usdc_native,
+        candid::Nat::from(110u128 * E18),
+        "reserve_usdc_native == the realized USDC (110e18)"
+    );
+    assert!(
+        !recon.unbacked_excess,
+        "reserve is BACKING, not unbacked supply (findings #17/#20/#29): unbacked_excess == false"
+    );
+
+    eprintln!("[swap] FULL swap path PASSED: detection marked an underwater vault (Bot tier, all collateral reserved), the settlement worker SUBMITTED swapExactETHForTokens (DEX reads + JIT min-out + oracle gate) and CONFIRMED it (decoded the realized 110 USDC Transfer to the reserve), moving 100e8 debt -> reserve_backing (vault Closed, debt 0). chain_supplies UNCHANGED (PSM, no icUSD burned); reconcile reports reserve_backing=100e8, reserve_usdc=110e18, unbacked_excess=false on chain 71.");
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_vault",
+            Encode!(&vault_id).unwrap(),
+        )
+        .expect("get_chain_vault query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Option<ChainVaultV1>).expect("decode get_chain_vault"),
+        WasmResult::Reject(msg) => panic!("get_chain_vault rejected: {msg}"),
+    }
+}
+
+fn get_liq_config(pic: &PocketIc, backend: Principal) -> Option<ChainLiquidationConfigV1> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_liquidation_config",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_chain_liquidation_config query");
+    match reply {
+        WasmResult::Reply(b) => {
+            Decode!(&b, Option<ChainLiquidationConfigV1>).expect("decode get_chain_liquidation_config")
+        }
+        WasmResult::Reject(msg) => panic!("get_chain_liquidation_config rejected: {msg}"),
+    }
+}
+
+fn get_reserve_address(pic: &PocketIc, backend: Principal) -> Result<String, ProtocolError> {
+    match update_dev(
+        pic,
+        backend,
+        "get_chain_reserve_address",
+        Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => {
+            Decode!(&b, Result<String, ProtocolError>).expect("decode get_chain_reserve_address")
+        }
+        WasmResult::Reject(msg) => {
+            // A transport-level reject (ECDSA off in this build) => treat as Err.
+            Err(ProtocolError::ChainAdmin(format!("reject: {msg}")))
+        }
+    }
+}
+
+fn reconcile_chain_supply(
+    pic: &PocketIc,
+    backend: Principal,
+) -> Result<ChainSupplyReconciliation, ProtocolError> {
+    match update_dev(
+        pic,
+        backend,
+        "reconcile_chain_supply",
+        Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<ChainSupplyReconciliation, ProtocolError>)
+            .expect("decode reconcile_chain_supply"),
+        WasmResult::Reject(msg) => panic!("reconcile_chain_supply rejected: {msg}"),
+    }
+}
+
+fn push_mint_log(
+    pic: &PocketIc,
+    mock: Principal,
+    vault_id: u64,
+    recipient: &str,
+    amount_e8s: u128,
+    tx_hash: &str,
+    block: u64,
+) {
+    let topics = vec![
+        MINT_EVENT_TOPIC0.to_string(),
+        word_u128(vault_id as u128),
+        word_addr(recipient),
+    ];
+    let data = word_u128(amount_e8s);
+    update_any(
+        pic,
+        mock,
+        "push_log",
+        Encode!(&topics, &data, &tx_hash.to_string(), &block).unwrap(),
+    );
+}


### PR DESCRIPTION
## Chains Liquidation — Increment 3: Tier-1 bot swap execution (tECDSA Swappi swap)

Fourth increment of the chains-rail liquidation engine. Makes the Tier-1 bot liquidation **execute**: the `LiquidationSwap` op (enqueued inert in Inc 2) now SUBMITS a `swapExactETHForTokens` signed by the vault's tECDSA custody key (native CFX → USDC into a protocol reserve address), CONFIRMS it (decoding the realized USDC `Transfer` log), and moves `debt_e8s → reserve_backing_e8s` via the Inc-1 `apply_debt_to_reserve_shift`. **icUSD supply is unchanged throughout (PSM model).** Built TDD-first, one commit per task; tested end-to-end against the EVM-RPC mock.

Plan: `docs/superpowers/plans/2026-06-21-chains-liquidation-increment-3.md`. Spec: `docs/superpowers/specs/2026-06-19-chains-liquidation-design.md` (§4.8/§4.9/§5/§8). Follows Inc 0 (#261), Inc 1 (#262), Inc 2 (#263).

### Ships disabled-by-default — NOT live
Detection + swap are gated behind the per-chain `ChainLiquidationConfigV1.enabled` master switch (default false). **Going live is an operator ENABLE step, not done here:** it requires the REAL Swappi router address, a confirmation of the deployed router's function selector, chain-1030 onboarding (a liquidation config row + `set_manual_collateral_price(1030,…)`), funding the tECDSA reserve address, and a mainnet-fork dry-run. This PR is **not deployed**.

### What landed (per task)
- **Config + chain target:** `ChainLiquidationConfigV1` gains `fee_bps`, `max_dex_oracle_divergence_bps`, `settle_stable_decimals`, `deadline_secs`; the setter's penalty-cushion invariant extends to `penalty > slippage + divergence` (#16); a `1030` (Conflux mainnet) collateral row is added so the rail is onboarding-ready (#23). Tests stay on 71 + mock.
- **Pure swap math:** `compute_amount_out_min` (V2 constant-product + fee + slippage haircut), the oracle cross-check, and `stable_native_to_e8s` — all unit-tested.
- **ABI encoder:** the dynamic `address[]` `swapExactETHForTokens` calldata encoder + `MonadTxKind::Swap` — pinned byte-for-byte by a reference-vector test (the only dynamic-type ABI encode in the codebase, highest encoder-bug risk per #31). Selector is canonical UniV2 `0x7ff36ab5` — **operator must confirm the deployed router selector before enabling.**
- **DEX reads:** `getReserves`/`token0`/`erc20_balanceOf` pinned to a FINALIZED block (#13 — a "latest" read fails the multi-provider quorum) + the `Transfer` log decode for the realized output.
- **Reserve address:** tECDSA-derived `cached_reserve_address` (the PSM sink) + a `get_chain_reserve_address` dev query so the operator can fund it. Not a config field.
- **Guard:** `ChainVaultLiquidationGuard` (per-vault async-swap lock, separate id-space).
- **Phase 2:** `apply_liquidation_settlement_in_state` clamps `actual_cleared = min(debt_to_clear, live_debt, realized_usd)` so `reserve_backing` NEVER exceeds the real USDC received; any shortfall goes to a new per-chain `chain_bad_debt_e8s` counter (#16/#1/#19). State-only (events emitted by the caller).
- **Confirm-timeout:** a net-new swap-kind timeout-to-Failed (#12/#22) — a never-mined swap can't wedge the vault marker (swaps are excluded from replace-by-fee).
- **Submit + confirm wiring:** the live-reserves JIT min-out + oracle gate at submit, the Transfer-decode → Phase 2 at confirm; every failure path (reserves err/zero, min-out 0, oracle divergence, gas, on-chain revert, never-mined timeout) is fail-closed — restore the reserved collateral under a marker-CAS, clear the marker, mark `sp_attempted`, and escalate (the Tier-2 SP consumer is Inc 4; until then it falls to Tier-3 manual). No bot retry loop (#10).
- **No new Event variants:** failures reuse `ChainSettlementFailed`; Phase-2 success reuses the Inc-1 `ChainVaultLiquidated` + `ChainReserveCredited`.

### Tests
- `cargo test -p rumi_protocol_backend --lib`: green (574+ — sizing/encoder-reference/DEX-parse/Phase-2/timeout/guard/escalation unit tests).
- `--bin`: green incl. `check_candid_interface_compatibility`.
- PocketIC (vs the EVM-RPC mock): the existing 3 suites (no regression) + a new `conflux_liquidation_swap_pic` — detection marks an underwater vault, the worker submits + confirms the swap, and asserts `debt_e8s` ↓, **`chain_supplies` UNCHANGED**, `reserve_backing_e8s` += cleared, `reserve_usdc_native` += realized, `unbacked_excess` false, vault Closed/reopened.

### Candid
Additive only: the 4 new `ChainLiquidationConfigV1` fields + `get_chain_reserve_address`. `SettlementOpKind::LiquidationSwap` is not on the candid surface (no `.did` change). **No new Event variant.** **Heads-up: the 4 new config fields are input-record additions → the same owner-gated `--yes` candid wall as Inc 2 (you run the install).**

### Findings folded in
#1/#16/#19 (Phase-2 clamp + bad-debt), #12/#22 (confirm-timeout), #13 (finalized-block reserves), #14 (bounded by the timeout), #23 (1030 row), #31 (reference-vector encoder + router-selector caveat), #39 (250k gas ceiling), #17/#20/#29 (reconcile reserve fields informational, not in `unbacked_excess`), #10 (escalation loop-breaker).

Deferred: Tier-2 SP absorb/burn/claim (#4/#6/#8/#9/#18/#21/#25/#27/#28/#30) → Inc 4; `settle_reserve_burn` + bridge reconciliation + surplus recognition (#35, §5.5) → Inc 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
