### PR TITLE
feat(chains): Inc7 auto-escalate timed-out bot liquidations

### DIFF
--- a/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-7.md
+++ b/docs/superpowers/plans/2026-06-24-chains-liquidation-increment-7.md
@@ -1,0 +1,225 @@
+# Chains Liquidation Increment 7 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire automatic bot-to-Stability-Pool escalation for stale chain liquidation swaps, without automatically burning SP depositor icUSD.
+
+**Architecture:** Keep the burn/absorb path SP-owned and opt-in gated. The backend observer will only perform the missing state transition for bot liquidations that have timed out: fail the bot swap op, restore reserved collateral, clear `pending_liquidation`, remove `bot_pending_chain_vaults`, and set `sp_attempted_chain_vaults`. The existing SP pull path then discovers the vault with `sp_attempted = true` and performs its current admin/SP-owned burn-proof flow.
+
+**Tech Stack:** Rust 2021, `ic-cdk` timers/update methods, existing EVM observer and settlement queue, Candid-compatible persisted state, Cargo unit tests.
+
+## Global Constraints
+
+- TDD is mandatory: write failing tests first, run them red, then implement the smallest change that turns them green.
+- Do not add automatic SP burns in this increment. A timer must not repeatedly burn IC-native icUSD if the backend rejects after a ledger burn.
+- Do not change the SP opt-in model: CFX remains explicit opt-in and `prepare_chain_absorb_plan_in_state` remains the capacity gate.
+- Preserve the chain supply invariant. Timeout escalation only changes routing/marker/collateral reservation state and settlement op status; it must not move debt, reserve backing, pending burn, or chain supply.
+- Do not re-route `sp_attempted` vaults back to the bot.
+- Do not add a new state version unless tests prove an additive persisted field is required. The intended implementation reuses existing V6 fields.
+- Use `icp`, not `dfx`, for build/deploy instructions.
+- Do not add `@rollup/rollup-darwin-*` to any `package.json`.
+
+---
+
+### Task 1: Backend Timeout Escalation State Helper
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/liquidation.rs`
+
+**Interfaces:**
+- Consumes:
+  - `MultiChainState::bot_pending_chain_vaults`
+  - `ChainVaultV1::pending_liquidation`
+  - `SettlementQueueV1` / `SettlementOpStatus`
+  - existing `should_escalate_to_sp`
+- Produces:
+  - `pub const DEFAULT_BOT_TO_SP_TIMEOUT_NS: u64`
+  - `pub struct ChainBotSpEscalation { pub vault_id: u64, pub op_id: u64, pub reason: String }`
+  - `pub fn escalate_timed_out_bot_liquidations_in_state(state: &mut MultiChainState, chain: ChainId, now_ns: u64, bot_timeout_ns: u64, max_per_tick: usize) -> Vec<ChainBotSpEscalation>`
+
+- [x] **Step 1: Write failing timeout escalation tests**
+
+Add tests in `src/rumi_protocol_backend/src/chains/liquidation.rs` proving:
+
+```rust
+#[test]
+fn timeout_escalation_restores_collateral_fails_op_and_sets_sp_attempted() {
+    let mut s = MultiChainState::default();
+    seed_cfg_unchecked(&mut s);
+    insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+    let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+    mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+
+    let escalated = escalate_timed_out_bot_liquidations_in_state(
+        &mut s,
+        ChainId(71),
+        10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+        DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+        10,
+    );
+
+    assert_eq!(escalated.len(), 1);
+    assert_eq!(escalated[0].vault_id, 7);
+    assert_eq!(escalated[0].op_id, op_id);
+    assert!(s.sp_attempted_chain_vaults.contains(&7));
+    assert!(!s.bot_pending_chain_vaults.contains_key(&7));
+    let v = s.chain_vaults.get(&7).unwrap();
+    assert!(v.pending_liquidation.is_none());
+    assert_eq!(v.collateral_amount_native, 1_400 * E18);
+    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    assert!(matches!(op.status, SettlementOpStatus::Failed { .. }));
+}
+```
+
+Also add tests proving no mutation before timeout and no double-restore when the op is already `Succeeded`.
+
+- [x] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture`
+
+Observed: FAIL because `DEFAULT_BOT_TO_SP_TIMEOUT_NS` and
+`escalate_timed_out_bot_liquidations_in_state` did not exist.
+
+- [x] **Step 3: Implement the helper**
+
+Implementation rules:
+
+- Collect candidates in a read-only pass from `bot_pending_chain_vaults`.
+- Candidate must be on the requested chain and have a `pending_liquidation` marker with `tier == LiquidationTier::Bot`.
+- Candidate escalates when `should_escalate_to_sp(bot_pending_since_ns, now_ns, bot_timeout_ns, op_failed)` returns true.
+- Treat `SettlementOpStatus::Failed` as terminal. Treat `SettlementOpStatus::Queued` as timeout-eligible. Treat missing/pruned ops as timeout-eligible repair cases. Treat `SettlementOpStatus::Inflight` and `SettlementOpStatus::Succeeded` as ineligible to avoid racing a live submit/confirm or double-restoring an already-settled bot liquidation.
+- For an eligible candidate, restore `collateral_reserved_native`, clear the marker, remove `bot_pending_chain_vaults`, insert `sp_attempted_chain_vaults`, and mark the settlement op failed with a timeout/escalation reason if it still exists.
+- Return one `ChainBotSpEscalation` per actual mutation. Respect `max_per_tick`.
+
+- [x] **Step 4: Run task tests**
+
+Run: `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture`
+
+Observed: PASS, 5 passed after adding the inflight-swap and missing-op repair regressions from adversarial review.
+
+### Task 2: Observer Wiring and Audit Event Emission
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs`
+- Test: `src/rumi_protocol_backend/src/chains/liquidation.rs`
+
+- [x] **Step 1: Wire the observer**
+
+In the chain liquidation detection block, call `escalate_timed_out_bot_liquidations_in_state` before routing fresh bot candidates. For each returned escalation, record:
+
+```rust
+crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+    chain_id: chain,
+    op_id: escalation.op_id,
+    reason: escalation.reason.clone(),
+    timestamp: now_ns,
+});
+```
+
+Then continue existing price freshness and routing behavior. Stale price should still emit `ChainLiquidationDeferred`, but timeout escalation does not need a fresh price because it only restores already-reserved collateral and hands the vault to the existing SP/manual path.
+
+- [x] **Step 2: Run focused observer-adjacent tests**
+
+Run: `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture`
+
+Observed: PASS.
+
+### Task 2b: Settlement Submit CAS For Queued Swap Race
+
+**Files:**
+- Modify: `src/rumi_protocol_backend/src/chains/evm/settlement.rs`
+- Test: `src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs`
+
+- [x] **Step 1: Fix reviewer blocker**
+
+Adversarial reviewers found that observer timeout escalation could race a
+settlement worker that had cloned a still-`Queued` `LiquidationSwap` before
+awaiting RPC/sign/broadcast. The fix adds
+`claim_liquidation_swap_submit_in_state`, which atomically verifies the live op
+is still `Queued`, the live vault marker still belongs to that op, and then
+marks the op `Inflight` with local tx hash + nonce immediately before the
+broadcast await. If the observer already cleared the marker or another worker
+claimed the op, submit aborts before broadcasting.
+
+- [x] **Step 2: Add focused CAS tests**
+
+Observed:
+
+- `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture`: PASS, 5 passed.
+- `cargo test -p rumi_protocol_backend claim_liquidation_swap_submit --lib -- --nocapture`: PASS, 3 passed.
+
+### Task 3: Verification and Review
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-24-chains-liquidation-increment-7.md`
+
+- [x] **Step 1: Run deterministic checks**
+
+Run:
+
+```bash
+cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture
+cargo test -p rumi_protocol_backend detect_skips_bot_failed_sp_attempted_vaults --lib -- --nocapture
+cargo test -p rumi_protocol_backend --lib
+cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
+cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture
+git diff --check
+```
+
+Observed:
+
+- `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture`: PASS, 5 passed.
+- `cargo test -p rumi_protocol_backend claim_liquidation_swap_submit --lib -- --nocapture`: PASS, 3 passed.
+- `cargo test -p rumi_protocol_backend detect_skips_bot_failed_sp_attempted_vaults --lib -- --nocapture`: PASS, 1 passed.
+- `cargo test -p rumi_protocol_backend --lib`: PASS, 663 passed, 1 ignored.
+- `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend`: PASS, 16 passed.
+- `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture`: PASS, 1 passed.
+- `git diff --check`: PASS.
+
+- [x] **Step 2: Adversarial verification**
+
+Run two independent reviewers against:
+
+- Diff for `liquidation.rs`, `deposit_watch.rs`, and this plan.
+- Deterministic test output.
+- Rubric:
+  - Timeout escalation cannot double-restore collateral.
+  - Timeout escalation cannot re-route an SP-attempted vault to the bot.
+  - Timeout escalation does not move debt, chain supply, reserve backing, or pending burn.
+  - Existing SP burn/absorb remains manual/SP-owned and opt-in gated.
+  - Rejection/stale-price paths do not wedge a bot marker forever.
+
+Observed: two independent reviewers found and then cleared the race/liveness
+issues after fixes:
+
+- Blocker 1: observer timeout escalation could restore collateral for an
+  `Inflight` swap that might still confirm. Fixed by skipping `Inflight` in the
+  observer helper and adding `timeout_escalation_skips_inflight_swap_to_avoid_live_submit_race`.
+- Blocker 2: observer timeout escalation could race a settlement worker holding
+  a stale cloned `Queued` op across awaits. Fixed by
+  `claim_liquidation_swap_submit_in_state`, which claims the live op as
+  `Inflight` with local tx hash + nonce immediately before broadcast.
+- Liveness finding: missing/pruned failed swap ops could leave markers wedged.
+  Fixed by treating missing ops as timeout-eligible repair cases and adding
+  `timeout_escalation_repairs_missing_swap_op_after_timeout`.
+
+Final reviewer status: no blockers. Residual risks are bounded to manual repair
+for corrupted marker-only state without `bot_pending_chain_vaults`, and to
+normal confirm-timeout liveness for already-`Inflight` swaps.
+
+- [ ] **Step 3: Open PR**
+
+Run:
+
+```bash
+git status --short
+git add -f docs/superpowers/plans/2026-06-24-chains-liquidation-increment-7.md
+git add src/rumi_protocol_backend/src/chains/liquidation.rs src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+git commit -m "feat(chains): Inc7 auto-escalate timed-out bot liquidations"
+git push -u origin codex/chains-liquidation-inc7
+gh pr create --title "feat(chains): Inc7 auto-escalate timed-out bot liquidations" --body-file /tmp/inc7-pr-body.md
+```
+
+## Notes For Future Increment
+
+SP-side auto absorb is still valuable, but it needs a durable burn-retry ledger or a backend/SP two-phase lock before a timer can safely burn IC-native icUSD. The current `burn_icusd_for_chain_writedown` uses a fresh `created_at_time` per call, so a naive retry loop could burn more than once if the backend rejects after the first ledger burn.

--- a/docs/superpowers/plans/2026-06-25-chains-liquidation-increment-8.md
+++ b/docs/superpowers/plans/2026-06-25-chains-liquidation-increment-8.md
@@ -1,0 +1,46 @@
+# Chains Liquidation Increment 8: Retry-Safe SP Chain Absorb Foundation
+
+## Goal
+
+Make Stability Pool absorption of escalated chain vaults safe to retry and observable before enabling any unattended auto-burn timer.
+
+Increment 7 repairs bot-failed liquidation markers and escalates timed-out bot work to `sp_attempted`. Increment 8 must not naively loop over those vaults: the current SP absorb path burns IC-native icUSD before the backend call, and a fresh ledger `created_at_time` on retry can create a second burn.
+
+## Scope
+
+- Add SP-side chain absorb candidate discovery for already-escalated (`sp_attempted = true`) vaults.
+- Add durable SP-side chain absorb intent state keyed by vault id.
+- Persist the intended icUSD amount, chain/vault metadata, burn memo timestamp, minting account, optional burn proof, optional backend result, and last error.
+- Reuse the persisted ledger timestamp and proof on retries so one vault intent cannot produce a second burn.
+- Keep pool balance/opt-in mutations blocked while a burned-but-unfinalized chain absorb intent exists.
+- Make local SP finalization idempotent by vault id so a resumed backend result does not double-deduct depositor icUSD or double-credit CFX claims.
+- Expose pending/completed chain absorb state for operators.
+
+## Non-Goals
+
+- No unattended timer auto-burn yet.
+- No automatic foreign-chain representation retirement.
+- No CFX payout retry/rollback automation.
+- No standalone backend result-recovery query; exact same-proof retries return the stored backend result from `stability_pool_liquidate_chain_vault`.
+
+## Safety Invariant
+
+For a given chain vault id, the SP may create at most one IC-native icUSD burn intent, with one stable `created_at_time` and one accepted burn proof. Any retry must resume that intent; it must not recompute the burn timestamp or draw a new live depositor denominator after the burn.
+
+## Acceptance
+
+- Tests prove candidate scanning filters to `sp_attempted` vaults with full icUSD coverage.
+- Tests prove pending intent decode is upgrade-compatible from pre-Inc-8 snapshots.
+- Tests prove an existing pending intent reuses the stored `created_at_time` and rejects conflicting recomputation.
+- Tests prove completed local finalization is idempotent and does not double-deduct depositor balances or double-credit CFX claims.
+- Tests prove balance/opt-in mutation guards observe pending chain absorbs.
+- Tests prove backend same-proof result replay accepts only the exact same caller/vault/amount/burn proof shape and rejects conflicting proof reuse.
+- Tests prove completed SP absorb journals and backend replay-result caches are bounded.
+- Tests prove post-await deposit credits recheck the pending-absorb guard before mutating balances.
+- Tests prove replay-cache retention never evicts the result that was just accepted.
+- Tests prove burn-watch defers user foreign-chain burns while a vault is SP-escalated.
+- Tests prove backend SP absorb rejects stale burn amounts that no longer match live debt without mutating chain debt, pending burn, supply, or claims.
+- Tests prove SP local finalization rejects partial backend results without deducting depositor icUSD or crediting CFX claims.
+- Tests prove SP chain absorb refuses to start while a deduct-before-transfer balance operation is awaiting a ledger response, so failed withdrawal rollback cannot restore stable balances during a pending chain absorb.
+- Tests prove a pending burned chain absorb blocks new vault absorb planning until that original intent is retried/finalized, so the same still-recorded icUSD balance cannot be burned twice.
+- Full relevant Stability Pool and backend tests pass.

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1326,6 +1326,7 @@ service : (ProtocolArg) -> {
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
       Result_17,
     );
+  stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
   submit_burn_proof : (nat32, text) -> (Result_18);
   sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -28,6 +28,11 @@ type BotStatsResponse = record {
   budget_total_e8s : nat64;
   budget_start_timestamp : nat64;
 };
+type BurnSettlementProofArg = record {
+  log_index : nat64;
+  expected_burner : opt text;
+  tx_hash : text;
+};
 type CandidVault = record {
   collateral_amount : nat64;
   owner : principal;
@@ -37,11 +42,25 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainBadDebtCircuitStatus = record {
+  tripped_at_ns : opt nat64;
+  tripped : bool;
+  bad_debt_e8s : nat;
+  chain_id : nat32;
+  threshold_e8s : opt nat;
+  registered : bool;
+};
+type ChainDebtConfigV1 = record {
+  debt_ceiling_e8s : opt nat;
+  min_vault_debt_e8s : nat;
+};
 type ChainLiquidatableVault = record {
   sized_repay_e8s : nat;
   cr_e4 : nat64;
   collateral_native : nat;
   vault_id : nat64;
+  sp_attempted : bool;
+  chain_collateral_sentinel : principal;
   chain_id : nat32;
   liquidation_threshold_e4 : nat64;
   effective_debt_e8s : nat;
@@ -63,6 +82,30 @@ type ChainLiquidationConfigV1 = record {
   router : text;
   settle_stable_token : text;
   deadline_secs : nat64;
+};
+type ChainReserveReport = record {
+  recorded_supply_e8s : nat;
+  onchain_usdc_balance_native : opt nat;
+  pending_chain_burn_e8s : nat;
+  reserve_backing_e8s : nat;
+  reserve_usdc_native : nat;
+  finalized_block : nat64;
+  bad_debt_e8s : nat;
+  reserve_address : opt text;
+  chain_id : nat32;
+  onchain_usdc_error : opt text;
+  settle_stable_token : opt text;
+};
+type ChainStabilityPoolLiquidationResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  success : bool;
 };
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
@@ -239,6 +282,11 @@ type Event = variant {
     chain_id : nat32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_cleared : record {
+    total_bad_debt_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -253,6 +301,12 @@ type Event = variant {
   set_rmr_ceiling_cr : record { value : text };
   set_amm1_canister : record { canister : principal };
   set_recovery_rate_curve : record { markers : text };
+  chain_reserve_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_ckstable_repay_fee : record { rate : text };
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
@@ -359,6 +413,12 @@ type Event = variant {
     reason : text;
   };
   set_rmr_floor_cr : record { value : text };
+  chain_pending_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_rmr_ceiling : record { value : text };
   set_collateral_liquidation_bonus : record {
     collateral_type : principal;
@@ -437,6 +497,11 @@ type Event = variant {
     reject_code : int32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_threshold_set : record {
+    chain_id : nat32;
+    threshold_e8s : opt nat;
+    timestamp : nat64;
+  };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
@@ -455,6 +520,13 @@ type Event = variant {
     vault_id : nat64;
     timestamp : opt nat64;
     amount : nat64;
+  };
+  chain_bad_debt_circuit_tripped : record {
+    total_bad_debt_e8s : nat;
+    bad_debt_e8s : nat;
+    chain_id : nat32;
+    threshold_e8s : nat;
+    timestamp : nat64;
   };
   set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
@@ -738,6 +810,13 @@ type LiquidityStatus = record {
 type ManualPriceInfo = record { set_at_ns : nat64; price_e8 : nat64 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type PendingChainBurnAging = record {
+  pending_chain_burn_e8s : nat;
+  proof_count : nat64;
+  age_ns : opt nat64;
+  chain_id : nat32;
+  oldest_reference_ns : opt nat64;
+};
 type PendingLiquidationV1 = record {
   started_at_ns : nat64;
   op_id : nat64;
@@ -896,31 +975,44 @@ type ReserveRedemptionResult = record {
   fee_amount : nat64;
   stable_amount_sent : nat64;
 };
+type ReserveSettlementProofArg = record {
+  expected_burner : opt text;
+  burn_tx_hash : text;
+  burn_log_index : nat64;
+  reserve_tx_hash : text;
+  reserve_transfer_log_index : nat64;
+};
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
-type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_11 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
-type Result_12 = variant {
+type Result_10 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_11 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_12 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
+type Result_13 = variant {
   Ok : ChainSupplyReconciliation;
   Err : ProtocolError;
 };
-type Result_13 = variant { Ok : bool; Err : ProtocolError };
-type Result_14 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_15 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_16 = variant { Ok : blob; Err : ProtocolError };
-type Result_17 = variant {
+type Result_14 = variant { Ok : bool; Err : ProtocolError };
+type Result_15 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_16 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_17 = variant { Ok : blob; Err : ProtocolError };
+type Result_18 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_18 = variant { Ok : nat32; Err : ProtocolError };
+type Result_19 = variant {
+  Ok : ChainStabilityPoolLiquidationResult;
+  Err : ProtocolError;
+};
 type Result_2 = variant { Ok : text; Err : ProtocolError };
+type Result_20 = variant { Ok : nat32; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
 type Result_5 = variant { Ok : opt nat64; Err : ProtocolError };
-type Result_6 = variant { Ok : nat8; Err : ProtocolError };
-type Result_7 = variant { Ok : float64; Err : ProtocolError };
-type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_9 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_6 = variant { Ok : ChainReserveReport; Err : ProtocolError };
+type Result_7 = variant { Ok : nat8; Err : ProtocolError };
+type Result_8 = variant { Ok : float64; Err : ProtocolError };
+type Result_9 = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type SettlementProofIds = record { pending : vec text; reserve : vec text };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -1055,9 +1147,9 @@ type XrpPendingDeposit = record {
 };
 type XrpSettlement = record {
   destination : opt text;
+  source_sequence : opt nat32;
   destination_tag : opt nat32;
   last_ledger_sequence : nat32;
-  source_sequence : opt nat32;
   tx_hash : text;
 };
 type XrpVaultOpenInfo = record { custody_address : text; vault_id : nat64 };
@@ -1077,7 +1169,9 @@ service : (ProtocolArg) -> {
   bot_confirm_liquidation : (nat64) -> (Result);
   cancel_xrp_pending_open : (nat64) -> (Result);
   chain_has_active_settlement_op : (nat32) -> (bool) query;
+  claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
+  clear_chain_bad_debt_circuit : (nat32) -> (Result);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
   clear_reorg_halt : (nat32) -> (Result);
@@ -1101,12 +1195,17 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_bad_debt_circuit_status : (nat32) -> (
+      ChainBadDebtCircuitStatus,
+    ) query;
+  get_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
   get_chain_liquidation_config : (nat32) -> (
       opt ChainLiquidationConfigV1,
     ) query;
   get_chain_reserve_address : (nat32) -> (Result_2);
+  get_chain_reserves : (nat32) -> (Result_6);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_chains_ecdsa_key_name : () -> (text) query;
@@ -1117,6 +1216,7 @@ service : (ProtocolArg) -> {
       vec record { SpProofLedger; nat64 },
     ) query;
   get_deposit_account : (opt principal) -> (Account) query;
+  get_effective_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_event_count : () -> (nat64) query;
   get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
@@ -1151,6 +1251,7 @@ service : (ProtocolArg) -> {
       vec record { nat64; XrpPendingDeposit },
     ) query;
   get_pending_amm1_donations_count : () -> (nat64) query;
+  get_pending_chain_burn_aging : () -> (vec PendingChainBurnAging) query;
   get_price_pusher_allowed : () -> (vec record { nat32; text }) query;
   get_price_pusher_principal : () -> (opt principal) query;
   get_protocol_3usd_reserves : () -> (nat64) query;
@@ -1162,7 +1263,7 @@ service : (ProtocolArg) -> {
   get_redemption_fee_ceiling : () -> (float64) query;
   get_redemption_fee_floor : () -> (float64) query;
   get_redemption_rate : () -> (float64) query;
-  get_redemption_tier : (principal) -> (Result_6) query;
+  get_redemption_tier : (principal) -> (Result_7) query;
   get_reserve_balances : () -> (vec ReserveBalance) query;
   get_reserve_redemption_fee : () -> (float64) query;
   get_reserve_redemptions_enabled : () -> (bool) query;
@@ -1170,6 +1271,7 @@ service : (ProtocolArg) -> {
   get_rmr_ceiling_cr : () -> (float64) query;
   get_rmr_floor : () -> (float64) query;
   get_rmr_floor_cr : () -> (float64) query;
+  get_settlement_proof_ids : (opt nat32) -> (SettlementProofIds) query;
   get_snapshot_count : () -> (nat64) query;
   get_sp_writedown_disabled : () -> (bool) query;
   get_stability_pool_config : () -> (StabilityPoolConfig) query;
@@ -1187,7 +1289,7 @@ service : (ProtocolArg) -> {
   get_vault_history_paged : (nat64, nat64, nat64) -> (
       GetEventsFilteredResponse,
     ) query;
-  get_vault_interest_rate : (nat64) -> (Result_7) query;
+  get_vault_interest_rate : (nat64) -> (Result_8) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_xrp_claims : () -> (vec record { nat64; XrpClaim }) query;
@@ -1198,7 +1300,7 @@ service : (ProtocolArg) -> {
   harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
-  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_9);
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;
   liquidate_chain_vault : (nat64) -> (Result_1);
   liquidate_vault : (nat64) -> (Result_3);
@@ -1207,23 +1309,23 @@ service : (ProtocolArg) -> {
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
-  open_solana_vault : (nat, nat, text) -> (Result_9);
-  open_vault : (nat64, opt principal) -> (Result_10);
-  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
-  open_vault_with_deposit : (nat64, opt principal) -> (Result_10);
-  open_xrp_vault : () -> (Result_11);
+  open_solana_vault : (nat, nat, text) -> (Result_10);
+  open_vault : (nat64, opt principal) -> (Result_11);
+  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_11);
+  open_vault_with_deposit : (nat64, opt principal) -> (Result_11);
+  open_xrp_vault : () -> (Result_12);
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  reconcile_chain_supply : (nat32) -> (Result_12);
-  recover_pending_transfer : (nat64) -> (Result_13);
+  reconcile_chain_supply : (nat32) -> (Result_13);
+  recover_pending_transfer : (nat64) -> (Result_14);
   recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_14);
+  redeem_reserves : (nat64, opt principal) -> (Result_15);
   register_chain : (RegisterChainArg) -> (Result);
   register_xrp_collateral : () -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_15);
+  repay_and_close_vault : (VaultArg) -> (Result_16);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
@@ -1237,8 +1339,10 @@ service : (ProtocolArg) -> {
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
+  set_chain_bad_debt_circuit_threshold : (nat32, opt nat) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
+  set_chain_debt_config : (nat32, ChainDebtConfigV1) -> (Result);
   set_chain_interest_min_realize_e8s : (nat) -> (Result);
   set_chain_interest_tick_interval_secs : (nat64) -> (Result);
   set_chain_liquidation_config : (nat32, ChainLiquidationConfigV1) -> (Result);
@@ -1312,22 +1416,33 @@ service : (ProtocolArg) -> {
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
   set_xrp_schnorr_key_name : (text) -> (Result);
+  settle_pending_chain_burn : (nat32, nat, text) -> (Result);
+  settle_pending_chain_burn_with_proof : (nat32, BurnSettlementProofArg) -> (
+      Result,
+    );
+  settle_reserve_burn : (nat32, nat, text) -> (Result);
+  settle_reserve_burn_with_proof : (nat32, ReserveSettlementProofArg) -> (
+      Result,
+    );
   settle_xrp_claim : (nat64, text) -> (Result_2);
   settle_xrp_claim_with_tag : (nat64, text, nat32) -> (Result_2);
   solana_bootstrap_nonce : (opt text) -> (Result);
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
   solana_settlement_address : () -> (Result_2);
-  solana_sign_test_transfer : (text, nat64) -> (Result_16);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_17);
+  solana_sign_test_transfer : (text, nat64) -> (Result_17);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_18);
+  stability_pool_liquidate_chain_vault : (nat64, nat64, SpWritedownProof) -> (
+      Result_19,
+    );
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_17,
+      Result_18,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_17,
+      Result_18,
     );
   stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
-  submit_burn_proof : (nat32, text) -> (Result_18);
+  submit_burn_proof : (nat32, text) -> (Result_20);
   sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -35,6 +35,11 @@ export interface BotStatsResponse {
   'budget_total_e8s' : bigint,
   'budget_start_timestamp' : bigint,
 }
+export interface BurnSettlementProofArg {
+  'log_index' : bigint,
+  'expected_burner' : [] | [string],
+  'tx_hash' : string,
+}
 export interface CandidVault {
   'collateral_amount' : bigint,
   'owner' : Principal,
@@ -43,6 +48,14 @@ export interface CandidVault {
   'accrued_interest' : bigint,
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
+}
+export interface ChainBadDebtCircuitStatus {
+  'tripped_at_ns' : [] | [bigint],
+  'tripped' : boolean,
+  'bad_debt_e8s' : bigint,
+  'chain_id' : number,
+  'threshold_e8s' : [] | [bigint],
+  'registered' : boolean,
 }
 export interface ChainDebtConfigV1 {
   'debt_ceiling_e8s' : [] | [bigint],
@@ -291,6 +304,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'usdc_native' : bigint,
       'backing_added_e8s' : bigint,
       'vault_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+    }
+  } |
+  {
+    'chain_bad_debt_circuit_cleared' : {
+      'total_bad_debt_e8s' : bigint,
       'chain_id' : number,
       'timestamp' : bigint,
     }
@@ -579,6 +599,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'chain_bad_debt_circuit_threshold_set' : {
+      'chain_id' : number,
+      'threshold_e8s' : [] | [bigint],
+      'timestamp' : bigint,
+    }
+  } |
+  {
     'set_rate_curve_markers' : {
       'markers' : string,
       'collateral_type' : [] | [string],
@@ -603,6 +630,15 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'vault_id' : bigint,
       'timestamp' : [] | [bigint],
       'amount' : bigint,
+    }
+  } |
+  {
+    'chain_bad_debt_circuit_tripped' : {
+      'total_bad_debt_e8s' : bigint,
+      'bad_debt_e8s' : bigint,
+      'chain_id' : number,
+      'threshold_e8s' : bigint,
+      'timestamp' : bigint,
     }
   } |
   { 'set_breaker_window_ns' : { 'window_ns' : bigint, 'timestamp' : bigint } } |
@@ -952,6 +988,13 @@ export interface OpenVaultSuccess {
   'block_index' : bigint,
   'vault_id' : bigint,
 }
+export interface PendingChainBurnAging {
+  'pending_chain_burn_e8s' : bigint,
+  'proof_count' : bigint,
+  'age_ns' : [] | [bigint],
+  'chain_id' : number,
+  'oldest_reference_ns' : [] | [bigint],
+}
 export interface PendingLiquidationV1 {
   'started_at_ns' : bigint,
   'op_id' : bigint,
@@ -1114,6 +1157,13 @@ export interface ReserveRedemptionResult {
   'fee_amount' : bigint,
   'stable_amount_sent' : bigint,
 }
+export interface ReserveSettlementProofArg {
+  'expected_burner' : [] | [string],
+  'burn_tx_hash' : string,
+  'burn_log_index' : bigint,
+  'reserve_tx_hash' : string,
+  'reserve_transfer_log_index' : bigint,
+}
 export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
@@ -1156,6 +1206,10 @@ export type Result_8 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_9 = { 'Ok' : ConsentInfo } |
   { 'Err' : Icrc21Error };
+export interface SettlementProofIds {
+  'pending' : Array<string>,
+  'reserve' : Array<string>,
+}
 export type SpProofLedger = { 'IcusdBurn' : null } |
   { 'ThreePoolTransfer' : null };
 export interface SpWritedownProof {
@@ -1341,6 +1395,7 @@ export interface _SERVICE {
     Result_1
   >,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
+  'clear_chain_bad_debt_circuit' : ActorMethod<[number], Result>,
   'clear_invariant_halt' : ActorMethod<[], Result>,
   'clear_liquidation_breaker' : ActorMethod<[], Result>,
   'clear_reorg_halt' : ActorMethod<[number], Result>,
@@ -1367,6 +1422,10 @@ export interface _SERVICE {
   'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
+  'get_chain_bad_debt_circuit_status' : ActorMethod<
+    [number],
+    ChainBadDebtCircuitStatus
+  >,
   'get_chain_debt_config' : ActorMethod<[number], [] | [ChainDebtConfigV1]>,
   'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
   'get_chain_liquidatable_vaults' : ActorMethod<
@@ -1443,6 +1502,10 @@ export interface _SERVICE {
     Array<[bigint, XrpPendingDeposit]>
   >,
   'get_pending_amm1_donations_count' : ActorMethod<[], bigint>,
+  'get_pending_chain_burn_aging' : ActorMethod<
+    [],
+    Array<PendingChainBurnAging>
+  >,
   'get_price_pusher_allowed' : ActorMethod<[], Array<[number, string]>>,
   'get_price_pusher_principal' : ActorMethod<[], [] | [Principal]>,
   'get_protocol_3usd_reserves' : ActorMethod<[], bigint>,
@@ -1465,6 +1528,7 @@ export interface _SERVICE {
   'get_rmr_ceiling_cr' : ActorMethod<[], number>,
   'get_rmr_floor' : ActorMethod<[], number>,
   'get_rmr_floor_cr' : ActorMethod<[], number>,
+  'get_settlement_proof_ids' : ActorMethod<[[] | [number]], SettlementProofIds>,
   'get_snapshot_count' : ActorMethod<[], bigint>,
   'get_sp_writedown_disabled' : ActorMethod<[], boolean>,
   'get_stability_pool_config' : ActorMethod<[], StabilityPoolConfig>,
@@ -1550,6 +1614,10 @@ export interface _SERVICE {
   'set_breaker_window_debt_ceiling_e8s' : ActorMethod<[bigint], Result>,
   'set_breaker_window_ns' : ActorMethod<[bigint], Result>,
   'set_burn_watch_poll_enabled' : ActorMethod<[number, boolean], Result>,
+  'set_chain_bad_debt_circuit_threshold' : ActorMethod<
+    [number, [] | [bigint]],
+    Result
+  >,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
   'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_chain_debt_config' : ActorMethod<[number, ChainDebtConfigV1], Result>,
@@ -1650,7 +1718,15 @@ export interface _SERVICE {
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrp_schnorr_key_name' : ActorMethod<[string], Result>,
   'settle_pending_chain_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_pending_chain_burn_with_proof' : ActorMethod<
+    [number, BurnSettlementProofArg],
+    Result
+  >,
   'settle_reserve_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_reserve_burn_with_proof' : ActorMethod<
+    [number, ReserveSettlementProofArg],
+    Result
+  >,
   'settle_xrp_claim' : ActorMethod<[bigint, string], Result_2>,
   'settle_xrp_claim_with_tag' : ActorMethod<[bigint, string, number], Result_2>,
   'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -1671,6 +1671,10 @@ export interface _SERVICE {
     [bigint, bigint, bigint, Principal],
     Result_18
   >,
+  'stability_pool_preflight_chain_absorb' : ActorMethod<
+    [bigint, bigint],
+    Result
+  >,
   'submit_burn_proof' : ActorMethod<[number, string], Result_20>,
   'sweep_xrp_pending_open' : ActorMethod<[bigint], Result>,
   'unfreeze_protocol' : ActorMethod<[], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -173,6 +173,14 @@ export const idlFactory = ({ IDL }) => {
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
   });
+  const ChainBadDebtCircuitStatus = IDL.Record({
+    'tripped_at_ns' : IDL.Opt(IDL.Nat64),
+    'tripped' : IDL.Bool,
+    'bad_debt_e8s' : IDL.Nat,
+    'chain_id' : IDL.Nat32,
+    'threshold_e8s' : IDL.Opt(IDL.Nat),
+    'registered' : IDL.Bool,
+  });
   const ChainDebtConfigV1 = IDL.Record({
     'debt_ceiling_e8s' : IDL.Opt(IDL.Nat),
     'min_vault_debt_e8s' : IDL.Nat,
@@ -444,6 +452,11 @@ export const idlFactory = ({ IDL }) => {
       'chain_id' : IDL.Nat32,
       'timestamp' : IDL.Nat64,
     }),
+    'chain_bad_debt_circuit_cleared' : IDL.Record({
+      'total_bad_debt_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+    }),
     'provide_liquidity' : IDL.Record({
       'block_index' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
@@ -660,6 +673,11 @@ export const idlFactory = ({ IDL }) => {
       'reject_code' : IDL.Int32,
       'timestamp' : IDL.Nat64,
     }),
+    'chain_bad_debt_circuit_threshold_set' : IDL.Record({
+      'chain_id' : IDL.Nat32,
+      'threshold_e8s' : IDL.Opt(IDL.Nat),
+      'timestamp' : IDL.Nat64,
+    }),
     'set_rate_curve_markers' : IDL.Record({
       'markers' : IDL.Text,
       'collateral_type' : IDL.Opt(IDL.Text),
@@ -678,6 +696,13 @@ export const idlFactory = ({ IDL }) => {
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
       'amount' : IDL.Nat64,
+    }),
+    'chain_bad_debt_circuit_tripped' : IDL.Record({
+      'total_bad_debt_e8s' : IDL.Nat,
+      'bad_debt_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'threshold_e8s' : IDL.Nat,
+      'timestamp' : IDL.Nat64,
     }),
     'set_breaker_window_ns' : IDL.Record({
       'window_ns' : IDL.Nat64,
@@ -935,6 +960,13 @@ export const idlFactory = ({ IDL }) => {
     'opened_at_ns' : IDL.Nat64,
     'derivation_nonce' : IDL.Nat64,
   });
+  const PendingChainBurnAging = IDL.Record({
+    'pending_chain_burn_e8s' : IDL.Nat,
+    'proof_count' : IDL.Nat64,
+    'age_ns' : IDL.Opt(IDL.Nat64),
+    'chain_id' : IDL.Nat32,
+    'oldest_reference_ns' : IDL.Opt(IDL.Nat64),
+  });
   const ProtocolConfig = IDL.Record({
     'global_rate_curve' : IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64)),
     'bot_budget_remaining_e8s' : IDL.Nat64,
@@ -1045,6 +1077,10 @@ export const idlFactory = ({ IDL }) => {
     'balance' : IDL.Nat64,
     'ledger' : IDL.Principal,
     'symbol' : IDL.Text,
+  });
+  const SettlementProofIds = IDL.Record({
+    'pending' : IDL.Vec(IDL.Text),
+    'reserve' : IDL.Vec(IDL.Text),
   });
   const StabilityPoolConfig = IDL.Record({
     'enabled' : IDL.Bool,
@@ -1208,6 +1244,18 @@ export const idlFactory = ({ IDL }) => {
     'display_name' : IDL.Opt(IDL.Text),
     'min_quorum_providers' : IDL.Opt(IDL.Opt(IDL.Nat32)),
   });
+  const BurnSettlementProofArg = IDL.Record({
+    'log_index' : IDL.Nat64,
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'tx_hash' : IDL.Text,
+  });
+  const ReserveSettlementProofArg = IDL.Record({
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'burn_tx_hash' : IDL.Text,
+    'burn_log_index' : IDL.Nat64,
+    'reserve_tx_hash' : IDL.Text,
+    'reserve_transfer_log_index' : IDL.Nat64,
+  });
   const Result_17 = IDL.Variant({
     'Ok' : IDL.Vec(IDL.Nat8),
     'Err' : ProtocolError,
@@ -1289,6 +1337,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
+    'clear_chain_bad_debt_circuit' : IDL.Func([IDL.Nat32], [Result], []),
     'clear_invariant_halt' : IDL.Func([], [Result], []),
     'clear_liquidation_breaker' : IDL.Func([], [Result], []),
     'clear_reorg_halt' : IDL.Func([IDL.Nat32], [Result], []),
@@ -1328,6 +1377,11 @@ export const idlFactory = ({ IDL }) => {
     'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_cr_tolerance_bps' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
+    'get_chain_bad_debt_circuit_status' : IDL.Func(
+        [IDL.Nat32],
+        [ChainBadDebtCircuitStatus],
+        ['query'],
+      ),
     'get_chain_debt_config' : IDL.Func(
         [IDL.Nat32],
         [IDL.Opt(ChainDebtConfigV1)],
@@ -1459,6 +1513,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_pending_amm1_donations_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_pending_chain_burn_aging' : IDL.Func(
+        [],
+        [IDL.Vec(PendingChainBurnAging)],
+        ['query'],
+      ),
     'get_price_pusher_allowed' : IDL.Func(
         [],
         [IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Text))],
@@ -1490,6 +1549,11 @@ export const idlFactory = ({ IDL }) => {
     'get_rmr_ceiling_cr' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor_cr' : IDL.Func([], [IDL.Float64], ['query']),
+    'get_settlement_proof_ids' : IDL.Func(
+        [IDL.Opt(IDL.Nat32)],
+        [SettlementProofIds],
+        ['query'],
+      ),
     'get_snapshot_count' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_sp_writedown_disabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_stability_pool_config' : IDL.Func(
@@ -1664,6 +1728,11 @@ export const idlFactory = ({ IDL }) => {
     'set_breaker_window_ns' : IDL.Func([IDL.Nat64], [Result], []),
     'set_burn_watch_poll_enabled' : IDL.Func(
         [IDL.Nat32, IDL.Bool],
+        [Result],
+        [],
+      ),
+    'set_chain_bad_debt_circuit_threshold' : IDL.Func(
+        [IDL.Nat32, IDL.Opt(IDL.Nat)],
         [Result],
         [],
       ),
@@ -1856,8 +1925,18 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'settle_pending_chain_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, BurnSettlementProofArg],
+        [Result],
+        [],
+      ),
     'settle_reserve_burn' : IDL.Func(
         [IDL.Nat32, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'settle_reserve_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, ReserveSettlementProofArg],
         [Result],
         [],
       ),

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -1896,6 +1896,11 @@ export const idlFactory = ({ IDL }) => {
         [Result_18],
         [],
       ),
+    'stability_pool_preflight_chain_absorb' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [Result],
+        [],
+      ),
     'submit_burn_proof' : IDL.Func([IDL.Nat32, IDL.Text], [Result_20], []),
     'sweep_xrp_pending_open' : IDL.Func([IDL.Nat64], [Result], []),
     'unfreeze_protocol' : IDL.Func([], [Result], []),

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -88,6 +88,119 @@ type LiquidationResult = record {
   error_message : opt text;
 };
 
+type ChainLiquidatableVaultInfo = record {
+  sized_repay_e8s : nat;
+  cr_e4 : nat64;
+  collateral_native : nat;
+  vault_id : nat64;
+  sp_attempted : bool;
+  chain_collateral_sentinel : principal;
+  chain_id : nat32;
+  liquidation_threshold_e4 : nat64;
+  effective_debt_e8s : nat;
+  debt_e8s : nat;
+};
+
+type ChainStabilityPoolLiquidationResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  success : bool;
+};
+
+type ChainSpAbsorbResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  icusd_burned_e8s : nat64;
+  success : bool;
+};
+
+type IcrcAccount = record {
+  owner : principal;
+  subaccount : opt vec nat8;
+};
+
+type SpProofLedger = variant {
+  IcusdBurn;
+  ThreePoolTransfer;
+};
+
+type SpWritedownProof = record {
+  block_index : nat64;
+  ledger_kind : SpProofLedger;
+  vault_id_memo : nat64;
+};
+
+type ChainSpAbsorbIntentStatus = variant {
+  Prepared;
+  Burned;
+  BackendAccepted;
+  LocalApplied;
+  BackendRejected;
+};
+
+type ChainSpAbsorbCandidate = record {
+  vault : ChainLiquidatableVaultInfo;
+  icusd_to_burn_e8s : nat64;
+  pending_status : opt ChainSpAbsorbIntentStatus;
+};
+
+type ChainSpAbsorbIntent = record {
+  vault_id : nat64;
+  chain_id : nat32;
+  chain_sentinel : principal;
+  icusd_ledger : principal;
+  icusd_minting_account : IcrcAccount;
+  icusd_to_burn_e8s : nat64;
+  stables_consumed : vec record { principal; nat64 };
+  burn_created_at_time_ns : nat64;
+  status : ChainSpAbsorbIntentStatus;
+  burn_proof : opt SpWritedownProof;
+  backend_result : opt ChainStabilityPoolLiquidationResult;
+  last_error : opt text;
+  created_at_ns : nat64;
+  updated_at_ns : nat64;
+};
+
+type ChainSpAbsorbCompletion = record {
+  vault_id : nat64;
+  result : ChainSpAbsorbResult;
+  completed_at_ns : nat64;
+};
+
+type ChainAbsorbAutoConfig = record {
+  enabled : bool;
+  interval_seconds : nat64;
+  max_scan_per_chain : nat64;
+};
+
+type ChainAbsorbAutoTickRecord = record {
+  started_at_ns : nat64;
+  completed_at_ns : nat64;
+  attempted_vault_id : opt nat64;
+  candidates_scanned : nat64;
+  absorbed : opt ChainSpAbsorbResult;
+  error : opt text;
+  skipped_reason : opt text;
+};
+
+type ChainAbsorbAutoStatus = record {
+  config : ChainAbsorbAutoConfig;
+  tick_in_flight : bool;
+  last_tick : opt ChainAbsorbAutoTickRecord;
+};
+
 type PoolLiquidationRecord = record {
   vault_id : nat64;
   timestamp : nat64;
@@ -241,14 +354,20 @@ service : (StabilityPoolInitArgs) -> {
   claim_collateral : (principal) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
+  claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
   opt_in_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_out_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_in_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Liquidation ──
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);
   execute_liquidation : (nat64) -> (variant { Ok : LiquidationResult; Err : StabilityPoolError });
+  sp_absorb_chain_vault : (nat64) -> (variant { Ok : ChainSpAbsorbResult; Err : StabilityPoolError });
+  scan_chain_absorb_candidates : (opt nat64) -> (variant { Ok : vec ChainSpAbsorbCandidate; Err : StabilityPoolError });
+  set_chain_absorb_auto_config : (ChainAbsorbAutoConfig) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Interest Revenue ──
   receive_interest_revenue : (principal, nat64, opt principal) -> (variant { Ok; Err : StabilityPoolError });
@@ -256,6 +375,7 @@ service : (StabilityPoolInitArgs) -> {
   // ── Admin: Registry ──
   register_stablecoin : (StablecoinConfig) -> (variant { Ok; Err : StabilityPoolError });
   register_collateral : (CollateralInfo) -> (variant { Ok; Err : StabilityPoolError });
+  register_cfx_collateral : (nat32) -> (variant { Ok : principal; Err : StabilityPoolError });
 
   // ── Admin: Configuration ──
   update_pool_configuration : (PoolConfiguration) -> (variant { Ok; Err : StabilityPoolError });
@@ -275,10 +395,15 @@ service : (StabilityPoolInitArgs) -> {
   get_user_position : (opt principal) -> (opt UserStabilityPosition) query;
   get_liquidation_history : (opt nat64) -> (vec PoolLiquidationRecord) query;
   check_pool_capacity : (principal, nat64) -> (bool) query;
+  check_chain_absorb_capacity : (principal, nat64) -> (bool) query;
   validate_pool_state : () -> (variant { Ok : text; Err : text }) query;
   get_suspended_tokens : () -> (vec record { principal; nat32 }) query;
   get_pool_events : (nat64, nat64) -> (vec PoolEvent) query;
   get_pool_event_count : () -> (nat64) query;
   list_depositor_principals : () -> (vec principal) query;
   get_pending_refunds : (opt principal) -> (vec PendingRefund) query;
+  get_pending_chain_absorbs : () -> (vec ChainSpAbsorbIntent) query;
+  get_completed_chain_absorbs : (opt nat64) -> (vec ChainSpAbsorbCompletion) query;
+  get_chain_absorb_auto_status : () -> (ChainAbsorbAutoStatus) query;
+  get_chain_collateral_sentinel : (nat32) -> (principal) query;
 };

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -63,6 +63,7 @@ type StabilityPoolStatus = record {
 type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
+  cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
@@ -177,6 +178,16 @@ type ChainSpAbsorbCompletion = record {
   vault_id : nat64;
   result : ChainSpAbsorbResult;
   completed_at_ns : nat64;
+};
+
+type CfxClaimPayoutRecovery = record {
+  chain_sentinel : principal;
+  op_id : nat64;
+  claim_id : nat64;
+  claimant : principal;
+  amount_wei : nat;
+  reason : text;
+  failed_at_ns : nat64;
 };
 
 type ChainAbsorbAutoConfig = record {
@@ -355,6 +366,7 @@ service : (StabilityPoolInitArgs) -> {
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
+  recredit_failed_cfx_claim_payout : (CfxClaimPayoutRecovery) -> (variant { Ok : bool; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -2,6 +2,15 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface CfxClaimPayoutRecovery {
+  'claim_id' : bigint,
+  'claimant' : Principal,
+  'op_id' : bigint,
+  'chain_sentinel' : Principal,
+  'amount_wei' : bigint,
+  'failed_at_ns' : bigint,
+  'reason' : string,
+}
 export interface ChainAbsorbAutoConfig {
   'enabled' : boolean,
   'interval_seconds' : bigint,
@@ -298,6 +307,7 @@ export interface UserStabilityPosition {
   'total_interest_earned_e8s' : bigint,
   'collateral_gains' : Array<[Principal, bigint]>,
   'stablecoin_balances' : Array<[Principal, bigint]>,
+  'cfx_claims' : [] | [Array<[Principal, bigint]>],
   'total_claimed_gains' : Array<[Principal, bigint]>,
   'total_usd_value_e8s' : bigint,
   'opted_out_collateral' : Array<Principal>,
@@ -411,6 +421,11 @@ export interface _SERVICE {
   'receive_interest_revenue' : ActorMethod<
     [Principal, bigint, [] | [Principal]],
     { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'recredit_failed_cfx_claim_payout' : ActorMethod<
+    [CfxClaimPayoutRecovery],
+    { 'Ok' : boolean } |
       { 'Err' : StabilityPoolError }
   >,
   'register_cfx_collateral' : ActorMethod<

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -2,6 +2,91 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface ChainAbsorbAutoConfig {
+  'enabled' : boolean,
+  'interval_seconds' : bigint,
+  'max_scan_per_chain' : bigint,
+}
+export interface ChainAbsorbAutoStatus {
+  'tick_in_flight' : boolean,
+  'last_tick' : [] | [ChainAbsorbAutoTickRecord],
+  'config' : ChainAbsorbAutoConfig,
+}
+export interface ChainAbsorbAutoTickRecord {
+  'skipped_reason' : [] | [string],
+  'started_at_ns' : bigint,
+  'attempted_vault_id' : [] | [bigint],
+  'candidates_scanned' : bigint,
+  'completed_at_ns' : bigint,
+  'error' : [] | [string],
+  'absorbed' : [] | [ChainSpAbsorbResult],
+}
+export interface ChainLiquidatableVaultInfo {
+  'sized_repay_e8s' : bigint,
+  'cr_e4' : bigint,
+  'collateral_native' : bigint,
+  'vault_id' : bigint,
+  'sp_attempted' : boolean,
+  'chain_collateral_sentinel' : Principal,
+  'chain_id' : number,
+  'liquidation_threshold_e4' : bigint,
+  'effective_debt_e8s' : bigint,
+  'debt_e8s' : bigint,
+}
+export interface ChainSpAbsorbCandidate {
+  'icusd_to_burn_e8s' : bigint,
+  'vault' : ChainLiquidatableVaultInfo,
+  'pending_status' : [] | [ChainSpAbsorbIntentStatus],
+}
+export interface ChainSpAbsorbCompletion {
+  'result' : ChainSpAbsorbResult,
+  'completed_at_ns' : bigint,
+  'vault_id' : bigint,
+}
+export interface ChainSpAbsorbIntent {
+  'last_error' : [] | [string],
+  'status' : ChainSpAbsorbIntentStatus,
+  'icusd_to_burn_e8s' : bigint,
+  'burn_proof' : [] | [SpWritedownProof],
+  'stables_consumed' : Array<[Principal, bigint]>,
+  'updated_at_ns' : bigint,
+  'vault_id' : bigint,
+  'chain_sentinel' : Principal,
+  'created_at_ns' : bigint,
+  'burn_created_at_time_ns' : bigint,
+  'chain_id' : number,
+  'backend_result' : [] | [ChainStabilityPoolLiquidationResult],
+  'icusd_ledger' : Principal,
+  'icusd_minting_account' : IcrcAccount,
+}
+export type ChainSpAbsorbIntentStatus = { 'BackendRejected' : null } |
+  { 'Burned' : null } |
+  { 'BackendAccepted' : null } |
+  { 'Prepared' : null } |
+  { 'LocalApplied' : null };
+export interface ChainSpAbsorbResult {
+  'collateral_price_e8s' : bigint,
+  'liquidated_debt_e8s' : bigint,
+  'collateral_received_native' : bigint,
+  'block_index' : bigint,
+  'claim_id' : bigint,
+  'custody_address' : string,
+  'vault_id' : bigint,
+  'chain_id' : number,
+  'icusd_burned_e8s' : bigint,
+  'success' : boolean,
+}
+export interface ChainStabilityPoolLiquidationResult {
+  'collateral_price_e8s' : bigint,
+  'liquidated_debt_e8s' : bigint,
+  'collateral_received_native' : bigint,
+  'block_index' : bigint,
+  'claim_id' : bigint,
+  'custody_address' : string,
+  'vault_id' : bigint,
+  'chain_id' : number,
+  'success' : boolean,
+}
 export interface CollateralInfo {
   'status' : CollateralStatus,
   'decimals' : number,
@@ -57,6 +142,10 @@ export interface Icrc21ErrorInfo { 'description' : string }
 export interface Icrc21LineDisplayLine { 'line' : string }
 export interface Icrc21LineDisplayPage {
   'lines' : Array<Icrc21LineDisplayLine>,
+}
+export interface IcrcAccount {
+  'owner' : Principal,
+  'subaccount' : [] | [Uint8Array | number[]],
 }
 export interface LiquidatableVaultInfo {
   'collateral_amount' : bigint,
@@ -147,6 +236,13 @@ export interface PoolLiquidationRecord {
   'timestamp' : bigint,
   'collateral_type' : Principal,
 }
+export type SpProofLedger = { 'IcusdBurn' : null } |
+  { 'ThreePoolTransfer' : null };
+export interface SpWritedownProof {
+  'block_index' : bigint,
+  'ledger_kind' : SpProofLedger,
+  'vault_id_memo' : bigint,
+}
 export type StabilityPoolError = {
     'LedgerTransferFailed' : { 'reason' : string }
   } |
@@ -217,10 +313,16 @@ export interface _SERVICE {
     { 'Ok' : string } |
       { 'Err' : StabilityPoolError }
   >,
+  'check_chain_absorb_capacity' : ActorMethod<[Principal, bigint], boolean>,
   'check_pool_capacity' : ActorMethod<[Principal, bigint], boolean>,
   'claim_all_collateral' : ActorMethod<
     [],
     { 'Ok' : Array<[Principal, bigint]> } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'claim_cfx' : ActorMethod<
+    [Principal, string],
+    { 'Ok' : bigint } |
       { 'Err' : StabilityPoolError }
   >,
   'claim_collateral' : ActorMethod<
@@ -253,10 +355,17 @@ export interface _SERVICE {
     { 'Ok' : LiquidationResult } |
       { 'Err' : StabilityPoolError }
   >,
+  'get_chain_absorb_auto_status' : ActorMethod<[], ChainAbsorbAutoStatus>,
+  'get_chain_collateral_sentinel' : ActorMethod<[number], Principal>,
+  'get_completed_chain_absorbs' : ActorMethod<
+    [[] | [bigint]],
+    Array<ChainSpAbsorbCompletion>
+  >,
   'get_liquidation_history' : ActorMethod<
     [[] | [bigint]],
     Array<PoolLiquidationRecord>
   >,
+  'get_pending_chain_absorbs' : ActorMethod<[], Array<ChainSpAbsorbIntent>>,
   'get_pending_refunds' : ActorMethod<[[] | [Principal]], Array<PendingRefund>>,
   'get_pool_event_count' : ActorMethod<[], bigint>,
   'get_pool_events' : ActorMethod<[bigint, bigint], Array<PoolEvent>>,
@@ -279,7 +388,17 @@ export interface _SERVICE {
     [Array<LiquidatableVaultInfo>],
     Array<LiquidationResult>
   >,
+  'opt_in_cfx' : ActorMethod<
+    [Principal],
+    { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
   'opt_in_collateral' : ActorMethod<
+    [Principal],
+    { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'opt_out_cfx' : ActorMethod<
     [Principal],
     { 'Ok' : null } |
       { 'Err' : StabilityPoolError }
@@ -292,6 +411,11 @@ export interface _SERVICE {
   'receive_interest_revenue' : ActorMethod<
     [Principal, bigint, [] | [Principal]],
     { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'register_cfx_collateral' : ActorMethod<
+    [number],
+    { 'Ok' : Principal } |
       { 'Err' : StabilityPoolError }
   >,
   'register_collateral' : ActorMethod<
@@ -307,6 +431,21 @@ export interface _SERVICE {
   'resume_operations' : ActorMethod<
     [],
     { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'scan_chain_absorb_candidates' : ActorMethod<
+    [[] | [bigint]],
+    { 'Ok' : Array<ChainSpAbsorbCandidate> } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'set_chain_absorb_auto_config' : ActorMethod<
+    [ChainAbsorbAutoConfig],
+    { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'sp_absorb_chain_vault' : ActorMethod<
+    [bigint],
+    { 'Ok' : ChainSpAbsorbResult } |
       { 'Err' : StabilityPoolError }
   >,
   'update_pool_configuration' : ActorMethod<

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -241,6 +241,7 @@ export const idlFactory = ({ IDL }) => {
     'total_interest_earned_e8s' : IDL.Nat64,
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'stablecoin_balances' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'cfx_claims' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat))),
     'total_claimed_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'total_usd_value_e8s' : IDL.Nat64,
     'opted_out_collateral' : IDL.Vec(IDL.Principal),
@@ -305,6 +306,15 @@ export const idlFactory = ({ IDL }) => {
     'debt_amount' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
+  });
+  const CfxClaimPayoutRecovery = IDL.Record({
+    'claim_id' : IDL.Nat64,
+    'claimant' : IDL.Principal,
+    'op_id' : IDL.Nat64,
+    'chain_sentinel' : IDL.Principal,
+    'amount_wei' : IDL.Nat,
+    'failed_at_ns' : IDL.Nat64,
+    'reason' : IDL.Text,
   });
   const ChainLiquidatableVaultInfo = IDL.Record({
     'sized_repay_e8s' : IDL.Nat,
@@ -485,6 +495,11 @@ export const idlFactory = ({ IDL }) => {
     'receive_interest_revenue' : IDL.Func(
         [IDL.Principal, IDL.Nat64, IDL.Opt(IDL.Principal)],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'recredit_failed_cfx_claim_payout' : IDL.Func(
+        [CfxClaimPayoutRecovery],
+        [IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : StabilityPoolError })],
         [],
       ),
     'register_cfx_collateral' : IDL.Func(

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -39,6 +39,42 @@ export const idlFactory = ({ IDL }) => {
     'success' : IDL.Bool,
     'collateral_type' : IDL.Principal,
   });
+  const ChainSpAbsorbResult = IDL.Record({
+    'collateral_price_e8s' : IDL.Nat64,
+    'liquidated_debt_e8s' : IDL.Nat,
+    'collateral_received_native' : IDL.Nat,
+    'block_index' : IDL.Nat64,
+    'claim_id' : IDL.Nat64,
+    'custody_address' : IDL.Text,
+    'vault_id' : IDL.Nat64,
+    'chain_id' : IDL.Nat32,
+    'icusd_burned_e8s' : IDL.Nat64,
+    'success' : IDL.Bool,
+  });
+  const ChainAbsorbAutoTickRecord = IDL.Record({
+    'skipped_reason' : IDL.Opt(IDL.Text),
+    'started_at_ns' : IDL.Nat64,
+    'attempted_vault_id' : IDL.Opt(IDL.Nat64),
+    'candidates_scanned' : IDL.Nat64,
+    'completed_at_ns' : IDL.Nat64,
+    'error' : IDL.Opt(IDL.Text),
+    'absorbed' : IDL.Opt(ChainSpAbsorbResult),
+  });
+  const ChainAbsorbAutoConfig = IDL.Record({
+    'enabled' : IDL.Bool,
+    'interval_seconds' : IDL.Nat64,
+    'max_scan_per_chain' : IDL.Nat64,
+  });
+  const ChainAbsorbAutoStatus = IDL.Record({
+    'tick_in_flight' : IDL.Bool,
+    'last_tick' : IDL.Opt(ChainAbsorbAutoTickRecord),
+    'config' : ChainAbsorbAutoConfig,
+  });
+  const ChainSpAbsorbCompletion = IDL.Record({
+    'result' : ChainSpAbsorbResult,
+    'completed_at_ns' : IDL.Nat64,
+    'vault_id' : IDL.Nat64,
+  });
   const PoolLiquidationRecord = IDL.Record({
     'collateral_price_e8s' : IDL.Opt(IDL.Nat64),
     'stables_consumed' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
@@ -47,6 +83,53 @@ export const idlFactory = ({ IDL }) => {
     'collateral_gained' : IDL.Nat64,
     'timestamp' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
+  });
+  const ChainSpAbsorbIntentStatus = IDL.Variant({
+    'BackendRejected' : IDL.Null,
+    'Burned' : IDL.Null,
+    'BackendAccepted' : IDL.Null,
+    'Prepared' : IDL.Null,
+    'LocalApplied' : IDL.Null,
+  });
+  const SpProofLedger = IDL.Variant({
+    'IcusdBurn' : IDL.Null,
+    'ThreePoolTransfer' : IDL.Null,
+  });
+  const SpWritedownProof = IDL.Record({
+    'block_index' : IDL.Nat64,
+    'ledger_kind' : SpProofLedger,
+    'vault_id_memo' : IDL.Nat64,
+  });
+  const ChainStabilityPoolLiquidationResult = IDL.Record({
+    'collateral_price_e8s' : IDL.Nat64,
+    'liquidated_debt_e8s' : IDL.Nat,
+    'collateral_received_native' : IDL.Nat,
+    'block_index' : IDL.Nat64,
+    'claim_id' : IDL.Nat64,
+    'custody_address' : IDL.Text,
+    'vault_id' : IDL.Nat64,
+    'chain_id' : IDL.Nat32,
+    'success' : IDL.Bool,
+  });
+  const IcrcAccount = IDL.Record({
+    'owner' : IDL.Principal,
+    'subaccount' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const ChainSpAbsorbIntent = IDL.Record({
+    'last_error' : IDL.Opt(IDL.Text),
+    'status' : ChainSpAbsorbIntentStatus,
+    'icusd_to_burn_e8s' : IDL.Nat64,
+    'burn_proof' : IDL.Opt(SpWritedownProof),
+    'stables_consumed' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'updated_at_ns' : IDL.Nat64,
+    'vault_id' : IDL.Nat64,
+    'chain_sentinel' : IDL.Principal,
+    'created_at_ns' : IDL.Nat64,
+    'burn_created_at_time_ns' : IDL.Nat64,
+    'chain_id' : IDL.Nat32,
+    'backend_result' : IDL.Opt(ChainStabilityPoolLiquidationResult),
+    'icusd_ledger' : IDL.Principal,
+    'icusd_minting_account' : IcrcAccount,
   });
   const PendingRefund = IDL.Record({
     'id' : IDL.Nat64,
@@ -223,6 +306,23 @@ export const idlFactory = ({ IDL }) => {
     'vault_id' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
   });
+  const ChainLiquidatableVaultInfo = IDL.Record({
+    'sized_repay_e8s' : IDL.Nat,
+    'cr_e4' : IDL.Nat64,
+    'collateral_native' : IDL.Nat,
+    'vault_id' : IDL.Nat64,
+    'sp_attempted' : IDL.Bool,
+    'chain_collateral_sentinel' : IDL.Principal,
+    'chain_id' : IDL.Nat32,
+    'liquidation_threshold_e4' : IDL.Nat64,
+    'effective_debt_e8s' : IDL.Nat,
+    'debt_e8s' : IDL.Nat,
+  });
+  const ChainSpAbsorbCandidate = IDL.Record({
+    'icusd_to_burn_e8s' : IDL.Nat64,
+    'vault' : ChainLiquidatableVaultInfo,
+    'pending_status' : IDL.Opt(ChainSpAbsorbIntentStatus),
+  });
   const PoolConfiguration = IDL.Record({
     'emergency_pause' : IDL.Bool,
     'min_deposit_e8s' : IDL.Nat64,
@@ -240,6 +340,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : IDL.Text, 'Err' : StabilityPoolError })],
         [],
       ),
+    'check_chain_absorb_capacity' : IDL.Func(
+        [IDL.Principal, IDL.Nat64],
+        [IDL.Bool],
+        ['query'],
+      ),
     'check_pool_capacity' : IDL.Func(
         [IDL.Principal, IDL.Nat64],
         [IDL.Bool],
@@ -253,6 +358,11 @@ export const idlFactory = ({ IDL }) => {
             'Err' : StabilityPoolError,
           }),
         ],
+        [],
+      ),
+    'claim_cfx' : IDL.Func(
+        [IDL.Principal, IDL.Text],
+        [IDL.Variant({ 'Ok' : IDL.Nat, 'Err' : StabilityPoolError })],
         [],
       ),
     'claim_collateral' : IDL.Func(
@@ -285,9 +395,29 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : LiquidationResult, 'Err' : StabilityPoolError })],
         [],
       ),
+    'get_chain_absorb_auto_status' : IDL.Func(
+        [],
+        [ChainAbsorbAutoStatus],
+        ['query'],
+      ),
+    'get_chain_collateral_sentinel' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Principal],
+        ['query'],
+      ),
+    'get_completed_chain_absorbs' : IDL.Func(
+        [IDL.Opt(IDL.Nat64)],
+        [IDL.Vec(ChainSpAbsorbCompletion)],
+        ['query'],
+      ),
     'get_liquidation_history' : IDL.Func(
         [IDL.Opt(IDL.Nat64)],
         [IDL.Vec(PoolLiquidationRecord)],
+        ['query'],
+      ),
+    'get_pending_chain_absorbs' : IDL.Func(
+        [],
+        [IDL.Vec(ChainSpAbsorbIntent)],
         ['query'],
       ),
     'get_pending_refunds' : IDL.Func(
@@ -332,7 +462,17 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(LiquidationResult)],
         [],
       ),
+    'opt_in_cfx' : IDL.Func(
+        [IDL.Principal],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
     'opt_in_collateral' : IDL.Func(
+        [IDL.Principal],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'opt_out_cfx' : IDL.Func(
         [IDL.Principal],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
         [],
@@ -345,6 +485,11 @@ export const idlFactory = ({ IDL }) => {
     'receive_interest_revenue' : IDL.Func(
         [IDL.Principal, IDL.Nat64, IDL.Opt(IDL.Principal)],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'register_cfx_collateral' : IDL.Func(
+        [IDL.Nat32],
+        [IDL.Variant({ 'Ok' : IDL.Principal, 'Err' : StabilityPoolError })],
         [],
       ),
     'register_collateral' : IDL.Func(
@@ -360,6 +505,31 @@ export const idlFactory = ({ IDL }) => {
     'resume_operations' : IDL.Func(
         [],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'scan_chain_absorb_candidates' : IDL.Func(
+        [IDL.Opt(IDL.Nat64)],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Vec(ChainSpAbsorbCandidate),
+            'Err' : StabilityPoolError,
+          }),
+        ],
+        [],
+      ),
+    'set_chain_absorb_auto_config' : IDL.Func(
+        [ChainAbsorbAutoConfig],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'sp_absorb_chain_vault' : IDL.Func(
+        [IDL.Nat64],
+        [
+          IDL.Variant({
+            'Ok' : ChainSpAbsorbResult,
+            'Err' : StabilityPoolError,
+          }),
+        ],
         [],
       ),
     'update_pool_configuration' : IDL.Func(

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -42,6 +42,14 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainBadDebtCircuitStatus = record {
+  tripped_at_ns : opt nat64;
+  tripped : bool;
+  bad_debt_e8s : nat;
+  chain_id : nat32;
+  threshold_e8s : opt nat;
+  registered : bool;
+};
 type ChainDebtConfigV1 = record {
   debt_ceiling_e8s : opt nat;
   min_vault_debt_e8s : nat;
@@ -274,6 +282,11 @@ type Event = variant {
     chain_id : nat32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_cleared : record {
+    total_bad_debt_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -484,6 +497,11 @@ type Event = variant {
     reject_code : int32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_threshold_set : record {
+    chain_id : nat32;
+    threshold_e8s : opt nat;
+    timestamp : nat64;
+  };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
@@ -502,6 +520,13 @@ type Event = variant {
     vault_id : nat64;
     timestamp : opt nat64;
     amount : nat64;
+  };
+  chain_bad_debt_circuit_tripped : record {
+    total_bad_debt_e8s : nat;
+    bad_debt_e8s : nat;
+    chain_id : nat32;
+    threshold_e8s : nat;
+    timestamp : nat64;
   };
   set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
@@ -1146,6 +1171,7 @@ service : (ProtocolArg) -> {
   chain_has_active_settlement_op : (nat32) -> (bool) query;
   claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
+  clear_chain_bad_debt_circuit : (nat32) -> (Result);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
   clear_reorg_halt : (nat32) -> (Result);
@@ -1169,6 +1195,9 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_bad_debt_circuit_status : (nat32) -> (
+      ChainBadDebtCircuitStatus,
+    ) query;
   get_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
@@ -1310,6 +1339,7 @@ service : (ProtocolArg) -> {
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
+  set_chain_bad_debt_circuit_threshold : (nat32, opt nat) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
   set_chain_debt_config : (nat32, ChainDebtConfigV1) -> (Result);

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1411,6 +1411,7 @@ service : (ProtocolArg) -> {
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
       Result_18,
     );
+  stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
   submit_burn_proof : (nat32, text) -> (Result_20);
   sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -16,7 +16,10 @@ use super::settlement_queue::SettlementQueueV1;
 /// (which reads at the `finalized` commitment) legitimately uses 0, so the floor
 /// applies only to EVM gas strategies.
 fn is_evm(gas: &GasStrategy) -> bool {
-    matches!(gas, GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. })
+    matches!(
+        gas,
+        GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. }
+    )
 }
 
 /// Audit M-04 (QUORUM-1): de-duplicate `rpc_endpoints` by URL, preserving the
@@ -98,7 +101,9 @@ pub fn register_chain_in_state(
     };
     state.chain_configs.insert(arg.chain_id, cfg.clone());
     state.chain_supplies.insert(arg.chain_id, 0);
-    state.settlement_queues.insert(arg.chain_id, SettlementQueueV1::default());
+    state
+        .settlement_queues
+        .insert(arg.chain_id, SettlementQueueV1::default());
     Ok(cfg)
 }
 
@@ -134,7 +139,11 @@ pub fn delete_chain_in_state(
             chain_id.0, supply
         )));
     }
-    if state.chain_vaults.values().any(|v| v.collateral_chain == chain_id) {
+    if state
+        .chain_vaults
+        .values()
+        .any(|v| v.collateral_chain == chain_id)
+    {
         return Err(ChainAdminError::InvalidConfig(format!(
             "chain {} still has vaults",
             chain_id.0
@@ -149,10 +158,15 @@ pub fn delete_chain_in_state(
     state.hot_wallet_balance_e18.remove(&chain_id);
     state.reorg_halted.remove(&chain_id);
     state.reorg_suspect_streak.remove(&chain_id); // Task-11 reorg-debounce streak
+    state.chain_bad_debt_e8s.remove(&chain_id);
+    state.chain_bad_debt_circuit_threshold_e8s.remove(&chain_id);
+    state.chain_bad_debt_circuit_tripped_at_ns.remove(&chain_id);
     // manual_prices + its paired freshness map are keyed by (ChainId, String) —
     // drop ALL entries for this chain from BOTH, or the timestamp map leaks.
     state.manual_prices.retain(|(c, _), _| *c != chain_id);
-    state.manual_price_set_at_ns.retain(|(c, _), _| *c != chain_id);
+    state
+        .manual_price_set_at_ns
+        .retain(|(c, _), _| *c != chain_id);
     Ok(())
 }
 

--- a/src/rumi_protocol_backend/src/chains/evm/conflux/config.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/conflux/config.rs
@@ -1,4 +1,4 @@
-//! Conflux eSpace TESTNET configuration (chain id 71).
+//! Conflux eSpace configuration.
 //!
 //! eSpace is EVM-compatible and supports EIP-1559 (since the v2.4.0 hardfork),
 //! so the shared EVM tx builder / tECDSA / EVM-RPC path applies unchanged.
@@ -11,9 +11,16 @@ use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
 
 /// Conflux eSpace TESTNET chain id (mainnet is 1030).
 pub const CONFLUX_TESTNET_CHAIN_ID: ChainId = ChainId(71);
+/// Conflux eSpace MAINNET chain id. This is where real Swappi liquidity lives.
+pub const CONFLUX_MAINNET_CHAIN_ID: ChainId = ChainId(1030);
 
 /// CFX native gas asset decimals (wei-style, like ETH).
 pub const CFX_NATIVE_DECIMALS: u8 = 18;
+
+/// Mainnet finality default used by the gated-launch runbook.
+pub const CONFLUX_MAINNET_FINALITY_DEPTH: u32 = 400;
+/// Minimum independent-provider quorum floor for mainnet financial reads.
+pub const CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS: u32 = 2;
 
 /// Candidate Conflux eSpace TESTNET RPC endpoints. VERIFY live at deploy time.
 /// NOTE: all three are Confura (the Conflux Foundation's own service, one
@@ -51,6 +58,26 @@ pub fn conflux_testnet_register_arg() -> RegisterChainArg {
     }
 }
 
+/// Registration payload for Conflux eSpace mainnet.
+///
+/// Operators must pass independent, deployment-vetted RPC endpoints. This helper
+/// deliberately does not carry baked-in provider URLs because the safety property
+/// is provider independence, not any specific public endpoint.
+pub fn conflux_mainnet_register_arg(rpc_endpoints: Vec<String>) -> RegisterChainArg {
+    RegisterChainArg {
+        chain_id: CONFLUX_MAINNET_CHAIN_ID,
+        display_name: "ConfluxESpaceMainnet".to_string(),
+        rpc_endpoints,
+        finality_depth: CONFLUX_MAINNET_FINALITY_DEPTH,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 1,
+            max_fee_gwei_ceiling: 200,
+        },
+        chain_native_decimals: CFX_NATIVE_DECIMALS,
+        min_quorum_providers: Some(CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +91,31 @@ mod tests {
         assert_eq!(arg.rpc_endpoints.len(), 3);
         assert!(matches!(arg.gas_strategy, GasStrategy::EvmEip1559 { .. }));
         assert!(arg.finality_depth >= 1); // register validation requires >= 1
+    }
+
+    #[test]
+    fn register_arg_is_conflux_mainnet() {
+        let endpoints = vec![
+            "https://evm.confluxrpc.com".to_string(),
+            "https://conflux-espace.example-rpc-a.invalid".to_string(),
+            "https://conflux-espace.example-rpc-b.invalid".to_string(),
+        ];
+        let arg = conflux_mainnet_register_arg(endpoints.clone());
+        assert_eq!(arg.chain_id, ChainId(1030));
+        assert_eq!(arg.display_name, "ConfluxESpaceMainnet");
+        assert_eq!(arg.rpc_endpoints, endpoints);
+        assert_eq!(arg.finality_depth, CONFLUX_MAINNET_FINALITY_DEPTH);
+        assert_eq!(arg.chain_native_decimals, CFX_NATIVE_DECIMALS);
+        assert_eq!(
+            arg.min_quorum_providers,
+            Some(CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS)
+        );
+        assert!(matches!(
+            arg.gas_strategy,
+            GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 1,
+                max_fee_gwei_ceiling: 200
+            }
+        ));
     }
 }

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -12,7 +12,8 @@
 //! The function enforces a strict no-mutation-on-rejection guarantee:
 //!
 //! 1. Look up vault (reject if unknown — no mutation).
-//! 2. Reject if `burn.amount_e8s > debt_e8s` (no mutation).
+//! 2. Defer if the vault is locked for liquidation/SP absorb, or reject if
+//!    `burn.amount_e8s > debt_e8s` (no mutation).
 //! 3. Call `apply_supply_delta(state, chain, Decrease(amount), new_total_debt)`.
 //!    `apply_supply_delta` validates underflow, divergence, and halt BEFORE
 //!    mutating chain_supplies; on any error it returns `Err` with state
@@ -78,13 +79,13 @@ pub enum BurnApplyError {
     /// The protocol must NOT advance the cursor past this; the invariant
     /// machinery halts.
     SupplyInvariant(crate::chains::supply::SupplyInvariantError),
-    /// The target vault is mid-liquidation (`pending_liquidation.is_some()`).
-    /// Applying the burn now would let debt shrink out from under an in-flight
-    /// seizure -> over-liquidation (findings #11/#19). DEFER: no mutation, do NOT
-    /// advance the cursor, retry once the marker clears. NOT a halt (the invariant
-    /// machinery is untouched). Head-of-line: stalls this chain's burn-watch for
-    /// the (bounded, disabled-by-default) liquidation window; finding #14 (a
-    /// separate queue) is a future refinement.
+    /// The target vault is locked by bot liquidation (`pending_liquidation`) or
+    /// by SP absorb escalation (`sp_attempted_chain_vaults`). Applying the burn
+    /// now would let debt shrink out from under an in-flight seizure/SP burn.
+    /// DEFER: no mutation, do NOT advance the cursor, retry once the lock clears.
+    /// NOT a halt (the invariant machinery is untouched). Head-of-line: stalls
+    /// this chain's burn-watch for the bounded liquidation/SP absorb window;
+    /// finding #14 (a separate queue) is a future refinement.
     DeferredLiquidation,
 }
 
@@ -200,12 +201,14 @@ pub fn apply_burn_to_state(
         let vault = state.chain_vaults.get(&burn.vault_id).ok_or_else(|| {
             BurnApplyError::InvalidBurn(format!("apply_burn: unknown vault_id {}", burn.vault_id))
         })?;
-        // Findings #11/#19: never decrement a vault's debt while it is mid-
-        // liquidation. The `pending_liquidation` marker is the lock (spec §10);
-        // the burn is deferred (retried) until the liquidation resolves and clears
-        // the marker, so a concurrent repayment cannot shrink debt out from under
-        // an in-flight seizure (over-liquidation).
-        if vault.pending_liquidation.is_some() {
+        // Findings #11/#19 + Inc8: never decrement a vault's debt while it is
+        // mid-liquidation or after it has escalated to SP absorb. The SP path
+        // burns IC-side icUSD before calling the backend; a foreign-chain burn
+        // applied during that await would make the proof amount stale and create
+        // an unrecoverable overburn unless deferred here.
+        if vault.pending_liquidation.is_some()
+            || state.sp_attempted_chain_vaults.contains(&burn.vault_id)
+        {
             return Err(BurnApplyError::DeferredLiquidation);
         }
         (vault.collateral_chain, vault.debt_e8s)
@@ -1105,6 +1108,20 @@ mod liq_defer_tests {
         s.chain_supplies.insert(CFX, 100);
         s.chain_vaults.insert(7, vault(true));
         let res = apply_burn_to_state(&mut s, &burn(50), 100);
+        assert!(matches!(res, Err(BurnApplyError::DeferredLiquidation)), "burn deferred, not applied");
+        assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 100, "debt unchanged");
+        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100, "supply unchanged");
+    }
+
+    #[test]
+    fn burn_deferred_while_sp_absorb_escalated() {
+        let mut s = MultiChainState::default();
+        s.chain_supplies.insert(CFX, 100);
+        s.chain_vaults.insert(7, vault(false));
+        s.sp_attempted_chain_vaults.insert(7);
+
+        let res = apply_burn_to_state(&mut s, &burn(50), 100);
+
         assert!(matches!(res, Err(BurnApplyError::DeferredLiquidation)), "burn deferred, not applied");
         assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 100, "debt unchanged");
         assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100, "supply unchanged");

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -531,6 +531,32 @@ pub async fn run_observer(chain: ChainId) {
             s.multi_chain.chain_liquidation_configs.get(&chain).map_or(false, |c| c.enabled)
         });
         if let (true, Some(threshold), Some(symbol)) = (enabled, liq_threshold_e4, symbol) {
+            let escalated = mutate_state(|s| {
+                crate::chains::liquidation::escalate_timed_out_bot_liquidations_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    now_ns,
+                    crate::chains::liquidation::DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+                    3,
+                )
+            });
+            for escalation in &escalated {
+                crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+                    chain_id: chain,
+                    op_id: escalation.op_id,
+                    reason: escalation.reason.clone(),
+                    timestamp: now_ns,
+                });
+            }
+            if !escalated.is_empty() {
+                log!(
+                    INFO,
+                    "[observer chain={:?}] liquidation timeout escalated {} vault(s) to SP/manual fallback",
+                    chain,
+                    escalated.len()
+                );
+            }
+
             // Probe price freshness so a stale price surfaces a deferral event
             // (the in-state detect re-checks freshness and no-ops on Err too).
             let price_ok = read_state(|s| {

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -758,13 +758,8 @@ pub async fn run_observer(chain: ChainId) {
         let recorded_supply = read_state(|s| {
             s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0)
         });
-        let has_inflight_mint = read_state(|s| {
-            s.multi_chain
-                .settlement_queues
-                .get(&chain)
-                .map(|q| q.has_active_mint_op())
-                .unwrap_or(false)
-        });
+        let has_inflight_mint =
+            read_state(|s| s.multi_chain.has_supply_increasing_settlement_op(chain));
         // Run the catch-up sweep ONLY on a proven divergence: no mint in flight
         // AND a readable totalSupply that has DROPPED below `recorded` (an
         // unsubmitted burn). Mint-in-flight, probe errors, and a mint EXCESS

--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -126,6 +126,8 @@ pub const TRANSFER_EVENT_TOPIC0: &str =
 pub const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
 /// `token0()[:4]` selector (UniswapV2 pair).
 pub const TOKEN0_SELECTOR: &str = "0x0dfe1681";
+/// `getPair(address,address)[:4]` selector (UniswapV2 factory).
+pub const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 /// `balanceOf(address)[:4]` selector (ERC-20).
 pub const BALANCE_OF_SELECTOR: &str = "0x70a08231";
 
@@ -388,6 +390,48 @@ pub fn parse_eth_call_u128(result_hex: &str) -> Result<u128, String> {
     }
     u128::from_str_radix(hex, 16)
         .map_err(|e| format!("eth_call result {:?} not a u128: {}", result_hex, e))
+}
+
+/// Decode an `eth_call` result word containing an ABI address into a normalized
+/// lowercase `0x` EVM address. Used for UniswapV2 factory `getPair`.
+pub fn parse_eth_call_address(result_hex: &str) -> Result<String, String> {
+    let hex = result_hex
+        .strip_prefix("0x")
+        .or_else(|| result_hex.strip_prefix("0X"))
+        .ok_or_else(|| format!("eth_call address result missing 0x prefix: {:?}", result_hex))?;
+    if hex.len() != 64 {
+        return Err(format!("eth_call address result must be one ABI word: {:?}", result_hex));
+    }
+    if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("eth_call address result not hex: {:?}", result_hex));
+    }
+    let word = hex;
+    if !word[..24].bytes().all(|b| b == b'0') {
+        return Err(format!("eth_call address result has non-zero padding: {:?}", result_hex));
+    }
+    let address = &word[24..64];
+    if address.bytes().all(|b| b == b'0') {
+        return Err(format!("eth_call address result is zero address: {:?}", result_hex));
+    }
+    Ok(format!("0x{}", address.to_lowercase()))
+}
+
+fn abi_word_address_hex(addr: &str) -> Result<String, String> {
+    let hex = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    if hex.len() != 40 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("invalid EVM address {:?}", addr));
+    }
+    Ok(format!("{:0>64}", hex.to_lowercase()))
+}
+
+/// ABI-encode UniswapV2 factory `getPair(address,address)`.
+pub fn encode_get_pair_calldata(token_a: &str, token_b: &str) -> Result<String, String> {
+    Ok(format!(
+        "{}{}{}",
+        GET_PAIR_SELECTOR,
+        abi_word_address_hex(token_a)?,
+        abi_word_address_hex(token_b)?
+    ))
 }
 
 // ─── BurnLog ─────────────────────────────────────────────────────────────────
@@ -1159,6 +1203,21 @@ pub async fn get_pair_token0(chain: ChainId, pair: &str, block: u64) -> Result<S
         return Err(format!("token0: result too short: {:?}", hex));
     }
     Ok(format!("0x{}", raw[raw.len() - 40..].to_lowercase()))
+}
+
+/// UniswapV2 factory `getPair(tokenA, tokenB)` at a pinned block -> the pair
+/// address registered by the factory. Used by config onboarding to ensure the
+/// operator-pinned pair is the canonical pool for the configured token path.
+pub async fn get_factory_pair(
+    chain: ChainId,
+    factory: &str,
+    token_a: &str,
+    token_b: &str,
+    block: u64,
+) -> Result<String, String> {
+    let data = encode_get_pair_calldata(token_a, token_b)?;
+    let hex = eth_call_at_block(chain, factory, &data, block).await?;
+    parse_eth_call_address(&hex)
 }
 
 /// ERC-20 `balanceOf(addr)` at a pinned block (native base units). Used to

--- a/src/rumi_protocol_backend/src/chains/evm/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/mod.rs
@@ -84,6 +84,13 @@ pub fn evm_chain_config(chain: ChainId) -> Option<EvmChainConfig> {
             native_decimals: 18,
             native_symbol: "CFX",
         }),
+        1030 => Some(EvmChainConfig {
+            chain_id: ChainId(1030),
+            ecdsa_key_name: "test_key_1",
+            getlogs_max_range: 1000,
+            native_decimals: 18,
+            native_symbol: "CFX",
+        }),
         _ => None,
     }
 }
@@ -107,6 +114,15 @@ mod tests {
         assert_eq!(c.getlogs_max_range, 1000);
         assert_eq!(c.native_symbol, "CFX");
         assert_eq!(c.native_decimals, 18);
+    }
+
+    #[test]
+    fn conflux_mainnet_1030_getlogs_range_1000() {
+        let c = evm_chain_config(ChainId(1030)).expect("conflux mainnet known");
+        assert_eq!(c.getlogs_max_range, 1000);
+        assert_eq!(c.native_symbol, "CFX");
+        assert_eq!(c.native_decimals, 18);
+        assert_eq!(c.ecdsa_key_name, "test_key_1");
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -838,7 +838,61 @@ pub(crate) fn fundable_swap_value(collateral_in: u128, custody_balance: u128, ma
     collateral_in.min(custody_balance.saturating_sub(gas_reserve))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ClaimLiquidationSwapSubmitError {
+    MissingOp,
+    WrongOpKind,
+    NotQueued,
+    MissingMarker,
+}
+
+/// Atomically claim a queued liquidation swap immediately before broadcast.
+/// Without this CAS, an observer timeout tick can clear the marker while the
+/// settlement worker is suspended across RPC awaits with a stale cloned op.
+pub(crate) fn claim_liquidation_swap_submit_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    vault_id: u64,
+    now_ns: u64,
+    tx_hash: String,
+    nonce: u64,
+) -> Result<(), ClaimLiquidationSwapSubmitError> {
+    let marker_owned = state
+        .chain_vaults
+        .get(&vault_id)
+        .and_then(|v| v.pending_liquidation.as_ref())
+        .map_or(false, |marker| {
+            marker.op_id == op_id
+                && marker.tier == crate::chains::vault::LiquidationTier::Bot
+        });
+    if !marker_owned {
+        return Err(ClaimLiquidationSwapSubmitError::MissingMarker);
+    }
+
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .ok_or(ClaimLiquidationSwapSubmitError::MissingOp)?;
+    match &op.kind {
+        SettlementOpKind::LiquidationSwap { vault_id: live_vault_id, .. }
+            if *live_vault_id == vault_id => {}
+        _ => return Err(ClaimLiquidationSwapSubmitError::WrongOpKind),
+    }
+    if !matches!(op.status, SettlementOpStatus::Queued) {
+        return Err(ClaimLiquidationSwapSubmitError::NotQueued);
+    }
+
+    op.mark_inflight(now_ns);
+    op.last_tx_hash = Some(tx_hash);
+    op.submit_nonce = Some(nonce);
+    Ok(())
+}
+
 /// Submit path: sign + broadcast a `Queued` op, then mark it `Inflight`.
+/// Liquidation swaps narrow the async race window further by claiming the live
+/// op as `Inflight` immediately before broadcast.
 ///
 /// Approach A (Task 11): the worker fetches the nonce itself and builds/signs
 /// the tx directly via `build_tx_plan` + `tx::sign_eip1559` (NOT through the
@@ -1294,17 +1348,35 @@ async fn submit_liquidation_swap(
         Ok(h) => h,
         Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: sign failed ({}); will retry", chain, op_id, e); return; }
     };
+    let local_tx_hash = match tx::raw_tx_hash(&raw) {
+        Ok(h) => h,
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: signed tx hash failed ({}); will retry", chain, op_id, e); return; }
+    };
+    let claim = mutate_state(|s| {
+        claim_liquidation_swap_submit_in_state(
+            &mut s.multi_chain,
+            chain,
+            op_id,
+            vault_id,
+            ic_cdk::api::time(),
+            local_tx_hash.clone(),
+            nonce,
+        )
+    });
+    if let Err(e) = claim {
+        log!(INFO, "[settlement chain={:?}] swap op {}: submit CAS aborted before broadcast ({:?})", chain, op_id, e);
+        return;
+    }
+
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw).await {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed after submit claim ({}); receipt timeout path will resolve", chain, op_id, e); return; }
     };
 
     mutate_state(|s| {
         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
             if let Some(o) = q.pending.get_mut(&op_id) {
-                o.mark_inflight(now);
                 o.last_tx_hash = Some(tx_hash.clone());
-                o.submit_nonce = Some(nonce);
             }
         }
     });

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -40,7 +40,9 @@ use ic_canister_log::log;
 use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
 use crate::chains::multi_chain_state::MultiChainState;
-use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
+use crate::chains::settlement_queue::{
+    SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
+};
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
@@ -224,19 +226,35 @@ async fn recredit_and_fail_chain_collateral_payout(
     }
 }
 
-/// Pick the next op to act on. Enforces one-in-flight-per-queue: if ANY op is
-/// `Inflight`, only that op (action `Confirm`) is actionable; otherwise the
-/// lowest-op_id `Queued` op (action `Submit`). `pending` is a
-/// `BTreeMap<u64, SettlementOp>`, so iteration is op_id-ascending and the
-/// drain is FIFO. Returns `None` when nothing is actionable.
+/// Pick the next op to act on without additional submit-time filters. Enforces
+/// one-in-flight-per-queue: if ANY op is `Inflight`, only that op (action
+/// `Confirm`) is actionable; otherwise the lowest-op_id `Queued` op (action
+/// `Submit`) is returned.
 pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
+    select_next_op_with_submit_filter(q, |_, _| false)
+}
+
+/// Pick the next op to act on, treating queued ops for which
+/// `submit_blocked(id, op)` is true as temporarily non-actionable. Inflight ops
+/// are never skipped: one-in-flight-per-queue remains the first rule.
+///
+/// `pending` is a `BTreeMap<u64, SettlementOp>`, so iteration is op_id-ascending
+/// and the drain stays FIFO among actionable queued ops. Returns `None` when
+/// nothing is actionable.
+pub fn select_next_op_with_submit_filter<F>(
+    q: &SettlementQueueV1,
+    mut submit_blocked: F,
+) -> Option<(u64, OpAction)>
+where
+    F: FnMut(u64, &SettlementOp) -> bool,
+{
     for (&id, op) in q.pending.iter() {
         if matches!(op.status, SettlementOpStatus::Inflight { .. }) {
             return Some((id, OpAction::Confirm));
         }
     }
     for (&id, op) in q.pending.iter() {
-        if matches!(op.status, SettlementOpStatus::Queued) {
+        if matches!(op.status, SettlementOpStatus::Queued) && !submit_blocked(id, op) {
             // Increment 3: LiquidationSwap ops are now actionable (submit_op routes
             // them through the dedicated swap path). The Inc-2 skip is removed.
             return Some((id, OpAction::Submit));
@@ -386,6 +404,7 @@ pub fn apply_liquidation_settlement_in_state(
     op_id: u64,
     realized_usdc_native: u128,
     settle_decimals: u8,
+    now_ns: u64,
 ) -> Result<LiquidationSettlement, String> {
     use crate::chains::monad::chain_vault::ChainVaultStatus;
 
@@ -431,9 +450,9 @@ pub fn apply_liquidation_settlement_in_state(
     .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
 
     // Step 4: record any shortfall as per-chain bad debt (never silent).
-    if debt_to_clear > actual_cleared {
-        *state.chain_bad_debt_e8s.entry(chain).or_default() += debt_to_clear - actual_cleared;
-    }
+    let bad_debt_added_e8s = debt_to_clear.saturating_sub(actual_cleared);
+    let bad_debt_circuit_tripped =
+        state.record_chain_bad_debt_and_maybe_trip(chain, bad_debt_added_e8s, now_ns);
 
     // Step 5: clear the marker + routing record; close the vault if fully drained.
     let v = state
@@ -451,6 +470,8 @@ pub fn apply_liquidation_settlement_in_state(
         collateral_seized_native: collateral_reserved,
         tier,
         realized_usdc_native,
+        bad_debt_added_e8s,
+        bad_debt_circuit_tripped,
     })
 }
 
@@ -462,6 +483,8 @@ pub struct LiquidationSettlement {
     pub collateral_seized_native: u128,
     pub tier: crate::chains::vault::LiquidationTier,
     pub realized_usdc_native: u128,
+    pub bad_debt_added_e8s: u128,
+    pub bad_debt_circuit_tripped: bool,
 }
 
 /// Result of the state-only Tier-2 SP absorb transition. The caller emits
@@ -978,20 +1001,21 @@ pub async fn run_settlement(chain: ChainId) {
         return;
     }
 
-    // Snapshot this chain's queue and pick the next actionable op.
-    let queue = read_state(|s| s.multi_chain.settlement_queues.get(&chain).cloned());
-    let queue = match queue {
-        Some(q) => q,
+    // Snapshot this chain's next actionable op. A tripped bad-debt circuit skips
+    // queued risk-increasing ops at selection time so later burns, liquidation
+    // swaps, and claim payouts can still reconcile.
+    let selected = read_state(|s| {
+        let q = s.multi_chain.settlement_queues.get(&chain)?;
+        let (op_id, action) = select_next_op_with_submit_filter(q, |_, op| {
+            s.multi_chain
+                .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+        })?;
+        let op = q.pending.get(&op_id)?.clone();
+        Some((op_id, action, op))
+    });
+    let (op_id, action, op) = match selected {
+        Some(selected) => selected,
         None => return, // chain not registered / no queue
-    };
-    let (op_id, action) = match select_next_op(&queue) {
-        Some(pair) => pair,
-        None => return, // nothing to do
-    };
-    // Clone the op out so we can drop the queue snapshot before awaiting.
-    let op = match queue.pending.get(&op_id).cloned() {
-        Some(o) => o,
-        None => return,
     };
 
     match action {
@@ -1448,6 +1472,20 @@ async fn submit_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_que
     // — route it to the dedicated path instead of the generic mint/withdrawal one.
     if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
         submit_liquidation_swap(chain, op_id, op).await;
+        return;
+    }
+
+    if read_state(|s| {
+        s.multi_chain
+            .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+    }) {
+        log!(
+            INFO,
+            "[settlement chain={:?}] bad-debt circuit tripped; deferring submit of op {} {:?}",
+            chain,
+            op_id,
+            op.kind
+        );
         return;
     }
 
@@ -2898,6 +2936,7 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_qu
                     op_id,
                     realized_usdc,
                     settle_decimals,
+                    now,
                 )
             });
             match settled {
@@ -2925,6 +2964,29 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_qu
                         usdc_native: res.realized_usdc_native,
                         timestamp: now,
                     });
+                    if res.bad_debt_circuit_tripped {
+                        crate::storage::record_event(
+                            &crate::event::Event::ChainBadDebtCircuitTripped {
+                                chain_id: chain,
+                                bad_debt_e8s: res.bad_debt_added_e8s,
+                                total_bad_debt_e8s: read_state(|s| {
+                                    s.multi_chain
+                                        .chain_bad_debt_e8s
+                                        .get(&chain)
+                                        .copied()
+                                        .unwrap_or(0)
+                                }),
+                                threshold_e8s: read_state(|s| {
+                                    s.multi_chain
+                                        .chain_bad_debt_circuit_threshold_e8s
+                                        .get(&chain)
+                                        .copied()
+                                        .unwrap_or(0)
+                                }),
+                                timestamp: now,
+                            },
+                        );
+                    }
                     log!(INFO, "[settlement chain={:?}] liquidation swap confirmed: op={} vault={} cleared_e8s={} realized_usdc={} block={} tx={}", chain, op_id, vault_id, res.actual_cleared, realized_usdc, block_number, tx_hash);
                 }
                 Err(e) => {

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -34,6 +34,7 @@
 //! bump-gas/resubmit on the Confirm path. Both are marked with `TASK 11 SEAM:`
 //! comments. This task references no hardening symbol.
 
+use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
@@ -56,6 +57,171 @@ pub enum OpAction {
     Submit,
     /// An `Inflight` op: check its receipt and (on a confirmed mint) finalize.
     Confirm,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SpCfxClaimPayoutRecovery {
+    chain_sentinel: Principal,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    failed_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum SpStabilityPoolError {
+    InsufficientBalance {
+        token: Principal,
+        required: u64,
+        available: u64,
+    },
+    AmountTooLow {
+        minimum_e8s: u64,
+    },
+    NoPositionFound,
+    InsufficientPoolBalance,
+    Unauthorized,
+    TokenNotAccepted {
+        ledger: Principal,
+    },
+    TokenNotActive {
+        ledger: Principal,
+    },
+    CollateralNotFound {
+        ledger: Principal,
+    },
+    LedgerTransferFailed {
+        reason: String,
+    },
+    InterCanisterCallFailed {
+        target: String,
+        method: String,
+    },
+    LiquidationFailed {
+        vault_id: u64,
+        reason: String,
+    },
+    EmergencyPaused,
+    SystemBusy,
+    AlreadyOptedOut {
+        collateral: Principal,
+    },
+    AlreadyOptedIn {
+        collateral: Principal,
+    },
+    RefundClaimNotFound,
+}
+
+fn sp_chain_collateral_sentinel(chain: ChainId) -> Principal {
+    let mut bytes = [0u8; 29];
+    let prefix = b"rumi-chain-collateral";
+    bytes[..prefix.len()].copy_from_slice(prefix);
+    bytes[24..28].copy_from_slice(&chain.0.to_le_bytes());
+    bytes[28] = 0x7f;
+    Principal::from_slice(&bytes)
+}
+
+async fn notify_sp_failed_cfx_claim_payout(
+    chain: ChainId,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    failed_at_ns: u64,
+) -> Result<bool, String> {
+    let Some(sp_canister) = read_state(|s| s.stability_pool_canister) else {
+        return Err("no stability pool canister is configured for recredit".to_string());
+    };
+
+    let payload = SpCfxClaimPayoutRecovery {
+        chain_sentinel: sp_chain_collateral_sentinel(chain),
+        op_id,
+        claim_id,
+        claimant,
+        amount_wei,
+        reason,
+        failed_at_ns,
+    };
+    let result: Result<(Result<bool, SpStabilityPoolError>,), _> =
+        ic_cdk::call(sp_canister, "recredit_failed_cfx_claim_payout", (payload,)).await;
+
+    match result {
+        Ok((Ok(true),)) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {} recredited on stability pool",
+                chain,
+                op_id,
+            );
+            Ok(true)
+        }
+        Ok((Ok(false),)) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {} stability pool recredit already recorded",
+                chain,
+                op_id,
+            );
+            Ok(false)
+        }
+        Ok((Err(error),)) => Err(format!("stability pool recredit rejected: {error:?}")),
+        Err((code, msg)) => Err(format!(
+            "stability pool recredit call failed: {code:?} {msg}"
+        )),
+    }
+}
+
+async fn recredit_and_fail_chain_collateral_payout(
+    chain: ChainId,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    now_ns: u64,
+) -> bool {
+    if let Err(error) = notify_sp_failed_cfx_claim_payout(
+        chain,
+        op_id,
+        claim_id,
+        claimant,
+        amount_wei,
+        reason.clone(),
+        now_ns,
+    )
+    .await
+    {
+        log!(INFO, "[settlement chain={:?}] claim payout op {} cannot be failed yet because stability pool recredit failed: {}", chain, op_id, error);
+        return false;
+    }
+
+    match mutate_state(|s| {
+        fail_chain_collateral_payout_in_state(
+            &mut s.multi_chain,
+            chain,
+            op_id,
+            reason.clone(),
+            now_ns,
+        )
+    }) {
+        Ok(true) => {
+            crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+                chain_id: chain,
+                op_id,
+                reason,
+                timestamp: now_ns,
+            });
+            true
+        }
+        Ok(false) => true,
+        Err(error) => {
+            log!(INFO, "[settlement chain={:?}] claim payout op {} failed after stability pool recredit but backend release failed: {}; left for retry", chain, op_id, error);
+            false
+        }
+    }
 }
 
 /// Pick the next op to act on. Enforces one-in-flight-per-queue: if ANY op is
@@ -122,8 +288,13 @@ pub fn confirm_mint_in_state(
     // Step 2: supply delta. The post-mint total is the pre-mint total plus the
     // amount this mint adds to the foreign-chain debt pool.
     let post_mint_total = pre_mint_total_debt.saturating_add(observed_e8s);
-    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_mint_total)
-        .map_err(|e| format!("{e:?}"))?;
+    apply_supply_delta(
+        state,
+        chain,
+        SupplyDelta::Increase(observed_e8s),
+        post_mint_total,
+    )
+    .map_err(|e| format!("{e:?}"))?;
 
     // Step 3: only reached when the supply delta succeeded — move pending -> debt.
     let v = state
@@ -172,8 +343,13 @@ pub fn confirm_interest_mint_in_state(
     // amount, so the foreign-chain invariant stays exact. Rejects (no mutation)
     // on divergence/halt.
     let post_total = pre_total.saturating_add(observed_e8s);
-    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_total)
-        .map_err(|e| format!("{e:?}"))?;
+    apply_supply_delta(
+        state,
+        chain,
+        SupplyDelta::Increase(observed_e8s),
+        post_total,
+    )
+    .map_err(|e| format!("{e:?}"))?;
 
     // Step 3: only reached when the supply delta succeeded. Realize the interest
     // into debt and advance the accrual window to the harvest snapshot time (NOT
@@ -219,29 +395,40 @@ pub fn apply_liquidation_settlement_in_state(
             .chain_vaults
             .get(&vault_id)
             .ok_or_else(|| format!("apply_liquidation_settlement: unknown vault {vault_id}"))?;
-        let m = v
-            .pending_liquidation
-            .as_ref()
-            .ok_or_else(|| format!("apply_liquidation_settlement: vault {vault_id} has no liquidation marker"))?;
+        let m = v.pending_liquidation.as_ref().ok_or_else(|| {
+            format!("apply_liquidation_settlement: vault {vault_id} has no liquidation marker")
+        })?;
         if m.op_id != op_id {
             return Err(format!(
                 "apply_liquidation_settlement: marker op {} != confirming op {}",
                 m.op_id, op_id
             ));
         }
-        (m.debt_to_clear_e8s, m.collateral_reserved_native, v.debt_e8s, m.tier)
+        (
+            m.debt_to_clear_e8s,
+            m.collateral_reserved_native,
+            v.debt_e8s,
+            m.tier,
+        )
     };
 
     // Step 2: clamp — reserve_backing NEVER exceeds the realized USD value, nor the
     // live debt (a concurrent burn is already blocked by the marker, so live_debt
     // == debt_at_phase1; the min is belt-and-suspenders).
-    let realized_usd_e8 = crate::chains::liquidation::stable_native_to_e8s(realized_usdc_native, settle_decimals);
+    let realized_usd_e8 =
+        crate::chains::liquidation::stable_native_to_e8s(realized_usdc_native, settle_decimals);
     let actual_cleared = debt_to_clear.min(live_debt).min(realized_usd_e8);
 
     // Step 3: the single guarded invariant move (debt -> reserve; supply untouched).
     // apply_debt_to_reserve_shift re-validates the unified invariant + caps at debt.
-    crate::chains::supply::apply_debt_to_reserve_shift(state, chain, vault_id, actual_cleared, realized_usdc_native)
-        .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
+    crate::chains::supply::apply_debt_to_reserve_shift(
+        state,
+        chain,
+        vault_id,
+        actual_cleared,
+        realized_usdc_native,
+    )
+    .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
 
     // Step 4: record any shortfall as per-chain bad debt (never silent).
     if debt_to_clear > actual_cleared {
@@ -313,7 +500,10 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             .get(&vault_id)
             .ok_or_else(|| format!("sp_absorb: unknown vault {vault_id}"))?;
         if v.collateral_chain != chain {
-            return Err(format!("sp_absorb: vault chain {:?} != requested chain {:?}", v.collateral_chain, chain));
+            return Err(format!(
+                "sp_absorb: vault chain {:?} != requested chain {:?}",
+                v.collateral_chain, chain
+            ));
         }
         if v.status != ChainVaultStatus::Open {
             return Err(format!("sp_absorb: vault {vault_id} is not Open"));
@@ -322,18 +512,30 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             return Err(format!("sp_absorb: vault {vault_id} has pending mint"));
         }
         if v.pending_interest_mint_e8s != 0 {
-            return Err(format!("sp_absorb: vault {vault_id} has pending interest mint"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} has pending interest mint"
+            ));
         }
         if v.pending_liquidation.is_some() {
-            return Err(format!("sp_absorb: vault {vault_id} already has liquidation marker"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} already has liquidation marker"
+            ));
         }
         if !state.sp_attempted_chain_vaults.contains(&vault_id) {
-            return Err(format!("sp_absorb: vault {vault_id} missing sp_attempted escalation gate"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} missing sp_attempted escalation gate"
+            ));
         }
         if state.chain_liquidation_claims.contains_key(&vault_id) {
-            return Err(format!("sp_absorb: vault {vault_id} already has chain liquidation claim"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} already has chain liquidation claim"
+            ));
         }
-        (v.debt_e8s, v.collateral_amount_native, v.custody_address.clone())
+        (
+            v.debt_e8s,
+            v.collateral_amount_native,
+            v.custody_address.clone(),
+        )
     };
 
     if live_debt == 0 {
@@ -348,10 +550,13 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
     let actual_burned = icusd_burned_e8s;
 
     let bonus_e4 = liq::bonus_e4_from_penalty_bps(liquidation_penalty_bps);
-    let collateral_seized = liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)
-        .min(collateral_available);
+    let collateral_seized =
+        liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)
+            .min(collateral_available);
     if collateral_seized == 0 {
-        return Err(format!("sp_absorb: vault {vault_id} has no collateral to seize"));
+        return Err(format!(
+            "sp_absorb: vault {vault_id} has no collateral to seize"
+        ));
     }
 
     crate::chains::supply::apply_debt_to_pending_burn_shift(state, chain, vault_id, actual_burned)
@@ -373,6 +578,7 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             custody_address: custody_address.clone(),
             seized_native_total: collateral_seized,
             paid_native: 0,
+            pending_native: 0,
         },
     );
 
@@ -387,9 +593,10 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
 /// entitlement from its own depositor accounting, then asks the backend to pay
 /// that exact amount from the reserved chain-liquidity claim.
 ///
-/// Mutation order is important: enqueue first, then mark the claim as paid. A
-/// duplicate idempotency key therefore rejects without double-deducting the
-/// claim balance.
+/// Mutation order is important: enqueue first, then reserve the claim as
+/// pending. A duplicate idempotency key therefore rejects without
+/// double-reserving the claim balance. The amount only moves to `paid_native`
+/// after the outbound chain transaction is confirmed final.
 pub fn claim_chain_collateral_in_state(
     state: &mut MultiChainState,
     claim_id: u64,
@@ -412,7 +619,9 @@ pub fn claim_chain_collateral_in_state(
             .get(&claim_id)
             .ok_or_else(|| format!("chain collateral claim: unknown claim {claim_id}"))?;
         if !claim.paid_within_seized() {
-            return Err(format!("chain collateral claim: claim {claim_id} is overpaid"));
+            return Err(format!(
+                "chain collateral claim: claim {claim_id} is overpaid"
+            ));
         }
         (claim.chain, claim.remaining_native())
     };
@@ -439,7 +648,7 @@ pub fn claim_chain_collateral_in_state(
         ));
     }
 
-    let op = crate::chains::settlement_queue::SettlementOp::new(
+    let mut op = crate::chains::settlement_queue::SettlementOp::new(
         SettlementOpKind::ChainCollateralPayout {
             recipient: dest_evm,
             amount_e18: owed_wei,
@@ -449,6 +658,7 @@ pub fn claim_chain_collateral_in_state(
         idempotency_key,
         now_ns,
     );
+    op.chain_payout_uses_pending_reservation = Some(true);
     let op_id = state
         .settlement_queues
         .entry(chain)
@@ -464,8 +674,191 @@ pub fn claim_chain_collateral_in_state(
         .chain_liquidation_claims
         .get_mut(&claim_id)
         .expect("claim present: checked above");
-    claim.paid_native += owed_wei;
+    claim.pending_native = claim
+        .pending_native
+        .checked_add(owed_wei)
+        .ok_or_else(|| format!("chain collateral claim: pending overflow for claim {claim_id}"))?;
     Ok(op_id)
+}
+
+pub fn confirm_chain_collateral_payout_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    tx_hash: String,
+    now_ns: u64,
+) -> Result<bool, String> {
+    let (claim_id, amount, uses_pending_reservation) = {
+        let op = state
+            .settlement_queues
+            .get(&chain)
+            .and_then(|q| q.pending.get(&op_id))
+            .ok_or_else(|| format!("chain collateral payout confirm: unknown op {op_id}"))?;
+        match &op.status {
+            SettlementOpStatus::Succeeded { .. } => return Ok(false),
+            SettlementOpStatus::Failed { reason, .. } => {
+                return Err(format!(
+                    "chain collateral payout confirm: op {op_id} already failed: {reason}"
+                ));
+            }
+            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. } => {}
+        }
+        match &op.kind {
+            SettlementOpKind::ChainCollateralPayout {
+                vault_id,
+                amount_e18,
+                ..
+            } => (
+                *vault_id,
+                *amount_e18,
+                op.chain_payout_uses_pending_reservation.unwrap_or(false),
+            ),
+            other => {
+                return Err(format!(
+                    "chain collateral payout confirm: op {op_id} is not a claim payout: {other:?}"
+                ));
+            }
+        }
+    };
+
+    let claim = state
+        .chain_liquidation_claims
+        .get_mut(&claim_id)
+        .ok_or_else(|| format!("chain collateral payout confirm: unknown claim {claim_id}"))?;
+    if claim.chain != chain {
+        return Err(format!(
+            "chain collateral payout confirm: claim {claim_id} chain {:?} != op chain {:?}",
+            claim.chain, chain
+        ));
+    }
+    if uses_pending_reservation {
+        if claim.pending_native < amount {
+            return Err(format!(
+                "chain collateral payout confirm: claim {claim_id} pending {} is below payout {amount}",
+                claim.pending_native
+            ));
+        }
+        let paid = claim.paid_native.checked_add(amount).ok_or_else(|| {
+            format!("chain collateral payout confirm: paid overflow for claim {claim_id}")
+        })?;
+        if paid > claim.seized_native_total {
+            return Err(format!(
+                "chain collateral payout confirm: claim {claim_id} paid {paid} exceeds seized {}",
+                claim.seized_native_total
+            ));
+        }
+        claim.pending_native -= amount;
+        claim.paid_native = paid;
+    } else if claim.paid_native >= amount {
+        if claim.paid_native > claim.seized_native_total {
+            return Err(format!(
+                "chain collateral payout confirm: legacy claim {claim_id} paid {} exceeds seized {}",
+                claim.paid_native, claim.seized_native_total
+            ));
+        }
+        // Pre-Inc10 live payout ops had already reserved capacity in
+        // `paid_native`. Confirmation only makes that reservation final.
+    } else {
+        return Err(format!(
+            "chain collateral payout confirm: claim {claim_id} pending {} is below payout {amount}",
+            claim.pending_native
+        ));
+    }
+
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .expect("op present: checked above");
+    op.mark_succeeded(tx_hash, now_ns);
+    Ok(true)
+}
+
+pub fn fail_chain_collateral_payout_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    reason: String,
+    now_ns: u64,
+) -> Result<bool, String> {
+    let (claim_id, amount, idempotency_key, uses_pending_reservation) = {
+        let op = state
+            .settlement_queues
+            .get(&chain)
+            .and_then(|q| q.pending.get(&op_id))
+            .ok_or_else(|| format!("chain collateral payout fail: unknown op {op_id}"))?;
+        match &op.status {
+            SettlementOpStatus::Failed { .. } => return Ok(false),
+            SettlementOpStatus::Succeeded { .. } => {
+                return Err(format!(
+                    "chain collateral payout fail: op {op_id} already succeeded"
+                ));
+            }
+            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. } => {}
+        }
+        match &op.kind {
+            SettlementOpKind::ChainCollateralPayout {
+                vault_id,
+                amount_e18,
+                ..
+            } => (
+                *vault_id,
+                *amount_e18,
+                op.idempotency_key.clone(),
+                op.chain_payout_uses_pending_reservation.unwrap_or(false),
+            ),
+            other => {
+                return Err(format!(
+                    "chain collateral payout fail: op {op_id} is not a claim payout: {other:?}"
+                ));
+            }
+        }
+    };
+
+    let release_error = match state.chain_liquidation_claims.get_mut(&claim_id) {
+        Some(claim) if claim.chain == chain && uses_pending_reservation => {
+            if claim.pending_native >= amount {
+                claim.pending_native -= amount;
+                None
+            } else {
+                Some(format!(
+                    "claim {claim_id} pending {} is below payout {amount}",
+                    claim.pending_native
+                ))
+            }
+        }
+        Some(claim) if claim.chain == chain && claim.paid_native >= amount => {
+            // Pre-Inc10 live payout ops had already reserved capacity in
+            // `paid_native`. A reverted tx must release that legacy reservation.
+            claim.paid_native -= amount;
+            None
+        }
+        Some(claim) if claim.chain == chain => Some(format!(
+            "claim {claim_id} paid {} is below legacy payout {amount}",
+            claim.paid_native
+        )),
+        Some(claim) => Some(format!(
+            "claim {claim_id} chain {:?} != op chain {:?}",
+            claim.chain, chain
+        )),
+        None => Some(format!("unknown claim {claim_id}")),
+    };
+
+    let queue = state
+        .settlement_queues
+        .get_mut(&chain)
+        .expect("queue present: checked above");
+    let op = queue
+        .pending
+        .get_mut(&op_id)
+        .expect("op present: checked above");
+    let terminal_reason = match release_error {
+        Some(error) => format!("{reason}; backend reservation release skipped: {error}"),
+        None => reason,
+    };
+    op.mark_failed(terminal_reason, now_ns);
+    queue.seen_idempotency_keys.remove(&idempotency_key);
+    Ok(true)
 }
 
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
@@ -575,7 +968,11 @@ pub async fn run_settlement(chain: ChainId) {
     let should_skip = read_state(|s| {
         s.mode == Mode::ReadOnly
             || s.multi_chain.invariant_halted
-            || s.multi_chain.reorg_halted.get(&chain).copied().unwrap_or(false)
+            || s.multi_chain
+                .reorg_halted
+                .get(&chain)
+                .copied()
+                .unwrap_or(false)
     });
     if should_skip {
         return;
@@ -665,7 +1062,11 @@ fn build_tx_plan(
     withdrawal_value: Option<u128>,
 ) -> Result<TxPlan, String> {
     match kind {
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s,
+            vault_id,
+        } => {
             let contract = contract.ok_or_else(|| "icUSD contract not set".to_string())?;
             // Delegate the per-op-kind field shape to the single source of truth.
             // `op_id` is the on-chain per-op idempotency key (so a resubmit of THIS
@@ -691,7 +1092,11 @@ fn build_tx_plan(
                 kind: TxPlanKind::Mint,
             })
         }
-        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+        SettlementOpKind::NativeWithdrawal {
+            recipient,
+            amount_e18,
+            vault_id,
+        } => {
             // `value` is wei (1e18 scale) — it goes straight into the EIP-1559
             // `value` of a native transfer. The withdrawal is signed by the
             // vault's own custody address, so `withdrawal_value` is the
@@ -700,7 +1105,10 @@ fn build_tx_plan(
             let value = withdrawal_value.unwrap_or(*amount_e18);
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
+                tx::MonadTxKind::NativeWithdrawal {
+                    recipient,
+                    amount_wei: value,
+                },
                 nonce,
                 prio,
                 max_fee,
@@ -713,11 +1121,18 @@ fn build_tx_plan(
                 kind: TxPlanKind::NativeWithdrawal,
             })
         }
-        SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, .. } => {
-            let value = withdrawal_value.unwrap_or(*amount_e18);
+        SettlementOpKind::ChainCollateralPayout {
+            recipient,
+            amount_e18,
+            vault_id,
+            ..
+        } => {
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
+                tx::MonadTxKind::NativeWithdrawal {
+                    recipient,
+                    amount_wei: *amount_e18,
+                },
                 nonce,
                 prio,
                 max_fee,
@@ -726,11 +1141,17 @@ fn build_tx_plan(
                 fields,
                 vault_id: *vault_id,
                 recipient: recipient.clone(),
-                amount: value,
+                amount: *amount_e18,
                 kind: TxPlanKind::ChainCollateralPayout,
             })
         }
-        SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, recipient, .. } => {
+        SettlementOpKind::InterestMint {
+            vault_id,
+            mint_id,
+            amount_e8s,
+            recipient,
+            ..
+        } => {
             // Task 12: identical IcUSD.mint calldata to a normal Mint, but the
             // on-chain `vault_id` arg is the SYNTHETIC `mint_id` (the real vault
             // already minted once at open and IcUSD.mint reverts a repeat id),
@@ -830,16 +1251,33 @@ async fn resolve_op_signer(
 /// netted out — the withdrawer bears their own gas, as on any native chain, and
 /// a tiny dust (`max_fee - actual_fee`) is left behind. A partial withdrawal
 /// that leaves a buffer sends the full requested amount.
-pub(crate) fn fundable_withdrawal_value(amount_e18: u128, custody_balance: u128, max_fee: u128) -> u128 {
+pub(crate) fn fundable_withdrawal_value(
+    amount_e18: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> u128 {
     let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
     amount_e18.min(custody_balance.saturating_sub(gas_reserve))
+}
+
+pub(crate) fn exact_native_transfer_is_funded(
+    amount_e18: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> bool {
+    let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
+    custody_balance >= amount_e18.saturating_add(gas_reserve)
 }
 
 /// The native CFX to swap (carried as the EIP-1559 `value`), capped so the
 /// custody signer can ALSO pay the swap gas (spec §4.8). Mirrors
 /// `fundable_withdrawal_value` but reserves the larger swap gas budget. If this
 /// goes to 0 the caller must NOT submit (escalate).
-pub(crate) fn fundable_swap_value(collateral_in: u128, custody_balance: u128, max_fee: u128) -> u128 {
+pub(crate) fn fundable_swap_value(
+    collateral_in: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> u128 {
     let gas_reserve = (tx::LIQUIDATION_SWAP_GAS_LIMIT as u128).saturating_mul(max_fee);
     collateral_in.min(custody_balance.saturating_sub(gas_reserve))
 }
@@ -850,6 +1288,20 @@ pub(crate) enum ClaimLiquidationSwapSubmitError {
     WrongOpKind,
     NotQueued,
     MissingMarker,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ClaimChainPayoutSubmitError {
+    MissingOp,
+    WrongOpKind,
+    NotQueued,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RecordChainPayoutReplacementError {
+    MissingOp,
+    WrongOpKind,
+    NotInflight,
 }
 
 /// Atomically claim a queued liquidation swap immediately before broadcast.
@@ -869,8 +1321,7 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
         .get(&vault_id)
         .and_then(|v| v.pending_liquidation.as_ref())
         .map_or(false, |marker| {
-            marker.op_id == op_id
-                && marker.tier == crate::chains::vault::LiquidationTier::Bot
+            marker.op_id == op_id && marker.tier == crate::chains::vault::LiquidationTier::Bot
         });
     if !marker_owned {
         return Err(ClaimLiquidationSwapSubmitError::MissingMarker);
@@ -882,8 +1333,10 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
         .and_then(|q| q.pending.get_mut(&op_id))
         .ok_or(ClaimLiquidationSwapSubmitError::MissingOp)?;
     match &op.kind {
-        SettlementOpKind::LiquidationSwap { vault_id: live_vault_id, .. }
-            if *live_vault_id == vault_id => {}
+        SettlementOpKind::LiquidationSwap {
+            vault_id: live_vault_id,
+            ..
+        } if *live_vault_id == vault_id => {}
         _ => return Err(ClaimLiquidationSwapSubmitError::WrongOpKind),
     }
     if !matches!(op.status, SettlementOpStatus::Queued) {
@@ -891,8 +1344,71 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
     }
 
     op.mark_inflight(now_ns);
-    op.last_tx_hash = Some(tx_hash);
+    op.record_tx_hash_candidate(tx_hash);
     op.submit_nonce = Some(nonce);
+    Ok(())
+}
+
+/// Atomically claim a queued CFX payout op before calling `eth_sendRawTransaction`.
+///
+/// A native payout has no contract-level idempotency discriminator. If the RPC
+/// accepted the signed tx but returned an error/timeout, retrying from Queued
+/// with a fresh nonce can pay the same SP claim twice. Recording the locally
+/// computed tx hash and nonce before the ambiguous send boundary makes all later
+/// retries use the receipt/replace-by-fee path for the same nonce.
+pub(crate) fn claim_chain_collateral_payout_submit_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    now_ns: u64,
+    tx_hash: String,
+    nonce: u64,
+) -> Result<(), ClaimChainPayoutSubmitError> {
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .ok_or(ClaimChainPayoutSubmitError::MissingOp)?;
+    if !matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+        return Err(ClaimChainPayoutSubmitError::WrongOpKind);
+    }
+    if !matches!(op.status, SettlementOpStatus::Queued) {
+        return Err(ClaimChainPayoutSubmitError::NotQueued);
+    }
+
+    op.mark_inflight(now_ns);
+    op.record_tx_hash_candidate(tx_hash);
+    op.submit_nonce = Some(nonce);
+    Ok(())
+}
+
+/// Record the locally computed hash of a same-nonce replacement payout before
+/// rebroadcast. If the RPC accepts the replacement but returns an error, the
+/// confirm path must watch the replacement hash rather than the stale tx.
+pub(crate) fn record_chain_collateral_payout_replacement_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    now_ns: u64,
+    tx_hash: String,
+) -> Result<(), RecordChainPayoutReplacementError> {
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .ok_or(RecordChainPayoutReplacementError::MissingOp)?;
+    if !matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+        return Err(RecordChainPayoutReplacementError::WrongOpKind);
+    }
+    match &mut op.status {
+        SettlementOpStatus::Inflight {
+            last_attempt_ns, ..
+        } => {
+            *last_attempt_ns = now_ns;
+        }
+        _ => return Err(RecordChainPayoutReplacementError::NotInflight),
+    }
+    op.record_tx_hash_candidate(tx_hash);
     Ok(())
 }
 
@@ -905,11 +1421,7 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
 /// adapter), so it KNOWS the exact nonce used and can store it on the op. The
 /// stuck-tx resubmit (`confirm_op`) re-signs on this stored nonce, making a
 /// bumped-gas resubmit a true replace-by-fee rather than a second mint.
-async fn submit_op(
-    chain: ChainId,
-    op_id: u64,
-    op: crate::chains::settlement_queue::SettlementOp,
-) {
+async fn submit_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_queue::SettlementOp) {
     // A Burn op is never signable in Phase 1b — fail it up front (no RPC).
     if matches!(op.kind, SettlementOpKind::Burn { .. }) {
         let now = ic_cdk::api::time();
@@ -954,7 +1466,12 @@ async fn submit_op(
     if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
         let vid = *vault_id;
         let (cursor, vinfo) = read_state(|s| {
-            let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+            let cursor = s
+                .multi_chain
+                .last_observed_block
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
             let v = s
                 .multi_chain
                 .chain_vaults
@@ -965,7 +1482,13 @@ async fn submit_op(
         let (custody, declared) = match vinfo {
             Some(p) => p,
             None => {
-                log!(INFO, "[settlement chain={:?}] mint op {}: unknown vault {}; will retry", chain, op_id, vid);
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] mint op {}: unknown vault {}; will retry",
+                    chain,
+                    op_id,
+                    vid
+                );
                 return;
             }
         };
@@ -1000,7 +1523,10 @@ async fn submit_op(
     // Task 12: interest mints are ALSO paid by the settlement hot wallet, so they
     // are gated on its balance too (a vault open mint and an interest mint cost
     // the same gas).
-    if matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }) {
+    if matches!(
+        op.kind,
+        SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+    ) {
         let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
         if let Some(bal) = cached {
             if !hardening::hot_wallet_ok(bal) {
@@ -1023,7 +1549,13 @@ async fn submit_op(
     let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resolve_op_signer failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] resolve_op_signer failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1033,7 +1565,13 @@ async fn submit_op(
     let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
         Ok(n) => n,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1042,77 +1580,193 @@ async fn submit_op(
     let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] fetch_fees failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] fetch_fees failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
     let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
 
-    // 4. For a native withdrawal, cap the transfer value so the custody signer
-    //    can also pay gas (a full close requests the entire custody balance).
-    //    Read the custody balance ONCE here; the value is recomputed identically
-    //    on a stuck-tx resubmit. Mints don't carry a value, so skip the read.
-    let withdrawal_value = if matches!(
-        op.kind,
-        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
-    ) {
-        match evm_rpc::get_balance(chain, &signer_addr).await {
-            Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
-                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
-                    Some(fundable_withdrawal_value(*amount_e18, bal, max_fee))
-                } else {
-                    None
+    // 4. Native withdrawals may net gas from the transfer value; claim payouts
+    //    are exact entitlements and must have enough custody balance for both
+    //    the full amount and gas before submission.
+    let withdrawal_value = match &op.kind {
+        SettlementOpKind::NativeWithdrawal { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => Some(fundable_withdrawal_value(*amount_e18, bal, max_fee)),
+                Err(e) => {
+                    log!(
+                        INFO,
+                        "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry",
+                        chain,
+                        op_id,
+                        e
+                    );
+                    return;
                 }
             }
+        }
+        SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            amount_e18,
+            claimant,
+            ..
+        } => match evm_rpc::get_balance(chain, &signer_addr).await {
+            Ok(bal) => {
+                if !exact_native_transfer_is_funded(*amount_e18, bal, max_fee) {
+                    let now = ic_cdk::api::time();
+                    let reason = format!(
+                        "custody balance {bal} cannot fund exact payout {amount_e18} plus gas"
+                    );
+                    if recredit_and_fail_chain_collateral_payout(
+                        chain,
+                        op_id,
+                        *vault_id,
+                        *claimant,
+                        *amount_e18,
+                        reason,
+                        now,
+                    )
+                    .await
+                    {
+                        log!(INFO, "[settlement chain={:?}] claim payout op {} failed before submit because custody balance {} cannot fund exact amount {} plus gas", chain, op_id, bal, amount_e18);
+                    }
+                    return;
+                }
+                None
+            }
             Err(e) => {
-                log!(INFO, "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry", chain, op_id, e);
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
+                return;
+            }
+        },
+        _ => None,
+    };
+
+    // 5. Resolve the contract (mints only) and build the tx plan.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+    let plan = match build_tx_plan(
+        chain,
+        &op.kind,
+        op_id,
+        nonce,
+        prio,
+        max_fee,
+        contract.as_deref(),
+        withdrawal_value,
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
+    };
+    let TxPlan {
+        fields,
+        vault_id,
+        recipient,
+        amount,
+        kind,
+    } = plan;
+
+    // 6. Sign with the resolved signer (settlement for mints, custody for withdrawals).
+    let raw_hex = match tx::sign_eip1559(&fields, path, &signer_addr).await {
+        Ok(h) => h,
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
+    };
+    let chain_payout_local_tx_hash = if kind == TxPlanKind::ChainCollateralPayout {
+        match tx::raw_tx_hash(&raw_hex) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] signed tx hash failed for claim payout op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
                 return;
             }
         }
     } else {
         None
     };
-
-    // 5. Resolve the contract (mints only) and build the tx plan.
-    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, prio, max_fee, contract.as_deref(), withdrawal_value) {
-        Ok(p) => p,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry", chain, op_id, e);
+    if let Some(local_tx_hash) = &chain_payout_local_tx_hash {
+        let claim = mutate_state(|s| {
+            claim_chain_collateral_payout_submit_in_state(
+                &mut s.multi_chain,
+                chain,
+                op_id,
+                ic_cdk::api::time(),
+                local_tx_hash.clone(),
+                nonce,
+            )
+        });
+        if let Err(e) = claim {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {}: submit CAS aborted before broadcast ({:?})",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
-    };
-    let TxPlan { fields, vault_id, recipient, amount, kind } = plan;
+    }
 
-    // 6. Sign with the resolved signer (settlement for mints, custody for withdrawals).
-    let raw_hex = match tx::sign_eip1559(&fields, path, &signer_addr).await {
-        Ok(h) => h,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry", chain, op_id, e);
-            return;
-        }
-    };
-
-    // 7. Broadcast. A transient send error is logged and retried next tick — we
-    //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
+    // 7. Broadcast. A transient send error is logged and retried next tick. For
+    //    ChainCollateralPayout, the op is already Inflight with its local hash
+    //    and nonce recorded, so an ambiguous RPC error cannot lead to a fresh
+    //    nonce duplicate payout.
     //
     //    ON-CHAIN DOUBLE-MINT DEPENDENCY: if send_raw_transaction returns Err but
-    //    the tx actually landed (an RPC false negative), this op stays Queued
-    //    with no submit_nonce recorded, so the next tick re-reads "latest" and
-    //    signs a NEW tx at nonce+1 — a genuine second on-chain mint. The
-    //    canister's supply accounting stays correct (confirm requires
-    //    observed_e8s == pending_mint_e8s and credits exactly once), but on-chain
-    //    icUSD could be minted twice. Protection lives OUTSIDE this function:
-    //    (a) IcUSD.mint MUST guard per vault_id (Task 19: `mapping(uint64 => bool)
-    //    minted`, revert on repeat — asserted by a Task 20 test), and (b) once an
-    //    op IS Inflight, Task-11's stuck-tx path resubmits on the SAME stored
-    //    nonce (true replace-by-fee). The unguarded window is only the
-    //    transient-error-before-Inflight case.
+    //    a Mint actually landed (an RPC false negative), the mint op stays
+    //    Queued with no submit_nonce recorded, so the next tick can re-read
+    //    "latest" and sign a NEW tx at nonce+1. The canister's supply accounting
+    //    stays correct (confirm requires observed_e8s == pending_mint_e8s and
+    //    credits exactly once), but on-chain icUSD could be minted twice unless
+    //    IcUSD.mint guards per op/vault id. Plain CFX claim payouts cannot rely
+    //    on that contract guard, so they are claimed Inflight before broadcast.
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] send_raw_transaction failed for op {}: {}; will retry", chain, op_id, e);
+            if kind == TxPlanKind::ChainCollateralPayout {
+                log!(INFO, "[settlement chain={:?}] claim payout op {}: broadcast failed after submit claim ({}); receipt/replace-by-fee path will resolve", chain, op_id, e);
+            } else {
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] send_raw_transaction failed for op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
+            }
             return;
         }
     };
@@ -1120,15 +1774,25 @@ async fn submit_op(
     // 8. Mark Inflight + record the tx hash AND the submit nonce. Emit
     //    ChainMintSubmitted for mints.
     let now = ic_cdk::api::time();
-    mutate_state(|s| {
-        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-            if let Some(o) = q.pending.get_mut(&op_id) {
-                o.mark_inflight(now);
-                o.last_tx_hash = Some(tx_hash.clone());
-                o.submit_nonce = Some(nonce);
+    if kind == TxPlanKind::ChainCollateralPayout {
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.record_tx_hash_candidate(tx_hash.clone());
+                }
             }
-        }
-    });
+        });
+    } else {
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.mark_inflight(now);
+                    o.last_tx_hash = Some(tx_hash.clone());
+                    o.submit_nonce = Some(nonce);
+                }
+            }
+        });
+    }
 
     match kind {
         TxPlanKind::Mint => {
@@ -1141,7 +1805,15 @@ async fn submit_op(
                 tx_hash: tx_hash.clone(),
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}",
+                chain,
+                op_id,
+                vault_id,
+                amount,
+                tx_hash
+            );
         }
         TxPlanKind::NativeWithdrawal => {
             crate::storage::record_event(&crate::event::Event::WithdrawalSigned {
@@ -1153,7 +1825,15 @@ async fn submit_op(
                 tx_hash: tx_hash.clone(),
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}",
+                chain,
+                op_id,
+                vault_id,
+                amount,
+                tx_hash
+            );
         }
         TxPlanKind::ChainCollateralPayout => {
             log!(INFO, "[settlement chain={:?}] chain-collateral payout submitted: op={} vault={} amount_e18={} recipient={} tx={}", chain, op_id, vault_id, amount, recipient, tx_hash);
@@ -1185,9 +1865,16 @@ fn escalate_failed_swap(chain: ChainId, op_id: u64, vault_id: u64, reason: Strin
         // Restore reserved collateral + clear the marker ONLY if THIS op still owns
         // it (a concurrent confirm or a post-upgrade re-run cannot double-restore).
         if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vault_id) {
-            let owns = v.pending_liquidation.as_ref().map_or(false, |m| m.op_id == op_id);
+            let owns = v
+                .pending_liquidation
+                .as_ref()
+                .map_or(false, |m| m.op_id == op_id);
             if owns {
-                let reserved = v.pending_liquidation.as_ref().map(|m| m.collateral_reserved_native).unwrap_or(0);
+                let reserved = v
+                    .pending_liquidation
+                    .as_ref()
+                    .map(|m| m.collateral_reserved_native)
+                    .unwrap_or(0);
                 v.collateral_amount_native = v.collateral_amount_native.saturating_add(reserved);
                 v.pending_liquidation = None;
             }
@@ -1202,7 +1889,14 @@ fn escalate_failed_swap(chain: ChainId, op_id: u64, vault_id: u64, reason: Strin
         reason: reason.clone(),
         timestamp: now,
     });
-    log!(INFO, "[settlement chain={:?}] liquidation swap op {} vault {} FAILED -> escalated: {}", chain, op_id, vault_id, reason);
+    log!(
+        INFO,
+        "[settlement chain={:?}] liquidation swap op {} vault {} FAILED -> escalated: {}",
+        chain,
+        op_id,
+        vault_id,
+        reason
+    );
 }
 
 /// Dedicated submit path for a `LiquidationSwap` op (spec §4.8). Reads live DEX
@@ -1223,13 +1917,27 @@ async fn submit_liquidation_swap(
     // Op fields.
     let (vault_id, collateral_in, router, pair, path0, path1, deadline_secs) = match &op.kind {
         SettlementOpKind::LiquidationSwap {
-            vault_id, collateral_in_native, router, pair, path, deadline_secs, ..
+            vault_id,
+            collateral_in_native,
+            router,
+            pair,
+            path,
+            deadline_secs,
+            ..
         } => {
             if path.len() < 2 {
                 escalate_failed_swap(chain, op_id, *vault_id, "swap path malformed".into());
                 return;
             }
-            (*vault_id, *collateral_in_native, router.clone(), pair.clone(), path[0].clone(), path[1].clone(), *deadline_secs)
+            (
+                *vault_id,
+                *collateral_in_native,
+                router.clone(),
+                pair.clone(),
+                path[0].clone(),
+                path[1].clone(),
+                *deadline_secs,
+            )
         }
         _ => return, // unreachable: caller matched LiquidationSwap
     };
@@ -1240,19 +1948,38 @@ async fn submit_liquidation_swap(
     // enabled without them.
     let snap = read_state(|s| {
         let cfg = s.multi_chain.chain_liquidation_configs.get(&chain)?;
-        let native_decimals =
-            s.multi_chain.chain_configs.get(&chain).map(|c| c.chain_native_decimals).unwrap_or(18);
+        let native_decimals = s
+            .multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.chain_native_decimals)
+            .unwrap_or(18);
         let symbol = crate::chains::evm::evm_chain_config(chain).map(|c| c.native_symbol)?;
-        let price = liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, cfg.max_price_age_ns).ok()?;
-        Some((cfg.fee_bps, cfg.slippage_cap_bps, cfg.max_dex_oracle_divergence_bps, cfg.settle_stable_decimals, native_decimals, price))
+        let price =
+            liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, cfg.max_price_age_ns)
+                .ok()?;
+        Some((
+            cfg.fee_bps,
+            cfg.slippage_cap_bps,
+            cfg.max_dex_oracle_divergence_bps,
+            cfg.settle_stable_decimals,
+            native_decimals,
+            price,
+        ))
     });
-    let (fee_bps, slippage_bps, divergence_bps, settle_decimals, native_decimals, price_e8) = match snap {
-        Some(t) => t,
-        None => {
-            escalate_failed_swap(chain, op_id, vault_id, "swap config/price unavailable".into());
-            return;
-        }
-    };
+    let (fee_bps, slippage_bps, divergence_bps, settle_decimals, native_decimals, price_e8) =
+        match snap {
+            Some(t) => t,
+            None => {
+                escalate_failed_swap(
+                    chain,
+                    op_id,
+                    vault_id,
+                    "swap config/price unavailable".into(),
+                );
+                return;
+            }
+        };
 
     // Custody signer (holds the CFX) + the derived reserve `to`.
     let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
@@ -1265,7 +1992,12 @@ async fn submit_liquidation_swap(
     let reserve_to = match tecdsa::cached_reserve_address(chain).await {
         Ok((_p, a)) => a,
         Err(e) => {
-            escalate_failed_swap(chain, op_id, vault_id, format!("reserve address derive: {e}"));
+            escalate_failed_swap(
+                chain,
+                op_id,
+                vault_id,
+                format!("reserve address derive: {e}"),
+            );
             return;
         }
     };
@@ -1274,7 +2006,13 @@ async fn submit_liquidation_swap(
     let finalized = match evm_rpc::fetch_block_numbers(chain).await {
         Ok((_l, f)) => f,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] swap op {}: fetch_block_numbers failed ({}); will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: fetch_block_numbers failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1293,37 +2031,89 @@ async fn submit_liquidation_swap(
             return;
         }
     };
-    let (reserve_in, reserve_out) = if token0.eq_ignore_ascii_case(&path0) { (r0, r1) } else { (r1, r0) };
+    let (reserve_in, reserve_out) = if token0.eq_ignore_ascii_case(&path0) {
+        (r0, r1)
+    } else {
+        (r1, r0)
+    };
 
     // Infra reads (transient -> retry, do NOT escalate on a blip).
     let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
         Ok(n) => n,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: nonce read failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: nonce read failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
         Ok(p) => p,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: fetch_fees failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: fetch_fees failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
     let custody_balance = match evm_rpc::get_balance(chain, &signer_addr).await {
         Ok(b) => b,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: get_balance failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: get_balance failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
 
     // Gas net + JIT min-out + oracle cross-check — all fail-CLOSED (escalate).
     let fundable = fundable_swap_value(collateral_in, custody_balance, max_fee);
     if fundable == 0 {
-        escalate_failed_swap(chain, op_id, vault_id, "custody cannot cover swap gas".into());
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "custody cannot cover swap gas".into(),
+        );
         return;
     }
-    let (expected_out, min_out) = liq::compute_amount_out_min(fundable, reserve_in, reserve_out, fee_bps, slippage_bps);
+    let (expected_out, min_out) =
+        liq::compute_amount_out_min(fundable, reserve_in, reserve_out, fee_bps, slippage_bps);
     if min_out == 0 {
-        escalate_failed_swap(chain, op_id, vault_id, "min-out 0 (reserves zero/too thin)".into());
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "min-out 0 (reserves zero/too thin)".into(),
+        );
         return;
     }
     let oracle_value_e8 = liq::collateral_value_e8s(fundable, native_decimals, price_e8);
-    if !liq::oracle_corroborated(expected_out, settle_decimals, oracle_value_e8, divergence_bps) {
-        escalate_failed_swap(chain, op_id, vault_id, "pool price diverges from oracle (thin/manipulated)".into());
+    if !liq::oracle_corroborated(
+        expected_out,
+        settle_decimals,
+        oracle_value_e8,
+        divergence_bps,
+    ) {
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "pool price diverges from oracle (thin/manipulated)".into(),
+        );
         return;
     }
 
@@ -1352,11 +2142,29 @@ async fn submit_liquidation_swap(
     };
     let raw = match tx::sign_eip1559(&fields, path, &signer_addr).await {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: sign failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: sign failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let local_tx_hash = match tx::raw_tx_hash(&raw) {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: signed tx hash failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: signed tx hash failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let claim = mutate_state(|s| {
         claim_liquidation_swap_submit_in_state(
@@ -1370,13 +2178,22 @@ async fn submit_liquidation_swap(
         )
     });
     if let Err(e) = claim {
-        log!(INFO, "[settlement chain={:?}] swap op {}: submit CAS aborted before broadcast ({:?})", chain, op_id, e);
+        log!(
+            INFO,
+            "[settlement chain={:?}] swap op {}: submit CAS aborted before broadcast ({:?})",
+            chain,
+            op_id,
+            e
+        );
         return;
     }
 
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw).await {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed after submit claim ({}); receipt timeout path will resolve", chain, op_id, e); return; }
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed after submit claim ({}); receipt timeout path will resolve", chain, op_id, e);
+            return;
+        }
     };
 
     mutate_state(|s| {
@@ -1390,41 +2207,63 @@ async fn submit_liquidation_swap(
 }
 
 /// Confirm path: check an `Inflight` op's receipt and finalize on success.
-async fn confirm_op(
-    chain: ChainId,
-    op_id: u64,
-    op: crate::chains::settlement_queue::SettlementOp,
-) {
-    // The submit path always sets last_tx_hash before going Inflight; a None
-    // here is defensive (e.g. a manually-poked state) — log and bail.
-    let tx_hash = match &op.last_tx_hash {
+async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_queue::SettlementOp) {
+    // The submit path always records at least one hash before going Inflight.
+    // `tx_hash_candidates` can include older same-nonce hashes retained across
+    // payout RBF attempts; if any candidate landed, that receipt is canonical.
+    let tx_hashes = op.receipt_tx_hash_candidates();
+    let latest_tx_hash = match tx_hashes.first() {
         Some(h) => h.clone(),
         None => {
-            log!(INFO, "[settlement chain={:?}] inflight op {} has no last_tx_hash; skipping", chain, op_id);
+            log!(
+                INFO,
+                "[settlement chain={:?}] inflight op {} has no tx hash candidates; skipping",
+                chain,
+                op_id
+            );
             return;
         }
     };
 
     // 1. Fetch the receipt.
-    let receipt = match evm_rpc::get_transaction_receipt(chain, &tx_hash).await {
-        Ok(r) => r,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] get_transaction_receipt failed for op {} tx {}: {}; will retry", chain, op_id, tx_hash, e);
-            return;
+    let mut mined_receipt = None;
+    let mut receipt_errors = Vec::new();
+    for candidate in &tx_hashes {
+        match evm_rpc::get_transaction_receipt(chain, candidate).await {
+            Ok(Some(pair)) => {
+                mined_receipt = Some((candidate.clone(), pair));
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                receipt_errors.push((candidate.clone(), e));
+            }
         }
-    };
+    }
+    if mined_receipt.is_none() && !receipt_errors.is_empty() {
+        let (candidate, err) = &receipt_errors[0];
+        log!(INFO, "[settlement chain={:?}] get_transaction_receipt failed for op {} tx {}: {}; will retry", chain, op_id, candidate, err);
+        return;
+    }
 
-    let (status_ok, block_number) = match receipt {
-        Some(pair) => pair,
+    let (tx_hash, status_ok, block_number) = match mined_receipt {
+        Some((hash, pair)) => (hash, pair.0, pair.1),
         None => {
             // LiquidationSwap: NEVER replace-by-fee (spec §4.8). A never-mined swap
             // instead TIMES OUT -> Failed -> escalate (findings #12/#22), so it can
             // never wedge the vault marker + reserved collateral. The timeout
             // (deadline + finality margin) exceeds chain finality, so a
             // mined-then-reverted swap is caught by the revert branch first.
-            if let SettlementOpKind::LiquidationSwap { vault_id, deadline_secs, .. } = &op.kind {
+            if let SettlementOpKind::LiquidationSwap {
+                vault_id,
+                deadline_secs,
+                ..
+            } = &op.kind
+            {
                 let last_attempt = match &op.status {
-                    SettlementOpStatus::Inflight { last_attempt_ns, .. } => *last_attempt_ns,
+                    SettlementOpStatus::Inflight {
+                        last_attempt_ns, ..
+                    } => *last_attempt_ns,
                     _ => return,
                 };
                 let now = ic_cdk::api::time();
@@ -1434,7 +2273,12 @@ async fn confirm_op(
                     *deadline_secs,
                     hardening::SWAP_CONFIRM_FINALITY_MARGIN_SECS,
                 ) {
-                    escalate_failed_swap(chain, op_id, *vault_id, "swap confirm timeout (never mined)".into());
+                    escalate_failed_swap(
+                        chain,
+                        op_id,
+                        *vault_id,
+                        "swap confirm timeout (never mined)".into(),
+                    );
                     return;
                 }
                 // Not timed out yet: advance tries for visibility, never resubmit.
@@ -1465,7 +2309,10 @@ async fn confirm_op(
                 }
             };
             let finality_depth = read_state(|s| {
-                s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
+                s.multi_chain
+                    .chain_configs
+                    .get(&chain)
+                    .map(|c| c.finality_depth)
             })
             .unwrap_or(1);
             let has_nonce = op.submit_nonce.is_some();
@@ -1491,7 +2338,15 @@ async fn confirm_op(
             // re-sign + rebroadcast and does NOT advance tries again (confirm_op
             // owns the per-tick advance now), avoiding a double-advance.
             if do_resubmit {
-                resubmit_if_stuck(chain, op_id, &op, &tx_hash, new_tries, finality_depth).await;
+                resubmit_if_stuck(
+                    chain,
+                    op_id,
+                    &op,
+                    &latest_tx_hash,
+                    new_tries,
+                    finality_depth,
+                )
+                .await;
             }
             return;
         }
@@ -1536,6 +2391,25 @@ async fn confirm_op(
             return;
         }
         let reason = "tx reverted".to_string();
+        if let SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            amount_e18,
+            claimant,
+            ..
+        } = &op.kind
+        {
+            let claim_id = *vault_id;
+            let amount_wei = *amount_e18;
+            let claimant = *claimant;
+            if recredit_and_fail_chain_collateral_payout(
+                chain, op_id, claim_id, claimant, amount_wei, reason, now,
+            )
+            .await
+            {
+                log!(INFO, "[settlement chain={:?}] claim payout op {} tx {} reverted; marked Failed and released pending claim", chain, op_id, tx_hash);
+            }
+            return;
+        }
         let did_revert = mutate_state(|s| {
             // CAS: only the first tick to observe this op Inflight does the work.
             let still_inflight = s
@@ -1556,7 +2430,11 @@ async fn confirm_op(
                         v.pending_mint_e8s = 0;
                     }
                 }
-                SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                SettlementOpKind::NativeWithdrawal {
+                    vault_id,
+                    amount_e18,
+                    ..
+                } => {
                     if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
                         v.collateral_amount_native =
                             v.collateral_amount_native.saturating_add(*amount_e18);
@@ -1566,9 +2444,9 @@ async fn confirm_op(
                     }
                 }
                 SettlementOpKind::ChainCollateralPayout { .. } => {
-                    // Claim payout reversals are NOT vault collateral reversals.
-                    // The SP-side cfx_claims rollback lands with claim_cfx; for
-                    // now just mark the op failed without touching the vault.
+                    // Handled above through fail_chain_collateral_payout_in_state
+                    // so backend claim capacity is released atomically with the
+                    // terminal op transition.
                 }
                 SettlementOpKind::InterestMint { vault_id, .. } => {
                     // Task 12: no debt/supply was credited (the mint reverted), so
@@ -1607,7 +2485,13 @@ async fn confirm_op(
                 reason,
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] op {} tx {} reverted; marked Failed", chain, op_id, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] op {} tx {} reverted; marked Failed",
+                chain,
+                op_id,
+                tx_hash
+            );
         }
         return;
     }
@@ -1640,7 +2524,15 @@ async fn confirm_op(
                 }
             };
 
-            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &contract,
+                evm_rpc::MINT_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] get_logs(mint) failed confirming op {}: {}; will retry", chain, op_id, e);
@@ -1671,7 +2563,13 @@ async fn confirm_op(
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        log!(INFO, "[settlement chain={:?}] decode_mint_log failed confirming op {}: {}", chain, op_id, e);
+                        log!(
+                            INFO,
+                            "[settlement chain={:?}] decode_mint_log failed confirming op {}: {}",
+                            chain,
+                            op_id,
+                            e
+                        );
                     }
                 }
             }
@@ -1689,8 +2587,12 @@ async fn confirm_op(
             // recipient-agnostic, so without this check a mint to the WRONG
             // address would still balance and be marked Succeeded. A mismatch is a
             // real divergence: leave the op Inflight and do NOT credit.
-            let intended_recipient =
-                read_state(|s| s.multi_chain.chain_vaults.get(&vault_id).map(|v| v.mint_recipient.clone()));
+            let intended_recipient = read_state(|s| {
+                s.multi_chain
+                    .chain_vaults
+                    .get(&vault_id)
+                    .map(|v| v.mint_recipient.clone())
+            });
             match intended_recipient {
                 Some(intended) if intended.eq_ignore_ascii_case(&observed_recipient) => {}
                 Some(intended) => {
@@ -1709,7 +2611,14 @@ async fn confirm_op(
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
 
             let result = mutate_state(|s| {
-                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, observed_e8s, pre_total, now)
+                confirm_mint_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    observed_e8s,
+                    pre_total,
+                    now,
+                )
             });
 
             match result {
@@ -1745,7 +2654,13 @@ async fn confirm_op(
                 }
             }
         }
-        SettlementOpKind::InterestMint { vault_id, mint_id, accrual_through_ns, recipient, .. } => {
+        SettlementOpKind::InterestMint {
+            vault_id,
+            mint_id,
+            accrual_through_ns,
+            recipient,
+            ..
+        } => {
             // Task 12: same Mint-log read as a vault mint, but matched by the
             // SYNTHETIC `mint_id` and recipient-verified against the interest
             // treasury. On confirm, debt + supply grow together for the REAL vault.
@@ -1763,7 +2678,15 @@ async fn confirm_op(
                 }
             };
 
-            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &contract,
+                evm_rpc::MINT_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] get_logs(interest mint) failed confirming op {}: {}; will retry", chain, op_id, e);
@@ -1809,7 +2732,12 @@ async fn confirm_op(
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
             let result = mutate_state(|s| {
                 confirm_interest_mint_in_state(
-                    &mut s.multi_chain, chain, vault_id, observed_e8s, accrual_through_ns, pre_total,
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    observed_e8s,
+                    accrual_through_ns,
+                    pre_total,
                 )
             });
 
@@ -1861,30 +2789,49 @@ async fn confirm_op(
             });
             log!(INFO, "[settlement chain={:?}] withdrawal op {} vault {} confirmed tx={} (Closing->Closed if applicable)", chain, op_id, vid, tx_hash);
         }
-        SettlementOpKind::ChainCollateralPayout { vault_id, recipient, amount_e18, .. } => {
+        SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            recipient,
+            amount_e18,
+            ..
+        } => {
             let vid = *vault_id;
             let recipient = recipient.clone();
             let amount = *amount_e18;
-            mutate_state(|s| {
-                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-                    if let Some(o) = q.pending.get_mut(&op_id) {
-                        o.mark_succeeded(tx_hash.clone(), now);
-                    }
+            match mutate_state(|s| {
+                confirm_chain_collateral_payout_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    op_id,
+                    tx_hash.clone(),
+                    now,
+                )
+            }) {
+                Ok(true) => {
+                    crate::storage::record_event(&crate::event::Event::ChainCfxClaimSettled {
+                        chain_id: chain,
+                        claim_id: vid,
+                        recipient: recipient.clone(),
+                        amount_native: amount,
+                        timestamp: now,
+                    });
+                    log!(INFO, "[settlement chain={:?}] chain-collateral payout op {} vault/claim {} confirmed tx={} recipient={} amount={}", chain, op_id, vid, tx_hash, recipient, amount);
                 }
-            });
-            crate::storage::record_event(&crate::event::Event::ChainCfxClaimSettled {
-                chain_id: chain,
-                claim_id: vid,
-                recipient: recipient.clone(),
-                amount_native: amount,
-                timestamp: now,
-            });
-            log!(INFO, "[settlement chain={:?}] chain-collateral payout op {} vault/claim {} confirmed tx={} recipient={} amount={}", chain, op_id, vid, tx_hash, recipient, amount);
+                Ok(false) => {}
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] chain-collateral payout confirm FAILED for op {} claim {}: {}; left Inflight", chain, op_id, vid, e);
+                }
+            }
         }
         SettlementOpKind::Burn { .. } => {
             // Unreachable: a Burn op is marked Failed on the submit path and
             // never goes Inflight. Log defensively rather than panic.
-            log!(INFO, "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
+            log!(
+                INFO,
+                "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly",
+                chain,
+                op_id
+            );
         }
         SettlementOpKind::LiquidationSwap { vault_id, path, .. } => {
             // Mined + ok + final: read the REALIZED settle-stable output from the
@@ -1900,11 +2847,22 @@ async fn confirm_op(
                 }
             };
             let settle_decimals = read_state(|s| {
-                s.multi_chain.chain_liquidation_configs.get(&chain).map(|c| c.settle_stable_decimals)
+                s.multi_chain
+                    .chain_liquidation_configs
+                    .get(&chain)
+                    .map(|c| c.settle_stable_decimals)
             })
             .unwrap_or(18);
 
-            let logs = match evm_rpc::get_logs(chain, &settle_stable, evm_rpc::TRANSFER_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &settle_stable,
+                evm_rpc::TRANSFER_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] swap confirm op {}: get_logs(Transfer) failed ({}); will retry", chain, op_id, e);
@@ -1933,7 +2891,14 @@ async fn confirm_op(
 
             // Phase 2 (state-only): clamp + move debt -> reserve; events emitted here.
             let settled = mutate_state(|s| {
-                apply_liquidation_settlement_in_state(&mut s.multi_chain, chain, vault_id, op_id, realized_usdc, settle_decimals)
+                apply_liquidation_settlement_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    op_id,
+                    realized_usdc,
+                    settle_decimals,
+                )
             });
             match settled {
                 Ok(res) => {
@@ -2000,7 +2965,12 @@ async fn resubmit_if_stuck(
     // A stuck swap simply hits its on-chain deadline and reverts; Increment 3's
     // confirm-timeout marks it Failed -> escalate. (Inert in Increment 2.)
     if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
-        log!(INFO, "[settlement chain={:?}] op {} is a liquidation swap; never replace-by-fee (spec §4.8)", chain, op_id);
+        log!(
+            INFO,
+            "[settlement chain={:?}] op {} is a liquidation swap; never replace-by-fee (spec §4.8)",
+            chain,
+            op_id
+        );
         return;
     }
     // We can only replace-by-fee if we know the nonce the op was first submitted
@@ -2035,35 +3005,50 @@ async fn resubmit_if_stuck(
     let base_max_fee = base_fee.saturating_mul(2).saturating_add(prio);
     let (bumped_prio, bumped_max) = hardening::bump_gas(prio, base_max_fee);
 
-    // Re-net the withdrawal value at the BUMPED fee so the replacement still
-    // fits within the custody balance (a higher gas reserve sends marginally
-    // less collateral — fine for a replace-by-fee). Mints carry no value.
-    let withdrawal_value = if matches!(
-        op.kind,
-        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
-    ) {
-        match evm_rpc::get_balance(chain, &signer_addr).await {
-            Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
-                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
-                    Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max))
-                } else {
-                    None
+    // Re-net withdrawal value at the BUMPED fee. Claim payouts remain exact:
+    // if custody cannot fund amount + bumped gas, leave the original tx Inflight
+    // and retry receipt/replacement later.
+    let withdrawal_value = match &op.kind {
+        SettlementOpKind::NativeWithdrawal { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max)),
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
+                    return;
                 }
             }
-            Err(e) => {
-                log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
-                return;
+        }
+        SettlementOpKind::ChainCollateralPayout { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => {
+                    if !exact_native_transfer_is_funded(*amount_e18, bal, bumped_max) {
+                        log!(INFO, "[settlement chain={:?}] resubmit claim payout op {} custody balance {} cannot fund exact amount {} plus bumped gas; leaving Inflight", chain, op_id, bal, amount_e18);
+                        return;
+                    }
+                    None
+                }
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
+                    return;
+                }
             }
         }
-    } else {
-        None
+        _ => None,
     };
 
     // Resolve the contract (mints only) and rebuild the SAME tx at the stored
     // nonce with the bumped fees.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, bumped_prio, bumped_max, contract.as_deref(), withdrawal_value) {
+    let plan = match build_tx_plan(
+        chain,
+        &op.kind,
+        op_id,
+        nonce,
+        bumped_prio,
+        bumped_max,
+        contract.as_deref(),
+        withdrawal_value,
+    ) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] resubmit build_tx_plan failed for op {}: {}; leaving Inflight", chain, op_id, e);
@@ -2079,12 +3064,45 @@ async fn resubmit_if_stuck(
             return;
         }
     };
+    let chain_payout_replacement_hash = if matches!(
+        op.kind,
+        SettlementOpKind::ChainCollateralPayout { .. }
+    ) {
+        match tx::raw_tx_hash(&raw_hex) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                log!(INFO, "[settlement chain={:?}] resubmit signed tx hash failed for claim payout op {}: {}; leaving Inflight", chain, op_id, e);
+                return;
+            }
+        }
+    } else {
+        None
+    };
+    if let Some(local_tx_hash) = &chain_payout_replacement_hash {
+        let recorded = mutate_state(|s| {
+            record_chain_collateral_payout_replacement_in_state(
+                &mut s.multi_chain,
+                chain,
+                op_id,
+                ic_cdk::api::time(),
+                local_tx_hash.clone(),
+            )
+        });
+        if let Err(e) = recorded {
+            log!(INFO, "[settlement chain={:?}] resubmit claim payout op {}: replacement record aborted before broadcast ({:?})", chain, op_id, e);
+            return;
+        }
+    }
 
     // Rebroadcast.
     let new_tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resubmit send_raw_transaction failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            if matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+                log!(INFO, "[settlement chain={:?}] resubmit claim payout op {}: broadcast failed after replacement record ({}); receipt path will watch replacement hash", chain, op_id, e);
+            } else {
+                log!(INFO, "[settlement chain={:?}] resubmit send_raw_transaction failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            }
             return;
         }
     };
@@ -2098,8 +3116,15 @@ async fn resubmit_if_stuck(
     mutate_state(|s| {
         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
             if let Some(o) = q.pending.get_mut(&op_id) {
-                o.last_tx_hash = Some(new_tx_hash.clone());
-                if let SettlementOpStatus::Inflight { last_attempt_ns, .. } = &mut o.status {
+                if matches!(o.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+                    o.record_tx_hash_candidate(new_tx_hash.clone());
+                } else {
+                    o.last_tx_hash = Some(new_tx_hash.clone());
+                }
+                if let SettlementOpStatus::Inflight {
+                    last_attempt_ns, ..
+                } = &mut o.status
+                {
                     *last_attempt_ns = now;
                 }
             }

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -336,10 +336,16 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
         (v.debt_e8s, v.collateral_amount_native, v.custody_address.clone())
     };
 
-    let actual_burned = icusd_burned_e8s.min(live_debt);
-    if actual_burned == 0 {
+    if live_debt == 0 {
         return Err(format!("sp_absorb: vault {vault_id} has nothing to absorb"));
     }
+    if icusd_burned_e8s != live_debt {
+        return Err(format!(
+            "sp_absorb: burned amount {} does not match live debt {} for vault {}",
+            icusd_burned_e8s, live_debt, vault_id
+        ));
+    }
+    let actual_burned = icusd_burned_e8s;
 
     let bonus_e4 = liq::bonus_e4_from_penalty_bps(liquidation_penalty_bps);
     let collateral_seized = liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)

--- a/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
@@ -376,6 +376,45 @@ fn parse_eth_call_u128_decodes_padded_word() {
     assert!(parse_eth_call_u128(&too_big).is_err());
 }
 
+#[test]
+fn parse_eth_call_address_decodes_padded_word() {
+    use crate::chains::monad::evm_rpc::parse_eth_call_address;
+
+    let word = "0x000000000000000000000000ABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD";
+    assert_eq!(
+        parse_eth_call_address(word).unwrap(),
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    );
+    assert!(parse_eth_call_address("0x1234").is_err());
+    assert!(parse_eth_call_address(
+        "0x00000000000000000000000000000000000000000000000000000000000000001234"
+    )
+    .is_err());
+    assert!(parse_eth_call_address(
+        "0x100000000000000000000000ABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+    )
+    .is_err());
+    assert!(parse_eth_call_address(
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    .is_err());
+    assert!(parse_eth_call_address("0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").is_err());
+}
+
+#[test]
+fn encode_get_pair_calldata_matches_uniswap_v2_factory_shape() {
+    use crate::chains::monad::evm_rpc::{encode_get_pair_calldata, GET_PAIR_SELECTOR};
+
+    let a = "0x1111111111111111111111111111111111111111";
+    let b = "0x2222222222222222222222222222222222222222";
+    let calldata = encode_get_pair_calldata(a, b).unwrap();
+    assert!(calldata.starts_with(GET_PAIR_SELECTOR));
+    assert_eq!(calldata.len(), 2 + 8 + 64 + 64);
+    assert_eq!(&calldata[10..74], &format!("{:0>64}", a.trim_start_matches("0x")));
+    assert_eq!(&calldata[74..138], &format!("{:0>64}", b.trim_start_matches("0x")));
+    assert!(encode_get_pair_calldata("0x1234", b).is_err());
+}
+
 // ─── Increment 3 / Task 4: DEX getReserves parse + Transfer-log decode ───
 #[test]
 fn parse_two_uint112_splits_getreserves() {

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,7 +1,7 @@
 use super::settlement::{
     claim_liquidation_swap_submit_in_state, confirm_interest_mint_in_state, confirm_mint_in_state,
     exact_native_transfer_is_funded, fundable_withdrawal_value, select_next_op,
-    ClaimLiquidationSwapSubmitError, OpAction,
+    select_next_op_with_submit_filter, ClaimLiquidationSwapSubmitError, OpAction,
 };
 use crate::chains::config::ChainId;
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
@@ -82,6 +82,42 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
     match select_next_op(&q) {
         Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
         other => panic!("expected Confirm of inflight op, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_next_op_filter_skips_blocked_queued_without_starving_later_allowed_ops() {
+    let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
+    let blocked_id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint {
+                recipient: "0xr".into(),
+                amount_e8s: 10,
+                vault_id: 1,
+            },
+            "blocked-mint".into(),
+            0,
+        ))
+        .unwrap();
+    let allowed_id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::ChainCollateralPayout {
+                recipient: "0x0000000000000000000000000000000000000abc".into(),
+                amount_e18: 1,
+                vault_id: 2,
+                claimant: Principal::anonymous(),
+            },
+            "allowed-payout".into(),
+            0,
+        ))
+        .unwrap();
+
+    assert_eq!(blocked_id, 0);
+    match select_next_op_with_submit_filter(&q, |_, op| {
+        matches!(op.kind, SettlementOpKind::Mint { .. })
+    }) {
+        Some((oid, OpAction::Submit)) => assert_eq!(oid, allowed_id),
+        other => panic!("expected later allowed op to submit, got {other:?}"),
     }
 }
 
@@ -440,6 +476,7 @@ mod phase2_tests {
     fn marked(
         s: &mut MultiChainState,
         vault_id: u64,
+        op_id: u64,
         debt_e8s: u128,
         collateral_remaining: u128,
         debt_to_clear: u128,
@@ -462,7 +499,7 @@ mod phase2_tests {
                 last_interest_accrual_ns: 0,
                 pending_interest_mint_e8s: 0,
                 pending_liquidation: Some(PendingLiquidationV1 {
-                    op_id: 9,
+                    op_id,
                     debt_to_clear_e8s: debt_to_clear,
                     collateral_reserved_native: collateral_reserved,
                     tier: LiquidationTier::Bot,
@@ -477,9 +514,10 @@ mod phase2_tests {
     #[test]
     fn shifts_debt_to_reserve_supply_unchanged() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // realized 75 USDC (18-dec) -> 75e8 >= debt_to_clear 67e8.
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18).expect("phase2 ok");
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18, 1)
+            .expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 33 * E8, "debt -= actual_cleared");
         assert_eq!(
@@ -511,9 +549,10 @@ mod phase2_tests {
     #[test]
     fn shortfall_clamps_and_records_bad_debt() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // realized only 60 USDC -> 60e8 < debt_to_clear 67e8.
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18).expect("phase2 ok");
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 1)
+            .expect("phase2 ok");
         assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 40 * E8);
         assert_eq!(
             *s.reserve_backing_e8s.get(&CFX).unwrap(),
@@ -525,6 +564,10 @@ mod phase2_tests {
             7 * E8,
             "shortfall recorded"
         );
+        assert!(
+            !s.chain_bad_debt_circuit_tripped(CFX),
+            "no threshold means accounting-only bad debt does not halt the chain"
+        );
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
             100 * E8,
@@ -533,11 +576,59 @@ mod phase2_tests {
     }
 
     #[test]
+    fn shortfall_below_threshold_records_bad_debt_without_tripping_circuit() {
+        let mut s = MultiChainState::default();
+        s.set_chain_bad_debt_circuit_threshold(CFX, Some(10 * E8), 10)
+            .expect("set threshold");
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+
+        let settled = apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 20)
+            .expect("phase2 ok");
+
+        assert_eq!(settled.bad_debt_added_e8s, 7 * E8);
+        assert!(!settled.bad_debt_circuit_tripped);
+        assert_eq!(s.chain_bad_debt_e8s.get(&CFX), Some(&(7 * E8)));
+        assert!(!s.chain_bad_debt_circuit_tripped(CFX));
+        assert_eq!(s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX), None);
+    }
+
+    #[test]
+    fn shortfall_at_threshold_trips_bad_debt_circuit_once() {
+        let mut s = MultiChainState::default();
+        s.set_chain_bad_debt_circuit_threshold(CFX, Some(7 * E8), 10)
+            .expect("set threshold");
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+
+        let first = apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 20)
+            .expect("phase2 ok");
+
+        assert_eq!(first.bad_debt_added_e8s, 7 * E8);
+        assert!(first.bad_debt_circuit_tripped);
+        assert_eq!(s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX), Some(&20));
+
+        marked(&mut s, 8, 10, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        let second = apply_liquidation_settlement_in_state(&mut s, CFX, 8, 10, 60 * E18, 18, 30)
+            .expect("second phase2 ok");
+
+        assert_eq!(second.bad_debt_added_e8s, 7 * E8);
+        assert!(
+            !second.bad_debt_circuit_tripped,
+            "already-tripped circuit must not emit duplicate trip decisions"
+        );
+        assert_eq!(
+            s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX),
+            Some(&20),
+            "original trip timestamp is preserved"
+        );
+    }
+
+    #[test]
     fn closes_vault_when_drained() {
         let mut s = MultiChainState::default();
         // collateral fully reserved in Phase 1 (remaining 0); clearing all debt drains it.
-        marked(&mut s, 7, 100 * E8, 0, 100 * E8, 1_400 * E18);
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 112 * E18, 18).expect("phase2 ok");
+        marked(&mut s, 7, 9, 100 * E8, 0, 100 * E8, 1_400 * E18);
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 112 * E18, 18, 1)
+            .expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 0);
         assert_eq!(v.status, ChainVaultStatus::Closed, "drained vault closes");
@@ -546,9 +637,11 @@ mod phase2_tests {
     #[test]
     fn rejects_op_mismatch_no_mutation() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // confirming op 99 != marker op 9.
-        assert!(apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18).is_err());
+        assert!(
+            apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18, 1).is_err()
+        );
         assert_eq!(
             s.chain_vaults.get(&7).unwrap().debt_e8s,
             100 * E8,

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -505,11 +505,12 @@ mod sp_absorb_tests {
     }
 
     #[test]
-    fn sp_absorb_caps_overburn_to_live_debt() {
+    fn sp_absorb_rejects_stale_overburn_without_mutation() {
         let mut s = MultiChainState::default();
         open_sp_attempted_vault(&mut s, 8, 80 * E8, 200 * E18);
 
-        let result = apply_sp_chain_liquidation_absorb_in_state(
+        let before = s.clone();
+        let err = apply_sp_chain_liquidation_absorb_in_state(
             &mut s,
             CFX,
             8,
@@ -518,13 +519,14 @@ mod sp_absorb_tests {
             18,
             1_200,
         )
-        .expect("sp absorb ok");
+        .unwrap_err();
 
-        assert_eq!(result.actual_burned_e8s, 80 * E8, "backend never clears more than live debt");
-        assert_eq!(result.collateral_seized_native, 89_600_000_000_000_000_000);
-        assert_eq!(s.chain_vaults.get(&8).unwrap().debt_e8s, 0);
-        assert_eq!(*s.pending_chain_burn_e8s.get(&CFX).unwrap(), 80 * E8);
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 80 * E8);
+        assert!(err.contains("does not match live debt"), "error should reject stale SP burn amount: {err}");
+        assert_eq!(s.chain_vaults.get(&8).unwrap().debt_e8s, 80 * E8);
+        assert_eq!(s.chain_vaults.get(&8).unwrap().collateral_amount_native, 200 * E18);
+        assert_eq!(s.pending_chain_burn_e8s.get(&CFX), before.pending_chain_burn_e8s.get(&CFX));
+        assert_eq!(s.chain_liquidation_claims.get(&8), before.chain_liquidation_claims.get(&8));
+        assert_eq!(s.chain_supplies.get(&CFX), before.chain_supplies.get(&CFX));
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,4 +1,5 @@
 use super::settlement::{
+    claim_liquidation_swap_submit_in_state, ClaimLiquidationSwapSubmitError,
     confirm_interest_mint_in_state, confirm_mint_in_state, fundable_withdrawal_value,
     select_next_op, OpAction,
 };
@@ -49,6 +50,138 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
         Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
         other => panic!("expected Confirm of inflight op, got {other:?}"),
     }
+}
+
+fn queued_liquidation_swap(s: &mut MultiChainState, vault_id: u64) -> u64 {
+    s.settlement_queues
+        .entry(ChainId(71))
+        .or_default()
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::LiquidationSwap {
+                vault_id,
+                collateral_in_native: 100,
+                min_usdc_out_native: 0,
+                debt_to_clear_e8s: 50,
+                router: "0x1111111111111111111111111111111111111111".into(),
+                pair: "0x3333333333333333333333333333333333333333".into(),
+                path: vec![
+                    "0x4444444444444444444444444444444444444444".into(),
+                    "0x5555555555555555555555555555555555555555".into(),
+                ],
+                reserve_recipient: "0x5555555555555555555555555555555555555555".into(),
+                deadline_secs: 180,
+            },
+            format!("liq-{vault_id}"),
+            0,
+        ))
+        .expect("enqueue swap")
+}
+
+fn marked_bot_liquidation(s: &mut MultiChainState, vault_id: u64, op_id: u64) {
+    use crate::chains::vault::{LiquidationTier, PendingLiquidationV1};
+
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(71),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 100,
+            debt_e8s: 50,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: Some(PendingLiquidationV1 {
+                op_id,
+                debt_to_clear_e8s: 50,
+                collateral_reserved_native: 100,
+                tier: LiquidationTier::Bot,
+                started_at_ns: 0,
+            }),
+        },
+    );
+    s.bot_pending_chain_vaults.insert(vault_id, 0);
+}
+
+#[test]
+fn claim_liquidation_swap_submit_marks_queued_op_inflight_before_broadcast() {
+    let mut s = MultiChainState::default();
+    let op_id = queued_liquidation_swap(&mut s, 7);
+    marked_bot_liquidation(&mut s, 7, op_id);
+
+    claim_liquidation_swap_submit_in_state(
+        &mut s,
+        ChainId(71),
+        op_id,
+        7,
+        42,
+        "0xabc".into(),
+        9,
+    )
+    .expect("claim submit");
+
+    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    assert_eq!(op.last_tx_hash.as_deref(), Some("0xabc"));
+    assert_eq!(op.submit_nonce, Some(9));
+    assert!(matches!(
+        op.status,
+        SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 42 }
+    ));
+}
+
+#[test]
+fn claim_liquidation_swap_submit_rejects_if_observer_already_cleared_marker() {
+    let mut s = MultiChainState::default();
+    let op_id = queued_liquidation_swap(&mut s, 7);
+
+    let err = claim_liquidation_swap_submit_in_state(
+        &mut s,
+        ChainId(71),
+        op_id,
+        7,
+        42,
+        "0xabc".into(),
+        9,
+    )
+    .unwrap_err();
+
+    assert_eq!(err, ClaimLiquidationSwapSubmitError::MissingMarker);
+    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    assert!(matches!(op.status, SettlementOpStatus::Queued));
+    assert!(op.last_tx_hash.is_none());
+    assert!(op.submit_nonce.is_none());
+}
+
+#[test]
+fn claim_liquidation_swap_submit_rejects_live_inflight_op() {
+    let mut s = MultiChainState::default();
+    let op_id = queued_liquidation_swap(&mut s, 7);
+    marked_bot_liquidation(&mut s, 7, op_id);
+    s.settlement_queues
+        .get_mut(&ChainId(71))
+        .unwrap()
+        .pending
+        .get_mut(&op_id)
+        .unwrap()
+        .mark_inflight(41);
+
+    let err = claim_liquidation_swap_submit_in_state(
+        &mut s,
+        ChainId(71),
+        op_id,
+        7,
+        42,
+        "0xabc".into(),
+        9,
+    )
+    .unwrap_err();
+
+    assert_eq!(err, ClaimLiquidationSwapSubmitError::NotQueued);
 }
 
 #[test]

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,32 +1,48 @@
 use super::settlement::{
-    claim_liquidation_swap_submit_in_state, ClaimLiquidationSwapSubmitError,
-    confirm_interest_mint_in_state, confirm_mint_in_state, fundable_withdrawal_value,
-    select_next_op, OpAction,
+    claim_liquidation_swap_submit_in_state, confirm_interest_mint_in_state, confirm_mint_in_state,
+    exact_native_transfer_is_funded, fundable_withdrawal_value, select_next_op,
+    ClaimLiquidationSwapSubmitError, OpAction,
 };
-use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
+use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
 
 fn vault_pending(s: &mut MultiChainState, vault_id: u64, pending: u128) {
-    s.chain_vaults.insert(vault_id, ChainVaultV1 {
-        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
-        custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
-        mint_recipient: "0xr".into(), pending_mint_e8s: pending,
-        status: ChainVaultStatus::MintPending, opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 0,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: pending,
+            status: ChainVaultStatus::MintPending,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
 }
 
 #[test]
 fn select_next_op_prefers_queued_then_inflight() {
     let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
     let op = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 },
-        "k0".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            vault_id: 1,
+        },
+        "k0".into(),
+        0,
+    );
     let id = q.enqueue(op).unwrap();
     // Queued -> action Submit.
     match select_next_op(&q) {
@@ -39,13 +55,30 @@ fn select_next_op_prefers_queued_then_inflight() {
 fn select_next_op_confirms_inflight_before_submitting_new() {
     let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
     let op0 = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 }, "k0".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            vault_id: 1,
+        },
+        "k0".into(),
+        0,
+    );
     let id0 = q.enqueue(op0).unwrap();
     let op1 = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 20, vault_id: 2 }, "k1".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 20,
+            vault_id: 2,
+        },
+        "k1".into(),
+        0,
+    );
     let _id1 = q.enqueue(op1).unwrap();
     // Put op0 inflight; with something inflight, only Confirm of op0 is actionable.
-    q.pending.get_mut(&id0).unwrap().status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    q.pending.get_mut(&id0).unwrap().status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 0,
+    };
     match select_next_op(&q) {
         Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
         other => panic!("expected Confirm of inflight op, got {other:?}"),
@@ -114,23 +147,24 @@ fn claim_liquidation_swap_submit_marks_queued_op_inflight_before_broadcast() {
     let op_id = queued_liquidation_swap(&mut s, 7);
     marked_bot_liquidation(&mut s, 7, op_id);
 
-    claim_liquidation_swap_submit_in_state(
-        &mut s,
-        ChainId(71),
-        op_id,
-        7,
-        42,
-        "0xabc".into(),
-        9,
-    )
-    .expect("claim submit");
+    claim_liquidation_swap_submit_in_state(&mut s, ChainId(71), op_id, 7, 42, "0xabc".into(), 9)
+        .expect("claim submit");
 
-    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    let op = s
+        .settlement_queues
+        .get(&ChainId(71))
+        .unwrap()
+        .pending
+        .get(&op_id)
+        .unwrap();
     assert_eq!(op.last_tx_hash.as_deref(), Some("0xabc"));
     assert_eq!(op.submit_nonce, Some(9));
     assert!(matches!(
         op.status,
-        SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 42 }
+        SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 42
+        }
     ));
 }
 
@@ -151,7 +185,13 @@ fn claim_liquidation_swap_submit_rejects_if_observer_already_cleared_marker() {
     .unwrap_err();
 
     assert_eq!(err, ClaimLiquidationSwapSubmitError::MissingMarker);
-    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    let op = s
+        .settlement_queues
+        .get(&ChainId(71))
+        .unwrap()
+        .pending
+        .get(&op_id)
+        .unwrap();
     assert!(matches!(op.status, SettlementOpStatus::Queued));
     assert!(op.last_tx_hash.is_none());
     assert!(op.submit_nonce.is_none());
@@ -189,8 +229,8 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
     let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
-    // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
-    // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
+                                              // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
+                                              // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
     confirm_mint_in_state(&mut s, ChainId(10143), 1, 10_000_000_000, 0, 7_777).expect("confirm");
     assert_eq!(s.chain_vaults[&1].debt_e8s, 10_000_000_000);
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
@@ -205,15 +245,25 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
 /// An Open vault with confirmed `debt` and an interest mint of `pending` in
 /// flight (`last_interest_accrual_ns = 1_000`).
 fn vault_interest_pending(s: &mut MultiChainState, vault_id: u64, debt: u128, pending: u128) {
-    s.chain_vaults.insert(vault_id, ChainVaultV1 {
-        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(71),
-        custody_address: "0xc".into(), collateral_amount_native: 1_400_000_000_000_000_000_000,
-        debt_e8s: debt, mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
-    owner_evm: None,
-        last_interest_accrual_ns: 1_000,
-        pending_interest_mint_e8s: pending,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(71),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 1_400_000_000_000_000_000_000,
+            debt_e8s: debt,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 1_000,
+            pending_interest_mint_e8s: pending,
+            pending_liquidation: None,
+        },
+    );
 }
 
 #[test]
@@ -224,8 +274,15 @@ fn confirm_interest_mint_grows_debt_and_supply_equally() {
     let pre = s.total_chain_vault_debt_e8s(); // 100e8
     confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 2 * 100_000_000, 5_000, pre)
         .expect("confirm");
-    assert_eq!(s.chain_vaults[&1].debt_e8s, 102 * 100_000_000, "debt += interest");
-    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0, "pending cleared");
+    assert_eq!(
+        s.chain_vaults[&1].debt_e8s,
+        102 * 100_000_000,
+        "debt += interest"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].pending_interest_mint_e8s, 0,
+        "pending cleared"
+    );
     assert_eq!(
         s.chain_vaults[&1].last_interest_accrual_ns, 5_000,
         "accrual window advanced to the harvest snapshot time"
@@ -245,10 +302,25 @@ fn confirm_interest_mint_rejects_amount_mismatch_no_mutation() {
     let pre = s.total_chain_vault_debt_e8s();
     let err = confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 3 * 100_000_000, 5_000, pre)
         .unwrap_err();
-    assert!(err.contains("observed"), "mismatch error mentions observed/pending: {err}");
-    assert_eq!(s.chain_vaults[&1].debt_e8s, 100 * 100_000_000, "debt untouched on reject");
-    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 2 * 100_000_000, "pending untouched");
-    assert_eq!(s.chain_supplies[&ChainId(71)], 100 * 100_000_000, "supply untouched");
+    assert!(
+        err.contains("observed"),
+        "mismatch error mentions observed/pending: {err}"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].debt_e8s,
+        100 * 100_000_000,
+        "debt untouched on reject"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].pending_interest_mint_e8s,
+        2 * 100_000_000,
+        "pending untouched"
+    );
+    assert_eq!(
+        s.chain_supplies[&ChainId(71)],
+        100 * 100_000_000,
+        "supply untouched"
+    );
 }
 
 #[test]
@@ -276,18 +348,29 @@ fn confirm_mint_second_vault_uses_running_total() {
     // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
     let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
-    s.chain_vaults.insert(1, ChainVaultV1 {
-        vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
-        custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 10_000_000_000,
-        mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 10_000_000_000,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
-    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0).expect("confirm 2nd");
+    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0)
+        .expect("confirm 2nd");
     assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
     assert_eq!(s.chain_supplies[&ChainId(10143)], 15_000_000_000);
 }
@@ -315,7 +398,28 @@ fn fundable_withdrawal_value_nets_gas_only_when_balance_is_tight() {
 
     // Degenerate: balance below the gas reserve -> saturates to 0 (never panics
     // / underflows), so the worker sends a 0-value tx rather than trapping.
-    assert_eq!(fundable_withdrawal_value(amount, gas_reserve / 2, max_fee), 0);
+    assert_eq!(
+        fundable_withdrawal_value(amount, gas_reserve / 2, max_fee),
+        0
+    );
+}
+
+#[test]
+fn exact_native_transfer_funding_requires_amount_plus_gas() {
+    let amount = 20_000_000_000_000_000_000u128;
+    let max_fee = 40_000_000_000u128;
+    let gas_reserve = 21_000u128 * max_fee;
+
+    assert!(!exact_native_transfer_is_funded(
+        amount,
+        amount + gas_reserve - 1,
+        max_fee
+    ));
+    assert!(exact_native_transfer_is_funded(
+        amount,
+        amount + gas_reserve,
+        max_fee
+    ));
 }
 
 // ─── Increment 3 / Task 7: apply_liquidation_settlement_in_state (Phase 2) ───
@@ -378,15 +482,29 @@ mod phase2_tests {
         apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18).expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 33 * E8, "debt -= actual_cleared");
-        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 67 * E8, "backing += actual_cleared");
-        assert_eq!(*s.reserve_usdc_native.get(&CFX).unwrap(), 75 * E18, "usdc += realized");
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply UNCHANGED (PSM)");
+        assert_eq!(
+            *s.reserve_backing_e8s.get(&CFX).unwrap(),
+            67 * E8,
+            "backing += actual_cleared"
+        );
+        assert_eq!(
+            *s.reserve_usdc_native.get(&CFX).unwrap(),
+            75 * E18,
+            "usdc += realized"
+        );
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "supply UNCHANGED (PSM)"
+        );
         assert!(v.pending_liquidation.is_none(), "marker cleared");
         assert!(s.chain_bad_debt_e8s.get(&CFX).is_none(), "no shortfall");
         // Unified invariant: supply == debt + reserve + pending_burn.
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
-            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+            s.total_chain_vault_debt_e8s()
+                + s.total_reserve_backing_e8s()
+                + s.total_pending_chain_burn_e8s()
         );
     }
 
@@ -397,9 +515,21 @@ mod phase2_tests {
         // realized only 60 USDC -> 60e8 < debt_to_clear 67e8.
         apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18).expect("phase2 ok");
         assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 40 * E8);
-        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 60 * E8, "backing capped at realized USD");
-        assert_eq!(*s.chain_bad_debt_e8s.get(&CFX).unwrap(), 7 * E8, "shortfall recorded");
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply unchanged");
+        assert_eq!(
+            *s.reserve_backing_e8s.get(&CFX).unwrap(),
+            60 * E8,
+            "backing capped at realized USD"
+        );
+        assert_eq!(
+            *s.chain_bad_debt_e8s.get(&CFX).unwrap(),
+            7 * E8,
+            "shortfall recorded"
+        );
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "supply unchanged"
+        );
     }
 
     #[test]
@@ -419,7 +549,11 @@ mod phase2_tests {
         marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // confirming op 99 != marker op 9.
         assert!(apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18).is_err());
-        assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 100 * E8, "no mutation on reject");
+        assert_eq!(
+            s.chain_vaults.get(&7).unwrap().debt_e8s,
+            100 * E8,
+            "no mutation on reject"
+        );
         assert!(s.reserve_backing_e8s.get(&CFX).is_none());
     }
 }
@@ -485,22 +619,38 @@ mod sp_absorb_tests {
         assert_eq!(result.collateral_seized_native, 224 * E18);
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 0, "debt cleared by the IC-side SP burn");
-        assert_eq!(v.collateral_amount_native, 776 * E18, "claim collateral reserved out of borrower balance");
+        assert_eq!(
+            v.collateral_amount_native,
+            776 * E18,
+            "claim collateral reserved out of borrower balance"
+        );
         assert_eq!(*s.pending_chain_burn_e8s.get(&CFX).unwrap(), 100 * E8);
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "foreign-chain supply accounting unchanged");
-        assert!(v.pending_liquidation.is_none(), "SP absorb does not create a fake foreign-burn marker");
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "foreign-chain supply accounting unchanged"
+        );
+        assert!(
+            v.pending_liquidation.is_none(),
+            "SP absorb does not create a fake foreign-burn marker"
+        );
 
         let claim = s.chain_liquidation_claims.get(&7).expect("claim record");
         assert_eq!(claim.vault_id, 7);
         assert_eq!(claim.chain, CFX);
-        assert_eq!(claim.custody_address, "0x00000000000000000000000000000000000000c7");
+        assert_eq!(
+            claim.custody_address,
+            "0x00000000000000000000000000000000000000c7"
+        );
         assert_eq!(claim.seized_native_total, 224 * E18);
         assert_eq!(claim.paid_native, 0);
         assert!(claim.paid_within_seized());
 
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
-            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+            s.total_chain_vault_debt_e8s()
+                + s.total_reserve_backing_e8s()
+                + s.total_pending_chain_burn_e8s()
         );
     }
 
@@ -521,11 +671,23 @@ mod sp_absorb_tests {
         )
         .unwrap_err();
 
-        assert!(err.contains("does not match live debt"), "error should reject stale SP burn amount: {err}");
+        assert!(
+            err.contains("does not match live debt"),
+            "error should reject stale SP burn amount: {err}"
+        );
         assert_eq!(s.chain_vaults.get(&8).unwrap().debt_e8s, 80 * E8);
-        assert_eq!(s.chain_vaults.get(&8).unwrap().collateral_amount_native, 200 * E18);
-        assert_eq!(s.pending_chain_burn_e8s.get(&CFX), before.pending_chain_burn_e8s.get(&CFX));
-        assert_eq!(s.chain_liquidation_claims.get(&8), before.chain_liquidation_claims.get(&8));
+        assert_eq!(
+            s.chain_vaults.get(&8).unwrap().collateral_amount_native,
+            200 * E18
+        );
+        assert_eq!(
+            s.pending_chain_burn_e8s.get(&CFX),
+            before.pending_chain_burn_e8s.get(&CFX)
+        );
+        assert_eq!(
+            s.chain_liquidation_claims.get(&8),
+            before.chain_liquidation_claims.get(&8)
+        );
         assert_eq!(s.chain_supplies.get(&CFX), before.chain_supplies.get(&CFX));
     }
 
@@ -535,10 +697,21 @@ mod sp_absorb_tests {
         open_sp_attempted_vault(&mut s, 9, 100 * E8, 1_000 * E18);
         s.sp_attempted_chain_vaults.remove(&9);
 
-        let err = apply_sp_chain_liquidation_absorb_in_state(&mut s, CFX, 9, 100 * E8, 50_000_000, 18, 1_200)
-            .unwrap_err();
+        let err = apply_sp_chain_liquidation_absorb_in_state(
+            &mut s,
+            CFX,
+            9,
+            100 * E8,
+            50_000_000,
+            18,
+            1_200,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("sp_attempted"), "error should name the missing escalation gate: {err}");
+        assert!(
+            err.contains("sp_attempted"),
+            "error should name the missing escalation gate: {err}"
+        );
         let v = s.chain_vaults.get(&9).unwrap();
         assert_eq!(v.debt_e8s, 100 * E8);
         assert_eq!(v.collateral_amount_native, 1_000 * E18);
@@ -549,10 +722,15 @@ mod sp_absorb_tests {
 
 // ─── Increment 4 / Task 6: enqueue SP claim payout from reserved CFX ───
 mod chain_claim_tests {
-    use super::super::settlement::claim_chain_collateral_in_state;
+    use super::super::settlement::{
+        claim_chain_collateral_in_state, claim_chain_collateral_payout_submit_in_state,
+        confirm_chain_collateral_payout_in_state, fail_chain_collateral_payout_in_state,
+        record_chain_collateral_payout_replacement_in_state, ClaimChainPayoutSubmitError,
+        RecordChainPayoutReplacementError,
+    };
     use crate::chains::config::ChainId;
     use crate::chains::multi_chain_state::{ChainLiqClaimV1, MultiChainState};
-    use crate::chains::settlement_queue::SettlementOpKind;
+    use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
     use candid::Principal;
 
     const CFX: ChainId = ChainId(71);
@@ -568,29 +746,63 @@ mod chain_claim_tests {
 
     fn state_with_claim() -> MultiChainState {
         let mut s = MultiChainState::default();
-        s.chain_liquidation_claims.insert(7, ChainLiqClaimV1 {
-            vault_id: 7,
-            chain: CFX,
-            custody_address: "0x00000000000000000000000000000000000000c7".into(),
-            seized_native_total: 10 * E18,
-            paid_native: 2 * E18,
-        });
+        s.chain_liquidation_claims.insert(
+            7,
+            ChainLiqClaimV1 {
+                vault_id: 7,
+                chain: CFX,
+                custody_address: "0x00000000000000000000000000000000000000c7".into(),
+                seized_native_total: 10 * E18,
+                paid_native: 2 * E18,
+                pending_native: 0,
+            },
+        );
         s
     }
 
     #[test]
-    fn claim_chain_collateral_enqueues_payout_and_marks_paid() {
+    fn claim_chain_collateral_enqueues_payout_and_marks_pending_not_paid() {
         let mut s = state_with_claim();
         let dest = "0x0000000000000000000000000000000000000abc".to_string();
 
-        let op_id = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
-            .expect("claim enqueued");
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
 
         let claim = s.chain_liquidation_claims.get(&7).unwrap();
-        assert_eq!(claim.paid_native, 5 * E18, "claim is deducted before async payout");
-        let op = s.settlement_queues.get(&CFX).unwrap().pending.get(&op_id).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18, "enqueue is not final payment");
+        assert_eq!(
+            claim.pending_native,
+            3 * E18,
+            "enqueue reserves pending payout capacity"
+        );
+        assert_eq!(
+            claim.remaining_native(),
+            5 * E18,
+            "remaining excludes paid and pending"
+        );
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.chain_payout_uses_pending_reservation, Some(true));
         match &op.kind {
-            SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, claimant: c } => {
+            SettlementOpKind::ChainCollateralPayout {
+                recipient,
+                amount_e18,
+                vault_id,
+                claimant: c,
+            } => {
                 assert_eq!(recipient, &dest);
                 assert_eq!(*amount_e18, 3 * E18);
                 assert_eq!(*vault_id, 7);
@@ -604,14 +816,35 @@ mod chain_claim_tests {
     fn claim_chain_collateral_rejects_duplicate_without_double_marking_paid() {
         let mut s = state_with_claim();
         let dest = "0x0000000000000000000000000000000000000abc".to_string();
-        claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
-            .expect("first claim enqueued");
+        claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("first claim enqueued");
 
-        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest, 43, valid_evm_address)
-            .unwrap_err();
+        let err = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            43,
+            valid_evm_address,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("Duplicate"), "expected duplicate idempotency error, got {err}");
-        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 5 * E18);
+        assert!(
+            err.contains("Duplicate"),
+            "expected duplicate idempotency error, got {err}"
+        );
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 3 * E18);
         assert_eq!(s.settlement_queues.get(&CFX).unwrap().pending.len(), 1);
     }
 
@@ -619,11 +852,638 @@ mod chain_claim_tests {
     fn claim_chain_collateral_validates_destination_before_mutation() {
         let mut s = state_with_claim();
 
-        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, "not-evm".into(), 42, valid_evm_address)
-            .unwrap_err();
+        let err = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "not-evm".into(),
+            42,
+            valid_evm_address,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("invalid EVM address"), "unexpected error: {err}");
-        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 2 * E18);
+        assert!(
+            err.contains("invalid EVM address"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().paid_native,
+            2 * E18
+        );
         assert!(s.settlement_queues.get(&CFX).is_none());
+    }
+
+    #[test]
+    fn chain_collateral_payout_success_moves_pending_to_paid_once() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("confirm payout"));
+        assert!(!confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            101,
+        )
+        .expect("confirm replay is idempotent"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_success_does_not_consume_new_pending_reservation() {
+        let mut s = state_with_claim();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let legacy = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: "0x0000000000000000000000000000000000000abc".to_string(),
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&legacy)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+        let new = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            E18,
+            "0x0000000000000000000000000000000000000def".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("new pending-reserved payout enqueued");
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            legacy,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("legacy confirm succeeds"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, E18);
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            new,
+            "0xbbb".to_string(),
+            101,
+        )
+        .expect("new confirm still consumes its own pending reservation"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 6 * E18);
+        assert_eq!(claim.pending_native, 0);
+    }
+
+    #[test]
+    fn chain_collateral_payout_failure_releases_pending_without_marking_paid() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("fail payout"));
+        assert!(!fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            101,
+        )
+        .expect("failure replay is idempotent"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(
+            claim.remaining_native(),
+            8 * E18,
+            "failed payout can be claimed again"
+        );
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert!(matches!(op.status, SettlementOpStatus::Failed { .. }));
+    }
+
+    #[test]
+    fn chain_collateral_payout_failure_is_terminal_when_reservation_already_missing() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        let idempotency_key = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap()
+            .idempotency_key
+            .clone();
+        s.chain_liquidation_claims
+            .get_mut(&7)
+            .unwrap()
+            .pending_native = 0;
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "sp recredit already committed".to_string(),
+            100,
+        )
+        .expect("failure remains terminal even when release cannot subtract"));
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        match &op.status {
+            SettlementOpStatus::Failed { reason, .. } => {
+                assert!(reason.contains("reservation release skipped"), "{reason}");
+            }
+            other => panic!("expected terminal failure, got {other:?}"),
+        }
+        assert!(
+            !s.settlement_queues
+                .get(&CFX)
+                .unwrap()
+                .seen_idempotency_keys
+                .contains(&idempotency_key),
+            "terminal failure releases the retry idempotency key"
+        );
+    }
+
+    #[test]
+    fn chain_collateral_payout_submit_marks_inflight_before_broadcast() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xabc".to_string(),
+            17,
+        )
+        .expect("submit claim");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.last_tx_hash.as_deref(), Some("0xabc"));
+        assert_eq!(op.tx_hash_candidates, vec!["0xabc".to_string()]);
+        assert_eq!(op.submit_nonce, Some(17));
+        assert!(matches!(
+            op.status,
+            SettlementOpStatus::Inflight {
+                tries: 1,
+                last_attempt_ns: 99
+            }
+        ));
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().pending_native,
+            3 * E18,
+            "pre-broadcast claim must not release or finalize the pending reservation"
+        );
+
+        let replay = claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            100,
+            "0xdef".to_string(),
+            18,
+        )
+        .unwrap_err();
+        assert_eq!(replay, ClaimChainPayoutSubmitError::NotQueued);
+    }
+
+    #[test]
+    fn chain_collateral_payout_replacement_records_new_hash_before_rebroadcast() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xold".to_string(),
+            17,
+        )
+        .expect("initial submit claim");
+
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            120,
+            "0xreplacement".to_string(),
+        )
+        .expect("replacement recorded");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.last_tx_hash.as_deref(), Some("0xreplacement"));
+        assert_eq!(
+            op.tx_hash_candidates,
+            vec!["0xold".to_string(), "0xreplacement".to_string()]
+        );
+        assert_eq!(
+            op.receipt_tx_hash_candidates(),
+            vec!["0xreplacement".to_string(), "0xold".to_string()],
+            "a rejected replacement broadcast must not make the receipt path forget the original hash"
+        );
+        assert_eq!(op.submit_nonce, Some(17), "replacement keeps same nonce");
+        assert!(matches!(
+            op.status,
+            SettlementOpStatus::Inflight {
+                tries: 1,
+                last_attempt_ns: 120
+            }
+        ));
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().pending_native,
+            3 * E18,
+            "replacement tracking must not mutate payout accounting"
+        );
+
+        assert_eq!(
+            record_chain_collateral_payout_replacement_in_state(
+                &mut s,
+                CFX,
+                op_id + 1,
+                121,
+                "0xmissing".to_string(),
+            )
+            .unwrap_err(),
+            RecordChainPayoutReplacementError::MissingOp,
+        );
+    }
+
+    #[test]
+    fn chain_collateral_payout_replacement_replay_does_not_drop_original_hash() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xold".to_string(),
+            17,
+        )
+        .expect("initial submit claim");
+
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            120,
+            "0xreplacement".to_string(),
+        )
+        .expect("first replacement record");
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            121,
+            "0xreplacement".to_string(),
+        )
+        .expect("same replacement record replay");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(
+            op.tx_hash_candidates,
+            vec!["0xold".to_string(), "0xreplacement".to_string()],
+            "candidate recording is idempotent and keeps the original accepted-or-pending tx"
+        );
+        assert_eq!(
+            op.receipt_tx_hash_candidates(),
+            vec!["0xreplacement".to_string(), "0xold".to_string()]
+        );
+    }
+
+    #[test]
+    fn failed_chain_collateral_payout_allows_same_claim_retry() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let first = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            first,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("fail payout"));
+
+        let retry = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            101,
+            valid_evm_address,
+        )
+        .expect("same failed payout can be retried");
+
+        assert_ne!(first, retry);
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 3 * E18);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+        assert_eq!(s.settlement_queues.get(&CFX).unwrap().pending.len(), 2);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_success_keeps_paid_reservation() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let op_id = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: dest,
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("legacy confirm succeeds"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_failure_releases_paid_reservation() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let op_id = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: dest,
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("legacy failure succeeds"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 8 * E18);
+        assert!(
+            !s.settlement_queues
+                .get(&CFX)
+                .unwrap()
+                .seen_idempotency_keys
+                .contains("legacy-cfx-payout"),
+            "failed legacy payout releases its retry idempotency key",
+        );
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_failure_does_not_consume_new_pending_reservation() {
+        let mut s = state_with_claim();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let legacy = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: "0x0000000000000000000000000000000000000abc".to_string(),
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&legacy)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+        let new = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            E18,
+            "0x0000000000000000000000000000000000000def".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("new pending-reserved payout enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            legacy,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("legacy failure succeeds"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, E18);
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            new,
+            "0xbbb".to_string(),
+            101,
+        )
+        .expect("new confirm still consumes its own pending reservation"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 3 * E18);
+        assert_eq!(claim.pending_native, 0);
     }
 }

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -26,8 +26,7 @@ pub fn accrued_chain_interest_e8s(debt_e8s: u128, apr_bps: u64, elapsed_ns: u64)
         None => return 0,
     };
     let rate = Decimal::from(apr_bps) / Decimal::from(10_000u64);
-    let factor =
-        Decimal::ONE + rate * Decimal::from(elapsed_ns) / Decimal::from(NANOS_PER_YEAR);
+    let factor = Decimal::ONE + rate * Decimal::from(elapsed_ns) / Decimal::from(NANOS_PER_YEAR);
     // new_debt = ceil(debt * factor); the accrued interest is the delta. Defer
     // on a Decimal->u128 overflow (unreachable at real debt scales).
     let new_debt = match (debt * factor).ceil().to_u128() {
@@ -60,6 +59,15 @@ pub fn harvest_chain_interest_in_state(
     now_ns: u64,
     mut alloc_mint_id: impl FnMut() -> u64,
 ) -> Vec<u64> {
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        ic_canister_log::log!(
+            crate::logs::INFO,
+            "[harvest chain={:?}] bad-debt circuit tripped; skipping interest mint enqueue",
+            chain
+        );
+        return Vec::new();
+    }
+
     // Phase 1: pick eligible vaults + locked-in amounts (immutable scan, so the
     // mint-id allocator + enqueue can borrow `state` mutably in phase 2).
     let eligible: Vec<(u64, u128)> = state
@@ -96,7 +104,12 @@ pub fn harvest_chain_interest_in_state(
             format!("interest-{}-{}", chain.0, mint_id),
             now_ns,
         );
-        match state.settlement_queues.entry(chain).or_default().enqueue(op) {
+        match state
+            .settlement_queues
+            .entry(chain)
+            .or_default()
+            .enqueue(op)
+        {
             Ok(op_id) => {
                 if let Some(v) = state.chain_vaults.get_mut(&vault_id) {
                     v.pending_interest_mint_e8s = amount;
@@ -129,12 +142,18 @@ mod tests {
 
     #[test]
     fn two_percent_full_year_on_100_icusd_is_2_icusd() {
-        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR), 2 * E8);
+        assert_eq!(
+            accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR),
+            2 * E8
+        );
     }
 
     #[test]
     fn half_year_is_half_the_interest() {
-        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR / 2), E8);
+        assert_eq!(
+            accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR / 2),
+            E8
+        );
     }
 
     #[test]
@@ -161,7 +180,10 @@ mod tests {
     #[test]
     fn overflow_defers_to_zero_not_panic() {
         // u128::MAX exceeds Decimal's range -> defer (0), never panic.
-        assert_eq!(accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR), 0);
+        assert_eq!(
+            accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR),
+            0
+        );
     }
 
     // ─── harvest_chain_interest_in_state ────────────────────────────────────
@@ -199,29 +221,51 @@ mod tests {
                 owner_evm: None,
                 last_interest_accrual_ns: last_accrual_ns,
                 pending_interest_mint_e8s: pending_interest,
-                pending_liquidation: None,            },
+                pending_liquidation: None,
+            },
         );
     }
 
     #[test]
     fn harvest_enqueues_one_interest_mint_per_eligible_vault() {
         let mut s = MultiChainState::default();
-        open_vault(&mut s, 1, 100 * E8, /*last accrual a year ago*/ 0, 0, ChainVaultStatus::Open);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            /*last accrual a year ago*/ 0,
+            0,
+            ChainVaultStatus::Open,
+        );
         let now = NANOS_PER_YEAR;
         let mut next = 1000u64;
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
-            next += 1;
-            next
-        });
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
+                next += 1;
+                next
+            });
         assert_eq!(ops.len(), 1, "one eligible vault -> one op");
         let v = &s.chain_vaults[&1];
-        assert_eq!(v.pending_interest_mint_e8s, 2 * E8, "reserved 2% of 100 for a year");
+        assert_eq!(
+            v.pending_interest_mint_e8s,
+            2 * E8,
+            "reserved 2% of 100 for a year"
+        );
         assert_eq!(v.debt_e8s, 100 * E8, "debt untouched until confirm");
-        assert_eq!(v.last_interest_accrual_ns, 0, "accrual window not advanced at harvest");
+        assert_eq!(
+            v.last_interest_accrual_ns, 0,
+            "accrual window not advanced at harvest"
+        );
         let q = &s.settlement_queues[&CHAIN];
         let op = q.pending.values().next().expect("op enqueued");
         match &op.kind {
-            SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, accrual_through_ns, recipient } => {
+            SettlementOpKind::InterestMint {
+                vault_id,
+                mint_id,
+                amount_e8s,
+                accrual_through_ns,
+                recipient,
+            } => {
                 assert_eq!(*vault_id, 1);
                 assert_eq!(*mint_id, 1001, "id from the allocator");
                 assert_eq!(*amount_e8s, 2 * E8);
@@ -233,11 +277,38 @@ mod tests {
     }
 
     #[test]
+    fn harvest_skips_interest_mint_when_bad_debt_circuit_tripped() {
+        let mut s = MultiChainState::default();
+        s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            /*last accrual a year ago*/ 0,
+            0,
+            ChainVaultStatus::Open,
+        );
+        let now = NANOS_PER_YEAR;
+        let mut next = 1000u64;
+
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
+                next += 1;
+                next
+            });
+
+        assert!(ops.is_empty());
+        assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0);
+        assert!(s.settlement_queues.get(&CHAIN).is_none());
+    }
+
+    #[test]
     fn harvest_skips_below_threshold() {
         let mut s = MultiChainState::default();
         // 1ns elapsed on 100 icUSD -> 1 e8s accrued, below a 1e6 threshold.
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
         assert!(ops.is_empty(), "below-threshold accrual is not realized");
         assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0);
     }
@@ -245,11 +316,22 @@ mod tests {
     #[test]
     fn harvest_skips_in_flight_non_open_and_zero_debt() {
         let mut s = MultiChainState::default();
-        open_vault(&mut s, 1, 100 * E8, 0, /*in flight*/ 50_000_000, ChainVaultStatus::Open);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            0,
+            /*in flight*/ 50_000_000,
+            ChainVaultStatus::Open,
+        );
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::MintPending); // not Open
         open_vault(&mut s, 3, 0, 0, 0, ChainVaultStatus::Open); // zero debt
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || 99);
-        assert!(ops.is_empty(), "in-flight / non-Open / zero-debt vaults are all skipped");
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || 99);
+        assert!(
+            ops.is_empty(),
+            "in-flight / non-Open / zero-debt vaults are all skipped"
+        );
     }
 
     #[test]
@@ -258,10 +340,18 @@ mod tests {
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::Open);
         let mut next = 5000u64;
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || {
-            next += 1;
-            next
-        });
+        let ops = harvest_chain_interest_in_state(
+            &mut s,
+            CHAIN,
+            200,
+            1,
+            TREASURY,
+            NANOS_PER_YEAR,
+            || {
+                next += 1;
+                next
+            },
+        );
         assert_eq!(ops.len(), 2);
         let mint_ids: Vec<u64> = s.settlement_queues[&CHAIN]
             .pending

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -100,6 +100,10 @@ pub fn collateral_in_native_for_repay(
 use crate::chains::config::ChainId;
 use crate::chains::multi_chain_state::MultiChainState;
 
+/// Default wall-clock time a bot-path liquidation swap may hold a vault before
+/// the backend routes the vault to the SP/manual fallback surface.
+pub const DEFAULT_BOT_TO_SP_TIMEOUT_NS: u64 = 30 * 60 * 1_000_000_000;
+
 /// Why a chain price was rejected by the fail-closed staleness gate (spec §4.3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PriceError {
@@ -147,6 +151,113 @@ pub fn should_escalate_to_sp(
     op_terminally_failed: bool,
 ) -> bool {
     op_terminally_failed || now_ns.saturating_sub(bot_pending_since_ns) >= bot_timeout_ns
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChainBotSpEscalation {
+    pub vault_id: u64,
+    pub op_id: u64,
+    pub reason: String,
+}
+
+/// Escalate stale bot-path liquidations to the SP/manual fallback surface. This
+/// is a synchronous state repair primitive: it fails the bot swap op when it
+/// still exists, restores only the collateral reserved by that exact marker, and
+/// moves the vault from `bot_pending_chain_vaults` to `sp_attempted_chain_vaults`.
+/// It deliberately does NOT burn SP icUSD or mutate chain supply; the existing
+/// SP/manual path consumes the resulting marker under its own authorization.
+pub fn escalate_timed_out_bot_liquidations_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    now_ns: u64,
+    bot_timeout_ns: u64,
+    max_per_tick: usize,
+) -> Vec<ChainBotSpEscalation> {
+    use crate::chains::settlement_queue::SettlementOpStatus;
+    use crate::chains::vault::LiquidationTier;
+
+    if max_per_tick == 0 {
+        return Vec::new();
+    }
+
+    let candidates: Vec<(u64, u64, u128, String)> = state
+        .bot_pending_chain_vaults
+        .iter()
+        .filter_map(|(&vault_id, &pending_since_ns)| {
+            let vault = state.chain_vaults.get(&vault_id)?;
+            if vault.collateral_chain != chain {
+                return None;
+            }
+            let marker = vault.pending_liquidation.as_ref()?;
+            if marker.tier != LiquidationTier::Bot {
+                return None;
+            }
+
+            let status = state
+                .settlement_queues
+                .get(&chain)
+                .and_then(|q| q.pending.get(&marker.op_id))
+                .map(|op| &op.status);
+            let reason = match status {
+                Some(SettlementOpStatus::Failed { .. }) => {
+                    "bot liquidation swap failed; escalated to stability pool".to_string()
+                }
+                Some(SettlementOpStatus::Queued) => {
+                    if !should_escalate_to_sp(pending_since_ns, now_ns, bot_timeout_ns, false) {
+                        return None;
+                    }
+                    format!(
+                        "bot liquidation timed out after {}ns; escalated to stability pool",
+                        now_ns.saturating_sub(pending_since_ns)
+                    )
+                }
+                Some(SettlementOpStatus::Inflight { .. })
+                | Some(SettlementOpStatus::Succeeded { .. }) => return None,
+                None => {
+                    if !should_escalate_to_sp(pending_since_ns, now_ns, bot_timeout_ns, false) {
+                        return None;
+                    }
+                    format!(
+                        "bot liquidation settlement op missing after {}ns; escalated to stability pool",
+                        now_ns.saturating_sub(pending_since_ns)
+                    )
+                }
+            };
+            Some((vault_id, marker.op_id, marker.collateral_reserved_native, reason))
+        })
+        .take(max_per_tick)
+        .collect();
+
+    let mut escalated = Vec::with_capacity(candidates.len());
+    for (vault_id, op_id, reserved_native, reason) in candidates {
+        let mut marker_owned_by_op = false;
+        if let Some(vault) = state.chain_vaults.get_mut(&vault_id) {
+            marker_owned_by_op = vault.pending_liquidation.as_ref().map_or(false, |marker| {
+                marker.op_id == op_id && marker.tier == LiquidationTier::Bot
+            });
+            if marker_owned_by_op {
+                vault.collateral_amount_native = vault.collateral_amount_native.saturating_add(reserved_native);
+                vault.pending_liquidation = None;
+            }
+        }
+        if !marker_owned_by_op {
+            continue;
+        }
+
+        if let Some(op) = state
+            .settlement_queues
+            .get_mut(&chain)
+            .and_then(|q| q.pending.get_mut(&op_id))
+        {
+            if !matches!(op.status, SettlementOpStatus::Succeeded { .. }) {
+                op.mark_failed(reason.clone(), now_ns);
+            }
+        }
+        state.bot_pending_chain_vaults.remove(&vault_id);
+        state.sp_attempted_chain_vaults.insert(vault_id);
+        escalated.push(ChainBotSpEscalation { vault_id, op_id, reason });
+    }
+    escalated
 }
 
 /// Clear routing state (`bot_pending_chain_vaults`, `sp_attempted_chain_vaults`)
@@ -583,6 +694,232 @@ mod tests {
         assert!(should_escalate_to_sp(1_000, 2_001, 1_000, false));
         // Op terminally failed -> escalate regardless of timeout.
         assert!(should_escalate_to_sp(1_000, 1_100, 1_000, true));
+    }
+
+    fn enqueue_bot_liquidation_swap(s: &mut MultiChainState, vault_id: u64, now_ns: u64) -> u64 {
+        use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind};
+
+        s.settlement_queues
+            .entry(ChainId(71))
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::LiquidationSwap {
+                    vault_id,
+                    collateral_in_native: 100 * E18,
+                    min_usdc_out_native: 0,
+                    debt_to_clear_e8s: 50 * E8,
+                    router: "0x1111111111111111111111111111111111111111".into(),
+                    pair: "0x3333333333333333333333333333333333333333".into(),
+                    path: vec![
+                        "0x4444444444444444444444444444444444444444".into(),
+                        "0x5555555555555555555555555555555555555555".into(),
+                    ],
+                    reserve_recipient: "0x5555555555555555555555555555555555555555".into(),
+                    deadline_secs: 180,
+                },
+                format!("liq-test-{vault_id}-{now_ns}"),
+                now_ns,
+            ))
+            .expect("enqueue liquidation swap")
+    }
+
+    fn mark_bot_liquidation_reserved(
+        s: &mut MultiChainState,
+        vault_id: u64,
+        op_id: u64,
+        reserved_native: u128,
+        started_at_ns: u64,
+    ) {
+        use crate::chains::vault::{LiquidationTier, PendingLiquidationV1};
+
+        let vault = s.chain_vaults.get_mut(&vault_id).expect("vault exists");
+        vault.collateral_amount_native = vault
+            .collateral_amount_native
+            .checked_sub(reserved_native)
+            .expect("test reserves available collateral");
+        vault.pending_liquidation = Some(PendingLiquidationV1 {
+            op_id,
+            debt_to_clear_e8s: 50 * E8,
+            collateral_reserved_native: reserved_native,
+            tier: LiquidationTier::Bot,
+            started_at_ns,
+        });
+        s.bot_pending_chain_vaults.insert(vault_id, started_at_ns);
+    }
+
+    #[test]
+    fn timeout_escalation_restores_collateral_fails_op_and_sets_sp_attempted() {
+        use crate::chains::settlement_queue::SettlementOpStatus;
+
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+        let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+        mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+
+        let escalated = escalate_timed_out_bot_liquidations_in_state(
+            &mut s,
+            ChainId(71),
+            10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            10,
+        );
+
+        assert_eq!(escalated.len(), 1);
+        assert_eq!(escalated[0].vault_id, 7);
+        assert_eq!(escalated[0].op_id, op_id);
+        assert!(escalated[0].reason.contains("timed out"));
+        assert!(s.sp_attempted_chain_vaults.contains(&7));
+        assert!(!s.bot_pending_chain_vaults.contains_key(&7));
+        let v = s.chain_vaults.get(&7).unwrap();
+        assert!(v.pending_liquidation.is_none());
+        assert_eq!(v.collateral_amount_native, 1_400 * E18);
+        let op = s
+            .settlement_queues
+            .get(&ChainId(71))
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert!(matches!(op.status, SettlementOpStatus::Failed { .. }));
+    }
+
+    #[test]
+    fn timeout_escalation_does_not_mutate_before_timeout() {
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+        let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+        mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+        let before = s.clone();
+
+        let escalated = escalate_timed_out_bot_liquidations_in_state(
+            &mut s,
+            ChainId(71),
+            10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS - 1,
+            DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            10,
+        );
+
+        assert!(escalated.is_empty());
+        assert_eq!(s.bot_pending_chain_vaults, before.bot_pending_chain_vaults);
+        assert_eq!(s.sp_attempted_chain_vaults, before.sp_attempted_chain_vaults);
+        assert_eq!(
+            s.chain_vaults.get(&7).unwrap().pending_liquidation,
+            before.chain_vaults.get(&7).unwrap().pending_liquidation
+        );
+        assert_eq!(
+            s.chain_vaults.get(&7).unwrap().collateral_amount_native,
+            before.chain_vaults.get(&7).unwrap().collateral_amount_native
+        );
+    }
+
+    #[test]
+    fn timeout_escalation_skips_succeeded_swap_to_avoid_double_restore() {
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+        let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+        mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+        s.settlement_queues
+            .get_mut(&ChainId(71))
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .mark_succeeded("0xtx".into(), 20);
+
+        let escalated = escalate_timed_out_bot_liquidations_in_state(
+            &mut s,
+            ChainId(71),
+            10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            10,
+        );
+
+        assert!(escalated.is_empty());
+        assert!(!s.sp_attempted_chain_vaults.contains(&7));
+        assert!(s.bot_pending_chain_vaults.contains_key(&7));
+        assert!(
+            s.chain_vaults.get(&7).unwrap().pending_liquidation.is_some(),
+            "do not double-restore an already-succeeded op; leave for manual repair"
+        );
+        assert_eq!(s.chain_vaults.get(&7).unwrap().collateral_amount_native, 1_300 * E18);
+    }
+
+    #[test]
+    fn timeout_escalation_skips_inflight_swap_to_avoid_live_submit_race() {
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+        let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+        mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+        s.settlement_queues
+            .get_mut(&ChainId(71))
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .mark_inflight(20);
+
+        let escalated = escalate_timed_out_bot_liquidations_in_state(
+            &mut s,
+            ChainId(71),
+            10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            10,
+        );
+
+        assert!(escalated.is_empty());
+        assert!(!s.sp_attempted_chain_vaults.contains(&7));
+        assert!(s.bot_pending_chain_vaults.contains_key(&7));
+        assert!(
+            s.chain_vaults.get(&7).unwrap().pending_liquidation.is_some(),
+            "settlement worker confirm-timeout owns inflight swap cleanup"
+        );
+        assert_eq!(s.chain_vaults.get(&7).unwrap().collateral_amount_native, 1_300 * E18);
+    }
+
+    #[test]
+    fn timeout_escalation_repairs_missing_swap_op_after_timeout() {
+        use crate::chains::settlement_queue::SettlementOpStatus;
+
+        let mut s = MultiChainState::default();
+        seed_cfg_unchecked(&mut s);
+        insert_vault_liq(&mut s, 7, 1_400, 100, ChainVaultStatus::Open);
+        let op_id = enqueue_bot_liquidation_swap(&mut s, 7, 10);
+        mark_bot_liquidation_reserved(&mut s, 7, op_id, 100 * E18, 10);
+        s.settlement_queues
+            .get_mut(&ChainId(71))
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .status = SettlementOpStatus::Failed {
+                reason: "manual recovery".into(),
+                failed_ns: 20,
+            };
+        s.settlement_queues
+            .get_mut(&ChainId(71))
+            .unwrap()
+            .prune_terminal();
+
+        let escalated = escalate_timed_out_bot_liquidations_in_state(
+            &mut s,
+            ChainId(71),
+            10 + DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            DEFAULT_BOT_TO_SP_TIMEOUT_NS,
+            10,
+        );
+
+        assert_eq!(escalated.len(), 1);
+        assert_eq!(escalated[0].vault_id, 7);
+        assert_eq!(escalated[0].op_id, op_id);
+        assert!(escalated[0].reason.contains("missing"));
+        assert!(s.sp_attempted_chain_vaults.contains(&7));
+        assert!(!s.bot_pending_chain_vaults.contains_key(&7));
+        assert!(s.chain_vaults.get(&7).unwrap().pending_liquidation.is_none());
+        assert_eq!(s.chain_vaults.get(&7).unwrap().collateral_amount_native, 1_400 * E18);
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/liquidation.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation.rs
@@ -289,7 +289,7 @@ pub fn prune_recovered_chain_routing_state(
         .map(|c| c.interest_apr_bps)
         .unwrap_or(0);
 
-    let mut recovered: Vec<u64> = Vec::new();
+    let mut recovered: Vec<(u64, bool)> = Vec::new();
     for (&vid, v) in state.chain_vaults.iter() {
         if v.collateral_chain != chain || v.pending_liquidation.is_some() {
             continue;
@@ -312,12 +312,14 @@ pub fn prune_recovered_chain_routing_state(
             Err(_) => false, // no fresh price -> do not prune on CR
         };
         if resolved || recovered_above {
-            recovered.push(vid);
+            recovered.push((vid, resolved));
         }
     }
-    for vid in recovered {
+    for (vid, resolved) in recovered {
         state.bot_pending_chain_vaults.remove(&vid);
-        state.sp_attempted_chain_vaults.remove(&vid);
+        if resolved {
+            state.sp_attempted_chain_vaults.remove(&vid);
+        }
     }
 }
 
@@ -923,7 +925,7 @@ mod tests {
     }
 
     #[test]
-    fn prune_clears_recovered_and_resolved_vaults() {
+    fn prune_keeps_sp_attempted_on_recovery_until_absorb_or_resolution() {
         let mut s = MultiChainState::default();
         seed_cfg_unchecked(&mut s);
         s.manual_prices.insert((ChainId(71), "CFX".into()), 15_000_000); // $0.15
@@ -940,7 +942,17 @@ mod tests {
 
         assert!(!s.bot_pending_chain_vaults.contains_key(&7), "recovered vault cleared");
         assert!(!s.bot_pending_chain_vaults.contains_key(&8), "resolved vault cleared");
-        assert!(!s.sp_attempted_chain_vaults.contains(&7), "sp-attempted cleared on recovery");
+        assert!(
+            s.sp_attempted_chain_vaults.contains(&7),
+            "sp-attempted must survive CR recovery so a just-burned SP absorb cannot be pruned before backend finalization",
+        );
+
+        s.chain_vaults.get_mut(&7).unwrap().status = ChainVaultStatus::Closed;
+        prune_recovered_chain_routing_state(&mut s, ChainId(71), "CFX", 13_300, 6_000);
+        assert!(
+            !s.sp_attempted_chain_vaults.contains(&7),
+            "resolved vaults still clear stale SP routing state",
+        );
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/liquidation_config.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation_config.rs
@@ -28,11 +28,10 @@ pub enum DexKind {
 }
 
 /// Per-chain liquidation config (operator-set, dev-gated). Holds the DEX wiring
-/// + the two risk knobs the bot path needs. Addresses are chain-native hex
-/// strings (validated by the engine's address validator at swap-build time, not
-/// here). `enabled` is the per-chain kill switch: even with the whole chains rail
-/// dev-gated, an operator must explicitly flip this on before any liquidation
-/// swap can run for the chain.
+/// + the two risk knobs the bot path needs. DEX/token addresses are EVM
+/// 0x-prefixed 20-byte hex strings validated at setter time. `enabled` is the
+/// per-chain kill switch: even with the whole chains rail dev-gated, an operator
+/// must explicitly flip this on before any liquidation swap can run for the chain.
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ChainLiquidationConfigV1 {
     /// Which DEX family to route the collateral->stable swap through.
@@ -101,6 +100,8 @@ pub enum LiquidationConfigError {
     /// An `enabled` config left a required address empty (the swap could never
     /// build). Disabled configs may carry placeholder/empty addresses.
     MissingAddress(&'static str),
+    /// A non-empty address is not an EVM `0x` + 40 hex digit address.
+    InvalidAddress { field: &'static str, address: String },
     /// An `enabled` config left the depth cap at 0 (spec §4.7): no swap could be
     /// sized. Disabled configs may carry 0.
     ZeroDepthCap,
@@ -130,22 +131,12 @@ impl ChainLiquidationConfigV1 {
                 restore_target_cr_e4: self.restore_target_cr_e4,
             });
         }
+        validate_evm_address_field("router", &self.router, self.enabled)?;
+        validate_evm_address_field("factory", &self.factory, self.enabled)?;
+        validate_evm_address_field("pair", &self.pair, self.enabled)?;
+        validate_evm_address_field("collateral_token", &self.collateral_token, self.enabled)?;
+        validate_evm_address_field("settle_stable_token", &self.settle_stable_token, self.enabled)?;
         if self.enabled {
-            if self.router.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("router"));
-            }
-            if self.factory.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("factory"));
-            }
-            if self.pair.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("pair"));
-            }
-            if self.collateral_token.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("collateral_token"));
-            }
-            if self.settle_stable_token.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("settle_stable_token"));
-            }
             if self.max_swap_value_e8s == 0 {
                 return Err(LiquidationConfigError::ZeroDepthCap);
             }
@@ -163,6 +154,49 @@ impl ChainLiquidationConfigV1 {
     }
 }
 
+fn validate_evm_address_field(
+    field: &'static str,
+    address: &str,
+    required: bool,
+) -> Result<(), LiquidationConfigError> {
+    if address.is_empty() {
+        return if required {
+            Err(LiquidationConfigError::MissingAddress(field))
+        } else {
+            Ok(())
+        };
+    }
+    canonical_evm_address(address).map(|_| ()).map_err(|_| LiquidationConfigError::InvalidAddress {
+        field,
+        address: address.to_string(),
+    })
+}
+
+/// Normalize an EVM address for equality checks after a value has passed the same
+/// setter-time validation as liquidation config addresses.
+pub fn canonical_evm_address(address: &str) -> Result<String, LiquidationConfigError> {
+    let hex = address
+        .strip_prefix("0x")
+        .or_else(|| address.strip_prefix("0X"))
+        .ok_or_else(|| LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        })?;
+    if hex.len() != 40 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        });
+    }
+    if hex.bytes().all(|b| b == b'0') {
+        return Err(LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        });
+    }
+    Ok(format!("0x{}", hex.to_lowercase()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,11 +204,11 @@ mod tests {
     fn enabled_cfg() -> ChainLiquidationConfigV1 {
         ChainLiquidationConfigV1 {
             dex: DexKind::UniswapV2,
-            router: "0xrouter".into(),
-            factory: "0xfactory".into(),
-            pair: "0xpair".into(),
-            collateral_token: "0xwcfx".into(),
-            settle_stable_token: "0xusdc".into(),
+            router: "0x1111111111111111111111111111111111111111".into(),
+            factory: "0x2222222222222222222222222222222222222222".into(),
+            pair: "0x3333333333333333333333333333333333333333".into(),
+            collateral_token: "0x4444444444444444444444444444444444444444".into(),
+            settle_stable_token: "0x5555555555555555555555555555555555555555".into(),
             slippage_cap_bps: 250,
             restore_target_cr_e4: 15_500,
             enabled: true,
@@ -240,6 +274,71 @@ mod tests {
         let mut c = enabled_cfg();
         c.pair = String::new();
         assert_eq!(c.validate(), Err(LiquidationConfigError::MissingAddress("pair")));
+    }
+
+    #[test]
+    fn enabled_config_with_malformed_address_rejected() {
+        let mut c = enabled_cfg();
+        c.router = "router-no-0x".into();
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::InvalidAddress {
+                field: "router",
+                address: "router-no-0x".into()
+            })
+        );
+    }
+
+    #[test]
+    fn disabled_config_rejects_malformed_non_empty_address() {
+        let mut c = enabled_cfg();
+        c.enabled = false;
+        c.max_swap_value_e8s = 0;
+        c.max_price_age_ns = 0;
+        c.settle_stable_decimals = 0;
+        c.deadline_secs = 0;
+        c.factory = "0xnothex".into();
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::InvalidAddress {
+                field: "factory",
+                address: "0xnothex".into()
+            })
+        );
+    }
+
+    #[test]
+    fn canonical_evm_address_lowercases_valid_input() {
+        assert_eq!(
+            canonical_evm_address("0XABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD").unwrap(),
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+        assert!(canonical_evm_address("0x1234").is_err());
+        assert!(canonical_evm_address("0x0000000000000000000000000000000000000000").is_err());
+    }
+
+    #[test]
+    fn enabled_config_rejects_zero_addresses_for_all_evm_fields() {
+        let zero = "0x0000000000000000000000000000000000000000".to_string();
+        for field in ["router", "factory", "pair", "collateral_token", "settle_stable_token"] {
+            let mut c = enabled_cfg();
+            match field {
+                "router" => c.router = zero.clone(),
+                "factory" => c.factory = zero.clone(),
+                "pair" => c.pair = zero.clone(),
+                "collateral_token" => c.collateral_token = zero.clone(),
+                "settle_stable_token" => c.settle_stable_token = zero.clone(),
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                c.validate(),
+                Err(LiquidationConfigError::InvalidAddress {
+                    field,
+                    address: zero.clone()
+                }),
+                "{field} zero address must reject"
+            );
+        }
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -33,7 +33,7 @@ use super::collateral_config::ChainDebtConfigV1;
 use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
 use super::liquidation_config::ChainLiquidationConfigV1;
 use super::monad::chain_vault::ChainVaultV1;
-use super::settlement_queue::SettlementQueueV1;
+use super::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -619,6 +619,16 @@ pub struct MultiChainStateV6 {
     /// but cumulative consumption must never exceed the verified transfer size.
     #[serde(default)]
     pub settled_reserve_transfer_e8s: BTreeMap<String, u128>,
+    /// Optional per-chain bad-debt circuit threshold (e8s). Missing row means the
+    /// circuit is disabled for that chain and `chain_bad_debt_e8s` remains pure
+    /// accounting.
+    #[serde(default)]
+    pub chain_bad_debt_circuit_threshold_e8s: BTreeMap<ChainId, u128>,
+    /// Per-chain bad-debt circuit latch timestamp. Presence means the circuit is
+    /// tripped; clearing removes only this latch and never erases cumulative bad
+    /// debt accounting.
+    #[serde(default)]
+    pub chain_bad_debt_circuit_tripped_at_ns: BTreeMap<ChainId, u64>,
 }
 
 impl MultiChainStateV6 {
@@ -679,6 +689,125 @@ impl MultiChainStateV6 {
                 })
             })
             .collect()
+    }
+
+    pub fn chain_bad_debt_circuit_tripped(&self, chain: ChainId) -> bool {
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .contains_key(&chain)
+    }
+
+    pub fn set_chain_bad_debt_circuit_threshold(
+        &mut self,
+        chain: ChainId,
+        threshold_e8s: Option<u128>,
+        now_ns: u64,
+    ) -> Result<(), String> {
+        match threshold_e8s {
+            Some(0) => Err("threshold must be > 0; use null/None to disable".to_string()),
+            Some(threshold) => {
+                self.chain_bad_debt_circuit_threshold_e8s
+                    .insert(chain, threshold);
+                let debt = self.chain_bad_debt_e8s.get(&chain).copied().unwrap_or(0);
+                if debt >= threshold {
+                    self.chain_bad_debt_circuit_tripped_at_ns
+                        .entry(chain)
+                        .or_insert(now_ns);
+                }
+                Ok(())
+            }
+            None => {
+                self.chain_bad_debt_circuit_threshold_e8s.remove(&chain);
+                self.chain_bad_debt_circuit_tripped_at_ns.remove(&chain);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn clear_chain_bad_debt_circuit(&mut self, chain: ChainId) -> bool {
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .remove(&chain)
+            .is_some()
+    }
+
+    /// Add realized bad debt and latch the per-chain circuit exactly once if the
+    /// post-add cumulative debt meets the configured threshold. Returns true only
+    /// on the transition from untripped -> tripped.
+    pub fn record_chain_bad_debt_and_maybe_trip(
+        &mut self,
+        chain: ChainId,
+        amount_e8s: u128,
+        now_ns: u64,
+    ) -> bool {
+        if amount_e8s == 0 {
+            return false;
+        }
+        let total = self
+            .chain_bad_debt_e8s
+            .entry(chain)
+            .and_modify(|v| *v = v.saturating_add(amount_e8s))
+            .or_insert(amount_e8s);
+        let Some(threshold) = self
+            .chain_bad_debt_circuit_threshold_e8s
+            .get(&chain)
+            .copied()
+        else {
+            return false;
+        };
+        if *total < threshold || self.chain_bad_debt_circuit_tripped(chain) {
+            return false;
+        }
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .insert(chain, now_ns);
+        true
+    }
+
+    /// True when a queued settlement op would increase protocol risk while the
+    /// chain's bad-debt circuit is tripped. Reconciliation and exposure-reducing
+    /// ops intentionally remain allowed.
+    pub fn bad_debt_circuit_blocks_settlement_op(
+        &self,
+        chain: ChainId,
+        kind: &SettlementOpKind,
+    ) -> bool {
+        if !self.chain_bad_debt_circuit_tripped(chain) {
+            return false;
+        }
+        match kind {
+            SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. } => true,
+            SettlementOpKind::NativeWithdrawal { vault_id, .. } => self
+                .chain_vaults
+                .get(vault_id)
+                .map(|v| v.debt_e8s > 0)
+                .unwrap_or(true),
+            SettlementOpKind::Burn { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => false,
+        }
+    }
+
+    /// True when a mint-like settlement op can still explain an on-chain supply
+    /// increase. Inflight mints always count because they may already have
+    /// landed. Queued mints count only when the bad-debt circuit would permit
+    /// submission; a circuit-blocked queued mint must not suppress burn catch-up.
+    pub fn has_supply_increasing_settlement_op(&self, chain: ChainId) -> bool {
+        self.settlement_queues
+            .get(&chain)
+            .map(|q| {
+                q.pending.values().any(|op| {
+                    matches!(
+                        op.kind,
+                        SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+                    ) && match op.status {
+                        SettlementOpStatus::Inflight { .. } => true,
+                        SettlementOpStatus::Queued => {
+                            !self.bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+                        }
+                        SettlementOpStatus::Succeeded { .. }
+                        | SettlementOpStatus::Failed { .. } => false,
+                    }
+                })
+            })
+            .unwrap_or(false)
     }
 
     /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -462,15 +462,21 @@ pub struct ChainLiqClaimV1 {
     pub custody_address: String,
     pub seized_native_total: u128,
     pub paid_native: u128,
+    #[serde(default)]
+    pub pending_native: u128,
 }
 
 impl ChainLiqClaimV1 {
     pub fn paid_within_seized(&self) -> bool {
-        self.paid_native <= self.seized_native_total
+        self.paid_native
+            .checked_add(self.pending_native)
+            .map(|reserved| reserved <= self.seized_native_total)
+            .unwrap_or(false)
     }
 
     pub fn remaining_native(&self) -> u128 {
-        self.seized_native_total.saturating_sub(self.paid_native)
+        self.seized_native_total
+            .saturating_sub(self.paid_native.saturating_add(self.pending_native))
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -51,6 +51,9 @@ pub enum RecoveryError {
     /// On-chain state shows the op DID land — reversing/releasing would create an
     /// unbacked mint or double-release collateral. Refused.
     OnChainLanded(String),
+    /// The op kind needs a specialized recovery path; generic stuck-op reversal
+    /// would leave cross-canister accounting inconsistent.
+    UnsupportedOpKind(String),
 }
 
 impl std::fmt::Display for RecoveryError {
@@ -72,7 +75,10 @@ fn snapshot_inflight_op_tx(chain: ChainId, op_id: u64) -> Result<Option<String>,
             .settlement_queues
             .get(&chain)
             .ok_or(RecoveryError::UnknownChain(chain))?;
-        let op = q.pending.get(&op_id).ok_or(RecoveryError::UnknownOp(op_id))?;
+        let op = q
+            .pending
+            .get(&op_id)
+            .ok_or(RecoveryError::UnknownOp(op_id))?;
         if !matches!(op.status, SettlementOpStatus::Inflight { .. }) {
             return Err(RecoveryError::NotInflight(format!(
                 "op {op_id} status {:?}",
@@ -93,7 +99,7 @@ pub fn apply_resolve_reversal_in_state(
     chain: ChainId,
     op_id: u64,
     now: u64,
-) -> bool {
+) -> Result<bool, RecoveryError> {
     let still_inflight = state
         .settlement_queues
         .get(&chain)
@@ -101,7 +107,7 @@ pub fn apply_resolve_reversal_in_state(
         .map(|o| matches!(o.status, SettlementOpStatus::Inflight { .. }))
         .unwrap_or(false);
     if !still_inflight {
-        return false;
+        return Ok(false);
     }
     // Clone the kind out so we can mutate vaults and the op without overlapping
     // borrows.
@@ -118,7 +124,11 @@ pub fn apply_resolve_reversal_in_state(
                     v.pending_mint_e8s = 0;
                 }
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 if let Some(v) = state.chain_vaults.get_mut(vault_id) {
                     v.collateral_amount_native =
                         v.collateral_amount_native.saturating_add(*amount_e18);
@@ -128,8 +138,10 @@ pub fn apply_resolve_reversal_in_state(
                 }
             }
             SettlementOpKind::ChainCollateralPayout { .. } => {
-                // Claim payout recovery must not re-credit vault collateral. The
-                // SP-side claim rollback is handled by the claim path/callback.
+                return Err(RecoveryError::UnsupportedOpKind(
+                    "ChainCollateralPayout requires SP claim recredit; use settlement retry path"
+                        .to_string(),
+                ));
             }
             SettlementOpKind::InterestMint { vault_id, .. } => {
                 if let Some(v) = state.chain_vaults.get_mut(vault_id) {
@@ -152,9 +164,12 @@ pub fn apply_resolve_reversal_in_state(
         .get_mut(&chain)
         .and_then(|q| q.pending.get_mut(&op_id))
     {
-        o.mark_failed("manually resolved (stuck Inflight, on-chain-verified not landed)".to_string(), now);
+        o.mark_failed(
+            "manually resolved (stuck Inflight, on-chain-verified not landed)".to_string(),
+            now,
+        );
     }
-    true
+    Ok(true)
 }
 
 /// M-08 (RECOV-01): resolve a stuck `Inflight` settlement op, but ONLY after
@@ -209,9 +224,7 @@ pub async fn resolve_stuck_settlement_op_verified(
     }
 
     let now = ic_cdk::api::time();
-    let did_reverse =
-        mutate_state(|s| apply_resolve_reversal_in_state(&mut s.multi_chain, chain, op_id, now));
-    Ok(did_reverse)
+    mutate_state(|s| apply_resolve_reversal_in_state(&mut s.multi_chain, chain, op_id, now))
 }
 
 // ─── M-09: recover a stuck chain vault, on-chain-verified ─────────────────────
@@ -275,10 +288,7 @@ pub fn precheck_recover_vault_in_state(
 }
 
 /// `read_state` wrapper over `precheck_recover_vault_in_state` for the async path.
-pub fn precheck_recover_vault(
-    chain: ChainId,
-    vault_id: u64,
-) -> Result<Vec<String>, RecoveryError> {
+pub fn precheck_recover_vault(chain: ChainId, vault_id: u64) -> Result<Vec<String>, RecoveryError> {
     read_state(|s| precheck_recover_vault_in_state(&s.multi_chain, chain, vault_id))
 }
 
@@ -374,8 +384,18 @@ pub async fn recover_stuck_chain_vault_verified(
     // cursor yet (then there can be no confirmed on-chain mint to find).
     let (contract, cursor, recorded_supply, in_flight_mint) = read_state(|s| {
         let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
-        let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
-        let recorded_supply = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+        let cursor = s
+            .multi_chain
+            .last_observed_block
+            .get(&chain)
+            .copied()
+            .unwrap_or(0);
+        let recorded_supply = s
+            .multi_chain
+            .chain_supplies
+            .get(&chain)
+            .copied()
+            .unwrap_or(0);
         let in_flight_mint: u128 = s
             .multi_chain
             .chain_vaults

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -14,15 +14,25 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum SettlementOpKind {
-    Mint { recipient: String, amount_e8s: u128, vault_id: u64 },
+    Mint {
+        recipient: String,
+        amount_e8s: u128,
+        vault_id: u64,
+    },
     /// Return native gas-asset (MON) collateral to `recipient`. `amount_e18`
     /// is wei (1e18 scale, NOT e8s — it goes straight into the EIP-1559
     /// `value`). `vault_id` lets the settlement worker emit `WithdrawalSigned`
     /// with the real id and flip the vault `Closing -> Closed` on confirmation
     /// (replaces the old placeholder `Withdrawal { recipient, amount_e8s }`,
     /// which was never enqueued anywhere and carried the wrong unit + no id).
-    NativeWithdrawal { recipient: String, amount_e18: u128, vault_id: u64 },
-    Burn { amount_e8s: u128 },
+    NativeWithdrawal {
+        recipient: String,
+        amount_e18: u128,
+        vault_id: u64,
+    },
+    Burn {
+        amount_e8s: u128,
+    },
     /// Task 12 (Option B): realize accrued interest by minting `amount_e8s`
     /// icUSD to the per-chain interest-treasury address. `mint_id` is a FRESH,
     /// globally-unique id (from `chain_vault_id_counter`) used as the on-chain
@@ -100,6 +110,19 @@ pub struct SettlementOp {
     /// pre-existing snapshot decoding cleanly.
     #[serde(default)]
     pub submit_nonce: Option<u64>,
+    /// Same-nonce transaction hashes that may have been accepted by an RPC
+    /// provider. This is primarily for retry-safe native payouts: an RBF
+    /// replacement can be pre-recorded before an ambiguous broadcast boundary,
+    /// but a definite rejection must not make the confirm path forget the
+    /// original same-nonce hash.
+    #[serde(default)]
+    pub tx_hash_candidates: Vec<String>,
+    /// `Some(true)` only for ChainCollateralPayout ops enqueued after Inc10,
+    /// where payout capacity is reserved in `ChainLiqClaimV1.pending_native`.
+    /// Older decoded payout ops have `None` and their live reservation remains
+    /// in `paid_native`.
+    #[serde(default)]
+    pub chain_payout_uses_pending_reservation: Option<bool>,
 }
 
 impl SettlementOp {
@@ -112,6 +135,8 @@ impl SettlementOp {
             status: SettlementOpStatus::Queued,
             last_tx_hash: None,
             submit_nonce: None,
+            tx_hash_candidates: Vec::new(),
+            chain_payout_uses_pending_reservation: None,
         }
     }
 
@@ -120,15 +145,53 @@ impl SettlementOp {
             SettlementOpStatus::Inflight { tries, .. } => tries.saturating_add(1),
             _ => 1,
         };
-        self.status = SettlementOpStatus::Inflight { tries, last_attempt_ns: now_ns };
+        self.status = SettlementOpStatus::Inflight {
+            tries,
+            last_attempt_ns: now_ns,
+        };
     }
 
     pub fn mark_succeeded(&mut self, tx_hash: String, now_ns: u64) {
-        self.status = SettlementOpStatus::Succeeded { tx_hash, confirmed_ns: now_ns };
+        self.status = SettlementOpStatus::Succeeded {
+            tx_hash,
+            confirmed_ns: now_ns,
+        };
     }
 
     pub fn mark_failed(&mut self, reason: String, now_ns: u64) {
-        self.status = SettlementOpStatus::Failed { reason, failed_ns: now_ns };
+        self.status = SettlementOpStatus::Failed {
+            reason,
+            failed_ns: now_ns,
+        };
+    }
+
+    pub fn record_tx_hash_candidate(&mut self, tx_hash: String) {
+        if self.tx_hash_candidates.is_empty() {
+            if let Some(existing) = &self.last_tx_hash {
+                if existing != &tx_hash {
+                    self.tx_hash_candidates.push(existing.clone());
+                }
+            }
+        }
+        if self.tx_hash_candidates.iter().any(|h| h == &tx_hash) {
+            self.last_tx_hash = Some(tx_hash);
+            return;
+        }
+        self.tx_hash_candidates.push(tx_hash.clone());
+        self.last_tx_hash = Some(tx_hash);
+    }
+
+    pub fn receipt_tx_hash_candidates(&self) -> Vec<String> {
+        let mut hashes = Vec::with_capacity(self.tx_hash_candidates.len() + 1);
+        if let Some(h) = &self.last_tx_hash {
+            hashes.push(h.clone());
+        }
+        for h in &self.tx_hash_candidates {
+            if !hashes.iter().any(|existing| existing == h) {
+                hashes.push(h.clone());
+            }
+        }
+        hashes
     }
 }
 
@@ -161,7 +224,8 @@ impl SettlementQueueV1 {
         }
         let assigned = self.tail;
         op.op_id = assigned;
-        self.seen_idempotency_keys.insert(op.idempotency_key.clone());
+        self.seen_idempotency_keys
+            .insert(op.idempotency_key.clone());
         self.drain_order.push_back(assigned);
         self.pending.insert(assigned, op);
         self.tail = self.tail.saturating_add(1);
@@ -197,11 +261,13 @@ impl SettlementQueueV1 {
     /// (`Succeeded`/`Failed`) ops never count.
     pub fn has_active_mint_op(&self) -> bool {
         self.pending.values().any(|op| {
-            matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. })
-                && matches!(
-                    op.status,
-                    SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
-                )
+            matches!(
+                op.kind,
+                SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+            ) && matches!(
+                op.status,
+                SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+            )
         })
     }
 
@@ -274,8 +340,14 @@ mod tests {
         assert_eq!(q.pending_len(), 3);
 
         // Mark op 0 Succeeded and op 1 Failed; op 2 stays Queued (live).
-        q.pending.get_mut(&id0).unwrap().mark_succeeded("0xhash".to_string(), 10);
-        q.pending.get_mut(&id1).unwrap().mark_failed("reverted".to_string(), 11);
+        q.pending
+            .get_mut(&id0)
+            .unwrap()
+            .mark_succeeded("0xhash".to_string(), 10);
+        q.pending
+            .get_mut(&id1)
+            .unwrap()
+            .mark_failed("reverted".to_string(), 11);
 
         q.prune_terminal();
 
@@ -297,7 +369,10 @@ mod tests {
         assert!(matches!(dup, Err(SettlementQueueError::DuplicateIdempotencyKey(k)) if k == "k0"));
 
         // select_next_op still returns the live Queued op (semantics unchanged).
-        let live = q.pending.values().find(|o| matches!(o.status, SettlementOpStatus::Queued));
+        let live = q
+            .pending
+            .values()
+            .find(|o| matches!(o.status, SettlementOpStatus::Queued));
         assert!(live.is_some());
     }
 
@@ -306,8 +381,14 @@ mod tests {
         let mut q = SettlementQueueV1::default();
         let id0 = q.enqueue(mint_op("a")).unwrap();
         let id1 = q.enqueue(mint_op("b")).unwrap();
-        q.pending.get_mut(&id0).unwrap().mark_succeeded("0x1".to_string(), 1);
-        q.pending.get_mut(&id1).unwrap().mark_succeeded("0x2".to_string(), 2);
+        q.pending
+            .get_mut(&id0)
+            .unwrap()
+            .mark_succeeded("0x1".to_string(), 1);
+        q.pending
+            .get_mut(&id1)
+            .unwrap()
+            .mark_succeeded("0x2".to_string(), 2);
 
         q.prune_terminal();
 
@@ -327,5 +408,35 @@ mod tests {
         q.prune_terminal();
         assert_eq!(q.pending_len(), 1);
         assert_eq!(q.head, before_head);
+    }
+
+    #[test]
+    fn tx_hash_candidates_seed_legacy_last_hash_and_do_not_evict_ambiguous_replacements() {
+        let mut op = mint_op("k");
+        op.last_tx_hash = Some("0xlegacy".to_string());
+        for i in 0..16 {
+            op.record_tx_hash_candidate(format!("0xreplacement{i}"));
+        }
+
+        assert_eq!(op.tx_hash_candidates.len(), 17);
+        assert_eq!(op.tx_hash_candidates.first().unwrap(), "0xlegacy");
+        assert_eq!(op.tx_hash_candidates.last().unwrap(), "0xreplacement15");
+        assert_eq!(
+            op.receipt_tx_hash_candidates().first().unwrap(),
+            op.last_tx_hash.as_ref().unwrap(),
+            "receipt polling still starts with the latest replacement"
+        );
+        assert!(
+            op.receipt_tx_hash_candidates()
+                .iter()
+                .any(|h| h == "0xlegacy"),
+            "a decoded legacy last_tx_hash remains observable after replacement recording"
+        );
+        assert!(
+            op.receipt_tx_hash_candidates()
+                .iter()
+                .any(|h| h == "0xreplacement0"),
+            "older ambiguous replacements remain observable"
+        );
     }
 }

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -53,7 +53,9 @@ use crate::Mode;
 // chain-independent: `select_next_op` scans a `SettlementQueueV1` and
 // `confirm_mint_in_state` operates on `MultiChainState`, neither of which is
 // Monad-specific.
-use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
+use crate::chains::monad::settlement::{
+    confirm_mint_in_state, select_next_op_with_submit_filter, OpAction,
+};
 
 use super::adapter::SolanaAdapter;
 use super::{hardening, sol_rpc, ted25519, tx};
@@ -138,20 +140,21 @@ pub async fn run_settlement(chain: ChainId) {
         return;
     }
 
-    // Snapshot this chain's queue and pick the next actionable op.
-    let queue = read_state(|s| s.multi_chain.settlement_queues.get(&chain).cloned());
-    let queue = match queue {
-        Some(q) => q,
+    // Snapshot this chain's next actionable op. A tripped bad-debt circuit skips
+    // queued risk-increasing ops at selection time so later reconciliation ops
+    // are not starved behind the blocked head of queue.
+    let selected = read_state(|s| {
+        let q = s.multi_chain.settlement_queues.get(&chain)?;
+        let (op_id, action) = select_next_op_with_submit_filter(q, |_, op| {
+            s.multi_chain
+                .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+        })?;
+        let op = q.pending.get(&op_id)?.clone();
+        Some((op_id, action, op))
+    });
+    let (op_id, action, op) = match selected {
+        Some(selected) => selected,
         None => return, // chain not registered / no queue
-    };
-    let (op_id, action) = match select_next_op(&queue) {
-        Some(pair) => pair,
-        None => return, // nothing to do
-    };
-    // Clone the op out so we can drop the queue snapshot before awaiting.
-    let op = match queue.pending.get(&op_id).cloned() {
-        Some(o) => o,
-        None => return,
     };
 
     match action {
@@ -189,7 +192,8 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
             | SettlementOpKind::ChainCollateralPayout { .. }
     ) {
         let now = ic_cdk::api::time();
-        let reason = "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
+        let reason =
+            "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
         mutate_state(|s| {
             if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                 if let Some(o) = q.pending.get_mut(&op_id) {
@@ -207,6 +211,20 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
         return;
     }
 
+    if read_state(|s| {
+        s.multi_chain
+            .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+    }) {
+        log!(
+            INFO,
+            "[solana settlement chain={:?}] bad-debt circuit tripped; deferring submit of op {} {:?}",
+            chain,
+            op_id,
+            op.kind
+        );
+        return;
+    }
+
     // GAS GATE: refuse a new outbound op when the settlement (mint-authority +
     // fee-payer) address lacks enough SOL for fees + a fresh-ATA rent touch.
     // Unlike Monad (which reads a cached balance the observer refreshes), the
@@ -215,18 +233,25 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // `hardening::hot_wallet_ok`. A derive/read failure logs and leaves the op
     // Queued (retry next tick); it does NOT fail the op.
     let settlement_path = ted25519::settlement_derivation_path(chain);
-    let (_settlement_pk, settlement_addr) =
-        match ted25519::derive_solana_address(settlement_path).await {
-            Ok(pair) => pair,
-            Err(e) => {
-                log!(INFO, "[solana settlement chain={:?}] derive settlement address failed for op {}: {}; will retry", chain, op_id, e);
-                return;
-            }
-        };
+    let (_settlement_pk, settlement_addr) = match ted25519::derive_solana_address(settlement_path)
+        .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            log!(INFO, "[solana settlement chain={:?}] derive settlement address failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
     let balance = match sol_rpc::get_balance(&settlement_addr).await {
         Ok(b) => b,
         Err(e) => {
-            log!(INFO, "[solana settlement chain={:?}] get_balance failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] get_balance failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -248,7 +273,11 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // NO state borrow is held across these awaits.
     let adapter = SolanaAdapter::new(chain);
     let (raw_tx, vault_id, recipient, amount, kind) = match &op.kind {
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s,
+            vault_id,
+        } => {
             let instr = MintInstruction {
                 recipient: recipient.clone(),
                 amount_e8s: *amount_e8s,
@@ -267,7 +296,11 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
                 Err(e) => return handle_adapter_error(chain, op_id, "sign_mint", e),
             }
         }
-        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+        SettlementOpKind::NativeWithdrawal {
+            recipient,
+            amount_e18,
+            vault_id,
+        } => {
             // `amount_e18` carries SOL lamports here (the e18 field is the shared
             // amount wart); the adapter does the checked u128 -> u64 conversion.
             let req = WithdrawalRequest {
@@ -395,7 +428,12 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     let signature = match &op.last_tx_hash {
         Some(h) => h.clone(),
         None => {
-            log!(INFO, "[solana settlement chain={:?}] inflight op {} has no last_tx_hash; skipping", chain, op_id);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] inflight op {} has no last_tx_hash; skipping",
+                chain,
+                op_id
+            );
             return;
         }
     };
@@ -417,7 +455,13 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: SettlementOp) {
             // Not finalized yet (or never landed). Leave Inflight; the next tick
             // re-confirms. A same-bytes resend for a truly-stuck tx is the
             // deferred M2 seam - we do NOT re-broadcast or re-sign here.
-            log!(INFO, "[solana settlement chain={:?}] op {} sig {} not finalized yet; leaving Inflight", chain, op_id, signature);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] op {} sig {} not finalized yet; leaving Inflight",
+                chain,
+                op_id,
+                signature
+            );
         }
         sol_rpc::TxStatus::Confirmed { slot } => {
             confirm_succeeded(chain, op_id, &op, &signature, slot, now);
@@ -439,7 +483,11 @@ fn confirm_succeeded(
     now: u64,
 ) {
     match &op.kind {
-        SettlementOpKind::Mint { vault_id, amount_e8s, .. } => {
+        SettlementOpKind::Mint {
+            vault_id,
+            amount_e8s,
+            ..
+        } => {
             let vault_id = *vault_id;
             let amount_e8s = *amount_e8s;
             // PRE-mint total: sum of foreign-chain vault debt BEFORE this mint
@@ -473,7 +521,14 @@ fn confirm_succeeded(
                 if !still_inflight {
                     return MintConfirm::AlreadyHandled;
                 }
-                match confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total, now) {
+                match confirm_mint_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    amount_e8s,
+                    pre_total,
+                    now,
+                ) {
                     Ok(()) => {
                         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                             if let Some(o) = q.pending.get_mut(&op_id) {
@@ -577,7 +632,11 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
                     v.pending_mint_e8s = 0;
                 }
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 // The transfer did not happen, so the reserved collateral was not
                 // paid out. ADD it back (undo the reserve-at-enqueue) and, if the
                 // vault had gone `Closing` (full withdrawal / close), revert it to
@@ -591,9 +650,9 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
                 }
             }
             SettlementOpKind::Burn { .. }
-        | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. }
-        | SettlementOpKind::ChainCollateralPayout { .. } => {}
+            | SettlementOpKind::InterestMint { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
         if let Some(o) = s
             .multi_chain
@@ -617,13 +676,17 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
             SettlementOpKind::Mint { vault_id, .. } => {
                 log!(INFO, "[solana settlement chain={:?}] MINT op {} vault {} REVERTED on-chain (sig {}); marked Failed, pending_mint cleared, vault left MintPending for manual resolution", chain, op_id, vault_id, signature);
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 log!(INFO, "[solana settlement chain={:?}] withdrawal op {} vault {} reverted on-chain (sig {}); marked Failed, restored {} lamports of reserved collateral", chain, op_id, vault_id, signature, amount_e18);
             }
             SettlementOpKind::Burn { .. }
-        | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. }
-        | SettlementOpKind::ChainCollateralPayout { .. } => {}
+            | SettlementOpKind::InterestMint { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
     }
 }
@@ -668,7 +731,14 @@ fn handle_adapter_error(
             log!(INFO, "[solana settlement chain={:?}] {} returned permanent InvalidPayload for op {}: {}; marked Failed", chain, what, op_id, reason);
         }
         other => {
-            log!(INFO, "[solana settlement chain={:?}] {} failed (transient) for op {}: {:?}; will retry", chain, what, op_id, other);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] {} failed (transient) for op {}: {:?}; will retry",
+                chain,
+                what,
+                op_id,
+                other
+            );
         }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -8,7 +8,10 @@ use super::config::{
 };
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use super::multi_chain_state::MultiChainState;
-use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
+use crate::chains::admin::{
+    delete_chain_in_state, disable_chain_in_state, register_chain_in_state,
+    update_chain_config_in_state,
+};
 use candid::Principal;
 
 fn arg() -> RegisterChainArg {
@@ -17,7 +20,10 @@ fn arg() -> RegisterChainArg {
         display_name: "Monad".into(),
         rpc_endpoints: vec!["https://rpc.example".into()],
         finality_depth: 1,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 200,
+        },
         chain_native_decimals: 18,
         min_quorum_providers: None,
     }
@@ -29,7 +35,10 @@ fn config_arg_999() -> RegisterChainArg {
         display_name: "ScratchChain".into(),
         rpc_endpoints: vec!["https://rpc.scratch".into()],
         finality_depth: 1,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 200,
+        },
         chain_native_decimals: 18,
         min_quorum_providers: None,
     }
@@ -50,7 +59,8 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    }
+        pending_liquidation: None,
+    }
 }
 
 #[test]
@@ -75,7 +85,10 @@ fn register_chain_rejects_duplicates() {
     let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
-    assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
+    assert!(matches!(
+        err,
+        ChainAdminError::ChainAlreadyRegistered(ChainId(101))
+    ));
 }
 
 #[test]
@@ -96,7 +109,10 @@ fn register_chain_rejects_out_of_range_decimals() {
     zero.chain_native_decimals = 0;
     let err = register_chain_in_state(&mut s, zero, 0).expect_err("zero decimals");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
-    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+    assert!(
+        !s.chain_configs.contains_key(&ChainId(101)),
+        "no partial insert on reject"
+    );
 
     // Absurdly large decimals are also rejected.
     let mut huge = arg();
@@ -120,14 +136,19 @@ fn register_chain_enforces_evm_finality_floor() {
     a.finality_depth = 0;
     let err = register_chain_in_state(&mut s, a, 0).expect_err("evm finality 0");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
-    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+    assert!(
+        !s.chain_configs.contains_key(&ChainId(101)),
+        "no partial insert on reject"
+    );
 
     // A Solana-style chain (non-EVM gas) MAY use finality_depth 0 (reads at the
     // `finalized` commitment).
     let mut sol = arg();
     sol.chain_id = ChainId(202);
     sol.chain_native_decimals = 9;
-    sol.gas_strategy = GasStrategy::SolanaPriorityFee { lamports_per_cu_ceiling: 10_000 };
+    sol.gas_strategy = GasStrategy::SolanaPriorityFee {
+        lamports_per_cu_ceiling: 10_000,
+    };
     sol.finality_depth = 0;
     register_chain_in_state(&mut s, sol, 0).expect("solana finality 0 ok");
     assert_eq!(s.chain_configs[&ChainId(202)].finality_depth, 0);
@@ -139,7 +160,10 @@ fn disable_chain_flips_status_and_preserves_supply() {
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
-    assert!(matches!(s.chain_configs[&ChainId(101)].status, ChainStatus::Disabled));
+    assert!(matches!(
+        s.chain_configs[&ChainId(101)].status,
+        ChainStatus::Disabled
+    ));
     assert_eq!(s.chain_supplies[&ChainId(101)], 999);
 }
 
@@ -164,11 +188,8 @@ fn set_chain_config_updates_supplied_fields_only() {
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
     let mut s = MultiChainState::default();
-    let err = update_chain_config_in_state(
-        &mut s,
-        ChainId(404),
-        UpdateChainConfigArg::default(),
-    ).expect_err("unknown chain");
+    let err = update_chain_config_in_state(&mut s, ChainId(404), UpdateChainConfigArg::default())
+        .expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(_)));
 }
 
@@ -185,28 +206,73 @@ fn delete_chain_removes_zero_supply_chain() {
     s.hot_wallet_balance_e18.insert(c, 1_000);
     s.reorg_halted.insert(c, true);
     s.reorg_suspect_streak.insert(c, 2);
+    s.chain_bad_debt_e8s.insert(c, 77);
+    s.chain_bad_debt_circuit_threshold_e8s.insert(c, 100);
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(c, 456);
     // An unrelated chain's manual_prices entry must SURVIVE the delete.
-    s.manual_prices.insert((ChainId(7), "MON".to_string()), 3_0000_0000);
-    s.manual_price_set_at_ns.insert((ChainId(7), "MON".to_string()), 456);
+    s.manual_prices
+        .insert((ChainId(7), "MON".to_string()), 3_0000_0000);
+    s.manual_price_set_at_ns
+        .insert((ChainId(7), "MON".to_string()), 456);
 
     delete_chain_in_state(&mut s, c).expect("delete");
 
     assert!(!s.chain_configs.contains_key(&c), "chain_configs retained");
-    assert!(!s.chain_supplies.contains_key(&c), "chain_supplies retained");
-    assert!(!s.settlement_queues.contains_key(&c), "settlement_queues retained");
-    assert!(!s.chain_contracts.contains_key(&c), "chain_contracts retained");
-    assert!(!s.last_observed_block.contains_key(&c), "last_observed_block retained");
-    assert!(!s.hot_wallet_balance_e18.contains_key(&c), "hot_wallet_balance_e18 retained");
-    assert!(!s.reorg_halted.contains_key(&c), "reorg_halted retained");
-    assert!(!s.reorg_suspect_streak.contains_key(&c), "reorg_suspect_streak retained");
-    assert!(!s.manual_prices.contains_key(&(c, "MON".to_string())), "manual_prices retained");
     assert!(
-        !s.manual_price_set_at_ns.contains_key(&(c, "MON".to_string())),
+        !s.chain_supplies.contains_key(&c),
+        "chain_supplies retained"
+    );
+    assert!(
+        !s.settlement_queues.contains_key(&c),
+        "settlement_queues retained"
+    );
+    assert!(
+        !s.chain_contracts.contains_key(&c),
+        "chain_contracts retained"
+    );
+    assert!(
+        !s.last_observed_block.contains_key(&c),
+        "last_observed_block retained"
+    );
+    assert!(
+        !s.hot_wallet_balance_e18.contains_key(&c),
+        "hot_wallet_balance_e18 retained"
+    );
+    assert!(!s.reorg_halted.contains_key(&c), "reorg_halted retained");
+    assert!(
+        !s.reorg_suspect_streak.contains_key(&c),
+        "reorg_suspect_streak retained"
+    );
+    assert!(
+        !s.chain_bad_debt_e8s.contains_key(&c),
+        "chain_bad_debt_e8s retained"
+    );
+    assert!(
+        !s.chain_bad_debt_circuit_threshold_e8s.contains_key(&c),
+        "chain_bad_debt_circuit_threshold_e8s retained"
+    );
+    assert!(
+        !s.chain_bad_debt_circuit_tripped_at_ns.contains_key(&c),
+        "chain_bad_debt_circuit_tripped_at_ns retained"
+    );
+    assert!(
+        !s.manual_prices.contains_key(&(c, "MON".to_string())),
+        "manual_prices retained"
+    );
+    assert!(
+        !s.manual_price_set_at_ns
+            .contains_key(&(c, "MON".to_string())),
         "manual_price_set_at_ns leaked (paired-map divergence)"
     );
     // The unrelated chain's price + timestamp survive.
-    assert_eq!(s.manual_prices[&(ChainId(7), "MON".to_string())], 3_0000_0000);
-    assert_eq!(s.manual_price_set_at_ns[&(ChainId(7), "MON".to_string())], 456);
+    assert_eq!(
+        s.manual_prices[&(ChainId(7), "MON".to_string())],
+        3_0000_0000
+    );
+    assert_eq!(
+        s.manual_price_set_at_ns[&(ChainId(7), "MON".to_string())],
+        456
+    );
 }
 
 #[test]
@@ -218,7 +284,10 @@ fn delete_chain_refuses_when_supply_nonzero() {
     let err = delete_chain_in_state(&mut s, c).expect_err("nonzero supply");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
     // No partial delete: the chain is STILL registered with its supply intact.
-    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert!(
+        s.chain_configs.contains_key(&c),
+        "chain dropped despite refusal"
+    );
     assert_eq!(s.chain_supplies[&c], 1);
 }
 
@@ -231,7 +300,10 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
     let err = delete_chain_in_state(&mut s, c).expect_err("referencing vault");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
     // No partial delete: the chain is STILL registered and the vault remains.
-    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert!(
+        s.chain_configs.contains_key(&c),
+        "chain dropped despite refusal"
+    );
     assert!(s.chain_vaults.contains_key(&1));
 }
 
@@ -239,5 +311,8 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
 fn delete_chain_unknown_is_rejected() {
     let mut s = MultiChainState::default();
     let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
-    assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
+    assert!(matches!(
+        err,
+        ChainAdminError::ChainNotRegistered(ChainId(404))
+    ));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -523,6 +523,7 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
             custody_address: "0xcustody".into(),
             seized_native_total: 12_345_000_000_000_000_000,
             paid_native: 1_000_000_000_000_000_000,
+            pending_native: 0,
         },
     );
     v6.chain_liquidation_configs.insert(
@@ -608,6 +609,17 @@ fn chain_liq_claim_invariant_rejects_overpaid_claims() {
         custody_address: "0xcustody".into(),
         seized_native_total: 10,
         paid_native: 11,
+        pending_native: 0,
+    };
+    assert!(!claim.paid_within_seized());
+
+    let claim = ChainLiqClaimV1 {
+        vault_id: 10,
+        chain: ChainId(1030),
+        custody_address: "0xcustody".into(),
+        seized_native_total: 10,
+        paid_native: 6,
+        pending_native: 5,
     };
     assert!(!claim.paid_within_seized());
 }
@@ -696,10 +708,8 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         .insert(pending.proof_id.clone(), pending.clone());
     v6.settled_reserve_burn_proofs
         .insert(reserve.proof_id.clone(), reserve.clone());
-    v6.settled_settlement_burn_logs.insert(format!(
-        "{}:{}",
-        pending.tx_hash, pending.log_index
-    ));
+    v6.settled_settlement_burn_logs
+        .insert(format!("{}:{}", pending.tx_hash, pending.log_index));
     v6.settled_reserve_transfer_e8s.insert(
         "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string(),
         50_000_000,
@@ -718,10 +728,9 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         decoded.settled_reserve_burn_proofs[&reserve.proof_id],
         reserve
     );
-    assert!(decoded.settled_settlement_burn_logs.contains(&format!(
-        "{}:{}",
-        pending.tx_hash, pending.log_index
-    )));
+    assert!(decoded
+        .settled_settlement_burn_logs
+        .contains(&format!("{}:{}", pending.tx_hash, pending.log_index)));
     assert_eq!(
         decoded.settled_reserve_transfer_e8s
             [&"0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string()],

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -682,6 +682,230 @@ fn settlement_proof_state_defaults_empty_from_pre_inc6_v6_snapshot() {
 }
 
 #[test]
+fn inc11_bad_debt_circuit_state_defaults_empty_from_v6_snapshot() {
+    use super::collateral_config::ChainDebtConfigV1;
+    use super::config::ChainConfigV3;
+    use super::liquidation_config::ChainLiquidationConfigV1;
+    use super::monad::chain_vault::ChainVaultV1;
+    use super::settlement_queue::SettlementQueueV1;
+    use candid::Principal;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[derive(serde::Serialize, Default)]
+    struct PreInc11MultiChainStateV6 {
+        pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
+        pub chain_supplies: BTreeMap<ChainId, u128>,
+        pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+        pub invariant_halted: bool,
+        pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+        pub chain_contracts: BTreeMap<ChainId, String>,
+        pub manual_prices: BTreeMap<(ChainId, String), u64>,
+        pub last_observed_block: BTreeMap<ChainId, u64>,
+        pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+        pub reorg_halted: BTreeMap<ChainId, bool>,
+        pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+        pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+        pub evm_owner_nonces: BTreeMap<Principal, u64>,
+        pub manual_price_set_at_ns: BTreeMap<(ChainId, String), u64>,
+        pub reserve_backing_e8s: BTreeMap<ChainId, u128>,
+        pub reserve_usdc_native: BTreeMap<ChainId, u128>,
+        pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
+        pub sp_attempted_chain_vaults: BTreeSet<u64>,
+        pub chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>,
+        pub chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>,
+        pub chain_debt_configs: BTreeMap<ChainId, ChainDebtConfigV1>,
+        pub bot_pending_chain_vaults: BTreeMap<u64, u64>,
+        pub chain_bad_debt_e8s: BTreeMap<ChainId, u128>,
+    }
+
+    const CFX: ChainId = ChainId(1030);
+    let mut pre = PreInc11MultiChainStateV6::default();
+    pre.chain_supplies.insert(CFX, 100);
+    pre.chain_bad_debt_e8s.insert(CFX, 7);
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&pre, &mut buf).expect("cbor encode pre-Inc11 V6");
+    let decoded: MultiChainState =
+        ciborium::de::from_reader(buf.as_slice()).expect("pre-Inc11 V6 decodes");
+
+    assert_eq!(decoded.chain_supplies.get(&CFX), Some(&100));
+    assert_eq!(decoded.chain_bad_debt_e8s.get(&CFX), Some(&7));
+    assert!(decoded.chain_bad_debt_circuit_threshold_e8s.is_empty());
+    assert!(decoded.chain_bad_debt_circuit_tripped_at_ns.is_empty());
+    assert!(!decoded.chain_bad_debt_circuit_tripped(CFX));
+}
+
+#[test]
+fn bad_debt_circuit_blocks_only_risk_increasing_settlement_ops() {
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::settlement_queue::SettlementOpKind;
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(1030);
+    let mut state = MultiChainState::default();
+    state.chain_bad_debt_circuit_tripped_at_ns.insert(CFX, 42);
+    state.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0xc".into(),
+            collateral_amount_native: 100,
+            debt_e8s: 10,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
+    state.chain_vaults.insert(
+        2,
+        ChainVaultV1 {
+            vault_id: 2,
+            owner: Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0xc".into(),
+            collateral_amount_native: 100,
+            debt_e8s: 0,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
+
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 1,
+            vault_id: 1,
+        }
+    ));
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::InterestMint {
+            vault_id: 1,
+            mint_id: 99,
+            amount_e8s: 1,
+            accrual_through_ns: 1,
+            recipient: "0xt".into(),
+        }
+    ));
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1,
+            vault_id: 1,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1,
+            vault_id: 2,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::LiquidationSwap {
+            vault_id: 1,
+            collateral_in_native: 1,
+            min_usdc_out_native: 1,
+            debt_to_clear_e8s: 1,
+            router: "0x1".into(),
+            pair: "0x2".into(),
+            path: vec![],
+            reserve_recipient: "0x3".into(),
+            deadline_secs: 1,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::ChainCollateralPayout {
+            vault_id: 1,
+            claimant: Principal::anonymous(),
+            recipient: "0xr".into(),
+            amount_e18: 1,
+        }
+    ));
+}
+
+#[test]
+fn supply_increasing_settlement_op_ignores_circuit_blocked_queued_mints() {
+    use super::settlement_queue::{
+        SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
+    };
+
+    const CFX: ChainId = ChainId(1030);
+    let mut state = MultiChainState::default();
+    state.chain_bad_debt_circuit_tripped_at_ns.insert(CFX, 42);
+    state
+        .settlement_queues
+        .insert(CFX, SettlementQueueV1::default());
+    let mint_id = state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint {
+                recipient: "0xr".into(),
+                amount_e8s: 1,
+                vault_id: 1,
+            },
+            "blocked-mint".into(),
+            0,
+        ))
+        .expect("enqueue mint");
+
+    assert!(
+        !state.has_supply_increasing_settlement_op(CFX),
+        "circuit-blocked queued mint cannot explain a supply increase"
+    );
+
+    state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .pending
+        .get_mut(&mint_id)
+        .unwrap()
+        .status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 1,
+    };
+    assert!(
+        state.has_supply_increasing_settlement_op(CFX),
+        "inflight mint can already have landed and must still mask backstop scans"
+    );
+
+    state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .pending
+        .get_mut(&mint_id)
+        .unwrap()
+        .status = SettlementOpStatus::Queued;
+    state.chain_bad_debt_circuit_tripped_at_ns.remove(&CFX);
+    assert!(
+        state.has_supply_increasing_settlement_op(CFX),
+        "queued mint is supply-increasing again once the circuit is clear"
+    );
+}
+
+#[test]
 fn settlement_proof_state_round_trip_preserves_compact_records() {
     let mut v6 = MultiChainStateV6::default();
     let pending = SettlementProofRecord {

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -10,8 +10,8 @@ use super::config::ChainId;
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use super::multi_chain_state::MultiChainState;
 use super::recovery::{
-    apply_recover_vault_in_state, apply_resolve_reversal_in_state,
-    precheck_recover_vault_in_state, RecoveryError,
+    apply_recover_vault_in_state, apply_resolve_reversal_in_state, precheck_recover_vault_in_state,
+    RecoveryError,
 };
 use super::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
@@ -33,13 +33,17 @@ fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u12
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    }
+        pending_liquidation: None,
+    }
 }
 
 fn inflight_op(op_id: u64, kind: SettlementOpKind, tx: Option<&str>) -> SettlementOp {
     let mut op = SettlementOp::new(kind, format!("key-{op_id}"), 0);
     op.op_id = op_id;
-    op.status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    op.status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 0,
+    };
     op.last_tx_hash = tx.map(|s| s.to_string());
     op
 }
@@ -60,12 +64,17 @@ fn state_with_op(op: SettlementOp) -> MultiChainState {
 fn resolve_reversal_mint_clears_pending_and_marks_failed() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 5, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 5, 0));
 
-    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("mint reversal");
     assert!(did, "first reversal applies");
     // Pending cleared, status stays MintPending (Design B: no debt was counted).
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
@@ -81,12 +90,17 @@ fn resolve_reversal_mint_clears_pending_and_marks_failed() {
 fn resolve_reversal_withdrawal_restores_collateral_and_reopens() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
 
-    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("withdrawal reversal");
     assert!(did);
     // Reserved collateral added back; Closing -> Open.
     assert_eq!(s.chain_vaults[&1].collateral_amount_native, 1_000);
@@ -99,18 +113,49 @@ fn resolve_reversal_is_idempotent_cas() {
     // the withdrawal collateral (the CAS guard prevents 2x amount_e18).
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
 
-    assert!(apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100));
-    let second = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 200);
-    assert!(!second, "second reversal is a no-op (op no longer Inflight)");
+    assert!(apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("first reversal"));
+    let second = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 200).expect("second reversal");
+    assert!(
+        !second,
+        "second reversal is a no-op (op no longer Inflight)"
+    );
     assert_eq!(
         s.chain_vaults[&1].collateral_amount_native, 1_000,
         "collateral credited exactly once"
     );
+}
+
+#[test]
+fn resolve_reversal_rejects_chain_collateral_payout_without_mutation() {
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::ChainCollateralPayout {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 7,
+            claimant: Principal::anonymous(),
+        },
+        Some("0xtx"),
+    ));
+
+    let err = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100)
+        .expect_err("claim payout needs specialized recovery");
+
+    assert!(matches!(err, RecoveryError::UnsupportedOpKind(_)));
+    assert!(matches!(
+        s.settlement_queues[&CHAIN].pending[&0].status,
+        SettlementOpStatus::Inflight { .. }
+    ));
 }
 
 // ── M-09: precheck + transition ───────────────────────────────────────────────
@@ -123,14 +168,22 @@ fn precheck_recover_returns_terminal_mint_tx_hashes() {
     let mut q = super::settlement_queue::SettlementQueueV1::default();
     let mut op = inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xmint_tx"),
     );
-    op.status = SettlementOpStatus::Failed { reason: "x".into(), failed_ns: 1 };
+    op.status = SettlementOpStatus::Failed {
+        reason: "x".into(),
+        failed_ns: 1,
+    };
     q.pending.insert(0, op);
     q.tail = 1;
     s.settlement_queues.insert(CHAIN, q);
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
 
     let hashes = precheck_recover_vault_in_state(&s, CHAIN, 1).expect("precheck ok");
     assert_eq!(hashes, vec!["0xmint_tx".to_string()]);
@@ -140,10 +193,15 @@ fn precheck_recover_returns_terminal_mint_tx_hashes() {
 fn precheck_recover_rejects_live_mint_op() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     )); // Inflight == live
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     let err = precheck_recover_vault_in_state(&s, CHAIN, 1).expect_err("live mint");
     assert!(matches!(err, RecoveryError::LiveMintOp(1)));
 }
@@ -152,13 +210,15 @@ fn precheck_recover_rejects_live_mint_op() {
 fn precheck_recover_rejects_nonzero_pending_or_wrong_status() {
     let mut s = MultiChainState::default();
     // Nonzero pending => not recoverable.
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
     assert!(matches!(
         precheck_recover_vault_in_state(&s, CHAIN, 1),
         Err(RecoveryError::NotRecoverable(_))
     ));
     // Wrong status (Open) => not recoverable.
-    s.chain_vaults.insert(2, vault(2, ChainVaultStatus::Open, 0, 9));
+    s.chain_vaults
+        .insert(2, vault(2, ChainVaultStatus::Open, 0, 9));
     assert!(matches!(
         precheck_recover_vault_in_state(&s, CHAIN, 2),
         Err(RecoveryError::NotRecoverable(_))
@@ -184,7 +244,8 @@ fn precheck_recover_rejects_wrong_chain_and_unknown() {
 #[test]
 fn apply_recover_vault_flips_mintpending_to_open() {
     let mut s = MultiChainState::default();
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     apply_recover_vault_in_state(&mut s, CHAIN, 1).expect("recover");
     assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::Open);
 }
@@ -195,10 +256,15 @@ fn apply_recover_vault_rechecks_guards_at_commit() {
     // (defense-in-depth re-check inside apply_recover_vault_in_state).
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     let err = apply_recover_vault_in_state(&mut s, CHAIN, 1).expect_err("live mint at commit");
     assert!(matches!(err, RecoveryError::LiveMintOp(1)));
     // Vault NOT flipped.

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -13,7 +13,9 @@
 
 use super::config::{ChainId, GasStrategy, RegisterChainArg};
 use super::multi_chain_state::MultiChainState;
-use super::vault::{open_chain_vault_in_state, OpenVaultError};
+use super::vault::{
+    open_chain_vault_in_state, verify_deposit_and_enqueue_mint_in_state, OpenVaultError,
+};
 use candid::Principal;
 
 /// A non-Monad chain id (Solana's SLIP-44 coin type) so nothing here can lean on
@@ -192,6 +194,75 @@ fn open_rejects_stale_price_when_age_gate_configured() {
     );
     assert_eq!(res, Err(OpenVaultError::StalePrice));
     assert!(s.chain_vaults.is_empty(), "no mutation on stale price");
+}
+
+#[test]
+fn open_rejects_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        100_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        12345,
+        7,
+    );
+
+    assert_eq!(
+        res,
+        Err(OpenVaultError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert!(
+        s.chain_vaults.is_empty(),
+        "no mutation while circuit is tripped"
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
+}
+
+#[test]
+fn verify_deposit_rejects_mint_enqueue_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        100_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        12345,
+        7,
+    )
+    .expect("open awaiting deposit");
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 7, 100 * ONE_SOL, 12346);
+
+    assert_eq!(
+        res,
+        Err(OpenVaultError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().status,
+        super::monad::chain_vault::ChainVaultStatus::AwaitingDeposit,
+        "vault remains retryable after clear"
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
 }
 
 // ─── M2: borrow + nonce + per-owner cap ───────────────────────────────────────
@@ -469,6 +540,39 @@ fn borrow_rejects_stale_price_when_age_gate_configured() {
     );
     assert_eq!(res, Err(BorrowError::StalePrice));
     assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0);
+}
+
+#[test]
+fn borrow_rejects_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
+
+    assert_eq!(
+        res,
+        Err(BorrowError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0);
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
 }
 
 // ─── Increment 0: min-debt floor + per-chain debt ceiling ─────────────────────
@@ -867,6 +971,40 @@ fn withdraw_rejects_stale_price_when_age_gate_configured() {
         1_101,
     );
     assert_eq!(res, Err(WithdrawError::StalePrice));
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().collateral_amount_native,
+        100 * ONE_SOL
+    );
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0);
+}
+
+#[test]
+fn withdraw_rejects_debt_bearing_vault_when_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        ONE_SOL,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        1_101,
+    );
+
+    assert_eq!(
+        res,
+        Err(WithdrawError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
     assert_eq!(
         s.chain_vaults.get(&7).unwrap().collateral_amount_native,
         100 * ONE_SOL

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -184,6 +184,9 @@ pub enum OpenVaultError {
         would_be_e8s: u128,
         ceiling_e8s: u128,
     },
+    /// The chain's bad-debt circuit is tripped; new debt or pending mint creation
+    /// is blocked until the developer clears the circuit.
+    ChainBadDebtCircuitTripped { chain: ChainId },
 }
 
 /// Reasons `withdraw_collateral_in_state` / `close_chain_vault_in_state` can
@@ -240,6 +243,9 @@ pub enum WithdrawError {
     /// collateral or under-collateralize the residual debt. Reject until the
     /// marker clears (mirrors `MintInFlight`). Spec 3.1.
     LiquidationInFlight,
+    /// The chain's bad-debt circuit is tripped; collateral-out from a debt-bearing
+    /// vault is blocked, while debt-free close payouts remain allowed.
+    ChainBadDebtCircuitTripped { chain: ChainId },
 }
 
 /// Why `begin_liquidation_in_state` (spec §4.9 Phase 1) rejected. No state is
@@ -450,6 +456,9 @@ pub fn open_chain_vault_in_state(
     if !state.chain_configs.contains_key(&chain) {
         return Err(OpenVaultError::UnknownChain);
     }
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        return Err(OpenVaultError::ChainBadDebtCircuitTripped { chain });
+    }
     // A zero-debt vault has nothing to mint; with debt 0 the CR check is a
     // no-op (u64::MAX) and deposit-watch would later enqueue a wasted
     // zero-value on-chain mint. Reject up front. (A zero-collateral vault with
@@ -578,6 +587,9 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
     // Not enough on-chain collateral yet - no mutation, retry next tick.
     if observed_balance_e18 < declared_e18 {
         return Ok(false);
+    }
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        return Err(OpenVaultError::ChainBadDebtCircuitTripped { chain });
     }
 
     // Enqueue FIRST (it can fail on a duplicate idempotency key). The key is
@@ -711,6 +723,11 @@ pub fn withdraw_collateral_in_state(
         }
         if amount_e18 > v.collateral_amount_native {
             return Err(WithdrawError::InsufficientCollateral);
+        }
+        if v.debt_e8s > 0 && state.chain_bad_debt_circuit_tripped(v.collateral_chain) {
+            return Err(WithdrawError::ChainBadDebtCircuitTripped {
+                chain: v.collateral_chain,
+            });
         }
         let remaining = v.collateral_amount_native - amount_e18;
         (
@@ -1097,6 +1114,11 @@ pub enum BorrowError {
     /// tier could leave the post-confirm vault under-collateralized. Reject until
     /// the marker clears (mirrors `MintInFlight`). Spec 3.1.
     LiquidationInFlight,
+    /// The chain's bad-debt circuit is tripped; additional debt creation is
+    /// blocked until the developer clears the circuit.
+    ChainBadDebtCircuitTripped {
+        chain: ChainId,
+    },
 }
 
 /// Borrow additional icUSD against an existing `Open` vault — a SECOND on-chain
@@ -1154,6 +1176,11 @@ pub fn borrow_chain_vault_in_state(
         // could leave the post-confirm vault under-collateralized.
         if v.pending_liquidation.is_some() {
             return Err(BorrowError::LiquidationInFlight);
+        }
+        if state.chain_bad_debt_circuit_tripped(v.collateral_chain) {
+            return Err(BorrowError::ChainBadDebtCircuitTripped {
+                chain: v.collateral_chain,
+            });
         }
         (
             v.collateral_chain,

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -748,6 +748,26 @@ pub enum Event {
         chain_id: crate::chains::config::ChainId,
         timestamp: u64,
     },
+    #[serde(rename = "chain_bad_debt_circuit_threshold_set")]
+    ChainBadDebtCircuitThresholdSet {
+        chain_id: crate::chains::config::ChainId,
+        threshold_e8s: Option<u128>,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_bad_debt_circuit_tripped")]
+    ChainBadDebtCircuitTripped {
+        chain_id: crate::chains::config::ChainId,
+        bad_debt_e8s: u128,
+        total_bad_debt_e8s: u128,
+        threshold_e8s: u128,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_bad_debt_circuit_cleared")]
+    ChainBadDebtCircuitCleared {
+        chain_id: crate::chains::config::ChainId,
+        total_bad_debt_e8s: u128,
+        timestamp: u64,
+    },
     // Phase 1a Task 11: Timer B supply-invariant self-check failure.
     #[serde(rename = "supply_invariant_self_check_failed")]
     SupplyInvariantSelfCheckFailed {
@@ -1019,7 +1039,10 @@ impl Event {
             // Phase 1a: chain-admin events are protocol-wide, not vault-scoped.
             Event::ChainRegistered { .. }
             | Event::ChainDisabled { .. }
-            | Event::ChainConfigUpdated { .. } => false,
+            | Event::ChainConfigUpdated { .. }
+            | Event::ChainBadDebtCircuitThresholdSet { .. }
+            | Event::ChainBadDebtCircuitTripped { .. }
+            | Event::ChainBadDebtCircuitCleared { .. } => false,
             // Phase 1a Task 11: supply invariant failure is protocol-wide.
             Event::SupplyInvariantSelfCheckFailed { .. } => false,
             // Phase 1b: vault-carrying foreign-chain events surface per-vault history.
@@ -1186,6 +1209,11 @@ impl Event {
             Event::ChainRegistered { .. } => Some("ChainRegistered"),
             Event::ChainDisabled { .. } => Some("ChainDisabled"),
             Event::ChainConfigUpdated { .. } => Some("ChainConfigUpdated"),
+            Event::ChainBadDebtCircuitThresholdSet { .. } => {
+                Some("ChainBadDebtCircuitThresholdSet")
+            }
+            Event::ChainBadDebtCircuitTripped { .. } => Some("ChainBadDebtCircuitTripped"),
+            Event::ChainBadDebtCircuitCleared { .. } => Some("ChainBadDebtCircuitCleared"),
             Event::ChainSettlementFailed { .. } => Some("ChainSettlementFailed"),
             Event::ChainReorgDetected { .. } => Some("ChainReorgDetected"),
             Event::ChainHotWalletLow { .. } => Some("ChainHotWalletLow"),
@@ -1241,6 +1269,9 @@ impl Event {
             Event::StabilityPoolCallFailed { timestamp, .. } => Some(*timestamp),
             Event::OracleCircuitBreaker { timestamp, .. } => Some(*timestamp),
             Event::OracleSourceCountInsufficient { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitThresholdSet { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitTripped { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitCleared { timestamp, .. } => Some(*timestamp),
             _ => None,
         }
     }
@@ -2099,7 +2130,10 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             // before recording the event; nothing to replay.
             Event::ChainRegistered { .. }
             | Event::ChainDisabled { .. }
-            | Event::ChainConfigUpdated { .. } => {},
+            | Event::ChainConfigUpdated { .. }
+            | Event::ChainBadDebtCircuitThresholdSet { .. }
+            | Event::ChainBadDebtCircuitTripped { .. }
+            | Event::ChainBadDebtCircuitCleared { .. } => {},
             // Phase 1a Task 11: informational audit trail; state mutation
             // (invariant_halted + mode flip) happens live in the timer tick.
             Event::SupplyInvariantSelfCheckFailed { .. } => {},

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2045,24 +2045,32 @@ fn set_chain_contract(
     Ok(())
 }
 
-/// Set (or replace) the per-chain liquidation config (spec 8, Tier B): the DEX
-/// wiring + risk knobs the bot path will read. Developer-gated. The config is
-/// validated (slippage cap <= 100%, restore target > par, required addresses
-/// present when `enabled`) before persisting; a rejected config mutates nothing.
-/// Inert until Increment 2+ reads it (Increment 1 ships only this scaffolding).
-#[candid_method(update)]
-#[update]
-fn set_chain_liquidation_config(
+fn validate_chain_liquidation_config_inputs(
     chain: rumi_protocol_backend::chains::config::ChainId,
-    config: rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
 ) -> Result<(), ProtocolError> {
-    let caller = ic_cdk::caller();
-    if read_state(|s| s.developer_principal != caller) {
-        return Err(ProtocolError::ChainAdmin("not developer".into()));
-    }
     config
         .validate()
         .map_err(|e| ProtocolError::ChainAdmin(format!("invalid liquidation config: {e:?}")))?;
+    if rumi_protocol_backend::chains::evm::evm_chain_config(chain).is_none() {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not a known EVM chain",
+            chain.0
+        )));
+    }
+    let chain_status = read_state(|s| s.multi_chain.chain_configs.get(&chain).map(|c| c.status));
+    match chain_status {
+        Some(rumi_protocol_backend::chains::config::ChainStatus::Registered) => {}
+        Some(status) => {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "chain {} is not registered: {:?}",
+                chain.0, status
+            )));
+        }
+        None => {
+            return Err(ProtocolError::ChainAdmin(format!("unknown chain {}", chain.0)));
+        }
+    }
     // Finding #16: the penalty cushion MUST exceed the slippage + oracle-divergence
     // budget, or a swap can structurally deliver less stable than the debt it
     // clears (under-cover). Increment 3 adds the max_dex_oracle_divergence_bps term.
@@ -2081,6 +2089,72 @@ fn set_chain_liquidation_config(
                 config.slippage_cap_bps, config.max_dex_oracle_divergence_bps, penalty_bps
             )));
         }
+    }
+    Ok(())
+}
+
+async fn validate_liquidation_factory_pair(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+) -> Result<(), ProtocolError> {
+    match config.dex {
+        rumi_protocol_backend::chains::liquidation_config::DexKind::UniswapV2 => {}
+    }
+    let (_latest, finalized) = rumi_protocol_backend::chains::evm::evm_rpc::fetch_block_numbers(chain)
+        .await
+        .map_err(|e| ProtocolError::ChainAdmin(format!("factory pair sanity block read failed: {e}")))?;
+    let derived_pair = rumi_protocol_backend::chains::evm::evm_rpc::get_factory_pair(
+        chain,
+        &config.factory,
+        &config.collateral_token,
+        &config.settle_stable_token,
+        finalized,
+    )
+    .await
+    .map_err(|e| ProtocolError::ChainAdmin(format!("factory pair sanity getPair failed: {e}")))?;
+    validate_liquidation_factory_pair_match(config, &derived_pair)
+}
+
+fn validate_liquidation_factory_pair_match(
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+    derived_pair: &str,
+) -> Result<(), ProtocolError> {
+    let derived_pair =
+        rumi_protocol_backend::chains::liquidation_config::canonical_evm_address(derived_pair)
+            .map_err(|e| ProtocolError::ChainAdmin(format!("invalid factory pair: {e:?}")))?;
+    let pinned_pair =
+        rumi_protocol_backend::chains::liquidation_config::canonical_evm_address(&config.pair)
+            .map_err(|e| ProtocolError::ChainAdmin(format!("invalid pinned pair: {e:?}")))?;
+    if derived_pair != pinned_pair {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "factory getPair({}, {}) returned {}, expected pinned pair {}",
+            config.collateral_token, config.settle_stable_token, derived_pair, pinned_pair
+        )));
+    }
+    Ok(())
+}
+
+/// Set (or replace) the per-chain liquidation config (spec 8, Tier B): the DEX
+/// wiring + risk knobs the bot path will read. Developer-gated. The config is
+/// validated (chain registered, EVM addresses well-formed, penalty cushion safe)
+/// before persisting; enabling also checks the UniswapV2 factory-derived pair
+/// matches the pinned pair. A rejected config mutates nothing.
+#[candid_method(update)]
+#[update]
+async fn set_chain_liquidation_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    validate_chain_liquidation_config_inputs(chain, &config)?;
+    if config.enabled {
+        validate_liquidation_factory_pair(chain, &config).await?;
+        // State may have changed during the RPC await. Re-check all synchronous
+        // invariants immediately before mutating.
+        validate_chain_liquidation_config_inputs(chain, &config)?;
     }
     mutate_state(|s| {
         s.multi_chain
@@ -11681,6 +11755,61 @@ fn check_candid_interface_compatibility() {
         "declared candid interface in rumi_protocol_backend.did file",
         CandidSource::File(did_path.as_path()),
     );
+}
+
+#[cfg(test)]
+mod inc12_liquidation_config_tests {
+    use super::validate_liquidation_factory_pair_match;
+    use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+
+    fn cfg() -> ChainLiquidationConfigV1 {
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0x1111111111111111111111111111111111111111".into(),
+            factory: "0x2222222222222222222222222222222222222222".into(),
+            pair: "0x3333333333333333333333333333333333333333".into(),
+            collateral_token: "0x4444444444444444444444444444444444444444".into(),
+            settle_stable_token: "0x5555555555555555555555555555555555555555".into(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+            max_swap_value_e8s: 2_000 * 100_000_000,
+            max_price_age_ns: 1_800_000_000_000,
+            max_dex_oracle_divergence_bps: 500,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
+        }
+    }
+
+    #[test]
+    fn factory_pair_match_accepts_case_normalized_pair() {
+        assert!(validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0X3333333333333333333333333333333333333333"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn factory_pair_match_rejects_different_pair() {
+        let err = validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0x9999999999999999999999999999999999999999",
+        )
+        .expect_err("mismatched factory pair rejects");
+        assert!(format!("{err:?}").contains("expected pinned pair"));
+    }
+
+    #[test]
+    fn factory_pair_match_rejects_zero_factory_pair() {
+        let err = validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0x0000000000000000000000000000000000000000",
+        )
+        .expect_err("zero factory pair rejects");
+        assert!(format!("{err:?}").contains("invalid factory pair"));
+    }
 }
 
 #[cfg(test)]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -11308,6 +11308,10 @@ mod chain_vault_param_tests {
             evm_vault_params(ChainId(71)).unwrap(),
             ("CFX", 15_000, 10_000_000, Some(500 * 100_000_000))
         ); // Conflux: 150% open gate + 500-icUSD ceiling
+        assert_eq!(
+            evm_vault_params(ChainId(1030)).unwrap(),
+            ("CFX", 15_000, 10_000_000, Some(500 * 100_000_000))
+        ); // Conflux mainnet mirrors testnet risk params
         assert!(evm_vault_params(ChainId(999)).is_err());
     }
 

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2798,8 +2798,7 @@ async fn settle_pending_chain_burn_with_proof(
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
 
-    let ctx =
-        read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Pending))?;
+    let ctx = read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Pending))?;
     let receipt = fetch_settlement_receipt(chain, &proof.tx_hash).await?;
     require_settlement_receipt_success(&receipt)?;
     require_settlement_receipt_final(chain, receipt.block_number, ctx.finality_depth).await?;
@@ -2852,8 +2851,7 @@ async fn settle_reserve_burn_with_proof(
         return Err(ProtocolError::ChainAdmin("not developer".into()));
     }
 
-    let mut ctx =
-        read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Reserve))?;
+    let mut ctx = read_state(|s| settlement_proof_context(s, chain, SettlementProofKind::Reserve))?;
     let (_, reserve_address) =
         rumi_protocol_backend::chains::evm::tecdsa::cached_reserve_address(chain)
             .await
@@ -4710,6 +4708,60 @@ async fn verify_sp_icusd_burn_proof(
     Ok(())
 }
 
+fn chain_sp_absorb_result_from_stored(
+    stored: rumi_protocol_backend::state::StoredChainSpAbsorbResult,
+) -> ChainStabilityPoolLiquidationResult {
+    ChainStabilityPoolLiquidationResult {
+        success: true,
+        vault_id: stored.vault_id,
+        chain_id: stored.chain_id,
+        liquidated_debt_e8s: stored.liquidated_debt_e8s,
+        collateral_received_native: stored.collateral_received_native,
+        claim_id: stored.claim_id,
+        custody_address: stored.custody_address,
+        block_index: stored.block_index,
+        collateral_price_e8s: stored.collateral_price_e8s,
+    }
+}
+
+fn stored_chain_sp_absorb_matches_retry(
+    stored: &rumi_protocol_backend::state::StoredChainSpAbsorbResult,
+    vault_id: u64,
+    icusd_burned_e8s: u64,
+    caller: Principal,
+    proof: &rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+) -> bool {
+    proof.ledger_kind == rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn
+        && proof.vault_id_memo == vault_id
+        && stored.caller == caller
+        && stored.vault_id == vault_id
+        && stored.icusd_burned_e8s == icusd_burned_e8s
+        && stored.block_index == proof.block_index
+}
+
+fn record_sp_chain_absorb_result_bounded(
+    state: &mut State,
+    proof_key: (rumi_protocol_backend::icrc3_proof::SpProofLedger, u64),
+    stored: rumi_protocol_backend::state::StoredChainSpAbsorbResult,
+) {
+    state
+        .sp_chain_absorb_results_by_proof
+        .insert(proof_key, stored);
+    while state.sp_chain_absorb_results_by_proof.len()
+        > rumi_protocol_backend::state::MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF
+    {
+        let Some(oldest_key) = state
+            .sp_chain_absorb_results_by_proof
+            .keys()
+            .copied()
+            .find(|key| *key != proof_key)
+        else {
+            break;
+        };
+        state.sp_chain_absorb_results_by_proof.remove(&oldest_key);
+    }
+}
+
 /// Called by the stability pool after it has burned IC-native icUSD to absorb a
 /// bot-failed foreign-chain vault. This does NOT burn the eSpace icUSD
 /// representation; it writes debt -> pending_chain_burn and reserves seized CFX
@@ -4744,6 +4796,19 @@ async fn stability_pool_liquidate_chain_vault(
             "Caller is not the registered stability pool canister".to_string(),
         ));
     }
+    let proof_key = (proof.ledger_kind, proof.block_index);
+    if let Some(stored) =
+        read_state(|s| s.sp_chain_absorb_results_by_proof.get(&proof_key).cloned())
+    {
+        if stored_chain_sp_absorb_matches_retry(&stored, vault_id, icusd_burned_e8s, caller, &proof)
+        {
+            return Ok(chain_sp_absorb_result_from_stored(stored));
+        }
+        return Err(ProtocolError::GenericError(format!(
+            "SP writedown proof replay rejected: ({:?}, block {}) already consumed for a different request",
+            proof.ledger_kind, proof.block_index
+        )));
+    }
 
     let _guard = rumi_protocol_backend::guard::ChainVaultLiquidationGuard::new(vault_id)?;
     let now = ic_cdk::api::time();
@@ -4751,8 +4816,7 @@ async fn stability_pool_liquidate_chain_vault(
 
     verify_sp_icusd_burn_proof(vault_id, icusd_burned_e8s, caller, &proof).await?;
 
-    let proof_key = (proof.ledger_kind, proof.block_index);
-    let absorbed = mutate_state(|s| {
+    let stored = mutate_state(|s| {
         if s.consumed_writedown_proofs.contains(&proof_key) {
             return Err(ProtocolError::GenericError(format!(
                 "SP writedown proof replay rejected: ({:?}, block {}) already consumed",
@@ -4770,34 +4834,37 @@ async fn stability_pool_liquidate_chain_vault(
         )
         .map_err(ProtocolError::ChainAdmin)?;
         s.consumed_writedown_proofs.insert(proof_key);
-        Ok(absorbed)
+        let stored = rumi_protocol_backend::state::StoredChainSpAbsorbResult {
+            caller,
+            vault_id,
+            chain_id: snapshot.chain,
+            icusd_burned_e8s,
+            liquidated_debt_e8s: absorbed.actual_burned_e8s,
+            collateral_received_native: absorbed.collateral_seized_native,
+            claim_id: vault_id,
+            custody_address: absorbed.custody_address,
+            block_index: proof.block_index,
+            collateral_price_e8s: snapshot.price_e8,
+        };
+        record_sp_chain_absorb_result_bounded(s, proof_key, stored.clone());
+        Ok(stored)
     })?;
 
     rumi_protocol_backend::storage::record_event(&Event::ChainVaultLiquidated {
         chain_id: snapshot.chain,
         vault_id,
         op_id: proof.block_index,
-        debt_cleared_e8s: absorbed.actual_burned_e8s,
-        collateral_seized_native: absorbed.collateral_seized_native,
+        debt_cleared_e8s: stored.liquidated_debt_e8s,
+        collateral_seized_native: stored.collateral_received_native,
         tier: rumi_protocol_backend::chains::vault::LiquidationTier::StabilityPool,
         timestamp: now,
     });
     log!(INFO,
         "[stability_pool_liquidate_chain_vault] chain={:?} vault={} burned_e8s={} collateral_seized_native={} proof_block={}",
-        snapshot.chain, vault_id, absorbed.actual_burned_e8s, absorbed.collateral_seized_native, proof.block_index
+        snapshot.chain, vault_id, stored.liquidated_debt_e8s, stored.collateral_received_native, proof.block_index
     );
 
-    Ok(ChainStabilityPoolLiquidationResult {
-        success: true,
-        vault_id,
-        chain_id: snapshot.chain,
-        liquidated_debt_e8s: absorbed.actual_burned_e8s,
-        collateral_received_native: absorbed.collateral_seized_native,
-        claim_id: vault_id,
-        custody_address: absorbed.custody_address,
-        block_index: proof.block_index,
-        collateral_price_e8s: snapshot.price_e8,
-    })
+    Ok(chain_sp_absorb_result_from_stored(stored))
 }
 
 /// Called by the stability pool to enqueue a native CFX payout from a reserved
@@ -10924,12 +10991,17 @@ mod chain_vault_param_tests {
 mod chain_sp_absorb_entry_tests {
     use super::{
         chain_collateral_sentinel, chain_liquidatable_vaults_in_state, chain_sp_absorb_snapshot,
+        record_sp_chain_absorb_result_bounded, stored_chain_sp_absorb_matches_retry,
     };
     use candid::Principal;
     use rumi_protocol_backend::chains::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
     use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
     use rumi_protocol_backend::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
     use rumi_protocol_backend::chains::multi_chain_state::MultiChainState;
+    use rumi_protocol_backend::icrc3_proof::{SpProofLedger, SpWritedownProof};
+    use rumi_protocol_backend::state::{
+        StoredChainSpAbsorbResult, MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF,
+    };
 
     const CFX: ChainId = ChainId(71);
 
@@ -10995,6 +11067,157 @@ mod chain_sp_absorb_entry_tests {
         );
         s.sp_attempted_chain_vaults.insert(7);
         s
+    }
+
+    fn stored_absorb_result(caller: Principal) -> StoredChainSpAbsorbResult {
+        StoredChainSpAbsorbResult {
+            caller,
+            vault_id: 77,
+            chain_id: CFX,
+            icusd_burned_e8s: 100_00000000,
+            liquidated_debt_e8s: 100_00000000,
+            collateral_received_native: 10_000_000_000_000_000_000u128,
+            claim_id: 77,
+            custody_address: "0xcustody".into(),
+            block_index: 44,
+            collateral_price_e8s: 5_000_000,
+        }
+    }
+
+    fn stored_absorb_result_for(caller: Principal, vault_id: u64) -> StoredChainSpAbsorbResult {
+        StoredChainSpAbsorbResult {
+            caller,
+            vault_id,
+            chain_id: CFX,
+            icusd_burned_e8s: 100_00000000,
+            liquidated_debt_e8s: 100_00000000,
+            collateral_received_native: 10_000_000_000_000_000_000u128,
+            claim_id: vault_id,
+            custody_address: "0xcustody".into(),
+            block_index: vault_id,
+            collateral_price_e8s: 5_000_000,
+        }
+    }
+
+    fn proof(block_index: u64, vault_id_memo: u64, ledger_kind: SpProofLedger) -> SpWritedownProof {
+        SpWritedownProof {
+            block_index,
+            ledger_kind,
+            vault_id_memo,
+        }
+    }
+
+    #[test]
+    fn stored_chain_sp_absorb_retry_match_requires_same_burn_proof_shape() {
+        let caller = Principal::from_slice(&[3u8; 29]);
+        let stored = stored_absorb_result(caller);
+        let exact = proof(44, 77, SpProofLedger::IcusdBurn);
+
+        assert!(stored_chain_sp_absorb_matches_retry(
+            &stored,
+            77,
+            100_00000000,
+            caller,
+            &exact,
+        ));
+        assert!(!stored_chain_sp_absorb_matches_retry(
+            &stored,
+            78,
+            100_00000000,
+            caller,
+            &proof(44, 78, SpProofLedger::IcusdBurn),
+        ));
+        assert!(!stored_chain_sp_absorb_matches_retry(
+            &stored,
+            77,
+            99_99999999,
+            caller,
+            &exact,
+        ));
+        assert!(!stored_chain_sp_absorb_matches_retry(
+            &stored,
+            77,
+            100_00000000,
+            Principal::from_slice(&[4u8; 29]),
+            &exact,
+        ));
+        assert!(!stored_chain_sp_absorb_matches_retry(
+            &stored,
+            77,
+            100_00000000,
+            caller,
+            &proof(44, 77, SpProofLedger::ThreePoolTransfer),
+        ));
+        assert!(!stored_chain_sp_absorb_matches_retry(
+            &stored,
+            77,
+            100_00000000,
+            caller,
+            &proof(45, 77, SpProofLedger::IcusdBurn),
+        ));
+    }
+
+    #[test]
+    fn backend_sp_chain_absorb_result_cache_is_bounded() {
+        let caller = Principal::from_slice(&[3u8; 29]);
+        let mut state = rumi_protocol_backend::state::State::default();
+
+        for block_index in 0..(MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF as u64 + 5) {
+            record_sp_chain_absorb_result_bounded(
+                &mut state,
+                (SpProofLedger::IcusdBurn, block_index),
+                stored_absorb_result_for(caller, block_index),
+            );
+        }
+
+        assert_eq!(
+            state.sp_chain_absorb_results_by_proof.len(),
+            MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF,
+        );
+        assert!(!state
+            .sp_chain_absorb_results_by_proof
+            .contains_key(&(SpProofLedger::IcusdBurn, 0)));
+        assert!(state.sp_chain_absorb_results_by_proof.contains_key(&(
+            SpProofLedger::IcusdBurn,
+            MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF as u64 + 4
+        )));
+    }
+
+    #[test]
+    fn backend_sp_chain_absorb_result_cache_keeps_just_recorded_old_proof() {
+        let caller = Principal::from_slice(&[3u8; 29]);
+        let mut state = rumi_protocol_backend::state::State::default();
+
+        for block_index in 1..=(MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF as u64) {
+            record_sp_chain_absorb_result_bounded(
+                &mut state,
+                (SpProofLedger::IcusdBurn, block_index),
+                stored_absorb_result_for(caller, block_index),
+            );
+        }
+
+        record_sp_chain_absorb_result_bounded(
+            &mut state,
+            (SpProofLedger::IcusdBurn, 0),
+            stored_absorb_result_for(caller, 0),
+        );
+
+        assert_eq!(
+            state.sp_chain_absorb_results_by_proof.len(),
+            MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF,
+        );
+        assert!(
+            state
+                .sp_chain_absorb_results_by_proof
+                .contains_key(&(SpProofLedger::IcusdBurn, 0)),
+            "lost-reply retry must remain possible for the proof just accepted",
+        );
+        assert!(
+            !state
+                .sp_chain_absorb_results_by_proof
+                .contains_key(&(SpProofLedger::IcusdBurn, 1)),
+            "one older non-current entry should be evicted to preserve the new result",
+        );
     }
 
     #[test]
@@ -11163,9 +11386,7 @@ mod inc6_settlement_proof_context_tests {
         chain_finality_depth_or_default, settlement_proof_context, settlement_proof_ids_from_state,
         SettlementProofKind,
     };
-    use rumi_protocol_backend::chains::config::{
-        ChainConfigV3, ChainId, ChainStatus, GasStrategy,
-    };
+    use rumi_protocol_backend::chains::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
     use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
     use rumi_protocol_backend::chains::multi_chain_state::SettlementProofRecord;
     use rumi_protocol_backend::state::State;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2216,6 +2216,8 @@ struct ChainSpAbsorbSnapshot {
     liquidation_penalty_bps: u64,
 }
 
+const CHAIN_SP_ABSORB_PREFLIGHT_TTL_NS: u64 = 15 * 60 * 1_000_000_000;
+
 /// Resolve the chain's native collateral symbol (the manual-price key) for the
 /// liquidation path. `Err` if the chain is not a known EVM chain.
 fn liquidation_price_symbol(
@@ -2268,17 +2270,83 @@ fn chain_sp_absorb_snapshot(
         .get(&chain)
         .map(|c| c.chain_native_decimals)
         .unwrap_or(18);
-    let liquidation_penalty_bps = chain_collateral_config(chain)
-        .map(|c| c.liquidation_penalty_bps)
-        .ok_or_else(|| {
-            ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
-        })?;
+    let collateral_cfg = chain_collateral_config(chain).ok_or_else(|| {
+        ProtocolError::ChainAdmin(format!("no collateral config for chain {}", chain.0))
+    })?;
+    let eff_debt = liq::effective_debt_e8s(
+        vault.debt_e8s,
+        vault.pending_interest_mint_e8s,
+        collateral_cfg.interest_apr_bps,
+        now_ns.saturating_sub(vault.last_interest_accrual_ns),
+    );
+    let cr_e4 = rumi_protocol_backend::chains::vault::collateral_ratio_e4(
+        vault.collateral_amount_native,
+        native_decimals,
+        price_e8,
+        eff_debt,
+    );
+    if cr_e4 >= collateral_cfg.liquidation_threshold_e4 {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain vault {vault_id} is no longer liquidatable: cr_e4 {} >= threshold {}",
+            cr_e4, collateral_cfg.liquidation_threshold_e4
+        )));
+    }
     Ok(ChainSpAbsorbSnapshot {
         chain,
         price_e8,
         native_decimals,
-        liquidation_penalty_bps,
+        liquidation_penalty_bps: collateral_cfg.liquidation_penalty_bps,
     })
+}
+
+fn chain_sp_absorb_preflight_snapshot(
+    state: &rumi_protocol_backend::chains::multi_chain_state::MultiChainState,
+    vault_id: u64,
+    expected_icusd_burn_e8s: u64,
+    now_ns: u64,
+) -> Result<ChainSpAbsorbSnapshot, ProtocolError> {
+    let snapshot = chain_sp_absorb_snapshot(state, vault_id, now_ns)?;
+    let live_debt = state
+        .chain_vaults
+        .get(&vault_id)
+        .map(|v| v.debt_e8s)
+        .ok_or_else(|| ProtocolError::ChainAdmin(format!("unknown chain vault {vault_id}")))?;
+    if live_debt != expected_icusd_burn_e8s as u128 {
+        return Err(ProtocolError::GenericError(format!(
+            "SP chain absorb preflight rejected: expected burn {} does not match live debt {} for vault {}",
+            expected_icusd_burn_e8s, live_debt, vault_id
+        )));
+    }
+    Ok(snapshot)
+}
+
+fn chain_sp_absorb_snapshot_from_preflight(
+    preflight: &rumi_protocol_backend::state::StoredChainSpAbsorbPreflight,
+) -> ChainSpAbsorbSnapshot {
+    ChainSpAbsorbSnapshot {
+        chain: preflight.chain_id,
+        price_e8: preflight.price_e8,
+        native_decimals: preflight.native_decimals,
+        liquidation_penalty_bps: preflight.liquidation_penalty_bps,
+    }
+}
+
+fn matching_chain_absorb_preflight(
+    state: &rumi_protocol_backend::state::State,
+    vault_id: u64,
+    icusd_burned_e8s: u64,
+    caller: Principal,
+    now_ns: u64,
+) -> Option<rumi_protocol_backend::state::StoredChainSpAbsorbPreflight> {
+    let preflight = state.sp_chain_absorb_preflights.get(&vault_id)?;
+    if preflight.caller == caller
+        && preflight.icusd_burn_e8s == icusd_burned_e8s
+        && preflight.expires_at_ns >= now_ns
+    {
+        Some(preflight.clone())
+    } else {
+        None
+    }
 }
 
 /// Dev-gated manual/permissionless liquidation trigger (spec §7). Runs the
@@ -4776,17 +4844,6 @@ async fn stability_pool_liquidate_chain_vault(
     if ic_cdk::caller() == Principal::anonymous() {
         return Err(ProtocolError::AnonymousCallerNotAllowed);
     }
-    if read_state(|s| s.frozen) {
-        return Err(ProtocolError::TemporarilyUnavailable(
-            "Protocol is frozen. All operations are suspended pending admin review.".to_string(),
-        ));
-    }
-    validate_liquidation_not_frozen()?;
-    if read_state(|s| s.sp_writedown_disabled) {
-        return Err(ProtocolError::TemporarilyUnavailable(
-            "SP writedown path is disabled by admin".to_string(),
-        ));
-    }
 
     let caller = ic_cdk::api::caller();
     let is_stability_pool =
@@ -4812,7 +4869,29 @@ async fn stability_pool_liquidate_chain_vault(
 
     let _guard = rumi_protocol_backend::guard::ChainVaultLiquidationGuard::new(vault_id)?;
     let now = ic_cdk::api::time();
-    let snapshot = read_state(|s| chain_sp_absorb_snapshot(&s.multi_chain, vault_id, now))?;
+    let preflight = read_state(|s| {
+        matching_chain_absorb_preflight(s, vault_id, icusd_burned_e8s, caller, now)
+    });
+    if preflight.is_none() {
+        if read_state(|s| s.frozen) {
+            return Err(ProtocolError::TemporarilyUnavailable(
+                "Protocol is frozen. All operations are suspended pending admin review."
+                    .to_string(),
+            ));
+        }
+        validate_liquidation_not_frozen()?;
+        if read_state(|s| s.sp_writedown_disabled) {
+            return Err(ProtocolError::TemporarilyUnavailable(
+                "SP writedown path is disabled by admin".to_string(),
+            ));
+        }
+    }
+    let snapshot = match &preflight {
+        Some(preflight) => chain_sp_absorb_snapshot_from_preflight(preflight),
+        None => read_state(|s| {
+            chain_sp_absorb_preflight_snapshot(&s.multi_chain, vault_id, icusd_burned_e8s, now)
+        })?,
+    };
 
     verify_sp_icusd_burn_proof(vault_id, icusd_burned_e8s, caller, &proof).await?;
 
@@ -4834,6 +4913,7 @@ async fn stability_pool_liquidate_chain_vault(
         )
         .map_err(ProtocolError::ChainAdmin)?;
         s.consumed_writedown_proofs.insert(proof_key);
+        s.sp_chain_absorb_preflights.remove(&vault_id);
         let stored = rumi_protocol_backend::state::StoredChainSpAbsorbResult {
             caller,
             vault_id,
@@ -4865,6 +4945,62 @@ async fn stability_pool_liquidate_chain_vault(
     );
 
     Ok(chain_sp_absorb_result_from_stored(stored))
+}
+
+/// Called by the stability pool immediately before a fresh IC-native icUSD burn.
+/// This lets the backend kill switch and live-debt check reject before the SP
+/// spends funds. It is intentionally non-mutating; the post-burn endpoint still
+/// performs the same checks before consuming the proof.
+#[update]
+#[candid_method(update)]
+fn stability_pool_preflight_chain_absorb(
+    vault_id: u64,
+    expected_icusd_burn_e8s: u64,
+) -> Result<(), ProtocolError> {
+    if ic_cdk::caller() == Principal::anonymous() {
+        return Err(ProtocolError::AnonymousCallerNotAllowed);
+    }
+    if read_state(|s| s.frozen) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "Protocol is frozen. All operations are suspended pending admin review.".to_string(),
+        ));
+    }
+    validate_liquidation_not_frozen()?;
+
+    let caller = ic_cdk::api::caller();
+    let is_stability_pool =
+        read_state(|s| s.stability_pool_canister.map_or(false, |sp| sp == caller));
+    if !is_stability_pool {
+        return Err(ProtocolError::GenericError(
+            "Caller is not the registered stability pool canister".to_string(),
+        ));
+    }
+    if read_state(|s| s.sp_writedown_disabled) {
+        return Err(ProtocolError::TemporarilyUnavailable(
+            "SP writedown path is disabled by admin".to_string(),
+        ));
+    }
+
+    let now = ic_cdk::api::time();
+    let snapshot = read_state(|s| {
+        chain_sp_absorb_preflight_snapshot(&s.multi_chain, vault_id, expected_icusd_burn_e8s, now)
+    })?;
+    mutate_state(|s| {
+        s.sp_chain_absorb_preflights.insert(
+            vault_id,
+            rumi_protocol_backend::state::StoredChainSpAbsorbPreflight {
+                caller,
+                vault_id,
+                icusd_burn_e8s: expected_icusd_burn_e8s,
+                chain_id: snapshot.chain,
+                price_e8: snapshot.price_e8,
+                native_decimals: snapshot.native_decimals,
+                liquidation_penalty_bps: snapshot.liquidation_penalty_bps,
+                expires_at_ns: now.saturating_add(CHAIN_SP_ABSORB_PREFLIGHT_TTL_NS),
+            },
+        );
+    });
+    Ok(())
 }
 
 /// Called by the stability pool to enqueue a native CFX payout from a reserved
@@ -10990,8 +11126,10 @@ mod chain_vault_param_tests {
 #[cfg(test)]
 mod chain_sp_absorb_entry_tests {
     use super::{
-        chain_collateral_sentinel, chain_liquidatable_vaults_in_state, chain_sp_absorb_snapshot,
-        record_sp_chain_absorb_result_bounded, stored_chain_sp_absorb_matches_retry,
+        chain_collateral_sentinel, chain_liquidatable_vaults_in_state,
+        chain_sp_absorb_preflight_snapshot, chain_sp_absorb_snapshot,
+        matching_chain_absorb_preflight, record_sp_chain_absorb_result_bounded,
+        stored_chain_sp_absorb_matches_retry,
     };
     use candid::Principal;
     use rumi_protocol_backend::chains::config::{ChainConfigV3, ChainId, ChainStatus, GasStrategy};
@@ -11000,7 +11138,8 @@ mod chain_sp_absorb_entry_tests {
     use rumi_protocol_backend::chains::multi_chain_state::MultiChainState;
     use rumi_protocol_backend::icrc3_proof::{SpProofLedger, SpWritedownProof};
     use rumi_protocol_backend::state::{
-        StoredChainSpAbsorbResult, MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF,
+        StoredChainSpAbsorbPreflight, StoredChainSpAbsorbResult,
+        MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF,
     };
 
     const CFX: ChainId = ChainId(71);
@@ -11221,6 +11360,31 @@ mod chain_sp_absorb_entry_tests {
     }
 
     #[test]
+    fn chain_sp_absorb_preflight_reservation_requires_exact_unexpired_match() {
+        let caller = Principal::from_slice(&[3u8; 29]);
+        let other = Principal::from_slice(&[4u8; 29]);
+        let mut state = rumi_protocol_backend::state::State::default();
+        state.sp_chain_absorb_preflights.insert(
+            7,
+            StoredChainSpAbsorbPreflight {
+                caller,
+                vault_id: 7,
+                icusd_burn_e8s: 100_00000000,
+                chain_id: CFX,
+                price_e8: 1_000_000,
+                native_decimals: 18,
+                liquidation_penalty_bps: 1_200,
+                expires_at_ns: 10_000,
+            },
+        );
+
+        assert!(matching_chain_absorb_preflight(&state, 7, 100_00000000, caller, 9_999).is_some());
+        assert!(matching_chain_absorb_preflight(&state, 7, 99_99999999, caller, 9_999).is_none());
+        assert!(matching_chain_absorb_preflight(&state, 7, 100_00000000, other, 9_999).is_none());
+        assert!(matching_chain_absorb_preflight(&state, 7, 100_00000000, caller, 10_001).is_none());
+    }
+
+    #[test]
     fn chain_sp_absorb_snapshot_rejects_halted_chain_rails() {
         let mut s = configured_state();
         s.set_manual_price(CFX, "CFX".into(), 50_000_000, 500);
@@ -11260,12 +11424,40 @@ mod chain_sp_absorb_entry_tests {
             "unexpected error: {err:?}"
         );
 
-        s.set_manual_price(CFX, "CFX".into(), 50_000_000, 500);
+        s.set_manual_price(CFX, "CFX".into(), 1_000_000, 500);
         let ok = chain_sp_absorb_snapshot(&s, 7, 600).expect("fresh price accepted");
         assert_eq!(ok.chain, CFX);
-        assert_eq!(ok.price_e8, 50_000_000);
+        assert_eq!(ok.price_e8, 1_000_000);
         assert_eq!(ok.native_decimals, 18);
         assert_eq!(ok.liquidation_penalty_bps, 1_200);
+    }
+
+    #[test]
+    fn chain_sp_absorb_preflight_rejects_stale_burn_amount() {
+        let mut s = configured_state();
+        s.set_manual_price(CFX, "CFX".into(), 1_000_000, 500);
+
+        assert!(chain_sp_absorb_preflight_snapshot(&s, 7, 100 * 100_000_000, 600).is_ok());
+
+        let err = chain_sp_absorb_preflight_snapshot(&s, 7, 99 * 100_000_000, 600)
+            .expect_err("stale expected burn should be rejected");
+        assert!(
+            format!("{err:?}").contains("does not match live debt"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn chain_sp_absorb_preflight_rejects_recovered_healthy_vault() {
+        let mut s = configured_state();
+        s.set_manual_price(CFX, "CFX".into(), 50_000_000, 500);
+
+        let err = chain_sp_absorb_preflight_snapshot(&s, 7, 100 * 100_000_000, 600)
+            .expect_err("healthy recovered vault should not absorb through SP");
+        assert!(
+            format!("{err:?}").contains("no longer liquidatable"),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2177,6 +2177,144 @@ fn get_effective_chain_debt_config(
     ))
 }
 
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ChainBadDebtCircuitStatus {
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub registered: bool,
+    pub bad_debt_e8s: u128,
+    pub threshold_e8s: Option<u128>,
+    pub tripped: bool,
+    pub tripped_at_ns: Option<u64>,
+}
+
+/// Public read-only status for the per-chain bad-debt circuit. No secrets.
+#[candid_method(query)]
+#[query]
+fn get_chain_bad_debt_circuit_status(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> ChainBadDebtCircuitStatus {
+    read_state(|s| ChainBadDebtCircuitStatus {
+        chain_id: chain,
+        registered: s.multi_chain.chain_configs.contains_key(&chain),
+        bad_debt_e8s: s
+            .multi_chain
+            .chain_bad_debt_e8s
+            .get(&chain)
+            .copied()
+            .unwrap_or(0),
+        threshold_e8s: s
+            .multi_chain
+            .chain_bad_debt_circuit_threshold_e8s
+            .get(&chain)
+            .copied(),
+        tripped: s.multi_chain.chain_bad_debt_circuit_tripped(chain),
+        tripped_at_ns: s
+            .multi_chain
+            .chain_bad_debt_circuit_tripped_at_ns
+            .get(&chain)
+            .copied(),
+    })
+}
+
+/// Developer-gated threshold setter. `None` disables the circuit for the chain
+/// and clears any existing latch; `Some(0)` is rejected to avoid ambiguous
+/// always-trip semantics.
+#[candid_method(update)]
+#[update]
+fn set_chain_bad_debt_circuit_threshold(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    threshold_e8s: Option<u128>,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    if !read_state(|s| s.multi_chain.chain_configs.contains_key(&chain)) {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not registered",
+            chain.0
+        )));
+    }
+    let now = ic_cdk::api::time();
+    let was_tripped = read_state(|s| s.multi_chain.chain_bad_debt_circuit_tripped(chain));
+    mutate_state(|s| {
+        s.multi_chain
+            .set_chain_bad_debt_circuit_threshold(chain, threshold_e8s, now)
+    })
+    .map_err(ProtocolError::ChainAdmin)?;
+    let status = get_chain_bad_debt_circuit_status(chain);
+    rumi_protocol_backend::storage::record_event(
+        &rumi_protocol_backend::event::Event::ChainBadDebtCircuitThresholdSet {
+            chain_id: chain,
+            threshold_e8s,
+            timestamp: now,
+        },
+    );
+    if status.tripped && !was_tripped {
+        rumi_protocol_backend::storage::record_event(
+            &rumi_protocol_backend::event::Event::ChainBadDebtCircuitTripped {
+                chain_id: chain,
+                bad_debt_e8s: status.bad_debt_e8s,
+                total_bad_debt_e8s: status.bad_debt_e8s,
+                threshold_e8s: status.threshold_e8s.unwrap_or(0),
+                timestamp: now,
+            },
+        );
+    }
+    log!(
+        INFO,
+        "[set_chain_bad_debt_circuit_threshold] chain={:?} threshold={:?} tripped={}",
+        chain,
+        threshold_e8s,
+        status.tripped
+    );
+    Ok(())
+}
+
+/// Developer-gated manual clear for the bad-debt circuit. Cumulative bad-debt
+/// accounting and the configured threshold are preserved.
+#[candid_method(update)]
+#[update]
+fn clear_chain_bad_debt_circuit(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    if !read_state(|s| s.multi_chain.chain_configs.contains_key(&chain)) {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not registered",
+            chain.0
+        )));
+    }
+    let now = ic_cdk::api::time();
+    let cleared = mutate_state(|s| s.multi_chain.clear_chain_bad_debt_circuit(chain));
+    if cleared {
+        let total_bad_debt_e8s = read_state(|s| {
+            s.multi_chain
+                .chain_bad_debt_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0)
+        });
+        rumi_protocol_backend::storage::record_event(
+            &rumi_protocol_backend::event::Event::ChainBadDebtCircuitCleared {
+                chain_id: chain,
+                total_bad_debt_e8s,
+                timestamp: now,
+            },
+        );
+    }
+    log!(
+        INFO,
+        "[clear_chain_bad_debt_circuit] chain={:?} cleared={}",
+        chain,
+        cleared
+    );
+    Ok(())
+}
+
 /// A chain vault currently liquidatable on `chain` (CR below the liquidation
 /// threshold), with its interest-aware CR + sizing surfaced for an operator/SP.
 /// The discovery channel for the eventual SP fallback (finding #30; SP-specific
@@ -4869,9 +5007,8 @@ async fn stability_pool_liquidate_chain_vault(
 
     let _guard = rumi_protocol_backend::guard::ChainVaultLiquidationGuard::new(vault_id)?;
     let now = ic_cdk::api::time();
-    let preflight = read_state(|s| {
-        matching_chain_absorb_preflight(s, vault_id, icusd_burned_e8s, caller, now)
-    });
+    let preflight =
+        read_state(|s| matching_chain_absorb_preflight(s, vault_id, icusd_burned_e8s, caller, now));
     if preflight.is_none() {
         if read_state(|s| s.frozen) {
             return Err(ProtocolError::TemporarilyUnavailable(

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1476,6 +1476,12 @@ pub struct State {
     #[serde(default)]
     pub sp_chain_absorb_results_by_proof:
         BTreeMap<(crate::icrc3_proof::SpProofLedger, u64), StoredChainSpAbsorbResult>,
+    /// Inc 9: short-lived pre-burn reservations keyed by vault id. The SP must
+    /// obtain one immediately before burning; a matching reservation lets the
+    /// backend finalize an already-burned absorb even if an admin kill switch
+    /// flips before the post-burn call returns.
+    #[serde(default)]
+    pub sp_chain_absorb_preflights: BTreeMap<u64, StoredChainSpAbsorbPreflight>,
 
     // ─── Wave-8e LIQ-005: bad-debt deficit account ───
     //
@@ -1763,6 +1769,18 @@ pub struct TreasuryStatsSnapshot {
     pub total_accrued_interest_system: u64,
 }
 
+#[derive(Clone, Debug, Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct StoredChainSpAbsorbPreflight {
+    pub caller: Principal,
+    pub vault_id: u64,
+    pub icusd_burn_e8s: u64,
+    pub chain_id: crate::chains::config::ChainId,
+    pub price_e8: u64,
+    pub native_decimals: u8,
+    pub liquidation_penalty_bps: u64,
+    pub expires_at_ns: u64,
+}
+
 /// Serde-only fallback: provides zero/empty/None defaults for fields missing from
 /// old CBOR snapshots. Never used for actual State construction (use From<InitArg>).
 impl Default for State {
@@ -1882,6 +1900,7 @@ impl Default for State {
             sp_writedown_disabled: false,
             consumed_writedown_proofs: BTreeSet::new(),
             sp_chain_absorb_results_by_proof: BTreeMap::new(),
+            sp_chain_absorb_preflights: BTreeMap::new(),
             // Wave-8e LIQ-005
             protocol_deficit_icusd: ICUSD::new(0),
             total_deficit_repaid_icusd: ICUSD::new(0),
@@ -2151,6 +2170,7 @@ impl From<InitArg> for State {
             sp_writedown_disabled: false,
             consumed_writedown_proofs: BTreeSet::new(),
             sp_chain_absorb_results_by_proof: BTreeMap::new(),
+            sp_chain_absorb_preflights: BTreeMap::new(),
             // Wave-8e LIQ-005
             protocol_deficit_icusd: ICUSD::new(0),
             total_deficit_repaid_icusd: ICUSD::new(0),

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -159,6 +159,21 @@ pub fn default_interest_split() -> Vec<InterestRecipient> {
     ]
 }
 pub const DUST_DEBT_THRESHOLD: u64 = 50_000; // 0.0005 icUSD — debt below this is forgiven on withdrawal
+pub const MAX_SP_CHAIN_ABSORB_RESULTS_BY_PROOF: usize = 10_000;
+
+#[derive(candid::CandidType, Clone, Debug, PartialEq, Eq, serde::Deserialize, Serialize)]
+pub struct StoredChainSpAbsorbResult {
+    pub caller: Principal,
+    pub vault_id: u64,
+    pub chain_id: crate::chains::config::ChainId,
+    pub icusd_burned_e8s: u64,
+    pub liquidated_debt_e8s: u128,
+    pub collateral_received_native: u128,
+    pub claim_id: u64,
+    pub custody_address: String,
+    pub block_index: u64,
+    pub collateral_price_e8s: u64,
+}
 
 /// Wave-8b LIQ-002: default tolerance band (in absolute CR units) above the
 /// worst-CR vault inside which liquidations are accepted. 0.01 = 1% CR. With
@@ -1456,6 +1471,11 @@ pub struct State {
     /// concern.
     #[serde(default)]
     pub consumed_writedown_proofs: BTreeSet<(crate::icrc3_proof::SpProofLedger, u64)>,
+    /// Inc 8: idempotent result cache for SP chain-vault absorbs keyed by the
+    /// consumed proof. Lets the SP recover a lost reply without burning again.
+    #[serde(default)]
+    pub sp_chain_absorb_results_by_proof:
+        BTreeMap<(crate::icrc3_proof::SpProofLedger, u64), StoredChainSpAbsorbResult>,
 
     // ─── Wave-8e LIQ-005: bad-debt deficit account ───
     //
@@ -1861,6 +1881,7 @@ impl Default for State {
             liquidation_ordering_tolerance: DEFAULT_LIQUIDATION_ORDERING_TOLERANCE,
             sp_writedown_disabled: false,
             consumed_writedown_proofs: BTreeSet::new(),
+            sp_chain_absorb_results_by_proof: BTreeMap::new(),
             // Wave-8e LIQ-005
             protocol_deficit_icusd: ICUSD::new(0),
             total_deficit_repaid_icusd: ICUSD::new(0),
@@ -2129,6 +2150,7 @@ impl From<InitArg> for State {
             liquidation_ordering_tolerance: DEFAULT_LIQUIDATION_ORDERING_TOLERANCE,
             sp_writedown_disabled: false,
             consumed_writedown_proofs: BTreeSet::new(),
+            sp_chain_absorb_results_by_proof: BTreeMap::new(),
             // Wave-8e LIQ-005
             protocol_deficit_icusd: ICUSD::new(0),
             total_deficit_repaid_icusd: ICUSD::new(0),
@@ -7122,6 +7144,21 @@ mod tests {
             .entry(Principal::anonymous())
             .or_default()
             .insert(42);
+        state.sp_chain_absorb_results_by_proof.insert(
+            (crate::icrc3_proof::SpProofLedger::IcusdBurn, 44),
+            StoredChainSpAbsorbResult {
+                caller: Principal::anonymous(),
+                vault_id: 77,
+                chain_id: crate::chains::config::ChainId(1030),
+                icusd_burned_e8s: 100_00000000,
+                liquidated_debt_e8s: 100_00000000,
+                collateral_received_native: 10_000_000_000_000_000_000u128,
+                claim_id: 77,
+                custody_address: "0xcustody".to_string(),
+                block_index: 44,
+                collateral_price_e8s: 5_000_000,
+            },
+        );
 
         // Serialize
         let mut buf = Vec::new();
@@ -7149,6 +7186,10 @@ mod tests {
         assert_eq!(
             restored.next_available_vault_id,
             state.next_available_vault_id
+        );
+        assert_eq!(
+            restored.sp_chain_absorb_results_by_proof, state.sp_chain_absorb_results_by_proof,
+            "SP chain absorb replay cache must survive upgrade round-trip",
         );
     }
 
@@ -7570,6 +7611,33 @@ mod tests {
             // Other fields should still be intact
             assert_eq!(restored.mode, state.mode);
             assert_eq!(restored.developer_principal, state.developer_principal);
+        } else {
+            panic!("expected CBOR map");
+        }
+    }
+
+    #[test]
+    fn sp_chain_absorb_results_decode_empty_when_missing() {
+        let state = test_state();
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&state, &mut buf).unwrap();
+
+        let value: ciborium::Value = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        if let ciborium::Value::Map(mut entries) = value {
+            let original_len = entries.len();
+            entries.retain(|(k, _)| {
+                !matches!(k, ciborium::Value::Text(key) if key == "sp_chain_absorb_results_by_proof")
+            });
+            assert_eq!(
+                entries.len(),
+                original_len - 1,
+                "should have removed sp_chain_absorb_results_by_proof",
+            );
+
+            let mut modified_buf = Vec::new();
+            ciborium::ser::into_writer(&ciborium::Value::Map(entries), &mut modified_buf).unwrap();
+            let restored: State = ciborium::de::from_reader(modified_buf.as_slice()).unwrap();
+            assert!(restored.sp_chain_absorb_results_by_proof.is_empty());
         } else {
             panic!("expected CBOR map");
         }

--- a/src/rumi_protocol_backend/src/tests.rs
+++ b/src/rumi_protocol_backend/src/tests.rs
@@ -2,9 +2,9 @@ use crate::Vault;
 use crate::{ICP, ICUSD};
 use candid::Principal;
 use ic_base_types::PrincipalId;
+use proptest::collection::vec as pvec;
 use proptest::prelude::*;
 use std::collections::BTreeMap;
-use proptest::collection::vec as pvec;
 
 fn arb_vault() -> impl Strategy<Value = Vault> {
     (arb_principal(), any::<u64>(), arb_amount()).prop_map(|(owner, borrowed_icusd, icp_margin)| {
@@ -34,14 +34,18 @@ fn arb_usd_amount() -> impl Strategy<Value = ICUSD> {
 }
 
 fn arb_amount() -> impl Strategy<Value = u64> {
-    1..1_000_000u64  // Reduced maximum to avoid impossible distributions
+    1..1_000_000u64 // Reduced maximum to avoid impossible distributions
 }
 
 fn vault_vec_to_map(vaults: Vec<Vault>) -> BTreeMap<u64, Vault> {
-    vaults.into_iter().enumerate().map(|(i, mut v)| {
-        v.vault_id = i as u64;
-        (i as u64, v)
-    }).collect()
+    vaults
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut v)| {
+            v.vault_id = i as u64;
+            (i as u64, v)
+        })
+        .collect()
 }
 
 proptest! {
@@ -66,7 +70,7 @@ proptest! {
                 accrued_interest: ICUSD::new(0),
                 bot_processing: false,
             };
-            
+
             let result = crate::state::distribute_across_vaults(&vaults, target_vault);
             let icusd_distributed: ICUSD = result.iter().map(|e| e.icusd_share_amount).sum();
             let icp_distributed: ICP = result.iter().map(|e| e.icp_share_amount).sum();
@@ -94,7 +98,10 @@ mod candid_compat {
 
     #[test]
     fn legacy_two_field_arg_decodes_into_extended_struct() {
-        let legacy = LegacyGetEventsArg { start: 0, length: 100 };
+        let legacy = LegacyGetEventsArg {
+            start: 0,
+            length: 100,
+        };
         let bytes = encode_one(&legacy).expect("encode legacy");
         let decoded: GetEventsArg = decode_one(&bytes).expect("decode into extended");
 
@@ -151,8 +158,8 @@ mod validate_f64_inclusive {
 
 #[test]
 fn protocol_error_carries_multi_chain_variants() {
-    use candid::{Decode, Encode};
     use crate::ProtocolError;
+    use candid::{Decode, Encode};
     let halt = ProtocolError::SupplyInvariantHalted;
     let admin = ProtocolError::ChainAdmin("not developer".to_string());
     let halt_bytes = Encode!(&halt).expect("encode halt");
@@ -163,15 +170,23 @@ fn protocol_error_carries_multi_chain_variants() {
 
 #[test]
 fn supply_audit_round_trips_via_candid() {
-    use candid::{Decode, Encode};
-    use crate::{SupplyAudit, SupplyAuditEntry};
     use crate::chains::config::ChainId;
+    use crate::{SupplyAudit, SupplyAuditEntry};
+    use candid::{Decode, Encode};
 
     let audit = SupplyAudit {
         total_e8s: 150_000,
         per_chain: vec![
-            SupplyAuditEntry { chain_id: ChainId(1), display_name: "ICP".into(), supply_e8s: 100_000 },
-            SupplyAuditEntry { chain_id: ChainId(2), display_name: "Monad".into(), supply_e8s: 50_000 },
+            SupplyAuditEntry {
+                chain_id: ChainId(1),
+                display_name: "ICP".into(),
+                supply_e8s: 100_000,
+            },
+            SupplyAuditEntry {
+                chain_id: ChainId(2),
+                display_name: "Monad".into(),
+                supply_e8s: 50_000,
+            },
         ],
     };
     let bytes = Encode!(&audit).expect("encode");
@@ -182,40 +197,89 @@ fn supply_audit_round_trips_via_candid() {
 
 #[test]
 fn monad_event_variants_round_trip_via_candid() {
-    use candid::{Decode, Encode};
-    use crate::event::Event;
     use crate::chains::config::ChainId;
+    use crate::event::Event;
+    use candid::{Decode, Encode};
 
     let events = vec![
         Event::DepositObserved {
-            chain_id: ChainId(10143), vault_id: 1,
-            custody_address: "0xa".into(), amount_e18: 5, tx_hash: "0xh".into(),
-            block_number: 100, timestamp: 1,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            custody_address: "0xa".into(),
+            amount_e18: 5,
+            tx_hash: "0xh".into(),
+            block_number: 100,
+            timestamp: 1,
         },
         Event::ChainMintSubmitted {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
-            recipient: "0xr".into(), amount_e8s: 10, tx_hash: "0xs".into(), timestamp: 2,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 0,
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            tx_hash: "0xs".into(),
+            timestamp: 2,
         },
         Event::ChainMintConfirmed {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
-            amount_e8s: 10, tx_hash: "0xs".into(), block_number: 102, timestamp: 3,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 0,
+            amount_e8s: 10,
+            tx_hash: "0xs".into(),
+            block_number: 102,
+            timestamp: 3,
         },
         Event::ChainBurnObserved {
-            chain_id: ChainId(10143), vault_id: 1,
-            amount_e8s: 4, tx_hash: "0xb".into(), block_number: 110, timestamp: 4,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            amount_e8s: 4,
+            tx_hash: "0xb".into(),
+            block_number: 110,
+            timestamp: 4,
         },
         Event::WithdrawalSigned {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 1,
-            recipient: "0xw".into(), amount_e18: 5, tx_hash: "0xt".into(), timestamp: 5,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 1,
+            recipient: "0xw".into(),
+            amount_e18: 5,
+            tx_hash: "0xt".into(),
+            timestamp: 5,
         },
         Event::ChainSettlementFailed {
-            chain_id: ChainId(10143), op_id: 1, reason: "reverted".into(), timestamp: 6,
+            chain_id: ChainId(10143),
+            op_id: 1,
+            reason: "reverted".into(),
+            timestamp: 6,
         },
         Event::ChainReorgDetected {
-            chain_id: ChainId(10143), observed_block: 100, reorg_depth: 5, timestamp: 7,
+            chain_id: ChainId(10143),
+            observed_block: 100,
+            reorg_depth: 5,
+            timestamp: 7,
         },
         Event::ChainHotWalletLow {
-            chain_id: ChainId(10143), balance_e18: 1, threshold_e18: 100, timestamp: 8,
+            chain_id: ChainId(10143),
+            balance_e18: 1,
+            threshold_e18: 100,
+            timestamp: 8,
+        },
+        Event::ChainBadDebtCircuitThresholdSet {
+            chain_id: ChainId(10143),
+            threshold_e8s: Some(10),
+            timestamp: 9,
+        },
+        Event::ChainBadDebtCircuitTripped {
+            chain_id: ChainId(10143),
+            bad_debt_e8s: 1,
+            total_bad_debt_e8s: 10,
+            threshold_e8s: 10,
+            timestamp: 10,
+        },
+        Event::ChainBadDebtCircuitCleared {
+            chain_id: ChainId(10143),
+            total_bad_debt_e8s: 10,
+            timestamp: 11,
         },
     ];
     for e in events {

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
@@ -213,6 +213,8 @@ const E8: u128 = 100_000_000;
 /// keccak256("Mint(uint256,address,uint256)"), must match evm_rpc.rs.
 const MINT_EVENT_TOPIC0: &str =
     "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+/// UniswapV2 factory `getPair(address,address)` selector.
+const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 
 /// Conflux register arg's `finality_depth` (mirrors conflux_testnet_register_arg()).
 const CONFLUX_FINALITY_DEPTH: u64 = 100;
@@ -364,6 +366,15 @@ fn word_addr(addr: &str) -> String {
     format!("0x{:0>64}", raw.to_lowercase())
 }
 
+fn script_factory_pair_sanity(pic: &PocketIc, mock: Principal, pair: &str) {
+    let _ = update_any(
+        pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_PAIR_SELECTOR.to_string(), &word_addr(pair)).unwrap(),
+    );
+}
+
 // ─── liquidation config builders ─────────────────────────────────────────────
 
 /// An ENABLED Conflux liquidation config with valid wiring. slippage 250 bps
@@ -510,6 +521,7 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
         None => {
             // ── GATED subset: the new config fields decode + the new query is
             // callable. No Open vaults exist yet, so the query is empty.
+            script_factory_pair_sanity(&pic, mock, VALID_EVM_ADDR);
             decode_result(
                 update_dev(
                     &pic,
@@ -617,6 +629,7 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
     let _ = update_dev(&pic, backend, "set_settlement_tick_interval_secs", Encode!(&31_536_000u64).unwrap());
 
     // ── Enable the liquidation config (master switch on) ─────────────────────
+    script_factory_pair_sanity(&pic, mock, VALID_EVM_ADDR);
     decode_result(
         update_dev(
             &pic,

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
@@ -458,6 +458,8 @@ const TRANSFER_TOPIC0: &str =
 const TOKEN0_SELECTOR: &str = "0x0dfe1681";
 /// UniswapV2 pair `getReserves()` selector (must match `GET_RESERVES_SELECTOR`).
 const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
+/// UniswapV2 factory `getPair(address,address)` selector.
+const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 
 /// Conflux register arg's `finality_depth` (mirrors conflux_testnet_register_arg()).
 const CONFLUX_FINALITY_DEPTH: u64 = 100;
@@ -739,6 +741,15 @@ fn word_addr(addr: &str) -> String {
     format!("0x{:0>64}", raw.to_lowercase())
 }
 
+fn script_factory_pair_sanity(pic: &PocketIc, mock: Principal, pair: &str) {
+    let _ = update_any(
+        pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_PAIR_SELECTOR.to_string(), &word_addr(pair)).unwrap(),
+    );
+}
+
 // ─── liquidation config builder (ENABLED, with the Increment-3 fields) ────────
 
 /// The ENABLED Conflux liquidation config used throughout this test. Uses the
@@ -891,6 +902,7 @@ fn conflux_liquidation_swap_executes_and_credits_reserve() {
             // ── GATED subset: the new config (incl. the 4 Increment-3 fields)
             // decodes + round-trips, and the reserve/settlement address endpoints
             // correctly signal ECDSA-unavailable. We do NOT fake the swap.
+            script_factory_pair_sanity(&pic, mock, DEX_PAIR);
             decode_result(
                 update_dev(
                     &pic,
@@ -1046,6 +1058,7 @@ fn conflux_liquidation_swap_executes_and_credits_reserve() {
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxswap1".to_string()).unwrap());
 
     // ── Step 4: enable the liquidation config + drop the price to $0.08 ──────
+    script_factory_pair_sanity(&pic, mock, DEX_PAIR);
     decode_result(
         update_dev(
             &pic,
@@ -1337,6 +1350,7 @@ fn conflux_liquidation_bot_failure_sp_absorb_claims_cfx() {
     );
     assert_supply(&pic, backend, 100 * E8, "after mint");
 
+    script_factory_pair_sanity(&pic, mock, DEX_PAIR);
     decode_result(
         update_dev(
             &pic,
@@ -1469,12 +1483,21 @@ fn conflux_liquidation_bot_failure_sp_absorb_claims_cfx() {
     assert!(v.pending_liquidation.is_none(), "SP absorb does not create a marker");
     assert_supply(&pic, backend, 100 * E8, "after SP absorb (foreign supply unchanged)");
     let duplicate_absorb = sp_absorb_chain_vault(&pic, sp, vault_id)
-        .expect_err("second SP absorb must reject");
-    assert!(
-        matches!(duplicate_absorb, StabilityPoolError::LiquidationFailed { .. }),
-        "duplicate absorb should reject cleanly, got {:?}",
-        duplicate_absorb
+        .expect("duplicate SP absorb returns the stored idempotent result");
+    assert!(duplicate_absorb.success, "duplicate SP absorb returns success");
+    assert_eq!(duplicate_absorb.vault_id, absorb.vault_id);
+    assert_eq!(duplicate_absorb.chain_id, absorb.chain_id);
+    assert_eq!(duplicate_absorb.icusd_burned_e8s, absorb.icusd_burned_e8s);
+    assert_eq!(
+        duplicate_absorb.liquidated_debt_e8s, absorb.liquidated_debt_e8s,
+        "duplicate SP absorb must not burn or absorb a different debt amount"
     );
+    assert_eq!(
+        duplicate_absorb.collateral_received_native, absorb.collateral_received_native,
+        "duplicate SP absorb must replay the stored collateral seizure"
+    );
+    assert_eq!(duplicate_absorb.claim_id, absorb.claim_id);
+    assert_eq!(duplicate_absorb.block_index, absorb.block_index);
 
     update_any(&pic, mock, "set_total_supply", Encode!(&(100u128 * E8)).unwrap());
     let recon = reconcile_chain_supply(&pic, backend).expect("reconcile_chain_supply Ok");

--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -1,15 +1,15 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use crate::logs::INFO;
+use crate::state::{mutate_state, read_state};
+use crate::types::*;
 use candid::Principal;
 use ic_canister_log::log;
 use ic_cdk::call;
-use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
-use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
-use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
 use icrc_ledger_types::icrc1::account::Account;
-use crate::logs::INFO;
-use crate::types::*;
-use crate::state::{read_state, mutate_state};
+use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
+use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
+use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromError};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
 
 /// Conservative fallback for a stablecoin ledger's transfer fee (native units),
 /// used when the live `icrc1_fee` query fails (IC-S-001). Erring high keeps the
@@ -22,6 +22,47 @@ thread_local! {
     /// `icrc1_fee`. Heap-only (not persisted), so it is simply re-warmed after
     /// an upgrade. Mirrors rumi_3pool::transfers::LEDGER_FEES.
     static REFUND_LEDGER_FEES: RefCell<HashMap<Principal, u64>> = RefCell::new(HashMap::new());
+}
+
+fn record_deposit_credit_after_async(
+    caller: Principal,
+    token_ledger: Principal,
+    amount: u64,
+) -> Result<(), StabilityPoolError> {
+    crate::ensure_pool_balance_mutation_allowed()?;
+    mutate_state(|s| {
+        s.add_deposit(caller, token_ledger, amount);
+        s.push_event(
+            caller,
+            PoolEventType::Deposit {
+                token_ledger,
+                amount,
+            },
+        );
+    });
+    Ok(())
+}
+
+fn record_deposit_as_3usd_credit_after_async(
+    caller: Principal,
+    token_ledger: Principal,
+    amount: u64,
+    three_usd_ledger: Principal,
+    lp_amount: u64,
+) -> Result<(), StabilityPoolError> {
+    crate::ensure_pool_balance_mutation_allowed()?;
+    mutate_state(|s| {
+        s.add_deposit(caller, three_usd_ledger, lp_amount);
+        s.push_event(
+            caller,
+            PoolEventType::DepositAs3USD {
+                token_ledger,
+                amount_in: amount,
+                lp_minted: lp_amount,
+            },
+        );
+    });
+    Ok(())
 }
 
 /// Fetch a stablecoin ledger's transfer fee, caching successful lookups per
@@ -40,11 +81,19 @@ async fn refund_ledger_fee(ledger: Principal) -> u64 {
         }
         Err(e) => {
             let registry_fee = read_state(|s| {
-                s.stablecoin_registry.get(&ledger).and_then(|c| c.transfer_fee).unwrap_or(0)
+                s.stablecoin_registry
+                    .get(&ledger)
+                    .and_then(|c| c.transfer_fee)
+                    .unwrap_or(0)
             });
             let fallback = registry_fee.max(DEFAULT_REFUND_LEDGER_FEE);
-            log!(INFO, "icrc1_fee query failed for {}: {:?}; using conservative fallback {}",
-                ledger, e, fallback);
+            log!(
+                INFO,
+                "icrc1_fee query failed for {}: {:?}; using conservative fallback {}",
+                ledger,
+                e,
+                fallback
+            );
             fallback
         }
     }
@@ -53,36 +102,56 @@ async fn refund_ledger_fee(ledger: Principal) -> u64 {
 /// Deposit a stablecoin into the pool. User must have pre-approved the pool canister.
 pub async fn deposit(token_ledger: Principal, amount: u64) -> Result<(), StabilityPoolError> {
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
 
     // Validate token is accepted
-    let config = read_state(|s| s.get_stablecoin_config(&token_ledger).cloned())
-        .ok_or(StabilityPoolError::TokenNotAccepted { ledger: token_ledger })?;
+    let config = read_state(|s| s.get_stablecoin_config(&token_ledger).cloned()).ok_or(
+        StabilityPoolError::TokenNotAccepted {
+            ledger: token_ledger,
+        },
+    )?;
 
     if !config.is_active {
-        return Err(StabilityPoolError::TokenNotActive { ledger: token_ledger });
+        return Err(StabilityPoolError::TokenNotActive {
+            ledger: token_ledger,
+        });
     }
 
     // Validate minimum deposit (normalize to e8s for comparison)
     let amount_e8s = normalize_to_e8s(amount, config.decimals);
     let min_deposit = read_state(|s| s.configuration.min_deposit_e8s);
     if amount_e8s < min_deposit {
-        return Err(StabilityPoolError::AmountTooLow { minimum_e8s: min_deposit });
+        return Err(StabilityPoolError::AmountTooLow {
+            minimum_e8s: min_deposit,
+        });
     }
 
     if read_state(|s| s.configuration.emergency_pause) {
         return Err(StabilityPoolError::EmergencyPaused);
     }
 
-    log!(INFO, "Deposit: {} {} ({}) from {}", amount, config.symbol, token_ledger, caller);
+    log!(
+        INFO,
+        "Deposit: {} {} ({}) from {}",
+        amount,
+        config.symbol,
+        token_ledger,
+        caller
+    );
 
     // ICRC-2 transfer_from: pull tokens from user to pool canister
     let transfer_args = TransferFromArgs {
-        from: Account { owner: caller, subaccount: None },
-        to: Account { owner: ic_cdk::api::id(), subaccount: None },
+        from: Account {
+            owner: caller,
+            subaccount: None,
+        },
+        to: Account {
+            owner: ic_cdk::api::id(),
+            subaccount: None,
+        },
         amount: amount.into(),
         fee: None,
         memo: None,
@@ -90,37 +159,52 @@ pub async fn deposit(token_ledger: Principal, amount: u64) -> Result<(), Stabili
         spender_subaccount: None,
     };
 
-    let result: Result<(Result<candid::Nat, TransferFromError>,), _> = call(
-        token_ledger, "icrc2_transfer_from", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferFromError>,), _> =
+        call(token_ledger, "icrc2_transfer_from", (transfer_args,)).await;
 
     match result {
         Ok((Ok(block_index),)) => {
             log!(INFO, "Transfer succeeded, block: {}", block_index);
-            mutate_state(|s| {
-                s.add_deposit(caller, token_ledger, amount);
-                s.push_event(caller, PoolEventType::Deposit { token_ledger, amount });
-            });
+            if let Err(error) = record_deposit_credit_after_async(caller, token_ledger, amount) {
+                refund_user(
+                    caller,
+                    token_ledger,
+                    amount,
+                    "deposit: pool balance mutation blocked after transfer",
+                )
+                .await;
+                return Err(error);
+            }
             log!(INFO, "Deposit recorded for {}", caller);
             Ok(())
-        },
+        }
         // Audit Wave-3 (ICRC-003): Duplicate from the ledger means the
         // previous transfer landed; the tokens are already in the pool.
         // Credit the deposit and treat as success.
         Ok((Err(TransferFromError::Duplicate { duplicate_of }),)) => {
-            log!(INFO, "Deposit transfer Duplicate (block {}); previous attempt landed, crediting deposit", duplicate_of);
-            mutate_state(|s| {
-                s.add_deposit(caller, token_ledger, amount);
-                s.push_event(caller, PoolEventType::Deposit { token_ledger, amount });
-            });
+            log!(
+                INFO,
+                "Deposit transfer Duplicate (block {}); previous attempt landed, crediting deposit",
+                duplicate_of
+            );
+            if let Err(error) = record_deposit_credit_after_async(caller, token_ledger, amount) {
+                refund_user(
+                    caller,
+                    token_ledger,
+                    amount,
+                    "deposit: pool balance mutation blocked after duplicate transfer",
+                )
+                .await;
+                return Err(error);
+            }
             Ok(())
-        },
+        }
         Ok((Err(transfer_error),)) => {
             log!(INFO, "Transfer failed: {:?}", transfer_error);
             Err(StabilityPoolError::LedgerTransferFailed {
                 reason: format!("{:?}", transfer_error),
             })
-        },
+        }
         Err(call_error) => {
             log!(INFO, "Inter-canister call failed: {:?}", call_error);
             Err(StabilityPoolError::InterCanisterCallFailed {
@@ -141,7 +225,7 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning,
     // so a withdraw cannot land between a liquidation's snapshot and its burn
     // apportionment and escape the depositor's share of the loss.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -154,7 +238,8 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
     // The ledger charges the fee on top of the transfer amount, so without this
     // the pool's ledger balance drifts below its recorded state on every withdrawal.
     let ledger_fee = read_state(|s| {
-        s.stablecoin_registry.get(&token_ledger)
+        s.stablecoin_registry
+            .get(&token_ledger)
             .and_then(|c| c.transfer_fee)
             .unwrap_or(0)
     });
@@ -168,13 +253,25 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
     // Deduct full amount from state BEFORE transfer to prevent double-spend.
     // If the transfer fails, we rollback below.
     mutate_state(|s| s.process_withdrawal(caller, token_ledger, amount))?;
+    let _balance_async_guard = crate::pool_guard::PoolBalanceAsyncGuard::new();
 
     // User receives amount minus fee; pool pays amount total (transfer + fee)
     let transfer_amount = amount - ledger_fee;
-    log!(INFO, "Withdraw: {} (transfer {} - fee {}) from {} by {}", amount, transfer_amount, ledger_fee, token_ledger, caller);
+    log!(
+        INFO,
+        "Withdraw: {} (transfer {} - fee {}) from {} by {}",
+        amount,
+        transfer_amount,
+        ledger_fee,
+        token_ledger,
+        caller
+    );
 
     let transfer_args = TransferArg {
-        to: Account { owner: caller, subaccount: None },
+        to: Account {
+            owner: caller,
+            subaccount: None,
+        },
         amount: transfer_amount.into(),
         fee: None,
         memo: None,
@@ -182,34 +279,65 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
         from_subaccount: None,
     };
 
-    let result: Result<(Result<candid::Nat, TransferError>,), _> = call(
-        token_ledger, "icrc1_transfer", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferError>,), _> =
+        call(token_ledger, "icrc1_transfer", (transfer_args,)).await;
 
     match result {
         Ok((Ok(block_index),)) => {
-            log!(INFO, "Withdrawal transfer succeeded, block: {}", block_index);
-            mutate_state(|s| s.push_event(caller, PoolEventType::Withdraw { token_ledger, amount }));
+            log!(
+                INFO,
+                "Withdrawal transfer succeeded, block: {}",
+                block_index
+            );
+            mutate_state(|s| {
+                s.push_event(
+                    caller,
+                    PoolEventType::Withdraw {
+                        token_ledger,
+                        amount,
+                    },
+                )
+            });
             Ok(())
-        },
+        }
         // Audit Wave-3 (ICRC-003): Duplicate means the previous withdrawal
         // attempt already paid the user. Don't restore — that would double-spend.
         Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
-            log!(INFO, "Withdrawal Duplicate (block {}); previous attempt landed, NOT restoring balance", duplicate_of);
-            mutate_state(|s| s.push_event(caller, PoolEventType::Withdraw { token_ledger, amount }));
+            log!(
+                INFO,
+                "Withdrawal Duplicate (block {}); previous attempt landed, NOT restoring balance",
+                duplicate_of
+            );
+            mutate_state(|s| {
+                s.push_event(
+                    caller,
+                    PoolEventType::Withdraw {
+                        token_ledger,
+                        amount,
+                    },
+                )
+            });
             Ok(())
-        },
+        }
         Ok((Err(transfer_error),)) => {
-            log!(INFO, "Withdrawal transfer failed, rolling back deduction: {:?}", transfer_error);
+            log!(
+                INFO,
+                "Withdrawal transfer failed, rolling back deduction: {:?}",
+                transfer_error
+            );
             // Rollback: re-credit the user's balance (clear ledger rejection,
             // tokens did NOT leave the pool).
             mutate_state(|s| s.add_deposit(caller, token_ledger, amount));
             Err(StabilityPoolError::LedgerTransferFailed {
                 reason: format!("{:?}", transfer_error),
             })
-        },
+        }
         Err(call_error) => {
-            log!(INFO, "Inter-canister call failed, rolling back deduction: {:?}", call_error);
+            log!(
+                INFO,
+                "Inter-canister call failed, rolling back deduction: {:?}",
+                call_error
+            );
             // Rollback: re-credit the user's balance.
             // NOTE: this is the audit ICRC-002 risk pattern — if the ledger
             // committed but the reply was lost, restoring creates a phantom
@@ -235,7 +363,7 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
 /// 3. If transfer fails, rollback the deduction
 pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, StabilityPoolError> {
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -247,7 +375,9 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
     // Read and deduct gains atomically BEFORE transfer.
     // mark_gains_claimed uses saturating_sub and cleans up zero entries.
     let gains = mutate_state(|s| {
-        let amount = s.deposits.get(&caller)
+        let amount = s
+            .deposits
+            .get(&caller)
             .and_then(|pos| pos.collateral_gains.get(&collateral_ledger).copied())
             .unwrap_or(0);
         if amount > 0 {
@@ -262,11 +392,12 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
 
     // Query the collateral ledger's transfer fee so we can deduct it from
     // what the user receives, keeping the pool's ledger balance in sync.
-    let ledger_fee: u64 = match call::<(), (candid::Nat,)>(collateral_ledger, "icrc1_fee", ()).await {
+    let ledger_fee: u64 = match call::<(), (candid::Nat,)>(collateral_ledger, "icrc1_fee", ()).await
+    {
         Ok((fee_nat,)) => {
             let fee_u128: u128 = fee_nat.0.try_into().unwrap_or(0);
             fee_u128 as u64
-        },
+        }
         Err(e) => {
             // ICRC-004 / SP-203: do NOT fall back to fee=0. The transfer still
             // deducts the real ledger fee, so a zero fallback over-credits the
@@ -275,7 +406,7 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
             log!(INFO, "icrc1_fee query failed for collateral {}: {:?}; using conservative fallback {} e8s",
                 collateral_ledger, e, crate::liquidation::FALLBACK_COLLATERAL_FEE_E8S);
             crate::liquidation::FALLBACK_COLLATERAL_FEE_E8S
-        },
+        }
     };
 
     if gains <= ledger_fee {
@@ -292,10 +423,21 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
     }
 
     let transfer_amount = gains - ledger_fee;
-    log!(INFO, "Claim: {} of collateral {} (transfer {} - fee {}) by {}", gains, collateral_ledger, transfer_amount, ledger_fee, caller);
+    log!(
+        INFO,
+        "Claim: {} of collateral {} (transfer {} - fee {}) by {}",
+        gains,
+        collateral_ledger,
+        transfer_amount,
+        ledger_fee,
+        caller
+    );
 
     let transfer_args = TransferArg {
-        to: Account { owner: caller, subaccount: None },
+        to: Account {
+            owner: caller,
+            subaccount: None,
+        },
         amount: transfer_amount.into(),
         fee: None,
         memo: None,
@@ -303,31 +445,52 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
         from_subaccount: None,
     };
 
-    let result: Result<(Result<candid::Nat, TransferError>,), _> = call(
-        collateral_ledger, "icrc1_transfer", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferError>,), _> =
+        call(collateral_ledger, "icrc1_transfer", (transfer_args,)).await;
 
     match result {
         Ok((Ok(block_index),)) => {
-            log!(INFO, "Collateral claim transfer succeeded, block: {}", block_index);
-            mutate_state(|s| s.push_event(caller, PoolEventType::ClaimCollateral {
-                collateral_ledger,
-                amount: transfer_amount,
-            }));
+            log!(
+                INFO,
+                "Collateral claim transfer succeeded, block: {}",
+                block_index
+            );
+            mutate_state(|s| {
+                s.push_event(
+                    caller,
+                    PoolEventType::ClaimCollateral {
+                        collateral_ledger,
+                        amount: transfer_amount,
+                    },
+                )
+            });
             Ok(transfer_amount)
-        },
+        }
         // Audit Wave-3 (ICRC-003): Duplicate means the previous claim already
         // paid the user. Don't restore — that would let them claim again.
         Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
-            log!(INFO, "Collateral claim Duplicate (block {}); previous attempt landed, NOT restoring", duplicate_of);
-            mutate_state(|s| s.push_event(caller, PoolEventType::ClaimCollateral {
-                collateral_ledger,
-                amount: transfer_amount,
-            }));
+            log!(
+                INFO,
+                "Collateral claim Duplicate (block {}); previous attempt landed, NOT restoring",
+                duplicate_of
+            );
+            mutate_state(|s| {
+                s.push_event(
+                    caller,
+                    PoolEventType::ClaimCollateral {
+                        collateral_ledger,
+                        amount: transfer_amount,
+                    },
+                )
+            });
             Ok(transfer_amount)
-        },
+        }
         Ok((Err(transfer_error),)) => {
-            log!(INFO, "Collateral claim failed, rolling back: {:?}", transfer_error);
+            log!(
+                INFO,
+                "Collateral claim failed, rolling back: {:?}",
+                transfer_error
+            );
             // Rollback: restore the gains (clear ledger rejection — tokens
             // did NOT leave the pool).
             mutate_state(|s| {
@@ -341,9 +504,13 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
             Err(StabilityPoolError::LedgerTransferFailed {
                 reason: format!("{:?}", transfer_error),
             })
-        },
+        }
         Err(call_error) => {
-            log!(INFO, "Inter-canister call failed, rolling back: {:?}", call_error);
+            log!(
+                INFO,
+                "Inter-canister call failed, rolling back: {:?}",
+                call_error
+            );
             // Rollback: restore the gains. See withdraw() for the same
             // ICRC-002 caveat about transport-error-then-no-retry.
             mutate_state(|s| {
@@ -365,7 +532,7 @@ pub async fn claim_collateral(collateral_ledger: Principal) -> Result<u64, Stabi
 /// Claim all nonzero collateral gains across all collateral types.
 pub async fn claim_all_collateral() -> Result<BTreeMap<Principal, u64>, StabilityPoolError> {
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -375,9 +542,8 @@ pub async fn claim_all_collateral() -> Result<BTreeMap<Principal, u64>, Stabilit
     }
 
     let all_gains = read_state(|s| s.get_collateral_gains(&caller));
-    let nonzero_gains: BTreeMap<Principal, u64> = all_gains.into_iter()
-        .filter(|(_, v)| *v > 0)
-        .collect();
+    let nonzero_gains: BTreeMap<Principal, u64> =
+        all_gains.into_iter().filter(|(_, v)| *v > 0).collect();
 
     if nonzero_gains.is_empty() {
         return Ok(BTreeMap::new());
@@ -388,9 +554,15 @@ pub async fn claim_all_collateral() -> Result<BTreeMap<Principal, u64>, Stabilit
         match claim_collateral(*collateral_ledger).await {
             Ok(claimed_amount) => {
                 claimed.insert(*collateral_ledger, claimed_amount);
-            },
+            }
             Err(e) => {
-                log!(INFO, "Failed to claim {} from {}: {:?}", amount, collateral_ledger, e);
+                log!(
+                    INFO,
+                    "Failed to claim {} from {}: {:?}",
+                    amount,
+                    collateral_ledger,
+                    e
+                );
                 // Continue claiming others — partial success is fine
             }
         }
@@ -406,18 +578,25 @@ pub async fn deposit_as_3usd(
     amount: u64,
 ) -> Result<u64, StabilityPoolError> {
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
 
-    let config = read_state(|s| s.get_stablecoin_config(&token_ledger).cloned())
-        .ok_or(StabilityPoolError::TokenNotAccepted { ledger: token_ledger })?;
+    let config = read_state(|s| s.get_stablecoin_config(&token_ledger).cloned()).ok_or(
+        StabilityPoolError::TokenNotAccepted {
+            ledger: token_ledger,
+        },
+    )?;
     if !config.is_active {
-        return Err(StabilityPoolError::TokenNotActive { ledger: token_ledger });
+        return Err(StabilityPoolError::TokenNotActive {
+            ledger: token_ledger,
+        });
     }
     if config.is_lp_token.unwrap_or(false) {
-        return Err(StabilityPoolError::TokenNotAccepted { ledger: token_ledger });
+        return Err(StabilityPoolError::TokenNotAccepted {
+            ledger: token_ledger,
+        });
     }
 
     if read_state(|s| s.configuration.emergency_pause) {
@@ -427,23 +606,42 @@ pub async fn deposit_as_3usd(
     let amount_e8s = normalize_to_e8s(amount, config.decimals);
     let min_deposit = read_state(|s| s.configuration.min_deposit_e8s);
     if amount_e8s < min_deposit {
-        return Err(StabilityPoolError::AmountTooLow { minimum_e8s: min_deposit });
+        return Err(StabilityPoolError::AmountTooLow {
+            minimum_e8s: min_deposit,
+        });
     }
 
     // Find the 3USD config (LP token with underlying_pool set)
     let (three_usd_ledger, three_pool_canister) = read_state(|s| {
-        s.stablecoin_registry.iter()
-            .find(|(_, c)| c.is_lp_token.unwrap_or(false) && c.underlying_pool.is_some() && c.is_active)
+        s.stablecoin_registry
+            .iter()
+            .find(|(_, c)| {
+                c.is_lp_token.unwrap_or(false) && c.underlying_pool.is_some() && c.is_active
+            })
             .map(|(ledger, c)| (*ledger, c.underlying_pool.unwrap()))
-            .ok_or(StabilityPoolError::TokenNotAccepted { ledger: token_ledger })
+            .ok_or(StabilityPoolError::TokenNotAccepted {
+                ledger: token_ledger,
+            })
     })?;
 
-    log!(INFO, "deposit_as_3usd: {} depositing {} of {} via 3pool", caller, amount, token_ledger);
+    log!(
+        INFO,
+        "deposit_as_3usd: {} depositing {} of {} via 3pool",
+        caller,
+        amount,
+        token_ledger
+    );
 
     // Step 1: Pull tokens from user
     let transfer_args = TransferFromArgs {
-        from: Account { owner: caller, subaccount: None },
-        to: Account { owner: ic_cdk::api::id(), subaccount: None },
+        from: Account {
+            owner: caller,
+            subaccount: None,
+        },
+        to: Account {
+            owner: ic_cdk::api::id(),
+            subaccount: None,
+        },
         amount: amount.into(),
         fee: None,
         memo: None,
@@ -451,25 +649,31 @@ pub async fn deposit_as_3usd(
         spender_subaccount: None,
     };
 
-    let result: Result<(Result<candid::Nat, TransferFromError>,), _> = call(
-        token_ledger, "icrc2_transfer_from", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferFromError>,), _> =
+        call(token_ledger, "icrc2_transfer_from", (transfer_args,)).await;
 
     match result {
-        Ok((Ok(_),)) => {},
-        Ok((Err(e),)) => return Err(StabilityPoolError::LedgerTransferFailed {
-            reason: format!("{:?}", e),
-        }),
-        Err(_e) => return Err(StabilityPoolError::InterCanisterCallFailed {
-            target: format!("{}", token_ledger),
-            method: "icrc2_transfer_from".to_string(),
-        }),
+        Ok((Ok(_),)) => {}
+        Ok((Err(e),)) => {
+            return Err(StabilityPoolError::LedgerTransferFailed {
+                reason: format!("{:?}", e),
+            })
+        }
+        Err(_e) => {
+            return Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", token_ledger),
+                method: "icrc2_transfer_from".to_string(),
+            })
+        }
     }
 
     // Step 2: Approve 3pool to spend the token
     let approve_args = ApproveArgs {
         from_subaccount: None,
-        spender: Account { owner: three_pool_canister, subaccount: None },
+        spender: Account {
+            owner: three_pool_canister,
+            subaccount: None,
+        },
         amount: candid::Nat::from(amount as u128 * 2), // 2x buffer for fees
         expected_allowance: None,
         expires_at: Some(ic_cdk::api::time() + 300_000_000_000), // 5 min
@@ -478,12 +682,17 @@ pub async fn deposit_as_3usd(
         created_at_time: Some(ic_cdk::api::time()),
     };
 
-    let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> = call(
-        token_ledger, "icrc2_approve", (approve_args,)
-    ).await;
+    let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> =
+        call(token_ledger, "icrc2_approve", (approve_args,)).await;
 
     if let Err(_) | Ok((Err(_),)) = approve_result {
-        refund_user(caller, token_ledger, amount, "deposit_as_3usd: icrc2_approve failed").await;
+        refund_user(
+            caller,
+            token_ledger,
+            amount,
+            "deposit_as_3usd: icrc2_approve failed",
+        )
+        .await;
         return Err(StabilityPoolError::InterCanisterCallFailed {
             target: format!("{}", token_ledger),
             method: "icrc2_approve".to_string(),
@@ -491,14 +700,19 @@ pub async fn deposit_as_3usd(
     }
 
     // Step 3: Query 3pool to find which coin index this token is
-    let pool_status_result: Result<(ThreePoolStatus,), _> = call(
-        three_pool_canister, "get_pool_status", ()
-    ).await;
+    let pool_status_result: Result<(ThreePoolStatus,), _> =
+        call(three_pool_canister, "get_pool_status", ()).await;
 
     let pool_status = match pool_status_result {
         Ok((status,)) => status,
         Err(_) => {
-            refund_user(caller, token_ledger, amount, "deposit_as_3usd: get_pool_status failed").await;
+            refund_user(
+                caller,
+                token_ledger,
+                amount,
+                "deposit_as_3usd: get_pool_status failed",
+            )
+            .await;
             return Err(StabilityPoolError::InterCanisterCallFailed {
                 target: "3pool".to_string(),
                 method: "get_pool_status".to_string(),
@@ -506,12 +720,23 @@ pub async fn deposit_as_3usd(
         }
     };
 
-    let coin_index = pool_status.tokens.iter().position(|t| t.ledger_id == token_ledger);
+    let coin_index = pool_status
+        .tokens
+        .iter()
+        .position(|t| t.ledger_id == token_ledger);
     let coin_index = match coin_index {
         Some(idx) => idx,
         None => {
-            refund_user(caller, token_ledger, amount, "deposit_as_3usd: token not in 3pool").await;
-            return Err(StabilityPoolError::TokenNotAccepted { ledger: token_ledger });
+            refund_user(
+                caller,
+                token_ledger,
+                amount,
+                "deposit_as_3usd: token not in 3pool",
+            )
+            .await;
+            return Err(StabilityPoolError::TokenNotAccepted {
+                ledger: token_ledger,
+            });
         }
     };
 
@@ -519,9 +744,8 @@ pub async fn deposit_as_3usd(
     amounts[coin_index] = amount as u128;
 
     // Step 4: Call add_liquidity on the 3pool
-    let lp_result: Result<(Result<u128, ThreePoolErrorRemote>,), _> = call(
-        three_pool_canister, "add_liquidity", (amounts, 0u128)
-    ).await;
+    let lp_result: Result<(Result<u128, ThreePoolErrorRemote>,), _> =
+        call(three_pool_canister, "add_liquidity", (amounts, 0u128)).await;
 
     let lp_minted = match lp_result {
         Ok((Ok(lp),)) => lp,
@@ -532,7 +756,13 @@ pub async fn deposit_as_3usd(
                 e,
                 amount
             );
-            refund_user(caller, token_ledger, amount, "deposit_as_3usd: add_liquidity rejected").await;
+            refund_user(
+                caller,
+                token_ledger,
+                amount,
+                "deposit_as_3usd: add_liquidity rejected",
+            )
+            .await;
             return Err(StabilityPoolError::InterCanisterCallFailed {
                 target: "3pool".to_string(),
                 method: "add_liquidity".to_string(),
@@ -546,7 +776,13 @@ pub async fn deposit_as_3usd(
                 msg,
                 amount
             );
-            refund_user(caller, token_ledger, amount, "deposit_as_3usd: add_liquidity call failed").await;
+            refund_user(
+                caller,
+                token_ledger,
+                amount,
+                "deposit_as_3usd: add_liquidity call failed",
+            )
+            .await;
             return Err(StabilityPoolError::InterCanisterCallFailed {
                 target: "3pool".to_string(),
                 method: "add_liquidity".to_string(),
@@ -556,16 +792,31 @@ pub async fn deposit_as_3usd(
 
     // Step 5: Credit user's 3USD balance
     let lp_amount_u64 = lp_minted as u64;
-    mutate_state(|s| {
-        s.add_deposit(caller, three_usd_ledger, lp_amount_u64);
-        s.push_event(caller, PoolEventType::DepositAs3USD {
-            token_ledger,
-            amount_in: amount,
-            lp_minted: lp_amount_u64,
-        });
-    });
+    if let Err(error) = record_deposit_as_3usd_credit_after_async(
+        caller,
+        token_ledger,
+        amount,
+        three_usd_ledger,
+        lp_amount_u64,
+    ) {
+        refund_user(
+            caller,
+            three_usd_ledger,
+            lp_amount_u64,
+            "deposit_as_3usd: pool balance mutation blocked after LP mint",
+        )
+        .await;
+        return Err(error);
+    }
 
-    log!(INFO, "deposit_as_3usd: {} deposited {} of {} → {} 3USD LP", caller, amount, token_ledger, lp_amount_u64);
+    log!(
+        INFO,
+        "deposit_as_3usd: {} deposited {} of {} → {} 3USD LP",
+        caller,
+        amount,
+        token_ledger,
+        lp_amount_u64
+    );
 
     Ok(lp_amount_u64)
 }
@@ -583,28 +834,40 @@ async fn refund_user(user: Principal, token_ledger: Principal, amount: u64, reas
     if amount <= fee {
         // Nothing transferable once the ledger fee is covered; the dust stays
         // in the pool (solvency-safe, mirrors rumi_3pool::transfer_to_user).
-        log!(INFO, "refund_user: {} of {} for {} not refundable (<= ledger fee {}); leaving as pool dust",
-            amount, token_ledger, user, fee);
+        log!(
+            INFO,
+            "refund_user: {} of {} for {} not refundable (<= ledger fee {}); leaving as pool dust",
+            amount,
+            token_ledger,
+            user,
+            fee
+        );
         return;
     }
     let transfer_args = TransferArg {
-        to: Account { owner: user, subaccount: None },
+        to: Account {
+            owner: user,
+            subaccount: None,
+        },
         amount: (amount - fee).into(),
         fee: None,
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),
         from_subaccount: None,
     };
-    let result: Result<(Result<candid::Nat, TransferError>,), _> = call(
-        token_ledger, "icrc1_transfer", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferError>,), _> =
+        call(token_ledger, "icrc1_transfer", (transfer_args,)).await;
     let failure = match result {
         Ok((Ok(_),)) => None,
         // Duplicate: a previous refund attempt already paid the user.
         Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
-            log!(INFO, "refund_user: Duplicate (block {}); previous refund landed", duplicate_of);
+            log!(
+                INFO,
+                "refund_user: Duplicate (block {}); previous refund landed",
+                duplicate_of
+            );
             None
-        },
+        }
         Ok((Err(e),)) => Some(format!("{}; refund transfer failed: {:?}", reason, e)),
         Err(e) => Some(format!("{}; refund call failed: {:?}", reason, e)),
     };
@@ -612,8 +875,15 @@ async fn refund_user(user: Principal, token_ledger: Principal, amount: u64, reas
         let id = mutate_state(|s| {
             s.record_pending_refund(user, token_ledger, amount, why.clone(), ic_cdk::api::time())
         });
-        log!(INFO, "refund_user: refund of {} {} to {} failed ({}); recorded pending refund #{}",
-            amount, token_ledger, user, why, id);
+        log!(
+            INFO,
+            "refund_user: refund of {} {} to {} failed ({}); recorded pending refund #{}",
+            amount,
+            token_ledger,
+            user,
+            why,
+            id
+        );
     }
 }
 
@@ -624,7 +894,7 @@ async fn refund_user(user: Principal, token_ledger: Principal, amount: u64, reas
 /// (gross minus the ledger fee). Mirrors rumi_3pool::claim_pending.
 pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolError> {
     // SP-102: refuse balance-mutating ops while a liquidation is apportioning.
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -649,39 +919,61 @@ pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolEr
     let net = refund.amount - fee;
 
     let transfer_args = TransferArg {
-        to: Account { owner: refund.user, subaccount: None },
+        to: Account {
+            owner: refund.user,
+            subaccount: None,
+        },
         amount: net.into(),
         fee: None,
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),
         from_subaccount: None,
     };
-    let result: Result<(Result<candid::Nat, TransferError>,), _> = call(
-        refund.token_ledger, "icrc1_transfer", (transfer_args,)
-    ).await;
+    let result: Result<(Result<candid::Nat, TransferError>,), _> =
+        call(refund.token_ledger, "icrc1_transfer", (transfer_args,)).await;
 
     match result {
         Ok((Ok(block_index),)) => {
-            log!(INFO, "claim_pending_refund: refund #{} paid {} (net of fee {}) of {} to {}, block {}",
-                refund_id, net, fee, refund.token_ledger, refund.user, block_index);
+            log!(
+                INFO,
+                "claim_pending_refund: refund #{} paid {} (net of fee {}) of {} to {}, block {}",
+                refund_id,
+                net,
+                fee,
+                refund.token_ledger,
+                refund.user,
+                block_index
+            );
             Ok(net)
-        },
+        }
         // Duplicate: a previous claim attempt already paid the user.
         Ok((Err(TransferError::Duplicate { duplicate_of }),)) => {
-            log!(INFO, "claim_pending_refund: refund #{} Duplicate (block {}); previous attempt landed",
-                refund_id, duplicate_of);
+            log!(
+                INFO,
+                "claim_pending_refund: refund #{} Duplicate (block {}); previous attempt landed",
+                refund_id,
+                duplicate_of
+            );
             Ok(net)
-        },
+        }
         Ok((Err(transfer_error),)) => {
-            log!(INFO, "claim_pending_refund: refund #{} transfer failed, re-inserting: {:?}",
-                refund_id, transfer_error);
+            log!(
+                INFO,
+                "claim_pending_refund: refund #{} transfer failed, re-inserting: {:?}",
+                refund_id,
+                transfer_error
+            );
             let reason = format!("{:?}", transfer_error);
             mutate_state(|s| s.put_pending_refund(refund));
             Err(StabilityPoolError::LedgerTransferFailed { reason })
-        },
+        }
         Err(call_error) => {
-            log!(INFO, "claim_pending_refund: refund #{} call failed, re-inserting: {:?}",
-                refund_id, call_error);
+            log!(
+                INFO,
+                "claim_pending_refund: refund #{} call failed, re-inserting: {:?}",
+                refund_id,
+                call_error
+            );
             let target = format!("{}", refund.token_ledger);
             mutate_state(|s| s.put_pending_refund(refund));
             Err(StabilityPoolError::InterCanisterCallFailed {
@@ -689,5 +981,95 @@ pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolEr
                 method: "icrc1_transfer".to_string(),
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rumi_protocol_backend::chains::config::ChainId;
+
+    fn principal(byte: u8) -> Principal {
+        Principal::from_slice(&[byte])
+    }
+
+    fn pending_intent() -> ChainSpAbsorbIntent {
+        let mut stables_consumed = BTreeMap::new();
+        stables_consumed.insert(principal(10), 100_00000000);
+        ChainSpAbsorbIntent {
+            vault_id: 77,
+            chain_id: ChainId(1030),
+            chain_sentinel: crate::state::chain_collateral_sentinel(1030),
+            icusd_ledger: principal(10),
+            icusd_minting_account: Account {
+                owner: principal(90),
+                subaccount: None,
+            },
+            icusd_to_burn_e8s: 100_00000000,
+            stables_consumed,
+            burn_created_at_time_ns: 123,
+            status: ChainSpAbsorbIntentStatus::Burned,
+            burn_proof: Some(rumi_protocol_backend::icrc3_proof::SpWritedownProof {
+                block_index: 44,
+                ledger_kind: rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn,
+                vault_id_memo: 77,
+            }),
+            backend_result: None,
+            last_error: None,
+            created_at_ns: 123,
+            updated_at_ns: 456,
+        }
+    }
+
+    #[test]
+    fn post_await_deposit_credit_rechecks_pending_chain_absorbs() {
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
+        mutate_state(|s| s.put_pending_chain_absorb(pending_intent()).unwrap());
+
+        let result = record_deposit_credit_after_async(principal(1), principal(10), 50_00000000);
+
+        assert!(
+            matches!(result, Err(StabilityPoolError::SystemBusy)),
+            "post-await deposit credit must stop when chain absorb is pending",
+        );
+        assert_eq!(
+            read_state(|s| s
+                .total_stablecoin_balances
+                .get(&principal(10))
+                .copied()
+                .unwrap_or(0)),
+            0,
+            "blocked post-await credit must not mutate the SP denominator",
+        );
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
+    }
+
+    #[test]
+    fn post_await_deposit_as_3usd_credit_rechecks_pending_chain_absorbs() {
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
+        mutate_state(|s| s.put_pending_chain_absorb(pending_intent()).unwrap());
+
+        let result = record_deposit_as_3usd_credit_after_async(
+            principal(1),
+            principal(10),
+            50_00000000,
+            principal(30),
+            49_00000000,
+        );
+
+        assert!(
+            matches!(result, Err(StabilityPoolError::SystemBusy)),
+            "post-await 3USD credit must stop when chain absorb is pending",
+        );
+        assert_eq!(
+            read_state(|s| s
+                .total_stablecoin_balances
+                .get(&principal(30))
+                .copied()
+                .unwrap_or(0)),
+            0,
+            "blocked post-await LP credit must not mutate the SP denominator",
+        );
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
     }
 }

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -15,6 +15,8 @@ use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
 use crate::types::*;
 
+const CHAIN_ABSORB_AUTO_TIMER_POLL_SECONDS: u64 = 60;
+
 pub(crate) fn pool_balance_mutation_blocked() -> bool {
     crate::pool_guard::liquidation_in_progress() || read_state(|s| s.has_pending_chain_absorbs())
 }
@@ -51,6 +53,10 @@ fn init(args: StabilityPoolInitArgs) {
         "Stability Pool initialized. Protocol: {}",
         read_state(|s| s.protocol_canister_id)
     );
+    ic_cdk_timers::set_timer(Duration::ZERO, || {
+        setup_virtual_price_timer();
+        setup_chain_absorb_auto_timer();
+    });
 }
 
 #[pre_upgrade]
@@ -95,6 +101,7 @@ fn post_upgrade(_args: StabilityPoolInitArgs) {
     // Defer timer setup to avoid ic0_call_new restriction during upgrade
     ic_cdk_timers::set_timer(Duration::ZERO, || {
         setup_virtual_price_timer();
+        setup_chain_absorb_auto_timer();
     });
 }
 
@@ -106,6 +113,19 @@ fn setup_virtual_price_timer() {
     ic_cdk_timers::set_timer_interval(Duration::from_secs(300), || {
         ic_cdk::spawn(fetch_virtual_prices());
     });
+}
+
+fn setup_chain_absorb_auto_timer() {
+    ic_cdk_timers::set_timer_interval(
+        Duration::from_secs(CHAIN_ABSORB_AUTO_TIMER_POLL_SECONDS),
+        || {
+            ic_cdk::spawn(async {
+                if let Err(error) = crate::liquidation::run_chain_absorb_auto_tick().await {
+                    log!(INFO, "chain absorb auto tick skipped: {:?}", error);
+                }
+            });
+        },
+    );
 }
 
 async fn fetch_virtual_prices() {
@@ -318,6 +338,33 @@ pub async fn scan_chain_absorb_candidates(
     max_per_chain: Option<u64>,
 ) -> Result<Vec<ChainSpAbsorbCandidate>, StabilityPoolError> {
     crate::liquidation::scan_chain_absorb_candidates(max_per_chain).await
+}
+
+#[update]
+pub fn set_chain_absorb_auto_config(
+    config: ChainAbsorbAutoConfig,
+) -> Result<(), StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    if caller == Principal::anonymous() {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    if !read_state(|s| s.is_admin(&caller)) {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    mutate_state(|s| {
+        s.set_chain_absorb_auto_config(config)?;
+        s.push_event(caller, PoolEventType::ConfigurationUpdated);
+        Ok(())
+    })
+}
+
+#[query]
+pub fn get_chain_absorb_auto_status() -> ChainAbsorbAutoStatus {
+    read_state(|s| ChainAbsorbAutoStatus {
+        config: s.chain_absorb_auto_config(),
+        tick_in_flight: crate::pool_guard::chain_absorb_auto_tick_in_flight(),
+        last_tick: s.chain_absorb_auto_last_tick(),
+    })
 }
 
 // ─── Interest Revenue ───

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -1,19 +1,37 @@
-use ic_cdk::{query, update, init, pre_upgrade, post_upgrade};
 use candid::Principal;
 use ic_canister_log::log;
+use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-pub mod types;
-pub mod state;
 pub mod deposits;
 pub mod liquidation;
 pub mod logs;
 pub mod pool_guard;
+pub mod state;
+pub mod types;
 
-use crate::types::*;
-use crate::state::{mutate_state, read_state};
 use crate::logs::INFO;
+use crate::state::{mutate_state, read_state};
+use crate::types::*;
+
+pub(crate) fn pool_balance_mutation_blocked() -> bool {
+    crate::pool_guard::liquidation_in_progress() || read_state(|s| s.has_pending_chain_absorbs())
+}
+
+pub(crate) fn ensure_pool_balance_mutation_allowed() -> Result<(), StabilityPoolError> {
+    if pool_balance_mutation_blocked() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_no_pool_balance_async_in_flight() -> Result<(), StabilityPoolError> {
+    if crate::pool_guard::balance_async_in_flight() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    Ok(())
+}
 
 // ─── Init / Upgrade ───
 
@@ -28,22 +46,31 @@ fn init(args: StabilityPoolInitArgs) {
         "refusing to init: stable memory non-empty; use upgrade mode not reinstall"
     );
     mutate_state(|s| s.initialize(args));
-    log!(INFO, "Stability Pool initialized. Protocol: {}",
-        read_state(|s| s.protocol_canister_id));
+    log!(
+        INFO,
+        "Stability Pool initialized. Protocol: {}",
+        read_state(|s| s.protocol_canister_id)
+    );
 }
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    log!(INFO, "Stability Pool pre-upgrade: saving state to stable memory");
+    log!(
+        INFO,
+        "Stability Pool pre-upgrade: saving state to stable memory"
+    );
     state::save_to_stable_memory();
 }
 
 #[post_upgrade]
 fn post_upgrade(_args: StabilityPoolInitArgs) {
     state::load_from_stable_memory();
-    log!(INFO, "Stability Pool post-upgrade: state restored. {} depositors, {} liquidations",
+    log!(
+        INFO,
+        "Stability Pool post-upgrade: state restored. {} depositors, {} liquidations",
         read_state(|s| s.deposits.len()),
-        read_state(|s| s.total_liquidations_executed));
+        read_state(|s| s.total_liquidations_executed)
+    );
 
     if let Err(error) = read_state(|s| s.validate_state()) {
         ic_cdk::trap(&format!("State validation failed after upgrade: {}", error));
@@ -53,8 +80,12 @@ fn post_upgrade(_args: StabilityPoolInitArgs) {
     mutate_state(|s| {
         for config in s.stablecoin_registry.values_mut() {
             match config.symbol.as_str() {
-                "icUSD" => { config.transfer_fee = Some(100_000); }
-                "3USD"  => { config.transfer_fee = Some(0); }
+                "icUSD" => {
+                    config.transfer_fee = Some(100_000);
+                }
+                "3USD" => {
+                    config.transfer_fee = Some(0);
+                }
                 _ => {}
             }
         }
@@ -79,16 +110,16 @@ fn setup_virtual_price_timer() {
 
 async fn fetch_virtual_prices() {
     let lp_configs: Vec<(Principal, Principal)> = read_state(|s| {
-        s.stablecoin_registry.iter()
+        s.stablecoin_registry
+            .iter()
             .filter(|(_, c)| c.is_lp_token.unwrap_or(false))
             .filter_map(|(ledger, c)| c.underlying_pool.map(|pool| (*ledger, pool)))
             .collect()
     });
 
     for (lp_ledger, pool_canister) in lp_configs {
-        let result: Result<(ThreePoolStatus,), _> = ic_cdk::call(
-            pool_canister, "get_pool_status", ()
-        ).await;
+        let result: Result<(ThreePoolStatus,), _> =
+            ic_cdk::call(pool_canister, "get_pool_status", ()).await;
 
         match result {
             Ok((status,)) => {
@@ -99,7 +130,12 @@ async fn fetch_virtual_prices() {
                 });
             }
             Err(e) => {
-                log!(INFO, "Failed to fetch virtual price from {}: {:?}", pool_canister, e);
+                log!(
+                    INFO,
+                    "Failed to fetch virtual price from {}: {:?}",
+                    pool_canister,
+                    e
+                );
             }
         }
     }
@@ -130,7 +166,10 @@ pub async fn claim_all_collateral() -> Result<BTreeMap<Principal, u64>, Stabilit
 /// Convenience: deposit a stablecoin (icUSD, ckUSDT, ckUSDC) and have the pool
 /// mint 3USD on the user's behalf by depositing into the 3pool.
 #[update]
-pub async fn deposit_as_3usd(token_ledger: Principal, amount: u64) -> Result<u64, StabilityPoolError> {
+pub async fn deposit_as_3usd(
+    token_ledger: Principal,
+    amount: u64,
+) -> Result<u64, StabilityPoolError> {
     crate::deposits::deposit_as_3usd(token_ledger, amount).await
 }
 
@@ -143,7 +182,10 @@ pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolEr
 }
 
 #[update]
-pub async fn claim_cfx(chain_sentinel: Principal, dest_evm: String) -> Result<u128, StabilityPoolError> {
+pub async fn claim_cfx(
+    chain_sentinel: Principal,
+    dest_evm: String,
+) -> Result<u128, StabilityPoolError> {
     crate::liquidation::claim_cfx(chain_sentinel, dest_evm).await
 }
 
@@ -154,7 +196,8 @@ pub fn opt_out_collateral(collateral_type: Principal) -> Result<(), StabilityPoo
     // SP-102 / AR-S-002: opt-in/out changes the apportionment denominator, so
     // it must not land between a liquidation's snapshot and its apportionment
     // (escape-the-burn + aggregate drift above the ledger balance).
-    if crate::pool_guard::liquidation_in_progress() {
+    // `pool_balance_mutation_blocked` includes `liquidation_in_progress`.
+    if pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -168,7 +211,8 @@ pub fn opt_out_collateral(collateral_type: Principal) -> Result<(), StabilityPoo
 #[update]
 pub fn opt_in_collateral(collateral_type: Principal) -> Result<(), StabilityPoolError> {
     // SP-102 / AR-S-002: see opt_out_collateral.
-    if crate::pool_guard::liquidation_in_progress() {
+    // `pool_balance_mutation_blocked` includes `liquidation_in_progress`.
+    if pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -182,13 +226,20 @@ pub fn opt_in_collateral(collateral_type: Principal) -> Result<(), StabilityPool
 #[update]
 pub fn opt_in_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> {
     // SP-102 / AR-S-002: see opt_out_collateral.
-    if crate::pool_guard::liquidation_in_progress() {
+    if pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
     let result = mutate_state(|s| s.opt_in_cfx(&caller, chain_sentinel));
     if result.is_ok() {
-        mutate_state(|s| s.push_event(caller, PoolEventType::OptInCollateral { collateral_type: chain_sentinel }));
+        mutate_state(|s| {
+            s.push_event(
+                caller,
+                PoolEventType::OptInCollateral {
+                    collateral_type: chain_sentinel,
+                },
+            )
+        });
     }
     result
 }
@@ -196,13 +247,20 @@ pub fn opt_in_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> {
 #[update]
 pub fn opt_out_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> {
     // SP-102 / AR-S-002: see opt_out_collateral.
-    if crate::pool_guard::liquidation_in_progress() {
+    if pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
     let result = mutate_state(|s| s.opt_out_cfx(&caller, chain_sentinel));
     if result.is_ok() {
-        mutate_state(|s| s.push_event(caller, PoolEventType::OptOutCollateral { collateral_type: chain_sentinel }));
+        mutate_state(|s| {
+            s.push_event(
+                caller,
+                PoolEventType::OptOutCollateral {
+                    collateral_type: chain_sentinel,
+                },
+            )
+        });
     }
     result
 }
@@ -218,16 +276,27 @@ pub fn opt_out_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> 
 /// with the per-token bookkeeping path), so the gate matches the pattern
 /// used by `receive_interest_revenue` below.
 #[update]
-pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> Vec<LiquidationResult> {
+pub async fn notify_liquidatable_vaults(
+    vaults: Vec<LiquidatableVaultInfo>,
+) -> Vec<LiquidationResult> {
     let caller = ic_cdk::api::caller();
     let expected = read_state(|s| s.protocol_canister_id);
     if caller != expected {
-        log!(INFO, "notify_liquidatable_vaults: rejected caller {} (expected protocol {})",
-            caller, expected);
+        log!(
+            INFO,
+            "notify_liquidatable_vaults: rejected caller {} (expected protocol {})",
+            caller,
+            expected
+        );
         return Vec::new();
     }
     let vault_count = vaults.len() as u64;
-    mutate_state(|s| s.push_event(caller, PoolEventType::LiquidationNotification { vault_count }));
+    mutate_state(|s| {
+        s.push_event(
+            caller,
+            PoolEventType::LiquidationNotification { vault_count },
+        )
+    });
     crate::liquidation::notify_liquidatable_vaults(vaults).await
 }
 
@@ -238,8 +307,17 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
 }
 
 #[update]
-pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+pub async fn sp_absorb_chain_vault(
+    vault_id: u64,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
     crate::liquidation::sp_absorb_chain_vault(vault_id).await
+}
+
+#[update]
+pub async fn scan_chain_absorb_candidates(
+    max_per_chain: Option<u64>,
+) -> Result<Vec<ChainSpAbsorbCandidate>, StabilityPoolError> {
+    crate::liquidation::scan_chain_absorb_candidates(max_per_chain).await
 }
 
 // ─── Interest Revenue ───
@@ -251,27 +329,46 @@ pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult,
 /// Depositors who opted out of that collateral are excluded from the distribution.
 /// The parameter is optional for backward compatibility with older backend versions.
 #[update]
-pub fn receive_interest_revenue(token_ledger: Principal, amount: u64, collateral_type: Option<Principal>) -> Result<(), StabilityPoolError> {
+pub fn receive_interest_revenue(
+    token_ledger: Principal,
+    amount: u64,
+    collateral_type: Option<Principal>,
+) -> Result<(), StabilityPoolError> {
     let caller = ic_cdk::api::caller();
     let expected = read_state(|s| s.protocol_canister_id);
     if caller != expected {
         return Err(StabilityPoolError::Unauthorized);
     }
+    ensure_pool_balance_mutation_allowed()?;
 
     if read_state(|s| s.configuration.emergency_pause) {
         return Err(StabilityPoolError::EmergencyPaused);
     }
 
     if !read_state(|s| s.stablecoin_registry.contains_key(&token_ledger)) {
-        return Err(StabilityPoolError::TokenNotAccepted { ledger: token_ledger });
+        return Err(StabilityPoolError::TokenNotAccepted {
+            ledger: token_ledger,
+        });
     }
 
     mutate_state(|s| {
         s.distribute_interest_revenue(token_ledger, amount, collateral_type);
-        s.push_event(caller, PoolEventType::InterestReceived { token_ledger, amount });
+        s.push_event(
+            caller,
+            PoolEventType::InterestReceived {
+                token_ledger,
+                amount,
+            },
+        );
     });
 
-    log!(INFO, "Distributed {} interest for token {} (collateral: {:?}) from backend", amount, token_ledger, collateral_type);
+    log!(
+        INFO,
+        "Distributed {} interest for token {} (collateral: {:?}) from backend",
+        amount,
+        token_ledger,
+        collateral_type
+    );
     Ok(())
 }
 
@@ -292,7 +389,12 @@ pub fn get_user_position(user: Option<Principal>) -> Option<UserStabilityPositio
 pub fn get_liquidation_history(limit: Option<u64>) -> Vec<PoolLiquidationRecord> {
     let limit = limit.unwrap_or(50).min(100) as usize;
     read_state(|s| {
-        s.liquidation_history.iter().rev().take(limit).cloned().collect()
+        s.liquidation_history
+            .iter()
+            .rev()
+            .take(limit)
+            .cloned()
+            .collect()
     })
 }
 
@@ -351,6 +453,17 @@ pub fn get_pending_refunds(user: Option<Principal>) -> Vec<PendingRefund> {
 }
 
 #[query]
+pub fn get_pending_chain_absorbs() -> Vec<ChainSpAbsorbIntent> {
+    read_state(|s| s.pending_chain_absorbs())
+}
+
+#[query]
+pub fn get_completed_chain_absorbs(limit: Option<u64>) -> Vec<ChainSpAbsorbCompletion> {
+    let limit = limit.unwrap_or(50).min(500) as usize;
+    read_state(|s| s.completed_chain_absorbs(limit))
+}
+
+#[query]
 pub fn get_chain_collateral_sentinel(chain_id: u32) -> Principal {
     crate::state::chain_collateral_sentinel(chain_id)
 }
@@ -361,8 +474,19 @@ pub fn check_pool_capacity(collateral_type: Principal, debt_amount_e8s: u64) -> 
 }
 
 #[query]
+pub fn check_chain_absorb_capacity(chain_sentinel: Principal, debt_amount_e8s: u64) -> bool {
+    read_state(|s| {
+        s.is_chain_collateral_sentinel(&chain_sentinel)
+            && s.effective_icusd_pool_for_collateral(&chain_sentinel) >= debt_amount_e8s
+    })
+}
+
+#[query]
 pub fn validate_pool_state() -> Result<String, String> {
-    read_state(|s| s.validate_state().map(|_| "Pool state is consistent".to_string()))
+    read_state(|s| {
+        s.validate_state()
+            .map(|_| "Pool state is consistent".to_string())
+    })
 }
 
 // ─── Admin: Registry Management ───
@@ -377,7 +501,10 @@ pub fn register_stablecoin(config: StablecoinConfig) -> Result<(), StabilityPool
     let symbol = config.symbol.clone();
     mutate_state(|s| {
         s.register_stablecoin(config);
-        s.push_event(caller, PoolEventType::StablecoinRegistered { ledger, symbol });
+        s.push_event(
+            caller,
+            PoolEventType::StablecoinRegistered { ledger, symbol },
+        );
     });
     Ok(())
 }
@@ -392,7 +519,10 @@ pub fn register_collateral(info: CollateralInfo) -> Result<(), StabilityPoolErro
     let symbol = info.symbol.clone();
     mutate_state(|s| {
         s.register_collateral(info);
-        s.push_event(caller, PoolEventType::CollateralRegistered { ledger, symbol });
+        s.push_event(
+            caller,
+            PoolEventType::CollateralRegistered { ledger, symbol },
+        );
     });
     Ok(())
 }
@@ -403,14 +533,15 @@ pub fn register_cfx_collateral(chain_id: u32) -> Result<Principal, StabilityPool
     if !read_state(|s| s.is_admin(&caller)) {
         return Err(StabilityPoolError::Unauthorized);
     }
-    let sentinel = mutate_state(|s| {
-        s.register_chain_collateral(chain_id, "CFX".to_string(), 18)
-    })?;
+    let sentinel = mutate_state(|s| s.register_chain_collateral(chain_id, "CFX".to_string(), 18))?;
     mutate_state(|s| {
-        s.push_event(caller, PoolEventType::CollateralRegistered {
-            ledger: sentinel,
-            symbol: "CFX".to_string(),
-        });
+        s.push_event(
+            caller,
+            PoolEventType::CollateralRegistered {
+                ledger: sentinel,
+                symbol: "CFX".to_string(),
+            },
+        );
     });
     Ok(sentinel)
 }
@@ -637,13 +768,17 @@ pub fn admin_correct_balance(
     if !read_state(|s| s.is_admin(&caller)) {
         return Err(StabilityPoolError::Unauthorized);
     }
+    ensure_pool_balance_mutation_allowed()?;
     let msg = mutate_state(|s| {
         let result = s.correct_balance(user, token_ledger, correct_amount);
-        s.push_event(caller, PoolEventType::BalanceCorrected {
-            user,
-            token_ledger,
-            new_amount: correct_amount,
-        });
+        s.push_event(
+            caller,
+            PoolEventType::BalanceCorrected {
+                user,
+                token_ledger,
+                new_amount: correct_amount,
+            },
+        );
         result
     });
     log!(INFO, "Admin balance correction by {}: {}", caller, msg);
@@ -662,13 +797,95 @@ pub fn admin_correct_collateral_gain(
     }
     let msg = mutate_state(|s| {
         let result = s.correct_collateral_gain(user, collateral_ledger, correct_amount);
-        s.push_event(caller, PoolEventType::CollateralGainCorrected {
-            user,
-            collateral_ledger,
-            new_amount: correct_amount,
-        });
+        s.push_event(
+            caller,
+            PoolEventType::CollateralGainCorrected {
+                user,
+                collateral_ledger,
+                new_amount: correct_amount,
+            },
+        );
         result
     });
-    log!(INFO, "Admin collateral gain correction by {}: {}", caller, msg);
+    log!(
+        INFO,
+        "Admin collateral gain correction by {}: {}",
+        caller,
+        msg
+    );
     Ok(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icrc_ledger_types::icrc1::account::Account;
+    use rumi_protocol_backend::chains::config::ChainId;
+
+    fn principal(byte: u8) -> Principal {
+        Principal::from_slice(&[byte])
+    }
+
+    fn pending_intent() -> ChainSpAbsorbIntent {
+        let mut stables_consumed = BTreeMap::new();
+        stables_consumed.insert(principal(10), 100_00000000);
+        ChainSpAbsorbIntent {
+            vault_id: 77,
+            chain_id: ChainId(1030),
+            chain_sentinel: crate::state::chain_collateral_sentinel(1030),
+            icusd_ledger: principal(10),
+            icusd_minting_account: Account {
+                owner: principal(90),
+                subaccount: None,
+            },
+            icusd_to_burn_e8s: 100_00000000,
+            stables_consumed,
+            burn_created_at_time_ns: 123,
+            status: ChainSpAbsorbIntentStatus::Burned,
+            burn_proof: Some(rumi_protocol_backend::icrc3_proof::SpWritedownProof {
+                block_index: 44,
+                ledger_kind: rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn,
+                vault_id_memo: 77,
+            }),
+            backend_result: None,
+            last_error: None,
+            created_at_ns: 123,
+            updated_at_ns: 456,
+        }
+    }
+
+    #[test]
+    fn pending_chain_absorb_blocks_pool_balance_mutations() {
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
+        assert!(
+            ensure_pool_balance_mutation_allowed().is_ok(),
+            "empty journal does not block ordinary mutations",
+        );
+
+        mutate_state(|s| s.put_pending_chain_absorb(pending_intent()).unwrap());
+        assert!(
+            matches!(
+                ensure_pool_balance_mutation_allowed(),
+                Err(StabilityPoolError::SystemBusy)
+            ),
+            "interest revenue and admin balance correction must not mutate live denominator while pending",
+        );
+
+        crate::state::replace_state(crate::state::StabilityPoolState::default());
+    }
+
+    #[test]
+    fn in_flight_balance_async_blocks_chain_absorb_start() {
+        assert!(ensure_no_pool_balance_async_in_flight().is_ok());
+        let guard = crate::pool_guard::PoolBalanceAsyncGuard::new();
+        assert!(
+            matches!(
+                ensure_no_pool_balance_async_in_flight(),
+                Err(StabilityPoolError::SystemBusy)
+            ),
+            "SP chain absorb must not start while withdrawal rollback could still restore balances",
+        );
+        drop(guard);
+        assert!(ensure_no_pool_balance_async_in_flight().is_ok());
+    }
 }

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -209,6 +209,21 @@ pub async fn claim_cfx(
     crate::liquidation::claim_cfx(chain_sentinel, dest_evm).await
 }
 
+#[update]
+pub fn recredit_failed_cfx_claim_payout(
+    recovery: CfxClaimPayoutRecovery,
+) -> Result<bool, StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    let expected = read_state(|s| s.protocol_canister_id);
+    if caller != expected {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        crate::liquidation::recredit_failed_cfx_claim_payout_in_state_at(s, recovery, now)
+    })
+}
+
 // ─── Opt-in / Opt-out ───
 
 #[update]

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -605,6 +605,73 @@ pub(crate) fn rollback_cfx_claim_payout_in_state(
     *entry = entry.saturating_add(plan.amount_wei);
 }
 
+pub(crate) fn recredit_failed_cfx_claim_payout_in_state(
+    state: &mut StabilityPoolState,
+    recovery: CfxClaimPayoutRecovery,
+) -> Result<bool, StabilityPoolError> {
+    recredit_failed_cfx_claim_payout_in_state_at(state, recovery.clone(), recovery.failed_at_ns)
+}
+
+pub(crate) fn recredit_failed_cfx_claim_payout_in_state_at(
+    state: &mut StabilityPoolState,
+    recovery: CfxClaimPayoutRecovery,
+    recovered_at_ns: u64,
+) -> Result<bool, StabilityPoolError> {
+    if recovery.amount_wei == 0 {
+        return Err(StabilityPoolError::AmountTooLow { minimum_e8s: 1 });
+    }
+    if !state.is_chain_collateral_sentinel(&recovery.chain_sentinel) {
+        return Err(StabilityPoolError::CollateralNotFound {
+            ledger: recovery.chain_sentinel,
+        });
+    }
+
+    let key = recovery.key();
+    if let Some(existing) = state.completed_cfx_claim_payout_recovery(&key) {
+        if existing.claim_id == recovery.claim_id
+            && existing.claimant == recovery.claimant
+            && existing.amount_wei == recovery.amount_wei
+        {
+            return Ok(false);
+        }
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: recovery.claim_id,
+            reason: format!(
+                "completed CFX claim payout recovery conflicts for op {}",
+                recovery.op_id
+            ),
+        });
+    }
+    if state.completed_cfx_claim_payout_recovery_was_evicted(&key) {
+        return Ok(false);
+    }
+
+    state.record_chain_claim_source(
+        recovery.chain_sentinel,
+        recovery.claim_id,
+        recovery.amount_wei,
+    );
+    let position = state
+        .deposits
+        .entry(recovery.claimant)
+        .or_insert_with(|| DepositPosition::new(0));
+    let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
+    let entry = claims.entry(recovery.chain_sentinel).or_insert(0);
+    *entry = entry.saturating_add(recovery.amount_wei);
+
+    state.record_completed_cfx_claim_payout_recovery(CfxClaimPayoutRecoveryRecord {
+        key,
+        claim_id: recovery.claim_id,
+        claimant: recovery.claimant,
+        amount_wei: recovery.amount_wei,
+        reason: recovery.reason,
+        failed_at_ns: recovery.failed_at_ns,
+        recovered_at_ns,
+    });
+
+    Ok(true)
+}
+
 pub(crate) fn is_duplicate_chain_claim_error(error: &rumi_protocol_backend::ProtocolError) -> bool {
     match error {
         rumi_protocol_backend::ProtocolError::ChainAdmin(msg)
@@ -2480,6 +2547,386 @@ mod tests {
             state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
             10,
             "rollback restores backend claim source",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_recredit_restores_user_claim_and_source_once() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 12);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+
+        let recovered = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 42,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds");
+
+        assert!(recovered, "first recovery mutates state");
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "failed payout recredits the user claim",
+        );
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10,
+            "failed payout restores backend claim source",
+        );
+
+        let replay = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 42,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "same failed op replay".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .expect("same recovery replay succeeds without mutation");
+
+        assert!(!replay, "replay is recognized as already recovered");
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "replay must not double-credit the user claim",
+        );
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10,
+            "replay must not double-restore backend claim source",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_replay_is_idempotent() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 10);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+        let recovery = CfxClaimPayoutRecovery {
+            chain_sentinel: sentinel,
+            op_id: 43,
+            claim_id: plan.claim_id,
+            claimant: user_a(),
+            amount_wei: plan.amount_wei,
+            reason: "tx reverted".to_string(),
+            failed_at_ns: 123,
+        };
+
+        assert!(
+            recredit_failed_cfx_claim_payout_in_state(&mut state, recovery.clone())
+                .expect("first recovery succeeds")
+        );
+        assert!(
+            !recredit_failed_cfx_claim_payout_in_state(&mut state, recovery)
+                .expect("exact replay succeeds")
+        );
+        assert_eq!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .map(|m| m.len()),
+            Some(1),
+            "journal stores one durable recovery record",
+        );
+    }
+
+    #[test]
+    fn evicted_failed_cfx_claim_payout_replay_remains_idempotent() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+
+        for op_id in 0..=(crate::state::MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES as u64) {
+            assert!(
+                recredit_failed_cfx_claim_payout_in_state(
+                    &mut state,
+                    CfxClaimPayoutRecovery {
+                        chain_sentinel: sentinel,
+                        op_id,
+                        claim_id: op_id,
+                        claimant: user_a(),
+                        amount_wei: 1,
+                        reason: "tx reverted".to_string(),
+                        failed_at_ns: op_id,
+                    },
+                )
+                .expect("recovery succeeds"),
+                "first recovery for op {op_id} mutates state",
+            );
+        }
+
+        assert!(
+            !state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .unwrap()
+                .contains_key(&CfxClaimPayoutRecoveryKey {
+                    chain_sentinel: sentinel,
+                    op_id: 0,
+                }),
+            "oldest recovery record should be evicted at the bound",
+        );
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let replay = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 0,
+                claim_id: 0,
+                claimant: user_a(),
+                amount_wei: 1,
+                reason: "old op replay after eviction".to_string(),
+                failed_at_ns: 999_999,
+            },
+        )
+        .expect("evicted replay succeeds without mutation");
+
+        assert!(!replay, "evicted replay is treated as already recovered");
+        assert_eq!(state.deposits[&user_a()].cfx_claims, before_claims);
+        assert_eq!(state.chain_claim_sources, before_sources);
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_conflicting_replay_rejects_without_mutation() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 10);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 44,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds"));
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let err = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 44,
+                claim_id: plan.claim_id,
+                claimant: user_b(),
+                amount_wei: plan.amount_wei,
+                reason: "conflicting replay".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, StabilityPoolError::LiquidationFailed { .. }));
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims,
+            before_claims,
+            "conflict must not mutate user claims",
+        );
+        assert_eq!(
+            state.chain_claim_sources, before_sources,
+            "conflict must not mutate backend claim sources",
+        );
+    }
+
+    #[test]
+    fn distinct_failed_cfx_claim_payout_ops_can_recredit_separate_payouts() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 20);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 20);
+
+        let first = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("first claim plan")
+        .expect("nonzero first claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 45,
+                claim_id: first.claim_id,
+                claimant: user_a(),
+                amount_wei: first.amount_wei,
+                reason: "first tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds"));
+
+        let second = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("second claim plan")
+        .expect("nonzero second claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 46,
+                claim_id: second.claim_id,
+                claimant: user_a(),
+                amount_wei: second.amount_wei,
+                reason: "second tx reverted".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .expect("second recovery succeeds"));
+
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            20,
+            "separate failed ops restore separate payout attempts",
+        );
+        assert_eq!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .map(|m| m.len()),
+            Some(2),
+            "journal keeps one record per failed backend op",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_recovery_rejects_invalid_input_without_mutation() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 5);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 5);
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let zero = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 47,
+                claim_id: 77,
+                claimant: user_a(),
+                amount_wei: 0,
+                reason: "zero amount".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(zero, StabilityPoolError::AmountTooLow { .. }));
+
+        let missing_sentinel = Principal::from_slice(&[99]);
+        let invalid_sentinel = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: missing_sentinel,
+                op_id: 48,
+                claim_id: 77,
+                claimant: user_a(),
+                amount_wei: 5,
+                reason: "bad sentinel".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            invalid_sentinel,
+            StabilityPoolError::CollateralNotFound { .. }
+        ));
+        assert_eq!(state.deposits[&user_a()].cfx_claims, before_claims);
+        assert_eq!(state.chain_claim_sources, before_sources);
+        assert!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "invalid input must not journal a recovery",
         );
     }
 

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use candid::{Nat, Principal};
 use ic_canister_log::log;
 use ic_cdk::call;
@@ -7,10 +6,11 @@ use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg, TransferError};
 use icrc_ledger_types::icrc2::approve::{ApproveArgs, ApproveError};
 use num_traits::ToPrimitive;
 use rumi_protocol_backend::chains::config::ChainId;
+use std::collections::BTreeMap;
 
 use crate::logs::INFO;
+use crate::state::{mutate_state, read_state, StabilityPoolState};
 use crate::types::*;
-use crate::state::{read_state, mutate_state, StabilityPoolState};
 
 /// Conservative fallback for a collateral ledger's transfer fee, used only when
 /// the live `icrc1_fee` query fails (SP-104). Set to the common ICRC fee
@@ -56,46 +56,36 @@ pub fn build_icusd_burn_proof(
     }
 }
 
-pub async fn burn_icusd_for_chain_writedown(
+pub async fn fetch_icusd_minting_account(
     icusd_ledger: Principal,
+) -> Result<Account, StabilityPoolError> {
+    match call::<(), (Option<Account>,)>(icusd_ledger, "icrc1_minting_account", ()).await {
+        Ok((Some(account),)) => Ok(account),
+        Ok((None,)) => Err(StabilityPoolError::LedgerTransferFailed {
+            reason: "icUSD ledger has no minting account; cannot burn".to_string(),
+        }),
+        Err(_) => Err(StabilityPoolError::InterCanisterCallFailed {
+            target: format!("{}", icusd_ledger),
+            method: "icrc1_minting_account".to_string(),
+        }),
+    }
+}
+
+pub async fn burn_icusd_for_chain_writedown_with_account(
+    icusd_ledger: Principal,
+    minting_account: Account,
     amount_e8s: u64,
     vault_id: u64,
+    created_at_time: u64,
 ) -> Result<rumi_protocol_backend::icrc3_proof::SpWritedownProof, StabilityPoolError> {
     if amount_e8s == 0 {
         return Err(StabilityPoolError::AmountTooLow { minimum_e8s: 1 });
     }
+    let transfer_arg =
+        build_icusd_burn_transfer_arg(minting_account, amount_e8s, vault_id, created_at_time);
 
-    let minting_account = match call::<(), (Option<Account>,)>(
-        icusd_ledger,
-        "icrc1_minting_account",
-        (),
-    ).await {
-        Ok((Some(account),)) => account,
-        Ok((None,)) => {
-            return Err(StabilityPoolError::LedgerTransferFailed {
-                reason: "icUSD ledger has no minting account; cannot burn".to_string(),
-            });
-        }
-        Err(_) => {
-            return Err(StabilityPoolError::InterCanisterCallFailed {
-                target: format!("{}", icusd_ledger),
-                method: "icrc1_minting_account".to_string(),
-            });
-        }
-    };
-
-    let transfer_arg = build_icusd_burn_transfer_arg(
-        minting_account,
-        amount_e8s,
-        vault_id,
-        ic_cdk::api::time(),
-    );
-
-    let result: Result<(Result<Nat, TransferError>,), _> = call(
-        icusd_ledger,
-        "icrc1_transfer",
-        (transfer_arg,),
-    ).await;
+    let result: Result<(Result<Nat, TransferError>,), _> =
+        call(icusd_ledger, "icrc1_transfer", (transfer_arg,)).await;
 
     let block_index = match result {
         Ok((Ok(block_index),)) => nat_block_index_to_u64(block_index)?,
@@ -118,10 +108,29 @@ pub async fn burn_icusd_for_chain_writedown(
     Ok(build_icusd_burn_proof(block_index, vault_id))
 }
 
+pub async fn burn_icusd_for_chain_writedown(
+    icusd_ledger: Principal,
+    amount_e8s: u64,
+    vault_id: u64,
+) -> Result<rumi_protocol_backend::icrc3_proof::SpWritedownProof, StabilityPoolError> {
+    let minting_account = fetch_icusd_minting_account(icusd_ledger).await?;
+    burn_icusd_for_chain_writedown_with_account(
+        icusd_ledger,
+        minting_account,
+        amount_e8s,
+        vault_id,
+        ic_cdk::api::time(),
+    )
+    .await
+}
+
 fn nat_block_index_to_u64(block_index: Nat) -> Result<u64, StabilityPoolError> {
-    block_index.0.to_u64().ok_or_else(|| StabilityPoolError::LedgerTransferFailed {
-        reason: format!("ledger block index {} does not fit in u64", block_index),
-    })
+    block_index
+        .0
+        .to_u64()
+        .ok_or_else(|| StabilityPoolError::LedgerTransferFailed {
+            reason: format!("ledger block index {} does not fit in u64", block_index),
+        })
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -132,6 +141,214 @@ pub(crate) struct ChainAbsorbPlan {
     pub icusd_ledger: Principal,
     pub icusd_to_burn_e8s: u64,
     pub stables_consumed: BTreeMap<Principal, u64>,
+}
+
+fn chain_absorb_result_from_backend(
+    plan: &ChainAbsorbPlan,
+    result: ChainStabilityPoolLiquidationResult,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+    if !result.success {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend reported unsuccessful chain absorb".to_string(),
+        });
+    }
+    if result.vault_id != plan.vault_id || result.chain_id != plan.chain_id {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend chain absorb result does not match requested vault".to_string(),
+        });
+    }
+    if result.liquidated_debt_e8s != plan.icusd_to_burn_e8s as u128 {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend liquidated debt does not match SP burn".to_string(),
+        });
+    }
+    if result.collateral_received_native == 0 {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "backend returned zero chain collateral".to_string(),
+        });
+    }
+
+    Ok(ChainSpAbsorbResult {
+        success: true,
+        vault_id: result.vault_id,
+        chain_id: result.chain_id,
+        icusd_burned_e8s: plan.icusd_to_burn_e8s,
+        liquidated_debt_e8s: result.liquidated_debt_e8s,
+        collateral_received_native: result.collateral_received_native,
+        claim_id: result.claim_id,
+        custody_address: result.custody_address,
+        block_index: result.block_index,
+        collateral_price_e8s: result.collateral_price_e8s,
+    })
+}
+
+fn intent_matches_plan(
+    intent: &ChainSpAbsorbIntent,
+    plan: &ChainAbsorbPlan,
+    minting_account: Account,
+) -> bool {
+    intent.vault_id == plan.vault_id
+        && intent.chain_id == plan.chain_id
+        && intent.chain_sentinel == plan.chain_sentinel
+        && intent.icusd_ledger == plan.icusd_ledger
+        && intent.icusd_minting_account == minting_account
+        && intent.icusd_to_burn_e8s == plan.icusd_to_burn_e8s
+        && intent.stables_consumed == plan.stables_consumed
+}
+
+fn chain_absorb_plan_from_intent(intent: &ChainSpAbsorbIntent) -> ChainAbsorbPlan {
+    ChainAbsorbPlan {
+        vault_id: intent.vault_id,
+        chain_id: intent.chain_id,
+        chain_sentinel: intent.chain_sentinel,
+        icusd_ledger: intent.icusd_ledger,
+        icusd_to_burn_e8s: intent.icusd_to_burn_e8s,
+        stables_consumed: intent.stables_consumed.clone(),
+    }
+}
+
+fn burned_chain_absorb_replay_plan(
+    intent: &ChainSpAbsorbIntent,
+) -> Option<(
+    ChainAbsorbPlan,
+    rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+)> {
+    intent
+        .burn_proof
+        .clone()
+        .map(|proof| (chain_absorb_plan_from_intent(intent), proof))
+}
+
+fn ensure_no_other_pending_chain_absorb(
+    state: &StabilityPoolState,
+    vault_id: u64,
+) -> Result<(), StabilityPoolError> {
+    if state.has_pending_chain_absorbs() && state.get_pending_chain_absorb(vault_id).is_none() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    Ok(())
+}
+
+pub(crate) fn prepare_or_reuse_chain_absorb_intent_in_state(
+    state: &mut StabilityPoolState,
+    plan: &ChainAbsorbPlan,
+    minting_account: Account,
+    now_ns: u64,
+) -> Result<ChainSpAbsorbIntent, StabilityPoolError> {
+    if let Some(completion) = state.completed_chain_absorb(plan.vault_id) {
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: format!(
+                "chain absorb already completed at block {}",
+                completion.result.block_index
+            ),
+        });
+    }
+
+    if let Some(existing) = state.get_pending_chain_absorb(plan.vault_id) {
+        if intent_matches_plan(&existing, plan, minting_account) {
+            return Ok(existing);
+        }
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: plan.vault_id,
+            reason: "pending chain absorb intent conflicts with current preflight".to_string(),
+        });
+    }
+
+    let intent = ChainSpAbsorbIntent {
+        vault_id: plan.vault_id,
+        chain_id: plan.chain_id,
+        chain_sentinel: plan.chain_sentinel,
+        icusd_ledger: plan.icusd_ledger,
+        icusd_minting_account: minting_account,
+        icusd_to_burn_e8s: plan.icusd_to_burn_e8s,
+        stables_consumed: plan.stables_consumed.clone(),
+        burn_created_at_time_ns: now_ns,
+        status: ChainSpAbsorbIntentStatus::Prepared,
+        burn_proof: None,
+        backend_result: None,
+        last_error: None,
+        created_at_ns: now_ns,
+        updated_at_ns: now_ns,
+    };
+    state.put_pending_chain_absorb(intent.clone())?;
+    Ok(intent)
+}
+
+pub(crate) fn mark_chain_absorb_burned_in_state(
+    state: &mut StabilityPoolState,
+    vault_id: u64,
+    proof: rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+    now_ns: u64,
+) -> Result<ChainSpAbsorbIntent, StabilityPoolError> {
+    let mut intent = state.get_pending_chain_absorb(vault_id).ok_or_else(|| {
+        StabilityPoolError::LiquidationFailed {
+            vault_id,
+            reason: "missing pending chain absorb intent".to_string(),
+        }
+    })?;
+    if let Some(existing) = &intent.burn_proof {
+        if existing != &proof {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id,
+                reason: "pending chain absorb burn proof conflicts with retry proof".to_string(),
+            });
+        }
+    }
+    intent.burn_proof = Some(proof);
+    intent.status = ChainSpAbsorbIntentStatus::Burned;
+    intent.last_error = None;
+    intent.updated_at_ns = now_ns;
+    state.put_pending_chain_absorb(intent.clone())?;
+    Ok(intent)
+}
+
+pub(crate) fn mark_chain_absorb_backend_result_in_state(
+    state: &mut StabilityPoolState,
+    vault_id: u64,
+    result: ChainStabilityPoolLiquidationResult,
+    now_ns: u64,
+) -> Result<ChainSpAbsorbIntent, StabilityPoolError> {
+    let mut intent = state.get_pending_chain_absorb(vault_id).ok_or_else(|| {
+        StabilityPoolError::LiquidationFailed {
+            vault_id,
+            reason: "missing pending chain absorb intent".to_string(),
+        }
+    })?;
+    if let Some(existing) = &intent.backend_result {
+        if existing != &result {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id,
+                reason: "pending chain absorb backend result conflicts with retry result"
+                    .to_string(),
+            });
+        }
+    }
+    intent.backend_result = Some(result);
+    intent.status = ChainSpAbsorbIntentStatus::BackendAccepted;
+    intent.last_error = None;
+    intent.updated_at_ns = now_ns;
+    state.put_pending_chain_absorb(intent.clone())?;
+    Ok(intent)
+}
+
+pub(crate) fn mark_chain_absorb_error_in_state(
+    state: &mut StabilityPoolState,
+    vault_id: u64,
+    status: ChainSpAbsorbIntentStatus,
+    reason: String,
+    now_ns: u64,
+) {
+    if let Some(mut intent) = state.get_pending_chain_absorb(vault_id) {
+        intent.status = status;
+        intent.last_error = Some(reason);
+        intent.updated_at_ns = now_ns;
+        let _ = state.put_pending_chain_absorb(intent);
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -158,7 +375,8 @@ fn chain_id_from_sentinel(sentinel: &Principal) -> Option<ChainId> {
 }
 
 pub(crate) fn registered_chain_ids_from_sentinels(state: &StabilityPoolState) -> Vec<ChainId> {
-    let mut chains: Vec<ChainId> = state.chain_collateral_sentinels
+    let mut chains: Vec<ChainId> = state
+        .chain_collateral_sentinels
         .as_ref()
         .into_iter()
         .flat_map(|sentinels| sentinels.iter())
@@ -190,12 +408,14 @@ pub(crate) fn prepare_chain_absorb_plan_in_state(
             reason: "chain collateral sentinel does not match chain id".to_string(),
         });
     }
-    let debt_e8s = u64::try_from(vault.debt_e8s).map_err(|_| {
-        StabilityPoolError::LiquidationFailed {
+    let debt_e8s =
+        u64::try_from(vault.debt_e8s).map_err(|_| StabilityPoolError::LiquidationFailed {
             vault_id: vault.vault_id,
-            reason: format!("chain vault debt {} exceeds SP u64 burn amount", vault.debt_e8s),
-        }
-    })?;
+            reason: format!(
+                "chain vault debt {} exceeds SP u64 burn amount",
+                vault.debt_e8s
+            ),
+        })?;
     if debt_e8s == 0 {
         return Err(StabilityPoolError::LiquidationFailed {
             vault_id: vault.vault_id,
@@ -203,14 +423,18 @@ pub(crate) fn prepare_chain_absorb_plan_in_state(
         });
     }
 
-    let available_icusd = state.effective_icusd_pool_for_collateral(&vault.chain_collateral_sentinel);
+    let available_icusd =
+        state.effective_icusd_pool_for_collateral(&vault.chain_collateral_sentinel);
     if available_icusd < debt_e8s {
         return Err(StabilityPoolError::InsufficientPoolBalance);
     }
-    let stables_consumed = state.compute_icusd_chain_draw(debt_e8s, &vault.chain_collateral_sentinel);
-    let icusd_ledger = state.icusd_ledger().ok_or(StabilityPoolError::TokenNotAccepted {
-        ledger: Principal::anonymous(),
-    })?;
+    let stables_consumed =
+        state.compute_icusd_chain_draw(debt_e8s, &vault.chain_collateral_sentinel);
+    let icusd_ledger = state
+        .icusd_ledger()
+        .ok_or(StabilityPoolError::TokenNotAccepted {
+            ledger: Principal::anonymous(),
+        })?;
     if stables_consumed.get(&icusd_ledger).copied().unwrap_or(0) != debt_e8s {
         return Err(StabilityPoolError::InsufficientPoolBalance);
     }
@@ -239,57 +463,38 @@ pub(crate) fn apply_chain_absorb_success_in_state_at(
     result: ChainStabilityPoolLiquidationResult,
     timestamp: u64,
 ) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
-    if !result.success {
+    let absorbed = chain_absorb_result_from_backend(plan, result)?;
+    if let Some(completion) = state.completed_chain_absorb(plan.vault_id) {
+        if completion.result == absorbed {
+            return Ok(completion.result);
+        }
         return Err(StabilityPoolError::LiquidationFailed {
             vault_id: plan.vault_id,
-            reason: "backend reported unsuccessful chain absorb".to_string(),
-        });
-    }
-    if result.vault_id != plan.vault_id || result.chain_id != plan.chain_id {
-        return Err(StabilityPoolError::LiquidationFailed {
-            vault_id: plan.vault_id,
-            reason: "backend chain absorb result does not match requested vault".to_string(),
-        });
-    }
-    if result.liquidated_debt_e8s > plan.icusd_to_burn_e8s as u128 {
-        return Err(StabilityPoolError::LiquidationFailed {
-            vault_id: plan.vault_id,
-            reason: "backend liquidated more debt than SP burned".to_string(),
-        });
-    }
-    if result.collateral_received_native == 0 {
-        return Err(StabilityPoolError::LiquidationFailed {
-            vault_id: plan.vault_id,
-            reason: "backend returned zero chain collateral".to_string(),
+            reason: "completed chain absorb conflicts with backend result".to_string(),
         });
     }
 
     state.record_chain_claim_source(
         plan.chain_sentinel,
-        result.claim_id,
-        result.collateral_received_native,
+        absorbed.claim_id,
+        absorbed.collateral_received_native,
     );
     state.process_chain_liquidation_gains_at(
         plan.vault_id,
         plan.chain_sentinel,
         &plan.stables_consumed,
-        result.collateral_received_native,
-        result.collateral_price_e8s,
+        absorbed.collateral_received_native,
+        absorbed.collateral_price_e8s,
         timestamp,
     );
+    state.take_pending_chain_absorb(plan.vault_id);
+    state.record_completed_chain_absorb(ChainSpAbsorbCompletion {
+        vault_id: plan.vault_id,
+        result: absorbed.clone(),
+        completed_at_ns: timestamp,
+    });
 
-    Ok(ChainSpAbsorbResult {
-        success: true,
-        vault_id: result.vault_id,
-        chain_id: result.chain_id,
-        icusd_burned_e8s: plan.icusd_to_burn_e8s,
-        liquidated_debt_e8s: result.liquidated_debt_e8s,
-        collateral_received_native: result.collateral_received_native,
-        claim_id: result.claim_id,
-        custody_address: result.custody_address,
-        block_index: result.block_index,
-        collateral_price_e8s: result.collateral_price_e8s,
-    })
+    Ok(absorbed)
 }
 
 pub(crate) fn prepare_cfx_claim_payout_in_state(
@@ -310,7 +515,8 @@ pub(crate) fn prepare_cfx_claim_payout_in_state(
             ledger: chain_sentinel,
         });
     }
-    let owed = state.deposits
+    let owed = state
+        .deposits
         .get(&claimant)
         .and_then(|pos| pos.cfx_claims.as_ref())
         .and_then(|claims| claims.get(&chain_sentinel).copied())
@@ -320,14 +526,16 @@ pub(crate) fn prepare_cfx_claim_payout_in_state(
     }
 
     let (claim_id, amount_wei) = {
-        let sources = state.chain_claim_sources
+        let sources = state
+            .chain_claim_sources
             .as_mut()
             .and_then(|m| m.get_mut(&chain_sentinel))
             .ok_or_else(|| StabilityPoolError::LiquidationFailed {
                 vault_id: 0,
                 reason: "no backend chain claim source available".to_string(),
             })?;
-        let source_index = sources.iter()
+        let source_index = sources
+            .iter()
             .position(|source| source.remaining_native > 0)
             .ok_or_else(|| StabilityPoolError::LiquidationFailed {
                 vault_id: 0,
@@ -343,7 +551,8 @@ pub(crate) fn prepare_cfx_claim_payout_in_state(
         (claim_id, amount_wei)
     };
 
-    if state.chain_claim_sources
+    if state
+        .chain_claim_sources
         .as_ref()
         .and_then(|m| m.get(&chain_sentinel))
         .map(|sources| sources.is_empty())
@@ -370,7 +579,8 @@ pub(crate) fn rollback_cfx_claim_payout_in_state(
     plan: &CfxClaimPayoutPlan,
 ) {
     state.record_chain_claim_source(plan.chain_sentinel, plan.claim_id, plan.amount_wei);
-    let position = state.deposits
+    let position = state
+        .deposits
         .entry(plan.claimant)
         .or_insert_with(|| DepositPosition::new(0));
     let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
@@ -390,9 +600,15 @@ pub(crate) fn is_duplicate_chain_claim_error(error: &rumi_protocol_backend::Prot
 
 /// Called by the backend when it detects liquidatable vaults (push model).
 /// Processes each vault sequentially, consuming stablecoins and distributing collateral.
-pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> Vec<LiquidationResult> {
+pub async fn notify_liquidatable_vaults(
+    vaults: Vec<LiquidatableVaultInfo>,
+) -> Vec<LiquidationResult> {
     if read_state(|s| s.configuration.emergency_pause) {
-        log!(INFO, "Pool is paused — ignoring {} liquidatable vaults", vaults.len());
+        log!(
+            INFO,
+            "Pool is paused — ignoring {} liquidatable vaults",
+            vaults.len()
+        );
         return vec![];
     }
 
@@ -409,7 +625,11 @@ pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> V
         }
     };
 
-    log!(INFO, "Received push notification: {} liquidatable vaults", vaults.len());
+    log!(
+        INFO,
+        "Received push notification: {} liquidatable vaults",
+        vaults.len()
+    );
 
     let max_batch = read_state(|s| s.configuration.max_liquidations_per_batch) as usize;
 
@@ -417,32 +637,54 @@ pub async fn notify_liquidatable_vaults(vaults: Vec<LiquidatableVaultInfo>) -> V
     for vault_info in vaults.into_iter().take(max_batch) {
         // Skip if already in-flight
         if read_state(|s| s.in_flight_liquidations.contains(&vault_info.vault_id)) {
-            log!(INFO, "Vault {} already in-flight, skipping", vault_info.vault_id);
+            log!(
+                INFO,
+                "Vault {} already in-flight, skipping",
+                vault_info.vault_id
+            );
             continue;
         }
 
         // Check effective pool coverage for this collateral type
-        let effective_pool = read_state(|s| s.effective_pool_for_collateral(&vault_info.collateral_type));
+        let effective_pool =
+            read_state(|s| s.effective_pool_for_collateral(&vault_info.collateral_type));
         if effective_pool < vault_info.debt_amount {
-            log!(INFO, "Insufficient pool coverage for vault {}: need {} e8s, have {} e8s",
-                vault_info.vault_id, vault_info.debt_amount, effective_pool);
+            log!(
+                INFO,
+                "Insufficient pool coverage for vault {}: need {} e8s, have {} e8s",
+                vault_info.vault_id,
+                vault_info.debt_amount,
+                effective_pool
+            );
             continue;
         }
 
         // Mark as in-flight
-        mutate_state(|s| { s.in_flight_liquidations.insert(vault_info.vault_id); });
+        mutate_state(|s| {
+            s.in_flight_liquidations.insert(vault_info.vault_id);
+        });
 
         let result = execute_single_liquidation(&vault_info).await;
 
         // Clear in-flight
-        mutate_state(|s| { s.in_flight_liquidations.remove(&vault_info.vault_id); });
+        mutate_state(|s| {
+            s.in_flight_liquidations.remove(&vault_info.vault_id);
+        });
 
         if result.success {
-            log!(INFO, "Liquidated vault {}: gained {} collateral",
-                vault_info.vault_id, result.collateral_gained);
+            log!(
+                INFO,
+                "Liquidated vault {}: gained {} collateral",
+                vault_info.vault_id,
+                result.collateral_gained
+            );
         } else {
-            log!(INFO, "Liquidation failed for vault {}: {}",
-                vault_info.vault_id, result.error_message.as_deref().unwrap_or("unknown"));
+            log!(
+                INFO,
+                "Liquidation failed for vault {}: {}",
+                vault_info.vault_id,
+                result.error_message.as_deref().unwrap_or("unknown")
+            );
         }
 
         results.push(result);
@@ -479,20 +721,23 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
     // Fetch vault info from backend
     let protocol_id = read_state(|s| s.protocol_canister_id);
 
-    let (vaults,): (Vec<rumi_protocol_backend::vault::CandidVault>,) = call(
-        protocol_id, "get_liquidatable_vaults", ()
-    ).await.map_err(|_e| StabilityPoolError::InterCanisterCallFailed {
-        target: "Protocol".to_string(),
-        method: "get_liquidatable_vaults".to_string(),
-    })?;
+    let (vaults,): (Vec<rumi_protocol_backend::vault::CandidVault>,) =
+        call(protocol_id, "get_liquidatable_vaults", ())
+            .await
+            .map_err(|_e| StabilityPoolError::InterCanisterCallFailed {
+                target: "Protocol".to_string(),
+                method: "get_liquidatable_vaults".to_string(),
+            })?;
     let target_vault = vaults.into_iter().find(|v| v.vault_id == vault_id);
 
     let vault = match target_vault {
         Some(v) => v,
-        None => return Err(StabilityPoolError::LiquidationFailed {
-            vault_id,
-            reason: "Vault not found in liquidatable list".to_string(),
-        }),
+        None => {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id,
+                reason: "Vault not found in liquidatable list".to_string(),
+            })
+        }
     };
 
     let vault_info = LiquidatableVaultInfo {
@@ -505,19 +750,131 @@ pub async fn execute_liquidation(vault_id: u64) -> Result<LiquidationResult, Sta
     };
 
     // Check pool coverage
-    let effective_pool = read_state(|s| s.effective_pool_for_collateral(&vault_info.collateral_type));
+    let effective_pool =
+        read_state(|s| s.effective_pool_for_collateral(&vault_info.collateral_type));
     if effective_pool < vault_info.debt_amount {
         return Err(StabilityPoolError::InsufficientPoolBalance);
     }
 
-    mutate_state(|s| { s.in_flight_liquidations.insert(vault_id); });
+    mutate_state(|s| {
+        s.in_flight_liquidations.insert(vault_id);
+    });
     let result = execute_single_liquidation(&vault_info).await;
-    mutate_state(|s| { s.in_flight_liquidations.remove(&vault_id); });
+    mutate_state(|s| {
+        s.in_flight_liquidations.remove(&vault_id);
+    });
 
     Ok(result)
 }
 
-pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
+pub async fn scan_chain_absorb_candidates(
+    max_per_chain: Option<u64>,
+) -> Result<Vec<ChainSpAbsorbCandidate>, StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    if caller == Principal::anonymous() {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    if !read_state(|s| s.is_admin(&caller)) {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+
+    let (protocol_id, chains) = read_state(|s| {
+        (
+            s.protocol_canister_id,
+            registered_chain_ids_from_sentinels(s),
+        )
+    });
+    let per_chain = max_per_chain.unwrap_or(100).min(500) as usize;
+    let mut candidates = Vec::new();
+    for chain in chains {
+        let call_result: Result<(Vec<ChainLiquidatableVaultInfo>,), _> =
+            call(protocol_id, "get_chain_liquidatable_vaults", (chain,)).await;
+        let (vaults,) = call_result.map_err(|_| StabilityPoolError::InterCanisterCallFailed {
+            target: format!("{}", protocol_id),
+            method: "get_chain_liquidatable_vaults".to_string(),
+        })?;
+
+        for vault in vaults
+            .into_iter()
+            .filter(|v| v.sp_attempted)
+            .take(per_chain)
+        {
+            if let Ok(plan) = read_state(|s| prepare_chain_absorb_plan_in_state(s, &vault)) {
+                let pending_status = read_state(|s| s.pending_chain_absorb_status(vault.vault_id));
+                candidates.push(ChainSpAbsorbCandidate {
+                    vault,
+                    icusd_to_burn_e8s: plan.icusd_to_burn_e8s,
+                    pending_status,
+                });
+            }
+        }
+    }
+
+    Ok(candidates)
+}
+
+async fn submit_chain_absorb_to_backend(
+    protocol_id: Principal,
+    vault_id: u64,
+    plan: &ChainAbsorbPlan,
+    proof: rumi_protocol_backend::icrc3_proof::SpWritedownProof,
+) -> Result<ChainStabilityPoolLiquidationResult, StabilityPoolError> {
+    let backend_result: Result<
+        (Result<ChainStabilityPoolLiquidationResult, rumi_protocol_backend::ProtocolError>,),
+        _,
+    > = call(
+        protocol_id,
+        "stability_pool_liquidate_chain_vault",
+        (vault_id, plan.icusd_to_burn_e8s, proof),
+    )
+    .await;
+
+    match backend_result {
+        Ok((Ok(result),)) => {
+            mutate_state(|s| {
+                mark_chain_absorb_backend_result_in_state(
+                    s,
+                    vault_id,
+                    result.clone(),
+                    ic_cdk::api::time(),
+                )
+            })?;
+            Ok(result)
+        }
+        Ok((Err(error),)) => {
+            let reason = format!("backend rejected chain absorb after burn: {:?}", error);
+            mutate_state(|s| {
+                mark_chain_absorb_error_in_state(
+                    s,
+                    vault_id,
+                    ChainSpAbsorbIntentStatus::BackendRejected,
+                    reason.clone(),
+                    ic_cdk::api::time(),
+                );
+            });
+            Err(StabilityPoolError::LiquidationFailed { vault_id, reason })
+        }
+        Err(_) => {
+            mutate_state(|s| {
+                mark_chain_absorb_error_in_state(
+                    s,
+                    vault_id,
+                    ChainSpAbsorbIntentStatus::Burned,
+                    "backend call failed after icUSD burn".to_string(),
+                    ic_cdk::api::time(),
+                );
+            });
+            Err(StabilityPoolError::InterCanisterCallFailed {
+                target: format!("{}", protocol_id),
+                method: "stability_pool_liquidate_chain_vault".to_string(),
+            })
+        }
+    }
+}
+
+pub async fn sp_absorb_chain_vault(
+    vault_id: u64,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
     let caller = ic_cdk::api::caller();
     if caller == Principal::anonymous() {
         return Err(StabilityPoolError::Unauthorized);
@@ -528,10 +885,31 @@ pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult,
     if read_state(|s| s.configuration.emergency_pause) {
         return Err(StabilityPoolError::EmergencyPaused);
     }
+    if let Some(completion) = read_state(|s| s.completed_chain_absorb(vault_id)) {
+        return Ok(completion.result);
+    }
 
+    crate::ensure_no_pool_balance_async_in_flight()?;
     let _liq_guard = crate::pool_guard::SpLiquidationGuard::new()?;
+    read_state(|s| ensure_no_other_pending_chain_absorb(s, vault_id))?;
+    if let Some(intent) = read_state(|s| s.get_pending_chain_absorb(vault_id)) {
+        let plan = chain_absorb_plan_from_intent(&intent);
+        if let Some(result) = intent.backend_result.clone() {
+            return mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result));
+        }
+        if let Some((plan, proof)) = burned_chain_absorb_replay_plan(&intent) {
+            let protocol_id = read_state(|s| s.protocol_canister_id);
+            let result =
+                submit_chain_absorb_to_backend(protocol_id, vault_id, &plan, proof).await?;
+            return mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result));
+        }
+    }
+
     let (protocol_id, chains) = read_state(|s| {
-        (s.protocol_canister_id, registered_chain_ids_from_sentinels(s))
+        (
+            s.protocol_canister_id,
+            registered_chain_ids_from_sentinels(s),
+        )
     });
     if chains.is_empty() {
         return Err(StabilityPoolError::LiquidationFailed {
@@ -542,11 +920,8 @@ pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult,
 
     let mut candidate: Option<ChainLiquidatableVaultInfo> = None;
     for chain in chains {
-        let call_result: Result<(Vec<ChainLiquidatableVaultInfo>,), _> = call(
-            protocol_id,
-            "get_chain_liquidatable_vaults",
-            (chain,),
-        ).await;
+        let call_result: Result<(Vec<ChainLiquidatableVaultInfo>,), _> =
+            call(protocol_id, "get_chain_liquidatable_vaults", (chain,)).await;
         let (vaults,) = call_result.map_err(|_| StabilityPoolError::InterCanisterCallFailed {
             target: format!("{}", protocol_id),
             method: "get_chain_liquidatable_vaults".to_string(),
@@ -563,32 +938,57 @@ pub async fn sp_absorb_chain_vault(vault_id: u64) -> Result<ChainSpAbsorbResult,
     })?;
     let plan = read_state(|s| prepare_chain_absorb_plan_in_state(s, &candidate))?;
 
-    let proof = burn_icusd_for_chain_writedown(
-        plan.icusd_ledger,
-        plan.icusd_to_burn_e8s,
-        vault_id,
-    ).await?;
+    let minting_account = match read_state(|s| s.get_pending_chain_absorb(vault_id)) {
+        Some(intent) => intent.icusd_minting_account,
+        None => fetch_icusd_minting_account(plan.icusd_ledger).await?,
+    };
+    let now = ic_cdk::api::time();
+    let mut intent = mutate_state(|s| {
+        prepare_or_reuse_chain_absorb_intent_in_state(s, &plan, minting_account, now)
+    })?;
 
-    let backend_result: Result<(Result<ChainStabilityPoolLiquidationResult, rumi_protocol_backend::ProtocolError>,), _> = call(
-        protocol_id,
-        "stability_pool_liquidate_chain_vault",
-        (vault_id, plan.icusd_to_burn_e8s, proof),
-    ).await;
+    let proof = if let Some(proof) = intent.burn_proof.clone() {
+        proof
+    } else {
+        match burn_icusd_for_chain_writedown_with_account(
+            intent.icusd_ledger,
+            intent.icusd_minting_account,
+            intent.icusd_to_burn_e8s,
+            intent.vault_id,
+            intent.burn_created_at_time_ns,
+        )
+        .await
+        {
+            Ok(proof) => {
+                intent = mutate_state(|s| {
+                    mark_chain_absorb_burned_in_state(
+                        s,
+                        vault_id,
+                        proof.clone(),
+                        ic_cdk::api::time(),
+                    )
+                })?;
+                proof
+            }
+            Err(error) => {
+                mutate_state(|s| {
+                    mark_chain_absorb_error_in_state(
+                        s,
+                        vault_id,
+                        ChainSpAbsorbIntentStatus::Prepared,
+                        format!("icUSD burn failed: {:?}", error),
+                        ic_cdk::api::time(),
+                    );
+                });
+                return Err(error);
+            }
+        }
+    };
 
-    let result = match backend_result {
-        Ok((Ok(result),)) => result,
-        Ok((Err(error),)) => {
-            return Err(StabilityPoolError::LiquidationFailed {
-                vault_id,
-                reason: format!("backend rejected chain absorb after burn: {:?}", error),
-            });
-        }
-        Err(_) => {
-            return Err(StabilityPoolError::InterCanisterCallFailed {
-                target: format!("{}", protocol_id),
-                method: "stability_pool_liquidate_chain_vault".to_string(),
-            });
-        }
+    let result = if let Some(result) = intent.backend_result.clone() {
+        result
+    } else {
+        submit_chain_absorb_to_backend(protocol_id, vault_id, &plan, proof).await?
     };
 
     mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result))
@@ -598,7 +998,7 @@ pub async fn claim_cfx(
     chain_sentinel: Principal,
     dest_evm: String,
 ) -> Result<u128, StabilityPoolError> {
-    if crate::pool_guard::liquidation_in_progress() {
+    if crate::pool_balance_mutation_blocked() {
         return Err(StabilityPoolError::SystemBusy);
     }
     let caller = ic_cdk::api::caller();
@@ -626,8 +1026,14 @@ pub async fn claim_cfx(
     let backend_result: Result<(Result<u64, rumi_protocol_backend::ProtocolError>,), _> = call(
         protocol_id,
         "claim_chain_collateral",
-        (plan.claim_id, plan.claimant, plan.amount_wei, plan.dest_evm.clone()),
-    ).await;
+        (
+            plan.claim_id,
+            plan.claimant,
+            plan.amount_wei,
+            plan.dest_evm.clone(),
+        ),
+    )
+    .await;
 
     match backend_result {
         Ok((Ok(_op_id),)) => Ok(plan.amount_wei),
@@ -681,38 +1087,64 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
         };
     }
 
-    log!(INFO, "Token draw for vault {}: {:?}", vault_info.vault_id, token_draw);
+    log!(
+        INFO,
+        "Token draw for vault {}: {:?}",
+        vault_info.vault_id,
+        token_draw
+    );
 
     // Step 2: Process each token in the draw
     let mut total_collateral_gained: u64 = 0;
     let mut actual_consumed: BTreeMap<Principal, u64> = BTreeMap::new();
 
-    let stablecoin_configs: BTreeMap<Principal, StablecoinConfig> = read_state(|s| s.stablecoin_registry.clone());
-    let icusd_ledger = stablecoin_configs.iter()
+    let stablecoin_configs: BTreeMap<Principal, StablecoinConfig> =
+        read_state(|s| s.stablecoin_registry.clone());
+    let icusd_ledger = stablecoin_configs
+        .iter()
         .find(|(_, c)| c.symbol == "icUSD")
         .map(|(id, _)| *id);
 
     // --- Non-LP tokens: approve + liquidate_vault_partial ---
     for (token_ledger, amount) in &token_draw {
         // Skip LP tokens — handled separately below
-        if stablecoin_configs.get(token_ledger).map(|c| c.is_lp_token.unwrap_or(false)).unwrap_or(false) {
+        if stablecoin_configs
+            .get(token_ledger)
+            .map(|c| c.is_lp_token.unwrap_or(false))
+            .unwrap_or(false)
+        {
             continue;
         }
 
         let is_icusd = icusd_ledger.map(|id| id == *token_ledger).unwrap_or(false);
-        let token_decimals = stablecoin_configs.get(token_ledger).map(|c| c.decimals).unwrap_or(8);
+        let token_decimals = stablecoin_configs
+            .get(token_ledger)
+            .map(|c| c.decimals)
+            .unwrap_or(8);
 
         // Pre-check: backend minimum is 10_000_000 e8s (0.1 icUSD)
-        let amount_e8s_check = if is_icusd { *amount } else { crate::types::normalize_to_e8s(*amount, token_decimals) };
+        let amount_e8s_check = if is_icusd {
+            *amount
+        } else {
+            crate::types::normalize_to_e8s(*amount, token_decimals)
+        };
         if amount_e8s_check < 10_000_000 {
-            log!(INFO, "Skipping token {}: amount {} e8s below backend minimum (0.1)", token_ledger, amount_e8s_check);
+            log!(
+                INFO,
+                "Skipping token {}: amount {} e8s below backend minimum (0.1)",
+                token_ledger,
+                amount_e8s_check
+            );
             continue;
         }
 
         // Approve backend to spend this token
         let approve_args = ApproveArgs {
             from_subaccount: None,
-            spender: Account { owner: protocol_id, subaccount: None },
+            spender: Account {
+                owner: protocol_id,
+                subaccount: None,
+            },
             amount: candid::Nat::from(*amount as u128 * 2), // 2x buffer for fees
             expected_allowance: None,
             expires_at: Some(ic_cdk::api::time() + 300_000_000_000), // 5 min
@@ -721,23 +1153,25 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
             created_at_time: Some(ic_cdk::api::time()),
         };
 
-        let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> = call(
-            *token_ledger, "icrc2_approve", (approve_args,)
-        ).await;
+        let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> =
+            call(*token_ledger, "icrc2_approve", (approve_args,)).await;
 
         match approve_result {
             Ok((Ok(_),)) => {
                 // Deduct the approve fee from tracked balances
-                if let Some(fee) = stablecoin_configs.get(token_ledger).and_then(|c| c.transfer_fee) {
+                if let Some(fee) = stablecoin_configs
+                    .get(token_ledger)
+                    .and_then(|c| c.transfer_fee)
+                {
                     if fee > 0 {
                         mutate_state(|s| s.deduct_fee_from_pool(*token_ledger, fee));
                     }
                 }
-            },
+            }
             Ok((Err(e),)) => {
                 log!(INFO, "Approve failed for {}: {:?}", token_ledger, e);
                 continue;
-            },
+            }
             Err(e) => {
                 log!(INFO, "Approve call failed for {}: {:?}", token_ledger, e);
                 continue;
@@ -754,34 +1188,56 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
 
         // Call the appropriate backend endpoint
         let liq_result = if is_icusd {
-            let call_result: Result<(Result<rumi_protocol_backend::SuccessWithFee, rumi_protocol_backend::ProtocolError>,), _> = call(
+            let call_result: Result<
+                (
+                    Result<
+                        rumi_protocol_backend::SuccessWithFee,
+                        rumi_protocol_backend::ProtocolError,
+                    >,
+                ),
+                _,
+            > = call(
                 protocol_id,
                 "liquidate_vault_partial",
                 (rumi_protocol_backend::vault::VaultArg {
                     vault_id: vault_info.vault_id,
                     amount: *amount,
-                },)
-            ).await;
+                },),
+            )
+            .await;
             call_result.map(|(r,)| r)
         } else {
             let token_type = determine_stable_token_type(*token_ledger, &stablecoin_configs);
             match token_type {
                 Some(tt) => {
                     let amount_e8s = crate::types::normalize_to_e8s(*amount, token_decimals);
-                    let call_result: Result<(Result<rumi_protocol_backend::SuccessWithFee, rumi_protocol_backend::ProtocolError>,), _> = call(
+                    let call_result: Result<
+                        (
+                            Result<
+                                rumi_protocol_backend::SuccessWithFee,
+                                rumi_protocol_backend::ProtocolError,
+                            >,
+                        ),
+                        _,
+                    > = call(
                         protocol_id,
                         "liquidate_vault_partial_with_stable",
                         (rumi_protocol_backend::VaultArgWithToken {
                             vault_id: vault_info.vault_id,
                             amount: amount_e8s,
                             token_type: tt,
-                        },)
-                    ).await;
+                        },),
+                    )
+                    .await;
                     call_result.map(|(r,)| r)
-                },
+                }
                 None => {
                     // Backend was never called; no bookkeeping to roll back.
-                    log!(INFO, "Unknown stable token type for {}, skipping", token_ledger);
+                    log!(
+                        INFO,
+                        "Unknown stable token type for {}, skipping",
+                        token_ledger
+                    );
                     continue;
                 }
             }
@@ -789,9 +1245,17 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
 
         match liq_result {
             Ok(Ok(success)) => {
-                let collateral = success.collateral_amount_received.unwrap_or(success.fee_amount_paid);
-                log!(INFO, "Liquidation succeeded for vault {} with token {}: collateral={}, fee={}",
-                    vault_info.vault_id, token_ledger, collateral, success.fee_amount_paid);
+                let collateral = success
+                    .collateral_amount_received
+                    .unwrap_or(success.fee_amount_paid);
+                log!(
+                    INFO,
+                    "Liquidation succeeded for vault {} with token {}: collateral={}, fee={}",
+                    vault_info.vault_id,
+                    token_ledger,
+                    collateral,
+                    success.fee_amount_paid
+                );
                 // SP-101 / SP-110: debit by what the backend ACTUALLY pulled from
                 // the pool, not the amount we requested, so the tracked aggregate
                 // never drifts from the real ledger balance. `process_liquidation_gains`
@@ -805,21 +1269,26 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 //     back to the base conversion for an older backend wasm.
                 let realized_consumed = match (success.debt_liquidated_e8s, is_icusd) {
                     (Some(debt_e8), true) => debt_e8,
-                    (Some(debt_e8), false) => success
-                        .stable_pulled_e6s
-                        .unwrap_or_else(|| crate::types::denormalize_from_e8s(debt_e8, token_decimals)),
+                    (Some(debt_e8), false) => success.stable_pulled_e6s.unwrap_or_else(|| {
+                        crate::types::denormalize_from_e8s(debt_e8, token_decimals)
+                    }),
                     (None, _) => *amount,
                 };
                 actual_consumed.insert(*token_ledger, realized_consumed);
                 total_collateral_gained += collateral;
                 // Bug 7: one token per vault per round — vault state changed, remaining draws are stale
                 break;
-            },
+            }
             Ok(Err(protocol_error)) => {
                 // Backend explicitly rejected; nothing was pre-deducted, so no rollback needed.
-                log!(INFO, "Protocol rejected liquidation for vault {} with token {}: {:?}",
-                    vault_info.vault_id, token_ledger, protocol_error);
-            },
+                log!(
+                    INFO,
+                    "Protocol rejected liquidation for vault {} with token {}: {:?}",
+                    vault_info.vault_id,
+                    token_ledger,
+                    protocol_error
+                );
+            }
             Err(call_error) => {
                 // Inter-canister call failed; outcome is unknown. We do NOT mutate
                 // depositor bookkeeping here — the previous "conservative deduct" path
@@ -828,10 +1297,15 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 // transfer_from but failed to reply), the next liquidation or a manual
                 // `correct_balance` reconciliation against `icrc1_balance_of(pool)`
                 // will reconcile the divergence. Log loudly so operators notice.
-                log!(INFO, "Liquidation call failed for vault {} with token {}: {:?}. \
+                log!(
+                    INFO,
+                    "Liquidation call failed for vault {} with token {}: {:?}. \
                       No bookkeeping change; ledger balance should be reconciled if \
                       tokens moved silently.",
-                    vault_info.vault_id, token_ledger, call_error);
+                    vault_info.vault_id,
+                    token_ledger,
+                    call_error
+                );
             }
         }
     }
@@ -845,19 +1319,30 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
 
         // Calculate icUSD equivalent using cached virtual price
         let vp = read_state(|s| {
-            s.virtual_prices().get(token_ledger).copied().unwrap_or(1_000_000_000_000_000_000)
+            s.virtual_prices()
+                .get(token_ledger)
+                .copied()
+                .unwrap_or(1_000_000_000_000_000_000)
         });
         let icusd_equiv_e8s = lp_to_usd_e8s(*amount, vp);
 
         if icusd_equiv_e8s < 10_000_000 {
-            log!(INFO, "Skipping LP token {}: icUSD equivalent {} e8s below backend minimum", token_ledger, icusd_equiv_e8s);
+            log!(
+                INFO,
+                "Skipping LP token {}: icUSD equivalent {} e8s below backend minimum",
+                token_ledger,
+                icusd_equiv_e8s
+            );
             continue;
         }
 
         // Step A: Approve backend to pull 3USD (same pattern as non-LP tokens)
         let approve_args = ApproveArgs {
             from_subaccount: None,
-            spender: Account { owner: protocol_id, subaccount: None },
+            spender: Account {
+                owner: protocol_id,
+                subaccount: None,
+            },
             amount: candid::Nat::from(*amount as u128 * 2), // 2x buffer for fees
             expected_allowance: None,
             expires_at: Some(ic_cdk::api::time() + 300_000_000_000), // 5 min
@@ -866,9 +1351,8 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
             created_at_time: Some(ic_cdk::api::time()),
         };
 
-        let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> = call(
-            *token_ledger, "icrc2_approve", (approve_args,)
-        ).await;
+        let approve_result: Result<(Result<candid::Nat, ApproveError>,), _> =
+            call(*token_ledger, "icrc2_approve", (approve_args,)).await;
 
         match approve_result {
             Ok((Ok(_),)) => {
@@ -878,13 +1362,23 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                         mutate_state(|s| s.deduct_fee_from_pool(*token_ledger, fee));
                     }
                 }
-            },
+            }
             Ok((Err(e),)) => {
-                log!(INFO, "3USD approve failed for vault {}: {:?}", vault_info.vault_id, e);
+                log!(
+                    INFO,
+                    "3USD approve failed for vault {}: {:?}",
+                    vault_info.vault_id,
+                    e
+                );
                 continue;
-            },
+            }
             Err(e) => {
-                log!(INFO, "3USD approve call failed for vault {}: {:?}", vault_info.vault_id, e);
+                log!(
+                    INFO,
+                    "3USD approve call failed for vault {}: {:?}",
+                    vault_info.vault_id,
+                    e
+                );
                 continue;
             }
         }
@@ -894,11 +1388,15 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
         // point of truth for bookkeeping — no pre-deduct (SP-001 regression fix,
         // audit 2026-04-22-28e9896).
 
-        let liq_result: Result<(Result<StabilityPoolLiquidationResult, rumi_protocol_backend::ProtocolError>,), _> = call(
+        let liq_result: Result<
+            (Result<StabilityPoolLiquidationResult, rumi_protocol_backend::ProtocolError>,),
+            _,
+        > = call(
             protocol_id,
             "stability_pool_liquidate_with_reserves",
             (vault_info.vault_id, icusd_equiv_e8s, *amount, *token_ledger),
-        ).await;
+        )
+        .await;
 
         match liq_result {
             Ok((Ok(success),)) => {
@@ -910,12 +1408,13 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 // balance both net to exactly the realized amount (no drift).
                 // `icusd_equiv_e8s` here equals the `icusd_debt_covered_e8s` the
                 // backend received, so the two formulas are identical.
-                let realized_3usd = if icusd_equiv_e8s > 0 && success.liquidated_debt < icusd_equiv_e8s {
-                    ((*amount as u128).saturating_mul(success.liquidated_debt as u128)
-                        / icusd_equiv_e8s as u128) as u64
-                } else {
-                    *amount
-                };
+                let realized_3usd =
+                    if icusd_equiv_e8s > 0 && success.liquidated_debt < icusd_equiv_e8s {
+                        ((*amount as u128).saturating_mul(success.liquidated_debt as u128)
+                            / icusd_equiv_e8s as u128) as u64
+                    } else {
+                        *amount
+                    };
                 actual_consumed.insert(*token_ledger, realized_3usd);
                 total_collateral_gained += success.collateral_received;
                 log!(INFO, "3USD reserves liquidation succeeded for vault {}: {} collateral, {} 3USD consumed (requested {})",
@@ -925,18 +1424,26 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
             Ok((Err(e),)) => {
                 // Backend explicitly rejected; approval expires harmlessly and nothing
                 // was pre-deducted, so there is no bookkeeping to roll back.
-                log!(INFO, "Backend rejected 3USD reserves liquidation for vault {}: {:?}",
-                    vault_info.vault_id, e);
+                log!(
+                    INFO,
+                    "Backend rejected 3USD reserves liquidation for vault {}: {:?}",
+                    vault_info.vault_id,
+                    e
+                );
             }
             Err(e) => {
                 // Inter-canister call failed; outcome unknown. We do NOT mutate
                 // depositor bookkeeping (SP-005 regression fix). If the backend
                 // pulled the 3USD silently, operator reconciliation against
                 // `icrc1_balance_of(pool)` will reconcile.
-                log!(INFO, "3USD reserves liquidation call failed for vault {}: {:?}. \
+                log!(
+                    INFO,
+                    "3USD reserves liquidation call failed for vault {}: {:?}. \
                       No bookkeeping change; ledger balance should be reconciled if \
                       tokens moved silently.",
-                    vault_info.vault_id, e);
+                    vault_info.vault_id,
+                    e
+                );
             }
         }
     }
@@ -962,12 +1469,16 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
         // Deduct the collateral ledger's transfer fee from gains — the backend reports
         // gross collateral but the transfer to the SP deducts one fee.
         let collateral_fee: u64 = match call::<(), (candid::Nat,)>(
-            vault_info.collateral_type, "icrc1_fee", ()
-        ).await {
+            vault_info.collateral_type,
+            "icrc1_fee",
+            (),
+        )
+        .await
+        {
             Ok((fee_nat,)) => {
                 let fee: u128 = fee_nat.0.try_into().unwrap_or(0);
                 fee as u64
-            },
+            }
             Err(e) => {
                 // SP-104 (audit 2026-06-05): do NOT fall back to fee=0. The actual
                 // payout transfer deducts the real ledger fee, so crediting the full
@@ -977,7 +1488,7 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                 log!(INFO, "icrc1_fee query failed for collateral {}: {:?}; using conservative fallback {} e8s",
                     vault_info.collateral_type, e, FALLBACK_COLLATERAL_FEE_E8S);
                 FALLBACK_COLLATERAL_FEE_E8S
-            },
+            }
         };
         let net_collateral = total_collateral_gained.saturating_sub(collateral_fee);
 
@@ -1040,9 +1551,9 @@ struct StabilityPoolLiquidationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::{chain_collateral_sentinel, StabilityPoolState};
     use candid::Nat;
     use icrc_ledger_types::icrc1::transfer::Memo;
-    use crate::state::{chain_collateral_sentinel, StabilityPoolState};
 
     fn principal(byte: u8) -> Principal {
         Principal::from_slice(&[byte])
@@ -1095,17 +1606,25 @@ mod tests {
         token: Principal,
         amount: u64,
     ) {
-        let position = state.deposits.entry(user).or_insert_with(|| DepositPosition::new(0));
+        let position = state
+            .deposits
+            .entry(user)
+            .or_insert_with(|| DepositPosition::new(0));
         *position.stablecoin_balances.entry(token).or_insert(0) += amount;
         *state.total_stablecoin_balances.entry(token).or_insert(0) += amount;
     }
 
-    fn chain_vault(
+    fn chain_vault(debt_e8s: u128, sp_attempted: bool) -> ChainLiquidatableVaultInfo {
+        chain_vault_with_id(77, debt_e8s, sp_attempted)
+    }
+
+    fn chain_vault_with_id(
+        vault_id: u64,
         debt_e8s: u128,
         sp_attempted: bool,
     ) -> ChainLiquidatableVaultInfo {
         ChainLiquidatableVaultInfo {
-            vault_id: 77,
+            vault_id,
             chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
             chain_collateral_sentinel: chain_collateral_sentinel(1030),
             sp_attempted,
@@ -1115,6 +1634,27 @@ mod tests {
             cr_e4: 12_000,
             liquidation_threshold_e4: 13_500,
             sized_repay_e8s: debt_e8s,
+        }
+    }
+
+    fn minting_account() -> Account {
+        Account {
+            owner: principal(90),
+            subaccount: None,
+        }
+    }
+
+    fn backend_chain_result() -> ChainStabilityPoolLiquidationResult {
+        ChainStabilityPoolLiquidationResult {
+            success: true,
+            vault_id: 77,
+            chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
+            liquidated_debt_e8s: 100_00000000,
+            collateral_received_native: 10_000_000_000_000_000_000u128,
+            claim_id: 77,
+            custody_address: "0xcustody".to_string(),
+            block_index: 44,
+            collateral_price_e8s: 5_000_000,
         }
     }
 
@@ -1134,22 +1674,24 @@ mod tests {
 
     #[test]
     fn icusd_burn_request_targets_minting_account_and_builds_proof() {
-        let minting_account = Account { owner: principal(90), subaccount: None };
+        let minting_account = Account {
+            owner: principal(90),
+            subaccount: None,
+        };
         let amount_e8s = 12_345_00000000;
         let vault_id = 77;
         let created_at_time = 123_456_789;
         let block_index = 999;
 
-        let transfer = build_icusd_burn_transfer_arg(
-            minting_account,
-            amount_e8s,
-            vault_id,
-            created_at_time,
-        );
+        let transfer =
+            build_icusd_burn_transfer_arg(minting_account, amount_e8s, vault_id, created_at_time);
 
         assert_eq!(transfer.to, minting_account);
         assert_eq!(transfer.amount, Nat::from(amount_e8s));
-        assert_eq!(transfer.fee, None, "ICRC-1 burns to the minting account have zero fee");
+        assert_eq!(
+            transfer.fee, None,
+            "ICRC-1 burns to the minting account have zero fee"
+        );
         assert_eq!(transfer.from_subaccount, None);
         assert_eq!(transfer.created_at_time, Some(created_at_time));
         assert_eq!(
@@ -1159,14 +1701,19 @@ mod tests {
 
         let proof = build_icusd_burn_proof(block_index, vault_id);
         assert_eq!(proof.block_index, block_index);
-        assert_eq!(proof.ledger_kind, rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn);
+        assert_eq!(
+            proof.ledger_kind,
+            rumi_protocol_backend::icrc3_proof::SpProofLedger::IcusdBurn
+        );
         assert_eq!(proof.vault_id_memo, vault_id);
     }
 
     #[test]
     fn registered_chain_ids_decode_from_registered_sentinels() {
         let mut state = test_state();
-        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
 
         assert_eq!(
             registered_chain_ids_from_sentinels(&state),
@@ -1177,81 +1724,380 @@ mod tests {
     #[test]
     fn chain_absorb_preflight_requires_escalation_and_icusd_coverage() {
         let mut state = test_state();
-        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 40_00000000);
         add_deposit_direct(&mut state, user_a(), ckusdc_ledger(), 5_000_000_000);
         add_deposit_direct(&mut state, user_b(), icusd_ledger(), 100_00000000);
 
-        let not_escalated = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, false))
-            .unwrap_err();
-        assert!(matches!(not_escalated, StabilityPoolError::LiquidationFailed { .. }));
+        let not_escalated =
+            prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, false))
+                .unwrap_err();
+        assert!(matches!(
+            not_escalated,
+            StabilityPoolError::LiquidationFailed { .. }
+        ));
 
         let no_opt_in = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
             .unwrap_err();
-        assert!(matches!(no_opt_in, StabilityPoolError::InsufficientPoolBalance));
+        assert!(matches!(
+            no_opt_in,
+            StabilityPoolError::InsufficientPoolBalance
+        ));
 
-        state.opt_in_cfx(&user_a(), chain_collateral_sentinel(1030)).unwrap();
-        let undercovered = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
-            .unwrap_err();
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let undercovered =
+            prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
+                .unwrap_err();
         assert!(
             matches!(undercovered, StabilityPoolError::InsufficientPoolBalance),
             "ckUSDC must not count toward chain absorb coverage",
         );
 
-        state.opt_in_cfx(&user_b(), chain_collateral_sentinel(1030)).unwrap();
+        state
+            .opt_in_cfx(&user_b(), chain_collateral_sentinel(1030))
+            .unwrap();
         let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(70_00000000, true))
             .expect("covered by opted-in icUSD");
         assert_eq!(plan.icusd_to_burn_e8s, 70_00000000);
-        assert_eq!(plan.stables_consumed.get(&icusd_ledger()).copied(), Some(70_00000000));
+        assert_eq!(
+            plan.stables_consumed.get(&icusd_ledger()).copied(),
+            Some(70_00000000)
+        );
         assert_eq!(plan.stables_consumed.len(), 1);
+    }
+
+    #[test]
+    fn chain_absorb_intent_reuses_timestamp_and_rejects_conflicting_recompute() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        let intent = prepare_or_reuse_chain_absorb_intent_in_state(
+            &mut state,
+            &plan,
+            minting_account(),
+            123,
+        )
+        .expect("intent is recorded");
+
+        assert_eq!(intent.burn_created_at_time_ns, 123);
+        assert!(state.has_pending_chain_absorbs());
+        assert_eq!(state.pending_chain_absorb_count(), 1);
+
+        let reused = prepare_or_reuse_chain_absorb_intent_in_state(
+            &mut state,
+            &plan,
+            minting_account(),
+            999,
+        )
+        .expect("same plan reuses existing intent");
+        assert_eq!(
+            reused.burn_created_at_time_ns, 123,
+            "retry must not recompute ledger dedupe timestamp",
+        );
+
+        let mut conflicting = plan.clone();
+        conflicting.icusd_to_burn_e8s -= 1;
+        let err = prepare_or_reuse_chain_absorb_intent_in_state(
+            &mut state,
+            &conflicting,
+            minting_account(),
+            1_000,
+        )
+        .unwrap_err();
+        assert!(matches!(err, StabilityPoolError::LiquidationFailed { .. }));
+    }
+
+    #[test]
+    fn chain_absorb_intent_records_single_burn_proof() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("intent is recorded");
+
+        let proof = build_icusd_burn_proof(44, 77);
+        let burned = mark_chain_absorb_burned_in_state(&mut state, 77, proof.clone(), 456)
+            .expect("proof recorded");
+        assert_eq!(burned.status, ChainSpAbsorbIntentStatus::Burned);
+        assert_eq!(burned.burn_proof, Some(proof.clone()));
+
+        mark_chain_absorb_burned_in_state(&mut state, 77, proof, 789)
+            .expect("same proof is idempotent");
+        let conflict =
+            mark_chain_absorb_burned_in_state(&mut state, 77, build_icusd_burn_proof(45, 77), 790)
+                .unwrap_err();
+        assert!(matches!(
+            conflict,
+            StabilityPoolError::LiquidationFailed { .. }
+        ));
+    }
+
+    #[test]
+    fn burned_chain_absorb_intent_replays_backend_without_discovery() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("intent is recorded");
+        let proof = build_icusd_burn_proof(44, 77);
+        let burned = mark_chain_absorb_burned_in_state(&mut state, 77, proof.clone(), 456)
+            .expect("proof recorded");
+
+        let (replay_plan, replay_proof) =
+            burned_chain_absorb_replay_plan(&burned).expect("burned intent replays by proof");
+        assert_eq!(replay_plan, plan);
+        assert_eq!(replay_proof, proof);
+        assert!(
+            burned.backend_result.is_none(),
+            "this covers backend-accepted/lost-reply state before local result journaling",
+        );
+    }
+
+    #[test]
+    fn other_pending_chain_absorb_blocks_new_burn_plan() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+
+        let plan_a =
+            prepare_chain_absorb_plan_in_state(&state, &chain_vault_with_id(77, 100_00000000, true))
+                .expect("vault A covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan_a, minting_account(), 123)
+            .expect("intent A is recorded");
+        mark_chain_absorb_burned_in_state(&mut state, 77, build_icusd_burn_proof(44, 77), 456)
+            .expect("intent A burn proof recorded");
+
+        assert!(
+            ensure_no_other_pending_chain_absorb(&state, 77).is_ok(),
+            "the original vault remains retryable",
+        );
+        assert!(
+            matches!(
+                ensure_no_other_pending_chain_absorb(&state, 78),
+                Err(StabilityPoolError::SystemBusy)
+            ),
+            "a burned pending intent reserves its icUSD until local finalization",
+        );
+    }
+
+    #[test]
+    fn chain_absorb_backend_result_intent_can_finalize_without_discovery() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("intent is recorded");
+        let backend_result = backend_chain_result();
+        let intent = mark_chain_absorb_backend_result_in_state(&mut state, 77, backend_result, 456)
+            .expect("backend result is stored");
+
+        let resumed_plan = chain_absorb_plan_from_intent(&intent);
+        let absorbed = apply_chain_absorb_success_in_state_at(
+            &mut state,
+            &resumed_plan,
+            intent.backend_result.expect("stored"),
+            789,
+        )
+        .expect("stored backend result finalizes locally");
+
+        assert_eq!(absorbed.icusd_burned_e8s, 100_00000000);
+        assert!(
+            state.get_pending_chain_absorb(77).is_none(),
+            "local finalization clears pending journal entry",
+        );
+        assert!(state.completed_chain_absorb(77).is_some());
+    }
+
+    #[test]
+    fn chain_absorb_rejects_partial_backend_result_without_deducting_pool() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        let mut partial = backend_chain_result();
+        partial.liquidated_debt_e8s = 80_00000000;
+
+        let err =
+            apply_chain_absorb_success_in_state_at(&mut state, &plan, partial, 123).unwrap_err();
+
+        assert!(
+            matches!(err, StabilityPoolError::LiquidationFailed { .. }),
+            "partial backend result must be rejected before pool accounting"
+        );
+        assert_eq!(
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied(),
+            Some(100_00000000),
+            "pool icUSD balance is unchanged",
+        );
+        assert!(
+            state
+                .deposits
+                .get(&user_a())
+                .unwrap()
+                .cfx_claims
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "no CFX claim is credited on a partial backend result",
+        );
+        assert!(state.completed_chain_absorb(77).is_none());
     }
 
     #[test]
     fn chain_absorb_success_credits_cfx_claims_and_deducts_burned_icusd() {
         let mut state = test_state();
-        state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 40_00000000);
         add_deposit_direct(&mut state, user_b(), icusd_ledger(), 60_00000000);
-        state.opt_in_cfx(&user_a(), chain_collateral_sentinel(1030)).unwrap();
-        state.opt_in_cfx(&user_b(), chain_collateral_sentinel(1030)).unwrap();
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        state
+            .opt_in_cfx(&user_b(), chain_collateral_sentinel(1030))
+            .unwrap();
 
         let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
             .expect("covered");
-        let result = ChainStabilityPoolLiquidationResult {
-            success: true,
-            vault_id: 77,
-            chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
-            liquidated_debt_e8s: 100_00000000,
-            collateral_received_native: 10_000_000_000_000_000_000u128,
-            claim_id: 77,
-            custody_address: "0xcustody".to_string(),
-            block_index: 44,
-            collateral_price_e8s: 5_000_000,
-        };
+        let result = backend_chain_result();
 
-        let absorbed = apply_chain_absorb_success_in_state_at(&mut state, &plan, result, 123)
-            .expect("success finalizes");
+        let absorbed =
+            apply_chain_absorb_success_in_state_at(&mut state, &plan, result.clone(), 123)
+                .expect("success finalizes");
 
         assert_eq!(absorbed.icusd_burned_e8s, 100_00000000);
         assert_eq!(
-            state.total_stablecoin_balances.get(&icusd_ledger()).copied(),
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied(),
             Some(0),
             "SP aggregate tracks the burned icUSD",
         );
-        let claim_a = state.deposits.get(&user_a()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&chain_collateral_sentinel(1030)).copied().unwrap_or(0);
-        let claim_b = state.deposits.get(&user_b()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&chain_collateral_sentinel(1030)).copied().unwrap_or(0);
+        let claim_a = state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&chain_collateral_sentinel(1030))
+            .copied()
+            .unwrap_or(0);
+        let claim_b = state
+            .deposits
+            .get(&user_b())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&chain_collateral_sentinel(1030))
+            .copied()
+            .unwrap_or(0);
         assert_eq!(claim_a, 4_000_000_000_000_000_000u128);
         assert_eq!(claim_b, 6_000_000_000_000_000_000u128);
+
+        let repeated = apply_chain_absorb_success_in_state_at(&mut state, &plan, result, 124)
+            .expect("same result is idempotent");
+        assert_eq!(repeated, absorbed);
+        assert_eq!(
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied(),
+            Some(0),
+            "replay must not double-deduct icUSD",
+        );
+        assert_eq!(
+            state
+                .deposits
+                .get(&user_a())
+                .unwrap()
+                .cfx_claims
+                .as_ref()
+                .unwrap()
+                .get(&chain_collateral_sentinel(1030))
+                .copied()
+                .unwrap_or(0),
+            claim_a,
+            "replay must not double-credit user A CFX",
+        );
+        assert_eq!(
+            state
+                .deposits
+                .get(&user_b())
+                .unwrap()
+                .cfx_claims
+                .as_ref()
+                .unwrap()
+                .get(&chain_collateral_sentinel(1030))
+                .copied()
+                .unwrap_or(0),
+            claim_b,
+            "replay must not double-credit user B CFX",
+        );
+        assert_eq!(state.completed_chain_absorbs(10).len(), 1);
     }
 
     #[test]
     fn cfx_claim_payout_deducts_from_user_and_claim_source() {
         let mut state = test_state();
-        let sentinel = state.register_chain_collateral(1030, "CFX".to_string(), 18).unwrap();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
         let mut pos = DepositPosition::new(0);
-        pos.cfx_claims.get_or_insert_with(BTreeMap::new).insert(sentinel, 12);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 12);
         state.deposits.insert(user_a(), pos);
         state.record_chain_claim_source(sentinel, 77, 10);
 
@@ -1261,14 +2107,21 @@ mod tests {
             sentinel,
             "not-evm".to_string(),
             |_| false,
-        ).unwrap_err();
-        assert!(matches!(invalid, StabilityPoolError::LiquidationFailed { .. }));
+        )
+        .unwrap_err();
+        assert!(matches!(
+            invalid,
+            StabilityPoolError::LiquidationFailed { .. }
+        ));
         assert_eq!(
             state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
             12,
             "destination validation happens before mutation",
         );
-        assert_eq!(state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native, 10);
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10
+        );
 
         let plan = prepare_cfx_claim_payout_in_state(
             &mut state,
@@ -1276,7 +2129,9 @@ mod tests {
             sentinel,
             "0x000000000000000000000000000000000000c0de".to_string(),
             rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
-        ).expect("claim plan").expect("nonzero claim");
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
         assert_eq!(plan.claim_id, 77);
         assert_eq!(plan.amount_wei, 10);
         assert_eq!(
@@ -1285,7 +2140,12 @@ mod tests {
             "only the covered source amount is deducted",
         );
         assert!(
-            state.chain_claim_sources.as_ref().unwrap().get(&sentinel).is_none(),
+            state
+                .chain_claim_sources
+                .as_ref()
+                .unwrap()
+                .get(&sentinel)
+                .is_none(),
             "depleted source is pruned before await",
         );
 
@@ -1305,7 +2165,8 @@ mod tests {
     #[test]
     fn duplicate_chain_claim_error_is_not_rolled_back() {
         let duplicate = rumi_protocol_backend::ProtocolError::ChainAdmin(
-            "Duplicate chain collateral claim payout idempotency key chain-collateral-claim-77".to_string(),
+            "Duplicate chain collateral claim payout idempotency key chain-collateral-claim-77"
+                .to_string(),
         );
         let ordinary = rumi_protocol_backend::ProtocolError::ChainAdmin(
             "chain collateral claim: unknown claim 77".to_string(),

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -351,6 +351,23 @@ pub(crate) fn mark_chain_absorb_error_in_state(
     }
 }
 
+pub(crate) fn clear_unburned_chain_absorb_intent_in_state(
+    state: &mut StabilityPoolState,
+    vault_id: u64,
+) -> bool {
+    let Some(intent) = state.get_pending_chain_absorb(vault_id) else {
+        return false;
+    };
+    if intent.status == ChainSpAbsorbIntentStatus::Prepared
+        && intent.burn_proof.is_none()
+        && intent.backend_result.is_none()
+    {
+        state.take_pending_chain_absorb(vault_id);
+        return true;
+    }
+    false
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CfxClaimPayoutPlan {
     pub claimant: Principal,
@@ -778,6 +795,12 @@ pub async fn scan_chain_absorb_candidates(
         return Err(StabilityPoolError::Unauthorized);
     }
 
+    discover_chain_absorb_candidates(max_per_chain).await
+}
+
+async fn discover_chain_absorb_candidates(
+    max_per_chain: Option<u64>,
+) -> Result<Vec<ChainSpAbsorbCandidate>, StabilityPoolError> {
     let (protocol_id, chains) = read_state(|s| {
         (
             s.protocol_canister_id,
@@ -794,11 +817,8 @@ pub async fn scan_chain_absorb_candidates(
             method: "get_chain_liquidatable_vaults".to_string(),
         })?;
 
-        for vault in vaults
-            .into_iter()
-            .filter(|v| v.sp_attempted)
-            .take(per_chain)
-        {
+        let mut eligible_for_chain = 0usize;
+        for vault in vaults.into_iter().filter(|v| v.sp_attempted) {
             if let Ok(plan) = read_state(|s| prepare_chain_absorb_plan_in_state(s, &vault)) {
                 let pending_status = read_state(|s| s.pending_chain_absorb_status(vault.vault_id));
                 candidates.push(ChainSpAbsorbCandidate {
@@ -806,11 +826,27 @@ pub async fn scan_chain_absorb_candidates(
                     icusd_to_burn_e8s: plan.icusd_to_burn_e8s,
                     pending_status,
                 });
+                eligible_for_chain += 1;
+                if eligible_for_chain >= per_chain {
+                    break;
+                }
             }
         }
     }
 
     Ok(candidates)
+}
+
+pub(crate) fn select_chain_absorb_auto_vault(
+    state: &StabilityPoolState,
+    candidates: &[ChainSpAbsorbCandidate],
+) -> Option<u64> {
+    state
+        .pending_chain_absorbs()
+        .into_iter()
+        .map(|intent| intent.vault_id)
+        .next()
+        .or_else(|| candidates.first().map(|candidate| candidate.vault.vault_id))
 }
 
 async fn submit_chain_absorb_to_backend(
@@ -872,6 +908,31 @@ async fn submit_chain_absorb_to_backend(
     }
 }
 
+async fn preflight_chain_absorb_with_backend(
+    protocol_id: Principal,
+    vault_id: u64,
+    icusd_to_burn_e8s: u64,
+) -> Result<(), StabilityPoolError> {
+    let preflight_result: Result<(Result<(), rumi_protocol_backend::ProtocolError>,), _> = call(
+        protocol_id,
+        "stability_pool_preflight_chain_absorb",
+        (vault_id, icusd_to_burn_e8s),
+    )
+    .await;
+
+    match preflight_result {
+        Ok((Ok(()),)) => Ok(()),
+        Ok((Err(error),)) => Err(StabilityPoolError::LiquidationFailed {
+            vault_id,
+            reason: format!("backend rejected chain absorb preflight: {:?}", error),
+        }),
+        Err(_) => Err(StabilityPoolError::InterCanisterCallFailed {
+            target: format!("{}", protocol_id),
+            method: "stability_pool_preflight_chain_absorb".to_string(),
+        }),
+    }
+}
+
 pub async fn sp_absorb_chain_vault(
     vault_id: u64,
 ) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
@@ -882,9 +943,12 @@ pub async fn sp_absorb_chain_vault(
     if !read_state(|s| s.is_admin(&caller)) {
         return Err(StabilityPoolError::Unauthorized);
     }
-    if read_state(|s| s.configuration.emergency_pause) {
-        return Err(StabilityPoolError::EmergencyPaused);
-    }
+    sp_absorb_chain_vault_core(vault_id).await
+}
+
+async fn sp_absorb_chain_vault_core(
+    vault_id: u64,
+) -> Result<ChainSpAbsorbResult, StabilityPoolError> {
     if let Some(completion) = read_state(|s| s.completed_chain_absorb(vault_id)) {
         return Ok(completion.result);
     }
@@ -903,6 +967,57 @@ pub async fn sp_absorb_chain_vault(
                 submit_chain_absorb_to_backend(protocol_id, vault_id, &plan, proof).await?;
             return mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result));
         }
+
+        if read_state(|s| s.configuration.emergency_pause) {
+            return Err(StabilityPoolError::EmergencyPaused);
+        }
+        let protocol_id = read_state(|s| s.protocol_canister_id);
+        if let Err(error) =
+            preflight_chain_absorb_with_backend(protocol_id, vault_id, plan.icusd_to_burn_e8s).await
+        {
+            mutate_state(|s| {
+                clear_unburned_chain_absorb_intent_in_state(s, vault_id);
+            });
+            return Err(error);
+        }
+        if read_state(|s| s.configuration.emergency_pause) {
+            return Err(StabilityPoolError::EmergencyPaused);
+        }
+
+        let proof = match burn_icusd_for_chain_writedown_with_account(
+            intent.icusd_ledger,
+            intent.icusd_minting_account,
+            intent.icusd_to_burn_e8s,
+            intent.vault_id,
+            intent.burn_created_at_time_ns,
+        )
+        .await
+        {
+            Ok(proof) => {
+                mutate_state(|s| {
+                    mark_chain_absorb_burned_in_state(
+                        s,
+                        vault_id,
+                        proof.clone(),
+                        ic_cdk::api::time(),
+                    )
+                })?;
+                proof
+            }
+            Err(error) => {
+                mutate_state(|s| {
+                    clear_unburned_chain_absorb_intent_in_state(s, vault_id);
+                });
+                return Err(error);
+            }
+        };
+
+        let result = submit_chain_absorb_to_backend(protocol_id, vault_id, &plan, proof).await?;
+        return mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result));
+    }
+
+    if read_state(|s| s.configuration.emergency_pause) {
+        return Err(StabilityPoolError::EmergencyPaused);
     }
 
     let (protocol_id, chains) = read_state(|s| {
@@ -942,10 +1057,23 @@ pub async fn sp_absorb_chain_vault(
         Some(intent) => intent.icusd_minting_account,
         None => fetch_icusd_minting_account(plan.icusd_ledger).await?,
     };
+    if read_state(|s| s.configuration.emergency_pause) {
+        return Err(StabilityPoolError::EmergencyPaused);
+    }
+    preflight_chain_absorb_with_backend(protocol_id, vault_id, plan.icusd_to_burn_e8s).await?;
+    if read_state(|s| s.configuration.emergency_pause) {
+        return Err(StabilityPoolError::EmergencyPaused);
+    }
     let now = ic_cdk::api::time();
     let mut intent = mutate_state(|s| {
         prepare_or_reuse_chain_absorb_intent_in_state(s, &plan, minting_account, now)
     })?;
+    if read_state(|s| s.configuration.emergency_pause) {
+        mutate_state(|s| {
+            clear_unburned_chain_absorb_intent_in_state(s, vault_id);
+        });
+        return Err(StabilityPoolError::EmergencyPaused);
+    }
 
     let proof = if let Some(proof) = intent.burn_proof.clone() {
         proof
@@ -972,13 +1100,7 @@ pub async fn sp_absorb_chain_vault(
             }
             Err(error) => {
                 mutate_state(|s| {
-                    mark_chain_absorb_error_in_state(
-                        s,
-                        vault_id,
-                        ChainSpAbsorbIntentStatus::Prepared,
-                        format!("icUSD burn failed: {:?}", error),
-                        ic_cdk::api::time(),
-                    );
+                    clear_unburned_chain_absorb_intent_in_state(s, vault_id);
                 });
                 return Err(error);
             }
@@ -992,6 +1114,103 @@ pub async fn sp_absorb_chain_vault(
     };
 
     mutate_state(|s| apply_chain_absorb_success_in_state(s, &plan, result))
+}
+
+pub async fn run_chain_absorb_auto_tick(
+) -> Result<Option<ChainAbsorbAutoTickRecord>, StabilityPoolError> {
+    let started_at_ns = ic_cdk::api::time();
+    if !read_state(|s| s.chain_absorb_auto_due(started_at_ns)) {
+        return Ok(None);
+    }
+
+    let _tick_guard = crate::pool_guard::ChainAbsorbAutoTickGuard::new()?;
+    let config = read_state(|s| s.chain_absorb_auto_config());
+    if !config.enabled || !read_state(|s| s.chain_absorb_auto_due(started_at_ns)) {
+        return Ok(None);
+    }
+
+    if read_state(|s| s.configuration.emergency_pause) {
+        let tick = ChainAbsorbAutoTickRecord {
+            started_at_ns,
+            completed_at_ns: ic_cdk::api::time(),
+            attempted_vault_id: None,
+            candidates_scanned: 0,
+            absorbed: None,
+            error: None,
+            skipped_reason: Some("emergency pause".to_string()),
+        };
+        mutate_state(|s| s.record_chain_absorb_auto_tick(tick.clone()));
+        return Ok(Some(tick));
+    }
+
+    let pending_vault = read_state(|s| {
+        s.pending_chain_absorbs()
+            .into_iter()
+            .map(|intent| intent.vault_id)
+            .next()
+    });
+    let (vault_id, candidates_scanned) = if let Some(vault_id) = pending_vault {
+        (vault_id, 0)
+    } else {
+        let candidates =
+            match discover_chain_absorb_candidates(Some(config.max_scan_per_chain)).await {
+                Ok(candidates) => candidates,
+                Err(error) => {
+                    let tick = ChainAbsorbAutoTickRecord {
+                        started_at_ns,
+                        completed_at_ns: ic_cdk::api::time(),
+                        attempted_vault_id: None,
+                        candidates_scanned: 0,
+                        absorbed: None,
+                        error: Some(format!("{error:?}")),
+                        skipped_reason: None,
+                    };
+                    mutate_state(|s| s.record_chain_absorb_auto_tick(tick.clone()));
+                    return Ok(Some(tick));
+                }
+            };
+        let candidates_scanned = candidates.len() as u64;
+        match read_state(|s| select_chain_absorb_auto_vault(s, &candidates)) {
+            Some(vault_id) => (vault_id, candidates_scanned),
+            None => {
+                let tick = ChainAbsorbAutoTickRecord {
+                    started_at_ns,
+                    completed_at_ns: ic_cdk::api::time(),
+                    attempted_vault_id: None,
+                    candidates_scanned,
+                    absorbed: None,
+                    error: None,
+                    skipped_reason: Some("no eligible candidates".to_string()),
+                };
+                mutate_state(|s| s.record_chain_absorb_auto_tick(tick.clone()));
+                return Ok(Some(tick));
+            }
+        }
+    };
+
+    let result = sp_absorb_chain_vault_core(vault_id).await;
+    let tick = match result {
+        Ok(absorbed) => ChainAbsorbAutoTickRecord {
+            started_at_ns,
+            completed_at_ns: ic_cdk::api::time(),
+            attempted_vault_id: Some(vault_id),
+            candidates_scanned,
+            absorbed: Some(absorbed),
+            error: None,
+            skipped_reason: None,
+        },
+        Err(error) => ChainAbsorbAutoTickRecord {
+            started_at_ns,
+            completed_at_ns: ic_cdk::api::time(),
+            attempted_vault_id: Some(vault_id),
+            candidates_scanned,
+            absorbed: None,
+            error: Some(format!("{error:?}")),
+            skipped_reason: None,
+        },
+    };
+    mutate_state(|s| s.record_chain_absorb_auto_tick(tick.clone()));
+    Ok(Some(tick))
 }
 
 pub async fn claim_cfx(
@@ -1852,6 +2071,53 @@ mod tests {
     }
 
     #[test]
+    fn unburned_prepared_chain_absorb_intent_can_be_cleared_after_failure() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("intent is recorded");
+
+        assert!(state.has_pending_chain_absorbs());
+        assert!(clear_unburned_chain_absorb_intent_in_state(&mut state, 77));
+        assert!(
+            !state.has_pending_chain_absorbs(),
+            "a failed pre-burn attempt must not wedge pool balance operations"
+        );
+    }
+
+    #[test]
+    fn burned_chain_absorb_intent_is_not_cleared_as_unburned_failure() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+        let plan = prepare_chain_absorb_plan_in_state(&state, &chain_vault(100_00000000, true))
+            .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("intent is recorded");
+        mark_chain_absorb_burned_in_state(&mut state, 77, build_icusd_burn_proof(44, 77), 456)
+            .expect("proof recorded");
+
+        assert!(!clear_unburned_chain_absorb_intent_in_state(&mut state, 77));
+        assert!(
+            state.has_pending_chain_absorbs(),
+            "burned intents must remain for backend finalization/retry"
+        );
+    }
+
+    #[test]
     fn burned_chain_absorb_intent_replays_backend_without_discovery() {
         let mut state = test_state();
         state
@@ -1890,9 +2156,11 @@ mod tests {
             .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
             .unwrap();
 
-        let plan_a =
-            prepare_chain_absorb_plan_in_state(&state, &chain_vault_with_id(77, 100_00000000, true))
-                .expect("vault A covered");
+        let plan_a = prepare_chain_absorb_plan_in_state(
+            &state,
+            &chain_vault_with_id(77, 100_00000000, true),
+        )
+        .expect("vault A covered");
         prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan_a, minting_account(), 123)
             .expect("intent A is recorded");
         mark_chain_absorb_burned_in_state(&mut state, 77, build_icusd_burn_proof(44, 77), 456)
@@ -1908,6 +2176,59 @@ mod tests {
                 Err(StabilityPoolError::SystemBusy)
             ),
             "a burned pending intent reserves its icUSD until local finalization",
+        );
+    }
+
+    #[test]
+    fn auto_absorb_selection_prefers_pending_intent_before_new_candidate() {
+        let mut state = test_state();
+        state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), chain_collateral_sentinel(1030))
+            .unwrap();
+
+        let plan = prepare_chain_absorb_plan_in_state(
+            &state,
+            &chain_vault_with_id(77, 100_00000000, true),
+        )
+        .expect("covered");
+        prepare_or_reuse_chain_absorb_intent_in_state(&mut state, &plan, minting_account(), 123)
+            .expect("pending intent");
+
+        let candidates = vec![ChainSpAbsorbCandidate {
+            vault: chain_vault_with_id(88, 100_00000000, true),
+            icusd_to_burn_e8s: 100_00000000,
+            pending_status: None,
+        }];
+
+        assert_eq!(
+            select_chain_absorb_auto_vault(&state, &candidates),
+            Some(77)
+        );
+    }
+
+    #[test]
+    fn auto_absorb_selection_uses_first_candidate_when_no_pending_intent() {
+        let state = test_state();
+        let candidates = vec![
+            ChainSpAbsorbCandidate {
+                vault: chain_vault_with_id(88, 100_00000000, true),
+                icusd_to_burn_e8s: 100_00000000,
+                pending_status: None,
+            },
+            ChainSpAbsorbCandidate {
+                vault: chain_vault_with_id(99, 100_00000000, true),
+                icusd_to_burn_e8s: 100_00000000,
+                pending_status: None,
+            },
+        ];
+
+        assert_eq!(
+            select_chain_absorb_auto_vault(&state, &candidates),
+            Some(88)
         );
     }
 

--- a/src/stability_pool/src/pool_guard.rs
+++ b/src/stability_pool/src/pool_guard.rs
@@ -24,6 +24,7 @@ use std::cell::RefCell;
 
 thread_local! {
     static LIQUIDATION_ACTIVE: RefCell<bool> = const { RefCell::new(false) };
+    static BALANCE_ASYNC_IN_FLIGHT: RefCell<u32> = const { RefCell::new(0) };
 }
 
 #[must_use]
@@ -58,6 +59,39 @@ pub fn liquidation_in_progress() -> bool {
     LIQUIDATION_ACTIVE.with(|f| *f.borrow())
 }
 
+#[must_use]
+pub struct PoolBalanceAsyncGuard;
+
+impl PoolBalanceAsyncGuard {
+    /// Mark a deduct-before-transfer balance operation as in flight across an
+    /// outbound ledger await. SP chain absorb must not start in this window:
+    /// rollback may need to restore stable balances if the ledger rejects.
+    pub fn new() -> Self {
+        BALANCE_ASYNC_IN_FLIGHT.with(|f| {
+            let mut count = f.borrow_mut();
+            *count = count.saturating_add(1);
+        });
+        Self
+    }
+}
+
+impl Drop for PoolBalanceAsyncGuard {
+    fn drop(&mut self) {
+        BALANCE_ASYNC_IN_FLIGHT.with(|f| {
+            let mut count = f.borrow_mut();
+            *count = count.saturating_sub(1);
+        });
+    }
+}
+
+/// True while a deduct-before-transfer balance operation is awaiting a ledger
+/// response. Chain absorb refuses to start while this is true, so a failed
+/// withdrawal rollback cannot mutate the stablecoin denominator after an SP
+/// chain burn intent has been prepared.
+pub fn balance_async_in_flight() -> bool {
+    BALANCE_ASYNC_IN_FLIGHT.with(|f| *f.borrow() > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,5 +108,22 @@ mod tests {
         drop(g);
         assert!(!liquidation_in_progress(), "lock released on drop");
         let _g2 = SpLiquidationGuard::new().expect("re-acquire after release");
+    }
+
+    #[test]
+    fn pool_balance_async_guard_tracks_nested_inflight_operations() {
+        assert!(!balance_async_in_flight());
+        let g1 = PoolBalanceAsyncGuard::new();
+        assert!(balance_async_in_flight());
+        {
+            let _g2 = PoolBalanceAsyncGuard::new();
+            assert!(balance_async_in_flight());
+        }
+        assert!(
+            balance_async_in_flight(),
+            "outer balance operation still blocks SP absorb",
+        );
+        drop(g1);
+        assert!(!balance_async_in_flight());
     }
 }

--- a/src/stability_pool/src/pool_guard.rs
+++ b/src/stability_pool/src/pool_guard.rs
@@ -25,6 +25,7 @@ use std::cell::RefCell;
 thread_local! {
     static LIQUIDATION_ACTIVE: RefCell<bool> = const { RefCell::new(false) };
     static BALANCE_ASYNC_IN_FLIGHT: RefCell<u32> = const { RefCell::new(0) };
+    static CHAIN_ABSORB_AUTO_TICK_ACTIVE: RefCell<bool> = const { RefCell::new(false) };
 }
 
 #[must_use]
@@ -92,6 +93,35 @@ pub fn balance_async_in_flight() -> bool {
     BALANCE_ASYNC_IN_FLIGHT.with(|f| *f.borrow() > 0)
 }
 
+#[must_use]
+pub struct ChainAbsorbAutoTickGuard;
+
+impl ChainAbsorbAutoTickGuard {
+    /// Acquire the exclusive automatic chain-absorb tick lock. Timer ticks may
+    /// overlap when an earlier tick is awaiting ledger/backend responses; the
+    /// second tick exits with `SystemBusy` instead of spawning another burn.
+    pub fn new() -> Result<Self, StabilityPoolError> {
+        CHAIN_ABSORB_AUTO_TICK_ACTIVE.with(|f| {
+            let mut held = f.borrow_mut();
+            if *held {
+                return Err(StabilityPoolError::SystemBusy);
+            }
+            *held = true;
+            Ok(Self)
+        })
+    }
+}
+
+impl Drop for ChainAbsorbAutoTickGuard {
+    fn drop(&mut self) {
+        CHAIN_ABSORB_AUTO_TICK_ACTIVE.with(|f| *f.borrow_mut() = false);
+    }
+}
+
+pub fn chain_absorb_auto_tick_in_flight() -> bool {
+    CHAIN_ABSORB_AUTO_TICK_ACTIVE.with(|f| *f.borrow())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,7 +130,10 @@ mod tests {
     fn sp_liquidation_guard_is_exclusive_and_blocks_ops() {
         assert!(!liquidation_in_progress());
         let g = SpLiquidationGuard::new().expect("first acquire");
-        assert!(liquidation_in_progress(), "deposit/withdraw/claim see the lock as held");
+        assert!(
+            liquidation_in_progress(),
+            "deposit/withdraw/claim see the lock as held"
+        );
         assert!(
             SpLiquidationGuard::new().is_err(),
             "a second concurrent liquidation must be rejected (SystemBusy)",
@@ -125,5 +158,21 @@ mod tests {
         );
         drop(g1);
         assert!(!balance_async_in_flight());
+    }
+
+    #[test]
+    fn chain_absorb_auto_tick_guard_is_exclusive() {
+        assert!(!chain_absorb_auto_tick_in_flight());
+        let guard = ChainAbsorbAutoTickGuard::new().expect("first tick starts");
+        assert!(chain_absorb_auto_tick_in_flight());
+        assert!(
+            matches!(
+                ChainAbsorbAutoTickGuard::new(),
+                Err(StabilityPoolError::SystemBusy)
+            ),
+            "a second timer tick must not overlap the first"
+        );
+        drop(guard);
+        assert!(!chain_absorb_auto_tick_in_flight());
     }
 }

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -54,6 +54,17 @@ pub struct StabilityPoolState {
     /// Latest automatic chain absorb tick, retained as bounded operator status.
     #[serde(default)]
     pub chain_absorb_auto_last_tick: Option<ChainAbsorbAutoTickRecord>,
+    /// Durable idempotency journal for backend-confirmed failed CFX claim payout
+    /// recovery. Without this, retrying the backend callback would double-credit
+    /// both the depositor claim and the backend claim source.
+    #[serde(default)]
+    pub completed_cfx_claim_payout_recoveries:
+        Option<BTreeMap<CfxClaimPayoutRecoveryKey, CfxClaimPayoutRecoveryRecord>>,
+    /// Compact idempotency watermark for recovery records evicted from
+    /// `completed_cfx_claim_payout_recoveries`. A replay with an op_id at or
+    /// below the per-sentinel floor is treated as already recovered.
+    #[serde(default)]
+    pub completed_cfx_claim_payout_recovery_floor: Option<BTreeMap<Principal, u64>>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -108,6 +119,8 @@ impl Default for StabilityPoolState {
             completed_chain_absorbs: Some(BTreeMap::new()),
             chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
             chain_absorb_auto_last_tick: None,
+            completed_cfx_claim_payout_recoveries: Some(BTreeMap::new()),
+            completed_cfx_claim_payout_recovery_floor: Some(BTreeMap::new()),
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -142,6 +155,7 @@ const MAX_POOL_EVENTS: usize = 10_000;
 pub const MAX_PENDING_REFUNDS: usize = 10_000;
 pub const MAX_PENDING_CHAIN_ABSORBS: usize = 1_000;
 pub const MAX_COMPLETED_CHAIN_ABSORBS: usize = 10_000;
+pub const MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES: usize = 10_000;
 
 impl StabilityPoolState {
     pub fn initialize(&mut self, args: StabilityPoolInitArgs) {
@@ -715,6 +729,52 @@ impl StabilityPoolState {
         self.completed_chain_absorbs
             .as_ref()
             .and_then(|m| m.get(&vault_id).cloned())
+    }
+
+    pub fn completed_cfx_claim_payout_recovery(
+        &self,
+        key: &CfxClaimPayoutRecoveryKey,
+    ) -> Option<CfxClaimPayoutRecoveryRecord> {
+        self.completed_cfx_claim_payout_recoveries
+            .as_ref()
+            .and_then(|m| m.get(key).cloned())
+    }
+
+    pub fn completed_cfx_claim_payout_recovery_was_evicted(
+        &self,
+        key: &CfxClaimPayoutRecoveryKey,
+    ) -> bool {
+        self.completed_cfx_claim_payout_recovery_floor
+            .as_ref()
+            .and_then(|m| m.get(&key.chain_sentinel))
+            .map(|floor| key.op_id <= *floor)
+            .unwrap_or(false)
+    }
+
+    pub fn record_completed_cfx_claim_payout_recovery(
+        &mut self,
+        record: CfxClaimPayoutRecoveryRecord,
+    ) {
+        let completed = self
+            .completed_cfx_claim_payout_recoveries
+            .get_or_insert_with(BTreeMap::new);
+        completed.insert(record.key.clone(), record);
+        while completed.len() > MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES {
+            let Some(oldest_key) = completed
+                .iter()
+                .min_by_key(|(key, record)| (record.recovered_at_ns, (*key).clone()))
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            if let Some(evicted) = completed.remove(&oldest_key) {
+                let floors = self
+                    .completed_cfx_claim_payout_recovery_floor
+                    .get_or_insert_with(BTreeMap::new);
+                let floor = floors.entry(evicted.key.chain_sentinel).or_insert(0);
+                *floor = (*floor).max(evicted.key.op_id);
+            }
+        }
     }
 
     pub fn chain_absorb_auto_config(&self) -> ChainAbsorbAutoConfig {
@@ -1577,6 +1637,7 @@ impl StabilityPoolState {
         self.deposits.get(user).map(|pos| UserStabilityPosition {
             stablecoin_balances: pos.stablecoin_balances.clone(),
             collateral_gains: pos.collateral_gains.clone(),
+            cfx_claims: pos.cfx_claims.clone(),
             opted_out_collateral: pos.opted_out_collateral.iter().cloned().collect(),
             deposit_timestamp: pos.deposit_timestamp,
             total_claimed_gains: pos.total_claimed_gains.clone(),
@@ -1832,6 +1893,8 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             completed_chain_absorbs: Some(BTreeMap::new()),
             chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
             chain_absorb_auto_last_tick: None,
+            completed_cfx_claim_payout_recoveries: Some(BTreeMap::new()),
+            completed_cfx_claim_payout_recovery_floor: Some(BTreeMap::new()),
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -3160,6 +3223,13 @@ mod tests {
 
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
         add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 25_000_000);
+        state
+            .deposits
+            .get_mut(&user_a())
+            .unwrap()
+            .cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(cfx_sentinel(), 1_000_000_000_000_000_000);
 
         let pos = state.get_user_position(&user_a()).unwrap();
         assert_eq!(pos.total_usd_value_e8s, 125_00000000); // 100 + 25
@@ -3171,9 +3241,24 @@ mod tests {
             pos.stablecoin_balances.get(&ckusdt_ledger()),
             Some(&25_000_000)
         );
+        assert_eq!(
+            pos.cfx_claims
+                .as_ref()
+                .and_then(|claims| claims.get(&cfx_sentinel()))
+                .copied(),
+            Some(1_000_000_000_000_000_000),
+            "user position exposes restored CFX claims for auditability",
+        );
+
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 1_00000000);
+        let pos_b = state.get_user_position(&user_b()).unwrap();
+        assert!(
+            pos_b.cfx_claims.clone().unwrap_or_default().is_empty(),
+            "normal depositors without chain claims expose an empty optional map",
+        );
 
         // Nonexistent user
-        assert!(state.get_user_position(&user_b()).is_none());
+        assert!(state.get_user_position(&user_c()).is_none());
     }
 
     // ─── Test: Multiple deposits accumulate ───
@@ -3986,6 +4071,22 @@ mod tests {
                 .unwrap_or_default()
                 .is_empty(),
             "missing completed chain absorb journal must decode as empty",
+        );
+        assert!(
+            decoded
+                .completed_cfx_claim_payout_recoveries
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing CFX claim payout recovery journal must decode as empty",
+        );
+        assert!(
+            decoded
+                .completed_cfx_claim_payout_recovery_floor
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing CFX claim payout recovery floor must decode as empty",
         );
     }
 

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -48,6 +48,12 @@ pub struct StabilityPoolState {
     /// Local idempotency record for completed chain-vault SP absorbs.
     #[serde(default)]
     pub completed_chain_absorbs: Option<BTreeMap<u64, ChainSpAbsorbCompletion>>,
+    /// Disabled-by-default automatic chain absorb scheduler configuration.
+    #[serde(default)]
+    pub chain_absorb_auto_config: Option<ChainAbsorbAutoConfig>,
+    /// Latest automatic chain absorb tick, retained as bounded operator status.
+    #[serde(default)]
+    pub chain_absorb_auto_last_tick: Option<ChainAbsorbAutoTickRecord>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -100,6 +106,8 @@ impl Default for StabilityPoolState {
             chain_claim_sources: Some(BTreeMap::new()),
             pending_chain_absorbs: Some(BTreeMap::new()),
             completed_chain_absorbs: Some(BTreeMap::new()),
+            chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
+            chain_absorb_auto_last_tick: None,
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -707,6 +715,56 @@ impl StabilityPoolState {
         self.completed_chain_absorbs
             .as_ref()
             .and_then(|m| m.get(&vault_id).cloned())
+    }
+
+    pub fn chain_absorb_auto_config(&self) -> ChainAbsorbAutoConfig {
+        self.chain_absorb_auto_config.clone().unwrap_or_default()
+    }
+
+    pub fn set_chain_absorb_auto_config(
+        &mut self,
+        mut config: ChainAbsorbAutoConfig,
+    ) -> Result<(), StabilityPoolError> {
+        if config.interval_seconds < MIN_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id: 0,
+                reason: format!(
+                    "chain absorb auto interval must be at least {} seconds",
+                    MIN_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS
+                ),
+            });
+        }
+        if config.max_scan_per_chain == 0 {
+            return Err(StabilityPoolError::LiquidationFailed {
+                vault_id: 0,
+                reason: "chain absorb auto max_scan_per_chain must be greater than 0".to_string(),
+            });
+        }
+        config.max_scan_per_chain = config
+            .max_scan_per_chain
+            .min(MAX_CHAIN_ABSORB_AUTO_SCAN_PER_CHAIN);
+        self.chain_absorb_auto_config = Some(config);
+        Ok(())
+    }
+
+    pub fn chain_absorb_auto_last_tick(&self) -> Option<ChainAbsorbAutoTickRecord> {
+        self.chain_absorb_auto_last_tick.clone()
+    }
+
+    pub fn record_chain_absorb_auto_tick(&mut self, tick: ChainAbsorbAutoTickRecord) {
+        self.chain_absorb_auto_last_tick = Some(tick);
+    }
+
+    pub fn chain_absorb_auto_due(&self, now_ns: u64) -> bool {
+        let config = self.chain_absorb_auto_config();
+        if !config.enabled {
+            return false;
+        }
+        let Some(last) = &self.chain_absorb_auto_last_tick else {
+            return true;
+        };
+        let elapsed_ns = now_ns.saturating_sub(last.completed_at_ns);
+        elapsed_ns >= config.interval_seconds.saturating_mul(1_000_000_000)
     }
 
     // ─── Opt-in / Opt-out ───
@@ -1772,6 +1830,8 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             chain_claim_sources: Some(BTreeMap::new()),
             pending_chain_absorbs: Some(BTreeMap::new()),
             completed_chain_absorbs: Some(BTreeMap::new()),
+            chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
+            chain_absorb_auto_last_tick: None,
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -2460,6 +2520,144 @@ mod tests {
         let state = test_state();
         // Empty state with zero totals should pass
         assert!(state.validate_state().is_ok());
+    }
+
+    #[test]
+    fn chain_absorb_auto_fields_decode_disabled_when_missing() {
+        let mut current = StabilityPoolState::default();
+        current
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+
+        #[derive(CandidType, Clone, Debug, Serialize, Deserialize)]
+        struct PreInc9State {
+            deposits: BTreeMap<Principal, DepositPosition>,
+            total_stablecoin_balances: BTreeMap<Principal, u64>,
+            stablecoin_registry: BTreeMap<Principal, StablecoinConfig>,
+            collateral_registry: BTreeMap<Principal, CollateralInfo>,
+            chain_collateral_sentinels: Option<BTreeSet<Principal>>,
+            chain_claim_sources: Option<BTreeMap<Principal, Vec<ChainClaimSource>>>,
+            pending_chain_absorbs: Option<BTreeMap<u64, ChainSpAbsorbIntent>>,
+            completed_chain_absorbs: Option<BTreeMap<u64, ChainSpAbsorbCompletion>>,
+            protocol_canister_id: Principal,
+            configuration: PoolConfiguration,
+            liquidation_history: Vec<PoolLiquidationRecord>,
+            in_flight_liquidations: BTreeSet<u64>,
+            total_liquidations_executed: u64,
+            pool_creation_timestamp: u64,
+            total_interest_received_e8s: Option<u64>,
+            token_consecutive_failures: Option<BTreeMap<Principal, u32>>,
+            cached_virtual_prices: Option<BTreeMap<Principal, u128>>,
+            protocol_reserve_address: Option<Principal>,
+            is_initialized: bool,
+            pool_events: Option<Vec<PoolEvent>>,
+            next_event_id: Option<u64>,
+            pending_refunds: Option<BTreeMap<u64, PendingRefund>>,
+            next_pending_refund_id: Option<u64>,
+        }
+
+        let old = PreInc9State {
+            deposits: current.deposits.clone(),
+            total_stablecoin_balances: current.total_stablecoin_balances.clone(),
+            stablecoin_registry: current.stablecoin_registry.clone(),
+            collateral_registry: current.collateral_registry.clone(),
+            chain_collateral_sentinels: current.chain_collateral_sentinels.clone(),
+            chain_claim_sources: current.chain_claim_sources.clone(),
+            pending_chain_absorbs: current.pending_chain_absorbs.clone(),
+            completed_chain_absorbs: current.completed_chain_absorbs.clone(),
+            protocol_canister_id: current.protocol_canister_id,
+            configuration: current.configuration.clone(),
+            liquidation_history: current.liquidation_history.clone(),
+            in_flight_liquidations: current.in_flight_liquidations.clone(),
+            total_liquidations_executed: current.total_liquidations_executed,
+            pool_creation_timestamp: current.pool_creation_timestamp,
+            total_interest_received_e8s: current.total_interest_received_e8s,
+            token_consecutive_failures: current.token_consecutive_failures.clone(),
+            cached_virtual_prices: current.cached_virtual_prices.clone(),
+            protocol_reserve_address: current.protocol_reserve_address,
+            is_initialized: current.is_initialized,
+            pool_events: current.pool_events.clone(),
+            next_event_id: current.next_event_id,
+            pending_refunds: current.pending_refunds.clone(),
+            next_pending_refund_id: current.next_pending_refund_id,
+        };
+
+        let bytes = Encode!(&old).unwrap();
+        let decoded = Decode!(&bytes, StabilityPoolState).unwrap();
+        let config = decoded.chain_absorb_auto_config();
+
+        assert!(!config.enabled);
+        assert_eq!(
+            config.interval_seconds,
+            DEFAULT_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS
+        );
+        assert_eq!(
+            config.max_scan_per_chain,
+            DEFAULT_CHAIN_ABSORB_AUTO_MAX_SCAN_PER_CHAIN
+        );
+        assert!(decoded.chain_absorb_auto_last_tick().is_none());
+    }
+
+    #[test]
+    fn chain_absorb_auto_config_validation_rejects_saturating_timer_values() {
+        let mut state = StabilityPoolState::default();
+        let too_fast = ChainAbsorbAutoConfig {
+            enabled: true,
+            interval_seconds: MIN_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS - 1,
+            max_scan_per_chain: 1,
+        };
+        assert!(matches!(
+            state.set_chain_absorb_auto_config(too_fast),
+            Err(StabilityPoolError::LiquidationFailed { .. })
+        ));
+
+        let no_scan = ChainAbsorbAutoConfig {
+            enabled: true,
+            interval_seconds: DEFAULT_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS,
+            max_scan_per_chain: 0,
+        };
+        assert!(matches!(
+            state.set_chain_absorb_auto_config(no_scan),
+            Err(StabilityPoolError::LiquidationFailed { .. })
+        ));
+
+        let accepted = ChainAbsorbAutoConfig {
+            enabled: true,
+            interval_seconds: MIN_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS,
+            max_scan_per_chain: 500,
+        };
+        state
+            .set_chain_absorb_auto_config(accepted.clone())
+            .unwrap();
+        assert_eq!(state.chain_absorb_auto_config(), accepted);
+    }
+
+    #[test]
+    fn chain_absorb_auto_due_requires_enabled_and_elapsed_interval() {
+        let mut state = StabilityPoolState::default();
+        assert!(!state.chain_absorb_auto_due(1_000_000_000_000));
+
+        state
+            .set_chain_absorb_auto_config(ChainAbsorbAutoConfig {
+                enabled: true,
+                interval_seconds: 300,
+                max_scan_per_chain: 1,
+            })
+            .unwrap();
+        assert!(state.chain_absorb_auto_due(1_000_000_000_000));
+
+        state.record_chain_absorb_auto_tick(ChainAbsorbAutoTickRecord {
+            started_at_ns: 1_000_000_000_000,
+            completed_at_ns: 1_001_000_000_000,
+            attempted_vault_id: None,
+            candidates_scanned: 0,
+            absorbed: None,
+            error: None,
+            skipped_reason: Some("no eligible candidates".to_string()),
+        });
+
+        assert!(!state.chain_absorb_auto_due(1_100_000_000_000));
+        assert!(state.chain_absorb_auto_due(1_301_000_000_000));
     }
 
     // ─── Test: DepositPosition helpers ───

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::cell::RefCell;
-use candid::{CandidType, Principal, Decode, Encode};
+use candid::{CandidType, Decode, Encode, Principal};
 use ic_canister_log::log;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::types::*;
 use crate::logs::INFO;
+use crate::types::*;
 
 /// Maximum number of liquidation records retained in memory.
 /// Older entries are dropped when this limit is exceeded.
@@ -41,6 +41,13 @@ pub struct StabilityPoolState {
     /// keyed by chain sentinel. `Option` keeps Candid stable memory upgrades safe.
     #[serde(default)]
     pub chain_claim_sources: Option<BTreeMap<Principal, Vec<ChainClaimSource>>>,
+    /// Retry journal for chain-vault SP absorbs that may have burned icUSD but
+    /// not yet finalized local depositor accounting.
+    #[serde(default)]
+    pub pending_chain_absorbs: Option<BTreeMap<u64, ChainSpAbsorbIntent>>,
+    /// Local idempotency record for completed chain-vault SP absorbs.
+    #[serde(default)]
+    pub completed_chain_absorbs: Option<BTreeMap<u64, ChainSpAbsorbCompletion>>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -91,6 +98,8 @@ impl Default for StabilityPoolState {
             collateral_registry: BTreeMap::new(),
             chain_collateral_sentinels: Some(BTreeSet::new()),
             chain_claim_sources: Some(BTreeMap::new()),
+            pending_chain_absorbs: Some(BTreeMap::new()),
+            completed_chain_absorbs: Some(BTreeMap::new()),
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -123,6 +132,8 @@ const MAX_POOL_EVENTS: usize = 10_000;
 /// which is not caller-controllable, so this is a memory-safety bound rather
 /// than an anti-DoS one (mirrors rumi_3pool's MAX_PENDING_CLAIMS).
 pub const MAX_PENDING_REFUNDS: usize = 10_000;
+pub const MAX_PENDING_CHAIN_ABSORBS: usize = 1_000;
+pub const MAX_COMPLETED_CHAIN_ABSORBS: usize = 10_000;
 
 impl StabilityPoolState {
     pub fn initialize(&mut self, args: StabilityPoolInitArgs) {
@@ -160,7 +171,10 @@ impl StabilityPoolState {
     }
 
     pub fn pool_event_count(&self) -> u64 {
-        self.pool_events.as_ref().map(|v| v.len() as u64).unwrap_or(0)
+        self.pool_events
+            .as_ref()
+            .map(|v| v.len() as u64)
+            .unwrap_or(0)
     }
 
     pub fn is_admin(&self, caller: &Principal) -> bool {
@@ -170,7 +184,9 @@ impl StabilityPoolState {
     // ─── Stablecoin Registry ───
 
     pub fn register_stablecoin(&mut self, config: StablecoinConfig) {
-        self.total_stablecoin_balances.entry(config.ledger_id).or_insert(0);
+        self.total_stablecoin_balances
+            .entry(config.ledger_id)
+            .or_insert(0);
         self.stablecoin_registry.insert(config.ledger_id, config);
     }
 
@@ -179,7 +195,10 @@ impl StabilityPoolState {
     }
 
     pub fn is_accepted_stablecoin(&self, ledger: &Principal) -> bool {
-        self.stablecoin_registry.get(ledger).map(|c| c.is_active).unwrap_or(false)
+        self.stablecoin_registry
+            .get(ledger)
+            .map(|c| c.is_active)
+            .unwrap_or(false)
     }
 
     /// Get cached virtual prices (empty if None for upgrade compat).
@@ -236,11 +255,18 @@ impl StabilityPoolState {
     // ─── Deposits ───
 
     pub fn add_deposit(&mut self, user: Principal, token_ledger: Principal, amount: u64) {
-        let position = self.deposits.entry(user).or_insert_with(|| {
-            DepositPosition::new(ic_cdk::api::time())
-        });
-        *position.stablecoin_balances.entry(token_ledger).or_insert(0) += amount;
-        *self.total_stablecoin_balances.entry(token_ledger).or_insert(0) += amount;
+        let position = self
+            .deposits
+            .entry(user)
+            .or_insert_with(|| DepositPosition::new(ic_cdk::api::time()));
+        *position
+            .stablecoin_balances
+            .entry(token_ledger)
+            .or_insert(0) += amount;
+        *self
+            .total_stablecoin_balances
+            .entry(token_ledger)
+            .or_insert(0) += amount;
     }
 
     /// Distribute icUSD interest revenue to eligible icUSD-holding depositors.
@@ -263,12 +289,19 @@ impl StabilityPoolState {
     /// the icUSD will be picked up on the next distribution that has eligible
     /// depositors, or will need manual reconciliation if the no-icUSD-depositors
     /// state persists.
-    pub fn distribute_interest_revenue(&mut self, token_ledger: Principal, amount: u64, collateral_type: Option<Principal>) {
+    pub fn distribute_interest_revenue(
+        &mut self,
+        token_ledger: Principal,
+        amount: u64,
+        collateral_type: Option<Principal>,
+    ) {
         if amount == 0 {
             return;
         }
 
-        let decimals = self.stablecoin_registry.get(&token_ledger)
+        let decimals = self
+            .stablecoin_registry
+            .get(&token_ledger)
             .map(|c| c.decimals)
             .unwrap_or(8);
 
@@ -279,7 +312,9 @@ impl StabilityPoolState {
             .as_ref()
             .map(|ct| self.is_chain_collateral_sentinel(ct))
             .unwrap_or(false);
-        let holders: Vec<(Principal, u64)> = self.deposits.iter()
+        let holders: Vec<(Principal, u64)> = self
+            .deposits
+            .iter()
             .filter_map(|(p, pos)| {
                 let icusd_value = pos.icusd_value(&self.stablecoin_registry);
                 if icusd_value == 0 {
@@ -326,7 +361,8 @@ impl StabilityPoolState {
             if credit > 0 {
                 if let Some(pos) = self.deposits.get_mut(principal) {
                     *pos.stablecoin_balances.entry(token_ledger).or_insert(0) += credit;
-                    *pos.total_interest_earned_e8s.get_or_insert(0) += normalize_to_e8s(credit, decimals);
+                    *pos.total_interest_earned_e8s.get_or_insert(0) +=
+                        normalize_to_e8s(credit, decimals);
                 }
                 distributed += credit;
             }
@@ -338,21 +374,36 @@ impl StabilityPoolState {
             if let Some(first) = first_eligible {
                 if let Some(pos) = self.deposits.get_mut(&first) {
                     *pos.stablecoin_balances.entry(token_ledger).or_insert(0) += dust;
-                    *pos.total_interest_earned_e8s.get_or_insert(0) += normalize_to_e8s(dust, decimals);
+                    *pos.total_interest_earned_e8s.get_or_insert(0) +=
+                        normalize_to_e8s(dust, decimals);
                 }
             }
         }
 
         // Update aggregate totals
-        *self.total_stablecoin_balances.entry(token_ledger).or_insert(0) += amount;
+        *self
+            .total_stablecoin_balances
+            .entry(token_ledger)
+            .or_insert(0) += amount;
         *self.total_interest_received_e8s.get_or_insert(0) += normalize_to_e8s(amount, decimals);
     }
 
-    pub fn process_withdrawal(&mut self, user: Principal, token_ledger: Principal, amount: u64) -> Result<(), StabilityPoolError> {
-        let position = self.deposits.get_mut(&user)
+    pub fn process_withdrawal(
+        &mut self,
+        user: Principal,
+        token_ledger: Principal,
+        amount: u64,
+    ) -> Result<(), StabilityPoolError> {
+        let position = self
+            .deposits
+            .get_mut(&user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
 
-        let balance = position.stablecoin_balances.get(&token_ledger).copied().unwrap_or(0);
+        let balance = position
+            .stablecoin_balances
+            .get(&token_ledger)
+            .copied()
+            .unwrap_or(0);
         if balance < amount {
             return Err(StabilityPoolError::InsufficientBalance {
                 token: token_ledger,
@@ -389,17 +440,31 @@ impl StabilityPoolState {
     /// migration quirk or an external reconciliation). `correct_balance` is the
     /// per-depositor-targeted analogue for surgical corrections.
     pub fn deduct_burned_lp_from_balances(&mut self, token_ledger: Principal, burned_amount: u64) {
-        let total = self.total_stablecoin_balances.get(&token_ledger).copied().unwrap_or(0);
+        let total = self
+            .total_stablecoin_balances
+            .get(&token_ledger)
+            .copied()
+            .unwrap_or(0);
         if total == 0 || burned_amount == 0 {
             return;
         }
         let actual_deduct = burned_amount.min(total);
 
         // Distribute proportionally across depositors
-        let depositors: Vec<(Principal, u64)> = self.deposits.iter()
+        let depositors: Vec<(Principal, u64)> = self
+            .deposits
+            .iter()
             .filter_map(|(p, pos)| {
-                let bal = pos.stablecoin_balances.get(&token_ledger).copied().unwrap_or(0);
-                if bal > 0 { Some((*p, bal)) } else { None }
+                let bal = pos
+                    .stablecoin_balances
+                    .get(&token_ledger)
+                    .copied()
+                    .unwrap_or(0);
+                if bal > 0 {
+                    Some((*p, bal))
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -418,7 +483,8 @@ impl StabilityPoolState {
         // Assign rounding dust to largest holder to prevent aggregate/individual drift
         let dust = actual_deduct.saturating_sub(total_deducted);
         if dust > 0 {
-            if let Some(largest_p) = depositors.iter()
+            if let Some(largest_p) = depositors
+                .iter()
                 .max_by_key(|(_, bal)| *bal)
                 .map(|(p, _)| *p)
             {
@@ -447,13 +513,26 @@ impl StabilityPoolState {
             return;
         }
         // Add back to aggregate
-        *self.total_stablecoin_balances.entry(token_ledger).or_insert(0) += amount;
+        *self
+            .total_stablecoin_balances
+            .entry(token_ledger)
+            .or_insert(0) += amount;
 
         // Distribute proportionally across depositors who hold this token
-        let holders: Vec<(Principal, u64)> = self.deposits.iter()
+        let holders: Vec<(Principal, u64)> = self
+            .deposits
+            .iter()
             .filter_map(|(p, pos)| {
-                let bal = pos.stablecoin_balances.get(&token_ledger).copied().unwrap_or(0);
-                if bal > 0 { Some((*p, bal)) } else { None }
+                let bal = pos
+                    .stablecoin_balances
+                    .get(&token_ledger)
+                    .copied()
+                    .unwrap_or(0);
+                if bal > 0 {
+                    Some((*p, bal))
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -492,12 +571,18 @@ impl StabilityPoolState {
     // ─── Collateral Gains ───
 
     pub fn get_collateral_gains(&self, user: &Principal) -> BTreeMap<Principal, u64> {
-        self.deposits.get(user)
+        self.deposits
+            .get(user)
             .map(|p| p.collateral_gains.clone())
             .unwrap_or_default()
     }
 
-    pub fn mark_gains_claimed(&mut self, user: &Principal, collateral_ledger: &Principal, amount: u64) {
+    pub fn mark_gains_claimed(
+        &mut self,
+        user: &Principal,
+        collateral_ledger: &Principal,
+        amount: u64,
+    ) {
         if let Some(position) = self.deposits.get_mut(user) {
             if let Some(gains) = position.collateral_gains.get_mut(collateral_ledger) {
                 *gains = gains.saturating_sub(amount);
@@ -505,7 +590,10 @@ impl StabilityPoolState {
                     position.collateral_gains.remove(collateral_ledger);
                 }
             }
-            *position.total_claimed_gains.entry(*collateral_ledger).or_insert(0) += amount;
+            *position
+                .total_claimed_gains
+                .entry(*collateral_ledger)
+                .or_insert(0) += amount;
         }
     }
 
@@ -531,7 +619,8 @@ impl StabilityPoolState {
         if amount_native == 0 {
             return;
         }
-        let sources = self.chain_claim_sources
+        let sources = self
+            .chain_claim_sources
             .get_or_insert_with(BTreeMap::new)
             .entry(chain_sentinel)
             .or_default();
@@ -545,54 +634,165 @@ impl StabilityPoolState {
         }
     }
 
+    pub fn pending_chain_absorb_count(&self) -> usize {
+        self.pending_chain_absorbs
+            .as_ref()
+            .map(|m| m.len())
+            .unwrap_or(0)
+    }
+
+    pub fn has_pending_chain_absorbs(&self) -> bool {
+        self.pending_chain_absorb_count() > 0
+    }
+
+    pub fn pending_chain_absorb_status(&self, vault_id: u64) -> Option<ChainSpAbsorbIntentStatus> {
+        self.pending_chain_absorbs
+            .as_ref()
+            .and_then(|m| m.get(&vault_id))
+            .map(|intent| intent.status)
+    }
+
+    pub fn pending_chain_absorbs(&self) -> Vec<ChainSpAbsorbIntent> {
+        self.pending_chain_absorbs
+            .as_ref()
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn completed_chain_absorbs(&self, limit: usize) -> Vec<ChainSpAbsorbCompletion> {
+        self.completed_chain_absorbs
+            .as_ref()
+            .map(|m| m.values().rev().take(limit).cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn get_pending_chain_absorb(&self, vault_id: u64) -> Option<ChainSpAbsorbIntent> {
+        self.pending_chain_absorbs
+            .as_ref()
+            .and_then(|m| m.get(&vault_id).cloned())
+    }
+
+    pub fn put_pending_chain_absorb(
+        &mut self,
+        intent: ChainSpAbsorbIntent,
+    ) -> Result<(), StabilityPoolError> {
+        let pending = self.pending_chain_absorbs.get_or_insert_with(BTreeMap::new);
+        if !pending.contains_key(&intent.vault_id) && pending.len() >= MAX_PENDING_CHAIN_ABSORBS {
+            return Err(StabilityPoolError::SystemBusy);
+        }
+        pending.insert(intent.vault_id, intent);
+        Ok(())
+    }
+
+    pub fn take_pending_chain_absorb(&mut self, vault_id: u64) -> Option<ChainSpAbsorbIntent> {
+        self.pending_chain_absorbs
+            .as_mut()
+            .and_then(|m| m.remove(&vault_id))
+    }
+
+    pub fn record_completed_chain_absorb(&mut self, completion: ChainSpAbsorbCompletion) {
+        let completed = self
+            .completed_chain_absorbs
+            .get_or_insert_with(BTreeMap::new);
+        completed.insert(completion.vault_id, completion);
+        while completed.len() > MAX_COMPLETED_CHAIN_ABSORBS {
+            let Some(oldest_vault_id) = completed.keys().next().copied() else {
+                break;
+            };
+            completed.remove(&oldest_vault_id);
+        }
+    }
+
+    pub fn completed_chain_absorb(&self, vault_id: u64) -> Option<ChainSpAbsorbCompletion> {
+        self.completed_chain_absorbs
+            .as_ref()
+            .and_then(|m| m.get(&vault_id).cloned())
+    }
+
     // ─── Opt-in / Opt-out ───
 
-    pub fn opt_out_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+    pub fn opt_out_collateral(
+        &mut self,
+        user: &Principal,
+        collateral_type: Principal,
+    ) -> Result<(), StabilityPoolError> {
         if self.is_chain_collateral_sentinel(&collateral_type) {
             return self.opt_out_cfx(user, collateral_type);
         }
-        let position = self.deposits.get_mut(user)
+        let position = self
+            .deposits
+            .get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
         if !position.opted_out_collateral.insert(collateral_type) {
-            return Err(StabilityPoolError::AlreadyOptedOut { collateral: collateral_type });
+            return Err(StabilityPoolError::AlreadyOptedOut {
+                collateral: collateral_type,
+            });
         }
         Ok(())
     }
 
-    pub fn opt_in_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+    pub fn opt_in_collateral(
+        &mut self,
+        user: &Principal,
+        collateral_type: Principal,
+    ) -> Result<(), StabilityPoolError> {
         if self.is_chain_collateral_sentinel(&collateral_type) {
             return self.opt_in_cfx(user, collateral_type);
         }
-        let position = self.deposits.get_mut(user)
+        let position = self
+            .deposits
+            .get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
         if !position.opted_out_collateral.remove(&collateral_type) {
-            return Err(StabilityPoolError::AlreadyOptedIn { collateral: collateral_type });
+            return Err(StabilityPoolError::AlreadyOptedIn {
+                collateral: collateral_type,
+            });
         }
         Ok(())
     }
 
-    pub fn opt_in_cfx(&mut self, user: &Principal, sentinel: Principal) -> Result<(), StabilityPoolError> {
+    pub fn opt_in_cfx(
+        &mut self,
+        user: &Principal,
+        sentinel: Principal,
+    ) -> Result<(), StabilityPoolError> {
         if !self.is_chain_collateral_sentinel(&sentinel) {
             return Err(StabilityPoolError::CollateralNotFound { ledger: sentinel });
         }
-        let position = self.deposits.get_mut(user)
+        let position = self
+            .deposits
+            .get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
-        let opted_in = position.opted_in_chain_collateral.get_or_insert_with(BTreeSet::new);
+        let opted_in = position
+            .opted_in_chain_collateral
+            .get_or_insert_with(BTreeSet::new);
         if !opted_in.insert(sentinel) {
-            return Err(StabilityPoolError::AlreadyOptedIn { collateral: sentinel });
+            return Err(StabilityPoolError::AlreadyOptedIn {
+                collateral: sentinel,
+            });
         }
         Ok(())
     }
 
-    pub fn opt_out_cfx(&mut self, user: &Principal, sentinel: Principal) -> Result<(), StabilityPoolError> {
+    pub fn opt_out_cfx(
+        &mut self,
+        user: &Principal,
+        sentinel: Principal,
+    ) -> Result<(), StabilityPoolError> {
         if !self.is_chain_collateral_sentinel(&sentinel) {
             return Err(StabilityPoolError::CollateralNotFound { ledger: sentinel });
         }
-        let position = self.deposits.get_mut(user)
+        let position = self
+            .deposits
+            .get_mut(user)
             .ok_or(StabilityPoolError::NoPositionFound)?;
-        let opted_in = position.opted_in_chain_collateral.get_or_insert_with(BTreeSet::new);
+        let opted_in = position
+            .opted_in_chain_collateral
+            .get_or_insert_with(BTreeSet::new);
         if !opted_in.remove(&sentinel) {
-            return Err(StabilityPoolError::AlreadyOptedOut { collateral: sentinel });
+            return Err(StabilityPoolError::AlreadyOptedOut {
+                collateral: sentinel,
+            });
         }
         Ok(())
     }
@@ -623,14 +823,17 @@ impl StabilityPoolState {
         }
         let id = self.next_pending_refund_id.unwrap_or(0);
         self.next_pending_refund_id = Some(id + 1);
-        refunds.insert(id, PendingRefund {
+        refunds.insert(
             id,
-            user,
-            token_ledger,
-            amount,
-            reason,
-            created_at: now,
-        });
+            PendingRefund {
+                id,
+                user,
+                token_ledger,
+                amount,
+                reason,
+                created_at: now,
+            },
+        );
         id
     }
 
@@ -659,14 +862,16 @@ impl StabilityPoolState {
     /// Compute total opted-in stablecoin value (e8s) for a given collateral type.
     pub fn effective_pool_for_collateral(&self, collateral_type: &Principal) -> u64 {
         let vps = self.virtual_prices();
-        self.deposits.values()
+        self.deposits
+            .values()
             .filter(|pos| self.position_opted_in_for(pos, collateral_type))
             .map(|pos| pos.total_usd_value(&self.stablecoin_registry, vps))
             .sum()
     }
 
     pub fn icusd_ledger(&self) -> Option<Principal> {
-        self.stablecoin_registry.iter()
+        self.stablecoin_registry
+            .iter()
             .find(|(_, config)| config.symbol == "icUSD")
             .map(|(ledger, _)| *ledger)
     }
@@ -674,7 +879,8 @@ impl StabilityPoolState {
     /// Compute opted-in icUSD coverage only. Chain-native liquidations use
     /// this instead of the mixed-token draw so Inc 4 burns only IC-native icUSD.
     pub fn effective_icusd_pool_for_collateral(&self, collateral_type: &Principal) -> u64 {
-        self.deposits.values()
+        self.deposits
+            .values()
             .filter(|pos| self.position_opted_in_for(pos, collateral_type))
             .map(|pos| pos.icusd_value(&self.stablecoin_registry))
             .sum()
@@ -688,7 +894,11 @@ impl StabilityPoolState {
     /// For small debts (< 1 icUSD / 100_000_000 e8s), uses a single token — whichever
     /// has the highest balance — to avoid splitting into amounts too small for the backend.
     /// For larger debts, follows priority ordering with proportional splits.
-    pub fn compute_token_draw(&self, debt_e8s: u64, collateral_type: &Principal) -> BTreeMap<Principal, u64> {
+    pub fn compute_token_draw(
+        &self,
+        debt_e8s: u64,
+        collateral_type: &Principal,
+    ) -> BTreeMap<Principal, u64> {
         let vps = self.virtual_prices();
 
         // Gather all available tokens with their e8s-equivalent balances
@@ -696,19 +906,29 @@ impl StabilityPoolState {
         let mut all_tokens: Vec<(Principal, u64, u8, bool, u64)> = Vec::new();
 
         for (ledger, config) in &self.stablecoin_registry {
-            let available_native: u64 = self.deposits.values()
+            let available_native: u64 = self
+                .deposits
+                .values()
                 .filter(|pos| self.position_opted_in_for(pos, collateral_type))
                 .map(|pos| pos.stablecoin_balances.get(ledger).copied().unwrap_or(0))
                 .sum();
             if available_native > 0 {
                 let is_lp = config.is_lp_token.unwrap_or(false);
                 let available_e8s = if is_lp {
-                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(available_native, vp)).unwrap_or(0)
+                    vps.get(ledger)
+                        .map(|&vp| lp_to_usd_e8s(available_native, vp))
+                        .unwrap_or(0)
                 } else {
                     normalize_to_e8s(available_native, config.decimals)
                 };
                 if available_e8s > 0 {
-                    all_tokens.push((*ledger, available_native, config.decimals, is_lp, available_e8s));
+                    all_tokens.push((
+                        *ledger,
+                        available_native,
+                        config.decimals,
+                        is_lp,
+                        available_e8s,
+                    ));
                 }
             }
         }
@@ -721,14 +941,17 @@ impl StabilityPoolState {
         // This avoids splitting into amounts that all fall below the backend minimum.
         const SMALL_DEBT_THRESHOLD: u64 = 100_000_000; // 1 icUSD
         if debt_e8s < SMALL_DEBT_THRESHOLD {
-            let best = all_tokens.iter()
+            let best = all_tokens
+                .iter()
                 .max_by_key(|(_, _, _, _, e8s)| *e8s)
                 .unwrap(); // safe: all_tokens is non-empty
 
             let (ledger, available_native, decimals, is_lp, available_e8s) = *best;
             let draw_e8s = debt_e8s.min(available_e8s);
             let draw_native = if is_lp {
-                vps.get(&ledger).map(|&vp| usd_e8s_to_lp(draw_e8s, vp)).unwrap_or(0)
+                vps.get(&ledger)
+                    .map(|&vp| usd_e8s_to_lp(draw_e8s, vp))
+                    .unwrap_or(0)
             } else {
                 normalize_from_e8s(draw_e8s, decimals)
             };
@@ -747,14 +970,20 @@ impl StabilityPoolState {
         // Group by priority
         let mut priority_buckets: BTreeMap<u8, Vec<(Principal, u64, u8, bool)>> = BTreeMap::new();
         for (ledger, config) in &self.stablecoin_registry {
-            let available_native: u64 = self.deposits.values()
+            let available_native: u64 = self
+                .deposits
+                .values()
                 .filter(|pos| self.position_opted_in_for(pos, collateral_type))
                 .map(|pos| pos.stablecoin_balances.get(ledger).copied().unwrap_or(0))
                 .sum();
             if available_native > 0 {
                 let is_lp = config.is_lp_token.unwrap_or(false);
-                priority_buckets.entry(config.priority).or_default()
-                    .push((*ledger, available_native, config.decimals, is_lp));
+                priority_buckets.entry(config.priority).or_default().push((
+                    *ledger,
+                    available_native,
+                    config.decimals,
+                    is_lp,
+                ));
             }
         }
 
@@ -768,10 +997,13 @@ impl StabilityPoolState {
             }
             let tokens = priority_buckets.get(&priority).unwrap();
 
-            let total_available_e8s: u64 = tokens.iter()
+            let total_available_e8s: u64 = tokens
+                .iter()
                 .map(|(ledger, amount, decimals, is_lp)| {
                     if *is_lp {
-                        vps.get(ledger).map(|&vp| lp_to_usd_e8s(*amount, vp)).unwrap_or(0)
+                        vps.get(ledger)
+                            .map(|&vp| lp_to_usd_e8s(*amount, vp))
+                            .unwrap_or(0)
                     } else {
                         normalize_to_e8s(*amount, *decimals)
                     }
@@ -786,16 +1018,21 @@ impl StabilityPoolState {
 
             for (ledger, available_native, decimals, is_lp) in tokens {
                 let token_available_e8s = if *is_lp {
-                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(*available_native, vp)).unwrap_or(0)
+                    vps.get(ledger)
+                        .map(|&vp| lp_to_usd_e8s(*available_native, vp))
+                        .unwrap_or(0)
                 } else {
                     normalize_to_e8s(*available_native, *decimals)
                 };
                 if token_available_e8s == 0 {
                     continue;
                 }
-                let token_draw_e8s = (draw_e8s as u128 * token_available_e8s as u128 / total_available_e8s as u128) as u64;
+                let token_draw_e8s = (draw_e8s as u128 * token_available_e8s as u128
+                    / total_available_e8s as u128) as u64;
                 let token_draw_native = if *is_lp {
-                    vps.get(ledger).map(|&vp| usd_e8s_to_lp(token_draw_e8s, vp)).unwrap_or(0)
+                    vps.get(ledger)
+                        .map(|&vp| usd_e8s_to_lp(token_draw_e8s, vp))
+                        .unwrap_or(0)
                 } else {
                     normalize_from_e8s(token_draw_e8s, *decimals)
                 };
@@ -843,7 +1080,14 @@ impl StabilityPoolState {
         collateral_gained: u64,
         collateral_price_e8s: u64,
     ) {
-        self.process_liquidation_gains_at(vault_id, collateral_type, stables_consumed, collateral_gained, collateral_price_e8s, ic_cdk::api::time());
+        self.process_liquidation_gains_at(
+            vault_id,
+            collateral_type,
+            stables_consumed,
+            collateral_gained,
+            collateral_price_e8s,
+            ic_cdk::api::time(),
+        );
     }
 
     pub fn process_chain_liquidation_gains(
@@ -875,7 +1119,9 @@ impl StabilityPoolState {
         timestamp: u64,
     ) {
         // Phase 1: Compute each opted-in depositor's share of the consumed stables (in e8s)
-        let opted_in_principals: Vec<Principal> = self.deposits.iter()
+        let opted_in_principals: Vec<Principal> = self
+            .deposits
+            .iter()
             .filter(|(_, pos)| self.position_opted_in_for(pos, &collateral_type))
             .map(|(p, _)| *p)
             .collect();
@@ -883,9 +1129,15 @@ impl StabilityPoolState {
         // For each consumed token, compute total opted-in balance for that token
         let mut per_token_opted_in_totals: BTreeMap<Principal, u64> = BTreeMap::new();
         for token_ledger in stables_consumed.keys() {
-            let total: u64 = opted_in_principals.iter()
+            let total: u64 = opted_in_principals
+                .iter()
                 .filter_map(|p| self.deposits.get(p))
-                .map(|pos| pos.stablecoin_balances.get(token_ledger).copied().unwrap_or(0))
+                .map(|pos| {
+                    pos.stablecoin_balances
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0)
+                })
                 .sum();
             per_token_opted_in_totals.insert(*token_ledger, total);
         }
@@ -894,18 +1146,23 @@ impl StabilityPoolState {
         // LP tokens are valued at virtual price, not face value.
         // Clone virtual prices and registry info upfront to avoid borrow conflicts with Phase 3.
         let vps = self.virtual_prices().clone();
-        let registry_snapshot: BTreeMap<Principal, (u8, bool)> = stables_consumed.keys()
+        let registry_snapshot: BTreeMap<Principal, (u8, bool)> = stables_consumed
+            .keys()
             .filter_map(|ledger| {
-                self.stablecoin_registry.get(ledger).map(|c| {
-                    (*ledger, (c.decimals, c.is_lp_token.unwrap_or(false)))
-                })
+                self.stablecoin_registry
+                    .get(ledger)
+                    .map(|c| (*ledger, (c.decimals, c.is_lp_token.unwrap_or(false))))
             })
             .collect();
-        let total_consumed_e8s: u64 = stables_consumed.iter()
+        let total_consumed_e8s: u64 = stables_consumed
+            .iter()
             .map(|(ledger, &amount)| {
-                let (decimals, is_lp) = registry_snapshot.get(ledger).copied().unwrap_or((8, false));
+                let (decimals, is_lp) =
+                    registry_snapshot.get(ledger).copied().unwrap_or((8, false));
                 if is_lp {
-                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(amount, vp)).unwrap_or(0)
+                    vps.get(ledger)
+                        .map(|&vp| lp_to_usd_e8s(amount, vp))
+                        .unwrap_or(0)
                 } else {
                     normalize_to_e8s(amount, decimals)
                 }
@@ -926,17 +1183,26 @@ impl StabilityPoolState {
 
             if let Some(position) = self.deposits.get_mut(principal) {
                 for (token_ledger, &total_consumed) in stables_consumed {
-                    let total_opted_in = per_token_opted_in_totals.get(token_ledger).copied().unwrap_or(0);
+                    let total_opted_in = per_token_opted_in_totals
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0);
                     if total_opted_in == 0 {
                         continue;
                     }
-                    let user_balance = position.stablecoin_balances.get(token_ledger).copied().unwrap_or(0);
+                    let user_balance = position
+                        .stablecoin_balances
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0);
                     if user_balance == 0 {
                         continue;
                     }
 
                     // User's share of this token's consumption
-                    let user_share_native = (total_consumed as u128 * user_balance as u128 / total_opted_in as u128) as u64;
+                    let user_share_native = (total_consumed as u128 * user_balance as u128
+                        / total_opted_in as u128)
+                        as u64;
                     let user_share_native = user_share_native.min(user_balance);
 
                     // Reduce balance
@@ -945,13 +1211,20 @@ impl StabilityPoolState {
                     }
 
                     // Track actual deduction for aggregate update
-                    *actual_deductions_per_token.entry(*token_ledger).or_insert(0) += user_share_native;
+                    *actual_deductions_per_token
+                        .entry(*token_ledger)
+                        .or_insert(0) += user_share_native;
 
                     // Track consumed value in e8s for collateral distribution.
                     // LP tokens valued at virtual price, not face value.
-                    let (decimals, is_lp) = registry_snapshot.get(token_ledger).copied().unwrap_or((8, false));
+                    let (decimals, is_lp) = registry_snapshot
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or((8, false));
                     let share_e8s = if is_lp {
-                        vps.get(token_ledger).map(|&vp| lp_to_usd_e8s(user_share_native, vp)).unwrap_or(0)
+                        vps.get(token_ledger)
+                            .map(|&vp| lp_to_usd_e8s(user_share_native, vp))
+                            .unwrap_or(0)
                     } else {
                         normalize_to_e8s(user_share_native, decimals)
                     };
@@ -960,8 +1233,13 @@ impl StabilityPoolState {
 
                 // Distribute collateral proportional to e8s consumed
                 if user_consumed_e8s > 0 {
-                    let user_collateral = (collateral_gained as u128 * user_consumed_e8s as u128 / total_consumed_e8s as u128) as u64;
-                    *position.collateral_gains.entry(collateral_type).or_insert(0) += user_collateral;
+                    let user_collateral = (collateral_gained as u128 * user_consumed_e8s as u128
+                        / total_consumed_e8s as u128)
+                        as u64;
+                    *position
+                        .collateral_gains
+                        .entry(collateral_type)
+                        .or_insert(0) += user_collateral;
                     total_collateral_distributed += user_collateral;
                 }
             }
@@ -1034,7 +1312,9 @@ impl StabilityPoolState {
             return;
         }
 
-        let opted_in_principals: Vec<Principal> = self.deposits.iter()
+        let opted_in_principals: Vec<Principal> = self
+            .deposits
+            .iter()
             .filter(|(_, pos)| pos.is_opted_in_for_chain(&chain_sentinel))
             .map(|(p, _)| *p)
             .collect();
@@ -1044,26 +1324,37 @@ impl StabilityPoolState {
 
         let mut per_token_opted_in_totals: BTreeMap<Principal, u64> = BTreeMap::new();
         for token_ledger in stables_consumed.keys() {
-            let total: u64 = opted_in_principals.iter()
+            let total: u64 = opted_in_principals
+                .iter()
                 .filter_map(|p| self.deposits.get(p))
-                .map(|pos| pos.stablecoin_balances.get(token_ledger).copied().unwrap_or(0))
+                .map(|pos| {
+                    pos.stablecoin_balances
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0)
+                })
                 .sum();
             per_token_opted_in_totals.insert(*token_ledger, total);
         }
 
         let vps = self.virtual_prices().clone();
-        let registry_snapshot: BTreeMap<Principal, (u8, bool)> = stables_consumed.keys()
+        let registry_snapshot: BTreeMap<Principal, (u8, bool)> = stables_consumed
+            .keys()
             .filter_map(|ledger| {
-                self.stablecoin_registry.get(ledger).map(|c| {
-                    (*ledger, (c.decimals, c.is_lp_token.unwrap_or(false)))
-                })
+                self.stablecoin_registry
+                    .get(ledger)
+                    .map(|c| (*ledger, (c.decimals, c.is_lp_token.unwrap_or(false))))
             })
             .collect();
-        let total_consumed_e8s: u64 = stables_consumed.iter()
+        let total_consumed_e8s: u64 = stables_consumed
+            .iter()
             .map(|(ledger, &amount)| {
-                let (decimals, is_lp) = registry_snapshot.get(ledger).copied().unwrap_or((8, false));
+                let (decimals, is_lp) =
+                    registry_snapshot.get(ledger).copied().unwrap_or((8, false));
                 if is_lp {
-                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(amount, vp)).unwrap_or(0)
+                    vps.get(ledger)
+                        .map(|&vp| lp_to_usd_e8s(amount, vp))
+                        .unwrap_or(0)
                 } else {
                     normalize_to_e8s(amount, decimals)
                 }
@@ -1081,25 +1372,41 @@ impl StabilityPoolState {
 
             if let Some(position) = self.deposits.get_mut(principal) {
                 for (token_ledger, &total_consumed) in stables_consumed {
-                    let total_opted_in = per_token_opted_in_totals.get(token_ledger).copied().unwrap_or(0);
+                    let total_opted_in = per_token_opted_in_totals
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0);
                     if total_opted_in == 0 {
                         continue;
                     }
-                    let user_balance = position.stablecoin_balances.get(token_ledger).copied().unwrap_or(0);
+                    let user_balance = position
+                        .stablecoin_balances
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or(0);
                     if user_balance == 0 {
                         continue;
                     }
 
-                    let user_share_native = (total_consumed as u128 * user_balance as u128 / total_opted_in as u128) as u64;
+                    let user_share_native = (total_consumed as u128 * user_balance as u128
+                        / total_opted_in as u128)
+                        as u64;
                     let user_share_native = user_share_native.min(user_balance);
                     if let Some(bal) = position.stablecoin_balances.get_mut(token_ledger) {
                         *bal = bal.saturating_sub(user_share_native);
                     }
-                    *actual_deductions_per_token.entry(*token_ledger).or_insert(0) += user_share_native;
+                    *actual_deductions_per_token
+                        .entry(*token_ledger)
+                        .or_insert(0) += user_share_native;
 
-                    let (decimals, is_lp) = registry_snapshot.get(token_ledger).copied().unwrap_or((8, false));
+                    let (decimals, is_lp) = registry_snapshot
+                        .get(token_ledger)
+                        .copied()
+                        .unwrap_or((8, false));
                     let share_e8s = if is_lp {
-                        vps.get(token_ledger).map(|&vp| lp_to_usd_e8s(user_share_native, vp)).unwrap_or(0)
+                        vps.get(token_ledger)
+                            .map(|&vp| lp_to_usd_e8s(user_share_native, vp))
+                            .unwrap_or(0)
                     } else {
                         normalize_to_e8s(user_share_native, decimals)
                     };
@@ -1107,8 +1414,7 @@ impl StabilityPoolState {
                 }
 
                 if user_consumed_e8s > 0 {
-                    let user_cfx = cfx_gained_native
-                        .saturating_mul(user_consumed_e8s as u128)
+                    let user_cfx = cfx_gained_native.saturating_mul(user_consumed_e8s as u128)
                         / total_consumed_e8s as u128;
                     let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
                     let entry = claims.entry(chain_sentinel).or_insert(0);
@@ -1148,11 +1454,18 @@ impl StabilityPoolState {
 
     pub fn get_pool_status(&self) -> StabilityPoolStatus {
         let vps = self.virtual_prices();
-        let total_e8s: u64 = self.total_stablecoin_balances.iter()
+        let total_e8s: u64 = self
+            .total_stablecoin_balances
+            .iter()
             .map(|(ledger, &amount)| {
                 let config = self.stablecoin_registry.get(ledger);
-                if config.map(|c| c.is_lp_token.unwrap_or(false)).unwrap_or(false) {
-                    vps.get(ledger).map(|&vp| lp_to_usd_e8s(amount, vp)).unwrap_or(0)
+                if config
+                    .map(|c| c.is_lp_token.unwrap_or(false))
+                    .unwrap_or(false)
+                {
+                    vps.get(ledger)
+                        .map(|&vp| lp_to_usd_e8s(amount, vp))
+                        .unwrap_or(0)
                 } else {
                     let decimals = config.map(|c| c.decimals).unwrap_or(8);
                     normalize_to_e8s(amount, decimals)
@@ -1188,13 +1501,18 @@ impl StabilityPoolState {
     /// now earn interest proportional to their total deposit value.
     fn eligible_icusd_per_collateral(&self) -> Vec<(Principal, u64)> {
         let vps = self.virtual_prices();
-        self.collateral_registry.keys().map(|ct| {
-            let eligible: u64 = self.deposits.values()
-                .filter(|pos| self.position_opted_in_for(pos, ct))
-                .map(|pos| pos.total_usd_value(&self.stablecoin_registry, vps))
-                .sum();
-            (*ct, eligible)
-        }).collect()
+        self.collateral_registry
+            .keys()
+            .map(|ct| {
+                let eligible: u64 = self
+                    .deposits
+                    .values()
+                    .filter(|pos| self.position_opted_in_for(pos, ct))
+                    .map(|pos| pos.total_usd_value(&self.stablecoin_registry, vps))
+                    .sum();
+                (*ct, eligible)
+            })
+            .collect()
     }
 
     pub fn get_user_position(&self, user: &Principal) -> Option<UserStabilityPosition> {
@@ -1204,7 +1522,8 @@ impl StabilityPoolState {
             opted_out_collateral: pos.opted_out_collateral.iter().cloned().collect(),
             deposit_timestamp: pos.deposit_timestamp,
             total_claimed_gains: pos.total_claimed_gains.clone(),
-            total_usd_value_e8s: pos.total_usd_value(&self.stablecoin_registry, self.virtual_prices()),
+            total_usd_value_e8s: pos
+                .total_usd_value(&self.stablecoin_registry, self.virtual_prices()),
             total_interest_earned_e8s: pos.total_interest_earned_e8s.unwrap_or(0),
         })
     }
@@ -1250,13 +1569,23 @@ impl StabilityPoolState {
     /// Set a depositor's balance for a specific token to `correct_amount`,
     /// adjusting the aggregate total accordingly.  Used to fix phantom balances
     /// that exist in state but not on the actual ledger.
-    pub fn correct_balance(&mut self, user: Principal, token_ledger: Principal, correct_amount: u64) -> String {
-        let old_amount = self.deposits.get(&user)
+    pub fn correct_balance(
+        &mut self,
+        user: Principal,
+        token_ledger: Principal,
+        correct_amount: u64,
+    ) -> String {
+        let old_amount = self
+            .deposits
+            .get(&user)
             .and_then(|pos| pos.stablecoin_balances.get(&token_ledger).copied())
             .unwrap_or(0);
 
         if old_amount == correct_amount {
-            return format!("No change needed: user {} balance for {} is already {}", user, token_ledger, correct_amount);
+            return format!(
+                "No change needed: user {} balance for {} is already {}",
+                user, token_ledger, correct_amount
+            );
         }
 
         let diff = old_amount as i128 - correct_amount as i128;
@@ -1281,36 +1610,55 @@ impl StabilityPoolState {
             }
         }
 
-        format!("Corrected {} balance for {}: {} -> {}", token_ledger, user, old_amount, correct_amount)
+        format!(
+            "Corrected {} balance for {}: {} -> {}",
+            token_ledger, user, old_amount, correct_amount
+        )
     }
 
     /// Set a depositor's collateral gain for a specific collateral type to `correct_amount`.
     /// Used to fix drift between tracked gains and actual ledger balance (e.g., transfer fee dust).
-    pub fn correct_collateral_gain(&mut self, user: Principal, collateral_ledger: Principal, correct_amount: u64) -> String {
-        let old_amount = self.deposits.get(&user)
+    pub fn correct_collateral_gain(
+        &mut self,
+        user: Principal,
+        collateral_ledger: Principal,
+        correct_amount: u64,
+    ) -> String {
+        let old_amount = self
+            .deposits
+            .get(&user)
             .and_then(|pos| pos.collateral_gains.get(&collateral_ledger).copied())
             .unwrap_or(0);
 
         if old_amount == correct_amount {
-            return format!("No change needed: user {} gain for {} is already {}", user, collateral_ledger, correct_amount);
+            return format!(
+                "No change needed: user {} gain for {} is already {}",
+                user, collateral_ledger, correct_amount
+            );
         }
 
         if let Some(pos) = self.deposits.get_mut(&user) {
             if correct_amount == 0 {
                 pos.collateral_gains.remove(&collateral_ledger);
             } else {
-                pos.collateral_gains.insert(collateral_ledger, correct_amount);
+                pos.collateral_gains
+                    .insert(collateral_ledger, correct_amount);
             }
         }
 
-        format!("Corrected {} collateral gain for {}: {} -> {}", collateral_ledger, user, old_amount, correct_amount)
+        format!(
+            "Corrected {} collateral gain for {}: {} -> {}",
+            collateral_ledger, user, old_amount, correct_amount
+        )
     }
 
     // ─── State Validation ───
 
     pub fn validate_state(&self) -> Result<(), String> {
         for (ledger, &tracked_total) in &self.total_stablecoin_balances {
-            let computed_total: u64 = self.deposits.values()
+            let computed_total: u64 = self
+                .deposits
+                .values()
                 .map(|pos| pos.stablecoin_balances.get(ledger).copied().unwrap_or(0))
                 .sum();
             if computed_total != tracked_total {
@@ -1331,17 +1679,23 @@ thread_local! {
 }
 
 pub fn mutate_state<F, R>(f: F) -> R
-where F: FnOnce(&mut StabilityPoolState) -> R {
+where
+    F: FnOnce(&mut StabilityPoolState) -> R,
+{
     STATE.with(|s| f(&mut s.borrow_mut()))
 }
 
 pub fn read_state<F, R>(f: F) -> R
-where F: FnOnce(&StabilityPoolState) -> R {
+where
+    F: FnOnce(&StabilityPoolState) -> R,
+{
     STATE.with(|s| f(&s.borrow()))
 }
 
 pub fn replace_state(state: StabilityPoolState) {
-    STATE.with(|s| { *s.borrow_mut() = state; });
+    STATE.with(|s| {
+        *s.borrow_mut() = state;
+    });
 }
 
 /// Serialize state to stable memory (called from pre_upgrade).
@@ -1416,6 +1770,8 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             collateral_registry: v1.collateral_registry,
             chain_collateral_sentinels: Some(BTreeSet::new()),
             chain_claim_sources: Some(BTreeMap::new()),
+            pending_chain_absorbs: Some(BTreeMap::new()),
+            completed_chain_absorbs: Some(BTreeMap::new()),
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -1518,15 +1874,33 @@ mod tests {
     use std::collections::BTreeMap;
 
     // Deterministic test principals
-    fn user_a() -> Principal { Principal::from_slice(&[1]) }
-    fn user_b() -> Principal { Principal::from_slice(&[2]) }
-    fn user_c() -> Principal { Principal::from_slice(&[3]) }
-    fn icusd_ledger() -> Principal { Principal::from_slice(&[10]) }
-    fn ckusdt_ledger() -> Principal { Principal::from_slice(&[11]) }
-    fn ckusdc_ledger() -> Principal { Principal::from_slice(&[12]) }
-    fn icp_ledger() -> Principal { Principal::from_slice(&[20]) }
-    fn ckbtc_ledger() -> Principal { Principal::from_slice(&[21]) }
-    fn cfx_sentinel() -> Principal { Principal::from_slice(&[30]) }
+    fn user_a() -> Principal {
+        Principal::from_slice(&[1])
+    }
+    fn user_b() -> Principal {
+        Principal::from_slice(&[2])
+    }
+    fn user_c() -> Principal {
+        Principal::from_slice(&[3])
+    }
+    fn icusd_ledger() -> Principal {
+        Principal::from_slice(&[10])
+    }
+    fn ckusdt_ledger() -> Principal {
+        Principal::from_slice(&[11])
+    }
+    fn ckusdc_ledger() -> Principal {
+        Principal::from_slice(&[12])
+    }
+    fn icp_ledger() -> Principal {
+        Principal::from_slice(&[20])
+    }
+    fn ckbtc_ledger() -> Principal {
+        Principal::from_slice(&[21])
+    }
+    fn cfx_sentinel() -> Principal {
+        Principal::from_slice(&[30])
+    }
 
     /// Build a test state with:
     /// - icUSD (8 decimals, priority 1)
@@ -1591,7 +1965,10 @@ mod tests {
         token: Principal,
         amount: u64,
     ) {
-        let position = state.deposits.entry(user).or_insert_with(|| DepositPosition::new(0));
+        let position = state
+            .deposits
+            .entry(user)
+            .or_insert_with(|| DepositPosition::new(0));
         *position.stablecoin_balances.entry(token).or_insert(0) += amount;
         *state.total_stablecoin_balances.entry(token).or_insert(0) += amount;
     }
@@ -1604,34 +1981,63 @@ mod tests {
 
         // Add deposits for user_a
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_000_000); // 1 icUSD
-        add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 2_000_000);  // 2 ckUSDT
+        add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 2_000_000); // 2 ckUSDT
 
         // Verify balances
         let pos = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()), Some(&100_000_000));
-        assert_eq!(pos.stablecoin_balances.get(&ckusdt_ledger()), Some(&2_000_000));
+        assert_eq!(
+            pos.stablecoin_balances.get(&icusd_ledger()),
+            Some(&100_000_000)
+        );
+        assert_eq!(
+            pos.stablecoin_balances.get(&ckusdt_ledger()),
+            Some(&2_000_000)
+        );
 
         // Verify aggregate totals
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()), Some(&100_000_000));
-        assert_eq!(state.total_stablecoin_balances.get(&ckusdt_ledger()), Some(&2_000_000));
+        assert_eq!(
+            state.total_stablecoin_balances.get(&icusd_ledger()),
+            Some(&100_000_000)
+        );
+        assert_eq!(
+            state.total_stablecoin_balances.get(&ckusdt_ledger()),
+            Some(&2_000_000)
+        );
 
         // Partial withdrawal
-        state.process_withdrawal(user_a(), icusd_ledger(), 30_000_000).unwrap();
+        state
+            .process_withdrawal(user_a(), icusd_ledger(), 30_000_000)
+            .unwrap();
         let pos = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()), Some(&70_000_000));
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()), Some(&70_000_000));
+        assert_eq!(
+            pos.stablecoin_balances.get(&icusd_ledger()),
+            Some(&70_000_000)
+        );
+        assert_eq!(
+            state.total_stablecoin_balances.get(&icusd_ledger()),
+            Some(&70_000_000)
+        );
 
         // Full withdrawal of ckUSDT -- zero-balance entry should be cleaned up
-        state.process_withdrawal(user_a(), ckusdt_ledger(), 2_000_000).unwrap();
+        state
+            .process_withdrawal(user_a(), ckusdt_ledger(), 2_000_000)
+            .unwrap();
         let pos = state.deposits.get(&user_a()).unwrap();
         assert_eq!(pos.stablecoin_balances.get(&ckusdt_ledger()), None);
 
         // Full withdrawal of remaining icUSD -- empty position should be removed
-        state.process_withdrawal(user_a(), icusd_ledger(), 70_000_000).unwrap();
-        assert!(state.deposits.get(&user_a()).is_none(), "Empty position should be removed");
+        state
+            .process_withdrawal(user_a(), icusd_ledger(), 70_000_000)
+            .unwrap();
+        assert!(
+            state.deposits.get(&user_a()).is_none(),
+            "Empty position should be removed"
+        );
 
         // Attempt to withdraw from nonexistent position
-        let err = state.process_withdrawal(user_a(), icusd_ledger(), 1).unwrap_err();
+        let err = state
+            .process_withdrawal(user_a(), icusd_ledger(), 1)
+            .unwrap_err();
         assert!(matches!(err, StabilityPoolError::NoPositionFound));
     }
 
@@ -1640,9 +2046,15 @@ mod tests {
         let mut state = test_state();
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 50_000_000);
 
-        let err = state.process_withdrawal(user_a(), icusd_ledger(), 100_000_000).unwrap_err();
+        let err = state
+            .process_withdrawal(user_a(), icusd_ledger(), 100_000_000)
+            .unwrap_err();
         match err {
-            StabilityPoolError::InsufficientBalance { token, required, available } => {
+            StabilityPoolError::InsufficientBalance {
+                token,
+                required,
+                available,
+            } => {
                 assert_eq!(token, icusd_ledger());
                 assert_eq!(required, 100_000_000);
                 assert_eq!(available, 50_000_000);
@@ -1691,7 +2103,10 @@ mod tests {
         let usdt_draw = draw.get(&ckusdt_ledger()).copied().unwrap_or(0);
         let icusd_draw = draw.get(&icusd_ledger()).copied().unwrap_or(0);
 
-        assert_eq!(usdt_draw, 80_000_000, "All 80 USD should come from ckUSDT (priority 2)");
+        assert_eq!(
+            usdt_draw, 80_000_000,
+            "All 80 USD should come from ckUSDT (priority 2)"
+        );
         assert_eq!(icusd_draw, 0, "icUSD (priority 1) should not be touched");
     }
 
@@ -1743,8 +2158,8 @@ mod tests {
             1, // vault_id
             icp_ledger(),
             &stables_consumed,
-            5_00000000, // 5 ICP
-            7_50000000, // collateral price $7.50
+            5_00000000,    // 5 ICP
+            7_50000000,    // collateral price $7.50
             1_000_000_000, // timestamp
         );
 
@@ -1756,21 +2171,67 @@ mod tests {
         let pos_b = state.deposits.get(&user_b()).unwrap();
         let pos_c = state.deposits.get(&user_c()).unwrap();
 
-        assert_eq!(pos_a.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 45_00000000);
-        assert_eq!(pos_b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 27_00000000);
-        assert_eq!(pos_c.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 18_00000000);
+        assert_eq!(
+            pos_a
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            45_00000000
+        );
+        assert_eq!(
+            pos_b
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            27_00000000
+        );
+        assert_eq!(
+            pos_c
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            18_00000000
+        );
 
         // Check proportional collateral gains:
         // user_a gain: 5 ICP * (5/10) = 2.5 ICP = 2_50000000
         // user_b gain: 5 ICP * (3/10) = 1.5 ICP = 1_50000000
         // user_c gain: 5 ICP * (2/10) = 1.0 ICP = 1_00000000
-        assert_eq!(pos_a.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 2_50000000);
-        assert_eq!(pos_b.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 1_50000000);
-        assert_eq!(pos_c.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 1_00000000);
+        assert_eq!(
+            pos_a
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            2_50000000
+        );
+        assert_eq!(
+            pos_b
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            1_50000000
+        );
+        assert_eq!(
+            pos_c
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            1_00000000
+        );
 
         // Verify aggregate total was reduced
         assert_eq!(
-            state.total_stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0),
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
             90_00000000, // 100 - 10 = 90
         );
 
@@ -1796,11 +2257,17 @@ mod tests {
 
         // Effective pool for ICP should only include user_a
         let effective = state.effective_pool_for_collateral(&icp_ledger());
-        assert_eq!(effective, 60_00000000, "Only user_a's 60 icUSD should be in effective pool");
+        assert_eq!(
+            effective, 60_00000000,
+            "Only user_a's 60 icUSD should be in effective pool"
+        );
 
         // Effective pool for ckBTC should include both (user_b only opted out of ICP)
         let effective_btc = state.effective_pool_for_collateral(&ckbtc_ledger());
-        assert_eq!(effective_btc, 100_00000000, "Both users should be in ckBTC pool");
+        assert_eq!(
+            effective_btc, 100_00000000,
+            "Both users should be in ckBTC pool"
+        );
 
         // Token draw for ICP should only draw from user_a's balance
         let draw = state.compute_token_draw(30_00000000, &icp_ledger());
@@ -1811,18 +2278,51 @@ mod tests {
         stables_consumed.insert(icusd_ledger(), 20_00000000);
 
         state.process_liquidation_gains_at(
-            2, icp_ledger(), &stables_consumed, 10_00000000, 7_50000000, 2_000_000_000,
+            2,
+            icp_ledger(),
+            &stables_consumed,
+            10_00000000,
+            7_50000000,
+            2_000_000_000,
         );
 
         // user_a should lose all 20 icUSD (only opted-in depositor)
         let pos_a = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos_a.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 40_00000000);
-        assert_eq!(pos_a.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 10_00000000);
+        assert_eq!(
+            pos_a
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            40_00000000
+        );
+        assert_eq!(
+            pos_a
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            10_00000000
+        );
 
         // user_b should be completely untouched
         let pos_b = state.deposits.get(&user_b()).unwrap();
-        assert_eq!(pos_b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 40_00000000);
-        assert_eq!(pos_b.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 0);
+        assert_eq!(
+            pos_b
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            40_00000000
+        );
+        assert_eq!(
+            pos_b
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            0
+        );
     }
 
     #[test]
@@ -1834,14 +2334,18 @@ mod tests {
         state.opt_out_collateral(&user_a(), icp_ledger()).unwrap();
 
         // Second opt-out of same collateral should fail
-        let err = state.opt_out_collateral(&user_a(), icp_ledger()).unwrap_err();
+        let err = state
+            .opt_out_collateral(&user_a(), icp_ledger())
+            .unwrap_err();
         assert!(matches!(err, StabilityPoolError::AlreadyOptedOut { .. }));
 
         // Opt back in
         state.opt_in_collateral(&user_a(), icp_ledger()).unwrap();
 
         // Double opt-in should fail
-        let err = state.opt_in_collateral(&user_a(), icp_ledger()).unwrap_err();
+        let err = state
+            .opt_in_collateral(&user_a(), icp_ledger())
+            .unwrap_err();
         assert!(matches!(err, StabilityPoolError::AlreadyOptedIn { .. }));
     }
 
@@ -1850,11 +2354,15 @@ mod tests {
         let mut state = test_state();
 
         // Opt-out on nonexistent position
-        let err = state.opt_out_collateral(&user_a(), icp_ledger()).unwrap_err();
+        let err = state
+            .opt_out_collateral(&user_a(), icp_ledger())
+            .unwrap_err();
         assert!(matches!(err, StabilityPoolError::NoPositionFound));
 
         // Opt-in on nonexistent position
-        let err = state.opt_in_collateral(&user_a(), icp_ledger()).unwrap_err();
+        let err = state
+            .opt_in_collateral(&user_a(), icp_ledger())
+            .unwrap_err();
         assert!(matches!(err, StabilityPoolError::NoPositionFound));
     }
 
@@ -1887,11 +2395,17 @@ mod tests {
 
         // Round-trip for 6-decimal
         let original = 12_345_678u64;
-        assert_eq!(normalize_from_e8s(normalize_to_e8s(original, 6), 6), original);
+        assert_eq!(
+            normalize_from_e8s(normalize_to_e8s(original, 6), 6),
+            original
+        );
 
         // Round-trip for 8-decimal
         let original = 98_765_432u64;
-        assert_eq!(normalize_from_e8s(normalize_to_e8s(original, 8), 8), original);
+        assert_eq!(
+            normalize_from_e8s(normalize_to_e8s(original, 8), 8),
+            original
+        );
 
         // Hypothetical 12-decimal token (greater than 8): e.g. 1.0 = 1_000_000_000_000
         // normalize_to_e8s: divide by 10^4 = 10_000
@@ -1915,15 +2429,29 @@ mod tests {
         assert!(state.validate_state().is_ok());
 
         // Corrupt the tracked total to create a mismatch
-        *state.total_stablecoin_balances.get_mut(&icusd_ledger()).unwrap() = 999;
+        *state
+            .total_stablecoin_balances
+            .get_mut(&icusd_ledger())
+            .unwrap() = 999;
         let err = state.validate_state();
         assert!(err.is_err());
         let msg = err.unwrap_err();
-        assert!(msg.contains("mismatch"), "Error should mention mismatch: {}", msg);
-        assert!(msg.contains("tracked=999"), "Error should show tracked value: {}", msg);
+        assert!(
+            msg.contains("mismatch"),
+            "Error should mention mismatch: {}",
+            msg
+        );
+        assert!(
+            msg.contains("tracked=999"),
+            "Error should show tracked value: {}",
+            msg
+        );
 
         // Fix the corruption
-        *state.total_stablecoin_balances.get_mut(&icusd_ledger()).unwrap() = 150_00000000;
+        *state
+            .total_stablecoin_balances
+            .get_mut(&icusd_ledger())
+            .unwrap() = 150_00000000;
         assert!(state.validate_state().is_ok());
     }
 
@@ -1966,8 +2494,13 @@ mod tests {
         assert!(!pos.is_empty());
 
         pos.collateral_gains.clear();
-        pos.cfx_claims.get_or_insert_with(BTreeMap::new).insert(cfx_sentinel(), 1_000_000_000_000_000_000);
-        assert!(!pos.is_empty(), "u128 CFX claims must prevent position cleanup");
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(cfx_sentinel(), 1_000_000_000_000_000_000);
+        assert!(
+            !pos.is_empty(),
+            "u128 CFX claims must prevent position cleanup"
+        );
     }
 
     // ─── Test: Mark gains claimed ───
@@ -1978,20 +2511,46 @@ mod tests {
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
 
         // Manually add collateral gains
-        state.deposits.get_mut(&user_a()).unwrap()
-            .collateral_gains.insert(icp_ledger(), 5_00000000);
+        state
+            .deposits
+            .get_mut(&user_a())
+            .unwrap()
+            .collateral_gains
+            .insert(icp_ledger(), 5_00000000);
 
         // Partially claim
         state.mark_gains_claimed(&user_a(), &icp_ledger(), 2_00000000);
         let pos = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 3_00000000);
-        assert_eq!(pos.total_claimed_gains.get(&icp_ledger()).copied().unwrap_or(0), 2_00000000);
+        assert_eq!(
+            pos.collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            3_00000000
+        );
+        assert_eq!(
+            pos.total_claimed_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            2_00000000
+        );
 
         // Claim the rest
         state.mark_gains_claimed(&user_a(), &icp_ledger(), 3_00000000);
         let pos = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos.collateral_gains.get(&icp_ledger()), None, "Zero gains should be cleaned up");
-        assert_eq!(pos.total_claimed_gains.get(&icp_ledger()).copied().unwrap_or(0), 5_00000000);
+        assert_eq!(
+            pos.collateral_gains.get(&icp_ledger()),
+            None,
+            "Zero gains should be cleaned up"
+        );
+        assert_eq!(
+            pos.total_claimed_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            5_00000000
+        );
     }
 
     // ─── Test: Effective pool computation ───
@@ -2007,14 +2566,23 @@ mod tests {
         add_deposit_direct(&mut state, user_b(), icusd_ledger(), 30_00000000);
 
         // All opted in -> total = 100 USD e8s
-        assert_eq!(state.effective_pool_for_collateral(&icp_ledger()), 100_00000000);
+        assert_eq!(
+            state.effective_pool_for_collateral(&icp_ledger()),
+            100_00000000
+        );
 
         // user_a opts out of ICP -> only user_b remains
         state.opt_out_collateral(&user_a(), icp_ledger()).unwrap();
-        assert_eq!(state.effective_pool_for_collateral(&icp_ledger()), 30_00000000);
+        assert_eq!(
+            state.effective_pool_for_collateral(&icp_ledger()),
+            30_00000000
+        );
 
         // ckBTC effective pool still has everyone
-        assert_eq!(state.effective_pool_for_collateral(&ckbtc_ledger()), 100_00000000);
+        assert_eq!(
+            state.effective_pool_for_collateral(&ckbtc_ledger()),
+            100_00000000
+        );
     }
 
     #[test]
@@ -2034,14 +2602,23 @@ mod tests {
             0,
             "chain sentinel starts default-out",
         );
-        assert!(state.compute_token_draw(10_00000000, &cfx_sentinel()).is_empty());
+        assert!(state
+            .compute_token_draw(10_00000000, &cfx_sentinel())
+            .is_empty());
 
-        state.opt_in_cfx(&user_a(), cfx_sentinel()).expect("user A opts into CFX");
-        assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 100_00000000);
+        state
+            .opt_in_cfx(&user_a(), cfx_sentinel())
+            .expect("user A opts into CFX");
+        assert_eq!(
+            state.effective_pool_for_collateral(&cfx_sentinel()),
+            100_00000000
+        );
         let draw = state.compute_token_draw(10_00000000, &cfx_sentinel());
         assert_eq!(draw.get(&icusd_ledger()).copied(), Some(10_00000000));
 
-        state.opt_out_cfx(&user_a(), cfx_sentinel()).expect("user A opts back out");
+        state
+            .opt_out_cfx(&user_a(), cfx_sentinel())
+            .expect("user A opts back out");
         assert_eq!(state.effective_pool_for_collateral(&cfx_sentinel()), 0);
     }
 
@@ -2054,16 +2631,23 @@ mod tests {
         assert_ne!(sentinel, icusd_ledger());
         assert_ne!(sentinel, icp_ledger());
 
-        let registered = state.register_chain_collateral(1030, "CFX".to_string(), 18)
+        let registered = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
             .expect("register CFX sentinel");
         assert_eq!(registered, sentinel);
         assert!(state.is_chain_collateral_sentinel(&sentinel));
-        let info = state.collateral_registry.get(&sentinel).expect("sentinel registered as collateral");
+        let info = state
+            .collateral_registry
+            .get(&sentinel)
+            .expect("sentinel registered as collateral");
         assert_eq!(info.symbol, "CFX");
         assert_eq!(info.decimals, 18);
         assert!(matches!(info.status, CollateralStatus::Active));
         assert_eq!(state.effective_pool_for_collateral(&sentinel), 0);
-        assert!(state.validate_state().is_ok(), "sentinel is metadata, not a ledger aggregate");
+        assert!(
+            state.validate_state().is_ok(),
+            "sentinel is metadata, not a ledger aggregate"
+        );
     }
 
     #[test]
@@ -2087,23 +2671,70 @@ mod tests {
             123,
         );
 
-        let claim_a = state.deposits.get(&user_a()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
-        let claim_b = state.deposits.get(&user_b()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
-        assert_eq!(claim_a, 10_000 * E18 + 1, "first opted-in depositor receives wei dust");
+        let claim_a = state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&cfx_sentinel())
+            .copied()
+            .unwrap_or(0);
+        let claim_b = state
+            .deposits
+            .get(&user_b())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&cfx_sentinel())
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            claim_a,
+            10_000 * E18 + 1,
+            "first opted-in depositor receives wei dust"
+        );
         assert_eq!(claim_b, 10_000 * E18);
-        assert!(claim_a > u64::MAX as u128, "CFX claim must not truncate to u64");
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()).copied(), Some(0));
-        assert!(state.deposits.contains_key(&user_a()), "CFX claim keeps drained position alive");
+        assert!(
+            claim_a > u64::MAX as u128,
+            "CFX claim must not truncate to u64"
+        );
+        assert_eq!(
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied(),
+            Some(0)
+        );
+        assert!(
+            state.deposits.contains_key(&user_a()),
+            "CFX claim keeps drained position alive"
+        );
 
         state.mark_cfx_claimed(&user_a(), &cfx_sentinel(), 3 * E18);
-        let after_partial = state.deposits.get(&user_a()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).copied().unwrap_or(0);
+        let after_partial = state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&cfx_sentinel())
+            .copied()
+            .unwrap_or(0);
         assert_eq!(after_partial, 9_997 * E18 + 1);
         state.mark_cfx_claimed(&user_a(), &cfx_sentinel(), 9_997 * E18 + 1);
-        assert!(state.deposits.get(&user_a()).unwrap()
-            .cfx_claims.as_ref().unwrap().get(&cfx_sentinel()).is_none());
+        assert!(state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .cfx_claims
+            .as_ref()
+            .unwrap()
+            .get(&cfx_sentinel())
+            .is_none());
     }
 
     #[test]
@@ -2130,8 +2761,14 @@ mod tests {
             Some(40_00000000),
             "chain draw caps to opted-in icUSD, not total stable value",
         );
-        assert!(!draw.contains_key(&ckusdc_ledger()), "ckUSDC must not be burned for Inc 4 chain absorb");
-        assert!(!draw.contains_key(&three_usd_ledger()), "3USD LP must not be burned for Inc 4 chain absorb");
+        assert!(
+            !draw.contains_key(&ckusdc_ledger()),
+            "ckUSDC must not be burned for Inc 4 chain absorb"
+        );
+        assert!(
+            !draw.contains_key(&three_usd_ledger()),
+            "3USD LP must not be burned for Inc 4 chain absorb"
+        );
 
         state.opt_in_cfx(&user_b(), cfx_sentinel()).unwrap();
         let full_draw = state.compute_icusd_chain_draw(70_00000000, &cfx_sentinel());
@@ -2160,27 +2797,67 @@ mod tests {
         let mut stables_consumed = BTreeMap::new();
         stables_consumed.insert(ckusdt_ledger(), 20_000_000); // 20 ckUSDT consumed
         stables_consumed.insert(ckusdc_ledger(), 20_000_000); // 20 ckUSDC consumed
-        // total consumed = 40 USD
+                                                              // total consumed = 40 USD
 
         state.process_liquidation_gains_at(
-            10, icp_ledger(), &stables_consumed, 20_00000000, 7_50000000, 3_000_000_000,
+            10,
+            icp_ledger(),
+            &stables_consumed,
+            20_00000000,
+            7_50000000,
+            3_000_000_000,
         );
 
         // user_a has all the ckUSDT, so consumes all 20 ckUSDT
         let pos_a = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos_a.stablecoin_balances.get(&ckusdt_ledger()).copied().unwrap_or(0), 30_000_000); // 50 - 20
-        // user_a's icUSD should be untouched (not consumed)
-        assert_eq!(pos_a.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 100_00000000);
+        assert_eq!(
+            pos_a
+                .stablecoin_balances
+                .get(&ckusdt_ledger())
+                .copied()
+                .unwrap_or(0),
+            30_000_000
+        ); // 50 - 20
+           // user_a's icUSD should be untouched (not consumed)
+        assert_eq!(
+            pos_a
+                .stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            100_00000000
+        );
 
         // user_b has all the ckUSDC, so consumes all 20 ckUSDC
         let pos_b = state.deposits.get(&user_b()).unwrap();
-        assert_eq!(pos_b.stablecoin_balances.get(&ckusdc_ledger()).copied().unwrap_or(0), 30_000_000); // 50 - 20
+        assert_eq!(
+            pos_b
+                .stablecoin_balances
+                .get(&ckusdc_ledger())
+                .copied()
+                .unwrap_or(0),
+            30_000_000
+        ); // 50 - 20
 
         // Collateral distribution: each consumed 20 USD worth out of 40 total = 50% each
         // user_a: 50% of 20 ICP = 10 ICP
         // user_b: 50% of 20 ICP = 10 ICP
-        assert_eq!(pos_a.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 10_00000000);
-        assert_eq!(pos_b.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 10_00000000);
+        assert_eq!(
+            pos_a
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            10_00000000
+        );
+        assert_eq!(
+            pos_b
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            10_00000000
+        );
     }
 
     // ─── Test: Liquidation cleans up fully consumed positions ───
@@ -2196,16 +2873,36 @@ mod tests {
         stables_consumed.insert(icusd_ledger(), 100_00000000); // consume all 100 icUSD
 
         state.process_liquidation_gains_at(
-            5, icp_ledger(), &stables_consumed, 50_00000000, 7_50000000, 4_000_000_000,
+            5,
+            icp_ledger(),
+            &stables_consumed,
+            50_00000000,
+            7_50000000,
+            4_000_000_000,
         );
 
         // user_a's stablecoin balance is zero, but they have collateral gains
         // so position should NOT be removed
         let pos = state.deposits.get(&user_a());
-        assert!(pos.is_some(), "Position with collateral gains should not be cleaned up");
+        assert!(
+            pos.is_some(),
+            "Position with collateral gains should not be cleaned up"
+        );
         let pos = pos.unwrap();
-        assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 0);
-        assert_eq!(pos.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 50_00000000);
+        assert_eq!(
+            pos.stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
+            0
+        );
+        assert_eq!(
+            pos.collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            50_00000000
+        );
     }
 
     // ─── Test: Token draw with no available balance ───
@@ -2226,9 +2923,18 @@ mod tests {
         let state = test_state();
 
         // Registration should initialize zero balances in total tracking
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()), Some(&0));
-        assert_eq!(state.total_stablecoin_balances.get(&ckusdt_ledger()), Some(&0));
-        assert_eq!(state.total_stablecoin_balances.get(&ckusdc_ledger()), Some(&0));
+        assert_eq!(
+            state.total_stablecoin_balances.get(&icusd_ledger()),
+            Some(&0)
+        );
+        assert_eq!(
+            state.total_stablecoin_balances.get(&ckusdt_ledger()),
+            Some(&0)
+        );
+        assert_eq!(
+            state.total_stablecoin_balances.get(&ckusdc_ledger()),
+            Some(&0)
+        );
     }
 
     // ─── Test: Pool status query ───
@@ -2259,8 +2965,14 @@ mod tests {
 
         let pos = state.get_user_position(&user_a()).unwrap();
         assert_eq!(pos.total_usd_value_e8s, 125_00000000); // 100 + 25
-        assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()), Some(&100_00000000));
-        assert_eq!(pos.stablecoin_balances.get(&ckusdt_ledger()), Some(&25_000_000));
+        assert_eq!(
+            pos.stablecoin_balances.get(&icusd_ledger()),
+            Some(&100_00000000)
+        );
+        assert_eq!(
+            pos.stablecoin_balances.get(&ckusdt_ledger()),
+            Some(&25_000_000)
+        );
 
         // Nonexistent user
         assert!(state.get_user_position(&user_b()).is_none());
@@ -2277,8 +2989,14 @@ mod tests {
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 20_00000000);
 
         let pos = state.deposits.get(&user_a()).unwrap();
-        assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()), Some(&100_00000000));
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()), Some(&100_00000000));
+        assert_eq!(
+            pos.stablecoin_balances.get(&icusd_ledger()),
+            Some(&100_00000000)
+        );
+        assert_eq!(
+            state.total_stablecoin_balances.get(&icusd_ledger()),
+            Some(&100_00000000)
+        );
     }
 
     // ─── Test: Interest Distribution ───
@@ -2294,7 +3012,10 @@ mod tests {
         assert_eq!(pos.stablecoin_balances[&icusd_ledger()], 105_00000000);
         assert_eq!(pos.total_interest_earned_e8s, Some(5_00000000)); // icUSD is 8 decimals = e8s
         assert_eq!(state.total_interest_received_e8s, Some(5_00000000));
-        assert_eq!(state.total_stablecoin_balances[&icusd_ledger()], 105_00000000);
+        assert_eq!(
+            state.total_stablecoin_balances[&icusd_ledger()],
+            105_00000000
+        );
     }
 
     #[test]
@@ -2312,7 +3033,10 @@ mod tests {
         assert_eq!(a.stablecoin_balances[&icusd_ledger()], 82_50000000);
         assert_eq!(b.stablecoin_balances[&icusd_ledger()], 27_50000000);
         // Total should be exactly original + interest
-        assert_eq!(state.total_stablecoin_balances[&icusd_ledger()], 110_00000000);
+        assert_eq!(
+            state.total_stablecoin_balances[&icusd_ledger()],
+            110_00000000
+        );
     }
 
     #[test]
@@ -2329,13 +3053,25 @@ mod tests {
         // 3 depositors with equal balances, interest = 10 (not divisible by 3)
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100);
         add_deposit_direct(&mut state, user_b(), icusd_ledger(), 100);
-        add_deposit_direct(&mut state, Principal::from_slice(&[99]), icusd_ledger(), 100);
+        add_deposit_direct(
+            &mut state,
+            Principal::from_slice(&[99]),
+            icusd_ledger(),
+            100,
+        );
 
         state.distribute_interest_revenue(icusd_ledger(), 10, None);
 
         // Each gets floor(10 * 100/300) = 3. Dust = 10 - 9 = 1 goes to first depositor.
-        let total: u64 = state.deposits.values()
-            .map(|p| p.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0))
+        let total: u64 = state
+            .deposits
+            .values()
+            .map(|p| {
+                p.stablecoin_balances
+                    .get(&icusd_ledger())
+                    .copied()
+                    .unwrap_or(0)
+            })
             .sum();
         assert_eq!(total, 310, "All interest must be accounted for");
         assert_eq!(state.total_stablecoin_balances[&icusd_ledger()], 310);
@@ -2358,13 +3094,30 @@ mod tests {
         let a = state.deposits.get(&user_a()).unwrap();
         let b = state.deposits.get(&user_b()).unwrap();
         let a_interest = a.stablecoin_balances[&icusd_ledger()] - 50_00000000;
-        let b_interest = b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let b_interest = b
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
         // icUSD-only rule: A (the icUSD depositor) gets the full 10 icUSD,
         // B (the ckUSDT depositor) gets nothing.
-        assert_eq!(a_interest, 10_00000000, "icUSD depositor should receive the full 10 icUSD interest");
-        assert_eq!(b_interest, 0, "ckUSDT depositor should earn no interest under icUSD-only rule");
-        assert_eq!(b.stablecoin_balances[&ckusdt_ledger()], 50_000_000, "B: ckUSDT unchanged");
-        assert_eq!(state.total_stablecoin_balances[&icusd_ledger()], 60_00000000);
+        assert_eq!(
+            a_interest, 10_00000000,
+            "icUSD depositor should receive the full 10 icUSD interest"
+        );
+        assert_eq!(
+            b_interest, 0,
+            "ckUSDT depositor should earn no interest under icUSD-only rule"
+        );
+        assert_eq!(
+            b.stablecoin_balances[&ckusdt_ledger()],
+            50_000_000,
+            "B: ckUSDT unchanged"
+        );
+        assert_eq!(
+            state.total_stablecoin_balances[&icusd_ledger()],
+            60_00000000
+        );
     }
 
     #[test]
@@ -2384,12 +3137,26 @@ mod tests {
         let a = state.deposits.get(&user_a()).unwrap();
         let b = state.deposits.get(&user_b()).unwrap();
         let a_interest = a.stablecoin_balances[&icusd_ledger()] - 100_00000000;
-        let b_interest = b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let b_interest = b
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
         // icUSD-only rule: A (the icUSD depositor) takes the entire 20 icUSD,
         // B (the 3USD LP depositor) gets nothing.
-        assert_eq!(a_interest, 20_00000000, "icUSD depositor should receive the full 20 icUSD interest");
-        assert_eq!(b_interest, 0, "3USD depositor should earn no interest under icUSD-only rule");
-        assert_eq!(b.stablecoin_balances[&three_usd_ledger()], 100_00000000, "B: 3USD position unchanged");
+        assert_eq!(
+            a_interest, 20_00000000,
+            "icUSD depositor should receive the full 20 icUSD interest"
+        );
+        assert_eq!(
+            b_interest, 0,
+            "3USD depositor should earn no interest under icUSD-only rule"
+        );
+        assert_eq!(
+            b.stablecoin_balances[&three_usd_ledger()],
+            100_00000000,
+            "B: 3USD position unchanged"
+        );
     }
 
     #[test]
@@ -2407,15 +3174,32 @@ mod tests {
 
         state.distribute_interest_revenue(icusd_ledger(), 10_00000000, Some(icp_ledger()));
 
-        let alice_icusd = state.deposits.get(&user_a()).unwrap()
-            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
-        let bob_icusd = state.deposits.get(&user_b()).unwrap()
-            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
+        let alice_icusd = state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
+        let bob_icusd = state
+            .deposits
+            .get(&user_b())
+            .unwrap()
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
 
-        assert_eq!(alice_icusd, 100_00000000 + 10_00000000,
-            "icUSD depositor should receive the full 10 icUSD interest");
-        assert_eq!(bob_icusd, 0,
-            "3USD depositor should receive no icUSD interest");
+        assert_eq!(
+            alice_icusd,
+            100_00000000 + 10_00000000,
+            "icUSD depositor should receive the full 10 icUSD interest"
+        );
+        assert_eq!(
+            bob_icusd, 0,
+            "3USD depositor should receive no icUSD interest"
+        );
     }
 
     #[test]
@@ -2438,19 +3222,43 @@ mod tests {
 
         state.distribute_interest_revenue(icusd_ledger(), 20_00000000, None);
 
-        let alice_icusd = state.deposits.get(&user_a()).unwrap()
-            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
-        let bob_icusd = state.deposits.get(&user_b()).unwrap()
-            .stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
-        let bob_three_usd = state.deposits.get(&user_b()).unwrap()
-            .stablecoin_balances.get(&three_usd_ledger()).copied().unwrap_or(0);
+        let alice_icusd = state
+            .deposits
+            .get(&user_a())
+            .unwrap()
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
+        let bob_icusd = state
+            .deposits
+            .get(&user_b())
+            .unwrap()
+            .stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
+        let bob_three_usd = state
+            .deposits
+            .get(&user_b())
+            .unwrap()
+            .stablecoin_balances
+            .get(&three_usd_ledger())
+            .copied()
+            .unwrap_or(0);
 
-        assert_eq!(alice_icusd, 110_00000000,
-            "user_a (100 icUSD) earns 10 icUSD on equal-icUSD share");
-        assert_eq!(bob_icusd, 110_00000000,
-            "user_b's icUSD slice (100) earns 10 icUSD (same as user_a)");
-        assert_eq!(bob_three_usd, 100_00000000,
-            "user_b's 3USD balance is not credited and not touched");
+        assert_eq!(
+            alice_icusd, 110_00000000,
+            "user_a (100 icUSD) earns 10 icUSD on equal-icUSD share"
+        );
+        assert_eq!(
+            bob_icusd, 110_00000000,
+            "user_b's icUSD slice (100) earns 10 icUSD (same as user_a)"
+        );
+        assert_eq!(
+            bob_three_usd, 100_00000000,
+            "user_b's 3USD balance is not credited and not touched"
+        );
     }
 
     #[test]
@@ -2466,25 +3274,49 @@ mod tests {
         add_deposit_direct(&mut state, user_b(), three_usd_ledger(), 100_00000000);
 
         let total_received_before = state.total_interest_received_e8s.unwrap_or(0);
-        let stable_balance_before = state.total_stablecoin_balances
-            .get(&icusd_ledger()).copied().unwrap_or(0);
+        let stable_balance_before = state
+            .total_stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
 
         state.distribute_interest_revenue(icusd_ledger(), 10_00000000, None);
 
         // Aggregates unchanged
-        assert_eq!(state.total_interest_received_e8s.unwrap_or(0), total_received_before,
-            "total_interest_received_e8s should not advance when no icUSD depositors");
-        assert_eq!(state.total_stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0),
+        assert_eq!(
+            state.total_interest_received_e8s.unwrap_or(0),
+            total_received_before,
+            "total_interest_received_e8s should not advance when no icUSD depositors"
+        );
+        assert_eq!(
+            state
+                .total_stablecoin_balances
+                .get(&icusd_ledger())
+                .copied()
+                .unwrap_or(0),
             stable_balance_before,
-            "total_stablecoin_balances[icusd] should not advance");
+            "total_stablecoin_balances[icusd] should not advance"
+        );
 
         // Neither depositor's balances changed
         for user in [user_a(), user_b()] {
             let pos = state.deposits.get(&user).unwrap();
-            assert_eq!(pos.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 0,
-                "depositor without icUSD should not be credited");
-            assert_eq!(pos.stablecoin_balances.get(&three_usd_ledger()).copied().unwrap_or(0),
-                100_00000000, "3USD balance unchanged");
+            assert_eq!(
+                pos.stablecoin_balances
+                    .get(&icusd_ledger())
+                    .copied()
+                    .unwrap_or(0),
+                0,
+                "depositor without icUSD should not be credited"
+            );
+            assert_eq!(
+                pos.stablecoin_balances
+                    .get(&three_usd_ledger())
+                    .copied()
+                    .unwrap_or(0),
+                100_00000000,
+                "3USD balance unchanged"
+            );
         }
     }
 
@@ -2512,25 +3344,51 @@ mod tests {
         consumed.insert(icusd_ledger(), 1_000_000);
 
         state.process_liquidation_gains_at(
-            1, icp_ledger(), &consumed, 500_000, 7_50000000, 1_000_000_000,
+            1,
+            icp_ledger(),
+            &consumed,
+            500_000,
+            7_50000000,
+            1_000_000_000,
         );
 
         // The critical assertion: aggregate should match sum of individual balances
         // even when rounding dust occurs. validate_state() checks this.
-        assert!(state.validate_state().is_ok(), "State must remain consistent after rounding");
+        assert!(
+            state.validate_state().is_ok(),
+            "State must remain consistent after rounding"
+        );
 
         // Verify individual balances sum to aggregate
-        let sum: u64 = state.deposits.values()
-            .map(|p| p.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0))
+        let sum: u64 = state
+            .deposits
+            .values()
+            .map(|p| {
+                p.stablecoin_balances
+                    .get(&icusd_ledger())
+                    .copied()
+                    .unwrap_or(0)
+            })
             .sum();
-        let tracked = state.total_stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0);
-        assert_eq!(sum, tracked, "Sum of individual balances must equal aggregate");
+        let tracked = state
+            .total_stablecoin_balances
+            .get(&icusd_ledger())
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            sum, tracked,
+            "Sum of individual balances must equal aggregate"
+        );
     }
 
     // ─── 3USD / LP Token Tests ───
 
-    fn three_usd_ledger() -> Principal { Principal::from_slice(&[30]) }
-    fn three_pool_canister() -> Principal { Principal::from_slice(&[31]) }
+    fn three_usd_ledger() -> Principal {
+        Principal::from_slice(&[30])
+    }
+    fn three_pool_canister() -> Principal {
+        Principal::from_slice(&[31])
+    }
 
     /// Build a test state with 3USD LP token registered.
     fn test_state_with_3usd() -> StabilityPoolState {
@@ -2546,7 +3404,8 @@ mod tests {
             underlying_pool: Some(three_pool_canister()),
         });
         // Set virtual price to ~1.0492 (scaled 1e18)
-        state.cached_virtual_prices
+        state
+            .cached_virtual_prices
             .get_or_insert_with(BTreeMap::new)
             .insert(three_usd_ledger(), 1_049_200_000_000_000_000u128);
         state
@@ -2565,7 +3424,10 @@ mod tests {
         assert_eq!(lp_to_usd_e8s(0, vp), 0);
 
         // vp=1.0 (exactly 1e18)
-        assert_eq!(lp_to_usd_e8s(100_000_000, 1_000_000_000_000_000_000), 100_000_000);
+        assert_eq!(
+            lp_to_usd_e8s(100_000_000, 1_000_000_000_000_000_000),
+            100_000_000
+        );
     }
 
     #[test]
@@ -2573,11 +3435,18 @@ mod tests {
         let vp = 1_049_200_000_000_000_000u128;
         // 1 USD → ~0.9531 3USD LP
         let lp = usd_e8s_to_lp(100_000_000, vp);
-        assert!(lp > 95_000_000 && lp < 96_000_000, "Expected ~95.3M, got {}", lp);
+        assert!(
+            lp > 95_000_000 && lp < 96_000_000,
+            "Expected ~95.3M, got {}",
+            lp
+        );
 
         // Round-trip: lp_to_usd then back (may lose 1 unit to rounding)
         let usd = lp_to_usd_e8s(lp, vp);
-        assert!((usd as i64 - 100_000_000i64).abs() <= 1, "Round-trip drift too large");
+        assert!(
+            (usd as i64 - 100_000_000i64).abs() <= 1,
+            "Round-trip drift too large"
+        );
 
         // Zero virtual price → 0
         assert_eq!(usd_e8s_to_lp(100_000_000, 0), 0);
@@ -2592,7 +3461,8 @@ mod tests {
         // 1 icUSD (e8s)
         pos.stablecoin_balances.insert(icusd_ledger(), 100_000_000);
         // 1 3USD LP (worth ~1.0492 USD)
-        pos.stablecoin_balances.insert(three_usd_ledger(), 100_000_000);
+        pos.stablecoin_balances
+            .insert(three_usd_ledger(), 100_000_000);
 
         let total = pos.total_usd_value(&state.stablecoin_registry, vp_map);
         // 100_000_000 + 104_920_000 = 204_920_000
@@ -2606,7 +3476,8 @@ mod tests {
         state.cached_virtual_prices = Some(BTreeMap::new());
 
         let mut pos = DepositPosition::new(0);
-        pos.stablecoin_balances.insert(three_usd_ledger(), 100_000_000);
+        pos.stablecoin_balances
+            .insert(three_usd_ledger(), 100_000_000);
 
         // Without virtual price, LP tokens valued at 0
         let total = pos.total_usd_value(&state.stablecoin_registry, state.virtual_prices());
@@ -2619,20 +3490,35 @@ mod tests {
 
         // Add deposits: 1 icUSD (priority 1), 2 ckUSDT (priority 2), 5 3USD (priority 0)
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_000_000); // 1 icUSD
-        add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 2_000_000);  // 2 ckUSDT
+        add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 2_000_000); // 2 ckUSDT
         add_deposit_direct(&mut state, user_a(), three_usd_ledger(), 500_000_000); // 5 3USD
 
         // Draw 3 USD — should consume ckUSDT first (priority 2), then icUSD (priority 1)
         let draw = state.compute_token_draw(300_000_000, &icp_ledger()); // 3 USD e8s
-        assert!(draw.contains_key(&ckusdt_ledger()), "Should draw from ckUSDT (priority 2)");
-        assert!(draw.contains_key(&icusd_ledger()), "Should draw from icUSD (priority 1)");
-        assert!(!draw.contains_key(&three_usd_ledger()), "Should NOT draw from 3USD yet (priority 0)");
+        assert!(
+            draw.contains_key(&ckusdt_ledger()),
+            "Should draw from ckUSDT (priority 2)"
+        );
+        assert!(
+            draw.contains_key(&icusd_ledger()),
+            "Should draw from icUSD (priority 1)"
+        );
+        assert!(
+            !draw.contains_key(&three_usd_ledger()),
+            "Should NOT draw from 3USD yet (priority 0)"
+        );
 
         // Draw 5 USD — should consume all ckUSDT + icUSD, then dip into 3USD
         let draw = state.compute_token_draw(500_000_000, &icp_ledger()); // 5 USD e8s
-        assert!(draw.contains_key(&ckusdt_ledger()), "Should draw from ckUSDT");
+        assert!(
+            draw.contains_key(&ckusdt_ledger()),
+            "Should draw from ckUSDT"
+        );
         assert!(draw.contains_key(&icusd_ledger()), "Should draw from icUSD");
-        assert!(draw.contains_key(&three_usd_ledger()), "Should draw from 3USD for remainder");
+        assert!(
+            draw.contains_key(&three_usd_ledger()),
+            "Should draw from 3USD for remainder"
+        );
     }
 
     #[test]
@@ -2655,11 +3541,26 @@ mod tests {
 
         // Record two refunds for user_a and one for user_b.
         let id0 = state.record_pending_refund(
-            user_a(), icusd_ledger(), 5_00000000, "approve failed".to_string(), 100);
+            user_a(),
+            icusd_ledger(),
+            5_00000000,
+            "approve failed".to_string(),
+            100,
+        );
         let id1 = state.record_pending_refund(
-            user_a(), ckusdt_ledger(), 7_000_000, "add_liquidity failed".to_string(), 200);
+            user_a(),
+            ckusdt_ledger(),
+            7_000_000,
+            "add_liquidity failed".to_string(),
+            200,
+        );
         let id2 = state.record_pending_refund(
-            user_b(), icusd_ledger(), 1_00000000, "approve failed".to_string(), 300);
+            user_b(),
+            icusd_ledger(),
+            1_00000000,
+            "approve failed".to_string(),
+            300,
+        );
         assert_eq!((id0, id1, id2), (0, 1, 2), "refund ids must be monotonic");
 
         // Per-user listing only returns the owner's records.
@@ -2673,7 +3574,10 @@ mod tests {
         // returns None, so two concurrent claims cannot both pay out.
         let taken = state.take_pending_refund(id0).expect("first take succeeds");
         assert_eq!(taken.amount, 5_00000000);
-        assert!(state.take_pending_refund(id0).is_none(), "double-claim must not pay twice");
+        assert!(
+            state.take_pending_refund(id0).is_none(),
+            "double-claim must not pay twice"
+        );
 
         // put_pending_refund restores the record after a failed payout transfer.
         state.put_pending_refund(taken);
@@ -2689,18 +3593,30 @@ mod tests {
         let mut state = test_state();
         for i in 0..MAX_PENDING_REFUNDS {
             state.record_pending_refund(
-                user_a(), icusd_ledger(), i as u64 + 1, "fail".to_string(), i as u64);
+                user_a(),
+                icusd_ledger(),
+                i as u64 + 1,
+                "fail".to_string(),
+                i as u64,
+            );
         }
-        assert_eq!(state.pending_refunds_for(&user_a()).len(), MAX_PENDING_REFUNDS);
+        assert_eq!(
+            state.pending_refunds_for(&user_a()).len(),
+            MAX_PENDING_REFUNDS
+        );
 
-        let id = state.record_pending_refund(user_a(), icusd_ledger(), 999, "fail".to_string(), 999);
+        let id =
+            state.record_pending_refund(user_a(), icusd_ledger(), 999, "fail".to_string(), 999);
         assert_eq!(id as usize, MAX_PENDING_REFUNDS);
         assert_eq!(
             state.pending_refunds_for(&user_a()).len(),
             MAX_PENDING_REFUNDS,
             "cap must hold",
         );
-        assert!(state.take_pending_refund(0).is_none(), "oldest record dropped at cap");
+        assert!(
+            state.take_pending_refund(0).is_none(),
+            "oldest record dropped at cap"
+        );
     }
 
     #[test]
@@ -2732,13 +3648,19 @@ mod tests {
 
         let decoded = try_decode_state(&bytes).expect("v1 snapshot must decode");
         assert_eq!(
-            decoded.deposits.get(&user_a())
+            decoded
+                .deposits
+                .get(&user_a())
                 .and_then(|p| p.stablecoin_balances.get(&icusd_ledger()).copied()),
             Some(42_00000000),
             "depositor positions must survive the v1 fallback",
         );
         assert!(
-            decoded.pending_refunds.clone().unwrap_or_default().is_empty(),
+            decoded
+                .pending_refunds
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
             "pending refunds must start empty after a v1 upgrade",
         );
         assert_eq!(decoded.next_pending_refund_id.unwrap_or(0), 0);
@@ -2783,14 +3705,17 @@ mod tests {
         add_deposit_direct(&mut current, user_a(), icusd_ledger(), 42_00000000);
         let pos = current.deposits.get(&user_a()).unwrap();
         let mut deposits = BTreeMap::new();
-        deposits.insert(user_a(), DepositPositionPreCfx {
-            stablecoin_balances: pos.stablecoin_balances.clone(),
-            collateral_gains: pos.collateral_gains.clone(),
-            opted_out_collateral: pos.opted_out_collateral.clone(),
-            deposit_timestamp: pos.deposit_timestamp,
-            total_claimed_gains: pos.total_claimed_gains.clone(),
-            total_interest_earned_e8s: pos.total_interest_earned_e8s,
-        });
+        deposits.insert(
+            user_a(),
+            DepositPositionPreCfx {
+                stablecoin_balances: pos.stablecoin_balances.clone(),
+                collateral_gains: pos.collateral_gains.clone(),
+                opted_out_collateral: pos.opted_out_collateral.clone(),
+                deposit_timestamp: pos.deposit_timestamp,
+                total_claimed_gains: pos.total_claimed_gains.clone(),
+                total_interest_earned_e8s: pos.total_interest_earned_e8s,
+            },
+        );
         let pre_cfx = StabilityPoolStatePreCfx {
             deposits,
             total_stablecoin_balances: current.total_stablecoin_balances.clone(),
@@ -2817,21 +3742,81 @@ mod tests {
         let decoded = try_decode_state(&bytes).expect("pre-CFX snapshot must decode");
         let decoded_pos = decoded.deposits.get(&user_a()).expect("deposit survives");
         assert!(
-            decoded_pos.cfx_claims.clone().unwrap_or_default().is_empty(),
+            decoded_pos
+                .cfx_claims
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
             "missing CFX claims field must decode as empty",
         );
         assert!(
-            decoded_pos.opted_in_chain_collateral.clone().unwrap_or_default().is_empty(),
+            decoded_pos
+                .opted_in_chain_collateral
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
             "missing chain opt-in field must decode as empty",
         );
         assert!(
-            decoded.chain_collateral_sentinels.clone().unwrap_or_default().is_empty(),
+            decoded
+                .chain_collateral_sentinels
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
             "missing chain sentinel registry must decode as empty",
         );
         assert!(
-            decoded.chain_claim_sources.clone().unwrap_or_default().is_empty(),
+            decoded
+                .chain_claim_sources
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
             "missing chain claim source inventory must decode as empty",
         );
+        assert!(
+            decoded
+                .pending_chain_absorbs
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing pending chain absorb journal must decode as empty",
+        );
+        assert!(
+            decoded
+                .completed_chain_absorbs
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing completed chain absorb journal must decode as empty",
+        );
+    }
+
+    #[test]
+    fn completed_chain_absorbs_are_bounded() {
+        let mut state = StabilityPoolState::default();
+        for vault_id in 0..(MAX_COMPLETED_CHAIN_ABSORBS as u64 + 5) {
+            state.record_completed_chain_absorb(ChainSpAbsorbCompletion {
+                vault_id,
+                result: ChainSpAbsorbResult {
+                    success: true,
+                    vault_id,
+                    chain_id: rumi_protocol_backend::chains::config::ChainId(1030),
+                    icusd_burned_e8s: 100_00000000,
+                    liquidated_debt_e8s: 100_00000000,
+                    collateral_received_native: 10_000_000_000_000_000_000u128,
+                    claim_id: vault_id,
+                    custody_address: "0xcustody".to_string(),
+                    block_index: vault_id,
+                    collateral_price_e8s: 5_000_000,
+                },
+                completed_at_ns: vault_id,
+            });
+        }
+
+        let completed = state.completed_chain_absorbs.as_ref().unwrap();
+        assert_eq!(completed.len(), MAX_COMPLETED_CHAIN_ABSORBS);
+        assert!(!completed.contains_key(&0));
+        assert!(completed.contains_key(&(MAX_COMPLETED_CHAIN_ABSORBS as u64 + 4)));
     }
 
     // ─── Test: Opt-out mid-liquidation burn escape (audit AR-S-002) ───
@@ -2858,7 +3843,12 @@ mod tests {
         state.opt_out_collateral(&user_b(), icp_ledger()).unwrap();
 
         state.process_liquidation_gains_at(
-            1, icp_ledger(), &draw, 10_00000000, 7_50000000, 1_000_000_000,
+            1,
+            icp_ledger(),
+            &draw,
+            10_00000000,
+            7_50000000,
+            1_000_000_000,
         );
 
         // user_b escaped the burn entirely (balance untouched, no gains)...
@@ -2868,7 +3858,14 @@ mod tests {
             Some(50_00000000),
             "opt-out mid-liquidation escapes the burn",
         );
-        assert_eq!(pos_b.collateral_gains.get(&icp_ledger()).copied().unwrap_or(0), 0);
+        assert_eq!(
+            pos_b
+                .collateral_gains
+                .get(&icp_ledger())
+                .copied()
+                .unwrap_or(0),
+            0
+        );
 
         // ...while user_a absorbed the FULL 40 instead of their fair 20.
         let pos_a = state.deposits.get(&user_a()).unwrap();

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -102,28 +102,26 @@ impl DepositPosition {
         stablecoin_registry: &BTreeMap<Principal, StablecoinConfig>,
         virtual_prices: &BTreeMap<Principal, u128>,
     ) -> u64 {
-        self.stablecoin_balances.iter().map(|(ledger, &amount)| {
-            match stablecoin_registry.get(ledger) {
-                Some(config) if config.is_lp_token.unwrap_or(false) => {
-                    virtual_prices.get(ledger)
-                        .map(|&vp| lp_to_usd_e8s(amount, vp))
-                        .unwrap_or(0)
-                }
+        self.stablecoin_balances
+            .iter()
+            .map(|(ledger, &amount)| match stablecoin_registry.get(ledger) {
+                Some(config) if config.is_lp_token.unwrap_or(false) => virtual_prices
+                    .get(ledger)
+                    .map(|&vp| lp_to_usd_e8s(amount, vp))
+                    .unwrap_or(0),
                 Some(config) => normalize_to_e8s(amount, config.decimals),
                 None => 0,
-            }
-        }).sum()
+            })
+            .sum()
     }
 
     /// icUSD-only stablecoin value in e8s.
     /// Identifies the icUSD ledger by symbol from the registry. Returns 0 if
     /// no icUSD ledger is registered or the depositor holds no icUSD.
     /// icUSD is 8 decimals, so the raw balance is the e8s value directly.
-    pub fn icusd_value(
-        &self,
-        stablecoin_registry: &BTreeMap<Principal, StablecoinConfig>,
-    ) -> u64 {
-        let icusd_ledger = stablecoin_registry.iter()
+    pub fn icusd_value(&self, stablecoin_registry: &BTreeMap<Principal, StablecoinConfig>) -> u64 {
+        let icusd_ledger = stablecoin_registry
+            .iter()
             .find(|(_, c)| c.symbol == "icUSD")
             .map(|(id, _)| *id);
 
@@ -150,7 +148,11 @@ impl DepositPosition {
     pub fn is_empty(&self) -> bool {
         self.stablecoin_balances.values().all(|&v| v == 0)
             && self.collateral_gains.values().all(|&v| v == 0)
-            && self.cfx_claims.as_ref().map(|m| m.values().all(|&v| v == 0)).unwrap_or(true)
+            && self
+                .cfx_claims
+                .as_ref()
+                .map(|m| m.values().all(|&v| v == 0))
+                .unwrap_or(true)
     }
 }
 
@@ -185,7 +187,9 @@ pub fn lp_to_usd_e8s(lp_amount: u64, virtual_price: u128) -> u64 {
 
 /// Convert a USD e8s amount to the equivalent 3USD LP token amount.
 pub fn usd_e8s_to_lp(usd_e8s: u64, virtual_price: u128) -> u64 {
-    if virtual_price == 0 { return 0; }
+    if virtual_price == 0 {
+        return 0;
+    }
     (usd_e8s as u128 * 1_000_000_000_000_000_000u128 / virtual_price) as u64
 }
 
@@ -208,8 +212,8 @@ pub fn normalize_from_e8s(amount_e8s: u64, decimals: u8) -> u64 {
 pub struct LiquidatableVaultInfo {
     pub vault_id: u64,
     pub collateral_type: Principal,
-    pub debt_amount: u64,         // icUSD e8s
-    pub collateral_amount: u64,   // native decimals
+    pub debt_amount: u64,       // icUSD e8s
+    pub collateral_amount: u64, // native decimals
     /// Recommended partial liquidation amount (e8s). Sent by backend, 0 if unknown.
     #[serde(default)]
     pub recommended_liquidation_amount: u64,
@@ -223,7 +227,7 @@ pub struct LiquidatableVaultInfo {
 pub struct LiquidationResult {
     pub vault_id: u64,
     pub stables_consumed: BTreeMap<Principal, u64>, // ledger -> amount consumed (native decimals)
-    pub collateral_gained: u64,                      // native decimals of collateral received
+    pub collateral_gained: u64,                     // native decimals of collateral received
     pub collateral_type: Principal,
     pub success: bool,
     pub error_message: Option<String>,
@@ -271,6 +275,47 @@ pub struct ChainSpAbsorbResult {
     pub custody_address: String,
     pub block_index: u64,
     pub collateral_price_e8s: u64,
+}
+
+#[derive(CandidType, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChainSpAbsorbIntentStatus {
+    Prepared,
+    Burned,
+    BackendAccepted,
+    LocalApplied,
+    BackendRejected,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainSpAbsorbCandidate {
+    pub vault: ChainLiquidatableVaultInfo,
+    pub icusd_to_burn_e8s: u64,
+    pub pending_status: Option<ChainSpAbsorbIntentStatus>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainSpAbsorbIntent {
+    pub vault_id: u64,
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub chain_sentinel: Principal,
+    pub icusd_ledger: Principal,
+    pub icusd_minting_account: icrc_ledger_types::icrc1::account::Account,
+    pub icusd_to_burn_e8s: u64,
+    pub stables_consumed: BTreeMap<Principal, u64>,
+    pub burn_created_at_time_ns: u64,
+    pub status: ChainSpAbsorbIntentStatus,
+    pub burn_proof: Option<rumi_protocol_backend::icrc3_proof::SpWritedownProof>,
+    pub backend_result: Option<ChainStabilityPoolLiquidationResult>,
+    pub last_error: Option<String>,
+    pub created_at_ns: u64,
+    pub updated_at_ns: u64,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainSpAbsorbCompletion {
+    pub vault_id: u64,
+    pub result: ChainSpAbsorbResult,
+    pub completed_at_ns: u64,
 }
 
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -361,21 +406,45 @@ pub struct UserStabilityPosition {
 
 #[derive(CandidType, Debug, Clone, Deserialize)]
 pub enum StabilityPoolError {
-    InsufficientBalance { token: Principal, required: u64, available: u64 },
-    AmountTooLow { minimum_e8s: u64 },
+    InsufficientBalance {
+        token: Principal,
+        required: u64,
+        available: u64,
+    },
+    AmountTooLow {
+        minimum_e8s: u64,
+    },
     NoPositionFound,
     InsufficientPoolBalance,
     Unauthorized,
-    TokenNotAccepted { ledger: Principal },
-    TokenNotActive { ledger: Principal },
-    CollateralNotFound { ledger: Principal },
-    LedgerTransferFailed { reason: String },
-    InterCanisterCallFailed { target: String, method: String },
-    LiquidationFailed { vault_id: u64, reason: String },
+    TokenNotAccepted {
+        ledger: Principal,
+    },
+    TokenNotActive {
+        ledger: Principal,
+    },
+    CollateralNotFound {
+        ledger: Principal,
+    },
+    LedgerTransferFailed {
+        reason: String,
+    },
+    InterCanisterCallFailed {
+        target: String,
+        method: String,
+    },
+    LiquidationFailed {
+        vault_id: u64,
+        reason: String,
+    },
     EmergencyPaused,
     SystemBusy,
-    AlreadyOptedOut { collateral: Principal },
-    AlreadyOptedIn { collateral: Principal },
+    AlreadyOptedOut {
+        collateral: Principal,
+    },
+    AlreadyOptedIn {
+        collateral: Principal,
+    },
     RefundClaimNotFound,
 }
 
@@ -453,7 +522,10 @@ pub struct Icrc21LineDisplayLine {
 pub enum Icrc21Error {
     UnsupportedCanisterCall(Icrc21ErrorInfo),
     ConsentMessageUnavailable(Icrc21ErrorInfo),
-    GenericError { error_code: Nat, description: String },
+    GenericError {
+        error_code: Nat,
+        description: String,
+    },
 }
 
 #[derive(CandidType, Serialize, Clone, Debug)]
@@ -493,22 +565,41 @@ pub struct ThreePoolTokenInfo {
 /// Remote 3pool error (for deserialization only).
 #[derive(CandidType, Clone, Debug, Deserialize)]
 pub enum ThreePoolErrorRemote {
-    InsufficientOutput { expected_min: u128, actual: u128 },
+    InsufficientOutput {
+        expected_min: u128,
+        actual: u128,
+    },
     InsufficientLiquidity,
     InvalidCoinIndex,
     ZeroAmount,
     PoolEmpty,
     SlippageExceeded,
-    TransferFailed { token: String, reason: String },
+    TransferFailed {
+        token: String,
+        reason: String,
+    },
     Unauthorized,
     MathOverflow,
     InvariantNotConverged,
     PoolPaused,
     NotAuthorizedBurnCaller,
-    BurnSlippageExceeded { max_bps: u16, actual_bps: u16 },
-    InsufficientPoolBalance { token: String, required: u128, available: u128 },
-    InsufficientLpBalance { required: u128, available: u128 },
-    BurnFailed { token: String, reason: String },
+    BurnSlippageExceeded {
+        max_bps: u16,
+        actual_bps: u16,
+    },
+    InsufficientPoolBalance {
+        token: String,
+        required: u128,
+        available: u128,
+    },
+    InsufficientLpBalance {
+        required: u128,
+        available: u128,
+    },
+    BurnFailed {
+        token: String,
+        reason: String,
+    },
     /// Audit fence B-01 (Wave 14a): rumi_3pool returns this when another
     /// concurrent operation holds the pool lock. The SP `add_liquidity`
     /// path will refund the user and surface a transient call failure.
@@ -617,7 +708,13 @@ mod icusd_value_tests {
     use candid::Principal;
     use std::collections::BTreeMap;
 
-    fn config(ledger: Principal, symbol: &str, decimals: u8, priority: u8, is_lp: bool) -> StablecoinConfig {
+    fn config(
+        ledger: Principal,
+        symbol: &str,
+        decimals: u8,
+        priority: u8,
+        is_lp: bool,
+    ) -> StablecoinConfig {
         StablecoinConfig {
             ledger_id: ledger,
             symbol: symbol.to_string(),
@@ -643,11 +740,14 @@ mod icusd_value_tests {
 
         let mut pos = DepositPosition::new(0);
         pos.stablecoin_balances.insert(icusd, 100_00_000_000); // 100 icUSD (e8s)
-        pos.stablecoin_balances.insert(ckusdc, 200_000_000);   // 200 ckUSDC (e6s)
+        pos.stablecoin_balances.insert(ckusdc, 200_000_000); // 200 ckUSDC (e6s)
         pos.stablecoin_balances.insert(three_usd, 50_00_000_000); // 50 3USD (e8s)
 
         let v = pos.icusd_value(&registry);
-        assert_eq!(v, 100_00_000_000, "should return only the icUSD balance in e8s");
+        assert_eq!(
+            v, 100_00_000_000,
+            "should return only the icUSD balance in e8s"
+        );
     }
 
     #[test]
@@ -673,7 +773,10 @@ mod icusd_value_tests {
         let mut pos = DepositPosition::new(0);
         pos.stablecoin_balances.insert(icusd, 100_00_000_000);
 
-        assert_eq!(pos.icusd_value(&registry), 0,
-            "registry without icUSD config means we can't identify which ledger is icUSD");
+        assert_eq!(
+            pos.icusd_value(&registry),
+            0,
+            "registry without icUSD config means we can't identify which ledger is icUSD"
+        );
     }
 }

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -364,6 +364,43 @@ pub struct ChainClaimSource {
     pub remaining_native: u128,
 }
 
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecoveryKey {
+    pub chain_sentinel: Principal,
+    pub op_id: u64,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecovery {
+    pub chain_sentinel: Principal,
+    pub op_id: u64,
+    pub claim_id: u64,
+    pub claimant: Principal,
+    pub amount_wei: u128,
+    pub reason: String,
+    pub failed_at_ns: u64,
+}
+
+impl CfxClaimPayoutRecovery {
+    pub fn key(&self) -> CfxClaimPayoutRecoveryKey {
+        CfxClaimPayoutRecoveryKey {
+            chain_sentinel: self.chain_sentinel,
+            op_id: self.op_id,
+        }
+    }
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecoveryRecord {
+    pub key: CfxClaimPayoutRecoveryKey,
+    pub claim_id: u64,
+    pub claimant: Principal,
+    pub amount_wei: u128,
+    pub reason: String,
+    pub failed_at_ns: u64,
+    pub recovered_at_ns: u64,
+}
+
 /// Audit trail record for a completed liquidation.
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolLiquidationRecord {
@@ -433,6 +470,7 @@ pub struct StabilityPoolStatus {
 pub struct UserStabilityPosition {
     pub stablecoin_balances: BTreeMap<Principal, u64>,
     pub collateral_gains: BTreeMap<Principal, u64>,
+    pub cfx_claims: Option<BTreeMap<Principal, u128>>,
     pub opted_out_collateral: Vec<Principal>,
     pub deposit_timestamp: u64,
     pub total_claimed_gains: BTreeMap<Principal, u64>,

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -318,6 +318,46 @@ pub struct ChainSpAbsorbCompletion {
     pub completed_at_ns: u64,
 }
 
+pub const MIN_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS: u64 = 60;
+pub const DEFAULT_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS: u64 = 300;
+pub const DEFAULT_CHAIN_ABSORB_AUTO_MAX_SCAN_PER_CHAIN: u64 = 1;
+pub const MAX_CHAIN_ABSORB_AUTO_SCAN_PER_CHAIN: u64 = 500;
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainAbsorbAutoConfig {
+    pub enabled: bool,
+    pub interval_seconds: u64,
+    pub max_scan_per_chain: u64,
+}
+
+impl Default for ChainAbsorbAutoConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_seconds: DEFAULT_CHAIN_ABSORB_AUTO_INTERVAL_SECONDS,
+            max_scan_per_chain: DEFAULT_CHAIN_ABSORB_AUTO_MAX_SCAN_PER_CHAIN,
+        }
+    }
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainAbsorbAutoTickRecord {
+    pub started_at_ns: u64,
+    pub completed_at_ns: u64,
+    pub attempted_vault_id: Option<u64>,
+    pub candidates_scanned: u64,
+    pub absorbed: Option<ChainSpAbsorbResult>,
+    pub error: Option<String>,
+    pub skipped_reason: Option<String>,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainAbsorbAutoStatus {
+    pub config: ChainAbsorbAutoConfig,
+    pub tick_in_flight: bool,
+    pub last_tick: Option<ChainAbsorbAutoTickRecord>,
+}
+
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChainClaimSource {
     pub claim_id: u64,

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -126,6 +126,59 @@ type ChainSpAbsorbResult = record {
   success : bool;
 };
 
+type IcrcAccount = record {
+  owner : principal;
+  subaccount : opt vec nat8;
+};
+
+type SpProofLedger = variant {
+  IcusdBurn;
+  ThreePoolTransfer;
+};
+
+type SpWritedownProof = record {
+  block_index : nat64;
+  ledger_kind : SpProofLedger;
+  vault_id_memo : nat64;
+};
+
+type ChainSpAbsorbIntentStatus = variant {
+  Prepared;
+  Burned;
+  BackendAccepted;
+  LocalApplied;
+  BackendRejected;
+};
+
+type ChainSpAbsorbCandidate = record {
+  vault : ChainLiquidatableVaultInfo;
+  icusd_to_burn_e8s : nat64;
+  pending_status : opt ChainSpAbsorbIntentStatus;
+};
+
+type ChainSpAbsorbIntent = record {
+  vault_id : nat64;
+  chain_id : nat32;
+  chain_sentinel : principal;
+  icusd_ledger : principal;
+  icusd_minting_account : IcrcAccount;
+  icusd_to_burn_e8s : nat64;
+  stables_consumed : vec record { principal; nat64 };
+  burn_created_at_time_ns : nat64;
+  status : ChainSpAbsorbIntentStatus;
+  burn_proof : opt SpWritedownProof;
+  backend_result : opt ChainStabilityPoolLiquidationResult;
+  last_error : opt text;
+  created_at_ns : nat64;
+  updated_at_ns : nat64;
+};
+
+type ChainSpAbsorbCompletion = record {
+  vault_id : nat64;
+  result : ChainSpAbsorbResult;
+  completed_at_ns : nat64;
+};
+
 type PoolLiquidationRecord = record {
   vault_id : nat64;
   timestamp : nat64;
@@ -291,6 +344,7 @@ service : (StabilityPoolInitArgs) -> {
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);
   execute_liquidation : (nat64) -> (variant { Ok : LiquidationResult; Err : StabilityPoolError });
   sp_absorb_chain_vault : (nat64) -> (variant { Ok : ChainSpAbsorbResult; Err : StabilityPoolError });
+  scan_chain_absorb_candidates : (opt nat64) -> (variant { Ok : vec ChainSpAbsorbCandidate; Err : StabilityPoolError });
 
   // ── Interest Revenue ──
   receive_interest_revenue : (principal, nat64, opt principal) -> (variant { Ok; Err : StabilityPoolError });
@@ -318,11 +372,14 @@ service : (StabilityPoolInitArgs) -> {
   get_user_position : (opt principal) -> (opt UserStabilityPosition) query;
   get_liquidation_history : (opt nat64) -> (vec PoolLiquidationRecord) query;
   check_pool_capacity : (principal, nat64) -> (bool) query;
+  check_chain_absorb_capacity : (principal, nat64) -> (bool) query;
   validate_pool_state : () -> (variant { Ok : text; Err : text }) query;
   get_suspended_tokens : () -> (vec record { principal; nat32 }) query;
   get_pool_events : (nat64, nat64) -> (vec PoolEvent) query;
   get_pool_event_count : () -> (nat64) query;
   list_depositor_principals : () -> (vec principal) query;
   get_pending_refunds : (opt principal) -> (vec PendingRefund) query;
+  get_pending_chain_absorbs : () -> (vec ChainSpAbsorbIntent) query;
+  get_completed_chain_absorbs : (opt nat64) -> (vec ChainSpAbsorbCompletion) query;
   get_chain_collateral_sentinel : (nat32) -> (principal) query;
 };

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -179,6 +179,28 @@ type ChainSpAbsorbCompletion = record {
   completed_at_ns : nat64;
 };
 
+type ChainAbsorbAutoConfig = record {
+  enabled : bool;
+  interval_seconds : nat64;
+  max_scan_per_chain : nat64;
+};
+
+type ChainAbsorbAutoTickRecord = record {
+  started_at_ns : nat64;
+  completed_at_ns : nat64;
+  attempted_vault_id : opt nat64;
+  candidates_scanned : nat64;
+  absorbed : opt ChainSpAbsorbResult;
+  error : opt text;
+  skipped_reason : opt text;
+};
+
+type ChainAbsorbAutoStatus = record {
+  config : ChainAbsorbAutoConfig;
+  tick_in_flight : bool;
+  last_tick : opt ChainAbsorbAutoTickRecord;
+};
+
 type PoolLiquidationRecord = record {
   vault_id : nat64;
   timestamp : nat64;
@@ -345,6 +367,7 @@ service : (StabilityPoolInitArgs) -> {
   execute_liquidation : (nat64) -> (variant { Ok : LiquidationResult; Err : StabilityPoolError });
   sp_absorb_chain_vault : (nat64) -> (variant { Ok : ChainSpAbsorbResult; Err : StabilityPoolError });
   scan_chain_absorb_candidates : (opt nat64) -> (variant { Ok : vec ChainSpAbsorbCandidate; Err : StabilityPoolError });
+  set_chain_absorb_auto_config : (ChainAbsorbAutoConfig) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Interest Revenue ──
   receive_interest_revenue : (principal, nat64, opt principal) -> (variant { Ok; Err : StabilityPoolError });
@@ -381,5 +404,6 @@ service : (StabilityPoolInitArgs) -> {
   get_pending_refunds : (opt principal) -> (vec PendingRefund) query;
   get_pending_chain_absorbs : () -> (vec ChainSpAbsorbIntent) query;
   get_completed_chain_absorbs : (opt nat64) -> (vec ChainSpAbsorbCompletion) query;
+  get_chain_absorb_auto_status : () -> (ChainAbsorbAutoStatus) query;
   get_chain_collateral_sentinel : (nat32) -> (principal) query;
 };

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -63,6 +63,7 @@ type StabilityPoolStatus = record {
 type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
+  cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
@@ -177,6 +178,16 @@ type ChainSpAbsorbCompletion = record {
   vault_id : nat64;
   result : ChainSpAbsorbResult;
   completed_at_ns : nat64;
+};
+
+type CfxClaimPayoutRecovery = record {
+  chain_sentinel : principal;
+  op_id : nat64;
+  claim_id : nat64;
+  claimant : principal;
+  amount_wei : nat;
+  reason : text;
+  failed_at_ns : nat64;
 };
 
 type ChainAbsorbAutoConfig = record {
@@ -355,6 +366,7 @@ service : (StabilityPoolInitArgs) -> {
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
+  recredit_failed_cfx_claim_payout : (CfxClaimPayoutRecovery) -> (variant { Ok : bool; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });


### PR DESCRIPTION
## Summary

- Wire Inc 7 backend timeout escalation for stale bot-path chain liquidations.
- Add a state helper that restores reserved collateral, fails eligible bot swap ops, clears bot routing, and marks vaults for SP/manual fallback without changing debt, chain supply, reserve backing, or pending burn accounting.
- Wire the EVM observer to emit `ChainSettlementFailed` events for timeout escalations before fresh liquidation routing.
- Add a settlement submit CAS so a queued `LiquidationSwap` is claimed as `Inflight` immediately before broadcast, closing the observer-vs-submit race found in adversarial review.
- Record the Inc 7 implementation and verification plan.

## Safety Notes

- Observer timeout escalation handles `Queued` timed-out swaps, already-`Failed` swaps, and missing/pruned swap-op repair cases.
- Observer timeout escalation skips `Inflight` swaps so the settlement confirm-timeout path owns live broadcast cleanup.
- Observer timeout escalation skips `Succeeded` swaps to avoid double-restoring collateral.
- SP burn/absorb remains explicit and SP-owned; this PR does not add automatic SP icUSD burns.

## Verification

- `cargo test -p rumi_protocol_backend timeout_escalation --lib -- --nocapture` PASS, 5 passed
- `cargo test -p rumi_protocol_backend claim_liquidation_swap_submit --lib -- --nocapture` PASS, 3 passed
- `cargo test -p rumi_protocol_backend detect_skips_bot_failed_sp_attempted_vaults --lib -- --nocapture` PASS, 1 passed
- `cargo test -p rumi_protocol_backend --lib` PASS, 663 passed, 1 ignored
- `cargo test -p rumi_protocol_backend --bin rumi_protocol_backend` PASS, 16 passed
- `cargo test -p rumi_protocol_backend check_candid_interface_compatibility --bin rumi_protocol_backend -- --nocapture` PASS, 1 passed
- `git diff --check` PASS

## Adversarial Review

- Reviewer blocker: observer escalation could double-restore an `Inflight` swap. Fixed by skipping `Inflight` and adding an inflight regression test.
- Reviewer blocker: observer escalation could race a settlement worker holding a stale cloned `Queued` swap. Fixed by adding the pre-broadcast submit CAS and focused tests.
- Reviewer liveness finding: missing/pruned failed swap ops could wedge markers. Fixed by treating missing ops as timeout-eligible repair cases and adding a regression test.
- Final reviewer re-check: no blockers.
