### PR TITLE
fix(xrp): add mainnet read provider fallback

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -890,7 +890,7 @@ environments:
         (variant {
           Upgrade = record {
             mode = null;
-            description = opt "PR #241: heal collateral_to_vault_ids stale ids (post_upgrade sweep) + fix close_vault double-remove trap + replay drain parity; rides with PR #240 explorer admin_label event labels"
+            description = opt "PR #276: add XRP mainnet read provider fallback so account_info quorum tolerates one unreachable public endpoint"
           }
         })
 

--- a/src/rumi_protocol_backend/src/chains/xrp/xrp_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/xrp/xrp_rpc.rs
@@ -40,7 +40,11 @@ use super::config::{is_xrp_production_key_name, xrp_schnorr_key_name};
 
 const MAINNET_URL: &str = "https://xrplcluster.com/";
 const TESTNET_URL: &str = "https://s.altnet.rippletest.net:51234/";
-const MAINNET_READ_URLS: &[&str] = &[MAINNET_URL, "https://s1.ripple.com:51234/"];
+const MAINNET_READ_URLS: &[&str] = &[
+    MAINNET_URL,
+    "https://xrpl.link/",
+    "https://s1.ripple.com:51234/",
+];
 const TESTNET_READ_URLS: &[&str] = &[TESTNET_URL, "https://testnet.xrpl-labs.com/"];
 
 pub const MAX_READ_BYTES: u64 = 8_192;
@@ -1128,5 +1132,18 @@ mod tests {
     fn rpc_url_selects_network_by_key() {
         assert_eq!(rpc_url("key_1"), MAINNET_URL);
         assert_eq!(rpc_url("test_key_1"), TESTNET_URL);
+    }
+
+    #[test]
+    fn production_reads_can_tolerate_one_provider_outage() {
+        let providers = read_provider_urls("key_1");
+        assert!(
+            providers.len() > READ_QUORUM,
+            "mainnet reads need spare providers so one unreachable public endpoint does not block deposits"
+        );
+        assert!(
+            providers.iter().any(|url| *url == "https://xrpl.link/"),
+            "xrpl.link is the 443 fallback for IC HTTPS outcalls when s1.ripple.com:51234 is unreachable"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add xrpl.link as a third XRP mainnet read provider
- keep account_info quorum at 2 providers while tolerating one unreachable endpoint
- add a unit test that production reads have spare provider capacity

## Verification
- cargo test -p rumi_protocol_backend --lib production_reads_can_tolerate_one_provider_outage
- icp build rumi_protocol_backend --environment mainnet-live
- icp deploy rumi_protocol_backend --environment mainnet-live --identity rumi_identity
- live xrp_balance known account returned Ok
- live pending #194 balance returned 0 drops
- live pending #195 balance returned 3,000,002 drops