### PR TITLE
fix(deps): sync package-lock (missing tailwindcss/yaml@2.9.0) so frontend deploy's npm ci passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5450,6 +5450,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",


### PR DESCRIPTION
The committed `package-lock.json` was out of sync with `package.json`: the `tailwindcss` dependency tree resolves to `yaml@2.9.0`, which was missing from the lock. The `@dfinity/asset-canister` deploy recipe runs strict `npm ci`, which fails with `Missing: yaml@2.9.0 from lock file`, blocking `icp deploy vault_frontend`.

Regenerated with `npm install --package-lock-only` — the only drift was this single transitive entry (17 additive lines, nothing else churned). Pre-existing on `main`, unrelated to feature work; needed to unblock the frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)