### PR TITLE
Native-XRP: explorer hash/decimals fix + remove launch debt-ceiling guardrail (set 2,500 icUSD)

### DIFF
--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -725,14 +725,6 @@ fn post_upgrade(arg: ProtocolArg) {
     };
     let xrp_guardrail_migration =
         rumi_protocol_backend::state::enforce_xrp_launch_guardrails(&mut state);
-    if let Some(previous) = xrp_guardrail_migration.previous_debt_ceiling {
-        log!(
-            INFO,
-            "[upgrade]: clamped XRP debt ceiling from {} to {} e8s",
-            previous,
-            rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
-        );
-    }
     if let Some(previous) = xrp_guardrail_migration.previous_status {
         log!(
             INFO,
@@ -5524,7 +5516,7 @@ async fn register_xrp_collateral() -> Result<(), ProtocolError> {
     rumi_protocol_backend::xrc::register_collateral_price_timer(xrp_ct);
     log!(
         INFO,
-        "[register_xrp_collateral] Registered native-XRP collateral {} (150/133/12, $100 ceiling)",
+        "[register_xrp_collateral] Registered native-XRP collateral {} (150/133/12, 2,500 icUSD ceiling)",
         xrp_ct
     );
     Ok(())
@@ -9927,15 +9919,6 @@ async fn set_collateral_debt_ceiling(
             "Collateral type not found".to_string(),
         ));
     }
-    if collateral_type == rumi_protocol_backend::state::xrp_collateral_principal()
-        && debt_ceiling > rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
-    {
-        return Err(ProtocolError::GenericError(format!(
-            "XRP debt ceiling cannot exceed {} e8s (100 icUSD)",
-            rumi_protocol_backend::state::XRP_LAUNCH_DEBT_CEILING_E8S
-        )));
-    }
-
     mutate_state(|s| {
         if let Some(config) = s.collateral_configs.get_mut(&collateral_type) {
             config.debt_ceiling = debt_ceiling;

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -681,12 +681,9 @@ pub fn xrp_collateral_principal() -> Principal {
     Principal::from_slice(b"rumi-xrp-native")
 }
 
-/// Launch cap for native-XRP borrowing: 100 icUSD, in e8s.
-pub const XRP_LAUNCH_DEBT_CEILING_E8S: u64 = 10_000_000_000;
-
 /// P5: the `CollateralConfig` for native-XRP collateral. Parameters (Rob's):
-/// 150% borrow threshold / 133% liquidation / 12% liquidation penalty / $100 debt
-/// ceiling. Borrowing-fee + interest BASE are copied from ICP ("same as ICP"); the
+/// 150% borrow threshold / 133% liquidation / 12% liquidation penalty / 2,500 icUSD
+/// debt ceiling. Borrowing-fee + interest BASE are copied from ICP ("same as ICP"); the
 /// dynamic curves are global (`borrowing_fee_curve`) or inherited (`rate_curve` =
 /// None). custody_kind = `NativeXrp`; `ledger_canister_id` is the synthetic key; 6
 /// decimals (drops); `ledger_fee` = 0 (the XRPL fee is handled by the rail at settle
@@ -706,7 +703,10 @@ pub fn xrp_collateral_config(
         liquidation_bonus: Ratio::new(dec!(1.12)),
         borrowing_fee: icp_borrowing_fee,
         interest_rate_apr: icp_interest_rate_apr,
-        debt_ceiling: XRP_LAUNCH_DEBT_CEILING_E8S,
+        // 2,500 icUSD e8s. This default applies to a FRESH registration only; an
+        // already-registered config keeps its live ceiling across upgrade (no clamp),
+        // so raise the live config via set_collateral_debt_ceiling(xrp, 250_000_000_000).
+        debt_ceiling: 250_000_000_000,
         min_vault_debt: ICUSD::new(10_000_000), // 0.1 icUSD (matches ICP)
         ledger_fee: 0,
         price_source: PriceSource::Xrc {
@@ -737,24 +737,20 @@ pub fn xrp_collateral_config(
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct XrpLaunchGuardrailMigration {
-    pub previous_debt_ceiling: Option<u64>,
     pub previous_status: Option<CollateralStatus>,
 }
 
-/// Converges already-registered native-XRP collateral onto launch guardrails.
-/// This is intentionally idempotent so upgrades, replay recovery, and tests can
-/// call it without needing a one-shot migration flag.
+/// Converges already-registered native-XRP collateral onto the launch guardrail:
+/// native-XRP cannot be left Active while signing off a non-production Schnorr key
+/// (the audit's F-01 fix). Intentionally idempotent so upgrades, replay recovery,
+/// and tests can call it without a one-shot migration flag. The debt ceiling is NOT
+/// clamped here — XRP uses a normal `debt_ceiling` like every other collateral.
 pub fn enforce_xrp_launch_guardrails(state: &mut State) -> XrpLaunchGuardrailMigration {
     let mut migration = XrpLaunchGuardrailMigration::default();
     let xrp_ct = xrp_collateral_principal();
     let Some(config) = state.collateral_configs.get_mut(&xrp_ct) else {
         return migration;
     };
-
-    if config.debt_ceiling > XRP_LAUNCH_DEBT_CEILING_E8S {
-        migration.previous_debt_ceiling = Some(config.debt_ceiling);
-        config.debt_ceiling = XRP_LAUNCH_DEBT_CEILING_E8S;
-    }
 
     if !crate::chains::xrp::config::is_xrp_production_key_name(&state.xrp_schnorr_key_name)
         && !matches!(
@@ -781,12 +777,6 @@ pub fn validate_xrp_launch_config_update(
         return Err(ProtocolError::GenericError(
             "XRP collateral config must keep custody_kind = NativeXrp".to_string(),
         ));
-    }
-    if config.debt_ceiling > XRP_LAUNCH_DEBT_CEILING_E8S {
-        return Err(ProtocolError::GenericError(format!(
-            "XRP debt ceiling cannot exceed {} e8s (100 icUSD)",
-            XRP_LAUNCH_DEBT_CEILING_E8S
-        )));
     }
     if !matches!(
         config.status,
@@ -7251,8 +7241,7 @@ mod tests {
         assert_eq!(cfg.ledger_canister_id, xrp_collateral_principal());
         assert_eq!(cfg.decimals, 6);
         assert_eq!(cfg.ledger_fee, 0);
-        assert_eq!(XRP_LAUNCH_DEBT_CEILING_E8S, 10_000_000_000); // $100
-        assert_eq!(cfg.debt_ceiling, XRP_LAUNCH_DEBT_CEILING_E8S);
+        assert_eq!(cfg.debt_ceiling, 250_000_000_000); // 2,500 icUSD
         assert_eq!(cfg.liquidation_ratio, Ratio::new(dec!(1.33)));
         assert_eq!(cfg.borrow_threshold_ratio, Ratio::new(dec!(1.50)));
         assert_eq!(cfg.liquidation_bonus, Ratio::new(dec!(1.12))); // 12% penalty
@@ -7277,7 +7266,7 @@ mod tests {
     }
 
     #[test]
-    fn xrp_launch_guardrails_clamp_existing_cap_and_freeze_non_production_key() {
+    fn xrp_launch_guardrails_freeze_non_production_key_without_clamping_ceiling() {
         let mut state = test_state();
         let xrp = xrp_collateral_principal();
         let mut cfg = xrp_collateral_config(
@@ -7294,27 +7283,37 @@ mod tests {
         let migration = enforce_xrp_launch_guardrails(&mut state);
         let migrated = state.collateral_configs.get(&xrp).unwrap();
 
-        assert_eq!(migration.previous_debt_ceiling, Some(20_000_000_000));
+        // F-01 key gate still freezes a non-production key...
         assert_eq!(migration.previous_status, Some(CollateralStatus::Active));
-        assert_eq!(migrated.debt_ceiling, XRP_LAUNCH_DEBT_CEILING_E8S);
         assert_eq!(migrated.status, CollateralStatus::Frozen);
+        // ...but the debt ceiling is no longer clamped — XRP is a normal asset now.
+        assert_eq!(migrated.debt_ceiling, 20_000_000_000);
     }
 
     #[test]
-    fn xrp_launch_config_update_rejects_cap_above_launch_ceiling() {
+    fn xrp_launch_config_update_allows_any_ceiling_but_keeps_key_gate() {
         let xrp = xrp_collateral_principal();
         let mut cfg = xrp_collateral_config(
             Ratio::new(dec!(0.005)),
             Ratio::new(dec!(0.0)),
             Ratio::new(dec!(1.033333333333333333)),
         );
-        cfg.debt_ceiling = XRP_LAUNCH_DEBT_CEILING_E8S + 1;
+        // A ceiling well above the old launch cap is now accepted (production key).
+        cfg.debt_ceiling = 500_000_000_000;
+        assert!(validate_xrp_launch_config_update(
+            xrp,
+            &cfg,
+            crate::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME,
+        )
+        .is_ok());
 
+        // The F-01 key gate is still enforced: a non-production key on an Active
+        // config is rejected regardless of the ceiling.
         assert!(matches!(
             validate_xrp_launch_config_update(
                 xrp,
                 &cfg,
-                crate::chains::xrp::config::XRP_PRODUCTION_SCHNORR_KEY_NAME,
+                crate::chains::xrp::config::XRP_TEST_SCHNORR_KEY_NAME,
             ),
             Err(ProtocolError::GenericError(_))
         ));

--- a/src/vault_frontend/src/lib/stores/collateralStore.ts
+++ b/src/vault_frontend/src/lib/stores/collateralStore.ts
@@ -216,7 +216,7 @@ export const collateralStore = createCollateralStore();
  * Tokens not in this list appear at the end, sorted alphabetically.
  */
 export const COLLATERAL_DISPLAY_ORDER: string[] = [
-  'ICP', 'ckBTC', 'ckETH', 'ckXAUT', 'nICP', 'BOB', 'EXE',
+  'ICP', 'XRP', 'ckBTC', 'ckETH', 'ckXAUT', 'nICP', 'BOB', 'EXE',
 ];
 
 /**

--- a/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerChartHelpers.ts
@@ -2,6 +2,7 @@
  * Shared chart utilities for the explorer.
  * Formatters, scales, and color constants for SVG charts.
  */
+import { getTokenSymbol, XRP_NATIVE_PRINCIPAL } from './explorerHelpers';
 
 /** Format a number with K/M/B suffixes for large magnitudes and appropriate
  *  decimals for small magnitudes. The previous version always used 0
@@ -71,9 +72,20 @@ export const CHART_COLORS = {
   textMuted: '#605a75',
 } as const;
 
-/** Known collateral symbols by principal. */
+/**
+ * Collateral principals the explorer's lenses chart. The explorer lenses
+ * (CollateralLens, RedemptionsLens) DRIVE their fetch + render loop from
+ * `Object.keys(COLLATERAL_SYMBOLS)`, so a collateral missing here is invisible in
+ * those lenses, not merely mislabeled. Keep this list in sync with registered
+ * collateral types. The displayed symbol text comes from `getCollateralSymbol`
+ * (single source of truth = KNOWN_TOKENS), so these values are only a fallback.
+ *
+ * Native-XRP uses the synthetic principal (XRP_NATIVE_PRINCIPAL); it has no ICRC
+ * ledger but does have an XRC price feed, so the lenses can chart it.
+ */
 export const COLLATERAL_SYMBOLS: Record<string, string> = {
   'ryjl3-tyaaa-aaaaa-aaaba-cai': 'ICP',
+  [XRP_NATIVE_PRINCIPAL]: 'XRP',
   'mxzaz-hqaaa-aaaar-qaada-cai': 'ckBTC',
   'ss2fx-dyaaa-aaaar-qacoq-cai': 'ckETH',
   'nza5v-qaaaa-aaaar-qahzq-cai': 'ckXAUT',
@@ -82,14 +94,20 @@ export const COLLATERAL_SYMBOLS: Record<string, string> = {
   'rh2pm-ryaaa-aaaan-qeniq-cai': 'EXE',
 };
 
-/** Get symbol for a collateral principal. */
+/**
+ * Get the display symbol for a collateral principal. Delegates to the shared
+ * KNOWN_TOKENS registry (`getTokenSymbol`) so symbol resolution has ONE source of
+ * truth across the explorer — adding a token to KNOWN_TOKENS fixes it everywhere,
+ * and this map can't drift out of sync the way it did for native-XRP.
+ */
 export function getCollateralSymbol(principal: string): string {
-  return COLLATERAL_SYMBOLS[principal] ?? principal.slice(0, 5) + '...';
+  return getTokenSymbol(principal);
 }
 
 /** Collateral brand colors. */
 export const COLLATERAL_COLORS: Record<string, string> = {
   ICP: '#29ABE2',
+  XRP: '#23292F',
   ckBTC: '#F7931A',
   ckETH: '#627EEA',
   ckXAUT: '#C9A96E',

--- a/src/vault_frontend/src/lib/utils/explorerHelpers.ts
+++ b/src/vault_frontend/src/lib/utils/explorerHelpers.ts
@@ -99,6 +99,15 @@ export interface TokenInfo {
   decimals: number;
 }
 
+/**
+ * Synthetic collateral principal for native-XRP — `Principal::from_slice(b"rumi-xrp-native")`
+ * in the backend's `xrp_collateral_principal()`. This is NOT a real ICRC ledger: native-XRP
+ * is custodied off-chain on the XRP Ledger, so there is no `icrc1_symbol`/`icrc1_total_supply`
+ * to query. Anything that needs to special-case native-XRP (e.g. the token detail page)
+ * should compare against this constant rather than re-hardcoding the text form.
+ */
+export const XRP_NATIVE_PRINCIPAL = '5zjma-7dsov-wwsll-yojyc-23tbo-ruxmz-i';
+
 export const KNOWN_TOKENS: Record<string, TokenInfo> = {
   // Core protocol tokens
   [CANISTER_IDS.ICP_LEDGER]: { symbol: 'ICP', name: 'Internet Computer', decimals: 8 },
@@ -106,6 +115,11 @@ export const KNOWN_TOKENS: Record<string, TokenInfo> = {
   [CANISTER_IDS.CKUSDT_LEDGER]: { symbol: 'ckUSDT', name: 'Chain-Key USDT', decimals: 6 },
   [CANISTER_IDS.CKUSDC_LEDGER]: { symbol: 'ckUSDC', name: 'Chain-Key USDC', decimals: 6 },
   [CANISTER_IDS.THREEPOOL]: { symbol: '3USD', name: 'Rumi 3Pool LP Token', decimals: 8 },
+  // Native-XRP collateral (see XRP_NATIVE_PRINCIPAL above). Listed statically because
+  // there is no icrc1 ledger to query. 6 decimals (drops): the backend stores XRP
+  // collateral_amount in drops, so the explorer must format with 6 decimals or amounts
+  // read 100x too small.
+  [XRP_NATIVE_PRINCIPAL]: { symbol: 'XRP', name: 'XRP (XRP Ledger)', decimals: 6 },
   // Collateral tokens
   'mxzaz-hqaaa-aaaar-qaada-cai': { symbol: 'ckBTC', name: 'Chain-Key Bitcoin', decimals: 8 },
   'ss2fx-dyaaa-aaaar-qacoq-cai': { symbol: 'ckETH', name: 'Chain-Key Ethereum', decimals: 18 },

--- a/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
@@ -39,6 +39,7 @@
     getTokenInfo,
     shortenPrincipal,
     formatBps,
+    XRP_NATIVE_PRINCIPAL,
   } from '$utils/explorerHelpers';
   import { extractEventTimestamp } from '$utils/displayEvent';
   import type { DisplayEvent } from '$utils/displayEvent';
@@ -102,6 +103,29 @@
       const pid = c.ledger_canister_id?.toText?.() ?? String(c.ledger_canister_id ?? '');
       return pid === tokenPrincipal;
     }),
+  );
+  // Native-XRP is a synthetic collateral key, not an ICRC ledger: it's custodied
+  // off-chain on the XRP Ledger, so holders / ICRC supply don't apply and the
+  // identity card needs different labels (see special-casing below).
+  const isNativeXrp = $derived(tokenPrincipal === XRP_NATIVE_PRINCIPAL);
+
+  // ── Derived: native-XRP locked as collateral ───────────────────────────────
+  // Stands in for "total supply" on the XRP page. collateral_amount is stored in
+  // drops (6 decimals), matching tokenDecimals for the XRP synthetic principal.
+  const xrpLockedDrops = $derived.by<bigint>(() => {
+    if (!isNativeXrp) return 0n;
+    let total = 0n;
+    for (const v of allVaults) {
+      const ct = v.collateral_type?.toText?.() ?? String(v.collateral_type ?? '');
+      if (ct === tokenPrincipal) total += BigInt(v.collateral_amount ?? 0);
+    }
+    return total;
+  });
+
+  const subtitle = $derived(
+    isNativeXrp
+      ? 'Native XRP · off-chain custody on the XRP Ledger'
+      : `${tokenName} · ledger ${shortenPrincipal(tokenPrincipal)}`,
   );
 
   // ── Derived: total supply ──────────────────────────────────────────────────
@@ -574,7 +598,8 @@
 
       // Live total supply for tokens analytics doesn't track. icUSD/3USD
       // already get total_supply from the holder snapshot, so skip the call.
-      if (topHoldersRes.source !== 'balance_tracker') {
+      // Native-XRP has no ICRC ledger to query — it uses xrpLockedDrops instead.
+      if (topHoldersRes.source !== 'balance_tracker' && !isNativeXrp) {
         liveTotalSupply = await fetchIcrc1TotalSupply(tokenPrincipal).catch(() => null);
       }
 
@@ -654,7 +679,7 @@
 
 <EntityShell
   title={symbol}
-  subtitle="{tokenName} · ledger {shortenPrincipal(tokenPrincipal)}"
+  {subtitle}
   {loading}
   {error}
   onRetry={loadToken}
@@ -662,9 +687,13 @@
   {#snippet identity()}
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
       <div class="rounded-lg border border-gray-700/60 bg-gray-900/40 p-3">
-        <div class="text-xs text-gray-500 uppercase tracking-wider">Total supply</div>
+        <div class="text-xs text-gray-500 uppercase tracking-wider">{isNativeXrp ? 'Locked as collateral' : 'Total supply'}</div>
         <div class="mt-1 text-lg font-semibold text-white">
-          {totalSupplyE8s > 0n ? formatE8s(totalSupplyE8s, tokenDecimals) : '—'}
+          {#if isNativeXrp}
+            {xrpLockedDrops > 0n ? formatE8s(xrpLockedDrops, tokenDecimals) : '—'}
+          {:else}
+            {totalSupplyE8s > 0n ? formatE8s(totalSupplyE8s, tokenDecimals) : '—'}
+          {/if}
         </div>
         <div class="text-xs text-gray-500">{symbol}</div>
       </div>
@@ -699,6 +728,12 @@
             <div class="mt-1 text-sm text-gray-500">—</div>
           {/if}
         </div>
+      {:else if isNativeXrp}
+        <div class="rounded-lg border border-gray-700/60 bg-gray-900/40 p-3">
+          <div class="text-xs text-gray-500 uppercase tracking-wider">Custody</div>
+          <div class="mt-1 text-lg font-semibold text-white">Off-chain</div>
+          <div class="text-xs text-gray-500">XRP Ledger · {tokenDecimals} decimals (drops)</div>
+        </div>
       {:else}
         <div class="rounded-lg border border-gray-700/60 bg-gray-900/40 p-3">
           <div class="text-xs text-gray-500 uppercase tracking-wider">Decimals</div>
@@ -709,12 +744,18 @@
     </div>
 
     <div class="flex items-center gap-2 text-xs text-gray-400">
-      <span class="text-gray-500">Ledger:</span>
+      <span class="text-gray-500">{isNativeXrp ? 'Synthetic key:' : 'Ledger:'}</span>
       <code class="font-mono text-gray-300">{tokenPrincipal}</code>
       <CopyButton text={tokenPrincipal} />
     </div>
 
-    {#if !knownToken}
+    {#if isNativeXrp}
+      <div class="rounded-lg border border-blue-500/20 bg-blue-500/5 p-4 text-sm text-gray-400">
+        Native XRP is custodied off-chain on the XRP Ledger, so there is no ICRC-1 ledger —
+        holder counts and on-chain supply don't apply. Price is the XRC oracle feed, and the
+        figure above is the total XRP currently locked across XRP collateral vaults.
+      </div>
+    {:else if !knownToken}
       <div class="rounded-lg border border-gray-700/60 bg-gray-900/40 p-4 text-sm text-gray-400">
         Limited data available for this token. Symbol, decimals, and price feeds
         aren't registered in the explorer; only on-chain ICRC-1 calls work.
@@ -929,11 +970,13 @@
       <!-- Supply over time -->
       <div class="rounded-lg border border-gray-700/60 bg-gray-900/40 p-4">
         <h3 class="text-sm font-semibold text-white mb-3">
-          {isIcUsd ? 'Supply over time (vault debt)' : isThreeUsd ? 'LP supply over time' : 'Tracked supply over time'}
+          {isNativeXrp ? 'XRP locked over time' : isIcUsd ? 'Supply over time (vault debt)' : isThreeUsd ? 'LP supply over time' : 'Tracked supply over time'}
         </h3>
         {#if supplySeries.length < 2}
           <div class="text-sm text-gray-500">
-            {isCollateral
+            {isNativeXrp
+              ? 'Custody totals over time aren\'t tracked yet — see the price chart above.'
+              : isCollateral
               ? 'Supply timeseries not collected for collateral tokens.'
               : 'Not enough data points yet.'}
           </div>


### PR DESCRIPTION
## Summary

Two native-XRP fixes on top of `origin/main`.

### 1. Explorer rendered the XRP collateral as a raw principal hash
The live explorer showed the synthetic XRP collateral principal `5zjma-7dsov-wwsll-yojyc-23tbo-ruxmz-i` as a shortened hash and, lacking a decimals entry, formatted XRP amounts at 8 decimals instead of 6 (100× too small). **Two** independent token registries both missed XRP:
- `explorerHelpers.ts` `KNOWN_TOKENS` — added XRP via a new exported `XRP_NATIVE_PRINCIPAL` constant (symbol/name/6 decimals). Fixes every surface that routes through `getTokenSymbol`/`getTokenDecimals`.
- `explorerChartHelpers.ts` `COLLATERAL_SYMBOLS`/`COLLATERAL_COLORS` — a second map that **drives** the Collateral/Redemptions lens render loops off its keys, so an XRP vault was *invisible* there, not just mislabeled. Added XRP, and routed `getCollateralSymbol` through `getTokenSymbol` so the two registries can't drift again.
- Token detail page: special-cased native-XRP (no ICRC ledger) — shows total XRP locked as collateral instead of ICRC supply, labels it off-chain XRP Ledger custody, skips the dead `icrc1_total_supply` call.

### 2. Removed the launch debt-ceiling guardrail; ceiling → 2,500 icUSD
Native-XRP carried a special launch guardrail (a hardcoded 100 icUSD `XRP_LAUNCH_DEBT_CEILING_E8S` used as the default, a hard rejection in `set_collateral_debt_ceiling` / `validate_xrp_launch_config_update`, and an upgrade migration that clamped any higher value back down). XRP now behaves like every other collateral: a plain `debt_ceiling` tuned via `set_collateral_debt_ceiling`. The `xrp_collateral_config` default is `250_000_000_000` (2,500 icUSD).

**Kept:** the F-01 production-key freeze that lives in the same guardrail path (freeze native-XRP if Active under a non-production Schnorr key) — that's the audit's HIGH-severity fix, unrelated to the ceiling.

> Live config: `post_upgrade` no longer clamps, so the already-registered config keeps its current ceiling across upgrade; the live ceiling is raised to 2,500 via a runtime `set_collateral_debt_ceiling(xrp, 250_000_000_000)` call after deploy.

## Verification
- `rumi_protocol_backend` compiles; XRP config/guardrail unit tests updated and green (2,500 default; freeze still fires; high ceiling now accepted under the production key).
- Frontend `svelte-check` clean on all touched files.
- Two adversarial review passes (financial/security + frontend/completeness): the second is what surfaced the second token map.

## Not included
The stability-pool native-collateral opt-in work is a parallel design to origin/main's #270 CFX SP model and needs its own reconciliation; it's intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)