### PR TITLE
fix(conflux-frontend): EIP-6963 multi-wallet picker (Rabby support)

### DIFF
--- a/src/conflux_espace_frontend/src/App.svelte
+++ b/src/conflux_espace_frontend/src/App.svelte
@@ -3,8 +3,11 @@
   import { backend, errText, type ChainVault } from "./backend";
   import { signIntent, toCandidIntent, type VaultIntentInput } from "./eip712";
   import {
-    connectMetaMask, connectDevKey, hasMetaMask, sendDeposit, burnIcusd, icusdBalance, cfxBalance,
-    fmtCfx, fmtIcusd, parseEther, toE8s, txUrl, type Wallet,
+    connectInjected, connectLegacyInjected, connectDevKey, hasLegacyInjected,
+    getInjectedWallets, subscribeWallets, refreshInjectedWallets,
+    sendDeposit, burnIcusd, icusdBalance, cfxBalance,
+    fmtCfx, fmtIcusd, parseEther, toE8s, txUrl,
+    type Wallet, type EIP6963ProviderDetail,
   } from "./evm";
   import VaultCard from "./VaultCard.svelte";
 
@@ -17,6 +20,14 @@
   let busy = $state<string | null>(null);
   let err = $state<string | null>(null);
   let ok = $state<string | null>(null);
+
+  // EIP-6963: discovered injected wallets (Rabby, MetaMask, ...). The list grows as
+  // wallets announce; we re-request on mount in case one injected after page load.
+  let injectedWallets = $state<EIP6963ProviderDetail[]>(getInjectedWallets());
+  $effect(() => {
+    refreshInjectedWallets();
+    return subscribeWallets((list) => { injectedWallets = list; });
+  });
 
   // open form
   let debtInput = $state("0.2");
@@ -55,9 +66,15 @@
     } catch (e: any) { err = `Refresh failed: ${e?.message ?? e}`; }
   }
 
-  async function connectMM() {
+  async function connectWith(detail: EIP6963ProviderDetail) {
+    reset(); busy = `Connecting ${detail.info.name}…`;
+    try { wallet = await connectInjected(detail); await refresh(); }
+    catch (e: any) { err = e?.message ?? String(e); }
+    finally { busy = null; }
+  }
+  async function connectLegacy() {
     reset(); busy = "Connecting…";
-    try { wallet = await connectMetaMask(); await refresh(); }
+    try { wallet = await connectLegacyInjected(); await refresh(); }
     catch (e: any) { err = e?.message ?? String(e); }
     finally { busy = null; }
   }
@@ -170,10 +187,25 @@
       <h2>Connect</h2>
       <p class="hint">Open a CFX-collateralized icUSD vault by signing an EIP-712 intent — no IC login.
         Your wallet is the only identity; the canister verifies the signature.</p>
-      <div class="row">
-        <button class="primary" onclick={connectMM} disabled={!!busy || !hasMetaMask()}>
-          {hasMetaMask() ? "Connect MetaMask" : "MetaMask not detected"}
-        </button>
+      {#if injectedWallets.length > 0}
+        <div class="wallets">
+          {#each injectedWallets as w (w.info.rdns)}
+            <button class="wallet" onclick={() => connectWith(w)} disabled={!!busy}>
+              <img class="wicon" src={w.info.icon} alt="" />
+              <span>Connect {w.info.name}</span>
+            </button>
+          {/each}
+        </div>
+      {:else if hasLegacyInjected()}
+        <div class="row">
+          <button class="primary" onclick={connectLegacy} disabled={!!busy}>Connect wallet</button>
+        </div>
+      {:else}
+        <p class="hint" style="margin:0 0 4px">No EVM wallet detected. Install
+          <a href="https://rabby.io" target="_blank" rel="noreferrer">Rabby</a>
+          (or another EVM wallet) and reload.</p>
+      {/if}
+      <div class="row" style="margin-top:12px">
         <button class="ghost sm" onclick={() => (showDevKey = !showDevKey)}>{showDevKey ? "Hide" : "Use a dev key"}</button>
       </div>
       {#if showDevKey}
@@ -195,7 +227,7 @@
       <div class="kv"><span class="k">Address</span><span class="v mono">{wallet.address}</span></div>
       <div class="kv"><span class="k">CFX</span><span class="v">{fmtCfx(cfx)}</span></div>
       <div class="kv"><span class="k">icUSD</span><span class="v">{fmtIcusd(icusd)}</span></div>
-      <div class="kv"><span class="k">Signer</span><span class="v">{wallet.kind === "metamask" ? "MetaMask" : "dev key"}</span></div>
+      <div class="kv"><span class="k">Signer</span><span class="v">{wallet.walletName}</span></div>
     </div>
 
     <div class="card">

--- a/src/conflux_espace_frontend/src/eip712.ts
+++ b/src/conflux_espace_frontend/src/eip712.ts
@@ -74,7 +74,7 @@ export function intentDigest(
 
 type TypedDataSigner = { signTypedData: (args: any) => Promise<`0x${string}`> };
 
-/** Sign with a viem account (MetaMask `walletClient`, or a dev-key `Account`).
+/** Sign with a viem account (an injected `walletClient`, or a dev-key `Account`).
  *  Returns the 65-byte r‖s‖v signature ready for the canister `blob` argument. */
 export async function signIntent(
   signer: TypedDataSigner,

--- a/src/conflux_espace_frontend/src/evm.ts
+++ b/src/conflux_espace_frontend/src/evm.ts
@@ -1,5 +1,6 @@
-// viem integration: MetaMask (primary) or an in-browser dev-key signer (the path
-// the staging round-trip used), the CFX deposit, the IcUSD.burn repay, and reads.
+// viem integration: EIP-6963 injected wallets (Rabby, MetaMask, ...) or an
+// in-browser dev-key signer (the path the staging round-trip used), the CFX
+// deposit, the IcUSD.burn repay, and reads.
 
 import {
   createPublicClient,
@@ -32,29 +33,101 @@ export const publicClient = createPublicClient({
 
 export interface Wallet {
   address: Address;
-  kind: "metamask" | "devkey";
+  kind: "injected" | "devkey";
+  walletName: string;
   client: WalletClient;
   account: Address | PrivateKeyAccount;
 }
 
-export function hasMetaMask(): boolean {
-  return typeof (window as any).ethereum !== "undefined";
+// ── EIP-6963 multi-injected-provider discovery ──────────────────────────────
+// Wallets (Rabby, MetaMask, Phantom, ...) all inject into `window.ethereum` and
+// race for the slot, so the legacy grab connects whoever won (often Phantom,
+// which doesn't even support eSpace). EIP-6963 lets us enumerate EVERY installed
+// wallet and let the user pick the one they want.
+// https://eips.ethereum.org/EIPS/eip-6963
+
+export interface EIP6963ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: string; // data-URI image
+  rdns: string; // reverse-DNS id, e.g. "io.rabby"
+}
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: any; // EIP-1193 provider
 }
 
-export async function connectMetaMask(): Promise<Wallet> {
-  const eth = (window as any).ethereum;
-  if (!eth) throw new Error("No injected wallet. Install MetaMask, or use the dev-key signer below.");
+const discovered = new Map<string, EIP6963ProviderDetail>();
+const listeners = new Set<(wallets: EIP6963ProviderDetail[]) => void>();
+
+function snapshot(): EIP6963ProviderDetail[] {
+  // Name-sorted so the picker order is stable as wallets announce asynchronously.
+  return [...discovered.values()].sort((a, b) => a.info.name.localeCompare(b.info.name));
+}
+function notify() {
+  const s = snapshot();
+  for (const cb of listeners) cb(s);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("eip6963:announceProvider", (e: any) => {
+    const detail = e?.detail as EIP6963ProviderDetail | undefined;
+    if (detail?.info?.rdns && detail.provider) {
+      discovered.set(detail.info.rdns, detail);
+      notify();
+    }
+  });
+  // Ask any already-loaded wallets to announce themselves.
+  window.dispatchEvent(new Event("eip6963:requestProvider"));
+}
+
+/** Current list of EIP-6963 wallets that have announced (name-sorted). */
+export function getInjectedWallets(): EIP6963ProviderDetail[] {
+  return snapshot();
+}
+/** Re-ask wallets to announce (call when the connect view mounts, in case a
+ * wallet injected after this module loaded). */
+export function refreshInjectedWallets(): void {
+  if (typeof window !== "undefined") window.dispatchEvent(new Event("eip6963:requestProvider"));
+}
+/** Subscribe to discovery changes; returns an unsubscribe fn. */
+export function subscribeWallets(cb: (wallets: EIP6963ProviderDetail[]) => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Connect to the specific EIP-6963 wallet the user picked. */
+export async function connectInjected(detail: EIP6963ProviderDetail): Promise<Wallet> {
+  const eth = detail.provider;
   const client = createWalletClient({ chain: confluxESpaceTestnet, transport: custom(eth) });
   const [address] = await client.requestAddresses();
   await ensureChain(client, eth);
-  return { address, kind: "metamask", client, account: address };
+  return { address, kind: "injected", walletName: detail.info.name, client, account: address };
+}
+
+/** True if a legacy `window.ethereum` exists (pre-EIP-6963 wallets / fallback). */
+export function hasLegacyInjected(): boolean {
+  return typeof window !== "undefined" && typeof (window as any).ethereum !== "undefined";
+}
+/** Fallback connect for a wallet that injects `window.ethereum` but never
+ * announced via EIP-6963. Best-effort labels Rabby/MetaMask from provider flags. */
+export async function connectLegacyInjected(): Promise<Wallet> {
+  const eth = (window as any).ethereum;
+  if (!eth) throw new Error("No EVM wallet found. Install Rabby (or another EVM wallet), then reload.");
+  const client = createWalletClient({ chain: confluxESpaceTestnet, transport: custom(eth) });
+  const [address] = await client.requestAddresses();
+  await ensureChain(client, eth);
+  const name = eth.isRabby ? "Rabby" : eth.isMetaMask ? "MetaMask" : "Injected wallet";
+  return { address, kind: "injected", walletName: name, client, account: address };
 }
 
 export function connectDevKey(pk: string): Wallet {
   const hex = (pk.startsWith("0x") ? pk : `0x${pk}`) as Hex;
   const account = privateKeyToAccount(hex);
   const client = createWalletClient({ account, chain: confluxESpaceTestnet, transport: http(ESPACE_RPC) });
-  return { address: account.address, kind: "devkey", client, account };
+  return { address: account.address, kind: "devkey", walletName: "Dev key", client, account };
 }
 
 async function ensureChain(client: WalletClient, eth: any) {

--- a/src/conflux_espace_frontend/src/styles.css
+++ b/src/conflux_espace_frontend/src/styles.css
@@ -94,6 +94,12 @@ button.sm { padding: 7px 11px; font-size: 12px; }
 .spin { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin .7s linear infinite; vertical-align: -2px; margin-right: 7px; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
+/* EIP-6963 injected-wallet picker */
+.wallets { display: flex; flex-direction: column; gap: 10px; }
+.wallet { display: flex; align-items: center; gap: 12px; justify-content: flex-start; text-align: left; width: 100%; }
+.wallet:hover:not(:disabled) { border-color: var(--accent); }
+.wicon { width: 24px; height: 24px; border-radius: 6px; flex: none; object-fit: contain; }
+
 .copy { cursor: pointer; color: var(--accent-2); }
 .muted { color: var(--muted); }
 .divider { height: 1px; background: var(--border); margin: 16px 0; }


### PR DESCRIPTION
## Problem
The Conflux eSpace frontend's connect flow grabbed \`window.ethereum\` directly and the only button said "Connect MetaMask". Every EVM wallet injects into that same slot and races for it, so whoever won got used — for anyone with **Phantom** installed (which doesn't support eSpace testnet) that's what popped up. **Rabby** users (i.e. everyone) had no way to pick their wallet.

## Fix
Replace the single-wallet grab with **EIP-6963** (Multi Injected Provider Discovery):
- Discover *every* installed wallet via the `eip6963:announceProvider` / `requestProvider` handshake (accumulating, so late-injecting wallets still appear).
- The connect screen renders a **picker** — each wallet shows its own icon + name, so you click **Rabby** (or MetaMask, or whatever).
- `window.ethereum` stays as a **legacy fallback** for wallets that don't implement EIP-6963; the empty state points to [Rabby](https://rabby.io).
- The Signer label now shows the chosen wallet's name instead of hardcoded "MetaMask".

No backend or candid changes — frontend only (`src/conflux_espace_frontend/`).

## Verification
- `svelte-check`: 0 errors / 0 warnings
- `vite build`: green

Wallet *selection* itself needs a real browser with the wallets installed — test by running `npm run dev` in `src/conflux_espace_frontend/` (it talks to the staging backend + eSpace testnet) and connecting Rabby, or after a staging redeploy of the `ucdmm-…` asset canister.

🤖 Generated with [Claude Code](https://claude.com/claude-code)