### PR TITLE
feat(chains): Inc6 proof-backed reconciliation

### DIFF
--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
@@ -1,0 +1,659 @@
+# Chains Liquidation Increment 6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Inc 5's manual reconciliation proof strings with finalized on-chain proof verification for pending-chain-burn and reserve-burn settlement, while keeping the existing manual endpoints as developer fallback.
+
+**Architecture:** Add an EVM settlement-proof module that reuses the existing `eth_getTransactionReceipt` and finality helpers, verifies exact receipt log identities, and returns compact verified proof metadata. Add separate proof-id dedupe maps to `MultiChainStateV6` so pending-burn and reserve-burn settlements cannot collide with user burn proofs. The async endpoints fetch and verify receipts before entering a synchronous `mutate_state` section that dedupes, settles accounting, stores proof metadata, and records the existing Inc 5 events atomically.
+
+**Tech Stack:** Rust 2021, `ic-cdk` update methods, existing hand-rolled EVM RPC wrapper on the repo's `ic-cdk` 0.12 pin, Candid, CBOR/serde stable snapshots, Cargo unit tests and targeted PocketIC tests.
+
+## Global Constraints
+
+- TDD is mandatory: write failing tests first, run them red, then implement the minimum code to turn them green.
+- Do not replace or remove the Inc 5 manual endpoints `settle_pending_chain_burn` and `settle_reserve_burn`; Inc 6 adds proof-backed endpoints beside them.
+- Do not settle accounting on caller-supplied amount alone; the amount must come from the verified receipt log.
+- Do not hold a state borrow across an `.await`; fetch and verify receipts first, then mutate state synchronously.
+- Every rejection path before mutation must leave `chain_supplies`, `pending_chain_burn_e8s`, `reserve_backing_e8s`, and proof-id maps unchanged.
+- Proof storage must be compact: store canonical proof id plus minimal metadata, never full receipts.
+- Proof domains are separate: user burn proof ids, pending-chain-burn settlement ids, and reserve-burn settlement ids must not share a dedupe map.
+- Use `icp`, not `dfx`, for build/deploy instructions.
+- Do not add `@rollup/rollup-darwin-*` to any `package.json`.
+- Stop at code, tests, and PR unless the user explicitly authorizes merge/deploy for Inc 6.
+
+---
+
+### Task 1: Receipt-Log Proof Parsing and Verification
+
+**Files:**
+- Create: `src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/evm/mod.rs`
+- Test: `src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs`
+
+**Interfaces:**
+- Consumes:
+  - `TxReceiptWithLogs { success, block_number, logs }`
+  - `BURN_EVENT_TOPIC0`
+  - `TRANSFER_EVENT_TOPIC0`
+  - `parse_hex_quantity`
+  - `is_block_final(chain, block_number, finality_depth)`
+- Produces:
+  - `pub struct BurnSettlementProofArg { pub tx_hash: String, pub log_index: u64, pub expected_burner: Option<String> }`
+  - `pub struct ReserveSettlementProofArg { pub burn_tx_hash: String, pub burn_log_index: u64, pub reserve_tx_hash: String, pub reserve_transfer_log_index: u64, pub expected_burner: Option<String> }`
+  - `pub struct VerifiedBurnSettlementProof { pub proof_id: String, pub tx_hash: String, pub log_index: u64, pub block_number: u64, pub burner: String, pub amount_e8s: u128 }`
+  - `pub struct VerifiedReserveSettlementProof { pub proof_id: String, pub burn_tx_hash: String, pub burn_log_index: u64, pub burn_block_number: u64, pub burner: String, pub amount_e8s: u128, pub reserve_tx_hash: String, pub reserve_transfer_log_index: u64, pub reserve_block_number: u64, pub reserve_transfer_amount_native: u128 }`
+  - `pub enum SettlementProofError`
+  - `pub fn decode_burn_log_with_burner(topics: &[String], data: &str, tx_hash: &str, block_number: u64) -> Result<BurnLogWithBurner, String>`
+  - `pub fn verify_pending_burn_receipt(contract: &str, proof: &BurnSettlementProofArg, receipt: &TxReceiptWithLogs) -> Result<VerifiedBurnSettlementProof, SettlementProofError>`
+  - `pub fn verify_reserve_burn_receipts(icusd_contract: &str, settle_stable_token: &str, reserve_address: &str, proof: &ReserveSettlementProofArg, burn_receipt: &TxReceiptWithLogs, reserve_receipt: &TxReceiptWithLogs) -> Result<VerifiedReserveSettlementProof, SettlementProofError>`
+
+- [ ] **Step 1: Write failing burner decode tests**
+
+Add to `src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs`:
+
+```rust
+#[test]
+fn burn_log_with_burner_decodes_indexed_burner_address() {
+    let topics = vec![
+        super::evm_rpc::BURN_EVENT_TOPIC0.to_string(),
+        format!("0x{:064x}", 7u64),
+        "0x0000000000000000000000001234567890abcdef1234567890abcdef12345678".to_string(),
+    ];
+    let burn = super::evm_rpc::decode_burn_log_with_burner(
+        &topics,
+        &format!("0x{:064x}", 40_000_000u128),
+        "0xabc",
+        99,
+    )
+    .expect("decode burn with burner");
+    assert_eq!(burn.vault_id, 7);
+    assert_eq!(burn.amount_e8s, 40_000_000);
+    assert_eq!(burn.burner, "0x1234567890abcdef1234567890abcdef12345678");
+}
+```
+
+- [ ] **Step 2: Run burner decode test to verify it fails**
+
+Run: `cargo test -p rumi_protocol_backend burn_log_with_burner --lib -- --nocapture`
+
+Expected: FAIL with an unresolved `decode_burn_log_with_burner` item.
+
+- [ ] **Step 3: Implement burner decode**
+
+In `evm_rpc.rs`, add:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BurnLogWithBurner {
+    pub vault_id: u64,
+    pub burner: String,
+    pub amount_e8s: u128,
+    pub tx_hash: String,
+    pub block_number: u64,
+}
+
+pub fn decode_burn_log_with_burner(
+    topics: &[String],
+    data: &str,
+    tx_hash: &str,
+    block_number: u64,
+) -> Result<BurnLogWithBurner, String> {
+    let base = BurnLog::from_raw(topics, data, tx_hash, block_number)?;
+    let raw = topics
+        .get(2)
+        .ok_or_else(|| "BurnLogWithBurner: missing burner topic".to_string())?;
+    let hex = raw.strip_prefix("0x").or_else(|| raw.strip_prefix("0X")).unwrap_or(raw);
+    if hex.len() < 40 {
+        return Err(format!("BurnLogWithBurner: burner topic too short: {raw}"));
+    }
+    let burner = format!("0x{}", hex[hex.len() - 40..].to_ascii_lowercase());
+    Ok(BurnLogWithBurner {
+        vault_id: base.vault_id,
+        burner,
+        amount_e8s: base.amount_e8s,
+        tx_hash: base.tx_hash,
+        block_number: base.block_number,
+    })
+}
+```
+
+- [ ] **Step 4: Run burner decode test to verify it passes**
+
+Run: `cargo test -p rumi_protocol_backend burn_log_with_burner --lib -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing pure settlement-proof tests**
+
+Create `src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs` with tests for:
+
+```rust
+#[test]
+fn pending_burn_proof_accepts_exact_contract_log_index_and_amount_from_log() {
+    let contract = "0x000000000000000000000000000000000000cafe";
+    let proof = BurnSettlementProofArg {
+        tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        log_index: 7,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+    let receipt = receipt(
+        true,
+        55,
+        vec![
+            transfer_log("0x000000000000000000000000000000000000feed", "0x000000000000000000000000000000000000aaaa", 1, 3),
+            burn_log(contract, 99, "0x000000000000000000000000000000000000beef", 25_000_000, 7),
+        ],
+    );
+
+    let verified = verify_pending_burn_receipt(contract, &proof, &receipt).expect("verified proof");
+    assert_eq!(verified.amount_e8s, 25_000_000);
+    assert_eq!(verified.block_number, 55);
+    assert_eq!(verified.log_index, 7);
+    assert_eq!(verified.burner, "0x000000000000000000000000000000000000beef");
+    assert_eq!(
+        verified.proof_id,
+        "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7"
+    );
+}
+
+#[test]
+fn pending_burn_proof_rejects_wrong_contract_wrong_log_index_and_wrong_burner() {
+    let contract = "0x000000000000000000000000000000000000cafe";
+    let proof = BurnSettlementProofArg {
+        tx_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        log_index: 2,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+    let wrong_contract = receipt(true, 55, vec![burn_log("0x000000000000000000000000000000000000dead", 99, "0x000000000000000000000000000000000000beef", 25_000_000, 2)]);
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_contract),
+        Err(SettlementProofError::NoMatchingBurnLog)
+    ));
+
+    let wrong_index = receipt(true, 55, vec![burn_log(contract, 99, "0x000000000000000000000000000000000000beef", 25_000_000, 3)]);
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_index),
+        Err(SettlementProofError::NoMatchingBurnLog)
+    ));
+
+    let wrong_burner = receipt(true, 55, vec![burn_log(contract, 99, "0x000000000000000000000000000000000000badd", 25_000_000, 2)]);
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_burner),
+        Err(SettlementProofError::UnexpectedBurner { .. })
+    ));
+}
+
+#[test]
+fn reserve_burn_proof_requires_icusd_burn_and_settle_stable_transfer_to_reserve() {
+    let icusd = "0x000000000000000000000000000000000000cafe";
+    let usdc = "0x0000000000000000000000000000000000001000";
+    let reserve = "0x0000000000000000000000000000000000002222";
+    let proof = ReserveSettlementProofArg {
+        burn_tx_hash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string(),
+        burn_log_index: 4,
+        reserve_tx_hash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string(),
+        reserve_transfer_log_index: 8,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+    let burn_receipt = receipt(true, 70, vec![burn_log(icusd, 0, "0x000000000000000000000000000000000000beef", 25_000_000, 4)]);
+    let reserve_receipt = receipt(true, 71, vec![transfer_log(usdc, reserve, 25_000_000, 8)]);
+
+    let verified = verify_reserve_burn_receipts(icusd, usdc, reserve, &proof, &burn_receipt, &reserve_receipt)
+        .expect("reserve proof verified");
+    assert_eq!(verified.amount_e8s, 25_000_000);
+    assert_eq!(verified.reserve_transfer_amount_native, 25_000_000);
+    assert_eq!(
+        verified.proof_id,
+        "reserve:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:4:0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:8"
+    );
+}
+
+#[test]
+fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfer() {
+    let icusd = "0x000000000000000000000000000000000000cafe";
+    let usdc = "0x0000000000000000000000000000000000001000";
+    let reserve = "0x0000000000000000000000000000000000002222";
+    let proof = ReserveSettlementProofArg {
+        burn_tx_hash: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string(),
+        burn_log_index: 4,
+        reserve_tx_hash: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string(),
+        reserve_transfer_log_index: 8,
+        expected_burner: None,
+    };
+    let burn_receipt = receipt(true, 70, vec![burn_log(icusd, 0, "0x000000000000000000000000000000000000beef", 25_000_000, 4)]);
+
+    let wrong_recipient = receipt(true, 71, vec![transfer_log(usdc, "0x0000000000000000000000000000000000003333", 25_000_000, 8)]);
+    assert!(matches!(
+        verify_reserve_burn_receipts(icusd, usdc, reserve, &proof, &burn_receipt, &wrong_recipient),
+        Err(SettlementProofError::ReserveTransferMissing)
+    ));
+
+    let too_small = receipt(true, 71, vec![transfer_log(usdc, reserve, 24_999_999, 8)]);
+    assert!(matches!(
+        verify_reserve_burn_receipts(icusd, usdc, reserve, &proof, &burn_receipt, &too_small),
+        Err(SettlementProofError::ReserveTransferTooSmall { .. })
+    ));
+}
+```
+
+Use helper constructors:
+
+```rust
+fn word(v: u128) -> String { format!("0x{v:064x}") }
+fn word_addr(addr: &str) -> String {
+    let h = addr.trim_start_matches("0x");
+    format!("0x{h:0>64}")
+}
+```
+
+- [ ] **Step 6: Run settlement-proof tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof --lib -- --nocapture`
+
+Expected: FAIL because `settlement_proof` module and proof types do not exist.
+
+- [ ] **Step 7: Implement pure proof module**
+
+Create `settlement_proof.rs`. The verification functions must:
+
+```rust
+pub fn canonical_tx_hash(tx_hash: &str) -> Result<String, SettlementProofError> {
+    let tx = tx_hash.trim().to_ascii_lowercase();
+    if !tx.starts_with("0x") || tx.len() != 66 {
+        return Err(SettlementProofError::InvalidTxHash);
+    }
+    Ok(tx)
+}
+```
+
+For pending burn:
+- reject `receipt.success == false`
+- find exactly `proof.log_index`
+- require `log.address == contract`
+- require `topics[0] == BURN_EVENT_TOPIC0`
+- decode amount and burner with `decode_burn_log_with_burner`
+- if `expected_burner` is `Some`, require exact lowercase match
+- return `proof_id = format!("pending:{}:{}", tx_hash, log_index)`
+
+For reserve burn:
+- verify burn receipt as above against `icusd_contract`
+- verify reserve transfer receipt at `reserve_transfer_log_index`
+- require transfer log address equals `settle_stable_token`
+- require decoded `Transfer(_, reserve_address, amount)` recipient equals `reserve_address`
+- require `transfer.amount >= burn.amount_e8s`
+- return `proof_id = format!("reserve:{}:{}:{}:{}", burn_tx_hash, burn_log_index, reserve_tx_hash, reserve_transfer_log_index)`
+
+- [ ] **Step 8: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof burn_log_with_burner --lib -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs \
+  src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs \
+  src/rumi_protocol_backend/src/chains/evm/mod.rs \
+  src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs \
+  src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs
+git commit -m "feat(chains): Inc6 settlement proof parsing"
+```
+
+Expected: commit succeeds.
+
+### Task 2: Proof Dedupe and Atomic Settlement State Helpers
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/multi_chain_state.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/supply.rs`
+- Modify: `src/rumi_protocol_backend/src/chains/tests_supply.rs`
+
+**Interfaces:**
+- Consumes:
+  - Task 1 verified proof structs.
+  - Inc 5 `settle_pending_chain_burn` and `settle_reserve_burn` helpers.
+- Produces:
+  - `pub struct SettlementProofRecord { pub proof_id: String, pub tx_hash: String, pub log_index: u64, pub amount_e8s: u128, pub block_number: u64, pub recorded_at_ns: u64 }`
+  - `MultiChainStateV6.settled_pending_burn_proofs: BTreeMap<String, SettlementProofRecord>`
+  - `MultiChainStateV6.settled_reserve_burn_proofs: BTreeMap<String, SettlementProofRecord>`
+  - `pub enum ProofBackedSettlementError`
+  - `pub fn settle_pending_chain_burn_with_verified_proof(state: &mut MultiChainState, chain: ChainId, proof: VerifiedBurnSettlementProof, now_ns: u64) -> Result<(), ProofBackedSettlementError>`
+  - `pub fn settle_reserve_burn_with_verified_proof(state: &mut MultiChainState, chain: ChainId, proof: VerifiedReserveSettlementProof, now_ns: u64) -> Result<(), ProofBackedSettlementError>`
+
+- [ ] **Step 1: Write failing state migration/dedupe tests**
+
+Add tests proving:
+- a pre-Inc6 V6 snapshot decodes with both proof maps empty,
+- a duplicate pending proof id rejects with no accounting mutation,
+- a duplicate reserve proof id rejects with no accounting mutation,
+- proof records store only ids and compact metadata.
+
+- [ ] **Step 2: Run state tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof_state --lib -- --nocapture`
+
+Expected: FAIL because proof maps and records do not exist.
+
+- [ ] **Step 3: Add state fields and record type**
+
+In `multi_chain_state.rs`, add:
+
+```rust
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SettlementProofRecord {
+    pub proof_id: String,
+    pub tx_hash: String,
+    pub log_index: u64,
+    pub amount_e8s: u128,
+    pub block_number: u64,
+    pub recorded_at_ns: u64,
+}
+```
+
+Add to `MultiChainStateV6`:
+
+```rust
+#[serde(default)]
+pub settled_pending_burn_proofs: BTreeMap<String, SettlementProofRecord>,
+#[serde(default)]
+pub settled_reserve_burn_proofs: BTreeMap<String, SettlementProofRecord>,
+```
+
+- [ ] **Step 4: Run state tests to verify they pass**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof_state --lib -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing atomic settlement tests**
+
+Add tests in `tests_supply.rs` proving:
+- pending proof settlement reduces `pending_chain_burn_e8s` and `chain_supplies`, inserts proof id, and preserves invariant;
+- reserve proof settlement reduces `reserve_backing_e8s` and `chain_supplies`, inserts proof id, and preserves invariant;
+- underflow/duplicate/unknown-chain rejection leaves all accounting and proof maps unchanged.
+
+- [ ] **Step 6: Run settlement tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend proof_backed_settlement --lib -- --nocapture`
+
+Expected: FAIL because proof-backed helper functions do not exist.
+
+- [ ] **Step 7: Implement proof-backed settlement helpers**
+
+Validation order:
+1. check proof id absent in the domain map;
+2. call the Inc 5 backing settlement helper on a cloned `MultiChainState`;
+3. insert compact proof record into the cloned state;
+4. assign cloned state back to `*state`.
+
+This clone-then-commit pattern guarantees no partial mutation if settlement or proof insertion rejects.
+
+- [ ] **Step 8: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend proof_backed_settlement settlement_proof_state --lib -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add src/rumi_protocol_backend/src/chains/multi_chain_state.rs \
+  src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs \
+  src/rumi_protocol_backend/src/chains/supply.rs \
+  src/rumi_protocol_backend/src/chains/tests_supply.rs
+git commit -m "feat(chains): Inc6 proof dedupe settlement state"
+```
+
+Expected: commit succeeds.
+
+### Task 3: Async Proof-Backed Operator Endpoints
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/main.rs`
+- Modify: `src/rumi_protocol_backend/src/event.rs`
+- Modify: `src/rumi_protocol_backend/src/lib.rs`
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did`
+
+**Interfaces:**
+- Consumes:
+  - Task 1 proof verification functions.
+  - Task 2 proof-backed state helpers.
+- Produces:
+  - `settle_pending_chain_burn_with_proof(chain: ChainId, proof: BurnSettlementProofArg) -> Result<(), ProtocolError>`
+  - `settle_reserve_burn_with_proof(chain: ChainId, proof: ReserveSettlementProofArg) -> Result<(), ProtocolError>`
+  - `get_settlement_proof_ids(chain: opt ChainId) -> SettlementProofIds`
+
+- [ ] **Step 1: Write failing endpoint helper tests**
+
+Add tests for a small pure function in `main.rs`:
+
+```rust
+fn chain_finality_depth_or_default(s: &State, chain: ChainId) -> u64
+fn settlement_proof_context(s: &State, chain: ChainId) -> Result<SettlementProofContext, ProtocolError>
+```
+
+The tests prove missing chain, missing icUSD contract, missing liquidation config, and missing reserve token/address reject before any RPC call.
+
+- [ ] **Step 2: Run endpoint helper tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof_context --bin rumi_protocol_backend -- --nocapture`
+
+Expected: FAIL because context helpers do not exist.
+
+- [ ] **Step 3: Implement endpoint context helpers**
+
+`SettlementProofContext` contains:
+
+```rust
+struct SettlementProofContext {
+    contract: String,
+    finality_depth: u64,
+    settle_stable_token: Option<String>,
+    reserve_address: Option<String>,
+}
+```
+
+For pending proofs, require only registered chain and `chain_contracts[chain]`. For reserve proofs, also require `chain_liquidation_configs[chain].settle_stable_token` and derived `reserve_address`.
+
+- [ ] **Step 4: Write failing async endpoint tests**
+
+Add a PocketIC test file only if the existing mock can set receipts with logs by tx hash; otherwise add unit tests around the async-free commit helpers and leave live RPC verification to staging. The test should prove the endpoint path rejects duplicate proof id before second accounting mutation.
+
+- [ ] **Step 5: Run endpoint tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof_context --bin rumi_protocol_backend -- --nocapture`
+
+Expected: FAIL until endpoint wiring exists.
+
+- [ ] **Step 6: Implement proof-backed endpoints**
+
+Endpoint flow:
+1. developer-gate the call;
+2. read context without awaiting;
+3. fetch receipt(s) through `get_transaction_receipt_with_logs`;
+4. require receipt present, `success == true`, and finality via `is_block_final`;
+5. run pure verifier from Task 1;
+6. call Task 2 helper inside `mutate_state`;
+7. record existing Inc 5 event with `proof = verified.proof_id`;
+8. log proof id and amount.
+
+Keep the Inc 5 manual endpoints unchanged.
+
+- [ ] **Step 7: Add proof-id query**
+
+Expose compact operator visibility:
+
+```rust
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct SettlementProofIds {
+    pub pending: Vec<String>,
+    pub reserve: Vec<String>,
+}
+```
+
+`get_settlement_proof_ids(chain)` may ignore `chain` in v1 if proof ids are globally unique, but keep the argument for future chain-specific filtering. Sort ids lexicographically.
+
+- [ ] **Step 8: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend settlement_proof_context --bin rumi_protocol_backend -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add src/rumi_protocol_backend/src/main.rs \
+  src/rumi_protocol_backend/src/event.rs \
+  src/rumi_protocol_backend/src/lib.rs \
+  src/rumi_protocol_backend/rumi_protocol_backend.did
+git commit -m "feat(chains): Inc6 proof-backed reconciliation endpoints"
+```
+
+Expected: commit succeeds.
+
+### Task 4: Aged Pending-Burn Monitor
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/multi_chain_state.rs`
+- Modify: `src/rumi_protocol_backend/src/main.rs`
+- Test: `src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs`
+
+**Interfaces:**
+- Consumes:
+  - `pending_chain_burn_e8s`
+  - existing event log and settlement proof maps
+- Produces:
+  - `pub struct PendingChainBurnAging { pub chain_id: ChainId, pub pending_chain_burn_e8s: u128, pub oldest_reference_ns: Option<u64>, pub age_ns: Option<u64>, pub proof_count: u64 }`
+  - `get_pending_chain_burn_aging() -> Vec<PendingChainBurnAging>`
+
+- [ ] **Step 1: Write failing aging tests**
+
+Add tests proving chains with nonzero `pending_chain_burn_e8s` are surfaced, zero-pending chains are omitted, and proof counts are reported without exposing receipt payloads.
+
+- [ ] **Step 2: Run aging tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend pending_chain_burn_aging --lib -- --nocapture`
+
+Expected: FAIL because aging report types and helpers do not exist.
+
+- [ ] **Step 3: Implement aging report helper**
+
+Use the oldest matching `ChainPendingBurnSettled` proof record when available. If no timestamp exists for a pending chain, return `oldest_reference_ns = None` and `age_ns = None` rather than manufacturing a timestamp.
+
+- [ ] **Step 4: Expose query endpoint**
+
+Add `get_pending_chain_burn_aging` as a query. It is operator visibility only and does not mutate state.
+
+- [ ] **Step 5: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend pending_chain_burn_aging --lib -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add src/rumi_protocol_backend/src/chains/multi_chain_state.rs \
+  src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs \
+  src/rumi_protocol_backend/src/main.rs
+git commit -m "feat(chains): Inc6 pending burn aging monitor"
+```
+
+Expected: commit succeeds.
+
+### Task 5: Candid, Verification, and PR
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/rumi_protocol_backend.did`
+- Modify: `docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-4 public API changes.
+- Produces: regenerated Candid and a reviewed PR branch.
+
+- [ ] **Step 1: Regenerate Candid**
+
+Run: `RUMI_REGEN_DID=1 cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
+
+Expected: PASS and `src/rumi_protocol_backend/rumi_protocol_backend.did` updated.
+
+- [ ] **Step 2: Run focused backend tests**
+
+Run:
+
+```bash
+cargo test -p rumi_protocol_backend settlement_proof proof_backed_settlement pending_chain_burn_aging --lib --bin rumi_protocol_backend -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full backend lib/bin checks**
+
+Run:
+
+```bash
+cargo test -p rumi_protocol_backend --lib
+cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run targeted formatting**
+
+Run:
+
+```bash
+rustfmt --edition 2021 --check \
+  src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs \
+  src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs \
+  src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs \
+  src/rumi_protocol_backend/src/chains/multi_chain_state.rs \
+  src/rumi_protocol_backend/src/chains/supply.rs \
+  src/rumi_protocol_backend/src/main.rs \
+  src/rumi_protocol_backend/src/lib.rs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit final verification metadata**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md \
+  src/rumi_protocol_backend/rumi_protocol_backend.did
+git commit -m "docs(chains): Inc6 proof verification plan"
+```
+
+Expected: commit succeeds if those files changed after prior commits; otherwise skip this commit with `git status --short` evidence.
+
+- [ ] **Step 6: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin codex/chains-liquidation-inc6
+gh pr create --title "feat(chains): Inc6 proof-backed reconciliation" --body-file /tmp/inc6-pr-body.md --base main --head codex/chains-liquidation-inc6
+```
+
+Expected: PR opens. Do not merge or deploy without explicit user authorization.
+
+## Self-Review
+
+**Spec coverage:** This plan implements the Inc 5 follow-up goal: verified finalized receipts/logs for pending-chain-burn settlement and reserve-burn settlement, proof dedupe, compact proof metadata, and aged pending visibility. It deliberately excludes automatic SP escalation to keep Inc 6 focused.
+
+**Placeholder scan:** No task uses TBD/TODO/fill-in language. Every task names concrete files, interfaces, commands, and expected outcomes.
+
+**Type consistency:** `BurnSettlementProofArg`, `ReserveSettlementProofArg`, `VerifiedBurnSettlementProof`, `VerifiedReserveSettlementProof`, and proof id map names are consistent across parsing, state, endpoint, and Candid tasks.

--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
@@ -17,6 +17,7 @@
 - PASS: `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
 - PASS: `cargo test -p rumi_protocol_backend --lib` (650 passed, 1 ignored)
 - PASS: `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
+- PASS: final post-review rerun `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
 - PASS: `git diff --check`
 - CAVEAT: the broad targeted `rustfmt --edition 2021 --check ... src/lib.rs` command fails on pre-existing formatting/trailing-whitespace outside this increment because rustfmt follows the full module tree from `lib.rs` (for example `test_helpers.rs` and `icrc21.rs`). No mass-formatting was applied.
 

--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace Inc 5's manual reconciliation proof strings with finalized on-chain proof verification for pending-chain-burn and reserve-burn settlement, while keeping the existing manual endpoints as developer fallback.
 
-**Architecture:** Add an EVM settlement-proof module that reuses the existing `eth_getTransactionReceipt` and finality helpers, verifies exact receipt log identities, and returns compact verified proof metadata. Add separate proof-id dedupe maps to `MultiChainStateV6` so pending-burn and reserve-burn settlements cannot collide with user burn proofs. The async endpoints fetch and verify receipts before entering a synchronous `mutate_state` section that dedupes, settles accounting, stores proof metadata, and records the existing Inc 5 events atomically.
+**Architecture:** Add an EVM settlement-proof module that reuses the existing `eth_getTransactionReceipt` and finality helpers, verifies exact receipt log identities, and returns compact verified proof metadata. Add separate proof-id dedupe maps to `MultiChainStateV6` so pending-burn and reserve-burn settlements cannot collide with user burn proofs, plus a shared settlement-burn-log ledger and reserve-transfer capacity ledger so a burn log cannot settle across domains and one reserve transfer cannot be over-consumed. The async endpoints fetch and verify receipts before entering a synchronous `mutate_state` section that dedupes, settles accounting, stores proof metadata, and records the existing Inc 5 events atomically.
 
 **Tech Stack:** Rust 2021, `ic-cdk` update methods, existing hand-rolled EVM RPC wrapper on the repo's `ic-cdk` 0.12 pin, Candid, CBOR/serde stable snapshots, Cargo unit tests and targeted PocketIC tests.
 
@@ -18,6 +18,14 @@
 - PASS: `cargo test -p rumi_protocol_backend --lib` (650 passed, 1 ignored)
 - PASS: `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
 - PASS: final post-review rerun `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
+- ROUND 1 ADVERSARIAL REVIEW: FAIL, fixed confirmed blockers: 18-decimal reserve transfer scaling, reserve transfer aggregate replay, cross-domain burn-log replay, and receipt transaction-hash binding.
+- PASS: red/green replay fix `cargo test -p rumi_protocol_backend settlement_proof --lib -- --nocapture` (8 passed)
+- PASS: red/green replay fix `cargo test -p rumi_protocol_backend proof_backed_settlement --lib -- --nocapture` (8 passed)
+- PASS: red/green replay fix `cargo test -p rumi_protocol_backend receipt_with_logs_parses_status_block_and_logs --lib -- --nocapture`
+- PASS: red/green replay fix `cargo test -p rumi_protocol_backend settlement_proof_context --bin rumi_protocol_backend -- --nocapture` (5 passed)
+- PASS: post-fix `cargo test -p rumi_protocol_backend --lib` (654 passed, 1 ignored)
+- PASS: post-fix `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
+- PASS: post-fix `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
 - PASS: `git diff --check`
 - CAVEAT: the broad targeted `rustfmt --edition 2021 --check ... src/lib.rs` command fails on pre-existing formatting/trailing-whitespace outside this increment because rustfmt follows the full module tree from `lib.rs` (for example `test_helpers.rs` and `icrc21.rs`). No mass-formatting was applied.
 

--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-6.md
@@ -8,6 +8,18 @@
 
 **Tech Stack:** Rust 2021, `ic-cdk` update methods, existing hand-rolled EVM RPC wrapper on the repo's `ic-cdk` 0.12 pin, Candid, CBOR/serde stable snapshots, Cargo unit tests and targeted PocketIC tests.
 
+## Verification Results
+
+- PASS: `cargo test -p rumi_protocol_backend settlement_proof --lib -- --nocapture`
+- PASS: `cargo test -p rumi_protocol_backend proof_backed_settlement --lib -- --nocapture`
+- PASS: `cargo test -p rumi_protocol_backend pending_chain_burn_aging --lib -- --nocapture`
+- PASS: `cargo test -p rumi_protocol_backend settlement_proof --bin rumi_protocol_backend -- --nocapture`
+- PASS: `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`
+- PASS: `cargo test -p rumi_protocol_backend --lib` (650 passed, 1 ignored)
+- PASS: `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` (16 passed)
+- PASS: `git diff --check`
+- CAVEAT: the broad targeted `rustfmt --edition 2021 --check ... src/lib.rs` command fails on pre-existing formatting/trailing-whitespace outside this increment because rustfmt follows the full module tree from `lib.rs` (for example `test_helpers.rs` and `icrc21.rs`). No mass-formatting was applied.
+
 ## Global Constraints
 
 - TDD is mandatory: write failing tests first, run them red, then implement the minimum code to turn them green.

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -28,6 +28,11 @@ type BotStatsResponse = record {
   budget_total_e8s : nat64;
   budget_start_timestamp : nat64;
 };
+type BurnSettlementProofArg = record {
+  log_index : nat64;
+  expected_burner : opt text;
+  tx_hash : text;
+};
 type CandidVault = record {
   collateral_amount : nat64;
   owner : principal;
@@ -938,6 +943,13 @@ type ReserveRedemptionResult = record {
   fee_amount : nat64;
   stable_amount_sent : nat64;
 };
+type ReserveSettlementProofArg = record {
+  expected_burner : opt text;
+  burn_tx_hash : text;
+  burn_log_index : nat64;
+  reserve_tx_hash : text;
+  reserve_transfer_log_index : nat64;
+};
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
 type Result_10 = variant { Ok : ChainVaultV1; Err : ProtocolError };
@@ -968,6 +980,7 @@ type Result_6 = variant { Ok : ChainReserveReport; Err : ProtocolError };
 type Result_7 = variant { Ok : nat8; Err : ProtocolError };
 type Result_8 = variant { Ok : float64; Err : ProtocolError };
 type Result_9 = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type SettlementProofIds = record { pending : vec text; reserve : vec text };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -1221,6 +1234,7 @@ service : (ProtocolArg) -> {
   get_rmr_ceiling_cr : () -> (float64) query;
   get_rmr_floor : () -> (float64) query;
   get_rmr_floor_cr : () -> (float64) query;
+  get_settlement_proof_ids : (opt nat32) -> (SettlementProofIds) query;
   get_snapshot_count : () -> (nat64) query;
   get_sp_writedown_disabled : () -> (bool) query;
   get_stability_pool_config : () -> (StabilityPoolConfig) query;
@@ -1365,7 +1379,13 @@ service : (ProtocolArg) -> {
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
   set_xrp_schnorr_key_name : (text) -> (Result);
   settle_pending_chain_burn : (nat32, nat, text) -> (Result);
+  settle_pending_chain_burn_with_proof : (nat32, BurnSettlementProofArg) -> (
+      Result,
+    );
   settle_reserve_burn : (nat32, nat, text) -> (Result);
+  settle_reserve_burn_with_proof : (nat32, ReserveSettlementProofArg) -> (
+      Result,
+    );
   settle_xrp_claim : (nat64, text) -> (Result_2);
   settle_xrp_claim_with_tag : (nat64, text, nat32) -> (Result_2);
   solana_bootstrap_nonce : (opt text) -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -785,6 +785,13 @@ type LiquidityStatus = record {
 type ManualPriceInfo = record { set_at_ns : nat64; price_e8 : nat64 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type PendingChainBurnAging = record {
+  pending_chain_burn_e8s : nat;
+  proof_count : nat64;
+  age_ns : opt nat64;
+  chain_id : nat32;
+  oldest_reference_ns : opt nat64;
+};
 type PendingLiquidationV1 = record {
   started_at_ns : nat64;
   op_id : nat64;
@@ -1215,6 +1222,7 @@ service : (ProtocolArg) -> {
       vec record { nat64; XrpPendingDeposit },
     ) query;
   get_pending_amm1_donations_count : () -> (nat64) query;
+  get_pending_chain_burn_aging : () -> (vec PendingChainBurnAging) query;
   get_price_pusher_allowed : () -> (vec record { nat32; text }) query;
   get_price_pusher_principal : () -> (opt principal) query;
   get_protocol_3usd_reserves : () -> (nat64) query;

--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -1342,6 +1342,7 @@ pub async fn get_transaction_receipt(
 /// `(address_lowercased, topics, data, log_index)`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TxReceiptWithLogs {
+    pub tx_hash: Option<String>,
     pub success: bool,
     pub block_number: u64,
     pub logs: Vec<(String, Vec<String>, String, u64)>,
@@ -1359,6 +1360,9 @@ pub fn parse_receipt_with_logs(text: &str) -> Result<Option<TxReceiptWithLogs>, 
         return Ok(None);
     }
     let res = &val["result"];
+    let tx_hash = res["transactionHash"]
+        .as_str()
+        .map(|hash| hash.to_ascii_lowercase());
     let success = parse_hex_quantity(res["status"].as_str().unwrap_or("0x0"))? == 1;
     let block_number = parse_hex_quantity(
         res["blockNumber"]
@@ -1382,6 +1386,7 @@ pub fn parse_receipt_with_logs(text: &str) -> Result<Option<TxReceiptWithLogs>, 
         }
     }
     Ok(Some(TxReceiptWithLogs {
+        tx_hash,
         success,
         block_number,
         logs,

--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -408,6 +408,17 @@ pub struct BurnLog {
     pub block_number: u64,
 }
 
+/// Parsed Burn log including the indexed `burner` address. The legacy
+/// `BurnLog` shape is kept because existing call sites only need the amount.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BurnLogWithBurner {
+    pub vault_id: u64,
+    pub burner: String,
+    pub amount_e8s: u128,
+    pub tx_hash: String,
+    pub block_number: u64,
+}
+
 impl BurnLog {
     /// Decode a `BurnLog` from raw log fields.
     ///
@@ -454,6 +465,34 @@ pub fn decode_burn_log(
     block_number: u64,
 ) -> Result<BurnLog, String> {
     BurnLog::from_raw(topics, data, tx_hash, block_number)
+}
+
+/// Decode a `Burn` event and return the indexed burner address as a normalized
+/// 0x-prefixed lowercase EVM address.
+pub fn decode_burn_log_with_burner(
+    topics: &[String],
+    data: &str,
+    tx_hash: &str,
+    block_number: u64,
+) -> Result<BurnLogWithBurner, String> {
+    let burn = BurnLog::from_raw(topics, data, tx_hash, block_number)?;
+    let raw = topics
+        .get(2)
+        .ok_or_else(|| "BurnLogWithBurner: missing burner topic".to_string())?;
+    let hex = raw
+        .strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .unwrap_or(raw);
+    if hex.len() < 40 {
+        return Err(format!("BurnLogWithBurner: burner topic too short: {raw}"));
+    }
+    Ok(BurnLogWithBurner {
+        vault_id: burn.vault_id,
+        burner: format!("0x{}", hex[hex.len() - 40..].to_ascii_lowercase()),
+        amount_e8s: burn.amount_e8s,
+        tx_hash: burn.tx_hash,
+        block_number: burn.block_number,
+    })
 }
 
 // ─── MintLog ─────────────────────────────────────────────────────────────────

--- a/src/rumi_protocol_backend/src/chains/evm/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/mod.rs
@@ -8,6 +8,7 @@ pub mod eip712;
 pub mod evm_rpc;
 pub mod hardening;
 pub mod settlement;
+pub mod settlement_proof;
 pub mod tecdsa;
 pub mod tx;
 
@@ -33,6 +34,9 @@ mod tests_hardening;
 
 #[cfg(test)]
 mod tests_settlement;
+
+#[cfg(test)]
+mod tests_settlement_proof;
 
 #[cfg(test)]
 mod tests_tecdsa;

--- a/src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs
@@ -1,0 +1,217 @@
+//! Pure proof verification for manual foreign-chain burn settlement.
+//!
+//! These helpers verify the operator-supplied transaction receipts before the
+//! accounting layer consumes Inc 5 pending burn balances. They intentionally
+//! inspect actual receipt logs and ignore caller-supplied amount claims.
+
+use candid::{CandidType, Deserialize};
+
+use super::evm_rpc::{
+    decode_burn_log_with_burner, TransferLog, TxReceiptWithLogs, BURN_EVENT_TOPIC0,
+    TRANSFER_EVENT_TOPIC0,
+};
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct BurnSettlementProofArg {
+    pub tx_hash: String,
+    pub log_index: u64,
+    pub expected_burner: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ReserveSettlementProofArg {
+    pub burn_tx_hash: String,
+    pub burn_log_index: u64,
+    pub reserve_tx_hash: String,
+    pub reserve_transfer_log_index: u64,
+    pub expected_burner: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedBurnSettlementProof {
+    pub proof_id: String,
+    pub tx_hash: String,
+    pub log_index: u64,
+    pub block_number: u64,
+    pub vault_id: u64,
+    pub burner: String,
+    pub amount_e8s: u128,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedReserveSettlementProof {
+    pub proof_id: String,
+    pub burn_tx_hash: String,
+    pub burn_log_index: u64,
+    pub burn_block_number: u64,
+    pub reserve_tx_hash: String,
+    pub reserve_transfer_log_index: u64,
+    pub reserve_block_number: u64,
+    pub vault_id: u64,
+    pub burner: String,
+    pub amount_e8s: u128,
+    pub reserve_transfer_amount_native: u128,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum SettlementProofError {
+    InvalidAddress(String),
+    InvalidTxHash(String),
+    MalformedLog(String),
+    ReceiptReverted,
+    NoMatchingBurnLog,
+    UnexpectedBurner {
+        expected: String,
+        actual: String,
+    },
+    ReserveTransferMissing,
+    ReserveTransferTooSmall {
+        expected_e8s: u128,
+        actual_native: u128,
+    },
+}
+
+pub fn verify_pending_burn_receipt(
+    icusd_contract: &str,
+    proof: &BurnSettlementProofArg,
+    receipt: &TxReceiptWithLogs,
+) -> Result<VerifiedBurnSettlementProof, SettlementProofError> {
+    let tx_hash = canonical_tx_hash(&proof.tx_hash)?;
+    verify_receipt_success(receipt)?;
+    let icusd_contract = canonical_address(icusd_contract)?;
+    let expected_burner = proof
+        .expected_burner
+        .as_deref()
+        .map(canonical_address)
+        .transpose()?;
+
+    let (_, topics, data, log_index) = receipt
+        .logs
+        .iter()
+        .find(|(address, topics, _, log_index)| {
+            *log_index == proof.log_index
+                && address.eq_ignore_ascii_case(&icusd_contract)
+                && topics
+                    .first()
+                    .map(|topic0| topic0.eq_ignore_ascii_case(BURN_EVENT_TOPIC0))
+                    .unwrap_or(false)
+        })
+        .ok_or(SettlementProofError::NoMatchingBurnLog)?;
+
+    let burn = decode_burn_log_with_burner(topics, data, &tx_hash, receipt.block_number)
+        .map_err(SettlementProofError::MalformedLog)?;
+
+    if let Some(expected) = expected_burner {
+        if burn.burner != expected {
+            return Err(SettlementProofError::UnexpectedBurner {
+                expected,
+                actual: burn.burner,
+            });
+        }
+    }
+
+    Ok(VerifiedBurnSettlementProof {
+        proof_id: format!("pending:{tx_hash}:{log_index}"),
+        tx_hash,
+        log_index: *log_index,
+        block_number: receipt.block_number,
+        vault_id: burn.vault_id,
+        burner: burn.burner,
+        amount_e8s: burn.amount_e8s,
+    })
+}
+
+pub fn verify_reserve_burn_receipts(
+    icusd_contract: &str,
+    settle_stable_token: &str,
+    reserve_address: &str,
+    proof: &ReserveSettlementProofArg,
+    burn_receipt: &TxReceiptWithLogs,
+    reserve_receipt: &TxReceiptWithLogs,
+) -> Result<VerifiedReserveSettlementProof, SettlementProofError> {
+    let burn_proof = BurnSettlementProofArg {
+        tx_hash: proof.burn_tx_hash.clone(),
+        log_index: proof.burn_log_index,
+        expected_burner: proof.expected_burner.clone(),
+    };
+    let burn = verify_pending_burn_receipt(icusd_contract, &burn_proof, burn_receipt)?;
+
+    let reserve_tx_hash = canonical_tx_hash(&proof.reserve_tx_hash)?;
+    verify_receipt_success(reserve_receipt)?;
+    let settle_stable_token = canonical_address(settle_stable_token)?;
+    let reserve_address = canonical_address(reserve_address)?;
+
+    let (_, topics, data, log_index) = reserve_receipt
+        .logs
+        .iter()
+        .find(|(address, topics, _, log_index)| {
+            *log_index == proof.reserve_transfer_log_index
+                && address.eq_ignore_ascii_case(&settle_stable_token)
+                && topics
+                    .first()
+                    .map(|topic0| topic0.eq_ignore_ascii_case(TRANSFER_EVENT_TOPIC0))
+                    .unwrap_or(false)
+        })
+        .ok_or(SettlementProofError::ReserveTransferMissing)?;
+
+    let transfer =
+        TransferLog::from_raw(topics, data).map_err(SettlementProofError::MalformedLog)?;
+    if transfer.to != reserve_address {
+        return Err(SettlementProofError::ReserveTransferMissing);
+    }
+    if transfer.amount < burn.amount_e8s {
+        return Err(SettlementProofError::ReserveTransferTooSmall {
+            expected_e8s: burn.amount_e8s,
+            actual_native: transfer.amount,
+        });
+    }
+
+    Ok(VerifiedReserveSettlementProof {
+        proof_id: format!(
+            "reserve:{}:{}:{}:{}",
+            burn.tx_hash, burn.log_index, reserve_tx_hash, log_index
+        ),
+        burn_tx_hash: burn.tx_hash,
+        burn_log_index: burn.log_index,
+        burn_block_number: burn.block_number,
+        reserve_tx_hash,
+        reserve_transfer_log_index: *log_index,
+        reserve_block_number: reserve_receipt.block_number,
+        vault_id: burn.vault_id,
+        burner: burn.burner,
+        amount_e8s: burn.amount_e8s,
+        reserve_transfer_amount_native: transfer.amount,
+    })
+}
+
+fn verify_receipt_success(receipt: &TxReceiptWithLogs) -> Result<(), SettlementProofError> {
+    if receipt.success {
+        Ok(())
+    } else {
+        Err(SettlementProofError::ReceiptReverted)
+    }
+}
+
+fn canonical_address(address: &str) -> Result<String, SettlementProofError> {
+    let hex = address
+        .trim()
+        .strip_prefix("0x")
+        .or_else(|| address.trim().strip_prefix("0X"))
+        .ok_or_else(|| SettlementProofError::InvalidAddress(address.to_string()))?;
+    if hex.len() != 40 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(SettlementProofError::InvalidAddress(address.to_string()));
+    }
+    Ok(format!("0x{}", hex.to_ascii_lowercase()))
+}
+
+fn canonical_tx_hash(tx_hash: &str) -> Result<String, SettlementProofError> {
+    let hex = tx_hash
+        .trim()
+        .strip_prefix("0x")
+        .or_else(|| tx_hash.trim().strip_prefix("0X"))
+        .ok_or_else(|| SettlementProofError::InvalidTxHash(tx_hash.to_string()))?;
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(SettlementProofError::InvalidTxHash(tx_hash.to_string()));
+    }
+    Ok(format!("0x{}", hex.to_ascii_lowercase()))
+}

--- a/src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement_proof.rs
@@ -51,6 +51,7 @@ pub struct VerifiedReserveSettlementProof {
     pub burner: String,
     pub amount_e8s: u128,
     pub reserve_transfer_amount_native: u128,
+    pub reserve_transfer_amount_e8s: u128,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -64,11 +65,16 @@ pub enum SettlementProofError {
         expected: String,
         actual: String,
     },
+    ReceiptTxHashMismatch {
+        expected: String,
+        actual: String,
+    },
     ReserveTransferMissing,
     ReserveTransferTooSmall {
         expected_e8s: u128,
-        actual_native: u128,
+        actual_e8s: u128,
     },
+    ReserveTransferScaleOverflow,
 }
 
 pub fn verify_pending_burn_receipt(
@@ -77,6 +83,7 @@ pub fn verify_pending_burn_receipt(
     receipt: &TxReceiptWithLogs,
 ) -> Result<VerifiedBurnSettlementProof, SettlementProofError> {
     let tx_hash = canonical_tx_hash(&proof.tx_hash)?;
+    verify_receipt_tx_hash(receipt, &tx_hash)?;
     verify_receipt_success(receipt)?;
     let icusd_contract = canonical_address(icusd_contract)?;
     let expected_burner = proof
@@ -125,6 +132,7 @@ pub fn verify_reserve_burn_receipts(
     icusd_contract: &str,
     settle_stable_token: &str,
     reserve_address: &str,
+    settle_stable_decimals: u8,
     proof: &ReserveSettlementProofArg,
     burn_receipt: &TxReceiptWithLogs,
     reserve_receipt: &TxReceiptWithLogs,
@@ -137,6 +145,7 @@ pub fn verify_reserve_burn_receipts(
     let burn = verify_pending_burn_receipt(icusd_contract, &burn_proof, burn_receipt)?;
 
     let reserve_tx_hash = canonical_tx_hash(&proof.reserve_tx_hash)?;
+    verify_receipt_tx_hash(reserve_receipt, &reserve_tx_hash)?;
     verify_receipt_success(reserve_receipt)?;
     let settle_stable_token = canonical_address(settle_stable_token)?;
     let reserve_address = canonical_address(reserve_address)?;
@@ -159,10 +168,12 @@ pub fn verify_reserve_burn_receipts(
     if transfer.to != reserve_address {
         return Err(SettlementProofError::ReserveTransferMissing);
     }
-    if transfer.amount < burn.amount_e8s {
+    let reserve_transfer_amount_e8s =
+        stable_native_to_e8s(transfer.amount, settle_stable_decimals)?;
+    if reserve_transfer_amount_e8s < burn.amount_e8s {
         return Err(SettlementProofError::ReserveTransferTooSmall {
             expected_e8s: burn.amount_e8s,
-            actual_native: transfer.amount,
+            actual_e8s: reserve_transfer_amount_e8s,
         });
     }
 
@@ -181,6 +192,7 @@ pub fn verify_reserve_burn_receipts(
         burner: burn.burner,
         amount_e8s: burn.amount_e8s,
         reserve_transfer_amount_native: transfer.amount,
+        reserve_transfer_amount_e8s,
     })
 }
 
@@ -190,6 +202,52 @@ fn verify_receipt_success(receipt: &TxReceiptWithLogs) -> Result<(), SettlementP
     } else {
         Err(SettlementProofError::ReceiptReverted)
     }
+}
+
+fn verify_receipt_tx_hash(
+    receipt: &TxReceiptWithLogs,
+    expected: &str,
+) -> Result<(), SettlementProofError> {
+    match receipt.tx_hash.as_deref() {
+        Some(actual) if actual.eq_ignore_ascii_case(expected) => Ok(()),
+        Some(actual) => Err(SettlementProofError::ReceiptTxHashMismatch {
+            expected: expected.to_string(),
+            actual: actual.to_ascii_lowercase(),
+        }),
+        None => Err(SettlementProofError::ReceiptTxHashMismatch {
+            expected: expected.to_string(),
+            actual: "<missing>".to_string(),
+        }),
+    }
+}
+
+fn stable_native_to_e8s(
+    amount_native: u128,
+    decimals: u8,
+) -> Result<u128, SettlementProofError> {
+    match decimals.cmp(&8) {
+        core::cmp::Ordering::Equal => Ok(amount_native),
+        core::cmp::Ordering::Greater => {
+            let scale = pow10_u128(decimals - 8)?;
+            Ok(amount_native / scale)
+        }
+        core::cmp::Ordering::Less => {
+            let scale = pow10_u128(8 - decimals)?;
+            amount_native
+                .checked_mul(scale)
+                .ok_or(SettlementProofError::ReserveTransferScaleOverflow)
+        }
+    }
+}
+
+fn pow10_u128(exp: u8) -> Result<u128, SettlementProofError> {
+    let mut out = 1u128;
+    for _ in 0..exp {
+        out = out
+            .checked_mul(10)
+            .ok_or(SettlementProofError::ReserveTransferScaleOverflow)?;
+    }
+    Ok(out)
 }
 
 fn canonical_address(address: &str) -> Result<String, SettlementProofError> {

--- a/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_burn_proof.rs
@@ -38,6 +38,7 @@ fn applies_burn_log_from_correct_contract_and_dedups() {
     let mut s = state_with_open_vault(100);
     let contract = "0xcafe";
     let receipt = TxReceiptWithLogs {
+        tx_hash: None,
         success: true,
         block_number: 10,
         logs: vec![(
@@ -66,6 +67,7 @@ fn applies_burn_log_from_correct_contract_and_dedups() {
 fn rejects_log_from_wrong_contract() {
     let mut s = state_with_open_vault(100);
     let receipt = TxReceiptWithLogs {
+        tx_hash: None,
         success: true,
         block_number: 10,
         logs: vec![(

--- a/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
@@ -308,6 +308,26 @@ fn decodes_burn_log() {
 }
 
 #[test]
+fn burn_log_with_burner_decodes_indexed_burner_address() {
+    let topics = vec![
+        super::evm_rpc::BURN_EVENT_TOPIC0.to_string(),
+        format!("0x{:064x}", 7u64),
+        "0x0000000000000000000000001234567890abcdef1234567890abcdef12345678"
+            .to_string(),
+    ];
+    let burn = super::evm_rpc::decode_burn_log_with_burner(
+        &topics,
+        &format!("0x{:064x}", 40_000_000u128),
+        "0xabc",
+        99,
+    )
+    .expect("decode burn with burner");
+    assert_eq!(burn.vault_id, 7);
+    assert_eq!(burn.amount_e8s, 40_000_000);
+    assert_eq!(burn.burner, "0x1234567890abcdef1234567890abcdef12345678");
+}
+
+#[test]
 fn rejects_log_with_wrong_topic0() {
     let res = BurnLog::from_raw(
         &["0xdeadbeef".into(), format!("0x{:064x}", 1u64), format!("0x{:064x}", 0u8)],

--- a/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
@@ -339,11 +339,16 @@ fn rejects_log_with_wrong_topic0() {
 fn receipt_with_logs_parses_status_block_and_logs() {
     // A minimal eth_getTransactionReceipt JSON with one log.
     let json = r#"{"jsonrpc":"2.0","id":1,"result":{
+        "transactionHash":"0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "status":"0x1","blockNumber":"0x10",
         "logs":[{"address":"0xCAFE","topics":["0xTOPIC0","0xVAULT","0xBURNER"],
                  "data":"0x2a","logIndex":"0x3"}]}}"#;
     let parsed = super::evm_rpc::parse_receipt_with_logs(json).expect("parse");
     let r = parsed.expect("receipt present");
+    assert_eq!(
+        r.tx_hash.as_deref(),
+        Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
     assert!(r.success);
     assert_eq!(r.block_number, 16);
     assert_eq!(r.logs.len(), 1);

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs
@@ -14,11 +14,13 @@ fn word_addr(addr: &str) -> String {
 }
 
 fn receipt(
+    tx_hash: &str,
     success: bool,
     block_number: u64,
     logs: Vec<(String, Vec<String>, String, u64)>,
 ) -> TxReceiptWithLogs {
     TxReceiptWithLogs {
+        tx_hash: Some(tx_hash.to_string()),
         success,
         block_number,
         logs,
@@ -71,6 +73,7 @@ fn pending_burn_proof_accepts_exact_contract_log_index_and_amount_from_log() {
         expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
     };
     let receipt = receipt(
+        &proof.tx_hash,
         true,
         55,
         vec![
@@ -114,6 +117,7 @@ fn pending_burn_proof_rejects_wrong_contract_wrong_log_index_and_wrong_burner() 
     };
 
     let wrong_contract = receipt(
+        &proof.tx_hash,
         true,
         55,
         vec![burn_log(
@@ -130,6 +134,7 @@ fn pending_burn_proof_rejects_wrong_contract_wrong_log_index_and_wrong_burner() 
     ));
 
     let wrong_index = receipt(
+        &proof.tx_hash,
         true,
         55,
         vec![burn_log(
@@ -146,6 +151,7 @@ fn pending_burn_proof_rejects_wrong_contract_wrong_log_index_and_wrong_burner() 
     ));
 
     let wrong_burner = receipt(
+        &proof.tx_hash,
         true,
         55,
         vec![burn_log(
@@ -177,6 +183,7 @@ fn reserve_burn_proof_requires_icusd_burn_and_settle_stable_transfer_to_reserve(
         expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
     };
     let burn_receipt = receipt(
+        &proof.burn_tx_hash,
         true,
         70,
         vec![burn_log(
@@ -187,19 +194,34 @@ fn reserve_burn_proof_requires_icusd_burn_and_settle_stable_transfer_to_reserve(
             4,
         )],
     );
-    let reserve_receipt = receipt(true, 71, vec![transfer_log(usdc, reserve, 25_000_000, 8)]);
+    let reserve_receipt = receipt(
+        &proof.reserve_tx_hash,
+        true,
+        71,
+        vec![transfer_log(
+            usdc,
+            reserve,
+            25_000_000u128 * 10_000_000_000u128,
+            8,
+        )],
+    );
 
     let verified = verify_reserve_burn_receipts(
         icusd,
         usdc,
         reserve,
+        18,
         &proof,
         &burn_receipt,
         &reserve_receipt,
     )
     .expect("reserve proof verified");
     assert_eq!(verified.amount_e8s, 25_000_000);
-    assert_eq!(verified.reserve_transfer_amount_native, 25_000_000);
+    assert_eq!(
+        verified.reserve_transfer_amount_native,
+        25_000_000u128 * 10_000_000_000u128
+    );
+    assert_eq!(verified.reserve_transfer_amount_e8s, 25_000_000);
     assert_eq!(
         verified.proof_id,
         "reserve:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:4:0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:8"
@@ -221,6 +243,7 @@ fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfe
         expected_burner: None,
     };
     let burn_receipt = receipt(
+        &proof.burn_tx_hash,
         true,
         70,
         vec![burn_log(
@@ -233,6 +256,7 @@ fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfe
     );
 
     let wrong_recipient = receipt(
+        &proof.reserve_tx_hash,
         true,
         71,
         vec![transfer_log(
@@ -247,6 +271,7 @@ fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfe
             icusd,
             usdc,
             reserve,
+            18,
             &proof,
             &burn_receipt,
             &wrong_recipient
@@ -254,9 +279,93 @@ fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfe
         Err(SettlementProofError::ReserveTransferMissing)
     ));
 
-    let too_small = receipt(true, 71, vec![transfer_log(usdc, reserve, 24_999_999, 8)]);
+    let too_small = receipt(
+        &proof.reserve_tx_hash,
+        true,
+        71,
+        vec![transfer_log(
+            usdc,
+            reserve,
+            25_000_000u128 * 10_000_000_000u128 - 1,
+            8,
+        )],
+    );
     assert!(matches!(
-        verify_reserve_burn_receipts(icusd, usdc, reserve, &proof, &burn_receipt, &too_small),
+        verify_reserve_burn_receipts(icusd, usdc, reserve, 18, &proof, &burn_receipt, &too_small),
         Err(SettlementProofError::ReserveTransferTooSmall { .. })
+    ));
+}
+
+#[test]
+fn reserve_burn_proof_rejects_unscaled_native_transfer_for_18_decimal_stable() {
+    let icusd = "0x000000000000000000000000000000000000cafe";
+    let usdc = "0x0000000000000000000000000000000000001000";
+    let reserve = "0x0000000000000000000000000000000000002222";
+    let proof = ReserveSettlementProofArg {
+        burn_tx_hash: "0x1212121212121212121212121212121212121212121212121212121212121212"
+            .to_string(),
+        burn_log_index: 4,
+        reserve_tx_hash: "0x3434343434343434343434343434343434343434343434343434343434343434"
+            .to_string(),
+        reserve_transfer_log_index: 8,
+        expected_burner: None,
+    };
+    let burn_receipt = receipt(
+        &proof.burn_tx_hash,
+        true,
+        70,
+        vec![burn_log(
+            icusd,
+            0,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            4,
+        )],
+    );
+    let unscaled_reserve_receipt = receipt(
+        &proof.reserve_tx_hash,
+        true,
+        71,
+        vec![transfer_log(usdc, reserve, 25_000_000, 8)],
+    );
+
+    assert!(matches!(
+        verify_reserve_burn_receipts(
+            icusd,
+            usdc,
+            reserve,
+            18,
+            &proof,
+            &burn_receipt,
+            &unscaled_reserve_receipt,
+        ),
+        Err(SettlementProofError::ReserveTransferTooSmall { .. })
+    ));
+}
+
+#[test]
+fn pending_burn_proof_rejects_receipt_transaction_hash_mismatch() {
+    let contract = "0x000000000000000000000000000000000000cafe";
+    let proof = BurnSettlementProofArg {
+        tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        log_index: 7,
+        expected_burner: None,
+    };
+    let mismatched_receipt = receipt(
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        true,
+        55,
+        vec![burn_log(
+            contract,
+            99,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            7,
+        )],
+    );
+
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &mismatched_receipt),
+        Err(SettlementProofError::ReceiptTxHashMismatch { .. })
     ));
 }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement_proof.rs
@@ -1,0 +1,262 @@
+use super::evm_rpc::{TxReceiptWithLogs, BURN_EVENT_TOPIC0, TRANSFER_EVENT_TOPIC0};
+use super::settlement_proof::{
+    verify_pending_burn_receipt, verify_reserve_burn_receipts, BurnSettlementProofArg,
+    ReserveSettlementProofArg, SettlementProofError,
+};
+
+fn word(v: u128) -> String {
+    format!("0x{v:064x}")
+}
+
+fn word_addr(addr: &str) -> String {
+    let h = addr.trim_start_matches("0x");
+    format!("0x{h:0>64}")
+}
+
+fn receipt(
+    success: bool,
+    block_number: u64,
+    logs: Vec<(String, Vec<String>, String, u64)>,
+) -> TxReceiptWithLogs {
+    TxReceiptWithLogs {
+        success,
+        block_number,
+        logs,
+    }
+}
+
+fn burn_log(
+    contract: &str,
+    vault_id: u64,
+    burner: &str,
+    amount_e8s: u128,
+    log_index: u64,
+) -> (String, Vec<String>, String, u64) {
+    (
+        contract.to_ascii_lowercase(),
+        vec![
+            BURN_EVENT_TOPIC0.to_string(),
+            word(vault_id as u128),
+            word_addr(burner),
+        ],
+        word(amount_e8s),
+        log_index,
+    )
+}
+
+fn transfer_log(
+    token: &str,
+    to: &str,
+    amount_native: u128,
+    log_index: u64,
+) -> (String, Vec<String>, String, u64) {
+    (
+        token.to_ascii_lowercase(),
+        vec![
+            TRANSFER_EVENT_TOPIC0.to_string(),
+            word_addr("0x000000000000000000000000000000000000aaaa"),
+            word_addr(to),
+        ],
+        word(amount_native),
+        log_index,
+    )
+}
+
+#[test]
+fn pending_burn_proof_accepts_exact_contract_log_index_and_amount_from_log() {
+    let contract = "0x000000000000000000000000000000000000cafe";
+    let proof = BurnSettlementProofArg {
+        tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        log_index: 7,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+    let receipt = receipt(
+        true,
+        55,
+        vec![
+            transfer_log(
+                "0x000000000000000000000000000000000000feed",
+                "0x000000000000000000000000000000000000aaaa",
+                1,
+                3,
+            ),
+            burn_log(
+                contract,
+                99,
+                "0x000000000000000000000000000000000000beef",
+                25_000_000,
+                7,
+            ),
+        ],
+    );
+
+    let verified = verify_pending_burn_receipt(contract, &proof, &receipt).expect("verified proof");
+    assert_eq!(verified.amount_e8s, 25_000_000);
+    assert_eq!(verified.block_number, 55);
+    assert_eq!(verified.log_index, 7);
+    assert_eq!(
+        verified.burner,
+        "0x000000000000000000000000000000000000beef"
+    );
+    assert_eq!(
+        verified.proof_id,
+        "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7"
+    );
+}
+
+#[test]
+fn pending_burn_proof_rejects_wrong_contract_wrong_log_index_and_wrong_burner() {
+    let contract = "0x000000000000000000000000000000000000cafe";
+    let proof = BurnSettlementProofArg {
+        tx_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        log_index: 2,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+
+    let wrong_contract = receipt(
+        true,
+        55,
+        vec![burn_log(
+            "0x000000000000000000000000000000000000dead",
+            99,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            2,
+        )],
+    );
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_contract),
+        Err(SettlementProofError::NoMatchingBurnLog)
+    ));
+
+    let wrong_index = receipt(
+        true,
+        55,
+        vec![burn_log(
+            contract,
+            99,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            3,
+        )],
+    );
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_index),
+        Err(SettlementProofError::NoMatchingBurnLog)
+    ));
+
+    let wrong_burner = receipt(
+        true,
+        55,
+        vec![burn_log(
+            contract,
+            99,
+            "0x000000000000000000000000000000000000badd",
+            25_000_000,
+            2,
+        )],
+    );
+    assert!(matches!(
+        verify_pending_burn_receipt(contract, &proof, &wrong_burner),
+        Err(SettlementProofError::UnexpectedBurner { .. })
+    ));
+}
+
+#[test]
+fn reserve_burn_proof_requires_icusd_burn_and_settle_stable_transfer_to_reserve() {
+    let icusd = "0x000000000000000000000000000000000000cafe";
+    let usdc = "0x0000000000000000000000000000000000001000";
+    let reserve = "0x0000000000000000000000000000000000002222";
+    let proof = ReserveSettlementProofArg {
+        burn_tx_hash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            .to_string(),
+        burn_log_index: 4,
+        reserve_tx_hash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            .to_string(),
+        reserve_transfer_log_index: 8,
+        expected_burner: Some("0x000000000000000000000000000000000000beef".to_string()),
+    };
+    let burn_receipt = receipt(
+        true,
+        70,
+        vec![burn_log(
+            icusd,
+            0,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            4,
+        )],
+    );
+    let reserve_receipt = receipt(true, 71, vec![transfer_log(usdc, reserve, 25_000_000, 8)]);
+
+    let verified = verify_reserve_burn_receipts(
+        icusd,
+        usdc,
+        reserve,
+        &proof,
+        &burn_receipt,
+        &reserve_receipt,
+    )
+    .expect("reserve proof verified");
+    assert_eq!(verified.amount_e8s, 25_000_000);
+    assert_eq!(verified.reserve_transfer_amount_native, 25_000_000);
+    assert_eq!(
+        verified.proof_id,
+        "reserve:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:4:0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:8"
+    );
+}
+
+#[test]
+fn reserve_burn_proof_rejects_mismatched_transfer_recipient_or_too_small_transfer() {
+    let icusd = "0x000000000000000000000000000000000000cafe";
+    let usdc = "0x0000000000000000000000000000000000001000";
+    let reserve = "0x0000000000000000000000000000000000002222";
+    let proof = ReserveSettlementProofArg {
+        burn_tx_hash: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            .to_string(),
+        burn_log_index: 4,
+        reserve_tx_hash: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            .to_string(),
+        reserve_transfer_log_index: 8,
+        expected_burner: None,
+    };
+    let burn_receipt = receipt(
+        true,
+        70,
+        vec![burn_log(
+            icusd,
+            0,
+            "0x000000000000000000000000000000000000beef",
+            25_000_000,
+            4,
+        )],
+    );
+
+    let wrong_recipient = receipt(
+        true,
+        71,
+        vec![transfer_log(
+            usdc,
+            "0x0000000000000000000000000000000000003333",
+            25_000_000,
+            8,
+        )],
+    );
+    assert!(matches!(
+        verify_reserve_burn_receipts(
+            icusd,
+            usdc,
+            reserve,
+            &proof,
+            &burn_receipt,
+            &wrong_recipient
+        ),
+        Err(SettlementProofError::ReserveTransferMissing)
+    ));
+
+    let too_small = receipt(true, 71, vec![transfer_log(usdc, reserve, 24_999_999, 8)]);
+    assert!(matches!(
+        verify_reserve_burn_receipts(icusd, usdc, reserve, &proof, &burn_receipt, &too_small),
+        Err(SettlementProofError::ReserveTransferTooSmall { .. })
+    ));
+}

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -479,11 +479,21 @@ impl ChainLiqClaimV1 {
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct SettlementProofRecord {
     pub proof_id: String,
+    pub chain_id: ChainId,
     pub tx_hash: String,
     pub log_index: u64,
     pub amount_e8s: u128,
     pub block_number: u64,
     pub recorded_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct PendingChainBurnAging {
+    pub chain_id: ChainId,
+    pub pending_chain_burn_e8s: u128,
+    pub oldest_reference_ns: Option<u64>,
+    pub age_ns: Option<u64>,
+    pub proof_count: u64,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
@@ -621,6 +631,38 @@ impl MultiChainStateV6 {
     /// summed across chains. 0 until Increment 4 wires the SP path.
     pub fn total_pending_chain_burn_e8s(&self) -> u128 {
         self.pending_chain_burn_e8s.values().copied().sum()
+    }
+
+    pub fn pending_chain_burn_aging(&self, now_ns: u64) -> Vec<PendingChainBurnAging> {
+        self.pending_chain_burn_e8s
+            .iter()
+            .filter_map(|(&chain_id, &pending_chain_burn_e8s)| {
+                if pending_chain_burn_e8s == 0 {
+                    return None;
+                }
+                let mut proof_count = 0u64;
+                let mut oldest_reference_ns: Option<u64> = None;
+                for record in self
+                    .settled_pending_burn_proofs
+                    .values()
+                    .filter(|record| record.chain_id == chain_id)
+                {
+                    proof_count = proof_count.saturating_add(1);
+                    oldest_reference_ns = Some(match oldest_reference_ns {
+                        Some(oldest) => oldest.min(record.recorded_at_ns),
+                        None => record.recorded_at_ns,
+                    });
+                }
+                let age_ns = oldest_reference_ns.map(|oldest| now_ns.saturating_sub(oldest));
+                Some(PendingChainBurnAging {
+                    chain_id,
+                    pending_chain_burn_e8s,
+                    oldest_reference_ns,
+                    age_ns,
+                    proof_count,
+                })
+            })
+            .collect()
     }
 
     /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -603,6 +603,16 @@ pub struct MultiChainStateV6 {
     /// both burn and stable-transfer receipt identities.
     #[serde(default)]
     pub settled_reserve_burn_proofs: BTreeMap<String, SettlementProofRecord>,
+    /// Burn log identities already consumed by either pending-chain-burn or
+    /// reserve-burn settlement. This closes cross-domain replay where the same
+    /// foreign icUSD burn could otherwise debit both backing buckets.
+    #[serde(default)]
+    pub settled_settlement_burn_logs: BTreeSet<String>,
+    /// Reserve transfer log identity -> e8s capacity already consumed by
+    /// reserve-burn settlements. One reserve transfer can fund several burns,
+    /// but cumulative consumption must never exceed the verified transfer size.
+    #[serde(default)]
+    pub settled_reserve_transfer_e8s: BTreeMap<String, u128>,
 }
 
 impl MultiChainStateV6 {

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -474,6 +474,18 @@ impl ChainLiqClaimV1 {
     }
 }
 
+/// Compact durable marker for an operator-settled foreign-chain burn proof.
+/// Full receipts/logs are intentionally not stored in stable state.
+#[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct SettlementProofRecord {
+    pub proof_id: String,
+    pub tx_hash: String,
+    pub log_index: u64,
+    pub amount_e8s: u128,
+    pub block_number: u64,
+    pub recorded_at_ns: u64,
+}
+
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, Default)]
 pub struct MultiChainStateV6 {
     pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
@@ -572,6 +584,15 @@ pub struct MultiChainStateV6 {
     /// (pre-deploy); `#[serde(default)]` mandatory.
     #[serde(default)]
     pub chain_bad_debt_e8s: BTreeMap<ChainId, u128>,
+    /// Proof ids already consumed to settle SP pending-chain-burn backing. Kept
+    /// separate from user burn ids and reserve-burn ids so domains cannot collide.
+    #[serde(default)]
+    pub settled_pending_burn_proofs: BTreeMap<String, SettlementProofRecord>,
+    /// Proof ids already consumed to settle Tier-1 reserve-backed burns. Kept
+    /// separate from pending-chain-burn proofs because a reserve proof id encodes
+    /// both burn and stable-transfer receipt identities.
+    #[serde(default)]
+    pub settled_reserve_burn_proofs: BTreeMap<String, SettlementProofRecord>,
 }
 
 impl MultiChainStateV6 {

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -364,7 +364,27 @@ pub fn settle_reserve_burn(
 #[derive(Debug, PartialEq, Eq)]
 pub enum ProofBackedSettlementError {
     DuplicateProof(String),
+    DuplicateBurnLog {
+        burn_key: String,
+    },
+    ReserveTransferOverConsumed {
+        transfer_key: String,
+        current_e8s: u128,
+        attempted_e8s: u128,
+        capacity_e8s: u128,
+    },
+    ReserveTransferConsumptionOverflow {
+        transfer_key: String,
+    },
     BackingSettlement(BackingSettlementError),
+}
+
+fn settlement_burn_key(tx_hash: &str, log_index: u64) -> String {
+    format!("{}:{}", tx_hash.to_ascii_lowercase(), log_index)
+}
+
+fn reserve_transfer_key(tx_hash: &str, log_index: u64) -> String {
+    format!("{}:{}", tx_hash.to_ascii_lowercase(), log_index)
 }
 
 pub fn settle_pending_chain_burn_with_verified_proof(
@@ -379,10 +399,15 @@ pub fn settle_pending_chain_burn_with_verified_proof(
     {
         return Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id));
     }
+    let burn_key = settlement_burn_key(&proof.tx_hash, proof.log_index);
+    if state.settled_settlement_burn_logs.contains(&burn_key) {
+        return Err(ProofBackedSettlementError::DuplicateBurnLog { burn_key });
+    }
 
     let mut next = state.clone();
     settle_pending_chain_burn(&mut next, chain, proof.amount_e8s)
         .map_err(ProofBackedSettlementError::BackingSettlement)?;
+    next.settled_settlement_burn_logs.insert(burn_key);
     next.settled_pending_burn_proofs.insert(
         proof.proof_id.clone(),
         SettlementProofRecord {
@@ -411,10 +436,37 @@ pub fn settle_reserve_burn_with_verified_proof(
     {
         return Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id));
     }
+    let burn_key = settlement_burn_key(&proof.burn_tx_hash, proof.burn_log_index);
+    if state.settled_settlement_burn_logs.contains(&burn_key) {
+        return Err(ProofBackedSettlementError::DuplicateBurnLog { burn_key });
+    }
+    let transfer_key =
+        reserve_transfer_key(&proof.reserve_tx_hash, proof.reserve_transfer_log_index);
+    let current_transfer_consumed = state
+        .settled_reserve_transfer_e8s
+        .get(&transfer_key)
+        .copied()
+        .unwrap_or(0);
+    let next_transfer_consumed = current_transfer_consumed
+        .checked_add(proof.amount_e8s)
+        .ok_or_else(|| ProofBackedSettlementError::ReserveTransferConsumptionOverflow {
+            transfer_key: transfer_key.clone(),
+        })?;
+    if next_transfer_consumed > proof.reserve_transfer_amount_e8s {
+        return Err(ProofBackedSettlementError::ReserveTransferOverConsumed {
+            transfer_key,
+            current_e8s: current_transfer_consumed,
+            attempted_e8s: proof.amount_e8s,
+            capacity_e8s: proof.reserve_transfer_amount_e8s,
+        });
+    }
 
     let mut next = state.clone();
     settle_reserve_burn(&mut next, chain, proof.amount_e8s)
         .map_err(ProofBackedSettlementError::BackingSettlement)?;
+    next.settled_settlement_burn_logs.insert(burn_key);
+    next.settled_reserve_transfer_e8s
+        .insert(transfer_key, next_transfer_consumed);
     next.settled_reserve_burn_proofs.insert(
         proof.proof_id.clone(),
         SettlementProofRecord {

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -387,6 +387,7 @@ pub fn settle_pending_chain_burn_with_verified_proof(
         proof.proof_id.clone(),
         SettlementProofRecord {
             proof_id: proof.proof_id,
+            chain_id: chain,
             tx_hash: proof.tx_hash,
             log_index: proof.log_index,
             amount_e8s: proof.amount_e8s,
@@ -418,6 +419,7 @@ pub fn settle_reserve_burn_with_verified_proof(
         proof.proof_id.clone(),
         SettlementProofRecord {
             proof_id: proof.proof_id,
+            chain_id: chain,
             tx_hash: proof.burn_tx_hash,
             log_index: proof.burn_log_index,
             amount_e8s: proof.amount_e8s,

--- a/src/rumi_protocol_backend/src/chains/supply.rs
+++ b/src/rumi_protocol_backend/src/chains/supply.rs
@@ -12,7 +12,10 @@
 //! can call it without inventing the invariant under deadline pressure.
 
 use super::config::ChainId;
-use super::multi_chain_state::{MultiChainState, MultiChainStateV1, MultiChainStateV2};
+use super::evm::settlement_proof::{VerifiedBurnSettlementProof, VerifiedReserveSettlementProof};
+use super::multi_chain_state::{
+    MultiChainState, MultiChainStateV1, MultiChainStateV2, SettlementProofRecord,
+};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
@@ -356,6 +359,74 @@ pub fn settle_reserve_burn(
     amount_e8s: u128,
 ) -> Result<(), BackingSettlementError> {
     settle_backing_burn(state, chain, amount_e8s, BackingTerm::ReserveBacking)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProofBackedSettlementError {
+    DuplicateProof(String),
+    BackingSettlement(BackingSettlementError),
+}
+
+pub fn settle_pending_chain_burn_with_verified_proof(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    proof: VerifiedBurnSettlementProof,
+    now_ns: u64,
+) -> Result<(), ProofBackedSettlementError> {
+    if state
+        .settled_pending_burn_proofs
+        .contains_key(&proof.proof_id)
+    {
+        return Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id));
+    }
+
+    let mut next = state.clone();
+    settle_pending_chain_burn(&mut next, chain, proof.amount_e8s)
+        .map_err(ProofBackedSettlementError::BackingSettlement)?;
+    next.settled_pending_burn_proofs.insert(
+        proof.proof_id.clone(),
+        SettlementProofRecord {
+            proof_id: proof.proof_id,
+            tx_hash: proof.tx_hash,
+            log_index: proof.log_index,
+            amount_e8s: proof.amount_e8s,
+            block_number: proof.block_number,
+            recorded_at_ns: now_ns,
+        },
+    );
+    *state = next;
+    Ok(())
+}
+
+pub fn settle_reserve_burn_with_verified_proof(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    proof: VerifiedReserveSettlementProof,
+    now_ns: u64,
+) -> Result<(), ProofBackedSettlementError> {
+    if state
+        .settled_reserve_burn_proofs
+        .contains_key(&proof.proof_id)
+    {
+        return Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id));
+    }
+
+    let mut next = state.clone();
+    settle_reserve_burn(&mut next, chain, proof.amount_e8s)
+        .map_err(ProofBackedSettlementError::BackingSettlement)?;
+    next.settled_reserve_burn_proofs.insert(
+        proof.proof_id.clone(),
+        SettlementProofRecord {
+            proof_id: proof.proof_id,
+            tx_hash: proof.burn_tx_hash,
+            log_index: proof.burn_log_index,
+            amount_e8s: proof.amount_e8s,
+            block_number: proof.burn_block_number,
+            recorded_at_ns: now_ns,
+        },
+    );
+    *state = next;
+    Ok(())
 }
 
 /// Bot/PSM Phase-2 accounting (spec 4.9, 5.3): atomically move `cleared_e8s` of a

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -673,6 +673,7 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
     let pending = SettlementProofRecord {
         proof_id: "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7"
             .to_string(),
+        chain_id: ChainId(1030),
         tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
         log_index: 7,
         amount_e8s: 25_000_000,
@@ -682,6 +683,7 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
     let reserve = SettlementProofRecord {
         proof_id: "reserve:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:2:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8"
             .to_string(),
+        chain_id: ChainId(1030),
         tx_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
         log_index: 2,
         amount_e8s: 50_000_000,
@@ -706,6 +708,61 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         decoded.settled_reserve_burn_proofs[&reserve.proof_id],
         reserve
     );
+}
+
+#[test]
+fn pending_chain_burn_aging_surfaces_nonzero_pending_and_proof_counts() {
+    let mut v6 = MultiChainStateV6::default();
+    let cfx = ChainId(1030);
+    let monad = ChainId(10143);
+    v6.pending_chain_burn_e8s.insert(cfx, 20);
+    v6.pending_chain_burn_e8s.insert(monad, 0);
+    v6.settled_pending_burn_proofs.insert(
+        "pending:newer".into(),
+        SettlementProofRecord {
+            proof_id: "pending:newer".into(),
+            chain_id: cfx,
+            tx_hash: "0xaaa".into(),
+            log_index: 1,
+            amount_e8s: 5,
+            block_number: 10,
+            recorded_at_ns: 200,
+        },
+    );
+    v6.settled_pending_burn_proofs.insert(
+        "pending:older".into(),
+        SettlementProofRecord {
+            proof_id: "pending:older".into(),
+            chain_id: cfx,
+            tx_hash: "0xbbb".into(),
+            log_index: 2,
+            amount_e8s: 7,
+            block_number: 9,
+            recorded_at_ns: 100,
+        },
+    );
+
+    let rows = v6.pending_chain_burn_aging(250);
+    assert_eq!(rows.len(), 1, "zero-pending chain omitted");
+    assert_eq!(rows[0].chain_id, cfx);
+    assert_eq!(rows[0].pending_chain_burn_e8s, 20);
+    assert_eq!(rows[0].proof_count, 2);
+    assert_eq!(rows[0].oldest_reference_ns, Some(100));
+    assert_eq!(rows[0].age_ns, Some(150));
+}
+
+#[test]
+fn pending_chain_burn_aging_uses_none_when_pending_has_no_proof_timestamp() {
+    let mut v6 = MultiChainStateV6::default();
+    let cfx = ChainId(1030);
+    v6.pending_chain_burn_e8s.insert(cfx, 20);
+
+    let rows = v6.pending_chain_burn_aging(250);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].chain_id, cfx);
+    assert_eq!(rows[0].oldest_reference_ns, None);
+    assert_eq!(rows[0].age_ns, None);
+    assert_eq!(rows[0].proof_count, 0);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -1,7 +1,7 @@
 use super::config::ChainId;
 use super::multi_chain_state::{
     ChainLiqClaimV1, MultiChainState, MultiChainStateV1, MultiChainStateV2, MultiChainStateV3,
-    MultiChainStateV4, MultiChainStateV5, MultiChainStateV6,
+    MultiChainStateV4, MultiChainStateV5, MultiChainStateV6, SettlementProofRecord,
 };
 use super::supply::migrate_multi_chain_state;
 
@@ -610,6 +610,102 @@ fn chain_liq_claim_invariant_rejects_overpaid_claims() {
         paid_native: 11,
     };
     assert!(!claim.paid_within_seized());
+}
+
+#[test]
+fn settlement_proof_state_defaults_empty_from_pre_inc6_v6_snapshot() {
+    use super::collateral_config::ChainDebtConfigV1;
+    use super::config::ChainConfigV3;
+    use super::liquidation_config::ChainLiquidationConfigV1;
+    use super::monad::chain_vault::ChainVaultV1;
+    use super::settlement_queue::SettlementQueueV1;
+    use candid::Principal;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[derive(serde::Serialize, Default)]
+    struct PreInc6MultiChainStateV6 {
+        pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
+        pub chain_supplies: BTreeMap<ChainId, u128>,
+        pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+        pub invariant_halted: bool,
+        pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+        pub chain_contracts: BTreeMap<ChainId, String>,
+        pub manual_prices: BTreeMap<(ChainId, String), u64>,
+        pub last_observed_block: BTreeMap<ChainId, u64>,
+        pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+        pub reorg_halted: BTreeMap<ChainId, bool>,
+        pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+        pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+        pub evm_owner_nonces: BTreeMap<Principal, u64>,
+        pub manual_price_set_at_ns: BTreeMap<(ChainId, String), u64>,
+        pub reserve_backing_e8s: BTreeMap<ChainId, u128>,
+        pub reserve_usdc_native: BTreeMap<ChainId, u128>,
+        pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
+        pub sp_attempted_chain_vaults: BTreeSet<u64>,
+        pub chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>,
+        pub chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>,
+        pub chain_debt_configs: BTreeMap<ChainId, ChainDebtConfigV1>,
+        pub bot_pending_chain_vaults: BTreeMap<u64, u64>,
+        pub chain_bad_debt_e8s: BTreeMap<ChainId, u128>,
+    }
+
+    const CFX: ChainId = ChainId(1030);
+    let mut pre = PreInc6MultiChainStateV6::default();
+    pre.chain_supplies.insert(CFX, 100);
+    pre.pending_chain_burn_e8s.insert(CFX, 20);
+    pre.reserve_backing_e8s.insert(CFX, 30);
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&pre, &mut buf).expect("cbor encode pre-Inc6 V6");
+    let decoded: MultiChainStateV6 =
+        ciborium::de::from_reader(buf.as_slice()).expect("pre-Inc6 V6 decodes");
+
+    assert_eq!(decoded.chain_supplies.get(&CFX), Some(&100));
+    assert_eq!(decoded.pending_chain_burn_e8s.get(&CFX), Some(&20));
+    assert_eq!(decoded.reserve_backing_e8s.get(&CFX), Some(&30));
+    assert!(decoded.settled_pending_burn_proofs.is_empty());
+    assert!(decoded.settled_reserve_burn_proofs.is_empty());
+}
+
+#[test]
+fn settlement_proof_state_round_trip_preserves_compact_records() {
+    let mut v6 = MultiChainStateV6::default();
+    let pending = SettlementProofRecord {
+        proof_id: "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7"
+            .to_string(),
+        tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        log_index: 7,
+        amount_e8s: 25_000_000,
+        block_number: 55,
+        recorded_at_ns: 1_700,
+    };
+    let reserve = SettlementProofRecord {
+        proof_id: "reserve:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:2:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8"
+            .to_string(),
+        tx_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        log_index: 2,
+        amount_e8s: 50_000_000,
+        block_number: 88,
+        recorded_at_ns: 1_800,
+    };
+    v6.settled_pending_burn_proofs
+        .insert(pending.proof_id.clone(), pending.clone());
+    v6.settled_reserve_burn_proofs
+        .insert(reserve.proof_id.clone(), reserve.clone());
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&v6, &mut buf).expect("cbor encode V6");
+    let decoded: MultiChainStateV6 =
+        ciborium::de::from_reader(buf.as_slice()).expect("V6 snapshot round-trips");
+
+    assert_eq!(
+        decoded.settled_pending_burn_proofs[&pending.proof_id],
+        pending
+    );
+    assert_eq!(
+        decoded.settled_reserve_burn_proofs[&reserve.proof_id],
+        reserve
+    );
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -665,6 +665,8 @@ fn settlement_proof_state_defaults_empty_from_pre_inc6_v6_snapshot() {
     assert_eq!(decoded.reserve_backing_e8s.get(&CFX), Some(&30));
     assert!(decoded.settled_pending_burn_proofs.is_empty());
     assert!(decoded.settled_reserve_burn_proofs.is_empty());
+    assert!(decoded.settled_settlement_burn_logs.is_empty());
+    assert!(decoded.settled_reserve_transfer_e8s.is_empty());
 }
 
 #[test]
@@ -694,6 +696,14 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         .insert(pending.proof_id.clone(), pending.clone());
     v6.settled_reserve_burn_proofs
         .insert(reserve.proof_id.clone(), reserve.clone());
+    v6.settled_settlement_burn_logs.insert(format!(
+        "{}:{}",
+        pending.tx_hash, pending.log_index
+    ));
+    v6.settled_reserve_transfer_e8s.insert(
+        "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string(),
+        50_000_000,
+    );
 
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&v6, &mut buf).expect("cbor encode V6");
@@ -707,6 +717,15 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
     assert_eq!(
         decoded.settled_reserve_burn_proofs[&reserve.proof_id],
         reserve
+    );
+    assert!(decoded.settled_settlement_burn_logs.contains(&format!(
+        "{}:{}",
+        pending.tx_hash, pending.log_index
+    )));
+    assert_eq!(
+        decoded.settled_reserve_transfer_e8s
+            [&"0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string()],
+        50_000_000
     );
 }
 

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -1,9 +1,12 @@
 use super::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
+use super::evm::settlement_proof::{VerifiedBurnSettlementProof, VerifiedReserveSettlementProof};
 use super::multi_chain_state::MultiChainState;
 use super::supply::{
     apply_debt_to_pending_burn_shift, apply_pending_burn_to_supply_shift, apply_supply_delta,
-    check_invariant, settle_pending_chain_burn, settle_reserve_burn, BackingSettlementError,
-    PendingBurnShiftError, PendingBurnSupplyShiftError, SupplyDelta, SupplyInvariantError,
+    check_invariant, settle_pending_chain_burn, settle_pending_chain_burn_with_verified_proof,
+    settle_reserve_burn, settle_reserve_burn_with_verified_proof, BackingSettlementError,
+    PendingBurnShiftError, PendingBurnSupplyShiftError, ProofBackedSettlementError, SupplyDelta,
+    SupplyInvariantError,
 };
 
 fn fixture_state() -> MultiChainState {
@@ -587,4 +590,193 @@ fn reserve_burn_settlement_rejects_over_settlement_without_mutation() {
     assert_eq!(s.chain_supplies[&CHAIN], 100);
     assert_eq!(s.reserve_backing_e8s[&CHAIN], 30);
     assert_eq!(s.reserve_usdc_native[&CHAIN], 45_000_000_000_000_000_000);
+}
+
+// ─── Increment 6 / Task 2: proof-backed reconciliation state helpers ───
+
+fn verified_pending(proof_id: &str, amount_e8s: u128) -> VerifiedBurnSettlementProof {
+    VerifiedBurnSettlementProof {
+        proof_id: proof_id.to_string(),
+        tx_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        log_index: 7,
+        block_number: 55,
+        vault_id: 1,
+        burner: "0x000000000000000000000000000000000000beef".to_string(),
+        amount_e8s,
+    }
+}
+
+fn verified_reserve(proof_id: &str, amount_e8s: u128) -> VerifiedReserveSettlementProof {
+    VerifiedReserveSettlementProof {
+        proof_id: proof_id.to_string(),
+        burn_tx_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .to_string(),
+        burn_log_index: 2,
+        burn_block_number: 88,
+        reserve_tx_hash: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            .to_string(),
+        reserve_transfer_log_index: 8,
+        reserve_block_number: 89,
+        vault_id: 1,
+        burner: "0x000000000000000000000000000000000000beef".to_string(),
+        amount_e8s,
+        reserve_transfer_amount_native: amount_e8s,
+    }
+}
+
+#[test]
+fn proof_backed_settlement_pending_reduces_pending_and_supply_and_records_proof() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 30);
+    let proof = verified_pending(
+        "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7",
+        10,
+    );
+
+    settle_pending_chain_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_700)
+        .expect("proof settlement");
+
+    assert_eq!(s.chain_supplies[&CHAIN], 90);
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 20);
+    assert_eq!(
+        s.settled_pending_burn_proofs[&proof.proof_id].amount_e8s,
+        10
+    );
+    assert_eq!(
+        s.settled_pending_burn_proofs[&proof.proof_id].recorded_at_ns,
+        1_700
+    );
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn proof_backed_settlement_reserve_reduces_reserve_and_supply_and_records_proof() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    let proof = verified_reserve(
+        "reserve:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:2:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8",
+        10,
+    );
+
+    settle_reserve_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_800)
+        .expect("proof settlement");
+
+    assert_eq!(s.chain_supplies[&CHAIN], 90);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], 20);
+    assert_eq!(
+        s.settled_reserve_burn_proofs[&proof.proof_id].amount_e8s,
+        10
+    );
+    assert_eq!(
+        s.settled_reserve_burn_proofs[&proof.proof_id].recorded_at_ns,
+        1_800
+    );
+    assert_eq!(check_invariant(&s, s.total_chain_vault_debt_e8s()), Ok(()));
+}
+
+#[test]
+fn proof_backed_settlement_rejects_duplicate_without_mutating_accounting() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 30);
+    let proof = verified_pending(
+        "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7",
+        10,
+    );
+
+    settle_pending_chain_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_700)
+        .expect("first settlement");
+    let supply_after_first = s.chain_supplies[&CHAIN];
+    let pending_after_first = s.pending_chain_burn_e8s[&CHAIN];
+    let record_after_first = s.settled_pending_burn_proofs[&proof.proof_id].clone();
+
+    assert_eq!(
+        settle_pending_chain_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_701),
+        Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id.clone()))
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], supply_after_first);
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], pending_after_first);
+    assert_eq!(
+        s.settled_pending_burn_proofs[&proof.proof_id],
+        record_after_first
+    );
+}
+
+#[test]
+fn proof_backed_settlement_rejects_duplicate_reserve_proof_without_mutating_accounting() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    let proof = verified_reserve(
+        "reserve:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:2:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8",
+        10,
+    );
+
+    settle_reserve_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_800)
+        .expect("first settlement");
+    let supply_after_first = s.chain_supplies[&CHAIN];
+    let reserve_after_first = s.reserve_backing_e8s[&CHAIN];
+    let record_after_first = s.settled_reserve_burn_proofs[&proof.proof_id].clone();
+
+    assert_eq!(
+        settle_reserve_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_801),
+        Err(ProofBackedSettlementError::DuplicateProof(proof.proof_id.clone()))
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], supply_after_first);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], reserve_after_first);
+    assert_eq!(
+        s.settled_reserve_burn_proofs[&proof.proof_id],
+        record_after_first
+    );
+}
+
+#[test]
+fn proof_backed_settlement_rejects_underflow_without_recording_proof() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 5);
+    let proof = verified_pending(
+        "pending:0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:1",
+        10,
+    );
+
+    assert_eq!(
+        settle_pending_chain_burn_with_verified_proof(&mut s, CHAIN, proof.clone(), 1_700),
+        Err(ProofBackedSettlementError::BackingSettlement(
+            BackingSettlementError::BackingUnderflow {
+                chain: CHAIN,
+                current: 5,
+                attempted_decrease: 10,
+            }
+        ))
+    );
+    assert_eq!(s.chain_supplies[&CHAIN], 100);
+    assert_eq!(s.pending_chain_burn_e8s[&CHAIN], 5);
+    assert!(!s.settled_pending_burn_proofs.contains_key(&proof.proof_id));
+}
+
+#[test]
+fn proof_backed_settlement_rejects_unknown_chain_without_recording_proof() {
+    let mut s = fixture_state();
+    let unknown = ChainId(999);
+    let proof = verified_pending(
+        "pending:0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee:1",
+        10,
+    );
+
+    assert_eq!(
+        settle_pending_chain_burn_with_verified_proof(&mut s, unknown, proof.clone(), 1_700),
+        Err(ProofBackedSettlementError::BackingSettlement(
+            BackingSettlementError::UnknownChain(unknown)
+        ))
+    );
+    assert!(!s.settled_pending_burn_proofs.contains_key(&proof.proof_id));
+    assert_eq!(s.chain_supplies[&CHAIN], 0);
 }

--- a/src/rumi_protocol_backend/src/chains/tests_supply.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_supply.rs
@@ -536,7 +536,7 @@ fn pending_chain_burn_settlement_reduces_pending_and_supply() {
 #[test]
 fn pending_chain_burn_settlement_rejects_over_settlement_without_mutation() {
     let mut s = fixture_state();
-    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_vaults.insert(1, vault_with(80, 0));
     s.chain_supplies.insert(CHAIN, 100);
     s.pending_chain_burn_e8s.insert(CHAIN, 30);
 
@@ -621,6 +621,7 @@ fn verified_reserve(proof_id: &str, amount_e8s: u128) -> VerifiedReserveSettleme
         burner: "0x000000000000000000000000000000000000beef".to_string(),
         amount_e8s,
         reserve_transfer_amount_native: amount_e8s,
+        reserve_transfer_amount_e8s: amount_e8s,
     }
 }
 
@@ -734,6 +735,76 @@ fn proof_backed_settlement_rejects_duplicate_reserve_proof_without_mutating_acco
         s.settled_reserve_burn_proofs[&proof.proof_id],
         record_after_first
     );
+}
+
+#[test]
+fn proof_backed_settlement_rejects_reserve_transfer_over_consumption_without_mutating_accounting() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(70, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.reserve_backing_e8s.insert(CHAIN, 30);
+    let first = verified_reserve(
+        "reserve:0x1111111111111111111111111111111111111111111111111111111111111111:1:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8",
+        10,
+    );
+    let mut second = verified_reserve(
+        "reserve:0x2222222222222222222222222222222222222222222222222222222222222222:2:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8",
+        10,
+    );
+    second.burn_tx_hash =
+        "0x2222222222222222222222222222222222222222222222222222222222222222".to_string();
+    second.burn_log_index = 2;
+    second.reserve_transfer_amount_e8s = 15;
+
+    settle_reserve_burn_with_verified_proof(&mut s, CHAIN, first, 1_800)
+        .expect("first settlement");
+    let supply_after_first = s.chain_supplies[&CHAIN];
+    let reserve_after_first = s.reserve_backing_e8s[&CHAIN];
+    let proof_count_after_first = s.settled_reserve_burn_proofs.len();
+
+    assert!(matches!(
+        settle_reserve_burn_with_verified_proof(&mut s, CHAIN, second, 1_801),
+        Err(ProofBackedSettlementError::ReserveTransferOverConsumed { .. })
+    ));
+    assert_eq!(s.chain_supplies[&CHAIN], supply_after_first);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], reserve_after_first);
+    assert_eq!(
+        s.settled_reserve_burn_proofs.len(),
+        proof_count_after_first
+    );
+}
+
+#[test]
+fn proof_backed_settlement_rejects_burn_log_reuse_across_pending_and_reserve_domains() {
+    let mut s = fixture_state();
+    s.chain_vaults.insert(1, vault_with(80, 0));
+    s.chain_supplies.insert(CHAIN, 100);
+    s.pending_chain_burn_e8s.insert(CHAIN, 10);
+    s.reserve_backing_e8s.insert(CHAIN, 10);
+    let pending = verified_pending(
+        "pending:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7",
+        10,
+    );
+    let mut reserve = verified_reserve(
+        "reserve:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:7:0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8",
+        10,
+    );
+    reserve.burn_tx_hash = pending.tx_hash.clone();
+    reserve.burn_log_index = pending.log_index;
+
+    settle_pending_chain_burn_with_verified_proof(&mut s, CHAIN, pending.clone(), 1_700)
+        .expect("pending settlement");
+    let supply_after_pending = s.chain_supplies[&CHAIN];
+    let reserve_backing_before = s.reserve_backing_e8s[&CHAIN];
+    let reserve_count_before = s.settled_reserve_burn_proofs.len();
+
+    assert!(matches!(
+        settle_reserve_burn_with_verified_proof(&mut s, CHAIN, reserve, 1_800),
+        Err(ProofBackedSettlementError::DuplicateBurnLog { .. })
+    ));
+    assert_eq!(s.chain_supplies[&CHAIN], supply_after_pending);
+    assert_eq!(s.reserve_backing_e8s[&CHAIN], reserve_backing_before);
+    assert_eq!(s.settled_reserve_burn_proofs.len(), reserve_count_before);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2904,6 +2904,14 @@ fn get_settlement_proof_ids(
     read_state(settlement_proof_ids_from_state)
 }
 
+#[candid_method(query)]
+#[query]
+fn get_pending_chain_burn_aging(
+) -> Vec<rumi_protocol_backend::chains::multi_chain_state::PendingChainBurnAging> {
+    let now_ns = ic_cdk::api::time();
+    read_state(|s| s.multi_chain.pending_chain_burn_aging(now_ns))
+}
+
 /// Developer-gated manual reconciliation for the SP path: called after the
 /// operator verifies the matching foreign-chain icUSD burn for an amount already
 /// booked in `pending_chain_burn_e8s`.
@@ -11245,6 +11253,7 @@ mod inc6_settlement_proof_context_tests {
         let mut s = State::default();
         let pending_a = SettlementProofRecord {
             proof_id: "pending:a".into(),
+            chain_id: CFX,
             tx_hash: "0xa".into(),
             log_index: 1,
             amount_e8s: 10,
@@ -11253,6 +11262,7 @@ mod inc6_settlement_proof_context_tests {
         };
         let pending_b = SettlementProofRecord {
             proof_id: "pending:b".into(),
+            chain_id: CFX,
             tx_hash: "0xb".into(),
             log_index: 2,
             amount_e8s: 20,
@@ -11261,6 +11271,7 @@ mod inc6_settlement_proof_context_tests {
         };
         let reserve = SettlementProofRecord {
             proof_id: "reserve:a".into(),
+            chain_id: CFX,
             tx_hash: "0xc".into(),
             log_index: 3,
             amount_e8s: 30,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2641,6 +2641,7 @@ struct SettlementProofContext {
     contract: String,
     finality_depth: u64,
     settle_stable_token: Option<String>,
+    settle_stable_decimals: Option<u8>,
     reserve_address: Option<String>,
 }
 
@@ -2679,10 +2680,11 @@ fn settlement_proof_context(
         .ok_or_else(|| {
             ProtocolError::ChainAdmin(format!("no icUSD contract for chain {}", chain.0))
         })?;
-    let settle_stable_token = match kind {
-        SettlementProofKind::Pending => None,
-        SettlementProofKind::Reserve => Some(
-            s.multi_chain
+    let (settle_stable_token, settle_stable_decimals) = match kind {
+        SettlementProofKind::Pending => (None, None),
+        SettlementProofKind::Reserve => {
+            let liq_cfg = s
+                .multi_chain
                 .chain_liquidation_configs
                 .get(&chain)
                 .ok_or_else(|| {
@@ -2690,16 +2692,19 @@ fn settlement_proof_context(
                         "no chain liquidation config for chain {}",
                         chain.0
                     ))
-                })?
-                .settle_stable_token
-                .clone(),
-        ),
+                })?;
+            (
+                Some(liq_cfg.settle_stable_token.clone()),
+                Some(liq_cfg.settle_stable_decimals),
+            )
+        }
     };
 
     Ok(SettlementProofContext {
         contract,
         finality_depth: cfg.finality_depth as u64,
         settle_stable_token,
+        settle_stable_decimals,
         reserve_address: None,
     })
 }
@@ -2876,6 +2881,8 @@ async fn settle_reserve_burn_with_proof(
             ctx.reserve_address
                 .as_deref()
                 .expect("reserve address derived"),
+            ctx.settle_stable_decimals
+                .expect("reserve context has settle stable decimals"),
             &proof,
             &burn_receipt,
             &reserve_receipt,
@@ -11254,6 +11261,7 @@ mod inc6_settlement_proof_context_tests {
         );
         assert_eq!(pending.finality_depth, 12);
         assert!(pending.settle_stable_token.is_none());
+        assert!(pending.settle_stable_decimals.is_none());
 
         let reserve =
             settlement_proof_context(&s, CFX, SettlementProofKind::Reserve).expect("reserve ctx");
@@ -11261,6 +11269,7 @@ mod inc6_settlement_proof_context_tests {
             reserve.settle_stable_token.as_deref(),
             Some("0x5555555555555555555555555555555555555555")
         );
+        assert_eq!(reserve.settle_stable_decimals, Some(18));
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2769,6 +2769,18 @@ async fn require_settlement_receipt_final(
     }
 }
 
+fn require_settlement_receipt_success(
+    receipt: &rumi_protocol_backend::chains::evm::evm_rpc::TxReceiptWithLogs,
+) -> Result<(), ProtocolError> {
+    if receipt.success {
+        Ok(())
+    } else {
+        Err(ProtocolError::ChainAdmin(
+            "settlement proof rejected: ReceiptReverted".into(),
+        ))
+    }
+}
+
 /// Developer-gated proof-backed reconciliation for the SP pending-burn path.
 #[candid_method(update)]
 #[update]
@@ -2784,6 +2796,7 @@ async fn settle_pending_chain_burn_with_proof(
     let ctx =
         read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Pending))?;
     let receipt = fetch_settlement_receipt(chain, &proof.tx_hash).await?;
+    require_settlement_receipt_success(&receipt)?;
     require_settlement_receipt_final(chain, receipt.block_number, ctx.finality_depth).await?;
     let verified =
         rumi_protocol_backend::chains::evm::settlement_proof::verify_pending_burn_receipt(
@@ -2847,8 +2860,10 @@ async fn settle_reserve_burn_with_proof(
     ctx.reserve_address = Some(reserve_address);
 
     let burn_receipt = fetch_settlement_receipt(chain, &proof.burn_tx_hash).await?;
+    require_settlement_receipt_success(&burn_receipt)?;
     require_settlement_receipt_final(chain, burn_receipt.block_number, ctx.finality_depth).await?;
     let reserve_receipt = fetch_settlement_receipt(chain, &proof.reserve_tx_hash).await?;
+    require_settlement_receipt_success(&reserve_receipt)?;
     require_settlement_receipt_final(chain, reserve_receipt.block_number, ctx.finality_depth)
         .await?;
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2630,6 +2630,280 @@ fn map_backing_settlement_error(
     ProtocolError::ChainAdmin(format!("{e:?}"))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SettlementProofKind {
+    Pending,
+    Reserve,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SettlementProofContext {
+    contract: String,
+    finality_depth: u64,
+    settle_stable_token: Option<String>,
+    reserve_address: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SettlementProofIds {
+    pub pending: Vec<String>,
+    pub reserve: Vec<String>,
+}
+
+fn chain_finality_depth_or_default(
+    s: &State,
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> u64 {
+    s.multi_chain
+        .chain_configs
+        .get(&chain)
+        .map(|cfg| cfg.finality_depth as u64)
+        .unwrap_or(0)
+}
+
+fn settlement_proof_context(
+    s: &State,
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    kind: SettlementProofKind,
+) -> Result<SettlementProofContext, ProtocolError> {
+    let cfg = s
+        .multi_chain
+        .chain_configs
+        .get(&chain)
+        .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain {}", chain.0)))?;
+    let contract = s
+        .multi_chain
+        .chain_contracts
+        .get(&chain)
+        .cloned()
+        .ok_or_else(|| {
+            ProtocolError::ChainAdmin(format!("no icUSD contract for chain {}", chain.0))
+        })?;
+    let settle_stable_token = match kind {
+        SettlementProofKind::Pending => None,
+        SettlementProofKind::Reserve => Some(
+            s.multi_chain
+                .chain_liquidation_configs
+                .get(&chain)
+                .ok_or_else(|| {
+                    ProtocolError::ChainAdmin(format!(
+                        "no chain liquidation config for chain {}",
+                        chain.0
+                    ))
+                })?
+                .settle_stable_token
+                .clone(),
+        ),
+    };
+
+    Ok(SettlementProofContext {
+        contract,
+        finality_depth: cfg.finality_depth as u64,
+        settle_stable_token,
+        reserve_address: None,
+    })
+}
+
+fn settlement_proof_ids_from_state(s: &State) -> SettlementProofIds {
+    let mut pending: Vec<String> = s
+        .multi_chain
+        .settled_pending_burn_proofs
+        .keys()
+        .cloned()
+        .collect();
+    let mut reserve: Vec<String> = s
+        .multi_chain
+        .settled_reserve_burn_proofs
+        .keys()
+        .cloned()
+        .collect();
+    pending.sort();
+    reserve.sort();
+    SettlementProofIds { pending, reserve }
+}
+
+fn map_settlement_proof_error(
+    e: rumi_protocol_backend::chains::evm::settlement_proof::SettlementProofError,
+) -> ProtocolError {
+    ProtocolError::ChainAdmin(format!("settlement proof rejected: {e:?}"))
+}
+
+fn map_proof_backed_settlement_error(
+    e: rumi_protocol_backend::chains::supply::ProofBackedSettlementError,
+) -> ProtocolError {
+    ProtocolError::ChainAdmin(format!("{e:?}"))
+}
+
+async fn fetch_settlement_receipt(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    tx_hash: &str,
+) -> Result<rumi_protocol_backend::chains::evm::evm_rpc::TxReceiptWithLogs, ProtocolError> {
+    rumi_protocol_backend::chains::evm::evm_rpc::get_transaction_receipt_with_logs(chain, tx_hash)
+        .await
+        .map_err(|e| {
+            ProtocolError::TemporarilyUnavailable(format!("receipt RPC error; retry: {e}"))
+        })?
+        .ok_or_else(|| ProtocolError::TemporarilyUnavailable("receipt not found; retry".into()))
+}
+
+async fn require_settlement_receipt_final(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    block_number: u64,
+    finality_depth: u64,
+) -> Result<(), ProtocolError> {
+    let final_enough = rumi_protocol_backend::chains::evm::evm_rpc::is_block_final(
+        chain,
+        block_number,
+        finality_depth,
+    )
+    .await
+    .map_err(|e| {
+        ProtocolError::TemporarilyUnavailable(format!("finality check failed; retry: {e}"))
+    })?;
+    if final_enough {
+        Ok(())
+    } else {
+        Err(ProtocolError::TemporarilyUnavailable(
+            "receipt not yet final; retry".into(),
+        ))
+    }
+}
+
+/// Developer-gated proof-backed reconciliation for the SP pending-burn path.
+#[candid_method(update)]
+#[update]
+async fn settle_pending_chain_burn_with_proof(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    proof: rumi_protocol_backend::chains::evm::settlement_proof::BurnSettlementProofArg,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+
+    let ctx =
+        read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Pending))?;
+    let receipt = fetch_settlement_receipt(chain, &proof.tx_hash).await?;
+    require_settlement_receipt_final(chain, receipt.block_number, ctx.finality_depth).await?;
+    let verified =
+        rumi_protocol_backend::chains::evm::settlement_proof::verify_pending_burn_receipt(
+            &ctx.contract,
+            &proof,
+            &receipt,
+        )
+        .map_err(map_settlement_proof_error)?;
+    let amount_e8s = verified.amount_e8s;
+    let proof_id = verified.proof_id.clone();
+    let timestamp = ic_cdk::api::time();
+
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::supply::settle_pending_chain_burn_with_verified_proof(
+            &mut s.multi_chain,
+            chain,
+            verified,
+            timestamp,
+        )
+    })
+    .map_err(map_proof_backed_settlement_error)?;
+
+    rumi_protocol_backend::storage::record_event(&Event::ChainPendingBurnSettled {
+        chain_id: chain,
+        amount_e8s,
+        proof: proof_id.clone(),
+        timestamp,
+    });
+    log!(
+        INFO,
+        "[settle_pending_chain_burn_with_proof] chain={:?} amount_e8s={} proof_id={}",
+        chain,
+        amount_e8s,
+        proof_id
+    );
+    Ok(())
+}
+
+/// Developer-gated proof-backed reconciliation for Tier-1 reserve retirement.
+#[candid_method(update)]
+#[update]
+async fn settle_reserve_burn_with_proof(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    proof: rumi_protocol_backend::chains::evm::settlement_proof::ReserveSettlementProofArg,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+
+    let mut ctx =
+        read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Reserve))?;
+    let (_, reserve_address) =
+        rumi_protocol_backend::chains::evm::tecdsa::cached_reserve_address(chain)
+            .await
+            .map_err(|e| {
+                ProtocolError::TemporarilyUnavailable(format!(
+                    "reserve address derivation failed; retry: {e}"
+                ))
+            })?;
+    ctx.reserve_address = Some(reserve_address);
+
+    let burn_receipt = fetch_settlement_receipt(chain, &proof.burn_tx_hash).await?;
+    require_settlement_receipt_final(chain, burn_receipt.block_number, ctx.finality_depth).await?;
+    let reserve_receipt = fetch_settlement_receipt(chain, &proof.reserve_tx_hash).await?;
+    require_settlement_receipt_final(chain, reserve_receipt.block_number, ctx.finality_depth)
+        .await?;
+
+    let verified =
+        rumi_protocol_backend::chains::evm::settlement_proof::verify_reserve_burn_receipts(
+            &ctx.contract,
+            ctx.settle_stable_token
+                .as_deref()
+                .expect("reserve context has settle stable token"),
+            ctx.reserve_address
+                .as_deref()
+                .expect("reserve address derived"),
+            &proof,
+            &burn_receipt,
+            &reserve_receipt,
+        )
+        .map_err(map_settlement_proof_error)?;
+    let amount_e8s = verified.amount_e8s;
+    let proof_id = verified.proof_id.clone();
+    let timestamp = ic_cdk::api::time();
+
+    mutate_state(|s| {
+        rumi_protocol_backend::chains::supply::settle_reserve_burn_with_verified_proof(
+            &mut s.multi_chain,
+            chain,
+            verified,
+            timestamp,
+        )
+    })
+    .map_err(map_proof_backed_settlement_error)?;
+
+    rumi_protocol_backend::storage::record_event(&Event::ChainReserveBurnSettled {
+        chain_id: chain,
+        amount_e8s,
+        proof: proof_id.clone(),
+        timestamp,
+    });
+    log!(
+        INFO,
+        "[settle_reserve_burn_with_proof] chain={:?} amount_e8s={} proof_id={}",
+        chain,
+        amount_e8s,
+        proof_id
+    );
+    Ok(())
+}
+
+#[candid_method(query)]
+#[query]
+fn get_settlement_proof_ids(
+    _chain: Option<rumi_protocol_backend::chains::config::ChainId>,
+) -> SettlementProofIds {
+    read_state(settlement_proof_ids_from_state)
+}
+
 /// Developer-gated manual reconciliation for the SP path: called after the
 /// operator verifies the matching foreign-chain icUSD burn for an amount already
 /// booked in `pending_chain_burn_e8s`.
@@ -10850,5 +11124,161 @@ mod inc5_reconciliation_tests {
         let proof = "x".repeat(513);
         let err = normalize_reconciliation_proof(&proof).unwrap_err();
         assert!(format!("{err:?}").contains("proof text too long"));
+    }
+}
+
+#[cfg(test)]
+mod inc6_settlement_proof_context_tests {
+    use super::{
+        chain_finality_depth_or_default, settlement_proof_context, settlement_proof_ids_from_state,
+        SettlementProofKind,
+    };
+    use rumi_protocol_backend::chains::config::{
+        ChainConfigV3, ChainId, ChainStatus, GasStrategy,
+    };
+    use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+    use rumi_protocol_backend::chains::multi_chain_state::SettlementProofRecord;
+    use rumi_protocol_backend::state::State;
+
+    const CFX: ChainId = ChainId(1030);
+
+    fn chain_config() -> ChainConfigV3 {
+        ChainConfigV3 {
+            chain_id: CFX,
+            display_name: "ConfluxESpace".into(),
+            rpc_endpoints: vec!["https://evm.confluxrpc.com".into()],
+            finality_depth: 12,
+            gas_strategy: GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 1,
+                max_fee_gwei_ceiling: 200,
+            },
+            chain_native_decimals: 18,
+            registered_at_ns: 1,
+            status: ChainStatus::Registered,
+            burn_watch_poll_enabled: true,
+            min_quorum_providers: Some(2),
+        }
+    }
+
+    fn liquidation_config() -> ChainLiquidationConfigV1 {
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0x1111111111111111111111111111111111111111".into(),
+            factory: "0x2222222222222222222222222222222222222222".into(),
+            pair: "0x3333333333333333333333333333333333333333".into(),
+            collateral_token: "0x4444444444444444444444444444444444444444".into(),
+            settle_stable_token: "0x5555555555555555555555555555555555555555".into(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+            max_swap_value_e8s: 1_000_000_000,
+            max_price_age_ns: 1_800_000_000_000,
+            max_dex_oracle_divergence_bps: 500,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
+        }
+    }
+
+    #[test]
+    fn settlement_proof_context_rejects_missing_chain_before_rpc() {
+        let s = State::default();
+        let err = settlement_proof_context(&s, CFX, SettlementProofKind::Pending)
+            .expect_err("missing chain rejects");
+        assert!(format!("{err:?}").contains("unknown chain"));
+    }
+
+    #[test]
+    fn settlement_proof_context_rejects_missing_icusd_contract_before_rpc() {
+        let mut s = State::default();
+        s.multi_chain.chain_configs.insert(CFX, chain_config());
+
+        let err = settlement_proof_context(&s, CFX, SettlementProofKind::Pending)
+            .expect_err("missing contract rejects");
+        assert!(format!("{err:?}").contains("no icUSD contract"));
+    }
+
+    #[test]
+    fn settlement_proof_context_rejects_missing_reserve_config_before_rpc() {
+        let mut s = State::default();
+        s.multi_chain.chain_configs.insert(CFX, chain_config());
+        s.multi_chain
+            .chain_contracts
+            .insert(CFX, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into());
+
+        let err = settlement_proof_context(&s, CFX, SettlementProofKind::Reserve)
+            .expect_err("missing reserve config rejects");
+        assert!(format!("{err:?}").contains("no chain liquidation config"));
+    }
+
+    #[test]
+    fn settlement_proof_context_returns_contract_finality_and_reserve_token() {
+        let mut s = State::default();
+        s.multi_chain.chain_configs.insert(CFX, chain_config());
+        s.multi_chain
+            .chain_contracts
+            .insert(CFX, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into());
+        s.multi_chain
+            .chain_liquidation_configs
+            .insert(CFX, liquidation_config());
+
+        assert_eq!(chain_finality_depth_or_default(&s, CFX), 12);
+        let pending =
+            settlement_proof_context(&s, CFX, SettlementProofKind::Pending).expect("pending ctx");
+        assert_eq!(
+            pending.contract,
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(pending.finality_depth, 12);
+        assert!(pending.settle_stable_token.is_none());
+
+        let reserve =
+            settlement_proof_context(&s, CFX, SettlementProofKind::Reserve).expect("reserve ctx");
+        assert_eq!(
+            reserve.settle_stable_token.as_deref(),
+            Some("0x5555555555555555555555555555555555555555")
+        );
+    }
+
+    #[test]
+    fn settlement_proof_ids_are_sorted_and_domain_separated() {
+        let mut s = State::default();
+        let pending_a = SettlementProofRecord {
+            proof_id: "pending:a".into(),
+            tx_hash: "0xa".into(),
+            log_index: 1,
+            amount_e8s: 10,
+            block_number: 11,
+            recorded_at_ns: 12,
+        };
+        let pending_b = SettlementProofRecord {
+            proof_id: "pending:b".into(),
+            tx_hash: "0xb".into(),
+            log_index: 2,
+            amount_e8s: 20,
+            block_number: 21,
+            recorded_at_ns: 22,
+        };
+        let reserve = SettlementProofRecord {
+            proof_id: "reserve:a".into(),
+            tx_hash: "0xc".into(),
+            log_index: 3,
+            amount_e8s: 30,
+            block_number: 31,
+            recorded_at_ns: 32,
+        };
+        s.multi_chain
+            .settled_pending_burn_proofs
+            .insert(pending_b.proof_id.clone(), pending_b);
+        s.multi_chain
+            .settled_pending_burn_proofs
+            .insert(pending_a.proof_id.clone(), pending_a);
+        s.multi_chain
+            .settled_reserve_burn_proofs
+            .insert(reserve.proof_id.clone(), reserve);
+
+        let ids = settlement_proof_ids_from_state(&s);
+        assert_eq!(ids.pending, vec!["pending:a", "pending:b"]);
+        assert_eq!(ids.reserve, vec!["reserve:a"]);
     }
 }


### PR DESCRIPTION
## Summary
- add EVM receipt proof parsing for pending-chain-burn and reserve-burn settlement
- add domain-separated settlement proof records plus proof-backed accounting helpers with duplicate rejection
- add developer-gated proof settlement endpoints, proof-id visibility, and pending-burn aging telemetry
- keep the Inc 5 manual reconciliation endpoints as fallback

## Verification
- PASS: cargo test -p rumi_protocol_backend settlement_proof --lib -- --nocapture
- PASS: cargo test -p rumi_protocol_backend proof_backed_settlement --lib -- --nocapture
- PASS: cargo test -p rumi_protocol_backend pending_chain_burn_aging --lib -- --nocapture
- PASS: cargo test -p rumi_protocol_backend settlement_proof --bin rumi_protocol_backend -- --nocapture
- PASS: RUMI_REGEN_DID=1 cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture
- PASS: cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture
- PASS: cargo test -p rumi_protocol_backend --lib
- PASS: cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
- PASS: git diff --check

Note: a broad rustfmt check that includes src/lib.rs still reports pre-existing formatting/trailing-whitespace outside this increment because rustfmt walks the full module tree. I did not mass-format unrelated files.