### PR TITLE
Increment 4: Tier-2 Stability Pool fallback for chain liquidations

### DIFF
--- a/docs/superpowers/plans/2026-06-21-chains-liquidation-increment-4.md
+++ b/docs/superpowers/plans/2026-06-21-chains-liquidation-increment-4.md
@@ -1,0 +1,167 @@
+# Chains-Rail Liquidation — Increment 4: Tier-2 ICP Stability Pool fallback
+
+Status: PLANNED (not started)
+Branch: `feat/chains-liquidation-inc4` (off merged `main` @ 67851b9)
+Spec: `docs/superpowers/specs/2026-06-19-chains-liquidation-design.md` §5–§6 + Appendix
+Surface map: workflow `wf_89c8bba2-ef9` (6 readers; file:line anchors below are post-Inc-3).
+
+## Goal
+
+When the Tier-1 bot cannot clear an underwater Conflux vault, the ICP Stability Pool
+absorbs the debt by burning real IC-native icUSD (PSM does NOT apply here — this tier
+DOES burn), takes the seized CFX at the 12% liquidation penalty into the vault's tECDSA
+custody, and credits opted-in SP depositors a pro-rata CFX claim they later pull to an
+EVM address. Ships **disabled-by-default / dev-gated / experimental**, on the same gating
+as Inc 0–3. NOT armed; no real funds; not on prod `tfesu`.
+
+## Rob's resolved decision (2026-06-21)
+
+**CFX is OPT-IN.** Tier 2 is inert until an SP depositor explicitly accepts CFX collateral.
+No existing depositor's risk profile changes silently. Reversible (can flip to opt-out later).
+
+## The two independently-consistent halves (spec §6.1)
+
+1. **Debt + supply (IC-side, synchronous at absorb).** SP burns IC icUSD → backend writes
+   down `debt_e8s` and moves the amount into `pending_chain_burn_e8s` (NOT `chain_supplies`,
+   NOT `reserve_backing`) + enqueues an eSpace `Burn` op. When that Burn confirms at finality,
+   `pending_chain_burn` AND `chain_supplies` drop together. Decoupled (option A): the vault
+   reopens the instant debt is absorbed, independent of the slow eSpace leg.
+2. **Collateral (EVM-side, async).** Seized CFX stays in the vault's per-vault custody.
+   Record a `ChainLiqClaimV1`; depositors pull via `claim_cfx` → backend `claim_chain_collateral`
+   → a custody-signed payout op.
+
+## The unified invariant (already fully wired — DO NOT touch the RHS math)
+
+`sum(chain_supplies) == total_chain_vault_debt_e8s() + total_reserve_backing_e8s() + total_pending_chain_burn_e8s()`
+
+`chain_backing_rhs_e8s` (supply.rs:86) centralizes the RHS; `apply_supply_delta`,
+`check_invariant`, the Timer-B self-check (xrc.rs:367), and `clear_invariant_halt`
+(main.rs:2213) all route through it. Term-3 (`pending_chain_burn_e8s`) has ZERO writers
+today. Inc 4 is the first writer. EVERY pending-burn mutation must go through a guarded
+helper (never a raw map insert) or a single tick of imbalance false-halts the chain → ReadOnly.
+
+## State / candid discipline (two canisters, two different rules)
+
+- **backend `MultiChainStateV6`** = ciborium CBOR. Additive `#[serde(default)]` fields are
+  proven-safe on live kvg63 (Inc 2/3 added fields to V6 with no V7 bump; V6→V6 decode preserved
+  Vault #3). Add `chain_liquidation_claims` as a `#[serde(default)]` field on V6 (mirror how Inc 3
+  added `chain_bad_debt_e8s`). NO V7. Gate: a V5→V6 + V6→V6 round-trip decode test (existing pattern).
+- **`SettlementOpKind`** is internal CBOR (NOT on the candid surface — confirmed by Inc 2's inert
+  LiquidationSwap). Add a NEW variant `EspaceBurn { vault_id, amount_e8s }` (do NOT mutate the dead
+  `Burn { amount_e8s }` variant — variant-add is additive-safe, field-add is a UPG hazard). Compiler
+  will force new match arms in EVM settlement, Solana settlement, and recovery.rs.
+- **stability_pool state** = Candid `Encode!/Decode!` (raw blob + `try_decode_state` V-fallback).
+  Per the hard rule, serde(default) does NOT save Candid Decode! on a missing NON-Option field.
+  Add new `DepositPosition` fields as `Option<...>` `#[serde(default)]` (the PROVEN additive pattern
+  in this canister — `total_interest_earned_e8s` / `pending_refunds` are Option and survived upgrades).
+  Gate: an old-bytes → new-struct Candid round-trip decode test. If it fails, add `StabilityPoolStateV2`
+  + `DepositPositionV2` snapshots + `From` + a `try_decode_state` branch. NEVER `-y` past a candid warning.
+- Expect the recurring owner-gated `--yes` candid wall (new backend entries' input records). Rob runs installs.
+
+## Implementation decisions (grounded in spec; not user-facing forks)
+
+- **SP burns icUSD** by `icrc1_transfer` to the icUSD ledger minting account
+  (`icrc1_minting_account`) with the `RUMI-LIQ-004:<vault_id BE>` memo, capturing the block index
+  for the `SpWritedownProof`. Draw restricted to **icUSD only** in v1 (spec §6.6 resolved: icUSD-only).
+- **Trigger = dev-gated manual** for v1 (matches experimental/disabled posture; spec §7 "manual = a
+  human invoking the endpoint"). `should_escalate_to_sp` + `sp_attempted_chain_vaults` membership are
+  the GATE; auto-timer escalation is a follow-up (Inc 5).
+- **Claim payout op** = a NEW `ChainCollateralPayout { recipient, amount_e18, vault_id }` (NOT a
+  reused `NativeWithdrawal` — its revert wrongly re-credits vault collateral). Its revert re-credits
+  the SP depositor's `cfx_claims` via a backend→SP callback.
+- **SP-absorb event** = reuse `ChainVaultLiquidated { tier: StabilityPool }` (the variant already
+  carries `tier`); claim-settle = existing `ChainCfxClaimSettled`. Do NOT add `ChainVaultLiquidatedBySp`
+  (avoids 3 exhaustive-match edits + a candid variant-add warning).
+- **No bot-marker-vs-SP double-settle window** by construction: `escalate_failed_swap` clears the
+  marker + restores collateral + sets sp_attempted BEFORE the SP can observe it. SP absorb's
+  precondition is `pending_liquidation.is_none()` + `sp_attempted` membership, re-checked inside its guard.
+
+## Tasks (TDD, per-task commit, all behind disabled-by-default config)
+
+Each task: write the failing test first, implement, `cargo test` green, commit.
+
+**Backend — invariant + settlement primitives**
+1. `apply_debt_to_pending_burn_shift(state, chain, vault_id, burned_e8s)` (supply.rs) — clone of
+   `apply_debt_to_reserve_shift`; debt→pending_chain_burn, supply untouched; same halt/cap/pre-RHS-check.
+   `apply_pending_burn_to_supply_shift(state, chain, amt)` — pending_burn-=amt AND chain_supplies-=amt
+   together. Pure property tests: invariant conserved; underflow fail-closed.
+2. `SettlementOpKind::EspaceBurn { vault_id, amount_e8s }` + `MonadTxKind::Burn { contract, amount_e8s,
+   vault_id }` + `encode_burn_calldata` (verify the IcUSD.sol burn selector/args; reference-vector test)
+   + `TxPlanKind::Burn`. Compiler-forced match arms in EVM/Solana settlement + recovery.rs.
+3. Activate the Burn op: `build_tx_plan` Burn arm; `resolve_op_signer` Burn arm (minter/settlement
+   signer — verify IcUSD.sol burn auth); replace the `submit_op` fail-up-front stub; `confirm_op`
+   success arm (get_logs BURN_EVENT_TOPIC0 → `decode_burn_log` (exists, carries vault_id) → exact
+   tx-hash match → `apply_pending_burn_to_supply_shift`); revert/never-mined arm = retryable (NOT
+   escalate), leave to `resubmit_if_stuck` (Burn stays NON-excluded). Aged-pending alarm getter
+   (App-finding-4 dead-letter).
+4. `deposit_watch` backstop no-debt gate: change `total_chain_vault_debt_e8s()==0` →
+   `... == 0 && total_pending_chain_burn_e8s()==0` (failing test first — a Burn mid-flight must keep scanning).
+
+**Backend — claim record + SP-facing entries**
+5. `ChainLiqClaimV1 { vault_id, chain, custody_address, seized_native_total, paid_native }` +
+   `chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>` (#[serde(default)] on V6) + V5→V6/V6→V6
+   round-trip decode test. Custody-claim invariant helper (`paid_native <= seized_native_total`).
+6. `ChainCollateralPayout { recipient, amount_e18, vault_id }` op + custody signer (reuse arm) +
+   confirm (increment `paid_native`, do NOT close vault) + revert (re-credit SP via callback, NOT vault).
+7. `stability_pool_liquidate_chain_vault(vault_id, icusd_burned_e8s, proof, depositor_evm_claims)`
+   #[update] — clone main.rs:3537 SP-caller gate; chains gates (invariant_halted/reorg_halted reject +
+   fresh manual CFX price via `fresh_chain_price_e8`, NOT `validate_freshness_for_vault`); ChainVault
+   per-vault guard; precondition `pending_liquidation.is_none()` + `sp_attempted` membership; TOCTOU
+   live-debt re-read; `burned=min(req, live_debt)` (un-refundable — burn EXACTLY capped);
+   `apply_debt_to_pending_burn_shift`; enqueue EspaceBurn op; reserve CFX; record ChainLiqClaimV1; set
+   marker tier=StabilityPool, op_id=burn op id; emit ChainVaultLiquidated{tier:StabilityPool}; ONE shot
+   (on any failure insert sp_attempted, NO retry); verify burn proof via `fetch_and_validate_block`.
+8. `claim_chain_collateral(claimer, owed_wei, dest_evm)` #[update] — SP-caller gated; validate dest_evm
+   (`is_valid_evm_address`) before mutation; enqueue ChainCollateralPayout; increment paid_native;
+   Duplicate idempotency.
+9. Discovery: add `sp_attempted: bool` (+ chain + sentinel) to `ChainLiquidatableVault` so the SP/UI
+   distinguishes never-tried from bot-failed-needs-SP (get_chain_liquidatable_vaults already surfaces
+   bot-failed vaults: marker None + CR<threshold).
+
+**stability_pool canister**
+10. `DepositPosition.cfx_claims: Option<BTreeMap<Principal, u128>>` (#[serde(default)]) + update
+    `new()` + fix `is_empty()` to count cfx_claims (silent-loss landmine at state.rs:818 retain) +
+    old→new Candid round-trip decode test (escalate to V2 snapshot only if it fails).
+11. CFX opt-IN: `opted_in_chain_collateral: Option<BTreeSet<Principal>>` on DepositPosition +
+    `chain_collateral_sentinels: BTreeSet<Principal>` on state + `is_opted_in_for_chain(sentinel)`
+    predicate + `opt_in_cfx`/`opt_out_cfx` state methods + #[update] endpoints (SpLiquidationGuard
+    busy-guard, mirror lib.rs:147-175). Branch the 3 consumers (`effective_pool_for_collateral`,
+    `compute_token_draw`, the new u128 gains sibling) to use the opt-in predicate for sentinels;
+    keep default-in/opt-out for all non-sentinel collaterals.
+12. `process_chain_liquidation_gains_at` (u128 sibling of state.rs:678) crediting `cfx_claims` +
+    wrapper + `mark_cfx_claimed` (u128). Property test: $1–3k CFX seizure (~1e22 wei) credited with NO
+    truncation; dust to first opted-in depositor.
+13. CFX sentinel: deterministic-from-chain_id principal helper (stable across upgrades, never collides
+    with a real ledger) + register via `register_collateral` (CollateralInfo{symbol:"CFX", decimals:18,
+    status:Active}) + add to `chain_collateral_sentinels`. Exclude the sentinel from `validate_state`'s
+    aggregate==ledger check (SP never physically holds CFX).
+14. SP icUSD-burn capability: burn icUSD (transfer to `icrc1_minting_account` with RUMI-LIQ-004 memo),
+    capture block index. icUSD-only draw filter (v1).
+15. `sp_absorb_chain_vault(vault_id)` dev-gated #[update] orchestrator: coverage gate
+    `effective_pool_for_collateral(cfx_sentinel) >= debt`; compute icUSD draw; burn; build proof; call
+    backend `stability_pool_liquidate_chain_vault` under SpLiquidationGuard (ONE shot, no retry);
+    credit `cfx_claims` u128 pro-rata on success; on failure → vault stays sp_attempted → Tier-3 manual.
+16. `claim_cfx(sentinel, dest_evm)` #[update] — clone `claim_collateral`; SP-102 busy guard; validate
+    EVM addr before mutation; deduct-before-async on cfx_claims (u128, zero first); call backend
+    `claim_chain_collateral`; rollback on Err except Duplicate. Backend revert callback re-credits.
+
+**Integration + ship**
+17. PocketIC e2e (bot→SP escalation): bot swap fails → vault bot-failed (marker cleared, collateral
+    restored, sp_attempted set) → depositor opts into CFX → dev `sp_absorb_chain_vault` → debt→
+    pending_chain_burn, EspaceBurn enqueued, supply unchanged, invariant holds, vault reopens → Burn
+    confirms → pending_chain_burn→chain_supplies decrement → ChainLiqClaimV1 recorded → cfx_claims (u128)
+    credited pro-rata → claim_cfx → ChainCollateralPayout → confirm → paid_native bumped. Assert NO
+    false-halt at any tick. Plus: no-retry (failed absorb → manual), over-burn cap, double-settle reject,
+    zero-opt-in coverage → clean escalate-to-manual (finding #18), claim-revert re-credit.
+18. Candid regen + breaking-change check (additive) + full verification (lib/bin/all PocketIC suites)
+    + plan/memory update + PR vs main. STOP. Ask before merge/deploy.
+
+## Folded adversarial findings (spec Appendix)
+#1/#16/#19 over-burn clamp to live debt; #18 zero-opt-in → clean manual escalation (Rob's opt-in makes
+this explicit); #26/#36 sp_attempted set-on-dispatch + CR-prune (prune already CR-derivable, better than
+ICP); double-settle window (marker precondition); pending_chain_burn-stuck-forever (Burn retryable at
+settlement layer + aged-pending alarm, never an SP retry); discovery gap (sp_attempted flag on the DTO).
+
+## What ships
+All write paths dev-gated; CFX sentinel inert until opt-in; no chain liquidation config enabled.
+The Tier-2 fallback is code-complete and PocketIC-proven against the mock, dormant in production.

--- a/docs/superpowers/plans/2026-06-21-chains-liquidation-increment-4.md
+++ b/docs/superpowers/plans/2026-06-21-chains-liquidation-increment-4.md
@@ -1,6 +1,6 @@
 # Chains-Rail Liquidation — Increment 4: Tier-2 ICP Stability Pool fallback
 
-Status: PLANNED (not started)
+Status: IN PROGRESS (Task 1 complete; plan corrected after burn-model review)
 Branch: `feat/chains-liquidation-inc4` (off merged `main` @ 67851b9)
 Spec: `docs/superpowers/specs/2026-06-19-chains-liquidation-design.md` §5–§6 + Appendix
 Surface map: workflow `wf_89c8bba2-ef9` (6 readers; file:line anchors below are post-Inc-3).
@@ -23,9 +23,13 @@ No existing depositor's risk profile changes silently. Reversible (can flip to o
 
 1. **Debt + supply (IC-side, synchronous at absorb).** SP burns IC icUSD → backend writes
    down `debt_e8s` and moves the amount into `pending_chain_burn_e8s` (NOT `chain_supplies`,
-   NOT `reserve_backing`) + enqueues an eSpace `Burn` op. When that Burn confirms at finality,
-   `pending_chain_burn` AND `chain_supplies` drop together. Decoupled (option A): the vault
-   reopens the instant debt is absorbed, independent of the slow eSpace leg.
+   NOT `reserve_backing`). There is **no automatic foreign-chain burn in Inc 4**: the eSpace
+   ERC-20 `burn(uint256,uint64)` can only burn the caller's own balance, and the protocol cannot
+   forcibly burn icUSD from the liquidated user's eSpace wallet. `pending_chain_burn` is the
+   durable backing/accounting term for "IC-side supply has already been burned; foreign
+   representation retirement is a later reconciliation step." A later Inc 5 manual settlement
+   can consume `pending_chain_burn` when an operator has acquired/bridged the foreign icUSD and
+   retired that representation.
 2. **Collateral (EVM-side, async).** Seized CFX stays in the vault's per-vault custody.
    Record a `ChainLiqClaimV1`; depositors pull via `claim_cfx` → backend `claim_chain_collateral`
    → a custody-signed payout op.
@@ -47,9 +51,10 @@ helper (never a raw map insert) or a single tick of imbalance false-halts the ch
   Vault #3). Add `chain_liquidation_claims` as a `#[serde(default)]` field on V6 (mirror how Inc 3
   added `chain_bad_debt_e8s`). NO V7. Gate: a V5→V6 + V6→V6 round-trip decode test (existing pattern).
 - **`SettlementOpKind`** is internal CBOR (NOT on the candid surface — confirmed by Inc 2's inert
-  LiquidationSwap). Add a NEW variant `EspaceBurn { vault_id, amount_e8s }` (do NOT mutate the dead
-  `Burn { amount_e8s }` variant — variant-add is additive-safe, field-add is a UPG hazard). Compiler
-  will force new match arms in EVM settlement, Solana settlement, and recovery.rs.
+  LiquidationSwap). Inc 4 does **not** activate the existing dead `Burn { amount_e8s }` variant and
+  does **not** add an automatic `EspaceBurn` variant. Foreign representation retirement belongs to
+  Inc 5's manual reconciliation flow, because the current eSpace `IcUSD.sol::burn` can only burn the
+  caller's own balance.
 - **stability_pool state** = Candid `Encode!/Decode!` (raw blob + `try_decode_state` V-fallback).
   Per the hard rule, serde(default) does NOT save Candid Decode! on a missing NON-Option field.
   Add new `DepositPosition` fields as `Option<...>` `#[serde(default)]` (the PROVEN additive pattern
@@ -60,7 +65,7 @@ helper (never a raw map insert) or a single tick of imbalance false-halts the ch
 
 ## Implementation decisions (grounded in spec; not user-facing forks)
 
-- **SP burns icUSD** by `icrc1_transfer` to the icUSD ledger minting account
+- **SP burns IC-native icUSD** by `icrc1_transfer` to the icUSD ledger minting account
   (`icrc1_minting_account`) with the `RUMI-LIQ-004:<vault_id BE>` memo, capturing the block index
   for the `SpWritedownProof`. Draw restricted to **icUSD only** in v1 (spec §6.6 resolved: icUSD-only).
 - **Trigger = dev-gated manual** for v1 (matches experimental/disabled posture; spec §7 "manual = a
@@ -83,84 +88,77 @@ Each task: write the failing test first, implement, `cargo test` green, commit.
 **Backend — invariant + settlement primitives**
 1. `apply_debt_to_pending_burn_shift(state, chain, vault_id, burned_e8s)` (supply.rs) — clone of
    `apply_debt_to_reserve_shift`; debt→pending_chain_burn, supply untouched; same halt/cap/pre-RHS-check.
-   `apply_pending_burn_to_supply_shift(state, chain, amt)` — pending_burn-=amt AND chain_supplies-=amt
-   together. Pure property tests: invariant conserved; underflow fail-closed.
-2. `SettlementOpKind::EspaceBurn { vault_id, amount_e8s }` + `MonadTxKind::Burn { contract, amount_e8s,
-   vault_id }` + `encode_burn_calldata` (verify the IcUSD.sol burn selector/args; reference-vector test)
-   + `TxPlanKind::Burn`. Compiler-forced match arms in EVM/Solana settlement + recovery.rs.
-3. Activate the Burn op: `build_tx_plan` Burn arm; `resolve_op_signer` Burn arm (minter/settlement
-   signer — verify IcUSD.sol burn auth); replace the `submit_op` fail-up-front stub; `confirm_op`
-   success arm (get_logs BURN_EVENT_TOPIC0 → `decode_burn_log` (exists, carries vault_id) → exact
-   tx-hash match → `apply_pending_burn_to_supply_shift`); revert/never-mined arm = retryable (NOT
-   escalate), leave to `resubmit_if_stuck` (Burn stays NON-excluded). Aged-pending alarm getter
-   (App-finding-4 dead-letter).
-4. `deposit_watch` backstop no-debt gate: change `total_chain_vault_debt_e8s()==0` →
-   `... == 0 && total_pending_chain_burn_e8s()==0` (failing test first — a Burn mid-flight must keep scanning).
+   `apply_pending_burn_to_supply_shift(state, chain, amt)` is retained as the future Inc 5 manual
+   settlement primitive (pending_burn-=amt AND chain_supplies-=amt together). Pure property tests:
+   invariant conserved; underflow fail-closed. **DONE in commit `6f0b16f`.**
+2. `deposit_watch` backstop no-debt gate: change `total_chain_vault_debt_e8s()==0` →
+   `... == 0 && total_pending_chain_burn_e8s()==0` (failing test first — a pending-burn balance means
+   foreign representation is still outstanding, so the burn watcher/reconciliation should not go idle).
 
 **Backend — claim record + SP-facing entries**
-5. `ChainLiqClaimV1 { vault_id, chain, custody_address, seized_native_total, paid_native }` +
+3. `ChainLiqClaimV1 { vault_id, chain, custody_address, seized_native_total, paid_native }` +
    `chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>` (#[serde(default)] on V6) + V5→V6/V6→V6
    round-trip decode test. Custody-claim invariant helper (`paid_native <= seized_native_total`).
-6. `ChainCollateralPayout { recipient, amount_e18, vault_id }` op + custody signer (reuse arm) +
+4. `ChainCollateralPayout { recipient, amount_e18, vault_id }` op + custody signer (reuse arm) +
    confirm (increment `paid_native`, do NOT close vault) + revert (re-credit SP via callback, NOT vault).
-7. `stability_pool_liquidate_chain_vault(vault_id, icusd_burned_e8s, proof, depositor_evm_claims)`
+5. `stability_pool_liquidate_chain_vault(vault_id, icusd_burned_e8s, proof, depositor_evm_claims)`
    #[update] — clone main.rs:3537 SP-caller gate; chains gates (invariant_halted/reorg_halted reject +
    fresh manual CFX price via `fresh_chain_price_e8`, NOT `validate_freshness_for_vault`); ChainVault
    per-vault guard; precondition `pending_liquidation.is_none()` + `sp_attempted` membership; TOCTOU
    live-debt re-read; `burned=min(req, live_debt)` (un-refundable — burn EXACTLY capped);
-   `apply_debt_to_pending_burn_shift`; enqueue EspaceBurn op; reserve CFX; record ChainLiqClaimV1; set
-   marker tier=StabilityPool, op_id=burn op id; emit ChainVaultLiquidated{tier:StabilityPool}; ONE shot
+   `apply_debt_to_pending_burn_shift`; reserve CFX; record ChainLiqClaimV1; emit
+   ChainVaultLiquidated{tier:StabilityPool}; ONE shot
    (on any failure insert sp_attempted, NO retry); verify burn proof via `fetch_and_validate_block`.
-8. `claim_chain_collateral(claimer, owed_wei, dest_evm)` #[update] — SP-caller gated; validate dest_evm
+6. `claim_chain_collateral(claimer, owed_wei, dest_evm)` #[update] — SP-caller gated; validate dest_evm
    (`is_valid_evm_address`) before mutation; enqueue ChainCollateralPayout; increment paid_native;
    Duplicate idempotency.
-9. Discovery: add `sp_attempted: bool` (+ chain + sentinel) to `ChainLiquidatableVault` so the SP/UI
+7. Discovery: add `sp_attempted: bool` (+ chain + sentinel) to `ChainLiquidatableVault` so the SP/UI
    distinguishes never-tried from bot-failed-needs-SP (get_chain_liquidatable_vaults already surfaces
    bot-failed vaults: marker None + CR<threshold).
 
 **stability_pool canister**
-10. `DepositPosition.cfx_claims: Option<BTreeMap<Principal, u128>>` (#[serde(default)]) + update
+8. `DepositPosition.cfx_claims: Option<BTreeMap<Principal, u128>>` (#[serde(default)]) + update
     `new()` + fix `is_empty()` to count cfx_claims (silent-loss landmine at state.rs:818 retain) +
     old→new Candid round-trip decode test (escalate to V2 snapshot only if it fails).
-11. CFX opt-IN: `opted_in_chain_collateral: Option<BTreeSet<Principal>>` on DepositPosition +
+9. CFX opt-IN: `opted_in_chain_collateral: Option<BTreeSet<Principal>>` on DepositPosition +
     `chain_collateral_sentinels: BTreeSet<Principal>` on state + `is_opted_in_for_chain(sentinel)`
     predicate + `opt_in_cfx`/`opt_out_cfx` state methods + #[update] endpoints (SpLiquidationGuard
     busy-guard, mirror lib.rs:147-175). Branch the 3 consumers (`effective_pool_for_collateral`,
     `compute_token_draw`, the new u128 gains sibling) to use the opt-in predicate for sentinels;
     keep default-in/opt-out for all non-sentinel collaterals.
-12. `process_chain_liquidation_gains_at` (u128 sibling of state.rs:678) crediting `cfx_claims` +
+10. `process_chain_liquidation_gains_at` (u128 sibling of state.rs:678) crediting `cfx_claims` +
     wrapper + `mark_cfx_claimed` (u128). Property test: $1–3k CFX seizure (~1e22 wei) credited with NO
     truncation; dust to first opted-in depositor.
-13. CFX sentinel: deterministic-from-chain_id principal helper (stable across upgrades, never collides
+11. CFX sentinel: deterministic-from-chain_id principal helper (stable across upgrades, never collides
     with a real ledger) + register via `register_collateral` (CollateralInfo{symbol:"CFX", decimals:18,
     status:Active}) + add to `chain_collateral_sentinels`. Exclude the sentinel from `validate_state`'s
     aggregate==ledger check (SP never physically holds CFX).
-14. SP icUSD-burn capability: burn icUSD (transfer to `icrc1_minting_account` with RUMI-LIQ-004 memo),
+12. SP icUSD-burn capability: burn IC-native icUSD (transfer to `icrc1_minting_account` with RUMI-LIQ-004 memo),
     capture block index. icUSD-only draw filter (v1).
-15. `sp_absorb_chain_vault(vault_id)` dev-gated #[update] orchestrator: coverage gate
+13. `sp_absorb_chain_vault(vault_id)` dev-gated #[update] orchestrator: coverage gate
     `effective_pool_for_collateral(cfx_sentinel) >= debt`; compute icUSD draw; burn; build proof; call
     backend `stability_pool_liquidate_chain_vault` under SpLiquidationGuard (ONE shot, no retry);
     credit `cfx_claims` u128 pro-rata on success; on failure → vault stays sp_attempted → Tier-3 manual.
-16. `claim_cfx(sentinel, dest_evm)` #[update] — clone `claim_collateral`; SP-102 busy guard; validate
+14. `claim_cfx(sentinel, dest_evm)` #[update] — clone `claim_collateral`; SP-102 busy guard; validate
     EVM addr before mutation; deduct-before-async on cfx_claims (u128, zero first); call backend
     `claim_chain_collateral`; rollback on Err except Duplicate. Backend revert callback re-credits.
 
 **Integration + ship**
-17. PocketIC e2e (bot→SP escalation): bot swap fails → vault bot-failed (marker cleared, collateral
+15. PocketIC e2e (bot→SP escalation): bot swap fails → vault bot-failed (marker cleared, collateral
     restored, sp_attempted set) → depositor opts into CFX → dev `sp_absorb_chain_vault` → debt→
-    pending_chain_burn, EspaceBurn enqueued, supply unchanged, invariant holds, vault reopens → Burn
-    confirms → pending_chain_burn→chain_supplies decrement → ChainLiqClaimV1 recorded → cfx_claims (u128)
+    pending_chain_burn, supply unchanged, invariant holds, vault reopens → ChainLiqClaimV1 recorded → cfx_claims (u128)
     credited pro-rata → claim_cfx → ChainCollateralPayout → confirm → paid_native bumped. Assert NO
     false-halt at any tick. Plus: no-retry (failed absorb → manual), over-burn cap, double-settle reject,
     zero-opt-in coverage → clean escalate-to-manual (finding #18), claim-revert re-credit.
-18. Candid regen + breaking-change check (additive) + full verification (lib/bin/all PocketIC suites)
+16. Candid regen + breaking-change check (additive) + full verification (lib/bin/all PocketIC suites)
     + plan/memory update + PR vs main. STOP. Ask before merge/deploy.
 
 ## Folded adversarial findings (spec Appendix)
 #1/#16/#19 over-burn clamp to live debt; #18 zero-opt-in → clean manual escalation (Rob's opt-in makes
 this explicit); #26/#36 sp_attempted set-on-dispatch + CR-prune (prune already CR-derivable, better than
-ICP); double-settle window (marker precondition); pending_chain_burn-stuck-forever (Burn retryable at
-settlement layer + aged-pending alarm, never an SP retry); discovery gap (sp_attempted flag on the DTO).
+ICP); double-settle window (marker precondition); pending_chain_burn-stuck-forever is handled by making
+it a durable reconciliation obligation for Inc 5 rather than a retry loop; discovery gap (sp_attempted
+flag on the DTO).
 
 ## What ships
 All write paths dev-gated; CFX sentinel inert until opt-in; no chain liquidation config enabled.

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -42,6 +42,8 @@ type ChainLiquidatableVault = record {
   cr_e4 : nat64;
   collateral_native : nat;
   vault_id : nat64;
+  sp_attempted : bool;
+  chain_collateral_sentinel : principal;
   chain_id : nat32;
   liquidation_threshold_e4 : nat64;
   effective_debt_e8s : nat;

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1070,6 +1070,7 @@ service : (ProtocolArg) -> {
   bot_claim_liquidation : (nat64) -> (Result_4);
   bot_confirm_liquidation : (nat64) -> (Result);
   chain_has_active_settlement_op : (nat32) -> (bool) query;
+  claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -64,6 +64,17 @@ type ChainLiquidationConfigV1 = record {
   settle_stable_token : text;
   deadline_secs : nat64;
 };
+type ChainStabilityPoolLiquidationResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  success : bool;
+};
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
   pending_chain_burn_e8s : nat;
@@ -912,7 +923,11 @@ type Result_17 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_18 = variant { Ok : nat32; Err : ProtocolError };
+type Result_18 = variant {
+  Ok : ChainStabilityPoolLiquidationResult;
+  Err : ProtocolError;
+};
+type Result_19 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
@@ -1286,13 +1301,16 @@ service : (ProtocolArg) -> {
   solana_settlement_address : () -> (Result_2);
   solana_sign_test_transfer : (text, nat64) -> (Result_16);
   stability_pool_liquidate : (nat64, nat64) -> (Result_17);
+  stability_pool_liquidate_chain_vault : (nat64, nat64, SpWritedownProof) -> (
+      Result_18,
+    );
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
       Result_17,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
       Result_17,
     );
-  submit_burn_proof : (nat32, text) -> (Result_18);
+  submit_burn_proof : (nat32, text) -> (Result_19);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -121,6 +121,18 @@ pub fn backstop_should_scan(
     !has_inflight_mint && onchain_total_supply_e8s < recorded_supply_e8s
 }
 
+/// The burn-watch cycle gate can skip only when the chain has no remaining
+/// foreign-supply obligation: no live vault debt and no SP-path pending burn
+/// backing. A nonzero pending-burn term means IC-side icUSD has already been
+/// burned while the foreign representation is still outstanding, so the watcher
+/// must stay active for reconciliation/backstop observability.
+pub fn burn_watch_can_skip_for_no_supply_obligation(
+    total_chain_debt_e8s: u128,
+    pending_chain_burn_e8s: u128,
+) -> bool {
+    total_chain_debt_e8s == 0 && pending_chain_burn_e8s == 0
+}
+
 /// Credit a confirmed on-chain deposit to a ChainVaultV1 record.
 ///
 /// Increments `collateral_amount_native` by `amount_e18` (saturating — overflow
@@ -666,20 +678,23 @@ pub async fn run_observer(chain: ChainId) {
         return;
     }
 
-    // ── No-debt fast path (cycle gate) ───────────────────────────────────────
+    // ── No-supply-obligation fast path (cycle gate) ──────────────────────────
     //
-    // A Burn can only ever apply to a chain-vault that HAS debt. When the total
-    // foreign-chain vault debt is 0 there is nothing any Burn in this range could
-    // decrement, so skip the (expensive) get_logs scan entirely — that is
-    // ceil(window / MONAD_GETLOGS_MAX_RANGE) EVM-RPC outcalls per advancing tick
-    // (~764M cycles each, measured 2026-05-31). We STILL advance the cursor to
-    // `finalized` (and prune) so the consensus-safe finality probe
-    // `fetch_block_numbers` (= last_observed + MAX_BLOCK_SCAN_WINDOW) stays
-    // current: a stalled cursor would leave the next mint unable to reach
-    // finality — the Gate-4 failure mode. No burn is missed: with zero
-    // chain-vault debt there is no vault a burn in this range could have repaid.
-    let total_chain_debt = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
-    if total_chain_debt == 0 {
+    // When there is no live vault debt AND no SP-path pending-burn backing, the
+    // chain has no foreign-supply obligation the burn watcher can resolve. Skip
+    // the expensive get_logs scan entirely — that is ceil(window /
+    // MONAD_GETLOGS_MAX_RANGE) EVM-RPC outcalls per advancing tick (~764M cycles
+    // each, measured 2026-05-31). A nonzero pending-burn term is different:
+    // IC-side icUSD was burned while the foreign representation is still
+    // outstanding, so the watcher/backstop must stay active for observability
+    // and later reconciliation.
+    let (total_chain_debt, pending_chain_burn) = read_state(|s| {
+        (
+            s.multi_chain.total_chain_vault_debt_e8s(),
+            s.multi_chain.total_pending_chain_burn_e8s(),
+        )
+    });
+    if burn_watch_can_skip_for_no_supply_obligation(total_chain_debt, pending_chain_burn) {
         mutate_state(|s| advance_cursor_and_prune(&mut s.multi_chain, chain, finalized));
         return;
     }

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -428,6 +428,7 @@ pub async fn run_settlement(chain: ChainId) {
 enum TxPlanKind {
     Mint,
     NativeWithdrawal,
+    ChainCollateralPayout,
     /// Task 12: an interest-realization mint (to the treasury). Submit-path logs
     /// it; the authoritative record is `ChainInterestMinted` on confirm.
     InterestMint,
@@ -521,6 +522,23 @@ fn build_tx_plan(
                 kind: TxPlanKind::NativeWithdrawal,
             })
         }
+        SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, .. } => {
+            let value = withdrawal_value.unwrap_or(*amount_e18);
+            let fields = tx::build_eip1559_fields(
+                chain.0 as u64,
+                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
+                nonce,
+                prio,
+                max_fee,
+            )?;
+            Ok(TxPlan {
+                fields,
+                vault_id: *vault_id,
+                recipient: recipient.clone(),
+                amount: value,
+                kind: TxPlanKind::ChainCollateralPayout,
+            })
+        }
         SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, recipient, .. } => {
             // Task 12: identical IcUSD.mint calldata to a normal Mint, but the
             // on-chain `vault_id` arg is the SYNTHETIC `mint_id` (the real vault
@@ -579,7 +597,8 @@ async fn resolve_op_signer(
         SettlementOpKind::Mint { .. } => tecdsa::cached_settlement_address(chain).await,
         // Task 12: interest mints are signed by the minter, same as a vault mint.
         SettlementOpKind::InterestMint { .. } => tecdsa::cached_settlement_address(chain).await,
-        SettlementOpKind::NativeWithdrawal { vault_id, .. } => {
+        SettlementOpKind::NativeWithdrawal { vault_id, .. }
+        | SettlementOpKind::ChainCollateralPayout { vault_id, .. } => {
             let vid = *vault_id;
             let info = read_state(|s| {
                 s.multi_chain
@@ -588,7 +607,7 @@ async fn resolve_op_signer(
                     .map(|v| (v.owner, v.custody_address.clone()))
             });
             let (owner, custody_addr) =
-                info.ok_or_else(|| format!("withdrawal signer: unknown vault {vid}"))?;
+                info.ok_or_else(|| format!("custody signer: unknown vault {vid}"))?;
             // The op's `chain` IS the vault's collateral chain (settlement queues
             // are keyed by chain), so re-derive the custody path on it.
             let path = tecdsa::custody_derivation_path(chain, owner, vid);
@@ -788,10 +807,14 @@ async fn submit_op(
     //    can also pay gas (a full close requests the entire custody balance).
     //    Read the custody balance ONCE here; the value is recomputed identically
     //    on a stuck-tx resubmit. Mints don't carry a value, so skip the read.
-    let withdrawal_value = if matches!(op.kind, SettlementOpKind::NativeWithdrawal { .. }) {
+    let withdrawal_value = if matches!(
+        op.kind,
+        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
+    ) {
         match evm_rpc::get_balance(chain, &signer_addr).await {
             Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. } = &op.kind {
+                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
+                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
                     Some(fundable_withdrawal_value(*amount_e18, bal, max_fee))
                 } else {
                     None
@@ -886,6 +909,9 @@ async fn submit_op(
                 timestamp: now,
             });
             log!(INFO, "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+        }
+        TxPlanKind::ChainCollateralPayout => {
+            log!(INFO, "[settlement chain={:?}] chain-collateral payout submitted: op={} vault={} amount_e18={} recipient={} tx={}", chain, op_id, vault_id, amount, recipient, tx_hash);
         }
         TxPlanKind::InterestMint => {
             // Submit-path log only; the authoritative event is ChainInterestMinted
@@ -1276,6 +1302,11 @@ async fn confirm_op(
                         }
                     }
                 }
+                SettlementOpKind::ChainCollateralPayout { .. } => {
+                    // Claim payout reversals are NOT vault collateral reversals.
+                    // The SP-side cfx_claims rollback lands with claim_cfx; for
+                    // now just mark the op failed without touching the vault.
+                }
                 SettlementOpKind::InterestMint { vault_id, .. } => {
                     // Task 12: no debt/supply was credited (the mint reverted), so
                     // just clear the reservation. last_interest_accrual_ns is left
@@ -1567,6 +1598,26 @@ async fn confirm_op(
             });
             log!(INFO, "[settlement chain={:?}] withdrawal op {} vault {} confirmed tx={} (Closing->Closed if applicable)", chain, op_id, vid, tx_hash);
         }
+        SettlementOpKind::ChainCollateralPayout { vault_id, recipient, amount_e18, .. } => {
+            let vid = *vault_id;
+            let recipient = recipient.clone();
+            let amount = *amount_e18;
+            mutate_state(|s| {
+                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                    if let Some(o) = q.pending.get_mut(&op_id) {
+                        o.mark_succeeded(tx_hash.clone(), now);
+                    }
+                }
+            });
+            crate::storage::record_event(&crate::event::Event::ChainCfxClaimSettled {
+                chain_id: chain,
+                claim_id: vid,
+                recipient: recipient.clone(),
+                amount_native: amount,
+                timestamp: now,
+            });
+            log!(INFO, "[settlement chain={:?}] chain-collateral payout op {} vault/claim {} confirmed tx={} recipient={} amount={}", chain, op_id, vid, tx_hash, recipient, amount);
+        }
         SettlementOpKind::Burn { .. } => {
             // Unreachable: a Burn op is marked Failed on the submit path and
             // never goes Inflight. Log defensively rather than panic.
@@ -1724,10 +1775,14 @@ async fn resubmit_if_stuck(
     // Re-net the withdrawal value at the BUMPED fee so the replacement still
     // fits within the custody balance (a higher gas reserve sends marginally
     // less collateral — fine for a replace-by-fee). Mints carry no value.
-    let withdrawal_value = if matches!(op.kind, SettlementOpKind::NativeWithdrawal { .. }) {
+    let withdrawal_value = if matches!(
+        op.kind,
+        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
+    ) {
         match evm_rpc::get_balance(chain, &signer_addr).await {
             Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. } = &op.kind {
+                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
+                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
                     Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max))
                 } else {
                     None

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -377,6 +377,91 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
     })
 }
 
+/// State-only SP claim payout enqueue. The SP canister computes each user's CFX
+/// entitlement from its own depositor accounting, then asks the backend to pay
+/// that exact amount from the reserved chain-liquidity claim.
+///
+/// Mutation order is important: enqueue first, then mark the claim as paid. A
+/// duplicate idempotency key therefore rejects without double-deducting the
+/// claim balance.
+pub fn claim_chain_collateral_in_state(
+    state: &mut MultiChainState,
+    claim_id: u64,
+    claimant: candid::Principal,
+    owed_wei: u128,
+    dest_evm: String,
+    now_ns: u64,
+    address_validator: impl Fn(&str) -> bool,
+) -> Result<u64, String> {
+    if owed_wei == 0 {
+        return Err("chain collateral claim: amount is zero".to_string());
+    }
+    if !address_validator(&dest_evm) {
+        return Err("chain collateral claim: invalid EVM address".to_string());
+    }
+
+    let (chain, remaining) = {
+        let claim = state
+            .chain_liquidation_claims
+            .get(&claim_id)
+            .ok_or_else(|| format!("chain collateral claim: unknown claim {claim_id}"))?;
+        if !claim.paid_within_seized() {
+            return Err(format!("chain collateral claim: claim {claim_id} is overpaid"));
+        }
+        (claim.chain, claim.remaining_native())
+    };
+
+    let idempotency_key = format!(
+        "chain-collateral-claim-{claim_id}-{claimant}-{}-{owed_wei}",
+        dest_evm.to_ascii_lowercase()
+    );
+
+    if state
+        .settlement_queues
+        .get(&chain)
+        .map(|q| q.seen_idempotency_keys.contains(&idempotency_key))
+        .unwrap_or(false)
+    {
+        return Err(format!(
+            "Duplicate chain collateral claim payout idempotency key {idempotency_key}"
+        ));
+    }
+
+    if owed_wei > remaining {
+        return Err(format!(
+            "chain collateral claim: requested {owed_wei} exceeds remaining {remaining}"
+        ));
+    }
+
+    let op = crate::chains::settlement_queue::SettlementOp::new(
+        SettlementOpKind::ChainCollateralPayout {
+            recipient: dest_evm,
+            amount_e18: owed_wei,
+            vault_id: claim_id,
+            claimant,
+        },
+        idempotency_key,
+        now_ns,
+    );
+    let op_id = state
+        .settlement_queues
+        .entry(chain)
+        .or_default()
+        .enqueue(op)
+        .map_err(|e| match e {
+            crate::chains::settlement_queue::SettlementQueueError::DuplicateIdempotencyKey(key) => {
+                format!("Duplicate chain collateral claim payout idempotency key {key}")
+            }
+        })?;
+
+    let claim = state
+        .chain_liquidation_claims
+        .get_mut(&claim_id)
+        .expect("claim present: checked above");
+    claim.paid_native += owed_wei;
+    Ok(op_id)
+}
+
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
 
 /// Timer D entry point: run one settlement cycle for every registered+enabled

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -277,6 +277,106 @@ pub struct LiquidationSettlement {
     pub realized_usdc_native: u128,
 }
 
+/// Result of the state-only Tier-2 SP absorb transition. The caller emits
+/// `ChainVaultLiquidated { tier: StabilityPool }` from this data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpChainLiquidationAbsorb {
+    pub actual_burned_e8s: u128,
+    pub collateral_seized_native: u128,
+    pub custody_address: String,
+}
+
+/// State-only Tier-2 SP absorb transition (spec §6.1):
+///
+/// - the Stability Pool has already burned IC-native icUSD,
+/// - backend moves live chain debt -> `pending_chain_burn_e8s`,
+/// - foreign-chain `chain_supplies` is NOT changed,
+/// - seized native CFX is reserved in a `ChainLiqClaimV1` for later pull claims.
+///
+/// No async, no events, no wall-clock reads. Public canister entrypoints perform
+/// caller/proof/price gates before calling this helper.
+pub fn apply_sp_chain_liquidation_absorb_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    vault_id: u64,
+    icusd_burned_e8s: u128,
+    price_e8: u64,
+    native_decimals: u8,
+    liquidation_penalty_bps: u64,
+) -> Result<SpChainLiquidationAbsorb, String> {
+    use crate::chains::liquidation as liq;
+    use crate::chains::multi_chain_state::ChainLiqClaimV1;
+
+    let (live_debt, collateral_available, custody_address) = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or_else(|| format!("sp_absorb: unknown vault {vault_id}"))?;
+        if v.collateral_chain != chain {
+            return Err(format!("sp_absorb: vault chain {:?} != requested chain {:?}", v.collateral_chain, chain));
+        }
+        if v.status != ChainVaultStatus::Open {
+            return Err(format!("sp_absorb: vault {vault_id} is not Open"));
+        }
+        if v.pending_mint_e8s != 0 {
+            return Err(format!("sp_absorb: vault {vault_id} has pending mint"));
+        }
+        if v.pending_interest_mint_e8s != 0 {
+            return Err(format!("sp_absorb: vault {vault_id} has pending interest mint"));
+        }
+        if v.pending_liquidation.is_some() {
+            return Err(format!("sp_absorb: vault {vault_id} already has liquidation marker"));
+        }
+        if !state.sp_attempted_chain_vaults.contains(&vault_id) {
+            return Err(format!("sp_absorb: vault {vault_id} missing sp_attempted escalation gate"));
+        }
+        if state.chain_liquidation_claims.contains_key(&vault_id) {
+            return Err(format!("sp_absorb: vault {vault_id} already has chain liquidation claim"));
+        }
+        (v.debt_e8s, v.collateral_amount_native, v.custody_address.clone())
+    };
+
+    let actual_burned = icusd_burned_e8s.min(live_debt);
+    if actual_burned == 0 {
+        return Err(format!("sp_absorb: vault {vault_id} has nothing to absorb"));
+    }
+
+    let bonus_e4 = liq::bonus_e4_from_penalty_bps(liquidation_penalty_bps);
+    let collateral_seized = liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)
+        .min(collateral_available);
+    if collateral_seized == 0 {
+        return Err(format!("sp_absorb: vault {vault_id} has no collateral to seize"));
+    }
+
+    crate::chains::supply::apply_debt_to_pending_burn_shift(state, chain, vault_id, actual_burned)
+        .map_err(|e| format!("apply_debt_to_pending_burn_shift: {e:?}"))?;
+
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.collateral_amount_native = v.collateral_amount_native.saturating_sub(collateral_seized);
+    if v.debt_e8s == 0 && v.collateral_amount_native == 0 {
+        v.status = ChainVaultStatus::Closed;
+    }
+    state.chain_liquidation_claims.insert(
+        vault_id,
+        ChainLiqClaimV1 {
+            vault_id,
+            chain,
+            custody_address: custody_address.clone(),
+            seized_native_total: collateral_seized,
+            paid_native: 0,
+        },
+    );
+
+    Ok(SpChainLiquidationAbsorb {
+        actual_burned_e8s: actual_burned,
+        collateral_seized_native: collateral_seized,
+        custody_address,
+    })
+}
+
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
 
 /// Timer D entry point: run one settlement cycle for every registered+enabled

--- a/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_deposit_watch.rs
@@ -146,3 +146,21 @@ fn backstop_scans_only_on_supply_drop_and_no_inflight_mint() {
     // Zero/zero -> skip.
     assert!(!backstop_should_scan(0, 0, false));
 }
+
+#[test]
+fn no_debt_fast_path_stays_active_with_pending_chain_burn() {
+    use super::deposit_watch::burn_watch_can_skip_for_no_supply_obligation;
+
+    assert!(
+        burn_watch_can_skip_for_no_supply_obligation(0, 0),
+        "zero debt and zero pending burn has no foreign-supply obligation"
+    );
+    assert!(
+        !burn_watch_can_skip_for_no_supply_obligation(0, 42),
+        "pending_chain_burn means IC-side icUSD was burned but foreign representation remains outstanding"
+    );
+    assert!(
+        !burn_watch_can_skip_for_no_supply_obligation(42, 0),
+        "live debt means user burns can still repay a vault"
+    );
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -411,3 +411,84 @@ mod sp_absorb_tests {
         assert!(s.chain_liquidation_claims.get(&9).is_none());
     }
 }
+
+// ─── Increment 4 / Task 6: enqueue SP claim payout from reserved CFX ───
+mod chain_claim_tests {
+    use super::super::settlement::claim_chain_collateral_in_state;
+    use crate::chains::config::ChainId;
+    use crate::chains::multi_chain_state::{ChainLiqClaimV1, MultiChainState};
+    use crate::chains::settlement_queue::SettlementOpKind;
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(71);
+    const E18: u128 = 1_000_000_000_000_000_000;
+
+    fn valid_evm_address(a: &str) -> bool {
+        a.starts_with("0x") && a.len() == 42
+    }
+
+    fn claimant() -> Principal {
+        Principal::from_slice(&[7u8; 29])
+    }
+
+    fn state_with_claim() -> MultiChainState {
+        let mut s = MultiChainState::default();
+        s.chain_liquidation_claims.insert(7, ChainLiqClaimV1 {
+            vault_id: 7,
+            chain: CFX,
+            custody_address: "0x00000000000000000000000000000000000000c7".into(),
+            seized_native_total: 10 * E18,
+            paid_native: 2 * E18,
+        });
+        s
+    }
+
+    #[test]
+    fn claim_chain_collateral_enqueues_payout_and_marks_paid() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+
+        let op_id = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
+            .expect("claim enqueued");
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18, "claim is deducted before async payout");
+        let op = s.settlement_queues.get(&CFX).unwrap().pending.get(&op_id).unwrap();
+        match &op.kind {
+            SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, claimant: c } => {
+                assert_eq!(recipient, &dest);
+                assert_eq!(*amount_e18, 3 * E18);
+                assert_eq!(*vault_id, 7);
+                assert_eq!(*c, claimant());
+            }
+            other => panic!("expected ChainCollateralPayout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claim_chain_collateral_rejects_duplicate_without_double_marking_paid() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
+            .expect("first claim enqueued");
+
+        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest, 43, valid_evm_address)
+            .unwrap_err();
+
+        assert!(err.contains("Duplicate"), "expected duplicate idempotency error, got {err}");
+        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 5 * E18);
+        assert_eq!(s.settlement_queues.get(&CFX).unwrap().pending.len(), 1);
+    }
+
+    #[test]
+    fn claim_chain_collateral_validates_destination_before_mutation() {
+        let mut s = state_with_claim();
+
+        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, "not-evm".into(), 42, valid_evm_address)
+            .unwrap_err();
+
+        assert!(err.contains("invalid EVM address"), "unexpected error: {err}");
+        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 2 * E18);
+        assert!(s.settlement_queues.get(&CFX).is_none());
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -290,3 +290,124 @@ mod phase2_tests {
         assert!(s.reserve_backing_e8s.get(&CFX).is_none());
     }
 }
+
+// ─── Increment 4 / Task 5a: SP chain-vault absorb state transition ───
+mod sp_absorb_tests {
+    use super::super::settlement::apply_sp_chain_liquidation_absorb_in_state;
+    use crate::chains::config::ChainId;
+    use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use crate::chains::multi_chain_state::MultiChainState;
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(1030);
+    const E8: u128 = 100_000_000;
+    const E18: u128 = 1_000_000_000_000_000_000;
+
+    fn open_sp_attempted_vault(
+        s: &mut MultiChainState,
+        vault_id: u64,
+        debt_e8s: u128,
+        collateral_native: u128,
+    ) {
+        s.chain_vaults.insert(
+            vault_id,
+            ChainVaultV1 {
+                vault_id,
+                owner: Principal::anonymous(),
+                collateral_chain: CFX,
+                custody_address: "0x00000000000000000000000000000000000000c7".into(),
+                collateral_amount_native: collateral_native,
+                debt_e8s,
+                mint_recipient: "0x00000000000000000000000000000000000000d7".into(),
+                pending_mint_e8s: 0,
+                status: ChainVaultStatus::Open,
+                opened_at_ns: 0,
+                owner_evm: None,
+                last_interest_accrual_ns: 0,
+                pending_interest_mint_e8s: 0,
+                pending_liquidation: None,
+            },
+        );
+        s.chain_supplies.insert(CFX, debt_e8s);
+        s.sp_attempted_chain_vaults.insert(vault_id);
+    }
+
+    #[test]
+    fn sp_absorb_moves_debt_to_pending_burn_and_reserves_claim_collateral() {
+        let mut s = MultiChainState::default();
+        open_sp_attempted_vault(&mut s, 7, 100 * E8, 1_000 * E18);
+
+        let result = apply_sp_chain_liquidation_absorb_in_state(
+            &mut s,
+            CFX,
+            7,
+            100 * E8,
+            50_000_000, // $0.50/CFX
+            18,
+            1_200,
+        )
+        .expect("sp absorb ok");
+
+        assert_eq!(result.actual_burned_e8s, 100 * E8);
+        assert_eq!(result.collateral_seized_native, 224 * E18);
+        let v = s.chain_vaults.get(&7).unwrap();
+        assert_eq!(v.debt_e8s, 0, "debt cleared by the IC-side SP burn");
+        assert_eq!(v.collateral_amount_native, 776 * E18, "claim collateral reserved out of borrower balance");
+        assert_eq!(*s.pending_chain_burn_e8s.get(&CFX).unwrap(), 100 * E8);
+        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "foreign-chain supply accounting unchanged");
+        assert!(v.pending_liquidation.is_none(), "SP absorb does not create a fake foreign-burn marker");
+
+        let claim = s.chain_liquidation_claims.get(&7).expect("claim record");
+        assert_eq!(claim.vault_id, 7);
+        assert_eq!(claim.chain, CFX);
+        assert_eq!(claim.custody_address, "0x00000000000000000000000000000000000000c7");
+        assert_eq!(claim.seized_native_total, 224 * E18);
+        assert_eq!(claim.paid_native, 0);
+        assert!(claim.paid_within_seized());
+
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+        );
+    }
+
+    #[test]
+    fn sp_absorb_caps_overburn_to_live_debt() {
+        let mut s = MultiChainState::default();
+        open_sp_attempted_vault(&mut s, 8, 80 * E8, 200 * E18);
+
+        let result = apply_sp_chain_liquidation_absorb_in_state(
+            &mut s,
+            CFX,
+            8,
+            100 * E8,
+            100_000_000, // $1.00/CFX
+            18,
+            1_200,
+        )
+        .expect("sp absorb ok");
+
+        assert_eq!(result.actual_burned_e8s, 80 * E8, "backend never clears more than live debt");
+        assert_eq!(result.collateral_seized_native, 89_600_000_000_000_000_000);
+        assert_eq!(s.chain_vaults.get(&8).unwrap().debt_e8s, 0);
+        assert_eq!(*s.pending_chain_burn_e8s.get(&CFX).unwrap(), 80 * E8);
+        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 80 * E8);
+    }
+
+    #[test]
+    fn sp_absorb_rejects_without_bot_escalation_no_mutation() {
+        let mut s = MultiChainState::default();
+        open_sp_attempted_vault(&mut s, 9, 100 * E8, 1_000 * E18);
+        s.sp_attempted_chain_vaults.remove(&9);
+
+        let err = apply_sp_chain_liquidation_absorb_in_state(&mut s, CFX, 9, 100 * E8, 50_000_000, 18, 1_200)
+            .unwrap_err();
+
+        assert!(err.contains("sp_attempted"), "error should name the missing escalation gate: {err}");
+        let v = s.chain_vaults.get(&9).unwrap();
+        assert_eq!(v.debt_e8s, 100 * E8);
+        assert_eq!(v.collateral_amount_native, 1_000 * E18);
+        assert!(s.pending_chain_burn_e8s.get(&CFX).is_none());
+        assert!(s.chain_liquidation_claims.get(&9).is_none());
+    }
+}

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -424,31 +424,53 @@ impl MultiChainStateV5 {
     }
 }
 
-/// Chains-liquidation Increment 1 snapshot. Carries every `MultiChainStateV5`
-/// field verbatim, plus the liquidation-engine accounting scaffolding: per-chain
-/// reserve backing (bot/PSM path), the physical USDC custody mirror, per-chain
-/// pending SP burn (pre-eSpace-burn), and the one-shot SP-attempted set. This is
-/// a NON-BREAKING reshape under ciborium, exactly like every prior bump:
+/// Chains-liquidation working snapshot. Carries every `MultiChainStateV5` field
+/// verbatim, plus additive liquidation-engine accounting/routing fields:
+/// per-chain reserve backing (bot/PSM path), the physical USDC custody mirror,
+/// per-chain pending SP burn, the one-shot SP-attempted set, liquidation config,
+/// bot-pending timestamps, bad-debt counters, and SP claim records. This is a
+/// NON-BREAKING reshape under ciborium, exactly like every prior bump:
 ///
 ///  - The fifteen V5 fields are byte-for-byte identical and map across by name
 ///    (the four originals are always present; every V2+-added map keeps its
 ///    `#[serde(default)]`).
-///  - The four new V6 fields each carry `#[serde(default)]`, so a live
+///  - The V6-added fields each carry `#[serde(default)]`, so a live
 ///    `MultiChainStateV5` CBOR snapshot (which lacks these keys entirely) decodes
 ///    into V6 with them defaulting to empty — NOT a state wipe. Proven by
 ///    `tests_multi_chain_state_v2::v5_cbor_snapshot_decodes_into_v6_without_wiping_state`.
 ///
-/// All four new fields are 0/empty until Increment 2 wires the liquidation
-/// engine, so the unified supply invariant (debt + reserve + pending-burn)
-/// reduces to the old `supply == debt` on the live snapshot — the upgrade is
-/// behavior-preserving.
+/// All additive fields default to 0/empty on snapshots that predate them, so the
+/// unified supply invariant (debt + reserve + pending-burn) reduces to the old
+/// `supply == debt` until the corresponding increment writes them — the upgrade
+/// is behavior-preserving.
 ///
 /// Because the decode is in-place, NO explicit `post_upgrade` migration call is
 /// needed; `migrate_multi_chain_state` in `supply.rs` remains the dormant
 /// template for the next BREAKING bump.
 ///
-/// Add the NEXT field by bumping to `MultiChainStateV7` (keep V6 verbatim),
-/// `#[serde(default)]` on the new field, and rebinding the alias below.
+/// Any further additive field on this CBOR root MUST use `#[serde(default)]` and
+/// extend the V5->V6 and V6->V6 decode tests. A genuinely breaking reshape
+/// should bump to `MultiChainStateV7` (keep V6 verbatim) and rebind the alias
+/// below.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ChainLiqClaimV1 {
+    pub vault_id: u64,
+    pub chain: ChainId,
+    pub custody_address: String,
+    pub seized_native_total: u128,
+    pub paid_native: u128,
+}
+
+impl ChainLiqClaimV1 {
+    pub fn paid_within_seized(&self) -> bool {
+        self.paid_native <= self.seized_native_total
+    }
+
+    pub fn remaining_native(&self) -> u128 {
+        self.seized_native_total.saturating_sub(self.paid_native)
+    }
+}
+
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct MultiChainStateV6 {
     pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
@@ -511,6 +533,13 @@ pub struct MultiChainStateV6 {
     /// harmless (worst case a vault waits one extra tick for manual).
     #[serde(default)]
     pub sp_attempted_chain_vaults: BTreeSet<u64>,
+    /// Vault_id -> SP liquidation claim record. Created when the Stability Pool
+    /// absorbs a foreign-chain vault; tracks how much seized native collateral is
+    /// reserved in that vault's custody address and how much has already been
+    /// paid out to CFX-claiming SP depositors. `#[serde(default)]` is mandatory:
+    /// live V6 snapshots written before Inc 4 lack this key.
+    #[serde(default)]
+    pub chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>,
     /// Per-chain, operator-settable liquidation config (spec 8): the DEX wiring +
     /// risk knobs the bot path reads, keyed by chain. Added directly to V6 (not a
     /// V7) because V6 has not yet been persisted to any live canister — same

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -495,10 +495,12 @@ pub struct MultiChainStateV6 {
     /// invariant RHS. Empty until Increment 2.
     #[serde(default)]
     pub reserve_usdc_native: BTreeMap<ChainId, u128>,
-    /// SP-path debt mid-burn per chain (e8s): the SP has absorbed it (icUSD
-    /// burned IC-side) but the matching eSpace burn is not yet confirmed. RHS
-    /// term-3 of the unified supply invariant. Moves to a `chain_supplies`
-    /// decrement when the eSpace Burn op confirms. Empty until Increment 4.
+    /// SP-path IC-side burn backing per chain (e8s): the SP has absorbed debt
+    /// by burning IC-native icUSD, while the foreign-chain icUSD representation
+    /// remains outstanding. RHS term-3 of the unified supply invariant. Later
+    /// manual reconciliation can consume this term together with a
+    /// `chain_supplies` decrement after the protocol acquires and retires the
+    /// foreign representation. Empty until Increment 4.
     #[serde(default)]
     pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
     /// Chains analog of the ICP `sp_attempted_vaults`: vaults whose bot

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -127,6 +127,10 @@ pub fn apply_resolve_reversal_in_state(
                     }
                 }
             }
+            SettlementOpKind::ChainCollateralPayout { .. } => {
+                // Claim payout recovery must not re-credit vault collateral. The
+                // SP-side claim rollback is handled by the claim path/callback.
+            }
             SettlementOpKind::InterestMint { vault_id, .. } => {
                 if let Some(v) = state.chain_vaults.get_mut(vault_id) {
                     // Task 12: clear the orphaned interest reservation; nothing was

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -8,7 +8,7 @@
 //! Versioned per the spec Section 3. Adding a field bumps to V2 plus a
 //! migration in `chains::supply::migrate_multi_chain_state`.
 
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -58,6 +58,16 @@ pub enum SettlementOpKind {
         path: Vec<String>,
         reserve_recipient: String,
         deadline_secs: u64,
+    },
+    /// Tier-2 SP CFX claim payout. This is deliberately NOT a NativeWithdrawal:
+    /// a reverted claim payout must re-credit the SP depositor's claim, not add
+    /// collateral back to the vault. Signed by the vault custody address and
+    /// value-denominated in native wei (`amount_e18`).
+    ChainCollateralPayout {
+        recipient: String,
+        amount_e18: u128,
+        vault_id: u64,
+        claimant: Principal,
     },
 }
 

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -179,9 +179,15 @@ pub async fn run_settlement(chain: ChainId) {
 async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // A Burn op is never signable in M2 - burns are user-initiated on-chain. Fail
     // it up front (no RPC), mirroring Monad. Task 12: an InterestMint can never be
-    // enqueued on a Solana queue (interest harvest is EVM-only), but fail it
-    // defensively too so a stray op can never wedge the worker.
-    if matches!(op.kind, SettlementOpKind::Burn { .. } | SettlementOpKind::InterestMint { .. }) {
+    // enqueued on a Solana queue (interest harvest is EVM-only), and CFX claim
+    // payouts are EVM-custody only. Fail unsupported ops defensively so a stray
+    // op can never wedge the worker.
+    if matches!(
+        op.kind,
+        SettlementOpKind::Burn { .. }
+            | SettlementOpKind::InterestMint { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. }
+    ) {
         let now = ic_cdk::api::time();
         let reason = "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
         mutate_state(|s| {
@@ -282,7 +288,8 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
         }
         SettlementOpKind::Burn { .. }
         | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. } => {
+        | SettlementOpKind::LiquidationSwap { .. }
+        | SettlementOpKind::ChainCollateralPayout { .. } => {
             // Unreachable: handled (marked Failed) at the top of this fn.
             return;
         }
@@ -525,7 +532,8 @@ fn confirm_succeeded(
         }
         SettlementOpKind::Burn { .. }
         | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. } => {
+        | SettlementOpKind::LiquidationSwap { .. }
+        | SettlementOpKind::ChainCollateralPayout { .. } => {
             // Unreachable: Burn/InterestMint ops are marked Failed on the submit
             // path and never go Inflight. Log defensively rather than panic.
             log!(INFO, "[solana settlement chain={:?}] inflight non-signable op {} reached confirm path unexpectedly", chain, op_id);
@@ -584,7 +592,8 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
             }
             SettlementOpKind::Burn { .. }
         | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. } => {}
+        | SettlementOpKind::LiquidationSwap { .. }
+        | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
         if let Some(o) = s
             .multi_chain
@@ -613,7 +622,8 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
             }
             SettlementOpKind::Burn { .. }
         | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. } => {}
+        | SettlementOpKind::LiquidationSwap { .. }
+        | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -247,6 +247,159 @@ pub fn apply_debt_to_reserve_shift(
     Ok(())
 }
 
+/// Reasons `apply_debt_to_pending_burn_shift` rejects (no state mutation on any error).
+#[derive(Debug, PartialEq, Eq)]
+pub enum PendingBurnShiftError {
+    /// The invariant self-check has halted the rail; do not move backing.
+    Halted,
+    /// No such chain vault.
+    UnknownVault(u64),
+    /// The vault's `collateral_chain` does not match the requested `chain`.
+    WrongChain { vault_chain: ChainId, requested: ChainId },
+    /// `burned_e8s` exceeds the vault's live `debt_e8s` (IC icUSD cannot be
+    /// un-burned and there is no proportional refund — over-burn would be
+    /// un-refundable bad debt against SP depositors).
+    ClearExceedsDebt { cleared_e8s: u128, vault_debt_e8s: u128 },
+    /// The post-move unified invariant would not hold. The move conserves
+    /// debt+pending, so this only fires if the invariant was ALREADY diverged
+    /// before the call (defensive; no mutation).
+    InvariantBroken { sum_supplies: u128, rhs: u128 },
+}
+
+/// Tier-2 SP-path absorb accounting (spec 5.3, 6.1 option A): atomically move
+/// `burned_e8s` of a vault's debt into the chain's pending-burn term (the SP has
+/// burned IC-native icUSD, but the matching eSpace burn has not confirmed yet, so
+/// `chain_supplies` is UNCHANGED). This is the SP analogue of
+/// `apply_debt_to_reserve_shift`: it moves debt -> `pending_chain_burn_e8s`
+/// instead of -> `reserve_backing_e8s`. It conserves `debt + pending`, so the
+/// unified invariant (debt + reserve + pending) is preserved BY CONSTRUCTION; the
+/// pre-apply check is a defensive assert that catches pre-existing drift (no
+/// mutation on rejection). The paired `apply_pending_burn_to_supply_shift` drops
+/// both terms when the eSpace `Burn` op confirms at finality.
+pub fn apply_debt_to_pending_burn_shift(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    vault_id: u64,
+    burned_e8s: u128,
+) -> Result<(), PendingBurnShiftError> {
+    if state.invariant_halted {
+        return Err(PendingBurnShiftError::Halted);
+    }
+    // Validate (read-only — no mutation on any rejection path).
+    let vault_debt = {
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(PendingBurnShiftError::UnknownVault(vault_id))?;
+        if v.collateral_chain != chain {
+            return Err(PendingBurnShiftError::WrongChain {
+                vault_chain: v.collateral_chain,
+                requested: chain,
+            });
+        }
+        v.debt_e8s
+    };
+    if burned_e8s > vault_debt {
+        return Err(PendingBurnShiftError::ClearExceedsDebt {
+            cleared_e8s: burned_e8s,
+            vault_debt_e8s: vault_debt,
+        });
+    }
+
+    // Pre-validate the post-move unified invariant WITHOUT mutating. chain_supplies
+    // is unchanged; debt drops by burned_e8s and pending_chain_burn rises by the
+    // same, so the RHS is invariant. A divergence here means the invariant was
+    // ALREADY broken before the call.
+    let sum_supplies = state.total_supply_all_chains_e8s();
+    let post_debt_total = state.total_chain_vault_debt_e8s().saturating_sub(burned_e8s);
+    let post_pending_total = state.total_pending_chain_burn_e8s().saturating_add(burned_e8s);
+    let post_rhs = post_debt_total
+        .saturating_add(state.total_reserve_backing_e8s())
+        .saturating_add(post_pending_total);
+    if sum_supplies != post_rhs {
+        return Err(PendingBurnShiftError::InvariantBroken { sum_supplies, rhs: post_rhs });
+    }
+
+    // Apply atomically (every reject above happened before any mutation).
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
+    v.debt_e8s -= burned_e8s;
+    *state.pending_chain_burn_e8s.entry(chain).or_default() += burned_e8s;
+    Ok(())
+}
+
+/// Reasons `apply_pending_burn_to_supply_shift` rejects (no state mutation on any error).
+#[derive(Debug, PartialEq, Eq)]
+pub enum PendingBurnSupplyShiftError {
+    /// The invariant self-check has halted the rail.
+    Halted,
+    /// No `chain_supplies` entry for the chain.
+    UnknownChain(ChainId),
+    /// `amount_e8s` exceeds the chain's booked `pending_chain_burn_e8s`.
+    PendingBurnUnderflow { chain: ChainId, booked: u128, attempted: u128 },
+    /// `amount_e8s` exceeds the chain's live `chain_supplies`.
+    SupplyUnderflow { chain: ChainId, current: u128, attempted: u128 },
+    /// The post-move unified invariant would not hold (defensive; only fires if
+    /// the invariant was already diverged — the move conserves supply+pending).
+    InvariantBroken { sum_supplies: u128, rhs: u128 },
+}
+
+/// Tier-2 SP-path eSpace-burn confirm accounting (spec 5.3, 6.1 option A):
+/// atomically drop `amount_e8s` from BOTH the chain's `pending_chain_burn_e8s` and
+/// its `chain_supplies` when the eSpace `Burn` op confirms at finality (the real
+/// foreign-supply burn has now landed). Both sides of the unified invariant drop by
+/// the same amount, so it is preserved BY CONSTRUCTION. Mirrors
+/// `apply_debt_to_pending_burn_shift`'s single-guarded-mutate discipline (no
+/// mutation on any rejection). The `pending_chain_burn` entry is kept at 0 for audit.
+pub fn apply_pending_burn_to_supply_shift(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    amount_e8s: u128,
+) -> Result<(), PendingBurnSupplyShiftError> {
+    if state.invariant_halted {
+        return Err(PendingBurnSupplyShiftError::Halted);
+    }
+    let current_supply = match state.chain_supplies.get(&chain) {
+        Some(v) => *v,
+        None => return Err(PendingBurnSupplyShiftError::UnknownChain(chain)),
+    };
+    let booked = state.pending_chain_burn_e8s.get(&chain).copied().unwrap_or(0);
+    if amount_e8s > booked {
+        return Err(PendingBurnSupplyShiftError::PendingBurnUnderflow {
+            chain,
+            booked,
+            attempted: amount_e8s,
+        });
+    }
+    if amount_e8s > current_supply {
+        return Err(PendingBurnSupplyShiftError::SupplyUnderflow {
+            chain,
+            current: current_supply,
+            attempted: amount_e8s,
+        });
+    }
+
+    // Pre-validate the post-move unified invariant WITHOUT mutating. supply and
+    // pending both drop by amount_e8s; debt + reserve are untouched.
+    let sum_after = state.total_supply_all_chains_e8s().saturating_sub(amount_e8s);
+    let post_pending_total = state.total_pending_chain_burn_e8s().saturating_sub(amount_e8s);
+    let post_rhs = state
+        .total_chain_vault_debt_e8s()
+        .saturating_add(state.total_reserve_backing_e8s())
+        .saturating_add(post_pending_total);
+    if sum_after != post_rhs {
+        return Err(PendingBurnSupplyShiftError::InvariantBroken { sum_supplies: sum_after, rhs: post_rhs });
+    }
+
+    // Apply atomically. Keep the pending entry at 0 (audit), mirroring how
+    // apply_supply_delta keeps a drained chain_supplies entry.
+    state.pending_chain_burn_e8s.insert(chain, booked - amount_e8s);
+    state.chain_supplies.insert(chain, current_supply - amount_e8s);
+    Ok(())
+}
+
 /// Phase 1b Task 12 migration: stamp `last_interest_accrual_ns = now_ns` for any
 /// chain vault that decoded with 0 (an existing vault from a snapshot written
 /// before the interest fields existed), so the first harvest does not bill

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -268,14 +268,15 @@ pub enum PendingBurnShiftError {
 
 /// Tier-2 SP-path absorb accounting (spec 5.3, 6.1 option A): atomically move
 /// `burned_e8s` of a vault's debt into the chain's pending-burn term (the SP has
-/// burned IC-native icUSD, but the matching eSpace burn has not confirmed yet, so
-/// `chain_supplies` is UNCHANGED). This is the SP analogue of
+/// burned IC-native icUSD, while the foreign-chain icUSD representation remains
+/// outstanding, so `chain_supplies` is UNCHANGED). This is the SP analogue of
 /// `apply_debt_to_reserve_shift`: it moves debt -> `pending_chain_burn_e8s`
 /// instead of -> `reserve_backing_e8s`. It conserves `debt + pending`, so the
 /// unified invariant (debt + reserve + pending) is preserved BY CONSTRUCTION; the
 /// pre-apply check is a defensive assert that catches pre-existing drift (no
-/// mutation on rejection). The paired `apply_pending_burn_to_supply_shift` drops
-/// both terms when the eSpace `Burn` op confirms at finality.
+/// mutation on rejection). The paired `apply_pending_burn_to_supply_shift` is the
+/// later manual-reconciliation primitive: it drops both terms when the foreign
+/// representation is actually retired.
 pub fn apply_debt_to_pending_burn_shift(
     state: &mut MultiChainState,
     chain: ChainId,
@@ -346,11 +347,11 @@ pub enum PendingBurnSupplyShiftError {
     InvariantBroken { sum_supplies: u128, rhs: u128 },
 }
 
-/// Tier-2 SP-path eSpace-burn confirm accounting (spec 5.3, 6.1 option A):
+/// Tier-2 SP-path foreign-representation retirement accounting (spec 5.3):
 /// atomically drop `amount_e8s` from BOTH the chain's `pending_chain_burn_e8s` and
-/// its `chain_supplies` when the eSpace `Burn` op confirms at finality (the real
-/// foreign-supply burn has now landed). Both sides of the unified invariant drop by
-/// the same amount, so it is preserved BY CONSTRUCTION. Mirrors
+/// its `chain_supplies` after the protocol has acquired and retired the foreign
+/// icUSD representation. Both sides of the unified invariant drop by the same
+/// amount, so it is preserved BY CONSTRUCTION. Mirrors
 /// `apply_debt_to_pending_burn_shift`'s single-guarded-mutate discipline (no
 /// mutation on any rejection). The `pending_chain_burn` entry is kept at 0 for audit.
 pub fn apply_pending_burn_to_supply_shift(

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,6 +1,6 @@
 use super::multi_chain_state::{
-    MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
-    MultiChainStateV5, MultiChainStateV6,
+    ChainLiqClaimV1, MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3,
+    MultiChainStateV4, MultiChainStateV5, MultiChainStateV6,
 };
 use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
@@ -372,6 +372,7 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
     assert!(v6.reserve_usdc_native.is_empty());
     assert!(v6.pending_chain_burn_e8s.is_empty());
     assert!(v6.sp_attempted_chain_vaults.is_empty());
+    assert!(v6.chain_liquidation_claims.is_empty());
 
     // Total debt still reconciles with supply (the invariant is intact post-decode;
     // with all-zero reserve/pending the generalized RHS reduces to bare debt).
@@ -397,6 +398,13 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     v6.pending_chain_burn_e8s.insert(CFX, 15);
     v6.sp_attempted_chain_vaults.insert(7);
     v6.sp_attempted_chain_vaults.insert(9);
+    v6.chain_liquidation_claims.insert(7, ChainLiqClaimV1 {
+        vault_id: 7,
+        chain: CFX,
+        custody_address: "0xcustody".into(),
+        seized_native_total: 12_345_000_000_000_000_000,
+        paid_native: 1_000_000_000_000_000_000,
+    });
     v6.chain_liquidation_configs.insert(CFX, ChainLiquidationConfigV1 {
         dex: DexKind::UniswapV2,
         router: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
@@ -424,6 +432,13 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     assert_eq!(decoded.reserve_usdc_native.get(&CFX), Some(&45_000_000_000_000_000_000));
     assert_eq!(decoded.pending_chain_burn_e8s.get(&CFX), Some(&15));
     assert_eq!(decoded.sp_attempted_chain_vaults, BTreeSet::from([7, 9]));
+    let claim = decoded.chain_liquidation_claims.get(&7).expect("claim survived");
+    assert_eq!(claim.vault_id, 7);
+    assert_eq!(claim.chain, CFX);
+    assert_eq!(claim.custody_address, "0xcustody");
+    assert_eq!(claim.seized_native_total, 12_345_000_000_000_000_000);
+    assert_eq!(claim.paid_native, 1_000_000_000_000_000_000);
+    assert!(claim.paid_within_seized(), "paid_native <= seized_native_total");
     let cfg = decoded.chain_liquidation_configs.get(&CFX).expect("config survived");
     assert_eq!(cfg.dex, DexKind::UniswapV2);
     assert_eq!(cfg.slippage_cap_bps, 250);
@@ -439,6 +454,18 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     // The aggregate accessors reflect the round-tripped reserve/pending terms.
     assert_eq!(decoded.total_reserve_backing_e8s(), 40);
     assert_eq!(decoded.total_pending_chain_burn_e8s(), 15);
+}
+
+#[test]
+fn chain_liq_claim_invariant_rejects_overpaid_claims() {
+    let claim = ChainLiqClaimV1 {
+        vault_id: 9,
+        chain: ChainId(1030),
+        custody_address: "0xcustody".into(),
+        seized_native_total: 10,
+        paid_native: 11,
+    };
+    assert!(!claim.paid_within_seized());
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_settlement_queue.rs
@@ -96,6 +96,36 @@ fn round_trip_via_candid() {
 }
 
 #[test]
+fn chain_collateral_payout_round_trips_and_is_not_a_mint() {
+    let mut q = SettlementQueueV1::default();
+    let op = SettlementOp::new(
+        SettlementOpKind::ChainCollateralPayout {
+            recipient: "0xclaimant".to_string(),
+            amount_e18: 42,
+            vault_id: 7,
+            claimant: candid::Principal::anonymous(),
+        },
+        "claim:7:2vxsx-fae:0xclaimant".to_string(),
+        0,
+    );
+    q.enqueue(op).expect("enqueue");
+    assert!(!q.has_active_mint_op(), "claim payout does not change icUSD supply");
+
+    let bytes = Encode!(&q).expect("encode");
+    let back: SettlementQueueV1 = Decode!(&bytes, SettlementQueueV1).expect("decode");
+    let op = back.pending.get(&0).expect("op survived");
+    match &op.kind {
+        SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, claimant } => {
+            assert_eq!(recipient, "0xclaimant");
+            assert_eq!(*amount_e18, 42);
+            assert_eq!(*vault_id, 7);
+            assert_eq!(*claimant, candid::Principal::anonymous());
+        }
+        other => panic!("unexpected op kind: {other:?}"),
+    }
+}
+
+#[test]
 fn op_status_transitions_only_to_terminal_states() {
     let mut op = SettlementOp::new(
         SettlementOpKind::Mint { recipient: "0xa".to_string(), amount_e8s: 1, vault_id: 1 },

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -315,9 +315,9 @@ fn reserve_shift_blocked_while_invariant_halted() {
 // into pending_chain_burn_e8s (RHS term-3), NOT reserve_backing_e8s (term-2). Two
 // guarded mutations, mirroring apply_debt_to_reserve_shift / apply_supply_delta:
 //   (1) absorb time: apply_debt_to_pending_burn_shift moves debt -> pending_burn,
-//       chain_supplies UNCHANGED (the eSpace burn has not landed yet).
-//   (2) eSpace-burn confirm: apply_pending_burn_to_supply_shift drops pending_burn
-//       AND chain_supplies together (the foreign supply actually dropped).
+//       chain_supplies UNCHANGED (foreign representation remains outstanding).
+//   (2) later manual reconciliation: apply_pending_burn_to_supply_shift drops
+//       pending_burn AND chain_supplies together (foreign supply retired).
 // Both conserve the unified RHS by construction.
 
 use super::supply::{
@@ -339,7 +339,7 @@ fn pending_burn_shift_moves_debt_to_pending_and_preserves_invariant() {
 
     assert_eq!(s.chain_vaults[&1].debt_e8s, 60, "vault debt reduced by absorbed amount");
     assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 40, "pending_chain_burn booked the absorbed debt");
-    assert_eq!(s.chain_supplies[&CHAIN], 100, "chain_supplies UNCHANGED (eSpace burn not yet confirmed)");
+    assert_eq!(s.chain_supplies[&CHAIN], 100, "chain_supplies UNCHANGED (foreign representation remains outstanding)");
     // post: 100 == 60 (debt) + 0 (reserve) + 40 (pending) -> invariant still holds
     assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
 }
@@ -391,7 +391,7 @@ fn pending_burn_shift_blocked_while_invariant_halted() {
     assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation while halted");
 }
 
-// (2a) confirm: pending_burn AND chain_supplies both drop, invariant preserved.
+// (2a) reconcile: pending_burn AND chain_supplies both drop, invariant preserved.
 #[test]
 fn pending_burn_to_supply_drops_both_and_preserves_invariant() {
     let mut s = fixture_state();
@@ -401,11 +401,11 @@ fn pending_burn_to_supply_drops_both_and_preserves_invariant() {
     s.pending_chain_burn_e8s.insert(CHAIN, 40);
     assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
 
-    // The eSpace burn of 40 confirms.
+    // The operator has retired 40 of the foreign representation.
     apply_pending_burn_to_supply_shift(&mut s, CHAIN, 40).expect("pending-burn -> supply shift");
 
     assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 0, "pending_chain_burn drained");
-    assert_eq!(s.chain_supplies[&CHAIN], 60, "chain_supplies dropped (real eSpace burn observed)");
+    assert_eq!(s.chain_supplies[&CHAIN], 60, "chain_supplies dropped (foreign representation retired)");
     // post: 60 == 60 (debt) + 0 (reserve) + 0 (pending) -> invariant still holds
     assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -308,3 +308,133 @@ fn reserve_shift_blocked_while_invariant_halted() {
     );
     assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation while halted");
 }
+
+// ─── Increment 4 / Task 1: the SP-path supply helpers ───
+//
+// The SP fallback BURNS IC-native icUSD, so unlike the bot/PSM path it moves debt
+// into pending_chain_burn_e8s (RHS term-3), NOT reserve_backing_e8s (term-2). Two
+// guarded mutations, mirroring apply_debt_to_reserve_shift / apply_supply_delta:
+//   (1) absorb time: apply_debt_to_pending_burn_shift moves debt -> pending_burn,
+//       chain_supplies UNCHANGED (the eSpace burn has not landed yet).
+//   (2) eSpace-burn confirm: apply_pending_burn_to_supply_shift drops pending_burn
+//       AND chain_supplies together (the foreign supply actually dropped).
+// Both conserve the unified RHS by construction.
+
+use super::supply::{
+    apply_debt_to_pending_burn_shift, apply_pending_burn_to_supply_shift,
+    PendingBurnShiftError, PendingBurnSupplyShiftError,
+};
+
+// (1a) absorb: debt -> pending_burn, supply unchanged, invariant preserved.
+#[test]
+fn pending_burn_shift_moves_debt_to_pending_and_preserves_invariant() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    // pre: 100 == 100 (debt) + 0 (reserve) + 0 (pending)
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+
+    // SP burns 40 of IC icUSD and absorbs 40 of debt.
+    apply_debt_to_pending_burn_shift(&mut s, CHAIN, 1, 40).expect("pending-burn shift");
+
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 60, "vault debt reduced by absorbed amount");
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 40, "pending_chain_burn booked the absorbed debt");
+    assert_eq!(s.chain_supplies[&CHAIN], 100, "chain_supplies UNCHANGED (eSpace burn not yet confirmed)");
+    // post: 100 == 60 (debt) + 0 (reserve) + 40 (pending) -> invariant still holds
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn pending_burn_shift_rejects_clearing_more_than_debt() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    assert_eq!(
+        apply_debt_to_pending_burn_shift(&mut s, CHAIN, 1, 150),
+        Err(PendingBurnShiftError::ClearExceedsDebt { cleared_e8s: 150, vault_debt_e8s: 100 })
+    );
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation on rejection");
+    assert_eq!(s.pending_chain_burn_e8s.get(&CHAIN).copied().unwrap_or(0), 0);
+}
+
+#[test]
+fn pending_burn_shift_rejects_unknown_vault() {
+    let mut s = fixture_state();
+    assert_eq!(
+        apply_debt_to_pending_burn_shift(&mut s, CHAIN, 99, 10),
+        Err(PendingBurnShiftError::UnknownVault(99))
+    );
+}
+
+#[test]
+fn pending_burn_shift_rejects_wrong_chain() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0)); // vault is on CHAIN (101)
+    s.chain_supplies.insert(CHAIN, 100);
+    assert_eq!(
+        apply_debt_to_pending_burn_shift(&mut s, ChainId(202), 1, 40),
+        Err(PendingBurnShiftError::WrongChain { vault_chain: CHAIN, requested: ChainId(202) })
+    );
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation on rejection");
+}
+
+#[test]
+fn pending_burn_shift_blocked_while_invariant_halted() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(100, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.invariant_halted = true;
+    assert_eq!(
+        apply_debt_to_pending_burn_shift(&mut s, CHAIN, 1, 40),
+        Err(PendingBurnShiftError::Halted)
+    );
+    assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation while halted");
+}
+
+// (2a) confirm: pending_burn AND chain_supplies both drop, invariant preserved.
+#[test]
+fn pending_burn_to_supply_drops_both_and_preserves_invariant() {
+    let mut s = fixture_state();
+    // State after an SP absorb of 40: debt 60, pending_burn 40, supply still 100.
+    s.chain_vaults.insert(1, vault_with(60, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 40);
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+
+    // The eSpace burn of 40 confirms.
+    apply_pending_burn_to_supply_shift(&mut s, CHAIN, 40).expect("pending-burn -> supply shift");
+
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 0, "pending_chain_burn drained");
+    assert_eq!(s.chain_supplies[&CHAIN], 60, "chain_supplies dropped (real eSpace burn observed)");
+    // post: 60 == 60 (debt) + 0 (reserve) + 0 (pending) -> invariant still holds
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn pending_burn_to_supply_rejects_amount_exceeding_pending() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(60, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 40);
+    assert_eq!(
+        apply_pending_burn_to_supply_shift(&mut s, CHAIN, 50),
+        Err(PendingBurnSupplyShiftError::PendingBurnUnderflow { chain: CHAIN, booked: 40, attempted: 50 })
+    );
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 40, "no mutation on rejection");
+    assert_eq!(s.chain_supplies[&CHAIN], 100, "no mutation on rejection");
+}
+
+#[test]
+fn pending_burn_to_supply_blocked_while_invariant_halted() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(60, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 40);
+    s.invariant_halted = true;
+    assert_eq!(
+        apply_pending_burn_to_supply_shift(&mut s, CHAIN, 40),
+        Err(PendingBurnSupplyShiftError::Halted)
+    );
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 40, "no mutation while halted");
+    assert_eq!(s.chain_supplies[&CHAIN], 100, "no mutation while halted");
+}

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1937,6 +1937,27 @@ pub struct ChainLiquidatableVault {
     pub sized_repay_e8s: u128,
 }
 
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ChainStabilityPoolLiquidationResult {
+    pub success: bool,
+    pub vault_id: u64,
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub liquidated_debt_e8s: u128,
+    pub collateral_received_native: u128,
+    pub claim_id: u64,
+    pub custody_address: String,
+    pub block_index: u64,
+    pub collateral_price_e8s: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChainSpAbsorbSnapshot {
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    price_e8: u64,
+    native_decimals: u8,
+    liquidation_penalty_bps: u64,
+}
+
 /// Resolve the chain's native collateral symbol (the manual-price key) for the
 /// liquidation path. `Err` if the chain is not a known EVM chain.
 fn liquidation_price_symbol(
@@ -1945,6 +1966,51 @@ fn liquidation_price_symbol(
     rumi_protocol_backend::chains::evm::evm_chain_config(chain)
         .map(|c| c.native_symbol)
         .ok_or_else(|| ProtocolError::ChainAdmin(format!("chain {} is not a known EVM chain", chain.0)))
+}
+
+fn chain_sp_absorb_snapshot(
+    state: &rumi_protocol_backend::chains::multi_chain_state::MultiChainState,
+    vault_id: u64,
+    now_ns: u64,
+) -> Result<ChainSpAbsorbSnapshot, ProtocolError> {
+    use rumi_protocol_backend::chains::collateral_config::chain_collateral_config;
+    use rumi_protocol_backend::chains::liquidation as liq;
+
+    if state.invariant_halted {
+        return Err(ProtocolError::SupplyInvariantHalted);
+    }
+    let vault = state
+        .chain_vaults
+        .get(&vault_id)
+        .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain vault {vault_id}")))?;
+    let chain = vault.collateral_chain;
+    if state.reorg_halted.get(&chain).copied().unwrap_or(false) {
+        return Err(ProtocolError::ChainAdmin(format!("chain {} reorg halted", chain.0)));
+    }
+    if !state.sp_attempted_chain_vaults.contains(&vault_id) {
+        return Err(ProtocolError::ChainAdmin(format!("chain vault {vault_id} missing sp_attempted escalation gate")));
+    }
+    let cfg = state
+        .chain_liquidation_configs
+        .get(&chain)
+        .ok_or_else(|| ProtocolError::ChainAdmin(format!("no chain liquidation config for chain {}", chain.0)))?;
+    let symbol = liquidation_price_symbol(chain)?;
+    let price_e8 = liq::fresh_chain_price_e8(state, chain, symbol, now_ns, cfg.max_price_age_ns)
+        .map_err(|e| ProtocolError::ChainAdmin(format!("fresh chain price unavailable for {symbol}: {e:?}")))?;
+    let native_decimals = state
+        .chain_configs
+        .get(&chain)
+        .map(|c| c.chain_native_decimals)
+        .unwrap_or(18);
+    let liquidation_penalty_bps = chain_collateral_config(chain)
+        .map(|c| c.liquidation_penalty_bps)
+        .ok_or_else(|| ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0)))?;
+    Ok(ChainSpAbsorbSnapshot {
+        chain,
+        price_e8,
+        native_decimals,
+        liquidation_penalty_bps,
+    })
 }
 
 /// Dev-gated manual/permissionless liquidation trigger (spec §7). Runs the
@@ -3558,6 +3624,157 @@ async fn stability_pool_liquidate_debt_burned(
         vault_id, icusd_burned_e8s, caller, None, proof,
     )
     .await
+}
+
+async fn verify_sp_icusd_burn_proof(
+    vault_id: u64,
+    icusd_burned_e8s: u64,
+    caller: Principal,
+    proof: &rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+) -> Result<(), ProtocolError> {
+    use rumi_protocol_backend::icrc3_proof::{ProofExpectations, SpProofLedger};
+
+    if proof.ledger_kind != SpProofLedger::IcusdBurn {
+        return Err(ProtocolError::GenericError(
+            "chain SP liquidation requires an icUSD burn proof".to_string(),
+        ));
+    }
+    if read_state(|s| {
+        s.consumed_writedown_proofs
+            .contains(&(proof.ledger_kind, proof.block_index))
+    }) {
+        return Err(ProtocolError::GenericError(format!(
+            "SP writedown proof replay rejected: ({:?}, block {}) already consumed",
+            proof.ledger_kind, proof.block_index
+        )));
+    }
+    let ledger_principal = read_state(|s| s.icusd_ledger_principal);
+    if ledger_principal == Principal::anonymous() {
+        return Err(ProtocolError::GenericError(
+            "icUSD ledger is not configured".to_string(),
+        ));
+    }
+
+    let expectations = ProofExpectations {
+        ledger_kind: proof.ledger_kind,
+        expected_amount_e8s: icusd_burned_e8s,
+        sp_principal: caller,
+        reserves_account: icrc_ledger_types::icrc1::account::Account {
+            owner: ic_cdk::id(),
+            subaccount: Some(rumi_protocol_backend::management::protocol_3usd_reserves_subaccount()),
+        },
+        vault_id_memo: vault_id,
+    };
+    if let Err(err) = rumi_protocol_backend::icrc3_proof::fetch_and_validate_block(
+        ledger_principal,
+        proof.block_index,
+        &expectations,
+    )
+    .await
+    {
+        return Err(ProtocolError::GenericError(format!(
+            "SP writedown proof verification failed: {}",
+            err
+        )));
+    }
+    if proof.vault_id_memo != vault_id {
+        return Err(ProtocolError::GenericError(format!(
+            "SP writedown proof vault_id_memo {} does not match call vault_id {}",
+            proof.vault_id_memo, vault_id
+        )));
+    }
+    Ok(())
+}
+
+/// Called by the stability pool after it has burned IC-native icUSD to absorb a
+/// bot-failed foreign-chain vault. This does NOT burn the eSpace icUSD
+/// representation; it writes debt -> pending_chain_burn and reserves seized CFX
+/// in a `ChainLiqClaimV1` for later SP depositor claims.
+#[update]
+#[candid_method(update)]
+async fn stability_pool_liquidate_chain_vault(
+    vault_id: u64,
+    icusd_burned_e8s: u64,
+    proof: rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+) -> Result<ChainStabilityPoolLiquidationResult, ProtocolError> {
+    if ic_cdk::caller() == Principal::anonymous() {
+        return Err(ProtocolError::AnonymousCallerNotAllowed);
+    }
+    if read_state(|s| s.frozen) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "Protocol is frozen. All operations are suspended pending admin review.".to_string(),
+        ));
+    }
+    validate_liquidation_not_frozen()?;
+    if read_state(|s| s.sp_writedown_disabled) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "SP writedown path is disabled by admin".to_string(),
+        ));
+    }
+
+    let caller = ic_cdk::api::caller();
+    let is_stability_pool = read_state(|s| {
+        s.stability_pool_canister.map_or(false, |sp| sp == caller)
+    });
+    if !is_stability_pool {
+        return Err(ProtocolError::GenericError(
+            "Caller is not the registered stability pool canister".to_string(),
+        ));
+    }
+
+    let _guard = rumi_protocol_backend::guard::ChainVaultLiquidationGuard::new(vault_id)?;
+    let now = ic_cdk::api::time();
+    let snapshot = read_state(|s| chain_sp_absorb_snapshot(&s.multi_chain, vault_id, now))?;
+
+    verify_sp_icusd_burn_proof(vault_id, icusd_burned_e8s, caller, &proof).await?;
+
+    let proof_key = (proof.ledger_kind, proof.block_index);
+    let absorbed = mutate_state(|s| {
+        if s.consumed_writedown_proofs.contains(&proof_key) {
+            return Err(ProtocolError::GenericError(format!(
+                "SP writedown proof replay rejected: ({:?}, block {}) already consumed",
+                proof.ledger_kind, proof.block_index
+            )));
+        }
+        let absorbed = rumi_protocol_backend::chains::evm::settlement::apply_sp_chain_liquidation_absorb_in_state(
+            &mut s.multi_chain,
+            snapshot.chain,
+            vault_id,
+            icusd_burned_e8s as u128,
+            snapshot.price_e8,
+            snapshot.native_decimals,
+            snapshot.liquidation_penalty_bps,
+        )
+        .map_err(ProtocolError::ChainAdmin)?;
+        s.consumed_writedown_proofs.insert(proof_key);
+        Ok(absorbed)
+    })?;
+
+    rumi_protocol_backend::storage::record_event(&Event::ChainVaultLiquidated {
+        chain_id: snapshot.chain,
+        vault_id,
+        op_id: proof.block_index,
+        debt_cleared_e8s: absorbed.actual_burned_e8s,
+        collateral_seized_native: absorbed.collateral_seized_native,
+        tier: rumi_protocol_backend::chains::vault::LiquidationTier::StabilityPool,
+        timestamp: now,
+    });
+    log!(INFO,
+        "[stability_pool_liquidate_chain_vault] chain={:?} vault={} burned_e8s={} collateral_seized_native={} proof_block={}",
+        snapshot.chain, vault_id, absorbed.actual_burned_e8s, absorbed.collateral_seized_native, proof.block_index
+    );
+
+    Ok(ChainStabilityPoolLiquidationResult {
+        success: true,
+        vault_id,
+        chain_id: snapshot.chain,
+        liquidated_debt_e8s: absorbed.actual_burned_e8s,
+        collateral_received_native: absorbed.collateral_seized_native,
+        claim_id: vault_id,
+        custody_address: absorbed.custody_address,
+        block_index: proof.block_index,
+        collateral_price_e8s: snapshot.price_e8,
+    })
 }
 
 /// Called by the stability pool to liquidate a vault using 3USD reserves.
@@ -8536,6 +8753,110 @@ mod chain_vault_param_tests {
     }
 }
 
+#[cfg(test)]
+mod chain_sp_absorb_entry_tests {
+    use super::chain_sp_absorb_snapshot;
+    use rumi_protocol_backend::chains::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
+    use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+    use rumi_protocol_backend::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use rumi_protocol_backend::chains::multi_chain_state::MultiChainState;
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(71);
+
+    fn cfg() -> ChainLiquidationConfigV1 {
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0xrouter".into(),
+            factory: "0xfactory".into(),
+            pair: "0xpair".into(),
+            collateral_token: "0xcollateral".into(),
+            settle_stable_token: "0xstable".into(),
+            slippage_cap_bps: 100,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+            max_swap_value_e8s: 1_000 * 100_000_000,
+            max_price_age_ns: 1_000,
+            max_dex_oracle_divergence_bps: 100,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
+        }
+    }
+
+    fn configured_state() -> MultiChainState {
+        let mut s = MultiChainState::default();
+        s.chain_configs.insert(CFX, ChainConfigV3 {
+            chain_id: CFX,
+            display_name: "Conflux eSpace".into(),
+            rpc_endpoints: vec![],
+            finality_depth: 12,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 1,
+                max_fee_gwei_ceiling: 100,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 0,
+            status: ChainStatus::Registered,
+            burn_watch_poll_enabled: false,
+            min_quorum_providers: None,
+        });
+        s.chain_liquidation_configs.insert(CFX, cfg());
+        s.chain_vaults.insert(7, ChainVaultV1 {
+            vault_id: 7,
+            owner: Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0x00000000000000000000000000000000000000c7".into(),
+            collateral_amount_native: 1_000_000_000_000_000_000_000,
+            debt_e8s: 100 * 100_000_000,
+            mint_recipient: "0x00000000000000000000000000000000000000d7".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        });
+        s.sp_attempted_chain_vaults.insert(7);
+        s
+    }
+
+    #[test]
+    fn chain_sp_absorb_snapshot_rejects_halted_chain_rails() {
+        let mut s = configured_state();
+        s.set_manual_price(CFX, "CFX".into(), 50_000_000, 500);
+
+        s.invariant_halted = true;
+        let err = chain_sp_absorb_snapshot(&s, 7, 600).unwrap_err();
+        assert!(format!("{err:?}").to_ascii_lowercase().contains("invariant"), "unexpected error: {err:?}");
+
+        s.invariant_halted = false;
+        s.reorg_halted.insert(CFX, true);
+        let err = chain_sp_absorb_snapshot(&s, 7, 600).unwrap_err();
+        assert!(format!("{err:?}").contains("reorg"), "unexpected error: {err:?}");
+    }
+
+    #[test]
+    fn chain_sp_absorb_snapshot_requires_fresh_chain_manual_price() {
+        let mut s = configured_state();
+
+        let err = chain_sp_absorb_snapshot(&s, 7, 600).unwrap_err();
+        assert!(format!("{err:?}").contains("price"), "unexpected error: {err:?}");
+
+        s.set_manual_price(CFX, "CFX".into(), 50_000_000, 1);
+        let err = chain_sp_absorb_snapshot(&s, 7, 1_100_000).unwrap_err();
+        assert!(format!("{err:?}").contains("price"), "unexpected error: {err:?}");
+
+        s.set_manual_price(CFX, "CFX".into(), 50_000_000, 500);
+        let ok = chain_sp_absorb_snapshot(&s, 7, 600).expect("fresh price accepted");
+        assert_eq!(ok.chain, CFX);
+        assert_eq!(ok.price_e8, 50_000_000);
+        assert_eq!(ok.native_decimals, 18);
+        assert_eq!(ok.liquidation_penalty_bps, 1_200);
+    }
+}
+
 // Checks the real candid interface against the one declared in the did file
 #[test]
 fn check_candid_interface_compatibility() {
@@ -8596,4 +8917,3 @@ fn check_candid_interface_compatibility() {
         CandidSource::File(did_path.as_path()),
     );
 }
-

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -3777,6 +3777,69 @@ async fn stability_pool_liquidate_chain_vault(
     })
 }
 
+/// Called by the stability pool to enqueue a native CFX payout from a reserved
+/// chain-liquidation claim. The SP owns depositor apportionment; the backend owns
+/// custody, idempotency, and the settlement queue.
+#[update]
+#[candid_method(update)]
+fn claim_chain_collateral(
+    claim_id: u64,
+    claimant: Principal,
+    owed_wei: u128,
+    dest_evm: String,
+) -> Result<u64, ProtocolError> {
+    if ic_cdk::caller() == Principal::anonymous() {
+        return Err(ProtocolError::AnonymousCallerNotAllowed);
+    }
+    if read_state(|s| s.frozen) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "Protocol is frozen. All operations are suspended pending admin review.".to_string(),
+        ));
+    }
+    validate_liquidation_not_frozen()?;
+    if read_state(|s| s.sp_writedown_disabled) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "SP writedown path is disabled by admin".to_string(),
+        ));
+    }
+
+    let caller = ic_cdk::api::caller();
+    let is_stability_pool = read_state(|s| {
+        s.stability_pool_canister.map_or(false, |sp| sp == caller)
+    });
+    if !is_stability_pool {
+        return Err(ProtocolError::GenericError(
+            "Caller is not the registered stability pool canister".to_string(),
+        ));
+    }
+    if !rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address(&dest_evm) {
+        return Err(ProtocolError::GenericError("invalid EVM address".to_string()));
+    }
+
+    let now = ic_cdk::api::time();
+    let op_id = mutate_state(|s| {
+        rumi_protocol_backend::chains::evm::settlement::claim_chain_collateral_in_state(
+            &mut s.multi_chain,
+            claim_id,
+            claimant,
+            owed_wei,
+            dest_evm.clone(),
+            now,
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .map_err(ProtocolError::ChainAdmin)
+    })?;
+    log!(
+        INFO,
+        "[claim_chain_collateral] claim={} claimant={} amount_wei={} op_id={}",
+        claim_id,
+        claimant,
+        owed_wei,
+        op_id
+    );
+    Ok(op_id)
+}
+
 /// Called by the stability pool to liquidate a vault using 3USD reserves.
 /// The SP must have approved this canister to spend `three_usd_amount_e8s` on `three_usd_ledger`.
 /// Validates vault first, then pulls 3USD, then writes down debt and releases collateral.

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1929,6 +1929,8 @@ fn get_chain_liquidation_config(
 pub struct ChainLiquidatableVault {
     pub vault_id: u64,
     pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub chain_collateral_sentinel: Principal,
+    pub sp_attempted: bool,
     pub debt_e8s: u128,
     pub effective_debt_e8s: u128,
     pub collateral_native: u128,
@@ -2045,6 +2047,100 @@ fn liquidate_chain_vault(vault_id: u64) -> Result<u64, ProtocolError> {
     .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))
 }
 
+/// Deterministic Principal key for chain-native collateral in the Stability Pool.
+/// This is a metadata key, never an ICRC ledger canister. The byte layout uses a
+/// reserved Rumi prefix plus the little-endian chain id and a non-canister tag.
+fn chain_collateral_sentinel(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Principal {
+    let mut bytes = [0u8; 29];
+    let prefix = b"rumi-chain-collateral";
+    bytes[..prefix.len()].copy_from_slice(prefix);
+    bytes[24..28].copy_from_slice(&chain.0.to_le_bytes());
+    bytes[28] = 0x7f;
+    Principal::from_slice(&bytes)
+}
+
+fn chain_liquidatable_vaults_in_state(
+    state: &rumi_protocol_backend::chains::multi_chain_state::MultiChainState,
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    now: u64,
+) -> Vec<ChainLiquidatableVault> {
+    use rumi_protocol_backend::chains::collateral_config::chain_collateral_config;
+    use rumi_protocol_backend::chains::liquidation as liq;
+    use rumi_protocol_backend::chains::monad::chain_vault::ChainVaultStatus;
+    let symbol = match liquidation_price_symbol(chain) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let cc = chain_collateral_config(chain);
+    let threshold = match cc.map(|c| c.liquidation_threshold_e4) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let apr_bps = cc.map(|c| c.interest_apr_bps).unwrap_or(0);
+    let max_age = state
+        .chain_liquidation_configs
+        .get(&chain)
+        .map(|c| c.max_price_age_ns)
+        .unwrap_or(0);
+    let price = match liq::fresh_chain_price_e8(state, chain, symbol, now, max_age) {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let nd = state
+        .chain_configs
+        .get(&chain)
+        .map(|c| c.chain_native_decimals)
+        .unwrap_or(18);
+    let bonus = liq::bonus_e4_from_penalty_bps(cc.map(|c| c.liquidation_penalty_bps).unwrap_or(0));
+    let target = cc.map(|c| c.recovery_target_cr_e4).unwrap_or(15_500);
+    let sentinel = chain_collateral_sentinel(chain);
+    state
+        .chain_vaults
+        .values()
+        .filter(|v| {
+            v.collateral_chain == chain
+                && v.status == ChainVaultStatus::Open
+                && v.pending_mint_e8s == 0
+                && v.pending_interest_mint_e8s == 0
+                && v.pending_liquidation.is_none()
+                && v.debt_e8s > 0
+        })
+        .filter_map(|v| {
+            let eff = liq::effective_debt_e8s(
+                v.debt_e8s,
+                v.pending_interest_mint_e8s,
+                apr_bps,
+                now.saturating_sub(v.last_interest_accrual_ns),
+            );
+            let cr = rumi_protocol_backend::chains::vault::collateral_ratio_e4(
+                v.collateral_amount_native,
+                nd,
+                price,
+                eff,
+            );
+            if cr >= threshold {
+                return None;
+            }
+            let cv = liq::collateral_value_e8s(v.collateral_amount_native, nd, price);
+            Some(ChainLiquidatableVault {
+                vault_id: v.vault_id,
+                chain_id: chain,
+                chain_collateral_sentinel: sentinel,
+                sp_attempted: state.sp_attempted_chain_vaults.contains(&v.vault_id),
+                debt_e8s: v.debt_e8s,
+                effective_debt_e8s: eff,
+                collateral_native: v.collateral_amount_native,
+                cr_e4: cr,
+                liquidation_threshold_e4: threshold,
+                sized_repay_e8s: liq::sized_repay_e8s(eff, cv, target, bonus),
+            })
+        })
+        .take(500)
+        .collect()
+}
+
 /// Public read: vaults currently liquidatable on `chain` (CR below the
 /// liquidation threshold, Open, not already marked, no in-flight mint). Capped
 /// for DOS safety. Returns empty if the chain has no collateral config or no
@@ -2054,81 +2150,8 @@ fn liquidate_chain_vault(vault_id: u64) -> Result<u64, ProtocolError> {
 fn get_chain_liquidatable_vaults(
     chain: rumi_protocol_backend::chains::config::ChainId,
 ) -> Vec<ChainLiquidatableVault> {
-    use rumi_protocol_backend::chains::collateral_config::chain_collateral_config;
-    use rumi_protocol_backend::chains::liquidation as liq;
-    use rumi_protocol_backend::chains::monad::chain_vault::ChainVaultStatus;
-    let symbol = match liquidation_price_symbol(chain) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
     let now = ic_cdk::api::time();
-    read_state(|s| {
-        let cc = chain_collateral_config(chain);
-        let threshold = match cc.map(|c| c.liquidation_threshold_e4) {
-            Some(t) => t,
-            None => return Vec::new(),
-        };
-        let apr_bps = cc.map(|c| c.interest_apr_bps).unwrap_or(0);
-        let max_age = s
-            .multi_chain
-            .chain_liquidation_configs
-            .get(&chain)
-            .map(|c| c.max_price_age_ns)
-            .unwrap_or(0);
-        let price = match liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, max_age) {
-            Ok(p) => p,
-            Err(_) => return Vec::new(),
-        };
-        let nd = s
-            .multi_chain
-            .chain_configs
-            .get(&chain)
-            .map(|c| c.chain_native_decimals)
-            .unwrap_or(18);
-        let bonus = liq::bonus_e4_from_penalty_bps(cc.map(|c| c.liquidation_penalty_bps).unwrap_or(0));
-        let target = cc.map(|c| c.recovery_target_cr_e4).unwrap_or(15_500);
-        s.multi_chain
-            .chain_vaults
-            .values()
-            .filter(|v| {
-                v.collateral_chain == chain
-                    && v.status == ChainVaultStatus::Open
-                    && v.pending_mint_e8s == 0
-                    && v.pending_interest_mint_e8s == 0
-                    && v.pending_liquidation.is_none()
-                    && v.debt_e8s > 0
-            })
-            .filter_map(|v| {
-                let eff = liq::effective_debt_e8s(
-                    v.debt_e8s,
-                    v.pending_interest_mint_e8s,
-                    apr_bps,
-                    now.saturating_sub(v.last_interest_accrual_ns),
-                );
-                let cr = rumi_protocol_backend::chains::vault::collateral_ratio_e4(
-                    v.collateral_amount_native,
-                    nd,
-                    price,
-                    eff,
-                );
-                if cr >= threshold {
-                    return None;
-                }
-                let cv = liq::collateral_value_e8s(v.collateral_amount_native, nd, price);
-                Some(ChainLiquidatableVault {
-                    vault_id: v.vault_id,
-                    chain_id: chain,
-                    debt_e8s: v.debt_e8s,
-                    effective_debt_e8s: eff,
-                    collateral_native: v.collateral_amount_native,
-                    cr_e4: cr,
-                    liquidation_threshold_e4: threshold,
-                    sized_repay_e8s: liq::sized_repay_e8s(eff, cv, target, bonus),
-                })
-            })
-            .take(500)
-            .collect()
-    })
+    read_state(|s| chain_liquidatable_vaults_in_state(&s.multi_chain, chain, now))
 }
 
 /// Manual-price readout for `(chain, symbol)`: the USD e8 price plus the
@@ -8818,7 +8841,7 @@ mod chain_vault_param_tests {
 
 #[cfg(test)]
 mod chain_sp_absorb_entry_tests {
-    use super::chain_sp_absorb_snapshot;
+    use super::{chain_collateral_sentinel, chain_liquidatable_vaults_in_state, chain_sp_absorb_snapshot};
     use rumi_protocol_backend::chains::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
     use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
     use rumi_protocol_backend::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
@@ -8917,6 +8940,26 @@ mod chain_sp_absorb_entry_tests {
         assert_eq!(ok.price_e8, 50_000_000);
         assert_eq!(ok.native_decimals, 18);
         assert_eq!(ok.liquidation_penalty_bps, 1_200);
+    }
+
+    #[test]
+    fn chain_liquidatable_discovery_marks_bot_failed_and_sentinel() {
+        let mut s = configured_state();
+        s.set_manual_price(CFX, "CFX".into(), 1_000_000, 500);
+        let mut never_tried = s.chain_vaults.get(&7).unwrap().clone();
+        never_tried.vault_id = 8;
+        never_tried.owner = Principal::from_slice(&[8u8; 29]);
+        never_tried.custody_address = "0x00000000000000000000000000000000000000c8".into();
+        s.chain_vaults.insert(8, never_tried);
+
+        let rows = chain_liquidatable_vaults_in_state(&s, CFX, 600);
+        assert_eq!(rows.len(), 2);
+        let attempted = rows.iter().find(|r| r.vault_id == 7).unwrap();
+        assert!(attempted.sp_attempted);
+        assert_eq!(attempted.chain_collateral_sentinel, chain_collateral_sentinel(CFX));
+        let fresh = rows.iter().find(|r| r.vault_id == 8).unwrap();
+        assert!(!fresh.sp_attempted);
+        assert_eq!(fresh.chain_collateral_sentinel, chain_collateral_sentinel(CFX));
     }
 }
 

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
@@ -33,7 +33,7 @@
 //! the reserve/settlement address endpoints signal ECDSA-unavailable) and returns
 //! early. The swap is NEVER faked.
 
-use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal};
+use candid::{decode_one, encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Nat, Principal};
 use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
 use std::time::Duration;
 
@@ -55,6 +55,104 @@ struct ProtocolInitArg {
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum ProtocolArg {
     Init(ProtocolInitArg),
+}
+
+// ─── ICRC-1 / Stability Pool mirrors used by the Inc-4 e2e ───────────────────
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct FeatureFlags {
+    icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum MetadataValue {
+    Nat(Nat),
+    Int(candid::Int),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct LedgerInitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum LedgerArg {
+    Init(LedgerInitArgs),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ApproveArgs {
+    from_subaccount: Option<[u8; 32]>,
+    spender: Account,
+    amount: Nat,
+    expected_allowance: Option<Nat>,
+    expires_at: Option<u64>,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ApproveError {
+    BadFee { expected_fee: Nat },
+    InsufficientFunds { balance: Nat },
+    AllowanceChanged { current_allowance: Nat },
+    Expired { ledger_time: u64 },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct StabilityPoolInitArgs {
+    protocol_canister_id: Principal,
+    authorized_admins: Vec<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct StablecoinConfig {
+    ledger_id: Principal,
+    symbol: String,
+    decimals: u8,
+    priority: u8,
+    is_active: bool,
+    transfer_fee: Option<u64>,
+    is_lp_token: Option<bool>,
+    underlying_pool: Option<Principal>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
@@ -196,27 +294,153 @@ struct SupplyAuditWire {
     per_chain: Vec<SupplyAuditEntryWire>,
 }
 
-/// Minimal mirror of `ProtocolError`: the chain endpoints here only ever return
-/// `ChainAdmin(text)` or (on ECDSA-derive failures) the same. Any other variant
-/// fails the Candid decode loudly (the correct signal that something unexpected
-/// happened). `TemporarilyUnavailable`/`EvmAuth` are included for completeness so
-/// a transient reconcile error decodes rather than mis-tags.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum TransferError {
+    GenericError { message: String, error_code: Nat },
+    TemporarilyUnavailable,
+    BadBurn { min_burn_amount: Nat },
+    Duplicate { duplicate_of: Nat },
+    BadFee { expected_fee: Nat },
+    CreatedInFuture { ledger_time: u64 },
+    TooOld,
+    InsufficientFunds { balance: Nat },
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum TransferFromError {
+    GenericError { message: String, error_code: Nat },
+    TemporarilyUnavailable,
+    InsufficientAllowance { allowance: Nat },
+    BadBurn { min_burn_amount: Nat },
+    Duplicate { duplicate_of: Nat },
+    BadFee { expected_fee: Nat },
+    CreatedInFuture { ledger_time: u64 },
+    TooOld,
+    InsufficientFunds { balance: Nat },
+}
+
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum ProtocolError {
     ChainAdmin(String),
     EvmAuth(String),
     TemporarilyUnavailable(String),
+    GenericError(String),
+    TransferError(TransferError),
+    TransferFromError(TransferFromError, u64),
+    AlreadyProcessing,
+    NotLowestCR,
+    SupplyInvariantHalted,
+    AnonymousCallerNotAllowed,
+    AmountTooLow { minimum_amount: u64 },
+    CallerNotOwner,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum StabilityPoolError {
+    InsufficientBalance { token: Principal, required: u64, available: u64 },
+    AmountTooLow { minimum_e8s: u64 },
+    NoPositionFound,
+    InsufficientPoolBalance,
+    Unauthorized,
+    TokenNotAccepted { ledger: Principal },
+    TokenNotActive { ledger: Principal },
+    CollateralNotFound { ledger: Principal },
+    LedgerTransferFailed { reason: String },
+    InterCanisterCallFailed { target: String, method: String },
+    LiquidationFailed { vault_id: u64, reason: String },
+    EmergencyPaused,
+    SystemBusy,
+    AlreadyOptedOut { collateral: Principal },
+    AlreadyOptedIn { collateral: Principal },
+    RefundClaimNotFound,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainLiquidatableVaultInfo {
+    vault_id: u64,
+    chain_id: ChainId,
+    chain_collateral_sentinel: Principal,
+    sp_attempted: bool,
+    debt_e8s: u128,
+    effective_debt_e8s: u128,
+    collateral_native: u128,
+    cr_e4: u64,
+    liquidation_threshold_e4: u64,
+    sized_repay_e8s: u128,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ChainSpAbsorbResult {
+    success: bool,
+    vault_id: u64,
+    chain_id: ChainId,
+    icusd_burned_e8s: u64,
+    liquidated_debt_e8s: u128,
+    collateral_received_native: u128,
+    claim_id: u64,
+    custody_address: String,
+    block_index: u64,
+    collateral_price_e8s: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct HttpRequest {
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct HttpResponse {
+    status_code: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+#[derive(Deserialize, Debug)]
+struct LogEntryWire {
+    #[allow(dead_code)]
+    timestamp: u64,
+    message: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct LogWire {
+    entries: Vec<LogEntryWire>,
 }
 
 // ─── Wasm loaders ────────────────────────────────────────────────────────────
 
 fn backend_wasm() -> Vec<u8> {
-    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
-        .to_vec()
+    read_workspace_wasm("rumi_protocol_backend.wasm")
 }
 
 fn mock_wasm() -> Vec<u8> {
-    include_bytes!("../../../target/wasm32-unknown-unknown/release/monad_rpc_mock.wasm").to_vec()
+    read_workspace_wasm("monad_rpc_mock.wasm")
+}
+
+fn stability_pool_wasm() -> Vec<u8> {
+    read_workspace_wasm("stability_pool.wasm")
+}
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn read_workspace_wasm(name: &str) -> Vec<u8> {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir.join("../../target/wasm32-unknown-unknown/release").join(name),
+        manifest_dir.join("../target/wasm32-unknown-unknown/release").join(name),
+        manifest_dir.join("../../../../target/wasm32-unknown-unknown/release").join(name),
+    ];
+    for path in candidates {
+        if let Ok(bytes) = std::fs::read(&path) {
+            return bytes;
+        }
+    }
+    panic!("missing wasm artifact {name} in worktree target/, worktree src/target/, or main checkout target/");
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -257,6 +481,21 @@ fn dev() -> Principal {
     Principal::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9])
 }
 
+fn depositor() -> Principal {
+    Principal::self_authenticating(b"inc4-cfx-sp-depositor")
+}
+
+fn minting_account_owner() -> Principal {
+    Principal::self_authenticating(b"inc4-icusd-minter")
+}
+
+fn account(owner: Principal) -> Account {
+    Account {
+        owner,
+        subaccount: None,
+    }
+}
+
 fn query_unit<T>(pic: &PocketIc, cid: Principal, method: &str) -> T
 where
     T: CandidType + for<'a> Deserialize<'a>,
@@ -282,6 +521,17 @@ fn update_dev(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> Wa
 
 fn update_any(pic: &PocketIc, cid: Principal, method: &str, args: Vec<u8>) -> WasmResult {
     pic.update_call(cid, Principal::anonymous(), method, args)
+        .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
+}
+
+fn update_as(
+    pic: &PocketIc,
+    cid: Principal,
+    caller: Principal,
+    method: &str,
+    args: Vec<u8>,
+) -> WasmResult {
+    pic.update_call(cid, caller, method, args)
         .unwrap_or_else(|e| panic!("update {} failed: {}", method, e))
 }
 
@@ -335,6 +585,105 @@ fn boot() -> (PocketIc, Principal, Principal) {
     let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
 
     (pic, backend_id, mock_id)
+}
+
+fn install_icrc1_ledger(
+    pic: &PocketIc,
+    ledger_id: Principal,
+    user: Principal,
+    initial_balance: u128,
+) {
+    let init = LedgerArg::Init(LedgerInitArgs {
+        minting_account: account(minting_account_owner()),
+        fee_collector_account: None,
+        transfer_fee: Nat::from(0u64),
+        decimals: Some(8),
+        max_memo_length: Some(64),
+        token_name: "Rumi icUSD".to_string(),
+        token_symbol: "icUSD".to_string(),
+        metadata: vec![],
+        initial_balances: vec![(account(user), Nat::from(initial_balance))],
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2_000,
+            trigger_threshold: 1_000,
+            controller_id: dev(),
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    });
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((init,)).expect("encode ledger init"),
+        None,
+    );
+}
+
+fn boot_with_sp() -> (PocketIc, Principal, Principal, Principal, Principal, Principal) {
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build();
+
+    let backend_id = pic.create_canister();
+    pic.add_cycles(backend_id, 100_000_000_000_000);
+    let mock_id = pic.create_canister();
+    pic.add_cycles(mock_id, 100_000_000_000_000);
+    let icusd_ledger = pic.create_canister();
+    pic.add_cycles(icusd_ledger, 10_000_000_000_000);
+    let sp_id = pic.create_canister();
+    pic.add_cycles(sp_id, 10_000_000_000_000);
+
+    let user = depositor();
+    install_icrc1_ledger(&pic, icusd_ledger, user, 1_000u128 * E8);
+
+    let mgmt = Principal::from_text("aaaaa-aa").expect("mgmt principal");
+    let init = ProtocolArg::Init(ProtocolInitArg {
+        xrc_principal: mgmt,
+        icusd_ledger_principal: icusd_ledger,
+        icp_ledger_principal: mgmt,
+        fee_e8s: 10_000,
+        developer_principal: dev(),
+        treasury_principal: None,
+        stability_pool_principal: Some(sp_id),
+        ckusdt_ledger_principal: None,
+        ckusdc_ledger_principal: None,
+    });
+    pic.install_canister(
+        backend_id,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
+    pic.install_canister(mock_id, mock_wasm(), Encode!().expect("encode mock init"), None);
+
+    let sp_init = StabilityPoolInitArgs {
+        protocol_canister_id: backend_id,
+        authorized_admins: vec![dev()],
+    };
+    pic.install_canister(
+        sp_id,
+        stability_pool_wasm(),
+        encode_one(sp_init).expect("encode sp init"),
+        None,
+    );
+    pic.set_controllers(backend_id, None, vec![Principal::anonymous(), dev()])
+        .expect("set backend controllers after install");
+
+    for _ in 0..5 {
+        pic.tick();
+    }
+
+    let _ = update_dev(&pic, backend_id, "set_observer_tick_interval_secs", Encode!(&30u64).unwrap());
+    let _ = update_dev(&pic, backend_id, "set_settlement_tick_interval_secs", Encode!(&30u64).unwrap());
+
+    (pic, backend_id, mock_id, sp_id, icusd_ledger, user)
 }
 
 /// Tick the canister timers across `windows` 35s windows so the observer (Timer
@@ -818,6 +1167,385 @@ fn conflux_liquidation_swap_executes_and_credits_reserve() {
     eprintln!("[swap] FULL swap path PASSED: detection marked an underwater vault (Bot tier, all collateral reserved), the settlement worker SUBMITTED swapExactETHForTokens (DEX reads + JIT min-out + oracle gate) and CONFIRMED it (decoded the realized 110 USDC Transfer to the reserve), moving 100e8 debt -> reserve_backing (vault Closed, debt 0). chain_supplies UNCHANGED (PSM, no icUSD burned); reconcile reports reserve_backing=100e8, reserve_usdc=110e18, unbacked_excess=false on chain 71.");
 }
 
+#[test]
+fn conflux_liquidation_bot_failure_sp_absorb_claims_cfx() {
+    let (pic, backend, mock, sp, icusd_ledger, user) = boot_with_sp();
+
+    decode_result(
+        update_dev(&pic, backend, "set_evm_rpc_principal", Encode!(&mock).unwrap()),
+        "set_evm_rpc_principal",
+    )
+    .expect("set_evm_rpc_principal");
+    update_any(&pic, mock, "set_getlogs_max_range", Encode!(&1000u64).unwrap());
+    update_any(&pic, mock, "set_espace_receipt_fields", Encode!(&true).unwrap());
+
+    let reg = RegisterChainArg {
+        chain_id: ChainId(CONFLUX_CHAIN_ID),
+        display_name: "ConfluxESpaceTestnet".to_string(),
+        rpc_endpoints: vec!["https://evmtestnet.confluxrpc.com".to_string()],
+        finality_depth: CONFLUX_FINALITY_DEPTH as u32,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 1,
+            max_fee_gwei_ceiling: 100,
+        },
+        chain_native_decimals: 18,
+        min_quorum_providers: Some(1),
+    };
+    decode_result(
+        update_dev(&pic, backend, "register_chain", Encode!(&reg).unwrap()),
+        "register_chain",
+    )
+    .expect("register_chain");
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_contract",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"0x00000000000000000000000000000000cf1c0de5".to_string())
+                .unwrap(),
+        ),
+        "set_chain_contract",
+    )
+    .expect("set_chain_contract");
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &15_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price",
+    )
+    .expect("set_manual_collateral_price");
+
+    let seed: u64 = 1_000_000;
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_last_observed_block",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &seed).unwrap(),
+        ),
+        "set_last_observed_block",
+    )
+    .expect("set_last_observed_block");
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_burn_watch_poll_enabled",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &true).unwrap(),
+        ),
+        "set_burn_watch_poll_enabled",
+    )
+    .expect("set_burn_watch_poll_enabled");
+
+    let cursor1 = seed + SCAN_WINDOW;
+    let head1 = cursor1 + CONFLUX_FINALITY_DEPTH + 24;
+    update_any(&pic, mock, "set_blocks", Encode!(&head1, &head1).unwrap());
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxmint-inc4".to_string()).unwrap());
+
+    let settlement_addr = match update_dev(
+        &pic,
+        backend,
+        "get_chain_settlement_address",
+        Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+    ) {
+        WasmResult::Reply(b) => match Decode!(&b, Result<String, ProtocolError>) {
+            Ok(Ok(addr)) => Some(addr),
+            Ok(Err(e)) => {
+                eprintln!("[sp-fallback] ECDSA UNAVAILABLE (get_chain_settlement_address returned Err: {e:?}); running gated subset");
+                None
+            }
+            Err(decode_err) => {
+                eprintln!("[sp-fallback] get_chain_settlement_address decode error ({decode_err}); running gated subset");
+                None
+            }
+        },
+        WasmResult::Reject(msg) => {
+            eprintln!("[sp-fallback] ECDSA UNAVAILABLE (get_chain_settlement_address rejected: {msg}); running gated subset");
+            None
+        }
+    };
+    let settlement_addr = match settlement_addr {
+        Some(addr) => addr,
+        None => {
+            let sentinel = register_sp_cfx(&pic, sp);
+            assert_ne!(sentinel, Principal::anonymous(), "gated: CFX sentinel registers");
+            register_sp_icusd(&pic, sp, icusd_ledger);
+            eprintln!("[sp-fallback] ECDSA unavailable; ran gated SP subset (icUSD + CFX sentinel registration)");
+            return;
+        }
+    };
+
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&settlement_addr, &candid::Nat::from(1_000_000u128 * E18)).unwrap(),
+    );
+
+    let collateral_e18 = 1_400u128 * E18;
+    let debt_e8s = 100u128 * E8;
+    let recipient = "0x000000000000000000000000000000000000c0de".to_string();
+    let vault_id: u64 = match update_dev(
+        &pic,
+        backend,
+        "open_chain_vault",
+        Encode!(
+            &ChainId(CONFLUX_CHAIN_ID),
+            &candid::Nat::from(collateral_e18),
+            &candid::Nat::from(debt_e8s),
+            &recipient
+        )
+        .unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u64, ProtocolError>)
+            .expect("decode open_chain_vault")
+            .expect("open_chain_vault Ok"),
+        WasmResult::Reject(msg) => panic!("open_chain_vault rejected: {msg}"),
+    };
+    let custody = get_vault(&pic, backend, vault_id)
+        .expect("vault exists")
+        .custody_address;
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(collateral_e18)).unwrap(),
+    );
+    advance_and_tick(&pic, 2);
+    assert_eq!(
+        get_vault(&pic, backend, vault_id).unwrap().status,
+        ChainVaultStatus::MintPending,
+        "deposit verified => MintPending"
+    );
+
+    advance_and_tick(&pic, 1);
+    update_any(
+        &pic,
+        mock,
+        "set_receipt",
+        Encode!(&"0xcfxmint-inc4".to_string(), &true, &cursor1).unwrap(),
+    );
+    push_mint_log(&pic, mock, vault_id, &recipient, debt_e8s, "0xcfxmint-inc4", cursor1);
+    advance_and_tick(&pic, 4);
+    assert_eq!(
+        get_vault(&pic, backend, vault_id).unwrap().status,
+        ChainVaultStatus::Open,
+        "mint confirmed => Open"
+    );
+    assert_supply(&pic, backend, 100 * E8, "after mint");
+
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_chain_liquidation_config",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &enabled_liq_config()).unwrap(),
+        ),
+        "set_chain_liquidation_config",
+    )
+    .expect("set_chain_liquidation_config");
+    update_any(
+        &pic,
+        mock,
+        "set_balance",
+        Encode!(&custody, &candid::Nat::from(10_000u128 * E18)).unwrap(),
+    );
+    update_any(
+        &pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&TOKEN0_SELECTOR.to_string(), &word_addr(WCFX)).unwrap(),
+    );
+    let zero_reserves_blob = format!("0x{:064x}{:064x}{:064x}", 0u128, 0u128, 0u128);
+    update_any(
+        &pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_RESERVES_SELECTOR.to_string(), &zero_reserves_blob).unwrap(),
+    );
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_manual_collateral_price",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID), &"CFX".to_string(), &8_000_000u64).unwrap(),
+        ),
+        "set_manual_collateral_price (drop)",
+    )
+    .expect("set_manual_collateral_price (drop)");
+
+    advance_and_tick(&pic, 3);
+    let v = get_vault(&pic, backend, vault_id).expect("vault after failed bot swap");
+    assert_eq!(v.status, ChainVaultStatus::Open, "bot failure restores the Open vault");
+    assert!(v.pending_liquidation.is_none(), "bot failure clears the pending marker");
+    assert_eq!(
+        v.collateral_amount_e18,
+        candid::Nat::from(collateral_e18),
+        "bot failure restores reserved collateral"
+    );
+    assert_eq!(v.debt_e8s, candid::Nat::from(debt_e8s), "bot failure leaves debt live");
+    let candidates = get_chain_liquidatable_vaults(&pic, backend);
+    let candidate = candidates
+        .iter()
+        .find(|v| v.vault_id == vault_id)
+        .expect("SP discovery sees the escalated vault");
+    assert!(candidate.sp_attempted, "bot failure sets sp_attempted");
+    assert_eq!(
+        candidate.chain_collateral_sentinel,
+        chain_collateral_sentinel_for(CONFLUX_CHAIN_ID),
+        "backend sentinel is deterministic from chain id"
+    );
+    assert_supply(&pic, backend, 100 * E8, "after bot failure");
+    advance_and_tick(&pic, 2);
+    let v = get_vault(&pic, backend, vault_id).expect("vault after no-retry windows");
+    assert!(
+        v.pending_liquidation.is_none(),
+        "sp_attempted vault must not be re-routed to the bot"
+    );
+
+    register_sp_icusd(&pic, sp, icusd_ledger);
+    let sentinel = register_sp_cfx(&pic, sp);
+    assert_eq!(
+        sentinel,
+        candidate.chain_collateral_sentinel,
+        "SP and backend derive the same CFX sentinel"
+    );
+    let no_coverage = sp_absorb_chain_vault(&pic, sp, vault_id)
+        .expect_err("zero icUSD coverage must not absorb");
+    assert!(
+        matches!(
+            no_coverage,
+            StabilityPoolError::InsufficientPoolBalance
+                | StabilityPoolError::LiquidationFailed { .. }
+        ),
+        "zero coverage error should be a clean pre-burn failure, got {:?}",
+        no_coverage
+    );
+    approve_icusd(&pic, icusd_ledger, user, sp, debt_e8s * 2);
+    deposit_sp_icusd(&pic, sp, user, icusd_ledger, debt_e8s as u64);
+    let zero_opt_in = sp_absorb_chain_vault(&pic, sp, vault_id)
+        .expect_err("deposited but not opted-in icUSD must not cover CFX");
+    assert!(
+        matches!(
+            zero_opt_in,
+            StabilityPoolError::InsufficientPoolBalance
+                | StabilityPoolError::LiquidationFailed { .. }
+        ),
+        "zero opt-in error should be a clean pre-burn failure, got {:?}",
+        zero_opt_in
+    );
+    assert_eq!(
+        icrc1_balance_of(&pic, icusd_ledger, sp),
+        debt_e8s,
+        "failed pre-opt absorb must not burn SP icUSD"
+    );
+    opt_in_sp_cfx(&pic, sp, user, sentinel);
+
+    let absorb = sp_absorb_chain_vault(&pic, sp, vault_id)
+        .expect("SP absorbs the bot-failed chain vault");
+    assert!(absorb.success, "SP absorb returns success");
+    assert_eq!(absorb.vault_id, vault_id);
+    assert_eq!(absorb.chain_id, ChainId(CONFLUX_CHAIN_ID));
+    assert_eq!(absorb.icusd_burned_e8s, debt_e8s as u64);
+    assert_eq!(absorb.liquidated_debt_e8s, debt_e8s);
+    assert_eq!(
+        absorb.collateral_received_native, collateral_e18,
+        "100 icUSD at $0.08 with 12% penalty seizes 1400 CFX"
+    );
+    assert_eq!(absorb.claim_id, vault_id, "claim id is the absorbed vault id");
+    assert_eq!(
+        icrc1_balance_of(&pic, icusd_ledger, sp),
+        0,
+        "SP burned the deposited icUSD during chain absorb"
+    );
+
+    let v = get_vault(&pic, backend, vault_id).expect("vault after SP absorb");
+    assert_eq!(v.debt_e8s, candid::Nat::from(0u32), "SP absorb clears live debt");
+    assert_eq!(v.collateral_amount_e18, candid::Nat::from(0u32), "SP absorb seizes collateral");
+    assert_eq!(v.status, ChainVaultStatus::Closed, "fully absorbed vault closes");
+    assert!(v.pending_liquidation.is_none(), "SP absorb does not create a marker");
+    assert_supply(&pic, backend, 100 * E8, "after SP absorb (foreign supply unchanged)");
+    let duplicate_absorb = sp_absorb_chain_vault(&pic, sp, vault_id)
+        .expect_err("second SP absorb must reject");
+    assert!(
+        matches!(duplicate_absorb, StabilityPoolError::LiquidationFailed { .. }),
+        "duplicate absorb should reject cleanly, got {:?}",
+        duplicate_absorb
+    );
+
+    update_any(&pic, mock, "set_total_supply", Encode!(&(100u128 * E8)).unwrap());
+    let recon = reconcile_chain_supply(&pic, backend).expect("reconcile_chain_supply Ok");
+    assert_eq!(recon.recorded_supply_e8s, candid::Nat::from(100u128 * E8));
+    assert_eq!(
+        recon.pending_chain_burn_e8s,
+        candid::Nat::from(100u128 * E8),
+        "SP burn is booked as pending foreign-chain burn"
+    );
+    assert_eq!(recon.reserve_backing_e8s, candid::Nat::from(0u32), "SP fallback is not PSM reserve");
+    assert!(!recon.unbacked_excess, "pending burn must not false-trip unbacked_excess");
+
+    let claim_dest = "0x000000000000000000000000000000000000c0de".to_string();
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_sp_writedown_disabled",
+            Encode!(&true).unwrap(),
+        ),
+        "set_sp_writedown_disabled(true)",
+    )
+    .expect("set_sp_writedown_disabled true");
+    let rejected_claim = claim_sp_cfx(&pic, sp, user, sentinel, claim_dest.clone())
+        .expect_err("backend rejection must surface to SP claimant");
+    assert!(
+        matches!(rejected_claim, StabilityPoolError::LiquidationFailed { .. }),
+        "backend rejection should return LiquidationFailed, got {:?}",
+        rejected_claim
+    );
+    decode_result(
+        update_dev(
+            &pic,
+            backend,
+            "set_sp_writedown_disabled",
+            Encode!(&false).unwrap(),
+        ),
+        "set_sp_writedown_disabled(false)",
+    )
+    .expect("set_sp_writedown_disabled false");
+    update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxclaim-inc4".to_string()).unwrap());
+    let claimed = claim_sp_cfx(&pic, sp, user, sentinel, claim_dest.clone())
+        .expect("claim_cfx enqueues backend CFX payout");
+    assert_eq!(claimed, collateral_e18, "single opted-in depositor claims all seized CFX");
+    let second_claim = claim_sp_cfx(&pic, sp, user, sentinel, claim_dest.clone())
+        .expect("second claim is idempotently empty at SP layer");
+    assert_eq!(second_claim, 0, "claim_cfx zeroes the SP-side entitlement");
+
+    advance_and_tick(&pic, 2);
+    update_any(
+        &pic,
+        mock,
+        "set_receipt",
+        Encode!(&"0xcfxclaim-inc4".to_string(), &true, &cursor1).unwrap(),
+    );
+    advance_and_tick(&pic, 4);
+    let logs = fetch_info_logs(&pic, backend);
+    assert!(
+        logs.iter().any(|m| {
+            m.contains("chain-collateral payout op")
+                && m.contains("confirmed")
+                && m.contains("0xcfxclaim-inc4")
+                && m.contains(&claim_dest)
+        }),
+        "payout confirm log not found; logs: {:?}",
+        logs
+    );
+
+    eprintln!("[sp-fallback] FULL path PASSED: bot swap failed closed into sp_attempted, SP burned 100e8 icUSD, backend moved debt -> pending_chain_burn (foreign supply unchanged), credited 1400 CFX to the opted-in depositor, claim_cfx enqueued and confirmed the ChainCollateralPayout.");
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<ChainVaultV1> {
@@ -883,6 +1611,208 @@ fn reconcile_chain_supply(
             .expect("decode reconcile_chain_supply"),
         WasmResult::Reject(msg) => panic!("reconcile_chain_supply rejected: {msg}"),
     }
+}
+
+fn get_chain_liquidatable_vaults(
+    pic: &PocketIc,
+    backend: Principal,
+) -> Vec<ChainLiquidatableVaultInfo> {
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "get_chain_liquidatable_vaults",
+            Encode!(&ChainId(CONFLUX_CHAIN_ID)).unwrap(),
+        )
+        .expect("get_chain_liquidatable_vaults query");
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Vec<ChainLiquidatableVaultInfo>)
+            .expect("decode get_chain_liquidatable_vaults"),
+        WasmResult::Reject(msg) => panic!("get_chain_liquidatable_vaults rejected: {msg}"),
+    }
+}
+
+fn chain_collateral_sentinel_for(chain_id: u32) -> Principal {
+    let mut bytes = [0u8; 29];
+    let prefix = b"rumi-chain-collateral";
+    bytes[..prefix.len()].copy_from_slice(prefix);
+    bytes[24..28].copy_from_slice(&chain_id.to_le_bytes());
+    bytes[28] = 0x7f;
+    Principal::from_slice(&bytes)
+}
+
+fn sp_result_unit(reply: WasmResult, method: &str) -> Result<(), StabilityPoolError> {
+    match reply {
+        WasmResult::Reply(b) => Decode!(&b, Result<(), StabilityPoolError>)
+            .unwrap_or_else(|e| panic!("decode {method} Result<(), StabilityPoolError>: {e}")),
+        WasmResult::Reject(msg) => panic!("{method} rejected: {msg}"),
+    }
+}
+
+fn register_sp_icusd(pic: &PocketIc, sp: Principal, ledger: Principal) {
+    let cfg = StablecoinConfig {
+        ledger_id: ledger,
+        symbol: "icUSD".to_string(),
+        decimals: 8,
+        priority: 0,
+        is_active: true,
+        transfer_fee: Some(0),
+        is_lp_token: Some(false),
+        underlying_pool: None,
+    };
+    sp_result_unit(
+        update_as(pic, sp, dev(), "register_stablecoin", Encode!(&cfg).unwrap()),
+        "register_stablecoin",
+    )
+    .expect("register icUSD in SP");
+}
+
+fn register_sp_cfx(pic: &PocketIc, sp: Principal) -> Principal {
+    match update_as(
+        pic,
+        sp,
+        dev(),
+        "register_cfx_collateral",
+        Encode!(&CONFLUX_CHAIN_ID).unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<Principal, StabilityPoolError>)
+            .expect("decode register_cfx_collateral")
+            .expect("register CFX collateral in SP"),
+        WasmResult::Reject(msg) => panic!("register_cfx_collateral rejected: {msg}"),
+    }
+}
+
+fn approve_icusd(
+    pic: &PocketIc,
+    ledger: Principal,
+    user: Principal,
+    spender: Principal,
+    amount: u128,
+) {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: account(spender),
+        amount: Nat::from(amount),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    match update_as(pic, ledger, user, "icrc2_approve", encode_args((args,)).unwrap()) {
+        WasmResult::Reply(b) => Decode!(&b, Result<Nat, ApproveError>)
+            .expect("decode icrc2_approve")
+            .expect("icrc2_approve"),
+        WasmResult::Reject(msg) => panic!("icrc2_approve rejected: {msg}"),
+    };
+}
+
+fn deposit_sp_icusd(
+    pic: &PocketIc,
+    sp: Principal,
+    user: Principal,
+    ledger: Principal,
+    amount_e8s: u64,
+) {
+    sp_result_unit(
+        update_as(
+            pic,
+            sp,
+            user,
+            "deposit",
+            Encode!(&ledger, &amount_e8s).unwrap(),
+        ),
+        "deposit",
+    )
+    .expect("deposit icUSD into SP");
+}
+
+fn opt_in_sp_cfx(pic: &PocketIc, sp: Principal, user: Principal, sentinel: Principal) {
+    sp_result_unit(
+        update_as(pic, sp, user, "opt_in_cfx", Encode!(&sentinel).unwrap()),
+        "opt_in_cfx",
+    )
+    .expect("opt in CFX");
+}
+
+fn sp_absorb_chain_vault(
+    pic: &PocketIc,
+    sp: Principal,
+    vault_id: u64,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    match update_as(
+        pic,
+        sp,
+        dev(),
+        "sp_absorb_chain_vault",
+        Encode!(&vault_id).unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<ChainSpAbsorbResult, StabilityPoolError>)
+            .expect("decode sp_absorb_chain_vault"),
+        WasmResult::Reject(msg) => panic!("sp_absorb_chain_vault rejected: {msg}"),
+    }
+}
+
+fn claim_sp_cfx(
+    pic: &PocketIc,
+    sp: Principal,
+    user: Principal,
+    sentinel: Principal,
+    dest_evm: String,
+) -> Result<u128, StabilityPoolError> {
+    match update_as(
+        pic,
+        sp,
+        user,
+        "claim_cfx",
+        Encode!(&sentinel, &dest_evm).unwrap(),
+    ) {
+        WasmResult::Reply(b) => Decode!(&b, Result<u128, StabilityPoolError>)
+            .expect("decode claim_cfx"),
+        WasmResult::Reject(msg) => panic!("claim_cfx rejected: {msg}"),
+    }
+}
+
+fn icrc1_balance_of(pic: &PocketIc, ledger: Principal, owner: Principal) -> u128 {
+    let reply = pic
+        .query_call(
+            ledger,
+            Principal::anonymous(),
+            "icrc1_balance_of",
+            encode_args((account(owner),)).unwrap(),
+        )
+        .expect("icrc1_balance_of query");
+    match reply {
+        WasmResult::Reply(b) => {
+            let balance: Nat = decode_one(&b).expect("decode icrc1_balance_of");
+            balance.0.try_into().expect("balance fits u128")
+        }
+        WasmResult::Reject(msg) => panic!("icrc1_balance_of rejected: {msg}"),
+    }
+}
+
+fn fetch_info_logs(pic: &PocketIc, backend: Principal) -> Vec<String> {
+    let req = HttpRequest {
+        method: "GET".to_string(),
+        url: "/logs?priority=info".to_string(),
+        headers: vec![],
+        body: vec![],
+    };
+    let reply = pic
+        .query_call(
+            backend,
+            Principal::anonymous(),
+            "http_request",
+            encode_one(req).unwrap(),
+        )
+        .expect("http_request query");
+    let response: HttpResponse = match reply {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode http response"),
+        WasmResult::Reject(msg) => panic!("http_request rejected: {msg}"),
+    };
+    let body = String::from_utf8(response.body).expect("logs response utf8");
+    let log: LogWire = serde_json::from_str(&body).expect("parse logs JSON");
+    log.entries.into_iter().map(|e| e.message).collect()
 }
 
 fn push_mint_log(

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -174,6 +174,34 @@ pub fn opt_in_collateral(collateral_type: Principal) -> Result<(), StabilityPool
     result
 }
 
+#[update]
+pub fn opt_in_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> {
+    // SP-102 / AR-S-002: see opt_out_collateral.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    let caller = ic_cdk::api::caller();
+    let result = mutate_state(|s| s.opt_in_cfx(&caller, chain_sentinel));
+    if result.is_ok() {
+        mutate_state(|s| s.push_event(caller, PoolEventType::OptInCollateral { collateral_type: chain_sentinel }));
+    }
+    result
+}
+
+#[update]
+pub fn opt_out_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> {
+    // SP-102 / AR-S-002: see opt_out_collateral.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    let caller = ic_cdk::api::caller();
+    let result = mutate_state(|s| s.opt_out_cfx(&caller, chain_sentinel));
+    if result.is_ok() {
+        mutate_state(|s| s.push_event(caller, PoolEventType::OptOutCollateral { collateral_type: chain_sentinel }));
+    }
+    result
+}
+
 // ─── Liquidation (Push + Fallback) ───
 
 /// Called by the backend to push liquidatable vault notifications.
@@ -446,6 +474,16 @@ pub fn icrc21_canister_call_consent_message(
         "opt_in_collateral" => {
             "## Opt In to Collateral\n\n\
              You are opting back in to receiving a specific collateral type from future liquidations."
+                .to_string()
+        }
+        "opt_in_cfx" => {
+            "## Opt In to CFX\n\n\
+             You are opting in to receiving CFX from future chain-vault liquidations."
+                .to_string()
+        }
+        "opt_out_cfx" => {
+            "## Opt Out of CFX\n\n\
+             You are opting out of receiving CFX from future chain-vault liquidations."
                 .to_string()
         }
         "deposit_as_3usd" => {

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -142,6 +142,11 @@ pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolEr
     crate::deposits::claim_pending_refund(refund_id).await
 }
 
+#[update]
+pub async fn claim_cfx(chain_sentinel: Principal, dest_evm: String) -> Result<u128, StabilityPoolError> {
+    crate::liquidation::claim_cfx(chain_sentinel, dest_evm).await
+}
+
 // ─── Opt-in / Opt-out ───
 
 #[update]
@@ -492,6 +497,11 @@ pub fn icrc21_canister_call_consent_message(
         "claim_all_collateral" => {
             "## Claim All Collateral Rewards\n\n\
              You are claiming **all** of your collateral rewards from the Rumi Protocol Stability Pool."
+                .to_string()
+        }
+        "claim_cfx" => {
+            "## Claim CFX Rewards\n\n\
+             You are claiming CFX rewards from chain-vault liquidations."
                 .to_string()
         }
         "opt_out_collateral" => {

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -341,6 +341,11 @@ pub fn get_pending_refunds(user: Option<Principal>) -> Vec<PendingRefund> {
 }
 
 #[query]
+pub fn get_chain_collateral_sentinel(chain_id: u32) -> Principal {
+    crate::state::chain_collateral_sentinel(chain_id)
+}
+
+#[query]
 pub fn check_pool_capacity(collateral_type: Principal, debt_amount_e8s: u64) -> bool {
     read_state(|s| s.effective_pool_for_collateral(&collateral_type) >= debt_amount_e8s)
 }
@@ -380,6 +385,24 @@ pub fn register_collateral(info: CollateralInfo) -> Result<(), StabilityPoolErro
         s.push_event(caller, PoolEventType::CollateralRegistered { ledger, symbol });
     });
     Ok(())
+}
+
+#[update]
+pub fn register_cfx_collateral(chain_id: u32) -> Result<Principal, StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    if !read_state(|s| s.is_admin(&caller)) {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    let sentinel = mutate_state(|s| {
+        s.register_chain_collateral(chain_id, "CFX".to_string(), 18)
+    })?;
+    mutate_state(|s| {
+        s.push_event(caller, PoolEventType::CollateralRegistered {
+            ledger: sentinel,
+            symbol: "CFX".to_string(),
+        });
+    });
+    Ok(sentinel)
 }
 
 // ─── Admin: Configuration ───

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -232,6 +232,11 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
     crate::liquidation::execute_liquidation(vault_id).await
 }
 
+#[update]
+pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    crate::liquidation::sp_absorb_chain_vault(vault_id).await
+}
+
 // ─── Interest Revenue ───
 
 /// Receive interest revenue from the protocol backend and distribute pro-rata to depositors.

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -134,6 +134,15 @@ pub(crate) struct ChainAbsorbPlan {
     pub stables_consumed: BTreeMap<Principal, u64>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CfxClaimPayoutPlan {
+    pub claimant: Principal,
+    pub chain_sentinel: Principal,
+    pub claim_id: u64,
+    pub amount_wei: u128,
+    pub dest_evm: String,
+}
+
 fn chain_id_from_sentinel(sentinel: &Principal) -> Option<ChainId> {
     let bytes = sentinel.as_slice();
     let prefix = b"rumi-chain-collateral";
@@ -255,6 +264,11 @@ pub(crate) fn apply_chain_absorb_success_in_state_at(
         });
     }
 
+    state.record_chain_claim_source(
+        plan.chain_sentinel,
+        result.claim_id,
+        result.collateral_received_native,
+    );
     state.process_chain_liquidation_gains_at(
         plan.vault_id,
         plan.chain_sentinel,
@@ -276,6 +290,102 @@ pub(crate) fn apply_chain_absorb_success_in_state_at(
         block_index: result.block_index,
         collateral_price_e8s: result.collateral_price_e8s,
     })
+}
+
+pub(crate) fn prepare_cfx_claim_payout_in_state(
+    state: &mut StabilityPoolState,
+    claimant: Principal,
+    chain_sentinel: Principal,
+    dest_evm: String,
+    address_validator: impl Fn(&str) -> bool,
+) -> Result<Option<CfxClaimPayoutPlan>, StabilityPoolError> {
+    if !address_validator(&dest_evm) {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: 0,
+            reason: "invalid EVM address".to_string(),
+        });
+    }
+    if !state.is_chain_collateral_sentinel(&chain_sentinel) {
+        return Err(StabilityPoolError::CollateralNotFound {
+            ledger: chain_sentinel,
+        });
+    }
+    let owed = state.deposits
+        .get(&claimant)
+        .and_then(|pos| pos.cfx_claims.as_ref())
+        .and_then(|claims| claims.get(&chain_sentinel).copied())
+        .unwrap_or(0);
+    if owed == 0 {
+        return Ok(None);
+    }
+
+    let (claim_id, amount_wei) = {
+        let sources = state.chain_claim_sources
+            .as_mut()
+            .and_then(|m| m.get_mut(&chain_sentinel))
+            .ok_or_else(|| StabilityPoolError::LiquidationFailed {
+                vault_id: 0,
+                reason: "no backend chain claim source available".to_string(),
+            })?;
+        let source_index = sources.iter()
+            .position(|source| source.remaining_native > 0)
+            .ok_or_else(|| StabilityPoolError::LiquidationFailed {
+                vault_id: 0,
+                reason: "no funded backend chain claim source available".to_string(),
+            })?;
+        let source = &mut sources[source_index];
+        let amount_wei = owed.min(source.remaining_native);
+        let claim_id = source.claim_id;
+        source.remaining_native = source.remaining_native.saturating_sub(amount_wei);
+        if source.remaining_native == 0 {
+            sources.remove(source_index);
+        }
+        (claim_id, amount_wei)
+    };
+
+    if state.chain_claim_sources
+        .as_ref()
+        .and_then(|m| m.get(&chain_sentinel))
+        .map(|sources| sources.is_empty())
+        .unwrap_or(false)
+    {
+        if let Some(sources) = state.chain_claim_sources.as_mut() {
+            sources.remove(&chain_sentinel);
+        }
+    }
+
+    state.mark_cfx_claimed(&claimant, &chain_sentinel, amount_wei);
+
+    Ok(Some(CfxClaimPayoutPlan {
+        claimant,
+        chain_sentinel,
+        claim_id,
+        amount_wei,
+        dest_evm,
+    }))
+}
+
+pub(crate) fn rollback_cfx_claim_payout_in_state(
+    state: &mut StabilityPoolState,
+    plan: &CfxClaimPayoutPlan,
+) {
+    state.record_chain_claim_source(plan.chain_sentinel, plan.claim_id, plan.amount_wei);
+    let position = state.deposits
+        .entry(plan.claimant)
+        .or_insert_with(|| DepositPosition::new(0));
+    let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
+    let entry = claims.entry(plan.chain_sentinel).or_insert(0);
+    *entry = entry.saturating_add(plan.amount_wei);
+}
+
+pub(crate) fn is_duplicate_chain_claim_error(error: &rumi_protocol_backend::ProtocolError) -> bool {
+    match error {
+        rumi_protocol_backend::ProtocolError::ChainAdmin(msg)
+        | rumi_protocol_backend::ProtocolError::GenericError(msg) => {
+            msg.contains("Duplicate chain collateral claim payout idempotency key")
+        }
+        _ => false,
+    }
 }
 
 /// Called by the backend when it detects liquidatable vaults (push model).
@@ -482,6 +592,61 @@ pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult,
     };
 
     mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result))
+}
+
+pub async fn claim_cfx(
+    chain_sentinel: Principal,
+    dest_evm: String,
+) -> Result<u128, StabilityPoolError> {
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    let caller = ic_cdk::api::caller();
+    if caller == Principal::anonymous() {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    if read_state(|s| s.configuration.emergency_pause) {
+        return Err(StabilityPoolError::EmergencyPaused);
+    }
+
+    let plan = mutate_state(|s| {
+        prepare_cfx_claim_payout_in_state(
+            s,
+            caller,
+            chain_sentinel,
+            dest_evm,
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+    })?;
+    let Some(plan) = plan else {
+        return Ok(0);
+    };
+
+    let protocol_id = read_state(|s| s.protocol_canister_id);
+    let backend_result: Result<(Result<u64, rumi_protocol_backend::ProtocolError>,), _> = call(
+        protocol_id,
+        "claim_chain_collateral",
+        (plan.claim_id, plan.claimant, plan.amount_wei, plan.dest_evm.clone()),
+    ).await;
+
+    match backend_result {
+        Ok((Ok(_op_id),)) => Ok(plan.amount_wei),
+        Ok((Err(error),)) if is_duplicate_chain_claim_error(&error) => Ok(plan.amount_wei),
+        Ok((Err(error),)) => {
+            mutate_state(|s| rollback_cfx_claim_payout_in_state(s, &plan));
+            Err(StabilityPoolError::LiquidationFailed {
+                vault_id: plan.claim_id,
+                reason: format!("backend rejected CFX claim: {:?}", error),
+            })
+        }
+        Err(_) => {
+            mutate_state(|s| rollback_cfx_claim_payout_in_state(s, &plan));
+            Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", protocol_id),
+                method: "claim_chain_collateral".to_string(),
+            })
+        }
+    }
 }
 
 /// Core liquidation logic for a single vault.
@@ -1079,5 +1244,74 @@ mod tests {
             .cfx_claims.as_ref().unwrap().get(&chain_collateral_sentinel(1030)).copied().unwrap_or(0);
         assert_eq!(claim_a, 4_000_000_000_000_000_000u128);
         assert_eq!(claim_b, 6_000_000_000_000_000_000u128);
+    }
+
+    #[test]
+    fn cfx_claim_payout_deducts_from_user_and_claim_source() {
+        let mut state = test_state();
+        let sentinel = state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims.get_or_insert_with(BTreeMap::new).insert(sentinel, 12);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+
+        let invalid = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "not-evm".to_string(),
+            |_| false,
+        ).unwrap_err();
+        assert!(matches!(invalid, StabilityPoolError::LiquidationFailed { .. }));
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "destination validation happens before mutation",
+        );
+        assert_eq!(state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native, 10);
+
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        ).expect("claim plan").expect("nonzero claim");
+        assert_eq!(plan.claim_id, 77);
+        assert_eq!(plan.amount_wei, 10);
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            2,
+            "only the covered source amount is deducted",
+        );
+        assert!(
+            state.chain_claim_sources.as_ref().unwrap().get(&sentinel).is_none(),
+            "depleted source is pruned before await",
+        );
+
+        rollback_cfx_claim_payout_in_state(&mut state, &plan);
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "rollback restores user claim",
+        );
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10,
+            "rollback restores backend claim source",
+        );
+    }
+
+    #[test]
+    fn duplicate_chain_claim_error_is_not_rolled_back() {
+        let duplicate = rumi_protocol_backend::ProtocolError::ChainAdmin(
+            "Duplicate chain collateral claim payout idempotency key chain-collateral-claim-77".to_string(),
+        );
+        let ordinary = rumi_protocol_backend::ProtocolError::ChainAdmin(
+            "chain collateral claim: unknown claim 77".to_string(),
+        );
+
+        assert!(is_duplicate_chain_claim_error(&duplicate));
+        assert!(!is_duplicate_chain_claim_error(&ordinary));
     }
 }

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
-use candid::Principal;
+use candid::{Nat, Principal};
 use ic_canister_log::log;
 use ic_cdk::call;
 use icrc_ledger_types::icrc1::account::Account;
+use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg, TransferError};
 use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
+use num_traits::ToPrimitive;
 
 use crate::logs::INFO;
 use crate::types::*;
@@ -16,6 +18,110 @@ use crate::state::{read_state, mutate_state};
 /// them as a fee=0 fallback would. The next successful liquidation reconciles.
 /// Shared with `claim_collateral`'s fee lookup (ICRC-004 / SP-203).
 pub(crate) const FALLBACK_COLLATERAL_FEE_E8S: u64 = 10_000;
+
+pub(crate) const CHAIN_WRITEDOWN_MEMO_PREFIX: &[u8] = b"RUMI-LIQ-004:";
+
+pub fn encode_chain_writedown_memo(vault_id: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(CHAIN_WRITEDOWN_MEMO_PREFIX.len() + 8);
+    out.extend_from_slice(CHAIN_WRITEDOWN_MEMO_PREFIX);
+    out.extend_from_slice(&vault_id.to_be_bytes());
+    out
+}
+
+pub fn build_icusd_burn_transfer_arg(
+    minting_account: Account,
+    amount_e8s: u64,
+    vault_id: u64,
+    created_at_time: u64,
+) -> TransferArg {
+    TransferArg {
+        from_subaccount: None,
+        to: minting_account,
+        fee: None,
+        created_at_time: Some(created_at_time),
+        memo: Some(Memo::from(encode_chain_writedown_memo(vault_id))),
+        amount: Nat::from(amount_e8s),
+    }
+}
+
+pub fn build_icusd_burn_proof(
+    block_index: u64,
+    vault_id: u64,
+) -> rumi_protocol_backend::icrc3_proof::SpWritedownProof {
+    rumi_protocol_backend::icrc3_proof::SpWritedownProof {
+        block_index,
+        ledger_kind: rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn,
+        vault_id_memo: vault_id,
+    }
+}
+
+pub async fn burn_icusd_for_chain_writedown(
+    icusd_ledger: Principal,
+    amount_e8s: u64,
+    vault_id: u64,
+) -> Result<rumi_protocol_backend::icrc3_proof::SpWritedownProof, StabilityPoolError> {
+    if amount_e8s == 0 {
+        return Err(StabilityPoolError::AmountTooLow { minimum_e8s: 1 });
+    }
+
+    let minting_account = match call::<(), (Option<Account>,)>(
+        icusd_ledger,
+        "icrc1_minting_account",
+        (),
+    ).await {
+        Ok((Some(account),)) => account,
+        Ok((None,)) => {
+            return Err(StabilityPoolError::LedgerTransferFailed {
+                reason: "icUSD ledger has no minting account; cannot burn".to_string(),
+            });
+        }
+        Err(_) => {
+            return Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", icusd_ledger),
+                method: "icrc1_minting_account".to_string(),
+            });
+        }
+    };
+
+    let transfer_arg = build_icusd_burn_transfer_arg(
+        minting_account,
+        amount_e8s,
+        vault_id,
+        ic_cdk::api::time(),
+    );
+
+    let result: Result<(Result<Nat, TransferError>,), _> = call(
+        icusd_ledger,
+        "icrc1_transfer",
+        (transfer_arg,),
+    ).await;
+
+    let block_index = match result {
+        Ok((Ok(block_index),)) => nat_block_index_to_u64(block_index)?,
+        Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
+            nat_block_index_to_u64(duplicate_of)?
+        }
+        Ok((Err(error),)) => {
+            return Err(StabilityPoolError::LedgerTransferFailed {
+                reason: format!("{:?}", error),
+            });
+        }
+        Err(_) => {
+            return Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", icusd_ledger),
+                method: "icrc1_transfer".to_string(),
+            });
+        }
+    };
+
+    Ok(build_icusd_burn_proof(block_index, vault_id))
+}
+
+fn nat_block_index_to_u64(block_index: Nat) -> Result<u64, StabilityPoolError> {
+    block_index.0.to_u64().ok_or_else(|| StabilityPoolError::LedgerTransferFailed {
+        reason: format!("ledger block index {} does not fit in u64", block_index),
+    })
+}
 
 /// Called by the backend when it detects liquidatable vaults (push model).
 /// Processes each vault sequentially, consuming stablecoins and distributing collateral.
@@ -532,4 +638,60 @@ struct StabilityPoolLiquidationResult {
     pub block_index: u64,
     pub fee: u64,
     pub collateral_price_e8s: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Nat;
+    use icrc_ledger_types::icrc1::transfer::Memo;
+
+    fn principal(byte: u8) -> Principal {
+        Principal::from_slice(&[byte])
+    }
+
+    #[test]
+    fn chain_writedown_memo_matches_backend_liq_004_shape() {
+        let vault_id: u64 = 0x0102_0304_0506_0708;
+        let memo = encode_chain_writedown_memo(vault_id);
+
+        assert_eq!(&memo[..13], b"RUMI-LIQ-004:");
+        assert_eq!(&memo[13..], &vault_id.to_be_bytes());
+        assert_eq!(
+            rumi_protocol_backend::icrc3_proof::decode_writedown_memo(&memo),
+            Ok(vault_id),
+            "SP burn memo must be accepted by backend proof verifier",
+        );
+    }
+
+    #[test]
+    fn icusd_burn_request_targets_minting_account_and_builds_proof() {
+        let minting_account = Account { owner: principal(90), subaccount: None };
+        let amount_e8s = 12_345_00000000;
+        let vault_id = 77;
+        let created_at_time = 123_456_789;
+        let block_index = 999;
+
+        let transfer = build_icusd_burn_transfer_arg(
+            minting_account,
+            amount_e8s,
+            vault_id,
+            created_at_time,
+        );
+
+        assert_eq!(transfer.to, minting_account);
+        assert_eq!(transfer.amount, Nat::from(amount_e8s));
+        assert_eq!(transfer.fee, None, "ICRC-1 burns to the minting account have zero fee");
+        assert_eq!(transfer.from_subaccount, None);
+        assert_eq!(transfer.created_at_time, Some(created_at_time));
+        assert_eq!(
+            transfer.memo,
+            Some(Memo::from(encode_chain_writedown_memo(vault_id))),
+        );
+
+        let proof = build_icusd_burn_proof(block_index, vault_id);
+        assert_eq!(proof.block_index, block_index);
+        assert_eq!(proof.ledger_kind, rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn);
+        assert_eq!(proof.vault_id_memo, vault_id);
+    }
 }

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -6,10 +6,11 @@ use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg, TransferError};
 use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
 use num_traits::ToPrimitive;
+use rumi_protocol_backend::chains::config::ChainId;
 
 use crate::logs::INFO;
 use crate::types::*;
-use crate::state::{read_state, mutate_state};
+use crate::state::{read_state, mutate_state, StabilityPoolState};
 
 /// Conservative fallback for a collateral ledger's transfer fee, used only when
 /// the live `icrc1_fee` query fails (SP-104). Set to the common ICRC fee
@@ -120,6 +121,160 @@ pub async fn burn_icusd_for_chain_writedown(
 fn nat_block_index_to_u64(block_index: Nat) -> Result<u64, StabilityPoolError> {
     block_index.0.to_u64().ok_or_else(|| StabilityPoolError::LedgerTransferFailed {
         reason: format!("ledger block index {} does not fit in u64", block_index),
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ChainAbsorbPlan {
+    pub vault_id: u64,
+    pub chain_id: ChainId,
+    pub chain_sentinel: Principal,
+    pub icusd_ledger: Principal,
+    pub icusd_to_burn_e8s: u64,
+    pub stables_consumed: BTreeMap<Principal, u64>,
+}
+
+fn chain_id_from_sentinel(sentinel: &Principal) -> Option<ChainId> {
+    let bytes = sentinel.as_slice();
+    let prefix = b"rumi-chain-collateral";
+    if bytes.len() != 29 || !bytes.starts_with(prefix) || bytes[28] != 0x7f {
+        return None;
+    }
+    if bytes[prefix.len()..24].iter().any(|b| *b != 0) {
+        return None;
+    }
+    let mut chain_bytes = [0u8; 4];
+    chain_bytes.copy_from_slice(&bytes[24..28]);
+    Some(ChainId(u32::from_le_bytes(chain_bytes)))
+}
+
+pub(crate) fn registered_chain_ids_from_sentinels(state: &StabilityPoolState) -> Vec<ChainId> {
+    let mut chains: Vec<ChainId> = state.chain_collateral_sentinels
+        .as_ref()
+        .into_iter()
+        .flat_map(|sentinels| sentinels.iter())
+        .filter_map(chain_id_from_sentinel)
+        .collect();
+    chains.sort();
+    chains.dedup();
+    chains
+}
+
+pub(crate) fn prepare_chain_absorb_plan_in_state(
+    state: &StabilityPoolState,
+    vault: &ChainLiquidatableVaultInfo,
+) -> Result<ChainAbsorbPlan, StabilityPoolError> {
+    if !vault.sp_attempted {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: vault.vault_id,
+            reason: "chain vault has not been escalated to the stability pool".to_string(),
+        });
+    }
+    if !state.is_chain_collateral_sentinel(&vault.chain_collateral_sentinel) {
+        return Err(StabilityPoolError::CollateralNotFound {
+            ledger: vault.chain_collateral_sentinel,
+        });
+    }
+    if chain_id_from_sentinel(&vault.chain_collateral_sentinel) != Some(vault.chain_id) {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: vault.vault_id,
+            reason: "chain collateral sentinel does not match chain id".to_string(),
+        });
+    }
+    let debt_e8s = u64::try_from(vault.debt_e8s).map_err(|_| {
+        StabilityPoolError::LiquidationFailed {
+            vault_id: vault.vault_id,
+            reason: format!("chain vault debt {} exceeds SP u64 burn amount", vault.debt_e8s),
+        }
+    })?;
+    if debt_e8s == 0 {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: vault.vault_id,
+            reason: "chain vault has no debt to absorb".to_string(),
+        });
+    }
+
+    let available_icusd = state.effective_icusd_pool_for_collateral(&vault.chain_collateral_sentinel);
+    if available_icusd < debt_e8s {
+        return Err(StabilityPoolError::InsufficientPoolBalance);
+    }
+    let stables_consumed = state.compute_icusd_chain_draw(debt_e8s, &vault.chain_collateral_sentinel);
+    let icusd_ledger = state.icusd_ledger().ok_or(StabilityPoolError::TokenNotAccepted {
+        ledger: Principal::anonymous(),
+    })?;
+    if stables_consumed.get(&icusd_ledger).copied().unwrap_or(0) != debt_e8s {
+        return Err(StabilityPoolError::InsufficientPoolBalance);
+    }
+
+    Ok(ChainAbsorbPlan {
+        vault_id: vault.vault_id,
+        chain_id: vault.chain_id,
+        chain_sentinel: vault.chain_collateral_sentinel,
+        icusd_ledger,
+        icusd_to_burn_e8s: debt_e8s,
+        stables_consumed,
+    })
+}
+
+pub(crate) fn apply_chain_absorb_success_in_state(
+    state: &mut StabilityPoolState,
+    plan: &ChainAbsorbPlan,
+    result: ChainStabilityPoolLiquidationResult,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    apply_chain_absorb_success_in_state_at(state, plan, result, ic_cdk::api::time())
+}
+
+pub(crate) fn apply_chain_absorb_success_in_state_at(
+    state: &mut StabilityPoolState,
+    plan: &ChainAbsorbPlan,
+    result: ChainStabilityPoolLiquidationResult,
+    timestamp: u64,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    if !result.success {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend reported unsuccessful chain absorb".to_string(),
+        });
+    }
+    if result.vault_id != plan.vault_id || result.chain_id != plan.chain_id {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend chain absorb result does not match requested vault".to_string(),
+        });
+    }
+    if result.liquidated_debt_e8s > plan.icusd_to_burn_e8s as u128 {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend liquidated more debt than SP burned".to_string(),
+        });
+    }
+    if result.collateral_received_native == 0 {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend returned zero chain collateral".to_string(),
+        });
+    }
+
+    state.process_chain_liquidation_gains_at(
+        plan.vault_id,
+        plan.chain_sentinel,
+        &plan.stables_consumed,
+        result.collateral_received_native,
+        result.collateral_price_e8s,
+        timestamp,
+    );
+
+    Ok(ChainSpAbsorbResult {
+        success: true,
+        vault_id: result.vault_id,
+        chain_id: result.chain_id,
+        icusd_burned_e8s: plan.icusd_to_burn_e8s,
+        liquidated_debt_e8s: result.liquidated_debt_e8s,
+        collateral_received_native: result.collateral_received_native,
+        claim_id: result.claim_id,
+        custody_address: result.custody_address,
+        block_index: result.block_index,
+        collateral_price_e8s: result.collateral_price_e8s,
     })
 }
 
@@ -250,6 +405,83 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
     mutate_state(|s| { s.in_flight_liquidations.remove(&vault_id); });
 
     Ok(result)
+}
+
+pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    if caller == Principal::anonymous() {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    if !read_state(|s| s.is_admin(&caller)) {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    if read_state(|s| s.configuration.emergency_pause) {
+        return Err(StabilityPoolError::EmergencyPaused);
+    }
+
+    let _liq_guard = crate::pool_guard::SpLiquidationGuard::new()?;
+    let (protocol_id, chains) = read_state(|s| {
+        (s.protocol_canister_id, registered_chain_ids_from_sentinels(s))
+    });
+    if chains.is_empty() {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id,
+            reason: "no registered chain collateral sentinels".to_string(),
+        });
+    }
+
+    let mut candidate: Option<ChainLiquidatableVaultInfo> = None;
+    for chain in chains {
+        let call_result: Result<(Vec<ChainLiquidatableVaultInfo>,), _> = call(
+            protocol_id,
+            "get_chain_liquidatable_vaults",
+            (chain,),
+        ).await;
+        let (vaults,) = call_result.map_err(|_| StabilityPoolError::InterCanisterCallFailed {
+            target: format!("{}", protocol_id),
+            method: "get_chain_liquidatable_vaults".to_string(),
+        })?;
+        if let Some(vault) = vaults.into_iter().find(|v| v.vault_id == vault_id) {
+            candidate = Some(vault);
+            break;
+        }
+    }
+
+    let candidate = candidate.ok_or_else(|| StabilityPoolError::LiquidationFailed {
+        vault_id,
+        reason: "chain vault not found in liquidatable discovery".to_string(),
+    })?;
+    let plan = read_state(|s| prepare_chain_absorb_plan_in_state(s, &candidate))?;
+
+    let proof = burn_icusd_for_chain_writedown(
+        plan.icusd_ledger,
+        plan.icusd_to_burn_e8s,
+        vault_id,
+    ).await?;
+
+    let backend_result: Result<(Result<ChainStabilityPoolLiquidationResult, rumi_protocol_backend::ProtocolError>,), _> = call(
+        protocol_id,
+        "stability_pool_liquidate_chain_vault",
+        (vault_id, plan.icusd_to_burn_e8s, proof),
+    ).await;
+
+    let result = match backend_result {
+        Ok((Ok(result),)) => result,
+        Ok((Err(error),)) => {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id,
+                reason: format!("backend rejected chain absorb after burn: {:?}", error),
+            });
+        }
+        Err(_) => {
+            return Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", protocol_id),
+                method: "stability_pool_liquidate_chain_vault".to_string(),
+            });
+        }
+    };
+
+    mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result))
 }
 
 /// Core liquidation logic for a single vault.
@@ -645,9 +877,80 @@ mod tests {
     use super::*;
     use candid::Nat;
     use icrc_ledger_types::icrc1::transfer::Memo;
+    use crate::state::{chain_collateral_sentinel, StabilityPoolState};
 
     fn principal(byte: u8) -> Principal {
         Principal::from_slice(&[byte])
+    }
+
+    fn icusd_ledger() -> Principal {
+        Principal::from_slice(&[10])
+    }
+
+    fn ckusdc_ledger() -> Principal {
+        Principal::from_slice(&[11])
+    }
+
+    fn user_a() -> Principal {
+        Principal::from_slice(&[1])
+    }
+
+    fn user_b() -> Principal {
+        Principal::from_slice(&[2])
+    }
+
+    fn test_state() -> StabilityPoolState {
+        let mut state = StabilityPoolState::default();
+        state.register_stablecoin(StablecoinConfig {
+            ledger_id: icusd_ledger(),
+            symbol: "icUSD".to_string(),
+            decimals: 8,
+            priority: 1,
+            is_active: true,
+            transfer_fee: Some(100_000),
+            is_lp_token: None,
+            underlying_pool: None,
+        });
+        state.register_stablecoin(StablecoinConfig {
+            ledger_id: ckusdc_ledger(),
+            symbol: "ckUSDC".to_string(),
+            decimals: 6,
+            priority: 2,
+            is_active: true,
+            transfer_fee: Some(10),
+            is_lp_token: None,
+            underlying_pool: None,
+        });
+        state
+    }
+
+    fn add_deposit_direct(
+        state: &mut StabilityPoolState,
+        user: Principal,
+        token: Principal,
+        amount: u64,
+    ) {
+        let position = state.deposits.entry(user).or_insert_with(|| DepositPosition::new(0));
+        *position.stablecoin_balances.entry(token).or_insert(0) += amount;
+        *state.total_stablecoin_balances.entry(token).or_insert(0) += amount;
+    }
+
+    fn chain_vault(
+        debt_e8s: u128,
+        sp_attempted: bool,
+    ) -> ChainLiquidatableVaultInfo {
+        ChainLiquidatableVaultInfo {
+            vault_id: 77,
+            chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
+            chain_collateral_sentinel: chain_collateral_sentinel(1030),
+            sp_attempted,
+            debt_e8s,
+            effective_debt_e8s: debt_e8s,
+            collateral_native: 1_000_000_000_000_000_000_000,
+            cr_e4: 12_000,
+            liquidation_threshold_e4: 13_500,
+            sized_repay_e8s: debt_e8s,
+        }
     }
 
     #[test]
@@ -693,5 +996,88 @@ mod tests {
         assert_eq!(proof.block_index, block_index);
         assert_eq!(proof.ledger_kind, rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn);
         assert_eq!(proof.vault_id_memo, vault_id);
+    }
+
+    #[test]
+    fn registered_chain_ids_decode_from_registered_sentinels() {
+        let mut state = test_state();
+        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+
+        assert_eq!(
+            registered_chain_ids_from_sentinels(&state),
+            vec![rumi_protocol_backend::chains::config::ChainId(1030)],
+        );
+    }
+
+    #[test]
+    fn chain_absorb_preflight_requires_escalation_and_icusd_coverage() {
+        let mut state = test_state();
+        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 40_00000000);
+        add_deposit_direct(&mut state, user_a(), ckusdc_ledger(), 5_000_000_000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 100_00000000);
+
+        let not_escalated = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, false))
+            .unwrap_err();
+        assert!(matches!(not_escalated, StabilityPoolError::LiquidationFailed { .. }));
+
+        let no_opt_in = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
+            .unwrap_err();
+        assert!(matches!(no_opt_in, StabilityPoolError::InsufficientPoolBalance));
+
+        state.opt_in_cfx(&user_a(), chain_collateral_sentinel(1030)).unwrap();
+        let undercovered = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
+            .unwrap_err();
+        assert!(
+            matches!(undercovered, StabilityPoolError::InsufficientPoolBalance),
+            "ckUSDC must not count toward chain absorb coverage",
+        );
+
+        state.opt_in_cfx(&user_b(), chain_collateral_sentinel(1030)).unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
+            .expect("covered by opted-in icUSD");
+        assert_eq!(plan.icusd_to_burn_e8s, 70_00000000);
+        assert_eq!(plan.stables_consumed.get(&icusd_ledger()).copied(), Some(70_00000000));
+        assert_eq!(plan.stables_consumed.len(), 1);
+    }
+
+    #[test]
+    fn chain_absorb_success_credits_cfx_claims_and_deducts_burned_icusd() {
+        let mut state = test_state();
+        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 40_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 60_00000000);
+        state.opt_in_cfx(&user_a(), chain_collateral_sentinel(1030)).unwrap();
+        state.opt_in_cfx(&user_b(), chain_collateral_sentinel(1030)).unwrap();
+
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        let result = ChainStabilityPoolLiquidationResult {
+            success: true,
+            vault_id: 77,
+            chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
+            liquidated_debt_e8s: 100_00000000,
+            collateral_received_native: 10_000_000_000_000_000_000u128,
+            claim_id: 77,
+            custody_address: "0xcustody".to_string(),
+            block_index: 44,
+            collateral_price_e8s: 5_000_000,
+        };
+
+        let absorbed = apply_chain_absorb_success_in_state_at(&mut state, &plan, result, 123)
+            .expect("success finalizes");
+
+        assert_eq!(absorbed.icusd_burned_e8s, 100_00000000);
+        assert_eq!(
+            state.total_stablecoin_balances.get(&icusd_ledger()).copied(),
+            Some(0),
+            "SP aggregate tracks the burned icUSD",
+        );
+        let claim_a = state.deposits.get(&user_a()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&chain_collateral_sentinel(1030)).copied().unwrap_or(0);
+        let claim_b = state.deposits.get(&user_b()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&chain_collateral_sentinel(1030)).copied().unwrap_or(0);
+        assert_eq!(claim_a, 4_000_000_000_000_000_000u128);
+        assert_eq!(claim_b, 6_000_000_000_000_000_000u128);
     }
 }

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -37,6 +37,10 @@ pub struct StabilityPoolState {
     /// Candid stable memory upgrade-compatible when decoding old snapshots.
     #[serde(default)]
     pub chain_collateral_sentinels: Option<BTreeSet<Principal>>,
+    /// Backend chain-liquidity claims available to pay SP depositor CFX claims,
+    /// keyed by chain sentinel. `Option` keeps Candid stable memory upgrades safe.
+    #[serde(default)]
+    pub chain_claim_sources: Option<BTreeMap<Principal, Vec<ChainClaimSource>>>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -86,6 +90,7 @@ impl Default for StabilityPoolState {
             stablecoin_registry: BTreeMap::new(),
             collateral_registry: BTreeMap::new(),
             chain_collateral_sentinels: Some(BTreeSet::new()),
+            chain_claim_sources: Some(BTreeMap::new()),
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -514,6 +519,29 @@ impl StabilityPoolState {
                     }
                 }
             }
+        }
+    }
+
+    pub fn record_chain_claim_source(
+        &mut self,
+        chain_sentinel: Principal,
+        claim_id: u64,
+        amount_native: u128,
+    ) {
+        if amount_native == 0 {
+            return;
+        }
+        let sources = self.chain_claim_sources
+            .get_or_insert_with(BTreeMap::new)
+            .entry(chain_sentinel)
+            .or_default();
+        if let Some(existing) = sources.iter_mut().find(|s| s.claim_id == claim_id) {
+            existing.remaining_native = existing.remaining_native.saturating_add(amount_native);
+        } else {
+            sources.push(ChainClaimSource {
+                claim_id,
+                remaining_native: amount_native,
+            });
         }
     }
 
@@ -1387,6 +1415,7 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             stablecoin_registry: v1.stablecoin_registry,
             collateral_registry: v1.collateral_registry,
             chain_collateral_sentinels: Some(BTreeSet::new()),
+            chain_claim_sources: Some(BTreeMap::new()),
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -2798,6 +2827,10 @@ mod tests {
         assert!(
             decoded.chain_collateral_sentinels.clone().unwrap_or_default().is_empty(),
             "missing chain sentinel registry must decode as empty",
+        );
+        assert!(
+            decoded.chain_claim_sources.clone().unwrap_or_default().is_empty(),
+            "missing chain claim source inventory must decode as empty",
         );
     }
 

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1208,6 +1208,7 @@ mod tests {
     fn ckusdc_ledger() -> Principal { Principal::from_slice(&[12]) }
     fn icp_ledger() -> Principal { Principal::from_slice(&[20]) }
     fn ckbtc_ledger() -> Principal { Principal::from_slice(&[21]) }
+    fn cfx_sentinel() -> Principal { Principal::from_slice(&[30]) }
 
     /// Build a test state with:
     /// - icUSD (8 decimals, priority 1)
@@ -1645,6 +1646,10 @@ mod tests {
         // Has collateral gains -> not empty
         pos.collateral_gains.insert(icp_ledger(), 100);
         assert!(!pos.is_empty());
+
+        pos.collateral_gains.clear();
+        pos.cfx_claims.get_or_insert_with(BTreeMap::new).insert(cfx_sentinel(), 1_000_000_000_000_000_000);
+        assert!(!pos.is_empty(), "u128 CFX claims must prevent position cleanup");
     }
 
     // ─── Test: Mark gains claimed ───
@@ -2294,6 +2299,84 @@ mod tests {
             "pending refunds must start empty after a v1 upgrade",
         );
         assert_eq!(decoded.next_pending_refund_id.unwrap_or(0), 0);
+    }
+
+    #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+    struct DepositPositionPreCfx {
+        pub stablecoin_balances: BTreeMap<Principal, u64>,
+        pub collateral_gains: BTreeMap<Principal, u64>,
+        pub opted_out_collateral: BTreeSet<Principal>,
+        pub deposit_timestamp: u64,
+        pub total_claimed_gains: BTreeMap<Principal, u64>,
+        pub total_interest_earned_e8s: Option<u64>,
+    }
+
+    #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+    struct StabilityPoolStatePreCfx {
+        pub deposits: BTreeMap<Principal, DepositPositionPreCfx>,
+        pub total_stablecoin_balances: BTreeMap<Principal, u64>,
+        pub stablecoin_registry: BTreeMap<Principal, StablecoinConfig>,
+        pub collateral_registry: BTreeMap<Principal, CollateralInfo>,
+        pub protocol_canister_id: Principal,
+        pub configuration: PoolConfiguration,
+        pub liquidation_history: Vec<PoolLiquidationRecord>,
+        pub in_flight_liquidations: BTreeSet<u64>,
+        pub total_liquidations_executed: u64,
+        pub pool_creation_timestamp: u64,
+        pub total_interest_received_e8s: Option<u64>,
+        pub token_consecutive_failures: Option<BTreeMap<Principal, u32>>,
+        pub cached_virtual_prices: Option<BTreeMap<Principal, u128>>,
+        pub protocol_reserve_address: Option<Principal>,
+        pub is_initialized: bool,
+        pub pool_events: Option<Vec<PoolEvent>>,
+        pub next_event_id: Option<u64>,
+        pub pending_refunds: Option<BTreeMap<u64, PendingRefund>>,
+        pub next_pending_refund_id: Option<u64>,
+    }
+
+    #[test]
+    fn pre_cfx_snapshot_decodes_with_empty_cfx_claims() {
+        let mut current = test_state();
+        add_deposit_direct(&mut current, user_a(), icusd_ledger(), 42_00000000);
+        let pos = current.deposits.get(&user_a()).unwrap();
+        let mut deposits = BTreeMap::new();
+        deposits.insert(user_a(), DepositPositionPreCfx {
+            stablecoin_balances: pos.stablecoin_balances.clone(),
+            collateral_gains: pos.collateral_gains.clone(),
+            opted_out_collateral: pos.opted_out_collateral.clone(),
+            deposit_timestamp: pos.deposit_timestamp,
+            total_claimed_gains: pos.total_claimed_gains.clone(),
+            total_interest_earned_e8s: pos.total_interest_earned_e8s,
+        });
+        let pre_cfx = StabilityPoolStatePreCfx {
+            deposits,
+            total_stablecoin_balances: current.total_stablecoin_balances.clone(),
+            stablecoin_registry: current.stablecoin_registry.clone(),
+            collateral_registry: current.collateral_registry.clone(),
+            protocol_canister_id: current.protocol_canister_id,
+            configuration: current.configuration.clone(),
+            liquidation_history: current.liquidation_history.clone(),
+            in_flight_liquidations: current.in_flight_liquidations.clone(),
+            total_liquidations_executed: current.total_liquidations_executed,
+            pool_creation_timestamp: current.pool_creation_timestamp,
+            total_interest_received_e8s: current.total_interest_received_e8s,
+            token_consecutive_failures: current.token_consecutive_failures.clone(),
+            cached_virtual_prices: current.cached_virtual_prices.clone(),
+            protocol_reserve_address: current.protocol_reserve_address,
+            is_initialized: current.is_initialized,
+            pool_events: current.pool_events.clone(),
+            next_event_id: current.next_event_id,
+            pending_refunds: current.pending_refunds.clone(),
+            next_pending_refund_id: current.next_pending_refund_id,
+        };
+        let bytes = Encode!(&pre_cfx).expect("encode pre-CFX snapshot");
+
+        let decoded = try_decode_state(&bytes).expect("pre-CFX snapshot must decode");
+        let decoded_pos = decoded.deposits.get(&user_a()).expect("deposit survives");
+        assert!(
+            decoded_pos.cfx_claims.clone().unwrap_or_default().is_empty(),
+            "missing CFX claims field must decode as empty",
+        );
     }
 
     // ─── Test: Opt-out mid-liquidation burn escape (audit AR-S-002) ───

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -11,6 +11,17 @@ use crate::logs::INFO;
 /// Older entries are dropped when this limit is exceeded.
 const MAX_LIQUIDATION_HISTORY: usize = 1_000;
 
+/// Deterministic Principal key for chain-native collateral. This is a metadata
+/// key, never an ICRC ledger canister. Must match the backend discovery helper.
+pub fn chain_collateral_sentinel(chain_id: u32) -> Principal {
+    let mut bytes = [0u8; 29];
+    let prefix = b"rumi-chain-collateral";
+    bytes[..prefix.len()].copy_from_slice(prefix);
+    bytes[24..28].copy_from_slice(&chain_id.to_le_bytes());
+    bytes[28] = 0x7f;
+    Principal::from_slice(&bytes)
+}
+
 #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
 pub struct StabilityPoolState {
     // Depositor positions
@@ -183,6 +194,23 @@ impl StabilityPoolState {
         self.chain_collateral_sentinels
             .get_or_insert_with(BTreeSet::new)
             .insert(sentinel);
+    }
+
+    pub fn register_chain_collateral(
+        &mut self,
+        chain_id: u32,
+        symbol: String,
+        decimals: u8,
+    ) -> Result<Principal, StabilityPoolError> {
+        let sentinel = chain_collateral_sentinel(chain_id);
+        self.register_collateral(CollateralInfo {
+            ledger_id: sentinel,
+            symbol,
+            decimals,
+            status: CollateralStatus::Active,
+        });
+        self.register_chain_collateral_sentinel(sentinel);
+        Ok(sentinel)
     }
 
     pub fn is_chain_collateral_sentinel(&self, collateral_type: &Principal) -> bool {
@@ -1950,6 +1978,27 @@ mod tests {
 
         state.opt_out_cfx(&user_a(), cfx_sentinel()).expect("user A opts back out");
         assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 0);
+    }
+
+    #[test]
+    fn chain_collateral_sentinel_registration_is_stable_and_validation_safe() {
+        let mut state = test_state();
+        let sentinel = chain_collateral_sentinel(1030);
+        assert_eq!(sentinel, chain_collateral_sentinel(1030));
+        assert_ne!(sentinel, chain_collateral_sentinel(71));
+        assert_ne!(sentinel, icusd_ledger());
+        assert_ne!(sentinel, icp_ledger());
+
+        let registered = state.register_chain_collateral(1030, "CFX".to_string(), 18)
+            .expect("register CFX sentinel");
+        assert_eq!(registered, sentinel);
+        assert!(state.is_chain_collateral_sentinel(&sentinel));
+        let info = state.collateral_registry.get(&sentinel).expect("sentinel registered as collateral");
+        assert_eq!(info.symbol, "CFX");
+        assert_eq!(info.decimals, 18);
+        assert!(matches!(info.status, CollateralStatus::Active));
+        assert_eq!(state.effective_pool_for_collateral(&sentinel), 0);
+        assert!(state.validate_state().is_ok(), "sentinel is metadata, not a ledger aggregate");
     }
 
     #[test]

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -637,6 +637,21 @@ impl StabilityPoolState {
             .sum()
     }
 
+    pub fn icusd_ledger(&self) -> Option<Principal> {
+        self.stablecoin_registry.iter()
+            .find(|(_, config)| config.symbol == "icUSD")
+            .map(|(ledger, _)| *ledger)
+    }
+
+    /// Compute opted-in icUSD coverage only. Chain-native liquidations use
+    /// this instead of the mixed-token draw so Inc 4 burns only IC-native icUSD.
+    pub fn effective_icusd_pool_for_collateral(&self, collateral_type: &Principal) -> u64 {
+        self.deposits.values()
+            .filter(|pos| self.position_opted_in_for(pos, collateral_type))
+            .map(|pos| pos.icusd_value(&self.stablecoin_registry))
+            .sum()
+    }
+
     // ─── Liquidation Processing ───
 
     /// Compute the stablecoin draw for a liquidation of a given debt amount (e8s).
@@ -764,6 +779,27 @@ impl StabilityPoolState {
             remaining_e8s -= draw_e8s;
         }
 
+        result
+    }
+
+    /// Compute an Inc 4 chain-vault draw. Returns at most one token, icUSD, in
+    /// e8s. ckStables and 3USD are intentionally excluded from this path.
+    pub fn compute_icusd_chain_draw(
+        &self,
+        debt_e8s: u64,
+        chain_sentinel: &Principal,
+    ) -> BTreeMap<Principal, u64> {
+        let mut result = BTreeMap::new();
+        if debt_e8s == 0 || !self.is_chain_collateral_sentinel(chain_sentinel) {
+            return result;
+        }
+        let Some(icusd_ledger) = self.icusd_ledger() else {
+            return result;
+        };
+        let draw_e8s = debt_e8s.min(self.effective_icusd_pool_for_collateral(chain_sentinel));
+        if draw_e8s > 0 {
+            result.insert(icusd_ledger, draw_e8s);
+        }
         result
     }
 
@@ -2039,6 +2075,42 @@ mod tests {
         state.mark_cfx_claimed(&user_a(), &cfx_sentinel(), 9_997 * E18 + 1);
         assert!(state.deposits.get(&user_a()).unwrap()
             .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).is_none());
+    }
+
+    #[test]
+    fn chain_icusd_draw_ignores_ckstables_and_lp_tokens() {
+        let mut state = test_state_with_3usd();
+        state.register_chain_collateral_sentinel(cfx_sentinel());
+
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 40_00000000);
+        add_deposit_direct(&mut state, user_a(), ckusdc_ledger(), 500_000_000);
+        add_deposit_direct(&mut state, user_a(), three_usd_ledger(), 500_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 100_00000000);
+        state.opt_in_cfx(&user_a(), cfx_sentinel()).unwrap();
+
+        assert_eq!(
+            state.effective_icusd_pool_for_collateral(&cfx_sentinel()),
+            40_00000000,
+            "only opted-in icUSD counts toward chain absorb coverage",
+        );
+
+        let draw = state.compute_icusd_chain_draw(70_00000000, &cfx_sentinel());
+        assert_eq!(draw.len(), 1, "chain draw should contain only icUSD");
+        assert_eq!(
+            draw.get(&icusd_ledger()).copied(),
+            Some(40_00000000),
+            "chain draw caps to opted-in icUSD, not total stable value",
+        );
+        assert!(!draw.contains_key(&ckusdc_ledger()), "ckUSDC must not be burned for Inc 4 chain absorb");
+        assert!(!draw.contains_key(&three_usd_ledger()), "3USD LP must not be burned for Inc 4 chain absorb");
+
+        state.opt_in_cfx(&user_b(), cfx_sentinel()).unwrap();
+        let full_draw = state.compute_icusd_chain_draw(70_00000000, &cfx_sentinel());
+        assert_eq!(
+            full_draw.get(&icusd_ledger()).copied(),
+            Some(70_00000000),
+            "additional opted-in icUSD can cover the requested debt",
+        );
     }
 
     // ─── Test: Multi-token liquidation with mixed decimals ───

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -22,6 +22,10 @@ pub struct StabilityPoolState {
     // Registries
     pub stablecoin_registry: BTreeMap<Principal, StablecoinConfig>,
     pub collateral_registry: BTreeMap<Principal, CollateralInfo>,
+    /// Deterministic chain-native collateral sentinel principals. `Option` keeps
+    /// Candid stable memory upgrade-compatible when decoding old snapshots.
+    #[serde(default)]
+    pub chain_collateral_sentinels: Option<BTreeSet<Principal>>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -70,6 +74,7 @@ impl Default for StabilityPoolState {
             total_stablecoin_balances: BTreeMap::new(),
             stablecoin_registry: BTreeMap::new(),
             collateral_registry: BTreeMap::new(),
+            chain_collateral_sentinels: Some(BTreeSet::new()),
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -174,6 +179,27 @@ impl StabilityPoolState {
         self.collateral_registry.insert(info.ledger_id, info);
     }
 
+    pub fn register_chain_collateral_sentinel(&mut self, sentinel: Principal) {
+        self.chain_collateral_sentinels
+            .get_or_insert_with(BTreeSet::new)
+            .insert(sentinel);
+    }
+
+    pub fn is_chain_collateral_sentinel(&self, collateral_type: &Principal) -> bool {
+        self.chain_collateral_sentinels
+            .as_ref()
+            .map(|s| s.contains(collateral_type))
+            .unwrap_or(false)
+    }
+
+    fn position_opted_in_for(&self, pos: &DepositPosition, collateral_type: &Principal) -> bool {
+        if self.is_chain_collateral_sentinel(collateral_type) {
+            pos.is_opted_in_for_chain(collateral_type)
+        } else {
+            pos.is_opted_in(collateral_type)
+        }
+    }
+
     // ─── Deposits ───
 
     pub fn add_deposit(&mut self, user: Principal, token_ledger: Principal, amount: u64) {
@@ -216,6 +242,10 @@ impl StabilityPoolState {
         // Only icUSD-denominated balances earn the interest stream.
         // 3USD, ckUSDC, ckUSDT depositors still participate in liquidations
         // pro-rata but no longer earn the interest distribution.
+        let collateral_is_chain_sentinel = collateral_type
+            .as_ref()
+            .map(|ct| self.is_chain_collateral_sentinel(ct))
+            .unwrap_or(false);
         let holders: Vec<(Principal, u64)> = self.deposits.iter()
             .filter_map(|(p, pos)| {
                 let icusd_value = pos.icusd_value(&self.stablecoin_registry);
@@ -224,7 +254,12 @@ impl StabilityPoolState {
                 }
                 // If we know the collateral source, skip opted-out depositors
                 if let Some(ct) = &collateral_type {
-                    if !pos.is_opted_in(ct) {
+                    let opted_in = if collateral_is_chain_sentinel {
+                        pos.is_opted_in_for_chain(ct)
+                    } else {
+                        pos.is_opted_in(ct)
+                    };
+                    if !opted_in {
                         return None;
                     }
                 }
@@ -444,6 +479,9 @@ impl StabilityPoolState {
     // ─── Opt-in / Opt-out ───
 
     pub fn opt_out_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+        if self.is_chain_collateral_sentinel(&collateral_type) {
+            return self.opt_out_cfx(user, collateral_type);
+        }
         let position = self.deposits.get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
         if !position.opted_out_collateral.insert(collateral_type) {
@@ -453,10 +491,39 @@ impl StabilityPoolState {
     }
 
     pub fn opt_in_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+        if self.is_chain_collateral_sentinel(&collateral_type) {
+            return self.opt_in_cfx(user, collateral_type);
+        }
         let position = self.deposits.get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
         if !position.opted_out_collateral.remove(&collateral_type) {
             return Err(StabilityPoolError::AlreadyOptedIn { collateral: collateral_type });
+        }
+        Ok(())
+    }
+
+    pub fn opt_in_cfx(&mut self, user: &Principal, sentinel: Principal) -> Result<(), StabilityPoolError> {
+        if !self.is_chain_collateral_sentinel(&sentinel) {
+            return Err(StabilityPoolError::CollateralNotFound { ledger: sentinel });
+        }
+        let position = self.deposits.get_mut(user)
+            .ok_or(StabilityPoolError::NoPositionFound)?;
+        let opted_in = position.opted_in_chain_collateral.get_or_insert_with(BTreeSet::new);
+        if !opted_in.insert(sentinel) {
+            return Err(StabilityPoolError::AlreadyOptedIn { collateral: sentinel });
+        }
+        Ok(())
+    }
+
+    pub fn opt_out_cfx(&mut self, user: &Principal, sentinel: Principal) -> Result<(), StabilityPoolError> {
+        if !self.is_chain_collateral_sentinel(&sentinel) {
+            return Err(StabilityPoolError::CollateralNotFound { ledger: sentinel });
+        }
+        let position = self.deposits.get_mut(user)
+            .ok_or(StabilityPoolError::NoPositionFound)?;
+        let opted_in = position.opted_in_chain_collateral.get_or_insert_with(BTreeSet::new);
+        if !opted_in.remove(&sentinel) {
+            return Err(StabilityPoolError::AlreadyOptedOut { collateral: sentinel });
         }
         Ok(())
     }
@@ -524,7 +591,7 @@ impl StabilityPoolState {
     pub fn effective_pool_for_collateral(&self, collateral_type: &Principal) -> u64 {
         let vps = self.virtual_prices();
         self.deposits.values()
-            .filter(|pos| pos.is_opted_in(collateral_type))
+            .filter(|pos| self.position_opted_in_for(pos, collateral_type))
             .map(|pos| pos.total_usd_value(&self.stablecoin_registry, vps))
             .sum()
     }
@@ -546,7 +613,7 @@ impl StabilityPoolState {
 
         for (ledger, config) in &self.stablecoin_registry {
             let available_native: u64 = self.deposits.values()
-                .filter(|pos| pos.is_opted_in(collateral_type))
+                .filter(|pos| self.position_opted_in_for(pos, collateral_type))
                 .map(|pos| pos.stablecoin_balances.get(ledger).copied().unwrap_or(0))
                 .sum();
             if available_native > 0 {
@@ -597,7 +664,7 @@ impl StabilityPoolState {
         let mut priority_buckets: BTreeMap<u8, Vec<(Principal, u64, u8, bool)>> = BTreeMap::new();
         for (ledger, config) in &self.stablecoin_registry {
             let available_native: u64 = self.deposits.values()
-                .filter(|pos| pos.is_opted_in(collateral_type))
+                .filter(|pos| self.position_opted_in_for(pos, collateral_type))
                 .map(|pos| pos.stablecoin_balances.get(ledger).copied().unwrap_or(0))
                 .sum();
             if available_native > 0 {
@@ -686,7 +753,7 @@ impl StabilityPoolState {
     ) {
         // Phase 1: Compute each opted-in depositor's share of the consumed stables (in e8s)
         let opted_in_principals: Vec<Principal> = self.deposits.iter()
-            .filter(|(_, pos)| pos.is_opted_in(&collateral_type))
+            .filter(|(_, pos)| self.position_opted_in_for(pos, &collateral_type))
             .map(|(p, _)| *p)
             .collect();
 
@@ -874,7 +941,7 @@ impl StabilityPoolState {
         let vps = self.virtual_prices();
         self.collateral_registry.keys().map(|ct| {
             let eligible: u64 = self.deposits.values()
-                .filter(|pos| pos.is_opted_in(ct))
+                .filter(|pos| self.position_opted_in_for(pos, ct))
                 .map(|pos| pos.total_usd_value(&self.stablecoin_registry, vps))
                 .sum();
             (*ct, eligible)
@@ -1098,6 +1165,7 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             total_stablecoin_balances: v1.total_stablecoin_balances,
             stablecoin_registry: v1.stablecoin_registry,
             collateral_registry: v1.collateral_registry,
+            chain_collateral_sentinels: Some(BTreeSet::new()),
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -1697,6 +1765,34 @@ mod tests {
 
         // ckBTC effective pool still has everyone
         assert_eq!(state.effective_pool_for_collateral(&ckbtc_ledger()), 100_00000000);
+    }
+
+    #[test]
+    fn cfx_sentinel_requires_explicit_opt_in_without_breaking_default_collateral() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 50_00000000);
+        state.register_chain_collateral_sentinel(cfx_sentinel());
+
+        assert_eq!(
+            state.effective_pool_for_collateral(&icp_ledger()),
+            150_00000000,
+            "non-chain collateral stays default-in",
+        );
+        assert_eq!(
+            state.effective_pool_for_collateral(&cfx_sentinel()),
+            0,
+            "chain sentinel starts default-out",
+        );
+        assert!(state.compute_token_draw(10_00000000, &cfx_sentinel()).is_empty());
+
+        state.opt_in_cfx(&user_a(), cfx_sentinel()).expect("user A opts into CFX");
+        assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 100_00000000);
+        let draw = state.compute_token_draw(10_00000000, &cfx_sentinel());
+        assert_eq!(draw.get(&icusd_ledger()).copied(), Some(10_00000000));
+
+        state.opt_out_cfx(&user_a(), cfx_sentinel()).expect("user A opts back out");
+        assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 0);
     }
 
     // ─── Test: Multi-token liquidation with mixed decimals ───
@@ -2376,6 +2472,14 @@ mod tests {
         assert!(
             decoded_pos.cfx_claims.clone().unwrap_or_default().is_empty(),
             "missing CFX claims field must decode as empty",
+        );
+        assert!(
+            decoded_pos.opted_in_chain_collateral.clone().unwrap_or_default().is_empty(),
+            "missing chain opt-in field must decode as empty",
+        );
+        assert!(
+            decoded.chain_collateral_sentinels.clone().unwrap_or_default().is_empty(),
+            "missing chain sentinel registry must decode as empty",
         );
     }
 

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -476,6 +476,19 @@ impl StabilityPoolState {
         }
     }
 
+    pub fn mark_cfx_claimed(&mut self, user: &Principal, chain_sentinel: &Principal, amount: u128) {
+        if let Some(position) = self.deposits.get_mut(user) {
+            if let Some(claims) = position.cfx_claims.as_mut() {
+                if let Some(gains) = claims.get_mut(chain_sentinel) {
+                    *gains = gains.saturating_sub(amount);
+                    if *gains == 0 {
+                        claims.remove(chain_sentinel);
+                    }
+                }
+            }
+        }
+    }
+
     // ─── Opt-in / Opt-out ───
 
     pub fn opt_out_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
@@ -741,6 +754,24 @@ impl StabilityPoolState {
         self.process_liquidation_gains_at(vault_id, collateral_type, stables_consumed, collateral_gained, collateral_price_e8s, ic_cdk::api::time());
     }
 
+    pub fn process_chain_liquidation_gains(
+        &mut self,
+        vault_id: u64,
+        chain_sentinel: Principal,
+        stables_consumed: &BTreeMap<Principal, u64>,
+        cfx_gained_native: u128,
+        collateral_price_e8s: u64,
+    ) {
+        self.process_chain_liquidation_gains_at(
+            vault_id,
+            chain_sentinel,
+            stables_consumed,
+            cfx_gained_native,
+            collateral_price_e8s,
+            ic_cdk::api::time(),
+        );
+    }
+
     /// Core liquidation gain processing logic with explicit timestamp (testable without IC runtime).
     pub fn process_liquidation_gains_at(
         &mut self,
@@ -892,6 +923,132 @@ impl StabilityPoolState {
             self.validate_state().is_ok(),
             "stability pool aggregate/per-depositor invariant violated after \
              process_liquidation_gains_at (likely regression of SP-001)"
+        );
+    }
+
+    /// CFX/native-chain sibling of `process_liquidation_gains_at`. Stablecoin
+    /// draw and rounding are identical, but collateral claims are u128 wei and
+    /// live in `DepositPosition::cfx_claims` instead of the u64 ICRC gains map.
+    pub fn process_chain_liquidation_gains_at(
+        &mut self,
+        _vault_id: u64,
+        chain_sentinel: Principal,
+        stables_consumed: &BTreeMap<Principal, u64>,
+        cfx_gained_native: u128,
+        _collateral_price_e8s: u64,
+        _timestamp: u64,
+    ) {
+        if !self.is_chain_collateral_sentinel(&chain_sentinel) || cfx_gained_native == 0 {
+            return;
+        }
+
+        let opted_in_principals: Vec<Principal> = self.deposits.iter()
+            .filter(|(_, pos)| pos.is_opted_in_for_chain(&chain_sentinel))
+            .map(|(p, _)| *p)
+            .collect();
+        if opted_in_principals.is_empty() {
+            return;
+        }
+
+        let mut per_token_opted_in_totals: BTreeMap<Principal, u64> = BTreeMap::new();
+        for token_ledger in stables_consumed.keys() {
+            let total: u64 = opted_in_principals.iter()
+                .filter_map(|p| self.deposits.get(p))
+                .map(|pos| pos.stablecoin_balances.get(token_ledger).copied().unwrap_or(0))
+                .sum();
+            per_token_opted_in_totals.insert(*token_ledger, total);
+        }
+
+        let vps = self.virtual_prices().clone();
+        let registry_snapshot: BTreeMap<Principal, (u8, bool)> = stables_consumed.keys()
+            .filter_map(|ledger| {
+                self.stablecoin_registry.get(ledger).map(|c| {
+                    (*ledger, (c.decimals, c.is_lp_token.unwrap_or(false)))
+                })
+            })
+            .collect();
+        let total_consumed_e8s: u64 = stables_consumed.iter()
+            .map(|(ledger, &amount)| {
+                let (decimals, is_lp) = registry_snapshot.get(ledger).copied().unwrap_or((8, false));
+                if is_lp {
+                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(amount, vp)).unwrap_or(0)
+                } else {
+                    normalize_to_e8s(amount, decimals)
+                }
+            })
+            .sum();
+        if total_consumed_e8s == 0 {
+            return;
+        }
+
+        let mut actual_deductions_per_token: BTreeMap<Principal, u64> = BTreeMap::new();
+        let mut total_cfx_distributed: u128 = 0;
+
+        for principal in &opted_in_principals {
+            let mut user_consumed_e8s: u64 = 0;
+
+            if let Some(position) = self.deposits.get_mut(principal) {
+                for (token_ledger, &total_consumed) in stables_consumed {
+                    let total_opted_in = per_token_opted_in_totals.get(token_ledger).copied().unwrap_or(0);
+                    if total_opted_in == 0 {
+                        continue;
+                    }
+                    let user_balance = position.stablecoin_balances.get(token_ledger).copied().unwrap_or(0);
+                    if user_balance == 0 {
+                        continue;
+                    }
+
+                    let user_share_native = (total_consumed as u128 * user_balance as u128 / total_opted_in as u128) as u64;
+                    let user_share_native = user_share_native.min(user_balance);
+                    if let Some(bal) = position.stablecoin_balances.get_mut(token_ledger) {
+                        *bal = bal.saturating_sub(user_share_native);
+                    }
+                    *actual_deductions_per_token.entry(*token_ledger).or_insert(0) += user_share_native;
+
+                    let (decimals, is_lp) = registry_snapshot.get(token_ledger).copied().unwrap_or((8, false));
+                    let share_e8s = if is_lp {
+                        vps.get(token_ledger).map(|&vp| lp_to_usd_e8s(user_share_native, vp)).unwrap_or(0)
+                    } else {
+                        normalize_to_e8s(user_share_native, decimals)
+                    };
+                    user_consumed_e8s = user_consumed_e8s.saturating_add(share_e8s);
+                }
+
+                if user_consumed_e8s > 0 {
+                    let user_cfx = cfx_gained_native
+                        .saturating_mul(user_consumed_e8s as u128)
+                        / total_consumed_e8s as u128;
+                    let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
+                    let entry = claims.entry(chain_sentinel).or_insert(0);
+                    *entry = entry.saturating_add(user_cfx);
+                    total_cfx_distributed = total_cfx_distributed.saturating_add(user_cfx);
+                }
+            }
+        }
+
+        let cfx_dust = cfx_gained_native.saturating_sub(total_cfx_distributed);
+        if cfx_dust > 0 {
+            if let Some(first) = opted_in_principals.first() {
+                if let Some(pos) = self.deposits.get_mut(first) {
+                    let claims = pos.cfx_claims.get_or_insert_with(BTreeMap::new);
+                    let entry = claims.entry(chain_sentinel).or_insert(0);
+                    *entry = entry.saturating_add(cfx_dust);
+                }
+            }
+        }
+
+        for (token_ledger, &actual_deducted) in &actual_deductions_per_token {
+            if let Some(total) = self.total_stablecoin_balances.get_mut(token_ledger) {
+                *total = total.saturating_sub(actual_deducted);
+            }
+        }
+
+        self.total_liquidations_executed += 1;
+        self.deposits.retain(|_, pos| !pos.is_empty());
+        debug_assert!(
+            self.validate_state().is_ok(),
+            "stability pool aggregate/per-depositor invariant violated after \
+             process_chain_liquidation_gains_at"
         );
     }
 
@@ -1793,6 +1950,46 @@ mod tests {
 
         state.opt_out_cfx(&user_a(), cfx_sentinel()).expect("user A opts back out");
         assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 0);
+    }
+
+    #[test]
+    fn chain_liquidation_gains_credit_u128_cfx_claims_with_dust() {
+        const E18: u128 = 1_000_000_000_000_000_000;
+        let mut state = test_state();
+        state.register_chain_collateral_sentinel(cfx_sentinel());
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 1_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 1_00000000);
+        state.opt_in_cfx(&user_a(), cfx_sentinel()).unwrap();
+        state.opt_in_cfx(&user_b(), cfx_sentinel()).unwrap();
+        let mut stables_consumed = BTreeMap::new();
+        stables_consumed.insert(icusd_ledger(), 2_00000000);
+
+        state.process_chain_liquidation_gains_at(
+            99,
+            cfx_sentinel(),
+            &stables_consumed,
+            20_000 * E18 + 1,
+            5_000_000,
+            123,
+        );
+
+        let claim_a = state.deposits.get(&user_a()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
+        let claim_b = state.deposits.get(&user_b()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
+        assert_eq!(claim_a, 10_000 * E18 + 1, "first opted-in depositor receives wei dust");
+        assert_eq!(claim_b, 10_000 * E18);
+        assert!(claim_a > u64::MAX as u128, "CFX claim must not truncate to u64");
+        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()).copied(), Some(0));
+        assert!(state.deposits.contains_key(&user_a()), "CFX claim keeps drained position alive");
+
+        state.mark_cfx_claimed(&user_a(), &cfx_sentinel(), 3 * E18);
+        let after_partial = state.deposits.get(&user_a()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
+        assert_eq!(after_partial, 9_997 * E18 + 1);
+        state.mark_cfx_claimed(&user_a(), &cfx_sentinel(), 9_997 * E18 + 1);
+        assert!(state.deposits.get(&user_a()).unwrap()
+            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).is_none());
     }
 
     // ─── Test: Multi-token liquidation with mixed decimals ───

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -60,6 +60,11 @@ pub struct DepositPosition {
     pub collateral_gains: BTreeMap<Principal, u64>,
     /// Collateral types this user has opted out of.
     pub opted_out_collateral: BTreeSet<Principal>,
+    /// Chain collateral sentinels this user has explicitly opted into.
+    /// Chain-native collateral is default-out; normal collateral remains
+    /// default-in via `opted_out_collateral`.
+    #[serde(default)]
+    pub opted_in_chain_collateral: Option<BTreeSet<Principal>>,
     /// First deposit timestamp (nanos).
     pub deposit_timestamp: u64,
     /// Lifetime claimed gains per collateral type.
@@ -81,6 +86,7 @@ impl DepositPosition {
             stablecoin_balances: BTreeMap::new(),
             collateral_gains: BTreeMap::new(),
             opted_out_collateral: BTreeSet::new(),
+            opted_in_chain_collateral: Some(BTreeSet::new()),
             deposit_timestamp: timestamp,
             total_claimed_gains: BTreeMap::new(),
             total_interest_earned_e8s: Some(0),
@@ -130,6 +136,14 @@ impl DepositPosition {
     /// Whether this user is opted in for a given collateral type.
     pub fn is_opted_in(&self, collateral_type: &Principal) -> bool {
         !self.opted_out_collateral.contains(collateral_type)
+    }
+
+    /// Whether this user has explicitly opted in for a chain-native sentinel.
+    pub fn is_opted_in_for_chain(&self, sentinel: &Principal) -> bool {
+        self.opted_in_chain_collateral
+            .as_ref()
+            .map(|s| s.contains(sentinel))
+            .unwrap_or(false)
     }
 
     /// Whether the position is entirely empty (no balances, no gains).

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -273,6 +273,12 @@ pub struct ChainSpAbsorbResult {
     pub collateral_price_e8s: u64,
 }
 
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainClaimSource {
+    pub claim_id: u64,
+    pub remaining_native: u128,
+}
+
 /// Audit trail record for a completed liquidation.
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolLiquidationRecord {

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -229,6 +229,50 @@ pub struct LiquidationResult {
     pub error_message: Option<String>,
 }
 
+/// Mirror of the backend's `ChainLiquidatableVault` Candid record. Kept local
+/// because the backend exports that type from its canister binary, not its lib.
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainLiquidatableVaultInfo {
+    pub vault_id: u64,
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub chain_collateral_sentinel: Principal,
+    pub sp_attempted: bool,
+    pub debt_e8s: u128,
+    pub effective_debt_e8s: u128,
+    pub collateral_native: u128,
+    pub cr_e4: u64,
+    pub liquidation_threshold_e4: u64,
+    pub sized_repay_e8s: u128,
+}
+
+/// Mirror of the backend's `ChainStabilityPoolLiquidationResult`.
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainStabilityPoolLiquidationResult {
+    pub success: bool,
+    pub vault_id: u64,
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub liquidated_debt_e8s: u128,
+    pub collateral_received_native: u128,
+    pub claim_id: u64,
+    pub custody_address: String,
+    pub block_index: u64,
+    pub collateral_price_e8s: u64,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainSpAbsorbResult {
+    pub success: bool,
+    pub vault_id: u64,
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub icusd_burned_e8s: u64,
+    pub liquidated_debt_e8s: u128,
+    pub collateral_received_native: u128,
+    pub claim_id: u64,
+    pub custody_address: String,
+    pub block_index: u64,
+    pub collateral_price_e8s: u64,
+}
+
 /// Audit trail record for a completed liquidation.
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolLiquidationRecord {

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -68,6 +68,11 @@ pub struct DepositPosition {
     /// `Option` is required for Candid backward-compatible stable memory upgrades.
     #[serde(default)]
     pub total_interest_earned_e8s: Option<u64>,
+    /// Claimable native-chain collateral keyed by deterministic chain sentinel,
+    /// in native base units (wei for CFX). `Option` is required for Candid
+    /// backward-compatible stable memory upgrades.
+    #[serde(default)]
+    pub cfx_claims: Option<BTreeMap<Principal, u128>>,
 }
 
 impl DepositPosition {
@@ -79,6 +84,7 @@ impl DepositPosition {
             deposit_timestamp: timestamp,
             total_claimed_gains: BTreeMap::new(),
             total_interest_earned_e8s: Some(0),
+            cfx_claims: Some(BTreeMap::new()),
         }
     }
 
@@ -130,6 +136,7 @@ impl DepositPosition {
     pub fn is_empty(&self) -> bool {
         self.stablecoin_balances.values().all(|&v| v == 0)
             && self.collateral_gains.values().all(|&v| v == 0)
+            && self.cfx_claims.as_ref().map(|m| m.values().all(|&v| v == 0)).unwrap_or(true)
     }
 }
 

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -279,6 +279,7 @@ service : (StabilityPoolInitArgs) -> {
   claim_collateral : (principal) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
+  claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -258,6 +258,7 @@ service : (StabilityPoolInitArgs) -> {
   // ── Admin: Registry ──
   register_stablecoin : (StablecoinConfig) -> (variant { Ok; Err : StabilityPoolError });
   register_collateral : (CollateralInfo) -> (variant { Ok; Err : StabilityPoolError });
+  register_cfx_collateral : (nat32) -> (variant { Ok : principal; Err : StabilityPoolError });
 
   // ── Admin: Configuration ──
   update_pool_configuration : (PoolConfiguration) -> (variant { Ok; Err : StabilityPoolError });
@@ -283,4 +284,5 @@ service : (StabilityPoolInitArgs) -> {
   get_pool_event_count : () -> (nat64) query;
   list_depositor_principals : () -> (vec principal) query;
   get_pending_refunds : (opt principal) -> (vec PendingRefund) query;
+  get_chain_collateral_sentinel : (nat32) -> (principal) query;
 };

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -88,6 +88,44 @@ type LiquidationResult = record {
   error_message : opt text;
 };
 
+type ChainLiquidatableVaultInfo = record {
+  sized_repay_e8s : nat;
+  cr_e4 : nat64;
+  collateral_native : nat;
+  vault_id : nat64;
+  sp_attempted : bool;
+  chain_collateral_sentinel : principal;
+  chain_id : nat32;
+  liquidation_threshold_e4 : nat64;
+  effective_debt_e8s : nat;
+  debt_e8s : nat;
+};
+
+type ChainStabilityPoolLiquidationResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  success : bool;
+};
+
+type ChainSpAbsorbResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  icusd_burned_e8s : nat64;
+  success : bool;
+};
+
 type PoolLiquidationRecord = record {
   vault_id : nat64;
   timestamp : nat64;
@@ -251,6 +289,7 @@ service : (StabilityPoolInitArgs) -> {
   // ── Liquidation ──
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);
   execute_liquidation : (nat64) -> (variant { Ok : LiquidationResult; Err : StabilityPoolError });
+  sp_absorb_chain_vault : (nat64) -> (variant { Ok : ChainSpAbsorbResult; Err : StabilityPoolError });
 
   // ── Interest Revenue ──
   receive_interest_revenue : (principal, nat64, opt principal) -> (variant { Ok; Err : StabilityPoolError });

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -245,6 +245,8 @@ service : (StabilityPoolInitArgs) -> {
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
   opt_in_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_out_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_in_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Liquidation ──
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);


### PR DESCRIPTION
## Summary
- Adds Tier-2 ICP Stability Pool fallback after Tier-1 bot swap failure, with SP-side icUSD burn and backend debt -> pending_chain_burn accounting.
- Adds durable chain liquidation claim state, ChainCollateralPayout settlement ops, CFX sentinel registration/explicit opt-in, u128 CFX claim accounting, and claim_cfx payout flow.
- Keeps foreign-chain supply unchanged in Inc 4; no eSpace burn is performed here. Reconciliation is represented as pending_chain_burn for the future bridge/reconciliation increment.
- Adds an end-to-end PocketIC proof for bot failure -> SP absorb -> CFX claim payout, including rollback on backend rejection and no Tier-1 retry after SP escalation.

## Verification
- `cargo test --lib -p stability_pool` -> 59 passed
- `cargo test --lib -p rumi_protocol_backend` -> 592 passed, 1 ignored
- `cargo test --bin rumi_protocol_backend` -> 7 passed, including `check_candid_interface_compatibility`
- `cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend -p monad_rpc_mock -p stability_pool` -> passed
- `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_liquidation_detection_pic -- --nocapture` -> 1 passed
- `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_liquidation_swap_pic -- --nocapture` -> 2 passed
- `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_espace_happy_path_pic -- --nocapture` -> 2 passed
- `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_interest_accrual_pic -- --nocapture` -> 1 passed
- `cargo build --target wasm32-unknown-unknown --release -p rumi_3pool` -> passed, to satisfy SP integration test WASM fixture
- `POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p stability_pool` -> full package passed, including lib, audit tests, PocketIC 3USD tests, and doc tests
- `git diff --check` -> clean

## Deployment Notes
- This PR is not merged or deployed.
- Backend candid changes are additive, but deployment may still hit an owner-gated candid `--yes` wall depending on the installed interface delta. Do not bypass that unattended.
- Inc 4 arms Tier-2 logic only when the SP is configured, CFX sentinel is registered, depositors explicitly opt in, and a Tier-1 bot failure marks the vault as SP-attemptable.