### PR TITLE
feat(chains): Inc5 reconciliation controls

### DIFF
--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-5.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-5.md
@@ -1,0 +1,227 @@
+# Chains Liquidation Increment 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the chains-liquidation reconciliation increment: manually settle pending foreign burns and reserve burns, expose reserve reconciliation, persist chain debt risk overrides, and apply the manual-price staleness gate outside liquidation.
+
+**Architecture:** Keep all supply-affecting state transitions inside `chains/supply.rs` so `chain_supplies`, `pending_chain_burn_e8s`, and `reserve_backing_e8s` move atomically with no mutation on rejection. Add developer-gated operator endpoints in `main.rs` that call the pure helpers, cap proof text, record events, and surface book-vs-on-chain reserve facts. Preserve current behavior by making chain debt config overrides optional and only enforcing price-age checks for chains with a configured non-zero `max_price_age_ns`.
+
+**Tech Stack:** Rust 2021, `ic-cdk` canister updates/queries, Candid, existing EVM RPC wrapper, CBOR/serde stable state snapshots, Cargo unit tests.
+
+## Global Constraints
+
+- Full Inc 5 scope is in: pending-chain-burn reconciliation, `settle_reserve_burn`, bridge/reserve getter, bad-debt/circuit-breaker visibility, Tier-B debt config persistence, and staleness-gate factoring.
+- Settlement proof model for this increment is developer-gated manual proof text recorded in logs/events; full on-chain proof verification is a follow-up goal.
+- Partial per-chain settlements are allowed, capped by available pending/reserve amount.
+- Tier-1 reserve retirement reduces both `chain_supplies` and `reserve_backing_e8s`; `reserve_usdc_native` remains as protocol reserve/surplus bookkeeping.
+- Reserve getter returns book values and attempts on-chain USDC `balanceOf` only through the existing low-risk EVM RPC helper.
+- Default debt config behavior must match current compile-time `chain_collateral_config` unless an override is explicitly set.
+- Stop at code, tests, and commit/PR. Do not merge or deploy without separate explicit authorization.
+- TDD is mandatory: write failing tests first, watch them fail, then implement.
+- Do not add `@rollup/rollup-darwin-*` to any `package.json`.
+
+---
+
+### Task 1: Atomic Burn/Reserve Settlement Helpers
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/supply.rs`
+- Test: `src/rumi_protocol_backend/src/chains/tests_supply.rs`
+
+**Interfaces:**
+- Consumes: `MultiChainState`, `ChainId`, existing `chain_backing_rhs_e8s`.
+- Produces:
+  - `pub enum BackingSettlementError`
+  - `pub fn settle_pending_chain_burn(state: &mut MultiChainState, chain: ChainId, amount_e8s: u128) -> Result<(), BackingSettlementError>`
+  - `pub fn settle_reserve_burn(state: &mut MultiChainState, chain: ChainId, amount_e8s: u128) -> Result<(), BackingSettlementError>`
+
+- [ ] **Step 1: Write failing pending-burn tests**
+
+Add tests proving a partial pending burn reduces `pending_chain_burn_e8s` and `chain_supplies` by the same amount, preserves the unified invariant, and rejects over-settlement with both fields unchanged.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend pending_chain_burn --lib -- --nocapture`
+Expected: FAIL because `settle_pending_chain_burn` does not exist.
+
+- [ ] **Step 3: Implement pending-burn helper**
+
+Implement read-only validation first: halted, unknown chain, zero amount, supply underflow, pending underflow, post-move invariant. Only after validation mutate `chain_supplies` and `pending_chain_burn_e8s`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rumi_protocol_backend pending_chain_burn --lib -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Write failing reserve-burn tests**
+
+Add tests proving reserve retirement reduces `reserve_backing_e8s` and `chain_supplies`, leaves `reserve_usdc_native` untouched, preserves the invariant, and rejects over-settlement with no mutation.
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend reserve_burn --lib -- --nocapture`
+Expected: FAIL because `settle_reserve_burn` does not exist.
+
+- [ ] **Step 7: Implement reserve-burn helper**
+
+Use the same shared internal settlement routine with the reserve term selected. Do not touch vault debt or `reserve_usdc_native`.
+
+- [ ] **Step 8: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend tests_supply --lib -- --nocapture`
+Expected: PASS.
+
+### Task 2: Developer-Gated Settlement Endpoints, Events, and Reserve Getter
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/main.rs`
+- Modify: `src/rumi_protocol_backend/src/event.rs`
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did`
+
+**Interfaces:**
+- Consumes: Task 1 helpers.
+- Produces:
+  - `settle_pending_chain_burn(chain, amount_e8s, proof) -> Result<(), ProtocolError>`
+  - `settle_reserve_burn(chain, amount_e8s, proof) -> Result<(), ProtocolError>`
+  - `get_chain_reserves(chain) -> Result<ChainReserveReport, ProtocolError>`
+  - Events `ChainPendingBurnSettled` and `ChainReserveBurnSettled`
+
+- [ ] **Step 1: Write failing endpoint-adjacent tests**
+
+Add unit tests for a pure proof normalizer in `main.rs` or a small helper module: empty proof rejected, proof longer than 512 bytes rejected, valid proof preserved. This bounds persistent event storage.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend reconciliation_proof --bin rumi_protocol_backend -- --nocapture`
+Expected: FAIL because the proof helper does not exist.
+
+- [ ] **Step 3: Implement proof helper and endpoints**
+
+Developer-gate both updates. Each endpoint normalizes proof, calls the Task 1 helper inside `mutate_state`, records the matching event, and logs `chain`, `amount_e8s`, and proof text.
+
+- [ ] **Step 4: Add reserve getter**
+
+`get_chain_reserves` returns book values (`recorded_supply_e8s`, `reserve_backing_e8s`, `reserve_usdc_native`, `pending_chain_burn_e8s`, `bad_debt_e8s`) and attempts `erc20_balance_of(chain, settle_stable_token, reserve_address, finalized_block)` when config/token/cursor/address are available. RPC/derive failures populate an `onchain_usdc_error: opt text` field rather than hiding the book values.
+
+- [ ] **Step 5: Wire event no-op replay/filter behavior**
+
+Add the new variants to event filtering and replay as observability-only events.
+
+- [ ] **Step 6: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend reconciliation_proof --bin rumi_protocol_backend -- --nocapture`
+Expected: PASS.
+
+### Task 3: Persisted Chain Debt Config and Price Staleness Gate Factoring
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/collateral_config.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/multi_chain_state.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/vault.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/tests_vault.rs`
+- Modify: `src/rumi_protocol_backend/src/main.rs`
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did`
+
+**Interfaces:**
+- Consumes: existing compile-time `ChainCollateralConfig`.
+- Produces:
+  - `ChainDebtConfigV1 { min_vault_debt_e8s: u128, debt_ceiling_e8s: Option<u128> }`
+  - `MultiChainStateV6.chain_debt_configs: BTreeMap<ChainId, ChainDebtConfigV1>`
+  - `set_chain_debt_config(chain, config) -> Result<(), ProtocolError>`
+  - `get_chain_debt_config(chain) -> Option<ChainDebtConfigV1>`
+  - `get_effective_chain_debt_config(chain) -> Option<ChainDebtConfigV1>`
+
+- [ ] **Step 1: Write failing config/default tests**
+
+Tests should prove absent overrides mirror current Conflux defaults exactly, an override changes effective min/ceiling, and V5/V6 snapshot decode defaults the new map empty.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend chain_debt_config --lib -- --nocapture`
+Expected: FAIL because `ChainDebtConfigV1` and the state map do not exist.
+
+- [ ] **Step 3: Implement config/state**
+
+Add the new serde-defaulted map, helper conversion from `ChainCollateralConfig`, and developer-gated set/get endpoints. Do not mutate compile-time defaults.
+
+- [ ] **Step 4: Route open/borrow through effective config**
+
+Change `evm_vault_params` to read the override from state, falling back to compile-time defaults. Existing no-override behavior must remain identical.
+
+- [ ] **Step 5: Write failing staleness tests**
+
+Tests should prove open, borrow, and withdraw reject stale/no-timestamp manual prices when `chain_liquidation_configs[chain].max_price_age_ns > 0`, and preserve legacy raw-price behavior when no max age is configured.
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend stale_price --lib -- --nocapture`
+Expected: FAIL because open/borrow/withdraw still read raw `manual_prices`.
+
+- [ ] **Step 7: Implement shared chain price helper**
+
+In `vault.rs`, add a helper that uses `liquidation::fresh_chain_price_e8` when `max_price_age_ns > 0`, otherwise falls back to the existing raw manual price. Add stale/no-timestamp error variants to pure errors as needed.
+
+- [ ] **Step 8: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend tests_vault chain_debt_config --lib -- --nocapture`
+Expected: PASS.
+
+### Task 4: Candid, Compatibility, and Final Verification
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did`
+- Modify: `docs/superpowers/plans/2026-06-24-chains-liquidation-increment-5.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 public API changes.
+- Produces: regenerated Candid and verified compatibility.
+
+- [ ] **Step 1: Regenerate Candid**
+
+Run: `RUMI_REGEN_DID=1 cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
+Expected: PASS and `rumi_protocol_backend.did` updated.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+`cargo test -p rumi_protocol_backend tests_supply tests_vault tests_multi_chain_state_v2 reconciliation_proof --lib --bin rumi_protocol_backend -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run candid compatibility**
+
+Run: `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 4: Run formatting/check**
+
+Run: `cargo fmt --all --check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+`git add docs/superpowers/plans/2026-06-24-chains-liquidation-increment-5.md src/rumi_protocol_backend/src/chains/supply.rs src/rumi_protocol_backend/src/chains/tests_supply.rs src/rumi_protocol_backend/src/chains/collateral_config.rs src/rumi_protocol_backend/src/chains/multi_chain_state.rs src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs src/rumi_protocol_backend/src/chains/vault.rs src/rumi_protocol_backend/src/chains/tests_vault.rs src/rumi_protocol_backend/src/event.rs src/rumi_protocol_backend/src/main.rs src/rumi_protocol_backend/rumi_protocol_backend.did`
+
+Run:
+`git commit -m "feat(chains): Inc5 reconciliation controls"`
+
+Expected: commit succeeds. Stop after commit/PR; do not merge or deploy.
+
+## Future Goal: Full On-Chain Proof Verification
+
+This increment records a manual proof string because it is the lowest-risk operator bridge between IC accounting and foreign-chain burn/bridge facts. The stronger target should be a proof-backed flow:
+
+- Pending-chain burn proof: accept a chain tx hash/log identity, fetch the finalized receipt through the EVM RPC wrapper, verify the `Burn` event amount and expected burn authority/sender, dedupe by `tx_hash:log_index`, then call `settle_pending_chain_burn`.
+- Reserve burn proof: verify both sides of the slow bridge leg: finalized foreign `Burn` event reducing icUSD supply and reserve-address `Transfer`/balance movement of settle-stable. Only then call `settle_reserve_burn`.
+- Aged pending monitor: expose pending burn age/op ids and alarm when a pending amount is older than the operator SLO.
+- Proof storage: store compact canonical proof ids and event metadata, not full receipts, to avoid unbounded stable-state growth.
+
+## Self-Review
+
+**Spec coverage:** Full Inc 5 approved scope maps to Task 1 (pending/reserve settlement), Task 2 (operator proof events and reserve getter), Task 3 (debt config + staleness gate), and Task 4 (Candid/verification). Full on-chain proof is documented as a follow-up goal per user instruction.
+
+**Placeholder scan:** No task uses TBD/TODO/fill-in language. Each task names concrete files, functions, and commands.
+
+**Type consistency:** `amount_e8s`, `ChainId`, and `ChainDebtConfigV1` names are consistent across helper, endpoint, and Candid tasks.

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,10 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainDebtConfigV1 = record {
+  debt_ceiling_e8s : opt nat;
+  min_vault_debt_e8s : nat;
+};
 type ChainLiquidatableVault = record {
   sized_repay_e8s : nat;
   cr_e4 : nat64;
@@ -63,6 +67,19 @@ type ChainLiquidationConfigV1 = record {
   router : text;
   settle_stable_token : text;
   deadline_secs : nat64;
+};
+type ChainReserveReport = record {
+  recorded_supply_e8s : nat;
+  onchain_usdc_balance_native : opt nat;
+  pending_chain_burn_e8s : nat;
+  reserve_backing_e8s : nat;
+  reserve_usdc_native : nat;
+  finalized_block : nat64;
+  bad_debt_e8s : nat;
+  reserve_address : opt text;
+  chain_id : nat32;
+  onchain_usdc_error : opt text;
+  settle_stable_token : opt text;
 };
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
@@ -253,6 +270,12 @@ type Event = variant {
   set_rmr_ceiling_cr : record { value : text };
   set_amm1_canister : record { canister : principal };
   set_recovery_rate_curve : record { markers : text };
+  chain_reserve_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_ckstable_repay_fee : record { rate : text };
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
@@ -359,6 +382,12 @@ type Event = variant {
     reason : text;
   };
   set_rmr_floor_cr : record { value : text };
+  chain_pending_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_rmr_ceiling : record { value : text };
   set_collateral_liquidation_bonus : record {
     collateral_type : principal;
@@ -898,29 +927,30 @@ type ReserveRedemptionResult = record {
 };
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
-type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_11 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
-type Result_12 = variant {
+type Result_10 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_11 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_12 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
+type Result_13 = variant {
   Ok : ChainSupplyReconciliation;
   Err : ProtocolError;
 };
-type Result_13 = variant { Ok : bool; Err : ProtocolError };
-type Result_14 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_15 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_16 = variant { Ok : blob; Err : ProtocolError };
-type Result_17 = variant {
+type Result_14 = variant { Ok : bool; Err : ProtocolError };
+type Result_15 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_16 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_17 = variant { Ok : blob; Err : ProtocolError };
+type Result_18 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_18 = variant { Ok : nat32; Err : ProtocolError };
+type Result_19 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
 type Result_5 = variant { Ok : opt nat64; Err : ProtocolError };
-type Result_6 = variant { Ok : nat8; Err : ProtocolError };
-type Result_7 = variant { Ok : float64; Err : ProtocolError };
-type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_9 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_6 = variant { Ok : ChainReserveReport; Err : ProtocolError };
+type Result_7 = variant { Ok : nat8; Err : ProtocolError };
+type Result_8 = variant { Ok : float64; Err : ProtocolError };
+type Result_9 = variant { Ok : ConsentInfo; Err : Icrc21Error };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -1094,12 +1124,14 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
   get_chain_liquidation_config : (nat32) -> (
       opt ChainLiquidationConfigV1,
     ) query;
   get_chain_reserve_address : (nat32) -> (Result_2);
+  get_chain_reserves : (nat32) -> (Result_6);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_chains_ecdsa_key_name : () -> (text) query;
@@ -1110,6 +1142,7 @@ service : (ProtocolArg) -> {
       vec record { SpProofLedger; nat64 },
     ) query;
   get_deposit_account : (opt principal) -> (Account) query;
+  get_effective_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_event_count : () -> (nat64) query;
   get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
@@ -1155,7 +1188,7 @@ service : (ProtocolArg) -> {
   get_redemption_fee_ceiling : () -> (float64) query;
   get_redemption_fee_floor : () -> (float64) query;
   get_redemption_rate : () -> (float64) query;
-  get_redemption_tier : (principal) -> (Result_6) query;
+  get_redemption_tier : (principal) -> (Result_7) query;
   get_reserve_balances : () -> (vec ReserveBalance) query;
   get_reserve_redemption_fee : () -> (float64) query;
   get_reserve_redemptions_enabled : () -> (bool) query;
@@ -1180,7 +1213,7 @@ service : (ProtocolArg) -> {
   get_vault_history_paged : (nat64, nat64, nat64) -> (
       GetEventsFilteredResponse,
     ) query;
-  get_vault_interest_rate : (nat64) -> (Result_7) query;
+  get_vault_interest_rate : (nat64) -> (Result_8) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_xrp_claims : () -> (vec record { nat64; XrpClaim }) query;
@@ -1190,7 +1223,7 @@ service : (ProtocolArg) -> {
   harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
-  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_9);
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;
   liquidate_chain_vault : (nat64) -> (Result_1);
   liquidate_vault : (nat64) -> (Result_3);
@@ -1199,23 +1232,23 @@ service : (ProtocolArg) -> {
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
-  open_solana_vault : (nat, nat, text) -> (Result_9);
-  open_vault : (nat64, opt principal) -> (Result_10);
-  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
-  open_vault_with_deposit : (nat64, opt principal) -> (Result_10);
-  open_xrp_vault : () -> (Result_11);
+  open_solana_vault : (nat, nat, text) -> (Result_10);
+  open_vault : (nat64, opt principal) -> (Result_11);
+  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_11);
+  open_vault_with_deposit : (nat64, opt principal) -> (Result_11);
+  open_xrp_vault : () -> (Result_12);
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  reconcile_chain_supply : (nat32) -> (Result_12);
-  recover_pending_transfer : (nat64) -> (Result_13);
+  reconcile_chain_supply : (nat32) -> (Result_13);
+  recover_pending_transfer : (nat64) -> (Result_14);
   recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_14);
+  redeem_reserves : (nat64, opt principal) -> (Result_15);
   register_chain : (RegisterChainArg) -> (Result);
   register_xrp_collateral : () -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_15);
+  repay_and_close_vault : (VaultArg) -> (Result_16);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
@@ -1231,6 +1264,7 @@ service : (ProtocolArg) -> {
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
+  set_chain_debt_config : (nat32, ChainDebtConfigV1) -> (Result);
   set_chain_interest_min_realize_e8s : (nat) -> (Result);
   set_chain_interest_tick_interval_secs : (nat64) -> (Result);
   set_chain_liquidation_config : (nat32, ChainLiquidationConfigV1) -> (Result);
@@ -1303,20 +1337,22 @@ service : (ProtocolArg) -> {
   set_treasury_principal : (principal) -> (Result);
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
+  settle_pending_chain_burn : (nat32, nat, text) -> (Result);
+  settle_reserve_burn : (nat32, nat, text) -> (Result);
   settle_xrp_claim : (nat64, text) -> (Result_2);
   solana_bootstrap_nonce : (opt text) -> (Result);
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
   solana_settlement_address : () -> (Result_2);
-  solana_sign_test_transfer : (text, nat64) -> (Result_16);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_17);
+  solana_sign_test_transfer : (text, nat64) -> (Result_17);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_18);
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_17,
+      Result_18,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_17,
+      Result_18,
     );
-  submit_burn_proof : (nat32, text) -> (Result_18);
+  submit_burn_proof : (nat32, text) -> (Result_19);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/chains/collateral_config.rs
+++ b/src/rumi_protocol_backend/src/chains/collateral_config.rs
@@ -12,6 +12,9 @@
 //! accrual (later task), and the liquidation/fee fields by the deferred
 //! liquidation + fee work. They are carried here so the params live in one place.
 
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
 use crate::chains::config::ChainId;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,6 +35,23 @@ pub struct ChainCollateralConfig {
     /// restore=`recovery_target_cr_e4`. (Compile-time; promoting to Tier-B
     /// persisted config is an Inc-5 follow-up.)
     pub liquidation_threshold_e4: u64,
+}
+
+/// Persisted Tier-B chain debt knobs. The absence of a row means "use
+/// `chain_collateral_config(chain)` exactly", preserving the pre-Inc-5 behavior.
+#[derive(CandidType, Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainDebtConfigV1 {
+    pub min_vault_debt_e8s: u128,
+    pub debt_ceiling_e8s: Option<u128>,
+}
+
+impl ChainDebtConfigV1 {
+    pub fn from_collateral_config(config: ChainCollateralConfig) -> Self {
+        Self {
+            min_vault_debt_e8s: config.min_vault_debt_e8s,
+            debt_ceiling_e8s: config.debt_ceiling_e8s,
+        }
+    }
 }
 
 /// ICP-mirrored defaults (the live dashboard values).
@@ -116,6 +136,14 @@ mod tests {
         assert_eq!(c.recovery_target_cr_e4, 15_500);
         assert_eq!(c.liquidation_penalty_bps, 1_200);
         assert_eq!(c.debt_ceiling_e8s, Some(500 * 100_000_000));
+    }
+
+    #[test]
+    fn chain_debt_config_from_defaults_preserves_conflux_values() {
+        let c = chain_collateral_config(ChainId(71)).expect("conflux known");
+        let debt = ChainDebtConfigV1::from_collateral_config(c);
+        assert_eq!(debt.min_vault_debt_e8s, 10_000_000);
+        assert_eq!(debt.debt_ceiling_e8s, Some(500 * 100_000_000));
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -29,6 +29,7 @@
 //! See spec Section 3 ("State wipe on upgrade") and the 2026-05-18 AMM
 //! incident (MEMORY.md: `project_amm_state_wipe_2026_05_18.md`).
 
+use super::collateral_config::ChainDebtConfigV1;
 use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
 use super::liquidation_config::ChainLiquidationConfigV1;
 use super::monad::chain_vault::ChainVaultV1;
@@ -297,7 +298,8 @@ impl MultiChainStateV4 {
         if nonce != expected {
             return Err(expected);
         }
-        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        self.evm_owner_nonces
+            .insert(*owner, expected.saturating_add(1));
         Ok(())
     }
 
@@ -391,7 +393,8 @@ impl MultiChainStateV5 {
         if nonce != expected {
             return Err(expected);
         }
-        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        self.evm_owner_nonces
+            .insert(*owner, expected.saturating_add(1));
         Ok(())
     }
 
@@ -517,6 +520,10 @@ pub struct MultiChainStateV6 {
     /// Increment 2+ reads it; Increment 1 ships only the getter/setter.
     #[serde(default)]
     pub chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>,
+    /// Optional Tier-B per-chain debt overrides. Missing row means the
+    /// compile-time `chain_collateral_config` values remain authoritative.
+    #[serde(default)]
+    pub chain_debt_configs: BTreeMap<ChainId, ChainDebtConfigV1>,
     /// Vault_id -> first-bot-routed wall-clock ns. Set when
     /// `begin_liquidation_in_state` routes a vault to the bot tier; the durable
     /// timestamp the bot->SP escalation predicate reads (spec §10, finding #10).
@@ -576,7 +583,8 @@ impl MultiChainStateV6 {
         if nonce != expected {
             return Err(expected);
         }
-        self.evm_owner_nonces.insert(*owner, expected.saturating_add(1));
+        self.evm_owner_nonces
+            .insert(*owner, expected.saturating_add(1));
         Ok(())
     }
 
@@ -643,7 +651,8 @@ mod manual_price_tests {
         // A price written before V5 lives in `manual_prices` with NO entry in
         // `manual_price_set_at_ns`. The getter must report set_at_ns = 0, not None.
         let mut mc = MultiChainState::default();
-        mc.manual_prices.insert((CFX, "CFX".to_string()), 15_000_000);
+        mc.manual_prices
+            .insert((CFX, "CFX".to_string()), 15_000_000);
         assert_eq!(mc.get_manual_price(CFX, "CFX"), Some((15_000_000, 0)));
     }
 
@@ -652,13 +661,17 @@ mod manual_price_tests {
         // State-wipe defense: a live V4 CBOR snapshot (no manual_price_set_at_ns
         // key) must decode into V5 with prices intact and the timestamp map empty.
         let mut v4 = MultiChainStateV4::default();
-        v4.manual_prices.insert((CFX, "CFX".to_string()), 15_000_000);
+        v4.manual_prices
+            .insert((CFX, "CFX".to_string()), 15_000_000);
         v4.chain_supplies.insert(CFX, 42);
         let mut buf = Vec::new();
         ciborium::ser::into_writer(&v4, &mut buf).unwrap();
 
         let v5: MultiChainStateV5 = ciborium::de::from_reader(buf.as_slice()).unwrap();
-        assert_eq!(v5.manual_prices.get(&(CFX, "CFX".to_string())), Some(&15_000_000));
+        assert_eq!(
+            v5.manual_prices.get(&(CFX, "CFX".to_string())),
+            Some(&15_000_000)
+        );
         assert_eq!(v5.chain_supplies.get(&CFX), Some(&42));
         assert!(v5.manual_price_set_at_ns.is_empty());
         assert_eq!(v5.get_manual_price(CFX, "CFX"), Some((15_000_000, 0)));

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,7 +12,7 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::{MultiChainStateV1, MultiChainStateV2, MultiChainState};
+use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
@@ -54,13 +54,20 @@ pub enum SupplyDelta {
 #[derive(Debug, PartialEq, Eq)]
 pub enum SupplyInvariantError {
     UnknownChain(ChainId),
-    Underflow { chain: ChainId, current: u128, attempted_decrease: u128 },
+    Underflow {
+        chain: ChainId,
+        current: u128,
+        attempted_decrease: u128,
+    },
     /// `sum(chain_supplies)` did not equal the unified-invariant RHS. `total_debt`
     /// carries that full RHS (debt + reserve_backing + pending_chain_burn — spec
     /// 5.2), NOT the bare debt; the field name is kept for wire stability. With
     /// all-zero reserve/pending (Increment 1) the RHS equals bare debt, so the
     /// reported pair is byte-identical to the pre-Increment-1 behavior.
-    Divergence { sum_after: u128, total_debt: u128 },
+    Divergence {
+        sum_after: u128,
+        total_debt: u128,
+    },
     HaltedAfterSelfCheckFailure,
 }
 
@@ -133,7 +140,10 @@ pub fn apply_supply_delta(
     // (finding #2). With all-zero reserve/pending this is `sum_after != total_debt`.
     let rhs = chain_backing_rhs_e8s(state, total_debt_e8s);
     if sum_after != rhs {
-        return Err(SupplyInvariantError::Divergence { sum_after, total_debt: rhs });
+        return Err(SupplyInvariantError::Divergence {
+            sum_after,
+            total_debt: rhs,
+        });
     }
 
     state.chain_supplies.insert(chain, new);
@@ -158,7 +168,10 @@ pub fn check_invariant(
     let sum: u128 = state.chain_supplies.values().copied().sum();
     let rhs = chain_backing_rhs_e8s(state, total_debt_e8s);
     if sum != rhs {
-        return Err(SupplyInvariantError::Divergence { sum_after: sum, total_debt: rhs });
+        return Err(SupplyInvariantError::Divergence {
+            sum_after: sum,
+            total_debt: rhs,
+        });
     }
     Ok(())
 }
@@ -171,14 +184,178 @@ pub enum ReserveShiftError {
     /// No such chain vault.
     UnknownVault(u64),
     /// The vault's `collateral_chain` does not match the requested `chain`.
-    WrongChain { vault_chain: ChainId, requested: ChainId },
+    WrongChain {
+        vault_chain: ChainId,
+        requested: ChainId,
+    },
     /// `cleared_e8s` exceeds the vault's live `debt_e8s` (would over-credit the
     /// reserve term relative to debt actually retired).
-    ClearExceedsDebt { cleared_e8s: u128, vault_debt_e8s: u128 },
+    ClearExceedsDebt {
+        cleared_e8s: u128,
+        vault_debt_e8s: u128,
+    },
     /// The post-move unified invariant would not hold. The move conserves
     /// debt+reserve, so this only fires if the invariant was ALREADY diverged
     /// before the call (defensive; no mutation).
     InvariantBroken { sum_supplies: u128, rhs: u128 },
+}
+
+/// Reasons a manual foreign-burn reconciliation rejects (no state mutation on
+/// any error). Covers both SP pending-burn settlement and Tier-1 reserve
+/// retirement because both operations burn circulating foreign icUSD and debit an
+/// internal RHS backing term by the same amount.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BackingSettlementError {
+    /// The invariant self-check has halted the rail; do not move backing.
+    Halted,
+    /// No `chain_supplies` entry exists for this chain.
+    UnknownChain(ChainId),
+    /// A zero-value burn proof is meaningless and would only produce noise.
+    ZeroAmount,
+    /// The requested foreign burn exceeds the recorded circulating supply.
+    SupplyUnderflow {
+        chain: ChainId,
+        current: u128,
+        attempted_decrease: u128,
+    },
+    /// The requested settlement exceeds the selected backing term.
+    BackingUnderflow {
+        chain: ChainId,
+        current: u128,
+        attempted_decrease: u128,
+    },
+    /// The post-move unified invariant would not hold. Since the operation
+    /// debits supply and a backing term by the same amount, this indicates the
+    /// invariant was already diverged before the call.
+    InvariantBroken { sum_after: u128, rhs: u128 },
+}
+
+#[derive(Clone, Copy)]
+enum BackingTerm {
+    PendingChainBurn,
+    ReserveBacking,
+}
+
+fn backing_term_value(state: &MultiChainState, chain: ChainId, term: BackingTerm) -> u128 {
+    match term {
+        BackingTerm::PendingChainBurn => state
+            .pending_chain_burn_e8s
+            .get(&chain)
+            .copied()
+            .unwrap_or(0),
+        BackingTerm::ReserveBacking => state.reserve_backing_e8s.get(&chain).copied().unwrap_or(0),
+    }
+}
+
+fn backing_rhs_after_settlement(
+    state: &MultiChainState,
+    amount_e8s: u128,
+    term: BackingTerm,
+) -> u128 {
+    let debt = state.total_chain_vault_debt_e8s();
+    let reserve = match term {
+        BackingTerm::ReserveBacking => state.total_reserve_backing_e8s().saturating_sub(amount_e8s),
+        BackingTerm::PendingChainBurn => state.total_reserve_backing_e8s(),
+    };
+    let pending = match term {
+        BackingTerm::PendingChainBurn => state
+            .total_pending_chain_burn_e8s()
+            .saturating_sub(amount_e8s),
+        BackingTerm::ReserveBacking => state.total_pending_chain_burn_e8s(),
+    };
+    debt.saturating_add(reserve).saturating_add(pending)
+}
+
+fn debit_backing_term(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    amount_e8s: u128,
+    term: BackingTerm,
+) {
+    let map = match term {
+        BackingTerm::PendingChainBurn => &mut state.pending_chain_burn_e8s,
+        BackingTerm::ReserveBacking => &mut state.reserve_backing_e8s,
+    };
+    let new = map.get(&chain).copied().unwrap_or(0) - amount_e8s;
+    if new == 0 {
+        map.remove(&chain);
+    } else {
+        map.insert(chain, new);
+    }
+}
+
+fn settle_backing_burn(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    amount_e8s: u128,
+    term: BackingTerm,
+) -> Result<(), BackingSettlementError> {
+    if state.invariant_halted {
+        return Err(BackingSettlementError::Halted);
+    }
+    if amount_e8s == 0 {
+        return Err(BackingSettlementError::ZeroAmount);
+    }
+
+    let current_supply = state
+        .chain_supplies
+        .get(&chain)
+        .copied()
+        .ok_or(BackingSettlementError::UnknownChain(chain))?;
+    if amount_e8s > current_supply {
+        return Err(BackingSettlementError::SupplyUnderflow {
+            chain,
+            current: current_supply,
+            attempted_decrease: amount_e8s,
+        });
+    }
+
+    let current_backing = backing_term_value(state, chain, term);
+    if amount_e8s > current_backing {
+        return Err(BackingSettlementError::BackingUnderflow {
+            chain,
+            current: current_backing,
+            attempted_decrease: amount_e8s,
+        });
+    }
+
+    let sum_after = state
+        .total_supply_all_chains_e8s()
+        .saturating_sub(amount_e8s);
+    let rhs = backing_rhs_after_settlement(state, amount_e8s, term);
+    if sum_after != rhs {
+        return Err(BackingSettlementError::InvariantBroken { sum_after, rhs });
+    }
+
+    state
+        .chain_supplies
+        .insert(chain, current_supply - amount_e8s);
+    debit_backing_term(state, chain, amount_e8s, term);
+    Ok(())
+}
+
+/// Settle the SP path's slow foreign burn leg: the SP already burned IC-side
+/// icUSD and the backend moved matching debt into `pending_chain_burn_e8s`; once
+/// the foreign-chain burn is manually verified, debit both `chain_supplies` and
+/// `pending_chain_burn_e8s` by the same amount.
+pub fn settle_pending_chain_burn(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    amount_e8s: u128,
+) -> Result<(), BackingSettlementError> {
+    settle_backing_burn(state, chain, amount_e8s, BackingTerm::PendingChainBurn)
+}
+
+/// Settle the Tier-1 reserve retirement leg: after the operator burns
+/// reserve-backed foreign icUSD, debit both circulating chain supply and the
+/// reserve-backing obligation. `reserve_usdc_native` is intentionally untouched;
+/// it remains the realized USDC/protocol-surplus book.
+pub fn settle_reserve_burn(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    amount_e8s: u128,
+) -> Result<(), BackingSettlementError> {
+    settle_backing_burn(state, chain, amount_e8s, BackingTerm::ReserveBacking)
 }
 
 /// Bot/PSM Phase-2 accounting (spec 4.9, 5.3): atomically move `cleared_e8s` of a
@@ -227,13 +404,20 @@ pub fn apply_debt_to_reserve_shift(
     // is unchanged; debt drops by cleared_e8s and reserve_backing rises by the same,
     // so the RHS is invariant. reserve_usdc_native is NOT an RHS term (spec 3.2/5.6).
     let sum_supplies = state.total_supply_all_chains_e8s();
-    let post_debt_total = state.total_chain_vault_debt_e8s().saturating_sub(cleared_e8s);
-    let post_reserve_total = state.total_reserve_backing_e8s().saturating_add(cleared_e8s);
+    let post_debt_total = state
+        .total_chain_vault_debt_e8s()
+        .saturating_sub(cleared_e8s);
+    let post_reserve_total = state
+        .total_reserve_backing_e8s()
+        .saturating_add(cleared_e8s);
     let post_rhs = post_debt_total
         .saturating_add(post_reserve_total)
         .saturating_add(state.total_pending_chain_burn_e8s());
     if sum_supplies != post_rhs {
-        return Err(ReserveShiftError::InvariantBroken { sum_supplies, rhs: post_rhs });
+        return Err(ReserveShiftError::InvariantBroken {
+            sum_supplies,
+            rhs: post_rhs,
+        });
     }
 
     // Apply atomically (every reject above happened before any mutation).

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,8 +1,8 @@
+use super::config::ChainId;
 use super::multi_chain_state::{
     MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3, MultiChainStateV4,
     MultiChainStateV5, MultiChainStateV6,
 };
-use super::config::ChainId;
 use super::supply::migrate_multi_chain_state;
 
 #[test]
@@ -19,18 +19,25 @@ fn v1_cbor_snapshot_decodes_into_v2_without_wiping_state() {
     use super::settlement_queue::SettlementQueueV1;
 
     let mut v1 = MultiChainStateV1::default();
-    v1.chain_configs.insert(ChainId(10143), ChainConfigV1 {
-        chain_id: ChainId(10143),
-        display_name: "MonadTestnet".into(),
-        rpc_endpoints: vec!["https://rpc".into()],
-        finality_depth: 1,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
-        chain_native_decimals: 18,
-        registered_at_ns: 123,
-        status: ChainStatus::Registered,
-    });
+    v1.chain_configs.insert(
+        ChainId(10143),
+        ChainConfigV1 {
+            chain_id: ChainId(10143),
+            display_name: "MonadTestnet".into(),
+            rpc_endpoints: vec!["https://rpc".into()],
+            finality_depth: 1,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 2,
+                max_fee_gwei_ceiling: 500,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 123,
+            status: ChainStatus::Registered,
+        },
+    );
     v1.chain_supplies.insert(ChainId(10143), 777);
-    v1.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
+    v1.settlement_queues
+        .insert(ChainId(10143), SettlementQueueV1::default());
     v1.invariant_halted = true;
 
     // Encode as V1 (the bytes Phase 1a wrote), decode as V2 (the new shape).
@@ -78,9 +85,15 @@ fn v2_cbor_round_trip_preserves_processed_burn_keys() {
     let decoded: MultiChainStateV2 =
         ciborium::de::from_reader(buf.as_slice()).expect("V2 snapshot round-trips");
 
-    assert_eq!(decoded.chain_supplies.get(&ChainId(10143)), Some(&6_000_000_000u128));
+    assert_eq!(
+        decoded.chain_supplies.get(&ChainId(10143)),
+        Some(&6_000_000_000u128)
+    );
     assert_eq!(decoded.processed_burn_keys.len(), 2);
-    let block = decoded.processed_burn_keys.get(&1_000_300).expect("block 1_000_300 present");
+    let block = decoded
+        .processed_burn_keys
+        .get(&1_000_300)
+        .expect("block 1_000_300 present");
     assert!(block.contains("0xgoodburn:1:4000000000"));
     assert!(block.contains("0xpoison:1:100000000000"));
     assert_eq!(block.len(), 2);
@@ -122,7 +135,9 @@ fn migration_preserves_v1_fields_and_defaults_new_ones() {
 
 #[test]
 fn active_alias_points_at_v6() {
-    fn _check(x: MultiChainState) -> MultiChainStateV6 { x }
+    fn _check(x: MultiChainState) -> MultiChainStateV6 {
+        x
+    }
 }
 
 #[test]
@@ -145,37 +160,49 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
     use std::collections::BTreeSet;
 
     let mut v2 = MultiChainStateV2::default();
-    v2.chain_configs.insert(ChainId(10143), ChainConfigV1 {
-        chain_id: ChainId(10143),
-        display_name: "MonadTestnet".into(),
-        rpc_endpoints: vec!["https://rpc".into()],
-        finality_depth: 3,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
-        chain_native_decimals: 18,
-        registered_at_ns: 123,
-        status: ChainStatus::Registered,
-    });
+    v2.chain_configs.insert(
+        ChainId(10143),
+        ChainConfigV1 {
+            chain_id: ChainId(10143),
+            display_name: "MonadTestnet".into(),
+            rpc_endpoints: vec!["https://rpc".into()],
+            finality_depth: 3,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 2,
+                max_fee_gwei_ceiling: 500,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 123,
+            status: ChainStatus::Registered,
+        },
+    );
     v2.chain_supplies.insert(ChainId(10143), 50_000_000);
-    v2.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
+    v2.settlement_queues
+        .insert(ChainId(10143), SettlementQueueV1::default());
     v2.invariant_halted = false;
-    v2.chain_vaults.insert(1, ChainVaultV1 {
-        vault_id: 1,
-        owner: candid::Principal::anonymous(),
-        collateral_chain: ChainId(10143),
-        custody_address: "0xcustody".into(),
-        collateral_amount_native: 1_000_000_000_000_000_000,
-        debt_e8s: 50_000_000,
-        mint_recipient: "0xrecipient".into(),
-        pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open,
-        opened_at_ns: 99,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    v2.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: candid::Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xcustody".into(),
+            collateral_amount_native: 1_000_000_000_000_000_000,
+            debt_e8s: 50_000_000,
+            mint_recipient: "0xrecipient".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 99,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     v2.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v2.last_observed_block.insert(ChainId(10143), 35_136_248);
-    v2.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+    v2.processed_burn_keys
+        .insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
 
     // Encode as V2 (the bytes the live canister wrote), decode as V3 (new shape).
     let mut buf = Vec::new();
@@ -184,18 +211,37 @@ fn v2_cbor_snapshot_decodes_into_v3_without_wiping_state() {
         ciborium::de::from_reader(buf.as_slice()).expect("V2 snapshot MUST decode into V3");
 
     // Outer state preserved:
-    assert_eq!(v3.chain_supplies.get(&ChainId(10143)), Some(&50_000_000u128));
+    assert_eq!(
+        v3.chain_supplies.get(&ChainId(10143)),
+        Some(&50_000_000u128)
+    );
     assert_eq!(v3.chain_vaults.len(), 1);
     assert_eq!(v3.chain_vaults[&1].debt_e8s, 50_000_000);
-    assert_eq!(v3.chain_contracts.get(&ChainId(10143)), Some(&"0xicusd".to_string()));
-    assert_eq!(v3.last_observed_block.get(&ChainId(10143)), Some(&35_136_248u64));
-    assert!(v3.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
+    assert_eq!(
+        v3.chain_contracts.get(&ChainId(10143)),
+        Some(&"0xicusd".to_string())
+    );
+    assert_eq!(
+        v3.last_observed_block.get(&ChainId(10143)),
+        Some(&35_136_248u64)
+    );
+    assert!(v3
+        .processed_burn_keys
+        .get(&35_136_200)
+        .unwrap()
+        .contains("0xtx:0"));
     // Nested config migrated V1 -> V2: V1 fields preserved, new flag defaulted off.
-    let cfg = v3.chain_configs.get(&ChainId(10143)).expect("config preserved");
+    let cfg = v3
+        .chain_configs
+        .get(&ChainId(10143))
+        .expect("config preserved");
     assert_eq!(cfg.finality_depth, 3);
     assert_eq!(cfg.display_name, "MonadTestnet");
     assert!(matches!(cfg.status, ChainStatus::Registered));
-    assert!(!cfg.burn_watch_poll_enabled, "poll-scan defaults OFF after upgrade");
+    assert!(
+        !cfg.burn_watch_poll_enabled,
+        "poll-scan defaults OFF after upgrade"
+    );
     // Total debt still reconciles (no state wipe).
     assert_eq!(v3.total_chain_vault_debt_e8s(), 50_000_000);
     assert_eq!(v3.total_supply_all_chains_e8s(), 50_000_000);
@@ -221,37 +267,49 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
     use std::collections::BTreeSet;
 
     let mut v3 = MultiChainStateV3::default();
-    v3.chain_configs.insert(ChainId(10143), ChainConfigV2 {
-        chain_id: ChainId(10143),
-        display_name: "MonadTestnet".into(),
-        rpc_endpoints: vec!["https://rpc".into()],
-        finality_depth: 3,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 500 },
-        chain_native_decimals: 18,
-        registered_at_ns: 123,
-        status: ChainStatus::Registered,
-        burn_watch_poll_enabled: true,
-    });
+    v3.chain_configs.insert(
+        ChainId(10143),
+        ChainConfigV2 {
+            chain_id: ChainId(10143),
+            display_name: "MonadTestnet".into(),
+            rpc_endpoints: vec!["https://rpc".into()],
+            finality_depth: 3,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 2,
+                max_fee_gwei_ceiling: 500,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 123,
+            status: ChainStatus::Registered,
+            burn_watch_poll_enabled: true,
+        },
+    );
     v3.chain_supplies.insert(ChainId(10143), 50_000_000);
-    v3.settlement_queues.insert(ChainId(10143), SettlementQueueV1::default());
-    v3.chain_vaults.insert(1, ChainVaultV1 {
-        vault_id: 1,
-        owner: candid::Principal::anonymous(),
-        collateral_chain: ChainId(10143),
-        custody_address: "0xcustody".into(),
-        collateral_amount_native: 1_000_000_000_000_000_000,
-        debt_e8s: 50_000_000,
-        mint_recipient: "0xrecipient".into(),
-        pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open,
-        opened_at_ns: 99,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    v3.settlement_queues
+        .insert(ChainId(10143), SettlementQueueV1::default());
+    v3.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: candid::Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xcustody".into(),
+            collateral_amount_native: 1_000_000_000_000_000_000,
+            debt_e8s: 50_000_000,
+            mint_recipient: "0xrecipient".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 99,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     v3.chain_contracts.insert(ChainId(10143), "0xicusd".into());
     v3.last_observed_block.insert(ChainId(10143), 35_136_248);
-    v3.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+    v3.processed_burn_keys
+        .insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
 
     // Encode as V3 (the bytes the live canister wrote), decode as V4 (new shape).
     let mut buf = Vec::new();
@@ -260,19 +318,38 @@ fn v3_cbor_snapshot_decodes_into_v4_without_wiping_state() {
         ciborium::de::from_reader(buf.as_slice()).expect("V3 snapshot MUST decode into V4");
 
     // Outer state preserved:
-    assert_eq!(v4.chain_supplies.get(&ChainId(10143)), Some(&50_000_000u128));
+    assert_eq!(
+        v4.chain_supplies.get(&ChainId(10143)),
+        Some(&50_000_000u128)
+    );
     assert_eq!(v4.chain_vaults.len(), 1);
     assert_eq!(v4.chain_vaults[&1].debt_e8s, 50_000_000);
-    assert_eq!(v4.chain_contracts.get(&ChainId(10143)), Some(&"0xicusd".to_string()));
-    assert_eq!(v4.last_observed_block.get(&ChainId(10143)), Some(&35_136_248u64));
-    assert!(v4.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
+    assert_eq!(
+        v4.chain_contracts.get(&ChainId(10143)),
+        Some(&"0xicusd".to_string())
+    );
+    assert_eq!(
+        v4.last_observed_block.get(&ChainId(10143)),
+        Some(&35_136_248u64)
+    );
+    assert!(v4
+        .processed_burn_keys
+        .get(&35_136_200)
+        .unwrap()
+        .contains("0xtx:0"));
     // Nested config migrated V2 -> V3: V2 fields preserved, new override defaulted None.
-    let cfg = v4.chain_configs.get(&ChainId(10143)).expect("config preserved");
+    let cfg = v4
+        .chain_configs
+        .get(&ChainId(10143))
+        .expect("config preserved");
     assert_eq!(cfg.finality_depth, 3);
     assert_eq!(cfg.display_name, "MonadTestnet");
     assert!(matches!(cfg.status, ChainStatus::Registered));
     assert!(cfg.burn_watch_poll_enabled, "V2 poll flag carried across");
-    assert_eq!(cfg.min_quorum_providers, None, "new quorum floor defaults to None");
+    assert_eq!(
+        cfg.min_quorum_providers, None,
+        "new quorum floor defaults to None"
+    );
     // Total debt still reconciles (no state wipe).
     assert_eq!(v4.total_chain_vault_debt_e8s(), 50_000_000);
     assert_eq!(v4.total_supply_all_chains_e8s(), 50_000_000);
@@ -303,40 +380,53 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
     const CFX: ChainId = ChainId(1030);
 
     let mut v5 = MultiChainStateV5::default();
-    v5.chain_configs.insert(CFX, ChainConfigV3 {
-        chain_id: CFX,
-        display_name: "ConfluxESpace".into(),
-        rpc_endpoints: vec!["https://evm.confluxrpc.com".into()],
-        finality_depth: 5,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 1, max_fee_gwei_ceiling: 200 },
-        chain_native_decimals: 18,
-        registered_at_ns: 123,
-        status: ChainStatus::Registered,
-        burn_watch_poll_enabled: true,
-        min_quorum_providers: Some(3),
-    });
+    v5.chain_configs.insert(
+        CFX,
+        ChainConfigV3 {
+            chain_id: CFX,
+            display_name: "ConfluxESpace".into(),
+            rpc_endpoints: vec!["https://evm.confluxrpc.com".into()],
+            finality_depth: 5,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 1,
+                max_fee_gwei_ceiling: 200,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 123,
+            status: ChainStatus::Registered,
+            burn_watch_poll_enabled: true,
+            min_quorum_providers: Some(3),
+        },
+    );
     v5.chain_supplies.insert(CFX, 100 * 100_000_000); // 100 icUSD in e8s
-    v5.settlement_queues.insert(CFX, SettlementQueueV1::default());
+    v5.settlement_queues
+        .insert(CFX, SettlementQueueV1::default());
     v5.invariant_halted = false;
-    v5.chain_vaults.insert(3, ChainVaultV1 {
-        vault_id: 3,
-        owner: candid::Principal::anonymous(),
-        collateral_chain: CFX,
-        custody_address: "0xcustody".into(),
-        collateral_amount_native: 1_000_000_000_000_000_000,
-        debt_e8s: 100 * 100_000_000,
-        mint_recipient: "0xrecipient".into(),
-        pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open,
-        opened_at_ns: 99,
-        owner_evm: Some("0xowner".into()),
-        last_interest_accrual_ns: 1_700_000_000_000_000_000,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    v5.chain_vaults.insert(
+        3,
+        ChainVaultV1 {
+            vault_id: 3,
+            owner: candid::Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0xcustody".into(),
+            collateral_amount_native: 1_000_000_000_000_000_000,
+            debt_e8s: 100 * 100_000_000,
+            mint_recipient: "0xrecipient".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 99,
+            owner_evm: Some("0xowner".into()),
+            last_interest_accrual_ns: 1_700_000_000_000_000_000,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     v5.chain_contracts.insert(CFX, "0xicusd".into());
     v5.last_observed_block.insert(CFX, 35_136_248);
-    v5.processed_burn_keys.insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
-    v5.evm_owner_nonces.insert(candid::Principal::anonymous(), 7);
+    v5.processed_burn_keys
+        .insert(35_136_200, BTreeSet::from(["0xtx:0".to_string()]));
+    v5.evm_owner_nonces
+        .insert(candid::Principal::anonymous(), 7);
     // Stamp a manual price + its freshness timestamp (the V5-added side-channel).
     v5.set_manual_price(CFX, "CFX".to_string(), 4_800_000, 1_700_000_000_000_000_001);
 
@@ -347,16 +437,30 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
         ciborium::de::from_reader(buf.as_slice()).expect("V5 snapshot MUST decode into V6");
 
     // --- Every carried field survived (NOT wiped) ---
-    assert_eq!(v6.chain_supplies, v5.chain_supplies, "chain_supplies carried");
+    assert_eq!(
+        v6.chain_supplies, v5.chain_supplies,
+        "chain_supplies carried"
+    );
     assert_eq!(v6.chain_supplies.get(&CFX), Some(&(100 * 100_000_000u128)));
     assert_eq!(v6.chain_vaults.len(), 1);
     assert_eq!(v6.chain_vaults[&3].debt_e8s, 100 * 100_000_000);
     assert_eq!(v6.chain_vaults[&3].owner_evm, Some("0xowner".to_string()));
-    assert_eq!(v6.chain_vaults[&3].last_interest_accrual_ns, 1_700_000_000_000_000_000);
+    assert_eq!(
+        v6.chain_vaults[&3].last_interest_accrual_ns,
+        1_700_000_000_000_000_000
+    );
     assert_eq!(v6.chain_contracts.get(&CFX), Some(&"0xicusd".to_string()));
     assert_eq!(v6.last_observed_block.get(&CFX), Some(&35_136_248u64));
-    assert!(v6.processed_burn_keys.get(&35_136_200).unwrap().contains("0xtx:0"));
-    assert_eq!(v6.expected_evm_nonce(&candid::Principal::anonymous()), 7, "nonce carried");
+    assert!(v6
+        .processed_burn_keys
+        .get(&35_136_200)
+        .unwrap()
+        .contains("0xtx:0"));
+    assert_eq!(
+        v6.expected_evm_nonce(&candid::Principal::anonymous()),
+        7,
+        "nonce carried"
+    );
     assert_eq!(
         v6.get_manual_price(CFX, "CFX"),
         Some((4_800_000, 1_700_000_000_000_000_001)),
@@ -368,10 +472,14 @@ fn v5_cbor_snapshot_decodes_into_v6_without_wiping_state() {
     assert_eq!(cfg.min_quorum_providers, Some(3));
 
     // --- The four NEW V6 fields defaulted EMPTY (state-wipe defense, not a wipe) ---
-    assert!(v6.reserve_backing_e8s.is_empty(), "new field defaulted empty, not wiped");
+    assert!(
+        v6.reserve_backing_e8s.is_empty(),
+        "new field defaulted empty, not wiped"
+    );
     assert!(v6.reserve_usdc_native.is_empty());
     assert!(v6.pending_chain_burn_e8s.is_empty());
     assert!(v6.sp_attempted_chain_vaults.is_empty());
+    assert!(v6.chain_debt_configs.is_empty());
 
     // Total debt still reconciles with supply (the invariant is intact post-decode;
     // with all-zero reserve/pending the generalized RHS reduces to bare debt).
@@ -385,6 +493,7 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     // carrying the new liquidation-engine fields (reserve maps, pending-burn,
     // sp-attempted set, the liquidation config) MUST survive an encode->decode
     // round-trip with every value intact. This is the path a V6->V6 upgrade runs.
+    use super::collateral_config::ChainDebtConfigV1;
     use super::liquidation_config::{ChainLiquidationConfigV1, DexKind};
     use std::collections::BTreeSet;
 
@@ -393,27 +502,38 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
     let mut v6 = MultiChainStateV6::default();
     v6.chain_supplies.insert(CFX, 100);
     v6.reserve_backing_e8s.insert(CFX, 40);
-    v6.reserve_usdc_native.insert(CFX, 45_000_000_000_000_000_000);
+    v6.reserve_usdc_native
+        .insert(CFX, 45_000_000_000_000_000_000);
     v6.pending_chain_burn_e8s.insert(CFX, 15);
     v6.sp_attempted_chain_vaults.insert(7);
     v6.sp_attempted_chain_vaults.insert(9);
-    v6.chain_liquidation_configs.insert(CFX, ChainLiquidationConfigV1 {
-        dex: DexKind::UniswapV2,
-        router: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
-        factory: "0xe2a6f7c0ce4d5d300f97aa7e125455f5cd3342f5".into(),
-        pair: "0xpair".into(),
-        collateral_token: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
-        settle_stable_token: "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372".into(),
-        slippage_cap_bps: 250,
-        restore_target_cr_e4: 15_500,
-        enabled: true,
-        max_swap_value_e8s: 2_000 * 100_000_000,
-        max_price_age_ns: 1_800_000_000_000,
-        max_dex_oracle_divergence_bps: 500,
-        fee_bps: 25,
-        settle_stable_decimals: 18,
-        deadline_secs: 180,
-    });
+    v6.chain_debt_configs.insert(
+        CFX,
+        ChainDebtConfigV1 {
+            min_vault_debt_e8s: 25_000_000,
+            debt_ceiling_e8s: Some(250 * 100_000_000),
+        },
+    );
+    v6.chain_liquidation_configs.insert(
+        CFX,
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
+            factory: "0xe2a6f7c0ce4d5d300f97aa7e125455f5cd3342f5".into(),
+            pair: "0xpair".into(),
+            collateral_token: "0x14b2D3bC65e74DAE1030EAFd8ac30c533c976A9b".into(),
+            settle_stable_token: "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372".into(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+            max_swap_value_e8s: 2_000 * 100_000_000,
+            max_price_age_ns: 1_800_000_000_000,
+            max_dex_oracle_divergence_bps: 500,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
+        },
+    );
 
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&v6, &mut buf).expect("cbor encode V6");
@@ -421,15 +541,30 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
         ciborium::de::from_reader(buf.as_slice()).expect("V6 snapshot round-trips");
 
     assert_eq!(decoded.reserve_backing_e8s.get(&CFX), Some(&40));
-    assert_eq!(decoded.reserve_usdc_native.get(&CFX), Some(&45_000_000_000_000_000_000));
+    assert_eq!(
+        decoded.reserve_usdc_native.get(&CFX),
+        Some(&45_000_000_000_000_000_000)
+    );
     assert_eq!(decoded.pending_chain_burn_e8s.get(&CFX), Some(&15));
     assert_eq!(decoded.sp_attempted_chain_vaults, BTreeSet::from([7, 9]));
-    let cfg = decoded.chain_liquidation_configs.get(&CFX).expect("config survived");
+    let debt = decoded
+        .chain_debt_configs
+        .get(&CFX)
+        .expect("debt config survived");
+    assert_eq!(debt.min_vault_debt_e8s, 25_000_000);
+    assert_eq!(debt.debt_ceiling_e8s, Some(250 * 100_000_000));
+    let cfg = decoded
+        .chain_liquidation_configs
+        .get(&CFX)
+        .expect("config survived");
     assert_eq!(cfg.dex, DexKind::UniswapV2);
     assert_eq!(cfg.slippage_cap_bps, 250);
     assert_eq!(cfg.restore_target_cr_e4, 15_500);
     assert!(cfg.enabled);
-    assert_eq!(cfg.settle_stable_token, "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372");
+    assert_eq!(
+        cfg.settle_stable_token,
+        "0x6963EfED0aB40F6C3d7BdA44A05dcf1437C44372"
+    );
     assert_eq!(cfg.max_swap_value_e8s, 2_000 * 100_000_000);
     assert_eq!(cfg.max_price_age_ns, 1_800_000_000_000);
     assert_eq!(cfg.max_dex_oracle_divergence_bps, 500);
@@ -443,40 +578,48 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
 
 #[test]
 fn chain_vault_debt_total_sums_only_chain_vaults() {
-    use super::monad::chain_vault::{ChainVaultV1, ChainVaultStatus};
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 
     let mut s = MultiChainStateV2::default();
     assert_eq!(s.total_chain_vault_debt_e8s(), 0);
-    s.chain_vaults.insert(1, ChainVaultV1 {
-        vault_id: 1,
-        owner: candid::Principal::anonymous(),
-        collateral_chain: ChainId(10143),
-        custody_address: "0xa".into(),
-        collateral_amount_native: 0,
-        debt_e8s: 7_000_000_000,
-        mint_recipient: "0xr".into(),
-        pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open,
-        opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
-    s.chain_vaults.insert(2, ChainVaultV1 {
-        vault_id: 2,
-        owner: candid::Principal::anonymous(),
-        collateral_chain: ChainId(10143),
-        custody_address: "0xb".into(),
-        collateral_amount_native: 0,
-        debt_e8s: 3_000_000_000,
-        mint_recipient: "0xr".into(),
-        pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open,
-        opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: candid::Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xa".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 7_000_000_000,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
+    s.chain_vaults.insert(
+        2,
+        ChainVaultV1 {
+            vault_id: 2,
+            owner: candid::Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xb".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 3_000_000_000,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     assert_eq!(s.total_chain_vault_debt_e8s(), 10_000_000_000);
 }
 
@@ -539,6 +682,12 @@ fn legacy_chain_vault_decodes_interest_fields_defaulted_then_stamped() {
     let mut s = MultiChainState::default();
     s.chain_vaults.insert(7, decoded);
     super::supply::stamp_chain_interest_accrual_start(&mut s, 1_700_000_000_000_000_000);
-    assert_eq!(s.chain_vaults[&7].last_interest_accrual_ns, 1_700_000_000_000_000_000);
-    assert_eq!(s.chain_vaults[&7].debt_e8s, 555, "stamp does not touch debt");
+    assert_eq!(
+        s.chain_vaults[&7].last_interest_accrual_ns,
+        1_700_000_000_000_000_000
+    );
+    assert_eq!(
+        s.chain_vaults[&7].debt_e8s, 555,
+        "stamp does not touch debt"
+    );
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,6 +1,9 @@
-use super::supply::{apply_supply_delta, check_invariant, SupplyDelta, SupplyInvariantError};
 use super::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
 use super::multi_chain_state::MultiChainState;
+use super::supply::{
+    apply_supply_delta, check_invariant, settle_pending_chain_burn, settle_reserve_burn,
+    BackingSettlementError, SupplyDelta, SupplyInvariantError,
+};
 
 fn fixture_state() -> MultiChainState {
     let mut s = MultiChainState::default();
@@ -59,7 +62,8 @@ fn decrease_to_exact_zero_keeps_entry_for_audit() {
         ChainId(101),
         SupplyDelta::Decrease(50),
         /* total_debt_e8s = */ 0,
-    ).expect("decrease to zero");
+    )
+    .expect("decrease to zero");
     assert_eq!(s.chain_supplies[&ChainId(101)], 0);
     assert!(s.chain_supplies.contains_key(&ChainId(101)));
 }
@@ -86,7 +90,10 @@ fn invariant_halted_blocks_every_mutation() {
         SupplyDelta::Increase(1),
         /* total_debt_e8s = */ 1,
     );
-    assert!(matches!(res, Err(SupplyInvariantError::HaltedAfterSelfCheckFailure)));
+    assert!(matches!(
+        res,
+        Err(SupplyInvariantError::HaltedAfterSelfCheckFailure)
+    ));
 }
 
 #[test]
@@ -124,16 +131,26 @@ fn stamp_sets_accrual_start_only_for_unstamped_vaults() {
         owner_evm: None,
         last_interest_accrual_ns: last,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    };
+        pending_liquidation: None,
+    };
     let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, mk(1, 0)); // unstamped (pre-field snapshot)
     s.chain_vaults.insert(2, mk(2, 5)); // already stamped
     super::supply::stamp_chain_interest_accrual_start(&mut s, 12_345);
-    assert_eq!(s.chain_vaults[&1].last_interest_accrual_ns, 12_345, "unstamped vault gets now");
-    assert_eq!(s.chain_vaults[&2].last_interest_accrual_ns, 5, "already-stamped untouched");
+    assert_eq!(
+        s.chain_vaults[&1].last_interest_accrual_ns, 12_345,
+        "unstamped vault gets now"
+    );
+    assert_eq!(
+        s.chain_vaults[&2].last_interest_accrual_ns, 5,
+        "already-stamped untouched"
+    );
     // Idempotent: a second run does not re-stamp the now-stamped vault.
     super::supply::stamp_chain_interest_accrual_start(&mut s, 99_999);
-    assert_eq!(s.chain_vaults[&1].last_interest_accrual_ns, 12_345, "idempotent");
+    assert_eq!(
+        s.chain_vaults[&1].last_interest_accrual_ns, 12_345,
+        "idempotent"
+    );
 }
 
 // ─── Increment 1 / Task 3: unified supply invariant (debt + reserve + pending-burn)
@@ -176,7 +193,7 @@ fn invariant_holds_with_nonzero_reserve_backing() {
     let mut s = fixture_state();
     s.chain_supplies.insert(CHAIN, 100); // 100 icUSD circulating
     s.reserve_backing_e8s.insert(CHAIN, 30); // 30 backed by bot-held USDC reserve
-    // debt component = 70; generalized RHS = 70 + 30 + 0 = 100 == supply.
+                                             // debt component = 70; generalized RHS = 70 + 30 + 0 = 100 == supply.
     assert_eq!(check_invariant(&s, 70), Ok(()));
 }
 
@@ -203,7 +220,10 @@ fn invariant_excludes_pending_interest_mint_from_rhs() {
     s.chain_supplies.insert(CHAIN, 100);
     s.reserve_backing_e8s.insert(CHAIN, 30);
     let debt = s.total_chain_vault_debt_e8s();
-    assert_eq!(debt, 70, "total debt counts only realized debt_e8s, excludes pending interest");
+    assert_eq!(
+        debt, 70,
+        "total debt counts only realized debt_e8s, excludes pending interest"
+    );
     // RHS = 70 + 30 + 0 = 100 == supply. If the 50 pending interest leaked onto the
     // RHS it would be 150 != 100 and this would FALSE-HALT.
     assert_eq!(check_invariant(&s, debt), Ok(()));
@@ -219,13 +239,19 @@ fn apply_supply_delta_enforces_generalized_rhs() {
     s.chain_supplies.insert(CHAIN, 100);
     s.reserve_backing_e8s.insert(CHAIN, 30);
     // A mint of +10 with debt now 80: 110 == 80 + 30 -> accept.
-    assert_eq!(apply_supply_delta(&mut s, CHAIN, SupplyDelta::Increase(10), 80), Ok(()));
+    assert_eq!(
+        apply_supply_delta(&mut s, CHAIN, SupplyDelta::Increase(10), 80),
+        Ok(())
+    );
     assert_eq!(s.chain_supplies[&CHAIN], 110);
     // A delta that breaks the generalized equality is rejected, no mutation:
     // +5 while still claiming debt 80 -> 115 != 80 + 30 = 110 -> Divergence.
     assert_eq!(
         apply_supply_delta(&mut s, CHAIN, SupplyDelta::Increase(5), 80),
-        Err(SupplyInvariantError::Divergence { sum_after: 115, total_debt: 110 })
+        Err(SupplyInvariantError::Divergence {
+            sum_after: 115,
+            total_debt: 110
+        })
     );
     assert_eq!(s.chain_supplies[&CHAIN], 110, "no mutation on rejection");
 }
@@ -238,7 +264,13 @@ fn invariant_reduces_to_bare_debt_when_reserve_and_pending_zero() {
     let mut s = fixture_state();
     s.chain_supplies.insert(CHAIN, 70);
     assert_eq!(check_invariant(&s, 70), Ok(()));
-    assert_eq!(check_invariant(&s, 71), Err(SupplyInvariantError::Divergence { sum_after: 70, total_debt: 71 }));
+    assert_eq!(
+        check_invariant(&s, 71),
+        Err(SupplyInvariantError::Divergence {
+            sum_after: 70,
+            total_debt: 71
+        })
+    );
 }
 
 // ─── Increment 1 / Task 4: apply_debt_to_reserve_shift (the reserve-term gate) ───
@@ -261,13 +293,22 @@ fn reserve_shift_moves_debt_to_reserve_and_preserves_invariant() {
     apply_debt_to_reserve_shift(&mut s, CHAIN, 1, 40, 45_000_000_000_000_000_000)
         .expect("reserve shift");
 
-    assert_eq!(s.chain_vaults[&1].debt_e8s, 60, "vault debt reduced by cleared amount");
-    assert_eq!(s.reserve_backing_e8s[&CHAIN], 40, "reserve_backing credited the cleared debt");
+    assert_eq!(
+        s.chain_vaults[&1].debt_e8s, 60,
+        "vault debt reduced by cleared amount"
+    );
+    assert_eq!(
+        s.reserve_backing_e8s[&CHAIN], 40,
+        "reserve_backing credited the cleared debt"
+    );
     assert_eq!(
         s.reserve_usdc_native[&CHAIN], 45_000_000_000_000_000_000,
         "realized USDC recorded (NOT on the invariant RHS)"
     );
-    assert_eq!(s.chain_supplies[&CHAIN], 100, "chain_supplies UNCHANGED (no burn)");
+    assert_eq!(
+        s.chain_supplies[&CHAIN], 100,
+        "chain_supplies UNCHANGED (no burn)"
+    );
     // post: 100 == 60 (debt) + 40 (reserve) + 0 (pending) -> invariant still holds
     assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
 }
@@ -279,7 +320,10 @@ fn reserve_shift_rejects_clearing_more_than_debt() {
     s.chain_supplies.insert(CHAIN, 100);
     assert_eq!(
         apply_debt_to_reserve_shift(&mut s, CHAIN, 1, 150, 1),
-        Err(ReserveShiftError::ClearExceedsDebt { cleared_e8s: 150, vault_debt_e8s: 100 })
+        Err(ReserveShiftError::ClearExceedsDebt {
+            cleared_e8s: 150,
+            vault_debt_e8s: 100
+        })
     );
     // No mutation on rejection.
     assert_eq!(s.chain_vaults[&1].debt_e8s, 100);
@@ -307,4 +351,80 @@ fn reserve_shift_blocked_while_invariant_halted() {
         Err(ReserveShiftError::Halted)
     );
     assert_eq!(s.chain_vaults[&1].debt_e8s, 100, "no mutation while halted");
+}
+
+// ─── Increment 5 / Task 1: manual foreign-burn reconciliation ───
+
+#[test]
+fn pending_chain_burn_settlement_reduces_pending_and_supply() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 30);
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+
+    settle_pending_chain_burn(&mut s, CHAIN, 10).expect("settle pending burn");
+
+    assert_eq!(s.chain_supplies[&CHAIN], 90);
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 20);
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn pending_chain_burn_settlement_rejects_over_settlement_without_mutation() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 30);
+
+    assert_eq!(
+        settle_pending_chain_burn(&mut s, CHAIN, 31),
+        Err(BackingSettlementError::BackingUnderflow {
+            chain: CHAIN,
+            current: 30,
+            attempted_decrease: 31,
+        })
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], 100);
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 30);
+}
+
+#[test]
+fn reserve_burn_settlement_reduces_reserve_and_supply_but_keeps_usdc_books() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    s.reserve_usdc_native
+        .insert(CHAIN, 45_000_000_000_000_000_000);
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+
+    settle_reserve_burn(&mut s, CHAIN, 10).expect("settle reserve burn");
+
+    assert_eq!(s.chain_supplies[&CHAIN], 90);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], 20);
+    assert_eq!(s.reserve_usdc_native[&CHAIN], 45_000_000_000_000_000_000);
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn reserve_burn_settlement_rejects_over_settlement_without_mutation() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    s.reserve_usdc_native
+        .insert(CHAIN, 45_000_000_000_000_000_000);
+
+    assert_eq!(
+        settle_reserve_burn(&mut s, CHAIN, 31),
+        Err(BackingSettlementError::BackingUnderflow {
+            chain: CHAIN,
+            current: 30,
+            attempted_decrease: 31,
+        })
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], 100);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], 30);
+    assert_eq!(s.reserve_usdc_native[&CHAIN], 45_000_000_000_000_000_000);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -53,6 +53,30 @@ fn setup(price_e8: u64) -> MultiChainState {
     s
 }
 
+fn enable_price_age_gate(s: &mut MultiChainState, max_price_age_ns: u64) {
+    use super::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+    s.chain_liquidation_configs.insert(
+        CHAIN,
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: String::new(),
+            factory: String::new(),
+            pair: String::new(),
+            collateral_token: String::new(),
+            settle_stable_token: String::new(),
+            slippage_cap_bps: 0,
+            restore_target_cr_e4: 13_000,
+            enabled: false,
+            max_swap_value_e8s: 0,
+            max_price_age_ns,
+            max_dex_oracle_divergence_bps: 0,
+            fee_bps: 0,
+            settle_stable_decimals: 0,
+            deadline_secs: 0,
+        },
+    );
+}
+
 // 1. A vault opens through the generalized helper when the injected validator
 //    accepts the recipient AND the (chain, "SOL") manual price is set. Proves the
 //    price_symbol seam reads a NON-"MON" key and the validator seam is honored.
@@ -76,7 +100,10 @@ fn open_succeeds_with_injected_validator_and_sol_price_symbol() {
         12345,
         7,
     );
-    assert!(res.is_ok(), "open should succeed via the generalized seam: {res:?}");
+    assert!(
+        res.is_ok(),
+        "open should succeed via the generalized seam: {res:?}"
+    );
     let v = s.chain_vaults.get(&7).expect("vault 7 created");
     assert_eq!(v.collateral_amount_native, 100 * ONE_SOL);
     assert_eq!(v.pending_mint_e8s, 100_00000000);
@@ -107,7 +134,10 @@ fn open_rejected_when_injected_validator_rejects() {
         12345,
         7,
     );
-    assert!(matches!(res, Err(OpenVaultError::InvalidAddress(_))), "got {res:?}");
+    assert!(
+        matches!(res, Err(OpenVaultError::InvalidAddress(_))),
+        "got {res:?}"
+    );
     assert!(s.chain_vaults.is_empty(), "no vault on a rejected address");
     assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
 }
@@ -138,23 +168,66 @@ fn open_no_price_when_symbol_key_absent() {
     assert!(s.chain_vaults.is_empty());
 }
 
+#[test]
+fn open_rejects_stale_price_when_age_gate_configured() {
+    let mut s = setup(PRICE_150_USD_E8);
+    s.manual_price_set_at_ns
+        .insert((CHAIN, "SOL".into()), 1_000);
+    enable_price_age_gate(&mut s, 100);
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        100_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1_101,
+        7,
+    );
+    assert_eq!(res, Err(OpenVaultError::StalePrice));
+    assert!(s.chain_vaults.is_empty(), "no mutation on stale price");
+}
+
 // ─── M2: borrow + nonce + per-owner cap ───────────────────────────────────────
 
-use super::vault::{borrow_chain_vault_in_state, BorrowError};
 use super::evm::settlement::confirm_mint_in_state;
+use super::vault::{borrow_chain_vault_in_state, BorrowError};
 
 /// Insert an Open vault (confirmed collateral + debt, no mint in flight) owned by
 /// `owner`, and seed the chain supply to match its debt so the invariant holds.
-fn insert_open_vault(s: &mut MultiChainState, owner: Principal, vault_id: u64, collateral: u128, debt: u128) {
+fn insert_open_vault(
+    s: &mut MultiChainState,
+    owner: Principal,
+    vault_id: u64,
+    collateral: u128,
+    debt: u128,
+) {
     use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
-    s.chain_vaults.insert(vault_id, ChainVaultV1 {
-        vault_id, owner, collateral_chain: CHAIN, custody_address: "custody".into(),
-        collateral_amount_native: collateral, debt_e8s: debt, mint_recipient: "good-address".into(),
-        pending_mint_e8s: 0, status: ChainVaultStatus::Open, opened_at_ns: 0,
-    last_interest_accrual_ns: 0,
-    pending_interest_mint_e8s: 0,
-    pending_liquidation: None,        owner_evm: Some("0xowner".into()),
-    });
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner,
+            collateral_chain: CHAIN,
+            custody_address: "custody".into(),
+            collateral_amount_native: collateral,
+            debt_e8s: debt,
+            mint_recipient: "good-address".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+            owner_evm: Some("0xowner".into()),
+        },
+    );
     *s.chain_supplies.entry(CHAIN).or_default() += debt;
 }
 
@@ -162,35 +235,107 @@ fn insert_open_vault(s: &mut MultiChainState, owner: Principal, vault_id: u64, c
 fn borrow_open_vault_enqueues_mint_and_reserves_pending() {
     let mut s = setup(PRICE_150_USD_E8);
     // 100 SOL ($15000) collateral, 100 icUSD debt; borrow 50 more → CR fine.
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
-    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    let r = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
     assert_eq!(r, Ok(()));
     let v = s.chain_vaults.get(&7).unwrap();
-    assert_eq!(v.pending_mint_e8s, 50_00000000, "borrow reserves the additional as pending");
-    assert_eq!(v.debt_e8s, 100_00000000, "confirmed debt unchanged until mint observed");
-    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 1, "one Mint op enqueued");
+    assert_eq!(
+        v.pending_mint_e8s, 50_00000000,
+        "borrow reserves the additional as pending"
+    );
+    assert_eq!(
+        v.debt_e8s, 100_00000000,
+        "confirmed debt unchanged until mint observed"
+    );
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).unwrap().pending_len(),
+        1,
+        "one Mint op enqueued"
+    );
 }
 
 #[test]
 fn borrow_then_confirm_preserves_supply_invariant() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
-    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1).unwrap();
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    )
+    .unwrap();
     let pre = s.total_chain_vault_debt_e8s();
     confirm_mint_in_state(&mut s, CHAIN, 7, 50_00000000, pre, 1).expect("confirm");
     let v = s.chain_vaults.get(&7).unwrap();
-    assert_eq!(v.debt_e8s, 150_00000000, "pending moved into confirmed debt");
+    assert_eq!(
+        v.debt_e8s, 150_00000000,
+        "pending moved into confirmed debt"
+    );
     assert_eq!(v.pending_mint_e8s, 0);
-    assert_eq!(s.chain_supplies.get(&CHAIN).copied().unwrap(), 150_00000000, "supply == total debt");
-    assert_eq!(s.chain_supplies.get(&CHAIN).copied().unwrap(), s.total_chain_vault_debt_e8s());
+    assert_eq!(
+        s.chain_supplies.get(&CHAIN).copied().unwrap(),
+        150_00000000,
+        "supply == total debt"
+    );
+    assert_eq!(
+        s.chain_supplies.get(&CHAIN).copied().unwrap(),
+        s.total_chain_vault_debt_e8s()
+    );
 }
 
 #[test]
 fn borrow_rejects_when_mint_in_flight() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
     s.chain_vaults.get_mut(&7).unwrap().pending_mint_e8s = 1; // a mint already pending
-    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1);
+    let r = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
     assert_eq!(r, Err(BorrowError::MintInFlight));
 }
 
@@ -198,10 +343,32 @@ fn borrow_rejects_when_mint_in_flight() {
 fn borrow_rejects_non_open_vault() {
     use super::monad::chain_vault::ChainVaultStatus;
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
     s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::AwaitingDeposit;
-    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1);
-    assert_eq!(r, Err(BorrowError::WrongStatus { status: ChainVaultStatus::AwaitingDeposit }));
+    let r = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
+    assert_eq!(
+        r,
+        Err(BorrowError::WrongStatus {
+            status: ChainVaultStatus::AwaitingDeposit
+        })
+    );
 }
 
 #[test]
@@ -210,17 +377,98 @@ fn borrow_rejects_below_min_cr() {
     // 1 SOL ($150) collateral, 100 icUSD debt (CR 150%); borrow 50 more → new debt
     // 150 icUSD, CR = 150/150 = 100% < 130% → reject.
     insert_open_vault(&mut s, Principal::anonymous(), 7, ONE_SOL, 100_00000000);
-    let r = borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1);
-    assert!(matches!(r, Err(BorrowError::BelowMinCr { .. })), "got {r:?}");
-    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0, "no mutation on reject");
+    let r = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
+    assert!(
+        matches!(r, Err(BorrowError::BelowMinCr { .. })),
+        "got {r:?}"
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().pending_mint_e8s,
+        0,
+        "no mutation on reject"
+    );
 }
 
 #[test]
 fn borrow_rejects_zero_debt_and_bad_recipient() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
-    assert_eq!(borrow_chain_vault_in_state(&mut s, 7, 0, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1), Err(BorrowError::ZeroDebt));
-    assert_eq!(borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "bad".into(), only_good, "SOL", 13_000, 0, None, 1), Err(BorrowError::InvalidAddress("bad".into())));
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    assert_eq!(
+        borrow_chain_vault_in_state(
+            &mut s,
+            7,
+            0,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            0,
+            None,
+            1
+        ),
+        Err(BorrowError::ZeroDebt)
+    );
+    assert_eq!(
+        borrow_chain_vault_in_state(
+            &mut s,
+            7,
+            50_00000000,
+            "bad".into(),
+            only_good,
+            "SOL",
+            13_000,
+            0,
+            None,
+            1
+        ),
+        Err(BorrowError::InvalidAddress("bad".into()))
+    );
+}
+
+#[test]
+fn borrow_rejects_stale_price_when_age_gate_configured() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.manual_price_set_at_ns
+        .insert((CHAIN, "SOL".into()), 1_000);
+    enable_price_age_gate(&mut s, 100);
+    let res = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1_101,
+    );
+    assert_eq!(res, Err(BorrowError::StalePrice));
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0);
 }
 
 // ─── Increment 0: min-debt floor + per-chain debt ceiling ─────────────────────
@@ -230,12 +478,31 @@ fn open_rejects_debt_below_min_vault_debt() {
     let mut s = setup(PRICE_150_USD_E8);
     // 1 SOL ($150) collateral easily clears CR; debt 0.05 icUSD < the 0.1 floor.
     let r = open_chain_vault_in_state(
-        &mut s, CHAIN, Principal::anonymous(), "custody".into(), ONE_SOL,
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        ONE_SOL,
         5_000_000, // 0.05 icUSD
-        "good-address".into(), only_good, "SOL",
-        13_000, /*min_vault_debt*/ 10_000_000, /*ceiling*/ None, 12345, 1,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        /*min_vault_debt*/ 10_000_000,
+        /*ceiling*/ None,
+        12345,
+        1,
     );
-    assert!(matches!(r, Err(OpenVaultError::BelowMinDebt { min_e8s: 10_000_000, .. })), "got {r:?}");
+    assert!(
+        matches!(
+            r,
+            Err(OpenVaultError::BelowMinDebt {
+                min_e8s: 10_000_000,
+                ..
+            })
+        ),
+        "got {r:?}"
+    );
     assert!(s.chain_vaults.is_empty(), "no mutation on rejection");
 }
 
@@ -243,29 +510,66 @@ fn open_rejects_debt_below_min_vault_debt() {
 fn open_rejects_when_over_debt_ceiling() {
     let mut s = setup(PRICE_150_USD_E8);
     // Seed 900 icUSD of existing chain debt, then open another 200 -> 1100 > 1000.
-    insert_open_vault(&mut s, Principal::anonymous(), 1, 100 * ONE_SOL, 900_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        1,
+        100 * ONE_SOL,
+        900_00000000,
+    );
     let r = open_chain_vault_in_state(
-        &mut s, CHAIN, Principal::anonymous(), "custody".into(), 100 * ONE_SOL,
-        200_00000000, "good-address".into(), only_good, "SOL",
-        13_000, 10_000_000, Some(1000_00000000), 12345, 2,
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        200_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        10_000_000,
+        Some(1000_00000000),
+        12345,
+        2,
     );
     assert!(
         matches!(r, Err(OpenVaultError::DebtCeilingExceeded { would_be_e8s, ceiling_e8s })
             if would_be_e8s == 1100_00000000 && ceiling_e8s == 1000_00000000),
         "got {r:?}"
     );
-    assert!(!s.chain_vaults.contains_key(&2), "no vault created over the ceiling");
+    assert!(
+        !s.chain_vaults.contains_key(&2),
+        "no vault created over the ceiling"
+    );
 }
 
 #[test]
 fn open_allows_debt_exactly_at_ceiling() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 1, 100 * ONE_SOL, 800_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        1,
+        100 * ONE_SOL,
+        800_00000000,
+    );
     // 800 + 200 == 1000 == ceiling -> allowed (only strictly over rejects).
     let r = open_chain_vault_in_state(
-        &mut s, CHAIN, Principal::anonymous(), "custody".into(), 100 * ONE_SOL,
-        200_00000000, "good-address".into(), only_good, "SOL",
-        13_000, 10_000_000, Some(1000_00000000), 12345, 2,
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        200_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        10_000_000,
+        Some(1000_00000000),
+        12345,
+        2,
     );
     assert_eq!(r, Ok(()), "open at exactly the ceiling is allowed");
 }
@@ -274,16 +578,34 @@ fn open_allows_debt_exactly_at_ceiling() {
 fn borrow_rejects_when_over_debt_ceiling() {
     let mut s = setup(PRICE_150_USD_E8);
     // Vault 7 holds 900 icUSD; borrowing 200 more pushes the chain total to 1100 > 1000.
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 1000 * ONE_SOL, 900_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        1000 * ONE_SOL,
+        900_00000000,
+    );
     let r = borrow_chain_vault_in_state(
-        &mut s, 7, 200_00000000, "good-address".into(), only_good, "SOL",
-        13_000, 10_000_000, Some(1000_00000000), 1,
+        &mut s,
+        7,
+        200_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        10_000_000,
+        Some(1000_00000000),
+        1,
     );
     assert!(
         matches!(r, Err(BorrowError::DebtCeilingExceeded { ceiling_e8s, .. }) if ceiling_e8s == 1000_00000000),
         "got {r:?}"
     );
-    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0, "no mutation on reject");
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().pending_mint_e8s,
+        0,
+        "no mutation on reject"
+    );
 }
 
 #[test]
@@ -293,8 +615,16 @@ fn nonce_consume_is_monotonic_and_rejects_replay() {
     assert_eq!(s.expected_evm_nonce(&owner), 0);
     assert_eq!(s.consume_evm_nonce(&owner, 0), Ok(()));
     assert_eq!(s.expected_evm_nonce(&owner), 1);
-    assert_eq!(s.consume_evm_nonce(&owner, 0), Err(1), "replay of nonce 0 rejected");
-    assert_eq!(s.consume_evm_nonce(&owner, 5), Err(1), "out-of-order rejected");
+    assert_eq!(
+        s.consume_evm_nonce(&owner, 0),
+        Err(1),
+        "replay of nonce 0 rejected"
+    );
+    assert_eq!(
+        s.consume_evm_nonce(&owner, 5),
+        Err(1),
+        "out-of-order rejected"
+    );
     assert_eq!(s.consume_evm_nonce(&owner, 1), Ok(()));
     // A different owner has an independent sequence.
     let other = Principal::from_slice(&[6, 6, 6]);
@@ -311,7 +641,7 @@ fn per_owner_cap_counts_non_terminal_only() {
     s.chain_vaults.get_mut(&2).unwrap().status = ChainVaultStatus::AwaitingDeposit;
     insert_open_vault(&mut s, owner, 3, 0, 0);
     s.chain_vaults.get_mut(&3).unwrap().status = ChainVaultStatus::Closed; // terminal, not counted
-    // A different owner's vault is not counted.
+                                                                           // A different owner's vault is not counted.
     insert_open_vault(&mut s, Principal::anonymous(), 4, 0, 0);
     assert_eq!(s.count_owner_active_vaults(&owner), 2);
 }
@@ -327,27 +657,50 @@ fn gc_prunes_only_stale_awaiting_deposit() {
     // and the GC is allowed to reap stale unfunded vaults on it (finding F).
     let mut s = setup(PRICE_150_USD_E8);
     let mk = |id: u64, st: ChainVaultStatus, opened: u64| ChainVaultV1 {
-        vault_id: id, owner: Principal::anonymous(), collateral_chain: CHAIN,
-        custody_address: "c".into(), collateral_amount_native: 0, debt_e8s: 0,
-        mint_recipient: "r".into(), pending_mint_e8s: 0, status: st, opened_at_ns: opened,
-    last_interest_accrual_ns: 0,
-    pending_interest_mint_e8s: 0,
-    pending_liquidation: None,        owner_evm: None,
+        vault_id: id,
+        owner: Principal::anonymous(),
+        collateral_chain: CHAIN,
+        custody_address: "c".into(),
+        collateral_amount_native: 0,
+        debt_e8s: 0,
+        mint_recipient: "r".into(),
+        pending_mint_e8s: 0,
+        status: st,
+        opened_at_ns: opened,
+        last_interest_accrual_ns: 0,
+        pending_interest_mint_e8s: 0,
+        pending_liquidation: None,
+        owner_evm: None,
     };
     let now = 100 * AWAITING_DEPOSIT_TTL_NS;
     // 1: stale AwaitingDeposit (older than TTL) -> pruned.
-    s.chain_vaults.insert(1, mk(1, ChainVaultStatus::AwaitingDeposit, now - AWAITING_DEPOSIT_TTL_NS - 1));
+    s.chain_vaults.insert(
+        1,
+        mk(
+            1,
+            ChainVaultStatus::AwaitingDeposit,
+            now - AWAITING_DEPOSIT_TTL_NS - 1,
+        ),
+    );
     // 2: young AwaitingDeposit (within TTL) -> kept.
-    s.chain_vaults.insert(2, mk(2, ChainVaultStatus::AwaitingDeposit, now - 1));
+    s.chain_vaults
+        .insert(2, mk(2, ChainVaultStatus::AwaitingDeposit, now - 1));
     // 3: old Open vault -> kept (only AwaitingDeposit is GC'd; a funded vault is safe).
     s.chain_vaults.insert(3, mk(3, ChainVaultStatus::Open, 0));
     // 4: old MintPending -> kept (a mint is in flight; not unfunded).
-    s.chain_vaults.insert(4, mk(4, ChainVaultStatus::MintPending, 0));
+    s.chain_vaults
+        .insert(4, mk(4, ChainVaultStatus::MintPending, 0));
 
     let pruned = prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS);
     assert_eq!(pruned, 1);
-    assert!(!s.chain_vaults.contains_key(&1), "stale AwaitingDeposit pruned");
-    assert!(s.chain_vaults.contains_key(&2), "young AwaitingDeposit kept");
+    assert!(
+        !s.chain_vaults.contains_key(&1),
+        "stale AwaitingDeposit pruned"
+    );
+    assert!(
+        s.chain_vaults.contains_key(&2),
+        "young AwaitingDeposit kept"
+    );
     assert!(s.chain_vaults.contains_key(&3), "Open kept");
     assert!(s.chain_vaults.contains_key(&4), "MintPending kept");
 }
@@ -357,26 +710,45 @@ fn gc_skips_stale_vaults_when_observer_inactive() {
     use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
     let now = 100 * AWAITING_DEPOSIT_TTL_NS;
     let stale = |id: u64| ChainVaultV1 {
-        vault_id: id, owner: Principal::anonymous(), collateral_chain: CHAIN,
-        custody_address: "c".into(), collateral_amount_native: 0, debt_e8s: 0,
-        mint_recipient: "r".into(), pending_mint_e8s: 0,
+        vault_id: id,
+        owner: Principal::anonymous(),
+        collateral_chain: CHAIN,
+        custody_address: "c".into(),
+        collateral_amount_native: 0,
+        debt_e8s: 0,
+        mint_recipient: "r".into(),
+        pending_mint_e8s: 0,
         status: ChainVaultStatus::AwaitingDeposit,
-        opened_at_ns: now - AWAITING_DEPOSIT_TTL_NS - 1, owner_evm: None,
+        opened_at_ns: now - AWAITING_DEPOSIT_TTL_NS - 1,
+        owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    };
+        pending_liquidation: None,
+    };
     // (a) Chain not registered at all -> no observer -> not reaped (would strand
     //     a funded-but-unobserved deposit).
     let mut s = MultiChainState::default();
     s.chain_vaults.insert(1, stale(1));
-    assert_eq!(prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS), 0);
-    assert!(s.chain_vaults.contains_key(&1), "unregistered-chain vault kept");
+    assert_eq!(
+        prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS),
+        0
+    );
+    assert!(
+        s.chain_vaults.contains_key(&1),
+        "unregistered-chain vault kept"
+    );
     // (b) Chain registered but reorg-halted -> observer halted -> not reaped.
     let mut s = setup(PRICE_150_USD_E8);
     s.reorg_halted.insert(CHAIN, true);
     s.chain_vaults.insert(1, stale(1));
-    assert_eq!(prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS), 0);
-    assert!(s.chain_vaults.contains_key(&1), "reorg-halted-chain vault kept");
+    assert_eq!(
+        prune_stale_awaiting_deposit(&mut s, now, AWAITING_DEPOSIT_TTL_NS),
+        0
+    );
+    assert!(
+        s.chain_vaults.contains_key(&1),
+        "reorg-halted-chain vault kept"
+    );
 }
 
 // ─── M2 review finding A: collateral release blocked while a borrow mint pends ─
@@ -387,16 +759,50 @@ use super::vault::{close_chain_vault_in_state, withdraw_collateral_in_state, Wit
 fn withdraw_and_close_reject_while_borrow_mint_in_flight() {
     let mut s = setup(PRICE_150_USD_E8);
     // Open vault, 100 SOL collateral, debt 100e8; borrow 50 more (pending=50e8).
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
-    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1).unwrap();
-    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 50_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    )
+    .unwrap();
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().pending_mint_e8s,
+        50_00000000
+    );
     // Withdraw must reject — releasing collateral now would undercollateralize
     // once the borrow mint confirms (debt would jump 100e8 -> 150e8).
     assert_eq!(
-        withdraw_collateral_in_state(&mut s, 7, 1, "good-address".into(), only_good, "SOL", 13_000, 2),
+        withdraw_collateral_in_state(
+            &mut s,
+            7,
+            1,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            2
+        ),
         Err(WithdrawError::MintInFlight)
     );
-    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 1, "no withdraw enqueued");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).unwrap().pending_len(),
+        1,
+        "no withdraw enqueued"
+    );
 }
 
 #[test]
@@ -404,10 +810,30 @@ fn close_rejects_while_borrow_mint_in_flight_even_if_debt_zero() {
     let mut s = setup(PRICE_150_USD_E8);
     // A repaid (debt 0) but still-Open vault that borrows: debt stays 0, pending=50e8.
     insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 0);
-    borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 1).unwrap();
+    borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    )
+    .unwrap();
     // Close (debt==0) must NOT release collateral while the borrow mint pends.
     assert_eq!(
-        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        close_chain_vault_in_state(
+            &mut s,
+            7,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            2
+        ),
         Err(WithdrawError::MintInFlight)
     );
     assert_eq!(
@@ -415,6 +841,37 @@ fn close_rejects_while_borrow_mint_in_flight_even_if_debt_zero() {
         super::monad::chain_vault::ChainVaultStatus::Open,
         "vault not closed"
     );
+}
+
+#[test]
+fn withdraw_rejects_stale_price_when_age_gate_configured() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.manual_price_set_at_ns
+        .insert((CHAIN, "SOL".into()), 1_000);
+    enable_price_age_gate(&mut s, 100);
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        ONE_SOL,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        1_101,
+    );
+    assert_eq!(res, Err(WithdrawError::StalePrice));
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().collateral_amount_native,
+        100 * ONE_SOL
+    );
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0);
 }
 
 // ─── Increment 1 / Task 2: pending_liquidation marker write-guards (spec 3.1) ───
@@ -435,13 +892,28 @@ fn liq_marker() -> PendingLiquidationV1 {
 #[test]
 fn withdraw_rejected_while_liquidation_in_flight() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
     // A liquidation is mid-flight: the vault's collateral is reserved/handed to a
     // tier. An owner withdraw (even a tiny, CR-safe 1-lamport one) must be rejected
     // so the collateral cannot be double-spent against an in-flight swap/burn.
     s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
     assert_eq!(
-        withdraw_collateral_in_state(&mut s, 7, 1, "good-address".into(), only_good, "SOL", 13_000, 2),
+        withdraw_collateral_in_state(
+            &mut s,
+            7,
+            1,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            2
+        ),
         Err(WithdrawError::LiquidationInFlight)
     );
     assert_eq!(
@@ -449,20 +921,49 @@ fn withdraw_rejected_while_liquidation_in_flight() {
         100 * ONE_SOL,
         "collateral untouched on rejection"
     );
-    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0, "no withdraw enqueued");
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).unwrap().pending_len(),
+        0,
+        "no withdraw enqueued"
+    );
 }
 
 #[test]
 fn borrow_rejected_while_liquidation_in_flight() {
     let mut s = setup(PRICE_150_USD_E8);
-    insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 100_00000000);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
     s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
     assert_eq!(
-        borrow_chain_vault_in_state(&mut s, 7, 50_00000000, "good-address".into(), only_good, "SOL", 13_000, 0, None, 2),
+        borrow_chain_vault_in_state(
+            &mut s,
+            7,
+            50_00000000,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            0,
+            None,
+            2
+        ),
         Err(BorrowError::LiquidationInFlight)
     );
-    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0, "no borrow reserved on rejection");
-    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0, "no mint enqueued");
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().pending_mint_e8s,
+        0,
+        "no borrow reserved on rejection"
+    );
+    assert_eq!(
+        s.settlement_queues.get(&CHAIN).unwrap().pending_len(),
+        0,
+        "no mint enqueued"
+    );
 }
 
 #[test]
@@ -473,7 +974,15 @@ fn close_rejected_while_liquidation_in_flight_via_withdraw_delegate() {
     insert_open_vault(&mut s, Principal::anonymous(), 7, 100 * ONE_SOL, 0);
     s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
     assert_eq!(
-        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        close_chain_vault_in_state(
+            &mut s,
+            7,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            2
+        ),
         Err(WithdrawError::LiquidationInFlight)
     );
     assert_eq!(
@@ -492,7 +1001,15 @@ fn close_rejected_while_liquidation_in_flight_degenerate_zero_collateral() {
     insert_open_vault(&mut s, Principal::anonymous(), 7, 0, 0);
     s.chain_vaults.get_mut(&7).unwrap().pending_liquidation = Some(liq_marker());
     assert_eq!(
-        close_chain_vault_in_state(&mut s, 7, "good-address".into(), only_good, "SOL", 13_000, 2),
+        close_chain_vault_in_state(
+            &mut s,
+            7,
+            "good-address".into(),
+            only_good,
+            "SOL",
+            13_000,
+            2
+        ),
         Err(WithdrawError::LiquidationInFlight)
     );
     assert_eq!(
@@ -504,13 +1021,13 @@ fn close_rejected_while_liquidation_in_flight_degenerate_zero_collateral() {
 
 // ─── Increment 2 / Task 6: begin_liquidation_in_state (spec §4.9 Phase 1) ───
 mod begin_liquidation_tests {
-    use super::super::vault::{begin_liquidation_in_state, LiquidationError, LiquidationTier};
     use super::super::config::ChainId;
     use super::super::liquidation::{bonus_e4_from_penalty_bps, value_cap_to_repay};
     use super::super::liquidation_config::{ChainLiquidationConfigV1, DexKind};
     use super::super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
     use super::super::multi_chain_state::MultiChainState;
     use super::super::settlement_queue::SettlementOpKind;
+    use super::super::vault::{begin_liquidation_in_state, LiquidationError, LiquidationTier};
     use candid::Principal;
 
     const CFX: ChainId = ChainId(71);
@@ -546,10 +1063,16 @@ mod begin_liquidation_tests {
 
     fn set_price(s: &mut MultiChainState, price_e8: u64, set_at_ns: u64) {
         s.manual_prices.insert((CFX, "CFX".into()), price_e8);
-        s.manual_price_set_at_ns.insert((CFX, "CFX".into()), set_at_ns);
+        s.manual_price_set_at_ns
+            .insert((CFX, "CFX".into()), set_at_ns);
     }
 
-    fn insert_vault(s: &mut MultiChainState, vault_id: u64, collateral_native: u128, debt_e8s: u128) {
+    fn insert_vault(
+        s: &mut MultiChainState,
+        vault_id: u64,
+        collateral_native: u128,
+        debt_e8s: u128,
+    ) {
         s.chain_vaults.insert(
             vault_id,
             ChainVaultV1 {
@@ -592,16 +1115,29 @@ mod begin_liquidation_tests {
         let m = v.pending_liquidation.as_ref().expect("marker set");
         assert_eq!(m.tier, LiquidationTier::Bot);
         assert_eq!(m.op_id, op_id);
-        assert!(m.collateral_reserved_native > 0 && m.collateral_reserved_native <= 1_400 * ONE_CFX);
-        assert!(v.collateral_amount_native < 1_400 * ONE_CFX, "collateral reserved (decremented)");
+        assert!(
+            m.collateral_reserved_native > 0 && m.collateral_reserved_native <= 1_400 * ONE_CFX
+        );
+        assert!(
+            v.collateral_amount_native < 1_400 * ONE_CFX,
+            "collateral reserved (decremented)"
+        );
         assert_eq!(
             v.collateral_amount_native + m.collateral_reserved_native,
             1_400 * ONE_CFX,
             "reserved + remaining == original"
         );
         assert_eq!(v.debt_e8s, 100 * E8, "debt UNCHANGED at trigger (Design B)");
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply UNCHANGED");
-        assert_eq!(s.bot_pending_chain_vaults.get(&7), Some(&2_000), "bot routing timestamp recorded");
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "supply UNCHANGED"
+        );
+        assert_eq!(
+            s.bot_pending_chain_vaults.get(&7),
+            Some(&2_000),
+            "bot routing timestamp recorded"
+        );
         let q = s.settlement_queues.get(&CFX).unwrap();
         assert!(q
             .pending
@@ -620,9 +1156,18 @@ mod begin_liquidation_tests {
             begin_liquidation_in_state(&mut s, 7, addr_ok, "CFX", 13_300, 2_000),
             Err(LiquidationError::NotLiquidatable { .. })
         ));
-        assert!(s.chain_vaults.get(&7).unwrap().pending_liquidation.is_none(), "no marker on reject");
         assert!(
-            s.settlement_queues.get(&CFX).map_or(true, |q| q.pending.is_empty()),
+            s.chain_vaults
+                .get(&7)
+                .unwrap()
+                .pending_liquidation
+                .is_none(),
+            "no marker on reject"
+        );
+        assert!(
+            s.settlement_queues
+                .get(&CFX)
+                .map_or(true, |q| q.pending.is_empty()),
             "no op on reject"
         );
     }
@@ -636,8 +1181,16 @@ mod begin_liquidation_tests {
             begin_liquidation_in_state(&mut s, 7, addr_ok, "CFX", 13_300, now),
             Err(LiquidationError::StalePrice)
         ));
-        assert!(s.chain_vaults.get(&7).unwrap().pending_liquidation.is_none());
-        assert!(s.settlement_queues.get(&CFX).map_or(true, |q| q.pending.is_empty()));
+        assert!(s
+            .chain_vaults
+            .get(&7)
+            .unwrap()
+            .pending_liquidation
+            .is_none());
+        assert!(s
+            .settlement_queues
+            .get(&CFX)
+            .map_or(true, |q| q.pending.is_empty()));
     }
 
     #[test]
@@ -688,7 +1241,10 @@ mod begin_liquidation_tests {
             Err(LiquidationError::MintInFlight)
         ));
         s.chain_vaults.get_mut(&7).unwrap().pending_mint_e8s = 0;
-        s.chain_vaults.get_mut(&7).unwrap().pending_interest_mint_e8s = 1;
+        s.chain_vaults
+            .get_mut(&7)
+            .unwrap()
+            .pending_interest_mint_e8s = 1;
         assert!(matches!(
             begin_liquidation_in_state(&mut s, 7, addr_ok, "CFX", 13_300, 2_000),
             Err(LiquidationError::InterestRealizationPending)
@@ -699,11 +1255,18 @@ mod begin_liquidation_tests {
     fn depth_cap_sizes_partial_of_partial() {
         let mut s = base_state(true);
         set_price(&mut s, 8_000_000, 1_000); // $0.08
-        // Tiny depth cap so the sized repay exceeds it -> effective_repay == cap.
+                                             // Tiny depth cap so the sized repay exceeds it -> effective_repay == cap.
         seed_cfg(&mut s, true, 50 * E8);
         insert_vault(&mut s, 7, 5_600 * ONE_CFX, 400 * E8); // big underwater vault
         begin_liquidation_in_state(&mut s, 7, addr_ok, "CFX", 13_300, 2_000).unwrap();
-        let m = s.chain_vaults.get(&7).unwrap().pending_liquidation.as_ref().unwrap().clone();
+        let m = s
+            .chain_vaults
+            .get(&7)
+            .unwrap()
+            .pending_liquidation
+            .as_ref()
+            .unwrap()
+            .clone();
         let cap_repay = value_cap_to_repay(50 * E8, bonus_e4_from_penalty_bps(1_200));
         assert!(m.debt_to_clear_e8s <= cap_repay, "sized down to depth cap");
         assert!(m.debt_to_clear_e8s < 400 * E8, "well under full debt");
@@ -719,7 +1282,15 @@ mod begin_liquidation_tests {
             begin_liquidation_in_state(&mut s, 7, addr_ok, "CFX", 13_300, 2_000),
             Err(LiquidationError::InvalidAddress(_))
         ));
-        assert!(s.chain_vaults.get(&7).unwrap().pending_liquidation.is_none());
-        assert!(s.settlement_queues.get(&CFX).map_or(true, |q| q.pending.is_empty()));
+        assert!(s
+            .chain_vaults
+            .get(&7)
+            .unwrap()
+            .pending_liquidation
+            .is_none());
+        assert!(s
+            .settlement_queues
+            .get(&CFX)
+            .map_or(true, |q| q.pending.is_empty()));
     }
 }

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -154,6 +154,12 @@ pub enum OpenVaultError {
     /// No manual native-asset price is set for the chain
     /// (`manual_prices[(chain, price_symbol)]`).
     NoPrice,
+    /// A staleness-gated price has no freshness timestamp.
+    NoPriceTimestamp,
+    /// A staleness-gated price is older than the configured max age.
+    StalePrice,
+    /// A staleness-gated price is zero.
+    ZeroPrice,
     /// Declared collateral ratio is below the minimum.
     BelowMinCr { cr_e4: u64, min_e4: u64 },
     /// Declared debt is zero. A zero-debt vault has nothing to mint; allowing it
@@ -174,7 +180,10 @@ pub enum OpenVaultError {
     BelowMinDebt { debt_e8s: u128, min_e8s: u128 },
     /// The open would push the chain's total outstanding+in-flight debt over the
     /// configured `debt_ceiling_e8s`.
-    DebtCeilingExceeded { would_be_e8s: u128, ceiling_e8s: u128 },
+    DebtCeilingExceeded {
+        would_be_e8s: u128,
+        ceiling_e8s: u128,
+    },
 }
 
 /// Reasons `withdraw_collateral_in_state` / `close_chain_vault_in_state` can
@@ -186,6 +195,12 @@ pub enum WithdrawError {
     /// No manual native-asset price is set for the chain
     /// (`manual_prices[(chain, price_symbol)]`).
     NoPrice,
+    /// A staleness-gated price has no freshness timestamp.
+    NoPriceTimestamp,
+    /// A staleness-gated price is older than the configured max age.
+    StalePrice,
+    /// A staleness-gated price is zero.
+    ZeroPrice,
     /// Requested amount exceeds the vault's `collateral_amount_native`.
     InsufficientCollateral,
     /// The post-withdrawal collateral ratio would fall below `min_cr_e4`.
@@ -233,7 +248,9 @@ pub enum WithdrawError {
 pub enum LiquidationError {
     UnknownVault,
     /// Vault status is not `Open` (only an Open vault has confirmed collateral+debt).
-    WrongStatus { status: ChainVaultStatus },
+    WrongStatus {
+        status: ChainVaultStatus,
+    },
     /// A borrow mint is in flight; liquidating now could leave debt unbacked once
     /// it confirms (spec §4.4). Exclude.
     MintInFlight,
@@ -256,7 +273,10 @@ pub enum LiquidationError {
     /// The manual price is older than the config's `max_price_age_ns` (spec §4.3).
     StalePrice,
     /// CR is at or above the liquidation threshold (not liquidatable).
-    NotLiquidatable { cr_e4: u64, threshold_e4: u64 },
+    NotLiquidatable {
+        cr_e4: u64,
+        threshold_e4: u64,
+    },
     /// The sized repay or its grossed-up collateral rounded to zero (nothing
     /// economical to seize at the current price/depth cap).
     NothingToLiquidate,
@@ -292,13 +312,79 @@ pub fn collateral_ratio_e4(
     // Dividing by the native scale drops the base-unit scale and leaves a USD
     // value in e8. Saturating so a colossal collateral input cannot overflow.
     let native_scale = 10u128.saturating_pow(native_decimals as u32);
-    let collateral_usd_e8 = collateral_native
-        .saturating_mul(price_e8 as u128)
-        / native_scale;
+    let collateral_usd_e8 = collateral_native.saturating_mul(price_e8 as u128) / native_scale;
     // cr_e4 = collateral_usd_e8 / debt_e8s * 10_000. Multiply first (saturating)
     // then divide so we keep e4 precision; both are e8 so the e8 scales cancel.
     let cr = collateral_usd_e8.saturating_mul(10_000) / debt_e8s;
     cr.min(u64::MAX as u128) as u64
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum VaultPriceError {
+    NoPrice,
+    NoTimestamp,
+    Stale,
+    ZeroPrice,
+}
+
+fn gated_chain_price_e8(
+    state: &MultiChainState,
+    chain: ChainId,
+    price_symbol: &str,
+    now_ns: u64,
+) -> Result<u64, VaultPriceError> {
+    let max_age = state
+        .chain_liquidation_configs
+        .get(&chain)
+        .map(|c| c.max_price_age_ns)
+        .unwrap_or(0);
+    if max_age > 0 {
+        return crate::chains::liquidation::fresh_chain_price_e8(
+            state,
+            chain,
+            price_symbol,
+            now_ns,
+            max_age,
+        )
+        .map_err(|e| match e {
+            crate::chains::liquidation::PriceError::NoPrice => VaultPriceError::NoPrice,
+            crate::chains::liquidation::PriceError::ZeroPrice => VaultPriceError::ZeroPrice,
+            crate::chains::liquidation::PriceError::NoTimestamp => VaultPriceError::NoTimestamp,
+            crate::chains::liquidation::PriceError::Stale => VaultPriceError::Stale,
+        });
+    }
+    state
+        .manual_prices
+        .get(&(chain, price_symbol.to_string()))
+        .copied()
+        .ok_or(VaultPriceError::NoPrice)
+}
+
+fn map_open_price_error(e: VaultPriceError) -> OpenVaultError {
+    match e {
+        VaultPriceError::NoPrice => OpenVaultError::NoPrice,
+        VaultPriceError::NoTimestamp => OpenVaultError::NoPriceTimestamp,
+        VaultPriceError::Stale => OpenVaultError::StalePrice,
+        VaultPriceError::ZeroPrice => OpenVaultError::ZeroPrice,
+    }
+}
+
+fn map_withdraw_price_error(e: VaultPriceError) -> WithdrawError {
+    match e {
+        VaultPriceError::NoPrice => WithdrawError::NoPrice,
+        VaultPriceError::NoTimestamp => WithdrawError::NoPriceTimestamp,
+        VaultPriceError::Stale => WithdrawError::StalePrice,
+        VaultPriceError::ZeroPrice => WithdrawError::ZeroPrice,
+    }
+}
+
+fn map_borrow_price_error(e: VaultPriceError) -> BorrowError {
+    match e {
+        VaultPriceError::NoPrice => BorrowError::NoPrice,
+        VaultPriceError::NoTimestamp => BorrowError::NoPriceTimestamp,
+        VaultPriceError::Stale => BorrowError::StalePrice,
+        VaultPriceError::ZeroPrice => BorrowError::ZeroPrice,
+    }
 }
 
 /// Sum of confirmed debt + intended/in-flight mints for all non-Closed vaults on
@@ -380,10 +466,8 @@ pub fn open_chain_vault_in_state(
         return Err(OpenVaultError::InvalidAddress(mint_recipient));
     }
     // Native-asset price (USD e8) for the declared-collateral CR check.
-    let price_e8 = *state
-        .manual_prices
-        .get(&(chain, price_symbol.to_string()))
-        .ok_or(OpenVaultError::NoPrice)?;
+    let price_e8 =
+        gated_chain_price_e8(state, chain, price_symbol, now_ns).map_err(map_open_price_error)?;
     // Native-asset decimals for the chain (18 for MON; falls back to 18 if the
     // config is somehow absent, though `chain` was verified registered above).
     let native_decimals = state
@@ -394,11 +478,17 @@ pub fn open_chain_vault_in_state(
 
     let cr_e4 = collateral_ratio_e4(collateral_e18, native_decimals, price_e8, debt_e8s);
     if cr_e4 < min_cr_e4 {
-        return Err(OpenVaultError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+        return Err(OpenVaultError::BelowMinCr {
+            cr_e4,
+            min_e4: min_cr_e4,
+        });
     }
     // Min-debt floor: a vault too small is uneconomical to liquidate.
     if debt_e8s < min_vault_debt_e8s {
-        return Err(OpenVaultError::BelowMinDebt { debt_e8s, min_e8s: min_vault_debt_e8s });
+        return Err(OpenVaultError::BelowMinDebt {
+            debt_e8s,
+            min_e8s: min_vault_debt_e8s,
+        });
     }
     // Per-chain debt ceiling: the new vault's intended debt is added (as
     // pending_mint) to the chain's outstanding+in-flight total; reject if that
@@ -436,7 +526,8 @@ pub fn open_chain_vault_in_state(
             // stamped to `now` at mint-confirm (Task 7). Open-time = 0 (debt 0).
             last_interest_accrual_ns: 0,
             pending_interest_mint_e8s: 0,
-            pending_liquidation: None,        },
+            pending_liquidation: None,
+        },
     );
     // No mint enqueued - that happens in verify_deposit_and_enqueue_mint_in_state.
     Ok(())
@@ -492,7 +583,11 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
     // Enqueue FIRST (it can fail on a duplicate idempotency key). The key is
     // per (chain, vault) so a retried tick cannot double-enqueue.
     let op = SettlementOp::new(
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id },
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s,
+            vault_id,
+        },
         format!("mint-{}-{}", chain.0, vault_id),
         now_ns,
     );
@@ -589,7 +684,9 @@ pub fn withdraw_collateral_in_state(
         // mutating anything. (close_chain_vault_in_state delegates here, so it
         // inherits this gate after its own debt==0 check.)
         if v.status != ChainVaultStatus::Open {
-            return Err(WithdrawError::WrongStatus { status: v.status.clone() });
+            return Err(WithdrawError::WrongStatus {
+                status: v.status.clone(),
+            });
         }
         // A borrow mint in flight means the CR check below would run against the
         // stale confirmed debt (pending borrow not yet folded in); releasing
@@ -616,14 +713,17 @@ pub fn withdraw_collateral_in_state(
             return Err(WithdrawError::InsufficientCollateral);
         }
         let remaining = v.collateral_amount_native - amount_e18;
-        (v.collateral_chain, remaining, v.debt_e8s, v.last_interest_accrual_ns)
+        (
+            v.collateral_chain,
+            remaining,
+            v.debt_e8s,
+            v.last_interest_accrual_ns,
+        )
     };
 
     // Price is needed for the post-withdrawal CR check (only when debt remains).
-    let price_e8 = *state
-        .manual_prices
-        .get(&(chain, price_symbol.to_string()))
-        .ok_or(WithdrawError::NoPrice)?;
+    let price_e8 = gated_chain_price_e8(state, chain, price_symbol, now_ns)
+        .map_err(map_withdraw_price_error)?;
     let native_decimals = state
         .chain_configs
         .get(&chain)
@@ -648,7 +748,10 @@ pub fn withdraw_collateral_in_state(
         let effective_debt = debt_e8s.saturating_add(accrued);
         let cr_e4 = collateral_ratio_e4(remaining, native_decimals, price_e8, effective_debt);
         if cr_e4 < min_cr_e4 {
-            return Err(WithdrawError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+            return Err(WithdrawError::BelowMinCr {
+                cr_e4,
+                min_e4: min_cr_e4,
+            });
         }
     }
 
@@ -809,7 +912,9 @@ pub fn begin_liquidation_in_state(
             .get(&vault_id)
             .ok_or(LiquidationError::UnknownVault)?;
         if v.status != ChainVaultStatus::Open {
-            return Err(LiquidationError::WrongStatus { status: v.status.clone() });
+            return Err(LiquidationError::WrongStatus {
+                status: v.status.clone(),
+            });
         }
         if v.pending_mint_e8s != 0 {
             return Err(LiquidationError::MintInFlight);
@@ -832,18 +937,21 @@ pub fn begin_liquidation_in_state(
         }
 
         // Fresh, fail-closed price (spec §4.3).
-        let price_e8 = liq::fresh_chain_price_e8(state, chain, price_symbol, now_ns, cfg.max_price_age_ns)
-            .map_err(|e| match e {
-                liq::PriceError::NoPrice => LiquidationError::NoPrice,
-                liq::PriceError::ZeroPrice => LiquidationError::ZeroPrice,
-                liq::PriceError::NoTimestamp => LiquidationError::NoTimestamp,
-                liq::PriceError::Stale => LiquidationError::StalePrice,
-            })?;
+        let price_e8 =
+            liq::fresh_chain_price_e8(state, chain, price_symbol, now_ns, cfg.max_price_age_ns)
+                .map_err(|e| match e {
+                    liq::PriceError::NoPrice => LiquidationError::NoPrice,
+                    liq::PriceError::ZeroPrice => LiquidationError::ZeroPrice,
+                    liq::PriceError::NoTimestamp => LiquidationError::NoTimestamp,
+                    liq::PriceError::Stale => LiquidationError::StalePrice,
+                })?;
 
         let cc = crate::chains::collateral_config::chain_collateral_config(chain);
         let apr_bps = cc.map(|c| c.interest_apr_bps).unwrap_or(0);
         let penalty_bps = cc.map(|c| c.liquidation_penalty_bps).unwrap_or(0);
-        let target_cr_e4 = cc.map(|c| c.recovery_target_cr_e4).unwrap_or(cfg.restore_target_cr_e4);
+        let target_cr_e4 = cc
+            .map(|c| c.recovery_target_cr_e4)
+            .unwrap_or(cfg.restore_target_cr_e4);
         let native_decimals = state
             .chain_configs
             .get(&chain)
@@ -857,7 +965,12 @@ pub fn begin_liquidation_in_state(
             apr_bps,
             now_ns.saturating_sub(v.last_interest_accrual_ns),
         );
-        let cr_e4 = collateral_ratio_e4(v.collateral_amount_native, native_decimals, price_e8, eff_debt);
+        let cr_e4 = collateral_ratio_e4(
+            v.collateral_amount_native,
+            native_decimals,
+            price_e8,
+            eff_debt,
+        );
         if cr_e4 >= liquidation_threshold_e4 {
             return Err(LiquidationError::NotLiquidatable {
                 cr_e4,
@@ -867,12 +980,18 @@ pub fn begin_liquidation_in_state(
 
         // Size: restore to target, clamp to the ADVISORY depth cap (spec §4.6/§4.7).
         let bonus_e4 = liq::bonus_e4_from_penalty_bps(penalty_bps);
-        let coll_value = liq::collateral_value_e8s(v.collateral_amount_native, native_decimals, price_e8);
+        let coll_value =
+            liq::collateral_value_e8s(v.collateral_amount_native, native_decimals, price_e8);
         let sized = liq::sized_repay_e8s(eff_debt, coll_value, target_cr_e4, bonus_e4);
         let value_cap = liq::value_cap_to_repay(cfg.max_swap_value_e8s, bonus_e4);
         let effective_repay = sized.min(value_cap);
-        let collateral_in = liq::collateral_in_native_for_repay(effective_repay, bonus_e4, native_decimals, price_e8)
-            .min(v.collateral_amount_native);
+        let collateral_in = liq::collateral_in_native_for_repay(
+            effective_repay,
+            bonus_e4,
+            native_decimals,
+            price_e8,
+        )
+        .min(v.collateral_amount_native);
         if effective_repay == 0 || collateral_in == 0 {
             return Err(LiquidationError::NothingToLiquidate);
         }
@@ -881,7 +1000,11 @@ pub fn begin_liquidation_in_state(
         // in Increment 3). The reserve recipient is the settle-stable sink for now;
         // a dedicated tECDSA reserve address + config field land with the swap (Inc 3).
         let reserve_recipient = cfg.settle_stable_token.clone();
-        for a in [cfg.router.as_str(), cfg.pair.as_str(), reserve_recipient.as_str()] {
+        for a in [
+            cfg.router.as_str(),
+            cfg.pair.as_str(),
+            reserve_recipient.as_str(),
+        ] {
             if !address_validator(a) {
                 return Err(LiquidationError::InvalidAddress(a.to_string()));
             }
@@ -893,7 +1016,10 @@ pub fn begin_liquidation_in_state(
             debt_to_clear_e8s: effective_repay,
             router: cfg.router.clone(),
             pair: cfg.pair.clone(),
-            path: vec![cfg.collateral_token.clone(), cfg.settle_stable_token.clone()],
+            path: vec![
+                cfg.collateral_token.clone(),
+                cfg.settle_stable_token.clone(),
+            ],
             reserve_recipient,
             deadline_secs: 180,
         };
@@ -939,19 +1065,33 @@ pub const MAX_VAULTS_PER_OWNER: usize = 25;
 pub enum BorrowError {
     UnknownVault,
     /// Vault is not `Open` (only an Open vault has confirmed collateral + debt).
-    WrongStatus { status: ChainVaultStatus },
+    WrongStatus {
+        status: ChainVaultStatus,
+    },
     /// A mint is already in flight for this vault (`pending_mint_e8s != 0`).
     MintInFlight,
     ZeroDebt,
     NoPrice,
-    BelowMinCr { cr_e4: u64, min_e4: u64 },
+    NoPriceTimestamp,
+    StalePrice,
+    ZeroPrice,
+    BelowMinCr {
+        cr_e4: u64,
+        min_e4: u64,
+    },
     QueueError(String),
     InvalidAddress(String),
     /// Post-borrow debt is below the chain's `min_vault_debt_e8s` floor.
-    BelowMinDebt { debt_e8s: u128, min_e8s: u128 },
+    BelowMinDebt {
+        debt_e8s: u128,
+        min_e8s: u128,
+    },
     /// The borrow would push the chain's total outstanding+in-flight debt over
     /// the configured `debt_ceiling_e8s`.
-    DebtCeilingExceeded { would_be_e8s: u128, ceiling_e8s: u128 },
+    DebtCeilingExceeded {
+        would_be_e8s: u128,
+        ceiling_e8s: u128,
+    },
     /// A liquidation is in flight for this vault (`pending_liquidation.is_some()`).
     /// Borrowing more against collateral that is reserved/handed to a liquidation
     /// tier could leave the post-confirm vault under-collateralized. Reject until
@@ -993,11 +1133,16 @@ pub fn borrow_chain_vault_in_state(
     }
     // Step 1: read-only validation — no mutation on any rejection path.
     let (chain, collateral, new_debt) = {
-        let v = state.chain_vaults.get(&vault_id).ok_or(BorrowError::UnknownVault)?;
+        let v = state
+            .chain_vaults
+            .get(&vault_id)
+            .ok_or(BorrowError::UnknownVault)?;
         // Only an Open vault has confirmed, on-chain-deposited collateral AND
         // confirmed debt to borrow against.
         if v.status != ChainVaultStatus::Open {
-            return Err(BorrowError::WrongStatus { status: v.status.clone() });
+            return Err(BorrowError::WrongStatus {
+                status: v.status.clone(),
+            });
         }
         // No stacked borrows: a non-zero pending means a mint is already in flight
         // for this vault, and the settlement queue is sequential per chain.
@@ -1016,10 +1161,8 @@ pub fn borrow_chain_vault_in_state(
             v.debt_e8s.saturating_add(additional_e8s),
         )
     };
-    let price_e8 = *state
-        .manual_prices
-        .get(&(chain, price_symbol.to_string()))
-        .ok_or(BorrowError::NoPrice)?;
+    let price_e8 =
+        gated_chain_price_e8(state, chain, price_symbol, now_ns).map_err(map_borrow_price_error)?;
     let native_decimals = state
         .chain_configs
         .get(&chain)
@@ -1027,10 +1170,16 @@ pub fn borrow_chain_vault_in_state(
         .unwrap_or(18);
     let cr_e4 = collateral_ratio_e4(collateral, native_decimals, price_e8, new_debt);
     if cr_e4 < min_cr_e4 {
-        return Err(BorrowError::BelowMinCr { cr_e4, min_e4: min_cr_e4 });
+        return Err(BorrowError::BelowMinCr {
+            cr_e4,
+            min_e4: min_cr_e4,
+        });
     }
     if new_debt < min_vault_debt_e8s {
-        return Err(BorrowError::BelowMinDebt { debt_e8s: new_debt, min_e8s: min_vault_debt_e8s });
+        return Err(BorrowError::BelowMinDebt {
+            debt_e8s: new_debt,
+            min_e8s: min_vault_debt_e8s,
+        });
     }
     // Debt ceiling: this borrow adds exactly `additional_e8s` to the chain's
     // outstanding+in-flight total (the vault's pending_mint was 0, checked above,
@@ -1048,7 +1197,11 @@ pub fn borrow_chain_vault_in_state(
     // Step 2: enqueue FIRST (can fail on a duplicate key). The `now_ns` suffix
     // keeps this key distinct from the genesis open mint (`mint-{chain}-{vault}`).
     let op = SettlementOp::new(
-        SettlementOpKind::Mint { recipient, amount_e8s: additional_e8s, vault_id },
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s: additional_e8s,
+            vault_id,
+        },
         format!("mint-{}-{}-{}", chain.0, vault_id, now_ns),
         now_ns,
     );
@@ -1059,7 +1212,10 @@ pub fn borrow_chain_vault_in_state(
         .enqueue(op)
         .map_err(|e| BorrowError::QueueError(format!("{e:?}")))?;
     // Step 3: only after a successful enqueue — reserve the borrow as pending.
-    let v = state.chain_vaults.get_mut(&vault_id).expect("vault present: checked above");
+    let v = state
+        .chain_vaults
+        .get_mut(&vault_id)
+        .expect("vault present: checked above");
     v.pending_mint_e8s = additional_e8s;
     Ok(())
 }
@@ -1096,9 +1252,16 @@ pub fn prune_stale_awaiting_deposit(
         .iter()
         .filter(|(_, v)| {
             let observer_active = matches!(
-                state.chain_configs.get(&v.collateral_chain).map(|c| c.status),
+                state
+                    .chain_configs
+                    .get(&v.collateral_chain)
+                    .map(|c| c.status),
                 Some(ChainStatus::Registered)
-            ) && !state.reorg_halted.get(&v.collateral_chain).copied().unwrap_or(false);
+            ) && !state
+                .reorg_halted
+                .get(&v.collateral_chain)
+                .copied()
+                .unwrap_or(false);
             observer_active
                 && v.status == ChainVaultStatus::AwaitingDeposit
                 && now_ns.saturating_sub(v.opened_at_ns) > ttl_ns

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -1,11 +1,13 @@
-use crate::numeric::{Ratio, UsdIcp, ICUSD, ICP};
-use crate::state::{CollateralConfig, CollateralStatus, CollateralType, PendingMarginTransfer, RateCurveV2, State};
+use crate::numeric::{Ratio, UsdIcp, ICP, ICUSD};
+use crate::state::{
+    CollateralConfig, CollateralStatus, CollateralType, PendingMarginTransfer, RateCurveV2, State,
+};
 use crate::storage::record_event;
 use crate::vault::Vault;
 use crate::{EventTimeRange, EventTypeFilter, InitArg, Mode, StableTokenType, UpgradeArg};
 use candid::{CandidType, Principal};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -301,14 +303,10 @@ pub enum Event {
     },
 
     #[serde(rename = "set_ckstable_repay_fee")]
-    SetCkstableRepayFee {
-        rate: String,
-    },
+    SetCkstableRepayFee { rate: String },
 
     #[serde(rename = "set_min_icusd_amount")]
-    SetMinIcusdAmount {
-        amount: String,
-    },
+    SetMinIcusdAmount { amount: String },
 
     /// Admin set global icUSD mint cap.
     /// Field `cap` is a legacy alias kept for replay compat.
@@ -333,19 +331,13 @@ pub enum Event {
     },
 
     #[serde(rename = "set_treasury_principal")]
-    SetTreasuryPrincipal {
-        principal: Principal,
-    },
+    SetTreasuryPrincipal { principal: Principal },
 
     #[serde(rename = "set_stability_pool_principal")]
-    SetStabilityPoolPrincipal {
-        principal: Principal,
-    },
+    SetStabilityPoolPrincipal { principal: Principal },
 
     #[serde(rename = "set_liquidation_bot_principal")]
-    SetLiquidationBotPrincipal {
-        principal: Principal,
-    },
+    SetLiquidationBotPrincipal { principal: Principal },
 
     #[serde(rename = "set_bot_budget")]
     SetBotBudget {
@@ -354,14 +346,10 @@ pub enum Event {
     },
 
     #[serde(rename = "set_bot_allowed_collateral_types")]
-    SetBotAllowedCollateralTypes {
-        collateral_types: Vec<Principal>,
-    },
+    SetBotAllowedCollateralTypes { collateral_types: Vec<Principal> },
 
     #[serde(rename = "set_bot_cr_tolerance_bps")]
-    SetBotCrToleranceBps {
-        bps: u64,
-    },
+    SetBotCrToleranceBps { bps: u64 },
 
     /// Wave-14a CDP-14 follow-up: per-collateral override for the XRC
     /// source-count floor (None = inherit global). Emitted when an admin
@@ -375,45 +363,34 @@ pub enum Event {
     },
 
     #[serde(rename = "set_liquidation_bonus")]
-    SetLiquidationBonus {
-        rate: String,
-    },
+    SetLiquidationBonus { rate: String },
 
     #[serde(rename = "set_borrowing_fee")]
-    SetBorrowingFee {
-        rate: String,
-    },
+    SetBorrowingFee { rate: String },
 
     #[serde(rename = "set_redemption_fee_floor")]
-    SetRedemptionFeeFloor {
-        rate: String,
-    },
+    SetRedemptionFeeFloor { rate: String },
 
     #[serde(rename = "set_redemption_fee_ceiling")]
-    SetRedemptionFeeCeiling {
-        rate: String,
-    },
+    SetRedemptionFeeCeiling { rate: String },
 
     #[serde(rename = "set_max_partial_liquidation_ratio")]
-    SetMaxPartialLiquidationRatio {
-        rate: String,
-    },
+    SetMaxPartialLiquidationRatio { rate: String },
 
     #[serde(rename = "set_recovery_target_cr")]
-    SetRecoveryTargetCr {
-        rate: String,
-    },
+    SetRecoveryTargetCr { rate: String },
 
-    #[serde(rename = "set_recovery_cr_multiplier", alias = "set_recovery_liquidation_buffer")]
+    #[serde(
+        rename = "set_recovery_cr_multiplier",
+        alias = "set_recovery_liquidation_buffer"
+    )]
     SetRecoveryCrMultiplier {
         #[serde(alias = "buffer")]
         multiplier: String,
     },
 
     #[serde(rename = "set_liquidation_protocol_share")]
-    SetLiquidationProtocolShare {
-        share: String,
-    },
+    SetLiquidationProtocolShare { share: String },
 
     #[serde(rename = "add_collateral_type")]
     AddCollateralType {
@@ -434,19 +411,13 @@ pub enum Event {
     },
 
     #[serde(rename = "set_reserve_redemptions_enabled")]
-    SetReserveRedemptionsEnabled {
-        enabled: bool,
-    },
+    SetReserveRedemptionsEnabled { enabled: bool },
 
     #[serde(rename = "set_icpswap_routing_enabled")]
-    SetIcpswapRoutingEnabled {
-        enabled: bool,
-    },
+    SetIcpswapRoutingEnabled { enabled: bool },
 
     #[serde(rename = "set_reserve_redemption_fee")]
-    SetReserveRedemptionFee {
-        fee: String,
-    },
+    SetReserveRedemptionFee { fee: String },
 
     #[serde(rename = "reserve_redemption")]
     ReserveRedemption {
@@ -488,14 +459,14 @@ pub enum Event {
     /// Admin set rate curve markers (per-asset or global)
     #[serde(rename = "set_rate_curve_markers")]
     SetRateCurveMarkers {
-        collateral_type: Option<String>,  // None for global
-        markers: String,                  // JSON-serialized marker pairs
+        collateral_type: Option<String>, // None for global
+        markers: String,                 // JSON-serialized marker pairs
     },
 
     /// Admin set recovery rate curve (system-wide Layer 2)
     #[serde(rename = "set_recovery_rate_curve")]
     SetRecoveryRateCurve {
-        markers: String,  // JSON-serialized (threshold, multiplier) pairs
+        markers: String, // JSON-serialized (threshold, multiplier) pairs
     },
 
     /// Admin set healthy CR for a collateral type
@@ -528,15 +499,11 @@ pub enum Event {
     /// Per-vault interest accrual tick. One event per timer tick.
     /// On replay, calls accrue_all_vault_interest(timestamp).
     #[serde(rename = "accrue_interest")]
-    AccrueInterest {
-        timestamp: u64,
-    },
+    AccrueInterest { timestamp: u64 },
 
     /// Admin set the interest revenue split ratio (stability pool share).
     #[serde(rename = "set_interest_pool_share")]
-    SetInterestPoolShare {
-        share: String,
-    },
+    SetInterestPoolShare { share: String },
 
     /// Admin set an RMR parameter.
     #[serde(rename = "set_rmr_floor")]
@@ -558,12 +525,9 @@ pub enum Event {
     },
 
     // (Legacy duplicates removed — merged into primary definitions above)
-
     /// Admin set the dynamic borrowing fee curve.
     #[serde(rename = "set_borrowing_fee_curve")]
-    SetBorrowingFeeCurve {
-        markers: String,
-    },
+    SetBorrowingFeeCurve { markers: String },
 
     /// Admin set the N-way interest split (replaces interest_pool_share).
     #[serde(rename = "set_interest_split")]
@@ -574,24 +538,18 @@ pub enum Event {
 
     /// Admin set the 3pool canister principal for interest donations.
     #[serde(rename = "set_three_pool_canister")]
-    SetThreePoolCanister {
-        canister: Principal,
-    },
+    SetThreePoolCanister { canister: Principal },
 
     /// Admin set the AMM1 canister principal for interest donations.
     #[serde(rename = "set_amm1_canister")]
-    SetAmm1Canister {
-        canister: Principal,
-    },
+    SetAmm1Canister { canister: Principal },
 
     /// Admin set the canonical AMM1 pool_id used by `donate_icusd_to_amm1`.
     /// Must match `make_pool_id(token_a, token_b)` on rumi_amm exactly,
     /// otherwise `notify_reward_received` returns PoolNotFound and donations
     /// re-queue indefinitely.
     #[serde(rename = "set_amm1_pool_id")]
-    SetAmm1PoolId {
-        pool_id: String,
-    },
+    SetAmm1PoolId { pool_id: String },
 
     /// Price update from XRC or other oracle. Recorded every time a collateral
     /// price is fetched so we have a complete price history.
@@ -681,18 +639,12 @@ pub enum Event {
     /// Wave-8e LIQ-005: admin tunes the per-fee fraction routed to deficit
     /// repayment. Default 0.5; bounded [0, 1].
     #[serde(rename = "set_deficit_repayment_fraction")]
-    SetDeficitRepaymentFraction {
-        fraction: Ratio,
-        timestamp: u64,
-    },
+    SetDeficitRepaymentFraction { fraction: Ratio, timestamp: u64 },
 
     /// Wave-8e LIQ-005: admin sets the deficit-driven ReadOnly auto-latch
     /// threshold. 0 disables the latch.
     #[serde(rename = "set_deficit_readonly_threshold_e8s")]
-    SetDeficitReadonlyThresholdE8s {
-        threshold_e8s: u64,
-        timestamp: u64,
-    },
+    SetDeficitReadonlyThresholdE8s { threshold_e8s: u64, timestamp: u64 },
 
     /// Wave-10 LIQ-008: circuit breaker auto-tripped because the rolling-
     /// window cumulative liquidation debt crossed the configured ceiling.
@@ -717,18 +669,12 @@ pub enum Event {
 
     /// Wave-10 LIQ-008: admin tuned the rolling-window length.
     #[serde(rename = "set_breaker_window_ns")]
-    SetBreakerWindowNs {
-        window_ns: u64,
-        timestamp: u64,
-    },
+    SetBreakerWindowNs { window_ns: u64, timestamp: u64 },
 
     /// Wave-10 LIQ-008: admin tuned the cumulative-debt ceiling. 0 disables
     /// the breaker.
     #[serde(rename = "set_breaker_window_debt_ceiling_e8s")]
-    SetBreakerWindowDebtCeilingE8s {
-        ceiling_e8s: u64,
-        timestamp: u64,
-    },
+    SetBreakerWindowDebtCeilingE8s { ceiling_e8s: u64, timestamp: u64 },
 
     /// Wave-11 BOT-001: `check_vaults` detected an expired `bot_claims` entry
     /// whose collateral was not returned (`icrc1_balance_of` < required).
@@ -923,6 +869,24 @@ pub enum Event {
         usdc_native: u128,
         timestamp: u64,
     },
+    /// Increment 5: the operator verified the foreign-chain burn for SP-absorbed
+    /// debt and settled `pending_chain_burn_e8s -> chain_supplies`.
+    #[serde(rename = "chain_pending_burn_settled")]
+    ChainPendingBurnSettled {
+        chain_id: crate::chains::config::ChainId,
+        amount_e8s: u128,
+        proof: String,
+        timestamp: u64,
+    },
+    /// Increment 5: the operator verified the reserve-backed foreign icUSD burn
+    /// after the slow bridge leg and settled `reserve_backing_e8s -> chain_supplies`.
+    #[serde(rename = "chain_reserve_burn_settled")]
+    ChainReserveBurnSettled {
+        chain_id: crate::chains::config::ChainId,
+        amount_e8s: u128,
+        proof: String,
+        timestamp: u64,
+    },
     /// Increment 4+: an SP depositor's CFX claim was settled (paid to their EVM
     /// address) for a chain-vault liquidation. Claim-scoped, not vault-scoped.
     #[serde(rename = "chain_cfx_claim_settled")]
@@ -1074,13 +1038,18 @@ impl Event {
             | Event::ChainReorgDetected { .. }
             // Increment 1: an SP CFX claim is claim-scoped, not vault-scoped.
             | Event::ChainCfxClaimSettled { .. }
+            | Event::ChainPendingBurnSettled { .. }
+            | Event::ChainReserveBurnSettled { .. }
             | Event::ChainHotWalletLow { .. } => false,
         }
     }
 
     /// Returns true if this is a noisy periodic event (hidden from explorer).
     pub fn is_accrue_interest(&self) -> bool {
-        matches!(self, Event::AccrueInterest { .. } | Event::PriceUpdate { .. })
+        matches!(
+            self,
+            Event::AccrueInterest { .. } | Event::PriceUpdate { .. }
+        )
     }
 
     /// Coarse type classification for the explorer's `types` facet.
@@ -1189,8 +1158,12 @@ impl Event {
             Event::SetCollateralLiquidationBonus { .. } => Some("SetCollateralLiquidationBonus"),
             Event::SetCollateralMinVaultDebt { .. } => Some("SetCollateralMinVaultDebt"),
             Event::SetCollateralLedgerFee { .. } => Some("SetCollateralLedgerFee"),
-            Event::SetCollateralRedemptionFeeFloor { .. } => Some("SetCollateralRedemptionFeeFloor"),
-            Event::SetCollateralRedemptionFeeCeiling { .. } => Some("SetCollateralRedemptionFeeCeiling"),
+            Event::SetCollateralRedemptionFeeFloor { .. } => {
+                Some("SetCollateralRedemptionFeeFloor")
+            }
+            Event::SetCollateralRedemptionFeeCeiling { .. } => {
+                Some("SetCollateralRedemptionFeeCeiling")
+            }
             Event::SetCollateralMinDeposit { .. } => Some("SetCollateralMinDeposit"),
             Event::SetCollateralDisplayColor { .. } => Some("SetCollateralDisplayColor"),
             Event::SetDeficitRepaymentFraction { .. } => Some("SetDeficitRepaymentFraction"),
@@ -1252,7 +1225,9 @@ impl Event {
             Event::VaultWithdrawnAndClosed { timestamp, .. } => Some(*timestamp),
             Event::PriceUpdate { timestamp, .. } => Some(*timestamp),
             Event::AccrueInterest { timestamp } => Some(*timestamp),
-            Event::SetBotBudget { start_timestamp, .. } => Some(*start_timestamp),
+            Event::SetBotBudget {
+                start_timestamp, ..
+            } => Some(*start_timestamp),
             // Wave-10 LIQ-008: surface breaker events in time-range queries so
             // operators can audit "every trip in the last 24h" and admin sets.
             Event::BreakerTripped { timestamp, .. } => Some(*timestamp),
@@ -1277,25 +1252,64 @@ impl Event {
     pub fn collateral_token(&self, vault_lookup: &HashMap<u64, Principal>) -> Option<Principal> {
         match self {
             Event::OpenVault { vault, .. } => Some(vault.collateral_type),
-            Event::AddCollateralType { collateral_type, .. }
-            | Event::UpdateCollateralStatus { collateral_type, .. }
-            | Event::UpdateCollateralConfig { collateral_type, .. }
-            | Event::SetCollateralBorrowingFee { collateral_type, .. }
-            | Event::SetInterestRate { collateral_type, .. }
-            | Event::SetRecoveryParameters { collateral_type, .. }
-            | Event::SetCollateralLiquidationRatio { collateral_type, .. }
-            | Event::SetCollateralBorrowThreshold { collateral_type, .. }
-            | Event::SetCollateralLiquidationBonus { collateral_type, .. }
-            | Event::SetCollateralMinVaultDebt { collateral_type, .. }
-            | Event::SetCollateralLedgerFee { collateral_type, .. }
-            | Event::SetCollateralRedemptionFeeFloor { collateral_type, .. }
-            | Event::SetCollateralRedemptionFeeCeiling { collateral_type, .. }
-            | Event::SetCollateralMinDeposit { collateral_type, .. }
-            | Event::SetCollateralDisplayColor { collateral_type, .. }
-            | Event::SetCollateralMinXrcSources { collateral_type, .. }
-            | Event::PriceUpdate { collateral_type, .. } => Some(*collateral_type),
-            Event::RedemptionOnVaults { collateral_type, .. } => *collateral_type,
-            Event::ReserveRedemption { stable_token_ledger, .. } => Some(*stable_token_ledger),
+            Event::AddCollateralType {
+                collateral_type, ..
+            }
+            | Event::UpdateCollateralStatus {
+                collateral_type, ..
+            }
+            | Event::UpdateCollateralConfig {
+                collateral_type, ..
+            }
+            | Event::SetCollateralBorrowingFee {
+                collateral_type, ..
+            }
+            | Event::SetInterestRate {
+                collateral_type, ..
+            }
+            | Event::SetRecoveryParameters {
+                collateral_type, ..
+            }
+            | Event::SetCollateralLiquidationRatio {
+                collateral_type, ..
+            }
+            | Event::SetCollateralBorrowThreshold {
+                collateral_type, ..
+            }
+            | Event::SetCollateralLiquidationBonus {
+                collateral_type, ..
+            }
+            | Event::SetCollateralMinVaultDebt {
+                collateral_type, ..
+            }
+            | Event::SetCollateralLedgerFee {
+                collateral_type, ..
+            }
+            | Event::SetCollateralRedemptionFeeFloor {
+                collateral_type, ..
+            }
+            | Event::SetCollateralRedemptionFeeCeiling {
+                collateral_type, ..
+            }
+            | Event::SetCollateralMinDeposit {
+                collateral_type, ..
+            }
+            | Event::SetCollateralDisplayColor {
+                collateral_type, ..
+            }
+            | Event::SetCollateralMinXrcSources {
+                collateral_type, ..
+            }
+            | Event::PriceUpdate {
+                collateral_type, ..
+            } => Some(*collateral_type),
+            Event::RedemptionOnVaults {
+                collateral_type, ..
+            } => *collateral_type,
+            Event::ReserveRedemption {
+                stable_token_ledger,
+                ..
+            } => Some(*stable_token_ledger),
             Event::CloseVault { vault_id, .. }
             | Event::MarginTransfer { vault_id, .. }
             | Event::LiquidateVault { vault_id, .. }
@@ -1327,7 +1341,9 @@ impl Event {
             ((native_amount as u128) * (icp_price_e8s as u128) / 100_000_000u128) as u64
         };
         match self {
-            Event::BorrowFromVault { borrowed_amount, .. } => Some(borrowed_amount.0),
+            Event::BorrowFromVault {
+                borrowed_amount, ..
+            } => Some(borrowed_amount.0),
             Event::RepayToVault { repayed_amount, .. } => Some(repayed_amount.0),
             Event::RedemptionOnVaults { icusd_amount, .. } => Some(icusd_amount.0),
             Event::ReserveRedemption { icusd_amount, .. } => Some(icusd_amount.0),
@@ -1335,7 +1351,9 @@ impl Event {
             Event::DustForgiven { amount, .. } => Some(amount.0),
             Event::ProvideLiquidity { amount, .. } => Some(amount.0),
             Event::WithdrawLiquidity { amount, .. } => Some(amount.0),
-            Event::PartialLiquidateVault { liquidator_payment, .. } => Some(liquidator_payment.0),
+            Event::PartialLiquidateVault {
+                liquidator_payment, ..
+            } => Some(liquidator_payment.0),
             Event::OpenVault { vault, .. } => Some(convert(vault.collateral_amount)),
             Event::AddMarginToVault { margin_added, .. } => Some(convert(margin_added.0)),
             Event::CollateralWithdrawn { amount, .. } => Some(convert(amount.0)),
@@ -2101,6 +2119,8 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             | Event::ChainVaultLiquidated { .. }
             | Event::ChainReserveCredited { .. }
             | Event::ChainCfxClaimSettled { .. }
+            | Event::ChainPendingBurnSettled { .. }
+            | Event::ChainReserveBurnSettled { .. }
             | Event::ChainLiquidationDeferred { .. }
             | Event::ChainHotWalletLow { .. } => {},
         }
@@ -2110,9 +2130,16 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
 }
 
 /// Helper: current canister time in nanoseconds.
-fn now() -> u64 { ic_cdk::api::time() }
+fn now() -> u64 {
+    ic_cdk::api::time()
+}
 
-pub fn record_liquidate_vault(state: &mut State, vault_id: u64, mode: Mode, collateral_price: UsdIcp) {
+pub fn record_liquidate_vault(
+    state: &mut State,
+    vault_id: u64,
+    mode: Mode,
+    collateral_price: UsdIcp,
+) {
     record_event(&Event::LiquidateVault {
         vault_id,
         mode,
@@ -2124,7 +2151,10 @@ pub fn record_liquidate_vault(state: &mut State, vault_id: u64, mode: Mode, coll
 }
 
 pub fn record_redistribute_vault(state: &mut State, vault_id: u64) {
-    record_event(&Event::RedistributeVault { vault_id, timestamp: Some(now()) });
+    record_event(&Event::RedistributeVault {
+        vault_id,
+        timestamp: Some(now()),
+    });
     state.redistribute_vault(vault_id);
 }
 
@@ -2191,7 +2221,12 @@ pub fn record_close_vault(state: &mut State, vault_id: u64, block_index: Option<
     state.close_vault(vault_id);
 }
 
-pub fn record_margin_transfer(state: &mut State, vault_id: u64, owner: Principal, block_index: u64) {
+pub fn record_margin_transfer(
+    state: &mut State,
+    vault_id: u64,
+    owner: Principal,
+    block_index: u64,
+) {
     record_event(&Event::MarginTransfer {
         vault_id,
         block_index,
@@ -2275,8 +2310,7 @@ pub fn record_set_deficit_readonly_threshold_e8s(state: &mut State, threshold_e8
 /// already tripped — vault.rs sites can call this unconditionally.
 pub fn record_liquidation_for_breaker(state: &mut State, debt_e8s: u64) {
     let now_ns = now();
-    let just_tripped =
-        crate::state::record_recent_liquidation(state, debt_e8s, now_ns);
+    let just_tripped = crate::state::record_recent_liquidation(state, debt_e8s, now_ns);
     if just_tripped {
         let total = state.windowed_liquidation_total(now_ns);
         let ceiling = state.breaker_window_debt_ceiling_e8s;
@@ -2430,7 +2464,8 @@ pub fn record_redemption_on_vaults(
     // Use the selected collateral type's price for both water-filling and
     // pending transfer amount calculation. The caller's collateral_price
     // parameter may be for a different collateral type.
-    let ct_price = state.get_collateral_config(&redeem_ct)
+    let ct_price = state
+        .get_collateral_config(&redeem_ct)
         .and_then(|c| c.last_price)
         .and_then(rust_decimal::Decimal::from_f64_retain)
         .map(UsdIcp::from)
@@ -2441,9 +2476,11 @@ pub fn record_redemption_on_vaults(
     // walked. `redeem_on_vaults` mutates state but doesn't touch
     // `collateral_configs`, so reading after is also safe — we read
     // here to keep the data flow explicit.
-    let (price_decimal, decimals) = state.get_collateral_config(&redeem_ct)
+    let (price_decimal, decimals) = state
+        .get_collateral_config(&redeem_ct)
         .map(|c| {
-            let p = c.last_price
+            let p = c
+                .last_price
                 .and_then(rust_decimal::Decimal::from_f64_retain)
                 .unwrap_or(ct_price.0);
             (p, c.decimals)
@@ -2459,7 +2496,11 @@ pub fn record_redemption_on_vaults(
         icusd_block_index,
         collateral_type: Some(redeem_ct),
         timestamp: Some(now()),
-        vault_redemptions: if vault_redemptions.is_empty() { None } else { Some(vault_redemptions.clone()) },
+        vault_redemptions: if vault_redemptions.is_empty() {
+            None
+        } else {
+            Some(vault_redemptions.clone())
+        },
     });
 
     // RED-001 (audit 2026-06-09): the payout is derived from the icUSD the
@@ -2472,7 +2513,10 @@ pub fn record_redemption_on_vaults(
     // genuine bad debt; the unconsumed remainder is not a deficit once it is
     // refunded.
     let consumed = ICUSD::from(
-        vault_redemptions.iter().map(|v| v.icusd_redeemed_e8s).sum::<u64>(),
+        vault_redemptions
+            .iter()
+            .map(|v| v.icusd_redeemed_e8s)
+            .sum::<u64>(),
     );
 
     // Wave-9 RED-002: route any redemption-side shortfall into the
@@ -2492,9 +2536,16 @@ pub fn record_redemption_on_vaults(
     let margin: ICP = consumed / ct_price;
     if margin.to_u64() > 0 {
         let op_nonce = state.next_op_nonce();
-        state
-            .pending_redemption_transfer
-            .insert(icusd_block_index, PendingMarginTransfer { owner, margin, collateral_type: redeem_ct, retry_count: 0, op_nonce });
+        state.pending_redemption_transfer.insert(
+            icusd_block_index,
+            PendingMarginTransfer {
+                owner,
+                margin,
+                collateral_type: redeem_ct,
+                retry_count: 0,
+                op_nonce,
+            },
+        );
     }
     RedemptionOutcome { consumed, margin }
 }
@@ -2521,8 +2572,7 @@ pub fn compute_redemption_shortfall(
     price_decimal: rust_decimal::Decimal,
     decimals: u8,
 ) -> ICUSD {
-    let total_collateral_seized: u64 =
-        vault_redemptions.iter().map(|v| v.collateral_seized).sum();
+    let total_collateral_seized: u64 = vault_redemptions.iter().map(|v| v.collateral_seized).sum();
     let value_seized_at_oracle =
         crate::numeric::collateral_usd_value(total_collateral_seized, price_decimal, decimals);
     target_icusd.saturating_sub(value_seized_at_oracle)
@@ -2546,12 +2596,8 @@ pub fn accrue_redemption_shortfall_at(
     decimals: u8,
     timestamp: u64,
 ) -> ICUSD {
-    let shortfall = compute_redemption_shortfall(
-        target_icusd,
-        vault_redemptions,
-        price_decimal,
-        decimals,
-    );
+    let shortfall =
+        compute_redemption_shortfall(target_icusd, vault_redemptions, price_decimal, decimals);
     if shortfall.0 > 0 {
         record_deficit_accrued(
             state,
@@ -2620,7 +2666,7 @@ pub fn record_withdraw_and_close_vault(
     state: &mut State,
     vault_id: u64,
     amount: ICP,
-    block_index: Option<u64>
+    block_index: Option<u64>,
 ) {
     record_event(&Event::WithdrawAndCloseVault {
         vault_id,
@@ -2656,7 +2702,11 @@ pub fn record_set_global_icusd_mint_cap(state: &mut State, amount: u64) {
     state.global_icusd_mint_cap = amount;
 }
 
-pub fn record_set_stable_token_enabled(state: &mut State, token_type: StableTokenType, enabled: bool) {
+pub fn record_set_stable_token_enabled(
+    state: &mut State,
+    token_type: StableTokenType,
+    enabled: bool,
+) {
     record_event(&Event::SetStableTokenEnabled {
         token_type: token_type.clone(),
         enabled,
@@ -2667,7 +2717,11 @@ pub fn record_set_stable_token_enabled(state: &mut State, token_type: StableToke
     }
 }
 
-pub fn record_set_stable_ledger_principal(state: &mut State, token_type: StableTokenType, principal: Principal) {
+pub fn record_set_stable_ledger_principal(
+    state: &mut State,
+    token_type: StableTokenType,
+    principal: Principal,
+) {
     record_event(&Event::SetStableLedgerPrincipal {
         token_type: token_type.clone(),
         principal,
@@ -2694,14 +2748,22 @@ pub fn record_set_liquidation_bot_principal(state: &mut State, principal: Princi
 }
 
 pub fn record_set_bot_budget(state: &mut State, total_e8s: u64, start_timestamp: u64) {
-    record_event(&Event::SetBotBudget { total_e8s, start_timestamp });
+    record_event(&Event::SetBotBudget {
+        total_e8s,
+        start_timestamp,
+    });
     state.bot_budget_total_e8s = total_e8s;
     state.bot_budget_remaining_e8s = total_e8s;
     state.bot_budget_start_timestamp = start_timestamp;
 }
 
-pub fn record_set_bot_allowed_collateral_types(state: &mut State, collateral_types: Vec<Principal>) {
-    record_event(&Event::SetBotAllowedCollateralTypes { collateral_types: collateral_types.clone() });
+pub fn record_set_bot_allowed_collateral_types(
+    state: &mut State,
+    collateral_types: Vec<Principal>,
+) {
+    record_event(&Event::SetBotAllowedCollateralTypes {
+        collateral_types: collateral_types.clone(),
+    });
     state.bot_allowed_collateral_types = collateral_types.into_iter().collect();
 }
 
@@ -2798,22 +2860,30 @@ pub fn record_set_interest_pool_share(state: &mut State, share: Ratio) {
 }
 
 pub fn record_set_rmr_floor(state: &mut State, value: Ratio) {
-    record_event(&Event::SetRmrFloor { value: value.0.to_string() });
+    record_event(&Event::SetRmrFloor {
+        value: value.0.to_string(),
+    });
     state.rmr_floor = value;
 }
 
 pub fn record_set_rmr_ceiling(state: &mut State, value: Ratio) {
-    record_event(&Event::SetRmrCeiling { value: value.0.to_string() });
+    record_event(&Event::SetRmrCeiling {
+        value: value.0.to_string(),
+    });
     state.rmr_ceiling = value;
 }
 
 pub fn record_set_rmr_floor_cr(state: &mut State, value: Ratio) {
-    record_event(&Event::SetRmrFloorCr { value: value.0.to_string() });
+    record_event(&Event::SetRmrFloorCr {
+        value: value.0.to_string(),
+    });
     state.rmr_floor_cr = value;
 }
 
 pub fn record_set_rmr_ceiling_cr(state: &mut State, value: Ratio) {
-    record_event(&Event::SetRmrCeilingCr { value: value.0.to_string() });
+    record_event(&Event::SetRmrCeilingCr {
+        value: value.0.to_string(),
+    });
     state.rmr_ceiling_cr = value;
 }
 
@@ -2893,12 +2963,7 @@ pub fn record_reserve_redemption(
     });
 }
 
-pub fn record_admin_mint(
-    amount: ICUSD,
-    to: Principal,
-    reason: String,
-    block_index: u64,
-) {
+pub fn record_admin_mint(amount: ICUSD, to: Principal, reason: String, block_index: u64) {
     record_event(&Event::AdminMint {
         amount,
         to,
@@ -2962,8 +3027,9 @@ pub fn record_set_rate_curve_markers(
     collateral_type: Option<CollateralType>,
     markers: Vec<(f64, f64)>,
 ) {
-    use crate::state::{RateMarker, RateCurve, InterpolationMethod};
-    let serialized: Vec<(String, String)> = markers.iter()
+    use crate::state::{InterpolationMethod, RateCurve, RateMarker};
+    let serialized: Vec<(String, String)> = markers
+        .iter()
         .map(|(cr, mult)| (cr.to_string(), mult.to_string()))
         .collect();
     let markers_json = serde_json::to_string(&serialized).unwrap_or_default();
@@ -2971,15 +3037,21 @@ pub fn record_set_rate_curve_markers(
         collateral_type: collateral_type.map(|ct| ct.to_text()),
         markers: markers_json,
     });
-    let parsed: Vec<RateMarker> = markers.iter()
+    let parsed: Vec<RateMarker> = markers
+        .iter()
         .map(|(cr, mult)| RateMarker {
             cr_level: Ratio::from_f64(*cr),
             multiplier: Ratio::from_f64(*mult),
         })
         .collect();
-    let curve = RateCurve { markers: parsed, method: InterpolationMethod::Linear };
+    let curve = RateCurve {
+        markers: parsed,
+        method: InterpolationMethod::Linear,
+    };
     match collateral_type {
-        None => { state.global_rate_curve = curve; },
+        None => {
+            state.global_rate_curve = curve;
+        }
         Some(ct) => {
             if let Some(config) = state.collateral_configs.get_mut(&ct) {
                 config.rate_curve = Some(curve);
@@ -2993,7 +3065,8 @@ pub fn record_set_recovery_rate_curve(
     markers: Vec<(crate::state::SystemThreshold, f64)>,
 ) {
     use crate::state::{RecoveryRateMarker, SystemThreshold};
-    let serialized: Vec<(String, String)> = markers.iter()
+    let serialized: Vec<(String, String)> = markers
+        .iter()
         .map(|(thresh, mult)| {
             let thresh_str = match thresh {
                 SystemThreshold::LiquidationRatio => "LiquidationRatio",
@@ -3009,7 +3082,8 @@ pub fn record_set_recovery_rate_curve(
     record_event(&Event::SetRecoveryRateCurve {
         markers: markers_json,
     });
-    state.recovery_rate_curve = markers.iter()
+    state.recovery_rate_curve = markers
+        .iter()
         .map(|(thresh, mult)| RecoveryRateMarker {
             threshold: thresh.clone(),
             multiplier: Ratio::from_f64(*mult),
@@ -3017,10 +3091,7 @@ pub fn record_set_recovery_rate_curve(
         .collect();
 }
 
-pub fn record_set_borrowing_fee_curve(
-    state: &mut State,
-    curve: Option<RateCurveV2>,
-) {
+pub fn record_set_borrowing_fee_curve(state: &mut State, curve: Option<RateCurveV2>) {
     let markers_json = match &curve {
         Some(c) => serde_json::to_string(&c).unwrap_or_default(),
         None => "null".to_string(),
@@ -3062,7 +3133,9 @@ pub fn record_set_amm1_canister(state: &mut State, canister: Principal) {
 }
 
 pub fn record_set_amm1_pool_id(state: &mut State, pool_id: String) {
-    record_event(&Event::SetAmm1PoolId { pool_id: pool_id.clone() });
+    record_event(&Event::SetAmm1PoolId {
+        pool_id: pool_id.clone(),
+    });
     state.amm1_pool_id = Some(pool_id);
 }
 
@@ -3226,7 +3299,9 @@ pub fn record_set_collateral_display_color(
 }
 
 pub fn record_accrue_interest(state: &mut State, now_nanos: u64) {
-    record_event(&Event::AccrueInterest { timestamp: now_nanos });
+    record_event(&Event::AccrueInterest {
+        timestamp: now_nanos,
+    });
     state.accrue_all_vault_interest(now_nanos);
 }
 
@@ -3247,10 +3322,18 @@ mod filter_tests {
         Principal::self_authenticating([seed; 32])
     }
 
-    fn caller_a() -> Principal { p(1) }
-    fn caller_b() -> Principal { p(2) }
-    fn icp_token() -> Principal { p(10) }
-    fn ckbtc_token() -> Principal { p(11) }
+    fn caller_a() -> Principal {
+        p(1)
+    }
+    fn caller_b() -> Principal {
+        p(2)
+    }
+    fn icp_token() -> Principal {
+        p(10)
+    }
+    fn ckbtc_token() -> Principal {
+        p(11)
+    }
 
     fn vault_with(id: u64, owner: Principal, ct: Principal, collateral_e8s: u64) -> Vault {
         Vault {
@@ -3309,7 +3392,11 @@ mod filter_tests {
     }
 
     fn price_event(ct: Principal, ts: u64) -> Event {
-        Event::PriceUpdate { collateral_type: ct, price: "5.0".into(), timestamp: ts }
+        Event::PriceUpdate {
+            collateral_type: ct,
+            price: "5.0".into(),
+            timestamp: ts,
+        }
     }
 
     /// Build a vault_id → collateral_type lookup for tests.
@@ -3321,15 +3408,35 @@ mod filter_tests {
 
     #[test]
     fn type_filter_classifies_each_user_facing_variant() {
-        assert_eq!(open_vault_event(1, caller_a(), icp_token()).type_filter(), EventTypeFilter::OpenVault);
-        assert_eq!(borrow_event(1, caller_a(), 100, 0).type_filter(), EventTypeFilter::Borrow);
-        assert_eq!(repay_event(1, caller_a(), 100, 0).type_filter(), EventTypeFilter::Repay);
-        assert_eq!(liquidate_event(1, caller_a(), 0).type_filter(), EventTypeFilter::Liquidation);
-        assert_eq!(accrue_event(0).type_filter(), EventTypeFilter::AccrueInterest);
-        assert_eq!(price_event(icp_token(), 0).type_filter(), EventTypeFilter::PriceUpdate);
+        assert_eq!(
+            open_vault_event(1, caller_a(), icp_token()).type_filter(),
+            EventTypeFilter::OpenVault
+        );
+        assert_eq!(
+            borrow_event(1, caller_a(), 100, 0).type_filter(),
+            EventTypeFilter::Borrow
+        );
+        assert_eq!(
+            repay_event(1, caller_a(), 100, 0).type_filter(),
+            EventTypeFilter::Repay
+        );
+        assert_eq!(
+            liquidate_event(1, caller_a(), 0).type_filter(),
+            EventTypeFilter::Liquidation
+        );
+        assert_eq!(
+            accrue_event(0).type_filter(),
+            EventTypeFilter::AccrueInterest
+        );
+        assert_eq!(
+            price_event(icp_token(), 0).type_filter(),
+            EventTypeFilter::PriceUpdate
+        );
 
         // Setter falls into Admin
-        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        let setter = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert_eq!(setter.type_filter(), EventTypeFilter::Admin);
     }
 
@@ -3337,7 +3444,10 @@ mod filter_tests {
 
     #[test]
     fn timestamp_ns_extracts_when_present_and_returns_none_otherwise() {
-        assert_eq!(borrow_event(1, caller_a(), 100, 12_345).timestamp_ns(), Some(12_345));
+        assert_eq!(
+            borrow_event(1, caller_a(), 100, 12_345).timestamp_ns(),
+            Some(12_345)
+        );
         assert_eq!(accrue_event(7).timestamp_ns(), Some(7));
 
         // Init has no timestamp.
@@ -3388,16 +3498,29 @@ mod filter_tests {
         let icp_e8s = 100_000_000u64;
         let price_e8s = 500_000_000u64;
         let ev = open_vault_event(1, caller_a(), icp_token());
-        let ev = if let Event::OpenVault { mut vault, block_index, timestamp } = ev {
+        let ev = if let Event::OpenVault {
+            mut vault,
+            block_index,
+            timestamp,
+        } = ev
+        {
             vault.collateral_amount = icp_e8s;
-            Event::OpenVault { vault, block_index, timestamp }
-        } else { unreachable!() };
+            Event::OpenVault {
+                vault,
+                block_index,
+                timestamp,
+            }
+        } else {
+            unreachable!()
+        };
         assert_eq!(ev.size_e8s_usd(price_e8s), Some(500_000_000));
     }
 
     #[test]
     fn size_returns_none_for_admin_setters() {
-        let ev = Event::SetBorrowingFee { rate: "0.005".into() };
+        let ev = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert_eq!(ev.size_e8s_usd(500_000_000), None);
     }
 
@@ -3407,46 +3530,125 @@ mod filter_tests {
     fn empty_filter_excludes_accrue_interest_and_price_update() {
         let lookup = HashMap::new();
         assert!(!accrue_event(0).passes_filters(None, None, None, None, None, None, &lookup, 0));
-        assert!(!price_event(icp_token(), 0).passes_filters(None, None, None, None, None, None, &lookup, 0));
-        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(None, None, None, None, None, None, &lookup, 0));
+        assert!(!price_event(icp_token(), 0)
+            .passes_filters(None, None, None, None, None, None, &lookup, 0));
+        assert!(borrow_event(1, caller_a(), 100, 0)
+            .passes_filters(None, None, None, None, None, None, &lookup, 0));
     }
 
     #[test]
     fn explicit_type_set_includes_accrue_interest_when_requested() {
         let lookup = HashMap::new();
         let set: HashSet<_> = [EventTypeFilter::AccrueInterest].into_iter().collect();
-        assert!(accrue_event(0).passes_filters(Some(&set), None, None, None, None, None, &lookup, 0));
-        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, None, &lookup, 0));
+        assert!(accrue_event(0).passes_filters(
+            Some(&set),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
+        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&set),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
     }
 
     #[test]
     fn type_filter_or_combines_within_the_set() {
         let lookup = HashMap::new();
-        let set: HashSet<_> = [EventTypeFilter::Borrow, EventTypeFilter::Repay].into_iter().collect();
-        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, None, &lookup, 0));
-        assert!(repay_event(1, caller_a(), 100, 0).passes_filters(Some(&set), None, None, None, None, None, &lookup, 0));
-        assert!(!liquidate_event(1, caller_a(), 0).passes_filters(Some(&set), None, None, None, None, None, &lookup, 0));
+        let set: HashSet<_> = [EventTypeFilter::Borrow, EventTypeFilter::Repay]
+            .into_iter()
+            .collect();
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&set),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
+        assert!(repay_event(1, caller_a(), 100, 0).passes_filters(
+            Some(&set),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
+        assert!(!liquidate_event(1, caller_a(), 0).passes_filters(
+            Some(&set),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
     }
 
     #[test]
     fn principal_filter_matches_caller_or_owner() {
         let lookup = HashMap::new();
-        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(None, Some(&caller_a()), None, None, None, None, &lookup, 0));
-        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(None, Some(&caller_b()), None, None, None, None, &lookup, 0));
+        assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(
+            None,
+            Some(&caller_a()),
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
+        assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(
+            None,
+            Some(&caller_b()),
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
     }
 
     #[test]
     fn collateral_token_filter_matches_via_vault_lookup() {
         let lookup = lookup(&[(1, ckbtc_token())]);
         let ev = borrow_event(1, caller_a(), 100, 0);
-        assert!(ev.passes_filters(None, None, Some(&ckbtc_token()), None, None, None, &lookup, 0));
+        assert!(ev.passes_filters(
+            None,
+            None,
+            Some(&ckbtc_token()),
+            None,
+            None,
+            None,
+            &lookup,
+            0
+        ));
         assert!(!ev.passes_filters(None, None, Some(&icp_token()), None, None, None, &lookup, 0));
     }
 
     #[test]
     fn time_range_excludes_outside_window_and_no_timestamp_events() {
         let lookup = HashMap::new();
-        let range = EventTimeRange { start_ns: 1_000, end_ns: 2_000 };
+        let range = EventTimeRange {
+            start_ns: 1_000,
+            end_ns: 2_000,
+        };
 
         let inside = borrow_event(1, caller_a(), 100, 1_500);
         let outside = borrow_event(1, caller_a(), 100, 5_000);
@@ -3480,7 +3682,9 @@ mod filter_tests {
         assert!(big.passes_filters(None, None, None, None, Some(threshold), None, &lookup, 0));
 
         // Admin setter has no size — passes through any threshold.
-        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        let setter = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert!(setter.passes_filters(None, None, None, None, Some(u64::MAX), None, &lookup, 0));
     }
 
@@ -3493,34 +3697,79 @@ mod filter_tests {
 
         // Right type AND right principal → match
         assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(
-            Some(&types), Some(&caller_a()), None, None, None, None, &lookup, 0,
+            Some(&types),
+            Some(&caller_a()),
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0,
         ));
         // Right type, wrong principal → reject
         assert!(!borrow_event(1, caller_a(), 100, 0).passes_filters(
-            Some(&types), Some(&caller_b()), None, None, None, None, &lookup, 0,
+            Some(&types),
+            Some(&caller_b()),
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0,
         ));
         // Wrong type, right principal → reject
         assert!(!repay_event(1, caller_a(), 100, 0).passes_filters(
-            Some(&types), Some(&caller_a()), None, None, None, None, &lookup, 0,
+            Some(&types),
+            Some(&caller_a()),
+            None,
+            None,
+            None,
+            None,
+            &lookup,
+            0,
         ));
     }
 
     #[test]
     fn time_and_token_combine_with_and_semantics() {
         let lookup = lookup(&[(1, ckbtc_token())]);
-        let range = EventTimeRange { start_ns: 1_000, end_ns: 2_000 };
+        let range = EventTimeRange {
+            start_ns: 1_000,
+            end_ns: 2_000,
+        };
 
         // In-window, right token → match
         assert!(borrow_event(1, caller_a(), 100, 1_500).passes_filters(
-            None, None, Some(&ckbtc_token()), Some(&range), None, None, &lookup, 0,
+            None,
+            None,
+            Some(&ckbtc_token()),
+            Some(&range),
+            None,
+            None,
+            &lookup,
+            0,
         ));
         // Out-of-window, right token → reject
         assert!(!borrow_event(1, caller_a(), 100, 9_999).passes_filters(
-            None, None, Some(&ckbtc_token()), Some(&range), None, None, &lookup, 0,
+            None,
+            None,
+            Some(&ckbtc_token()),
+            Some(&range),
+            None,
+            None,
+            &lookup,
+            0,
         ));
         // In-window, wrong token → reject
         assert!(!borrow_event(1, caller_a(), 100, 1_500).passes_filters(
-            None, None, Some(&icp_token()), Some(&range), None, None, &lookup, 0,
+            None,
+            None,
+            Some(&icp_token()),
+            Some(&range),
+            None,
+            None,
+            &lookup,
+            0,
         ));
     }
 
@@ -3528,7 +3777,9 @@ mod filter_tests {
 
     #[test]
     fn admin_label_returns_variant_name_for_admin_variants() {
-        let borrow_fee = Event::SetBorrowingFee { rate: "0.005".into() };
+        let borrow_fee = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert_eq!(borrow_fee.admin_label(), Some("SetBorrowingFee"));
         let healthy = Event::SetHealthyCr {
             collateral_type: "ICP".to_string(),
@@ -3551,17 +3802,33 @@ mod filter_tests {
         let types: HashSet<_> = [EventTypeFilter::Admin].into_iter().collect();
         let labels: HashSet<String> = ["SetBorrowingFee".to_string()].into_iter().collect();
 
-        let borrow_fee = Event::SetBorrowingFee { rate: "0.005".into() };
+        let borrow_fee = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         let healthy = Event::SetHealthyCr {
             collateral_type: "ICP".to_string(),
             healthy_cr: Some("1.2".to_string()),
         };
 
         assert!(borrow_fee.passes_filters(
-            Some(&types), None, None, None, None, Some(&labels), &lookup, 0,
+            Some(&types),
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
         assert!(!healthy.passes_filters(
-            Some(&types), None, None, None, None, Some(&labels), &lookup, 0,
+            Some(&types),
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
     }
 
@@ -3574,14 +3841,30 @@ mod filter_tests {
         let labels: HashSet<String> = ["SetBorrowingFee".to_string()].into_iter().collect();
 
         assert!(borrow_event(1, caller_a(), 100, 0).passes_filters(
-            Some(&types), None, None, None, None, Some(&labels), &lookup, 0,
+            Some(&types),
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
 
         // An admin event is excluded because the types filter doesn't include
         // Admin. admin_labels doesn't re-enable it.
-        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        let setter = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert!(!setter.passes_filters(
-            Some(&types), None, None, None, None, Some(&labels), &lookup, 0,
+            Some(&types),
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
     }
 
@@ -3593,7 +3876,9 @@ mod filter_tests {
         let lookup = HashMap::new();
         let labels: HashSet<String> = ["SetBorrowingFee".to_string()].into_iter().collect();
 
-        let matching_admin = Event::SetBorrowingFee { rate: "0.005".into() };
+        let matching_admin = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         let non_matching_admin = Event::SetHealthyCr {
             collateral_type: "ICP".to_string(),
             healthy_cr: Some("1.2".to_string()),
@@ -3601,14 +3886,26 @@ mod filter_tests {
         let non_admin = borrow_event(1, caller_a(), 100, 0);
 
         assert!(matching_admin.passes_filters(
-            None, None, None, None, None, Some(&labels), &lookup, 0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
         assert!(!non_matching_admin.passes_filters(
-            None, None, None, None, None, Some(&labels), &lookup, 0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&labels),
+            &lookup,
+            0,
         ));
-        assert!(non_admin.passes_filters(
-            None, None, None, None, None, Some(&labels), &lookup, 0,
-        ));
+        assert!(non_admin.passes_filters(None, None, None, None, None, Some(&labels), &lookup, 0,));
     }
 
     #[test]
@@ -3618,9 +3915,18 @@ mod filter_tests {
         let types: HashSet<_> = [EventTypeFilter::Admin].into_iter().collect();
         let empty: HashSet<String> = HashSet::new();
 
-        let setter = Event::SetBorrowingFee { rate: "0.005".into() };
+        let setter = Event::SetBorrowingFee {
+            rate: "0.005".into(),
+        };
         assert!(setter.passes_filters(
-            Some(&types), None, None, None, None, Some(&empty), &lookup, 0,
+            Some(&types),
+            None,
+            None,
+            None,
+            None,
+            Some(&empty),
+            &lookup,
+            0,
         ));
     }
 }

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -1,36 +1,35 @@
 use candid::{candid_method, Principal};
+use candid::{CandidType, Deserialize};
 use ic_canister_log::log;
 use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
-use ic_cdk_macros::{init, pre_upgrade, post_upgrade, query, update};
+use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
+use rumi_protocol_backend::event;
+use rumi_protocol_backend::logs::DEBUG;
+use rumi_protocol_backend::management;
+use rumi_protocol_backend::state::mutate_state;
+use rumi_protocol_backend::storage::events;
+use rumi_protocol_backend::treasury;
+use rumi_protocol_backend::LiquidityStatus;
 use rumi_protocol_backend::{
     event::Event,
     logs::INFO,
-    numeric::{ICUSD, ICP, Ratio, UsdIcp},
-    state::{read_state, replace_state, Mode, State, RateCurveV2},
+    numeric::{Ratio, UsdIcp, ICP, ICUSD},
+    state::{read_state, replace_state, Mode, RateCurveV2, State},
     vault::{CandidVault, OpenVaultSuccess, VaultArg},
-    EventTypeFilter, Fees, GetEventsArg, ProtocolArg, ProtocolError, ProtocolStatus, SuccessWithFee,
-    ReserveRedemptionResult, ReserveBalance, CollateralTotals, CollateralInterestInfo, PerCollateralRateCurve,
-    VaultArgWithToken, StableTokenType, InterestSplitArg,
-    GetSnapshotsArg, ProtocolSnapshot, CollateralSnapshot,
-    GetEventsFilteredResponse, ForwardFilteredEventsResponse, StabilityPoolLiquidationResult,
-    VaultHistoryPagedResponse, EventsByPrincipalPagedResponse, VaultsPageResponse,
-    SupplyAudit, SupplyAuditEntry,
-    MAX_VAULT_HISTORY, MAX_EVENTS_BY_PRINCIPAL_LEGACY, MAX_EVENTS_BY_PRINCIPAL_SCAN,
-    MAX_EVENTS_BY_PRINCIPAL_OUTPUT, MAX_VAULTS_LEGACY_PAGE, MAX_VAULTS_PAGE_LIMIT,
+    CollateralInterestInfo, CollateralSnapshot, CollateralTotals, EventTypeFilter,
+    EventsByPrincipalPagedResponse, Fees, ForwardFilteredEventsResponse, GetEventsArg,
+    GetEventsFilteredResponse, GetSnapshotsArg, InterestSplitArg, PerCollateralRateCurve,
+    ProtocolArg, ProtocolError, ProtocolSnapshot, ProtocolStatus, ReserveBalance,
+    ReserveRedemptionResult, StabilityPoolLiquidationResult, StableTokenType, SuccessWithFee,
+    SupplyAudit, SupplyAuditEntry, VaultArgWithToken, VaultHistoryPagedResponse,
+    VaultsPageResponse, MAX_EVENTS_BY_PRINCIPAL_LEGACY, MAX_EVENTS_BY_PRINCIPAL_OUTPUT,
+    MAX_EVENTS_BY_PRINCIPAL_SCAN, MAX_VAULTS_LEGACY_PAGE, MAX_VAULTS_PAGE_LIMIT, MAX_VAULT_HISTORY,
     PROTOCOL_STATUS_SNAPSHOT_TTL_NANOS, TREASURY_STATS_SNAPSHOT_TTL_NANOS,
 };
-use rumi_protocol_backend::logs::DEBUG;
-use rumi_protocol_backend::state::mutate_state;
-use rumi_protocol_backend::management;
-use rumi_protocol_backend::event;
-use rumi_protocol_backend::treasury;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use rumi_protocol_backend::storage::events;
-use rumi_protocol_backend::LiquidityStatus;
-use candid::{CandidType, Deserialize};
 
 /// Stability pool configuration
 #[derive(CandidType, Deserialize, Debug)]
@@ -114,7 +113,7 @@ fn validate_mode() -> Result<(), ProtocolError> {
         // (audit RED-101).
         Mode::ReadOnly => Err(ProtocolError::read_only_mode()),
         Mode::GeneralAvailability => Ok(()),
-        Mode::Recovery => Ok(())
+        Mode::Recovery => Ok(()),
     }
 }
 
@@ -147,7 +146,9 @@ fn validate_liquidation_not_frozen() -> Result<(), ProtocolError> {
 /// own `Vault not found` error rather than masking it here.
 async fn validate_freshness_for_vault(vault_id: u64) -> Result<(), ProtocolError> {
     let collateral_type = read_state(|s| {
-        s.vault_id_to_vaults.get(&vault_id).map(|v| v.collateral_type)
+        s.vault_id_to_vaults
+            .get(&vault_id)
+            .map(|v| v.collateral_type)
     });
     match collateral_type {
         Some(ct) => rumi_protocol_backend::xrc::ensure_fresh_price_for(&ct).await,
@@ -188,7 +189,9 @@ fn inspect_message() {
         // signature verification + per-owner nonce/cap are the real boundary; this
         // accept just lets the message reach the method body. inspect_message is a
         // single-replica pre-filter, never a security boundary.
-        "open_chain_vault_evm" | "borrow_chain_vault_evm" | "withdraw_chain_collateral_evm"
+        "open_chain_vault_evm"
+        | "borrow_chain_vault_evm"
+        | "withdraw_chain_collateral_evm"
         | "close_chain_vault_evm" => {
             ic_cdk::api::call::accept_message();
         }
@@ -230,10 +233,10 @@ fn register_xrc_fetch_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(rumi_protocol_backend::xrc::fetch_icp_rate()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(rumi_protocol_backend::xrc::fetch_icp_rate())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -244,10 +247,10 @@ fn register_interest_treasury_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(rumi_protocol_backend::xrc::interest_and_treasury_tick()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(rumi_protocol_backend::xrc::interest_and_treasury_tick())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -258,10 +261,10 @@ fn register_vault_check_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(rumi_protocol_backend::xrc::vault_check_tick()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(rumi_protocol_backend::xrc::vault_check_tick())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -298,7 +301,10 @@ fn registered_chains_and_solana_flag() -> (Vec<rumi_protocol_backend::chains::co
             .chain_configs
             .iter()
             .filter(|(_, c)| {
-                matches!(c.status, rumi_protocol_backend::chains::config::ChainStatus::Registered)
+                matches!(
+                    c.status,
+                    rumi_protocol_backend::chains::config::ChainStatus::Registered
+                )
             })
             .map(|(id, _)| *id)
             .collect();
@@ -350,10 +356,10 @@ fn register_settlement_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(run_all_settlements()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(run_all_settlements())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -421,7 +427,13 @@ async fn harvest_one_chain_interest(
         ops.len() as u64
     });
     if enqueued > 0 {
-        log!(INFO, "[interest harvest chain={:?}] enqueued {} interest mint(s) to treasury {}", chain, enqueued, treasury);
+        log!(
+            INFO,
+            "[interest harvest chain={:?}] enqueued {} interest mint(s) to treasury {}",
+            chain,
+            enqueued,
+            treasury
+        );
     }
     Ok(enqueued)
 }
@@ -436,10 +448,10 @@ fn register_chain_interest_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(run_all_chain_interest_harvests()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(run_all_chain_interest_harvests())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -453,10 +465,10 @@ fn register_observer_timer() {
         if let Some(old) = cell.get() {
             ic_cdk_timers::clear_timer(old);
         }
-        let new_id = ic_cdk_timers::set_timer_interval(
-            std::time::Duration::from_secs(secs),
-            || ic_cdk::spawn(run_all_observers()),
-        );
+        let new_id =
+            ic_cdk_timers::set_timer_interval(std::time::Duration::from_secs(secs), || {
+                ic_cdk::spawn(run_all_observers())
+            });
         cell.set(Some(new_id));
     });
 }
@@ -472,14 +484,17 @@ fn setup_timers() {
     });
     let non_icp_collaterals_immediate: Vec<candid::Principal> = read_state(|s| {
         let icp = s.icp_collateral_type();
-        s.collateral_configs.keys()
+        s.collateral_configs
+            .keys()
             .filter(|ct| **ct != icp)
             .cloned()
             .collect()
     });
     for ledger_id in non_icp_collaterals_immediate {
         ic_cdk_timers::set_timer(std::time::Duration::ZERO, move || {
-            ic_cdk::spawn(rumi_protocol_backend::management::fetch_collateral_price(ledger_id))
+            ic_cdk::spawn(rumi_protocol_backend::management::fetch_collateral_price(
+                ledger_id,
+            ))
         });
     }
 
@@ -502,13 +517,18 @@ fn setup_timers() {
     // XRC call until status flips back to Active or Paused.
     let non_icp_collaterals: Vec<candid::Principal> = read_state(|s| {
         let icp = s.icp_collateral_type();
-        s.collateral_configs.keys()
+        s.collateral_configs
+            .keys()
             .filter(|ct| **ct != icp)
             .cloned()
             .collect()
     });
     for ledger_id in non_icp_collaterals {
-        log!(INFO, "[setup_timers] Registering price timer for collateral {}", ledger_id);
+        log!(
+            INFO,
+            "[setup_timers] Registering price timer for collateral {}",
+            ledger_id
+        );
         rumi_protocol_backend::xrc::register_collateral_price_timer(ledger_id);
     }
 
@@ -560,7 +580,11 @@ fn register_chain_vault_gc_timer() {
             )
         });
         if pruned > 0 {
-            log!(INFO, "[chain_vault_gc] pruned {} stale AwaitingDeposit vaults", pruned);
+            log!(
+                INFO,
+                "[chain_vault_gc] pruned {} stale AwaitingDeposit vaults",
+                pruned
+            );
         }
     });
 }
@@ -575,15 +599,16 @@ fn capture_protocol_snapshot() {
         for (ct, config) in s.collateral_configs.iter() {
             let col_total = s.total_collateral_for(ct);
             let debt = s.total_debt_for_collateral(ct).to_u64();
-            let vault_count = s.collateral_to_vault_ids
+            let vault_count = s
+                .collateral_to_vault_ids
                 .get(ct)
                 .map(|ids| ids.len() as u64)
                 .unwrap_or(0);
             let price = config.last_price.unwrap_or(0.0);
 
             // Convert collateral to USD value (e8s)
-            let col_decimal = Decimal::from(col_total)
-                / Decimal::from(10u64.pow(config.decimals as u32));
+            let col_decimal =
+                Decimal::from(col_total) / Decimal::from(10u64.pow(config.decimals as u32));
             let usd_value = (col_decimal * Decimal::try_from(price).unwrap_or_default())
                 * Decimal::from(100_000_000u64);
             let usd_e8s = usd_value.to_u64().unwrap_or(0);
@@ -664,11 +689,7 @@ fn post_upgrade(arg: ProtocolArg) {
     let upgrade_args = match arg {
         ProtocolArg::Init(_) => ic_cdk::trap("expected Upgrade got Init"),
         ProtocolArg::Upgrade(args) => {
-            log!(
-                INFO,
-                "[upgrade]: updating configuration with {:?}",
-                args
-            );
+            log!(INFO, "[upgrade]: updating configuration with {:?}", args);
             record_event(&Event::Upgrade(args.clone()));
             args
         }
@@ -677,7 +698,11 @@ fn post_upgrade(arg: ProtocolArg) {
     // Try to restore from stable memory (fast path, no drift)
     let state = match rumi_protocol_backend::storage::load_state_from_stable() {
         Some(mut state) => {
-            log!(INFO, "[upgrade]: restored state from stable memory (skipped event replay of {} events)", count_events());
+            log!(
+                INFO,
+                "[upgrade]: restored state from stable memory (skipped event replay of {} events)",
+                count_events()
+            );
             // Apply upgrade args to the restored state (the snapshot was taken
             // before this upgrade event, so we must apply it explicitly)
             state.upgrade(upgrade_args);
@@ -685,7 +710,11 @@ fn post_upgrade(arg: ProtocolArg) {
         }
         None => {
             // Fallback: replay events (first upgrade after this change, or recovery)
-            log!(INFO, "[upgrade]: no stable state found, replaying {} events", count_events());
+            log!(
+                INFO,
+                "[upgrade]: no stable state found, replaying {} events",
+                count_events()
+            );
             replay(events()).unwrap_or_else(|e| {
                 ic_cdk::trap(&format!(
                     "[upgrade]: failed to replay the event log: {:?}",
@@ -714,7 +743,12 @@ fn post_upgrade(arg: ProtocolArg) {
         count
     });
     if migrated > 0 {
-        log!(INFO, "[upgrade]: migrated {} vaults: set last_accrual_time to {}", migrated, now);
+        log!(
+            INFO,
+            "[upgrade]: migrated {} vaults: set last_accrual_time to {}",
+            migrated,
+            now
+        );
     }
 
     // Task 12: mirror the above for FOREIGN-CHAIN vaults — stamp
@@ -731,8 +765,12 @@ fn post_upgrade(arg: ProtocolArg) {
     // Safety net: if bot is configured but allowlist is empty, default to ICP
     mutate_state(|s| {
         if s.liquidation_bot_principal.is_some() && s.bot_allowed_collateral_types.is_empty() {
-            s.bot_allowed_collateral_types.insert(s.icp_ledger_principal);
-            log!(INFO, "[upgrade]: bot_allowed_collateral_types was empty, defaulted to ICP");
+            s.bot_allowed_collateral_types
+                .insert(s.icp_ledger_principal);
+            log!(
+                INFO,
+                "[upgrade]: bot_allowed_collateral_types was empty, defaulted to ICP"
+            );
         }
     });
 
@@ -746,7 +784,9 @@ fn post_upgrade(arg: ProtocolArg) {
     // this block runs they already have tuple keys.
     mutate_state(|s| {
         let mut backfilled = 0u64;
-        let margin_keys: Vec<(u64, candid::Principal)> = s.pending_margin_transfers.iter()
+        let margin_keys: Vec<(u64, candid::Principal)> = s
+            .pending_margin_transfers
+            .iter()
             .filter(|(_, t)| t.op_nonce == 0)
             .map(|(k, _)| *k)
             .collect();
@@ -757,7 +797,9 @@ fn post_upgrade(arg: ProtocolArg) {
                 backfilled += 1;
             }
         }
-        let excess_keys: Vec<(u64, candid::Principal)> = s.pending_excess_transfers.iter()
+        let excess_keys: Vec<(u64, candid::Principal)> = s
+            .pending_excess_transfers
+            .iter()
             .filter(|(_, t)| t.op_nonce == 0)
             .map(|(k, _)| *k)
             .collect();
@@ -768,7 +810,9 @@ fn post_upgrade(arg: ProtocolArg) {
                 backfilled += 1;
             }
         }
-        let redemption_ids: Vec<u64> = s.pending_redemption_transfer.iter()
+        let redemption_ids: Vec<u64> = s
+            .pending_redemption_transfer
+            .iter()
             .filter(|(_, t)| t.op_nonce == 0)
             .map(|(id, _)| *id)
             .collect();
@@ -780,7 +824,11 @@ fn post_upgrade(arg: ProtocolArg) {
             }
         }
         if backfilled > 0 {
-            log!(INFO, "[upgrade]: backfilled op_nonce on {} legacy pending transfers (Wave-3 migration)", backfilled);
+            log!(
+                INFO,
+                "[upgrade]: backfilled op_nonce on {} legacy pending transfers (Wave-3 migration)",
+                backfilled
+            );
         }
     });
 
@@ -788,10 +836,15 @@ fn post_upgrade(arg: ProtocolArg) {
     mutate_state(|s| {
         let phasma = candid::Principal::from_text("np5km-uyaaa-aaaaq-aadrq-cai").unwrap();
         if s.collateral_configs.remove(&phasma).is_some() {
-            log!(INFO, "[upgrade]: removed PHASMA test collateral from configs");
+            log!(
+                INFO,
+                "[upgrade]: removed PHASMA test collateral from configs"
+            );
         }
         // Remove empty vaults (fully liquidated shells with zero debt and zero collateral)
-        let empty_vault_ids: Vec<u64> = s.vault_id_to_vaults.iter()
+        let empty_vault_ids: Vec<u64> = s
+            .vault_id_to_vaults
+            .iter()
             .filter(|(_, v)| v.borrowed_icusd_amount.0 == 0 && v.collateral_amount == 0)
             .map(|(id, _)| *id)
             .collect();
@@ -799,7 +852,12 @@ fn post_upgrade(arg: ProtocolArg) {
             s.remove_vault_and_unindex(*vault_id);
         }
         if !empty_vault_ids.is_empty() {
-            log!(INFO, "[upgrade]: cleaned up {} empty vaults: {:?}", empty_vault_ids.len(), empty_vault_ids);
+            log!(
+                INFO,
+                "[upgrade]: cleaned up {} empty vaults: {:?}",
+                empty_vault_ids.len(),
+                empty_vault_ids
+            );
         }
     });
 
@@ -869,9 +927,17 @@ fn post_upgrade(arg: ProtocolArg) {
     // explicit migrate call is needed here; `migrate_multi_chain_state` exists
     // as the unit-tested template for the NEXT version bump.
     let (chains, chain_vaults) = read_state(|s| {
-        (s.multi_chain.chain_configs.len(), s.multi_chain.chain_vaults.len())
+        (
+            s.multi_chain.chain_configs.len(),
+            s.multi_chain.chain_vaults.len(),
+        )
     });
-    log!(INFO, "[post_upgrade] multi_chain: {} chains, {} chain_vaults", chains, chain_vaults);
+    log!(
+        INFO,
+        "[post_upgrade] multi_chain: {} chains, {} chain_vaults",
+        chains,
+        chain_vaults
+    );
 
     setup_timers();
 }
@@ -883,33 +949,70 @@ fn validate_collateral_state(state: &State) {
     // 1. Check that ICP is in collateral_configs
     let icp = state.icp_collateral_type();
     if !state.collateral_configs.contains_key(&icp) {
-        log!(INFO, "[post_upgrade_validation] WARNING: ICP ledger {} not found in collateral_configs!", icp);
+        log!(
+            INFO,
+            "[post_upgrade_validation] WARNING: ICP ledger {} not found in collateral_configs!",
+            icp
+        );
     } else {
-        log!(INFO, "[post_upgrade_validation] ICP collateral config present");
+        log!(
+            INFO,
+            "[post_upgrade_validation] ICP collateral config present"
+        );
     }
 
     // 2. Check that all vaults reference a known collateral type
     let mut orphaned_vaults = 0u64;
     for (vault_id, vault) in &state.vault_id_to_vaults {
         if vault.collateral_type == candid::Principal::anonymous() {
-            log!(INFO, "[post_upgrade_validation] WARNING: vault #{} still has anonymous collateral_type", vault_id);
+            log!(
+                INFO,
+                "[post_upgrade_validation] WARNING: vault #{} still has anonymous collateral_type",
+                vault_id
+            );
             orphaned_vaults += 1;
-        } else if !state.collateral_configs.contains_key(&vault.collateral_type) {
-            log!(INFO, "[post_upgrade_validation] WARNING: vault #{} references unknown collateral {}", vault_id, vault.collateral_type);
+        } else if !state
+            .collateral_configs
+            .contains_key(&vault.collateral_type)
+        {
+            log!(
+                INFO,
+                "[post_upgrade_validation] WARNING: vault #{} references unknown collateral {}",
+                vault_id,
+                vault.collateral_type
+            );
             orphaned_vaults += 1;
         }
     }
     if orphaned_vaults == 0 {
-        log!(INFO, "[post_upgrade_validation] All {} vaults have valid collateral_type", state.vault_id_to_vaults.len());
+        log!(
+            INFO,
+            "[post_upgrade_validation] All {} vaults have valid collateral_type",
+            state.vault_id_to_vaults.len()
+        );
     } else {
-        log!(INFO, "[post_upgrade_validation] {} vault(s) with invalid collateral_type!", orphaned_vaults);
+        log!(
+            INFO,
+            "[post_upgrade_validation] {} vault(s) with invalid collateral_type!",
+            orphaned_vaults
+        );
     }
 
     // 3. Log summary of collateral configs
-    log!(INFO, "[post_upgrade_validation] {} collateral types configured", state.collateral_configs.len());
+    log!(
+        INFO,
+        "[post_upgrade_validation] {} collateral types configured",
+        state.collateral_configs.len()
+    );
     for (ct, config) in &state.collateral_configs {
-        log!(INFO, "[post_upgrade_validation]   {} => status={:?}, decimals={}, price={:?}",
-            ct, config.status, config.decimals, config.last_price);
+        log!(
+            INFO,
+            "[post_upgrade_validation]   {} => status={:?}, decimals={}, price={:?}",
+            ct,
+            config.status,
+            config.decimals,
+            config.last_price
+        );
     }
 }
 
@@ -979,29 +1082,46 @@ fn get_protocol_status() -> ProtocolStatus {
         interest_pool_share: s.interest_pool_share.to_f64(),
         weighted_average_interest_rate: snapshot.weighted_average_interest_rate,
         borrowing_fee_curve_resolved: snapshot.borrowing_fee_curve_resolved.clone(),
-        per_collateral_interest: snapshot.per_collateral_interest.iter()
+        per_collateral_interest: snapshot
+            .per_collateral_interest
+            .iter()
             .map(|p| CollateralInterestInfo {
                 collateral_type: p.collateral_type,
                 total_debt_e8s: p.total_debt_e8s,
                 weighted_interest_rate: p.weighted_interest_rate,
             })
             .collect(),
-        per_collateral_rate_curves: snapshot.per_collateral_rate_curves.iter()
+        per_collateral_rate_curves: snapshot
+            .per_collateral_rate_curves
+            .iter()
             .map(|p| PerCollateralRateCurve {
                 collateral_type: p.collateral_type,
                 base_rate: p.base_rate,
                 markers: p.markers.clone(),
             })
             .collect(),
-        interest_split: s.interest_split.iter().map(|r| {
-            let dest = match &r.destination {
-                rumi_protocol_backend::state::InterestDestination::StabilityPool => "stability_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Treasury => "treasury".to_string(),
-                rumi_protocol_backend::state::InterestDestination::ThreePool => "three_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
-            };
-            InterestSplitArg { destination: dest, bps: r.bps }
-        }).collect(),
+        interest_split: s
+            .interest_split
+            .iter()
+            .map(|r| {
+                let dest = match &r.destination {
+                    rumi_protocol_backend::state::InterestDestination::StabilityPool => {
+                        "stability_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Treasury => {
+                        "treasury".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::ThreePool => {
+                        "three_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
+                };
+                InterestSplitArg {
+                    destination: dest,
+                    bps: r.bps,
+                }
+            })
+            .collect(),
         // Wave-8e LIQ-005 — live (changes on liquidation/redemption + admin)
         protocol_deficit_icusd: s.protocol_deficit_icusd.to_u64(),
         total_deficit_repaid_icusd: s.total_deficit_repaid_icusd.to_u64(),
@@ -1040,7 +1160,12 @@ fn get_supply_audit() -> SupplyAudit {
     read_state(|s| {
         let mut per_chain = Vec::with_capacity(s.multi_chain.chain_configs.len());
         for (chain_id, cfg) in s.multi_chain.chain_configs.iter() {
-            let supply = s.multi_chain.chain_supplies.get(chain_id).copied().unwrap_or(0);
+            let supply = s
+                .multi_chain
+                .chain_supplies
+                .get(chain_id)
+                .copied()
+                .unwrap_or(0);
             per_chain.push(SupplyAuditEntry {
                 chain_id: *chain_id,
                 display_name: cfg.display_name.clone(),
@@ -1058,7 +1183,9 @@ fn get_supply_audit() -> SupplyAudit {
 
 #[candid_method(update)]
 #[update]
-fn register_chain(arg: rumi_protocol_backend::chains::config::RegisterChainArg) -> Result<(), ProtocolError> {
+fn register_chain(
+    arg: rumi_protocol_backend::chains::config::RegisterChainArg,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
@@ -1067,14 +1194,18 @@ fn register_chain(arg: rumi_protocol_backend::chains::config::RegisterChainArg) 
     let now = ic_cdk::api::time();
     let chain_id = arg.chain_id;
     let display_name = arg.display_name.clone();
-    let result = mutate_state(|s| rumi_protocol_backend::chains::admin::register_chain_in_state(&mut s.multi_chain, arg, now));
+    let result = mutate_state(|s| {
+        rumi_protocol_backend::chains::admin::register_chain_in_state(&mut s.multi_chain, arg, now)
+    });
     match result {
         Ok(_) => {
-            rumi_protocol_backend::storage::record_event(&rumi_protocol_backend::event::Event::ChainRegistered {
-                chain_id,
-                display_name,
-                timestamp: now,
-            });
+            rumi_protocol_backend::storage::record_event(
+                &rumi_protocol_backend::event::Event::ChainRegistered {
+                    chain_id,
+                    display_name,
+                    timestamp: now,
+                },
+            );
             log!(INFO, "[register_chain] chain_id={:?} registered", chain_id);
             Ok(())
         }
@@ -1084,20 +1215,26 @@ fn register_chain(arg: rumi_protocol_backend::chains::config::RegisterChainArg) 
 
 #[candid_method(update)]
 #[update]
-fn disable_chain(chain_id: rumi_protocol_backend::chains::config::ChainId) -> Result<(), ProtocolError> {
+fn disable_chain(
+    chain_id: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    let result = mutate_state(|s| rumi_protocol_backend::chains::admin::disable_chain_in_state(&mut s.multi_chain, chain_id));
+    let result = mutate_state(|s| {
+        rumi_protocol_backend::chains::admin::disable_chain_in_state(&mut s.multi_chain, chain_id)
+    });
     match result {
         Ok(()) => {
             let now = ic_cdk::api::time();
-            rumi_protocol_backend::storage::record_event(&rumi_protocol_backend::event::Event::ChainDisabled {
-                chain_id,
-                timestamp: now,
-            });
+            rumi_protocol_backend::storage::record_event(
+                &rumi_protocol_backend::event::Event::ChainDisabled {
+                    chain_id,
+                    timestamp: now,
+                },
+            );
             log!(INFO, "[disable_chain] chain_id={:?} disabled", chain_id);
             Ok(())
         }
@@ -1116,14 +1253,22 @@ fn set_chain_config(
     if !is_developer {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    let result = mutate_state(|s| rumi_protocol_backend::chains::admin::update_chain_config_in_state(&mut s.multi_chain, chain_id, update));
+    let result = mutate_state(|s| {
+        rumi_protocol_backend::chains::admin::update_chain_config_in_state(
+            &mut s.multi_chain,
+            chain_id,
+            update,
+        )
+    });
     match result {
         Ok(()) => {
             let now = ic_cdk::api::time();
-            rumi_protocol_backend::storage::record_event(&rumi_protocol_backend::event::Event::ChainConfigUpdated {
-                chain_id,
-                timestamp: now,
-            });
+            rumi_protocol_backend::storage::record_event(
+                &rumi_protocol_backend::event::Event::ChainConfigUpdated {
+                    chain_id,
+                    timestamp: now,
+                },
+            );
             log!(INFO, "[set_chain_config] chain_id={:?} updated", chain_id);
             Ok(())
         }
@@ -1147,7 +1292,16 @@ fn evm_vault_params(
         .ok_or_else(|| {
             ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
         })?;
-    Ok((symbol, cfg.min_cr_e4, cfg.min_vault_debt_e8s, cfg.debt_ceiling_e8s))
+    let debt_cfg = read_state(|s| s.multi_chain.chain_debt_configs.get(&chain).copied())
+        .unwrap_or_else(|| {
+            rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1::from_collateral_config(cfg)
+        });
+    Ok((
+        symbol,
+        cfg.min_cr_e4,
+        debt_cfg.min_vault_debt_e8s,
+        debt_cfg.debt_ceiling_e8s,
+    ))
 }
 
 /// Phase 1b Task 12: open a foreign-chain EVM (Monad or Conflux) vault, OPEN-THEN-VERIFY.
@@ -1356,8 +1510,8 @@ fn verify_intent_ctx(
 ) -> Result<VerifiedIntent, ProtocolError> {
     let chain = rumi_protocol_backend::chains::config::ChainId(intent.chain_id as u32);
     // Resolve symbol + min CR (fails fast for a non-EVM / unregistered chain).
-    let (symbol, min_cr, min_vault_debt_e8s, debt_ceiling_e8s) = evm_vault_params(chain)
-        .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
+    let (symbol, min_cr, min_vault_debt_e8s, debt_ceiling_e8s) =
+        evm_vault_params(chain).map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
     // The deployed IcUSD address binds the EIP-712 domain to this chain+deployment.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned())
         .ok_or_else(|| ProtocolError::EvmAuth(format!("no contract set for chain {}", chain.0)))?;
@@ -1370,7 +1524,15 @@ fn verify_intent_ctx(
         now_secs,
     )
     .map_err(|e| ProtocolError::EvmAuth(format!("{e:?}")))?;
-    Ok(VerifiedIntent { chain, owner_evm, synthetic, symbol, min_cr, min_vault_debt_e8s, debt_ceiling_e8s })
+    Ok(VerifiedIntent {
+        chain,
+        owner_evm,
+        synthetic,
+        symbol,
+        min_cr,
+        min_vault_debt_e8s,
+        debt_ceiling_e8s,
+    })
 }
 
 /// Authorize a borrow/withdraw/close `_evm` op against an existing vault: the
@@ -1429,10 +1591,9 @@ async fn open_chain_vault_evm(
         v.synthetic,
         vault_id,
     );
-    let (_pubkey, custody) =
-        rumi_protocol_backend::chains::evm::tecdsa::derive_evm_address(path)
-            .await
-            .map_err(|e| ProtocolError::EvmAuth(format!("derive: {e}")))?;
+    let (_pubkey, custody) = rumi_protocol_backend::chains::evm::tecdsa::derive_evm_address(path)
+        .await
+        .map_err(|e| ProtocolError::EvmAuth(format!("derive: {e}")))?;
     let now = ic_cdk::api::time();
     let owner_evm = v.owner_evm.clone();
     mutate_state(|s| {
@@ -1664,8 +1825,7 @@ async fn open_solana_vault(
         .map_err(|e| ProtocolError::ChainAdmin(format!("{e:?}")))?;
         // Return the inserted vault. `open_chain_vault_in_state` inserts it on
         // success, so the lookup cannot miss.
-        Ok(s
-            .multi_chain
+        Ok(s.multi_chain
             .chain_vaults
             .get(&vault_id)
             .cloned()
@@ -1815,9 +1975,7 @@ fn list_chain_vaults(
 /// read-only query; no gate (mirrors `get_chain_vault`).
 #[candid_method(query)]
 #[query]
-fn chain_has_active_settlement_op(
-    chain: rumi_protocol_backend::chains::config::ChainId,
-) -> bool {
+fn chain_has_active_settlement_op(chain: rumi_protocol_backend::chains::config::ChainId) -> bool {
     read_state(|s| {
         s.multi_chain
             .settlement_queues
@@ -1849,15 +2007,24 @@ fn set_chain_contract(
     // (Monad + any EVM chain) keeps the original EVM validation unchanged.
     if chain == rumi_protocol_backend::chains::solana::config::SOLANA_CHAIN_ID {
         if !rumi_protocol_backend::chains::solana::ted25519::is_valid_solana_address(&address) {
-            return Err(ProtocolError::ChainAdmin(format!("invalid Solana address: {address}")));
+            return Err(ProtocolError::ChainAdmin(format!(
+                "invalid Solana address: {address}"
+            )));
         }
     } else if !rumi_protocol_backend::chains::monad::tecdsa::is_valid_evm_address(&address) {
-        return Err(ProtocolError::ChainAdmin(format!("invalid EVM address: {address}")));
+        return Err(ProtocolError::ChainAdmin(format!(
+            "invalid EVM address: {address}"
+        )));
     }
     mutate_state(|s| {
         s.multi_chain.chain_contracts.insert(chain, address.clone());
     });
-    log!(INFO, "[set_chain_contract] chain={:?} address={}", chain, address);
+    log!(
+        INFO,
+        "[set_chain_contract] chain={:?} address={}",
+        chain,
+        address
+    );
     Ok(())
 }
 
@@ -1883,13 +2050,14 @@ fn set_chain_liquidation_config(
     // budget, or a swap can structurally deliver less stable than the debt it
     // clears (under-cover). Increment 3 adds the max_dex_oracle_divergence_bps term.
     if config.enabled {
-        let penalty_bps = rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)
-            .map(|c| c.liquidation_penalty_bps)
-            .ok_or_else(|| {
-                ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
-            })?;
-        let budget_bps =
-            (config.slippage_cap_bps as u64).saturating_add(config.max_dex_oracle_divergence_bps as u64);
+        let penalty_bps =
+            rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)
+                .map(|c| c.liquidation_penalty_bps)
+                .ok_or_else(|| {
+                    ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
+                })?;
+        let budget_bps = (config.slippage_cap_bps as u64)
+            .saturating_add(config.max_dex_oracle_divergence_bps as u64);
         if budget_bps >= penalty_bps {
             return Err(ProtocolError::ChainAdmin(format!(
                 "slippage_cap_bps {} + max_dex_oracle_divergence_bps {} must be < liquidation_penalty_bps {} (penalty cushion, finding #16)",
@@ -1898,7 +2066,9 @@ fn set_chain_liquidation_config(
         }
     }
     mutate_state(|s| {
-        s.multi_chain.chain_liquidation_configs.insert(chain, config.clone());
+        s.multi_chain
+            .chain_liquidation_configs
+            .insert(chain, config.clone());
     });
     log!(
         INFO,
@@ -1919,6 +2089,75 @@ fn get_chain_liquidation_config(
     chain: rumi_protocol_backend::chains::config::ChainId,
 ) -> Option<rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1> {
     read_state(|s| s.multi_chain.chain_liquidation_configs.get(&chain).cloned())
+}
+
+fn validate_chain_debt_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1,
+) -> Result<(), ProtocolError> {
+    if rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain).is_none() {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "no collateral config for chain {}",
+            chain.0
+        )));
+    }
+    if let Some(ceiling) = config.debt_ceiling_e8s {
+        if ceiling < config.min_vault_debt_e8s {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "debt_ceiling_e8s {} must be >= min_vault_debt_e8s {}",
+                ceiling, config.min_vault_debt_e8s
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Persist Tier-B debt knobs for a chain. Missing config means the compile-time
+/// defaults from `chain_collateral_config` remain authoritative.
+#[candid_method(update)]
+#[update]
+fn set_chain_debt_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    validate_chain_debt_config(chain, config)?;
+    mutate_state(|s| {
+        s.multi_chain.chain_debt_configs.insert(chain, config);
+    });
+    log!(
+        INFO,
+        "[set_chain_debt_config] chain={:?} min_vault_debt_e8s={} debt_ceiling_e8s={:?}",
+        chain,
+        config.min_vault_debt_e8s,
+        config.debt_ceiling_e8s
+    );
+    Ok(())
+}
+
+/// Return the explicit Tier-B debt override for `chain`, if one has been set.
+#[candid_method(query)]
+#[query]
+fn get_chain_debt_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Option<rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1> {
+    read_state(|s| s.multi_chain.chain_debt_configs.get(&chain).copied())
+}
+
+/// Return the debt config actually used by EVM open/borrow: explicit override
+/// when present, otherwise the compile-time collateral default.
+#[candid_method(query)]
+#[query]
+fn get_effective_chain_debt_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Option<rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1> {
+    let base = rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)?;
+    Some(read_state(|s| s.multi_chain.chain_debt_configs.get(&chain).copied()).unwrap_or_else(
+        || rumi_protocol_backend::chains::collateral_config::ChainDebtConfigV1::from_collateral_config(base),
+    ))
 }
 
 /// A chain vault currently liquidatable on `chain` (CR below the liquidation
@@ -1944,7 +2183,9 @@ fn liquidation_price_symbol(
 ) -> Result<&'static str, ProtocolError> {
     rumi_protocol_backend::chains::evm::evm_chain_config(chain)
         .map(|c| c.native_symbol)
-        .ok_or_else(|| ProtocolError::ChainAdmin(format!("chain {} is not a known EVM chain", chain.0)))
+        .ok_or_else(|| {
+            ProtocolError::ChainAdmin(format!("chain {} is not a known EVM chain", chain.0))
+        })
 }
 
 /// Dev-gated manual/permissionless liquidation trigger (spec §7). Runs the
@@ -1959,11 +2200,19 @@ fn liquidate_chain_vault(vault_id: u64) -> Result<u64, ProtocolError> {
     if read_state(|s| s.developer_principal != caller) {
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
-    let chain = read_state(|s| s.multi_chain.chain_vaults.get(&vault_id).map(|v| v.collateral_chain))
-        .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown vault {vault_id}")))?;
-    let threshold = rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)
-        .map(|c| c.liquidation_threshold_e4)
-        .ok_or_else(|| ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0)))?;
+    let chain = read_state(|s| {
+        s.multi_chain
+            .chain_vaults
+            .get(&vault_id)
+            .map(|v| v.collateral_chain)
+    })
+    .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown vault {vault_id}")))?;
+    let threshold =
+        rumi_protocol_backend::chains::collateral_config::chain_collateral_config(chain)
+            .map(|c| c.liquidation_threshold_e4)
+            .ok_or_else(|| {
+                ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
+            })?;
     let symbol = liquidation_price_symbol(chain)?;
     let now = ic_cdk::api::time();
     mutate_state(|s| {
@@ -2019,7 +2268,8 @@ fn get_chain_liquidatable_vaults(
             .get(&chain)
             .map(|c| c.chain_native_decimals)
             .unwrap_or(18);
-        let bonus = liq::bonus_e4_from_penalty_bps(cc.map(|c| c.liquidation_penalty_bps).unwrap_or(0));
+        let bonus =
+            liq::bonus_e4_from_penalty_bps(cc.map(|c| c.liquidation_penalty_bps).unwrap_or(0));
         let target = cc.map(|c| c.recovery_target_cr_e4).unwrap_or(15_500);
         s.multi_chain
             .chain_vaults
@@ -2090,20 +2340,32 @@ fn set_manual_collateral_price(
 ) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     if read_state(|s| !s.is_price_setter_authorized(caller, chain.0, &symbol)) {
-        return Err(ProtocolError::ChainAdmin("not authorized to set price".into()));
+        return Err(ProtocolError::ChainAdmin(
+            "not authorized to set price".into(),
+        ));
     }
     // Reject a zero price. A 0 price drives `collateral_ratio_e4` to 0, which
     // fails-closed (every open/withdraw with debt rejects with BelowMinCr), so
     // it cannot mint under-collateralized — but it is never a legitimate value
     // and silently freezes the chain's vaults. Catch the fat-finger explicitly.
     if price_e8 == 0 {
-        return Err(ProtocolError::ChainAdmin("price_e8 must be greater than 0".into()));
+        return Err(ProtocolError::ChainAdmin(
+            "price_e8 must be greater than 0".into(),
+        ));
     }
     let now = ic_cdk::api::time();
     mutate_state(|s| {
-        s.multi_chain.set_manual_price(chain, symbol.clone(), price_e8, now);
+        s.multi_chain
+            .set_manual_price(chain, symbol.clone(), price_e8, now);
     });
-    log!(INFO, "[set_manual_collateral_price] chain={:?} symbol={} price_e8={} set_at_ns={}", chain, symbol, price_e8, now);
+    log!(
+        INFO,
+        "[set_manual_collateral_price] chain={:?} symbol={} price_e8={} set_at_ns={}",
+        chain,
+        symbol,
+        price_e8,
+        now
+    );
     Ok(())
 }
 
@@ -2120,7 +2382,10 @@ fn get_manual_collateral_price(
     read_state(|s| {
         s.multi_chain
             .get_manual_price(chain, &symbol)
-            .map(|(price_e8, set_at_ns)| ManualPriceInfo { price_e8, set_at_ns })
+            .map(|(price_e8, set_at_ns)| ManualPriceInfo {
+                price_e8,
+                set_at_ns,
+            })
     })
 }
 
@@ -2223,9 +2488,114 @@ fn clear_invariant_halt() -> Result<(), ProtocolError> {
         }
     });
     if result.is_ok() {
-        log!(INFO, "[clear_invariant_halt] global invariant halt cleared (invariant re-verified)");
+        log!(
+            INFO,
+            "[clear_invariant_halt] global invariant halt cleared (invariant re-verified)"
+        );
     }
     result
+}
+
+const MAX_RECONCILIATION_PROOF_BYTES: usize = 512;
+
+fn normalize_reconciliation_proof(proof: &str) -> Result<String, ProtocolError> {
+    let trimmed = proof.trim();
+    if trimmed.is_empty() {
+        return Err(ProtocolError::ChainAdmin("proof text required".into()));
+    }
+    if trimmed.as_bytes().len() > MAX_RECONCILIATION_PROOF_BYTES {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "proof text too long: {} bytes > {}",
+            trimmed.as_bytes().len(),
+            MAX_RECONCILIATION_PROOF_BYTES
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn map_backing_settlement_error(
+    e: rumi_protocol_backend::chains::supply::BackingSettlementError,
+) -> ProtocolError {
+    ProtocolError::ChainAdmin(format!("{e:?}"))
+}
+
+/// Developer-gated manual reconciliation for the SP path: called after the
+/// operator verifies the matching foreign-chain icUSD burn for an amount already
+/// booked in `pending_chain_burn_e8s`.
+#[candid_method(update)]
+#[update]
+fn settle_pending_chain_burn(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    amount_e8s: u128,
+    proof: String,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let proof = normalize_reconciliation_proof(&proof)?;
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::supply::settle_pending_chain_burn(
+            &mut s.multi_chain,
+            chain,
+            amount_e8s,
+        )
+    })
+    .map_err(map_backing_settlement_error)?;
+    let timestamp = ic_cdk::api::time();
+    rumi_protocol_backend::storage::record_event(&Event::ChainPendingBurnSettled {
+        chain_id: chain,
+        amount_e8s,
+        proof: proof.clone(),
+        timestamp,
+    });
+    log!(
+        INFO,
+        "[settle_pending_chain_burn] chain={:?} amount_e8s={} proof={}",
+        chain,
+        amount_e8s,
+        proof
+    );
+    Ok(())
+}
+
+/// Developer-gated manual reconciliation for Tier-1 reserve retirement: called
+/// after the operator verifies the reserve-backed foreign icUSD was burned.
+#[candid_method(update)]
+#[update]
+fn settle_reserve_burn(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    amount_e8s: u128,
+    proof: String,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let proof = normalize_reconciliation_proof(&proof)?;
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::supply::settle_reserve_burn(
+            &mut s.multi_chain,
+            chain,
+            amount_e8s,
+        )
+    })
+    .map_err(map_backing_settlement_error)?;
+    let timestamp = ic_cdk::api::time();
+    rumi_protocol_backend::storage::record_event(&Event::ChainReserveBurnSettled {
+        chain_id: chain,
+        amount_e8s,
+        proof: proof.clone(),
+        timestamp,
+    });
+    log!(
+        INFO,
+        "[settle_reserve_burn] chain={:?} amount_e8s={} proof={}",
+        chain,
+        amount_e8s,
+        proof
+    );
+    Ok(())
 }
 
 /// Clear a chain's reorg circuit breaker. Resets BOTH `reorg_halted` AND the
@@ -2246,7 +2616,11 @@ fn clear_reorg_halt(
         s.multi_chain.reorg_halted.remove(&chain);
         s.multi_chain.reorg_suspect_streak.remove(&chain);
     });
-    log!(INFO, "[clear_reorg_halt] chain={:?} reorg halt + suspect streak cleared", chain);
+    log!(
+        INFO,
+        "[clear_reorg_halt] chain={:?} reorg halt + suspect streak cleared",
+        chain
+    );
     Ok(())
 }
 
@@ -2267,7 +2641,12 @@ fn set_last_observed_block(
     mutate_state(|s| {
         s.multi_chain.last_observed_block.insert(chain, block);
     });
-    log!(INFO, "[set_last_observed_block] chain={:?} block={}", chain, block);
+    log!(
+        INFO,
+        "[set_last_observed_block] chain={:?} block={}",
+        chain,
+        block
+    );
     Ok(())
 }
 
@@ -2276,10 +2655,14 @@ fn set_last_observed_block(
 /// confirm the cursor advances.
 #[candid_method(query)]
 #[query]
-fn get_last_observed_block(
-    chain: rumi_protocol_backend::chains::config::ChainId,
-) -> u64 {
-    read_state(|s| s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0))
+fn get_last_observed_block(chain: rumi_protocol_backend::chains::config::ChainId) -> u64 {
+    read_state(|s| {
+        s.multi_chain
+            .last_observed_block
+            .get(&chain)
+            .copied()
+            .unwrap_or(0)
+    })
 }
 
 /// Phase 1c notify-then-verify: submit a burn transaction hash for verification.
@@ -2330,7 +2713,9 @@ async fn submit_burn_proof(
                 log!(
                     INFO,
                     "[submit_burn_proof] chain={:?} tx={} applied {} burn(s)",
-                    chain_id, tx_hash, n
+                    chain_id,
+                    tx_hash,
+                    n
                 );
             }
             Ok(n)
@@ -2347,7 +2732,10 @@ async fn submit_burn_proof(
         ))),
         // Terminal: reverted tx, unknown chain/contract, or a halt-class
         // supply-invariant failure. None of these is fixed by retrying.
-        Err(e) => Err(ProtocolError::ChainAdmin(format!("burn proof rejected: {:?}", e))),
+        Err(e) => Err(ProtocolError::ChainAdmin(format!(
+            "burn proof rejected: {:?}",
+            e
+        ))),
     }
 }
 
@@ -2398,7 +2786,11 @@ fn delete_chain(
     });
     match result {
         Ok(()) => {
-            log!(INFO, "[delete_chain] chain={:?} deleted (all per-chain state purged)", chain);
+            log!(
+                INFO,
+                "[delete_chain] chain={:?} deleted (all per-chain state purged)",
+                chain
+            );
             Ok(())
         }
         Err(e) => Err(ProtocolError::ChainAdmin(format!("{e:?}"))),
@@ -2509,6 +2901,139 @@ pub struct ChainSupplyReconciliation {
     pub reserve_usdc_native: u128,
 }
 
+/// Operator report for Inc 5 reserve/bridge reconciliation. Book values are
+/// always returned; the on-chain settle-stable balance is best-effort because it
+/// depends on configured DEX token, seeded finalized cursor, reserve-address
+/// derivation, and EVM RPC availability.
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ChainReserveReport {
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub recorded_supply_e8s: u128,
+    pub reserve_backing_e8s: u128,
+    pub reserve_usdc_native: u128,
+    pub pending_chain_burn_e8s: u128,
+    pub bad_debt_e8s: u128,
+    pub finalized_block: u64,
+    pub settle_stable_token: Option<String>,
+    pub reserve_address: Option<String>,
+    pub onchain_usdc_balance_native: Option<u128>,
+    pub onchain_usdc_error: Option<String>,
+}
+
+/// Developer-gated reserve reconciliation view. Uses an update method because
+/// the optional `balanceOf` probe makes an inter-canister EVM RPC call and burns
+/// cycles; no protocol state is mutated.
+#[candid_method(update)]
+#[update]
+async fn get_chain_reserves(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<ChainReserveReport, ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    let (
+        registered,
+        recorded_supply,
+        reserve_backing,
+        reserve_usdc,
+        pending_burn,
+        bad_debt,
+        finalized_block,
+        settle_stable_token,
+    ) = read_state(|s| {
+        (
+            s.multi_chain.chain_configs.contains_key(&chain),
+            s.multi_chain
+                .chain_supplies
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .reserve_backing_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .reserve_usdc_native
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .pending_chain_burn_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .chain_bad_debt_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .last_observed_block
+                .get(&chain)
+                .copied()
+                .unwrap_or(0),
+            s.multi_chain
+                .chain_liquidation_configs
+                .get(&chain)
+                .map(|c| c.settle_stable_token.clone())
+                .filter(|token| !token.is_empty()),
+        )
+    });
+    if !registered {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not registered",
+            chain.0
+        )));
+    }
+
+    let mut report = ChainReserveReport {
+        chain_id: chain,
+        recorded_supply_e8s: recorded_supply,
+        reserve_backing_e8s: reserve_backing,
+        reserve_usdc_native: reserve_usdc,
+        pending_chain_burn_e8s: pending_burn,
+        bad_debt_e8s: bad_debt,
+        finalized_block,
+        settle_stable_token: settle_stable_token.clone(),
+        reserve_address: None,
+        onchain_usdc_balance_native: None,
+        onchain_usdc_error: None,
+    };
+
+    let Some(token) = settle_stable_token else {
+        report.onchain_usdc_error = Some("settle stable token not configured".into());
+        return Ok(report);
+    };
+    if finalized_block == 0 {
+        report.onchain_usdc_error = Some("finalized cursor unseeded".into());
+        return Ok(report);
+    }
+
+    let reserve_address =
+        match rumi_protocol_backend::chains::evm::tecdsa::cached_reserve_address(chain).await {
+            Ok((_path, address)) => address,
+            Err(e) => {
+                report.onchain_usdc_error = Some(format!("reserve address derive failed: {e}"));
+                return Ok(report);
+            }
+        };
+    report.reserve_address = Some(reserve_address.clone());
+    match rumi_protocol_backend::chains::evm::evm_rpc::erc20_balance_of(
+        chain,
+        &token,
+        &reserve_address,
+        finalized_block,
+    )
+    .await
+    {
+        Ok(balance) => report.onchain_usdc_balance_native = Some(balance),
+        Err(e) => report.onchain_usdc_error = Some(format!("reserve balance read failed: {e}")),
+    }
+    Ok(report)
+}
+
 /// Developer-gated, on-demand supply reconciliation against the chain (audit
 /// FLAG-2). The Timer-B self-check only compares two INTERNAL mirror fields
 /// (`sum(chain_supplies)` vs `total_chain_vault_debt`), which are kept in
@@ -2530,7 +3055,12 @@ async fn reconcile_chain_supply(
     let (contract, recorded, in_flight, cursor, reserve_backing, pending_burn, reserve_usdc) =
         read_state(|s| {
             let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
-            let recorded = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+            let recorded = s
+                .multi_chain
+                .chain_supplies
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
             let in_flight = s
                 .multi_chain
                 .settlement_queues
@@ -2542,7 +3072,8 @@ async fn reconcile_chain_supply(
                             SettlementOpKind::Mint { amount_e8s, .. }
                                 if matches!(
                                     op.status,
-                                    SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+                                    SettlementOpStatus::Queued
+                                        | SettlementOpStatus::Inflight { .. }
                                 ) =>
                             {
                                 Some(*amount_e8s)
@@ -2552,28 +3083,60 @@ async fn reconcile_chain_supply(
                         .sum::<u128>()
                 })
                 .unwrap_or(0);
-            let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+            let cursor = s
+                .multi_chain
+                .last_observed_block
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
             // Informational RHS breakdown for this chain (NOT part of the
             // unbacked_excess check — findings #17/#20/#29).
-            let reserve_backing = s.multi_chain.reserve_backing_e8s.get(&chain).copied().unwrap_or(0);
-            let pending_burn = s.multi_chain.pending_chain_burn_e8s.get(&chain).copied().unwrap_or(0);
-            let reserve_usdc = s.multi_chain.reserve_usdc_native.get(&chain).copied().unwrap_or(0);
-            (contract, recorded, in_flight, cursor, reserve_backing, pending_burn, reserve_usdc)
+            let reserve_backing = s
+                .multi_chain
+                .reserve_backing_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
+            let pending_burn = s
+                .multi_chain
+                .pending_chain_burn_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
+            let reserve_usdc = s
+                .multi_chain
+                .reserve_usdc_native
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
+            (
+                contract,
+                recorded,
+                in_flight,
+                cursor,
+                reserve_backing,
+                pending_burn,
+                reserve_usdc,
+            )
         });
     let contract = contract.ok_or_else(|| {
-        ProtocolError::ChainAdmin(format!("no icUSD contract configured for chain {:?}", chain))
+        ProtocolError::ChainAdmin(format!(
+            "no icUSD contract configured for chain {:?}",
+            chain
+        ))
     })?;
     if cursor == 0 {
         return Err(ProtocolError::ChainAdmin(
             "finalized cursor unseeded; call set_last_observed_block(chain, <tip>) first".into(),
         ));
     }
-    let onchain =
-        rumi_protocol_backend::chains::monad::evm_rpc::erc20_total_supply_at(chain, &contract, cursor)
-            .await
-            .map_err(|e| {
-                ProtocolError::TemporarilyUnavailable(format!("totalSupply read failed; retry: {e}"))
-            })?;
+    let onchain = rumi_protocol_backend::chains::monad::evm_rpc::erc20_total_supply_at(
+        chain, &contract, cursor,
+    )
+    .await
+    .map_err(|e| {
+        ProtocolError::TemporarilyUnavailable(format!("totalSupply read failed; retry: {e}"))
+    })?;
     let gap_e8s = onchain as i128 - recorded as i128;
     // The unbacked-excess test compares on-chain totalSupply against recorded
     // chain_supplies (+ in-flight mints) ONLY. reserve_backing / pending_chain_burn
@@ -2628,24 +3191,44 @@ fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {
         global_icusd_mint_cap: s.global_icusd_mint_cap,
         interest_flush_threshold_e8s: s.interest_flush_threshold_e8s,
 
-        interest_split: s.interest_split.iter().map(|r| {
-            let dest = match &r.destination {
-                rumi_protocol_backend::state::InterestDestination::StabilityPool => "stability_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Treasury => "treasury".to_string(),
-                rumi_protocol_backend::state::InterestDestination::ThreePool => "three_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
-            };
-            InterestSplitArg { destination: dest, bps: r.bps }
-        }).collect(),
+        interest_split: s
+            .interest_split
+            .iter()
+            .map(|r| {
+                let dest = match &r.destination {
+                    rumi_protocol_backend::state::InterestDestination::StabilityPool => {
+                        "stability_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Treasury => {
+                        "treasury".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::ThreePool => {
+                        "three_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
+                };
+                InterestSplitArg {
+                    destination: dest,
+                    bps: r.bps,
+                }
+            })
+            .collect(),
 
-        global_rate_curve: s.global_rate_curve.markers.iter()
+        global_rate_curve: s
+            .global_rate_curve
+            .markers
+            .iter()
             .map(|m| (m.cr_level.to_f64(), m.multiplier.to_f64()))
             .collect(),
-        recovery_rate_curve: s.recovery_rate_curve.iter()
+        recovery_rate_curve: s
+            .recovery_rate_curve
+            .iter()
             .map(|m| (format!("{:?}", m.threshold), m.multiplier.to_f64()))
             .collect(),
         borrowing_fee_curve: match &s.borrowing_fee_curve {
-            Some(curve) => s.resolve_curve(curve, None).iter()
+            Some(curve) => s
+                .resolve_curve(curve, None)
+                .iter()
                 .map(|(cr, mult)| (cr.to_f64(), mult.to_f64()))
                 .collect(),
             None => vec![],
@@ -2669,7 +3252,9 @@ fn get_protocol_config() -> rumi_protocol_backend::ProtocolConfig {
         bot_allowed_collateral_types: s.bot_allowed_collateral_types.iter().cloned().collect(),
         bot_cr_tolerance_bps: s.bot_cr_tolerance_bps,
 
-        collateral_configs: s.collateral_configs.iter()
+        collateral_configs: s
+            .collateral_configs
+            .iter()
             .map(|(ct, config)| {
                 let mut cfg = config.clone();
                 cfg.recovery_target_cr = cfg.borrow_threshold_ratio * s.recovery_cr_multiplier;
@@ -2686,7 +3271,9 @@ fn get_fees(redeemed_amount: u64) -> Fees {
         let icp_ct = s.icp_collateral_type();
         Fees {
             borrowing_fee: s.get_borrowing_fee().to_f64(),
-            redemption_fee: s.get_redemption_fee_for(&icp_ct, redeemed_amount.into()).to_f64(),
+            redemption_fee: s
+                .get_redemption_fee_for(&icp_ct, redeemed_amount.into())
+                .to_f64(),
         }
     })
 }
@@ -2696,7 +3283,9 @@ fn get_fees(redeemed_amount: u64) -> Fees {
 fn get_fees_for_collateral(collateral_type: Principal, redeemed_amount: u64) -> Fees {
     read_state(|s| Fees {
         borrowing_fee: s.get_borrowing_fee().to_f64(),
-        redemption_fee: s.get_redemption_fee_for(&collateral_type, redeemed_amount.into()).to_f64(),
+        redemption_fee: s
+            .get_redemption_fee_for(&collateral_type, redeemed_amount.into())
+            .to_f64(),
     })
 }
 
@@ -2865,34 +3454,39 @@ fn get_events_filtered(args: GetEventsArg) -> GetEventsFilteredResponse {
             .unwrap_or(0)
     });
 
-    let types_set: Option<std::collections::HashSet<EventTypeFilter>> = args.types
+    let types_set: Option<std::collections::HashSet<EventTypeFilter>> = args
+        .types
         .as_ref()
         .filter(|v| !v.is_empty())
         .map(|v| v.iter().cloned().collect());
 
-    let admin_labels_set: Option<std::collections::HashSet<String>> = args.admin_labels
+    let admin_labels_set: Option<std::collections::HashSet<String>> = args
+        .admin_labels
         .as_ref()
         .filter(|v| !v.is_empty())
         .map(|v| v.iter().cloned().collect());
 
     let filtered: Vec<(u64, Event)> = events()
         .enumerate()
-        .filter(|(_, e)| e.passes_filters(
-            types_set.as_ref(),
-            args.principal.as_ref(),
-            args.collateral_token.as_ref(),
-            args.time_range.as_ref(),
-            args.min_size_e8s,
-            admin_labels_set.as_ref(),
-            &vault_lookup,
-            icp_price_e8s,
-        ))
+        .filter(|(_, e)| {
+            e.passes_filters(
+                types_set.as_ref(),
+                args.principal.as_ref(),
+                args.collateral_token.as_ref(),
+                args.time_range.as_ref(),
+                args.min_size_e8s,
+                admin_labels_set.as_ref(),
+                &vault_lookup,
+                icp_price_e8s,
+            )
+        })
         .map(|(i, e)| (i as u64, e))
         .collect();
 
     let total = filtered.len() as u64;
     let start_idx = page * page_size;
-    let page_events: Vec<(u64, Event)> = filtered.into_iter()
+    let page_events: Vec<(u64, Event)> = filtered
+        .into_iter()
         .rev()
         .skip(start_idx)
         .take(page_size)
@@ -3217,7 +3811,10 @@ fn get_vaults_page(start_id: u64, limit: u64) -> VaultsPageResponse {
             vaults.push(CandidVault::from(vault.clone()));
         }
         let next_start_id = iter.next().map(|(id, _)| *id);
-        VaultsPageResponse { vaults, next_start_id }
+        VaultsPageResponse {
+            vaults,
+            next_start_id,
+        }
     })
 }
 
@@ -3248,7 +3845,10 @@ async fn redeem_icp(icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> 
 /// `redeem_icp` remains as a convenience wrapper for ICP specifically.
 #[candid_method(update)]
 #[update]
-async fn redeem_collateral(collateral_type: Principal, icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
+async fn redeem_collateral(
+    collateral_type: Principal,
+    icusd_amount: u64,
+) -> Result<SuccessWithFee, ProtocolError> {
     validate_call().await?;
     // Wave-9 RED-003: gate redemption on protocol mode. ReadOnly auto-latches
     // when total collateral ratio drops below 100% (Wave-1) or when the
@@ -3264,7 +3864,9 @@ async fn redeem_collateral(collateral_type: Principal, icusd_amount: u64) -> Res
     // delegates to ensure_fresh_price for ICP (already handled), so this is
     // safe to call unconditionally.
     rumi_protocol_backend::xrc::ensure_fresh_price_for(&collateral_type).await?;
-    check_postcondition(rumi_protocol_backend::vault::redeem_collateral(collateral_type, icusd_amount).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::redeem_collateral(collateral_type, icusd_amount).await,
+    )
 }
 
 #[candid_method(query)]
@@ -3272,15 +3874,21 @@ async fn redeem_collateral(collateral_type: Principal, icusd_amount: u64) -> Res
 fn get_redemption_rate() -> f64 {
     read_state(|s| {
         let icp_ct = s.icp_collateral_type();
-        s.get_redemption_fee_for(&icp_ct, ICUSD::from(100_000_000)).to_f64()
+        s.get_redemption_fee_for(&icp_ct, ICUSD::from(100_000_000))
+            .to_f64()
     })
 }
 
 #[candid_method(update)]
 #[update]
-async fn open_vault(collateral_amount: u64, collateral_type: Option<Principal>) -> Result<OpenVaultSuccess, ProtocolError> {
+async fn open_vault(
+    collateral_amount: u64,
+    collateral_type: Option<Principal>,
+) -> Result<OpenVaultSuccess, ProtocolError> {
     validate_call().await?;
-    check_postcondition(rumi_protocol_backend::vault::open_vault(collateral_amount, collateral_type).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::open_vault(collateral_amount, collateral_type).await,
+    )
 }
 
 /// Compound open vault + borrow in a single canister call.
@@ -3297,7 +3905,12 @@ async fn open_vault_and_borrow(
     // ORACLE-001: refresh the (possibly non-ICP) collateral price before minting.
     validate_freshness_for_collateral(collateral_type).await?;
     check_postcondition(
-        rumi_protocol_backend::vault::open_vault_and_borrow(collateral_amount, borrow_amount, collateral_type).await,
+        rumi_protocol_backend::vault::open_vault_and_borrow(
+            collateral_amount,
+            borrow_amount,
+            collateral_type,
+        )
+        .await,
     )
 }
 
@@ -3339,7 +3952,9 @@ async fn add_margin_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
 /// then calls open_vault_with_deposit or add_margin_with_deposit.
 #[candid_method(query)]
 #[query]
-fn get_deposit_account(_collateral_type: Option<Principal>) -> icrc_ledger_types::icrc1::account::Account {
+fn get_deposit_account(
+    _collateral_type: Option<Principal>,
+) -> icrc_ledger_types::icrc1::account::Account {
     let caller = ic_cdk::caller();
     rumi_protocol_backend::management::get_deposit_account_for(&caller)
 }
@@ -3348,12 +3963,17 @@ fn get_deposit_account(_collateral_type: Option<Principal>) -> icrc_ledger_types
 /// Use this instead of open_vault when the wallet cannot do ICRC-2 approve (e.g., Oisy).
 #[candid_method(update)]
 #[update]
-async fn open_vault_with_deposit(borrow_amount: u64, collateral_type: Option<Principal>) -> Result<OpenVaultSuccess, ProtocolError> {
+async fn open_vault_with_deposit(
+    borrow_amount: u64,
+    collateral_type: Option<Principal>,
+) -> Result<OpenVaultSuccess, ProtocolError> {
     validate_call().await?;
     validate_mode()?;
     // ORACLE-001: refresh the (possibly non-ICP) collateral price before minting.
     validate_freshness_for_collateral(collateral_type).await?;
-    check_postcondition(rumi_protocol_backend::vault::open_vault_with_deposit(borrow_amount, collateral_type).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::open_vault_with_deposit(borrow_amount, collateral_type).await,
+    )
 }
 
 /// Add margin to a vault using funds already deposited to the caller's deposit account.
@@ -3384,11 +4004,15 @@ async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
 
 #[candid_method(update)]
 #[update]
-async fn withdraw_partial_collateral(arg: rumi_protocol_backend::vault::VaultArg) -> Result<u64, ProtocolError> {
+async fn withdraw_partial_collateral(
+    arg: rumi_protocol_backend::vault::VaultArg,
+) -> Result<u64, ProtocolError> {
     validate_call().await?;
     // ORACLE-001: refresh this vault's collateral price before releasing collateral.
     validate_freshness_for_vault(arg.vault_id).await?;
-    check_postcondition(rumi_protocol_backend::vault::withdraw_partial_collateral(arg.vault_id, arg.amount).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::withdraw_partial_collateral(arg.vault_id, arg.amount).await,
+    )
 }
 
 #[candid_method(update)]
@@ -3402,7 +4026,9 @@ async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, Protocol
 /// Saves one Oisy consent screen for users closing borrowed vaults.
 #[candid_method(update)]
 #[update]
-async fn repay_and_close_vault(arg: VaultArg) -> Result<rumi_protocol_backend::vault::RepayAndCloseSuccess, ProtocolError> {
+async fn repay_and_close_vault(
+    arg: VaultArg,
+) -> Result<rumi_protocol_backend::vault::RepayAndCloseSuccess, ProtocolError> {
     validate_call().await?;
     check_postcondition(rumi_protocol_backend::vault::repay_and_close_vault(arg).await)
 }
@@ -3434,24 +4060,38 @@ async fn liquidate_vault_partial(arg: VaultArg) -> Result<SuccessWithFee, Protoc
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
     validate_freshness_for_vault(arg.vault_id).await?;
-    check_postcondition(rumi_protocol_backend::vault::liquidate_vault_partial(arg.vault_id, arg.amount).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::liquidate_vault_partial(arg.vault_id, arg.amount).await,
+    )
 }
 
 /// Liquidate a vault using ckUSDT or ckUSDC (1:1 with icUSD)
 #[update]
 #[candid_method(update)]
-async fn liquidate_vault_partial_with_stable(arg: VaultArgWithToken) -> Result<SuccessWithFee, ProtocolError> {
+async fn liquidate_vault_partial_with_stable(
+    arg: VaultArgWithToken,
+) -> Result<SuccessWithFee, ProtocolError> {
     validate_call().await?;
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
     validate_freshness_for_vault(arg.vault_id).await?;
-    check_postcondition(rumi_protocol_backend::vault::liquidate_vault_partial_with_stable(arg.vault_id, arg.amount, arg.token_type).await)
+    check_postcondition(
+        rumi_protocol_backend::vault::liquidate_vault_partial_with_stable(
+            arg.vault_id,
+            arg.amount,
+            arg.token_type,
+        )
+        .await,
+    )
 }
 
 // Stability Pool Integration - allows stability pool to execute liquidations
 #[update]
 #[candid_method(update)]
-async fn stability_pool_liquidate(vault_id: u64, max_debt_to_liquidate: u64) -> Result<StabilityPoolLiquidationResult, ProtocolError> {
+async fn stability_pool_liquidate(
+    vault_id: u64,
+    max_debt_to_liquidate: u64,
+) -> Result<StabilityPoolLiquidationResult, ProtocolError> {
     validate_call().await?;
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
@@ -3467,9 +4107,8 @@ async fn stability_pool_liquidate(vault_id: u64, max_debt_to_liquidate: u64) -> 
     let caller = ic_cdk::api::caller();
 
     // Authorization: only the registered stability pool canister can call this
-    let is_stability_pool = read_state(|s| {
-        s.stability_pool_canister.map_or(false, |sp| sp == caller)
-    });
+    let is_stability_pool =
+        read_state(|s| s.stability_pool_canister.map_or(false, |sp| sp == caller));
     if !is_stability_pool {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered stability pool canister".to_string(),
@@ -3481,10 +4120,12 @@ async fn stability_pool_liquidate(vault_id: u64, max_debt_to_liquidate: u64) -> 
         match s.vault_id_to_vaults.get(&vault_id) {
             Some(vault) => {
                 // Per-collateral price lookup
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
+                let price = s
+                    .get_collateral_price_decimal(&vault.collateral_type)
                     .ok_or("No price available for this collateral type")?;
                 let collateral_price_usd = UsdIcp::from(price);
-                let ratio = rumi_protocol_backend::compute_collateral_ratio(vault, collateral_price_usd, s);
+                let ratio =
+                    rumi_protocol_backend::compute_collateral_ratio(vault, collateral_price_usd, s);
 
                 let min_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
                 if ratio >= min_ratio {
@@ -3498,26 +4139,39 @@ async fn stability_pool_liquidate(vault_id: u64, max_debt_to_liquidate: u64) -> 
 
                 // Calculate optimal amount to restore vault to target CR
                 let optimal_amount = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
-                let actual_liquidatable_debt = optimal_amount.min(vault.borrowed_icusd_amount).min(max_debt_to_liquidate.into());
+                let actual_liquidatable_debt = optimal_amount
+                    .min(vault.borrowed_icusd_amount)
+                    .min(max_debt_to_liquidate.into());
 
                 // Calculate collateral that will be seized (debt + liquidation bonus)
                 let liquidation_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
                 let icp_equivalent = actual_liquidatable_debt / collateral_price_usd;
                 let collateral_with_bonus = icp_equivalent * liquidation_bonus;
-                let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+                let collateral_to_seize =
+                    collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
-                Ok((vault.clone(), collateral_price_usd, actual_liquidatable_debt, collateral_to_seize))
-            },
+                Ok((
+                    vault.clone(),
+                    collateral_price_usd,
+                    actual_liquidatable_debt,
+                    collateral_to_seize,
+                ))
+            }
             None => Err(format!("Vault #{} not found", vault_id)),
         }
-    }).map_err(|e| ProtocolError::GenericError(e))?;
+    })
+    .map_err(|e| ProtocolError::GenericError(e))?;
 
     if liquidatable_debt == ICUSD::new(0) {
-        return Err(ProtocolError::GenericError("No liquidatable debt available".to_string()));
+        return Err(ProtocolError::GenericError(
+            "No liquidatable debt available".to_string(),
+        ));
     }
 
     // Execute the liquidation using existing logic
-    let result = rumi_protocol_backend::vault::liquidate_vault_partial(vault_id, liquidatable_debt.to_u64()).await?;
+    let result =
+        rumi_protocol_backend::vault::liquidate_vault_partial(vault_id, liquidatable_debt.to_u64())
+            .await?;
 
     // Return structured result for stability pool
     Ok(StabilityPoolLiquidationResult {
@@ -3561,9 +4215,8 @@ async fn stability_pool_liquidate_debt_burned(
     }
     let caller = ic_cdk::api::caller();
 
-    let is_stability_pool = read_state(|s| {
-        s.stability_pool_canister.map_or(false, |sp| sp == caller)
-    });
+    let is_stability_pool =
+        read_state(|s| s.stability_pool_canister.map_or(false, |sp| sp == caller));
     if !is_stability_pool {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered stability pool canister".to_string(),
@@ -3571,7 +4224,11 @@ async fn stability_pool_liquidate_debt_burned(
     }
 
     rumi_protocol_backend::vault::liquidate_vault_debt_already_burned(
-        vault_id, icusd_burned_e8s, caller, None, proof,
+        vault_id,
+        icusd_burned_e8s,
+        caller,
+        None,
+        proof,
     )
     .await
 }
@@ -3613,9 +4270,8 @@ async fn stability_pool_liquidate_with_reserves(
     }
     let caller = ic_cdk::api::caller();
 
-    let is_stability_pool = read_state(|s| {
-        s.stability_pool_canister.map_or(false, |sp| sp == caller)
-    });
+    let is_stability_pool =
+        read_state(|s| s.stability_pool_canister.map_or(false, |sp| sp == caller));
     if !is_stability_pool {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered stability pool canister".to_string(),
@@ -3630,43 +4286,48 @@ async fn stability_pool_liquidate_with_reserves(
             minimum_amount: read_state(|s| s.min_icusd_amount).to_u64(),
         });
     }
-    read_state(|s| {
-        match s.vault_id_to_vaults.get(&vault_id) {
-            Some(vault) => {
-                if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
-                    if !status.allows_liquidation() {
-                        return Err(ProtocolError::GenericError(
-                            "Liquidation is not allowed for this collateral type".to_string(),
-                        ));
-                    }
-                }
-                if s.get_collateral_price_decimal(&vault.collateral_type).is_none() {
+    read_state(|s| match s.vault_id_to_vaults.get(&vault_id) {
+        Some(vault) => {
+            if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
+                if !status.allows_liquidation() {
                     return Err(ProtocolError::GenericError(
-                        "No price available for collateral. Price feed may be down.".to_string(),
+                        "Liquidation is not allowed for this collateral type".to_string(),
                     ));
                 }
-                let capped = liquidation_amount.min(vault.borrowed_icusd_amount);
-                if capped == rumi_protocol_backend::numeric::ICUSD::new(0) {
-                    return Err(ProtocolError::GenericError(
-                        "Cannot liquidate zero amount — vault has no debt".to_string(),
-                    ));
-                }
-                Ok(())
             }
-            None => Err(ProtocolError::GenericError(
-                format!("Vault #{} not found", vault_id),
-            )),
+            if s.get_collateral_price_decimal(&vault.collateral_type)
+                .is_none()
+            {
+                return Err(ProtocolError::GenericError(
+                    "No price available for collateral. Price feed may be down.".to_string(),
+                ));
+            }
+            let capped = liquidation_amount.min(vault.borrowed_icusd_amount);
+            if capped == rumi_protocol_backend::numeric::ICUSD::new(0) {
+                return Err(ProtocolError::GenericError(
+                    "Cannot liquidate zero amount — vault has no debt".to_string(),
+                ));
+            }
+            Ok(())
         }
+        None => Err(ProtocolError::GenericError(format!(
+            "Vault #{} not found",
+            vault_id
+        ))),
     })?;
 
     // Pull 3USD from the SP into protocol reserves subaccount (ICRC-2 transfer_from).
     // Only runs after validation passes — no tokens move if vault is stale.
     // The block index returned drives the Phase-2 internal proof below.
     let transfer_block_index = rumi_protocol_backend::management::transfer_3usd_to_reserves(
-        three_usd_ledger, caller, three_usd_amount_e8s
-    ).await.map_err(|e| ProtocolError::GenericError(
-        format!("Failed to pull 3USD from stability pool: {:?}", e)
-    ))?;
+        three_usd_ledger,
+        caller,
+        three_usd_amount_e8s,
+    )
+    .await
+    .map_err(|e| {
+        ProtocolError::GenericError(format!("Failed to pull 3USD from stability pool: {:?}", e))
+    })?;
 
     // Wave-8d LIQ-004 Phase 2: build the writedown proof from the just-
     // produced transfer block. Vault binding is set here at construction
@@ -3686,8 +4347,14 @@ async fn stability_pool_liquidate_with_reserves(
     // got a chance to mark it consumed. Refund it so the SP's ledger balance and
     // bookkeeping stay in sync.
     match rumi_protocol_backend::vault::liquidate_vault_debt_already_burned(
-        vault_id, icusd_debt_covered_e8s, caller, Some(three_usd_amount_e8s), proof,
-    ).await {
+        vault_id,
+        icusd_debt_covered_e8s,
+        caller,
+        Some(three_usd_amount_e8s),
+        proof,
+    )
+    .await
+    {
         Ok(success) => {
             // VER-002 (audit 2026-06-05): the full `three_usd_amount_e8s` was
             // pulled above, but the writedown is capped to the vault's current
@@ -3703,19 +4370,23 @@ async fn stability_pool_liquidate_with_reserves(
                     / (icusd_debt_covered_e8s as u128);
                 let excess = three_usd_amount_e8s.saturating_sub(realized_3usd as u64);
                 if excess > 0 {
-                    log!(INFO,
+                    log!(
+                        INFO,
                         "[stability_pool_liquidate_with_reserves] vault #{}: writedown capped \
                          ({} of {} icUSD realized); refunding {} excess 3USD to SP",
-                        vault_id, success.liquidated_debt, icusd_debt_covered_e8s, excess);
+                        vault_id,
+                        success.liquidated_debt,
+                        icusd_debt_covered_e8s,
+                        excess
+                    );
                     refund_3usd_to_stability_pool(three_usd_ledger, caller, excess, vault_id).await;
                 }
             }
             Ok(success)
         }
         Err(liq_error) => {
-            refund_3usd_to_stability_pool(
-                three_usd_ledger, caller, three_usd_amount_e8s, vault_id,
-            ).await;
+            refund_3usd_to_stability_pool(three_usd_ledger, caller, three_usd_amount_e8s, vault_id)
+                .await;
             Err(liq_error)
         }
     }
@@ -3753,10 +4424,14 @@ async fn refund_3usd_to_stability_pool(
         }
     };
     if amount_e8s <= fee {
-        log!(INFO,
+        log!(
+            INFO,
             "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
              to SP {} aborted (amount does not cover ledger fee {}). Tokens stranded in reserves.",
-            amount_e8s, vault_id, sp_caller, fee
+            amount_e8s,
+            vault_id,
+            sp_caller,
+            fee
         );
         return;
     }
@@ -3765,7 +4440,10 @@ async fn refund_3usd_to_stability_pool(
     let result = rumi_protocol_backend::management::transfer_idempotent(
         three_usd_ledger,
         Some(rumi_protocol_backend::management::protocol_3usd_reserves_subaccount()),
-        icrc_ledger_types::icrc1::account::Account { owner: sp_caller, subaccount: None },
+        icrc_ledger_types::icrc1::account::Account {
+            owner: sp_caller,
+            subaccount: None,
+        },
         refund_amount as u128,
         refund_nonce,
         None,
@@ -3884,7 +4562,10 @@ fn get_liquidatable_vaults_page(start_id: u64, limit: u64) -> VaultsPageResponse
                 vaults.push(CandidVault::from(vault.clone()));
             }
         }
-        VaultsPageResponse { vaults, next_start_id }
+        VaultsPageResponse {
+            vaults,
+            next_start_id,
+        }
     })
 }
 
@@ -4060,9 +4741,7 @@ async fn confirm_xrp_deposit(vault_id: u64) -> Result<u64, ProtocolError> {
 #[update]
 async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<String, ProtocolError> {
     validate_call().await?;
-    check_postcondition(
-        rumi_protocol_backend::vault::settle_xrp_claim(claim_id, destination).await,
-    )
+    check_postcondition(rumi_protocol_backend::vault::settle_xrp_claim(claim_id, destination).await)
 }
 
 /// P5 (native-XRP collateral): register XRP as a collateral (developer-gated). XRP
@@ -4094,7 +4773,8 @@ async fn register_xrp_collateral() -> Result<(), ProtocolError> {
         let icp = s.get_collateral_config(&icp_ct);
         (
             icp.map(|c| c.borrowing_fee).unwrap_or(Ratio::from_f64(0.0)),
-            icp.map(|c| c.interest_rate_apr).unwrap_or(Ratio::from_f64(0.0)),
+            icp.map(|c| c.interest_rate_apr)
+                .unwrap_or(Ratio::from_f64(0.0)),
             s.recovery_cr_multiplier,
         )
     });
@@ -4130,7 +4810,10 @@ fn get_xrp_pending_deposits() -> Vec<(u64, rumi_protocol_backend::state::XrpPend
         if s.developer_principal != caller {
             return Vec::new();
         }
-        s.xrp_pending_deposits.iter().map(|(id, d)| (*id, d.clone())).collect()
+        s.xrp_pending_deposits
+            .iter()
+            .map(|(id, d)| (*id, d.clone()))
+            .collect()
     })
 }
 
@@ -4146,7 +4829,10 @@ fn get_xrp_claims() -> Vec<(u64, rumi_protocol_backend::state::XrpClaim)> {
         if s.developer_principal != caller {
             return Vec::new();
         }
-        s.xrp_claims.iter().map(|(id, c)| (*id, c.clone())).collect()
+        s.xrp_claims
+            .iter()
+            .map(|(id, c)| (*id, c.clone()))
+            .collect()
     })
 }
 
@@ -4273,15 +4959,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 
                 let total_tvl = total_icp_dec * s.last_icp_rate.unwrap_or(UsdIcp::from(dec!(0))).0;
 
-                w.encode_gauge(
-                    "total_tvl",
-                    total_tvl.to_f64().unwrap(),
-                    "Total TVL.",
-                )?;
+                w.encode_gauge("total_tvl", total_tvl.to_f64().unwrap(), "Total TVL.")?;
 
-                let total_borrowed_icusd_amount = Decimal::from_u64(s.total_borrowed_icusd_amount().0)
-                    .expect("failed to construct decimal from u64")
-                    / dec!(100_000_000);
+                let total_borrowed_icusd_amount =
+                    Decimal::from_u64(s.total_borrowed_icusd_amount().0)
+                        .expect("failed to construct decimal from u64")
+                        / dec!(100_000_000);
 
                 w.encode_gauge(
                     "icusd_total_borrowed_amount",
@@ -4368,7 +5051,6 @@ fn http_request(req: HttpRequest) -> HttpResponse {
     }
 }
 
-
 #[candid_method(update)]
 #[update]
 async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> {
@@ -4376,7 +5058,8 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
     // ASYNC-003: serialize per-caller so two concurrent manual recoveries cannot
     // both pay out the same pending entry (the entry is only removed AFTER the
     // await below). Defense-in-depth on top of the nonce-dedup fix.
-    let _guard = rumi_protocol_backend::guard::GuardPrincipal::new(caller, "recover_pending_transfer")?;
+    let _guard =
+        rumi_protocol_backend::guard::GuardPrincipal::new(caller, "recover_pending_transfer")?;
 
     // Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are
     // keyed by (vault_id, owner). Look up the entry that belongs to the caller.
@@ -4385,29 +5068,35 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
         if let Some(t) = s.pending_margin_transfers.get(&key).cloned() {
             Some(("margin", t))
         } else {
-            s.pending_excess_transfers.get(&key).cloned().map(|t| ("excess", t))
+            s.pending_excess_transfers
+                .get(&key)
+                .cloned()
+                .map(|t| ("excess", t))
         }
     });
 
     if let Some((source, transfer)) = transfer_info {
         // Look up per-collateral config for ledger and fee; fall back to global ICP defaults
-        let (ledger, transfer_fee) = read_state(|s| {
-            match s.get_collateral_config(&transfer.collateral_type) {
-                Some(config) => (config.ledger_canister_id, ICP::from(config.ledger_fee)),
-                None => (s.icp_ledger_principal, s.icp_ledger_fee),
-            }
-        });
+        let (ledger, transfer_fee) =
+            read_state(
+                |s| match s.get_collateral_config(&transfer.collateral_type) {
+                    Some(config) => (config.ledger_canister_id, ICP::from(config.ledger_fee)),
+                    None => (s.icp_ledger_principal, s.icp_ledger_fee),
+                },
+            );
 
         if transfer.margin <= transfer_fee {
             // Margin too small to cover fee — clean it up
-            mutate_state(|s| {
-                match source {
-                    "margin" => { s.pending_margin_transfers.remove(&key); },
-                    _ => { s.pending_excess_transfers.remove(&key); },
+            mutate_state(|s| match source {
+                "margin" => {
+                    s.pending_margin_transfers.remove(&key);
+                }
+                _ => {
+                    s.pending_excess_transfers.remove(&key);
                 }
             });
             return Err(ProtocolError::GenericError(
-                "Pending transfer margin is too small to cover the ledger fee".to_string()
+                "Pending transfer margin is too small to cover the ledger fee".to_string(),
             ));
         }
 
@@ -4421,14 +5110,17 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
             transfer.owner,
             ledger,
             transfer.op_nonce,
-        ).await;
+        )
+        .await;
 
         match result {
             Ok(block_index) => {
-                mutate_state(|s| {
-                    match source {
-                        "margin" => { event::record_margin_transfer(s, vault_id, caller, block_index); },
-                        _ => { s.pending_excess_transfers.remove(&key); },
+                mutate_state(|s| match source {
+                    "margin" => {
+                        event::record_margin_transfer(s, vault_id, caller, block_index);
+                    }
+                    _ => {
+                        s.pending_excess_transfers.remove(&key);
                     }
                 });
                 Ok(true)
@@ -4446,7 +5138,9 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
         }
     } else {
         // No pending transfer found for this caller + vault
-        Err(ProtocolError::GenericError("No pending transfer found for this vault".to_string()))
+        Err(ProtocolError::GenericError(
+            "No pending transfer found for this vault".to_string(),
+        ))
     }
 }
 
@@ -4455,18 +5149,24 @@ async fn recover_pending_transfer(vault_id: u64) -> Result<bool, ProtocolError> 
 #[update]
 async fn set_treasury_principal(treasury_principal: Principal) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
-    
+
     // Only developer can set treasury principal
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set treasury principal".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set treasury principal".to_string(),
+        ));
     }
-    
+
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_treasury_principal(s, treasury_principal);
     });
 
-    log!(INFO, "[set_treasury_principal] Treasury principal set to: {}", treasury_principal);
+    log!(
+        INFO,
+        "[set_treasury_principal] Treasury principal set to: {}",
+        treasury_principal
+    );
     Ok(())
 }
 
@@ -4479,20 +5179,31 @@ fn get_treasury_principal() -> Option<Principal> {
 // Add stability pool configuration endpoint (developer only)
 #[candid_method(update)]
 #[update]
-async fn set_stability_pool_principal(stability_pool_principal: Principal) -> Result<(), ProtocolError> {
+async fn set_stability_pool_principal(
+    stability_pool_principal: Principal,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
-    
+
     // Only developer can set stability pool principal
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set stability pool principal".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set stability pool principal".to_string(),
+        ));
     }
-    
+
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_stability_pool_principal(s, stability_pool_principal);
+        rumi_protocol_backend::event::record_set_stability_pool_principal(
+            s,
+            stability_pool_principal,
+        );
     });
 
-    log!(INFO, "[set_stability_pool_principal] Stability pool principal set to: {}", stability_pool_principal);
+    log!(
+        INFO,
+        "[set_stability_pool_principal] Stability pool principal set to: {}",
+        stability_pool_principal
+    );
     Ok(())
 }
 
@@ -4525,21 +5236,36 @@ pub struct BotStatsResponse {
 
 #[candid_method(update)]
 #[update]
-async fn set_liquidation_bot_config(bot_principal: Principal, monthly_budget_e8s: u64) -> Result<(), ProtocolError> {
+async fn set_liquidation_bot_config(
+    bot_principal: Principal,
+    monthly_budget_e8s: u64,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set liquidation bot config".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set liquidation bot config".to_string(),
+        ));
     }
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_liquidation_bot_principal(s, bot_principal);
-        rumi_protocol_backend::event::record_set_bot_budget(s, monthly_budget_e8s, ic_cdk::api::time());
+        rumi_protocol_backend::event::record_set_bot_budget(
+            s,
+            monthly_budget_e8s,
+            ic_cdk::api::time(),
+        );
         // Default: allow ICP if the allowlist is empty (first-time setup)
         if s.bot_allowed_collateral_types.is_empty() {
-            s.bot_allowed_collateral_types.insert(s.icp_ledger_principal);
+            s.bot_allowed_collateral_types
+                .insert(s.icp_ledger_principal);
         }
     });
-    log!(INFO, "[set_liquidation_bot_config] Bot principal: {}, budget: {} e8s", bot_principal, monthly_budget_e8s);
+    log!(
+        INFO,
+        "[set_liquidation_bot_config] Bot principal: {}, budget: {} e8s",
+        bot_principal,
+        monthly_budget_e8s
+    );
     Ok(())
 }
 
@@ -4549,12 +5275,18 @@ async fn reset_bot_budget(new_budget_e8s: u64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can reset bot budget".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can reset bot budget".to_string(),
+        ));
     }
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_bot_budget(s, new_budget_e8s, ic_cdk::api::time());
     });
-    log!(INFO, "[reset_bot_budget] Budget reset to {} e8s", new_budget_e8s);
+    log!(
+        INFO,
+        "[reset_bot_budget] Budget reset to {} e8s",
+        new_budget_e8s
+    );
     Ok(())
 }
 
@@ -4562,7 +5294,9 @@ async fn reset_bot_budget(new_budget_e8s: u64) -> Result<(), ProtocolError> {
 /// Pass an empty vec to disable bot liquidations entirely.
 #[candid_method(update)]
 #[update]
-async fn set_bot_allowed_collateral_types(collateral_types: Vec<Principal>) -> Result<(), ProtocolError> {
+async fn set_bot_allowed_collateral_types(
+    collateral_types: Vec<Principal>,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
@@ -4571,10 +5305,17 @@ async fn set_bot_allowed_collateral_types(collateral_types: Vec<Principal>) -> R
         ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_bot_allowed_collateral_types(s, collateral_types.clone());
+        rumi_protocol_backend::event::record_set_bot_allowed_collateral_types(
+            s,
+            collateral_types.clone(),
+        );
     });
-    log!(INFO, "[set_bot_allowed_collateral_types] Set {} allowed types: {:?}",
-        collateral_types.len(), collateral_types);
+    log!(
+        INFO,
+        "[set_bot_allowed_collateral_types] Set {} allowed types: {:?}",
+        collateral_types.len(),
+        collateral_types
+    );
     Ok(())
 }
 
@@ -4650,9 +5391,7 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
     }
     let caller = ic_cdk::api::caller();
 
-    let is_bot = read_state(|s| {
-        s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
-    });
+    let is_bot = read_state(|s| s.liquidation_bot_principal.map_or(false, |bp| bp == caller));
     if !is_bot {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered liquidation bot canister".to_string(),
@@ -4671,45 +5410,55 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
     let existing_claim = read_state(|s| s.bot_claims.contains_key(&vault_id));
     if existing_claim {
         return Err(ProtocolError::GenericError(format!(
-            "Vault #{} already has an active bot claim", vault_id
+            "Vault #{} already has an active bot claim",
+            vault_id
         )));
     }
 
     // Get vault info, validate collateral type, compute amounts, check budget
-    let (collateral_price_usd, liquidatable_debt, collateral_to_seize, collateral_type) = read_state(|s| {
-        let vault = s.vault_id_to_vaults.get(&vault_id)
-            .ok_or_else(|| ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))?;
+    let (collateral_price_usd, liquidatable_debt, collateral_to_seize, collateral_type) =
+        read_state(|s| {
+            let vault = s.vault_id_to_vaults.get(&vault_id).ok_or_else(|| {
+                ProtocolError::GenericError(format!("Vault #{} not found", vault_id))
+            })?;
 
-        if vault.bot_processing {
-            return Err(ProtocolError::GenericError(format!(
-                "Vault #{} is already being processed", vault_id
-            )));
-        }
+            if vault.bot_processing {
+                return Err(ProtocolError::GenericError(format!(
+                    "Vault #{} is already being processed",
+                    vault_id
+                )));
+            }
 
-        // Guard: reject collateral types the bot isn't configured to handle
-        if !s.bot_allowed_collateral_types.contains(&vault.collateral_type) {
-            return Err(ProtocolError::GenericError(format!(
-                "Collateral type {} is not in the bot's allowed list.", vault.collateral_type
-            )));
-        }
+            // Guard: reject collateral types the bot isn't configured to handle
+            if !s
+                .bot_allowed_collateral_types
+                .contains(&vault.collateral_type)
+            {
+                return Err(ProtocolError::GenericError(format!(
+                    "Collateral type {} is not in the bot's allowed list.",
+                    vault.collateral_type
+                )));
+            }
 
-        let price = s.get_collateral_price_decimal(&vault.collateral_type)
-            .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
-        let collateral_price_usd = UsdIcp::from(price);
-        let ratio = rumi_protocol_backend::compute_collateral_ratio(vault, collateral_price_usd, s);
-        let min_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
-        // Apply scan→claim TOCTOU tolerance. The scan in `check_vaults`
-        // flagged this vault as below `min_ratio`; an XRC tick between
-        // that scan and this call can recompute CR slightly above
-        // `min_ratio`. Allowing up to `min_ratio + tolerance` here
-        // closes the race without widening the strict threshold the
-        // manual liquidation paths enforce. The `actual > 0` guard
-        // below catches the Recovery-mode case where `min_ratio +
-        // tolerance` exceeds the partial-cap target CR.
-        let bot_max_ratio = s.get_bot_claim_max_ratio_for(&vault.collateral_type);
+            let price = s
+                .get_collateral_price_decimal(&vault.collateral_type)
+                .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
+            let collateral_price_usd = UsdIcp::from(price);
+            let ratio =
+                rumi_protocol_backend::compute_collateral_ratio(vault, collateral_price_usd, s);
+            let min_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
+            // Apply scan→claim TOCTOU tolerance. The scan in `check_vaults`
+            // flagged this vault as below `min_ratio`; an XRC tick between
+            // that scan and this call can recompute CR slightly above
+            // `min_ratio`. Allowing up to `min_ratio + tolerance` here
+            // closes the race without widening the strict threshold the
+            // manual liquidation paths enforce. The `actual > 0` guard
+            // below catches the Recovery-mode case where `min_ratio +
+            // tolerance` exceeds the partial-cap target CR.
+            let bot_max_ratio = s.get_bot_claim_max_ratio_for(&vault.collateral_type);
 
-        if ratio >= bot_max_ratio {
-            return Err(ProtocolError::GenericError(format!(
+            if ratio >= bot_max_ratio {
+                return Err(ProtocolError::GenericError(format!(
                 "Vault #{} is not liquidatable (CR {:.2}% >= {:.2}%, base {:.2}% + tolerance {} bps)",
                 vault_id,
                 ratio.to_f64() * 100.0,
@@ -4717,55 +5466,77 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
                 min_ratio.to_f64() * 100.0,
                 s.bot_cr_tolerance_bps
             )));
-        }
+            }
 
-        let actual = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
+            let actual = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
 
-        // Defense-in-depth: with the tolerance applied, `ratio` may sit
-        // above the partial-cap target CR (`borrow_threshold_ratio`),
-        // in which case `compute_partial_liquidation_cap` returns 0.
-        // Reject explicitly rather than claiming a 0-debt liquidation,
-        // which would deduct nothing from the budget and seize 0
-        // collateral — pointless work that would still write a noisy
-        // BotClaim record.
-        if actual.to_u64() == 0 {
-            return Err(ProtocolError::GenericError(format!(
-                "Vault #{} has no liquidatable debt at current CR {:.2}% (target CR {:.2}%)",
-                vault_id,
-                ratio.to_f64() * 100.0,
-                s.get_min_collateral_ratio_for(&vault.collateral_type).to_f64() * 100.0
-            )));
-        }
+            // Defense-in-depth: with the tolerance applied, `ratio` may sit
+            // above the partial-cap target CR (`borrow_threshold_ratio`),
+            // in which case `compute_partial_liquidation_cap` returns 0.
+            // Reject explicitly rather than claiming a 0-debt liquidation,
+            // which would deduct nothing from the budget and seize 0
+            // collateral — pointless work that would still write a noisy
+            // BotClaim record.
+            if actual.to_u64() == 0 {
+                return Err(ProtocolError::GenericError(format!(
+                    "Vault #{} has no liquidatable debt at current CR {:.2}% (target CR {:.2}%)",
+                    vault_id,
+                    ratio.to_f64() * 100.0,
+                    s.get_min_collateral_ratio_for(&vault.collateral_type)
+                        .to_f64()
+                        * 100.0
+                )));
+            }
 
-        if s.bot_budget_remaining_e8s < actual.to_u64() {
-            return Err(ProtocolError::GenericError(format!(
-                "Bot budget insufficient: {} remaining, need {}",
-                s.bot_budget_remaining_e8s, actual.to_u64()
-            )));
-        }
+            if s.bot_budget_remaining_e8s < actual.to_u64() {
+                return Err(ProtocolError::GenericError(format!(
+                    "Bot budget insufficient: {} remaining, need {}",
+                    s.bot_budget_remaining_e8s,
+                    actual.to_u64()
+                )));
+            }
 
-        let decimals = s.get_collateral_config(&vault.collateral_type)
-            .map(|c| c.decimals)
-            .unwrap_or(8);
-        let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
-        let collateral_raw = rumi_protocol_backend::numeric::icusd_to_collateral_amount(actual, price, decimals);
-        let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-        let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+            let decimals = s
+                .get_collateral_config(&vault.collateral_type)
+                .map(|c| c.decimals)
+                .unwrap_or(8);
+            let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
+            let collateral_raw =
+                rumi_protocol_backend::numeric::icusd_to_collateral_amount(actual, price, decimals);
+            let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
+            let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
-        Ok((collateral_price_usd, actual, collateral_to_seize, vault.collateral_type))
-    })?;
+            Ok((
+                collateral_price_usd,
+                actual,
+                collateral_to_seize,
+                vault.collateral_type,
+            ))
+        })?;
 
     // Transfer collateral to bot
     match rumi_protocol_backend::management::transfer_collateral(
-        collateral_to_seize.to_u64(), caller, collateral_type
-    ).await {
+        collateral_to_seize.to_u64(),
+        caller,
+        collateral_type,
+    )
+    .await
+    {
         Ok(block) => {
             log!(INFO, "[bot_claim_liquidation] Transferred {} collateral ({}) to bot for vault #{}, block {}",
                 collateral_to_seize.to_u64(), collateral_type, vault_id, block);
         }
         Err(e) => {
-            log!(INFO, "[bot_claim_liquidation] Collateral transfer failed for vault #{}: {:?}", vault_id, e);
-            return Err(ProtocolError::GenericError(format!("Collateral transfer failed: {:?}", e)));
+            log!(
+                INFO,
+                "[bot_claim_liquidation] Collateral transfer failed for vault #{}: {:?}",
+                vault_id,
+                e
+            );
+            return Err(ProtocolError::GenericError(format!(
+                "Collateral transfer failed: {:?}",
+                e
+            )));
         }
     }
 
@@ -4775,20 +5546,30 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
             vault.bot_processing = true;
         }
-        s.bot_claims.insert(vault_id, rumi_protocol_backend::state::BotClaim {
+        s.bot_claims.insert(
             vault_id,
-            collateral_amount: collateral_to_seize.to_u64(),
-            debt_amount: liquidatable_debt.to_u64(),
-            collateral_type,
-            claimed_at: now,
-            collateral_price_e8s: collateral_price_usd.to_e8s(),
-        });
+            rumi_protocol_backend::state::BotClaim {
+                vault_id,
+                collateral_amount: collateral_to_seize.to_u64(),
+                debt_amount: liquidatable_debt.to_u64(),
+                collateral_type,
+                claimed_at: now,
+                collateral_price_e8s: collateral_price_usd.to_e8s(),
+            },
+        );
         // Deduct from budget immediately to prevent over-claiming
-        s.bot_budget_remaining_e8s = s.bot_budget_remaining_e8s.saturating_sub(liquidatable_debt.to_u64());
+        s.bot_budget_remaining_e8s = s
+            .bot_budget_remaining_e8s
+            .saturating_sub(liquidatable_debt.to_u64());
     });
 
-    log!(INFO, "[bot_claim_liquidation] Claimed vault #{}: debt={}, collateral={}",
-        vault_id, liquidatable_debt.to_u64(), collateral_to_seize.to_u64());
+    log!(
+        INFO,
+        "[bot_claim_liquidation] Claimed vault #{}: debt={}, collateral={}",
+        vault_id,
+        liquidatable_debt.to_u64(),
+        collateral_to_seize.to_u64()
+    );
 
     Ok(BotLiquidationResult {
         vault_id,
@@ -4806,19 +5587,16 @@ async fn bot_confirm_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
     validate_call().await?;
     let caller = ic_cdk::api::caller();
 
-    let is_bot = read_state(|s| {
-        s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
-    });
+    let is_bot = read_state(|s| s.liquidation_bot_principal.map_or(false, |bp| bp == caller));
     if !is_bot {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered liquidation bot canister".to_string(),
         ));
     }
 
-    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned())
-        .ok_or_else(|| ProtocolError::GenericError(format!(
-            "No active claim for vault #{}", vault_id
-        )))?;
+    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned()).ok_or_else(|| {
+        ProtocolError::GenericError(format!("No active claim for vault #{}", vault_id))
+    })?;
 
     mutate_state(|s| {
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
@@ -4829,9 +5607,12 @@ async fn bot_confirm_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
             // paid. The redemption skip + user-op rejection make that window
             // race-free today; saturating keeps a residual drift from ever
             // bricking the vault (it degrades to under-reduction instead).
-            vault.borrowed_icusd_amount =
-                vault.borrowed_icusd_amount.saturating_sub(ICUSD::new(claim.debt_amount));
-            vault.collateral_amount = vault.collateral_amount.saturating_sub(claim.collateral_amount);
+            vault.borrowed_icusd_amount = vault
+                .borrowed_icusd_amount
+                .saturating_sub(ICUSD::new(claim.debt_amount));
+            vault.collateral_amount = vault
+                .collateral_amount
+                .saturating_sub(claim.collateral_amount);
             vault.bot_processing = false;
         }
 
@@ -4840,7 +5621,9 @@ async fn bot_confirm_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
             liquidator_payment: ICUSD::new(claim.debt_amount),
             icp_to_liquidator: ICP::from(claim.collateral_amount),
             liquidator: Some(caller),
-            icp_rate: Some(UsdIcp::from(Decimal::from(claim.collateral_price_e8s) / dec!(100_000_000))),
+            icp_rate: Some(UsdIcp::from(
+                Decimal::from(claim.collateral_price_e8s) / dec!(100_000_000),
+            )),
             protocol_fee_collateral: None,
             timestamp: Some(ic_cdk::api::time()),
             three_usd_reserves_e8s: None,
@@ -4854,12 +5637,21 @@ async fn bot_confirm_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
         // the write-down emptied the vault it must be removed like every
         // other PartialLiquidateVault path, or replay diverges.
         if s.cleanup_if_drained(vault_id) {
-            log!(INFO, "[bot_confirm_liquidation] Vault #{} fully liquidated — removed", vault_id);
+            log!(
+                INFO,
+                "[bot_confirm_liquidation] Vault #{} fully liquidated — removed",
+                vault_id
+            );
         }
     });
 
-    log!(INFO, "[bot_confirm_liquidation] Confirmed liquidation for vault #{}: debt={}, collateral={}",
-        vault_id, claim.debt_amount, claim.collateral_amount);
+    log!(
+        INFO,
+        "[bot_confirm_liquidation] Confirmed liquidation for vault #{}: debt={}, collateral={}",
+        vault_id,
+        claim.debt_amount,
+        claim.collateral_amount
+    );
 
     Ok(())
 }
@@ -4873,19 +5665,16 @@ async fn bot_cancel_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
     validate_call().await?;
     let caller = ic_cdk::api::caller();
 
-    let is_bot = read_state(|s| {
-        s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
-    });
+    let is_bot = read_state(|s| s.liquidation_bot_principal.map_or(false, |bp| bp == caller));
     if !is_bot {
         return Err(ProtocolError::GenericError(
             "Caller is not the registered liquidation bot canister".to_string(),
         ));
     }
 
-    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned())
-        .ok_or_else(|| ProtocolError::GenericError(format!(
-            "No active claim for vault #{}", vault_id
-        )))?;
+    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned()).ok_or_else(|| {
+        ProtocolError::GenericError(format!("No active claim for vault #{}", vault_id))
+    })?;
 
     // Verify the collateral was actually returned by checking the backend's balance
     let backend_id = ic_cdk::id();
@@ -4896,7 +5685,8 @@ async fn bot_cancel_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
             owner: backend_id,
             subaccount: None,
         },),
-    ).await;
+    )
+    .await;
 
     // Wave-12 BOT-001b: gate the explicit cancel on the protocol's collateral
     // balance having returned to (>=) `claim.collateral_amount - ledger_fee`.
@@ -4908,8 +5698,13 @@ async fn bot_cancel_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
     let observed = match balance_result {
         Ok((bal,)) => bal.0.to_u64().unwrap_or(0),
         Err((code, msg)) => {
-            log!(INFO, "[BOT-001b] balance query failed for vault #{}: {:?} {}",
-                vault_id, code, msg);
+            log!(
+                INFO,
+                "[BOT-001b] balance query failed for vault #{}: {:?} {}",
+                vault_id,
+                code,
+                msg
+            );
             return Err(ProtocolError::TemporarilyUnavailable(format!(
                 "Could not verify collateral return for vault #{}: {:?} {}. Retry once the ledger is available.",
                 vault_id, code, msg
@@ -4934,8 +5729,13 @@ async fn bot_cancel_liquidation(vault_id: u64) -> Result<(), ProtocolError> {
         )));
     }
 
-    log!(INFO, "[BOT-001b] balance check passed for vault #{}: balance {} >= required {}",
-        vault_id, observed, required);
+    log!(
+        INFO,
+        "[BOT-001b] balance check passed for vault #{}: balance {} >= required {}",
+        vault_id,
+        observed,
+        required
+    );
 
     mutate_state(|s| {
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
@@ -4969,58 +5769,88 @@ async fn dev_force_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, 
             || s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
     });
     if !is_authorized {
-        return Err(ProtocolError::GenericError("Only developer or bot can force bot liquidation".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer or bot can force bot liquidation".to_string(),
+        ));
     }
 
     let existing_claim = read_state(|s| s.bot_claims.contains_key(&vault_id));
     if existing_claim {
         return Err(ProtocolError::GenericError(format!(
-            "Vault #{} already has an active bot claim", vault_id
+            "Vault #{} already has an active bot claim",
+            vault_id
         )));
     }
 
     // Get vault info — NO CR check, but still check collateral allowlist
-    let (collateral_price_usd, debt_to_cover, collateral_to_seize, collateral_type) = read_state(|s| {
-        let vault = s.vault_id_to_vaults.get(&vault_id)
-            .ok_or_else(|| ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))?;
+    let (collateral_price_usd, debt_to_cover, collateral_to_seize, collateral_type) =
+        read_state(|s| {
+            let vault = s.vault_id_to_vaults.get(&vault_id).ok_or_else(|| {
+                ProtocolError::GenericError(format!("Vault #{} not found", vault_id))
+            })?;
 
-        if vault.bot_processing {
-            return Err(ProtocolError::GenericError(format!(
-                "Vault #{} is already being processed", vault_id
-            )));
-        }
+            if vault.bot_processing {
+                return Err(ProtocolError::GenericError(format!(
+                    "Vault #{} is already being processed",
+                    vault_id
+                )));
+            }
 
-        if !s.bot_allowed_collateral_types.contains(&vault.collateral_type) {
-            return Err(ProtocolError::GenericError(format!(
-                "Collateral type {} is not in the bot's allowed list.", vault.collateral_type
-            )));
-        }
+            if !s
+                .bot_allowed_collateral_types
+                .contains(&vault.collateral_type)
+            {
+                return Err(ProtocolError::GenericError(format!(
+                    "Collateral type {} is not in the bot's allowed list.",
+                    vault.collateral_type
+                )));
+            }
 
-        let price = s.get_collateral_price_decimal(&vault.collateral_type)
-            .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
-        let collateral_price_usd = UsdIcp::from(price);
-        let decimals = s.get_collateral_config(&vault.collateral_type)
-            .map(|c| c.decimals)
-            .unwrap_or(8);
+            let price = s
+                .get_collateral_price_decimal(&vault.collateral_type)
+                .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
+            let collateral_price_usd = UsdIcp::from(price);
+            let decimals = s
+                .get_collateral_config(&vault.collateral_type)
+                .map(|c| c.decimals)
+                .unwrap_or(8);
 
-        let debt = vault.borrowed_icusd_amount;
-        let collateral_raw = rumi_protocol_backend::numeric::icusd_to_collateral_amount(debt, price, decimals);
-        let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
-        let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-        let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+            let debt = vault.borrowed_icusd_amount;
+            let collateral_raw =
+                rumi_protocol_backend::numeric::icusd_to_collateral_amount(debt, price, decimals);
+            let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
+            let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
+            let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
-        Ok::<_, ProtocolError>((collateral_price_usd, debt, collateral_to_seize, vault.collateral_type))
-    })?;
+            Ok::<_, ProtocolError>((
+                collateral_price_usd,
+                debt,
+                collateral_to_seize,
+                vault.collateral_type,
+            ))
+        })?;
 
     // Transfer collateral
     match rumi_protocol_backend::management::transfer_collateral(
-        collateral_to_seize.to_u64(), caller, collateral_type
-    ).await {
+        collateral_to_seize.to_u64(),
+        caller,
+        collateral_type,
+    )
+    .await
+    {
         Ok(block) => {
-            log!(INFO, "[dev_force_bot_liquidate] Transferred {} collateral to caller, block {}", collateral_to_seize.to_u64(), block);
+            log!(
+                INFO,
+                "[dev_force_bot_liquidate] Transferred {} collateral to caller, block {}",
+                collateral_to_seize.to_u64(),
+                block
+            );
         }
         Err(e) => {
-            return Err(ProtocolError::GenericError(format!("Collateral transfer failed: {:?}", e)));
+            return Err(ProtocolError::GenericError(format!(
+                "Collateral transfer failed: {:?}",
+                e
+            )));
         }
     }
 
@@ -5030,18 +5860,26 @@ async fn dev_force_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, 
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
             vault.bot_processing = true;
         }
-        s.bot_claims.insert(vault_id, rumi_protocol_backend::state::BotClaim {
+        s.bot_claims.insert(
             vault_id,
-            collateral_amount: collateral_to_seize.to_u64(),
-            debt_amount: debt_to_cover.to_u64(),
-            collateral_type,
-            claimed_at: now,
-            collateral_price_e8s: collateral_price_usd.to_e8s(),
-        });
+            rumi_protocol_backend::state::BotClaim {
+                vault_id,
+                collateral_amount: collateral_to_seize.to_u64(),
+                debt_amount: debt_to_cover.to_u64(),
+                collateral_type,
+                claimed_at: now,
+                collateral_price_e8s: collateral_price_usd.to_e8s(),
+            },
+        );
     });
 
-    log!(INFO, "[dev_force_bot_liquidate] Force-claimed vault #{}: debt={}, collateral={}",
-        vault_id, debt_to_cover.to_u64(), collateral_to_seize.to_u64());
+    log!(
+        INFO,
+        "[dev_force_bot_liquidate] Force-claimed vault #{}: debt={}, collateral={}",
+        vault_id,
+        debt_to_cover.to_u64(),
+        collateral_to_seize.to_u64()
+    );
 
     Ok(BotLiquidationResult {
         vault_id,
@@ -5059,7 +5897,9 @@ async fn dev_force_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, 
 #[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
-async fn dev_force_partial_bot_liquidate(vault_id: u64) -> Result<BotLiquidationResult, ProtocolError> {
+async fn dev_force_partial_bot_liquidate(
+    vault_id: u64,
+) -> Result<BotLiquidationResult, ProtocolError> {
     validate_call().await?;
     let caller = ic_cdk::caller();
     let is_authorized = read_state(|s| {
@@ -5067,60 +5907,90 @@ async fn dev_force_partial_bot_liquidate(vault_id: u64) -> Result<BotLiquidation
             || s.liquidation_bot_principal.map_or(false, |bp| bp == caller)
     });
     if !is_authorized {
-        return Err(ProtocolError::GenericError("Only developer or bot can force partial bot liquidation".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer or bot can force partial bot liquidation".to_string(),
+        ));
     }
 
     let existing_claim = read_state(|s| s.bot_claims.contains_key(&vault_id));
     if existing_claim {
         return Err(ProtocolError::GenericError(format!(
-            "Vault #{} already has an active bot claim", vault_id
+            "Vault #{} already has an active bot claim",
+            vault_id
         )));
     }
 
     // Get vault info — NO CR check, uses partial liquidation cap, checks collateral allowlist
-    let (collateral_price_usd, debt_to_cover, collateral_to_seize, collateral_type) = read_state(|s| {
-        let vault = s.vault_id_to_vaults.get(&vault_id)
-            .ok_or_else(|| ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))?;
+    let (collateral_price_usd, debt_to_cover, collateral_to_seize, collateral_type) =
+        read_state(|s| {
+            let vault = s.vault_id_to_vaults.get(&vault_id).ok_or_else(|| {
+                ProtocolError::GenericError(format!("Vault #{} not found", vault_id))
+            })?;
 
-        if vault.bot_processing {
-            return Err(ProtocolError::GenericError(format!(
-                "Vault #{} is already being processed", vault_id
-            )));
-        }
+            if vault.bot_processing {
+                return Err(ProtocolError::GenericError(format!(
+                    "Vault #{} is already being processed",
+                    vault_id
+                )));
+            }
 
-        if !s.bot_allowed_collateral_types.contains(&vault.collateral_type) {
-            return Err(ProtocolError::GenericError(format!(
-                "Collateral type {} is not in the bot's allowed list.", vault.collateral_type
-            )));
-        }
+            if !s
+                .bot_allowed_collateral_types
+                .contains(&vault.collateral_type)
+            {
+                return Err(ProtocolError::GenericError(format!(
+                    "Collateral type {} is not in the bot's allowed list.",
+                    vault.collateral_type
+                )));
+            }
 
-        let price = s.get_collateral_price_decimal(&vault.collateral_type)
-            .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
-        let collateral_price_usd = UsdIcp::from(price);
-        let decimals = s.get_collateral_config(&vault.collateral_type)
-            .map(|c| c.decimals)
-            .unwrap_or(8);
+            let price = s
+                .get_collateral_price_decimal(&vault.collateral_type)
+                .ok_or_else(|| ProtocolError::GenericError("No price available".to_string()))?;
+            let collateral_price_usd = UsdIcp::from(price);
+            let decimals = s
+                .get_collateral_config(&vault.collateral_type)
+                .map(|c| c.decimals)
+                .unwrap_or(8);
 
-        // Use partial liquidation cap — same as bot_claim_liquidation
-        let actual = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
+            // Use partial liquidation cap — same as bot_claim_liquidation
+            let actual = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
 
-        let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
-        let collateral_raw = rumi_protocol_backend::numeric::icusd_to_collateral_amount(actual, price, decimals);
-        let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-        let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+            let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
+            let collateral_raw =
+                rumi_protocol_backend::numeric::icusd_to_collateral_amount(actual, price, decimals);
+            let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
+            let collateral_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
-        Ok::<_, ProtocolError>((collateral_price_usd, actual, collateral_to_seize, vault.collateral_type))
-    })?;
+            Ok::<_, ProtocolError>((
+                collateral_price_usd,
+                actual,
+                collateral_to_seize,
+                vault.collateral_type,
+            ))
+        })?;
 
     // Transfer collateral
     match rumi_protocol_backend::management::transfer_collateral(
-        collateral_to_seize.to_u64(), caller, collateral_type
-    ).await {
+        collateral_to_seize.to_u64(),
+        caller,
+        collateral_type,
+    )
+    .await
+    {
         Ok(block) => {
-            log!(INFO, "[dev_force_partial_bot_liquidate] Transferred {} collateral to caller, block {}", collateral_to_seize.to_u64(), block);
+            log!(
+                INFO,
+                "[dev_force_partial_bot_liquidate] Transferred {} collateral to caller, block {}",
+                collateral_to_seize.to_u64(),
+                block
+            );
         }
         Err(e) => {
-            return Err(ProtocolError::GenericError(format!("Collateral transfer failed: {:?}", e)));
+            return Err(ProtocolError::GenericError(format!(
+                "Collateral transfer failed: {:?}",
+                e
+            )));
         }
     }
 
@@ -5130,18 +6000,26 @@ async fn dev_force_partial_bot_liquidate(vault_id: u64) -> Result<BotLiquidation
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
             vault.bot_processing = true;
         }
-        s.bot_claims.insert(vault_id, rumi_protocol_backend::state::BotClaim {
+        s.bot_claims.insert(
             vault_id,
-            collateral_amount: collateral_to_seize.to_u64(),
-            debt_amount: debt_to_cover.to_u64(),
-            collateral_type,
-            claimed_at: now,
-            collateral_price_e8s: collateral_price_usd.to_e8s(),
-        });
+            rumi_protocol_backend::state::BotClaim {
+                vault_id,
+                collateral_amount: collateral_to_seize.to_u64(),
+                debt_amount: debt_to_cover.to_u64(),
+                collateral_type,
+                claimed_at: now,
+                collateral_price_e8s: collateral_price_usd.to_e8s(),
+            },
+        );
     });
 
-    log!(INFO, "[dev_force_partial_bot_liquidate] Force-partial-claimed vault #{}: debt={}, collateral={}",
-        vault_id, debt_to_cover.to_u64(), collateral_to_seize.to_u64());
+    log!(
+        INFO,
+        "[dev_force_partial_bot_liquidate] Force-partial-claimed vault #{}: debt={}, collateral={}",
+        vault_id,
+        debt_to_cover.to_u64(),
+        collateral_to_seize.to_u64()
+    );
 
     Ok(BotLiquidationResult {
         vault_id,
@@ -5171,18 +6049,24 @@ async fn dev_test_pool_only_liquidation(vault_id: u64) -> Result<String, Protoco
 
     // Build vault notification (skips CR check — force test)
     let vault_info = read_state(|s| {
-        let vault = s.vault_id_to_vaults.get(&vault_id)
+        let vault = s
+            .vault_id_to_vaults
+            .get(&vault_id)
             .ok_or_else(|| ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))?;
 
         if vault.bot_processing {
             return Err(ProtocolError::GenericError(format!(
-                "Vault #{} is locked by bot_processing", vault_id
+                "Vault #{} is locked by bot_processing",
+                vault_id
             )));
         }
 
-        let collateral_price_usd = s.get_collateral_price_decimal(&vault.collateral_type)
+        let collateral_price_usd = s
+            .get_collateral_price_decimal(&vault.collateral_type)
             .map(|p| UsdIcp::from(p))
-            .ok_or(ProtocolError::GenericError("No price available".to_string()))?;
+            .ok_or(ProtocolError::GenericError(
+                "No price available".to_string(),
+            ))?;
         let price_e8s = collateral_price_usd.to_e8s();
         let optimal_liq = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
 
@@ -5201,18 +6085,25 @@ async fn dev_test_pool_only_liquidation(vault_id: u64) -> Result<String, Protoco
         pool_canister,
         "notify_liquidatable_vaults",
         (vec![vault_info],),
-    ).await;
+    )
+    .await;
 
     match result {
         Ok(()) => {
-            log!(INFO, "[dev_test_pool_only_liquidation] Sent vault #{} to stability pool", vault_id);
-            Ok(format!("Vault #{} sent to stability pool for liquidation", vault_id))
+            log!(
+                INFO,
+                "[dev_test_pool_only_liquidation] Sent vault #{} to stability pool",
+                vault_id
+            );
+            Ok(format!(
+                "Vault #{} sent to stability pool for liquidation",
+                vault_id
+            ))
         }
-        Err((code, msg)) => {
-            Err(ProtocolError::GenericError(format!(
-                "Stability pool notification failed: {:?} {}", code, msg
-            )))
-        }
+        Err((code, msg)) => Err(ProtocolError::GenericError(format!(
+            "Stability pool notification failed: {:?} {}",
+            code, msg
+        ))),
     }
 }
 
@@ -5223,7 +6114,10 @@ async fn dev_test_pool_only_liquidation(vault_id: u64) -> Result<String, Protoco
 #[cfg(feature = "test_endpoints")]
 #[candid_method(update)]
 #[update]
-async fn dev_set_collateral_price(collateral_type: Principal, price_usd: f64) -> Result<String, ProtocolError> {
+async fn dev_set_collateral_price(
+    collateral_type: Principal,
+    price_usd: f64,
+) -> Result<String, ProtocolError> {
     validate_call().await?;
     let caller = ic_cdk::caller();
     let is_dev = read_state(|s| s.developer_principal == caller);
@@ -5232,22 +6126,30 @@ async fn dev_set_collateral_price(collateral_type: Principal, price_usd: f64) ->
     }
 
     let ts = ic_cdk::api::time();
-    let old_price = mutate_state(|s| {
-        match s.collateral_configs.get_mut(&collateral_type) {
-            Some(config) => {
-                let old = config.last_price;
-                config.last_price = Some(price_usd);
-                config.last_price_timestamp = Some(ts);
-                Ok(old)
-            }
-            None => Err(ProtocolError::GenericError(
-                format!("Collateral type {} not found in configs", collateral_type)
-            ))
+    let old_price = mutate_state(|s| match s.collateral_configs.get_mut(&collateral_type) {
+        Some(config) => {
+            let old = config.last_price;
+            config.last_price = Some(price_usd);
+            config.last_price_timestamp = Some(ts);
+            Ok(old)
         }
+        None => Err(ProtocolError::GenericError(format!(
+            "Collateral type {} not found in configs",
+            collateral_type
+        ))),
     })?;
 
-    log!(INFO, "[dev_set_collateral_price] {} price set: {:?} → {}", collateral_type, old_price, price_usd);
-    Ok(format!("Price for {} set to ${:.6} (was {:?})", collateral_type, price_usd, old_price))
+    log!(
+        INFO,
+        "[dev_set_collateral_price] {} price set: {:?} → {}",
+        collateral_type,
+        old_price,
+        price_usd
+    );
+    Ok(format!(
+        "Price for {} set to ${:.6} (was {:?})",
+        collateral_type, price_usd, old_price
+    ))
 }
 
 #[candid_method(query)]
@@ -5285,17 +6187,21 @@ fn get_bot_claim_vault_ids() -> Vec<u64> {
 ///   so also write down the vault's debt and collateral (same as what confirm would do).
 #[candid_method(update)]
 #[update]
-fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Result<(), ProtocolError> {
+fn admin_resolve_stuck_claim(
+    vault_id: u64,
+    apply_debt_reduction: bool,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_dev = read_state(|s| s.developer_principal == caller);
     if !is_dev {
-        return Err(ProtocolError::GenericError("Unauthorized: developer only".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unauthorized: developer only".to_string(),
+        ));
     }
 
-    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned())
-        .ok_or_else(|| ProtocolError::GenericError(format!(
-            "No active claim for vault #{}", vault_id
-        )))?;
+    let claim = read_state(|s| s.bot_claims.get(&vault_id).cloned()).ok_or_else(|| {
+        ProtocolError::GenericError(format!("No active claim for vault #{}", vault_id))
+    })?;
 
     mutate_state(|s| {
         if let Some(vault) = s.vault_id_to_vaults.get_mut(&vault_id) {
@@ -5304,9 +6210,12 @@ fn admin_resolve_stuck_claim(vault_id: u64, apply_debt_reduction: bool) -> Resul
                 // bot_confirm_liquidation. The non-saturating `-=` made this
                 // recovery endpoint trap on exactly the stuck state it exists
                 // to resolve (debt already reduced below the claim amount).
-                vault.borrowed_icusd_amount =
-                    vault.borrowed_icusd_amount.saturating_sub(ICUSD::new(claim.debt_amount));
-                vault.collateral_amount = vault.collateral_amount.saturating_sub(claim.collateral_amount);
+                vault.borrowed_icusd_amount = vault
+                    .borrowed_icusd_amount
+                    .saturating_sub(ICUSD::new(claim.debt_amount));
+                vault.collateral_amount = vault
+                    .collateral_amount
+                    .saturating_sub(claim.collateral_amount);
                 s.bot_total_debt_covered_e8s += claim.debt_amount;
             }
             vault.bot_processing = false;
@@ -5339,17 +6248,27 @@ async fn set_ckstable_repay_fee(new_rate: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set ckstable repay fee".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set ckstable repay fee".to_string(),
+        ));
     }
     if new_rate < 0.0 || new_rate > 0.05 {
-        return Err(ProtocolError::GenericError("Fee rate must be between 0 and 0.05 (5%)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Fee rate must be between 0 and 0.05 (5%)".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid fee rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid fee rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_ckstable_repay_fee(s, rate);
     });
-    log!(INFO, "[set_ckstable_repay_fee] Fee rate set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_ckstable_repay_fee] Fee rate set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5368,16 +6287,24 @@ async fn set_min_icusd_amount(new_amount_e8s: u64) -> Result<(), ProtocolError> 
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set min icUSD amount".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set min icUSD amount".to_string(),
+        ));
     }
     if new_amount_e8s == 0 || new_amount_e8s > 10_000_000_000 {
-        return Err(ProtocolError::GenericError("Amount must be > 0 and <= 100 icUSD (10_000_000_000 e8s)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Amount must be > 0 and <= 100 icUSD (10_000_000_000 e8s)".to_string(),
+        ));
     }
     let amount = ICUSD::new(new_amount_e8s);
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_min_icusd_amount(s, amount);
     });
-    log!(INFO, "[set_min_icusd_amount] Min icUSD amount set to: {} e8s", new_amount_e8s);
+    log!(
+        INFO,
+        "[set_min_icusd_amount] Min icUSD amount set to: {} e8s",
+        new_amount_e8s
+    );
     Ok(())
 }
 
@@ -5396,15 +6323,24 @@ async fn set_global_icusd_mint_cap(amount_e8s: u64) -> Result<(), ProtocolError>
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set global icUSD mint cap".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set global icUSD mint cap".to_string(),
+        ));
     }
     if amount_e8s == 0 {
-        return Err(ProtocolError::GenericError("Amount must be > 0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Amount must be > 0".to_string(),
+        ));
     }
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_global_icusd_mint_cap(s, amount_e8s);
     });
-    log!(INFO, "[set_global_icusd_mint_cap] Global icUSD mint cap set to: {} e8s ({} icUSD)", amount_e8s, amount_e8s as f64 / 1e8);
+    log!(
+        INFO,
+        "[set_global_icusd_mint_cap] Global icUSD mint cap set to: {} e8s ({} icUSD)",
+        amount_e8s,
+        amount_e8s as f64 / 1e8
+    );
     Ok(())
 }
 
@@ -5418,16 +6354,30 @@ fn get_global_icusd_mint_cap() -> u64 {
 /// Enable or disable a specific stable token for repayments/liquidations (developer only)
 #[candid_method(update)]
 #[update]
-async fn set_stable_token_enabled(token_type: StableTokenType, enabled: bool) -> Result<(), ProtocolError> {
+async fn set_stable_token_enabled(
+    token_type: StableTokenType,
+    enabled: bool,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can toggle stable token acceptance".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can toggle stable token acceptance".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_stable_token_enabled(s, token_type.clone(), enabled);
+        rumi_protocol_backend::event::record_set_stable_token_enabled(
+            s,
+            token_type.clone(),
+            enabled,
+        );
     });
-    log!(INFO, "[set_stable_token_enabled] {:?} enabled: {}", token_type, enabled);
+    log!(
+        INFO,
+        "[set_stable_token_enabled] {:?} enabled: {}",
+        token_type,
+        enabled
+    );
     Ok(())
 }
 
@@ -5444,16 +6394,30 @@ fn get_stable_token_enabled(token_type: StableTokenType) -> bool {
 /// Set the ckUSDT or ckUSDC ledger principal (developer only)
 #[candid_method(update)]
 #[update]
-async fn set_stable_ledger_principal(token_type: StableTokenType, principal: Principal) -> Result<(), ProtocolError> {
+async fn set_stable_ledger_principal(
+    token_type: StableTokenType,
+    principal: Principal,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set stable ledger principals".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set stable ledger principals".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_stable_ledger_principal(s, token_type.clone(), principal);
+        rumi_protocol_backend::event::record_set_stable_ledger_principal(
+            s,
+            token_type.clone(),
+            principal,
+        );
     });
-    log!(INFO, "[set_stable_ledger_principal] {:?} set to {}", token_type, principal);
+    log!(
+        INFO,
+        "[set_stable_ledger_principal] {:?} set to {}",
+        token_type,
+        principal
+    );
     Ok(())
 }
 
@@ -5465,17 +6429,27 @@ async fn set_liquidation_bonus(new_rate: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set liquidation bonus".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set liquidation bonus".to_string(),
+        ));
     }
     if new_rate < 1.0 || new_rate > 1.5 {
-        return Err(ProtocolError::GenericError("Liquidation bonus must be between 1.0 and 1.5".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Liquidation bonus must be between 1.0 and 1.5".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_liquidation_bonus(s, rate);
     });
-    log!(INFO, "[set_liquidation_bonus] Liquidation bonus set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_liquidation_bonus] Liquidation bonus set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5494,32 +6468,45 @@ fn set_redemption_tier(ledger_canister_id: Principal, tier: u8) -> Result<(), Pr
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set redemption tier".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set redemption tier".to_string(),
+        ));
     }
     if tier < 1 || tier > 3 {
-        return Err(ProtocolError::GenericError("Tier must be 1, 2, or 3".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Tier must be 1, 2, or 3".to_string(),
+        ));
     }
-    mutate_state(|s| {
-        match s.collateral_configs.get_mut(&ledger_canister_id) {
+    mutate_state(
+        |s| match s.collateral_configs.get_mut(&ledger_canister_id) {
             Some(config) => {
                 config.redemption_tier = tier;
-                log!(INFO, "[set_redemption_tier] {} set to tier {}", ledger_canister_id, tier);
+                log!(
+                    INFO,
+                    "[set_redemption_tier] {} set to tier {}",
+                    ledger_canister_id,
+                    tier
+                );
                 Ok(())
             }
-            None => Err(ProtocolError::GenericError(format!("No collateral config for {}", ledger_canister_id))),
-        }
-    })
+            None => Err(ProtocolError::GenericError(format!(
+                "No collateral config for {}",
+                ledger_canister_id
+            ))),
+        },
+    )
 }
 
 /// Get the redemption priority tier for a collateral type.
 #[candid_method(query)]
 #[query]
 fn get_redemption_tier(ledger_canister_id: Principal) -> Result<u8, ProtocolError> {
-    read_state(|s| {
-        match s.collateral_configs.get(&ledger_canister_id) {
-            Some(config) => Ok(config.redemption_tier),
-            None => Err(ProtocolError::GenericError(format!("No collateral config for {}", ledger_canister_id))),
-        }
+    read_state(|s| match s.collateral_configs.get(&ledger_canister_id) {
+        Some(config) => Ok(config.redemption_tier),
+        None => Err(ProtocolError::GenericError(format!(
+            "No collateral config for {}",
+            ledger_canister_id
+        ))),
     })
 }
 
@@ -5531,17 +6518,27 @@ async fn set_borrowing_fee(new_rate: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set borrowing fee".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set borrowing fee".to_string(),
+        ));
     }
     if new_rate < 0.0 || new_rate > 0.10 {
-        return Err(ProtocolError::GenericError("Borrowing fee must be between 0 and 0.10 (10%)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Borrowing fee must be between 0 and 0.10 (10%)".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_borrowing_fee(s, rate);
     });
-    log!(INFO, "[set_borrowing_fee] Borrowing fee set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_borrowing_fee] Borrowing fee set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5560,17 +6557,27 @@ async fn set_redemption_fee_floor(new_rate: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set redemption fee floor".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set redemption fee floor".to_string(),
+        ));
     }
     if new_rate < 0.0 || new_rate > 0.10 {
-        return Err(ProtocolError::GenericError("Redemption fee floor must be between 0 and 0.10 (10%)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Redemption fee floor must be between 0 and 0.10 (10%)".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_redemption_fee_floor(s, rate);
     });
-    log!(INFO, "[set_redemption_fee_floor] Redemption fee floor set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_redemption_fee_floor] Redemption fee floor set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5589,17 +6596,27 @@ async fn set_redemption_fee_ceiling(new_rate: f64) -> Result<(), ProtocolError> 
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set redemption fee ceiling".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set redemption fee ceiling".to_string(),
+        ));
     }
     if new_rate < 0.0 || new_rate > 0.50 {
-        return Err(ProtocolError::GenericError("Redemption fee ceiling must be between 0 and 0.50 (50%)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Redemption fee ceiling must be between 0 and 0.50 (50%)".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_redemption_fee_ceiling(s, rate);
     });
-    log!(INFO, "[set_redemption_fee_ceiling] Redemption fee ceiling set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_redemption_fee_ceiling] Redemption fee ceiling set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5619,12 +6636,18 @@ async fn set_reserve_redemptions_enabled(enabled: bool) -> Result<(), ProtocolEr
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can toggle reserve redemptions".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can toggle reserve redemptions".to_string(),
+        ));
     }
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_reserve_redemptions_enabled(s, enabled);
     });
-    log!(INFO, "[set_reserve_redemptions_enabled] Reserve redemptions enabled: {}", enabled);
+    log!(
+        INFO,
+        "[set_reserve_redemptions_enabled] Reserve redemptions enabled: {}",
+        enabled
+    );
     Ok(())
 }
 
@@ -5652,7 +6675,11 @@ async fn set_icpswap_routing_enabled(enabled: bool) -> Result<(), ProtocolError>
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_icpswap_routing_enabled(s, enabled);
     });
-    log!(INFO, "[set_icpswap_routing_enabled] ICPswap routing enabled: {}", enabled);
+    log!(
+        INFO,
+        "[set_icpswap_routing_enabled] ICPswap routing enabled: {}",
+        enabled
+    );
     Ok(())
 }
 
@@ -5671,17 +6698,27 @@ async fn set_reserve_redemption_fee(new_rate: f64) -> Result<(), ProtocolError> 
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set reserve redemption fee".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set reserve redemption fee".to_string(),
+        ));
     }
     if new_rate < 0.0 || new_rate > 0.10 {
-        return Err(ProtocolError::GenericError("Reserve redemption fee must be between 0 and 0.10 (10%)".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Reserve redemption fee must be between 0 and 0.10 (10%)".to_string(),
+        ));
     }
-    let rate = Ratio::from(rust_decimal::Decimal::try_from(new_rate)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let rate = Ratio::from(
+        rust_decimal::Decimal::try_from(new_rate)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_reserve_redemption_fee(s, rate);
     });
-    log!(INFO, "[set_reserve_redemption_fee] Reserve redemption fee set to: {}", new_rate);
+    log!(
+        INFO,
+        "[set_reserve_redemption_fee] Reserve redemption fee set to: {}",
+        new_rate
+    );
     Ok(())
 }
 
@@ -5711,7 +6748,10 @@ fn enter_recovery_mode() -> Result<(), ProtocolError> {
     mutate_state(|s| {
         s.mode = Mode::Recovery;
         s.manual_mode_override = true;
-        log!(INFO, "[admin] entered Recovery mode (manual override active)");
+        log!(
+            INFO,
+            "[admin] entered Recovery mode (manual override active)"
+        );
     });
     Ok(())
 }
@@ -5725,7 +6765,10 @@ fn exit_recovery_mode() -> Result<(), ProtocolError> {
     mutate_state(|s| {
         s.mode = Mode::GeneralAvailability;
         s.manual_mode_override = false;
-        log!(INFO, "[admin] exited Recovery mode, automatic mode management restored");
+        log!(
+            INFO,
+            "[admin] exited Recovery mode, automatic mode management restored"
+        );
     });
     Ok(())
 }
@@ -5766,11 +6809,7 @@ fn set_liquidation_frozen(frozen: bool) -> Result<(), ProtocolError> {
     require_controller()?;
     mutate_state(|s| {
         s.liquidation_frozen = frozen;
-        log!(
-            INFO,
-            "[admin] liquidation_frozen set to {}",
-            frozen
-        );
+        log!(INFO, "[admin] liquidation_frozen set to {}", frozen);
     });
     Ok(())
 }
@@ -5795,11 +6834,7 @@ fn set_sp_writedown_disabled(disabled: bool) -> Result<(), ProtocolError> {
     require_controller()?;
     mutate_state(|s| {
         s.sp_writedown_disabled = disabled;
-        log!(
-            INFO,
-            "[admin] sp_writedown_disabled set to {}",
-            disabled
-        );
+        log!(INFO, "[admin] sp_writedown_disabled set to {}", disabled);
     });
     Ok(())
 }
@@ -5817,8 +6852,8 @@ fn get_sp_writedown_disabled() -> bool {
 /// than a Set so it round-trips cleanly through Candid.
 #[candid_method(query)]
 #[query]
-fn get_consumed_writedown_proofs(
-) -> Vec<(rumi_protocol_backend::icrc3_proof::SpProofLedger, u64)> {
+fn get_consumed_writedown_proofs() -> Vec<(rumi_protocol_backend::icrc3_proof::SpProofLedger, u64)>
+{
     read_state(|s| s.consumed_writedown_proofs.iter().copied().collect())
 }
 
@@ -5835,9 +6870,7 @@ fn set_liquidation_ordering_tolerance(tolerance_e4: u64) -> Result<(), ProtocolE
     // Argument is in basis points (10_000 = 1.0 = 100%). Convert to Decimal
     // by dividing by 10_000. This keeps the wire format integer-only and
     // matches `cr_index_key`'s scaling.
-    let tolerance = Ratio::from(
-        Decimal::from(tolerance_e4) / Decimal::from(10_000u64),
-    );
+    let tolerance = Ratio::from(Decimal::from(tolerance_e4) / Decimal::from(10_000u64));
     mutate_state(|s| {
         s.set_liquidation_ordering_tolerance(tolerance);
         log!(
@@ -5867,7 +6900,10 @@ fn get_liquidation_ordering_tolerance_bps() -> u64 {
 /// Redeem icUSD for ckStable tokens from reserves (with vault spillover fallback)
 #[candid_method(update)]
 #[update]
-async fn redeem_reserves(amount: u64, preferred_token: Option<Principal>) -> Result<ReserveRedemptionResult, ProtocolError> {
+async fn redeem_reserves(
+    amount: u64,
+    preferred_token: Option<Principal>,
+) -> Result<ReserveRedemptionResult, ProtocolError> {
     validate_call().await?;
     // Wave-9 RED-003: reserve redemption walks the same vault cr-index as
     // redeem_collateral on its spillover branch, so the same ReadOnly gate
@@ -5909,22 +6945,31 @@ fn get_reserve_balances() -> Vec<ReserveBalance> {
 /// Every use is recorded as an on-chain event with a stated reason.
 #[candid_method(update)]
 #[update]
-async fn admin_mint_icusd(amount_e8s: u64, to: Principal, reason: String) -> Result<u64, ProtocolError> {
+async fn admin_mint_icusd(
+    amount_e8s: u64,
+    to: Principal,
+    reason: String,
+) -> Result<u64, ProtocolError> {
     const ADMIN_MINT_CAP_E8S: u64 = 150_000_000_000; // 1,500 icUSD
     const ADMIN_MINT_COOLDOWN_NS: u64 = 72 * 3600 * 1_000_000_000; // 72 hours
 
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can call admin_mint_icusd".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can call admin_mint_icusd".to_string(),
+        ));
     }
     if amount_e8s == 0 {
-        return Err(ProtocolError::GenericError("Amount must be > 0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Amount must be > 0".to_string(),
+        ));
     }
     if amount_e8s > ADMIN_MINT_CAP_E8S {
-        return Err(ProtocolError::GenericError(
-            format!("Amount exceeds admin mint cap of {} e8s (1,500 icUSD)", ADMIN_MINT_CAP_E8S)
-        ));
+        return Err(ProtocolError::GenericError(format!(
+            "Amount exceeds admin mint cap of {} e8s (1,500 icUSD)",
+            ADMIN_MINT_CAP_E8S
+        )));
     }
 
     // Enforce 72-hour cooldown
@@ -5933,23 +6978,33 @@ async fn admin_mint_icusd(amount_e8s: u64, to: Principal, reason: String) -> Res
     if last_mint_time > 0 && now.saturating_sub(last_mint_time) < ADMIN_MINT_COOLDOWN_NS {
         let remaining_ns = ADMIN_MINT_COOLDOWN_NS - (now - last_mint_time);
         let remaining_hours = remaining_ns / (3600 * 1_000_000_000);
-        return Err(ProtocolError::GenericError(
-            format!("Admin mint cooldown active. ~{} hours remaining.", remaining_hours)
-        ));
+        return Err(ProtocolError::GenericError(format!(
+            "Admin mint cooldown active. ~{} hours remaining.",
+            remaining_hours
+        )));
     }
 
     let amount = rumi_protocol_backend::numeric::ICUSD::from(amount_e8s);
-    let block_index = rumi_protocol_backend::management::mint_icusd(amount, to).await
+    let block_index = rumi_protocol_backend::management::mint_icusd(amount, to)
+        .await
         .map_err(|e| ProtocolError::GenericError(format!("Mint failed: {:?}", e)))?;
 
     // Update cooldown timestamp
-    mutate_state(|s| { s.last_admin_mint_time = now; });
+    mutate_state(|s| {
+        s.last_admin_mint_time = now;
+    });
 
     // Record on-chain event for transparency
     rumi_protocol_backend::event::record_admin_mint(amount, to, reason.clone(), block_index);
 
-    log!(INFO, "[admin_mint_icusd] Minted {} e8s icUSD to {} (block {}). Reason: {}",
-        amount_e8s, to, block_index, reason);
+    log!(
+        INFO,
+        "[admin_mint_icusd] Minted {} e8s icUSD to {} (block {}). Reason: {}",
+        amount_e8s,
+        to,
+        block_index,
+        reason
+    );
     Ok(block_index)
 }
 
@@ -5968,15 +7023,23 @@ async fn set_recovery_cr_multiplier(new_multiplier: f64) -> Result<(), ProtocolE
     }
     if new_multiplier < 1.001 || new_multiplier > 1.5 {
         return Err(ProtocolError::GenericError(
-            "Recovery CR multiplier must be between 1.001 (0.1% buffer) and 1.5 (50% buffer)".to_string(),
+            "Recovery CR multiplier must be between 1.001 (0.1% buffer) and 1.5 (50% buffer)"
+                .to_string(),
         ));
     }
-    let multiplier = Ratio::from(rust_decimal::Decimal::try_from(new_multiplier)
-        .map_err(|_| ProtocolError::GenericError("Invalid multiplier value".to_string()))?);
+    let multiplier = Ratio::from(
+        rust_decimal::Decimal::try_from(new_multiplier)
+            .map_err(|_| ProtocolError::GenericError("Invalid multiplier value".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_recovery_cr_multiplier(s, multiplier);
     });
-    log!(INFO, "[set_recovery_cr_multiplier] Multiplier set to: {} ({}% buffer)", new_multiplier, (new_multiplier - 1.0) * 100.0);
+    log!(
+        INFO,
+        "[set_recovery_cr_multiplier] Multiplier set to: {} ({}% buffer)",
+        new_multiplier,
+        (new_multiplier - 1.0) * 100.0
+    );
     Ok(())
 }
 
@@ -6004,12 +7067,19 @@ async fn set_liquidation_protocol_share(new_share: f64) -> Result<(), ProtocolEr
             "Liquidation protocol share must be between 0.0 and 1.0".to_string(),
         ));
     }
-    let share = Ratio::from(rust_decimal::Decimal::try_from(new_share)
-        .map_err(|_| ProtocolError::GenericError("Invalid share value".to_string()))?);
+    let share = Ratio::from(
+        rust_decimal::Decimal::try_from(new_share)
+            .map_err(|_| ProtocolError::GenericError("Invalid share value".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_liquidation_protocol_share(s, share);
     });
-    log!(INFO, "[set_liquidation_protocol_share] Share set to: {} ({}%)", new_share, new_share * 100.0);
+    log!(
+        INFO,
+        "[set_liquidation_protocol_share] Share set to: {} ({}%)",
+        new_share,
+        new_share * 100.0
+    );
     Ok(())
 }
 
@@ -6075,7 +7145,11 @@ async fn set_deficit_readonly_threshold_e8s(new_threshold: u64) -> Result<(), Pr
         INFO,
         "[set_deficit_readonly_threshold_e8s] Threshold set to: {} e8s ({})",
         new_threshold,
-        if new_threshold == 0 { "latch disabled" } else { "latch armed" }
+        if new_threshold == 0 {
+            "latch disabled"
+        } else {
+            "latch armed"
+        }
     );
     Ok(())
 }
@@ -6100,7 +7174,11 @@ async fn set_breaker_window_ns(new_window_ns: u64) -> Result<(), ProtocolError> 
         INFO,
         "[set_breaker_window_ns] Window set to: {} ns ({})",
         new_window_ns,
-        if new_window_ns == 0 { "breaker disabled" } else { "breaker armed" }
+        if new_window_ns == 0 {
+            "breaker disabled"
+        } else {
+            "breaker armed"
+        }
     );
     Ok(())
 }
@@ -6126,7 +7204,11 @@ async fn set_breaker_window_debt_ceiling_e8s(new_ceiling: u64) -> Result<(), Pro
         INFO,
         "[set_breaker_window_debt_ceiling_e8s] Ceiling set to: {} e8s ({})",
         new_ceiling,
-        if new_ceiling == 0 { "breaker disabled" } else { "breaker armed" }
+        if new_ceiling == 0 {
+            "breaker disabled"
+        } else {
+            "breaker armed"
+        }
     );
     Ok(())
 }
@@ -6212,7 +7294,11 @@ async fn set_xrc_fetch_interval_secs(secs: u64) -> Result<(), ProtocolError> {
     }
     mutate_state(|s| s.xrc_fetch_interval_secs = secs);
     register_xrc_fetch_timer();
-    log!(INFO, "[set_xrc_fetch_interval_secs] Timer A interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_xrc_fetch_interval_secs] Timer A interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6241,7 +7327,11 @@ async fn set_interest_treasury_tick_interval_secs(secs: u64) -> Result<(), Proto
     }
     mutate_state(|s| s.interest_treasury_tick_interval_secs = secs);
     register_interest_treasury_timer();
-    log!(INFO, "[set_interest_treasury_tick_interval_secs] Timer B interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_interest_treasury_tick_interval_secs] Timer B interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6271,7 +7361,11 @@ async fn set_vault_check_tick_interval_secs(secs: u64) -> Result<(), ProtocolErr
     }
     mutate_state(|s| s.vault_check_tick_interval_secs = secs);
     register_vault_check_timer();
-    log!(INFO, "[set_vault_check_tick_interval_secs] Timer C interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_vault_check_tick_interval_secs] Timer C interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6301,7 +7395,11 @@ async fn set_settlement_tick_interval_secs(secs: u64) -> Result<(), ProtocolErro
     }
     mutate_state(|s| s.settlement_tick_interval_secs = secs);
     register_settlement_timer();
-    log!(INFO, "[set_settlement_tick_interval_secs] Timer D interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_settlement_tick_interval_secs] Timer D interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6324,7 +7422,11 @@ async fn set_chain_interest_tick_interval_secs(secs: u64) -> Result<(), Protocol
     }
     mutate_state(|s| s.chain_interest_tick_interval_secs = secs);
     register_chain_interest_timer();
-    log!(INFO, "[set_chain_interest_tick_interval_secs] interest harvest interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_chain_interest_tick_interval_secs] interest harvest interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6341,7 +7443,11 @@ async fn set_chain_interest_min_realize_e8s(e8s: u128) -> Result<(), ProtocolErr
         ));
     }
     mutate_state(|s| s.chain_interest_min_realize_e8s = e8s);
-    log!(INFO, "[set_chain_interest_min_realize_e8s] interest dust floor set to {} e8s", e8s);
+    log!(
+        INFO,
+        "[set_chain_interest_min_realize_e8s] interest dust floor set to {} e8s",
+        e8s
+    );
     Ok(())
 }
 
@@ -6378,7 +7484,11 @@ fn set_chains_ecdsa_key_name(name: String) -> Result<(), ProtocolError> {
     let has_vaults = read_state(|s| !s.multi_chain.chain_vaults.is_empty());
     validate_ecdsa_key_change(&name, has_vaults)?;
     mutate_state(|s| s.chains_ecdsa_key_name = name.clone());
-    log!(INFO, "[set_chains_ecdsa_key_name] chains EVM tECDSA key set to {}", name);
+    log!(
+        INFO,
+        "[set_chains_ecdsa_key_name] chains EVM tECDSA key set to {}",
+        name
+    );
     Ok(())
 }
 
@@ -6473,7 +7583,11 @@ async fn set_observer_tick_interval_secs(secs: u64) -> Result<(), ProtocolError>
     }
     mutate_state(|s| s.observer_tick_interval_secs = secs);
     register_observer_timer();
-    log!(INFO, "[set_observer_tick_interval_secs] Observer interval set to {}s", secs);
+    log!(
+        INFO,
+        "[set_observer_tick_interval_secs] Observer interval set to {}s",
+        secs
+    );
     Ok(())
 }
 
@@ -6666,7 +7780,11 @@ async fn set_solana_workers_enabled(enabled: bool) -> Result<(), ProtocolError> 
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
     mutate_state(|s| s.solana_workers_enabled = enabled);
-    log!(INFO, "[set_solana_workers_enabled] Solana workers {}", if enabled { "ENABLED" } else { "disabled" });
+    log!(
+        INFO,
+        "[set_solana_workers_enabled] Solana workers {}",
+        if enabled { "ENABLED" } else { "disabled" }
+    );
     Ok(())
 }
 
@@ -6677,15 +7795,12 @@ async fn set_solana_workers_enabled(enabled: bool) -> Result<(), ProtocolError> 
 /// pre-Wave-9c behavior).
 #[candid_method(update)]
 #[update]
-async fn set_check_vaults_full_sweep_every_n_ticks(
-    new_n: u64,
-) -> Result<(), ProtocolError> {
+async fn set_check_vaults_full_sweep_every_n_ticks(new_n: u64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
         return Err(ProtocolError::GenericError(
-            "Only the developer principal can set check_vaults full-sweep cadence"
-                .to_string(),
+            "Only the developer principal can set check_vaults full-sweep cadence".to_string(),
         ));
     }
     mutate_state(|s| s.set_check_vaults_full_sweep_every_n_ticks(new_n));
@@ -6746,12 +7861,19 @@ async fn set_interest_pool_share(new_share: f64) -> Result<(), ProtocolError> {
             "Interest pool share must be between 0.0 and 1.0".to_string(),
         ));
     }
-    let share = Ratio::from(rust_decimal::Decimal::try_from(new_share)
-        .map_err(|_| ProtocolError::GenericError("Invalid share value".to_string()))?);
+    let share = Ratio::from(
+        rust_decimal::Decimal::try_from(new_share)
+            .map_err(|_| ProtocolError::GenericError("Invalid share value".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_interest_pool_share(s, share);
     });
-    log!(INFO, "[set_interest_pool_share] Set to: {} ({}% to stability pool)", new_share, new_share * 100.0);
+    log!(
+        INFO,
+        "[set_interest_pool_share] Set to: {} ({}% to stability pool)",
+        new_share,
+        new_share * 100.0
+    );
     Ok(())
 }
 
@@ -6781,9 +7903,10 @@ async fn set_interest_split(recipients: Vec<InterestSplitArg>) -> Result<(), Pro
     // Validate bps sum
     let total_bps: u64 = recipients.iter().map(|r| r.bps).sum();
     if total_bps != 10_000 {
-        return Err(ProtocolError::GenericError(
-            format!("Interest split bps must sum to 10000, got {}", total_bps),
-        ));
+        return Err(ProtocolError::GenericError(format!(
+            "Interest split bps must sum to 10000, got {}",
+            total_bps
+        )));
     }
 
     // Validate no zero-bps entries and no duplicate destinations
@@ -6795,30 +7918,40 @@ async fn set_interest_split(recipients: Vec<InterestSplitArg>) -> Result<(), Pro
             ));
         }
         if !seen.insert(r.destination.clone()) {
-            return Err(ProtocolError::GenericError(
-                format!("Duplicate destination: {}", r.destination),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Duplicate destination: {}",
+                r.destination
+            )));
         }
     }
 
     // Convert string destinations to enum
-    let split: Vec<rumi_protocol_backend::state::InterestRecipient> = recipients.iter().map(|r| {
-        let dest = match r.destination.as_str() {
-            "stability_pool" => rumi_protocol_backend::state::InterestDestination::StabilityPool,
-            "treasury" => rumi_protocol_backend::state::InterestDestination::Treasury,
-            "three_pool" => rumi_protocol_backend::state::InterestDestination::ThreePool,
-            "amm1" => rumi_protocol_backend::state::InterestDestination::Amm1,
-            _ => rumi_protocol_backend::state::InterestDestination::Treasury, // fallback
-        };
-        rumi_protocol_backend::state::InterestRecipient { destination: dest, bps: r.bps }
-    }).collect();
+    let split: Vec<rumi_protocol_backend::state::InterestRecipient> = recipients
+        .iter()
+        .map(|r| {
+            let dest = match r.destination.as_str() {
+                "stability_pool" => {
+                    rumi_protocol_backend::state::InterestDestination::StabilityPool
+                }
+                "treasury" => rumi_protocol_backend::state::InterestDestination::Treasury,
+                "three_pool" => rumi_protocol_backend::state::InterestDestination::ThreePool,
+                "amm1" => rumi_protocol_backend::state::InterestDestination::Amm1,
+                _ => rumi_protocol_backend::state::InterestDestination::Treasury, // fallback
+            };
+            rumi_protocol_backend::state::InterestRecipient {
+                destination: dest,
+                bps: r.bps,
+            }
+        })
+        .collect();
 
     // Validate destinations are known
     for r in &recipients {
         if !["stability_pool", "treasury", "three_pool", "amm1"].contains(&r.destination.as_str()) {
-            return Err(ProtocolError::GenericError(
-                format!("Unknown destination: '{}'. Valid: stability_pool, treasury, three_pool, amm1", r.destination),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Unknown destination: '{}'. Valid: stability_pool, treasury, three_pool, amm1",
+                r.destination
+            )));
         }
     }
 
@@ -6835,15 +7968,27 @@ async fn set_interest_split(recipients: Vec<InterestSplitArg>) -> Result<(), Pro
 #[query]
 fn get_interest_split() -> Vec<InterestSplitArg> {
     read_state(|s| {
-        s.interest_split.iter().map(|r| {
-            let dest = match &r.destination {
-                rumi_protocol_backend::state::InterestDestination::StabilityPool => "stability_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Treasury => "treasury".to_string(),
-                rumi_protocol_backend::state::InterestDestination::ThreePool => "three_pool".to_string(),
-                rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
-            };
-            InterestSplitArg { destination: dest, bps: r.bps }
-        }).collect()
+        s.interest_split
+            .iter()
+            .map(|r| {
+                let dest = match &r.destination {
+                    rumi_protocol_backend::state::InterestDestination::StabilityPool => {
+                        "stability_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Treasury => {
+                        "treasury".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::ThreePool => {
+                        "three_pool".to_string()
+                    }
+                    rumi_protocol_backend::state::InterestDestination::Amm1 => "amm1".to_string(),
+                };
+                InterestSplitArg {
+                    destination: dest,
+                    bps: r.bps,
+                }
+            })
+            .collect()
     })
 }
 
@@ -6993,10 +8138,7 @@ pub struct ProtocolStatusLite {
 #[query]
 fn get_icp_usd_price_e8s() -> ProtocolStatusLite {
     read_state(|s| ProtocolStatusLite {
-        price_e8s: s
-            .last_icp_rate
-            .map(|p| p.to_e8s() as u128)
-            .unwrap_or(0),
+        price_e8s: s.last_icp_rate.map(|p| p.to_e8s() as u128).unwrap_or(0),
     })
 }
 
@@ -7035,20 +8177,37 @@ fn get_rmr_ceiling_cr() -> f64 {
 #[update]
 async fn set_rmr_floor(value: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
-    let (is_dev, ceiling) = read_state(|s| (s.developer_principal == caller, s.rmr_ceiling.to_f64()));
+    let (is_dev, ceiling) =
+        read_state(|s| (s.developer_principal == caller, s.rmr_ceiling.to_f64()));
     if !is_dev {
-        return Err(ProtocolError::GenericError("Only the developer principal can set RMR floor".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set RMR floor".to_string(),
+        ));
     }
     if !(0.0..=1.0).contains(&value) {
-        return Err(ProtocolError::GenericError("RMR floor must be between 0.0 and 1.0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "RMR floor must be between 0.0 and 1.0".to_string(),
+        ));
     }
     if value > ceiling {
-        return Err(ProtocolError::GenericError(format!("RMR floor ({}) must be ≤ RMR ceiling ({})", value, ceiling)));
+        return Err(ProtocolError::GenericError(format!(
+            "RMR floor ({}) must be ≤ RMR ceiling ({})",
+            value, ceiling
+        )));
     }
-    let ratio = Ratio::from(rust_decimal::Decimal::try_from(value)
-        .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?);
-    mutate_state(|s| { rumi_protocol_backend::event::record_set_rmr_floor(s, ratio); });
-    log!(INFO, "[set_rmr_floor] Set to: {} ({}%)", value, value * 100.0);
+    let ratio = Ratio::from(
+        rust_decimal::Decimal::try_from(value)
+            .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_rmr_floor(s, ratio);
+    });
+    log!(
+        INFO,
+        "[set_rmr_floor] Set to: {} ({}%)",
+        value,
+        value * 100.0
+    );
     Ok(())
 }
 
@@ -7059,18 +8218,34 @@ async fn set_rmr_ceiling(value: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let (is_dev, floor) = read_state(|s| (s.developer_principal == caller, s.rmr_floor.to_f64()));
     if !is_dev {
-        return Err(ProtocolError::GenericError("Only the developer principal can set RMR ceiling".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set RMR ceiling".to_string(),
+        ));
     }
     if !(0.0..=1.0).contains(&value) {
-        return Err(ProtocolError::GenericError("RMR ceiling must be between 0.0 and 1.0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "RMR ceiling must be between 0.0 and 1.0".to_string(),
+        ));
     }
     if value < floor {
-        return Err(ProtocolError::GenericError(format!("RMR ceiling ({}) must be ≥ RMR floor ({})", value, floor)));
+        return Err(ProtocolError::GenericError(format!(
+            "RMR ceiling ({}) must be ≥ RMR floor ({})",
+            value, floor
+        )));
     }
-    let ratio = Ratio::from(rust_decimal::Decimal::try_from(value)
-        .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?);
-    mutate_state(|s| { rumi_protocol_backend::event::record_set_rmr_ceiling(s, ratio); });
-    log!(INFO, "[set_rmr_ceiling] Set to: {} ({}%)", value, value * 100.0);
+    let ratio = Ratio::from(
+        rust_decimal::Decimal::try_from(value)
+            .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_rmr_ceiling(s, ratio);
+    });
+    log!(
+        INFO,
+        "[set_rmr_ceiling] Set to: {} ({}%)",
+        value,
+        value * 100.0
+    );
     Ok(())
 }
 
@@ -7079,20 +8254,37 @@ async fn set_rmr_ceiling(value: f64) -> Result<(), ProtocolError> {
 #[update]
 async fn set_rmr_floor_cr(value: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
-    let (is_dev, ceiling_cr) = read_state(|s| (s.developer_principal == caller, s.rmr_ceiling_cr.to_f64()));
+    let (is_dev, ceiling_cr) =
+        read_state(|s| (s.developer_principal == caller, s.rmr_ceiling_cr.to_f64()));
     if !is_dev {
-        return Err(ProtocolError::GenericError("Only the developer principal can set RMR floor CR".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set RMR floor CR".to_string(),
+        ));
     }
     if value < 1.0 {
-        return Err(ProtocolError::GenericError("RMR floor CR must be ≥ 1.0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "RMR floor CR must be ≥ 1.0".to_string(),
+        ));
     }
     if value < ceiling_cr {
-        return Err(ProtocolError::GenericError(format!("RMR floor CR ({}) must be ≥ RMR ceiling CR ({})", value, ceiling_cr)));
+        return Err(ProtocolError::GenericError(format!(
+            "RMR floor CR ({}) must be ≥ RMR ceiling CR ({})",
+            value, ceiling_cr
+        )));
     }
-    let ratio = Ratio::from(rust_decimal::Decimal::try_from(value)
-        .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?);
-    mutate_state(|s| { rumi_protocol_backend::event::record_set_rmr_floor_cr(s, ratio); });
-    log!(INFO, "[set_rmr_floor_cr] Set to: {} ({}%)", value, value * 100.0);
+    let ratio = Ratio::from(
+        rust_decimal::Decimal::try_from(value)
+            .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_rmr_floor_cr(s, ratio);
+    });
+    log!(
+        INFO,
+        "[set_rmr_floor_cr] Set to: {} ({}%)",
+        value,
+        value * 100.0
+    );
     Ok(())
 }
 
@@ -7101,20 +8293,37 @@ async fn set_rmr_floor_cr(value: f64) -> Result<(), ProtocolError> {
 #[update]
 async fn set_rmr_ceiling_cr(value: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
-    let (is_dev, floor_cr) = read_state(|s| (s.developer_principal == caller, s.rmr_floor_cr.to_f64()));
+    let (is_dev, floor_cr) =
+        read_state(|s| (s.developer_principal == caller, s.rmr_floor_cr.to_f64()));
     if !is_dev {
-        return Err(ProtocolError::GenericError("Only the developer principal can set RMR ceiling CR".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set RMR ceiling CR".to_string(),
+        ));
     }
     if value < 1.0 {
-        return Err(ProtocolError::GenericError("RMR ceiling CR must be ≥ 1.0".to_string()));
+        return Err(ProtocolError::GenericError(
+            "RMR ceiling CR must be ≥ 1.0".to_string(),
+        ));
     }
     if value > floor_cr {
-        return Err(ProtocolError::GenericError(format!("RMR ceiling CR ({}) must be ≤ RMR floor CR ({})", value, floor_cr)));
+        return Err(ProtocolError::GenericError(format!(
+            "RMR ceiling CR ({}) must be ≤ RMR floor CR ({})",
+            value, floor_cr
+        )));
     }
-    let ratio = Ratio::from(rust_decimal::Decimal::try_from(value)
-        .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?);
-    mutate_state(|s| { rumi_protocol_backend::event::record_set_rmr_ceiling_cr(s, ratio); });
-    log!(INFO, "[set_rmr_ceiling_cr] Set to: {} ({}%)", value, value * 100.0);
+    let ratio = Ratio::from(
+        rust_decimal::Decimal::try_from(value)
+            .map_err(|_| ProtocolError::GenericError("Invalid value".to_string()))?,
+    );
+    mutate_state(|s| {
+        rumi_protocol_backend::event::record_set_rmr_ceiling_cr(s, ratio);
+    });
+    log!(
+        INFO,
+        "[set_rmr_ceiling_cr] Set to: {} ({}%)",
+        value,
+        value * 100.0
+    );
     Ok(())
 }
 
@@ -7210,12 +8419,19 @@ async fn set_recovery_target_cr(new_rate: f64) -> Result<(), ProtocolError> {
             multiplier_val, new_rate, threshold
         )));
     }
-    let multiplier = Ratio::from(rust_decimal::Decimal::try_from(multiplier_val)
-        .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?);
+    let multiplier = Ratio::from(
+        rust_decimal::Decimal::try_from(multiplier_val)
+            .map_err(|_| ProtocolError::GenericError("Invalid rate".to_string()))?,
+    );
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_recovery_cr_multiplier(s, multiplier);
     });
-    log!(INFO, "[set_recovery_target_cr] (legacy) → multiplier set to: {} ({}% buffer)", multiplier_val, (multiplier_val - 1.0) * 100.0);
+    log!(
+        INFO,
+        "[set_recovery_target_cr] (legacy) → multiplier set to: {} ({}% buffer)",
+        multiplier_val,
+        (multiplier_val - 1.0) * 100.0
+    );
     Ok(())
 }
 
@@ -7387,14 +8603,16 @@ async fn set_rate_curve_markers(
     // Validate finite values, sorted ascending, and positive multipliers
     for i in 0..markers.len() {
         if !markers[i].0.is_finite() || !markers[i].1.is_finite() {
-            return Err(ProtocolError::GenericError(
-                format!("Marker at index {} must contain finite numbers, got ({}, {})", i, markers[i].0, markers[i].1),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Marker at index {} must contain finite numbers, got ({}, {})",
+                i, markers[i].0, markers[i].1
+            )));
         }
         if markers[i].1 <= 0.0 {
-            return Err(ProtocolError::GenericError(
-                format!("Multiplier at index {} must be positive", i),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Multiplier at index {} must be positive",
+                i
+            )));
         }
         if i > 0 && markers[i].0 <= markers[i - 1].0 {
             return Err(ProtocolError::GenericError(
@@ -7406,15 +8624,24 @@ async fn set_rate_curve_markers(
     if let Some(ct) = collateral_type {
         let exists = read_state(|s| s.collateral_configs.contains_key(&ct));
         if !exists {
-            return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+            return Err(ProtocolError::GenericError(
+                "Unknown collateral type".to_string(),
+            ));
         }
     }
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_rate_curve_markers(
-            s, collateral_type, markers.clone(),
+            s,
+            collateral_type,
+            markers.clone(),
         );
     });
-    log!(INFO, "[set_rate_curve_markers] collateral={:?}, markers={:?}", collateral_type, markers);
+    log!(
+        INFO,
+        "[set_rate_curve_markers] collateral={:?}, markers={:?}",
+        collateral_type,
+        markers
+    );
     Ok(())
 }
 
@@ -7422,9 +8649,7 @@ async fn set_rate_curve_markers(
 /// `markers`: Vec of (SystemThreshold variant name, multiplier) pairs.
 #[candid_method(update)]
 #[update]
-async fn set_recovery_rate_curve(
-    markers: Vec<(String, f64)>,
-) -> Result<(), ProtocolError> {
+async fn set_recovery_rate_curve(markers: Vec<(String, f64)>) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
@@ -7442,9 +8667,10 @@ async fn set_recovery_rate_curve(
     let mut parsed: Vec<(SystemThreshold, f64)> = Vec::new();
     for (thresh_str, mult) in &markers {
         if !mult.is_finite() || *mult <= 0.0 {
-            return Err(ProtocolError::GenericError(
-                format!("Multiplier for {} must be a finite positive number, got {}", thresh_str, mult),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Multiplier for {} must be a finite positive number, got {}",
+                thresh_str, mult
+            )));
         }
         let threshold = match thresh_str.as_str() {
             "LiquidationRatio" => SystemThreshold::LiquidationRatio,
@@ -7470,9 +8696,7 @@ async fn set_recovery_rate_curve(
 /// Accepts a JSON-serialized RateCurveV2.
 #[candid_method(update)]
 #[update]
-async fn set_borrowing_fee_curve(
-    curve_json: Option<String>,
-) -> Result<(), ProtocolError> {
+async fn set_borrowing_fee_curve(curve_json: Option<String>) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
@@ -7488,16 +8712,17 @@ async fn set_borrowing_fee_curve(
             // INT-003: validate structure and multiplier upper bound. The
             // upper bound prevents a runaway fee from underflowing
             // `amount - fee` in `borrow_from_vault_internal`.
-            parsed
-                .validate()
-                .map_err(ProtocolError::GenericError)?;
+            parsed.validate().map_err(ProtocolError::GenericError)?;
             Some(parsed)
         }
     };
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_borrowing_fee_curve(s, curve);
     });
-    log!(INFO, "[set_borrowing_fee_curve] Updated borrowing fee curve");
+    log!(
+        INFO,
+        "[set_borrowing_fee_curve] Updated borrowing fee curve"
+    );
     Ok(())
 }
 
@@ -7518,24 +8743,29 @@ async fn set_healthy_cr(
     }
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     // Validate healthy_cr > borrow_threshold if set
     if let Some(cr) = healthy_cr {
         if !cr.is_finite() {
             return Err(ProtocolError::GenericError(format!(
-                "healthy_cr ({}) must be a finite number", cr
+                "healthy_cr ({}) must be a finite number",
+                cr
             )));
         }
         let borrow_threshold = read_state(|s| {
-            s.collateral_configs.get(&collateral_type)
+            s.collateral_configs
+                .get(&collateral_type)
                 .map(|c| c.borrow_threshold_ratio.to_f64())
                 .unwrap_or(1.5)
         });
         if cr <= borrow_threshold {
-            return Err(ProtocolError::GenericError(
-                format!("healthy_cr ({}) must be greater than borrow_threshold_ratio ({})", cr, borrow_threshold),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "healthy_cr ({}) must be greater than borrow_threshold_ratio ({})",
+                cr, borrow_threshold
+            )));
         }
     }
     let ratio = healthy_cr
@@ -7546,7 +8776,12 @@ async fn set_healthy_cr(
     mutate_state(|s| {
         rumi_protocol_backend::event::record_set_healthy_cr(s, collateral_type, ratio);
     });
-    log!(INFO, "[set_healthy_cr] collateral={}, healthy_cr={:?}", collateral_type, healthy_cr);
+    log!(
+        INFO,
+        "[set_healthy_cr] collateral={}, healthy_cr={:?}",
+        collateral_type,
+        healthy_cr
+    );
     Ok(())
 }
 
@@ -7555,13 +8790,17 @@ async fn set_healthy_cr(
 #[query]
 fn get_vault_interest_rate(vault_id: u64) -> Result<f64, ProtocolError> {
     read_state(|s| {
-        let vault = s.vault_id_to_vaults.get(&vault_id)
+        let vault = s
+            .vault_id_to_vaults
+            .get(&vault_id)
             .ok_or_else(|| ProtocolError::GenericError(format!("Vault {} not found", vault_id)))?;
-        let config = s.get_collateral_config(&vault.collateral_type)
+        let config = s
+            .get_collateral_config(&vault.collateral_type)
             .ok_or_else(|| ProtocolError::GenericError("Unknown collateral type".to_string()))?;
         // Compute vault CR
-        let price = config.last_price
-            .ok_or_else(|| ProtocolError::GenericError("No price available for collateral".to_string()))?;
+        let price = config.last_price.ok_or_else(|| {
+            ProtocolError::GenericError("No price available for collateral".to_string())
+        })?;
         let price_dec = Decimal::from_f64(price).unwrap_or(Decimal::ZERO);
         let vault_value = rumi_protocol_backend::numeric::collateral_usd_value(
             vault.collateral_amount,
@@ -7573,7 +8812,10 @@ fn get_vault_interest_rate(vault_id: u64) -> Result<f64, ProtocolError> {
         } else {
             vault_value / vault.borrowed_icusd_amount
         };
-        Ok(s.get_dynamic_interest_rate_for(&vault.collateral_type, vault_cr).to_f64())
+        Ok(
+            s.get_dynamic_interest_rate_for(&vault.collateral_type, vault_cr)
+                .to_f64(),
+        )
     })
 }
 
@@ -7582,13 +8824,15 @@ fn get_vault_interest_rate(vault_id: u64) -> Result<f64, ProtocolError> {
 #[update]
 async fn clear_stuck_operations(principal_id: Option<Principal>) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::caller();
-    
+
     // Only developer can clear stuck operations
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can clear stuck operations".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can clear stuck operations".to_string(),
+        ));
     }
-    
+
     let cleared_count = mutate_state(|s| {
         use ic_cdk::api::time;
         let current_time = time();
@@ -7600,9 +8844,11 @@ async fn clear_stuck_operations(principal_id: Option<Principal>) -> Result<u64, 
             if s.principal_guards.contains(&target_principal) {
                 principals_to_remove.push(target_principal);
                 if let Some(op_name) = s.operation_names.get(&target_principal) {
-                    log!(INFO,
+                    log!(
+                        INFO,
                         "[clear_stuck_operations] Clearing operation '{}' for principal: {}",
-                        op_name, target_principal.to_string()
+                        op_name,
+                        target_principal.to_string()
                     );
                 }
                 count += 1;
@@ -7642,8 +8888,12 @@ async fn clear_stuck_operations(principal_id: Option<Principal>) -> Result<u64, 
 
         count
     });
-    
-    log!(INFO, "[clear_stuck_operations] Cleared {} stuck operations", cleared_count);
+
+    log!(
+        INFO,
+        "[clear_stuck_operations] Cleared {} stuck operations",
+        cleared_count
+    );
     Ok(cleared_count)
 }
 
@@ -7651,21 +8901,28 @@ async fn clear_stuck_operations(principal_id: Option<Principal>) -> Result<u64, 
 
 #[candid_method(update)]
 #[update]
-async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> Result<(), ProtocolError> {
+async fn add_collateral_token(
+    arg: rumi_protocol_backend::AddCollateralArg,
+) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can add collateral types".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can add collateral types".to_string(),
+        ));
     }
 
     // Check it doesn't already exist
     let already_exists = read_state(|s| s.collateral_configs.contains_key(&arg.ledger_canister_id));
     if already_exists {
-        return Err(ProtocolError::GenericError("Collateral type already exists".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Collateral type already exists".to_string(),
+        ));
     }
 
     // Query icrc1_decimals from the ledger
-    let decimals_result: Result<(u8,), _> = ic_cdk::call(arg.ledger_canister_id, "icrc1_decimals", ()).await;
+    let decimals_result: Result<(u8,), _> =
+        ic_cdk::call(arg.ledger_canister_id, "icrc1_decimals", ()).await;
     let decimals = match decimals_result {
         Ok((d,)) => d,
         Err((code, msg)) => {
@@ -7677,7 +8934,8 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
     };
 
     // Query icrc1_fee from the ledger
-    let fee_result: Result<(candid::Nat,), _> = ic_cdk::call(arg.ledger_canister_id, "icrc1_fee", ()).await;
+    let fee_result: Result<(candid::Nat,), _> =
+        ic_cdk::call(arg.ledger_canister_id, "icrc1_fee", ()).await;
     let ledger_fee = match fee_result {
         Ok((f,)) => {
             use num_traits::ToPrimitive;
@@ -7713,7 +8971,8 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
         current_base_rate: Ratio::from_f64(0.0),
         last_redemption_time: 0,
         // Computed from borrow_threshold_ratio × recovery_cr_multiplier; not user-supplied.
-        recovery_target_cr: Ratio::from_f64(arg.borrow_threshold_ratio) * read_state(|s| s.recovery_cr_multiplier),
+        recovery_target_cr: Ratio::from_f64(arg.borrow_threshold_ratio)
+            * read_state(|s| s.recovery_cr_multiplier),
         min_collateral_deposit: arg.min_collateral_deposit,
         recovery_borrowing_fee: None,
         recovery_interest_rate_apr: None,
@@ -7746,11 +9005,20 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
     let ledger_id = arg.ledger_canister_id;
     let is_icp = read_state(|s| s.icp_collateral_type() == ledger_id);
     if !is_icp {
-        log!(INFO, "[add_collateral_token] Registering price timer for collateral {}", ledger_id);
+        log!(
+            INFO,
+            "[add_collateral_token] Registering price timer for collateral {}",
+            ledger_id
+        );
         rumi_protocol_backend::xrc::register_collateral_price_timer(ledger_id);
     }
 
-    log!(INFO, "[add_collateral_token] Added collateral type: {} (decimals={})", arg.ledger_canister_id, decimals);
+    log!(
+        INFO,
+        "[add_collateral_token] Added collateral type: {} (decimals={})",
+        arg.ledger_canister_id,
+        decimals
+    );
 
     // Best-effort: register the new collateral on the stability pool so it
     // can accept liquidation proceeds in this token.  If the SP call fails
@@ -7774,7 +9042,9 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
             status: SpCollateralStatus,
         }
         #[derive(candid::CandidType)]
-        enum SpCollateralStatus { Active }
+        enum SpCollateralStatus {
+            Active,
+        }
 
         let info = SpCollateralInfo {
             ledger_id: ledger_id,
@@ -7785,9 +9055,17 @@ async fn add_collateral_token(arg: rumi_protocol_backend::AddCollateralArg) -> R
 
         // We ignore the SP's Result return value — if the call itself succeeds,
         // registration worked (or the collateral already existed, which is fine).
-        match ic_cdk::call::<(SpCollateralInfo,), ()>(sp_canister, "register_collateral", (info,)).await {
+        match ic_cdk::call::<(SpCollateralInfo,), ()>(sp_canister, "register_collateral", (info,))
+            .await
+        {
             Ok(()) => {
-                log!(INFO, "[add_collateral_token] Registered {} ({}) on stability pool {}", symbol, ledger_id, sp_canister);
+                log!(
+                    INFO,
+                    "[add_collateral_token] Registered {} ({}) on stability pool {}",
+                    symbol,
+                    ledger_id,
+                    sp_canister
+                );
             }
             Err((code, msg)) => {
                 log!(INFO, "[add_collateral_token] WARNING: Failed to register collateral on SP: {:?} {} — register manually", code, msg);
@@ -7807,19 +9085,28 @@ async fn set_collateral_status(
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can change collateral status".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can change collateral status".to_string(),
+        ));
     }
 
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Collateral type not found".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Collateral type not found".to_string(),
+        ));
     }
 
     mutate_state(|s| {
         event::record_update_collateral_status(s, collateral_type, status);
     });
 
-    log!(INFO, "[set_collateral_status] Collateral {} status set to {:?}", collateral_type, status);
+    log!(
+        INFO,
+        "[set_collateral_status] Collateral {} status set to {:?}",
+        collateral_type,
+        status
+    );
     Ok(())
 }
 
@@ -7888,12 +9175,16 @@ async fn set_collateral_debt_ceiling(
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can change debt ceiling".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can change debt ceiling".to_string(),
+        ));
     }
 
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Collateral type not found".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Collateral type not found".to_string(),
+        ));
     }
 
     mutate_state(|s| {
@@ -7902,7 +9193,12 @@ async fn set_collateral_debt_ceiling(
         }
     });
 
-    log!(INFO, "[set_collateral_debt_ceiling] Collateral {} debt ceiling set to {}", collateral_type, debt_ceiling);
+    log!(
+        INFO,
+        "[set_collateral_debt_ceiling] Collateral {} debt ceiling set to {}",
+        collateral_type,
+        debt_ceiling
+    );
     Ok(())
 }
 
@@ -7910,14 +9206,13 @@ async fn set_collateral_debt_ceiling(
 /// Haircut is a decimal: 0.07 = 7%, range 0.0–0.50.
 #[candid_method(update)]
 #[update]
-async fn set_lst_haircut(
-    collateral_type: Principal,
-    haircut: f64,
-) -> Result<(), ProtocolError> {
+async fn set_lst_haircut(collateral_type: Principal, haircut: f64) -> Result<(), ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can set LST haircut".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can set LST haircut".to_string(),
+        ));
     }
 
     rumi_protocol_backend::validate_f64_inclusive("haircut", haircut, 0.0, 0.50)
@@ -7928,10 +9223,19 @@ async fn set_lst_haircut(
             match &mut config.price_source {
                 rumi_protocol_backend::state::PriceSource::LstWrapped { haircut: h, .. } => {
                     *h = haircut;
-                    log!(INFO, "[set_lst_haircut] Collateral {} haircut set to {}", collateral_type, haircut);
+                    log!(
+                        INFO,
+                        "[set_lst_haircut] Collateral {} haircut set to {}",
+                        collateral_type,
+                        haircut
+                    );
                 }
                 _ => {
-                    log!(INFO, "[set_lst_haircut] Collateral {} is not LstWrapped, ignoring", collateral_type);
+                    log!(
+                        INFO,
+                        "[set_lst_haircut] Collateral {} is not LstWrapped, ignoring",
+                        collateral_type
+                    );
                 }
             }
         }
@@ -7968,7 +9272,11 @@ async fn set_collateral_liquidation_ratio(
     });
     let borrow_threshold = match borrow_threshold {
         Some(bt) => bt,
-        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+        None => {
+            return Err(ProtocolError::GenericError(
+                "Unknown collateral type".to_string(),
+            ))
+        }
     };
     if liquidation_ratio >= borrow_threshold {
         return Err(ProtocolError::GenericError(format!(
@@ -7976,14 +9284,23 @@ async fn set_collateral_liquidation_ratio(
             liquidation_ratio, borrow_threshold
         )));
     }
-    let ratio = Ratio::from(
-        Decimal::try_from(liquidation_ratio)
-            .map_err(|_| ProtocolError::GenericError("Invalid liquidation_ratio value".to_string()))?,
-    );
+    let ratio =
+        Ratio::from(Decimal::try_from(liquidation_ratio).map_err(|_| {
+            ProtocolError::GenericError("Invalid liquidation_ratio value".to_string())
+        })?);
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_liquidation_ratio(s, collateral_type, ratio);
+        rumi_protocol_backend::event::record_set_collateral_liquidation_ratio(
+            s,
+            collateral_type,
+            ratio,
+        );
     });
-    log!(INFO, "[set_collateral_liquidation_ratio] collateral={}, liquidation_ratio={}", collateral_type, liquidation_ratio);
+    log!(
+        INFO,
+        "[set_collateral_liquidation_ratio] collateral={}, liquidation_ratio={}",
+        collateral_type,
+        liquidation_ratio
+    );
     Ok(())
 }
 
@@ -8003,7 +9320,10 @@ async fn set_collateral_borrow_threshold(
             "Only the developer principal can set borrow threshold".to_string(),
         ));
     }
-    if !borrow_threshold_ratio.is_finite() || borrow_threshold_ratio <= 1.0 || borrow_threshold_ratio > 5.0 {
+    if !borrow_threshold_ratio.is_finite()
+        || borrow_threshold_ratio <= 1.0
+        || borrow_threshold_ratio > 5.0
+    {
         return Err(ProtocolError::GenericError(format!(
             "borrow_threshold_ratio ({}) must be a finite number > 1.0 and ≤ 5.0",
             borrow_threshold_ratio
@@ -8012,15 +9332,19 @@ async fn set_collateral_borrow_threshold(
     let (liq_ratio, healthy_cr) = read_state(|s| {
         s.collateral_configs
             .get(&collateral_type)
-            .map(|c| (
-                c.liquidation_ratio.to_f64(),
-                c.healthy_cr.map(|r| r.to_f64()),
-            ))
+            .map(|c| {
+                (
+                    c.liquidation_ratio.to_f64(),
+                    c.healthy_cr.map(|r| r.to_f64()),
+                )
+            })
             .unwrap_or((0.0, None))
     });
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     if borrow_threshold_ratio <= liq_ratio {
         return Err(ProtocolError::GenericError(format!(
@@ -8036,14 +9360,22 @@ async fn set_collateral_borrow_threshold(
             )));
         }
     }
-    let ratio = Ratio::from(
-        Decimal::try_from(borrow_threshold_ratio)
-            .map_err(|_| ProtocolError::GenericError("Invalid borrow_threshold_ratio value".to_string()))?,
-    );
+    let ratio = Ratio::from(Decimal::try_from(borrow_threshold_ratio).map_err(|_| {
+        ProtocolError::GenericError("Invalid borrow_threshold_ratio value".to_string())
+    })?);
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_borrow_threshold(s, collateral_type, ratio);
+        rumi_protocol_backend::event::record_set_collateral_borrow_threshold(
+            s,
+            collateral_type,
+            ratio,
+        );
     });
-    log!(INFO, "[set_collateral_borrow_threshold] collateral={}, borrow_threshold_ratio={}", collateral_type, borrow_threshold_ratio);
+    log!(
+        INFO,
+        "[set_collateral_borrow_threshold] collateral={}, borrow_threshold_ratio={}",
+        collateral_type,
+        borrow_threshold_ratio
+    );
     Ok(())
 }
 
@@ -8066,16 +9398,27 @@ async fn set_collateral_liquidation_bonus(
         .map_err(ProtocolError::GenericError)?;
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
-    let ratio = Ratio::from(
-        Decimal::try_from(liquidation_bonus)
-            .map_err(|_| ProtocolError::GenericError("Invalid liquidation_bonus value".to_string()))?,
-    );
+    let ratio =
+        Ratio::from(Decimal::try_from(liquidation_bonus).map_err(|_| {
+            ProtocolError::GenericError("Invalid liquidation_bonus value".to_string())
+        })?);
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_liquidation_bonus(s, collateral_type, ratio);
+        rumi_protocol_backend::event::record_set_collateral_liquidation_bonus(
+            s,
+            collateral_type,
+            ratio,
+        );
     });
-    log!(INFO, "[set_collateral_liquidation_bonus] collateral={}, liquidation_bonus={}", collateral_type, liquidation_bonus);
+    log!(
+        INFO,
+        "[set_collateral_liquidation_bonus] collateral={}, liquidation_bonus={}",
+        collateral_type,
+        liquidation_bonus
+    );
     Ok(())
 }
 
@@ -8096,12 +9439,23 @@ async fn set_collateral_min_vault_debt(
     }
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_min_vault_debt(s, collateral_type, min_vault_debt);
+        rumi_protocol_backend::event::record_set_collateral_min_vault_debt(
+            s,
+            collateral_type,
+            min_vault_debt,
+        );
     });
-    log!(INFO, "[set_collateral_min_vault_debt] collateral={}, min_vault_debt={}", collateral_type, min_vault_debt);
+    log!(
+        INFO,
+        "[set_collateral_min_vault_debt] collateral={}, min_vault_debt={}",
+        collateral_type,
+        min_vault_debt
+    );
     Ok(())
 }
 
@@ -8123,12 +9477,23 @@ async fn set_collateral_ledger_fee(
     }
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_ledger_fee(s, collateral_type, ledger_fee);
+        rumi_protocol_backend::event::record_set_collateral_ledger_fee(
+            s,
+            collateral_type,
+            ledger_fee,
+        );
     });
-    log!(INFO, "[set_collateral_ledger_fee] collateral={}, ledger_fee={}", collateral_type, ledger_fee);
+    log!(
+        INFO,
+        "[set_collateral_ledger_fee] collateral={}, ledger_fee={}",
+        collateral_type,
+        ledger_fee
+    );
     Ok(())
 }
 
@@ -8147,8 +9512,13 @@ async fn set_collateral_redemption_fee_floor(
             "Only the developer principal can set redemption fee floor".to_string(),
         ));
     }
-    rumi_protocol_backend::validate_f64_inclusive("redemption_fee_floor", redemption_fee_floor, 0.0, 0.10)
-        .map_err(ProtocolError::GenericError)?;
+    rumi_protocol_backend::validate_f64_inclusive(
+        "redemption_fee_floor",
+        redemption_fee_floor,
+        0.0,
+        0.10,
+    )
+    .map_err(ProtocolError::GenericError)?;
     let ceiling = read_state(|s| {
         s.collateral_configs
             .get(&collateral_type)
@@ -8156,7 +9526,11 @@ async fn set_collateral_redemption_fee_floor(
     });
     let ceiling = match ceiling {
         Some(c) => c,
-        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+        None => {
+            return Err(ProtocolError::GenericError(
+                "Unknown collateral type".to_string(),
+            ))
+        }
     };
     if redemption_fee_floor > ceiling {
         return Err(ProtocolError::GenericError(format!(
@@ -8164,14 +9538,22 @@ async fn set_collateral_redemption_fee_floor(
             redemption_fee_floor, ceiling
         )));
     }
-    let ratio = Ratio::from(
-        Decimal::try_from(redemption_fee_floor)
-            .map_err(|_| ProtocolError::GenericError("Invalid redemption_fee_floor value".to_string()))?,
-    );
+    let ratio = Ratio::from(Decimal::try_from(redemption_fee_floor).map_err(|_| {
+        ProtocolError::GenericError("Invalid redemption_fee_floor value".to_string())
+    })?);
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_redemption_fee_floor(s, collateral_type, ratio);
+        rumi_protocol_backend::event::record_set_collateral_redemption_fee_floor(
+            s,
+            collateral_type,
+            ratio,
+        );
     });
-    log!(INFO, "[set_collateral_redemption_fee_floor] collateral={}, redemption_fee_floor={}", collateral_type, redemption_fee_floor);
+    log!(
+        INFO,
+        "[set_collateral_redemption_fee_floor] collateral={}, redemption_fee_floor={}",
+        collateral_type,
+        redemption_fee_floor
+    );
     Ok(())
 }
 
@@ -8190,8 +9572,13 @@ async fn set_collateral_redemption_fee_ceiling(
             "Only the developer principal can set redemption fee ceiling".to_string(),
         ));
     }
-    rumi_protocol_backend::validate_f64_inclusive("redemption_fee_ceiling", redemption_fee_ceiling, 0.0, 0.50)
-        .map_err(ProtocolError::GenericError)?;
+    rumi_protocol_backend::validate_f64_inclusive(
+        "redemption_fee_ceiling",
+        redemption_fee_ceiling,
+        0.0,
+        0.50,
+    )
+    .map_err(ProtocolError::GenericError)?;
     let floor = read_state(|s| {
         s.collateral_configs
             .get(&collateral_type)
@@ -8199,7 +9586,11 @@ async fn set_collateral_redemption_fee_ceiling(
     });
     let floor = match floor {
         Some(f) => f,
-        None => return Err(ProtocolError::GenericError("Unknown collateral type".to_string())),
+        None => {
+            return Err(ProtocolError::GenericError(
+                "Unknown collateral type".to_string(),
+            ))
+        }
     };
     if redemption_fee_ceiling < floor {
         return Err(ProtocolError::GenericError(format!(
@@ -8207,14 +9598,22 @@ async fn set_collateral_redemption_fee_ceiling(
             redemption_fee_ceiling, floor
         )));
     }
-    let ratio = Ratio::from(
-        Decimal::try_from(redemption_fee_ceiling)
-            .map_err(|_| ProtocolError::GenericError("Invalid redemption_fee_ceiling value".to_string()))?,
-    );
+    let ratio = Ratio::from(Decimal::try_from(redemption_fee_ceiling).map_err(|_| {
+        ProtocolError::GenericError("Invalid redemption_fee_ceiling value".to_string())
+    })?);
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_redemption_fee_ceiling(s, collateral_type, ratio);
+        rumi_protocol_backend::event::record_set_collateral_redemption_fee_ceiling(
+            s,
+            collateral_type,
+            ratio,
+        );
     });
-    log!(INFO, "[set_collateral_redemption_fee_ceiling] collateral={}, redemption_fee_ceiling={}", collateral_type, redemption_fee_ceiling);
+    log!(
+        INFO,
+        "[set_collateral_redemption_fee_ceiling] collateral={}, redemption_fee_ceiling={}",
+        collateral_type,
+        redemption_fee_ceiling
+    );
     Ok(())
 }
 
@@ -8235,12 +9634,23 @@ async fn set_collateral_min_deposit(
     }
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_min_deposit(s, collateral_type, min_collateral_deposit);
+        rumi_protocol_backend::event::record_set_collateral_min_deposit(
+            s,
+            collateral_type,
+            min_collateral_deposit,
+        );
     });
-    log!(INFO, "[set_collateral_min_deposit] collateral={}, min_collateral_deposit={}", collateral_type, min_collateral_deposit);
+    log!(
+        INFO,
+        "[set_collateral_min_deposit] collateral={}, min_collateral_deposit={}",
+        collateral_type,
+        min_collateral_deposit
+    );
     Ok(())
 }
 
@@ -8268,31 +9678,48 @@ async fn set_collateral_display_color(
     }
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Unknown collateral type".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Unknown collateral type".to_string(),
+        ));
     }
     mutate_state(|s| {
-        rumi_protocol_backend::event::record_set_collateral_display_color(s, collateral_type, display_color.clone());
+        rumi_protocol_backend::event::record_set_collateral_display_color(
+            s,
+            collateral_type,
+            display_color.clone(),
+        );
     });
-    log!(INFO, "[set_collateral_display_color] collateral={}, display_color={:?}", collateral_type, display_color);
+    log!(
+        INFO,
+        "[set_collateral_display_color] collateral={}, display_color={:?}",
+        collateral_type,
+        display_color
+    );
     Ok(())
 }
 
 #[candid_method(query)]
 #[query]
-fn get_collateral_config(collateral_type: Principal) -> Option<rumi_protocol_backend::state::CollateralConfig> {
+fn get_collateral_config(
+    collateral_type: Principal,
+) -> Option<rumi_protocol_backend::state::CollateralConfig> {
     read_state(|s| {
-        s.get_collateral_config(&collateral_type).cloned().map(|mut config| {
-            // Always compute recovery_target_cr from the formula rather than returning
-            // the cached value, which may be stale if the multiplier changed after config creation.
-            config.recovery_target_cr = config.borrow_threshold_ratio * s.recovery_cr_multiplier;
-            config
-        })
+        s.get_collateral_config(&collateral_type)
+            .cloned()
+            .map(|mut config| {
+                // Always compute recovery_target_cr from the formula rather than returning
+                // the cached value, which may be stale if the multiplier changed after config creation.
+                config.recovery_target_cr =
+                    config.borrow_threshold_ratio * s.recovery_cr_multiplier;
+                config
+            })
     })
 }
 
 #[candid_method(query)]
 #[query]
-fn get_supported_collateral_types() -> Vec<(Principal, rumi_protocol_backend::state::CollateralStatus)> {
+fn get_supported_collateral_types(
+) -> Vec<(Principal, rumi_protocol_backend::state::CollateralStatus)> {
     read_state(|s| s.supported_collateral_types())
 }
 
@@ -8341,12 +9768,16 @@ async fn update_collateral_config(
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can update collateral config".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can update collateral config".to_string(),
+        ));
     }
 
     let exists = read_state(|s| s.collateral_configs.contains_key(&collateral_type));
     if !exists {
-        return Err(ProtocolError::GenericError("Collateral type not found".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Collateral type not found".to_string(),
+        ));
     }
 
     // Ensure the ledger_canister_id in the config matches the collateral_type key
@@ -8360,7 +9791,11 @@ async fn update_collateral_config(
         event::record_update_collateral_config(s, collateral_type, config);
     });
 
-    log!(INFO, "[update_collateral_config] Updated config for collateral {}", collateral_type);
+    log!(
+        INFO,
+        "[update_collateral_config] Updated config for collateral {}",
+        collateral_type
+    );
     Ok(())
 }
 
@@ -8377,14 +9812,19 @@ async fn admin_correct_vault_collateral(
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
-        return Err(ProtocolError::GenericError("Only developer can correct vault collateral".to_string()));
+        return Err(ProtocolError::GenericError(
+            "Only developer can correct vault collateral".to_string(),
+        ));
     }
 
     let old_amount = read_state(|s| {
         s.vault_id_to_vaults
             .get(&vault_id)
             .map(|v| v.collateral_amount)
-            .ok_or(ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))
+            .ok_or(ProtocolError::GenericError(format!(
+                "Vault #{} not found",
+                vault_id
+            )))
     })?;
 
     // Safety: only allow downward corrections. Reducing collateral is conservative
@@ -8392,21 +9832,31 @@ async fn admin_correct_vault_collateral(
     // against phantom value — if collateral was under-reported, the safe fix is for
     // the user to deposit more.
     if new_collateral_amount > old_amount {
-        return Err(ProtocolError::GenericError(
-            format!(
-                "Admin corrections can only reduce collateral (current: {}, requested: {}). \
+        return Err(ProtocolError::GenericError(format!(
+            "Admin corrections can only reduce collateral (current: {}, requested: {}). \
                  To increase collateral, the vault owner should deposit more.",
-                old_amount, new_collateral_amount
-            )
-        ));
+            old_amount, new_collateral_amount
+        )));
     }
 
     mutate_state(|s| {
-        event::record_admin_vault_correction(s, vault_id, old_amount, new_collateral_amount, reason.clone());
+        event::record_admin_vault_correction(
+            s,
+            vault_id,
+            old_amount,
+            new_collateral_amount,
+            reason.clone(),
+        );
     });
 
-    log!(INFO, "[admin_correct_vault_collateral] Vault #{}: {} -> {} raw units. Reason: {}",
-        vault_id, old_amount, new_collateral_amount, reason);
+    log!(
+        INFO,
+        "[admin_correct_vault_collateral] Vault #{}: {} -> {} raw units. Reason: {}",
+        vault_id,
+        old_amount,
+        new_collateral_amount,
+        reason
+    );
     Ok(())
 }
 
@@ -8427,7 +9877,11 @@ async fn admin_sweep_to_treasury(reason: String) -> Result<u64, ProtocolError> {
     }
 
     let (treasury, icp_ledger, icp_fee) = read_state(|s| {
-        (s.treasury_principal, s.icp_ledger_principal, s.icp_ledger_fee)
+        (
+            s.treasury_principal,
+            s.icp_ledger_principal,
+            s.icp_ledger_fee,
+        )
     });
     let treasury = treasury.ok_or(ProtocolError::GenericError(
         "Treasury principal not configured".to_string(),
@@ -8541,7 +9995,9 @@ struct VaultDebtCorrection {
 /// Records an auditable event for each correction.
 #[update]
 #[candid_method(update)]
-fn admin_correct_vault_debts(corrections: Vec<VaultDebtCorrection>) -> Result<String, ProtocolError> {
+fn admin_correct_vault_debts(
+    corrections: Vec<VaultDebtCorrection>,
+) -> Result<String, ProtocolError> {
     let caller = ic_cdk::caller();
     let is_developer = read_state(|s| s.developer_principal == caller);
     if !is_developer {
@@ -8572,8 +10028,11 @@ fn admin_correct_vault_debts(corrections: Vec<VaultDebtCorrection>) -> Result<St
 
                 results.push(format!(
                     "vault#{}: borrowed {}→{}, accrued {}→{}",
-                    c.vault_id, old_borrowed, c.correct_borrowed_e8s,
-                    old_accrued, c.correct_accrued_interest_e8s
+                    c.vault_id,
+                    old_borrowed,
+                    c.correct_borrowed_e8s,
+                    old_accrued,
+                    c.correct_accrued_interest_e8s
                 ));
 
                 // Wave-8b LIQ-002: admin correction changes debt → re-key.
@@ -8584,7 +10043,11 @@ fn admin_correct_vault_debts(corrections: Vec<VaultDebtCorrection>) -> Result<St
         }
     });
 
-    log!(INFO, "[admin_correct_vault_debts] Applied {} corrections", results.len());
+    log!(
+        INFO,
+        "[admin_correct_vault_debts] Applied {} corrections",
+        results.len()
+    );
     Ok(results.join("\n"))
 }
 
@@ -8625,10 +10088,12 @@ fn forward_filtered_scan_windows_filters_and_advances_cursor() {
     let close_filter: HashSet<EventTypeFilter> = HashSet::from([EventTypeFilter::CloseVault]);
     let borrow_filter: HashSet<EventTypeFilter> = HashSet::from([EventTypeFilter::Borrow]);
 
-    let ids = |r: &ForwardFilteredEventsResponse| r.events.iter().map(|(i, _)| *i).collect::<Vec<_>>();
+    let ids =
+        |r: &ForwardFilteredEventsResponse| r.events.iter().map(|(i, _)| *i).collect::<Vec<_>>();
 
     // Full scan: all three match, tagged with their global indices, caught up.
-    let r = scan_events_forward_filtered(evs.clone().into_iter(), 0, 10, count, Some(&close_filter));
+    let r =
+        scan_events_forward_filtered(evs.clone().into_iter(), 0, 10, count, Some(&close_filter));
     assert_eq!(ids(&r), vec![0, 1, 2]);
     assert_eq!(r.next_start, 3);
     assert!(r.reached_end);
@@ -8640,7 +10105,8 @@ fn forward_filtered_scan_windows_filters_and_advances_cursor() {
     assert!(!r.reached_end);
 
     // Resume from cursor 2: only index 2, then caught up.
-    let r = scan_events_forward_filtered(evs.clone().into_iter(), 2, 10, count, Some(&close_filter));
+    let r =
+        scan_events_forward_filtered(evs.clone().into_iter(), 2, 10, count, Some(&close_filter));
     assert_eq!(ids(&r), vec![2]);
     assert_eq!(r.next_start, 3);
     assert!(r.reached_end);
@@ -8659,12 +10125,16 @@ fn forward_filtered_scan_windows_filters_and_advances_cursor() {
 // 13_300). Non-EVM / unknown chains error rather than silently defaulting.
 #[cfg(test)]
 mod chain_vault_param_tests {
-    use super::evm_vault_params;
+    use super::{evm_vault_params, replace_state, State};
 
     #[test]
     fn evm_vault_params_resolves_per_chain() {
         use rumi_protocol_backend::chains::config::ChainId;
-        assert_eq!(evm_vault_params(ChainId(10143)).unwrap(), ("MON", 13_000, 10_000_000, None)); // Monad preserved
+        replace_state(State::default());
+        assert_eq!(
+            evm_vault_params(ChainId(10143)).unwrap(),
+            ("MON", 13_000, 10_000_000, None)
+        ); // Monad preserved
         assert_eq!(
             evm_vault_params(ChainId(71)).unwrap(),
             ("CFX", 15_000, 10_000_000, Some(500 * 100_000_000))
@@ -8693,13 +10163,11 @@ fn check_candid_interface_compatibility() {
 
     fn source_to_str(source: &CandidSource) -> String {
         match source {
-            CandidSource::File(f) => {
-                std::fs::read_to_string(f).unwrap_or_else(|_| "".to_string())
-            }
+            CandidSource::File(f) => std::fs::read_to_string(f).unwrap_or_else(|_| "".to_string()),
             CandidSource::Text(t) => t.to_string(),
         }
     }
-    
+
     fn check_service_compatible(
         new_name: &str,
         new: CandidSource,
@@ -8747,3 +10215,28 @@ fn check_candid_interface_compatibility() {
     );
 }
 
+#[cfg(test)]
+mod inc5_reconciliation_tests {
+    use super::normalize_reconciliation_proof;
+
+    #[test]
+    fn reconciliation_proof_accepts_trimmed_nonempty_text() {
+        assert_eq!(
+            normalize_reconciliation_proof("  cfx burn tx 0xabc:7  ").expect("valid proof"),
+            "cfx burn tx 0xabc:7"
+        );
+    }
+
+    #[test]
+    fn reconciliation_proof_rejects_empty_text() {
+        let err = normalize_reconciliation_proof("   ").unwrap_err();
+        assert!(format!("{err:?}").contains("proof text required"));
+    }
+
+    #[test]
+    fn reconciliation_proof_rejects_text_over_512_bytes() {
+        let proof = "x".repeat(513);
+        let err = normalize_reconciliation_proof(&proof).unwrap_err();
+        assert!(format!("{err:?}").contains("proof text too long"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements chains-liquidation Increment 5 reconciliation controls:

- adds atomic settlement helpers for `pending_chain_burn_e8s` and `reserve_backing_e8s`
- adds developer-gated settlement endpoints with bounded manual proof text and audit events
- exposes `get_chain_reserves` for book-vs-on-chain reserve reconciliation
- persists optional per-chain debt config overrides while preserving compile-time defaults
- routes open/borrow/withdraw through the manual price staleness gate when configured
- regenerates the backend Candid interface
- records the full Inc 5 plan and future on-chain proof-verification goal

## Validation

- `cargo test -p rumi_protocol_backend --lib`
  - 587 passed, 0 failed, 1 ignored
- `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend`
  - 7 passed, 0 failed

## Notes

`cargo fmt --all --check` is still blocked by unrelated pre-existing trailing whitespace in `src/rumi_protocol_backend/src/test_helpers.rs` and `src/rumi_protocol_backend/src/icrc21.rs`. The Inc 5 files pass targeted `rustfmt --edition 2021 --check`.
