### PR TITLE
fix(chains): harden native XRP launch path

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -37,6 +37,45 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainLiquidatableVault = record {
+  sized_repay_e8s : nat;
+  cr_e4 : nat64;
+  collateral_native : nat;
+  vault_id : nat64;
+  chain_id : nat32;
+  liquidation_threshold_e4 : nat64;
+  effective_debt_e8s : nat;
+  debt_e8s : nat;
+};
+type ChainLiquidationConfigV1 = record {
+  dex : DexKind;
+  max_swap_value_e8s : nat;
+  pair : text;
+  max_price_age_ns : nat64;
+  fee_bps : nat16;
+  restore_target_cr_e4 : nat64;
+  max_dex_oracle_divergence_bps : nat32;
+  enabled : bool;
+  collateral_token : text;
+  settle_stable_decimals : nat8;
+  factory : text;
+  slippage_cap_bps : nat16;
+  router : text;
+  settle_stable_token : text;
+  deadline_secs : nat64;
+};
+type ChainSupplyReconciliation = record {
+  recorded_supply_e8s : nat;
+  pending_chain_burn_e8s : nat;
+  reserve_backing_e8s : nat;
+  gap_e8s : int;
+  reserve_usdc_native : nat;
+  unbacked_excess : bool;
+  finalized_block : nat64;
+  in_flight_mint_e8s : nat;
+  chain_id : nat32;
+  onchain_total_supply_e8s : nat;
+};
 type ChainVaultStatus = variant {
   MintPending;
   Open;
@@ -46,12 +85,16 @@ type ChainVaultStatus = variant {
 };
 type ChainVaultV1 = record {
   status : ChainVaultStatus;
+  owner_evm : opt text;
   owner : principal;
   pending_mint_e8s : nat;
+  pending_interest_mint_e8s : nat;
   custody_address : text;
   collateral_amount_e18 : nat;
   opened_at_ns : nat64;
   vault_id : nat64;
+  last_interest_accrual_ns : nat64;
+  pending_liquidation : opt PendingLiquidationV1;
   collateral_chain : nat32;
   mint_recipient : text;
   debt_e8s : nat;
@@ -74,6 +117,7 @@ type CollateralConfig = record {
   redemption_tier : nat8;
   redemption_fee_floor : blob;
   borrow_threshold_ratio : blob;
+  custody_kind : opt CustodyKind;
   ledger_fee : nat64;
   recovery_target_cr : blob;
   current_base_rate : blob;
@@ -128,6 +172,7 @@ type ConsentMessageSpec = record {
   metadata : ConsentMessageMetadata;
   device_spec : opt DeviceSpec;
 };
+type CustodyKind = variant { IcrcLedger; NativeXrp };
 type DeficitSource = variant {
   Liquidation : record { vault_id : nat64 };
   Redemption : record { redeemer : principal };
@@ -136,6 +181,7 @@ type DeviceSpec = variant {
   GenericDisplay;
   LineDisplay : record { characters_per_line : nat16; lines_per_page : nat16 };
 };
+type DexKind = variant { UniswapV2 };
 type ErrorInfo = record { description : text };
 type Event = variant {
   set_borrowing_fee : record { rate : text };
@@ -179,6 +225,19 @@ type Event = variant {
     chain_id : nat32;
     timestamp : nat64;
     tx_hash : text;
+  };
+  chain_liquidation_deferred : record {
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    reason : text;
+  };
+  chain_reserve_credited : record {
+    usdc_native : nat;
+    backing_added_e8s : nat;
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
   };
   provide_liquidity : record {
     block_index : nat64;
@@ -326,6 +385,15 @@ type Event = variant {
   set_reserve_redemptions_enabled : record { enabled : bool };
   set_min_icusd_amount : record { amount : text };
   set_borrowing_fee_curve : record { markers : text };
+  chain_interest_minted : record {
+    mint_id : nat64;
+    vault_id : nat64;
+    block_number : nat64;
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    tx_hash : text;
+  };
   set_interest_pool_share : record { share : text };
   set_liquidation_protocol_share : record { share : text };
   update_collateral_config : record {
@@ -471,6 +539,13 @@ type Event = variant {
   set_icpswap_routing_enabled : record { enabled : bool };
   set_bot_budget : record { start_timestamp : nat64; total_e8s : nat64 };
   set_rmr_floor : record { value : text };
+  chain_cfx_claim_settled : record {
+    claim_id : nat64;
+    amount_native : nat;
+    recipient : text;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   set_redemption_fee_floor : record { rate : text };
   set_interest_rate : record {
     collateral_type : principal;
@@ -517,6 +592,15 @@ type Event = variant {
   set_collateral_borrow_threshold : record {
     borrow_threshold_ratio : text;
     collateral_type : principal;
+  };
+  chain_vault_liquidated : record {
+    collateral_seized_native : nat;
+    op_id : nat64;
+    tier : LiquidationTier;
+    vault_id : nat64;
+    chain_id : nat32;
+    timestamp : nat64;
+    debt_cleared_e8s : nat;
   };
   add_collateral_type : record {
     config : CollateralConfig;
@@ -577,6 +661,11 @@ type EventsByPrincipalPagedResponse = record {
 };
 type FeeSource = variant { BorrowingFee; RedemptionFee };
 type Fees = record { redemption_fee : float64; borrowing_fee : float64 };
+type ForwardFilteredEventsResponse = record {
+  next_start : nat64;
+  reached_end : bool;
+  events : vec record { nat64; Event };
+};
 type GasStrategy = variant {
   NotApplicable;
   SolanaPriorityFee : record { lamports_per_cu_ceiling : nat64 };
@@ -638,6 +727,7 @@ type InitArg = record {
 type InterestSplitArg = record { bps : nat64; destination : text };
 type InterpolationMethod = variant { Linear };
 type LineDisplayPage = record { lines : vec text };
+type LiquidationTier = variant { Bot; StabilityPool };
 type LiquidityStatus = record {
   liquidity_provided : nat64;
   total_liquidity_provided : nat64;
@@ -645,8 +735,16 @@ type LiquidityStatus = record {
   available_liquidity_reward : nat64;
   total_available_returns : nat64;
 };
+type ManualPriceInfo = record { set_at_ns : nat64; price_e8 : nat64 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type PendingLiquidationV1 = record {
+  started_at_ns : nat64;
+  op_id : nat64;
+  tier : LiquidationTier;
+  debt_to_clear_e8s : nat;
+  collateral_reserved_native : nat;
+};
 type PerCollateralRateCurve = record {
   markers : vec record { float64; float64 };
   base_rate : float64;
@@ -719,6 +817,7 @@ type ProtocolError = variant {
   AlreadyProcessing;
   NotLowestCR;
   SupplyInvariantHalted;
+  EvmAuth : text;
   AnonymousCallerNotAllowed;
   ChainAdmin : text;
   AmountTooLow : record { minimum_amount : nat64 };
@@ -779,6 +878,7 @@ type RegisterChainArg = record {
   chain_native_decimals : nat8;
   display_name : text;
   chain_id : nat32;
+  min_quorum_providers : opt nat32;
 };
 type RepayAndCloseSuccess = record {
   collateral_return_block_index : opt nat64;
@@ -798,13 +898,21 @@ type ReserveRedemptionResult = record {
 };
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
-type Result_10 = variant { Ok : bool; Err : ProtocolError };
-type Result_11 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_12 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_13 = variant {
+type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_11 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
+type Result_12 = variant {
+  Ok : ChainSupplyReconciliation;
+  Err : ProtocolError;
+};
+type Result_13 = variant { Ok : bool; Err : ProtocolError };
+type Result_14 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_15 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_16 = variant { Ok : blob; Err : ProtocolError };
+type Result_17 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
+type Result_18 = variant { Ok : nat32; Err : ProtocolError };
 type Result_2 = variant { Ok : text; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
@@ -812,7 +920,7 @@ type Result_5 = variant { Ok : opt nat64; Err : ProtocolError };
 type Result_6 = variant { Ok : nat8; Err : ProtocolError };
 type Result_7 = variant { Ok : float64; Err : ProtocolError };
 type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_9 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_9 = variant { Ok : ChainVaultV1; Err : ProtocolError };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -838,10 +946,10 @@ type StableTokenType = variant { CKUSDC; CKUSDT };
 type StandardRecord = record { url : text; name : text };
 type SuccessWithFee = record {
   block_index : nat64;
-  fee_amount_paid : nat64;
-  collateral_amount_received : opt nat64;
   debt_liquidated_e8s : opt nat64;
+  fee_amount_paid : nat64;
   stable_pulled_e6s : opt nat64;
+  collateral_amount_received : opt nat64;
 };
 type SupplyAudit = record { total_e8s : nat; per_chain : vec SupplyAuditEntry };
 type SupplyAuditEntry = record {
@@ -886,6 +994,7 @@ type UpdateChainConfigArg = record {
   gas_strategy : opt GasStrategy;
   finality_depth : opt nat32;
   display_name : opt text;
+  min_quorum_providers : opt opt nat32;
 };
 type UpgradeArg = record { mode : opt Mode; description : opt text };
 type Vault = record {
@@ -909,6 +1018,17 @@ type VaultDebtCorrection = record {
   vault_id : nat64;
   correct_borrowed_e8s : nat64;
 };
+type VaultIntent = record {
+  action : nat8;
+  owner : text;
+  recipient : text;
+  collateral_wei : nat;
+  vault_id : nat64;
+  chain_id : nat64;
+  nonce : nat64;
+  deadline_secs : nat64;
+  debt_e8s : nat;
+};
 type VaultRedemption = record {
   icusd_redeemed_e8s : nat64;
   vault_id : nat64;
@@ -919,6 +1039,28 @@ type VaultsPageResponse = record {
   next_start_id : opt nat64;
 };
 type XrcAssetClass = variant { Cryptocurrency; FiatCurrency };
+type XrpClaim = record {
+  custody_nonce : nat64;
+  claimant : principal;
+  created_at_ns : nat64;
+  custody_owner : principal;
+  drops : nat64;
+  settlement : opt XrpSettlement;
+};
+type XrpPendingDeposit = record {
+  owner : principal;
+  custody_address : text;
+  opened_at_ns : nat64;
+  derivation_nonce : nat64;
+};
+type XrpSettlement = record {
+  destination : opt text;
+  destination_tag : opt nat32;
+  last_ledger_sequence : nat32;
+  source_sequence : opt nat32;
+  tx_hash : text;
+};
+type XrpVaultOpenInfo = record { custody_address : text; vault_id : nat64 };
 service : (ProtocolArg) -> {
   add_collateral_token : (AddCollateralArg) -> (Result);
   add_margin_to_vault : (VaultArg) -> (Result_1);
@@ -928,18 +1070,24 @@ service : (ProtocolArg) -> {
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
   admin_sweep_to_treasury : (text) -> (Result_1);
+  borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
   borrow_from_vault : (VaultArg) -> (Result_3);
   bot_cancel_liquidation : (nat64) -> (Result);
   bot_claim_liquidation : (nat64) -> (Result_4);
   bot_confirm_liquidation : (nat64) -> (Result);
+  cancel_xrp_pending_open : (nat64) -> (Result);
+  chain_has_active_settlement_op : (nat32) -> (bool) query;
   claim_liquidity_returns : () -> (Result_1);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
   clear_reorg_halt : (nat32) -> (Result);
   clear_stuck_operations : (opt principal) -> (Result_1);
   close_chain_vault : (nat64, text) -> (Result);
+  close_chain_vault_evm : (VaultIntent, blob) -> (Result);
+  close_solana_vault : (nat64, text) -> (Result);
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
+  confirm_xrp_deposit : (nat64) -> (Result_1);
   delete_chain : (nat32) -> (Result);
   disable_chain : (nat32) -> (Result);
   enter_recovery_mode : () -> (Result);
@@ -953,8 +1101,15 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_interest_treasury_address : (nat32) -> (Result_2);
+  get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
+  get_chain_liquidation_config : (nat32) -> (
+      opt ChainLiquidationConfigV1,
+    ) query;
+  get_chain_reserve_address : (nat32) -> (Result_2);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
+  get_chains_ecdsa_key_name : () -> (text) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
@@ -970,6 +1125,9 @@ service : (ProtocolArg) -> {
       EventsByPrincipalPagedResponse,
     ) query;
   get_events_filtered : (GetEventsArg) -> (GetEventsFilteredResponse) query;
+  get_events_forward_filtered : (nat64, nat64, opt vec EventTypeFilter) -> (
+      ForwardFilteredEventsResponse,
+    ) query;
   get_fees : (nat64) -> (Fees) query;
   get_fees_for_collateral : (principal, nat64) -> (Fees) query;
   get_global_icusd_mint_cap : () -> (nat64) query;
@@ -986,8 +1144,15 @@ service : (ProtocolArg) -> {
   get_liquidation_ordering_tolerance_bps : () -> (nat64) query;
   get_liquidation_protocol_share : () -> (float64) query;
   get_liquidity_status : (principal) -> (LiquidityStatus) query;
+  get_manual_collateral_price : (nat32, text) -> (opt ManualPriceInfo) query;
   get_min_icusd_amount : () -> (nat64) query;
+  get_my_xrp_claims : () -> (vec record { nat64; XrpClaim }) query;
+  get_my_xrp_pending_deposits : () -> (
+      vec record { nat64; XrpPendingDeposit },
+    ) query;
   get_pending_amm1_donations_count : () -> (nat64) query;
+  get_price_pusher_allowed : () -> (vec record { nat32; text }) query;
+  get_price_pusher_principal : () -> (opt principal) query;
   get_protocol_3usd_reserves : () -> (nat64) query;
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
@@ -1025,30 +1190,44 @@ service : (ProtocolArg) -> {
   get_vault_interest_rate : (nat64) -> (Result_7) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
+  get_xrp_claims : () -> (vec record { nat64; XrpClaim }) query;
+  get_xrp_pending_deposits : () -> (
+      vec record { nat64; XrpPendingDeposit },
+    ) query;
+  get_xrp_schnorr_key_name : () -> (text) query;
+  harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
   icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;
+  liquidate_chain_vault : (nat64) -> (Result_1);
   liquidate_vault : (nat64) -> (Result_3);
   liquidate_vault_partial : (VaultArg) -> (Result_3);
   liquidate_vault_partial_with_stable : (VaultArgWithToken) -> (Result_3);
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
-  open_vault : (nat64, opt principal) -> (Result_9);
-  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_9);
-  open_vault_with_deposit : (nat64, opt principal) -> (Result_9);
+  open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
+  open_solana_vault : (nat, nat, text) -> (Result_9);
+  open_vault : (nat64, opt principal) -> (Result_10);
+  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
+  open_vault_with_deposit : (nat64, opt principal) -> (Result_10);
+  open_xrp_vault : () -> (Result_11);
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  recover_pending_transfer : (nat64) -> (Result_10);
+  reconcile_chain_supply : (nat32) -> (Result_12);
+  recover_pending_transfer : (nat64) -> (Result_13);
+  recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_11);
+  redeem_reserves : (nat64, opt principal) -> (Result_14);
   register_chain : (RegisterChainArg) -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_12);
+  register_xrp_collateral : () -> (Result);
+  repay_and_close_vault : (VaultArg) -> (Result_15);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
+  resolve_stuck_settlement_op : (nat32, nat64) -> (Result);
   set_amm1_canister : (principal) -> (Result);
   set_amm1_pool_id : (text) -> (Result);
   set_borrowing_fee : (float64) -> (Result);
@@ -1057,8 +1236,13 @@ service : (ProtocolArg) -> {
   set_bot_cr_tolerance_bps : (nat64) -> (Result);
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
+  set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
+  set_chain_interest_min_realize_e8s : (nat) -> (Result);
+  set_chain_interest_tick_interval_secs : (nat64) -> (Result);
+  set_chain_liquidation_config : (nat32, ChainLiquidationConfigV1) -> (Result);
+  set_chains_ecdsa_key_name : (text) -> (Result);
   set_check_vaults_alert_band_bps : (nat64) -> (Result);
   set_check_vaults_full_sweep_every_n_ticks : (nat64) -> (Result);
   set_ckstable_repay_fee : (float64) -> (Result);
@@ -1097,6 +1281,9 @@ service : (ProtocolArg) -> {
   set_min_icusd_amount : (nat64) -> (Result);
   set_min_xrc_sources_used : (nat32) -> (Result);
   set_observer_tick_interval_secs : (nat64) -> (Result);
+  set_price_pusher_principal : (opt principal, vec record { nat32; text }) -> (
+      Result,
+    );
   set_rate_curve_markers : (opt principal, vec record { float64; float64 }) -> (
       Result,
     );
@@ -1114,6 +1301,8 @@ service : (ProtocolArg) -> {
   set_rmr_floor : (float64) -> (Result);
   set_rmr_floor_cr : (float64) -> (Result);
   set_settlement_tick_interval_secs : (nat64) -> (Result);
+  set_sol_rpc_principal : (principal) -> (Result);
+  set_solana_workers_enabled : (bool) -> (Result);
   set_sp_writedown_disabled : (bool) -> (Result);
   set_stability_pool_principal : (principal) -> (Result);
   set_stable_ledger_principal : (StableTokenType, principal) -> (Result);
@@ -1122,18 +1311,37 @@ service : (ProtocolArg) -> {
   set_treasury_principal : (principal) -> (Result);
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_13);
+  set_xrp_schnorr_key_name : (text) -> (Result);
+  settle_xrp_claim : (nat64, text) -> (Result_2);
+  settle_xrp_claim_with_tag : (nat64, text, nat32) -> (Result_2);
+  solana_bootstrap_nonce : (opt text) -> (Result);
+  solana_get_balance : (text) -> (Result_1);
+  solana_get_mint_supply : () -> (Result_1);
+  solana_settlement_address : () -> (Result_2);
+  solana_sign_test_transfer : (text, nat64) -> (Result_16);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_17);
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_13,
+      Result_17,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_13,
+      Result_17,
     );
+  submit_burn_proof : (nat32, text) -> (Result_18);
+  sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);
   withdraw_chain_collateral : (nat64, nat, text) -> (Result);
+  withdraw_chain_collateral_evm : (VaultIntent, blob) -> (Result);
   withdraw_collateral : (nat64) -> (Result_1);
   withdraw_liquidity : (nat64) -> (Result_1);
   withdraw_partial_collateral : (VaultArg) -> (Result_1);
+  withdraw_solana_collateral : (nat64, nat, text) -> (Result);
+  xrp_balance : (text) -> (Result_1);
+  xrp_custody_address : (principal, nat64) -> (Result_2);
+  xrp_settlement_address : () -> (Result_2);
+  xrp_transform_account : (TransformArgs) -> (HttpResponse) query;
+  xrp_transform_server : (TransformArgs) -> (HttpResponse) query;
+  xrp_transform_submit : (TransformArgs) -> (HttpResponse) query;
+  xrp_transform_tx : (TransformArgs) -> (HttpResponse) query;
 }

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -44,11 +44,17 @@ export interface CandidVault {
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
 }
+export interface ChainDebtConfigV1 {
+  'debt_ceiling_e8s' : [] | [bigint],
+  'min_vault_debt_e8s' : bigint,
+}
 export interface ChainLiquidatableVault {
   'sized_repay_e8s' : bigint,
   'cr_e4' : bigint,
   'collateral_native' : bigint,
   'vault_id' : bigint,
+  'sp_attempted' : boolean,
+  'chain_collateral_sentinel' : Principal,
   'chain_id' : number,
   'liquidation_threshold_e4' : bigint,
   'effective_debt_e8s' : bigint,
@@ -70,6 +76,30 @@ export interface ChainLiquidationConfigV1 {
   'router' : string,
   'settle_stable_token' : string,
   'deadline_secs' : bigint,
+}
+export interface ChainReserveReport {
+  'recorded_supply_e8s' : bigint,
+  'onchain_usdc_balance_native' : [] | [bigint],
+  'pending_chain_burn_e8s' : bigint,
+  'reserve_backing_e8s' : bigint,
+  'reserve_usdc_native' : bigint,
+  'finalized_block' : bigint,
+  'bad_debt_e8s' : bigint,
+  'reserve_address' : [] | [string],
+  'chain_id' : number,
+  'onchain_usdc_error' : [] | [string],
+  'settle_stable_token' : [] | [string],
+}
+export interface ChainStabilityPoolLiquidationResult {
+  'collateral_price_e8s' : bigint,
+  'liquidated_debt_e8s' : bigint,
+  'collateral_received_native' : bigint,
+  'block_index' : bigint,
+  'claim_id' : bigint,
+  'custody_address' : string,
+  'vault_id' : bigint,
+  'chain_id' : number,
+  'success' : boolean,
 }
 export interface ChainSupplyReconciliation {
   'recorded_supply_e8s' : bigint,
@@ -283,6 +313,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
   { 'set_rmr_ceiling_cr' : { 'value' : string } } |
   { 'set_amm1_canister' : { 'canister' : Principal } } |
   { 'set_recovery_rate_curve' : { 'markers' : string } } |
+  {
+    'chain_reserve_burn_settled' : {
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'proof' : string,
+    }
+  } |
   { 'set_ckstable_repay_fee' : { 'rate' : string } } |
   { 'set_treasury_principal' : { 'principal' : Principal } } |
   { 'accrue_interest' : { 'timestamp' : bigint } } |
@@ -425,6 +463,14 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   { 'set_rmr_floor_cr' : { 'value' : string } } |
+  {
+    'chain_pending_burn_settled' : {
+      'amount_e8s' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+      'proof' : string,
+    }
+  } |
   { 'set_rmr_ceiling' : { 'value' : string } } |
   {
     'set_collateral_liquidation_bonus' : {
@@ -1072,25 +1118,29 @@ export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
   { 'Err' : ProtocolError };
-export type Result_10 = { 'Ok' : OpenVaultSuccess } |
+export type Result_10 = { 'Ok' : ChainVaultV1 } |
   { 'Err' : ProtocolError };
-export type Result_11 = { 'Ok' : XrpVaultOpenInfo } |
+export type Result_11 = { 'Ok' : OpenVaultSuccess } |
   { 'Err' : ProtocolError };
-export type Result_12 = { 'Ok' : ChainSupplyReconciliation } |
+export type Result_12 = { 'Ok' : XrpVaultOpenInfo } |
   { 'Err' : ProtocolError };
-export type Result_13 = { 'Ok' : boolean } |
+export type Result_13 = { 'Ok' : ChainSupplyReconciliation } |
   { 'Err' : ProtocolError };
-export type Result_14 = { 'Ok' : ReserveRedemptionResult } |
+export type Result_14 = { 'Ok' : boolean } |
   { 'Err' : ProtocolError };
-export type Result_15 = { 'Ok' : RepayAndCloseSuccess } |
+export type Result_15 = { 'Ok' : ReserveRedemptionResult } |
   { 'Err' : ProtocolError };
-export type Result_16 = { 'Ok' : Uint8Array | number[] } |
+export type Result_16 = { 'Ok' : RepayAndCloseSuccess } |
   { 'Err' : ProtocolError };
-export type Result_17 = { 'Ok' : StabilityPoolLiquidationResult } |
+export type Result_17 = { 'Ok' : Uint8Array | number[] } |
   { 'Err' : ProtocolError };
-export type Result_18 = { 'Ok' : number } |
+export type Result_18 = { 'Ok' : StabilityPoolLiquidationResult } |
+  { 'Err' : ProtocolError };
+export type Result_19 = { 'Ok' : ChainStabilityPoolLiquidationResult } |
   { 'Err' : ProtocolError };
 export type Result_2 = { 'Ok' : string } |
+  { 'Err' : ProtocolError };
+export type Result_20 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_3 = { 'Ok' : SuccessWithFee } |
   { 'Err' : ProtocolError };
@@ -1098,14 +1148,14 @@ export type Result_4 = { 'Ok' : BotLiquidationResult } |
   { 'Err' : ProtocolError };
 export type Result_5 = { 'Ok' : [] | [bigint] } |
   { 'Err' : ProtocolError };
-export type Result_6 = { 'Ok' : number } |
+export type Result_6 = { 'Ok' : ChainReserveReport } |
   { 'Err' : ProtocolError };
 export type Result_7 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
-export type Result_8 = { 'Ok' : ConsentInfo } |
-  { 'Err' : Icrc21Error };
-export type Result_9 = { 'Ok' : ChainVaultV1 } |
+export type Result_8 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
+export type Result_9 = { 'Ok' : ConsentInfo } |
+  { 'Err' : Icrc21Error };
 export type SpProofLedger = { 'IcusdBurn' : null } |
   { 'ThreePoolTransfer' : null };
 export interface SpWritedownProof {
@@ -1251,6 +1301,9 @@ export interface XrpPendingDeposit {
   'derivation_nonce' : bigint,
 }
 export interface XrpSettlement {
+  'destination' : [] | [string],
+  'source_sequence' : [] | [number],
+  'destination_tag' : [] | [number],
   'last_ledger_sequence' : number,
   'tx_hash' : string,
 }
@@ -1281,7 +1334,12 @@ export interface _SERVICE {
   'bot_cancel_liquidation' : ActorMethod<[bigint], Result>,
   'bot_claim_liquidation' : ActorMethod<[bigint], Result_4>,
   'bot_confirm_liquidation' : ActorMethod<[bigint], Result>,
+  'cancel_xrp_pending_open' : ActorMethod<[bigint], Result>,
   'chain_has_active_settlement_op' : ActorMethod<[number], boolean>,
+  'claim_chain_collateral' : ActorMethod<
+    [bigint, Principal, bigint, string],
+    Result_1
+  >,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
   'clear_invariant_halt' : ActorMethod<[], Result>,
   'clear_liquidation_breaker' : ActorMethod<[], Result>,
@@ -1309,6 +1367,7 @@ export interface _SERVICE {
   'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
+  'get_chain_debt_config' : ActorMethod<[number], [] | [ChainDebtConfigV1]>,
   'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
   'get_chain_liquidatable_vaults' : ActorMethod<
     [number],
@@ -1319,6 +1378,7 @@ export interface _SERVICE {
     [] | [ChainLiquidationConfigV1]
   >,
   'get_chain_reserve_address' : ActorMethod<[number], Result_2>,
+  'get_chain_reserves' : ActorMethod<[number], Result_6>,
   'get_chain_settlement_address' : ActorMethod<[number], Result_2>,
   'get_chain_vault' : ActorMethod<[bigint], [] | [ChainVaultV1]>,
   'get_chains_ecdsa_key_name' : ActorMethod<[], string>,
@@ -1330,6 +1390,10 @@ export interface _SERVICE {
     Array<[SpProofLedger, bigint]>
   >,
   'get_deposit_account' : ActorMethod<[[] | [Principal]], Account>,
+  'get_effective_chain_debt_config' : ActorMethod<
+    [number],
+    [] | [ChainDebtConfigV1]
+  >,
   'get_event_count' : ActorMethod<[], bigint>,
   'get_event_timestamps' : ActorMethod<
     [bigint, bigint],
@@ -1393,7 +1457,7 @@ export interface _SERVICE {
   'get_redemption_fee_ceiling' : ActorMethod<[], number>,
   'get_redemption_fee_floor' : ActorMethod<[], number>,
   'get_redemption_rate' : ActorMethod<[], number>,
-  'get_redemption_tier' : ActorMethod<[Principal], Result_6>,
+  'get_redemption_tier' : ActorMethod<[Principal], Result_7>,
   'get_reserve_balances' : ActorMethod<[], Array<ReserveBalance>>,
   'get_reserve_redemption_fee' : ActorMethod<[], number>,
   'get_reserve_redemptions_enabled' : ActorMethod<[], boolean>,
@@ -1420,7 +1484,7 @@ export interface _SERVICE {
     [bigint, bigint, bigint],
     GetEventsFilteredResponse
   >,
-  'get_vault_interest_rate' : ActorMethod<[bigint], Result_7>,
+  'get_vault_interest_rate' : ActorMethod<[bigint], Result_8>,
   'get_vaults' : ActorMethod<[[] | [Principal]], Array<CandidVault>>,
   'get_vaults_page' : ActorMethod<[bigint, bigint], VaultsPageResponse>,
   'get_xrp_claims' : ActorMethod<[], Array<[bigint, XrpClaim]>>,
@@ -1428,12 +1492,13 @@ export interface _SERVICE {
     [],
     Array<[bigint, XrpPendingDeposit]>
   >,
+  'get_xrp_schnorr_key_name' : ActorMethod<[], string>,
   'harvest_chain_interest' : ActorMethod<[number], Result_1>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,
   'icrc10_supported_standards' : ActorMethod<[], Array<StandardRecord>>,
   'icrc21_canister_call_consent_message' : ActorMethod<
     [ConsentMessageRequest],
-    Result_8
+    Result_9
   >,
   'icrc28_trusted_origins' : ActorMethod<[], Icrc28TrustedOriginsResponse>,
   'liquidate_chain_vault' : ActorMethod<[bigint], Result_1>,
@@ -1449,29 +1514,29 @@ export interface _SERVICE {
     [VaultIntent, Uint8Array | number[]],
     Result_1
   >,
-  'open_solana_vault' : ActorMethod<[bigint, bigint, string], Result_9>,
-  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_10>,
+  'open_solana_vault' : ActorMethod<[bigint, bigint, string], Result_10>,
+  'open_vault' : ActorMethod<[bigint, [] | [Principal]], Result_11>,
   'open_vault_and_borrow' : ActorMethod<
     [bigint, bigint, [] | [Principal]],
-    Result_10
+    Result_11
   >,
   'open_vault_with_deposit' : ActorMethod<
     [bigint, [] | [Principal]],
-    Result_10
+    Result_11
   >,
-  'open_xrp_vault' : ActorMethod<[], Result_11>,
+  'open_xrp_vault' : ActorMethod<[], Result_12>,
   'partial_liquidate_vault' : ActorMethod<[VaultArg], Result_3>,
   'partial_repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'provide_liquidity' : ActorMethod<[bigint], Result_1>,
-  'reconcile_chain_supply' : ActorMethod<[number], Result_12>,
-  'recover_pending_transfer' : ActorMethod<[bigint], Result_13>,
+  'reconcile_chain_supply' : ActorMethod<[number], Result_13>,
+  'recover_pending_transfer' : ActorMethod<[bigint], Result_14>,
   'recover_stuck_chain_vault' : ActorMethod<[number, bigint], Result>,
   'redeem_collateral' : ActorMethod<[Principal, bigint], Result_3>,
   'redeem_icp' : ActorMethod<[bigint], Result_3>,
-  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_14>,
+  'redeem_reserves' : ActorMethod<[bigint, [] | [Principal]], Result_15>,
   'register_chain' : ActorMethod<[RegisterChainArg], Result>,
   'register_xrp_collateral' : ActorMethod<[], Result>,
-  'repay_and_close_vault' : ActorMethod<[VaultArg], Result_15>,
+  'repay_and_close_vault' : ActorMethod<[VaultArg], Result_16>,
   'repay_to_vault' : ActorMethod<[VaultArg], Result_1>,
   'repay_to_vault_with_stable' : ActorMethod<[VaultArgWithToken], Result_1>,
   'reset_bot_budget' : ActorMethod<[bigint], Result>,
@@ -1487,6 +1552,7 @@ export interface _SERVICE {
   'set_burn_watch_poll_enabled' : ActorMethod<[number, boolean], Result>,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
   'set_chain_contract' : ActorMethod<[number, string], Result>,
+  'set_chain_debt_config' : ActorMethod<[number, ChainDebtConfigV1], Result>,
   'set_chain_interest_min_realize_e8s' : ActorMethod<[bigint], Result>,
   'set_chain_interest_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_chain_liquidation_config' : ActorMethod<
@@ -1582,22 +1648,31 @@ export interface _SERVICE {
   'set_treasury_principal' : ActorMethod<[Principal], Result>,
   'set_vault_check_tick_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
+  'set_xrp_schnorr_key_name' : ActorMethod<[string], Result>,
+  'settle_pending_chain_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_reserve_burn' : ActorMethod<[number, bigint, string], Result>,
   'settle_xrp_claim' : ActorMethod<[bigint, string], Result_2>,
+  'settle_xrp_claim_with_tag' : ActorMethod<[bigint, string, number], Result_2>,
   'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,
   'solana_get_balance' : ActorMethod<[string], Result_1>,
   'solana_get_mint_supply' : ActorMethod<[], Result_1>,
   'solana_settlement_address' : ActorMethod<[], Result_2>,
-  'solana_sign_test_transfer' : ActorMethod<[string, bigint], Result_16>,
-  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_17>,
+  'solana_sign_test_transfer' : ActorMethod<[string, bigint], Result_17>,
+  'stability_pool_liquidate' : ActorMethod<[bigint, bigint], Result_18>,
+  'stability_pool_liquidate_chain_vault' : ActorMethod<
+    [bigint, bigint, SpWritedownProof],
+    Result_19
+  >,
   'stability_pool_liquidate_debt_burned' : ActorMethod<
     [bigint, bigint, SpWritedownProof],
-    Result_17
+    Result_18
   >,
   'stability_pool_liquidate_with_reserves' : ActorMethod<
     [bigint, bigint, bigint, Principal],
-    Result_17
+    Result_18
   >,
-  'submit_burn_proof' : ActorMethod<[number, string], Result_18>,
+  'submit_burn_proof' : ActorMethod<[number, string], Result_20>,
+  'sweep_xrp_pending_open' : ActorMethod<[bigint], Result>,
   'unfreeze_protocol' : ActorMethod<[], Result>,
   'update_collateral_config' : ActorMethod<
     [Principal, CollateralConfig],

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -173,11 +173,17 @@ export const idlFactory = ({ IDL }) => {
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
   });
+  const ChainDebtConfigV1 = IDL.Record({
+    'debt_ceiling_e8s' : IDL.Opt(IDL.Nat),
+    'min_vault_debt_e8s' : IDL.Nat,
+  });
   const ChainLiquidatableVault = IDL.Record({
     'sized_repay_e8s' : IDL.Nat,
     'cr_e4' : IDL.Nat64,
     'collateral_native' : IDL.Nat,
     'vault_id' : IDL.Nat64,
+    'sp_attempted' : IDL.Bool,
+    'chain_collateral_sentinel' : IDL.Principal,
     'chain_id' : IDL.Nat32,
     'liquidation_threshold_e4' : IDL.Nat64,
     'effective_debt_e8s' : IDL.Nat,
@@ -200,6 +206,23 @@ export const idlFactory = ({ IDL }) => {
     'router' : IDL.Text,
     'settle_stable_token' : IDL.Text,
     'deadline_secs' : IDL.Nat64,
+  });
+  const ChainReserveReport = IDL.Record({
+    'recorded_supply_e8s' : IDL.Nat,
+    'onchain_usdc_balance_native' : IDL.Opt(IDL.Nat),
+    'pending_chain_burn_e8s' : IDL.Nat,
+    'reserve_backing_e8s' : IDL.Nat,
+    'reserve_usdc_native' : IDL.Nat,
+    'finalized_block' : IDL.Nat64,
+    'bad_debt_e8s' : IDL.Nat,
+    'reserve_address' : IDL.Opt(IDL.Text),
+    'chain_id' : IDL.Nat32,
+    'onchain_usdc_error' : IDL.Opt(IDL.Text),
+    'settle_stable_token' : IDL.Opt(IDL.Text),
+  });
+  const Result_6 = IDL.Variant({
+    'Ok' : ChainReserveReport,
+    'Err' : ProtocolError,
   });
   const ChainVaultStatus = IDL.Variant({
     'MintPending' : IDL.Null,
@@ -435,6 +458,12 @@ export const idlFactory = ({ IDL }) => {
     'set_rmr_ceiling_cr' : IDL.Record({ 'value' : IDL.Text }),
     'set_amm1_canister' : IDL.Record({ 'canister' : IDL.Principal }),
     'set_recovery_rate_curve' : IDL.Record({ 'markers' : IDL.Text }),
+    'chain_reserve_burn_settled' : IDL.Record({
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'proof' : IDL.Text,
+    }),
     'set_ckstable_repay_fee' : IDL.Record({ 'rate' : IDL.Text }),
     'set_treasury_principal' : IDL.Record({ 'principal' : IDL.Principal }),
     'accrue_interest' : IDL.Record({ 'timestamp' : IDL.Nat64 }),
@@ -541,6 +570,12 @@ export const idlFactory = ({ IDL }) => {
       'reason' : IDL.Text,
     }),
     'set_rmr_floor_cr' : IDL.Record({ 'value' : IDL.Text }),
+    'chain_pending_burn_settled' : IDL.Record({
+      'amount_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+      'proof' : IDL.Text,
+    }),
     'set_rmr_ceiling' : IDL.Record({ 'value' : IDL.Text }),
     'set_collateral_liquidation_bonus' : IDL.Record({
       'collateral_type' : IDL.Principal,
@@ -880,6 +915,9 @@ export const idlFactory = ({ IDL }) => {
     'price_e8' : IDL.Nat64,
   });
   const XrpSettlement = IDL.Record({
+    'destination' : IDL.Opt(IDL.Text),
+    'source_sequence' : IDL.Opt(IDL.Nat32),
+    'destination_tag' : IDL.Opt(IDL.Nat32),
     'last_ledger_sequence' : IDL.Nat32,
     'tx_hash' : IDL.Text,
   });
@@ -1002,7 +1040,7 @@ export const idlFactory = ({ IDL }) => {
     'breaker_window_debt_ceiling_e8s' : IDL.Nat64,
     'last_icp_rate' : IDL.Float64,
   });
-  const Result_6 = IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : ProtocolError });
+  const Result_7 = IDL.Variant({ 'Ok' : IDL.Nat8, 'Err' : ProtocolError });
   const ReserveBalance = IDL.Record({
     'balance' : IDL.Nat64,
     'ledger' : IDL.Principal,
@@ -1032,7 +1070,7 @@ export const idlFactory = ({ IDL }) => {
     'total_accrued_interest_system' : IDL.Nat64,
     'pending_interest_for_pools_total' : IDL.Nat64,
   });
-  const Result_7 = IDL.Variant({ 'Ok' : IDL.Float64, 'Err' : ProtocolError });
+  const Result_8 = IDL.Variant({ 'Ok' : IDL.Float64, 'Err' : ProtocolError });
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
     'method' : IDL.Text,
@@ -1083,7 +1121,7 @@ export const idlFactory = ({ IDL }) => {
     'UnsupportedCanisterCall' : ErrorInfo,
     'ConsentMessageUnavailable' : ErrorInfo,
   });
-  const Result_8 = IDL.Variant({ 'Ok' : ConsentInfo, 'Err' : Icrc21Error });
+  const Result_9 = IDL.Variant({ 'Ok' : ConsentInfo, 'Err' : Icrc21Error });
   const Icrc28TrustedOriginsResponse = IDL.Record({
     'trusted_origins' : IDL.Vec(IDL.Text),
   });
@@ -1092,12 +1130,12 @@ export const idlFactory = ({ IDL }) => {
     'amount' : IDL.Nat64,
     'token_type' : StableTokenType,
   });
-  const Result_9 = IDL.Variant({ 'Ok' : ChainVaultV1, 'Err' : ProtocolError });
+  const Result_10 = IDL.Variant({ 'Ok' : ChainVaultV1, 'Err' : ProtocolError });
   const OpenVaultSuccess = IDL.Record({
     'block_index' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
   });
-  const Result_10 = IDL.Variant({
+  const Result_11 = IDL.Variant({
     'Ok' : OpenVaultSuccess,
     'Err' : ProtocolError,
   });
@@ -1105,7 +1143,7 @@ export const idlFactory = ({ IDL }) => {
     'custody_address' : IDL.Text,
     'vault_id' : IDL.Nat64,
   });
-  const Result_11 = IDL.Variant({
+  const Result_12 = IDL.Variant({
     'Ok' : XrpVaultOpenInfo,
     'Err' : ProtocolError,
   });
@@ -1121,11 +1159,11 @@ export const idlFactory = ({ IDL }) => {
     'chain_id' : IDL.Nat32,
     'onchain_total_supply_e8s' : IDL.Nat,
   });
-  const Result_12 = IDL.Variant({
+  const Result_13 = IDL.Variant({
     'Ok' : ChainSupplyReconciliation,
     'Err' : ProtocolError,
   });
-  const Result_13 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
+  const Result_14 = IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : ProtocolError });
   const ReserveRedemptionResult = IDL.Record({
     'icusd_block_index' : IDL.Nat64,
     'stable_token_used' : IDL.Principal,
@@ -1133,7 +1171,7 @@ export const idlFactory = ({ IDL }) => {
     'fee_amount' : IDL.Nat64,
     'stable_amount_sent' : IDL.Nat64,
   });
-  const Result_14 = IDL.Variant({
+  const Result_15 = IDL.Variant({
     'Ok' : ReserveRedemptionResult,
     'Err' : ProtocolError,
   });
@@ -1159,7 +1197,7 @@ export const idlFactory = ({ IDL }) => {
     'collateral_return_block_index' : IDL.Opt(IDL.Nat64),
     'repay_block_index' : IDL.Nat64,
   });
-  const Result_15 = IDL.Variant({
+  const Result_16 = IDL.Variant({
     'Ok' : RepayAndCloseSuccess,
     'Err' : ProtocolError,
   });
@@ -1170,7 +1208,7 @@ export const idlFactory = ({ IDL }) => {
     'display_name' : IDL.Opt(IDL.Text),
     'min_quorum_providers' : IDL.Opt(IDL.Opt(IDL.Nat32)),
   });
-  const Result_16 = IDL.Variant({
+  const Result_17 = IDL.Variant({
     'Ok' : IDL.Vec(IDL.Nat8),
     'Err' : ProtocolError,
   });
@@ -1184,7 +1222,7 @@ export const idlFactory = ({ IDL }) => {
     'collateral_type' : IDL.Text,
     'collateral_received' : IDL.Nat64,
   });
-  const Result_17 = IDL.Variant({
+  const Result_18 = IDL.Variant({
     'Ok' : StabilityPoolLiquidationResult,
     'Err' : ProtocolError,
   });
@@ -1193,7 +1231,22 @@ export const idlFactory = ({ IDL }) => {
     'ledger_kind' : SpProofLedger,
     'vault_id_memo' : IDL.Nat64,
   });
-  const Result_18 = IDL.Variant({ 'Ok' : IDL.Nat32, 'Err' : ProtocolError });
+  const ChainStabilityPoolLiquidationResult = IDL.Record({
+    'collateral_price_e8s' : IDL.Nat64,
+    'liquidated_debt_e8s' : IDL.Nat,
+    'collateral_received_native' : IDL.Nat,
+    'block_index' : IDL.Nat64,
+    'claim_id' : IDL.Nat64,
+    'custody_address' : IDL.Text,
+    'vault_id' : IDL.Nat64,
+    'chain_id' : IDL.Nat32,
+    'success' : IDL.Bool,
+  });
+  const Result_19 = IDL.Variant({
+    'Ok' : ChainStabilityPoolLiquidationResult,
+    'Err' : ProtocolError,
+  });
+  const Result_20 = IDL.Variant({ 'Ok' : IDL.Nat32, 'Err' : ProtocolError });
   return IDL.Service({
     'add_collateral_token' : IDL.Func([AddCollateralArg], [Result], []),
     'add_margin_to_vault' : IDL.Func([VaultArg], [Result_1], []),
@@ -1224,10 +1277,16 @@ export const idlFactory = ({ IDL }) => {
     'bot_cancel_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
     'bot_claim_liquidation' : IDL.Func([IDL.Nat64], [Result_4], []),
     'bot_confirm_liquidation' : IDL.Func([IDL.Nat64], [Result], []),
+    'cancel_xrp_pending_open' : IDL.Func([IDL.Nat64], [Result], []),
     'chain_has_active_settlement_op' : IDL.Func(
         [IDL.Nat32],
         [IDL.Bool],
         ['query'],
+      ),
+    'claim_chain_collateral' : IDL.Func(
+        [IDL.Nat64, IDL.Principal, IDL.Nat, IDL.Text],
+        [Result_1],
+        [],
       ),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
     'clear_invariant_halt' : IDL.Func([], [Result], []),
@@ -1269,6 +1328,11 @@ export const idlFactory = ({ IDL }) => {
     'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_cr_tolerance_bps' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
+    'get_chain_debt_config' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Opt(ChainDebtConfigV1)],
+        ['query'],
+      ),
     'get_chain_interest_treasury_address' : IDL.Func(
         [IDL.Nat32],
         [Result_2],
@@ -1285,6 +1349,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_chain_reserve_address' : IDL.Func([IDL.Nat32], [Result_2], []),
+    'get_chain_reserves' : IDL.Func([IDL.Nat32], [Result_6], []),
     'get_chain_settlement_address' : IDL.Func([IDL.Nat32], [Result_2], []),
     'get_chain_vault' : IDL.Func(
         [IDL.Nat64],
@@ -1311,6 +1376,11 @@ export const idlFactory = ({ IDL }) => {
     'get_deposit_account' : IDL.Func(
         [IDL.Opt(IDL.Principal)],
         [Account],
+        ['query'],
+      ),
+    'get_effective_chain_debt_config' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Opt(ChainDebtConfigV1)],
         ['query'],
       ),
     'get_event_count' : IDL.Func([], [IDL.Nat64], ['query']),
@@ -1412,7 +1482,7 @@ export const idlFactory = ({ IDL }) => {
     'get_redemption_fee_ceiling' : IDL.Func([], [IDL.Float64], ['query']),
     'get_redemption_fee_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_redemption_rate' : IDL.Func([], [IDL.Float64], ['query']),
-    'get_redemption_tier' : IDL.Func([IDL.Principal], [Result_6], ['query']),
+    'get_redemption_tier' : IDL.Func([IDL.Principal], [Result_7], ['query']),
     'get_reserve_balances' : IDL.Func([], [IDL.Vec(ReserveBalance)], ['query']),
     'get_reserve_redemption_fee' : IDL.Func([], [IDL.Float64], ['query']),
     'get_reserve_redemptions_enabled' : IDL.Func([], [IDL.Bool], ['query']),
@@ -1465,7 +1535,7 @@ export const idlFactory = ({ IDL }) => {
         [GetEventsFilteredResponse],
         ['query'],
       ),
-    'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_7], ['query']),
+    'get_vault_interest_rate' : IDL.Func([IDL.Nat64], [Result_8], ['query']),
     'get_vaults' : IDL.Func(
         [IDL.Opt(IDL.Principal)],
         [IDL.Vec(CandidVault)],
@@ -1486,6 +1556,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Tuple(IDL.Nat64, XrpPendingDeposit))],
         ['query'],
       ),
+    'get_xrp_schnorr_key_name' : IDL.Func([], [IDL.Text], ['query']),
     'harvest_chain_interest' : IDL.Func([IDL.Nat32], [Result_1], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse_1], ['query']),
     'icrc10_supported_standards' : IDL.Func(
@@ -1495,7 +1566,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'icrc21_canister_call_consent_message' : IDL.Func(
         [ConsentMessageRequest],
-        [Result_8],
+        [Result_9],
         [],
       ),
     'icrc28_trusted_origins' : IDL.Func(
@@ -1528,30 +1599,30 @@ export const idlFactory = ({ IDL }) => {
       ),
     'open_solana_vault' : IDL.Func(
         [IDL.Nat, IDL.Nat, IDL.Text],
-        [Result_9],
+        [Result_10],
         [],
       ),
     'open_vault' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_10],
+        [Result_11],
         [],
       ),
     'open_vault_and_borrow' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_10],
+        [Result_11],
         [],
       ),
     'open_vault_with_deposit' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_10],
+        [Result_11],
         [],
       ),
-    'open_xrp_vault' : IDL.Func([], [Result_11], []),
+    'open_xrp_vault' : IDL.Func([], [Result_12], []),
     'partial_liquidate_vault' : IDL.Func([VaultArg], [Result_3], []),
     'partial_repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'provide_liquidity' : IDL.Func([IDL.Nat64], [Result_1], []),
-    'reconcile_chain_supply' : IDL.Func([IDL.Nat32], [Result_12], []),
-    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_13], []),
+    'reconcile_chain_supply' : IDL.Func([IDL.Nat32], [Result_13], []),
+    'recover_pending_transfer' : IDL.Func([IDL.Nat64], [Result_14], []),
     'recover_stuck_chain_vault' : IDL.Func(
         [IDL.Nat32, IDL.Nat64],
         [Result],
@@ -1561,12 +1632,12 @@ export const idlFactory = ({ IDL }) => {
     'redeem_icp' : IDL.Func([IDL.Nat64], [Result_3], []),
     'redeem_reserves' : IDL.Func(
         [IDL.Nat64, IDL.Opt(IDL.Principal)],
-        [Result_14],
+        [Result_15],
         [],
       ),
     'register_chain' : IDL.Func([RegisterChainArg], [Result], []),
     'register_xrp_collateral' : IDL.Func([], [Result], []),
-    'repay_and_close_vault' : IDL.Func([VaultArg], [Result_15], []),
+    'repay_and_close_vault' : IDL.Func([VaultArg], [Result_16], []),
     'repay_to_vault' : IDL.Func([VaultArg], [Result_1], []),
     'repay_to_vault_with_stable' : IDL.Func(
         [VaultArgWithToken],
@@ -1602,6 +1673,11 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'set_chain_contract' : IDL.Func([IDL.Nat32, IDL.Text], [Result], []),
+    'set_chain_debt_config' : IDL.Func(
+        [IDL.Nat32, ChainDebtConfigV1],
+        [Result],
+        [],
+      ),
     'set_chain_interest_min_realize_e8s' : IDL.Func([IDL.Nat], [Result], []),
     'set_chain_interest_tick_interval_secs' : IDL.Func(
         [IDL.Nat64],
@@ -1774,32 +1850,54 @@ export const idlFactory = ({ IDL }) => {
     'set_treasury_principal' : IDL.Func([IDL.Principal], [Result], []),
     'set_vault_check_tick_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
     'set_xrc_fetch_interval_secs' : IDL.Func([IDL.Nat64], [Result], []),
+    'set_xrp_schnorr_key_name' : IDL.Func([IDL.Text], [Result], []),
+    'settle_pending_chain_burn' : IDL.Func(
+        [IDL.Nat32, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'settle_reserve_burn' : IDL.Func(
+        [IDL.Nat32, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
     'settle_xrp_claim' : IDL.Func([IDL.Nat64, IDL.Text], [Result_2], []),
+    'settle_xrp_claim_with_tag' : IDL.Func(
+        [IDL.Nat64, IDL.Text, IDL.Nat32],
+        [Result_2],
+        [],
+      ),
     'solana_bootstrap_nonce' : IDL.Func([IDL.Opt(IDL.Text)], [Result], []),
     'solana_get_balance' : IDL.Func([IDL.Text], [Result_1], []),
     'solana_get_mint_supply' : IDL.Func([], [Result_1], []),
     'solana_settlement_address' : IDL.Func([], [Result_2], []),
     'solana_sign_test_transfer' : IDL.Func(
         [IDL.Text, IDL.Nat64],
-        [Result_16],
+        [Result_17],
         [],
       ),
     'stability_pool_liquidate' : IDL.Func(
         [IDL.Nat64, IDL.Nat64],
-        [Result_17],
+        [Result_18],
+        [],
+      ),
+    'stability_pool_liquidate_chain_vault' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64, SpWritedownProof],
+        [Result_19],
         [],
       ),
     'stability_pool_liquidate_debt_burned' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, SpWritedownProof],
-        [Result_17],
+        [Result_18],
         [],
       ),
     'stability_pool_liquidate_with_reserves' : IDL.Func(
         [IDL.Nat64, IDL.Nat64, IDL.Nat64, IDL.Principal],
-        [Result_17],
+        [Result_18],
         [],
       ),
-    'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_18], []),
+    'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_20], []),
+    'sweep_xrp_pending_open' : IDL.Func([IDL.Nat64], [Result], []),
     'unfreeze_protocol' : IDL.Func([], [Result], []),
     'update_collateral_config' : IDL.Func(
         [IDL.Principal, CollateralConfig],

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1100,7 +1100,13 @@ type XrpPendingDeposit = record {
   opened_at_ns : nat64;
   derivation_nonce : nat64;
 };
-type XrpSettlement = record { last_ledger_sequence : nat32; tx_hash : text };
+type XrpSettlement = record {
+  destination : opt text;
+  source_sequence : opt nat32;
+  destination_tag : opt nat32;
+  last_ledger_sequence : nat32;
+  tx_hash : text;
+};
 type XrpVaultOpenInfo = record { custody_address : text; vault_id : nat64 };
 service : (ProtocolArg) -> {
   add_collateral_token : (AddCollateralArg) -> (Result);
@@ -1116,6 +1122,7 @@ service : (ProtocolArg) -> {
   bot_cancel_liquidation : (nat64) -> (Result);
   bot_claim_liquidation : (nat64) -> (Result_4);
   bot_confirm_liquidation : (nat64) -> (Result);
+  cancel_xrp_pending_open : (nat64) -> (Result);
   chain_has_active_settlement_op : (nat32) -> (bool) query;
   claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
@@ -1238,6 +1245,7 @@ service : (ProtocolArg) -> {
   get_xrp_pending_deposits : () -> (
       vec record { nat64; XrpPendingDeposit },
     ) query;
+  get_xrp_schnorr_key_name : () -> (text) query;
   harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
@@ -1355,9 +1363,11 @@ service : (ProtocolArg) -> {
   set_treasury_principal : (principal) -> (Result);
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
+  set_xrp_schnorr_key_name : (text) -> (Result);
   settle_pending_chain_burn : (nat32, nat, text) -> (Result);
   settle_reserve_burn : (nat32, nat, text) -> (Result);
   settle_xrp_claim : (nat64, text) -> (Result_2);
+  settle_xrp_claim_with_tag : (nat64, text, nat32) -> (Result_2);
   solana_bootstrap_nonce : (opt text) -> (Result);
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
@@ -1374,6 +1384,7 @@ service : (ProtocolArg) -> {
       Result_18,
     );
   submit_burn_proof : (nat32, text) -> (Result_20);
+  sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);
   withdraw_and_close_vault : (nat64) -> (Result_5);

--- a/src/rumi_protocol_backend/src/chains/xrp/adapter.rs
+++ b/src/rumi_protocol_backend/src/chains/xrp/adapter.rs
@@ -55,6 +55,15 @@ pub struct XrpAdapter {
     chain_id: ChainId,
 }
 
+/// Fully signed XRPL Payment plus source-account metadata needed by settlement
+/// recovery. `source_sequence` is the account Sequence embedded in the signed tx.
+#[derive(Clone, Debug)]
+pub struct SignedXrpPayment {
+    pub signed: SignedWithdrawal,
+    pub last_ledger_sequence: u32,
+    pub source_sequence: u32,
+}
+
 impl XrpAdapter {
     /// Create a new `XrpAdapter`. In production this is `XRP_CHAIN_ID` (144);
     /// tests may pass an arbitrary id for isolation.
@@ -74,7 +83,7 @@ impl XrpAdapter {
         let path = ted25519::settlement_derivation_path(self.chain_id);
         self.sign_xrp_payment_from(path, recipient, amount_drops_u128, destination_tag)
             .await
-            .map(|(signed, _last_ledger_sequence)| signed)
+            .map(|payment| payment.signed)
     }
 
     /// Build + threshold-sign a native-XRP `Payment` from an ARBITRARY custody
@@ -90,7 +99,7 @@ impl XrpAdapter {
         recipient: &str,
         amount_drops_u128: u128,
         destination_tag: Option<u32>,
-    ) -> Result<(SignedWithdrawal, u32), ChainAdapterError> {
+    ) -> Result<SignedXrpPayment, ChainAdapterError> {
         let dest_id = decode_recipient(recipient)?;
         let amount_drops = checked_drops_u64(amount_drops_u128)?;
 
@@ -106,12 +115,13 @@ impl XrpAdapter {
                 provider: "rippled".to_string(),
                 message,
             })?;
-        let reserve = xrp_rpc::fetch_reserve_base()
-            .await
-            .map_err(|message| ChainAdapterError::RpcError {
-                provider: "rippled".to_string(),
-                message,
-            })?;
+        let reserve =
+            xrp_rpc::fetch_reserve_base()
+                .await
+                .map_err(|message| ChainAdapterError::RpcError {
+                    provider: "rippled".to_string(),
+                    message,
+                })?;
 
         let payment = build_withdrawal_payment(
             sender_id,
@@ -129,15 +139,17 @@ impl XrpAdapter {
             .await
             .map_err(ChainAdapterError::SignatureFailed)?;
         let last_ledger_sequence = payment.last_ledger_sequence;
+        let source_sequence = payment.sequence;
         let signed = codec::serialize_signed(&payment, &signature);
         let tx_hash = hex::encode_upper(sign::tx_hash(&signed));
-        Ok((
-            SignedWithdrawal {
+        Ok(SignedXrpPayment {
+            signed: SignedWithdrawal {
                 raw_tx: signed,
                 tx_hash,
             },
             last_ledger_sequence,
-        ))
+            source_sequence,
+        })
     }
 }
 
@@ -348,9 +360,16 @@ mod tests {
     #[test]
     fn build_payment_happy_path_sets_sequence_and_lls() {
         let (s, d, pk) = ids();
-        let p =
-            build_withdrawal_payment(s, d, &pk, &acct(42, 50_000_000), 1_000_000, 1_000_000, Some(99))
-                .unwrap();
+        let p = build_withdrawal_payment(
+            s,
+            d,
+            &pk,
+            &acct(42, 50_000_000),
+            1_000_000,
+            1_000_000,
+            Some(99),
+        )
+        .unwrap();
         assert_eq!(p.sequence, 42);
         assert_eq!(p.last_ledger_sequence, 9_000_000 + LAST_LEDGER_BUFFER);
         assert_eq!(p.fee_drops, XRP_FEE_DROPS);
@@ -377,16 +396,9 @@ mod tests {
         ));
         // Exactly affordable: balance == amount + fee + reserve.
         let need = 600_000u128 + u128::from(XRP_FEE_DROPS) + 1_000_000;
-        assert!(build_withdrawal_payment(
-            s,
-            d,
-            &pk,
-            &acct(1, need),
-            1_000_000,
-            600_000,
-            None
-        )
-        .is_ok());
+        assert!(
+            build_withdrawal_payment(s, d, &pk, &acct(1, need), 1_000_000, 600_000, None).is_ok()
+        );
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/xrp/config.rs
+++ b/src/rumi_protocol_backend/src/chains/xrp/config.rs
@@ -26,23 +26,34 @@ pub const XRP_NATIVE_DECIMALS: u8 = 6;
 /// configurability is a later refinement.
 pub const XRP_MIN_CR_E4: u64 = 13_000;
 
+/// Production threshold-Ed25519 key name. Higher-level deployment/config wiring
+/// must opt into this explicitly; local/test defaults stay on `test_key_1`.
+pub const XRP_PRODUCTION_SCHNORR_KEY_NAME: &str = "key_1";
+
+/// Non-production threshold-Ed25519 key name used by default.
+pub const XRP_TEST_SCHNORR_KEY_NAME: &str = "test_key_1";
+
+/// True only for the management-canister production Schnorr key.
+pub fn is_xrp_production_key_name(name: &str) -> bool {
+    name == XRP_PRODUCTION_SCHNORR_KEY_NAME
+}
+
 /// Threshold-Ed25519 key name. XRPL Ed25519 reuses the SAME threshold Schnorr
 /// Ed25519 key as Solana (`test_key_1` is the mainnet test key — Ed25519 has no
 /// local dfx key); switch to `key_1` for production. The XRP rail keeps its keys
 /// distinct from Solana's by using a DIFFERENT derivation path (the chain-id 144
 /// prefix), not a different key name — see `ted25519`.
 pub fn xrp_schnorr_key_name() -> String {
-    "test_key_1".to_string()
+    crate::read_state(|s| s.xrp_schnorr_key_name.clone())
 }
 
 /// Default registration payload for the XRP Ledger.
 ///
-/// `rpc_endpoints` is left empty: `xrp_rpc` selects the public rippled cluster by
-/// key name (mainnet for `key_1`, the altnet testnet otherwise), like Solana's
+/// `rpc_endpoints` is left empty: `xrp_rpc` selects its hardcoded XRPL provider
+/// quorum by key name (mainnet only for `key_1`, testnet otherwise), like Solana's
 /// built-in providers. `finality_depth` is 0 — XRPL has no block-depth finality;
 /// a validated ledger IS final, and reads use `ledger_index: "validated"`.
-/// `min_quorum_providers` is `None`: like Solana, XRP does not use the EVM quorum
-/// floor (Phase 1 is single-cluster; multi-node agreement is Phase 2).
+/// `min_quorum_providers` is `None`: XRP does not use the EVM quorum floor.
 pub fn xrp_default_register_arg() -> RegisterChainArg {
     RegisterChainArg {
         chain_id: XRP_CHAIN_ID,
@@ -76,6 +87,23 @@ mod tests {
         // SLIP-44: XRP = 144, Solana = 501. A collision would alias derivation
         // paths and merge the two chains' keys/state.
         assert_eq!(XRP_CHAIN_ID.0, 144);
-        assert_ne!(XRP_CHAIN_ID.0, crate::chains::solana::config::SOLANA_CHAIN_ID.0);
+        assert_ne!(
+            XRP_CHAIN_ID.0,
+            crate::chains::solana::config::SOLANA_CHAIN_ID.0
+        );
+    }
+
+    #[test]
+    fn key_names_are_explicit_and_default_to_test_key() {
+        assert_eq!(XRP_PRODUCTION_SCHNORR_KEY_NAME, "key_1");
+        assert_eq!(XRP_TEST_SCHNORR_KEY_NAME, "test_key_1");
+        assert_eq!(
+            crate::state::State::default().xrp_schnorr_key_name,
+            XRP_TEST_SCHNORR_KEY_NAME
+        );
+
+        assert!(is_xrp_production_key_name(XRP_PRODUCTION_SCHNORR_KEY_NAME));
+        assert!(!is_xrp_production_key_name(XRP_TEST_SCHNORR_KEY_NAME));
+        assert!(!is_xrp_production_key_name("key_10"));
     }
 }

--- a/src/rumi_protocol_backend/src/chains/xrp/xrp_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/xrp/xrp_rpc.rs
@@ -6,12 +6,14 @@
 //!      collapsing volatile rippled fields (server time, load factors, per-edge
 //!      error tokens) so replicas converge. A raw rippled body would void
 //!      consensus.
-//!  (b) Reads are wrapped in a consensus-retry (`outcall_read`): a "validated"
-//!      ledger advances every ~3-4s, so replicas can disagree when a ledger
-//!      validates mid-fetch ("No consensus could be reached"). Re-issuing lands
-//!      them on the same ledger. `submit` uses a NARROWER path (`outcall_submit`,
-//!      single attempt) — a submit that reached a node may already have broadcast,
-//!      so it must never be blindly re-issued on a consensus miss.
+//!  (b) Reads are wrapped in a consensus-retry and provider quorum
+//!      (`outcall_read_provider_bodies` + typed quorum): a "validated" ledger
+//!      advances every ~3-4s, so providers can report the same account or reserve
+//!      state at different ledger indices. Reads require a semantic quorum over
+//!      the consumed fields instead of byte-for-byte ledger identity. `submit`
+//!      uses a NARROWER path (`outcall_submit`, single attempt) — a submit that
+//!      reached a node may already have broadcast, so it must never be blindly
+//!      re-issued on a consensus miss.
 //!
 //! ## Wiring note (deferred)
 //! For the outcalls to run, the four `transform_*` functions below must be exposed
@@ -34,12 +36,15 @@ use ic_cdk::api::management_canister::http_request::{
 };
 use serde_json::{json, Value};
 
-use super::config::xrp_schnorr_key_name;
+use super::config::{is_xrp_production_key_name, xrp_schnorr_key_name};
 
 const MAINNET_URL: &str = "https://xrplcluster.com/";
 const TESTNET_URL: &str = "https://s.altnet.rippletest.net:51234/";
+const MAINNET_READ_URLS: &[&str] = &[MAINNET_URL, "https://s1.ripple.com:51234/"];
+const TESTNET_READ_URLS: &[&str] = &[TESTNET_URL, "https://testnet.xrpl-labs.com/"];
 
 pub const MAX_READ_BYTES: u64 = 8_192;
+pub const MAX_TX_BYTES: u64 = 65_536;
 pub const MAX_SUBMIT_BYTES: u64 = 8_192;
 pub const READ_CYCLES: u128 = 2_000_000_000;
 pub const SUBMIT_CYCLES: u128 = 4_000_000_000;
@@ -67,7 +72,10 @@ pub enum XrpTxStatus {
     /// `delivered_drops` is the partial-payment-safe `meta.delivered_amount` in
     /// drops (0 if the delivery was a non-native issued currency, or rippled
     /// reports it `"unavailable"`). Deposit crediting MUST use this, never `Amount`.
-    Validated { ledger_index: u32, delivered_drops: u128 },
+    Validated {
+        ledger_index: u32,
+        delivered_drops: u128,
+    },
     /// Not (yet) validated, or `txnNotFound`.
     NotFound,
     /// Validated but the transaction failed (non-`tes*` result).
@@ -77,10 +85,14 @@ pub enum XrpTxStatus {
 /// Select the rippled cluster by key name: mainnet for the production key,
 /// the public altnet testnet otherwise (matches the `test_key_1` default).
 pub fn rpc_url(chain_key_name: &str) -> &'static str {
-    if chain_key_name == "key_1" {
-        MAINNET_URL
+    read_provider_urls(chain_key_name)[0]
+}
+
+fn read_provider_urls(chain_key_name: &str) -> &'static [&'static str] {
+    if is_xrp_production_key_name(chain_key_name) {
+        MAINNET_READ_URLS
     } else {
-        TESTNET_URL
+        TESTNET_READ_URLS
     }
 }
 
@@ -97,8 +109,24 @@ fn build_request(
     max_response_bytes: u64,
     transform_name: &str,
 ) -> CanisterHttpRequestArgument {
+    build_request_to_url(
+        rpc_url(chain_key_name),
+        method,
+        params,
+        max_response_bytes,
+        transform_name,
+    )
+}
+
+fn build_request_to_url(
+    url: &str,
+    method: &str,
+    params: Value,
+    max_response_bytes: u64,
+    transform_name: &str,
+) -> CanisterHttpRequestArgument {
     CanisterHttpRequestArgument {
-        url: rpc_url(chain_key_name).to_string(),
+        url: url.to_string(),
         method: HttpMethod::POST,
         body: Some(rpc_body(method, params)),
         max_response_bytes: Some(max_response_bytes),
@@ -106,13 +134,16 @@ fn build_request(
             name: "content-type".to_string(),
             value: "application/json".to_string(),
         }],
-        transform: Some(TransformContext::from_name(transform_name.to_string(), vec![])),
+        transform: Some(TransformContext::from_name(
+            transform_name.to_string(),
+            vec![],
+        )),
     }
 }
 
-pub fn account_info_request(chain_key_name: &str, account: &str) -> CanisterHttpRequestArgument {
-    build_request(
-        chain_key_name,
+fn account_info_request_to_url(url: &str, account: &str) -> CanisterHttpRequestArgument {
+    build_request_to_url(
+        url,
         "account_info",
         json!({ "account": account, "ledger_index": "validated", "strict": true }),
         MAX_READ_BYTES,
@@ -120,14 +151,22 @@ pub fn account_info_request(chain_key_name: &str, account: &str) -> CanisterHttp
     )
 }
 
-pub fn server_state_request(chain_key_name: &str) -> CanisterHttpRequestArgument {
-    build_request(
-        chain_key_name,
+pub fn account_info_request(chain_key_name: &str, account: &str) -> CanisterHttpRequestArgument {
+    account_info_request_to_url(rpc_url(chain_key_name), account)
+}
+
+fn server_state_request_to_url(url: &str) -> CanisterHttpRequestArgument {
+    build_request_to_url(
+        url,
         "server_state",
         json!({}),
         MAX_READ_BYTES,
         "xrp_transform_server",
     )
+}
+
+pub fn server_state_request(chain_key_name: &str) -> CanisterHttpRequestArgument {
+    server_state_request_to_url(rpc_url(chain_key_name))
 }
 
 pub fn submit_request(chain_key_name: &str, tx_blob_hex: &str) -> CanisterHttpRequestArgument {
@@ -141,11 +180,19 @@ pub fn submit_request(chain_key_name: &str, tx_blob_hex: &str) -> CanisterHttpRe
 }
 
 pub fn tx_request(chain_key_name: &str, tx_hash: &str) -> CanisterHttpRequestArgument {
-    build_request(
-        chain_key_name,
+    tx_request_to_url(rpc_url(chain_key_name), tx_hash)
+}
+
+pub fn tx_max_response_bytes() -> u64 {
+    MAX_TX_BYTES
+}
+
+fn tx_request_to_url(url: &str, tx_hash: &str) -> CanisterHttpRequestArgument {
+    build_request_to_url(
+        url,
         "tx",
         json!({ "transaction": tx_hash, "binary": false }),
-        MAX_READ_BYTES,
+        tx_max_response_bytes(),
         "xrp_transform_tx",
     )
 }
@@ -176,7 +223,9 @@ pub fn transform_account(args: TransformArgs) -> HttpResponse {
                 "sequence": r.and_then(|r| r.pointer("/account_data/Sequence")),
                 "balance": r.and_then(|r| r.pointer("/account_data/Balance")),
                 "ledger_index": r.and_then(|r| r.get("ledger_index")),
+                "ledger_hash": r.and_then(|r| r.get("ledger_hash")),
                 "ledger_current_index": r.and_then(|r| r.get("ledger_current_index")),
+                "validated": r.and_then(|r| r.get("validated")),
                 "error": r.and_then(|r| r.get("error")),
             })
         }
@@ -189,6 +238,8 @@ pub fn transform_server(args: TransformArgs) -> HttpResponse {
     let reduced = match serde_json::from_slice::<Value>(&args.response.body) {
         Ok(v) => json!({
             "reserve_base": v.pointer("/result/state/validated_ledger/reserve_base"),
+            "ledger_index": v.pointer("/result/state/validated_ledger/seq"),
+            "ledger_hash": v.pointer("/result/state/validated_ledger/hash"),
             "error": v.pointer("/result/error"),
         }),
         Err(_) => json!({ "parse_error": true }),
@@ -216,6 +267,8 @@ pub fn transform_tx(args: TransformArgs) -> HttpResponse {
                 "validated": r.and_then(|r| r.get("validated")),
                 "engine_result": r.and_then(|r| r.pointer("/meta/TransactionResult")),
                 "ledger_index": r.and_then(|r| r.get("ledger_index")),
+                "ledger_hash": r.and_then(|r| r.get("ledger_hash")),
+                "tx_hash": r.and_then(|r| r.get("hash")),
                 // Partial-payment-safe delivered amount: credit THIS, never the
                 // Payment's `Amount` (tfPartialPayment can make Amount > delivered —
                 // the classic exchange-drainer). rippled synthesizes the top-level
@@ -235,7 +288,8 @@ pub fn transform_tx(args: TransformArgs) -> HttpResponse {
 // ---- parsers (operate on the reduced transform output) ----
 
 fn as_u64(v: &Value) -> Option<u64> {
-    v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+    v.as_u64()
+        .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
 }
 fn as_u128(v: &Value) -> Option<u128> {
     v.as_u64()
@@ -268,7 +322,8 @@ pub fn parse_account_info(body: &[u8]) -> Result<XrpAccountInfo, String> {
     if err == Some("actNotFound") {
         let ledger_index = as_u64(v.get("ledger_current_index").unwrap_or(&Value::Null))
             .or_else(|| as_u64(v.get("ledger_index").unwrap_or(&Value::Null)))
-            .ok_or_else(|| "actNotFound without a ledger index".to_string())? as u32;
+            .ok_or_else(|| "actNotFound without a ledger index".to_string())?
+            as u32;
         return Ok(XrpAccountInfo {
             exists: false,
             sequence: 0,
@@ -279,11 +334,10 @@ pub fn parse_account_info(body: &[u8]) -> Result<XrpAccountInfo, String> {
     if let Some(e) = err {
         return Err(format!("account_info error: {e}"));
     }
-    let sequence =
-        as_u64(v.get("sequence").unwrap_or(&Value::Null)).ok_or_else(|| "missing Sequence".to_string())?
-            as u32;
-    let balance_drops =
-        as_u128(v.get("balance").unwrap_or(&Value::Null)).ok_or_else(|| "missing Balance".to_string())?;
+    let sequence = as_u64(v.get("sequence").unwrap_or(&Value::Null))
+        .ok_or_else(|| "missing Sequence".to_string())? as u32;
+    let balance_drops = as_u128(v.get("balance").unwrap_or(&Value::Null))
+        .ok_or_else(|| "missing Balance".to_string())?;
     let ledger_index = as_u64(v.get("ledger_index").unwrap_or(&Value::Null))
         .ok_or_else(|| "missing ledger_index".to_string())? as u32;
     Ok(XrpAccountInfo {
@@ -325,8 +379,16 @@ pub fn parse_submit(body: &[u8]) -> Result<String, String> {
     }
 }
 
-pub fn parse_tx_status(body: &[u8]) -> Result<XrpTxStatus, String> {
-    let v: Value = serde_json::from_slice(body).map_err(|e| format!("json: {e}"))?;
+fn parse_tx_status_value(v: &Value, expected_hash: Option<&str>) -> Result<XrpTxStatus, String> {
+    if let Some(expected) = expected_hash {
+        if let Some(actual) = v.get("tx_hash").and_then(Value::as_str) {
+            if !actual.eq_ignore_ascii_case(expected) {
+                return Err(format!(
+                    "tx hash mismatch: expected {expected}, got {actual}"
+                ));
+            }
+        }
+    }
     if v.get("parse_error").and_then(Value::as_bool) == Some(true) {
         return Err("tx: unparseable rippled response".to_string());
     }
@@ -340,10 +402,14 @@ pub fn parse_tx_status(body: &[u8]) -> Result<XrpTxStatus, String> {
     if v.get("validated").and_then(Value::as_bool) != Some(true) {
         return Ok(XrpTxStatus::NotFound);
     }
+    if expected_hash.is_some() && v.get("tx_hash").and_then(Value::as_str).is_none() {
+        return Err("validated tx without tx_hash".to_string());
+    }
     let engine = v.get("engine_result").and_then(Value::as_str).unwrap_or("");
     if engine.starts_with("tes") {
         let ledger_index = as_u64(v.get("ledger_index").unwrap_or(&Value::Null))
-            .ok_or_else(|| "validated tx without ledger_index".to_string())? as u32;
+            .ok_or_else(|| "validated tx without ledger_index".to_string())?
+            as u32;
         let delivered_drops =
             parse_delivered_drops(v.get("delivered_amount").unwrap_or(&Value::Null));
         Ok(XrpTxStatus::Validated {
@@ -355,7 +421,17 @@ pub fn parse_tx_status(body: &[u8]) -> Result<XrpTxStatus, String> {
     }
 }
 
-// ---- async outcalls (consensus-retry wrapped) ----
+pub fn parse_tx_status(body: &[u8]) -> Result<XrpTxStatus, String> {
+    let v: Value = serde_json::from_slice(body).map_err(|e| format!("json: {e}"))?;
+    parse_tx_status_value(&v, None)
+}
+
+fn parse_tx_status_for_hash(body: &[u8], expected_hash: &str) -> Result<XrpTxStatus, String> {
+    let v: Value = serde_json::from_slice(body).map_err(|e| format!("json: {e}"))?;
+    parse_tx_status_value(&v, Some(expected_hash))
+}
+
+// ---- async outcalls (consensus-retry + provider-quorum wrapped) ----
 
 /// True for the transient consensus-miss class that is safe to re-issue on a READ.
 fn is_transient(code: RejectionCode, msg: &str) -> bool {
@@ -364,20 +440,179 @@ fn is_transient(code: RejectionCode, msg: &str) -> bool {
         || msg.contains("Timeout expired")
 }
 
-/// Issue a consensus-relative READ, re-issuing on the transient consensus-miss
-/// class up to `READ_RETRIES` times. Returns the (already-transformed) body.
-async fn outcall_read(req: CanisterHttpRequestArgument) -> Result<Vec<u8>, String> {
-    let mut last = String::new();
-    for attempt in 0..READ_RETRIES {
-        match http_request(req.clone(), READ_CYCLES).await {
-            Ok((resp,)) => return Ok(resp.body),
-            Err((code, msg)) if is_transient(code, &msg) => {
-                last = format!("attempt {}: {code:?}: {msg}", attempt + 1);
-            }
-            Err((code, msg)) => return Err(format!("{code:?}: {msg}")),
+const READ_QUORUM: usize = 2;
+
+fn require_minimum_provider_set(provider_bodies: &[Vec<u8>]) -> Result<(), String> {
+    if provider_bodies.len() < READ_QUORUM {
+        return Err(format!(
+            "read quorum requires at least {READ_QUORUM} provider responses"
+        ));
+    }
+    Ok(())
+}
+
+fn quorum_account_info(provider_bodies: &[Vec<u8>]) -> Result<XrpAccountInfo, String> {
+    require_minimum_provider_set(provider_bodies)?;
+    let mut parsed = Vec::with_capacity(provider_bodies.len());
+    let mut parse_errors = Vec::new();
+    for (idx, body) in provider_bodies.iter().enumerate() {
+        match parse_account_info(body) {
+            Ok(info) => parsed.push((idx, info)),
+            Err(e) => parse_errors.push(format!("provider {idx}: {e}")),
         }
     }
-    Err(format!("read failed after {READ_RETRIES} attempts ({last})"))
+
+    for (_, candidate) in &parsed {
+        let mut votes = 0usize;
+        let mut latest = candidate.clone();
+        for (_, info) in &parsed {
+            if info.exists == candidate.exists
+                && info.sequence == candidate.sequence
+                && info.balance_drops == candidate.balance_drops
+            {
+                votes += 1;
+                if info.ledger_index > latest.ledger_index {
+                    latest.ledger_index = info.ledger_index;
+                }
+            }
+        }
+        if votes >= READ_QUORUM {
+            return Ok(latest);
+        }
+    }
+
+    Err(format!(
+        "account_info semantic quorum failed: {} parsed responses, errors: {}",
+        parsed.len(),
+        parse_errors.join("; ")
+    ))
+}
+
+fn quorum_reserve_base(provider_bodies: &[Vec<u8>]) -> Result<u128, String> {
+    require_minimum_provider_set(provider_bodies)?;
+    let mut parsed = Vec::with_capacity(provider_bodies.len());
+    let mut parse_errors = Vec::new();
+    for (idx, body) in provider_bodies.iter().enumerate() {
+        match parse_reserve_base(body) {
+            Ok(reserve) => parsed.push((idx, reserve)),
+            Err(e) => parse_errors.push(format!("provider {idx}: {e}")),
+        }
+    }
+
+    for (_, candidate) in &parsed {
+        let votes = parsed
+            .iter()
+            .filter(|(_, reserve)| reserve == candidate)
+            .count();
+        if votes >= READ_QUORUM {
+            return Ok(*candidate);
+        }
+    }
+
+    Err(format!(
+        "server_state semantic quorum failed: {} parsed responses, errors: {}",
+        parsed.len(),
+        parse_errors.join("; ")
+    ))
+}
+
+fn quorum_tx_status(
+    provider_bodies: &[Vec<u8>],
+    expected_hash: &str,
+) -> Result<XrpTxStatus, String> {
+    require_minimum_provider_set(provider_bodies)?;
+    let mut parsed = Vec::with_capacity(provider_bodies.len());
+    let mut parse_errors = Vec::new();
+    for (idx, body) in provider_bodies.iter().enumerate() {
+        match parse_tx_status_for_hash(body, expected_hash) {
+            Ok(status) => parsed.push((idx, status)),
+            Err(e) => parse_errors.push(format!("provider {idx}: {e}")),
+        }
+    }
+
+    for (_, candidate) in &parsed {
+        let votes = parsed
+            .iter()
+            .filter(|(_, status)| status == candidate)
+            .count();
+        if votes >= READ_QUORUM {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Err(format!(
+        "tx semantic quorum failed: {} parsed responses, errors: {}",
+        parsed.len(),
+        parse_errors.join("; ")
+    ))
+}
+
+async fn outcall_read_provider_bodies<F>(
+    provider_urls: &[&str],
+    mut build: F,
+) -> Result<Vec<Vec<u8>>, String>
+where
+    F: FnMut(&str) -> CanisterHttpRequestArgument,
+{
+    if provider_urls.len() < READ_QUORUM {
+        return Err(format!(
+            "read quorum requires at least {READ_QUORUM} configured providers"
+        ));
+    }
+
+    let mut last = String::new();
+    for attempt in 0..READ_RETRIES {
+        let mut provider_bodies = Vec::with_capacity(provider_urls.len());
+        let mut errors = Vec::new();
+        let mut has_transient = false;
+
+        for provider_url in provider_urls {
+            match http_request(build(provider_url), READ_CYCLES).await {
+                Ok((resp,)) => provider_bodies.push(resp.body),
+                Err((code, msg)) => {
+                    has_transient |= is_transient(code, &msg);
+                    errors.push(format!(
+                        "attempt {} provider {provider_url}: {code:?}: {msg}",
+                        attempt + 1
+                    ));
+                }
+            }
+        }
+
+        if provider_bodies.len() >= READ_QUORUM {
+            return Ok(provider_bodies);
+        }
+
+        last = errors.join("; ");
+        if !has_transient {
+            break;
+        }
+    }
+    Err(format!(
+        "read quorum failed after {READ_RETRIES} attempts ({last})"
+    ))
+}
+
+async fn outcall_read_quorum<F, T, Q>(
+    provider_urls: &[&str],
+    mut build: F,
+    quorum: Q,
+) -> Result<T, String>
+where
+    F: FnMut(&str) -> CanisterHttpRequestArgument,
+    Q: Fn(&[Vec<u8>]) -> Result<T, String>,
+{
+    let mut last = String::new();
+    for attempt in 0..READ_RETRIES {
+        let bodies = outcall_read_provider_bodies(provider_urls, |url| build(url)).await?;
+        match quorum(&bodies) {
+            Ok(value) => return Ok(value),
+            Err(e) => last = format!("attempt {}: {e}", attempt + 1),
+        }
+    }
+    Err(format!(
+        "read semantic quorum failed after {READ_RETRIES} attempts ({last})"
+    ))
 }
 
 /// Issue `submit` exactly ONCE. A submit that reached a node may already have
@@ -393,14 +628,24 @@ async fn outcall_submit(req: CanisterHttpRequestArgument) -> Result<Vec<u8>, Str
 
 /// Read `account_info` (validated): sequence, balance, ledger index.
 pub async fn fetch_account_info(account: &str) -> Result<XrpAccountInfo, String> {
-    let body = outcall_read(account_info_request(&xrp_schnorr_key_name(), account)).await?;
-    parse_account_info(&body)
+    let key_name = xrp_schnorr_key_name();
+    outcall_read_quorum(
+        read_provider_urls(&key_name),
+        |url| account_info_request_to_url(url, account),
+        quorum_account_info,
+    )
+    .await
 }
 
 /// Read the base reserve (drops) from `server_state`.
 pub async fn fetch_reserve_base() -> Result<u128, String> {
-    let body = outcall_read(server_state_request(&xrp_schnorr_key_name())).await?;
-    parse_reserve_base(&body)
+    let key_name = xrp_schnorr_key_name();
+    outcall_read_quorum(
+        read_provider_urls(&key_name),
+        server_state_request_to_url,
+        quorum_reserve_base,
+    )
+    .await
 }
 
 /// Submit a hex-encoded signed tx blob; returns the rippled-reported hash on a
@@ -413,12 +658,18 @@ pub async fn submit_blob(tx_blob_hex: &str) -> Result<String, String> {
 
 /// Look up a transaction's validation status (deposit confirmation).
 pub async fn fetch_tx_status(tx_hash: &str) -> Result<XrpTxStatus, String> {
-    let body = outcall_read(tx_request(&xrp_schnorr_key_name(), tx_hash)).await?;
-    parse_tx_status(&body)
+    let key_name = xrp_schnorr_key_name();
+    outcall_read_quorum(
+        read_provider_urls(&key_name),
+        |url| tx_request_to_url(url, tx_hash),
+        |bodies| quorum_tx_status(bodies, tx_hash),
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::config::{XRP_PRODUCTION_SCHNORR_KEY_NAME, XRP_TEST_SCHNORR_KEY_NAME};
     use super::*;
 
     #[test]
@@ -465,11 +716,13 @@ mod tests {
 
     #[test]
     fn parse_submit_rejects_tec_and_tef() {
+        assert!(parse_submit(
+            br#"{"engine_result":"tecUNFUNDED_PAYMENT","hash":"X","error":null}"#
+        )
+        .is_err());
         assert!(
-            parse_submit(br#"{"engine_result":"tecUNFUNDED_PAYMENT","hash":"X","error":null}"#)
-                .is_err()
+            parse_submit(br#"{"engine_result":"tefMAX_LEDGER","hash":null,"error":null}"#).is_err()
         );
-        assert!(parse_submit(br#"{"engine_result":"tefMAX_LEDGER","hash":null,"error":null}"#).is_err());
     }
 
     #[test]
@@ -486,8 +739,14 @@ mod tests {
 
     #[test]
     fn parse_delivered_drops_variants() {
-        assert_eq!(parse_delivered_drops(&serde_json::json!("1000000")), 1_000_000);
-        assert_eq!(parse_delivered_drops(&serde_json::json!(1_000_000u64)), 1_000_000);
+        assert_eq!(
+            parse_delivered_drops(&serde_json::json!("1000000")),
+            1_000_000
+        );
+        assert_eq!(
+            parse_delivered_drops(&serde_json::json!(1_000_000u64)),
+            1_000_000
+        );
         // issued-currency object -> not native XRP -> 0
         assert_eq!(
             parse_delivered_drops(
@@ -524,7 +783,9 @@ mod tests {
         };
         let reduced = transform_tx(args);
         match parse_tx_status(&reduced.body).unwrap() {
-            XrpTxStatus::Validated { delivered_drops, .. } => {
+            XrpTxStatus::Validated {
+                delivered_drops, ..
+            } => {
                 assert_eq!(delivered_drops, 500_000, "must credit delivered_amount");
                 assert_ne!(delivered_drops, 9_999_999_999, "must NOT credit Amount");
             }
@@ -554,24 +815,43 @@ mod tests {
     #[test]
     fn transform_server_strips_volatile_fields() {
         // Two replicas: identical reserve_base, different server time/load.
-        let mk = |t: &str| TransformArgs {
-            response: HttpResponse {
-                status: candid::Nat::from(200u32),
-                headers: vec![HttpHeader {
-                    name: "date".into(),
-                    value: "now".into(),
-                }],
-                body: format!(
-                    r#"{{"result":{{"state":{{"server_state":"full","time":"{t}","load_factor":256,"validated_ledger":{{"reserve_base":1000000,"seq":9000000}}}}}}}}"#
-                )
-                .into_bytes(),
-            },
-            context: vec![],
+        let mk = |t: &str| -> TransformArgs {
+            TransformArgs {
+                response: HttpResponse {
+                    status: candid::Nat::from(200u32),
+                    headers: vec![HttpHeader {
+                        name: "date".into(),
+                        value: "now".into(),
+                    }],
+                    body: format!(
+                        r#"{{"result":{{"state":{{"server_state":"full","time":"{t}","load_factor":256,"validated_ledger":{{"reserve_base":1000000,"seq":9000000}}}}}}}}"#
+                    )
+                    .into_bytes(),
+                },
+                context: vec![],
+            }
         };
         let a = transform_server(mk("A"));
         let b = transform_server(mk("B"));
         assert_eq!(a.body, b.body, "replicas converge");
         assert_eq!(parse_reserve_base(&a.body).unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn transform_server_keeps_validated_ledger_identity_for_quorum() {
+        let reduced = transform_server(TransformArgs {
+            response: HttpResponse {
+                status: candid::Nat::from(200u32),
+                headers: vec![],
+                body: br#"{"result":{"state":{"validated_ledger":{"reserve_base":1000000,"seq":9000000,"hash":"ABCDEF"}}}}"#
+                    .to_vec(),
+            },
+            context: vec![],
+        });
+        let v: Value = serde_json::from_slice(&reduced.body).unwrap();
+        assert_eq!(v.get("reserve_base"), Some(&json!(1_000_000)));
+        assert_eq!(v.get("ledger_index"), Some(&json!(9_000_000)));
+        assert_eq!(v.get("ledger_hash"), Some(&json!("ABCDEF")));
     }
 
     #[test]
@@ -587,7 +867,9 @@ mod tests {
         let a = transform_account(mk(b"<html>ray=A</html>"));
         let b = transform_account(mk(b"<html>ray=B</html>"));
         assert_eq!(a.body, b.body);
-        assert!(parse_account_info(&a.body).unwrap_err().contains("unparseable"));
+        assert!(parse_account_info(&a.body)
+            .unwrap_err()
+            .contains("unparseable"));
     }
 
     #[test]
@@ -596,42 +878,50 @@ mod tests {
         // for the same logical body (e.g. 200 vs 503 during a rate-limit blip).
         // Consensus runs over the FULL response (status + body), so the transform
         // must pin the status; assert convergence on the whole response, not body.
-        let mk = |status: u32| TransformArgs {
-            response: HttpResponse {
-                status: candid::Nat::from(status),
-                headers: vec![HttpHeader {
-                    name: "x-edge".into(),
-                    value: format!("node-{status}"),
-                }],
-                body: br#"{"result":{"account_data":{"Sequence":42,"Balance":"25000000"},"ledger_index":9000000}}"#
-                    .to_vec(),
-            },
-            context: vec![],
+        let mk = |status: u32| -> TransformArgs {
+            TransformArgs {
+                response: HttpResponse {
+                    status: candid::Nat::from(status),
+                    headers: vec![HttpHeader {
+                        name: "x-edge".into(),
+                        value: format!("node-{status}"),
+                    }],
+                    body: br#"{"result":{"account_data":{"Sequence":42,"Balance":"25000000"},"ledger_index":9000000}}"#
+                        .to_vec(),
+                },
+                context: vec![],
+            }
         };
         let ok = transform_account(mk(200));
         let throttled = transform_account(mk(503));
         assert_eq!(ok.status, throttled.status, "status pinned for consensus");
         assert_eq!(ok.body, throttled.body, "bodies converge");
-        assert_eq!(ok.status, candid::Nat::from(200u32), "canonical status is 200");
+        assert_eq!(
+            ok.status,
+            candid::Nat::from(200u32),
+            "canonical status is 200"
+        );
         // The reduced body still parses the consumed fields.
         assert_eq!(parse_account_info(&ok.body).unwrap().sequence, 42);
     }
 
     #[test]
     fn transform_tx_reduces_and_converges() {
-        let mk = |edge: &str| TransformArgs {
-            response: HttpResponse {
-                status: candid::Nat::from(200u32),
-                headers: vec![HttpHeader {
-                    name: "x-ripple-edge".into(),
-                    value: edge.into(),
-                }],
-                body: format!(
-                    r#"{{"result":{{"validated":true,"ledger_index":9000000,"close_time_human":"{edge}","meta":{{"TransactionResult":"tesSUCCESS","delivered_amount":"1000000"}}}}}}"#
-                )
-                .into_bytes(),
-            },
-            context: vec![],
+        let mk = |edge: &str| -> TransformArgs {
+            TransformArgs {
+                response: HttpResponse {
+                    status: candid::Nat::from(200u32),
+                    headers: vec![HttpHeader {
+                        name: "x-ripple-edge".into(),
+                        value: edge.into(),
+                    }],
+                    body: format!(
+                        r#"{{"result":{{"validated":true,"ledger_index":9000000,"close_time_human":"{edge}","meta":{{"TransactionResult":"tesSUCCESS","delivered_amount":"1000000"}}}}}}"#
+                    )
+                    .into_bytes(),
+                },
+                context: vec![],
+            }
         };
         let a = transform_tx(mk("A"));
         let b = transform_tx(mk("B"));
@@ -642,6 +932,127 @@ mod tests {
                 ledger_index: 9_000_000,
                 delivered_drops: 1_000_000
             }
+        );
+    }
+
+    #[test]
+    fn transform_tx_keeps_ledger_hash_for_quorum() {
+        let reduced = transform_tx(TransformArgs {
+            response: HttpResponse {
+                status: candid::Nat::from(200u32),
+                headers: vec![],
+                body: br#"{"result":{"validated":true,"hash":"TXHASH","ledger_index":9000000,"ledger_hash":"LEDGERHASH","meta":{"TransactionResult":"tesSUCCESS","delivered_amount":"1000000"}}}"#
+                    .to_vec(),
+            },
+            context: vec![],
+        });
+        let v: Value = serde_json::from_slice(&reduced.body).unwrap();
+        assert_eq!(v.get("ledger_index"), Some(&json!(9_000_000)));
+        assert_eq!(v.get("ledger_hash"), Some(&json!("LEDGERHASH")));
+        assert_eq!(v.get("tx_hash"), Some(&json!("TXHASH")));
+    }
+
+    #[test]
+    fn read_provider_urls_are_quorum_sets_by_key_network() {
+        let mainnet = read_provider_urls(XRP_PRODUCTION_SCHNORR_KEY_NAME);
+        let testnet = read_provider_urls(XRP_TEST_SCHNORR_KEY_NAME);
+
+        assert!(
+            mainnet.len() >= 2,
+            "mainnet reads must not trust one provider"
+        );
+        assert!(
+            testnet.len() >= 2,
+            "testnet reads must not trust one provider"
+        );
+        assert_eq!(rpc_url(XRP_PRODUCTION_SCHNORR_KEY_NAME), mainnet[0]);
+        assert_eq!(rpc_url(XRP_TEST_SCHNORR_KEY_NAME), testnet[0]);
+        assert_ne!(
+            mainnet, testnet,
+            "production key must select mainnet providers"
+        );
+        assert!(
+            !mainnet.iter().any(|url| url.contains("xrpl.ws")),
+            "xrpl.ws is an alias for xrplcluster.com and must not be counted as an independent provider"
+        );
+        assert!(
+            !mainnet.iter().any(|url| url.contains("s2.ripple.com")),
+            "do not let one operator form the read quorum by listing both Ripple public clusters"
+        );
+    }
+
+    #[test]
+    fn account_quorum_accepts_same_state_across_ledger_progress() {
+        let provider_a =
+            br#"{"sequence":42,"balance":"25000000","ledger_index":9000000,"ledger_hash":"A","error":null}"#
+                .to_vec();
+        let provider_b =
+            br#"{"sequence":42,"balance":"25000000","ledger_index":9000001,"ledger_hash":"B","error":null}"#
+                .to_vec();
+        let info = quorum_account_info(&[provider_a, provider_b]).unwrap();
+        assert_eq!(info.sequence, 42);
+        assert_eq!(info.balance_drops, 25_000_000);
+        assert_eq!(
+            info.ledger_index, 9_000_001,
+            "return the freshest ledger index among agreeing providers"
+        );
+    }
+
+    #[test]
+    fn account_quorum_rejects_state_disagreement_without_majority() {
+        let provider_a =
+            br#"{"sequence":42,"balance":"25000000","ledger_index":9000000,"ledger_hash":"A","error":null}"#
+                .to_vec();
+        let provider_b =
+            br#"{"sequence":43,"balance":"24000000","ledger_index":9000001,"ledger_hash":"B","error":null}"#
+                .to_vec();
+        let err = quorum_account_info(&[provider_a, provider_b]).unwrap_err();
+        assert!(err.contains("semantic quorum failed"), "{err}");
+    }
+
+    #[test]
+    fn reserve_quorum_accepts_matching_reserve_across_ledger_progress() {
+        let provider_a =
+            br#"{"reserve_base":1000000,"ledger_index":9000000,"ledger_hash":"A","error":null}"#
+                .to_vec();
+        let provider_b =
+            br#"{"reserve_base":1000000,"ledger_index":9000001,"ledger_hash":"B","error":null}"#
+                .to_vec();
+        assert_eq!(
+            quorum_reserve_base(&[provider_a, provider_b]).unwrap(),
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn tx_status_for_hash_rejects_mismatched_hash() {
+        let body = br#"{"validated":true,"tx_hash":"WRONG","engine_result":"tesSUCCESS","ledger_index":9000000,"delivered_amount":"1000000","error":null}"#;
+        let err = parse_tx_status_for_hash(body, "EXPECTED").unwrap_err();
+        assert!(err.contains("tx hash mismatch"), "{err}");
+    }
+
+    #[test]
+    fn tx_quorum_accepts_matching_validated_status() {
+        let provider_a =
+            br#"{"validated":true,"tx_hash":"ABC","engine_result":"tesSUCCESS","ledger_index":9000000,"delivered_amount":"1000000","error":null}"#
+                .to_vec();
+        let provider_b =
+            br#"{"validated":true,"tx_hash":"abc","engine_result":"tesSUCCESS","ledger_index":9000000,"delivered_amount":"1000000","error":null}"#
+                .to_vec();
+        assert_eq!(
+            quorum_tx_status(&[provider_a, provider_b], "ABC").unwrap(),
+            XrpTxStatus::Validated {
+                ledger_index: 9_000_000,
+                delivered_drops: 1_000_000
+            }
+        );
+    }
+
+    #[test]
+    fn tx_lookup_uses_confirmation_response_limit_not_generic_read_limit() {
+        assert!(
+            tx_max_response_bytes() > MAX_READ_BYTES,
+            "tx confirmation can include metadata and must not be capped at generic read size"
         );
     }
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -696,7 +696,7 @@ fn post_upgrade(arg: ProtocolArg) {
     };
 
     // Try to restore from stable memory (fast path, no drift)
-    let state = match rumi_protocol_backend::storage::load_state_from_stable() {
+    let mut state = match rumi_protocol_backend::storage::load_state_from_stable() {
         Some(mut state) => {
             log!(
                 INFO,
@@ -723,6 +723,23 @@ fn post_upgrade(arg: ProtocolArg) {
             })
         }
     };
+    let xrp_guardrail_migration =
+        rumi_protocol_backend::state::enforce_xrp_launch_guardrails(&mut state);
+    if let Some(previous) = xrp_guardrail_migration.previous_debt_ceiling {
+        log!(
+            INFO,
+            "[upgrade]: clamped XRP debt ceiling from {} to {} e8s",
+            previous,
+            rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
+        );
+    }
+    if let Some(previous) = xrp_guardrail_migration.previous_status {
+        log!(
+            INFO,
+            "[upgrade]: froze XRP collateral status from {:?} because the configured Schnorr key is not production",
+            previous
+        );
+    }
 
     // Post-upgrade validation: ensure collateral_configs is consistent
     validate_collateral_state(&state);
@@ -4980,6 +4997,70 @@ fn xrp_require_developer() -> Result<(), ProtocolError> {
     }
 }
 
+fn xrp_require_production_schnorr_key() -> Result<(), ProtocolError> {
+    let configured_key = rumi_protocol_backend::chains::xrp::config::xrp_schnorr_key_name();
+    if rumi_protocol_backend::chains::xrp::config::is_xrp_production_key_name(&configured_key) {
+        return Ok(());
+    }
+    let required = rumi_protocol_backend::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME;
+    Err(ProtocolError::GenericError(format!(
+        "XRP collateral registration requires production Schnorr key {required} (configured: {configured_key})"
+    )))
+}
+
+fn validate_xrp_schnorr_key_change(name: &str, has_xrp_state: bool) -> Result<(), ProtocolError> {
+    if name != rumi_protocol_backend::chains::xrp::config::XRP_TEST_SCHNORR_KEY_NAME
+        && name != rumi_protocol_backend::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME
+    {
+        return Err(ProtocolError::GenericError(format!(
+            "unsupported XRP Schnorr key name '{name}' (expected test_key_1 or key_1)"
+        )));
+    }
+    if has_xrp_state {
+        return Err(ProtocolError::GenericError(
+            "cannot change the XRP Schnorr key after XRP collateral state exists".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn xrp_has_key_bound_state() -> bool {
+    let xrp_ct = rumi_protocol_backend::state::xrp_collateral_principal();
+    read_state(|s| {
+        s.collateral_configs.contains_key(&xrp_ct)
+            || !s.xrp_pending_deposits.is_empty()
+            || !s.xrp_claims.is_empty()
+            || s.vault_id_to_vaults
+                .values()
+                .any(|vault| vault.collateral_type == xrp_ct)
+    })
+}
+
+#[candid_method(update)]
+#[update]
+fn set_xrp_schnorr_key_name(name: String) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if !read_state(|s| s.developer_principal == caller) {
+        return Err(ProtocolError::GenericError(
+            "Only developer can set XRP Schnorr key".to_string(),
+        ));
+    }
+    validate_xrp_schnorr_key_change(&name, xrp_has_key_bound_state())?;
+    mutate_state(|s| s.xrp_schnorr_key_name = name.clone());
+    log!(
+        INFO,
+        "[set_xrp_schnorr_key_name] XRP Schnorr key set to {}",
+        name
+    );
+    Ok(())
+}
+
+#[candid_method(query)]
+#[query]
+fn get_xrp_schnorr_key_name() -> String {
+    rumi_protocol_backend::chains::xrp::config::xrp_schnorr_key_name()
+}
+
 /// P1 observability (developer-gated, no funds touched): derive the protocol's XRP
 /// settlement (custody) classic address via threshold Ed25519 and return it, so an
 /// operator can see it on XRPL testnet. The chains::xrp module is dormant; this
@@ -5054,10 +5135,46 @@ async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<String, 
     check_postcondition(rumi_protocol_backend::vault::settle_xrp_claim(claim_id, destination).await)
 }
 
+/// XRP-007: settle an XRP collateral claim to a destination that requires an XRPL
+/// destination tag. The legacy untagged endpoint remains available for ordinary
+/// self-custody addresses.
+#[update]
+async fn settle_xrp_claim_with_tag(
+    claim_id: u64,
+    destination: String,
+    destination_tag: u32,
+) -> Result<String, ProtocolError> {
+    validate_call().await?;
+    check_postcondition(
+        rumi_protocol_backend::vault::settle_xrp_claim_with_tag(
+            claim_id,
+            destination,
+            Some(destination_tag),
+        )
+        .await,
+    )
+}
+
+/// XRP-006: owner cleanup for an abandoned native-XRP open. The vault layer
+/// verifies live XRPL state and removes the pending entry only if it is unfunded.
+#[update]
+async fn cancel_xrp_pending_open(vault_id: u64) -> Result<(), ProtocolError> {
+    validate_call().await?;
+    check_postcondition(rumi_protocol_backend::vault::cancel_xrp_pending_open(vault_id).await)
+}
+
+/// XRP-006: developer cleanup for abandoned native-XRP opens. This is also
+/// unfunded-only; funded custody addresses remain confirmable by their owners.
+#[update]
+async fn sweep_xrp_pending_open(vault_id: u64) -> Result<(), ProtocolError> {
+    validate_call().await?;
+    check_postcondition(rumi_protocol_backend::vault::sweep_xrp_pending_open(vault_id).await)
+}
+
 /// P5 (native-XRP collateral): register XRP as a collateral (developer-gated). XRP
 /// has no IC ledger, so decimals (6 / drops) and fee (0) are NOT queried;
 /// custody_kind = NativeXrp routes deposits/payouts through the chains::xrp rail +
-/// the XrpClaim model. Params: 150% borrow / 133% liquidation / 12% penalty / $200
+/// the XrpClaim model. Params: 150% borrow / 133% liquidation / 12% penalty / $100
 /// debt ceiling; borrowing-fee + interest inherited from ICP. Calling this is the
 /// deliberate act that ACTIVATES the native-XRP rail — do NOT call on mainnet
 /// before the security audit.
@@ -5069,6 +5186,7 @@ async fn register_xrp_collateral() -> Result<(), ProtocolError> {
             "Only the developer can register XRP collateral".to_string(),
         ));
     }
+    xrp_require_production_schnorr_key()?;
     let xrp_ct = rumi_protocol_backend::state::xrp_collateral_principal();
     if read_state(|s| s.collateral_configs.contains_key(&xrp_ct)) {
         return Err(ProtocolError::GenericError(
@@ -5102,7 +5220,7 @@ async fn register_xrp_collateral() -> Result<(), ProtocolError> {
     rumi_protocol_backend::xrc::register_collateral_price_timer(xrp_ct);
     log!(
         INFO,
-        "[register_xrp_collateral] Registered native-XRP collateral {} (150/133/12, $200 ceiling)",
+        "[register_xrp_collateral] Registered native-XRP collateral {} (150/133/12, $100 ceiling)",
         xrp_ct
     );
     Ok(())
@@ -9406,6 +9524,15 @@ async fn set_collateral_status(
             "Collateral type not found".to_string(),
         ));
     }
+    if collateral_type == rumi_protocol_backend::state::xrp_collateral_principal()
+        && !matches!(
+            status,
+            rumi_protocol_backend::state::CollateralStatus::Frozen
+                | rumi_protocol_backend::state::CollateralStatus::Deprecated
+        )
+    {
+        xrp_require_production_schnorr_key()?;
+    }
 
     mutate_state(|s| {
         event::record_update_collateral_status(s, collateral_type, status);
@@ -9495,6 +9622,14 @@ async fn set_collateral_debt_ceiling(
         return Err(ProtocolError::GenericError(
             "Collateral type not found".to_string(),
         ));
+    }
+    if collateral_type == rumi_protocol_backend::state::xrp_collateral_principal()
+        && debt_ceiling > rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
+    {
+        return Err(ProtocolError::GenericError(format!(
+            "XRP debt ceiling cannot exceed {} e8s (100 icUSD)",
+            rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
+        )));
     }
 
     mutate_state(|s| {
@@ -10096,6 +10231,12 @@ async fn update_collateral_config(
             "ledger_canister_id in config must match collateral_type".to_string(),
         ));
     }
+    let configured_xrp_key = read_state(|s| s.xrp_schnorr_key_name.clone());
+    rumi_protocol_backend::state::validate_xrp_launch_config_update(
+        collateral_type,
+        &config,
+        &configured_xrp_key,
+    )?;
 
     mutate_state(|s| {
         event::record_update_collateral_config(s, collateral_type, config);
@@ -10463,6 +10604,15 @@ mod chain_vault_param_tests {
         // Changing the key while chain vaults exist is blocked (would re-derive +
         // orphan every custody address).
         assert!(validate_ecdsa_key_change("key_1", true).is_err());
+    }
+
+    #[test]
+    fn xrp_schnorr_key_change_rules() {
+        use super::validate_xrp_schnorr_key_change;
+        assert!(validate_xrp_schnorr_key_change("key_1", false).is_ok());
+        assert!(validate_xrp_schnorr_key_change("test_key_1", false).is_ok());
+        assert!(validate_xrp_schnorr_key_change("bogus_key", false).is_err());
+        assert!(validate_xrp_schnorr_key_change("key_1", true).is_err());
     }
 }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1,4 +1,5 @@
-use crate::numeric::{Ratio, UsdIcp, ICUSD, ICP};
+use crate::guard::OperationState;
+use crate::numeric::{Ratio, UsdIcp, ICP, ICUSD};
 use crate::vault::Vault;
 use crate::{
     compute_collateral_ratio, InitArg, ProtocolError, UpgradeArg, MINIMUM_COLLATERAL_RATIO,
@@ -15,7 +16,6 @@ use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::ops::Bound;
-use crate::guard::OperationState;
 
 // Like assert_eq, but returns an error instead of panicking.
 macro_rules! ensure_eq {
@@ -81,21 +81,31 @@ pub struct InterestRecipient {
 }
 
 /// Default interest split: 50% 3pool, 40% stability pool, 10% treasury.
-fn default_flush_threshold() -> u64 { 10_000_000 } // 0.1 icUSD
+fn default_flush_threshold() -> u64 {
+    10_000_000
+} // 0.1 icUSD
 
 /// Wave-14a CDP-14: production default for the XRC source-count floor.
 /// Mirrors `xrc::MIN_XRC_SOURCES`. Lives here (not in `xrc.rs`) so the
 /// `#[serde(default = ...)]` attribute on `State::min_xrc_sources_used`
 /// can reference it without a cross-module import dance.
-fn default_min_xrc_sources_used() -> u32 { 3 }
+fn default_min_xrc_sources_used() -> u32 {
+    3
+}
 
 /// Wave-14b CDP-12 follow-up: production defaults for the three timer
 /// cadences. Mirror the consts in `xrc.rs` so legacy snapshots without
 /// these fields hydrate to the same cadence the canister has shipped
 /// with from Wave 14b onward.
-fn default_xrc_fetch_interval_secs() -> u64 { 300 }
-fn default_interest_treasury_tick_interval_secs() -> u64 { 60 }
-fn default_vault_check_tick_interval_secs() -> u64 { 300 }
+fn default_xrc_fetch_interval_secs() -> u64 {
+    300
+}
+fn default_interest_treasury_tick_interval_secs() -> u64 {
+    60
+}
+fn default_vault_check_tick_interval_secs() -> u64 {
+    300
+}
 
 /// Phase 1b Task 15: production defaults for the Monad async-loop cadences.
 /// Timer D (settlement) and the observer both default to 300s. The previous 30s
@@ -107,25 +117,45 @@ fn default_vault_check_tick_interval_secs() -> u64 { 300 }
 /// these fields) off the catastrophic 30s cadence. The register fns still floor a
 /// 0 to 30 so a busy-loop is impossible even with a corrupt value, and the
 /// developer-gated setters tune the live cadence without an upgrade.
-fn default_settlement_tick_interval_secs() -> u64 { 300 }
-fn default_observer_tick_interval_secs() -> u64 { 300 }
+fn default_settlement_tick_interval_secs() -> u64 {
+    300
+}
+fn default_observer_tick_interval_secs() -> u64 {
+    300
+}
 /// Task 12: ~1 year (365 days) — effectively OFF by default (realization is
 /// deliberate, not an always-on heartbeat).
-fn default_chain_interest_tick_interval_secs() -> u64 { 31_536_000 }
+fn default_chain_interest_tick_interval_secs() -> u64 {
+    31_536_000
+}
 /// Task 12: 0.01 icUSD dust floor for interest realization.
-fn default_chain_interest_min_realize_e8s() -> u128 { 1_000_000 }
+fn default_chain_interest_min_realize_e8s() -> u128 {
+    1_000_000
+}
 /// Production tECDSA key name for the EVM chains rail. Default `test_key_1`
 /// (single-sourced from `monad_ecdsa_key_name`); a fresh production canister sets
 /// `key_1` via `set_chains_ecdsa_key_name` before registering any chain.
 fn default_chains_ecdsa_key_name() -> String {
     crate::chains::monad::config::monad_ecdsa_key_name()
 }
+fn default_xrp_schnorr_key_name() -> String {
+    crate::chains::xrp::config::XRP_TEST_SCHNORR_KEY_NAME.to_string()
+}
 
 pub fn default_interest_split() -> Vec<InterestRecipient> {
     vec![
-        InterestRecipient { destination: InterestDestination::ThreePool, bps: 5000 },
-        InterestRecipient { destination: InterestDestination::StabilityPool, bps: 4000 },
-        InterestRecipient { destination: InterestDestination::Treasury, bps: 1000 },
+        InterestRecipient {
+            destination: InterestDestination::ThreePool,
+            bps: 5000,
+        },
+        InterestRecipient {
+            destination: InterestDestination::StabilityPool,
+            bps: 4000,
+        },
+        InterestRecipient {
+            destination: InterestDestination::Treasury,
+            bps: 1000,
+        },
     ]
 }
 pub const DUST_DEBT_THRESHOLD: u64 = 50_000; // 0.0005 icUSD — debt below this is forgiven on withdrawal
@@ -179,10 +209,10 @@ pub const DEFAULT_HEALTHY_CR_MULTIPLIER: Ratio = Ratio::new(dec!(1.5));
 
 /// Default Redemption Margin Ratio parameters (admin-configurable).
 /// Redeemers receive RMR × face value of their icUSD.
-pub const DEFAULT_RMR_FLOOR: Ratio = Ratio::new(dec!(0.96));      // 96% at healthy system
-pub const DEFAULT_RMR_CEILING: Ratio = Ratio::new(dec!(1.0));     // 100% at/below stressed CR
-pub const DEFAULT_RMR_FLOOR_CR: Ratio = Ratio::new(dec!(2.25));   // CR above which floor applies (recovery × 1.5)
-pub const DEFAULT_RMR_CEILING_CR: Ratio = Ratio::new(dec!(1.5));  // CR below which ceiling applies (= recovery)
+pub const DEFAULT_RMR_FLOOR: Ratio = Ratio::new(dec!(0.96)); // 96% at healthy system
+pub const DEFAULT_RMR_CEILING: Ratio = Ratio::new(dec!(1.0)); // 100% at/below stressed CR
+pub const DEFAULT_RMR_FLOOR_CR: Ratio = Ratio::new(dec!(2.25)); // CR above which floor applies (recovery × 1.5)
+pub const DEFAULT_RMR_CEILING_CR: Ratio = Ratio::new(dec!(1.5)); // CR below which ceiling applies (= recovery)
 
 /// Wave-5 LIQ-007: minimum tolerated ratio between a new XRC sample and the
 /// stored price. A new rate is considered "in band" when
@@ -236,7 +266,10 @@ impl CollateralStatus {
 
     /// Whether repaying debt is allowed
     pub fn allows_repay(&self) -> bool {
-        matches!(self, CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset)
+        matches!(
+            self,
+            CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset
+        )
     }
 
     /// Whether adding collateral is allowed
@@ -251,7 +284,10 @@ impl CollateralStatus {
 
     /// Whether closing a vault is allowed (requires zero debt and zero collateral)
     pub fn allows_close(&self) -> bool {
-        matches!(self, CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset)
+        matches!(
+            self,
+            CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset
+        )
     }
 
     /// Whether liquidations are allowed
@@ -342,23 +378,56 @@ impl PartialEq for PriceSource {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (
-                PriceSource::Xrc { base_asset: ba1, base_asset_class: bac1, quote_asset: qa1, quote_asset_class: qac1 },
-                PriceSource::Xrc { base_asset: ba2, base_asset_class: bac2, quote_asset: qa2, quote_asset_class: qac2 },
+                PriceSource::Xrc {
+                    base_asset: ba1,
+                    base_asset_class: bac1,
+                    quote_asset: qa1,
+                    quote_asset_class: qac1,
+                },
+                PriceSource::Xrc {
+                    base_asset: ba2,
+                    base_asset_class: bac2,
+                    quote_asset: qa2,
+                    quote_asset_class: qac2,
+                },
             ) => ba1 == ba2 && bac1 == bac2 && qa1 == qa2 && qac1 == qac2,
             (
                 PriceSource::LstWrapped {
-                    base_asset: ba1, base_asset_class: bac1, quote_asset: qa1, quote_asset_class: qac1,
-                    rate_canister_id: rc1, rate_method: rm1, haircut: h1,
+                    base_asset: ba1,
+                    base_asset_class: bac1,
+                    quote_asset: qa1,
+                    quote_asset_class: qac1,
+                    rate_canister_id: rc1,
+                    rate_method: rm1,
+                    haircut: h1,
                 },
                 PriceSource::LstWrapped {
-                    base_asset: ba2, base_asset_class: bac2, quote_asset: qa2, quote_asset_class: qac2,
-                    rate_canister_id: rc2, rate_method: rm2, haircut: h2,
+                    base_asset: ba2,
+                    base_asset_class: bac2,
+                    quote_asset: qa2,
+                    quote_asset_class: qac2,
+                    rate_canister_id: rc2,
+                    rate_method: rm2,
+                    haircut: h2,
                 },
-            ) => ba1 == ba2 && bac1 == bac2 && qa1 == qa2 && qac1 == qac2
-                && rc1 == rc2 && rm1 == rm2 && h1.to_bits() == h2.to_bits(),
+            ) => {
+                ba1 == ba2
+                    && bac1 == bac2
+                    && qa1 == qa2
+                    && qac1 == qac2
+                    && rc1 == rc2
+                    && rm1 == rm2
+                    && h1.to_bits() == h2.to_bits()
+            }
             (
-                PriceSource::CoinGecko { coin_id: c1, vs_currency: v1 },
-                PriceSource::CoinGecko { coin_id: c2, vs_currency: v2 },
+                PriceSource::CoinGecko {
+                    coin_id: c1,
+                    vs_currency: v1,
+                },
+                PriceSource::CoinGecko {
+                    coin_id: c2,
+                    vs_currency: v2,
+                },
             ) => c1 == c2 && v1 == v2,
             _ => false,
         }
@@ -390,13 +459,16 @@ pub struct RateMarker {
 /// A per-asset rate curve: ordered markers + interpolation method.
 #[derive(candid::CandidType, Clone, Debug, PartialEq, Eq, serde::Deserialize, Serialize)]
 pub struct RateCurve {
-    pub markers: Vec<RateMarker>,  // sorted by cr_level ascending
+    pub markers: Vec<RateMarker>, // sorted by cr_level ascending
     pub method: InterpolationMethod,
 }
 
 impl Default for RateCurve {
     fn default() -> Self {
-        Self { markers: Vec::new(), method: InterpolationMethod::default() }
+        Self {
+            markers: Vec::new(),
+            method: InterpolationMethod::default(),
+        }
     }
 }
 
@@ -600,8 +672,11 @@ pub fn xrp_collateral_principal() -> Principal {
     Principal::from_slice(b"rumi-xrp-native")
 }
 
+/// Launch cap for native-XRP borrowing: 100 icUSD, in e8s.
+pub const XRP_LAUNCH_DEBT_CEILING_E8S: u64 = 10_000_000_000;
+
 /// P5: the `CollateralConfig` for native-XRP collateral. Parameters (Rob's):
-/// 150% borrow threshold / 133% liquidation / 12% liquidation penalty / $200 debt
+/// 150% borrow threshold / 133% liquidation / 12% liquidation penalty / $100 debt
 /// ceiling. Borrowing-fee + interest BASE are copied from ICP ("same as ICP"); the
 /// dynamic curves are global (`borrowing_fee_curve`) or inherited (`rate_curve` =
 /// None). custody_kind = `NativeXrp`; `ledger_canister_id` is the synthetic key; 6
@@ -622,7 +697,7 @@ pub fn xrp_collateral_config(
         liquidation_bonus: Ratio::new(dec!(1.12)),
         borrowing_fee: icp_borrowing_fee,
         interest_rate_apr: icp_interest_rate_apr,
-        debt_ceiling: 20_000_000_000, // $200 in icUSD e8s; bump via set_collateral_debt_ceiling
+        debt_ceiling: XRP_LAUNCH_DEBT_CEILING_E8S,
         min_vault_debt: ICUSD::new(10_000_000), // 0.1 icUSD (matches ICP)
         ledger_fee: 0,
         price_source: PriceSource::Xrc {
@@ -649,6 +724,73 @@ pub fn xrp_collateral_config(
         min_xrc_sources: None,
         custody_kind: Some(CustodyKind::NativeXrp),
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct XrpLaunchGuardrailMigration {
+    pub previous_debt_ceiling: Option<u64>,
+    pub previous_status: Option<CollateralStatus>,
+}
+
+/// Converges already-registered native-XRP collateral onto launch guardrails.
+/// This is intentionally idempotent so upgrades, replay recovery, and tests can
+/// call it without needing a one-shot migration flag.
+pub fn enforce_xrp_launch_guardrails(state: &mut State) -> XrpLaunchGuardrailMigration {
+    let mut migration = XrpLaunchGuardrailMigration::default();
+    let xrp_ct = xrp_collateral_principal();
+    let Some(config) = state.collateral_configs.get_mut(&xrp_ct) else {
+        return migration;
+    };
+
+    if config.debt_ceiling > XRP_LAUNCH_DEBT_CEILING_E8S {
+        migration.previous_debt_ceiling = Some(config.debt_ceiling);
+        config.debt_ceiling = XRP_LAUNCH_DEBT_CEILING_E8S;
+    }
+
+    if !crate::chains::xrp::config::is_xrp_production_key_name(&state.xrp_schnorr_key_name)
+        && !matches!(
+            config.status,
+            CollateralStatus::Frozen | CollateralStatus::Deprecated
+        )
+    {
+        migration.previous_status = Some(config.status);
+        config.status = CollateralStatus::Frozen;
+    }
+
+    migration
+}
+
+pub fn validate_xrp_launch_config_update(
+    collateral_type: Principal,
+    config: &CollateralConfig,
+    configured_key: &str,
+) -> Result<(), ProtocolError> {
+    if collateral_type != xrp_collateral_principal() {
+        return Ok(());
+    }
+    if !config.is_native_xrp() {
+        return Err(ProtocolError::GenericError(
+            "XRP collateral config must keep custody_kind = NativeXrp".to_string(),
+        ));
+    }
+    if config.debt_ceiling > XRP_LAUNCH_DEBT_CEILING_E8S {
+        return Err(ProtocolError::GenericError(format!(
+            "XRP debt ceiling cannot exceed {} e8s (100 icUSD)",
+            XRP_LAUNCH_DEBT_CEILING_E8S
+        )));
+    }
+    if !matches!(
+        config.status,
+        CollateralStatus::Frozen | CollateralStatus::Deprecated
+    ) && !crate::chains::xrp::config::is_xrp_production_key_name(configured_key)
+    {
+        return Err(ProtocolError::GenericError(format!(
+            "XRP collateral cannot be activated without production Schnorr key {} (configured: {})",
+            crate::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME,
+            configured_key
+        )));
+    }
+    Ok(())
 }
 
 /// P4: an unsettled claim on native-XRP collateral that left a vault. The XRP sits
@@ -680,6 +822,20 @@ pub struct XrpClaim {
 pub struct XrpSettlement {
     pub tx_hash: String,
     pub last_ledger_sequence: u32,
+    /// Source account `Sequence` used by the signed Payment. `None` means this
+    /// settlement was decoded from a pre-XRP-004 snapshot and must not be replaced
+    /// after expiry because the canister cannot prove whether that sequence was
+    /// consumed by the missing transaction.
+    #[serde(default)]
+    pub source_sequence: Option<u32>,
+    /// Original XRPL destination used for this settlement. Re-signing an expired
+    /// or failed payment must reuse this value so UI confirm calls do not need to
+    /// expose an address field while a settlement is in flight.
+    #[serde(default)]
+    pub destination: Option<String>,
+    /// Original optional destination tag used for this settlement.
+    #[serde(default)]
+    pub destination_tag: Option<u32>,
 }
 
 impl CollateralConfig {
@@ -702,7 +858,9 @@ impl CollateralConfig {
     }
 }
 
-fn default_redemption_tier() -> u8 { 1 }
+fn default_redemption_tier() -> u8 {
+    1
+}
 
 impl PartialEq for CollateralConfig {
     fn eq(&self, other: &Self) -> bool {
@@ -751,7 +909,6 @@ pub enum Mode {
     Recovery,
 }
 
-
 impl Mode {
     pub fn is_available(&self) -> bool {
         match self {
@@ -785,8 +942,6 @@ impl Default for Mode {
         Self::GeneralAvailability
     }
 }
-
-
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, Serialize, Copy)]
 pub struct PendingMarginTransfer {
@@ -828,11 +983,9 @@ pub struct PendingRefund {
     pub op_nonce: u128,
 }
 
-
 thread_local! {
     static __STATE: RefCell<Option<State>> = RefCell::default();
 }
-
 
 // Wave-4 LIQ-001: pending_margin_transfers and pending_excess_transfers are keyed
 // by (VaultId, Principal) so concurrent liquidators on the same vault each have
@@ -865,7 +1018,9 @@ where
         type Value = BTreeMap<(VaultId, Principal), PendingMarginTransfer>;
 
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str("a map of pending margin transfers (legacy u64 keys or new (u64, Principal) keys)")
+            f.write_str(
+                "a map of pending margin transfers (legacy u64 keys or new (u64, Principal) keys)",
+            )
         }
 
         fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -984,6 +1139,12 @@ pub struct State {
     /// custody address, which would orphan already-deposited collateral.
     #[serde(default = "default_chains_ecdsa_key_name")]
     pub chains_ecdsa_key_name: String,
+    /// Threshold Schnorr Ed25519 key name for the native-XRP rail. Like the EVM
+    /// tECDSA key, this must be set to `key_1` on a fresh production canister
+    /// before registering XRP collateral; changing it later would re-derive every
+    /// XRP custody address.
+    #[serde(default = "default_xrp_schnorr_key_name")]
+    pub xrp_schnorr_key_name: String,
     pub fee: Ratio,
     pub developer_principal: Principal,
     /// Optional narrowly-scoped principal (audit F-01) that may ONLY call
@@ -1017,7 +1178,7 @@ pub struct State {
     pub principal_guards: BTreeSet<Principal>,
     pub principal_guard_timestamps: BTreeMap<Principal, u64>, // Add timestamps for guards
     pub operation_states: BTreeMap<Principal, OperationState>, // Track operation states
-    pub operation_names: BTreeMap<Principal, String>, // Track operation names
+    pub operation_names: BTreeMap<Principal, String>,         // Track operation names
     /// Transient runtime lock for `TimerLogicGuard`. Cleared on guard `Drop`.
     /// `serde(default, skip_serializing)`: NEVER persisted across upgrades —
     /// otherwise an upgrade caught with the lock held would leave it stuck `true`
@@ -1064,10 +1225,10 @@ pub struct State {
     pub ckusdt_enabled: bool,
     pub ckusdc_enabled: bool,
     // Cached ckstable prices (from XRC, on-demand only)
-    pub last_ckusdt_rate: Option<rust_decimal::Decimal>,  // USDT/USD price (should be ~1.0)
-    pub last_ckusdt_timestamp: Option<u64>,                // nanos
-    pub last_ckusdc_rate: Option<rust_decimal::Decimal>,  // USDC/USD price (should be ~1.0)
-    pub last_ckusdc_timestamp: Option<u64>,                // nanos
+    pub last_ckusdt_rate: Option<rust_decimal::Decimal>, // USDT/USD price (should be ~1.0)
+    pub last_ckusdt_timestamp: Option<u64>,              // nanos
+    pub last_ckusdc_rate: Option<rust_decimal::Decimal>, // USDC/USD price (should be ~1.0)
+    pub last_ckusdc_timestamp: Option<u64>,              // nanos
     pub liquidation_bonus: Ratio,
     pub max_partial_liquidation_ratio: Ratio,
     pub redemption_fee_floor: Ratio,
@@ -1306,7 +1467,6 @@ pub struct State {
     //
     // `serde(default)` on every field — pre-Wave-8e snapshots decode to
     // zero deficit, half-fraction repayment, and a disabled ReadOnly latch.
-
     /// Cumulative bad debt the protocol has absorbed from underwater
     /// liquidations. Increments via `accrue_deficit_shortfall` at every
     /// liquidation site that nets seized USD < debt cleared. Decreases only
@@ -1349,7 +1509,6 @@ pub struct State {
     // serde(default) on every field — pre-Wave-10 snapshots decode to an
     // empty log, the 30-minute default window, a disabled ceiling (0), and
     // a not-tripped flag.
-
     /// Rolling-window log of liquidations for circuit-breaker gating.
     /// Each entry is `(timestamp_ns, debt_cleared_icusd_e8s)`. Pruned in
     /// place inside `record_recent_liquidation` to keep entries within
@@ -1389,7 +1548,6 @@ pub struct State {
     //
     // `serde(default)`: pre-Wave-9b snapshots decode `None`, the next
     // query recomputes and the result is cached.
-
     /// Wave-9b DOS-006: cached `get_protocol_status` heavy aggregates
     /// with the nanosecond timestamp at which they were computed.
     #[serde(default)]
@@ -1414,7 +1572,6 @@ pub struct State {
     // matching `default_*` fn (or 0 for the counter), so the post-
     // upgrade behavior matches the audit-spec defaults without a
     // snapshot-format migration.
-
     /// Wave-9c DOS-005: alert band (in bps) above the worst per-
     /// collateral `min_liquidation_ratio` within which `check_vaults`
     /// walks the sorted-troves index on band-only ticks. Default
@@ -1609,6 +1766,7 @@ impl Default for State {
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
             chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
             chains_ecdsa_key_name: default_chains_ecdsa_key_name(),
+            xrp_schnorr_key_name: default_xrp_schnorr_key_name(),
             fee: Ratio::from(Decimal::ZERO),
             developer_principal: Principal::anonymous(),
             price_pusher_principal: None,
@@ -1717,8 +1875,7 @@ impl Default for State {
             treasury_stats_snapshot: None,
             // Wave-9c DOS-005
             check_vaults_alert_band_bps: default_check_vaults_alert_band_bps(),
-            check_vaults_full_sweep_every_n_ticks:
-                default_check_vaults_full_sweep_every_n_ticks(),
+            check_vaults_full_sweep_every_n_ticks: default_check_vaults_full_sweep_every_n_ticks(),
             ticks_since_full_sweep: 0,
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
@@ -1763,6 +1920,7 @@ impl From<InitArg> for State {
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
             chain_interest_min_realize_e8s: default_chain_interest_min_realize_e8s(),
             chains_ecdsa_key_name: default_chains_ecdsa_key_name(),
+            xrp_schnorr_key_name: default_xrp_schnorr_key_name(),
             total_collateral_ratio: Ratio::from(Decimal::MAX),
             last_icp_timestamp: None,
             last_icp_rate: None,
@@ -1820,41 +1978,44 @@ impl From<InitArg> for State {
             // Multi-collateral: initialize with ICP as the default collateral
             collateral_configs: {
                 let mut configs = BTreeMap::new();
-                configs.insert(args.icp_ledger_principal, CollateralConfig {
-                    ledger_canister_id: args.icp_ledger_principal,
-                    decimals: 8,
-                    liquidation_ratio: MINIMUM_COLLATERAL_RATIO,
-                    borrow_threshold_ratio: RECOVERY_COLLATERAL_RATIO,
-                    liquidation_bonus: DEFAULT_LIQUIDATION_BONUS,
-                    borrowing_fee: Ratio::from(fee),
-                    interest_rate_apr: DEFAULT_INTEREST_RATE_APR,
-                    debt_ceiling: u64::MAX,
-                    min_vault_debt: ICUSD::new(10_000_000), // 0.1 icUSD
-                    ledger_fee: ICP_TRANSFER_FEE.to_u64(),
-                    price_source: PriceSource::Xrc {
-                        base_asset: "ICP".to_string(),
-                        base_asset_class: XrcAssetClass::Cryptocurrency,
-                        quote_asset: "USD".to_string(),
-                        quote_asset_class: XrcAssetClass::FiatCurrency,
+                configs.insert(
+                    args.icp_ledger_principal,
+                    CollateralConfig {
+                        ledger_canister_id: args.icp_ledger_principal,
+                        decimals: 8,
+                        liquidation_ratio: MINIMUM_COLLATERAL_RATIO,
+                        borrow_threshold_ratio: RECOVERY_COLLATERAL_RATIO,
+                        liquidation_bonus: DEFAULT_LIQUIDATION_BONUS,
+                        borrowing_fee: Ratio::from(fee),
+                        interest_rate_apr: DEFAULT_INTEREST_RATE_APR,
+                        debt_ceiling: u64::MAX,
+                        min_vault_debt: ICUSD::new(10_000_000), // 0.1 icUSD
+                        ledger_fee: ICP_TRANSFER_FEE.to_u64(),
+                        price_source: PriceSource::Xrc {
+                            base_asset: "ICP".to_string(),
+                            base_asset_class: XrcAssetClass::Cryptocurrency,
+                            quote_asset: "USD".to_string(),
+                            quote_asset_class: XrcAssetClass::FiatCurrency,
+                        },
+                        status: CollateralStatus::Active,
+                        last_price: None,
+                        last_price_timestamp: None,
+                        redemption_fee_floor: DEFAULT_REDEMPTION_FEE_FLOOR,
+                        redemption_fee_ceiling: DEFAULT_REDEMPTION_FEE_CEILING,
+                        current_base_rate: Ratio::from(Decimal::ZERO),
+                        last_redemption_time: 0,
+                        recovery_target_cr: DEFAULT_RECOVERY_TARGET_CR,
+                        min_collateral_deposit: 100_000, // 0.001 ICP
+                        recovery_borrowing_fee: None,
+                        recovery_interest_rate_apr: None,
+                        display_color: Some("#2DD4BF".to_string()),
+                        healthy_cr: None,
+                        rate_curve: None,
+                        redemption_tier: 1,
+                        min_xrc_sources: None, // inherit global floor for ICP
+                        custody_kind: None,    // ICRC (ICP ledger) — legacy default
                     },
-                    status: CollateralStatus::Active,
-                    last_price: None,
-                    last_price_timestamp: None,
-                    redemption_fee_floor: DEFAULT_REDEMPTION_FEE_FLOOR,
-                    redemption_fee_ceiling: DEFAULT_REDEMPTION_FEE_CEILING,
-                    current_base_rate: Ratio::from(Decimal::ZERO),
-                    last_redemption_time: 0,
-                    recovery_target_cr: DEFAULT_RECOVERY_TARGET_CR,
-                    min_collateral_deposit: 100_000, // 0.001 ICP
-                    recovery_borrowing_fee: None,
-                    recovery_interest_rate_apr: None,
-                    display_color: Some("#2DD4BF".to_string()),
-                    healthy_cr: None,
-                    rate_curve: None,
-                    redemption_tier: 1,
-                    min_xrc_sources: None, // inherit global floor for ICP
-                    custody_kind: None,    // ICRC (ICP ledger) — legacy default
-                });
+                );
                 configs
             },
             collateral_to_vault_ids: BTreeMap::new(),
@@ -1862,18 +2023,42 @@ impl From<InitArg> for State {
             // Dynamic interest rates
             global_rate_curve: RateCurve {
                 markers: vec![
-                    RateMarker { cr_level: Ratio::new(dec!(0)), multiplier: DEFAULT_RATE_MULTIPLIER_LIQUIDATION },
-                    RateMarker { cr_level: Ratio::new(dec!(0)), multiplier: DEFAULT_RATE_MULTIPLIER_BORROW_THRESHOLD },
-                    RateMarker { cr_level: Ratio::new(dec!(0)), multiplier: DEFAULT_RATE_MULTIPLIER_WARNING },
-                    RateMarker { cr_level: Ratio::new(dec!(0)), multiplier: DEFAULT_RATE_MULTIPLIER_HEALTHY },
+                    RateMarker {
+                        cr_level: Ratio::new(dec!(0)),
+                        multiplier: DEFAULT_RATE_MULTIPLIER_LIQUIDATION,
+                    },
+                    RateMarker {
+                        cr_level: Ratio::new(dec!(0)),
+                        multiplier: DEFAULT_RATE_MULTIPLIER_BORROW_THRESHOLD,
+                    },
+                    RateMarker {
+                        cr_level: Ratio::new(dec!(0)),
+                        multiplier: DEFAULT_RATE_MULTIPLIER_WARNING,
+                    },
+                    RateMarker {
+                        cr_level: Ratio::new(dec!(0)),
+                        multiplier: DEFAULT_RATE_MULTIPLIER_HEALTHY,
+                    },
                 ],
                 method: InterpolationMethod::Linear,
             },
             recovery_rate_curve: vec![
-                RecoveryRateMarker { threshold: SystemThreshold::LiquidationRatio, multiplier: DEFAULT_RECOVERY_MULTIPLIER_LIQUIDATION },
-                RecoveryRateMarker { threshold: SystemThreshold::BorrowThreshold, multiplier: DEFAULT_RECOVERY_MULTIPLIER_BORROW_THRESHOLD },
-                RecoveryRateMarker { threshold: SystemThreshold::WarningCr, multiplier: DEFAULT_RECOVERY_MULTIPLIER_WARNING },
-                RecoveryRateMarker { threshold: SystemThreshold::HealthyCr, multiplier: DEFAULT_RECOVERY_MULTIPLIER_HEALTHY },
+                RecoveryRateMarker {
+                    threshold: SystemThreshold::LiquidationRatio,
+                    multiplier: DEFAULT_RECOVERY_MULTIPLIER_LIQUIDATION,
+                },
+                RecoveryRateMarker {
+                    threshold: SystemThreshold::BorrowThreshold,
+                    multiplier: DEFAULT_RECOVERY_MULTIPLIER_BORROW_THRESHOLD,
+                },
+                RecoveryRateMarker {
+                    threshold: SystemThreshold::WarningCr,
+                    multiplier: DEFAULT_RECOVERY_MULTIPLIER_WARNING,
+                },
+                RecoveryRateMarker {
+                    threshold: SystemThreshold::HealthyCr,
+                    multiplier: DEFAULT_RECOVERY_MULTIPLIER_HEALTHY,
+                },
             ],
             weighted_avg_recovery_cr: Ratio::new(dec!(0)),
             weighted_avg_warning_cr: Ratio::new(dec!(0)),
@@ -1891,7 +2076,9 @@ impl From<InitArg> for State {
                     RateMarkerV2 {
                         cr_anchor: CrAnchor::Midpoint(
                             Box::new(CrAnchor::SystemThreshold(SystemThreshold::BorrowThreshold)),
-                            Box::new(CrAnchor::SystemThreshold(SystemThreshold::TotalCollateralRatio)),
+                            Box::new(CrAnchor::SystemThreshold(
+                                SystemThreshold::TotalCollateralRatio,
+                            )),
                         ),
                         multiplier: Ratio::new(dec!(1.75)),
                     },
@@ -1956,8 +2143,7 @@ impl From<InitArg> for State {
             treasury_stats_snapshot: None,
             // Wave-9c DOS-005
             check_vaults_alert_band_bps: default_check_vaults_alert_band_bps(),
-            check_vaults_full_sweep_every_n_ticks:
-                default_check_vaults_full_sweep_every_n_ticks(),
+            check_vaults_full_sweep_every_n_ticks: default_check_vaults_full_sweep_every_n_ticks(),
             ticks_since_full_sweep: 0,
             bot_cr_tolerance_bps: default_bot_cr_tolerance_bps(),
             multi_chain: crate::chains::MultiChainState::default(),
@@ -1973,13 +2159,17 @@ impl From<InitArg> for State {
 }
 
 impl State {
-
     /// True iff `caller` may set the manual price for `(chain_id, symbol)`:
     /// the developer may set any pair; the narrowly-scoped price-pusher principal
     /// (audit F-01) may set ONLY the pairs in `price_pusher_allowed`. Every other
     /// developer-gated endpoint stays developer-only; setting these allow-listed
     /// prices is the ONLY capability the pusher unlocks.
-    pub fn is_price_setter_authorized(&self, caller: Principal, chain_id: u32, symbol: &str) -> bool {
+    pub fn is_price_setter_authorized(
+        &self,
+        caller: Principal,
+        chain_id: u32,
+        symbol: &str,
+    ) -> bool {
         if self.developer_principal == caller {
             return true;
         }
@@ -1990,19 +2180,22 @@ impl State {
     }
 
     // Rate limiting functions for close_vault operations
-    pub fn check_close_vault_rate_limit(&mut self, principal: Principal) -> Result<(), ProtocolError> {
+    pub fn check_close_vault_rate_limit(
+        &mut self,
+        principal: Principal,
+    ) -> Result<(), ProtocolError> {
         let current_time = ic_cdk::api::time();
         let minute_nanos = 60 * 1_000_000_000; // 1 minute in nanoseconds
         let day_nanos = 24 * 60 * minute_nanos; // 24 hours in nanoseconds
-        
+
         // Clean old timestamps (older than 24 hours)
         let cutoff_time = current_time.saturating_sub(day_nanos);
-        
+
         // Clean user's timestamps
         if let Some(user_requests) = self.close_vault_requests.get_mut(&principal) {
             user_requests.retain(|&timestamp| timestamp > cutoff_time);
         }
-        
+
         // Clean global timestamps. Wave-14c CDP-09: timestamps are appended
         // chronologically, so the deque is sorted ascending. `partition_point`
         // gives the first index whose timestamp is > cutoff in O(log N), and
@@ -2011,30 +2204,37 @@ impl State {
             .global_close_requests
             .partition_point(|&timestamp| timestamp <= cutoff_time);
         self.global_close_requests.drain(..expired_until);
-        
+
         // Check user rate limits (5 per minute, 60 per day)
-        let user_recent_requests = self.close_vault_requests
+        let user_recent_requests = self
+            .close_vault_requests
             .get(&principal)
-            .map(|requests| requests.iter().filter(|&&timestamp| timestamp > current_time - minute_nanos).count())
+            .map(|requests| {
+                requests
+                    .iter()
+                    .filter(|&&timestamp| timestamp > current_time - minute_nanos)
+                    .count()
+            })
             .unwrap_or(0);
-            
-        let user_daily_requests = self.close_vault_requests
+
+        let user_daily_requests = self
+            .close_vault_requests
             .get(&principal)
             .map(|requests| requests.len())
             .unwrap_or(0);
-            
+
         if user_recent_requests >= 5 {
             return Err(ProtocolError::GenericError(
-                "Rate limit exceeded: Maximum 5 close_vault calls per minute per user".to_string()
+                "Rate limit exceeded: Maximum 5 close_vault calls per minute per user".to_string(),
             ));
         }
-        
+
         if user_daily_requests >= 60 {
             return Err(ProtocolError::GenericError(
-                "Rate limit exceeded: Maximum 60 close_vault calls per day per user".to_string()
+                "Rate limit exceeded: Maximum 60 close_vault calls per day per user".to_string(),
             ));
         }
-        
+
         // Check global rate limits (300 per minute, 30,000 per day).
         // Wave-14c CDP-09: deque is sorted ascending, so `partition_point`
         // finds the first index whose timestamp is past the minute cutoff
@@ -2044,47 +2244,49 @@ impl State {
             .global_close_requests
             .partition_point(|&timestamp| timestamp <= minute_cutoff);
         let global_recent_requests = self.global_close_requests.len() - recent_start;
-            
+
         let global_daily_requests = self.global_close_requests.len();
-        
+
         if global_recent_requests >= 300 {
             return Err(ProtocolError::GenericError(
-                "Rate limit exceeded: Maximum 300 close_vault calls per minute globally".to_string()
+                "Rate limit exceeded: Maximum 300 close_vault calls per minute globally"
+                    .to_string(),
             ));
         }
-        
+
         if global_daily_requests >= 30_000 {
             return Err(ProtocolError::GenericError(
-                "Rate limit exceeded: Maximum 30,000 close_vault calls per day globally".to_string()
+                "Rate limit exceeded: Maximum 30,000 close_vault calls per day globally"
+                    .to_string(),
             ));
         }
-        
+
         // Check concurrent operations limit (200)
         if self.concurrent_close_operations >= 200 {
             return Err(ProtocolError::GenericError(
-                "Rate limit exceeded: Maximum 200 concurrent close_vault operations".to_string()
+                "Rate limit exceeded: Maximum 200 concurrent close_vault operations".to_string(),
             ));
         }
-        
+
         Ok(())
     }
-    
+
     pub fn record_close_vault_request(&mut self, principal: Principal) {
         let current_time = ic_cdk::api::time();
-        
+
         // Record user request
         self.close_vault_requests
             .entry(principal)
             .or_insert_with(Vec::new)
             .push(current_time);
-            
+
         // Record global request. Wave-14c CDP-09: VecDeque, append to back.
         self.global_close_requests.push_back(current_time);
-        
+
         // Increment concurrent operations
         self.concurrent_close_operations += 1;
     }
-    
+
     pub fn complete_close_vault_request(&mut self) {
         // Decrement concurrent operations
         if self.concurrent_close_operations > 0 {
@@ -2131,11 +2333,7 @@ impl State {
     /// arbitrarily, including triggering the `rate < $0.01` ReadOnly latch
     /// (ORACLE-009). With the gate, an outlier needs N consecutive consistent
     /// confirmations before it's accepted.
-    pub fn check_price_sanity_band(
-        &mut self,
-        collateral_type: &Principal,
-        new_rate: f64,
-    ) -> bool {
+    pub fn check_price_sanity_band(&mut self, collateral_type: &Principal, new_rate: f64) -> bool {
         if !new_rate.is_finite() || new_rate <= 0.0 {
             return false;
         }
@@ -2171,9 +2369,7 @@ impl State {
         }
 
         let cand_ratio = new_rate / candidate;
-        if cand_ratio >= PRICE_SANITY_BAND_RATIO
-            && cand_ratio <= 1.0 / PRICE_SANITY_BAND_RATIO
-        {
+        if cand_ratio >= PRICE_SANITY_BAND_RATIO && cand_ratio <= 1.0 / PRICE_SANITY_BAND_RATIO {
             entry.1 = entry.1.saturating_add(1);
             if entry.1 >= PRICE_OUTLIER_CONFIRM_COUNT {
                 self.pending_outlier_prices.remove(collateral_type);
@@ -2279,8 +2475,7 @@ impl State {
         if total_debt == ICUSD::new(0) {
             return RECOVERY_COLLATERAL_RATIO;
         }
-        let total_debt_dec = Decimal::from_u64(total_debt.to_u64())
-            .unwrap_or(Decimal::ZERO);
+        let total_debt_dec = Decimal::from_u64(total_debt.to_u64()).unwrap_or(Decimal::ZERO);
 
         let mut weighted_sum = Decimal::ZERO;
         for (ct, config) in &self.collateral_configs {
@@ -2288,8 +2483,7 @@ impl State {
             if debt_i == ICUSD::new(0) {
                 continue;
             }
-            let debt_i_dec = Decimal::from_u64(debt_i.to_u64())
-                .unwrap_or(Decimal::ZERO);
+            let debt_i_dec = Decimal::from_u64(debt_i.to_u64()).unwrap_or(Decimal::ZERO);
             weighted_sum += (debt_i_dec / total_debt_dec) * config.borrow_threshold_ratio.0;
         }
 
@@ -2316,8 +2510,7 @@ impl State {
                 RECOVERY_COLLATERAL_RATIO * DEFAULT_HEALTHY_CR_MULTIPLIER,
             );
         }
-        let total_debt_dec = Decimal::from_u64(total_debt.to_u64())
-            .unwrap_or(Decimal::ZERO);
+        let total_debt_dec = Decimal::from_u64(total_debt.to_u64()).unwrap_or(Decimal::ZERO);
 
         let mut w_recovery = Decimal::ZERO;
         let mut w_warning = Decimal::ZERO;
@@ -2328,12 +2521,13 @@ impl State {
             if debt_i == ICUSD::new(0) {
                 continue;
             }
-            let weight = Decimal::from_u64(debt_i.to_u64())
-                .unwrap_or(Decimal::ZERO) / total_debt_dec;
+            let weight =
+                Decimal::from_u64(debt_i.to_u64()).unwrap_or(Decimal::ZERO) / total_debt_dec;
 
             let recovery_cr = config.borrow_threshold_ratio.0 * self.recovery_cr_multiplier.0;
             let warning_cr = recovery_cr + recovery_cr - config.borrow_threshold_ratio.0;
-            let healthy_cr = config.healthy_cr
+            let healthy_cr = config
+                .healthy_cr
                 .map(|h| h.0)
                 .unwrap_or(config.borrow_threshold_ratio.0 * DEFAULT_HEALTHY_CR_MULTIPLIER.0);
 
@@ -2342,7 +2536,11 @@ impl State {
             w_healthy += weight * healthy_cr;
         }
 
-        (Ratio::from(w_recovery), Ratio::from(w_warning), Ratio::from(w_healthy))
+        (
+            Ratio::from(w_recovery),
+            Ratio::from(w_warning),
+            Ratio::from(w_healthy),
+        )
     }
 
     pub fn get_redemption_fee(&self, redeemed_amount: ICUSD) -> Ratio {
@@ -2402,7 +2600,10 @@ impl State {
 
     /// Get a mutable reference to the collateral config.
     /// Resolves `Principal::anonymous()` to the ICP ledger.
-    pub fn get_collateral_config_mut(&mut self, ct: &CollateralType) -> Option<&mut CollateralConfig> {
+    pub fn get_collateral_config_mut(
+        &mut self,
+        ct: &CollateralType,
+    ) -> Option<&mut CollateralConfig> {
         let resolved = if ct == &Principal::anonymous() {
             self.icp_ledger_principal
         } else {
@@ -2438,7 +2639,7 @@ impl State {
             }
             // Verify price exists (needed for CR computation inside compute_collateral_ratio)
             match config.last_price {
-                Some(p) if p > 0.0 => { /* price is available */ },
+                Some(p) if p > 0.0 => { /* price is available */ }
                 _ => continue,
             };
 
@@ -2478,9 +2679,8 @@ impl State {
 
         // Sort: tier ascending, then worst health ascending (most vulnerable first)
         entries.sort_by(|a, b| {
-            a.0.cmp(&b.0).then_with(|| {
-                a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal)
-            })
+            a.0.cmp(&b.0)
+                .then_with(|| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
         });
 
         entries.into_iter().map(|(_, _, ct)| ct).collect()
@@ -2538,7 +2738,8 @@ impl State {
                     let first_mult = &resolved.first().unwrap().1;
                     let last_mult = &resolved.last().unwrap().1;
                     if last_mult.0 > first_mult.0 {
-                        return resolved.iter()
+                        return resolved
+                            .iter()
                             .max_by(|a, b| a.1 .0.cmp(&b.1 .0))
                             .map(|(_, m)| *m)
                             .unwrap_or(Ratio::new(dec!(1.0)));
@@ -2559,13 +2760,17 @@ impl State {
                 .or_else(|| config.map(|c| c.interest_rate_apr))
                 .unwrap_or(DEFAULT_INTEREST_RATE_APR);
         }
-        config.map(|c| c.interest_rate_apr).unwrap_or(DEFAULT_INTEREST_RATE_APR)
+        config
+            .map(|c| c.interest_rate_apr)
+            .unwrap_or(DEFAULT_INTEREST_RATE_APR)
     }
 
     /// Per-asset recovery CR = borrow_threshold_ratio × recovery_cr_multiplier.
     /// E.g., 150% × 1.0333 = 155%.
     pub fn get_recovery_cr_for(&self, ct: &CollateralType) -> Ratio {
-        let borrow_threshold = self.collateral_configs.get(ct)
+        let borrow_threshold = self
+            .collateral_configs
+            .get(ct)
             .map(|c| c.borrow_threshold_ratio)
             .unwrap_or(RECOVERY_COLLATERAL_RATIO);
         borrow_threshold * self.recovery_cr_multiplier
@@ -2574,7 +2779,9 @@ impl State {
     /// Per-asset warning CR = 2 * recovery_cr - borrow_threshold.
     /// E.g., 2 * 155% - 150% = 160%.
     pub fn get_warning_cr_for(&self, ct: &CollateralType) -> Ratio {
-        let borrow_threshold = self.collateral_configs.get(ct)
+        let borrow_threshold = self
+            .collateral_configs
+            .get(ct)
             .map(|c| c.borrow_threshold_ratio)
             .unwrap_or(RECOVERY_COLLATERAL_RATIO);
         let recovery_cr = borrow_threshold * self.recovery_cr_multiplier;
@@ -2621,12 +2828,12 @@ impl State {
             let lo = &resolved_markers[i];
             let hi = &resolved_markers[i + 1];
             if cr >= lo.0 && cr <= hi.0 {
-                let range = hi.0.0 - lo.0.0;
+                let range = hi.0 .0 - lo.0 .0;
                 if range == Decimal::ZERO {
                     return lo.1;
                 }
-                let t = (cr.0 - lo.0.0) / range;
-                let multiplier = lo.1.0 + t * (hi.1.0 - lo.1.0);
+                let t = (cr.0 - lo.0 .0) / range;
+                let multiplier = lo.1 .0 + t * (hi.1 .0 - lo.1 .0);
                 return Ratio::from(multiplier);
             }
         }
@@ -2643,7 +2850,9 @@ impl State {
 
         // If asset has a per-asset rate_curve, use it directly (markers already have concrete CRs)
         if let Some(curve) = config.and_then(|c| c.rate_curve.as_ref()) {
-            return curve.markers.iter()
+            return curve
+                .markers
+                .iter()
                 .map(|m| (m.cr_level, m.multiplier))
                 .collect();
         }
@@ -2663,21 +2872,28 @@ impl State {
         let cr_levels = [liq_ratio, borrow_threshold, warning_cr, healthy_cr];
         let markers = &self.global_rate_curve.markers;
 
-        let mut resolved: Vec<(Ratio, Ratio)> = markers.iter()
+        let mut resolved: Vec<(Ratio, Ratio)> = markers
+            .iter()
             .enumerate()
             .map(|(i, m)| {
-                let cr = if i < cr_levels.len() { cr_levels[i] } else { m.cr_level };
+                let cr = if i < cr_levels.len() {
+                    cr_levels[i]
+                } else {
+                    m.cr_level
+                };
                 (cr, m.multiplier)
             })
             .collect();
-        resolved.sort_by(|a, b| a.0.0.cmp(&b.0.0));
+        resolved.sort_by(|a, b| a.0 .0.cmp(&b.0 .0));
         resolved
     }
 
     /// Resolve Layer 2 recovery rate markers to concrete (cr_level, multiplier) pairs
     /// using the cached weighted average thresholds.
     fn resolve_layer2_markers(&self) -> Vec<(Ratio, Ratio)> {
-        let mut resolved: Vec<(Ratio, Ratio)> = self.recovery_rate_curve.iter()
+        let mut resolved: Vec<(Ratio, Ratio)> = self
+            .recovery_rate_curve
+            .iter()
             .map(|m| {
                 let cr = match m.threshold {
                     SystemThreshold::LiquidationRatio => self.compute_weighted_liquidation_ratio(),
@@ -2689,7 +2905,7 @@ impl State {
                 (cr, m.multiplier)
             })
             .collect();
-        resolved.sort_by(|a, b| a.0.0.cmp(&b.0.0));
+        resolved.sort_by(|a, b| a.0 .0.cmp(&b.0 .0));
         resolved
     }
 
@@ -2706,11 +2922,11 @@ impl State {
                 let ct = asset_context.expect("AssetThreshold requires asset context");
                 match t {
                     AssetThreshold::LiquidationRatio => self.get_liquidation_ratio_for(ct),
-                    AssetThreshold::BorrowThreshold => {
-                        self.collateral_configs.get(ct)
-                            .map(|c| c.borrow_threshold_ratio)
-                            .unwrap_or(RECOVERY_COLLATERAL_RATIO)
-                    }
+                    AssetThreshold::BorrowThreshold => self
+                        .collateral_configs
+                        .get(ct)
+                        .map(|c| c.borrow_threshold_ratio)
+                        .unwrap_or(RECOVERY_COLLATERAL_RATIO),
                     AssetThreshold::WarningCr => self.get_warning_cr_for(ct),
                     AssetThreshold::HealthyCr => self.get_healthy_cr_for(ct),
                 }
@@ -2748,8 +2964,15 @@ impl State {
         curve: &RateCurveV2,
         asset_context: Option<&CollateralType>,
     ) -> Vec<(Ratio, Ratio)> {
-        let mut resolved: Vec<(Ratio, Ratio)> = curve.markers.iter()
-            .map(|m| (self.resolve_anchor(&m.cr_anchor, asset_context), m.multiplier))
+        let mut resolved: Vec<(Ratio, Ratio)> = curve
+            .markers
+            .iter()
+            .map(|m| {
+                (
+                    self.resolve_anchor(&m.cr_anchor, asset_context),
+                    m.multiplier,
+                )
+            })
             .collect();
         resolved.sort_by(|a, b| a.0 .0.cmp(&b.0 .0));
         resolved
@@ -2761,16 +2984,15 @@ impl State {
         if total_debt == ICUSD::new(0) {
             return MINIMUM_COLLATERAL_RATIO;
         }
-        let total_debt_dec = Decimal::from_u64(total_debt.to_u64())
-            .unwrap_or(Decimal::ZERO);
+        let total_debt_dec = Decimal::from_u64(total_debt.to_u64()).unwrap_or(Decimal::ZERO);
         let mut weighted_sum = Decimal::ZERO;
         for (ct, config) in &self.collateral_configs {
             let debt_i = self.total_debt_for_collateral(ct);
             if debt_i == ICUSD::new(0) {
                 continue;
             }
-            let weight = Decimal::from_u64(debt_i.to_u64())
-                .unwrap_or(Decimal::ZERO) / total_debt_dec;
+            let weight =
+                Decimal::from_u64(debt_i.to_u64()).unwrap_or(Decimal::ZERO) / total_debt_dec;
             weighted_sum += weight * config.liquidation_ratio.0;
         }
         if weighted_sum == Decimal::ZERO {
@@ -2809,7 +3031,8 @@ impl State {
         // Layer 2: system-wide recovery multiplier (only in Recovery mode)
         if self.mode == Mode::Recovery {
             let layer2_markers = self.resolve_layer2_markers();
-            let layer2_mult = Self::interpolate_multiplier(&layer2_markers, self.total_collateral_ratio);
+            let layer2_mult =
+                Self::interpolate_multiplier(&layer2_markers, self.total_collateral_ratio);
             return layer1_rate * layer2_mult;
         }
 
@@ -2831,8 +3054,7 @@ impl State {
             let s: &State = &*self;
             match s.vault_id_to_vaults.get(&vault_id) {
                 Some(vault)
-                    if vault.borrowed_icusd_amount.0 > 0
-                        && vault.last_accrual_time < now_nanos =>
+                    if vault.borrowed_icusd_amount.0 > 0 && vault.last_accrual_time < now_nanos =>
                 {
                     let dummy_rate = s
                         .last_icp_rate
@@ -2894,13 +3116,10 @@ impl State {
                 .unwrap_or(UsdIcp::from(rust_decimal_macros::dec!(1.0)));
             s.vault_id_to_vaults
                 .iter()
-                .filter(|(_, v)| {
-                    v.borrowed_icusd_amount.0 > 0 && v.last_accrual_time < now_nanos
-                })
+                .filter(|(_, v)| v.borrowed_icusd_amount.0 > 0 && v.last_accrual_time < now_nanos)
                 .map(|(id, vault)| {
                     let cr = crate::compute_collateral_ratio(vault, dummy_rate, s);
-                    let rate =
-                        s.get_dynamic_interest_rate_for(&vault.collateral_type, cr);
+                    let rate = s.get_dynamic_interest_rate_for(&vault.collateral_type, cr);
                     let elapsed = now_nanos.saturating_sub(vault.last_accrual_time);
                     (*id, rate, elapsed)
                 })
@@ -3114,8 +3333,7 @@ impl State {
 
     /// Get the last known price for a collateral type (USD per 1 whole token)
     pub fn get_price_for(&self, ct: &CollateralType) -> Option<f64> {
-        self.get_collateral_config(ct)
-            .and_then(|c| c.last_price)
+        self.get_collateral_config(ct).and_then(|c| c.last_price)
     }
 
     /// Get the collateral's USD price as Decimal, or None.
@@ -3138,8 +3356,8 @@ impl State {
     /// - Recovery: `config.borrow_threshold_ratio` (e.g., 1.50) — recovery mode liquidates more aggressively
     pub fn get_min_liquidation_ratio_for(&self, ct: &CollateralType) -> Ratio {
         match self.mode {
-            Mode::Recovery => self.get_min_collateral_ratio_for(ct),     // borrow_threshold_ratio
-            _ => self.get_liquidation_ratio_for(ct),                      // liquidation_ratio
+            Mode::Recovery => self.get_min_collateral_ratio_for(ct), // borrow_threshold_ratio
+            _ => self.get_liquidation_ratio_for(ct),                 // liquidation_ratio
         }
     }
 
@@ -3294,9 +3512,10 @@ impl State {
             fresh.entry(vault.collateral_type).or_default().insert(*id);
         }
 
-        let in_index = |index: &BTreeMap<CollateralType, BTreeSet<u64>>,
-                        ct: &CollateralType,
-                        id: &u64| index.get(ct).is_some_and(|ids| ids.contains(id));
+        let in_index =
+            |index: &BTreeMap<CollateralType, BTreeSet<u64>>, ct: &CollateralType, id: &u64| {
+                index.get(ct).is_some_and(|ids| ids.contains(id))
+            };
         let stale_removed = self
             .collateral_to_vault_ids
             .iter()
@@ -3454,8 +3673,7 @@ impl State {
             Some(k) => *k,
             None => return false,
         };
-        let tolerance_bps = (self.liquidation_ordering_tolerance.0
-            * Decimal::from(10_000u64))
+        let tolerance_bps = (self.liquidation_ordering_tolerance.0 * Decimal::from(10_000u64))
             .to_u64()
             .unwrap_or(0);
         my_key.saturating_sub(bottom_key) <= tolerance_bps
@@ -3555,9 +3773,8 @@ impl State {
     /// liquidation paths still enforce.
     pub fn get_bot_claim_max_ratio_for(&self, ct: &CollateralType) -> Ratio {
         let base = self.get_min_liquidation_ratio_for(ct);
-        let tolerance = Ratio::from(
-            Decimal::from(self.bot_cr_tolerance_bps) / Decimal::from(10_000u64),
-        );
+        let tolerance =
+            Ratio::from(Decimal::from(self.bot_cr_tolerance_bps) / Decimal::from(10_000u64));
         base + tolerance
     }
 
@@ -3795,7 +4012,9 @@ impl State {
                     log!(
                         crate::INFO,
                         "[remove_margin_from_vault] clamp: vault #{} collateral {} < withdraw {}",
-                        vault_id, vault.collateral_amount, amount.to_u64()
+                        vault_id,
+                        vault.collateral_amount,
+                        amount.to_u64()
                     );
                 }
                 vault.collateral_amount = vault.collateral_amount.saturating_sub(amount.to_u64());
@@ -3818,25 +4037,28 @@ impl State {
                 // clamp instead of asserting so any residual drift degrades
                 // to a smaller applied repayment, never a trap-after-pull.
                 let repayed_amount = repayed_amount.min(vault.borrowed_icusd_amount);
-                let interest_share = if vault.accrued_interest.0 > 0 && vault.borrowed_icusd_amount.0 > 0 {
-                    let share = (rust_decimal::Decimal::from(repayed_amount.0)
-                        * rust_decimal::Decimal::from(vault.accrued_interest.0)
-                        / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                        .to_u64().unwrap_or(0);
-                    // INT-001: also cap by `repayed_amount` so the saturating
-                    // subtraction below cannot lose principal silently. The
-                    // deduct-side clamp keeps `accrued <= borrowed`, but defense
-                    // in depth here pins the property even on legacy state.
-                    ICUSD::new(share.min(vault.accrued_interest.0).min(repayed_amount.0))
-                } else {
-                    ICUSD::new(0)
-                };
+                let interest_share =
+                    if vault.accrued_interest.0 > 0 && vault.borrowed_icusd_amount.0 > 0 {
+                        let share = (rust_decimal::Decimal::from(repayed_amount.0)
+                            * rust_decimal::Decimal::from(vault.accrued_interest.0)
+                            / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
+                        .to_u64()
+                        .unwrap_or(0);
+                        // INT-001: also cap by `repayed_amount` so the saturating
+                        // subtraction below cannot lose principal silently. The
+                        // deduct-side clamp keeps `accrued <= borrowed`, but defense
+                        // in depth here pins the property even on legacy state.
+                        ICUSD::new(share.min(vault.accrued_interest.0).min(repayed_amount.0))
+                    } else {
+                        ICUSD::new(0)
+                    };
                 // INT-001: saturating subtraction so a stale `accrued > borrowed`
                 // state cannot panic the canister via `Token::Sub`. With the
                 // `.min(repayed_amount)` cap above this can never under-flow
                 // in practice, but the saturating form documents the contract.
                 let principal_share = repayed_amount.saturating_sub(interest_share);
-                vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(repayed_amount);
+                vault.borrowed_icusd_amount =
+                    vault.borrowed_icusd_amount.saturating_sub(repayed_amount);
                 vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_share);
                 (interest_share, principal_share)
             }
@@ -3898,30 +4120,35 @@ impl State {
     }
 
     pub fn get_provided_liquidity(&self, principal: Principal) -> ICUSD {
-        *self.liquidity_pool.get(&principal).unwrap_or(&ICUSD::from(0))
+        *self
+            .liquidity_pool
+            .get(&principal)
+            .unwrap_or(&ICUSD::from(0))
     }
 
     /// Compute the icUSD repayment needed to restore a vault's CR to recovery_target_cr.
     /// Returns None if not applicable (not in recovery, or vault CR outside the per-collateral
     /// liquidation_ratio..borrow_threshold_ratio range).
-    pub fn compute_recovery_repay_cap(&self, vault: &Vault, collateral_price: UsdIcp) -> Option<ICUSD> {
+    pub fn compute_recovery_repay_cap(
+        &self,
+        vault: &Vault,
+        collateral_price: UsdIcp,
+    ) -> Option<ICUSD> {
         if self.mode != Mode::Recovery {
             return None;
         }
         let vault_cr = compute_collateral_ratio(vault, collateral_price, self);
         let per_collateral_liq_ratio = self.get_liquidation_ratio_for(&vault.collateral_type);
-        let per_collateral_borrow_threshold = self.get_min_collateral_ratio_for(&vault.collateral_type);
+        let per_collateral_borrow_threshold =
+            self.get_min_collateral_ratio_for(&vault.collateral_type);
         if vault_cr <= per_collateral_liq_ratio || vault_cr >= per_collateral_borrow_threshold {
             return None;
         }
         let ct = &vault.collateral_type;
         let config = self.get_collateral_config(ct)?;
         let price = Decimal::from_f64(config.last_price?)?;
-        let collateral_value: ICUSD = crate::numeric::collateral_usd_value(
-            vault.collateral_amount,
-            price,
-            config.decimals,
-        );
+        let collateral_value: ICUSD =
+            crate::numeric::collateral_usd_value(vault.collateral_amount, price, config.decimals);
         let recovery_target = self.get_recovery_target_cr_for(ct);
         let liq_bonus = self.get_liquidation_bonus_for(ct);
         let numerator_icusd = vault.borrowed_icusd_amount * recovery_target;
@@ -3937,11 +4164,19 @@ impl State {
     /// Compute the max partial liquidation amount: enough to restore a vault's CR to
     /// recovery_target_cr. Works in all modes. Returns the full debt if the vault is
     /// so deeply undercollateralized that the formula exceeds 100%.
-    pub fn compute_partial_liquidation_cap(&self, vault: &Vault, _collateral_price: UsdIcp) -> ICUSD {
+    pub fn compute_partial_liquidation_cap(
+        &self,
+        vault: &Vault,
+        _collateral_price: UsdIcp,
+    ) -> ICUSD {
         let ct = &vault.collateral_type;
         let collateral_value: ICUSD = if let Some(config) = self.get_collateral_config(ct) {
             if let Some(price) = config.last_price.and_then(Decimal::from_f64) {
-                crate::numeric::collateral_usd_value(vault.collateral_amount, price, config.decimals)
+                crate::numeric::collateral_usd_value(
+                    vault.collateral_amount,
+                    price,
+                    config.decimals,
+                )
             } else {
                 // No price — conservatively return full debt (allows full liquidation)
                 return vault.borrowed_icusd_amount;
@@ -3990,8 +4225,7 @@ impl State {
         if self.protocol_deficit_icusd.0 == 0 || self.deficit_repayment_fraction.0.is_zero() {
             return ICUSD::new(0);
         }
-        let candidate_dec =
-            rust_decimal::Decimal::from(fee.0) * self.deficit_repayment_fraction.0;
+        let candidate_dec = rust_decimal::Decimal::from(fee.0) * self.deficit_repayment_fraction.0;
         let candidate_e8s = candidate_dec.to_u64().unwrap_or(0);
         let capped = candidate_e8s.min(self.protocol_deficit_icusd.0);
         ICUSD::new(capped)
@@ -4033,11 +4267,14 @@ impl State {
     /// collateral rollups. Pure read; no mutation. Cached by callers
     /// in `protocol_status_snapshot`.
     pub fn compute_protocol_status_snapshot(&self) -> ProtocolStatusSnapshot {
-        let total_icp_margin = ICP::from(self.total_collateral_for(&self.icp_ledger_principal)).to_u64();
+        let total_icp_margin =
+            ICP::from(self.total_collateral_for(&self.icp_ledger_principal)).to_u64();
         let total_icusd_borrowed = self.total_borrowed_icusd_amount().to_u64();
         let weighted_average_interest_rate = self.weighted_average_interest_rate().to_f64();
 
-        let per_collateral_interest: Vec<PerCollateralInterestSnap> = self.collateral_configs.keys()
+        let per_collateral_interest: Vec<PerCollateralInterestSnap> = self
+            .collateral_configs
+            .keys()
             .map(|ct| PerCollateralInterestSnap {
                 collateral_type: *ct,
                 total_debt_e8s: self.total_debt_for_collateral(ct).to_u64(),
@@ -4045,22 +4282,31 @@ impl State {
             })
             .collect();
 
-        let per_collateral_rate_curves: Vec<PerCollateralRateCurveSnap> = self.collateral_configs.keys()
+        let per_collateral_rate_curves: Vec<PerCollateralRateCurveSnap> = self
+            .collateral_configs
+            .keys()
             .map(|ct| {
                 let markers = self.resolve_layer1_markers(ct);
-                let base = self.collateral_configs.get(ct)
+                let base = self
+                    .collateral_configs
+                    .get(ct)
                     .map(|c| c.interest_rate_apr)
                     .unwrap_or(DEFAULT_INTEREST_RATE_APR);
                 PerCollateralRateCurveSnap {
                     collateral_type: *ct,
                     base_rate: base.to_f64(),
-                    markers: markers.iter().map(|(cr, m)| (cr.to_f64(), m.to_f64())).collect(),
+                    markers: markers
+                        .iter()
+                        .map(|(cr, m)| (cr.to_f64(), m.to_f64()))
+                        .collect(),
                 }
             })
             .collect();
 
         let borrowing_fee_curve_resolved: Vec<(f64, f64)> = match &self.borrowing_fee_curve {
-            Some(curve) => self.resolve_curve(curve, None).iter()
+            Some(curve) => self
+                .resolve_curve(curve, None)
+                .iter()
                 .map(|(cr, mult)| (cr.to_f64(), mult.to_f64()))
                 .collect(),
             None => vec![],
@@ -4082,7 +4328,9 @@ impl State {
     /// (sum across every vault); the rest of `TreasuryStats` is read
     /// fresh by the caller.
     pub fn compute_treasury_stats_snapshot(&self) -> TreasuryStatsSnapshot {
-        let total_accrued_interest_system = self.vault_id_to_vaults.values()
+        let total_accrued_interest_system = self
+            .vault_id_to_vaults
+            .values()
             .map(|v| v.accrued_interest.to_u64())
             .sum();
         TreasuryStatsSnapshot {
@@ -4135,7 +4383,12 @@ impl State {
 
     /// Liquidate a vault. Returns the interest share of the debt reduction
     /// so callers can route it to treasury.
-    pub fn liquidate_vault(&mut self, vault_id: u64, mode: Mode, collateral_price: UsdIcp) -> ICUSD {
+    pub fn liquidate_vault(
+        &mut self,
+        vault_id: u64,
+        mode: Mode,
+        collateral_price: UsdIcp,
+    ) -> ICUSD {
         // ASYNC-002 defense-in-depth: never trap on a missing vault. The
         // vault-level `vault::liquidate_vault` now presence-checks and refunds
         // the liquidator before reaching here, but a concurrent liquidation
@@ -4163,11 +4416,8 @@ impl State {
             };
             let decimals = config.decimals;
 
-            let collateral_value: ICUSD = crate::numeric::collateral_usd_value(
-                vault.collateral_amount,
-                price,
-                decimals,
-            );
+            let collateral_value: ICUSD =
+                crate::numeric::collateral_usd_value(vault.collateral_amount, price, decimals);
             let recovery_target = self.get_recovery_target_cr_for(&ct);
             let liq_bonus = self.get_liquidation_bonus_for(&ct);
             let numerator_icusd = vault.borrowed_icusd_amount * recovery_target;
@@ -4182,25 +4432,29 @@ impl State {
 
             // Collateral seized = icusd_to_collateral_amount(repay_amount * bonus)
             let repay_with_bonus: ICUSD = repay_amount * liq_bonus;
-            let collateral_seized = crate::numeric::icusd_to_collateral_amount(
-                repay_with_bonus,
-                price,
-                decimals,
-            ).min(vault.collateral_amount);
+            let collateral_seized =
+                crate::numeric::icusd_to_collateral_amount(repay_with_bonus, price, decimals)
+                    .min(vault.collateral_amount);
 
             let interest_share = match self.vault_id_to_vaults.get_mut(&vault_id) {
                 Some(vault) => {
                     // Compute interest share proportionally before reducing debt
-                    let interest_share = if vault.accrued_interest.0 > 0 && vault.borrowed_icusd_amount.0 > 0 {
-                        let share = (rust_decimal::Decimal::from(repay_amount.0)
-                            * rust_decimal::Decimal::from(vault.accrued_interest.0)
-                            / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                            .to_u64().unwrap_or(0);
-                        ICUSD::new(share.min(vault.accrued_interest.0))
-                    } else { ICUSD::new(0) };
+                    let interest_share =
+                        if vault.accrued_interest.0 > 0 && vault.borrowed_icusd_amount.0 > 0 {
+                            let share = (rust_decimal::Decimal::from(repay_amount.0)
+                                * rust_decimal::Decimal::from(vault.accrued_interest.0)
+                                / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
+                            .to_u64()
+                            .unwrap_or(0);
+                            ICUSD::new(share.min(vault.accrued_interest.0))
+                        } else {
+                            ICUSD::new(0)
+                        };
 
-                    vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(repay_amount);
-                    vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_seized);
+                    vault.borrowed_icusd_amount =
+                        vault.borrowed_icusd_amount.saturating_sub(repay_amount);
+                    vault.collateral_amount =
+                        vault.collateral_amount.saturating_sub(collateral_seized);
                     vault.accrued_interest = vault.accrued_interest.saturating_sub(interest_share);
                     interest_share
                 }
@@ -4219,7 +4473,6 @@ impl State {
         }
     }
 
-        
     pub fn redistribute_vault(&mut self, vault_id: u64) {
         let vault = self
             .vault_id_to_vaults
@@ -4244,7 +4497,7 @@ impl State {
             self.reindex_vault_cr(tid);
         }
     }
-    
+
     /// Water-filling redemption: spread redemptions across vaults to equalize CR.
     ///
     /// Instead of draining the lowest-CR vault completely, this algorithm raises
@@ -4268,7 +4521,8 @@ impl State {
         // so fall back to the price stored in the event (passed as collateral_price).
         let (price, decimals) = match self.get_collateral_config(collateral_type) {
             Some(config) => {
-                let p = config.last_price
+                let p = config
+                    .last_price
                     .and_then(Decimal::from_f64)
                     .unwrap_or(collateral_price.0);
                 (p, config.decimals)
@@ -4337,10 +4591,19 @@ impl State {
 
             // Compute total debt in the current band
             let band_vault_ids: Vec<VaultId> = vault_entries[band_start..band_end]
-                .iter().map(|(_, id)| *id).collect();
-            let band_debts: Vec<u128> = band_vault_ids.iter().map(|id| {
-                self.vault_id_to_vaults.get(id).unwrap().borrowed_icusd_amount.to_u64() as u128
-            }).collect();
+                .iter()
+                .map(|(_, id)| *id)
+                .collect();
+            let band_debts: Vec<u128> = band_vault_ids
+                .iter()
+                .map(|id| {
+                    self.vault_id_to_vaults
+                        .get(id)
+                        .unwrap()
+                        .borrowed_icusd_amount
+                        .to_u64() as u128
+                })
+                .collect();
             let total_band_debt: u128 = band_debts.iter().sum();
 
             if total_band_debt == 0 {
@@ -4351,8 +4614,13 @@ impl State {
             if band_end >= vault_entries.len() {
                 // No next tier — distribute all remaining proportionally across band
                 self.distribute_redemption_across_band(
-                    &band_vault_ids, &band_debts, total_band_debt,
-                    remaining, price, decimals, &mut results,
+                    &band_vault_ids,
+                    &band_debts,
+                    total_band_debt,
+                    remaining,
+                    price,
+                    decimals,
+                    &mut results,
                 );
                 break;
             }
@@ -4365,8 +4633,13 @@ impl State {
             if cr_denom <= Decimal::ZERO {
                 // Safety: if next CR <= 1, just drain proportionally
                 self.distribute_redemption_across_band(
-                    &band_vault_ids, &band_debts, total_band_debt,
-                    remaining, price, decimals, &mut results,
+                    &band_vault_ids,
+                    &band_debts,
+                    total_band_debt,
+                    remaining,
+                    price,
+                    decimals,
+                    &mut results,
                 );
                 break;
             }
@@ -4378,8 +4651,13 @@ impl State {
             if remaining >= total_needed && total_needed > 0 {
                 // Level up the entire band
                 self.distribute_redemption_across_band(
-                    &band_vault_ids, &band_debts, total_band_debt,
-                    total_needed, price, decimals, &mut results,
+                    &band_vault_ids,
+                    &band_debts,
+                    total_band_debt,
+                    total_needed,
+                    price,
+                    decimals,
+                    &mut results,
                 );
                 remaining -= total_needed;
 
@@ -4395,8 +4673,13 @@ impl State {
             } else {
                 // Can't reach next tier. Distribute remaining proportionally.
                 self.distribute_redemption_across_band(
-                    &band_vault_ids, &band_debts, total_band_debt,
-                    remaining, price, decimals, &mut results,
+                    &band_vault_ids,
+                    &band_debts,
+                    total_band_debt,
+                    remaining,
+                    price,
+                    decimals,
+                    &mut results,
                 );
                 break;
             }
@@ -4442,11 +4725,8 @@ impl State {
             let actual_share = share.min(max_share);
 
             let icusd_to_deduct = ICUSD::from(actual_share as u64);
-            let collateral_to_deduct = crate::numeric::icusd_to_collateral_amount(
-                icusd_to_deduct,
-                price,
-                decimals,
-            );
+            let collateral_to_deduct =
+                crate::numeric::icusd_to_collateral_amount(icusd_to_deduct, price, decimals);
             // Wave-9 RED-002: capture the actual collateral seized (post
             // saturating-sub). For solvent vaults this equals
             // `collateral_to_deduct`; for underwater vaults the
@@ -4545,9 +4825,12 @@ impl State {
                 // Use saturating arithmetic: during event replay, interest
                 // drift can inflate debt/collateral values, causing the
                 // deduction to exceed the vault's balance.
-                vault.borrowed_icusd_amount = vault.borrowed_icusd_amount.saturating_sub(icusd_amount_to_deduct);
+                vault.borrowed_icusd_amount = vault
+                    .borrowed_icusd_amount
+                    .saturating_sub(icusd_amount_to_deduct);
                 let pre_collateral = vault.collateral_amount;
-                vault.collateral_amount = vault.collateral_amount.saturating_sub(collateral_to_deduct);
+                vault.collateral_amount =
+                    vault.collateral_amount.saturating_sub(collateral_to_deduct);
                 let actual = pre_collateral.saturating_sub(vault.collateral_amount);
                 // INT-001: redemption can shrink `borrowed_icusd_amount` below
                 // `accrued_interest`, breaking the invariant that drives the
@@ -4689,7 +4972,7 @@ impl State {
             *state = OperationState::Failed;
         }
     }
-    
+
     // clean_stale_operations REMOVED — it contained a dangerous Recovery→GA auto-reset
     // that could silently exit Recovery mode based on a timeout. Mode transitions are now
     // handled exclusively by update_mode() (automatic, based on collateral ratio) or by
@@ -4746,7 +5029,7 @@ pub(crate) fn distribute_across_vaults(
             .iter()
             .filter(|&(&vault_id, _vault)| vault_id != target_vault_id)
             .map(|(_vault_id, vault)| vault.collateral_amount)
-            .sum::<u64>()
+            .sum::<u64>(),
     );
     assert_ne!(total_icp_margin, ICP::new(0));
 
@@ -4778,7 +5061,6 @@ pub(crate) fn distribute_across_vaults(
     result
 }
 
-
 pub fn compute_redemption_fee(
     elapsed_hours: u64,
     redeemed_amount: ICUSD,
@@ -4801,12 +5083,8 @@ pub fn compute_redemption_fee(
     let rate = current_base_rate * DECAY_FACTOR.pow(elapsed_hours);
     let total_rate = rate + redeemed_amount / total_borrowed_icusd_amount * REEDEMED_PROPORTION;
     debug_assert!(total_rate < Ratio::from(dec!(1.0)));
-    total_rate
-        .max(fee_floor)
-        .min(fee_ceiling)
+    total_rate.max(fee_floor).min(fee_ceiling)
 }
-
-
 
 pub fn mutate_state<F, R>(f: F) -> R
 where
@@ -4832,8 +5110,6 @@ pub fn replace_state(state: State) {
     });
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4855,15 +5131,27 @@ mod tests {
 
         // ICP vault: CR = 1.50, liq_ratio = 1.33 → health = 1.50 / 1.33 ≈ 1.1278
         let health = vault.health_score(1.50, 1.33);
-        assert!((health - 1.1278).abs() < 0.001, "Expected ~1.1278, got {}", health);
+        assert!(
+            (health - 1.1278).abs() < 0.001,
+            "Expected ~1.1278, got {}",
+            health
+        );
 
         // ckBTC vault: CR = 1.25, liq_ratio = 1.15 → health = 1.25 / 1.15 ≈ 1.0870
         let health2 = vault.health_score(1.25, 1.15);
-        assert!((health2 - 1.0870).abs() < 0.001, "Expected ~1.0870, got {}", health2);
+        assert!(
+            (health2 - 1.0870).abs() < 0.001,
+            "Expected ~1.0870, got {}",
+            health2
+        );
 
         // At exact liquidation threshold: health = 1.0
         let health3 = vault.health_score(1.33, 1.33);
-        assert!((health3 - 1.0).abs() < 0.0001, "Expected 1.0, got {}", health3);
+        assert!(
+            (health3 - 1.0).abs() < 0.0001,
+            "Expected 1.0, got {}",
+            health3
+        );
 
         // Zero-debt vault: should return f64::MAX (infinite health)
         let zero_debt_vault = Vault {
@@ -4871,27 +5159,31 @@ mod tests {
             ..vault.clone()
         };
         let health4 = zero_debt_vault.health_score(1.50, 1.33);
-        assert!(health4 > 1_000_000.0, "Zero-debt vault should have very high health score");
+        assert!(
+            health4 > 1_000_000.0,
+            "Zero-debt vault should have very high health score"
+        );
     }
 
     #[test]
     fn test_tiered_redemption_ordering() {
         // Verify sort logic: tier ascending, then health score ascending
         let mut entries: Vec<(u8, f64, u64)> = vec![
-            (2, 1.05, 10),  // tier 2, low health
-            (1, 1.20, 20),  // tier 1, moderate health
-            (1, 1.08, 30),  // tier 1, low health
-            (3, 1.01, 40),  // tier 3, very low health
-            (1, 1.15, 50),  // tier 1, moderate health
+            (2, 1.05, 10), // tier 2, low health
+            (1, 1.20, 20), // tier 1, moderate health
+            (1, 1.08, 30), // tier 1, low health
+            (3, 1.01, 40), // tier 3, very low health
+            (1, 1.15, 50), // tier 1, moderate health
         ];
 
-        entries.sort_by(|a, b| {
-            a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap())
-        });
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap()));
 
         let order: Vec<u64> = entries.iter().map(|e| e.2).collect();
-        assert_eq!(order, vec![30, 50, 20, 10, 40],
-            "Expected tier-1 vaults first (health-sorted), then tier-2, then tier-3");
+        assert_eq!(
+            order,
+            vec![30, 50, 20, 10, 40],
+            "Expected tier-1 vaults first (health-sorted), then tier-2, then tier-3"
+        );
     }
 
     #[test]
@@ -4905,7 +5197,7 @@ mod tests {
         state.open_vault(crate::vault::Vault {
             owner: Principal::anonymous(),
             vault_id: 1,
-            collateral_amount: 500_000_000, // 5 ICP
+            collateral_amount: 500_000_000,                 // 5 ICP
             borrowed_icusd_amount: ICUSD::new(300_000_000), // 3 icUSD
             collateral_type: icp_ct,
             last_accrual_time: 0,
@@ -4915,7 +5207,7 @@ mod tests {
         state.open_vault(crate::vault::Vault {
             owner: Principal::anonymous(),
             vault_id: 2,
-            collateral_amount: 800_000_000, // 8 ICP
+            collateral_amount: 800_000_000,                 // 8 ICP
             borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
             collateral_type: icp_ct,
             last_accrual_time: 0,
@@ -4998,8 +5290,7 @@ mod tests {
         // Repay all 5M residual; pre-fix this panics with `underflow` in
         // `Token::Sub`. Post-fix the saturating subtraction zeroes the
         // principal share without panicking.
-        let (interest_share, principal_share) =
-            state.repay_to_vault(1, ICUSD::new(5_000_000));
+        let (interest_share, principal_share) = state.repay_to_vault(1, ICUSD::new(5_000_000));
 
         assert_eq!(interest_share, ICUSD::new(5_000_000));
         assert_eq!(principal_share, ICUSD::new(0));
@@ -5076,7 +5367,7 @@ mod tests {
         state.open_vault(Vault {
             owner,
             vault_id,
-            collateral_amount: 1_000_000, // 0.01 ICP
+            collateral_amount: 1_000_000,                   // 0.01 ICP
             borrowed_icusd_amount: ICUSD::new(200_000_000), // 2 icUSD
             collateral_type: Principal::anonymous(),
             last_accrual_time: 0,
@@ -5098,28 +5389,40 @@ mod tests {
         let mut state = accrual_test_state();
         let icp = state.icp_ledger_principal;
 
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000,
-            borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD total
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(100_000_000), // 1 icUSD is interest
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000,
+                borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD total
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(100_000_000), // 1 icUSD is interest
+                bot_processing: false,
+            },
+        );
 
         let (interest_share, principal_share) = state.repay_to_vault(1, ICUSD::new(250_000_000));
 
         let vault = state.vault_id_to_vaults.get(&1).unwrap();
         assert_eq!(vault.borrowed_icusd_amount.0, 250_000_000);
         // 100/500 = 20% is interest, so 20% of 250M = 50M
-        assert_eq!(interest_share.0, 50_000_000,
-            "interest share of repayment should be 50M, got {}", interest_share.0);
-        assert_eq!(principal_share.0, 200_000_000,
-            "principal share should be 200M, got {}", principal_share.0);
-        assert_eq!(vault.accrued_interest.0, 50_000_000,
-            "remaining accrued_interest should be 50M, got {}", vault.accrued_interest.0);
+        assert_eq!(
+            interest_share.0, 50_000_000,
+            "interest share of repayment should be 50M, got {}",
+            interest_share.0
+        );
+        assert_eq!(
+            principal_share.0, 200_000_000,
+            "principal share should be 200M, got {}",
+            principal_share.0
+        );
+        assert_eq!(
+            vault.accrued_interest.0, 50_000_000,
+            "remaining accrued_interest should be 50M, got {}",
+            vault.accrued_interest.0
+        );
     }
 
     // Pre-existing test failure: this test exercises a code path that calls
@@ -5146,9 +5449,18 @@ mod tests {
             bot_processing: false,
         });
 
-        crate::event::record_borrow_from_vault(&mut state, 1, ICUSD::new(100_000_000), ICUSD::new(500_000), 0);
-        assert_eq!(state.get_provided_liquidity(dev).0, 0,
-            "Borrowing fee should NOT go to developer liquidity pool");
+        crate::event::record_borrow_from_vault(
+            &mut state,
+            1,
+            ICUSD::new(100_000_000),
+            ICUSD::new(500_000),
+            0,
+        );
+        assert_eq!(
+            state.get_provided_liquidity(dev).0,
+            0,
+            "Borrowing fee should NOT go to developer liquidity pool"
+        );
     }
 
     #[test]
@@ -5194,8 +5506,11 @@ mod tests {
             let vault = s.vault_id_to_vaults.get(&vault_id).unwrap();
             compute_collateral_ratio(vault, collateral_price, s)
         });
-        assert!(cr_before.to_f64() > 1.33 && cr_before.to_f64() < 1.50,
-            "CR before should be between 133% and 150%, got {}", cr_before.to_f64());
+        assert!(
+            cr_before.to_f64() > 1.33 && cr_before.to_f64() < 1.50,
+            "CR before should be between 133% and 150%, got {}",
+            cr_before.to_f64()
+        );
 
         // Execute protocol's recovery liquidation logic
         mutate_state(|s| s.liquidate_vault(vault_id, s.mode, collateral_price));
@@ -5206,14 +5521,22 @@ mod tests {
         // - CR should be approximately 1.55 (recovery_target_cr)
         let (borrowed_amount, cr_after) = read_state(|s| {
             let vault = s.vault_id_to_vaults.get(&vault_id).unwrap();
-            (vault.borrowed_icusd_amount, compute_collateral_ratio(vault, collateral_price, s))
+            (
+                vault.borrowed_icusd_amount,
+                compute_collateral_ratio(vault, collateral_price, s),
+            )
         });
-        assert!(borrowed_amount > ICUSD::new(0),
-            "Debt should not be zero after targeted recovery liquidation");
+        assert!(
+            borrowed_amount > ICUSD::new(0),
+            "Debt should not be zero after targeted recovery liquidation"
+        );
 
         let cr_f64 = cr_after.to_f64();
-        assert!(cr_f64 > 1.54 && cr_f64 < 1.56,
-            "CR after should be approximately 1.55 (155%), got {:.4}", cr_f64);
+        assert!(
+            cr_f64 > 1.54 && cr_f64 < 1.56,
+            "CR after should be approximately 1.55 (155%), got {:.4}",
+            cr_f64
+        );
     }
 
     // --- Dynamic Interest Rate Tests ---
@@ -5257,15 +5580,21 @@ mod tests {
         ];
         // Midpoint between 150% and 160% => t=0.5 => 2.5 - 0.5*(2.5-1.75) = 2.125
         let m = State::interpolate_multiplier(&markers, Ratio::from_f64(1.55));
-        assert!((m.to_f64() - 2.125).abs() < 0.001,
-            "Expected 2.125, got {}", m.to_f64());
+        assert!(
+            (m.to_f64() - 2.125).abs() < 0.001,
+            "Expected 2.125, got {}",
+            m.to_f64()
+        );
     }
 
     #[test]
     fn test_interpolate_multiplier_empty_markers() {
         let markers: Vec<(Ratio, Ratio)> = vec![];
         let m = State::interpolate_multiplier(&markers, Ratio::from_f64(1.5));
-        assert!((m.to_f64() - 1.0).abs() < 0.001, "Empty markers should return 1.0x");
+        assert!(
+            (m.to_f64() - 1.0).abs() < 0.001,
+            "Empty markers should return 1.0x"
+        );
     }
 
     #[test]
@@ -5286,18 +5615,27 @@ mod tests {
         // ICP: borrow_threshold=1.5, multiplier=1.0333
         // recovery_cr = 1.5 * 1.0333 ≈ 1.55
         let recovery_cr = state.get_recovery_cr_for(&icp);
-        assert!((recovery_cr.to_f64() - 1.55).abs() < 0.001,
-            "Expected recovery_cr 1.55, got {}", recovery_cr.to_f64());
+        assert!(
+            (recovery_cr.to_f64() - 1.55).abs() < 0.001,
+            "Expected recovery_cr 1.55, got {}",
+            recovery_cr.to_f64()
+        );
 
         // warning_cr = 2 * 1.55 - 1.5 = 1.6
         let warning_cr = state.get_warning_cr_for(&icp);
-        assert!((warning_cr.to_f64() - 1.60).abs() < 0.001,
-            "Expected warning_cr 1.60, got {}", warning_cr.to_f64());
+        assert!(
+            (warning_cr.to_f64() - 1.60).abs() < 0.001,
+            "Expected warning_cr 1.60, got {}",
+            warning_cr.to_f64()
+        );
 
         // healthy_cr = 1.5 * 1.5 = 2.25
         let healthy_cr = state.get_healthy_cr_for(&icp);
-        assert!((healthy_cr.to_f64() - 2.25).abs() < 0.001,
-            "Expected healthy_cr 2.25, got {}", healthy_cr.to_f64());
+        assert!(
+            (healthy_cr.to_f64() - 2.25).abs() < 0.001,
+            "Expected healthy_cr 2.25, got {}",
+            healthy_cr.to_f64()
+        );
     }
 
     #[test]
@@ -5318,8 +5656,12 @@ mod tests {
         // A vault at 300% CR (well above healthy 225%) → multiplier = 1.0x
         let rate = state.get_dynamic_interest_rate_for(&icp, Ratio::from_f64(3.0));
         let base = DEFAULT_INTEREST_RATE_APR.to_f64();
-        assert!((rate.to_f64() - base).abs() < 0.0001,
-            "Healthy vault should get base rate {}, got {}", base, rate.to_f64());
+        assert!(
+            (rate.to_f64() - base).abs() < 0.0001,
+            "Healthy vault should get base rate {}, got {}",
+            base,
+            rate.to_f64()
+        );
     }
 
     #[test]
@@ -5341,8 +5683,12 @@ mod tests {
         // Expected: interpolation between 2.5x and 1.75x at t=0.5 => 2.125x
         let rate = state.get_dynamic_interest_rate_for(&icp, Ratio::from_f64(1.55));
         let expected = DEFAULT_INTEREST_RATE_APR.to_f64() * 2.125;
-        assert!((rate.to_f64() - expected).abs() < 0.001,
-            "Expected rate {}, got {}", expected, rate.to_f64());
+        assert!(
+            (rate.to_f64() - expected).abs() < 0.001,
+            "Expected rate {}, got {}",
+            expected,
+            rate.to_f64()
+        );
     }
 
     #[test]
@@ -5363,8 +5709,12 @@ mod tests {
         // Vault at exactly liquidation_ratio (133%) → 5.0x multiplier
         let rate = state.get_dynamic_interest_rate_for(&icp, Ratio::from_f64(1.33));
         let expected = DEFAULT_INTEREST_RATE_APR.to_f64() * 5.0;
-        assert!((rate.to_f64() - expected).abs() < 0.001,
-            "Expected rate {}, got {}", expected, rate.to_f64());
+        assert!(
+            (rate.to_f64() - expected).abs() < 0.001,
+            "Expected rate {}, got {}",
+            expected,
+            rate.to_f64()
+        );
     }
 
     #[test]
@@ -5390,8 +5740,11 @@ mod tests {
 
         // Should return the static override regardless of vault CR
         let rate = state.get_dynamic_interest_rate_for(&icp, Ratio::from_f64(3.0));
-        assert!((rate.to_f64() - 0.10).abs() < 0.001,
-            "Expected static override 0.10, got {}", rate.to_f64());
+        assert!(
+            (rate.to_f64() - 0.10).abs() < 0.001,
+            "Expected static override 0.10, got {}",
+            rate.to_f64()
+        );
     }
 
     // --- Interest Accrual Tests ---
@@ -5431,7 +5784,7 @@ mod tests {
         let vault = Vault {
             owner: Principal::anonymous(),
             vault_id: 1,
-            collateral_amount: 150_000_000, // 1.5 ICP
+            collateral_amount: 150_000_000,                 // 1.5 ICP
             borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
             collateral_type: icp,
             last_accrual_time: 0, // t=0
@@ -5449,12 +5802,17 @@ mod tests {
         // rate = 5% × 1.0 = 5%
         // After 1 year: debt = 500_000_000 × 1.05 = 525_000_000, plus at most
         // one e8s unit of DBT-001 ceil rounding (protocol favor).
-        assert!((525_000_000..=525_000_001).contains(&vault_after.borrowed_icusd_amount.0),
+        assert!(
+            (525_000_000..=525_000_001).contains(&vault_after.borrowed_icusd_amount.0),
             "After 1 year at 5%, 500M should become 525M (+<=1 ceil unit), got {}",
-            vault_after.borrowed_icusd_amount.0);
+            vault_after.borrowed_icusd_amount.0
+        );
         assert_eq!(vault_after.last_accrual_time, one_year_nanos);
-        assert!((25_000_000..=25_000_001).contains(&vault_after.accrued_interest.0),
-            "accrued_interest should track the 25M delta (+<=1 ceil unit), got {}", vault_after.accrued_interest.0);
+        assert!(
+            (25_000_000..=25_000_001).contains(&vault_after.accrued_interest.0),
+            "accrued_interest should track the 25M delta (+<=1 ceil unit), got {}",
+            vault_after.accrued_interest.0
+        );
     }
 
     #[test]
@@ -5463,16 +5821,19 @@ mod tests {
         let icp = state.icp_ledger_principal;
 
         // Start with some pre-existing accrued interest
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000, // 1.5 ICP
-            borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(10_000_000), // 0.1 icUSD pre-existing
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000, // 1.5 ICP
+                borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(10_000_000), // 0.1 icUSD pre-existing
+                bot_processing: false,
+            },
+        );
 
         state.accrue_single_vault(1, crate::numeric::NANOS_PER_YEAR);
 
@@ -5480,8 +5841,11 @@ mod tests {
         // DBT-001: ceil rounding may add one e8s unit (protocol favor).
         assert!((525_000_000..=525_000_001).contains(&vault.borrowed_icusd_amount.0));
         // 10M pre-existing + 25M new delta = 35M (+<=1 ceil unit)
-        assert!((35_000_000..=35_000_001).contains(&vault.accrued_interest.0),
-            "accrued_interest should be 10M + 25M = 35M (+<=1), got {}", vault.accrued_interest.0);
+        assert!(
+            (35_000_000..=35_000_001).contains(&vault.accrued_interest.0),
+            "accrued_interest should be 10M + 25M = 35M (+<=1), got {}",
+            vault.accrued_interest.0
+        );
     }
 
     #[test]
@@ -5538,40 +5902,49 @@ mod tests {
         let icp = state.icp_ledger_principal;
 
         // Vault 1: 1.5 ICP, 5 icUSD → CR = 300% (above healthy 225%)
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000,
-            borrowed_icusd_amount: ICUSD::new(500_000_000),
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000,
+                borrowed_icusd_amount: ICUSD::new(500_000_000),
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
         // Vault 2: 2 ICP, 5 icUSD → CR = 400% (above healthy 225%)
-        state.vault_id_to_vaults.insert(2, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 2,
-            collateral_amount: 200_000_000,
-            borrowed_icusd_amount: ICUSD::new(500_000_000),
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            2,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 2,
+                collateral_amount: 200_000_000,
+                borrowed_icusd_amount: ICUSD::new(500_000_000),
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
         // Vault 3: zero debt (should be skipped)
-        state.vault_id_to_vaults.insert(3, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 3,
-            collateral_amount: 100_000_000,
-            borrowed_icusd_amount: ICUSD::new(0),
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            3,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 3,
+                collateral_amount: 100_000_000,
+                borrowed_icusd_amount: ICUSD::new(0),
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
         let one_year = crate::numeric::NANOS_PER_YEAR;
         state.accrue_all_vault_interest(one_year);
@@ -5579,14 +5952,20 @@ mod tests {
         // Vault 1 (300% CR, above healthy): multiplier = 1.0x, rate = 5%
         // DBT-001: ceil rounding may add one e8s unit (protocol favor).
         let v1 = state.vault_id_to_vaults.get(&1).unwrap();
-        assert!((525_000_000..=525_000_001).contains(&v1.borrowed_icusd_amount.0),
-            "Vault 1 expected ~525M (+<=1 ceil unit), got {}", v1.borrowed_icusd_amount.0);
+        assert!(
+            (525_000_000..=525_000_001).contains(&v1.borrowed_icusd_amount.0),
+            "Vault 1 expected ~525M (+<=1 ceil unit), got {}",
+            v1.borrowed_icusd_amount.0
+        );
         assert_eq!(v1.last_accrual_time, one_year);
 
         // Vault 2 (400% CR, well above healthy): multiplier = 1.0x, rate = 5%
         let v2 = state.vault_id_to_vaults.get(&2).unwrap();
-        assert!((525_000_000..=525_000_001).contains(&v2.borrowed_icusd_amount.0),
-            "Vault 2 expected ~525M (+<=1 ceil unit), got {}", v2.borrowed_icusd_amount.0);
+        assert!(
+            (525_000_000..=525_000_001).contains(&v2.borrowed_icusd_amount.0),
+            "Vault 2 expected ~525M (+<=1 ceil unit), got {}",
+            v2.borrowed_icusd_amount.0
+        );
         assert_eq!(v2.last_accrual_time, one_year);
 
         // Vault 3 (zero debt): unchanged
@@ -5601,16 +5980,19 @@ mod tests {
         let icp = state.icp_ledger_principal;
 
         // 1.5 ICP, 5 icUSD debt → CR = 300% (above healthy) → multiplier 1.0x
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000,
-            borrowed_icusd_amount: ICUSD::new(500_000_000),
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000,
+                borrowed_icusd_amount: ICUSD::new(500_000_000),
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
         // 300 seconds in nanos
         let tick = 300_000_000_000u64;
@@ -5624,10 +6006,16 @@ mod tests {
         // ≈ 1.00000047565
         // new_debt = 500_000_000 * 1.00000047565 ≈ 500_000_237
         // With u64 truncation it should be 500_000_237 or close
-        assert!(v.borrowed_icusd_amount.0 > 500_000_000,
-            "Debt should increase after 300s tick, got {}", v.borrowed_icusd_amount.0);
-        assert!(v.borrowed_icusd_amount.0 < 500_001_000,
-            "Debt increase should be small for 300s, got {}", v.borrowed_icusd_amount.0);
+        assert!(
+            v.borrowed_icusd_amount.0 > 500_000_000,
+            "Debt should increase after 300s tick, got {}",
+            v.borrowed_icusd_amount.0
+        );
+        assert!(
+            v.borrowed_icusd_amount.0 < 500_001_000,
+            "Debt increase should be small for 300s, got {}",
+            v.borrowed_icusd_amount.0
+        );
         assert_eq!(v.last_accrual_time, tick);
     }
 
@@ -5640,41 +6028,68 @@ mod tests {
         let start = 1_000_000_000_000u64; // 1 trillion nanos
 
         // Vault with 1.5 ICP ($15), 5 icUSD debt → CR = 300% (healthy)
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000,
-            borrowed_icusd_amount: ICUSD::new(500_000_000),
-            collateral_type: icp,
-            last_accrual_time: start,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000,
+                borrowed_icusd_amount: ICUSD::new(500_000_000),
+                collateral_type: icp,
+                last_accrual_time: start,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
-        let initial_debt = state.vault_id_to_vaults.get(&1).unwrap().borrowed_icusd_amount;
+        let initial_debt = state
+            .vault_id_to_vaults
+            .get(&1)
+            .unwrap()
+            .borrowed_icusd_amount;
 
         // Simulate timer tick: 300 seconds later
         let tick1 = start + 300 * 1_000_000_000;
         state.accrue_all_vault_interest(tick1);
 
-        let debt_after_tick1 = state.vault_id_to_vaults.get(&1).unwrap().borrowed_icusd_amount;
-        assert!(debt_after_tick1 > initial_debt,
-            "Debt should increase after first tick: {} > {}", debt_after_tick1.0, initial_debt.0);
+        let debt_after_tick1 = state
+            .vault_id_to_vaults
+            .get(&1)
+            .unwrap()
+            .borrowed_icusd_amount;
+        assert!(
+            debt_after_tick1 > initial_debt,
+            "Debt should increase after first tick: {} > {}",
+            debt_after_tick1.0,
+            initial_debt.0
+        );
 
         // Simulate second timer tick: another 300 seconds
         let tick2 = tick1 + 300 * 1_000_000_000;
         state.accrue_all_vault_interest(tick2);
 
-        let debt_after_tick2 = state.vault_id_to_vaults.get(&1).unwrap().borrowed_icusd_amount;
-        assert!(debt_after_tick2 > debt_after_tick1,
-            "Debt should increase after second tick: {} > {}", debt_after_tick2.0, debt_after_tick1.0);
+        let debt_after_tick2 = state
+            .vault_id_to_vaults
+            .get(&1)
+            .unwrap()
+            .borrowed_icusd_amount;
+        assert!(
+            debt_after_tick2 > debt_after_tick1,
+            "Debt should increase after second tick: {} > {}",
+            debt_after_tick2.0,
+            debt_after_tick1.0
+        );
 
         // Verify the increase is proportional across ticks
         let increase1 = debt_after_tick1.0 - initial_debt.0;
         let increase2 = debt_after_tick2.0 - debt_after_tick1.0;
         // Second increase should be >= first (compounding on larger base)
-        assert!(increase2 >= increase1,
-            "Compounding: second increase {} should be >= first {}", increase2, increase1);
+        assert!(
+            increase2 >= increase1,
+            "Compounding: second increase {} should be >= first {}",
+            increase2,
+            increase1
+        );
     }
 
     #[test]
@@ -5691,22 +6106,28 @@ mod tests {
 
         // Single vault at CR = 300% (above healthy_cr 225%) → multiplier 1.0x
         // Base APR = 5%, so weighted avg should be 5%
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            collateral_amount: 150_000_000, // 1.5 ICP
-            borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
-            collateral_type: icp,
-            last_accrual_time: 0,
-            accrued_interest: ICUSD::new(0),
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                collateral_amount: 150_000_000, // 1.5 ICP
+                borrowed_icusd_amount: ICUSD::new(500_000_000), // 5 icUSD
+                collateral_type: icp,
+                last_accrual_time: 0,
+                accrued_interest: ICUSD::new(0),
+                bot_processing: false,
+            },
+        );
 
         let avg = state.weighted_average_interest_rate();
         // At 300% CR with base 5% and 1.0x multiplier, should be ~0.05
         let diff = (avg.0 - rust_decimal_macros::dec!(0.05)).abs();
-        assert!(diff < rust_decimal_macros::dec!(0.001),
-            "Weighted avg rate should be ~5%, got {}", avg.0);
+        assert!(
+            diff < rust_decimal_macros::dec!(0.001),
+            "Weighted avg rate should be ~5%, got {}",
+            avg.0
+        );
     }
 
     #[test]
@@ -5719,8 +6140,11 @@ mod tests {
         let collateral_price = UsdIcp::from(dec!(10.0));
 
         // Verify default protocol share is 3%
-        assert_eq!(state.get_liquidation_protocol_share().0, dec!(0.03),
-            "Default liquidation_protocol_share should be 3%");
+        assert_eq!(
+            state.get_liquidation_protocol_share().0,
+            dec!(0.03),
+            "Default liquidation_protocol_share should be 3%"
+        );
 
         // Vault with 1.5 ICP ($15), $11.5 debt → CR = 15/11.5 ≈ 1.304
         state.open_vault(Vault {
@@ -5740,36 +6164,54 @@ mod tests {
         let protocol_share = state.get_liquidation_protocol_share(); // 0.03
 
         // collateral_raw: 5 icUSD / $10 = 0.5 ICP = 50_000_000 e8s
-        let collateral_raw = crate::numeric::icusd_to_collateral_amount(
-            liquidator_payment, dec!(10.0), 8
+        let collateral_raw =
+            crate::numeric::icusd_to_collateral_amount(liquidator_payment, dec!(10.0), 8);
+        assert_eq!(
+            collateral_raw, 50_000_000,
+            "collateral_raw should be 0.5 ICP"
         );
-        assert_eq!(collateral_raw, 50_000_000, "collateral_raw should be 0.5 ICP");
 
         // total_to_seize = 0.5 ICP * 1.15 = 0.575 ICP = 57_500_000 e8s
         let total_to_seize = (ICP::from(collateral_raw) * liq_bonus).min(ICP::from(150_000_000u64));
-        assert_eq!(total_to_seize.to_u64(), 57_500_000, "total_to_seize should be 0.575 ICP");
+        assert_eq!(
+            total_to_seize.to_u64(),
+            57_500_000,
+            "total_to_seize should be 0.575 ICP"
+        );
 
         // bonus_portion = 57_500_000 - 50_000_000 = 7_500_000 (0.075 ICP)
         let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
-        assert_eq!(bonus_portion, 7_500_000, "bonus_portion should be 0.075 ICP");
+        assert_eq!(
+            bonus_portion, 7_500_000,
+            "bonus_portion should be 0.075 ICP"
+        );
 
         // protocol_cut = 7_500_000 * 0.03 = 225_000 (0.00225 ICP)
         let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-            .to_u64().unwrap_or(0);
+            .to_u64()
+            .unwrap_or(0);
         assert_eq!(protocol_cut, 225_000, "protocol_cut should be 0.00225 ICP");
 
         // collateral_to_liquidator = 57_500_000 - 225_000 = 57_275_000
         let collateral_to_liquidator = total_to_seize.to_u64() - protocol_cut;
-        assert_eq!(collateral_to_liquidator, 57_275_000,
-            "liquidator should get total_to_seize minus protocol_cut");
+        assert_eq!(
+            collateral_to_liquidator, 57_275_000,
+            "liquidator should get total_to_seize minus protocol_cut"
+        );
 
         // Verify the sync State::liquidate_vault still works correctly
         // (it doesn't split the fee — the async callers do that)
         let interest_share = state.liquidate_vault(10, Mode::GeneralAvailability, collateral_price);
         // Full liquidation: all accrued_interest is returned
-        assert_eq!(interest_share.0, 100_000_000, "Full liquidation should return all accrued_interest");
+        assert_eq!(
+            interest_share.0, 100_000_000,
+            "Full liquidation should return all accrued_interest"
+        );
         // Vault should be removed
-        assert!(state.vault_id_to_vaults.get(&10).is_none(), "Vault should be removed after full liquidation");
+        assert!(
+            state.vault_id_to_vaults.get(&10).is_none(),
+            "Vault should be removed after full liquidation"
+        );
     }
 
     #[test]
@@ -5863,16 +6305,19 @@ mod tests {
         let icp = state.icp_ledger_principal;
 
         // Create vault with 100 icUSD debt, 5 icUSD accrued interest
-        state.vault_id_to_vaults.insert(1, Vault {
-            owner: Principal::anonymous(),
-            vault_id: 1,
-            borrowed_icusd_amount: ICUSD::new(10_000_000_000), // 100 icUSD
-            collateral_amount: 1_000_000_000,
-            collateral_type: icp,
-            accrued_interest: ICUSD::new(500_000_000), // 5 icUSD interest
-            last_accrual_time: 0,
-            bot_processing: false,
-        });
+        state.vault_id_to_vaults.insert(
+            1,
+            Vault {
+                owner: Principal::anonymous(),
+                vault_id: 1,
+                borrowed_icusd_amount: ICUSD::new(10_000_000_000), // 100 icUSD
+                collateral_amount: 1_000_000_000,
+                collateral_type: icp,
+                accrued_interest: ICUSD::new(500_000_000), // 5 icUSD interest
+                last_accrual_time: 0,
+                bot_processing: false,
+            },
+        );
 
         // Repay 50 icUSD worth
         let (interest_share, principal_share) = state.repay_to_vault(1, ICUSD::new(5_000_000_000));
@@ -5945,7 +6390,11 @@ mod tests {
             "bot-claimed vault must be skipped by the redemption water-fill"
         );
         assert_eq!(
-            state.vault_id_to_vaults.get(&1).unwrap().borrowed_icusd_amount,
+            state
+                .vault_id_to_vaults
+                .get(&1)
+                .unwrap()
+                .borrowed_icusd_amount,
             ICUSD::new(300_000_000),
             "bot-claimed vault untouched"
         );
@@ -5987,9 +6436,15 @@ mod tests {
         // Claim 10 icUSD against 3 icUSD of total debt.
         let results = state.redeem_on_vaults(ICUSD::new(1_000_000_000), price, &icp_ct);
         let consumed: u64 = results.iter().map(|r| r.icusd_redeemed_e8s).sum();
-        assert_eq!(consumed, 300_000_000, "consumed capped at total redeemable debt");
+        assert_eq!(
+            consumed, 300_000_000,
+            "consumed capped at total redeemable debt"
+        );
         let seized: u64 = results.iter().map(|r| r.collateral_seized).sum();
-        assert!(seized <= 500_000_000, "seized cannot exceed vault collateral");
+        assert!(
+            seized <= 500_000_000,
+            "seized cannot exceed vault collateral"
+        );
     }
 
     #[test]
@@ -6017,15 +6472,26 @@ mod tests {
         state.open_vault(audit_vault(1, icp_ct, 500_000_000, 300_000_000));
 
         let vrs = vec![
-            crate::event::VaultRedemption { vault_id: 1, icusd_redeemed_e8s: 100_000_000, collateral_seized: 20_000_000 },
-            crate::event::VaultRedemption { vault_id: 99, icusd_redeemed_e8s: 50_000_000, collateral_seized: 10_000_000 },
+            crate::event::VaultRedemption {
+                vault_id: 1,
+                icusd_redeemed_e8s: 100_000_000,
+                collateral_seized: 20_000_000,
+            },
+            crate::event::VaultRedemption {
+                vault_id: 99,
+                icusd_redeemed_e8s: 50_000_000,
+                collateral_seized: 10_000_000,
+            },
         ];
         state.apply_vault_redemptions(&vrs);
 
         let v1 = state.vault_id_to_vaults.get(&1).unwrap();
         assert_eq!(v1.borrowed_icusd_amount, ICUSD::new(200_000_000));
         assert_eq!(v1.collateral_amount, 480_000_000);
-        assert!(!state.vault_id_to_vaults.contains_key(&99), "unknown vault skipped, no trap");
+        assert!(
+            !state.vault_id_to_vaults.contains_key(&99),
+            "unknown vault skipped, no trap"
+        );
     }
 
     #[test]
@@ -6041,7 +6507,11 @@ mod tests {
         assert_eq!(interest, ICUSD::new(0));
         assert_eq!(principal, ICUSD::new(100_000_000), "clamped to live debt");
         assert_eq!(
-            state.vault_id_to_vaults.get(&1).unwrap().borrowed_icusd_amount,
+            state
+                .vault_id_to_vaults
+                .get(&1)
+                .unwrap()
+                .borrowed_icusd_amount,
             ICUSD::new(0)
         );
     }
@@ -6066,7 +6536,7 @@ mod tests {
         // vault's gap is booked, but an unconsumed remainder (refunded to the
         // redeemer) is NOT.
         let consumed = ICUSD::new(300_000_000); // 3 icUSD retired
-        // Seized only 0.4 ICP at $5 = $2 of collateral for $3 of debt.
+                                                // Seized only 0.4 ICP at $5 = $2 of collateral for $3 of debt.
         let vrs = vec![crate::event::VaultRedemption {
             vault_id: 1,
             icusd_redeemed_e8s: 300_000_000,
@@ -6078,7 +6548,11 @@ mod tests {
             rust_decimal_macros::dec!(5.0),
             8,
         );
-        assert_eq!(shortfall, ICUSD::new(100_000_000), "underwater gap booked: $3 - $2 = $1");
+        assert_eq!(
+            shortfall,
+            ICUSD::new(100_000_000),
+            "underwater gap booked: $3 - $2 = $1"
+        );
     }
 
     #[test]
@@ -6112,7 +6586,8 @@ mod tests {
         let rmr = state.get_redemption_margin_ratio();
         assert!(
             (rmr.to_f64() - 0.96).abs() < 0.001,
-            "RMR at 1.5x recovery should be 0.96, got {}", rmr.to_f64()
+            "RMR at 1.5x recovery should be 0.96, got {}",
+            rmr.to_f64()
         );
     }
 
@@ -6124,7 +6599,8 @@ mod tests {
         let rmr = state.get_redemption_margin_ratio();
         assert!(
             (rmr.to_f64() - 1.0).abs() < 0.001,
-            "RMR at recovery threshold should be 1.0, got {}", rmr.to_f64()
+            "RMR at recovery threshold should be 1.0, got {}",
+            rmr.to_f64()
         );
     }
 
@@ -6136,7 +6612,8 @@ mod tests {
         let rmr = state.get_redemption_margin_ratio();
         assert!(
             (rmr.to_f64() - 0.98).abs() < 0.001,
-            "RMR at midpoint should be 0.98, got {}", rmr.to_f64()
+            "RMR at midpoint should be 0.98, got {}",
+            rmr.to_f64()
         );
     }
 
@@ -6148,7 +6625,8 @@ mod tests {
         let rmr = state.get_redemption_margin_ratio();
         assert!(
             (rmr.to_f64() - 1.0).abs() < 0.001,
-            "RMR below recovery should be 1.0, got {}", rmr.to_f64()
+            "RMR below recovery should be 1.0, got {}",
+            rmr.to_f64()
         );
     }
 
@@ -6160,7 +6638,8 @@ mod tests {
         let rmr = state.get_redemption_margin_ratio();
         assert!(
             (rmr.to_f64() - 0.96).abs() < 0.001,
-            "RMR above 1.5x should be capped at 0.96, got {}", rmr.to_f64()
+            "RMR above 1.5x should be capped at 0.96, got {}",
+            rmr.to_f64()
         );
     }
 
@@ -6169,24 +6648,27 @@ mod tests {
         let state = test_state();
         assert!(
             (state.interest_pool_share.to_f64() - 0.75).abs() < 0.001,
-            "Default interest pool share should be 0.75, got {}", state.interest_pool_share.to_f64()
+            "Default interest pool share should be 0.75, got {}",
+            state.interest_pool_share.to_f64()
         );
 
         let interest = ICUSD::from(100_000_000_00u64); // 100 icUSD
         let pool_share = ICUSD::from(
             (Decimal::from(interest.to_u64()) * state.interest_pool_share.0)
                 .to_u64()
-                .unwrap_or(0)
+                .unwrap_or(0),
         );
         let treasury_share = ICUSD::from(interest.to_u64() - pool_share.to_u64());
 
         assert!(
             (pool_share.to_u64() as f64 / 1e8 - 75.0).abs() < 0.01,
-            "Pool share should be ~75, got {}", pool_share.to_u64() as f64 / 1e8
+            "Pool share should be ~75, got {}",
+            pool_share.to_u64() as f64 / 1e8
         );
         assert!(
             (treasury_share.to_u64() as f64 / 1e8 - 25.0).abs() < 0.01,
-            "Treasury share should be ~25, got {}", treasury_share.to_u64() as f64 / 1e8
+            "Treasury share should be ~25, got {}",
+            treasury_share.to_u64() as f64 / 1e8
         );
     }
 
@@ -6199,17 +6681,19 @@ mod tests {
         let pool_share = ICUSD::from(
             (Decimal::from(interest.to_u64()) * state.interest_pool_share.0)
                 .to_u64()
-                .unwrap_or(0)
+                .unwrap_or(0),
         );
         let treasury_share = ICUSD::from(interest.to_u64() - pool_share.to_u64());
 
         assert!(
             (pool_share.to_u64() as f64 / 1e8 - 100.0).abs() < 0.01,
-            "Pool share should be ~100, got {}", pool_share.to_u64() as f64 / 1e8
+            "Pool share should be ~100, got {}",
+            pool_share.to_u64() as f64 / 1e8
         );
         assert!(
             (treasury_share.to_u64() as f64 / 1e8 - 100.0).abs() < 0.01,
-            "Treasury share should be ~100, got {}", treasury_share.to_u64() as f64 / 1e8
+            "Treasury share should be ~100, got {}",
+            treasury_share.to_u64() as f64 / 1e8
         );
     }
 
@@ -6220,12 +6704,20 @@ mod tests {
         let pool_share = ICUSD::from(
             (Decimal::from(interest.to_u64()) * state.interest_pool_share.0)
                 .to_u64()
-                .unwrap_or(0)
+                .unwrap_or(0),
         );
         let treasury_share = ICUSD::from(interest.to_u64() - pool_share.to_u64());
 
-        assert_eq!(pool_share.to_u64(), 0, "Pool share should be 0 for zero interest");
-        assert_eq!(treasury_share.to_u64(), 0, "Treasury share should be 0 for zero interest");
+        assert_eq!(
+            pool_share.to_u64(),
+            0,
+            "Pool share should be 0 for zero interest"
+        );
+        assert_eq!(
+            treasury_share.to_u64(),
+            0,
+            "Treasury share should be 0 for zero interest"
+        );
     }
 
     #[test]
@@ -6237,7 +6729,7 @@ mod tests {
         let treasury_e8s = interest_e8s - pool_e8s;
 
         // Convert to e6s (ckStable)
-        let pool_e6s = pool_e8s / 100;      // 3_750_000 = 3.75 ckUSDT
+        let pool_e6s = pool_e8s / 100; // 3_750_000 = 3.75 ckUSDT
         let treasury_e6s = treasury_e8s / 100; // 1_250_000 = 1.25 ckUSDT
 
         assert_eq!(pool_e6s, 3_750_000);
@@ -6277,11 +6769,16 @@ mod tests {
         state.recovery_mode_threshold = Ratio::from_f64(1.5);
         let anchor = CrAnchor::Midpoint(
             Box::new(CrAnchor::SystemThreshold(SystemThreshold::BorrowThreshold)),
-            Box::new(CrAnchor::SystemThreshold(SystemThreshold::TotalCollateralRatio)),
+            Box::new(CrAnchor::SystemThreshold(
+                SystemThreshold::TotalCollateralRatio,
+            )),
         );
         let result = state.resolve_anchor(&anchor, None);
-        assert!((result.to_f64() - 1.75).abs() < 0.001,
-            "Midpoint of 1.5 and 2.0 should be 1.75, got {}", result.to_f64());
+        assert!(
+            (result.to_f64() - 1.75).abs() < 0.001,
+            "Midpoint of 1.5 and 2.0 should be 1.75, got {}",
+            result.to_f64()
+        );
     }
 
     #[test]
@@ -6293,8 +6790,11 @@ mod tests {
             Ratio::from_f64(0.05),
         );
         let result = state.resolve_anchor(&anchor, None);
-        assert!((result.to_f64() - 1.55).abs() < 0.001,
-            "1.5 + 0.05 should be 1.55, got {}", result.to_f64());
+        assert!(
+            (result.to_f64() - 1.55).abs() < 0.001,
+            "1.5 + 0.05 should be 1.55, got {}",
+            result.to_f64()
+        );
     }
 
     #[test]
@@ -6304,8 +6804,11 @@ mod tests {
         let anchor = CrAnchor::AssetThreshold(AssetThreshold::BorrowThreshold);
         let result = state.resolve_anchor(&anchor, Some(&icp));
         // ICP borrow threshold — check what accrual_test_state sets
-        assert!(result.to_f64() > 1.0,
-            "ICP borrow threshold should be > 1.0, got {}", result.to_f64());
+        assert!(
+            result.to_f64() > 1.0,
+            "ICP borrow threshold should be > 1.0, got {}",
+            result.to_f64()
+        );
     }
 
     #[test]
@@ -6328,8 +6831,12 @@ mod tests {
             method: InterpolationMethod::Linear,
         };
         let resolved = state.resolve_curve(&curve, None);
-        assert!(resolved[0].0.to_f64() < resolved[1].0.to_f64(),
-            "Should be sorted ascending: {} < {}", resolved[0].0.to_f64(), resolved[1].0.to_f64());
+        assert!(
+            resolved[0].0.to_f64() < resolved[1].0.to_f64(),
+            "Should be sorted ascending: {} < {}",
+            resolved[0].0.to_f64(),
+            resolved[1].0.to_f64()
+        );
         assert!((resolved[0].0.to_f64() - 1.5).abs() < 0.01);
         assert!((resolved[1].0.to_f64() - 2.0).abs() < 0.01);
     }
@@ -6342,8 +6849,11 @@ mod tests {
 
         // Vault CR = 2.0 (above TCR of 1.75) → multiplier should be 1.0
         let mult = state.get_borrowing_fee_multiplier(Ratio::from_f64(2.0));
-        assert!((mult.to_f64() - 1.0).abs() < 0.01,
-            "Above TCR should be 1.0x, got {}", mult.to_f64());
+        assert!(
+            (mult.to_f64() - 1.0).abs() < 0.01,
+            "Above TCR should be 1.0x, got {}",
+            mult.to_f64()
+        );
     }
 
     #[test]
@@ -6354,8 +6864,11 @@ mod tests {
         // Midpoint = (1.5 + 2.0) / 2 = 1.75
 
         let mult = state.get_borrowing_fee_multiplier(Ratio::from_f64(1.75));
-        assert!((mult.to_f64() - 1.75).abs() < 0.01,
-            "At midpoint should be 1.75x, got {}", mult.to_f64());
+        assert!(
+            (mult.to_f64() - 1.75).abs() < 0.01,
+            "At midpoint should be 1.75x, got {}",
+            mult.to_f64()
+        );
     }
 
     #[test]
@@ -6366,8 +6879,11 @@ mod tests {
         // Floor = BorrowThreshold + 0.05 = 1.55
 
         let mult = state.get_borrowing_fee_multiplier(Ratio::from_f64(1.55));
-        assert!((mult.to_f64() - 3.0).abs() < 0.01,
-            "At floor should be 3.0x, got {}", mult.to_f64());
+        assert!(
+            (mult.to_f64() - 3.0).abs() < 0.01,
+            "At floor should be 3.0x, got {}",
+            mult.to_f64()
+        );
     }
 
     #[test]
@@ -6377,8 +6893,11 @@ mod tests {
         state.recovery_mode_threshold = Ratio::from_f64(1.5);
 
         let mult = state.get_borrowing_fee_multiplier(Ratio::from_f64(1.4));
-        assert!((mult.to_f64() - 3.0).abs() < 0.01,
-            "Below floor should still be 3.0x (capped), got {}", mult.to_f64());
+        assert!(
+            (mult.to_f64() - 3.0).abs() < 0.01,
+            "Below floor should still be 3.0x (capped), got {}",
+            mult.to_f64()
+        );
     }
 
     #[test]
@@ -6400,12 +6919,18 @@ mod tests {
         // A healthy vault at CR=2.0 should NOT get 3.0x from interpolation above the last marker.
         // The inversion guard should return 3.0x (max multiplier) for all CRs.
         let mult_healthy = state.get_borrowing_fee_multiplier(Ratio::from_f64(2.0));
-        assert!((mult_healthy.to_f64() - 3.0).abs() < 0.01,
-            "Inverted curve should return max multiplier (3.0x), got {}", mult_healthy.to_f64());
+        assert!(
+            (mult_healthy.to_f64() - 3.0).abs() < 0.01,
+            "Inverted curve should return max multiplier (3.0x), got {}",
+            mult_healthy.to_f64()
+        );
 
         let mult_low = state.get_borrowing_fee_multiplier(Ratio::from_f64(1.0));
-        assert!((mult_low.to_f64() - 3.0).abs() < 0.01,
-            "Inverted curve should return max multiplier (3.0x) for low CR too, got {}", mult_low.to_f64());
+        assert!(
+            (mult_low.to_f64() - 3.0).abs() < 0.01,
+            "Inverted curve should return max multiplier (3.0x) for low CR too, got {}",
+            mult_low.to_f64()
+        );
     }
 
     // ─── Regression Tests (bugs caught on mainnet) ───
@@ -6435,18 +6960,25 @@ mod tests {
         }
 
         assert_eq!(state.vault_id_to_vaults.len(), 5);
-        assert!(state.pending_margin_transfers.is_empty(),
-            "No pending transfers before closing");
+        assert!(
+            state.pending_margin_transfers.is_empty(),
+            "No pending transfers before closing"
+        );
 
         // Close all 5 vaults
         for i in 1..=5u64 {
             state.close_vault(i);
         }
 
-        assert!(state.vault_id_to_vaults.is_empty(), "All vaults should be removed");
-        assert!(state.pending_margin_transfers.is_empty(),
+        assert!(
+            state.vault_id_to_vaults.is_empty(),
+            "All vaults should be removed"
+        );
+        assert!(
+            state.pending_margin_transfers.is_empty(),
             "close_vault must NOT create phantom pending_margin_transfers, found {}",
-            state.pending_margin_transfers.len());
+            state.pending_margin_transfers.len()
+        );
     }
 
     /// Regression: RMR must be applied exactly once during reserve redemption spillover.
@@ -6484,23 +7016,33 @@ mod tests {
         let effective_spillover_buggy = (spillover_icusd - vault_fee) * rmr;
 
         // The correct value should be higher than the buggy value
-        assert!(effective_spillover_correct > effective_spillover_buggy,
+        assert!(
+            effective_spillover_correct > effective_spillover_buggy,
             "Correct spillover ({}) must be > buggy double-RMR spillover ({})",
-            effective_spillover_correct.to_u64(), effective_spillover_buggy.to_u64());
+            effective_spillover_correct.to_u64(),
+            effective_spillover_buggy.to_u64()
+        );
 
         // Verify the difference is exactly the second RMR application
         // buggy = correct * 0.96, so correct / buggy ≈ 1/0.96 ≈ 1.0417
-        let ratio = effective_spillover_correct.to_u64() as f64
-            / effective_spillover_buggy.to_u64() as f64;
-        assert!((ratio - 1.0 / 0.96).abs() < 0.001,
-            "Difference should be exactly the second RMR factor, ratio = {}", ratio);
+        let ratio =
+            effective_spillover_correct.to_u64() as f64 / effective_spillover_buggy.to_u64() as f64;
+        assert!(
+            (ratio - 1.0 / 0.96).abs() < 0.001,
+            "Difference should be exactly the second RMR factor, ratio = {}",
+            ratio
+        );
 
         // Verify the effective spillover is exactly: (original * (1-fee) * rmr) * (1 - vault_fee_ratio)
         // NOT: (original * (1-fee) * rmr) * (1 - vault_fee_ratio) * rmr
         let expected = 100.0 * (1.0 - 0.003) * 0.96 * (1.0 - 0.005);
         let actual = effective_spillover_correct.to_u64() as f64 / 1e8;
-        assert!((actual - expected).abs() < 0.01,
-            "Effective spillover should be {:.4} icUSD, got {:.4}", expected, actual);
+        assert!(
+            (actual - expected).abs() < 0.01,
+            "Effective spillover should be {:.4} icUSD, got {:.4}",
+            expected,
+            actual
+        );
     }
 
     // ─── Liquidation Bot Tests ───
@@ -6520,7 +7062,11 @@ mod tests {
         let seized = l * b;
         let new_collateral = c - seized;
         let new_cr = new_collateral / new_debt;
-        assert!((new_cr - 1.50).abs() < 0.01, "New CR should be 1.50, got {}", new_cr);
+        assert!(
+            (new_cr - 1.50).abs() < 0.01,
+            "New CR should be 1.50, got {}",
+            new_cr
+        );
     }
 
     #[test]
@@ -6534,7 +7080,10 @@ mod tests {
         state.bot_budget_remaining_e8s -= liquidation_amount;
         state.bot_total_debt_covered_e8s += liquidation_amount;
 
-        assert_eq!(state.bot_budget_remaining_e8s, 1_000_000_000_000 - 28_571_000_000);
+        assert_eq!(
+            state.bot_budget_remaining_e8s,
+            1_000_000_000_000 - 28_571_000_000
+        );
         assert_eq!(state.bot_total_debt_covered_e8s, 28_571_000_000);
     }
 
@@ -6544,8 +7093,10 @@ mod tests {
         state.bot_budget_remaining_e8s = 10_000_000; // 0.1 icUSD remaining
 
         let liquidation_amount = 28_571_000_000u64; // 285.71 icUSD
-        assert!(state.bot_budget_remaining_e8s < liquidation_amount,
-            "Budget should be insufficient");
+        assert!(
+            state.bot_budget_remaining_e8s < liquidation_amount,
+            "Budget should be insufficient"
+        );
     }
 
     #[test]
@@ -6566,7 +7117,8 @@ mod tests {
             bot_processing: false,
         };
         state.vault_id_to_vaults.insert(42, vault);
-        state.principal_to_vault_ids
+        state
+            .principal_to_vault_ids
             .entry(Principal::anonymous())
             .or_default()
             .insert(42);
@@ -6579,7 +7131,10 @@ mod tests {
         let restored: State = ciborium::de::from_reader(buf.as_slice()).unwrap();
 
         // Verify vault fields are preserved exactly
-        assert_eq!(restored.vault_id_to_vaults.len(), state.vault_id_to_vaults.len());
+        assert_eq!(
+            restored.vault_id_to_vaults.len(),
+            state.vault_id_to_vaults.len()
+        );
         let v = &restored.vault_id_to_vaults[&42];
         assert_eq!(v.borrowed_icusd_amount, ICUSD::new(100_000_000));
         assert_eq!(v.accrued_interest, ICUSD::new(5_000_000));
@@ -6591,7 +7146,10 @@ mod tests {
         assert_eq!(restored.fee, state.fee);
         assert_eq!(restored.developer_principal, state.developer_principal);
         assert_eq!(restored.icp_ledger_principal, state.icp_ledger_principal);
-        assert_eq!(restored.next_available_vault_id, state.next_available_vault_id);
+        assert_eq!(
+            restored.next_available_vault_id,
+            state.next_available_vault_id
+        );
     }
 
     #[test]
@@ -6630,7 +7188,11 @@ mod tests {
             ciborium::Value::Map(mut e) => {
                 let before = e.len();
                 e.retain(|(k, _)| !matches!(k, ciborium::Value::Text(s) if s == "custody_kind"));
-                assert_eq!(e.len(), before - 1, "custody_kind key should have been present");
+                assert_eq!(
+                    e.len(),
+                    before - 1,
+                    "custody_kind key should have been present"
+                );
                 e
             }
             other => panic!("expected a CBOR map, got {other:?}"),
@@ -6680,24 +7242,73 @@ mod tests {
         assert_eq!(cfg.ledger_canister_id, xrp_collateral_principal());
         assert_eq!(cfg.decimals, 6);
         assert_eq!(cfg.ledger_fee, 0);
-        assert_eq!(cfg.debt_ceiling, 20_000_000_000); // $200
+        assert_eq!(XRP_LAUNCH_DEBT_CEILING_E8S, 10_000_000_000); // $100
+        assert_eq!(cfg.debt_ceiling, XRP_LAUNCH_DEBT_CEILING_E8S);
         assert_eq!(cfg.liquidation_ratio, Ratio::new(dec!(1.33)));
         assert_eq!(cfg.borrow_threshold_ratio, Ratio::new(dec!(1.50)));
         assert_eq!(cfg.liquidation_bonus, Ratio::new(dec!(1.12))); // 12% penalty
         assert_eq!(cfg.borrowing_fee, Ratio::new(dec!(0.005))); // inherited from ICP
-        // recovery CR = 150% × 1.0333... = 155%
+                                                                // recovery CR = 150% × 1.0333... = 155%
         assert!(
             (cfg.recovery_target_cr.to_f64() - 1.55).abs() < 0.001,
             "recovery ~155%, got {}",
             cfg.recovery_target_cr.to_f64()
         );
         match cfg.price_source {
-            PriceSource::Xrc { base_asset, quote_asset, .. } => {
+            PriceSource::Xrc {
+                base_asset,
+                quote_asset,
+                ..
+            } => {
                 assert_eq!(base_asset, "XRP");
                 assert_eq!(quote_asset, "USD");
             }
             other => panic!("expected XRC price source, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn xrp_launch_guardrails_clamp_existing_cap_and_freeze_non_production_key() {
+        let mut state = test_state();
+        let xrp = xrp_collateral_principal();
+        let mut cfg = xrp_collateral_config(
+            Ratio::new(dec!(0.005)),
+            Ratio::new(dec!(0.0)),
+            Ratio::new(dec!(1.033333333333333333)),
+        );
+        cfg.debt_ceiling = 20_000_000_000;
+        cfg.status = CollateralStatus::Active;
+        state.collateral_configs.insert(xrp, cfg);
+        state.xrp_schnorr_key_name =
+            crate::chains::xrp::config::XRP_TEST_SCHNORR_KEY_NAME.to_string();
+
+        let migration = enforce_xrp_launch_guardrails(&mut state);
+        let migrated = state.collateral_configs.get(&xrp).unwrap();
+
+        assert_eq!(migration.previous_debt_ceiling, Some(20_000_000_000));
+        assert_eq!(migration.previous_status, Some(CollateralStatus::Active));
+        assert_eq!(migrated.debt_ceiling, XRP_LAUNCH_DEBT_CEILING_E8S);
+        assert_eq!(migrated.status, CollateralStatus::Frozen);
+    }
+
+    #[test]
+    fn xrp_launch_config_update_rejects_cap_above_launch_ceiling() {
+        let xrp = xrp_collateral_principal();
+        let mut cfg = xrp_collateral_config(
+            Ratio::new(dec!(0.005)),
+            Ratio::new(dec!(0.0)),
+            Ratio::new(dec!(1.033333333333333333)),
+        );
+        cfg.debt_ceiling = XRP_LAUNCH_DEBT_CEILING_E8S + 1;
+
+        assert!(matches!(
+            validate_xrp_launch_config_update(
+                xrp,
+                &cfg,
+                crate::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME,
+            ),
+            Err(ProtocolError::GenericError(_))
+        ));
     }
 
     #[test]
@@ -6745,7 +7356,10 @@ mod tests {
             true,
         );
         let ids: Vec<u64> = scan.unhealthy_vaults.iter().map(|v| v.vault_id).collect();
-        assert!(ids.contains(&1), "ICP vault should be flagged unhealthy: {ids:?}");
+        assert!(
+            ids.contains(&1),
+            "ICP vault should be flagged unhealthy: {ids:?}"
+        );
         assert!(
             !ids.contains(&2),
             "native-XRP vault must be excluded from the automated scan: {ids:?}"
@@ -6794,7 +7408,10 @@ mod tests {
         });
 
         let priority = s.get_collateral_types_by_redemption_priority();
-        assert!(priority.contains(&icp), "ICRC collateral must remain redeemable");
+        assert!(
+            priority.contains(&icp),
+            "ICRC collateral must remain redeemable"
+        );
         assert!(
             !priority.contains(&xrp),
             "native-XRP must be excluded from redemption priority"
@@ -6866,6 +7483,55 @@ mod tests {
     }
 
     #[test]
+    fn xrp_settlement_round_trips_source_sequence() {
+        let settlement = XrpSettlement {
+            tx_hash: "ABC".to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: Some(42),
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: Some(7),
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&settlement, &mut buf).unwrap();
+        let back: XrpSettlement = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        assert_eq!(settlement, back);
+    }
+
+    #[test]
+    fn xrp_settlement_source_sequence_defaults_none_on_old_snapshot() {
+        let settlement = XrpSettlement {
+            tx_hash: "ABC".to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: Some(42),
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: Some(7),
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&settlement, &mut buf).unwrap();
+        let value: ciborium::Value = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        let entries = match value {
+            ciborium::Value::Map(mut e) => {
+                e.retain(|(k, _)| {
+                    !matches!(
+                        k,
+                        ciborium::Value::Text(s)
+                            if s == "source_sequence" || s == "destination" || s == "destination_tag"
+                    )
+                });
+                e
+            }
+            other => panic!("expected a CBOR map, got {other:?}"),
+        };
+        let mut modified = Vec::new();
+        ciborium::ser::into_writer(&ciborium::Value::Map(entries), &mut modified).unwrap();
+        let restored: XrpSettlement =
+            ciborium::de::from_reader(modified.as_slice()).expect("old snapshot must decode");
+        assert_eq!(restored.source_sequence, None);
+        assert_eq!(restored.destination, None);
+        assert_eq!(restored.destination_tag, None);
+    }
+
+    #[test]
     fn test_serde_default_handles_missing_fields() {
         // Simulate old CBOR that's missing a field by serializing a subset,
         // then verifying ciborium + serde(default) fills in the missing field.
@@ -6887,7 +7553,11 @@ mod tests {
                     true
                 }
             });
-            assert_eq!(entries.len(), original_len - 1, "should have removed one field");
+            assert_eq!(
+                entries.len(),
+                original_len - 1,
+                "should have removed one field"
+            );
 
             // Re-encode the modified map
             let mut modified_buf = Vec::new();
@@ -6919,8 +7589,14 @@ mod tests {
         assert!(state.is_price_setter_authorized(dev, 71, "MON"));
         // pusher may set ONLY the allow-listed pair
         assert!(state.is_price_setter_authorized(pusher, 1030, "CFX"));
-        assert!(!state.is_price_setter_authorized(pusher, 1030, "MON"), "out-of-scope symbol rejected");
-        assert!(!state.is_price_setter_authorized(pusher, 71, "CFX"), "out-of-scope chain rejected");
+        assert!(
+            !state.is_price_setter_authorized(pusher, 1030, "MON"),
+            "out-of-scope symbol rejected"
+        );
+        assert!(
+            !state.is_price_setter_authorized(pusher, 71, "CFX"),
+            "out-of-scope chain rejected"
+        );
         // stranger never
         assert!(!state.is_price_setter_authorized(stranger, 1030, "CFX"));
     }
@@ -6967,7 +7643,10 @@ mod tests {
             ciborium::ser::into_writer(&ciborium::Value::Map(entries), &mut modified_buf).unwrap();
             let restored: State = ciborium::de::from_reader(modified_buf.as_slice()).unwrap();
             assert_eq!(restored.price_pusher_principal, None);
-            assert!(restored.price_pusher_allowed.is_empty(), "allow-list defaults empty");
+            assert!(
+                restored.price_pusher_allowed.is_empty(),
+                "allow-list defaults empty"
+            );
         } else {
             panic!("expected CBOR map");
         }
@@ -7025,7 +7704,10 @@ mod tests {
     #[test]
     fn test_bot_cr_tolerance_default_is_two_percent() {
         let state = test_state();
-        assert_eq!(state.bot_cr_tolerance_bps, crate::DEFAULT_BOT_CR_TOLERANCE_BPS);
+        assert_eq!(
+            state.bot_cr_tolerance_bps,
+            crate::DEFAULT_BOT_CR_TOLERANCE_BPS
+        );
         assert_eq!(crate::DEFAULT_BOT_CR_TOLERANCE_BPS, 200);
     }
 
@@ -7036,8 +7718,7 @@ mod tests {
 
         // Default tolerance (200 bps) → 133% + 2% = 135%.
         let max = state.get_bot_claim_max_ratio_for(&icp);
-        let expected = state.get_min_liquidation_ratio_for(&icp)
-            + Ratio::from(dec!(0.02));
+        let expected = state.get_min_liquidation_ratio_for(&icp) + Ratio::from(dec!(0.02));
         assert_eq!(max, expected);
 
         // 0 bps → no slack; bot threshold collapses to the strict
@@ -7049,8 +7730,7 @@ mod tests {
         // 500 bps (the configured admin cap) → 133% + 5% = 138%.
         state.set_bot_cr_tolerance_bps(500);
         let max_500 = state.get_bot_claim_max_ratio_for(&icp);
-        let expected_500 = state.get_min_liquidation_ratio_for(&icp)
-            + Ratio::from(dec!(0.05));
+        let expected_500 = state.get_min_liquidation_ratio_for(&icp) + Ratio::from(dec!(0.05));
         assert_eq!(max_500, expected_500);
     }
 
@@ -7065,9 +7745,8 @@ mod tests {
 
         let max = state.get_bot_claim_max_ratio_for(&icp);
         let base = state.get_min_liquidation_ratio_for(&icp);
-        let tolerance = Ratio::from(
-            Decimal::from(state.bot_cr_tolerance_bps) / Decimal::from(10_000u64),
-        );
+        let tolerance =
+            Ratio::from(Decimal::from(state.bot_cr_tolerance_bps) / Decimal::from(10_000u64));
         assert_eq!(max, base + tolerance);
 
         // Sanity: in Recovery the base is at or above the borrow threshold.

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -3,28 +3,29 @@ use crate::event::{
     record_redemption_on_vaults, record_repayed_to_vault,
 };
 use crate::guard::{GuardPrincipal, VaultLiquidationGuard};
-use crate::GuardError;
 use crate::logs::INFO;
-use crate::management::{mint_icusd, transfer_collateral, transfer_collateral_from, transfer_icusd_from, transfer_stable_from};
-use crate::numeric::{ICUSD, ICP, Ratio, UsdIcp};
-use crate::{
-    mutate_state, read_state, ProtocolError, SuccessWithFee,
-    StabilityPoolLiquidationResult,
-    DUST_THRESHOLD,
-    StableTokenType, VaultArgWithToken,
+use crate::management;
+use crate::management::{
+    mint_icusd, transfer_collateral, transfer_collateral_from, transfer_icusd_from,
+    transfer_stable_from,
 };
+use crate::numeric::{Ratio, UsdIcp, ICP, ICUSD};
 use crate::state::Mode;
+use crate::GuardError;
+use crate::PendingMarginTransfer;
+use crate::DEBUG;
+use crate::{
+    mutate_state, read_state, ProtocolError, StabilityPoolLiquidationResult, StableTokenType,
+    SuccessWithFee, VaultArgWithToken, DUST_THRESHOLD,
+};
 use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
 use icrc_ledger_types::icrc2::transfer_from::TransferFromError;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::Serialize;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use crate::DEBUG;
-use crate::management;
-use crate::PendingMarginTransfer;
-use rust_decimal::Decimal;
-use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
-use rust_decimal_macros::dec;
 
 use crate::compute_collateral_ratio;
 
@@ -165,7 +166,8 @@ impl Vault {
 pub fn require_vault_not_processing(vault: &Vault) -> Result<(), ProtocolError> {
     if vault.bot_processing {
         Err(ProtocolError::GenericError(format!(
-            "Vault #{} is locked — bot liquidation in progress", vault.vault_id
+            "Vault #{} is locked — bot liquidation in progress",
+            vault.vault_id
         )))
     } else {
         Ok(())
@@ -217,7 +219,10 @@ impl From<Vault> for CandidVault {
 
 /// Redeem icUSD for ckStable tokens from the protocol's reserves.
 /// Two-tier system: reserves first (flat fee), then vault spillover (dynamic fee).
-pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Principal>) -> Result<crate::ReserveRedemptionResult, ProtocolError> {
+pub async fn redeem_reserves(
+    icusd_amount_raw: u64,
+    preferred_token: Option<Principal>,
+) -> Result<crate::ReserveRedemptionResult, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let _guard_principal = GuardPrincipal::new(caller, "redeem_reserves")?;
 
@@ -239,13 +244,15 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
     }
 
     // Check reserve redemptions are enabled
-    let (enabled, reserve_fee_ratio, ckusdt_ledger, ckusdc_ledger, treasury) = read_state(|s| (
-        s.reserve_redemptions_enabled,
-        s.reserve_redemption_fee,
-        s.ckusdt_ledger_principal,
-        s.ckusdc_ledger_principal,
-        s.treasury_principal,
-    ));
+    let (enabled, reserve_fee_ratio, ckusdt_ledger, ckusdc_ledger, treasury) = read_state(|s| {
+        (
+            s.reserve_redemptions_enabled,
+            s.reserve_redemption_fee,
+            s.ckusdt_ledger_principal,
+            s.ckusdc_ledger_principal,
+            s.treasury_principal,
+        )
+    });
 
     if !enabled {
         return Err(ProtocolError::GenericError(
@@ -265,9 +272,9 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
         }
     } else {
         // Default: try ckUSDT first, then ckUSDC
-        ckusdt_ledger
-            .or(ckusdc_ledger)
-            .ok_or_else(|| ProtocolError::GenericError("No reserve token ledgers configured.".to_string()))?
+        ckusdt_ledger.or(ckusdc_ledger).ok_or_else(|| {
+            ProtocolError::GenericError("No reserve token ledgers configured.".to_string())
+        })?
     };
 
     // Calculate fee (flat rate)
@@ -289,15 +296,23 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
     }
 
     // Check reserve balance before pulling icUSD
-    let reserve_balance = management::get_token_balance(stable_ledger).await
-        .map_err(|e| ProtocolError::TemporarilyUnavailable(format!("Cannot query reserve balance: {}", e)))?;
+    let reserve_balance = management::get_token_balance(stable_ledger)
+        .await
+        .map_err(|e| {
+            ProtocolError::TemporarilyUnavailable(format!("Cannot query reserve balance: {}", e))
+        })?;
 
     // Determine how much can come from reserves vs vault spillover.
     // Each ICRC-1 transfer also costs a ledger fee (deducted from sender balance).
     // Query the actual fee from the ledger rather than hardcoding.
-    let ledger_fee = management::get_ledger_fee(stable_ledger).await
+    let ledger_fee = management::get_ledger_fee(stable_ledger)
+        .await
         .unwrap_or(10_000); // fallback to 10_000 e6s (0.01 USD) if query fails
-    let fee_budget = if fee_e6s > 0 { ledger_fee * 2 } else { ledger_fee };
+    let fee_budget = if fee_e6s > 0 {
+        ledger_fee * 2
+    } else {
+        ledger_fee
+    };
     let total_needed_e6s = net_e6s + fee_e6s + fee_budget;
     let available_for_user = if reserve_balance >= total_needed_e6s {
         net_e6s
@@ -312,7 +327,8 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
     let spillover_e8s = spillover_e6s * 100; // convert back to icUSD e8s
 
     // Pull icUSD from caller (effectively burns it)
-    let icusd_block_index = transfer_icusd_from(icusd_amount, caller).await
+    let icusd_block_index = transfer_icusd_from(icusd_amount, caller)
+        .await
         .map_err(|e| ProtocolError::TransferFromError(e, icusd_amount.to_u64()))?;
 
     // Transfer ckStable to user from reserves.
@@ -325,17 +341,25 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
     // retries it until success or MAX_PENDING_RETRIES. The op_nonce is minted
     // once and reused across retries (idempotent at the icUSD ledger).
     if available_for_user > 0 {
-        if let Err(transfer_err) = management::transfer_collateral(available_for_user, caller, stable_ledger).await {
-            log!(crate::INFO,
+        if let Err(transfer_err) =
+            management::transfer_collateral(available_for_user, caller, stable_ledger).await
+        {
+            log!(
+                crate::INFO,
                 "[redeem_reserves] ckStable transfer failed for {}: {:?}. Refunding {} icUSD.",
-                caller, transfer_err, icusd_amount.to_u64()
+                caller,
+                transfer_err,
+                icusd_amount.to_u64()
             );
             let refund_nonce = mutate_state(|s| s.next_op_nonce());
             match management::transfer_icusd_with_nonce(icusd_amount, caller, refund_nonce).await {
                 Ok(refund_block) => {
-                    log!(crate::INFO,
+                    log!(
+                        crate::INFO,
                         "[redeem_reserves] Refunded {} icUSD to {} (block {})",
-                        icusd_amount.to_u64(), caller, refund_block
+                        icusd_amount.to_u64(),
+                        caller,
+                        refund_block
                     );
                 }
                 Err(refund_err) => {
@@ -361,16 +385,19 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
                     });
                 }
             }
-            return Err(ProtocolError::GenericError(
-                format!("Reserve transfer failed; your icUSD refund is in flight. Error: {:?}", transfer_err),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Reserve transfer failed; your icUSD refund is in flight. Error: {:?}",
+                transfer_err
+            )));
         }
     }
 
     // Transfer fee to treasury (if configured), otherwise fee stays in reserves
     if fee_e6s > 0 {
         if let Some(treasury_principal) = treasury {
-            if let Err(e) = management::transfer_collateral(fee_e6s, treasury_principal, stable_ledger).await {
+            if let Err(e) =
+                management::transfer_collateral(fee_e6s, treasury_principal, stable_ledger).await
+            {
                 log!(crate::INFO,
                     "[redeem_reserves] WARNING: treasury fee transfer failed ({} e6s to {}): {:?}. Fee stays in reserves.",
                     fee_e6s, treasury_principal, e
@@ -420,8 +447,11 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
         // spillover collateral's price on-demand so the redeemer can't capture a
         // stale price during the 300s background-timer window.
         crate::xrc::ensure_fresh_price_for(&best_ct).await?;
-        let collateral_price = read_state(|s| s.get_collateral_price_decimal(&best_ct))
-            .ok_or(ProtocolError::TemporarilyUnavailable("No price for vault spillover collateral".to_string()))?;
+        let collateral_price = read_state(|s| s.get_collateral_price_decimal(&best_ct)).ok_or(
+            ProtocolError::TemporarilyUnavailable(
+                "No price for vault spillover collateral".to_string(),
+            ),
+        )?;
         let current_price = UsdIcp::from(collateral_price);
 
         let refund_e8s = mutate_state(|s| {
@@ -431,12 +461,7 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
             // so the base rate is read from and written back to that
             // collateral's config alone.
             let base_fee = s.get_redemption_fee_for(&best_ct, spillover_icusd);
-            crate::record_per_collateral_redemption_fee(
-                s,
-                &best_ct,
-                base_fee,
-                ic_cdk::api::time(),
-            );
+            crate::record_per_collateral_redemption_fee(s, &best_ct, base_fee, ic_cdk::api::time());
             let vault_fee = spillover_icusd * base_fee;
 
             // Note: RMR was already applied when computing spillover_e8s (line 160).
@@ -464,15 +489,26 @@ pub async fn redeem_reserves(icusd_amount_raw: u64, preferred_token: Option<Prin
             // RED-001: unconsumed spillover is refunded (RMR already applied
             // upstream, so the unconsumed effective amount IS the raw refund;
             // the fee stays with the protocol as priced).
-            effective_spillover.saturating_sub(outcome.consumed).to_u64()
+            effective_spillover
+                .saturating_sub(outcome.consumed)
+                .to_u64()
         });
         if refund_e8s > 0 {
             let refund_nonce = mutate_state(|s| s.next_op_nonce());
-            match management::transfer_icusd_with_nonce(ICUSD::from(refund_e8s), caller, refund_nonce).await {
+            match management::transfer_icusd_with_nonce(
+                ICUSD::from(refund_e8s),
+                caller,
+                refund_nonce,
+            )
+            .await
+            {
                 Ok(refund_block) => {
-                    log!(crate::INFO,
+                    log!(
+                        crate::INFO,
                         "[redeem_reserves] Refunded {} unconsumed spillover icUSD to {} (block {})",
-                        refund_e8s, caller, refund_block
+                        refund_e8s,
+                        caller,
+                        refund_block
                     );
                 }
                 Err(refund_err) => {
@@ -521,7 +557,10 @@ pub async fn redeem_icp(icusd_amount: u64) -> Result<SuccessWithFee, ProtocolErr
 /// Currently the redemption logic (vault sorting, pending transfers) is ICP-centric,
 /// but the API surface supports any collateral type. The internal logic will be
 /// generalized per-collateral when a second collateral type is actually added.
-pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
+pub async fn redeem_collateral(
+    collateral_type: Principal,
+    _icusd_amount: u64,
+) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let _guard_principal = GuardPrincipal::new(caller, "redeem_collateral")?;
 
@@ -551,9 +590,10 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
     // caller's argument cannot target a specific collateral (priority order
     // is a protocol-level peg defense).
     if read_state(|s| s.get_collateral_status(&collateral_type)).is_none() {
-        return Err(ProtocolError::GenericError(
-            format!("Collateral type {} not found.", collateral_type),
-        ));
+        return Err(ProtocolError::GenericError(format!(
+            "Collateral type {} not found.",
+            collateral_type
+        )));
     }
 
     // RED-002 (audit 2026-06-09): resolve the redemption-priority winner
@@ -572,22 +612,25 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
     let redeem_status = read_state(|s| s.get_collateral_status(&redeem_ct));
     if let Some(status) = redeem_status {
         if !status.allows_redemption() {
-            return Err(ProtocolError::GenericError(
-                format!("Redemption is not allowed for collateral type {}.", redeem_ct),
-            ));
+            return Err(ProtocolError::GenericError(format!(
+                "Redemption is not allowed for collateral type {}.",
+                redeem_ct
+            )));
         }
     } else {
-        return Err(ProtocolError::GenericError(
-            format!("Collateral type {} not found.", redeem_ct),
-        ));
+        return Err(ProtocolError::GenericError(format!(
+            "Collateral type {} not found.",
+            redeem_ct
+        )));
     }
 
     // Fail closed on a stale price for the collateral actually being seized
     // (VER-001 ceiling applies inside ensure_fresh_price_for).
     crate::xrc::ensure_fresh_price_for(&redeem_ct).await?;
 
-    let collateral_price = read_state(|s| s.get_collateral_price_decimal(&redeem_ct))
-        .ok_or(ProtocolError::TemporarilyUnavailable("No price available for collateral".to_string()))?;
+    let collateral_price = read_state(|s| s.get_collateral_price_decimal(&redeem_ct)).ok_or(
+        ProtocolError::TemporarilyUnavailable("No price available for collateral".to_string()),
+    )?;
     let current_collateral_price = UsdIcp::from(collateral_price);
 
     // RED-001 (audit 2026-06-09): reject claims that exceed what the
@@ -652,14 +695,15 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
                 // priced). Floor division favors the protocol; capped at the
                 // post-fee pull so a refund can never exceed what was taken.
                 let unconsumed = effective_icusd.saturating_sub(outcome.consumed);
-                let refund_e8s: u64 = if unconsumed.to_u64() == 0 || rmr.0 <= rust_decimal::Decimal::ZERO {
-                    0
-                } else {
-                    let raw = (rust_decimal::Decimal::from(unconsumed.to_u64()) / rmr.0)
-                        .to_u64()
-                        .unwrap_or(0);
-                    raw.min((icusd_amount - fee_amount).to_u64())
-                };
+                let refund_e8s: u64 =
+                    if unconsumed.to_u64() == 0 || rmr.0 <= rust_decimal::Decimal::ZERO {
+                        0
+                    } else {
+                        let raw = (rust_decimal::Decimal::from(unconsumed.to_u64()) / rmr.0)
+                            .to_u64()
+                            .unwrap_or(0);
+                        raw.min((icusd_amount - fee_amount).to_u64())
+                    };
 
                 // Wave-8e LIQ-005: route a configurable fraction of the
                 // redemption fee toward deficit repayment. The redeemer's
@@ -682,11 +726,20 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
             // nonce reused across retries) if the inline transfer fails.
             if refund_e8s > 0 {
                 let refund_nonce = mutate_state(|s| s.next_op_nonce());
-                match management::transfer_icusd_with_nonce(ICUSD::from(refund_e8s), caller, refund_nonce).await {
+                match management::transfer_icusd_with_nonce(
+                    ICUSD::from(refund_e8s),
+                    caller,
+                    refund_nonce,
+                )
+                .await
+                {
                     Ok(refund_block) => {
-                        log!(INFO,
+                        log!(
+                            INFO,
                             "[redeem_collateral] Refunded {} unconsumed icUSD to {} (block {})",
-                            refund_e8s, caller, refund_block
+                            refund_e8s,
+                            caller,
+                            refund_block
                         );
                     }
                     Err(refund_err) => {
@@ -717,7 +770,7 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
                 fee_amount_paid: fee_amount.to_u64(),
                 collateral_amount_received: Some(outcome.margin.to_u64()),
                 debt_liquidated_e8s: None, // SP-101
-                stable_pulled_e6s: None, // SP-110
+                stable_pulled_e6s: None,   // SP-110
             })
         }
         Err(transfer_from_error) => Err(ProtocolError::TransferFromError(
@@ -727,39 +780,53 @@ pub async fn redeem_collateral(collateral_type: Principal, _icusd_amount: u64) -
     }
 }
 
-pub async fn open_vault(collateral_amount_raw: u64, collateral_type_opt: Option<Principal>) -> Result<OpenVaultSuccess, ProtocolError> {
+pub async fn open_vault(
+    collateral_amount_raw: u64,
+    collateral_type_opt: Option<Principal>,
+) -> Result<OpenVaultSuccess, ProtocolError> {
     let caller = ic_cdk::api::caller();
     // Pass operation name to guard for better tracking
     let guard_principal = match GuardPrincipal::new(caller, "open_vault") {
         Ok(guard) => guard,
         Err(GuardError::AlreadyProcessing) => {
-            log!(INFO, "[open_vault] Principal {:?} already has an ongoing operation", caller);
+            log!(
+                INFO,
+                "[open_vault] Principal {:?} already has an ongoing operation",
+                caller
+            );
             return Err(ProtocolError::AlreadyProcessing);
-        },
+        }
         Err(GuardError::StaleOperation) => {
-            log!(INFO, "[open_vault] Principal {:?} has a stale operation that's being cleaned up", caller);
+            log!(
+                INFO,
+                "[open_vault] Principal {:?} has a stale operation that's being cleaned up",
+                caller
+            );
             return Err(ProtocolError::TemporarilyUnavailable(
-                "Previous operation is being cleaned up. Please try again in a few seconds.".to_string()
+                "Previous operation is being cleaned up. Please try again in a few seconds."
+                    .to_string(),
             ));
-        },
+        }
         Err(err) => return Err(err.into()),
     };
 
     // Resolve collateral type: default to ICP if not specified
-    let collateral_type = collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
+    let collateral_type =
+        collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
 
     // Look up CollateralConfig; check status is Active
-    let (config_ledger, config_status, min_deposit, is_native_xrp) = read_state(|s| {
-        match s.get_collateral_config(&collateral_type) {
+    let (config_ledger, config_status, min_deposit, is_native_xrp) =
+        read_state(|s| match s.get_collateral_config(&collateral_type) {
             Some(config) => Ok((
                 config.ledger_canister_id,
                 config.status,
                 config.min_collateral_deposit,
                 config.is_native_xrp(),
             )),
-            None => Err(ProtocolError::GenericError("Collateral type not supported.".to_string())),
-        }
-    })?;
+            None => Err(ProtocolError::GenericError(
+                "Collateral type not supported.".to_string(),
+            )),
+        })?;
 
     // P2: native-XRP collateral is custodied on the XRP Ledger (chains::xrp), not
     // pulled via an ICRC `transfer_from`. Its deposit flow (open-then-verify) is
@@ -842,11 +909,16 @@ pub async fn open_vault(collateral_amount_raw: u64, collateral_type_opt: Option<
                             collateral_amount_raw - ledger_fee,
                             caller,
                             config_ledger,
-                        ).await {
+                        )
+                        .await
+                        {
                             Ok(refund_block) => {
-                                log!(INFO,
+                                log!(
+                                    INFO,
                                     "[open_vault] Refunded {} collateral to {} (block {})",
-                                    collateral_amount_raw - ledger_fee, caller, refund_block
+                                    collateral_amount_raw - ledger_fee,
+                                    caller,
+                                    refund_block
                                 );
                             }
                             Err(refund_err) => {
@@ -902,6 +974,16 @@ pub struct XrpVaultOpenInfo {
     pub custody_address: String,
 }
 
+fn require_xrp_production_key() -> Result<(), ProtocolError> {
+    let configured_key = crate::chains::xrp::config::xrp_schnorr_key_name();
+    if crate::chains::xrp::config::is_xrp_production_key_name(&configured_key) {
+        return Ok(());
+    }
+    Err(ProtocolError::GenericError(format!(
+        "native-XRP operations require production Schnorr key key_1 (configured: {configured_key})"
+    )))
+}
+
 /// P3 (native-XRP collateral): open a vault in the open-then-verify staging area.
 /// Derives the per-vault XRPL custody address (threshold Ed25519), records an
 /// `XrpPendingDeposit` under a freshly reserved vault_id, and returns the address
@@ -911,6 +993,10 @@ pub struct XrpVaultOpenInfo {
 pub async fn open_xrp_vault() -> Result<XrpVaultOpenInfo, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal = GuardPrincipal::new(caller, "open_xrp_vault")?;
+    if let Err(e) = require_xrp_production_key() {
+        guard_principal.fail();
+        return Err(e);
+    }
 
     let xrp_ct = crate::state::xrp_collateral_principal();
     let cfg = read_state(|s| {
@@ -951,7 +1037,10 @@ pub async fn open_xrp_vault() -> Result<XrpVaultOpenInfo, ProtocolError> {
     let (global_pending, caller_pending) = read_state(|s| {
         (
             s.xrp_pending_deposits.len(),
-            s.xrp_pending_deposits.values().filter(|d| d.owner == caller).count(),
+            s.xrp_pending_deposits
+                .values()
+                .filter(|d| d.owner == caller)
+                .count(),
         )
     });
     if global_pending >= MAX_XRP_PENDING_GLOBAL {
@@ -1036,6 +1125,10 @@ pub async fn confirm_xrp_deposit(vault_id: u64) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::api::caller();
     let guard_principal =
         GuardPrincipal::new(caller, &format!("confirm_xrp_deposit_{}", vault_id))?;
+    if let Err(e) = require_xrp_production_key() {
+        guard_principal.fail();
+        return Err(e);
+    }
 
     let pending = match read_state(|s| s.xrp_pending_deposits.get(&vault_id).cloned()) {
         Some(p) => p,
@@ -1059,16 +1152,16 @@ pub async fn confirm_xrp_deposit(vault_id: u64) -> Result<u64, ProtocolError> {
     });
 
     // Verify on the XRP Ledger (consensus-retry-wrapped reads).
-    let acct =
-        match crate::chains::xrp::xrp_rpc::fetch_account_info(&pending.custody_address).await {
-            Ok(a) => a,
-            Err(e) => {
-                guard_principal.fail();
-                return Err(ProtocolError::GenericError(format!(
-                    "xrp account_info failed: {e}"
-                )));
-            }
-        };
+    let acct = match crate::chains::xrp::xrp_rpc::fetch_account_info(&pending.custody_address).await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(format!(
+                "xrp account_info failed: {e}"
+            )));
+        }
+    };
     if !acct.exists {
         guard_principal.fail();
         return Err(ProtocolError::GenericError(
@@ -1180,7 +1273,14 @@ fn queue_collateral_payout(
         .map(|c| c.is_native_xrp())
         .unwrap_or(false);
     if is_xrp {
-        record_xrp_claim(s, recipient, custody_owner, vault_id, margin.to_u64(), now_ns);
+        record_xrp_claim(
+            s,
+            recipient,
+            custody_owner,
+            vault_id,
+            margin.to_u64(),
+            now_ns,
+        );
     } else {
         s.pending_margin_transfers.insert(
             (vault_id, recipient),
@@ -1221,14 +1321,354 @@ pub(crate) fn xrp_claim_send_amount(drops: u64, fee: u64) -> Result<u64, Protoco
     }
 }
 
+pub(crate) fn xrp_unresolved_claim_drops_for_custody(
+    s: &crate::state::State,
+    custody_owner: Principal,
+    custody_nonce: u64,
+) -> Result<u128, ProtocolError> {
+    s.xrp_claims
+        .values()
+        .filter(|claim| {
+            claim.custody_owner == custody_owner && claim.custody_nonce == custody_nonce
+        })
+        .try_fold(0u128, |total, claim| {
+            total.checked_add(u128::from(claim.drops)).ok_or_else(|| {
+                ProtocolError::GenericError(
+                    "Aggregate XRP claims exceed supported drops range".to_string(),
+                )
+            })
+        })
+}
+
+pub(crate) fn xrp_inflight_claims_for_custody(
+    s: &crate::state::State,
+    current_claim_id: u64,
+    custody_owner: Principal,
+    custody_nonce: u64,
+) -> Vec<(u64, crate::state::XrpSettlement)> {
+    s.xrp_claims
+        .iter()
+        .filter_map(|(claim_id, claim)| {
+            if *claim_id != current_claim_id
+                && claim.custody_owner == custody_owner
+                && claim.custody_nonce == custody_nonce
+            {
+                claim
+                    .settlement
+                    .as_ref()
+                    .map(|settlement| (*claim_id, settlement.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum XrpSettlementReconciliation {
+    Paid,
+    FailedFeeCharged,
+    ExpiredNotFound,
+}
+
+pub(crate) fn reconcile_xrp_settlement_snapshot(
+    s: &mut crate::state::State,
+    claim_id: u64,
+    tx_hash: &str,
+    outcome: XrpSettlementReconciliation,
+) -> bool {
+    let hash_matches = s
+        .xrp_claims
+        .get(&claim_id)
+        .and_then(|claim| claim.settlement.as_ref())
+        .map(|settlement| settlement.tx_hash == tx_hash)
+        .unwrap_or(false);
+    if !hash_matches {
+        return false;
+    }
+
+    match outcome {
+        XrpSettlementReconciliation::Paid => {
+            s.xrp_claims.remove(&claim_id);
+        }
+        XrpSettlementReconciliation::FailedFeeCharged => {
+            if let Some(claim) = s.xrp_claims.get_mut(&claim_id) {
+                claim.drops = claim
+                    .drops
+                    .saturating_sub(crate::chains::xrp::adapter::XRP_FEE_DROPS);
+                claim.settlement = None;
+            }
+        }
+        XrpSettlementReconciliation::ExpiredNotFound => {
+            if let Some(claim) = s.xrp_claims.get_mut(&claim_id) {
+                claim.settlement = None;
+            }
+        }
+    }
+    true
+}
+
+async fn reconcile_xrp_other_inflight_claims(
+    current_claim_id: u64,
+    custody_owner: Principal,
+    custody_nonce: u64,
+    acct: &crate::chains::xrp::xrp_rpc::XrpAccountInfo,
+) -> Result<Option<u64>, ProtocolError> {
+    let in_flight = read_state(|s| {
+        xrp_inflight_claims_for_custody(s, current_claim_id, custody_owner, custody_nonce)
+    });
+    for (other_claim_id, settlement) in in_flight {
+        match crate::chains::xrp::xrp_rpc::fetch_tx_status(&settlement.tx_hash).await {
+            Ok(crate::chains::xrp::xrp_rpc::XrpTxStatus::Validated { .. }) => {
+                mutate_state(|s| {
+                    reconcile_xrp_settlement_snapshot(
+                        s,
+                        other_claim_id,
+                        &settlement.tx_hash,
+                        XrpSettlementReconciliation::Paid,
+                    );
+                });
+            }
+            Ok(crate::chains::xrp::xrp_rpc::XrpTxStatus::Failed) => {
+                mutate_state(|s| {
+                    reconcile_xrp_settlement_snapshot(
+                        s,
+                        other_claim_id,
+                        &settlement.tx_hash,
+                        XrpSettlementReconciliation::FailedFeeCharged,
+                    );
+                });
+            }
+            Ok(crate::chains::xrp::xrp_rpc::XrpTxStatus::NotFound) => {
+                if acct.ledger_index <= settlement.last_ledger_sequence {
+                    return Ok(Some(other_claim_id));
+                }
+                mutate_state(|s| {
+                    reconcile_xrp_settlement_snapshot(
+                        s,
+                        other_claim_id,
+                        &settlement.tx_hash,
+                        XrpSettlementReconciliation::ExpiredNotFound,
+                    );
+                });
+            }
+            Err(e) => {
+                return Err(ProtocolError::GenericError(format!(
+                    "xrp tx status for claim #{other_claim_id} failed: {e}"
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+pub(crate) fn ensure_xrp_claim_aggregate_solvency(
+    acct: &crate::chains::xrp::xrp_rpc::XrpAccountInfo,
+    reserve_drops: u128,
+    unresolved_claim_drops: u128,
+) -> Result<(), ProtocolError> {
+    if !acct.exists {
+        return Err(ProtocolError::GenericError(
+            "XRP custody account is unfunded; cannot settle claim.".to_string(),
+        ));
+    }
+    let required = reserve_drops
+        .checked_add(unresolved_claim_drops)
+        .ok_or_else(|| {
+            ProtocolError::GenericError(
+                "Aggregate XRP claims plus reserve exceed supported drops range".to_string(),
+            )
+        })?;
+    if acct.balance_drops < required {
+        return Err(ProtocolError::GenericError(format!(
+            "insufficient XRP for unresolved claims: balance {} drops < aggregate claims {} + reserve {}",
+            acct.balance_drops, unresolved_claim_drops, reserve_drops
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_xrp_replacement_sequence_safe(
+    prev: &crate::state::XrpSettlement,
+    acct: &crate::chains::xrp::xrp_rpc::XrpAccountInfo,
+) -> Result<(), ProtocolError> {
+    let Some(source_sequence) = prev.source_sequence else {
+        return Err(ProtocolError::GenericError(
+            "Cannot replace XRP settlement from legacy state without source sequence.".to_string(),
+        ));
+    };
+    if acct.sequence > source_sequence {
+        return Err(ProtocolError::GenericError(format!(
+            "Cannot replace XRP settlement: source sequence advanced from {} to {}.",
+            source_sequence, acct.sequence
+        )));
+    }
+    if acct.sequence < source_sequence {
+        return Err(ProtocolError::GenericError(format!(
+            "Cannot replace XRP settlement: live source sequence {} is behind stored sequence {}.",
+            acct.sequence, source_sequence
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_xrp_pending_deposit_if_unfunded_snapshot(
+    s: &mut crate::state::State,
+    vault_id: u64,
+    expected: &crate::state::XrpPendingDeposit,
+    acct: &crate::chains::xrp::xrp_rpc::XrpAccountInfo,
+) -> Result<bool, ProtocolError> {
+    if acct.exists {
+        return Err(ProtocolError::GenericError(
+            "XRP custody account is funded; confirm the deposit instead of cancelling.".to_string(),
+        ));
+    }
+    match s.xrp_pending_deposits.get(&vault_id) {
+        Some(current) if current == expected => {
+            s.xrp_pending_deposits.remove(&vault_id);
+            Ok(true)
+        }
+        Some(_) | None => Ok(false),
+    }
+}
+
+const XRP_PENDING_CLEANUP_MIN_AGE_NS: u64 = 10 * 60 * 1_000_000_000;
+
+pub(crate) fn ensure_xrp_pending_cleanup_age(
+    pending: &crate::state::XrpPendingDeposit,
+    now_ns: u64,
+) -> Result<(), ProtocolError> {
+    let age_ns = now_ns.saturating_sub(pending.opened_at_ns);
+    if age_ns < XRP_PENDING_CLEANUP_MIN_AGE_NS {
+        return Err(ProtocolError::GenericError(
+            "XRP pending deposit is too new to cancel; wait for the XRPL funding window to pass."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// XRP-006: owner cleanup for an unfunded native-XRP open. This never removes a
+/// funded custody account; users must confirm funded deposits into real vaults.
+pub async fn cancel_xrp_pending_open(vault_id: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::api::caller();
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("cancel_xrp_pending_open_{}", vault_id))?;
+
+    let pending = match read_state(|s| s.xrp_pending_deposits.get(&vault_id).cloned()) {
+        Some(p) => p,
+        None => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(
+                "No pending XRP deposit for this vault.".to_string(),
+            ));
+        }
+    };
+    if pending.owner != caller {
+        guard_principal.fail();
+        return Err(ProtocolError::CallerNotOwner);
+    }
+    if let Err(e) = ensure_xrp_pending_cleanup_age(&pending, ic_cdk::api::time()) {
+        guard_principal.fail();
+        return Err(e);
+    }
+
+    let acct = match crate::chains::xrp::xrp_rpc::fetch_account_info(&pending.custody_address).await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(format!(
+                "xrp account_info failed: {e}"
+            )));
+        }
+    };
+
+    let removed = mutate_state(|s| {
+        ensure_xrp_pending_cleanup_age(&pending, ic_cdk::api::time())?;
+        remove_xrp_pending_deposit_if_unfunded_snapshot(s, vault_id, &pending, &acct)
+    })?;
+    if !removed {
+        guard_principal.fail();
+        return Err(ProtocolError::GenericError(
+            "XRP pending deposit changed concurrently; refresh and retry.".to_string(),
+        ));
+    }
+
+    guard_principal.complete();
+    Ok(())
+}
+
+/// XRP-006: developer cleanup for abandoned unfunded native-XRP opens. This is
+/// deliberately unfunded-only; if XRP has reached the custody address the entry
+/// must remain confirmable by its owner.
+pub async fn sweep_xrp_pending_open(vault_id: u64) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::api::caller();
+    if !read_state(|s| s.developer_principal == caller) {
+        return Err(ProtocolError::GenericError(
+            "Only the developer can sweep XRP pending opens.".to_string(),
+        ));
+    }
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("sweep_xrp_pending_open_{}", vault_id))?;
+
+    let pending = match read_state(|s| s.xrp_pending_deposits.get(&vault_id).cloned()) {
+        Some(p) => p,
+        None => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(
+                "No pending XRP deposit for this vault.".to_string(),
+            ));
+        }
+    };
+    if let Err(e) = ensure_xrp_pending_cleanup_age(&pending, ic_cdk::api::time()) {
+        guard_principal.fail();
+        return Err(e);
+    }
+
+    let acct = match crate::chains::xrp::xrp_rpc::fetch_account_info(&pending.custody_address).await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(format!(
+                "xrp account_info failed: {e}"
+            )));
+        }
+    };
+
+    let removed = mutate_state(|s| {
+        ensure_xrp_pending_cleanup_age(&pending, ic_cdk::api::time())?;
+        remove_xrp_pending_deposit_if_unfunded_snapshot(s, vault_id, &pending, &acct)
+    })?;
+    if !removed {
+        guard_principal.fail();
+        return Err(ProtocolError::GenericError(
+            "XRP pending deposit changed concurrently; refresh and retry.".to_string(),
+        ));
+    }
+
+    guard_principal.complete();
+    Ok(())
+}
+
 /// P4: settle an XRP claim — sign + submit a `Payment` from the source vault's
 /// custody address (re-derived from the claim) to `destination`, for
 /// `claim.drops - fee` (the claimant bears the fee). Claimant-only. One in-flight
 /// Payment per custody address (sequence serialization, keyed on the source vault
 /// id). On success the claim is removed; returns the locally computed tx hash.
 pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<String, ProtocolError> {
+    settle_xrp_claim_with_tag(claim_id, destination, None).await
+}
+
+pub async fn settle_xrp_claim_with_tag(
+    claim_id: u64,
+    destination: String,
+    destination_tag: Option<u32>,
+) -> Result<String, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let claim = match read_state(|s| s.xrp_claims.get(&claim_id).cloned()) {
+    require_xrp_production_key()?;
+    let mut claim = match read_state(|s| s.xrp_claims.get(&claim_id).cloned()) {
         Some(c) => c,
         None => {
             return Err(ProtocolError::GenericError(
@@ -1236,6 +1676,8 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
             ))
         }
     };
+    let mut replacement_destination = destination;
+    let mut replacement_destination_tag = destination_tag;
     if claim.claimant != caller {
         return Err(ProtocolError::CallerNotOwner);
     }
@@ -1277,14 +1719,16 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
                 // Not validated yet. Only sign a fresh tx if the prior one can NEVER
                 // apply anymore (its LastLedgerSequence has passed); otherwise it may
                 // still land, so refuse to sign a second one.
-                let addr = match crate::chains::xrp::ted25519::derive_xrp_address(path.clone()).await
-                {
-                    Ok((_pk, addr)) => addr,
-                    Err(e) => {
-                        guard_principal.fail();
-                        return Err(ProtocolError::GenericError(format!("xrp derive failed: {e}")));
-                    }
-                };
+                let addr =
+                    match crate::chains::xrp::ted25519::derive_xrp_address(path.clone()).await {
+                        Ok((_pk, addr)) => addr,
+                        Err(e) => {
+                            guard_principal.fail();
+                            return Err(ProtocolError::GenericError(format!(
+                                "xrp derive failed: {e}"
+                            )));
+                        }
+                    };
                 let acct = match crate::chains::xrp::xrp_rpc::fetch_account_info(&addr).await {
                     Ok(a) => a,
                     Err(e) => {
@@ -1301,14 +1745,57 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
                             .to_string(),
                     ));
                 }
+                if let Err(e) = ensure_xrp_replacement_sequence_safe(&prev, &acct) {
+                    guard_principal.fail();
+                    return Err(e);
+                }
+                if replacement_destination.trim().is_empty() {
+                    replacement_destination = match prev.destination.clone() {
+                        Some(dest) => dest,
+                        None => {
+                            guard_principal.fail();
+                            return Err(ProtocolError::GenericError(
+                                "XRP settlement replacement requires a destination address."
+                                    .to_string(),
+                            ));
+                        }
+                    };
+                }
+                if replacement_destination_tag.is_none() {
+                    replacement_destination_tag = prev.destination_tag;
+                }
                 // Expired and never applied -> safe to sign a fresh settlement.
             }
             Ok(crate::chains::xrp::xrp_rpc::XrpTxStatus::Failed) => {
-                // Validated but failed -> funds did not move -> safe to re-sign.
+                // Validated but failed -> funds did not move, but XRPL still
+                // consumed the source-account fee. Charge it to this claim once,
+                // clear the failed settlement, and allow a replacement.
+                let fee = crate::chains::xrp::adapter::XRP_FEE_DROPS;
+                claim.drops = claim.drops.saturating_sub(fee);
+                mutate_state(|s| {
+                    if let Some(c) = s.xrp_claims.get_mut(&claim_id) {
+                        if c.settlement
+                            .as_ref()
+                            .map(|settlement| settlement.tx_hash == prev.tx_hash)
+                            .unwrap_or(false)
+                        {
+                            c.drops = claim.drops;
+                            c.settlement = None;
+                        }
+                    }
+                });
+                if replacement_destination.trim().is_empty() {
+                    replacement_destination = prev.destination.clone().unwrap_or_default();
+                }
+                if replacement_destination_tag.is_none() {
+                    replacement_destination_tag = prev.destination_tag;
+                }
             }
             Err(e) => {
                 guard_principal.fail();
-                return Err(ProtocolError::GenericError(format!("xrp tx status failed: {e}")));
+                return Err(ProtocolError::GenericError(format!(
+                    "xrp tx status failed: {e}"
+                )));
             }
         }
     }
@@ -1322,9 +1809,83 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
                 return Err(e);
             }
         };
+
+    let (source_address, acct) =
+        match crate::chains::xrp::ted25519::derive_xrp_address(path.clone()).await {
+            Ok((_pk, addr)) => match crate::chains::xrp::xrp_rpc::fetch_account_info(&addr).await {
+                Ok(a) => (addr, a),
+                Err(e) => {
+                    guard_principal.fail();
+                    return Err(ProtocolError::GenericError(format!(
+                        "xrp account_info failed: {e}"
+                    )));
+                }
+            },
+            Err(e) => {
+                guard_principal.fail();
+                return Err(ProtocolError::GenericError(format!(
+                    "xrp derive failed: {e}"
+                )));
+            }
+        };
+    let reserve = match crate::chains::xrp::xrp_rpc::fetch_reserve_base().await {
+        Ok(r) => r,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(ProtocolError::GenericError(format!(
+                "xrp server_state failed: {e}"
+            )));
+        }
+    };
+    let blocking_other_claim = match reconcile_xrp_other_inflight_claims(
+        claim_id,
+        claim.custody_owner,
+        claim.custody_nonce,
+        &acct,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(e);
+        }
+    };
+    if let Some(other_claim_id) = blocking_other_claim {
+        guard_principal.fail();
+        return Err(ProtocolError::GenericError(format!(
+            "XRP settlement for claim #{other_claim_id} is already in flight for this custody address; confirm it before settling another claim."
+        )));
+    }
+    let unresolved_claim_drops = match read_state(|s| {
+        xrp_unresolved_claim_drops_for_custody(s, claim.custody_owner, claim.custody_nonce)
+    }) {
+        Ok(drops) => drops,
+        Err(e) => {
+            guard_principal.fail();
+            return Err(e);
+        }
+    };
+    if let Err(e) = ensure_xrp_claim_aggregate_solvency(&acct, reserve, unresolved_claim_drops) {
+        log!(
+            INFO,
+            "[settle_xrp_claim] aggregate solvency rejected claim #{} from {}: {:?}",
+            claim_id,
+            source_address,
+            e
+        );
+        guard_principal.fail();
+        return Err(e);
+    }
+
     let adapter = crate::chains::xrp::adapter::XrpAdapter::new(crate::chains::xrp::XRP_CHAIN_ID);
-    let (signed, last_ledger_sequence) = match adapter
-        .sign_xrp_payment_from(path, &destination, send_drops as u128, None)
+    let payment = match adapter
+        .sign_xrp_payment_from(
+            path,
+            &replacement_destination,
+            send_drops as u128,
+            replacement_destination_tag,
+        )
         .await
     {
         Ok(v) => v,
@@ -1335,6 +1896,7 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
             )));
         }
     };
+    let signed = payment.signed;
 
     // Record the in-flight settlement BEFORE submitting, so a submit whose outcall
     // errors after rippled broadcast is reconciled on the next settle (confirm) call
@@ -1343,12 +1905,16 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
         if let Some(c) = s.xrp_claims.get_mut(&claim_id) {
             c.settlement = Some(crate::state::XrpSettlement {
                 tx_hash: signed.tx_hash.clone(),
-                last_ledger_sequence,
+                last_ledger_sequence: payment.last_ledger_sequence,
+                source_sequence: Some(payment.source_sequence),
+                destination: Some(replacement_destination.clone()),
+                destination_tag: replacement_destination_tag,
             });
         }
     });
 
-    if let Err(e) = crate::chains::xrp::xrp_rpc::submit_blob(&hex::encode_upper(&signed.raw_tx)).await
+    if let Err(e) =
+        crate::chains::xrp::xrp_rpc::submit_blob(&hex::encode_upper(&signed.raw_tx)).await
     {
         guard_principal.fail();
         return Err(ProtocolError::GenericError(format!(
@@ -1366,6 +1932,32 @@ pub async fn settle_xrp_claim(claim_id: u64, destination: String) -> Result<Stri
 #[cfg(test)]
 mod xrp_p4_tests {
     use super::*;
+
+    fn claim(
+        claimant: Principal,
+        custody_owner: Principal,
+        custody_nonce: u64,
+        drops: u64,
+    ) -> crate::state::XrpClaim {
+        crate::state::XrpClaim {
+            claimant,
+            drops,
+            custody_owner,
+            custody_nonce,
+            created_at_ns: 0,
+            settlement: None,
+        }
+    }
+
+    fn settlement(tx_hash: &str) -> crate::state::XrpSettlement {
+        crate::state::XrpSettlement {
+            tx_hash: tx_hash.to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: Some(41),
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: None,
+        }
+    }
 
     #[test]
     fn claim_send_amount_subtracts_fee() {
@@ -1400,16 +1992,263 @@ mod xrp_p4_tests {
         assert_eq!(c0.custody_nonce, 7);
         assert_eq!(c0.drops, 4_000_000);
     }
+
+    #[test]
+    fn unresolved_claim_drops_aggregates_only_same_custody_address() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let other_owner = Principal::from_slice(&[0xbb; 16]);
+        s.xrp_claims.insert(0, claim(claimant, owner, 7, 2_000_000));
+        s.xrp_claims.insert(1, claim(claimant, owner, 7, 3_000_000));
+        s.xrp_claims.insert(2, claim(claimant, owner, 8, 5_000_000));
+        s.xrp_claims
+            .insert(3, claim(claimant, other_owner, 7, 7_000_000));
+
+        assert_eq!(
+            xrp_unresolved_claim_drops_for_custody(&s, owner, 7).unwrap(),
+            5_000_000
+        );
+    }
+
+    #[test]
+    fn inflight_claims_for_custody_detects_same_custody_only() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let other_owner = Principal::from_slice(&[0xbb; 16]);
+        s.xrp_claims.insert(0, claim(claimant, owner, 7, 2_000_000));
+        s.xrp_claims.insert(1, {
+            let mut c = claim(claimant, owner, 7, 3_000_000);
+            c.settlement = Some(settlement("ABC"));
+            c
+        });
+        s.xrp_claims.insert(2, {
+            let mut c = claim(claimant, other_owner, 7, 5_000_000);
+            c.settlement = Some(crate::state::XrpSettlement {
+                tx_hash: "DEF".to_string(),
+                last_ledger_sequence: 9_000_000,
+                source_sequence: Some(12),
+                destination: Some("rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD".to_string()),
+                destination_tag: Some(99),
+            });
+            c
+        });
+
+        assert_eq!(
+            xrp_inflight_claims_for_custody(&s, 0, owner, 7)
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert!(xrp_inflight_claims_for_custody(&s, 1, owner, 7).is_empty());
+        assert!(xrp_inflight_claims_for_custody(&s, 0, owner, 8).is_empty());
+    }
+
+    #[test]
+    fn inflight_claims_for_custody_returns_settlement_snapshots() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        s.xrp_claims.insert(0, claim(claimant, owner, 7, 2_000_000));
+        s.xrp_claims.insert(1, {
+            let mut c = claim(claimant, owner, 7, 3_000_000);
+            c.settlement = Some(settlement("ABC"));
+            c
+        });
+
+        let in_flight = xrp_inflight_claims_for_custody(&s, 0, owner, 7);
+
+        assert_eq!(in_flight.len(), 1);
+        assert_eq!(in_flight[0].0, 1);
+        assert_eq!(in_flight[0].1.tx_hash, "ABC");
+    }
+
+    #[test]
+    fn reconcile_paid_settlement_removes_claim_only_for_matching_hash() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let mut c = claim(claimant, owner, 7, 3_000_000);
+        c.settlement = Some(settlement("ABC"));
+        s.xrp_claims.insert(1, c);
+
+        assert!(!reconcile_xrp_settlement_snapshot(
+            &mut s,
+            1,
+            "DEF",
+            XrpSettlementReconciliation::Paid,
+        ));
+        assert!(s.xrp_claims.contains_key(&1));
+        assert!(reconcile_xrp_settlement_snapshot(
+            &mut s,
+            1,
+            "ABC",
+            XrpSettlementReconciliation::Paid,
+        ));
+        assert!(!s.xrp_claims.contains_key(&1));
+    }
+
+    #[test]
+    fn reconcile_failed_settlement_charges_fee_once_and_clears_blocker() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let mut c = claim(claimant, owner, 7, 3_000_000);
+        c.settlement = Some(settlement("ABC"));
+        s.xrp_claims.insert(1, c);
+
+        assert!(reconcile_xrp_settlement_snapshot(
+            &mut s,
+            1,
+            "ABC",
+            XrpSettlementReconciliation::FailedFeeCharged,
+        ));
+        let claim = s.xrp_claims.get(&1).unwrap();
+        assert_eq!(
+            claim.drops,
+            3_000_000 - crate::chains::xrp::adapter::XRP_FEE_DROPS
+        );
+        assert!(claim.settlement.is_none());
+    }
+
+    #[test]
+    fn reconcile_expired_not_found_clears_blocker_without_charging_fee() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let mut c = claim(claimant, owner, 7, 3_000_000);
+        c.settlement = Some(settlement("ABC"));
+        s.xrp_claims.insert(1, c);
+
+        assert!(reconcile_xrp_settlement_snapshot(
+            &mut s,
+            1,
+            "ABC",
+            XrpSettlementReconciliation::ExpiredNotFound,
+        ));
+        let claim = s.xrp_claims.get(&1).unwrap();
+        assert_eq!(claim.drops, 3_000_000);
+        assert!(claim.settlement.is_none());
+    }
+
+    #[test]
+    fn aggregate_solvency_rejects_balance_that_only_covers_current_claim() {
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 41,
+            balance_drops: 4_000_020,
+            ledger_index: 9_000_000,
+        };
+
+        assert!(matches!(
+            ensure_xrp_claim_aggregate_solvency(&acct, 1_000_000, 5_000_000),
+            Err(ProtocolError::GenericError(_))
+        ));
+    }
+
+    #[test]
+    fn aggregate_solvency_accepts_exact_balance_for_all_unresolved_claims() {
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 41,
+            balance_drops: 6_000_000,
+            ledger_index: 9_000_000,
+        };
+
+        assert!(ensure_xrp_claim_aggregate_solvency(&acct, 1_000_000, 5_000_000).is_ok());
+    }
+
+    #[test]
+    fn replacement_rejects_missing_prior_source_sequence() {
+        let prev = crate::state::XrpSettlement {
+            tx_hash: "ABC".to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: None,
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: None,
+        };
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 41,
+            balance_drops: 10_000_000,
+            ledger_index: 9_000_100,
+        };
+
+        assert!(matches!(
+            ensure_xrp_replacement_sequence_safe(&prev, &acct),
+            Err(ProtocolError::GenericError(_))
+        ));
+    }
+
+    #[test]
+    fn replacement_rejects_when_live_sequence_advanced_past_prior_source_sequence() {
+        let prev = crate::state::XrpSettlement {
+            tx_hash: "ABC".to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: Some(41),
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: None,
+        };
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 42,
+            balance_drops: 10_000_000,
+            ledger_index: 9_000_100,
+        };
+
+        assert!(matches!(
+            ensure_xrp_replacement_sequence_safe(&prev, &acct),
+            Err(ProtocolError::GenericError(_))
+        ));
+    }
+
+    #[test]
+    fn replacement_allows_same_live_sequence_after_expiry() {
+        let prev = crate::state::XrpSettlement {
+            tx_hash: "ABC".to_string(),
+            last_ledger_sequence: 9_000_000,
+            source_sequence: Some(41),
+            destination: Some("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh".to_string()),
+            destination_tag: None,
+        };
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 41,
+            balance_drops: 10_000_000,
+            ledger_index: 9_000_100,
+        };
+
+        assert!(ensure_xrp_replacement_sequence_safe(&prev, &acct).is_ok());
+    }
+
+    #[test]
+    fn settle_xrp_claim_with_tag_is_exposed_at_vault_level() {
+        let _ = settle_xrp_claim_with_tag;
+    }
 }
 
 #[cfg(test)]
 mod xrp_p3_tests {
     use super::*;
 
+    fn pending(owner: Principal, custody_address: &str) -> crate::state::XrpPendingDeposit {
+        crate::state::XrpPendingDeposit {
+            owner,
+            custody_address: custody_address.to_string(),
+            derivation_nonce: 7,
+            opened_at_ns: 123,
+        }
+    }
+
     #[test]
     fn credit_nets_the_base_reserve() {
         // 5 XRP balance, 1 XRP reserve -> 4 XRP (drops) credited.
-        assert_eq!(xrp_credit_amount(5_000_000, 1_000_000, 0).unwrap(), 4_000_000);
+        assert_eq!(
+            xrp_credit_amount(5_000_000, 1_000_000, 0).unwrap(),
+            4_000_000
+        );
     }
 
     #[test]
@@ -1422,6 +2261,88 @@ mod xrp_p3_tests {
             xrp_credit_amount(1_000_000, 1_000_000, 0),
             Err(ProtocolError::AmountTooLow { .. })
         ));
+    }
+
+    #[test]
+    fn pending_cleanup_removes_only_when_live_account_is_unfunded() {
+        let owner = Principal::from_slice(&[0x44; 16]);
+        let dep = pending(owner, "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
+        let mut s = crate::state::State::default();
+        s.xrp_pending_deposits.insert(7, dep.clone());
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: false,
+            sequence: 0,
+            balance_drops: 0,
+            ledger_index: 9_000_000,
+        };
+
+        assert_eq!(
+            remove_xrp_pending_deposit_if_unfunded_snapshot(&mut s, 7, &dep, &acct).unwrap(),
+            true
+        );
+        assert!(!s.xrp_pending_deposits.contains_key(&7));
+    }
+
+    #[test]
+    fn pending_cleanup_refuses_funded_account() {
+        let owner = Principal::from_slice(&[0x44; 16]);
+        let dep = pending(owner, "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
+        let mut s = crate::state::State::default();
+        s.xrp_pending_deposits.insert(7, dep.clone());
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: true,
+            sequence: 1,
+            balance_drops: 1_000_000,
+            ledger_index: 9_000_000,
+        };
+
+        assert!(matches!(
+            remove_xrp_pending_deposit_if_unfunded_snapshot(&mut s, 7, &dep, &acct),
+            Err(ProtocolError::GenericError(_))
+        ));
+        assert!(s.xrp_pending_deposits.contains_key(&7));
+    }
+
+    #[test]
+    fn pending_cleanup_rechecks_snapshot_after_await_before_removing() {
+        let owner = Principal::from_slice(&[0x44; 16]);
+        let dep = pending(owner, "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
+        let changed = pending(owner, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh");
+        let mut s = crate::state::State::default();
+        s.xrp_pending_deposits.insert(7, changed);
+        let acct = crate::chains::xrp::xrp_rpc::XrpAccountInfo {
+            exists: false,
+            sequence: 0,
+            balance_drops: 0,
+            ledger_index: 9_000_000,
+        };
+
+        assert_eq!(
+            remove_xrp_pending_deposit_if_unfunded_snapshot(&mut s, 7, &dep, &acct).unwrap(),
+            false
+        );
+        assert!(s.xrp_pending_deposits.contains_key(&7));
+    }
+
+    #[test]
+    fn pending_cleanup_age_rejects_recent_entries() {
+        let owner = Principal::from_slice(&[0x44; 16]);
+        let dep = pending(owner, "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
+        assert!(matches!(
+            ensure_xrp_pending_cleanup_age(&dep, dep.opened_at_ns + 1),
+            Err(ProtocolError::GenericError(_))
+        ));
+    }
+
+    #[test]
+    fn pending_cleanup_age_accepts_old_entries() {
+        let owner = Principal::from_slice(&[0x44; 16]);
+        let dep = pending(owner, "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
+        assert!(ensure_xrp_pending_cleanup_age(
+            &dep,
+            dep.opened_at_ns + XRP_PENDING_CLEANUP_MIN_AGE_NS
+        )
+        .is_ok());
     }
 
     #[test]
@@ -1459,33 +2380,44 @@ pub async fn open_vault_and_borrow(
     let guard_principal = match GuardPrincipal::new(caller, "open_vault_and_borrow") {
         Ok(guard) => guard,
         Err(GuardError::AlreadyProcessing) => {
-            log!(INFO, "[open_vault_and_borrow] Principal {:?} already has an ongoing operation", caller);
+            log!(
+                INFO,
+                "[open_vault_and_borrow] Principal {:?} already has an ongoing operation",
+                caller
+            );
             return Err(ProtocolError::AlreadyProcessing);
-        },
+        }
         Err(GuardError::StaleOperation) => {
-            log!(INFO, "[open_vault_and_borrow] Principal {:?} has a stale operation being cleaned up", caller);
+            log!(
+                INFO,
+                "[open_vault_and_borrow] Principal {:?} has a stale operation being cleaned up",
+                caller
+            );
             return Err(ProtocolError::TemporarilyUnavailable(
-                "Previous operation is being cleaned up. Please try again in a few seconds.".to_string()
+                "Previous operation is being cleaned up. Please try again in a few seconds."
+                    .to_string(),
             ));
-        },
+        }
         Err(err) => return Err(err.into()),
     };
 
     // Resolve collateral type: default to ICP if not specified
-    let collateral_type = collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
+    let collateral_type =
+        collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
 
     // Look up CollateralConfig; check status is Active
-    let (config_ledger, config_status, min_deposit, is_native_xrp) = read_state(|s| {
-        match s.get_collateral_config(&collateral_type) {
+    let (config_ledger, config_status, min_deposit, is_native_xrp) =
+        read_state(|s| match s.get_collateral_config(&collateral_type) {
             Some(config) => Ok((
                 config.ledger_canister_id,
                 config.status,
                 config.min_collateral_deposit,
                 config.is_native_xrp(),
             )),
-            None => Err(ProtocolError::GenericError("Collateral type not supported.".to_string())),
-        }
-    })?;
+            None => Err(ProtocolError::GenericError(
+                "Collateral type not supported.".to_string(),
+            )),
+        })?;
 
     // P2: native-XRP collateral is custodied on the XRP Ledger (chains::xrp), not
     // pulled via an ICRC `transfer_from`. Its deposit flow (open-then-verify) is
@@ -1515,25 +2447,26 @@ pub async fn open_vault_and_borrow(
     }
 
     // Pull collateral via ICRC-2 transfer_from (caller must have approved first)
-    let block_index = match transfer_collateral_from(collateral_amount_raw, caller, config_ledger).await {
-        Ok(bi) => bi,
-        Err(transfer_from_error) => {
-            guard_principal.fail();
-            if let TransferFromError::BadFee { expected_fee } = transfer_from_error.clone() {
-                mutate_state(|s| {
-                    if let Ok(fee) = u64::try_from(expected_fee.0) {
-                        if let Some(config) = s.get_collateral_config_mut(&collateral_type) {
-                            config.ledger_fee = fee;
+    let block_index =
+        match transfer_collateral_from(collateral_amount_raw, caller, config_ledger).await {
+            Ok(bi) => bi,
+            Err(transfer_from_error) => {
+                guard_principal.fail();
+                if let TransferFromError::BadFee { expected_fee } = transfer_from_error.clone() {
+                    mutate_state(|s| {
+                        if let Ok(fee) = u64::try_from(expected_fee.0) {
+                            if let Some(config) = s.get_collateral_config_mut(&collateral_type) {
+                                config.ledger_fee = fee;
+                            }
                         }
-                    }
-                });
-            };
-            return Err(ProtocolError::TransferFromError(
-                transfer_from_error,
-                icp_margin_amount.to_u64(),
-            ));
-        }
-    };
+                    });
+                };
+                return Err(ProtocolError::TransferFromError(
+                    transfer_from_error,
+                    icp_margin_amount.to_u64(),
+                ));
+            }
+        };
 
     // Create the vault
     let vault_id = mutate_state(|s| {
@@ -1555,7 +2488,10 @@ pub async fn open_vault_and_borrow(
         vault_id
     });
 
-    log!(INFO, "[open_vault_and_borrow] opened vault {vault_id}, now borrowing {borrow_amount_raw}");
+    log!(
+        INFO,
+        "[open_vault_and_borrow] opened vault {vault_id}, now borrowing {borrow_amount_raw}"
+    );
 
     // Borrow icUSD — reuse internal fn to avoid guard conflict
     if borrow_amount_raw > 0 {
@@ -1570,11 +2506,24 @@ pub async fn open_vault_and_borrow(
                 )));
             }
         };
-        match borrow_from_vault_internal(caller, VaultArg { vault_id, amount: borrow_amount_raw }).await {
-            Ok(borrow_result) => {
-                log!(INFO, "[open_vault_and_borrow] vault {} borrow of {} succeeded (fee: {})",
-                    vault_id, borrow_amount_raw, borrow_result.fee_amount_paid);
+        match borrow_from_vault_internal(
+            caller,
+            VaultArg {
+                vault_id,
+                amount: borrow_amount_raw,
             },
+        )
+        .await
+        {
+            Ok(borrow_result) => {
+                log!(
+                    INFO,
+                    "[open_vault_and_borrow] vault {} borrow of {} succeeded (fee: {})",
+                    vault_id,
+                    borrow_amount_raw,
+                    borrow_result.fee_amount_paid
+                );
+            }
             Err(e) => {
                 guard_principal.fail();
                 return Err(ProtocolError::GenericError(format!(
@@ -1586,13 +2535,19 @@ pub async fn open_vault_and_borrow(
     }
 
     guard_principal.complete();
-    Ok(OpenVaultSuccess { vault_id, block_index })
+    Ok(OpenVaultSuccess {
+        vault_id,
+        block_index,
+    })
 }
 
 /// Internal borrow logic without guard management.
 /// Called by both `borrow_from_vault` (which acquires its own guard) and
 /// `open_vault_with_deposit` (which already holds a guard for the same principal).
-async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<SuccessWithFee, ProtocolError> {
+async fn borrow_from_vault_internal(
+    caller: Principal,
+    arg: VaultArg,
+) -> Result<SuccessWithFee, ProtocolError> {
     let amount: ICUSD = arg.amount.into();
 
     if amount < read_state(|s| s.min_icusd_amount) {
@@ -1605,21 +2560,25 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
     let now = ic_cdk::api::time();
     mutate_state(|s| s.accrue_single_vault(arg.vault_id, now));
 
-    let (vault, collateral_price, config_decimals) = read_state(|s| {
-        match s.vault_id_to_vaults.get(&arg.vault_id) {
+    let (vault, collateral_price, config_decimals, is_native_xrp) =
+        read_state(|s| match s.vault_id_to_vaults.get(&arg.vault_id) {
             Some(vault) => {
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
+                let price = s
+                    .get_collateral_price_decimal(&vault.collateral_type)
                     .ok_or("No price available for collateral. Price feed may be down.")?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
-                    .map(|c| c.decimals)
-                    .unwrap_or(8);
-                Ok((vault.clone(), price, decimals))
-            },
-            None => {
-                Err("Vault not found. Please check the vault ID.")
+                let config = s
+                    .get_collateral_config(&vault.collateral_type)
+                    .ok_or("Collateral type not configured.")?;
+                Ok((
+                    vault.clone(),
+                    price,
+                    config.decimals,
+                    config.is_native_xrp(),
+                ))
             }
-        }
-    }).map_err(|msg: &str| ProtocolError::GenericError(msg.to_string()))?;
+            None => Err("Vault not found. Please check the vault ID."),
+        })
+        .map_err(|msg: &str| ProtocolError::GenericError(msg.to_string()))?;
 
     require_vault_not_processing(&vault)?;
 
@@ -1631,6 +2590,9 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
                 "Borrowing is not allowed for this collateral type.".to_string(),
             ));
         }
+    }
+    if is_native_xrp {
+        require_xrp_production_key()?;
     }
 
     if caller != vault.owner {
@@ -1653,7 +2615,8 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
             .map(|c| c.debt_ceiling)
             .unwrap_or(u64::MAX)
     });
-    let (global_cap, total_borrowed) = read_state(|s| (s.global_icusd_mint_cap, s.total_borrowed_icusd_amount()));
+    let (global_cap, total_borrowed) =
+        read_state(|s| (s.global_icusd_mint_cap, s.total_borrowed_icusd_amount()));
     let _borrow_reservation = crate::guard::BorrowReservationGuard::try_reserve(
         vault.collateral_type,
         amount.to_u64(),
@@ -1664,12 +2627,20 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
     )
     .map_err(ProtocolError::GenericError)?;
 
-    let collateral_value = crate::numeric::collateral_usd_value(vault.collateral_amount, collateral_price, config_decimals);
+    let collateral_value = crate::numeric::collateral_usd_value(
+        vault.collateral_amount,
+        collateral_price,
+        config_decimals,
+    );
     let min_ratio = read_state(|s| {
         let base = s.get_min_collateral_ratio_for(&vault.collateral_type);
         if s.mode == Mode::Recovery {
             let recovery_cr = s.get_recovery_cr_for(&vault.collateral_type);
-            if recovery_cr > base { recovery_cr } else { base }
+            if recovery_cr > base {
+                recovery_cr
+            } else {
+                base
+            }
         } else {
             base
         }
@@ -1690,7 +2661,7 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
     } else {
         Ratio::from(
             Decimal::from_u64(collateral_value.to_u64()).unwrap_or(Decimal::ZERO)
-                / Decimal::from_u64(new_total_debt.to_u64()).unwrap_or(Decimal::ONE)
+                / Decimal::from_u64(new_total_debt.to_u64()).unwrap_or(Decimal::ONE),
         )
     };
 
@@ -1719,25 +2690,28 @@ async fn borrow_from_vault_internal(caller: Principal, arg: VaultArg) -> Result<
                 fee_amount_paid: fee.to_u64(),
                 collateral_amount_received: None,
                 debt_liquidated_e8s: None, // SP-101
-                stable_pulled_e6s: None, // SP-110
+                stable_pulled_e6s: None,   // SP-110
             })
         }
-        Err(mint_error) => {
-            Err(ProtocolError::TransferError(mint_error))
-        }
+        Err(mint_error) => Err(ProtocolError::TransferError(mint_error)),
     }
 }
 
 pub async fn borrow_from_vault(arg: VaultArg) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = match GuardPrincipal::new(caller, &format!("borrow_vault_{}", arg.vault_id)) {
-        Ok(guard) => guard,
-        Err(GuardError::AlreadyProcessing) => {
-            log!(INFO, "[borrow_from_vault] Principal {:?} already has an ongoing operation", caller);
-            return Err(ProtocolError::AlreadyProcessing);
-        },
-        Err(err) => return Err(err.into()),
-    };
+    let guard_principal =
+        match GuardPrincipal::new(caller, &format!("borrow_vault_{}", arg.vault_id)) {
+            Ok(guard) => guard,
+            Err(GuardError::AlreadyProcessing) => {
+                log!(
+                    INFO,
+                    "[borrow_from_vault] Principal {:?} already has an ongoing operation",
+                    caller
+                );
+                return Err(ProtocolError::AlreadyProcessing);
+            }
+            Err(err) => return Err(err.into()),
+        };
 
     // AR-B-003 (audit 2026-06-09): per-vault op lock. The per-caller guard
     // above does not exclude a concurrent liquidation/redemption of this
@@ -1781,7 +2755,11 @@ pub async fn borrow_from_vault(arg: VaultArg) -> Result<SuccessWithFee, Protocol
 /// guarantee — an explicit flag (rather than `amount == debt` equality) avoids
 /// brittleness from interest accruing between the caller's debt fetch and
 /// this helper's read.
-async fn repay_to_vault_internal(caller: Principal, arg: VaultArg, is_full_close: bool) -> Result<u64, ProtocolError> {
+async fn repay_to_vault_internal(
+    caller: Principal,
+    arg: VaultArg,
+    is_full_close: bool,
+) -> Result<u64, ProtocolError> {
     let amount: ICUSD = arg.amount.into();
 
     // Accrue interest before repayment so the correct debt balance is used.
@@ -1832,12 +2810,19 @@ async fn repay_to_vault_internal(caller: Principal, arg: VaultArg, is_full_close
 
     match transfer_icusd_from(amount, caller).await {
         Ok(block_index) => {
-            let interest_share = mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
+            let interest_share =
+                mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
             // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
             // next flush retries it instead of silently dropping treasury revenue.
-            let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+            let unminted_interest =
+                crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
             if unminted_interest.to_u64() > 0 {
-                mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+                mutate_state(|s| {
+                    s.restore_pending_interest_for_pool(
+                        vault.collateral_type,
+                        unminted_interest.to_u64(),
+                    )
+                });
             }
             Ok(block_index)
         }
@@ -1875,7 +2860,8 @@ pub async fn repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
 /// Repay vault debt using ckUSDT or ckUSDC (1:1 with icUSD, plus configurable fee)
 pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("repay_vault_stable_{}", arg.vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("repay_vault_stable_{}", arg.vault_id))?;
     // AR-B-003: per-vault op lock; see guard.rs::VaultLiquidationGuard.
     let _vault_op_guard = match VaultLiquidationGuard::new(arg.vault_id) {
         Ok(g) => g,
@@ -1892,7 +2878,10 @@ pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, P
     });
     if !is_enabled {
         guard_principal.fail();
-        return Err(ProtocolError::GenericError(format!("{:?} repayments are currently disabled", arg.token_type)));
+        return Err(ProtocolError::GenericError(format!(
+            "{:?} repayments are currently disabled",
+            arg.token_type
+        )));
     }
 
     // Depeg protection: fetch fresh stablecoin price and reject if outside $0.95–$1.05
@@ -1969,13 +2958,15 @@ pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, P
     let base_stable_e6s = raw_amount_e8s / 100;
     let fee_rate = read_state(|s| s.ckstable_repay_fee);
     let fee_e6s = (rust_decimal::Decimal::from(base_stable_e6s) * fee_rate.0)
-        .to_u64().unwrap_or(0);
+        .to_u64()
+        .unwrap_or(0);
     let total_pull_e6s = base_stable_e6s + fee_e6s;
 
     // Transfer the stable token from user (in 6-decimal units)
     match transfer_stable_from(arg.token_type.clone(), total_pull_e6s, caller).await {
         Ok(block_index) => {
-            let interest_share = mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
+            let interest_share =
+                mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
 
             // Route interest via N-way split (stablecoin-denominated)
             if interest_share.to_u64() > 0 {
@@ -1983,7 +2974,8 @@ pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, P
                     interest_share.to_u64(),
                     vault.collateral_type,
                     arg.token_type.clone(),
-                ).await;
+                )
+                .await;
             }
 
             // Route fee surcharge to treasury as stablecoins
@@ -1996,11 +2988,19 @@ pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, P
                     (s.treasury_principal, ledger)
                 });
                 if let (Some(treasury_principal), Some(stable_ledger)) = (treasury, stable_ledger) {
-                    match management::transfer_collateral(fee_e6s, treasury_principal, stable_ledger).await {
+                    match management::transfer_collateral(
+                        fee_e6s,
+                        treasury_principal,
+                        stable_ledger,
+                    )
+                    .await
+                    {
                         Ok(block) => {
-                            log!(INFO,
+                            log!(
+                                INFO,
                                 "[repay_with_stable] Transferred {} e6s fee to treasury (block {})",
-                                fee_e6s, block
+                                fee_e6s,
+                                block
                             );
                         }
                         Err(e) => {
@@ -2029,7 +3029,8 @@ pub async fn repay_to_vault_with_stable(arg: VaultArgWithToken) -> Result<u64, P
 
 pub async fn add_margin_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("add_margin_vault_{}", arg.vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("add_margin_vault_{}", arg.vault_id))?;
     // AR-B-003: per-vault op lock; see guard.rs::VaultLiquidationGuard.
     let _vault_op_guard = match VaultLiquidationGuard::new(arg.vault_id) {
         Ok(g) => g,
@@ -2040,10 +3041,11 @@ pub async fn add_margin_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
     };
     let amount: ICP = arg.amount.into();
 
-    let (vault, config_ledger, min_deposit, is_native_xrp) = match read_state(|s| {
-        match s.vault_id_to_vaults.get(&arg.vault_id) {
+    let (vault, config_ledger, min_deposit, is_native_xrp) =
+        match read_state(|s| match s.vault_id_to_vaults.get(&arg.vault_id) {
             Some(v) => {
-                let config = s.get_collateral_config(&v.collateral_type)
+                let config = s
+                    .get_collateral_config(&v.collateral_type)
                     .ok_or("Collateral type not configured")?;
                 Ok((
                     v.clone(),
@@ -2051,16 +3053,15 @@ pub async fn add_margin_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
                     config.min_collateral_deposit,
                     config.is_native_xrp(),
                 ))
-            },
+            }
             None => Err("Vault not found"),
-        }
-    }) {
-        Ok(result) => result,
-        Err(msg) => {
-            guard_principal.fail();
-            return Err(ProtocolError::GenericError(msg.to_string()));
-        }
-    };
+        }) {
+            Ok(result) => result,
+            Err(msg) => {
+                guard_principal.fail();
+                return Err(ProtocolError::GenericError(msg.to_string()));
+            }
+        };
 
     // P2: native-XRP collateral is not custodied via ICRC; its add-collateral flow
     // is wired with the XRP deposit path (P3). Reject so XRP collateral can never be
@@ -2138,18 +3139,23 @@ pub async fn open_vault_with_deposit(
     let guard_principal = match GuardPrincipal::new(caller, "open_vault_with_deposit") {
         Ok(guard) => guard,
         Err(GuardError::AlreadyProcessing) => {
-            log!(INFO, "[open_vault_with_deposit] Principal {:?} already has an ongoing operation", caller);
+            log!(
+                INFO,
+                "[open_vault_with_deposit] Principal {:?} already has an ongoing operation",
+                caller
+            );
             return Err(ProtocolError::AlreadyProcessing);
-        },
+        }
         Err(err) => return Err(err.into()),
     };
 
     // Resolve collateral type: default to ICP if not specified
-    let collateral_type = collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
+    let collateral_type =
+        collateral_type_opt.unwrap_or_else(|| read_state(|s| s.icp_collateral_type()));
 
     // Look up CollateralConfig
-    let (config_ledger, config_status, config_fee, min_deposit, is_native_xrp) = read_state(|s| {
-        match s.get_collateral_config(&collateral_type) {
+    let (config_ledger, config_status, config_fee, min_deposit, is_native_xrp) =
+        read_state(|s| match s.get_collateral_config(&collateral_type) {
             Some(config) => Ok((
                 config.ledger_canister_id,
                 config.status,
@@ -2157,9 +3163,10 @@ pub async fn open_vault_with_deposit(
                 config.min_collateral_deposit,
                 config.is_native_xrp(),
             )),
-            None => Err(ProtocolError::GenericError("Collateral type not supported.".to_string())),
-        }
-    })?;
+            None => Err(ProtocolError::GenericError(
+                "Collateral type not supported.".to_string(),
+            )),
+        })?;
 
     // P2: native-XRP collateral is custodied on the XRP Ledger (chains::xrp), not
     // swept from an ICRC deposit subaccount. Reject until the XRP deposit flow (P3).
@@ -2178,7 +3185,13 @@ pub async fn open_vault_with_deposit(
     }
 
     // Sweep funds from the caller's deposit subaccount
-    let (collateral_amount, sweep_block_index) = match management::sweep_deposit(&caller, config_ledger, config_fee).await {
+    let (collateral_amount, sweep_block_index) = match management::sweep_deposit(
+        &caller,
+        config_ledger,
+        config_fee,
+    )
+    .await
+    {
         Ok(result) => result,
         Err(e) => {
             guard_principal.fail();
@@ -2225,11 +3238,24 @@ pub async fn open_vault_with_deposit(
     if borrow_amount_raw > 0 {
         // AR-B-003: per-vault op lock across the borrow's mint await.
         let _vault_op_guard = VaultLiquidationGuard::new(vault_id)?;
-        match borrow_from_vault_internal(caller, VaultArg { vault_id, amount: borrow_amount_raw }).await {
-            Ok(borrow_result) => {
-                log!(INFO, "[open_vault_with_deposit] vault {} initial borrow of {} succeeded (fee: {})",
-                    vault_id, borrow_amount_raw, borrow_result.fee_amount_paid);
+        match borrow_from_vault_internal(
+            caller,
+            VaultArg {
+                vault_id,
+                amount: borrow_amount_raw,
             },
+        )
+        .await
+        {
+            Ok(borrow_result) => {
+                log!(
+                    INFO,
+                    "[open_vault_with_deposit] vault {} initial borrow of {} succeeded (fee: {})",
+                    vault_id,
+                    borrow_amount_raw,
+                    borrow_result.fee_amount_paid
+                );
+            }
             Err(e) => {
                 guard_principal.fail();
                 return Err(ProtocolError::GenericError(format!(
@@ -2259,10 +3285,11 @@ pub async fn add_margin_with_deposit(vault_id: u64) -> Result<u64, ProtocolError
         }
     };
 
-    let (vault, config_ledger, config_fee, min_deposit, is_native_xrp) = match read_state(|s| {
-        match s.vault_id_to_vaults.get(&vault_id) {
+    let (vault, config_ledger, config_fee, min_deposit, is_native_xrp) =
+        match read_state(|s| match s.vault_id_to_vaults.get(&vault_id) {
             Some(v) => {
-                let config = s.get_collateral_config(&v.collateral_type)
+                let config = s
+                    .get_collateral_config(&v.collateral_type)
                     .ok_or("Collateral type not configured")?;
                 Ok((
                     v.clone(),
@@ -2271,16 +3298,15 @@ pub async fn add_margin_with_deposit(vault_id: u64) -> Result<u64, ProtocolError
                     config.min_collateral_deposit,
                     config.is_native_xrp(),
                 ))
-            },
+            }
             None => Err("Vault not found"),
-        }
-    }) {
-        Ok(result) => result,
-        Err(msg) => {
-            guard_principal.fail();
-            return Err(ProtocolError::GenericError(msg.to_string()));
-        }
-    };
+        }) {
+            Ok(result) => result,
+            Err(msg) => {
+                guard_principal.fail();
+                return Err(ProtocolError::GenericError(msg.to_string()));
+            }
+        };
 
     // P2: native-XRP collateral is not custodied via ICRC; its add-collateral flow
     // is wired with the XRP deposit path (P3). Reject so XRP collateral can never be
@@ -2314,7 +3340,13 @@ pub async fn add_margin_with_deposit(vault_id: u64) -> Result<u64, ProtocolError
     }
 
     // Sweep funds from deposit subaccount
-    let (collateral_amount, sweep_block_index) = match management::sweep_deposit(&caller, config_ledger, config_fee).await {
+    let (collateral_amount, sweep_block_index) = match management::sweep_deposit(
+        &caller,
+        config_ledger,
+        config_fee,
+    )
+    .await
+    {
         Ok(result) => result,
         Err(e) => {
             guard_principal.fail();
@@ -2349,7 +3381,7 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
 
     // Check rate limits first
     mutate_state(|s| s.check_close_vault_rate_limit(caller))?;
-    
+
     // Record the close request for rate limiting
     mutate_state(|s| s.record_close_vault_request(caller));
 
@@ -2359,7 +3391,7 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
 
     // Check if the vault exists first
     let vault_exists = read_state(|s| s.vault_id_to_vaults.contains_key(&vault_id));
-    
+
     if !vault_exists {
         mutate_state(|s| s.complete_close_vault_request());
         log!(
@@ -2368,9 +3400,12 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
             vault_id,
             caller
         );
-        return Err(ProtocolError::GenericError(format!("Vault #{} not found", vault_id)));
+        return Err(ProtocolError::GenericError(format!(
+            "Vault #{} not found",
+            vault_id
+        )));
     }
-    
+
     // Get the vault
     let vault = read_state(|s| {
         s.vault_id_to_vaults
@@ -2412,13 +3447,13 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
             vault.borrowed_icusd_amount,
             vault_id
         );
-        
+
         // Record dust forgiveness (no real payment, no treasury routing)
         mutate_state(|s| {
             s.dust_forgiven_total += vault.borrowed_icusd_amount;
             let _ = s.repay_to_vault(vault_id, vault.borrowed_icusd_amount);
         });
-        
+
         // Record dust forgiveness event
         crate::storage::record_event(&crate::event::Event::DustForgiven {
             vault_id,
@@ -2434,7 +3469,7 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
             vault.borrowed_icusd_amount
         );
         return Err(ProtocolError::GenericError(
-            "Cannot close vault with outstanding debt. Repay all debt first.".to_string()
+            "Cannot close vault with outstanding debt. Repay all debt first.".to_string(),
         ));
     }
 
@@ -2448,7 +3483,7 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
             vault.collateral_amount
         );
         return Err(ProtocolError::GenericError(
-            "Cannot close vault with remaining collateral. Withdraw collateral first.".to_string()
+            "Cannot close vault with remaining collateral. Withdraw collateral first.".to_string(),
         ));
     }
 
@@ -2466,7 +3501,7 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
 
             // Complete the close request
             s.complete_close_vault_request();
-            
+
             log!(
                 INFO,
                 "[close_vault] Successfully closed vault #{} for principal {}",
@@ -2483,14 +3518,15 @@ pub async fn close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
             s.complete_close_vault_request();
         }
     });
-    
+
     // Return success with no block index (since no transfer was made)
     Ok(None)
 }
 
 pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::caller();
-    let _guard_principal = GuardPrincipal::new(caller, &format!("withdraw_collateral_{}", vault_id))?;
+    let _guard_principal =
+        GuardPrincipal::new(caller, &format!("withdraw_collateral_{}", vault_id))?;
     // AR-B-003: per-vault op lock; see guard.rs::VaultLiquidationGuard.
     let _vault_op_guard = VaultLiquidationGuard::new(vault_id)?;
 
@@ -2500,10 +3536,11 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
         vault_id,
         caller
     );
-    
+
     // Check vault exists and caller is owner
     let vault = read_state(|state| {
-        state.vault_id_to_vaults
+        state
+            .vault_id_to_vaults
             .get(&vault_id)
             .cloned()
             .ok_or(ProtocolError::GenericError("Vault not found".to_string()))
@@ -2530,7 +3567,7 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
         );
         return Err(ProtocolError::CallerNotOwner);
     }
-    
+
     // Check there's no debt
     if vault.borrowed_icusd_amount > ICUSD::new(0) {
         log!(
@@ -2544,7 +3581,7 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
             vault.borrowed_icusd_amount
         )));
     }
-    
+
     // Check there's collateral to withdraw
     if vault.collateral_amount == 0 {
         log!(
@@ -2552,15 +3589,23 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
             "[withdraw_collateral] Vault #{} has no collateral to withdraw",
             vault_id
         );
-        return Err(ProtocolError::GenericError("No collateral to withdraw".to_string()));
+        return Err(ProtocolError::GenericError(
+            "No collateral to withdraw".to_string(),
+        ));
     }
 
     // Look up per-collateral config (incl. custody kind for P4 native-XRP routing).
-    let (ledger_canister_id, ledger_fee, is_native_xrp) = read_state(|s| {
-        let config = s.get_collateral_config(&vault.collateral_type)
-            .ok_or(ProtocolError::GenericError("Collateral type not configured".to_string()))?;
-        Ok::<_, ProtocolError>((config.ledger_canister_id, config.ledger_fee, config.is_native_xrp()))
-    })?;
+    let (ledger_canister_id, ledger_fee, is_native_xrp) =
+        read_state(|s| {
+            let config = s.get_collateral_config(&vault.collateral_type).ok_or(
+                ProtocolError::GenericError("Collateral type not configured".to_string()),
+            )?;
+            Ok::<_, ProtocolError>((
+                config.ledger_canister_id,
+                config.ledger_fee,
+                config.is_native_xrp(),
+            ))
+        })?;
 
     // Get the amount to transfer
     let amount_to_transfer = ICP::from(vault.collateral_amount);
@@ -2588,7 +3633,14 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
         let now_ns = ic_cdk::api::time();
         let claim_id = mutate_state(|s| {
             crate::event::record_collateral_withdrawn(s, vault_id, amount_to_transfer, 0);
-            record_xrp_claim(s, caller, caller, vault_id, amount_to_transfer.to_u64(), now_ns)
+            record_xrp_claim(
+                s,
+                caller,
+                caller,
+                vault_id,
+                amount_to_transfer.to_u64(),
+                now_ns,
+            )
         });
         log!(
             INFO,
@@ -2610,11 +3662,20 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
         caller
     );
 
-    match management::transfer_collateral(transfer_amount.to_u64(), caller, ledger_canister_id).await {
+    match management::transfer_collateral(transfer_amount.to_u64(), caller, ledger_canister_id)
+        .await
+    {
         Ok(block_index) => {
             // Fix for the lifetime issue - we need to use a separate mutate_state call
             // Rather than passing a mutable reference to the state
-            mutate_state(|s| crate::event::record_collateral_withdrawn(s, vault_id, amount_to_transfer, block_index));
+            mutate_state(|s| {
+                crate::event::record_collateral_withdrawn(
+                    s,
+                    vault_id,
+                    amount_to_transfer,
+                    block_index,
+                )
+            });
 
             log!(
                 INFO,
@@ -2625,7 +3686,7 @@ pub async fn withdraw_collateral(vault_id: u64) -> Result<u64, ProtocolError> {
             );
 
             Ok(block_index)
-        },
+        }
         Err(error) => {
             // If the transfer fails, we need to restore the collateral in the vault
             mutate_state(|state| {
@@ -2668,17 +3729,33 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
     mutate_state(|s| s.accrue_single_vault(vault_id, now));
 
     // Read vault, per-collateral price + config from state
-    let (vault, collateral_price, config_decimals, ledger_canister_id, ledger_fee, min_deposit, is_native_xrp) = match read_state(|s| {
-        match s.vault_id_to_vaults.get(&vault_id) {
-            Some(vault) => {
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or("No price available for collateral. Price feed may be down.")?;
-                let config = s.get_collateral_config(&vault.collateral_type)
-                    .ok_or("Collateral type not configured.")?;
-                Ok((vault.clone(), price, config.decimals, config.ledger_canister_id, config.ledger_fee, config.min_collateral_deposit, config.is_native_xrp()))
-            },
-            None => Err("Vault not found. Please check the vault ID.")
+    let (
+        vault,
+        collateral_price,
+        config_decimals,
+        ledger_canister_id,
+        ledger_fee,
+        min_deposit,
+        is_native_xrp,
+    ) = match read_state(|s| match s.vault_id_to_vaults.get(&vault_id) {
+        Some(vault) => {
+            let price = s
+                .get_collateral_price_decimal(&vault.collateral_type)
+                .ok_or("No price available for collateral. Price feed may be down.")?;
+            let config = s
+                .get_collateral_config(&vault.collateral_type)
+                .ok_or("Collateral type not configured.")?;
+            Ok((
+                vault.clone(),
+                price,
+                config.decimals,
+                config.ledger_canister_id,
+                config.ledger_fee,
+                config.min_collateral_deposit,
+                config.is_native_xrp(),
+            ))
         }
+        None => Err("Vault not found. Please check the vault ID."),
     }) {
         Ok(result) => result,
         Err(msg) => return Err(ProtocolError::GenericError(msg.to_string())),
@@ -2717,7 +3794,9 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
     let vault_collateral = ICP::from(vault.collateral_amount);
 
     if vault_collateral == ICP::new(0) {
-        return Err(ProtocolError::GenericError("No collateral to withdraw".to_string()));
+        return Err(ProtocolError::GenericError(
+            "No collateral to withdraw".to_string(),
+        ));
     }
 
     // Forgive dust debt: if remaining debt is below threshold, zero it out
@@ -2752,13 +3831,21 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
             let base = s.get_min_collateral_ratio_for(&vault.collateral_type);
             if s.mode == Mode::Recovery {
                 let recovery_cr = s.get_recovery_cr_for(&vault.collateral_type);
-                if recovery_cr > base { recovery_cr } else { base }
+                if recovery_cr > base {
+                    recovery_cr
+                } else {
+                    base
+                }
             } else {
                 base
             }
         });
         let min_collateral_value: ICUSD = vault.borrowed_icusd_amount * min_ratio;
-        let min_collateral_raw = crate::numeric::icusd_to_collateral_amount(min_collateral_value, collateral_price, config_decimals);
+        let min_collateral_raw = crate::numeric::icusd_to_collateral_amount(
+            min_collateral_value,
+            collateral_price,
+            config_decimals,
+        );
         let min_collateral = ICP::from(min_collateral_raw);
 
         if vault_collateral <= min_collateral {
@@ -2795,7 +3882,14 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
         let now_ns = ic_cdk::api::time();
         let claim_id = mutate_state(|s| {
             crate::event::record_partial_collateral_withdrawn(s, vault_id, withdraw_amount, 0);
-            record_xrp_claim(s, caller, caller, vault_id, withdraw_amount.to_u64(), now_ns)
+            record_xrp_claim(
+                s,
+                caller,
+                caller,
+                vault_id,
+                withdraw_amount.to_u64(),
+                now_ns,
+            )
         });
         log!(
             INFO,
@@ -2816,9 +3910,18 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
         caller
     );
 
-    match management::transfer_collateral(transfer_amount.to_u64(), caller, ledger_canister_id).await {
+    match management::transfer_collateral(transfer_amount.to_u64(), caller, ledger_canister_id)
+        .await
+    {
         Ok(block_index) => {
-            mutate_state(|s| crate::event::record_partial_collateral_withdrawn(s, vault_id, withdraw_amount, block_index));
+            mutate_state(|s| {
+                crate::event::record_partial_collateral_withdrawn(
+                    s,
+                    vault_id,
+                    withdraw_amount,
+                    block_index,
+                )
+            });
 
             log!(
                 INFO,
@@ -2829,7 +3932,7 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
             );
 
             Ok(block_index)
-        },
+        }
         Err(error) => {
             // No need to restore vault state — collateral is only deducted on success
             // (in record_partial_collateral_withdrawn via remove_margin_from_vault).
@@ -2856,7 +3959,10 @@ pub async fn withdraw_partial_collateral(vault_id: u64, amount: u64) -> Result<u
 /// Forgives dust debt, validates collateral status, optimistically zeroes the
 /// vault's collateral, transfers it out, and deletes the vault entry. On
 /// transfer failure the collateral amount is restored and the vault stays open.
-async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> Result<Option<u64>, ProtocolError> {
+async fn withdraw_and_close_vault_internal(
+    caller: Principal,
+    vault_id: u64,
+) -> Result<Option<u64>, ProtocolError> {
     log!(
         INFO,
         "[withdraw_and_close] Request for vault #{} by principal {}",
@@ -2869,7 +3975,10 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
         s.vault_id_to_vaults
             .get(&vault_id)
             .cloned()
-            .ok_or(ProtocolError::GenericError(format!("Vault #{} not found", vault_id)))
+            .ok_or(ProtocolError::GenericError(format!(
+                "Vault #{} not found",
+                vault_id
+            )))
     })?;
 
     require_vault_not_processing(&vault)?;
@@ -2925,13 +4034,19 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
             vault.borrowed_icusd_amount
         )));
     }
-    
+
     // Look up per-collateral config
-    let (ledger_canister_id, ledger_fee, is_native_xrp) = read_state(|s| {
-        let config = s.get_collateral_config(&vault.collateral_type)
-            .ok_or(ProtocolError::GenericError("Collateral type not configured".to_string()))?;
-        Ok::<_, ProtocolError>((config.ledger_canister_id, config.ledger_fee, config.is_native_xrp()))
-    })?;
+    let (ledger_canister_id, ledger_fee, is_native_xrp) =
+        read_state(|s| {
+            let config = s.get_collateral_config(&vault.collateral_type).ok_or(
+                ProtocolError::GenericError("Collateral type not configured".to_string()),
+            )?;
+            Ok::<_, ProtocolError>((
+                config.ledger_canister_id,
+                config.ledger_fee,
+                config.is_native_xrp(),
+            ))
+        })?;
 
     // If there's collateral, withdraw it first
     let mut block_index: Option<u64> = None;
@@ -2959,7 +4074,14 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
             let now_ns = ic_cdk::api::time();
             let claim_id = mutate_state(|s| {
                 crate::event::record_collateral_withdrawn(s, vault_id, amount_to_transfer, 0);
-                record_xrp_claim(s, caller, caller, vault_id, amount_to_transfer.to_u64(), now_ns)
+                record_xrp_claim(
+                    s,
+                    caller,
+                    caller,
+                    vault_id,
+                    amount_to_transfer.to_u64(),
+                    now_ns,
+                )
             });
             log!(
                 INFO,
@@ -2969,23 +4091,36 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
             );
             block_index = Some(claim_id);
         } else {
-        // Make the collateral transfer with appropriate fee deduction
-        let fee = ICP::from(ledger_fee);
-        let transfer_amount = amount_to_transfer - fee;
+            // Make the collateral transfer with appropriate fee deduction
+            let fee = ICP::from(ledger_fee);
+            let transfer_amount = amount_to_transfer - fee;
 
-        log!(
-            INFO,
-            "[withdraw_and_close] Transferring {} (after fee deduction) to {}",
-            transfer_amount,
-            caller
-        );
+            log!(
+                INFO,
+                "[withdraw_and_close] Transferring {} (after fee deduction) to {}",
+                transfer_amount,
+                caller
+            );
 
-        match management::transfer_collateral(transfer_amount.to_u64(), caller, ledger_canister_id).await {
-            Ok(idx) => {
-                // Record the withdrawal event
-                mutate_state(|s| crate::event::record_collateral_withdrawn(s, vault_id, amount_to_transfer, idx));
+            match management::transfer_collateral(
+                transfer_amount.to_u64(),
+                caller,
+                ledger_canister_id,
+            )
+            .await
+            {
+                Ok(idx) => {
+                    // Record the withdrawal event
+                    mutate_state(|s| {
+                        crate::event::record_collateral_withdrawn(
+                            s,
+                            vault_id,
+                            amount_to_transfer,
+                            idx,
+                        )
+                    });
 
-                log!(
+                    log!(
                     INFO,
                     "[withdraw_and_close] Successfully withdrew {} from vault #{}, block_index: {}",
                     amount_to_transfer,
@@ -2993,42 +4128,51 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
                     idx
                 );
 
-                block_index = Some(idx);
-            },
-            Err(error) => {
-                // CRITICAL: If the transfer fails, restore the collateral and exit WITHOUT closing the vault
-                mutate_state(|state| {
-                    if let Some(vault) = state.vault_id_to_vaults.get_mut(&vault_id) {
-                        vault.collateral_amount = amount_to_transfer.to_u64();
-                    }
-                    // Wave-8b LIQ-002: rollback restores collateral → re-key.
-                    state.reindex_vault_cr(vault_id);
-                });
+                    block_index = Some(idx);
+                }
+                Err(error) => {
+                    // CRITICAL: If the transfer fails, restore the collateral and exit WITHOUT closing the vault
+                    mutate_state(|state| {
+                        if let Some(vault) = state.vault_id_to_vaults.get_mut(&vault_id) {
+                            vault.collateral_amount = amount_to_transfer.to_u64();
+                        }
+                        // Wave-8b LIQ-002: rollback restores collateral → re-key.
+                        state.reindex_vault_cr(vault_id);
+                    });
 
-                log!(
-                    DEBUG,
-                    "[withdraw_and_close] Failed to transfer {} to {}, error: {}",
-                    transfer_amount,
-                    caller,
-                    error
-                );
+                    log!(
+                        DEBUG,
+                        "[withdraw_and_close] Failed to transfer {} to {}, error: {}",
+                        transfer_amount,
+                        caller,
+                        error
+                    );
 
-                return Err(ProtocolError::TransferError(error));
+                    return Err(ProtocolError::TransferError(error));
+                }
             }
-        }
         } // end native-XRP `else` (the ICRC transfer path)
     } else {
-        log!(INFO, "[withdraw_and_close] Vault #{} has no collateral to withdraw", vault_id);
+        log!(
+            INFO,
+            "[withdraw_and_close] Vault #{} has no collateral to withdraw",
+            vault_id
+        );
     };
-    
+
     // Now close the vault - only if we've successfully transferred any funds
     // or if there were no funds to transfer
     mutate_state(|s| {
         // Make sure vault exists before attempting to remove
         if s.vault_id_to_vaults.contains_key(&vault_id) {
             // Record the combined withdraw and close event
-            crate::event::record_withdraw_and_close_vault(s, vault_id, amount_to_transfer, block_index);
-            
+            crate::event::record_withdraw_and_close_vault(
+                s,
+                vault_id,
+                amount_to_transfer,
+                block_index,
+            );
+
             log!(
                 INFO,
                 "[withdraw_and_close] Successfully closed vault #{} for principal {}",
@@ -3044,7 +4188,7 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
             );
         }
     });
-    
+
     // Return the block index if we did a transfer, otherwise None
     Ok(block_index)
 }
@@ -3052,7 +4196,8 @@ async fn withdraw_and_close_vault_internal(caller: Principal, vault_id: u64) -> 
 pub async fn withdraw_and_close_vault(vault_id: u64) -> Result<Option<u64>, ProtocolError> {
     let caller = ic_cdk::caller();
     // Use a specific name for better tracking
-    let _guard_principal = GuardPrincipal::new(caller, &format!("withdraw_and_close_{}", vault_id))?;
+    let _guard_principal =
+        GuardPrincipal::new(caller, &format!("withdraw_and_close_{}", vault_id))?;
     // AR-B-003: per-vault op lock; see guard.rs::VaultLiquidationGuard.
     let _vault_op_guard = VaultLiquidationGuard::new(vault_id)?;
 
@@ -3132,12 +4277,16 @@ pub async fn repay_and_close_vault(arg: VaultArg) -> Result<RepayAndCloseSuccess
     }
 }
 
-pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result<SuccessWithFee, ProtocolError> {
+pub async fn liquidate_vault_partial(
+    vault_id: u64,
+    icusd_amount: u64,
+) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_partial_{}", vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("liquidate_vault_partial_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
-    // BK-001/002: per-vault lock so two different callers can't race this vault
-    // and both be paid the full pre-state collateral from the shared pool.
+                                         // BK-001/002: per-vault lock so two different callers can't race this vault
+                                         // and both be paid the full pre-state collateral from the shared pool.
     let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?;
 
     // Wave-8b LIQ-002 band gate deactivated 2026-05-18. The per-vault CR
@@ -3156,21 +4305,37 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
             minimum_amount: read_state(|s| s.min_icusd_amount).to_u64(),
         });
     }
-    
+
     // Step 1: Validate vault is liquidatable and get partial liquidation amounts
-    let (vault, collateral_price, config_decimals, collateral_price_usd, _mode, max_liquidatable_debt, collateral_to_liquidator, total_to_seize, protocol_cut) = match read_state(|s| {
+    let (
+        vault,
+        collateral_price,
+        config_decimals,
+        collateral_price_usd,
+        _mode,
+        max_liquidatable_debt,
+        collateral_to_liquidator,
+        total_to_seize,
+        protocol_cut,
+    ) = match read_state(|s| {
         match s.vault_id_to_vaults.get(&vault_id) {
             Some(vault) => {
                 // Check collateral status allows liquidation
                 if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
                     if !status.allows_liquidation() {
-                        return Err("Liquidation is not allowed for this collateral type.".to_string());
+                        return Err(
+                            "Liquidation is not allowed for this collateral type.".to_string()
+                        );
                     }
                 }
 
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or_else(|| "No price available for collateral. Price feed may be down.".to_string())?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
+                let price = s
+                    .get_collateral_price_decimal(&vault.collateral_type)
+                    .ok_or_else(|| {
+                        "No price available for collateral. Price feed may be down.".to_string()
+                    })?;
+                let decimals = s
+                    .get_collateral_config(&vault.collateral_type)
                     .map(|c| c.decimals)
                     .unwrap_or(8);
                 let collateral_price_usd = UsdIcp::from(price);
@@ -3186,17 +4351,22 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
                     ))
                 } else {
                     // Cap at the amount needed to restore vault CR to recovery_target_cr
-                    let max_liquidatable = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
+                    let max_liquidatable =
+                        s.compute_partial_liquidation_cap(vault, collateral_price_usd);
 
                     // Ensure requested amount doesn't exceed maximum
-                    let capped_amount = liquidation_amount.min(max_liquidatable).min(vault.borrowed_icusd_amount);
+                    let capped_amount = liquidation_amount
+                        .min(max_liquidatable)
+                        .min(vault.borrowed_icusd_amount);
 
                     // LIQ-003: round residual up to full debt if it would land
                     // in (0, min_vault_debt). Mirrors the repay-side invariant.
-                    let min_vault_debt = s.get_collateral_config(&vault.collateral_type)
+                    let min_vault_debt = s
+                        .get_collateral_config(&vault.collateral_type)
                         .map(|c| c.min_vault_debt)
                         .unwrap_or(ICUSD::new(0));
-                    let actual_liquidation_amount = round_up_partial_liq_dust(vault, capped_amount, min_vault_debt);
+                    let actual_liquidation_amount =
+                        round_up_partial_liq_dust(vault, capped_amount, min_vault_debt);
 
                     if actual_liquidation_amount == ICUSD::new(0) {
                         return Err("Cannot liquidate zero amount".to_string());
@@ -3205,19 +4375,37 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
                     // Calculate collateral to transfer (debt + liquidation bonus)
                     let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
                     let protocol_share = s.get_liquidation_protocol_share();
-                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(actual_liquidation_amount, price, decimals);
+                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(
+                        actual_liquidation_amount,
+                        price,
+                        decimals,
+                    );
                     let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-                    let total_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+                    let total_to_seize =
+                        collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
                     // Split: protocol gets a share of the bonus portion (liquidator's profit)
                     let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
-                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-                        .to_u64().unwrap_or(0);
-                    let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
+                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion)
+                        * protocol_share.0)
+                        .to_u64()
+                        .unwrap_or(0);
+                    let collateral_to_liquidator =
+                        ICP::from(total_to_seize.to_u64() - protocol_cut);
 
-                    Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode, actual_liquidation_amount, collateral_to_liquidator, total_to_seize, protocol_cut))
+                    Ok((
+                        vault.clone(),
+                        price,
+                        decimals,
+                        collateral_price_usd,
+                        s.mode,
+                        actual_liquidation_amount,
+                        collateral_to_liquidator,
+                        total_to_seize,
+                        protocol_cut,
+                    ))
                 }
-            },
+            }
             None => Err(format!("Vault #{} not found", vault_id)),
         }
     }) {
@@ -3240,12 +4428,19 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
     // Step 2: Take icUSD from liquidator
     let icusd_block_index = match transfer_icusd_from(max_liquidatable_debt, caller).await {
         Ok(block_index) => {
-            log!(INFO, "[liquidate_vault_partial] Received {} icUSD from liquidator", max_liquidatable_debt.to_u64());
+            log!(
+                INFO,
+                "[liquidate_vault_partial] Received {} icUSD from liquidator",
+                max_liquidatable_debt.to_u64()
+            );
             block_index
-        },
+        }
         Err(transfer_from_error) => {
             guard_principal.fail();
-            return Err(ProtocolError::TransferFromError(transfer_from_error, max_liquidatable_debt.to_u64()));
+            return Err(ProtocolError::TransferFromError(
+                transfer_from_error,
+                max_liquidatable_debt.to_u64(),
+            ));
         }
     };
 
@@ -3257,10 +4452,15 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
                 let share = (rust_decimal::Decimal::from(max_liquidatable_debt.0)
                     * rust_decimal::Decimal::from(vault.accrued_interest.0)
                     / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                    .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
                 ICUSD::new(share.min(vault.accrued_interest.0))
-            } else { ICUSD::new(0) }
-        } else { ICUSD::new(0) };
+            } else {
+                ICUSD::new(0)
+            }
+        } else {
+            ICUSD::new(0)
+        };
 
         // Reduce vault debt and collateral directly
         // Vault loses total_to_seize (liquidator + protocol cut)
@@ -3329,7 +4529,11 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
             icp_to_liquidator: payout_to_liquidator,
             liquidator: Some(caller),
             icp_rate: Some(collateral_price_usd),
-            protocol_fee_collateral: if protocol_cut > 0 { Some(protocol_cut.min(collateral_applied)) } else { None },
+            protocol_fee_collateral: if protocol_cut > 0 {
+                Some(protocol_cut.min(collateral_applied))
+            } else {
+                None
+            },
             timestamp: Some(ic_cdk::api::time()),
             three_usd_reserves_e8s: None,
         };
@@ -3352,19 +4556,30 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
         // Shared drain rule (see state::cleanup_if_drained): remove the vault
         // if this liquidation emptied it, else re-key its CR index entry.
         if s.cleanup_if_drained(vault_id) {
-            log!(INFO, "[liquidate_vault_partial] Vault #{} fully liquidated — removed", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_partial] Vault #{} fully liquidated — removed",
+                vault_id
+            );
         }
 
-        log!(INFO, "[liquidate_vault_partial] Partial liquidation completed, {} pending transfers created", 1);
+        log!(
+            INFO,
+            "[liquidate_vault_partial] Partial liquidation completed, {} pending transfers created",
+            1
+        );
         interest_share
     });
 
     // Route interest share via N-way split
     // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
     // next flush retries it instead of silently dropping treasury revenue.
-    let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+    let unminted_interest =
+        crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
     if unminted_interest.to_u64() > 0 {
-        mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+        mutate_state(|s| {
+            s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64())
+        });
     }
 
     // Send protocol's liquidation fee cut to treasury (fire-and-forget)
@@ -3377,36 +4592,60 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
             let dev = read_state(|s| s.developer_principal);
             let now_ns = ic_cdk::api::time();
             mutate_state(|s| {
-                record_xrp_claim(s, dev, vault.owner, vault.vault_id, protocol_cut.to_u64().unwrap_or(0), now_ns);
+                record_xrp_claim(
+                    s,
+                    dev,
+                    vault.owner,
+                    vault.vault_id,
+                    protocol_cut.to_u64().unwrap_or(0),
+                    now_ns,
+                );
             });
         } else {
             let asset_type = crate::treasury::collateral_to_asset_type(&vault.collateral_type);
-            crate::treasury::send_liquidation_fee_to_treasury(protocol_cut, vault.collateral_type, asset_type).await;
+            crate::treasury::send_liquidation_fee_to_treasury(
+                protocol_cut,
+                vault.collateral_type,
+                asset_type,
+            )
+            .await;
         }
     }
 
     // Step 4: Process transfer (same as complete liquidation)
     match try_process_pending_transfers_immediate(vault_id).await {
         Ok(processed_count) => {
-            log!(INFO, "[liquidate_vault_partial] Successfully processed {} transfers immediately", processed_count);
-        },
+            log!(
+                INFO,
+                "[liquidate_vault_partial] Successfully processed {} transfers immediately",
+                processed_count
+            );
+        }
         Err(e) => {
             log!(INFO, "[liquidate_vault_partial] Immediate processing failed: {}. Transfers will be retried via timer", e);
             schedule_transfer_retry(vault_id, 0);
         }
     }
-    
+
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[liquidate_vault_partial] Backup timer processing transfers for vault #{}", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_partial] Backup timer processing transfers for vault #{}",
+                vault_id
+            );
             let _ = crate::process_pending_transfer().await;
         })
     });
-    
+
     guard_principal.complete();
-    
+
     // Calculate fee (liquidator bonus)
-    let liquidator_value_received = crate::numeric::collateral_usd_value(collateral_to_liquidator.to_u64(), collateral_price, config_decimals);
+    let liquidator_value_received = crate::numeric::collateral_usd_value(
+        collateral_to_liquidator.to_u64(),
+        collateral_price,
+        config_decimals,
+    );
     let fee_amount = if liquidator_value_received > max_liquidatable_debt {
         liquidator_value_received - max_liquidatable_debt
     } else {
@@ -3429,10 +4668,11 @@ pub async fn liquidate_vault_partial(vault_id: u64, icusd_amount: u64) -> Result
 pub async fn liquidate_vault_partial_with_stable(
     vault_id: u64,
     stable_amount: u64,
-    token_type: StableTokenType
+    token_type: StableTokenType,
 ) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_stable_{}", vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("liquidate_vault_stable_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
     let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?; // BK-001/002 per-vault lock
 
@@ -3446,7 +4686,10 @@ pub async fn liquidate_vault_partial_with_stable(
     });
     if !is_enabled {
         guard_principal.fail();
-        return Err(ProtocolError::GenericError(format!("{:?} liquidations are currently disabled", token_type)));
+        return Err(ProtocolError::GenericError(format!(
+            "{:?} liquidations are currently disabled",
+            token_type
+        )));
     }
 
     // Depeg protection: fetch fresh stablecoin price and reject if outside $0.95–$1.05
@@ -3467,19 +4710,35 @@ pub async fn liquidate_vault_partial_with_stable(
     }
 
     // Step 1: Validate vault is liquidatable and get partial liquidation amounts
-    let (vault, collateral_price, config_decimals, collateral_price_usd, _mode, max_liquidatable_debt, collateral_to_liquidator, total_to_seize, protocol_cut) = match read_state(|s| {
+    let (
+        vault,
+        collateral_price,
+        config_decimals,
+        collateral_price_usd,
+        _mode,
+        max_liquidatable_debt,
+        collateral_to_liquidator,
+        total_to_seize,
+        protocol_cut,
+    ) = match read_state(|s| {
         match s.vault_id_to_vaults.get(&vault_id) {
             Some(vault) => {
                 // Check collateral status allows liquidation
                 if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
                     if !status.allows_liquidation() {
-                        return Err("Liquidation is not allowed for this collateral type.".to_string());
+                        return Err(
+                            "Liquidation is not allowed for this collateral type.".to_string()
+                        );
                     }
                 }
 
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or_else(|| "No price available for collateral. Price feed may be down.".to_string())?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
+                let price = s
+                    .get_collateral_price_decimal(&vault.collateral_type)
+                    .ok_or_else(|| {
+                        "No price available for collateral. Price feed may be down.".to_string()
+                    })?;
+                let decimals = s
+                    .get_collateral_config(&vault.collateral_type)
                     .map(|c| c.decimals)
                     .unwrap_or(8);
                 let collateral_price_usd = UsdIcp::from(price);
@@ -3495,16 +4754,21 @@ pub async fn liquidate_vault_partial_with_stable(
                     ))
                 } else {
                     // Cap at the amount needed to restore vault CR to recovery_target_cr
-                    let max_liquidatable = s.compute_partial_liquidation_cap(vault, collateral_price_usd);
+                    let max_liquidatable =
+                        s.compute_partial_liquidation_cap(vault, collateral_price_usd);
 
-                    let capped_amount = liquidation_amount.min(max_liquidatable).min(vault.borrowed_icusd_amount);
+                    let capped_amount = liquidation_amount
+                        .min(max_liquidatable)
+                        .min(vault.borrowed_icusd_amount);
 
                     // LIQ-003: round residual up to full debt if it would land
                     // in (0, min_vault_debt). Mirrors the repay-side invariant.
-                    let min_vault_debt = s.get_collateral_config(&vault.collateral_type)
+                    let min_vault_debt = s
+                        .get_collateral_config(&vault.collateral_type)
                         .map(|c| c.min_vault_debt)
                         .unwrap_or(ICUSD::new(0));
-                    let actual_liquidation_amount = round_up_partial_liq_dust(vault, capped_amount, min_vault_debt);
+                    let actual_liquidation_amount =
+                        round_up_partial_liq_dust(vault, capped_amount, min_vault_debt);
 
                     if actual_liquidation_amount == ICUSD::new(0) {
                         return Err("Cannot liquidate zero amount".to_string());
@@ -3512,19 +4776,37 @@ pub async fn liquidate_vault_partial_with_stable(
 
                     let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
                     let protocol_share = s.get_liquidation_protocol_share();
-                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(actual_liquidation_amount, price, decimals);
+                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(
+                        actual_liquidation_amount,
+                        price,
+                        decimals,
+                    );
                     let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-                    let total_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+                    let total_to_seize =
+                        collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
                     // Split: protocol gets a share of the bonus portion
                     let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
-                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-                        .to_u64().unwrap_or(0);
-                    let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
+                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion)
+                        * protocol_share.0)
+                        .to_u64()
+                        .unwrap_or(0);
+                    let collateral_to_liquidator =
+                        ICP::from(total_to_seize.to_u64() - protocol_cut);
 
-                    Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode, actual_liquidation_amount, collateral_to_liquidator, total_to_seize, protocol_cut))
+                    Ok((
+                        vault.clone(),
+                        price,
+                        decimals,
+                        collateral_price_usd,
+                        s.mode,
+                        actual_liquidation_amount,
+                        collateral_to_liquidator,
+                        total_to_seize,
+                        protocol_cut,
+                    ))
                 }
-            },
+            }
             None => Err(format!("Vault #{} not found", vault_id)),
         }
     }) {
@@ -3550,19 +4832,30 @@ pub async fn liquidate_vault_partial_with_stable(
     let base_stable_e6s = debt_e8s / 100;
     let fee_rate = read_state(|s| s.ckstable_repay_fee);
     let fee_e6s = (rust_decimal::Decimal::from(base_stable_e6s) * fee_rate.0)
-        .to_u64().unwrap_or(0);
+        .to_u64()
+        .unwrap_or(0);
     let total_pull_e6s = base_stable_e6s + fee_e6s;
 
-    let stable_block_index = match transfer_stable_from(token_type.clone(), total_pull_e6s, caller).await {
-        Ok(block_index) => {
-            log!(INFO, "[liquidate_vault_stable] Received {} e6s {:?} from liquidator (fee: {} e6s)", total_pull_e6s, token_type, fee_e6s);
-            block_index
-        },
-        Err(transfer_from_error) => {
-            guard_principal.fail();
-            return Err(ProtocolError::TransferFromError(transfer_from_error, total_pull_e6s));
-        }
-    };
+    let stable_block_index =
+        match transfer_stable_from(token_type.clone(), total_pull_e6s, caller).await {
+            Ok(block_index) => {
+                log!(
+                    INFO,
+                    "[liquidate_vault_stable] Received {} e6s {:?} from liquidator (fee: {} e6s)",
+                    total_pull_e6s,
+                    token_type,
+                    fee_e6s
+                );
+                block_index
+            }
+            Err(transfer_from_error) => {
+                guard_principal.fail();
+                return Err(ProtocolError::TransferFromError(
+                    transfer_from_error,
+                    total_pull_e6s,
+                ));
+            }
+        };
 
     // Step 3: Update protocol state (partial liquidation)
     let interest_share = mutate_state(|s| {
@@ -3572,10 +4865,15 @@ pub async fn liquidate_vault_partial_with_stable(
                 let share = (rust_decimal::Decimal::from(max_liquidatable_debt.0)
                     * rust_decimal::Decimal::from(vault.accrued_interest.0)
                     / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                    .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
                 ICUSD::new(share.min(vault.accrued_interest.0))
-            } else { ICUSD::new(0) }
-        } else { ICUSD::new(0) };
+            } else {
+                ICUSD::new(0)
+            }
+        } else {
+            ICUSD::new(0)
+        };
 
         // Reduce vault debt and collateral directly
         // Vault loses total_to_seize (liquidator + protocol cut)
@@ -3638,7 +4936,11 @@ pub async fn liquidate_vault_partial_with_stable(
             icp_to_liquidator: payout_to_liquidator,
             liquidator: Some(caller),
             icp_rate: Some(collateral_price_usd),
-            protocol_fee_collateral: if protocol_cut > 0 { Some(protocol_cut.min(collateral_applied)) } else { None },
+            protocol_fee_collateral: if protocol_cut > 0 {
+                Some(protocol_cut.min(collateral_applied))
+            } else {
+                None
+            },
             timestamp: Some(ic_cdk::api::time()),
             three_usd_reserves_e8s: None,
         };
@@ -3660,10 +4962,17 @@ pub async fn liquidate_vault_partial_with_stable(
         // Shared drain rule (see state::cleanup_if_drained): remove the vault
         // if this liquidation emptied it, else re-key its CR index entry.
         if s.cleanup_if_drained(vault_id) {
-            log!(INFO, "[liquidate_vault_stable] Vault #{} fully liquidated — removed", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_stable] Vault #{} fully liquidated — removed",
+                vault_id
+            );
         }
 
-        log!(INFO, "[liquidate_vault_stable] Partial liquidation completed, pending transfer created");
+        log!(
+            INFO,
+            "[liquidate_vault_stable] Partial liquidation completed, pending transfer created"
+        );
         interest_share
     });
 
@@ -3673,7 +4982,8 @@ pub async fn liquidate_vault_partial_with_stable(
             interest_share.to_u64(),
             vault.collateral_type,
             token_type.clone(),
-        ).await;
+        )
+        .await;
     }
 
     // Route fee surcharge to treasury as stablecoins (mirrors repay_to_vault_with_stable)
@@ -3686,7 +4996,8 @@ pub async fn liquidate_vault_partial_with_stable(
             (s.treasury_principal, ledger)
         });
         if let (Some(treasury_principal), Some(stable_ledger)) = (treasury, stable_ledger) {
-            match management::transfer_collateral(fee_e6s, treasury_principal, stable_ledger).await {
+            match management::transfer_collateral(fee_e6s, treasury_principal, stable_ledger).await
+            {
                 Ok(block) => {
                     log!(INFO,
                         "[liquidate_vault_stable] Transferred {} e6s fee surcharge to treasury (block {})",
@@ -3713,19 +5024,35 @@ pub async fn liquidate_vault_partial_with_stable(
             let dev = read_state(|s| s.developer_principal);
             let now_ns = ic_cdk::api::time();
             mutate_state(|s| {
-                record_xrp_claim(s, dev, vault.owner, vault.vault_id, protocol_cut.to_u64().unwrap_or(0), now_ns);
+                record_xrp_claim(
+                    s,
+                    dev,
+                    vault.owner,
+                    vault.vault_id,
+                    protocol_cut.to_u64().unwrap_or(0),
+                    now_ns,
+                );
             });
         } else {
             let asset_type = crate::treasury::collateral_to_asset_type(&vault.collateral_type);
-            crate::treasury::send_liquidation_fee_to_treasury(protocol_cut, vault.collateral_type, asset_type).await;
+            crate::treasury::send_liquidation_fee_to_treasury(
+                protocol_cut,
+                vault.collateral_type,
+                asset_type,
+            )
+            .await;
         }
     }
 
     // Step 4: Process transfer
     match try_process_pending_transfers_immediate(vault_id).await {
         Ok(processed_count) => {
-            log!(INFO, "[liquidate_vault_stable] Successfully processed {} transfers immediately", processed_count);
-        },
+            log!(
+                INFO,
+                "[liquidate_vault_stable] Successfully processed {} transfers immediately",
+                processed_count
+            );
+        }
         Err(e) => {
             log!(INFO, "[liquidate_vault_stable] Immediate processing failed: {}. Transfers will be retried via timer", e);
             schedule_transfer_retry(vault_id, 0);
@@ -3734,7 +5061,11 @@ pub async fn liquidate_vault_partial_with_stable(
 
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[liquidate_vault_stable] Backup timer processing transfers for vault #{}", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_stable] Backup timer processing transfers for vault #{}",
+                vault_id
+            );
             let _ = crate::process_pending_transfer().await;
         })
     });
@@ -3742,15 +5073,24 @@ pub async fn liquidate_vault_partial_with_stable(
     guard_principal.complete();
 
     // Calculate fee (liquidator bonus)
-    let liquidator_value_received = crate::numeric::collateral_usd_value(collateral_to_liquidator.to_u64(), collateral_price, config_decimals);
+    let liquidator_value_received = crate::numeric::collateral_usd_value(
+        collateral_to_liquidator.to_u64(),
+        collateral_price,
+        config_decimals,
+    );
     let fee_amount = if liquidator_value_received > max_liquidatable_debt {
         liquidator_value_received - max_liquidatable_debt
     } else {
         ICUSD::new(0)
     };
 
-    log!(INFO, "[liquidate_vault_stable] Liquidation completed. Block index: {}, Fee: {}, Collateral: {}",
-         stable_block_index, fee_amount.to_u64(), collateral_to_liquidator.to_u64());
+    log!(
+        INFO,
+        "[liquidate_vault_stable] Liquidation completed. Block index: {}, Fee: {}, Collateral: {}",
+        stable_block_index,
+        fee_amount.to_u64(),
+        collateral_to_liquidator.to_u64()
+    );
 
     Ok(SuccessWithFee {
         block_index: stable_block_index,
@@ -3819,7 +5159,8 @@ pub async fn liquidate_vault_debt_already_burned(
         ));
     }
 
-    let guard_principal = GuardPrincipal::new(caller, &format!("liquidate_vault_debt_burned_{}", vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("liquidate_vault_debt_burned_{}", vault_id))?;
     reject_if_bot_processing(vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault (SP path)
     let _vault_liq_guard = VaultLiquidationGuard::new(vault_id)?; // BK-001/002 per-vault lock
 
@@ -3874,9 +5215,7 @@ pub async fn liquidate_vault_debt_already_burned(
 
     let expected_amount_e8s = match proof.ledger_kind {
         crate::icrc3_proof::SpProofLedger::IcusdBurn => icusd_burned_e8s,
-        crate::icrc3_proof::SpProofLedger::ThreePoolTransfer => {
-            three_usd_received_e8s.unwrap_or(0)
-        }
+        crate::icrc3_proof::SpProofLedger::ThreePoolTransfer => three_usd_received_e8s.unwrap_or(0),
     };
 
     let expectations = crate::icrc3_proof::ProofExpectations {
@@ -3895,10 +5234,14 @@ pub async fn liquidate_vault_debt_already_burned(
     .await
     {
         guard_principal.fail();
-        log!(INFO,
+        log!(
+            INFO,
             "[liquidate_vault_debt_burned] [LIQ-004] proof verification FAILED for vault #{} \
              ({:?} block {}): {}",
-            vault_id, proof.ledger_kind, proof.block_index, err
+            vault_id,
+            proof.ledger_kind,
+            proof.block_index,
+            err
         );
         return Err(ProtocolError::GenericError(format!(
             "SP writedown proof verification failed: {}",
@@ -3920,18 +5263,33 @@ pub async fn liquidate_vault_debt_already_burned(
     }
 
     // Step 1: Validate vault is liquidatable and compute collateral to release
-    let (vault, collateral_price, config_decimals, collateral_price_usd, max_liquidatable_debt, collateral_to_liquidator, total_to_seize, protocol_cut) = match read_state(|s| {
+    let (
+        vault,
+        collateral_price,
+        config_decimals,
+        collateral_price_usd,
+        max_liquidatable_debt,
+        collateral_to_liquidator,
+        total_to_seize,
+        protocol_cut,
+    ) = match read_state(|s| {
         match s.vault_id_to_vaults.get(&vault_id) {
             Some(vault) => {
                 if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
                     if !status.allows_liquidation() {
-                        return Err("Liquidation is not allowed for this collateral type.".to_string());
+                        return Err(
+                            "Liquidation is not allowed for this collateral type.".to_string()
+                        );
                     }
                 }
 
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or_else(|| "No price available for collateral. Price feed may be down.".to_string())?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
+                let price = s
+                    .get_collateral_price_decimal(&vault.collateral_type)
+                    .ok_or_else(|| {
+                        "No price available for collateral. Price feed may be down.".to_string()
+                    })?;
+                let decimals = s
+                    .get_collateral_config(&vault.collateral_type)
                     .map(|c| c.decimals)
                     .unwrap_or(8);
                 let collateral_price_usd = UsdIcp::from(price);
@@ -3940,7 +5298,8 @@ pub async fn liquidate_vault_debt_already_burned(
                 // The backend MUST honor the write-down regardless of vault health.
                 // Rejecting would leave burned icUSD unaccounted for.
                 {
-                    let actual_liquidation_amount = liquidation_amount.min(vault.borrowed_icusd_amount);
+                    let actual_liquidation_amount =
+                        liquidation_amount.min(vault.borrowed_icusd_amount);
 
                     if actual_liquidation_amount == ICUSD::new(0) {
                         return Err("Cannot liquidate zero amount".to_string());
@@ -3948,18 +5307,35 @@ pub async fn liquidate_vault_debt_already_burned(
 
                     let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
                     let protocol_share = s.get_liquidation_protocol_share();
-                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(actual_liquidation_amount, price, decimals);
+                    let collateral_raw = crate::numeric::icusd_to_collateral_amount(
+                        actual_liquidation_amount,
+                        price,
+                        decimals,
+                    );
                     let collateral_with_bonus = ICP::from(collateral_raw) * liq_bonus;
-                    let total_to_seize = collateral_with_bonus.min(ICP::from(vault.collateral_amount));
+                    let total_to_seize =
+                        collateral_with_bonus.min(ICP::from(vault.collateral_amount));
 
                     let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
-                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-                        .to_u64().unwrap_or(0);
-                    let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
+                    let protocol_cut = (rust_decimal::Decimal::from(bonus_portion)
+                        * protocol_share.0)
+                        .to_u64()
+                        .unwrap_or(0);
+                    let collateral_to_liquidator =
+                        ICP::from(total_to_seize.to_u64() - protocol_cut);
 
-                    Ok((vault.clone(), price, decimals, collateral_price_usd, actual_liquidation_amount, collateral_to_liquidator, total_to_seize, protocol_cut))
+                    Ok((
+                        vault.clone(),
+                        price,
+                        decimals,
+                        collateral_price_usd,
+                        actual_liquidation_amount,
+                        collateral_to_liquidator,
+                        total_to_seize,
+                        protocol_cut,
+                    ))
                 }
-            },
+            }
             None => Err(format!("Vault #{} not found", vault_id)),
         }
     }) {
@@ -4008,10 +5384,15 @@ pub async fn liquidate_vault_debt_already_burned(
                 let share = (rust_decimal::Decimal::from(max_liquidatable_debt.0)
                     * rust_decimal::Decimal::from(vault.accrued_interest.0)
                     / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                    .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
                 ICUSD::new(share.min(vault.accrued_interest.0))
-            } else { ICUSD::new(0) }
-        } else { ICUSD::new(0) };
+            } else {
+                ICUSD::new(0)
+            }
+        } else {
+            ICUSD::new(0)
+        };
 
         // AR-B-001/BK-001 (audit 2026-06-09): capture applied amounts and
         // re-cap the payout, mirroring `liquidate_vault_partial`.
@@ -4078,7 +5459,11 @@ pub async fn liquidate_vault_debt_already_burned(
             icp_to_liquidator: payout_to_liquidator,
             liquidator: Some(caller),
             icp_rate: Some(collateral_price_usd),
-            protocol_fee_collateral: if protocol_cut > 0 { Some(protocol_cut.min(collateral_applied)) } else { None },
+            protocol_fee_collateral: if protocol_cut > 0 {
+                Some(protocol_cut.min(collateral_applied))
+            } else {
+                None
+            },
             timestamp: Some(ic_cdk::api::time()),
             three_usd_reserves_e8s: three_usd_received_e8s,
         };
@@ -4107,7 +5492,11 @@ pub async fn liquidate_vault_debt_already_burned(
         // 2026-05-18, but `check_vaults`' at-risk-band sharding (Wave-9c
         // DOS-005) still relies on accurate CR keys.
         if s.cleanup_if_drained(vault_id) {
-            log!(INFO, "[liquidate_vault_debt_burned] Vault #{} fully liquidated — removed", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_debt_burned] Vault #{} fully liquidated — removed",
+                vault_id
+            );
         }
 
         interest_share
@@ -4116,9 +5505,12 @@ pub async fn liquidate_vault_debt_already_burned(
     // Route interest share via N-way split
     // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
     // next flush retries it instead of silently dropping treasury revenue.
-    let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+    let unminted_interest =
+        crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
     if unminted_interest.to_u64() > 0 {
-        mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+        mutate_state(|s| {
+            s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64())
+        });
     }
 
     // Send protocol's liquidation fee cut to treasury
@@ -4131,43 +5523,75 @@ pub async fn liquidate_vault_debt_already_burned(
             let dev = read_state(|s| s.developer_principal);
             let now_ns = ic_cdk::api::time();
             mutate_state(|s| {
-                record_xrp_claim(s, dev, vault.owner, vault.vault_id, protocol_cut.to_u64().unwrap_or(0), now_ns);
+                record_xrp_claim(
+                    s,
+                    dev,
+                    vault.owner,
+                    vault.vault_id,
+                    protocol_cut.to_u64().unwrap_or(0),
+                    now_ns,
+                );
             });
         } else {
             let asset_type = crate::treasury::collateral_to_asset_type(&vault.collateral_type);
-            crate::treasury::send_liquidation_fee_to_treasury(protocol_cut, vault.collateral_type, asset_type).await;
+            crate::treasury::send_liquidation_fee_to_treasury(
+                protocol_cut,
+                vault.collateral_type,
+                asset_type,
+            )
+            .await;
         }
     }
 
     // Step 4: Process collateral transfer to stability pool
     match try_process_pending_transfers_immediate(vault_id).await {
         Ok(processed_count) => {
-            log!(INFO, "[liquidate_vault_debt_burned] Processed {} transfers immediately", processed_count);
-        },
+            log!(
+                INFO,
+                "[liquidate_vault_debt_burned] Processed {} transfers immediately",
+                processed_count
+            );
+        }
         Err(e) => {
-            log!(INFO, "[liquidate_vault_debt_burned] Immediate processing failed: {}. Retrying via timer", e);
+            log!(
+                INFO,
+                "[liquidate_vault_debt_burned] Immediate processing failed: {}. Retrying via timer",
+                e
+            );
             schedule_transfer_retry(vault_id, 0);
         }
     }
 
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[liquidate_vault_debt_burned] Backup timer for vault #{}", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault_debt_burned] Backup timer for vault #{}",
+                vault_id
+            );
             let _ = crate::process_pending_transfer().await;
         })
     });
 
     guard_principal.complete();
 
-    let liquidator_value_received = crate::numeric::collateral_usd_value(collateral_to_liquidator.to_u64(), collateral_price, config_decimals);
+    let liquidator_value_received = crate::numeric::collateral_usd_value(
+        collateral_to_liquidator.to_u64(),
+        collateral_price,
+        config_decimals,
+    );
     let fee_amount = if liquidator_value_received > max_liquidatable_debt {
         liquidator_value_received - max_liquidatable_debt
     } else {
         ICUSD::new(0)
     };
 
-    log!(INFO, "[liquidate_vault_debt_burned] Completed. Fee: {}, Collateral: {}",
-         fee_amount.to_u64(), collateral_to_liquidator.to_u64());
+    log!(
+        INFO,
+        "[liquidate_vault_debt_burned] Completed. Fee: {}, Collateral: {}",
+        fee_amount.to_u64(),
+        collateral_to_liquidator.to_u64()
+    );
 
     Ok(StabilityPoolLiquidationResult {
         success: true,
@@ -4191,75 +5615,110 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
     // `liquidate_vault_partial` above for rationale).
 
     // Step 1: Validate vault is liquidatable
-    let (vault, collateral_price, config_decimals, collateral_price_usd, mode) = match read_state(|s| {
-        match s.vault_id_to_vaults.get(&vault_id) {
-            Some(vault) => {
-                // Check collateral status allows liquidation
-                if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
-                    if !status.allows_liquidation() {
-                        return Err("Liquidation is not allowed for this collateral type.".to_string());
+    let (vault, collateral_price, config_decimals, collateral_price_usd, mode) =
+        match read_state(|s| {
+            match s.vault_id_to_vaults.get(&vault_id) {
+                Some(vault) => {
+                    // Check collateral status allows liquidation
+                    if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
+                        if !status.allows_liquidation() {
+                            return Err(
+                                "Liquidation is not allowed for this collateral type.".to_string()
+                            );
+                        }
+                    }
+
+                    let price = s
+                        .get_collateral_price_decimal(&vault.collateral_type)
+                        .ok_or_else(|| {
+                            "No price available for collateral. Price feed may be down.".to_string()
+                        })?;
+                    let decimals = s
+                        .get_collateral_config(&vault.collateral_type)
+                        .map(|c| c.decimals)
+                        .unwrap_or(8);
+                    let collateral_price_usd = UsdIcp::from(price);
+                    let ratio = compute_collateral_ratio(vault, collateral_price_usd, s);
+                    let min_liq_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
+
+                    if ratio >= min_liq_ratio {
+                        Err(format!(
+                            "Vault #{} is not liquidatable. Current ratio: {}, minimum: {}",
+                            vault_id,
+                            ratio.to_f64(),
+                            min_liq_ratio.to_f64()
+                        ))
+                    } else {
+                        Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode))
                     }
                 }
-
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or_else(|| "No price available for collateral. Price feed may be down.".to_string())?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
-                    .map(|c| c.decimals)
-                    .unwrap_or(8);
-                let collateral_price_usd = UsdIcp::from(price);
-                let ratio = compute_collateral_ratio(vault, collateral_price_usd, s);
-                let min_liq_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
-
-                if ratio >= min_liq_ratio {
-                    Err(format!(
-                        "Vault #{} is not liquidatable. Current ratio: {}, minimum: {}",
-                        vault_id,
-                        ratio.to_f64(),
-                        min_liq_ratio.to_f64()
-                    ))
-                } else {
-                    Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode))
-                }
-            },
-            None => Err(format!("Vault #{} not found", vault_id)),
-        }
-    }) {
-        Ok(result) => result,
-        Err(msg) => {
-            guard_principal.fail();
-            return Err(ProtocolError::GenericError(msg));
-        }
-    };
+                None => Err(format!("Vault #{} not found", vault_id)),
+            }
+        }) {
+            Ok(result) => result,
+            Err(msg) => {
+                guard_principal.fail();
+                return Err(ProtocolError::GenericError(msg));
+            }
+        };
 
     // Step 2: Calculate liquidation amounts
     // Check if this is a recovery-mode targeted liquidation (vault CR between 133-150%)
     let vault_collateral = ICP::from(vault.collateral_amount);
-    let (debt_amount, collateral_to_liquidator, total_to_seize, protocol_cut, excess_collateral, is_recovery_partial) = read_state(|s| {
+    let (
+        debt_amount,
+        collateral_to_liquidator,
+        total_to_seize,
+        protocol_cut,
+        excess_collateral,
+        is_recovery_partial,
+    ) = read_state(|s| {
         let liq_bonus = s.get_liquidation_bonus_for(&vault.collateral_type);
         let protocol_share = s.get_liquidation_protocol_share();
         if let Some(repay_cap) = s.compute_recovery_repay_cap(&vault, collateral_price_usd) {
             // Recovery mode: only liquidate enough to restore CR to target
-            let collateral_raw = crate::numeric::icusd_to_collateral_amount(repay_cap, collateral_price, config_decimals);
+            let collateral_raw = crate::numeric::icusd_to_collateral_amount(
+                repay_cap,
+                collateral_price,
+                config_decimals,
+            );
             let total_to_seize = (ICP::from(collateral_raw) * liq_bonus).min(vault_collateral);
             // Split: protocol gets a share of the bonus portion (liquidator's profit)
             let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
             let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-                .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
             let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
-            (repay_cap, collateral_to_liquidator, total_to_seize, protocol_cut, ICP::new(0), true)
+            (
+                repay_cap,
+                collateral_to_liquidator,
+                total_to_seize,
+                protocol_cut,
+                ICP::new(0),
+                true,
+            )
         } else {
             // Normal full liquidation
             let debt = vault.borrowed_icusd_amount;
-            let collateral_raw = crate::numeric::icusd_to_collateral_amount(debt, collateral_price, config_decimals);
+            let collateral_raw =
+                crate::numeric::icusd_to_collateral_amount(debt, collateral_price, config_decimals);
             let icp_with_bonus = ICP::from(collateral_raw) * liq_bonus;
             let total_to_seize = icp_with_bonus.min(vault_collateral);
             // Split: protocol gets a share of the bonus portion (liquidator's profit)
             let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
             let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-                .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
             let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
             let excess = vault_collateral.saturating_sub(total_to_seize);
-            (debt, collateral_to_liquidator, total_to_seize, protocol_cut, excess, false)
+            (
+                debt,
+                collateral_to_liquidator,
+                total_to_seize,
+                protocol_cut,
+                excess,
+                false,
+            )
         }
     });
 
@@ -4276,12 +5735,19 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
     // Step 3: Take icUSD from liquidator (this must succeed for liquidation to proceed)
     let icusd_block_index = match transfer_icusd_from(debt_amount, caller).await {
         Ok(block_index) => {
-            log!(INFO, "[liquidate_vault] Received {} icUSD from liquidator", debt_amount.to_u64());
+            log!(
+                INFO,
+                "[liquidate_vault] Received {} icUSD from liquidator",
+                debt_amount.to_u64()
+            );
             block_index
-        },
+        }
         Err(transfer_from_error) => {
             guard_principal.fail();
-            return Err(ProtocolError::TransferFromError(transfer_from_error, debt_amount.to_u64()));
+            return Err(ProtocolError::TransferFromError(
+                transfer_from_error,
+                debt_amount.to_u64(),
+            ));
         }
     };
 
@@ -4385,11 +5851,24 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         // Create pending transfer for excess collateral to vault owner (if any)
         // (only for full liquidations, not recovery partial)
         if !is_recovery_partial && excess_pay > ICP::new(0) {
-            log!(INFO, "[liquidate_vault] Scheduling excess collateral return to vault owner");
+            log!(
+                INFO,
+                "[liquidate_vault] Scheduling excess collateral return to vault owner"
+            );
             // Native-XRP excess returns to the owner as an XrpClaim; ICRC excess
             // goes through the pending-excess transfer machinery.
-            if s.get_collateral_config(&vault.collateral_type).map(|c| c.is_native_xrp()).unwrap_or(false) {
-                record_xrp_claim(s, vault.owner, vault.owner, vault_id, excess_pay.to_u64(), ic_cdk::api::time());
+            if s.get_collateral_config(&vault.collateral_type)
+                .map(|c| c.is_native_xrp())
+                .unwrap_or(false)
+            {
+                record_xrp_claim(
+                    s,
+                    vault.owner,
+                    vault.owner,
+                    vault_id,
+                    excess_pay.to_u64(),
+                    ic_cdk::api::time(),
+                );
             } else {
                 let excess_nonce = s.next_op_nonce();
                 s.pending_excess_transfers.insert(
@@ -4405,8 +5884,15 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
             }
         }
 
-        log!(INFO, "[liquidate_vault] Protocol state updated, {} pending transfers created",
-             if !is_recovery_partial && excess_pay > ICP::new(0) { 2 } else { 1 });
+        log!(
+            INFO,
+            "[liquidate_vault] Protocol state updated, {} pending transfers created",
+            if !is_recovery_partial && excess_pay > ICP::new(0) {
+                2
+            } else {
+                1
+            }
+        );
         Some(interest_share)
     }) {
         Some(share) => share,
@@ -4422,8 +5908,13 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
             let refund_nonce = mutate_state(|s| s.next_op_nonce());
             match management::transfer_icusd_with_nonce(debt_amount, caller, refund_nonce).await {
                 Ok(refund_block) => {
-                    log!(INFO, "[liquidate_vault] Refunded {} icUSD to {} (block {})",
-                        debt_amount.to_u64(), caller, refund_block);
+                    log!(
+                        INFO,
+                        "[liquidate_vault] Refunded {} icUSD to {} (block {})",
+                        debt_amount.to_u64(),
+                        caller,
+                        refund_block
+                    );
                 }
                 Err(refund_err) => {
                     log!(INFO,
@@ -4456,9 +5947,12 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
     // Route interest share via N-way split
     // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
     // next flush retries it instead of silently dropping treasury revenue.
-    let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+    let unminted_interest =
+        crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
     if unminted_interest.to_u64() > 0 {
-        mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+        mutate_state(|s| {
+            s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64())
+        });
     }
 
     // Send protocol's liquidation fee cut to treasury (fire-and-forget)
@@ -4471,43 +5965,70 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
             let dev = read_state(|s| s.developer_principal);
             let now_ns = ic_cdk::api::time();
             mutate_state(|s| {
-                record_xrp_claim(s, dev, vault.owner, vault.vault_id, protocol_cut.to_u64().unwrap_or(0), now_ns);
+                record_xrp_claim(
+                    s,
+                    dev,
+                    vault.owner,
+                    vault.vault_id,
+                    protocol_cut.to_u64().unwrap_or(0),
+                    now_ns,
+                );
             });
         } else {
             let asset_type = crate::treasury::collateral_to_asset_type(&vault.collateral_type);
-            crate::treasury::send_liquidation_fee_to_treasury(protocol_cut, vault.collateral_type, asset_type).await;
+            crate::treasury::send_liquidation_fee_to_treasury(
+                protocol_cut,
+                vault.collateral_type,
+                asset_type,
+            )
+            .await;
         }
     }
 
     // Step 5: Attempt immediate transfer processing (best effort)
-    log!(INFO, "[liquidate_vault] Attempting immediate transfer processing...");
-    
+    log!(
+        INFO,
+        "[liquidate_vault] Attempting immediate transfer processing..."
+    );
+
     // Try to process transfers immediately
     match try_process_pending_transfers_immediate(vault_id).await {
         Ok(processed_count) => {
-            log!(INFO, "[liquidate_vault] Successfully processed {} transfers immediately", processed_count);
-        },
+            log!(
+                INFO,
+                "[liquidate_vault] Successfully processed {} transfers immediately",
+                processed_count
+            );
+        }
         Err(e) => {
             log!(INFO, "[liquidate_vault] Immediate processing failed: {}. Transfers will be retried via timer", e);
-            
+
             // Schedule retry with exponential backoff
             schedule_transfer_retry(vault_id, 0);
         }
     }
-    
+
     // Step 6: Always schedule a backup timer (in case immediate processing failed)
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[liquidate_vault] Backup timer processing transfers for vault #{}", vault_id);
+            log!(
+                INFO,
+                "[liquidate_vault] Backup timer processing transfers for vault #{}",
+                vault_id
+            );
             let _ = crate::process_pending_transfer().await;
         })
     });
-    
+
     // Step 7: Liquidation is successful (protocol state is consistent)
     guard_principal.complete();
-    
+
     // Calculate fee
-    let liquidator_value_received = crate::numeric::collateral_usd_value(collateral_to_liquidator.to_u64(), collateral_price, config_decimals);
+    let liquidator_value_received = crate::numeric::collateral_usd_value(
+        collateral_to_liquidator.to_u64(),
+        collateral_price,
+        config_decimals,
+    );
     let fee_amount = if liquidator_value_received > debt_amount {
         liquidator_value_received - debt_amount
     } else {
@@ -4522,7 +6043,7 @@ pub async fn liquidate_vault(vault_id: u64) -> Result<SuccessWithFee, ProtocolEr
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: None, // SP-101
-        stable_pulled_e6s: None, // SP-110
+        stable_pulled_e6s: None,   // SP-110
     })
 }
 
@@ -4558,12 +6079,13 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
         // `queue_collateral_payout`), so a NativeXrp `collateral_type` cannot appear
         // in pending_margin_transfers / pending_excess_transfers.
         // Look up per-collateral ledger fee and canister ID
-        let (ledger_fee, ledger_canister_id) = read_state(|s| {
-            match s.get_collateral_config(&transfer.collateral_type) {
-                Some(config) => (ICP::from(config.ledger_fee), config.ledger_canister_id),
-                None => (s.icp_ledger_fee, s.icp_ledger_principal),
-            }
-        });
+        let (ledger_fee, ledger_canister_id) =
+            read_state(
+                |s| match s.get_collateral_config(&transfer.collateral_type) {
+                    Some(config) => (ICP::from(config.ledger_fee), config.ledger_canister_id),
+                    None => (s.icp_ledger_fee, s.icp_ledger_principal),
+                },
+            );
 
         if transfer.margin <= ledger_fee {
             log!(INFO, "[immediate_transfer] Skipping {} transfer {} owner {} - margin {} <= fee {}, removing",
@@ -4571,8 +6093,12 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
             mutate_state(|s| {
                 let key = (transfer_vault_id, transfer_owner);
                 match transfer_type {
-                    "margin" => { s.pending_margin_transfers.remove(&key); },
-                    "excess" => { s.pending_excess_transfers.remove(&key); },
+                    "margin" => {
+                        s.pending_margin_transfers.remove(&key);
+                    }
+                    "excess" => {
+                        s.pending_excess_transfers.remove(&key);
+                    }
                     _ => {}
                 }
             });
@@ -4581,29 +6107,56 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
         }
         let transfer_amount = transfer.margin - ledger_fee;
 
-        log!(INFO, "[immediate_transfer] Processing {} transfer {} of {} collateral to {}",
-             transfer_type, transfer_vault_id, transfer_amount.to_u64(), transfer.owner);
+        log!(
+            INFO,
+            "[immediate_transfer] Processing {} transfer {} of {} collateral to {}",
+            transfer_type,
+            transfer_vault_id,
+            transfer_amount.to_u64(),
+            transfer.owner
+        );
 
-        match management::transfer_collateral_with_nonce(transfer_amount.to_u64(), transfer.owner, ledger_canister_id, transfer.op_nonce).await {
+        match management::transfer_collateral_with_nonce(
+            transfer_amount.to_u64(),
+            transfer.owner,
+            ledger_canister_id,
+            transfer.op_nonce,
+        )
+        .await
+        {
             Ok(block_index) => {
-                log!(INFO, "[immediate_transfer] Transfer {} owner {} successful, block: {}",
-                    transfer_vault_id, transfer_owner, block_index);
+                log!(
+                    INFO,
+                    "[immediate_transfer] Transfer {} owner {} successful, block: {}",
+                    transfer_vault_id,
+                    transfer_owner,
+                    block_index
+                );
 
                 // Remove from the appropriate pending map
                 mutate_state(|s| {
                     let key = (transfer_vault_id, transfer_owner);
                     match transfer_type {
-                        "margin" => { s.pending_margin_transfers.remove(&key); },
-                        "excess" => { s.pending_excess_transfers.remove(&key); },
+                        "margin" => {
+                            s.pending_margin_transfers.remove(&key);
+                        }
+                        "excess" => {
+                            s.pending_excess_transfers.remove(&key);
+                        }
                         _ => {}
                     }
                 });
 
                 processed_count += 1;
-            },
+            }
             Err(error) => {
-                log!(INFO, "[immediate_transfer] Transfer {} owner {} failed: {}. Will retry later",
-                    transfer_vault_id, transfer_owner, error);
+                log!(
+                    INFO,
+                    "[immediate_transfer] Transfer {} owner {} failed: {}. Will retry later",
+                    transfer_vault_id,
+                    transfer_owner,
+                    error
+                );
                 // Leave in pending transfers for retry
                 return Err(format!("Transfer {} failed: {}", transfer_vault_id, error));
             }
@@ -4617,26 +6170,49 @@ async fn try_process_pending_transfers_immediate(vault_id: u64) -> Result<u32, S
 fn schedule_transfer_retry(vault_id: u64, retry_count: u32) {
     let max_retries = 5;
     if retry_count >= max_retries {
-        log!(INFO, "[retry_scheduler] Max retries reached for vault #{}", vault_id);
+        log!(
+            INFO,
+            "[retry_scheduler] Max retries reached for vault #{}",
+            vault_id
+        );
         return;
     }
-    
+
     // Exponential backoff: 1s, 2s, 4s, 8s, 16s
     let delay_seconds = 1u64 << retry_count;
-    
-    log!(INFO, "[retry_scheduler] Scheduling retry #{} for vault #{} in {}s", 
-         retry_count + 1, vault_id, delay_seconds);
-    
+
+    log!(
+        INFO,
+        "[retry_scheduler] Scheduling retry #{} for vault #{} in {}s",
+        retry_count + 1,
+        vault_id,
+        delay_seconds
+    );
+
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(delay_seconds), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[retry_scheduler] Retry #{} executing for vault #{}", retry_count + 1, vault_id);
-            
+            log!(
+                INFO,
+                "[retry_scheduler] Retry #{} executing for vault #{}",
+                retry_count + 1,
+                vault_id
+            );
+
             match try_process_pending_transfers_immediate(vault_id).await {
                 Ok(processed) => {
-                    log!(INFO, "[retry_scheduler] Retry #{} successful, processed {} transfers", retry_count + 1, processed);
-                },
+                    log!(
+                        INFO,
+                        "[retry_scheduler] Retry #{} successful, processed {} transfers",
+                        retry_count + 1,
+                        processed
+                    );
+                }
                 Err(_) => {
-                    log!(INFO, "[retry_scheduler] Retry #{} failed, scheduling next retry", retry_count + 1);
+                    log!(
+                        INFO,
+                        "[retry_scheduler] Retry #{} failed, scheduling next retry",
+                        retry_count + 1
+                    );
                     schedule_transfer_retry(vault_id, retry_count + 1);
                 }
             }
@@ -4646,7 +6222,8 @@ fn schedule_transfer_retry(vault_id: u64, retry_count: u32) {
 
 pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("partial_repay_vault_{}", arg.vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("partial_repay_vault_{}", arg.vault_id))?;
     // AR-B-003: per-vault op lock; see guard.rs::VaultLiquidationGuard. This
     // endpoint pulls icUSD across an await then commits via repay_to_vault, so
     // it needs the same serialization vs liquidation/redemption as its siblings.
@@ -4667,7 +6244,10 @@ pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError>
         Some(v) => v,
         None => {
             guard_principal.fail();
-            return Err(ProtocolError::GenericError(format!("Vault #{} not found", arg.vault_id)));
+            return Err(ProtocolError::GenericError(format!(
+                "Vault #{} not found",
+                arg.vault_id
+            )));
         }
     };
 
@@ -4676,9 +6256,10 @@ pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError>
     if let Some(status) = collateral_status {
         if !status.allows_repay() {
             guard_principal.fail();
-            return Err(ProtocolError::TemporarilyUnavailable(
-                format!("Collateral is {:?}, repayment not allowed", status)
-            ));
+            return Err(ProtocolError::TemporarilyUnavailable(format!(
+                "Collateral is {:?}, repayment not allowed",
+                status
+            )));
         }
     }
 
@@ -4716,12 +6297,19 @@ pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError>
 
     match transfer_icusd_from(amount, caller).await {
         Ok(block_index) => {
-            let interest_share = mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
+            let interest_share =
+                mutate_state(|s| record_repayed_to_vault(s, arg.vault_id, amount, block_index));
             // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
             // next flush retries it instead of silently dropping treasury revenue.
-            let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+            let unminted_interest =
+                crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
             if unminted_interest.to_u64() > 0 {
-                mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+                mutate_state(|s| {
+                    s.restore_pending_interest_for_pool(
+                        vault.collateral_type,
+                        unminted_interest.to_u64(),
+                    )
+                });
             }
             guard_principal.complete(); // Mark as completed
             Ok(block_index)
@@ -4738,7 +6326,8 @@ pub async fn partial_repay_to_vault(arg: VaultArg) -> Result<u64, ProtocolError>
 
 pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, ProtocolError> {
     let caller = ic_cdk::api::caller();
-    let guard_principal = GuardPrincipal::new(caller, &format!("partial_liquidate_vault_{}", arg.vault_id))?;
+    let guard_principal =
+        GuardPrincipal::new(caller, &format!("partial_liquidate_vault_{}", arg.vault_id))?;
     reject_if_bot_processing(arg.vault_id)?; // LIQ-101: don't double-seize a bot-claimed vault
     let _vault_liq_guard = VaultLiquidationGuard::new(arg.vault_id)?; // BK-001/002 per-vault lock
 
@@ -4752,45 +6341,52 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
     mutate_state(|s| s.accrue_single_vault(arg.vault_id, now));
 
     // Step 1: Validate vault is liquidatable
-    let (vault, collateral_price, config_decimals, collateral_price_usd, _mode) = match read_state(|s| {
-        match s.vault_id_to_vaults.get(&arg.vault_id) {
-            Some(vault) => {
-                // Check collateral status allows liquidation
-                if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
-                    if !status.allows_liquidation() {
-                        return Err("Liquidation is not allowed for this collateral type.".to_string());
+    let (vault, collateral_price, config_decimals, collateral_price_usd, _mode) =
+        match read_state(|s| {
+            match s.vault_id_to_vaults.get(&arg.vault_id) {
+                Some(vault) => {
+                    // Check collateral status allows liquidation
+                    if let Some(status) = s.get_collateral_status(&vault.collateral_type) {
+                        if !status.allows_liquidation() {
+                            return Err(
+                                "Liquidation is not allowed for this collateral type.".to_string()
+                            );
+                        }
+                    }
+
+                    let price = s
+                        .get_collateral_price_decimal(&vault.collateral_type)
+                        .ok_or_else(|| {
+                            "No price available for collateral. Price feed may be down.".to_string()
+                        })?;
+                    let decimals = s
+                        .get_collateral_config(&vault.collateral_type)
+                        .map(|c| c.decimals)
+                        .unwrap_or(8);
+                    let collateral_price_usd = UsdIcp::from(price);
+                    let ratio = compute_collateral_ratio(vault, collateral_price_usd, s);
+                    let min_liq_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
+
+                    if ratio >= min_liq_ratio {
+                        Err(format!(
+                            "Vault #{} is not liquidatable. Current ratio: {}, minimum: {}",
+                            arg.vault_id,
+                            ratio.to_f64(),
+                            min_liq_ratio.to_f64()
+                        ))
+                    } else {
+                        Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode))
                     }
                 }
-
-                let price = s.get_collateral_price_decimal(&vault.collateral_type)
-                    .ok_or_else(|| "No price available for collateral. Price feed may be down.".to_string())?;
-                let decimals = s.get_collateral_config(&vault.collateral_type)
-                    .map(|c| c.decimals)
-                    .unwrap_or(8);
-                let collateral_price_usd = UsdIcp::from(price);
-                let ratio = compute_collateral_ratio(vault, collateral_price_usd, s);
-                let min_liq_ratio = s.get_min_liquidation_ratio_for(&vault.collateral_type);
-
-                if ratio >= min_liq_ratio {
-                    Err(format!(
-                        "Vault #{} is not liquidatable. Current ratio: {}, minimum: {}",
-                        arg.vault_id,
-                        ratio.to_f64(),
-                        min_liq_ratio.to_f64()
-                    ))
-                } else {
-                    Ok((vault.clone(), price, decimals, collateral_price_usd, s.mode))
-                }
-            },
-            None => Err(format!("Vault #{} not found", arg.vault_id)),
-        }
-    }) {
-        Ok(result) => result,
-        Err(msg) => {
-            guard_principal.fail();
-            return Err(ProtocolError::GenericError(msg));
-        }
-    };
+                None => Err(format!("Vault #{} not found", arg.vault_id)),
+            }
+        }) {
+            Ok(result) => result,
+            Err(msg) => {
+                guard_principal.fail();
+                return Err(ProtocolError::GenericError(msg));
+            }
+        };
 
     // Step 2: Validate liquidator payment amount
     if liquidator_payment < read_state(|s| s.min_icusd_amount) {
@@ -4806,7 +6402,8 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
     let liquidator_payment = read_state(|s| {
         let cap = s.compute_partial_liquidation_cap(&vault, collateral_price_usd);
         let capped = liquidator_payment.min(cap);
-        let min_vault_debt = s.get_collateral_config(&vault.collateral_type)
+        let min_vault_debt = s
+            .get_collateral_config(&vault.collateral_type)
             .map(|c| c.min_vault_debt)
             .unwrap_or(ICUSD::new(0));
         round_up_partial_liq_dust(&vault, capped, min_vault_debt)
@@ -4822,16 +6419,24 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
 
     // Step 3: Calculate liquidation amounts with liquidation bonus and protocol fee
     let (liq_bonus, protocol_share) = read_state(|s| {
-        (s.get_liquidation_bonus_for(&vault.collateral_type), s.get_liquidation_protocol_share())
+        (
+            s.get_liquidation_bonus_for(&vault.collateral_type),
+            s.get_liquidation_protocol_share(),
+        )
     });
-    let collateral_raw = crate::numeric::icusd_to_collateral_amount(liquidator_payment, collateral_price, config_decimals);
+    let collateral_raw = crate::numeric::icusd_to_collateral_amount(
+        liquidator_payment,
+        collateral_price,
+        config_decimals,
+    );
     let icp_with_bonus = ICP::from(collateral_raw) * liq_bonus;
     let total_to_seize = icp_with_bonus.min(ICP::from(vault.collateral_amount));
 
     // Split: protocol gets a share of the bonus portion (liquidator's profit)
     let bonus_portion = total_to_seize.to_u64().saturating_sub(collateral_raw);
     let protocol_cut = (rust_decimal::Decimal::from(bonus_portion) * protocol_share.0)
-        .to_u64().unwrap_or(0);
+        .to_u64()
+        .unwrap_or(0);
     let collateral_to_liquidator = ICP::from(total_to_seize.to_u64() - protocol_cut);
 
     log!(INFO,
@@ -4842,19 +6447,26 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         protocol_cut,
         liq_bonus.to_f64()
     );
-    
+
     // Step 4: Take icUSD from liquidator
     let icusd_block_index = match transfer_icusd_from(liquidator_payment, caller).await {
         Ok(block_index) => {
-            log!(INFO, "[partial_liquidate_vault] Received {} icUSD from liquidator", liquidator_payment.to_u64());
+            log!(
+                INFO,
+                "[partial_liquidate_vault] Received {} icUSD from liquidator",
+                liquidator_payment.to_u64()
+            );
             block_index
-        },
+        }
         Err(transfer_from_error) => {
             guard_principal.fail();
-            return Err(ProtocolError::TransferFromError(transfer_from_error, liquidator_payment.to_u64()));
+            return Err(ProtocolError::TransferFromError(
+                transfer_from_error,
+                liquidator_payment.to_u64(),
+            ));
         }
     };
-    
+
     // Step 5: Update protocol state ATOMICALLY
     let interest_share = mutate_state(|s| {
         // Compute proportional interest share before reducing debt
@@ -4863,10 +6475,15 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
                 let share = (rust_decimal::Decimal::from(liquidator_payment.0)
                     * rust_decimal::Decimal::from(vault.accrued_interest.0)
                     / rust_decimal::Decimal::from(vault.borrowed_icusd_amount.0))
-                    .to_u64().unwrap_or(0);
+                .to_u64()
+                .unwrap_or(0);
                 ICUSD::new(share.min(vault.accrued_interest.0))
-            } else { ICUSD::new(0) }
-        } else { ICUSD::new(0) };
+            } else {
+                ICUSD::new(0)
+            }
+        } else {
+            ICUSD::new(0)
+        };
 
         // Reduce the vault's debt by the liquidator payment amount
         // Vault loses total_to_seize (liquidator + protocol cut)
@@ -4905,7 +6522,9 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         if shortfall.0 > 0 {
             crate::event::record_deficit_accrued(
                 s,
-                crate::event::DeficitSource::Liquidation { vault_id: arg.vault_id },
+                crate::event::DeficitSource::Liquidation {
+                    vault_id: arg.vault_id,
+                },
                 shortfall,
                 ic_cdk::api::time(),
             );
@@ -4924,7 +6543,11 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
             icp_to_liquidator: payout_to_liquidator,
             liquidator: Some(caller),
             icp_rate: Some(collateral_price_usd),
-            protocol_fee_collateral: if protocol_cut > 0 { Some(protocol_cut.min(collateral_applied)) } else { None },
+            protocol_fee_collateral: if protocol_cut > 0 {
+                Some(protocol_cut.min(collateral_applied))
+            } else {
+                None
+            },
             timestamp: Some(ic_cdk::api::time()),
             three_usd_reserves_e8s: None,
         };
@@ -4946,19 +6569,29 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         // Shared drain rule (see state::cleanup_if_drained): remove the vault
         // if this liquidation emptied it, else re-key its CR index entry.
         if s.cleanup_if_drained(arg.vault_id) {
-            log!(INFO, "[partial_liquidate_vault] Vault #{} fully liquidated — removed", arg.vault_id);
+            log!(
+                INFO,
+                "[partial_liquidate_vault] Vault #{} fully liquidated — removed",
+                arg.vault_id
+            );
         }
 
-        log!(INFO, "[partial_liquidate_vault] Protocol state updated, pending transfer created");
+        log!(
+            INFO,
+            "[partial_liquidate_vault] Protocol state updated, pending transfer created"
+        );
         interest_share
     });
 
     // Route interest share via N-way split
     // IC-B-002 (audit 2026-06-09): re-queue any unminted interest share so the
     // next flush retries it instead of silently dropping treasury revenue.
-    let unminted_interest = crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
+    let unminted_interest =
+        crate::treasury::distribute_interest(interest_share, vault.collateral_type).await;
     if unminted_interest.to_u64() > 0 {
-        mutate_state(|s| s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64()));
+        mutate_state(|s| {
+            s.restore_pending_interest_for_pool(vault.collateral_type, unminted_interest.to_u64())
+        });
     }
 
     // Send protocol's liquidation fee cut to treasury (fire-and-forget)
@@ -4971,40 +6604,67 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
             let dev = read_state(|s| s.developer_principal);
             let now_ns = ic_cdk::api::time();
             mutate_state(|s| {
-                record_xrp_claim(s, dev, vault.owner, vault.vault_id, protocol_cut.to_u64().unwrap_or(0), now_ns);
+                record_xrp_claim(
+                    s,
+                    dev,
+                    vault.owner,
+                    vault.vault_id,
+                    protocol_cut.to_u64().unwrap_or(0),
+                    now_ns,
+                );
             });
         } else {
             let asset_type = crate::treasury::collateral_to_asset_type(&vault.collateral_type);
-            crate::treasury::send_liquidation_fee_to_treasury(protocol_cut, vault.collateral_type, asset_type).await;
+            crate::treasury::send_liquidation_fee_to_treasury(
+                protocol_cut,
+                vault.collateral_type,
+                asset_type,
+            )
+            .await;
         }
     }
 
     // Step 6: Attempt immediate transfer processing
-    log!(INFO, "[partial_liquidate_vault] Attempting immediate transfer processing...");
-    
+    log!(
+        INFO,
+        "[partial_liquidate_vault] Attempting immediate transfer processing..."
+    );
+
     match try_process_pending_transfers_immediate(arg.vault_id).await {
         Ok(processed_count) => {
-            log!(INFO, "[partial_liquidate_vault] Successfully processed {} transfers immediately", processed_count);
-        },
+            log!(
+                INFO,
+                "[partial_liquidate_vault] Successfully processed {} transfers immediately",
+                processed_count
+            );
+        }
         Err(e) => {
             log!(INFO, "[partial_liquidate_vault] Immediate processing failed: {}. Transfers will be retried via timer", e);
             schedule_transfer_retry(arg.vault_id, 0);
         }
     }
-    
+
     // Step 7: Schedule backup timer
     ic_cdk_timers::set_timer(std::time::Duration::from_secs(2), move || {
         ic_cdk::spawn(async move {
-            log!(INFO, "[partial_liquidate_vault] Backup timer processing transfers for vault #{}", arg.vault_id);
+            log!(
+                INFO,
+                "[partial_liquidate_vault] Backup timer processing transfers for vault #{}",
+                arg.vault_id
+            );
             let _ = crate::process_pending_transfer().await;
         })
     });
-    
+
     // Step 8: Liquidation is successful
     guard_principal.complete();
-    
+
     // Calculate fee (the 10% discount is the fee)
-    let liquidator_value_received = crate::numeric::collateral_usd_value(collateral_to_liquidator.to_u64(), collateral_price, config_decimals);
+    let liquidator_value_received = crate::numeric::collateral_usd_value(
+        collateral_to_liquidator.to_u64(),
+        collateral_price,
+        config_decimals,
+    );
     let fee_amount = if liquidator_value_received > liquidator_payment {
         liquidator_value_received - liquidator_payment
     } else {
@@ -5019,7 +6679,7 @@ pub async fn partial_liquidate_vault(arg: VaultArg) -> Result<SuccessWithFee, Pr
         fee_amount_paid: fee_amount.to_u64(),
         collateral_amount_received: Some(collateral_to_liquidator.to_u64()),
         debt_liquidated_e8s: None, // SP-101
-        stable_pulled_e6s: None, // SP-110
+        stable_pulled_e6s: None,   // SP-110
     })
 }
 
@@ -5109,7 +6769,9 @@ mod sp_writedown_native_xrp_guard_tests {
         ));
         match result {
             Err(ProtocolError::GenericError(msg)) => assert!(
-                msg.contains("Native-XRP collateral cannot be liquidated via the SP write-down path"),
+                msg.contains(
+                    "Native-XRP collateral cannot be liquidated via the SP write-down path"
+                ),
                 "expected the native-XRP reject, got: {msg}"
             ),
             other => panic!("expected a native-XRP GenericError reject, got {other:?}"),
@@ -5123,7 +6785,13 @@ mod sp_writedown_native_xrp_guard_tests {
     fn vault_is_native_xrp_is_scoped_to_xrp_custody() {
         install_two_collateral_state(2, 1);
         assert!(vault_is_native_xrp(2), "native-XRP vault must be flagged");
-        assert!(!vault_is_native_xrp(1), "ICRC (ICP) vault must not be flagged");
-        assert!(!vault_is_native_xrp(999), "missing vault must not be flagged");
+        assert!(
+            !vault_is_native_xrp(1),
+            "ICRC (ICP) vault must not be flagged"
+        );
+        assert!(
+            !vault_is_native_xrp(999),
+            "missing vault must not be flagged"
+        );
     }
 }

--- a/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
+++ b/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
@@ -9,7 +9,7 @@
 //!     test mocks them (native canister-http mocking — a first for this repo;
 //!     every other chain test redirects to a mock *canister*).
 //!   * claim settlement       — `settle_xrp_claim` threshold-Ed25519 signs an XRPL
-//!     Payment (`test_key_1`, provisioned by PocketIC's II subnet) and makes
+//!     Payment (`key_1`, provisioned by PocketIC's II subnet) and makes
 //!     `submit` + `tx` outcalls, again mocked here.
 //!
 //! Happy path: register XRP -> open -> confirm deposit -> borrow -> repay ->
@@ -23,17 +23,17 @@
 //! ## tEd25519-in-PocketIC: full vs gated
 //!
 //! `open_xrp_vault` / `settle_xrp_claim` call the management-canister threshold
-//! Schnorr (Ed25519) API with key `test_key_1`. We boot `.with_ii_subnet()
-//! .with_application_subnet()`. If this build cannot provision `test_key_1`,
+//! Schnorr (Ed25519) API with key `key_1`. We boot `.with_ii_subnet()
+//! .with_application_subnet()`. If this build cannot provision `key_1`,
 //! `open_xrp_vault` errors and the test degrades to a gated subset (the same
 //! auto-degrade split the Solana/Monad happy-path tests use).
 
-use candid::{encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal, Reserved};
+use candid::{
+    encode_args, encode_one, CandidType, Decode, Deserialize, Encode, Principal, Reserved,
+};
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
-use pocket_ic::common::rest::{
-    CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse,
-};
+use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -194,7 +194,13 @@ fn xrp_collateral_principal() -> Principal {
 
 // ─── Call helpers ────────────────────────────────────────────────────────────
 
-fn update_as(pic: &PocketIc, cid: Principal, sender: Principal, method: &str, args: Vec<u8>) -> WasmResult {
+fn update_as(
+    pic: &PocketIc,
+    cid: Principal,
+    sender: Principal,
+    method: &str,
+    args: Vec<u8>,
+) -> WasmResult {
     pic.update_call(cid, sender, method, args)
         .unwrap_or_else(|e| panic!("update {method} failed: {e}"))
 }
@@ -203,7 +209,10 @@ fn query_as<T>(pic: &PocketIc, cid: Principal, sender: Principal, method: &str, 
 where
     T: CandidType + for<'a> Deserialize<'a>,
 {
-    match pic.query_call(cid, sender, method, args).expect("query call") {
+    match pic
+        .query_call(cid, sender, method, args)
+        .expect("query call")
+    {
         WasmResult::Reply(b) => Decode!(&b, T).expect("decode query reply"),
         WasmResult::Reject(m) => panic!("query {method} rejected: {m}"),
     }
@@ -217,9 +226,8 @@ where
     T: CandidType + for<'a> Deserialize<'a>,
 {
     match reply {
-        WasmResult::Reply(b) => {
-            Decode!(&b, Result<T, Reserved>).unwrap_or_else(|e| panic!("decode {method} Result: {e}"))
-        }
+        WasmResult::Reply(b) => Decode!(&b, Result<T, Reserved>)
+            .unwrap_or_else(|e| panic!("decode {method} Result: {e}")),
         WasmResult::Reject(m) => panic!("{method} rejected: {m}"),
     }
 }
@@ -312,10 +320,11 @@ fn rippled_submit_ok() -> Value {
 }
 
 /// `tx` reporting a validated Payment delivering `delivered_drops`.
-fn rippled_tx_validated(delivered_drops: u64, ledger_index: u32) -> Value {
+fn rippled_tx_validated(tx_hash: &str, delivered_drops: u64, ledger_index: u32) -> Value {
     json!({
         "result": {
             "validated": true,
+            "hash": tx_hash,
             "ledger_index": ledger_index,
             "meta": {
                 "TransactionResult": "tesSUCCESS",
@@ -376,18 +385,31 @@ fn boot() -> Env {
         ckusdt_ledger_principal: None,
         ckusdc_ledger_principal: None,
     });
-    pic.install_canister(backend, backend_wasm(), encode_args((init,)).expect("encode init"), None);
+    pic.install_canister(
+        backend,
+        backend_wasm(),
+        encode_args((init,)).expect("encode init"),
+        None,
+    );
 
     for _ in 0..5 {
         pic.tick();
     }
 
-    Env { pic, backend, icusd, xrc }
+    Env {
+        pic,
+        backend,
+        icusd,
+        xrc,
+    }
 }
 
 fn install_ledger(pic: &PocketIc, ledger: Principal, minter: Principal, name: &str, symbol: &str) {
     let args = LedgerArg::Init(LedgerInitArgs {
-        minting_account: Account { owner: minter, subaccount: None },
+        minting_account: Account {
+            owner: minter,
+            subaccount: None,
+        },
         fee_collector_account: None,
         transfer_fee: candid::Nat::from(10_000u64),
         decimals: Some(8),
@@ -410,14 +432,24 @@ fn install_ledger(pic: &PocketIc, ledger: Principal, minter: Principal, name: &s
             more_controller_ids: None,
         },
     });
-    pic.install_canister(ledger, ledger_wasm(), encode_one(args).expect("encode ledger init"), None);
+    pic.install_canister(
+        ledger,
+        ledger_wasm(),
+        encode_one(args).expect("encode ledger init"),
+        None,
+    );
 }
 
 // ─── Reads ───────────────────────────────────────────────────────────────────
 
 fn get_vault(pic: &PocketIc, backend: Principal, vault_id: u64) -> Option<CandidVault> {
-    let vaults: Vec<CandidVault> =
-        query_as(pic, backend, Principal::anonymous(), "get_vaults", Encode!(&Some(user())).unwrap());
+    let vaults: Vec<CandidVault> = query_as(
+        pic,
+        backend,
+        Principal::anonymous(),
+        "get_vaults",
+        Encode!(&Some(user())).unwrap(),
+    );
     vaults.into_iter().find(|v| v.vault_id == vault_id)
 }
 
@@ -427,7 +459,11 @@ fn icusd_balance(pic: &PocketIc, icusd: Principal, who: Principal) -> u64 {
         icusd,
         Principal::anonymous(),
         "icrc1_balance_of",
-        Encode!(&Account { owner: who, subaccount: None }).unwrap(),
+        Encode!(&Account {
+            owner: who,
+            subaccount: None
+        })
+        .unwrap(),
     );
     bal.0.try_into().unwrap_or(u64::MAX)
 }
@@ -436,17 +472,43 @@ fn icusd_balance(pic: &PocketIc, icusd: Principal, who: Principal) -> u64 {
 /// on failure. Probes tEd25519 availability and skips the test body if absent.
 fn register_xrp(pic: &PocketIc, backend: Principal) {
     decode_result::<()>(
-        update_as(pic, backend, dev(), "register_xrp_collateral", Encode!().unwrap()),
+        update_as(
+            pic,
+            backend,
+            dev(),
+            "set_xrp_schnorr_key_name",
+            Encode!(&"key_1".to_string()).unwrap(),
+        ),
+        "set_xrp_schnorr_key_name",
+    )
+    .expect("set_xrp_schnorr_key_name");
+    decode_result::<()>(
+        update_as(
+            pic,
+            backend,
+            dev(),
+            "register_xrp_collateral",
+            Encode!().unwrap(),
+        ),
         "register_xrp_collateral",
     )
     .expect("register_xrp_collateral");
 }
 
 /// icrc2-approve the backend to pull `amount` icUSD from `owner` (for repay/liquidate).
-fn approve_icusd(pic: &PocketIc, icusd: Principal, owner: Principal, spender: Principal, amount: u64) {
+fn approve_icusd(
+    pic: &PocketIc,
+    icusd: Principal,
+    owner: Principal,
+    spender: Principal,
+    amount: u64,
+) {
     let args = ApproveArgs {
         from_subaccount: None,
-        spender: Account { owner: spender, subaccount: None },
+        spender: Account {
+            owner: spender,
+            subaccount: None,
+        },
         amount: candid::Nat::from(amount),
         expected_allowance: None,
         expires_at: None,
@@ -457,7 +519,9 @@ fn approve_icusd(pic: &PocketIc, icusd: Principal, owner: Principal, spender: Pr
     let reply = update_as(pic, icusd, owner, "icrc2_approve", Encode!(&args).unwrap());
     match reply {
         WasmResult::Reply(b) => {
-            Decode!(&b, Result<candid::Nat, Reserved>).expect("decode approve").expect("approve ok");
+            Decode!(&b, Result<candid::Nat, Reserved>)
+                .expect("decode approve")
+                .expect("approve ok");
         }
         WasmResult::Reject(m) => panic!("icrc2_approve rejected: {m}"),
     }
@@ -469,58 +533,100 @@ fn approve_icusd(pic: &PocketIc, icusd: Principal, owner: Principal, spender: Pr
 
 #[test]
 fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
-    let Env { pic, backend, icusd, xrc: _ } = boot();
+    let Env {
+        pic,
+        backend,
+        icusd,
+        xrc: _,
+    } = boot();
     register_xrp(&pic, backend);
 
     // ── open_xrp_vault (derives custody address via tEd25519) ────────────────
-    // If PocketIC cannot provision test_key_1, this errors -> gated skip.
+    // If PocketIC cannot provision key_1, this errors -> gated skip.
     let open_reply = update_as(&pic, backend, user(), "open_xrp_vault", Encode!().unwrap());
-    let open: XrpVaultOpenInfo = match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
-        Ok(info) => info,
-        Err(_) => {
-            eprintln!("[gated] tEd25519 unavailable in this PocketIC build; skipping XRP e2e");
-            return;
-        }
-    };
+    let open: XrpVaultOpenInfo =
+        match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
+            Ok(info) => info,
+            Err(_) => {
+                eprintln!("[gated] tEd25519 unavailable in this PocketIC build; skipping XRP e2e");
+                return;
+            }
+        };
     let vault_id = open.vault_id;
     assert!(!open.custody_address.is_empty(), "custody address derived");
-    assert!(open.custody_address.starts_with('r'), "XRPL classic address starts with r");
+    assert!(
+        open.custody_address.starts_with('r'),
+        "XRPL classic address starts with r"
+    );
     // No vault yet (deposit unconfirmed).
-    assert!(get_vault(&pic, backend, vault_id).is_none(), "no Vault before deposit confirm");
+    assert!(
+        get_vault(&pic, backend, vault_id).is_none(),
+        "no Vault before deposit confirm"
+    );
 
     // ── confirm_xrp_deposit: 500 XRP funded on custody (native http mock) ─────
     let deposit_drops = 500 * XRP;
     let credited = decode_result::<u64>(
-        call_with_rippled(&pic, backend, user(), "confirm_xrp_deposit", Encode!(&vault_id).unwrap(), |m| {
-            match m {
+        call_with_rippled(
+            &pic,
+            backend,
+            user(),
+            "confirm_xrp_deposit",
+            Encode!(&vault_id).unwrap(),
+            |m| match m {
                 "account_info" => rippled_account_info(deposit_drops, 1, 100),
                 "server_state" => rippled_server_state(RESERVE_DROPS),
                 other => panic!("unexpected rippled method in confirm: {other}"),
-            }
-        }),
+            },
+        ),
         "confirm_xrp_deposit",
     )
     .expect("confirm_xrp_deposit ok");
     // Credited = balance - reserve = 500 XRP - 1 XRP.
-    assert_eq!(credited, deposit_drops - RESERVE_DROPS, "credited = balance - base reserve");
+    assert_eq!(
+        credited,
+        deposit_drops - RESERVE_DROPS,
+        "credited = balance - base reserve"
+    );
 
     let v = get_vault(&pic, backend, vault_id).expect("Vault exists after confirm");
-    assert_eq!(v.collateral_type, xrp_collateral_principal(), "collateral is native-XRP");
-    assert_eq!(v.collateral_amount, deposit_drops - RESERVE_DROPS, "collateral credited in drops");
+    assert_eq!(
+        v.collateral_type,
+        xrp_collateral_principal(),
+        "collateral is native-XRP"
+    );
+    assert_eq!(
+        v.collateral_amount,
+        deposit_drops - RESERVE_DROPS,
+        "collateral credited in drops"
+    );
     assert_eq!(v.borrowed_icusd_amount, 0, "no debt yet");
 
     // ── borrow 50 icUSD (XRP price auto-pulled from XRC: $0.50) ──────────────
     // 499 XRP * $0.50 = ~$249 collateral; $50 debt -> CR ~498% (> 150%).
     let borrow_amount = 50 * E8;
     decode_result::<rumi_protocol_backend::SuccessWithFee>(
-        update_as(&pic, backend, user(), "borrow_from_vault", Encode!(&VaultArg { vault_id, amount: borrow_amount }).unwrap()),
+        update_as(
+            &pic,
+            backend,
+            user(),
+            "borrow_from_vault",
+            Encode!(&VaultArg {
+                vault_id,
+                amount: borrow_amount
+            })
+            .unwrap(),
+        ),
         "borrow_from_vault",
     )
     .expect("borrow ok");
     let v = get_vault(&pic, backend, vault_id).expect("vault");
     assert_eq!(v.borrowed_icusd_amount, borrow_amount, "debt = borrowed");
     let bal = icusd_balance(&pic, icusd, user());
-    assert!(bal >= borrow_amount - E8, "user received ~50 icUSD (net of borrow fee): {bal}");
+    assert!(
+        bal >= borrow_amount - E8,
+        "user received ~50 icUSD (net of borrow fee): {bal}"
+    );
 
     // ── repay the full debt (approve backend to pull icUSD, then repay) ───────
     // Top up the user so they can cover the debt + the one-time borrow fee + ledger
@@ -529,7 +635,17 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
     mint_icusd(&pic, icusd, backend, user(), 5 * E8);
     approve_icusd(&pic, icusd, user(), backend, borrow_amount + 5 * E8);
     decode_result::<u64>(
-        update_as(&pic, backend, user(), "repay_to_vault", Encode!(&VaultArg { vault_id, amount: borrow_amount }).unwrap()),
+        update_as(
+            &pic,
+            backend,
+            user(),
+            "repay_to_vault",
+            Encode!(&VaultArg {
+                vault_id,
+                amount: borrow_amount
+            })
+            .unwrap(),
+        ),
         "repay_to_vault",
     )
     .expect("repay ok");
@@ -538,7 +654,13 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
 
     // ── withdraw & close: creates an XrpClaim for the full collateral ─────────
     decode_result::<Option<u64>>(
-        update_as(&pic, backend, user(), "withdraw_and_close_vault", Encode!(&vault_id).unwrap()),
+        update_as(
+            &pic,
+            backend,
+            user(),
+            "withdraw_and_close_vault",
+            Encode!(&vault_id).unwrap(),
+        ),
         "withdraw_and_close_vault",
     )
     .expect("withdraw_and_close ok");
@@ -555,36 +677,60 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
     // so a retry confirms instead of re-paying.
     let dest = "rPdvC6ccq8hCdPKSPJkPmyZ4Mi1oG2FFkT".to_string(); // a valid XRPL classic addr
     let tx_hash = decode_result::<String>(
-        call_with_rippled(&pic, backend, user(), "settle_xrp_claim", Encode!(&claim_id, &dest).unwrap(), |m| {
-            match m {
+        call_with_rippled(
+            &pic,
+            backend,
+            user(),
+            "settle_xrp_claim",
+            Encode!(&claim_id, &dest).unwrap(),
+            |m| match m {
                 "account_info" => rippled_account_info(deposit_drops, 5, 200),
                 "server_state" => rippled_server_state(RESERVE_DROPS),
                 "submit" => rippled_submit_ok(),
-                "tx" => rippled_tx_validated(deposit_drops - RESERVE_DROPS, 201),
+                "tx" => rippled_tx_validated(
+                    "E2E0000000000000000000000000000000000000000000000000000000000001",
+                    deposit_drops - RESERVE_DROPS,
+                    201,
+                ),
                 other => panic!("unexpected rippled method in settle (submit phase): {other}"),
-            }
-        }),
+            },
+        ),
         "settle_xrp_claim (submit)",
     )
     .expect("settle submit ok");
     assert!(!tx_hash.is_empty(), "settle returns the local tx hash");
-    assert_eq!(xrp_claims(&pic, backend).len(), 1, "claim retained until the Payment validates");
+    assert_eq!(
+        xrp_claims(&pic, backend).len(),
+        1,
+        "claim retained until the Payment validates"
+    );
 
     // Call 2 confirms the recorded settlement: fetch_tx_status -> Validated -> remove.
     let confirm_hash = decode_result::<String>(
-        call_with_rippled(&pic, backend, user(), "settle_xrp_claim", Encode!(&claim_id, &dest).unwrap(), |m| {
-            match m {
-                "tx" => rippled_tx_validated(deposit_drops - RESERVE_DROPS, 201),
+        call_with_rippled(
+            &pic,
+            backend,
+            user(),
+            "settle_xrp_claim",
+            Encode!(&claim_id, &dest).unwrap(),
+            |m| match m {
+                "tx" => rippled_tx_validated(&tx_hash, deposit_drops - RESERVE_DROPS, 201),
                 "account_info" => rippled_account_info(deposit_drops, 6, 250),
                 "server_state" => rippled_server_state(RESERVE_DROPS),
                 other => panic!("unexpected rippled method in settle (confirm phase): {other}"),
-            }
-        }),
+            },
+        ),
         "settle_xrp_claim (confirm)",
     )
     .expect("settle confirm ok");
-    assert_eq!(confirm_hash, tx_hash, "confirm returns the same (already-broadcast) hash");
-    assert!(xrp_claims(&pic, backend).is_empty(), "claim removed after validated settlement");
+    assert_eq!(
+        confirm_hash, tx_hash,
+        "confirm returns the same (already-broadcast) hash"
+    );
+    assert!(
+        xrp_claims(&pic, backend).is_empty(),
+        "claim removed after validated settlement"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -593,26 +739,39 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
 
 #[test]
 fn xrp_native_liquidation_is_claim_based() {
-    let Env { pic, backend, icusd, xrc } = boot();
+    let Env {
+        pic,
+        backend,
+        icusd,
+        xrc,
+    } = boot();
     register_xrp(&pic, backend);
 
     let open_reply = update_as(&pic, backend, user(), "open_xrp_vault", Encode!().unwrap());
-    let open: XrpVaultOpenInfo = match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
-        Ok(info) => info,
-        Err(_) => {
-            eprintln!("[gated] tEd25519 unavailable; skipping XRP liquidation e2e");
-            return;
-        }
-    };
+    let open: XrpVaultOpenInfo =
+        match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
+            Ok(info) => info,
+            Err(_) => {
+                eprintln!("[gated] tEd25519 unavailable; skipping XRP liquidation e2e");
+                return;
+            }
+        };
     let vault_id = open.vault_id;
 
     let deposit_drops = 200 * XRP;
     decode_result::<u64>(
-        call_with_rippled(&pic, backend, user(), "confirm_xrp_deposit", Encode!(&vault_id).unwrap(), |m| match m {
-            "account_info" => rippled_account_info(deposit_drops, 1, 100),
-            "server_state" => rippled_server_state(RESERVE_DROPS),
-            other => panic!("unexpected rippled method: {other}"),
-        }),
+        call_with_rippled(
+            &pic,
+            backend,
+            user(),
+            "confirm_xrp_deposit",
+            Encode!(&vault_id).unwrap(),
+            |m| match m {
+                "account_info" => rippled_account_info(deposit_drops, 1, 100),
+                "server_state" => rippled_server_state(RESERVE_DROPS),
+                other => panic!("unexpected rippled method: {other}"),
+            },
+        ),
         "confirm_xrp_deposit",
     )
     .expect("confirm ok");
@@ -620,7 +779,17 @@ fn xrp_native_liquidation_is_claim_based() {
     // Borrow near the limit at $0.50: ~199 XRP * $0.50 = ~$99.5; borrow $60 -> CR ~165%.
     let borrow_amount = 60 * E8;
     decode_result::<rumi_protocol_backend::SuccessWithFee>(
-        update_as(&pic, backend, user(), "borrow_from_vault", Encode!(&VaultArg { vault_id, amount: borrow_amount }).unwrap()),
+        update_as(
+            &pic,
+            backend,
+            user(),
+            "borrow_from_vault",
+            Encode!(&VaultArg {
+                vault_id,
+                amount: borrow_amount
+            })
+            .unwrap(),
+        ),
         "borrow_from_vault",
     )
     .expect("borrow ok");
@@ -642,7 +811,17 @@ fn xrp_native_liquidation_is_claim_based() {
     // the seized XRP becomes an XrpClaim they later settle to an XRPL address.
     let before = xrp_claims(&pic, backend).len();
     decode_result::<rumi_protocol_backend::SuccessWithFee>(
-        update_as(&pic, backend, liquidator(), "liquidate_vault_partial", Encode!(&VaultArg { vault_id, amount: 30 * E8 }).unwrap()),
+        update_as(
+            &pic,
+            backend,
+            liquidator(),
+            "liquidate_vault_partial",
+            Encode!(&VaultArg {
+                vault_id,
+                amount: 30 * E8
+            })
+            .unwrap(),
+        ),
         "liquidate_vault_partial",
     )
     .expect("claim-based partial liquidation ok");
@@ -678,7 +857,10 @@ fn xrp_collateral_contract_matches_frontend_expectations() {
     assert!(
         supported.iter().any(|(p, _)| *p == xrp),
         "native-XRP must appear in get_supported_collateral_types: {:?}",
-        supported.iter().map(|(p, _)| p.to_text()).collect::<Vec<_>>()
+        supported
+            .iter()
+            .map(|(p, _)| p.to_text())
+            .collect::<Vec<_>>()
     );
 
     // The UI reads get_collateral_config(xrp): custody_kind drives `hasXrpCollateral`
@@ -727,7 +909,13 @@ struct XrpClaimView {
 /// re-fetch resets the timestamp, so the price is FRESH (within the 10-min hard
 /// ceiling) when liquidation reads it.
 fn crash_xrp_price(pic: &PocketIc, xrc: Principal, price_e8: u64) {
-    let reply = update_as(pic, xrc, Principal::anonymous(), "set_exchange_rate", Encode!(&"XRP".to_string(), &"USD".to_string(), &price_e8).unwrap());
+    let reply = update_as(
+        pic,
+        xrc,
+        Principal::anonymous(),
+        "set_exchange_rate",
+        Encode!(&"XRP".to_string(), &"USD".to_string(), &price_e8).unwrap(),
+    );
     if let WasmResult::Reject(m) = reply {
         panic!("set_exchange_rate rejected: {m}");
     }
@@ -746,7 +934,10 @@ fn mint_icusd(pic: &PocketIc, icusd: Principal, minter: Principal, to: Principal
 fn transfer_icusd(pic: &PocketIc, icusd: Principal, from: Principal, to: Principal, amount: u64) {
     let args = icrc_ledger_types::icrc1::transfer::TransferArg {
         from_subaccount: None,
-        to: Account { owner: to, subaccount: None },
+        to: Account {
+            owner: to,
+            subaccount: None,
+        },
         fee: None,
         created_at_time: None,
         memo: None,
@@ -755,7 +946,9 @@ fn transfer_icusd(pic: &PocketIc, icusd: Principal, from: Principal, to: Princip
     let reply = update_as(pic, icusd, from, "icrc1_transfer", Encode!(&args).unwrap());
     match reply {
         WasmResult::Reply(b) => {
-            Decode!(&b, Result<candid::Nat, Reserved>).expect("decode transfer").expect("transfer ok");
+            Decode!(&b, Result<candid::Nat, Reserved>)
+                .expect("decode transfer")
+                .expect("transfer ok");
         }
         WasmResult::Reject(m) => panic!("icrc1_transfer rejected: {m}"),
     }

--- a/src/vault_frontend/src/lib/components/vault/XrpVaultPanel.svelte
+++ b/src/vault_frontend/src/lib/components/vault/XrpVaultPanel.svelte
@@ -38,6 +38,7 @@
   let busyClaimId: number | null = null;
   // Per-claim destination address inputs, keyed by claim id.
   let claimDest: Record<number, string> = {};
+  let claimTag: Record<number, string> = {};
 
   $: connected = $walletStore.isConnected;
 
@@ -106,17 +107,32 @@
     // "Confirm" of an in-flight settlement) is a pure confirm: the backend ignores
     // `destination` on the validated path, so we pass '' and never let a freshly
     // typed address redirect an already-submitted (or to-be-re-signed) Payment.
-    let dest = '';
+    let dest = (claimDest[claim.claimId] ?? '').trim();
+    let destinationTag: number | undefined;
     if (!claim.inFlight) {
-      dest = (claimDest[claim.claimId] ?? '').trim();
       if (!isValidXrplClassicAddress(dest)) {
         toastStore.error('Enter a valid XRPL classic address (starts with r)');
+        return;
+      }
+    } else if (dest !== '' && !isValidXrplClassicAddress(dest)) {
+      toastStore.error('Enter a valid replacement XRPL classic address (starts with r)');
+      return;
+    }
+    const tag = (claimTag[claim.claimId] ?? '').trim();
+    if (tag !== '') {
+      if (!/^\d+$/.test(tag)) {
+        toastStore.error('Destination tag must be a whole number');
+        return;
+      }
+      destinationTag = Number(tag);
+      if (!Number.isSafeInteger(destinationTag) || destinationTag > 0xffffffff) {
+        toastStore.error('Destination tag must be between 0 and 4294967295');
         return;
       }
     }
     busyClaimId = claim.claimId;
     try {
-      const res = await XrpVaultService.settleXrpClaim(claim.claimId, dest);
+      const res = await XrpVaultService.settleXrpClaim(claim.claimId, dest, destinationTag);
       if (res.success) {
         // Two-phase: the first call submits the XRPL Payment but KEEPS the claim;
         // it clears only after a follow-up "Confirm" once the Payment validates
@@ -218,17 +234,27 @@
               <span class="xrp-amt">{c.xrp} XRP</span>
               {#if c.inFlight}
                 <span class="xrp-hint">
-                  Settlement in flight{c.inFlightTxHash ? ` (tx ${formatAddress(c.inFlightTxHash, 8, 6)})` : ''} — click Confirm once it validates.
+                  Settlement in flight{c.inFlightTxHash ? ` (tx ${formatAddress(c.inFlightTxHash, 8, 6)})` : ''} — click Confirm once it validates, or enter replacement details if it expired or failed.
                 </span>
-              {:else}
-                <input
-                  class="xrp-input"
-                  placeholder="Your XRPL address (r…)"
-                  bind:value={claimDest[c.claimId]}
-                  spellcheck="false"
-                  autocomplete="off"
-                />
               {/if}
+                <div class="xrp-inputs">
+                  <input
+                    class="xrp-input"
+                    placeholder={c.inFlight ? 'Replacement address (optional)' : 'Your XRPL address (r…)'}
+                    bind:value={claimDest[c.claimId]}
+                    spellcheck="false"
+                    autocomplete="off"
+                  />
+                  <input
+                    class="xrp-input xrp-tag-input"
+                    placeholder="Destination tag"
+                    bind:value={claimTag[c.claimId]}
+                    spellcheck="false"
+                    autocomplete="off"
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                  />
+                </div>
             </div>
             <button class="xrp-action" disabled={busyClaimId === c.claimId} on:click={() => settleClaim(c)}>
               {busyClaimId === c.claimId ? 'Settling…' : c.inFlight ? 'Confirm' : 'Settle'}
@@ -335,6 +361,15 @@
     font-family: ui-monospace, monospace;
     font-size: 0.82rem;
     min-width: 240px;
+  }
+  .xrp-inputs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .xrp-tag-input {
+    min-width: 150px;
+    max-width: 180px;
   }
   .xrp-action {
     padding: 7px 13px;

--- a/src/vault_frontend/src/lib/services/xrpVaultService.ts
+++ b/src/vault_frontend/src/lib/services/xrpVaultService.ts
@@ -159,15 +159,31 @@ export class XrpVaultService {
    * Settle an XRP claim: sign + broadcast the XRPL Payment to `destination`. This is
    * a two-phase, anti-double-pay flow on the backend — the first call signs+submits
    * (the claim stays until the Payment validates), a follow-up call confirms it and
-   * clears the claim. The UI should call this again (or rely on polling) until the
-   * claim disappears from {@link getMyClaims}. Returns the (local) tx hash.
+   * clears the claim. Pass `destinationTag` for exchange-hosted accounts that need
+   * one; ordinary self-custody addresses continue through the legacy untagged
+   * endpoint. The UI should call this again (or rely on polling) until the claim
+   * disappears from {@link getMyClaims}. Returns the (local) tx hash.
    */
-  static async settleXrpClaim(claimId: number, destination: string): Promise<XrpOpResult<{ txHash: string }>> {
+  static async settleXrpClaim(
+    claimId: number,
+    destination: string,
+    destinationTag?: number
+  ): Promise<XrpOpResult<{ txHash: string }>> {
     return ApiClient.executeSequentialOperation(async () => {
       try {
+        if (
+          destinationTag !== undefined &&
+          (!Number.isInteger(destinationTag) || destinationTag < 0 || destinationTag > 0xffffffff)
+        ) {
+          return { success: false, error: 'Destination tag must be a whole number from 0 to 4294967295.' };
+        }
         const actor = await this.actor();
+        const operation =
+          destinationTag === undefined
+            ? () => actor.settle_xrp_claim(BigInt(claimId), destination)
+            : () => actor.settle_xrp_claim_with_tag(BigInt(claimId), destination, destinationTag);
         const result = await callWithOisyFalseNegativeGuard(
-          () => actor.settle_xrp_claim(BigInt(claimId), destination),
+          operation,
           // Verifier: the first settle phase records `claim.settlement` BEFORE the
           // submit outcall (backend vault.rs), so if the canister executed at all the
           // claim is now either gone (validated + removed) or carries a settlement.
@@ -178,7 +194,7 @@ export class XrpVaultService {
             const entry = claims.find(([id]) => Number(id) === claimId);
             return !entry || entry[1].settlement.length > 0;
           },
-          `settle_xrp_claim #${claimId}`
+          destinationTag === undefined ? `settle_xrp_claim #${claimId}` : `settle_xrp_claim_with_tag #${claimId}`
         );
         if (isOisyLandedSentinel(result)) {
           return { success: true, oisyResilient: true, data: { txHash: '' } };


### PR DESCRIPTION
## Summary
- cap native XRP launch debt ceiling at 100 icUSD and enforce it on config updates
- require production Schnorr key before enabling native XRP collateral outside frozen/deprecated states
- harden XRPL RPC quorum/transform behavior, XRP settlement sequencing, and destination-tag claim settlement
- refresh generated backend Candid declarations and vault frontend XRP call surface

## Validation
- cargo test -p rumi_protocol_backend xrp --lib
- cargo test -p rumi_protocol_backend --lib
- POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test xrp_native_e2e_pic -- --nocapture
- cargo check -p rumi_protocol_backend --lib
- cargo test -p rumi_protocol_backend --bin rumi_protocol_backend check_candid_interface_compatibility
- cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend
- npm --workspace=src/vault_frontend exec eslint -- src/lib/services/xrpVaultService.ts src/lib/components/vault/XrpVaultPanel.svelte
- npm --workspace=src/vault_frontend run build
- git diff --check
- rg "@rollup/rollup-darwin" --glob package.json