### PR TITLE
feat(chains): Inc10 retry-safe CFX payout recovery

### DIFF
--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -63,6 +63,7 @@ type StabilityPoolStatus = record {
 type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
+  cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
@@ -177,6 +178,16 @@ type ChainSpAbsorbCompletion = record {
   vault_id : nat64;
   result : ChainSpAbsorbResult;
   completed_at_ns : nat64;
+};
+
+type CfxClaimPayoutRecovery = record {
+  chain_sentinel : principal;
+  op_id : nat64;
+  claim_id : nat64;
+  claimant : principal;
+  amount_wei : nat;
+  reason : text;
+  failed_at_ns : nat64;
 };
 
 type ChainAbsorbAutoConfig = record {
@@ -355,6 +366,7 @@ service : (StabilityPoolInitArgs) -> {
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
+  recredit_failed_cfx_claim_payout : (CfxClaimPayoutRecovery) -> (variant { Ok : bool; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -2,6 +2,15 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface CfxClaimPayoutRecovery {
+  'claim_id' : bigint,
+  'claimant' : Principal,
+  'op_id' : bigint,
+  'chain_sentinel' : Principal,
+  'amount_wei' : bigint,
+  'failed_at_ns' : bigint,
+  'reason' : string,
+}
 export interface ChainAbsorbAutoConfig {
   'enabled' : boolean,
   'interval_seconds' : bigint,
@@ -298,6 +307,7 @@ export interface UserStabilityPosition {
   'total_interest_earned_e8s' : bigint,
   'collateral_gains' : Array<[Principal, bigint]>,
   'stablecoin_balances' : Array<[Principal, bigint]>,
+  'cfx_claims' : [] | [Array<[Principal, bigint]>],
   'total_claimed_gains' : Array<[Principal, bigint]>,
   'total_usd_value_e8s' : bigint,
   'opted_out_collateral' : Array<Principal>,
@@ -411,6 +421,11 @@ export interface _SERVICE {
   'receive_interest_revenue' : ActorMethod<
     [Principal, bigint, [] | [Principal]],
     { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'recredit_failed_cfx_claim_payout' : ActorMethod<
+    [CfxClaimPayoutRecovery],
+    { 'Ok' : boolean } |
       { 'Err' : StabilityPoolError }
   >,
   'register_cfx_collateral' : ActorMethod<

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -241,6 +241,7 @@ export const idlFactory = ({ IDL }) => {
     'total_interest_earned_e8s' : IDL.Nat64,
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'stablecoin_balances' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'cfx_claims' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat))),
     'total_claimed_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'total_usd_value_e8s' : IDL.Nat64,
     'opted_out_collateral' : IDL.Vec(IDL.Principal),
@@ -305,6 +306,15 @@ export const idlFactory = ({ IDL }) => {
     'debt_amount' : IDL.Nat64,
     'vault_id' : IDL.Nat64,
     'collateral_type' : IDL.Principal,
+  });
+  const CfxClaimPayoutRecovery = IDL.Record({
+    'claim_id' : IDL.Nat64,
+    'claimant' : IDL.Principal,
+    'op_id' : IDL.Nat64,
+    'chain_sentinel' : IDL.Principal,
+    'amount_wei' : IDL.Nat,
+    'failed_at_ns' : IDL.Nat64,
+    'reason' : IDL.Text,
   });
   const ChainLiquidatableVaultInfo = IDL.Record({
     'sized_repay_e8s' : IDL.Nat,
@@ -485,6 +495,11 @@ export const idlFactory = ({ IDL }) => {
     'receive_interest_revenue' : IDL.Func(
         [IDL.Principal, IDL.Nat64, IDL.Opt(IDL.Principal)],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'recredit_failed_cfx_claim_payout' : IDL.Func(
+        [CfxClaimPayoutRecovery],
+        [IDL.Variant({ 'Ok' : IDL.Bool, 'Err' : StabilityPoolError })],
         [],
       ),
     'register_cfx_collateral' : IDL.Func(

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -34,6 +34,7 @@
 //! bump-gas/resubmit on the Confirm path. Both are marked with `TASK 11 SEAM:`
 //! comments. This task references no hardening symbol.
 
+use candid::{CandidType, Deserialize, Principal};
 use ic_canister_log::log;
 
 use crate::chains::config::{ChainId, ChainStatus};
@@ -56,6 +57,171 @@ pub enum OpAction {
     Submit,
     /// An `Inflight` op: check its receipt and (on a confirmed mint) finalize.
     Confirm,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct SpCfxClaimPayoutRecovery {
+    chain_sentinel: Principal,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    failed_at_ns: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum SpStabilityPoolError {
+    InsufficientBalance {
+        token: Principal,
+        required: u64,
+        available: u64,
+    },
+    AmountTooLow {
+        minimum_e8s: u64,
+    },
+    NoPositionFound,
+    InsufficientPoolBalance,
+    Unauthorized,
+    TokenNotAccepted {
+        ledger: Principal,
+    },
+    TokenNotActive {
+        ledger: Principal,
+    },
+    CollateralNotFound {
+        ledger: Principal,
+    },
+    LedgerTransferFailed {
+        reason: String,
+    },
+    InterCanisterCallFailed {
+        target: String,
+        method: String,
+    },
+    LiquidationFailed {
+        vault_id: u64,
+        reason: String,
+    },
+    EmergencyPaused,
+    SystemBusy,
+    AlreadyOptedOut {
+        collateral: Principal,
+    },
+    AlreadyOptedIn {
+        collateral: Principal,
+    },
+    RefundClaimNotFound,
+}
+
+fn sp_chain_collateral_sentinel(chain: ChainId) -> Principal {
+    let mut bytes = [0u8; 29];
+    let prefix = b"rumi-chain-collateral";
+    bytes[..prefix.len()].copy_from_slice(prefix);
+    bytes[24..28].copy_from_slice(&chain.0.to_le_bytes());
+    bytes[28] = 0x7f;
+    Principal::from_slice(&bytes)
+}
+
+async fn notify_sp_failed_cfx_claim_payout(
+    chain: ChainId,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    failed_at_ns: u64,
+) -> Result<bool, String> {
+    let Some(sp_canister) = read_state(|s| s.stability_pool_canister) else {
+        return Err("no stability pool canister is configured for recredit".to_string());
+    };
+
+    let payload = SpCfxClaimPayoutRecovery {
+        chain_sentinel: sp_chain_collateral_sentinel(chain),
+        op_id,
+        claim_id,
+        claimant,
+        amount_wei,
+        reason,
+        failed_at_ns,
+    };
+    let result: Result<(Result<bool, SpStabilityPoolError>,), _> =
+        ic_cdk::call(sp_canister, "recredit_failed_cfx_claim_payout", (payload,)).await;
+
+    match result {
+        Ok((Ok(true),)) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {} recredited on stability pool",
+                chain,
+                op_id,
+            );
+            Ok(true)
+        }
+        Ok((Ok(false),)) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {} stability pool recredit already recorded",
+                chain,
+                op_id,
+            );
+            Ok(false)
+        }
+        Ok((Err(error),)) => Err(format!("stability pool recredit rejected: {error:?}")),
+        Err((code, msg)) => Err(format!(
+            "stability pool recredit call failed: {code:?} {msg}"
+        )),
+    }
+}
+
+async fn recredit_and_fail_chain_collateral_payout(
+    chain: ChainId,
+    op_id: u64,
+    claim_id: u64,
+    claimant: Principal,
+    amount_wei: u128,
+    reason: String,
+    now_ns: u64,
+) -> bool {
+    if let Err(error) = notify_sp_failed_cfx_claim_payout(
+        chain,
+        op_id,
+        claim_id,
+        claimant,
+        amount_wei,
+        reason.clone(),
+        now_ns,
+    )
+    .await
+    {
+        log!(INFO, "[settlement chain={:?}] claim payout op {} cannot be failed yet because stability pool recredit failed: {}", chain, op_id, error);
+        return false;
+    }
+
+    match mutate_state(|s| {
+        fail_chain_collateral_payout_in_state(
+            &mut s.multi_chain,
+            chain,
+            op_id,
+            reason.clone(),
+            now_ns,
+        )
+    }) {
+        Ok(true) => {
+            crate::storage::record_event(&crate::event::Event::ChainSettlementFailed {
+                chain_id: chain,
+                op_id,
+                reason,
+                timestamp: now_ns,
+            });
+            true
+        }
+        Ok(false) => true,
+        Err(error) => {
+            log!(INFO, "[settlement chain={:?}] claim payout op {} failed after stability pool recredit but backend release failed: {}; left for retry", chain, op_id, error);
+            false
+        }
+    }
 }
 
 /// Pick the next op to act on. Enforces one-in-flight-per-queue: if ANY op is
@@ -122,8 +288,13 @@ pub fn confirm_mint_in_state(
     // Step 2: supply delta. The post-mint total is the pre-mint total plus the
     // amount this mint adds to the foreign-chain debt pool.
     let post_mint_total = pre_mint_total_debt.saturating_add(observed_e8s);
-    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_mint_total)
-        .map_err(|e| format!("{e:?}"))?;
+    apply_supply_delta(
+        state,
+        chain,
+        SupplyDelta::Increase(observed_e8s),
+        post_mint_total,
+    )
+    .map_err(|e| format!("{e:?}"))?;
 
     // Step 3: only reached when the supply delta succeeded — move pending -> debt.
     let v = state
@@ -172,8 +343,13 @@ pub fn confirm_interest_mint_in_state(
     // amount, so the foreign-chain invariant stays exact. Rejects (no mutation)
     // on divergence/halt.
     let post_total = pre_total.saturating_add(observed_e8s);
-    apply_supply_delta(state, chain, SupplyDelta::Increase(observed_e8s), post_total)
-        .map_err(|e| format!("{e:?}"))?;
+    apply_supply_delta(
+        state,
+        chain,
+        SupplyDelta::Increase(observed_e8s),
+        post_total,
+    )
+    .map_err(|e| format!("{e:?}"))?;
 
     // Step 3: only reached when the supply delta succeeded. Realize the interest
     // into debt and advance the accrual window to the harvest snapshot time (NOT
@@ -219,29 +395,40 @@ pub fn apply_liquidation_settlement_in_state(
             .chain_vaults
             .get(&vault_id)
             .ok_or_else(|| format!("apply_liquidation_settlement: unknown vault {vault_id}"))?;
-        let m = v
-            .pending_liquidation
-            .as_ref()
-            .ok_or_else(|| format!("apply_liquidation_settlement: vault {vault_id} has no liquidation marker"))?;
+        let m = v.pending_liquidation.as_ref().ok_or_else(|| {
+            format!("apply_liquidation_settlement: vault {vault_id} has no liquidation marker")
+        })?;
         if m.op_id != op_id {
             return Err(format!(
                 "apply_liquidation_settlement: marker op {} != confirming op {}",
                 m.op_id, op_id
             ));
         }
-        (m.debt_to_clear_e8s, m.collateral_reserved_native, v.debt_e8s, m.tier)
+        (
+            m.debt_to_clear_e8s,
+            m.collateral_reserved_native,
+            v.debt_e8s,
+            m.tier,
+        )
     };
 
     // Step 2: clamp — reserve_backing NEVER exceeds the realized USD value, nor the
     // live debt (a concurrent burn is already blocked by the marker, so live_debt
     // == debt_at_phase1; the min is belt-and-suspenders).
-    let realized_usd_e8 = crate::chains::liquidation::stable_native_to_e8s(realized_usdc_native, settle_decimals);
+    let realized_usd_e8 =
+        crate::chains::liquidation::stable_native_to_e8s(realized_usdc_native, settle_decimals);
     let actual_cleared = debt_to_clear.min(live_debt).min(realized_usd_e8);
 
     // Step 3: the single guarded invariant move (debt -> reserve; supply untouched).
     // apply_debt_to_reserve_shift re-validates the unified invariant + caps at debt.
-    crate::chains::supply::apply_debt_to_reserve_shift(state, chain, vault_id, actual_cleared, realized_usdc_native)
-        .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
+    crate::chains::supply::apply_debt_to_reserve_shift(
+        state,
+        chain,
+        vault_id,
+        actual_cleared,
+        realized_usdc_native,
+    )
+    .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
 
     // Step 4: record any shortfall as per-chain bad debt (never silent).
     if debt_to_clear > actual_cleared {
@@ -313,7 +500,10 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             .get(&vault_id)
             .ok_or_else(|| format!("sp_absorb: unknown vault {vault_id}"))?;
         if v.collateral_chain != chain {
-            return Err(format!("sp_absorb: vault chain {:?} != requested chain {:?}", v.collateral_chain, chain));
+            return Err(format!(
+                "sp_absorb: vault chain {:?} != requested chain {:?}",
+                v.collateral_chain, chain
+            ));
         }
         if v.status != ChainVaultStatus::Open {
             return Err(format!("sp_absorb: vault {vault_id} is not Open"));
@@ -322,18 +512,30 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             return Err(format!("sp_absorb: vault {vault_id} has pending mint"));
         }
         if v.pending_interest_mint_e8s != 0 {
-            return Err(format!("sp_absorb: vault {vault_id} has pending interest mint"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} has pending interest mint"
+            ));
         }
         if v.pending_liquidation.is_some() {
-            return Err(format!("sp_absorb: vault {vault_id} already has liquidation marker"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} already has liquidation marker"
+            ));
         }
         if !state.sp_attempted_chain_vaults.contains(&vault_id) {
-            return Err(format!("sp_absorb: vault {vault_id} missing sp_attempted escalation gate"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} missing sp_attempted escalation gate"
+            ));
         }
         if state.chain_liquidation_claims.contains_key(&vault_id) {
-            return Err(format!("sp_absorb: vault {vault_id} already has chain liquidation claim"));
+            return Err(format!(
+                "sp_absorb: vault {vault_id} already has chain liquidation claim"
+            ));
         }
-        (v.debt_e8s, v.collateral_amount_native, v.custody_address.clone())
+        (
+            v.debt_e8s,
+            v.collateral_amount_native,
+            v.custody_address.clone(),
+        )
     };
 
     if live_debt == 0 {
@@ -348,10 +550,13 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
     let actual_burned = icusd_burned_e8s;
 
     let bonus_e4 = liq::bonus_e4_from_penalty_bps(liquidation_penalty_bps);
-    let collateral_seized = liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)
-        .min(collateral_available);
+    let collateral_seized =
+        liq::collateral_in_native_for_repay(actual_burned, bonus_e4, native_decimals, price_e8)
+            .min(collateral_available);
     if collateral_seized == 0 {
-        return Err(format!("sp_absorb: vault {vault_id} has no collateral to seize"));
+        return Err(format!(
+            "sp_absorb: vault {vault_id} has no collateral to seize"
+        ));
     }
 
     crate::chains::supply::apply_debt_to_pending_burn_shift(state, chain, vault_id, actual_burned)
@@ -373,6 +578,7 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
             custody_address: custody_address.clone(),
             seized_native_total: collateral_seized,
             paid_native: 0,
+            pending_native: 0,
         },
     );
 
@@ -387,9 +593,10 @@ pub fn apply_sp_chain_liquidation_absorb_in_state(
 /// entitlement from its own depositor accounting, then asks the backend to pay
 /// that exact amount from the reserved chain-liquidity claim.
 ///
-/// Mutation order is important: enqueue first, then mark the claim as paid. A
-/// duplicate idempotency key therefore rejects without double-deducting the
-/// claim balance.
+/// Mutation order is important: enqueue first, then reserve the claim as
+/// pending. A duplicate idempotency key therefore rejects without
+/// double-reserving the claim balance. The amount only moves to `paid_native`
+/// after the outbound chain transaction is confirmed final.
 pub fn claim_chain_collateral_in_state(
     state: &mut MultiChainState,
     claim_id: u64,
@@ -412,7 +619,9 @@ pub fn claim_chain_collateral_in_state(
             .get(&claim_id)
             .ok_or_else(|| format!("chain collateral claim: unknown claim {claim_id}"))?;
         if !claim.paid_within_seized() {
-            return Err(format!("chain collateral claim: claim {claim_id} is overpaid"));
+            return Err(format!(
+                "chain collateral claim: claim {claim_id} is overpaid"
+            ));
         }
         (claim.chain, claim.remaining_native())
     };
@@ -439,7 +648,7 @@ pub fn claim_chain_collateral_in_state(
         ));
     }
 
-    let op = crate::chains::settlement_queue::SettlementOp::new(
+    let mut op = crate::chains::settlement_queue::SettlementOp::new(
         SettlementOpKind::ChainCollateralPayout {
             recipient: dest_evm,
             amount_e18: owed_wei,
@@ -449,6 +658,7 @@ pub fn claim_chain_collateral_in_state(
         idempotency_key,
         now_ns,
     );
+    op.chain_payout_uses_pending_reservation = Some(true);
     let op_id = state
         .settlement_queues
         .entry(chain)
@@ -464,8 +674,191 @@ pub fn claim_chain_collateral_in_state(
         .chain_liquidation_claims
         .get_mut(&claim_id)
         .expect("claim present: checked above");
-    claim.paid_native += owed_wei;
+    claim.pending_native = claim
+        .pending_native
+        .checked_add(owed_wei)
+        .ok_or_else(|| format!("chain collateral claim: pending overflow for claim {claim_id}"))?;
     Ok(op_id)
+}
+
+pub fn confirm_chain_collateral_payout_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    tx_hash: String,
+    now_ns: u64,
+) -> Result<bool, String> {
+    let (claim_id, amount, uses_pending_reservation) = {
+        let op = state
+            .settlement_queues
+            .get(&chain)
+            .and_then(|q| q.pending.get(&op_id))
+            .ok_or_else(|| format!("chain collateral payout confirm: unknown op {op_id}"))?;
+        match &op.status {
+            SettlementOpStatus::Succeeded { .. } => return Ok(false),
+            SettlementOpStatus::Failed { reason, .. } => {
+                return Err(format!(
+                    "chain collateral payout confirm: op {op_id} already failed: {reason}"
+                ));
+            }
+            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. } => {}
+        }
+        match &op.kind {
+            SettlementOpKind::ChainCollateralPayout {
+                vault_id,
+                amount_e18,
+                ..
+            } => (
+                *vault_id,
+                *amount_e18,
+                op.chain_payout_uses_pending_reservation.unwrap_or(false),
+            ),
+            other => {
+                return Err(format!(
+                    "chain collateral payout confirm: op {op_id} is not a claim payout: {other:?}"
+                ));
+            }
+        }
+    };
+
+    let claim = state
+        .chain_liquidation_claims
+        .get_mut(&claim_id)
+        .ok_or_else(|| format!("chain collateral payout confirm: unknown claim {claim_id}"))?;
+    if claim.chain != chain {
+        return Err(format!(
+            "chain collateral payout confirm: claim {claim_id} chain {:?} != op chain {:?}",
+            claim.chain, chain
+        ));
+    }
+    if uses_pending_reservation {
+        if claim.pending_native < amount {
+            return Err(format!(
+                "chain collateral payout confirm: claim {claim_id} pending {} is below payout {amount}",
+                claim.pending_native
+            ));
+        }
+        let paid = claim.paid_native.checked_add(amount).ok_or_else(|| {
+            format!("chain collateral payout confirm: paid overflow for claim {claim_id}")
+        })?;
+        if paid > claim.seized_native_total {
+            return Err(format!(
+                "chain collateral payout confirm: claim {claim_id} paid {paid} exceeds seized {}",
+                claim.seized_native_total
+            ));
+        }
+        claim.pending_native -= amount;
+        claim.paid_native = paid;
+    } else if claim.paid_native >= amount {
+        if claim.paid_native > claim.seized_native_total {
+            return Err(format!(
+                "chain collateral payout confirm: legacy claim {claim_id} paid {} exceeds seized {}",
+                claim.paid_native, claim.seized_native_total
+            ));
+        }
+        // Pre-Inc10 live payout ops had already reserved capacity in
+        // `paid_native`. Confirmation only makes that reservation final.
+    } else {
+        return Err(format!(
+            "chain collateral payout confirm: claim {claim_id} pending {} is below payout {amount}",
+            claim.pending_native
+        ));
+    }
+
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .expect("op present: checked above");
+    op.mark_succeeded(tx_hash, now_ns);
+    Ok(true)
+}
+
+pub fn fail_chain_collateral_payout_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    reason: String,
+    now_ns: u64,
+) -> Result<bool, String> {
+    let (claim_id, amount, idempotency_key, uses_pending_reservation) = {
+        let op = state
+            .settlement_queues
+            .get(&chain)
+            .and_then(|q| q.pending.get(&op_id))
+            .ok_or_else(|| format!("chain collateral payout fail: unknown op {op_id}"))?;
+        match &op.status {
+            SettlementOpStatus::Failed { .. } => return Ok(false),
+            SettlementOpStatus::Succeeded { .. } => {
+                return Err(format!(
+                    "chain collateral payout fail: op {op_id} already succeeded"
+                ));
+            }
+            SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. } => {}
+        }
+        match &op.kind {
+            SettlementOpKind::ChainCollateralPayout {
+                vault_id,
+                amount_e18,
+                ..
+            } => (
+                *vault_id,
+                *amount_e18,
+                op.idempotency_key.clone(),
+                op.chain_payout_uses_pending_reservation.unwrap_or(false),
+            ),
+            other => {
+                return Err(format!(
+                    "chain collateral payout fail: op {op_id} is not a claim payout: {other:?}"
+                ));
+            }
+        }
+    };
+
+    let release_error = match state.chain_liquidation_claims.get_mut(&claim_id) {
+        Some(claim) if claim.chain == chain && uses_pending_reservation => {
+            if claim.pending_native >= amount {
+                claim.pending_native -= amount;
+                None
+            } else {
+                Some(format!(
+                    "claim {claim_id} pending {} is below payout {amount}",
+                    claim.pending_native
+                ))
+            }
+        }
+        Some(claim) if claim.chain == chain && claim.paid_native >= amount => {
+            // Pre-Inc10 live payout ops had already reserved capacity in
+            // `paid_native`. A reverted tx must release that legacy reservation.
+            claim.paid_native -= amount;
+            None
+        }
+        Some(claim) if claim.chain == chain => Some(format!(
+            "claim {claim_id} paid {} is below legacy payout {amount}",
+            claim.paid_native
+        )),
+        Some(claim) => Some(format!(
+            "claim {claim_id} chain {:?} != op chain {:?}",
+            claim.chain, chain
+        )),
+        None => Some(format!("unknown claim {claim_id}")),
+    };
+
+    let queue = state
+        .settlement_queues
+        .get_mut(&chain)
+        .expect("queue present: checked above");
+    let op = queue
+        .pending
+        .get_mut(&op_id)
+        .expect("op present: checked above");
+    let terminal_reason = match release_error {
+        Some(error) => format!("{reason}; backend reservation release skipped: {error}"),
+        None => reason,
+    };
+    op.mark_failed(terminal_reason, now_ns);
+    queue.seen_idempotency_keys.remove(&idempotency_key);
+    Ok(true)
 }
 
 // ─── Timer D tick (fan-out) ─────────────────────────────────────────────────
@@ -575,7 +968,11 @@ pub async fn run_settlement(chain: ChainId) {
     let should_skip = read_state(|s| {
         s.mode == Mode::ReadOnly
             || s.multi_chain.invariant_halted
-            || s.multi_chain.reorg_halted.get(&chain).copied().unwrap_or(false)
+            || s.multi_chain
+                .reorg_halted
+                .get(&chain)
+                .copied()
+                .unwrap_or(false)
     });
     if should_skip {
         return;
@@ -665,7 +1062,11 @@ fn build_tx_plan(
     withdrawal_value: Option<u128>,
 ) -> Result<TxPlan, String> {
     match kind {
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s,
+            vault_id,
+        } => {
             let contract = contract.ok_or_else(|| "icUSD contract not set".to_string())?;
             // Delegate the per-op-kind field shape to the single source of truth.
             // `op_id` is the on-chain per-op idempotency key (so a resubmit of THIS
@@ -691,7 +1092,11 @@ fn build_tx_plan(
                 kind: TxPlanKind::Mint,
             })
         }
-        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+        SettlementOpKind::NativeWithdrawal {
+            recipient,
+            amount_e18,
+            vault_id,
+        } => {
             // `value` is wei (1e18 scale) — it goes straight into the EIP-1559
             // `value` of a native transfer. The withdrawal is signed by the
             // vault's own custody address, so `withdrawal_value` is the
@@ -700,7 +1105,10 @@ fn build_tx_plan(
             let value = withdrawal_value.unwrap_or(*amount_e18);
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
+                tx::MonadTxKind::NativeWithdrawal {
+                    recipient,
+                    amount_wei: value,
+                },
                 nonce,
                 prio,
                 max_fee,
@@ -713,11 +1121,18 @@ fn build_tx_plan(
                 kind: TxPlanKind::NativeWithdrawal,
             })
         }
-        SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, .. } => {
-            let value = withdrawal_value.unwrap_or(*amount_e18);
+        SettlementOpKind::ChainCollateralPayout {
+            recipient,
+            amount_e18,
+            vault_id,
+            ..
+        } => {
             let fields = tx::build_eip1559_fields(
                 chain.0 as u64,
-                tx::MonadTxKind::NativeWithdrawal { recipient, amount_wei: value },
+                tx::MonadTxKind::NativeWithdrawal {
+                    recipient,
+                    amount_wei: *amount_e18,
+                },
                 nonce,
                 prio,
                 max_fee,
@@ -726,11 +1141,17 @@ fn build_tx_plan(
                 fields,
                 vault_id: *vault_id,
                 recipient: recipient.clone(),
-                amount: value,
+                amount: *amount_e18,
                 kind: TxPlanKind::ChainCollateralPayout,
             })
         }
-        SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, recipient, .. } => {
+        SettlementOpKind::InterestMint {
+            vault_id,
+            mint_id,
+            amount_e8s,
+            recipient,
+            ..
+        } => {
             // Task 12: identical IcUSD.mint calldata to a normal Mint, but the
             // on-chain `vault_id` arg is the SYNTHETIC `mint_id` (the real vault
             // already minted once at open and IcUSD.mint reverts a repeat id),
@@ -830,16 +1251,33 @@ async fn resolve_op_signer(
 /// netted out — the withdrawer bears their own gas, as on any native chain, and
 /// a tiny dust (`max_fee - actual_fee`) is left behind. A partial withdrawal
 /// that leaves a buffer sends the full requested amount.
-pub(crate) fn fundable_withdrawal_value(amount_e18: u128, custody_balance: u128, max_fee: u128) -> u128 {
+pub(crate) fn fundable_withdrawal_value(
+    amount_e18: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> u128 {
     let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
     amount_e18.min(custody_balance.saturating_sub(gas_reserve))
+}
+
+pub(crate) fn exact_native_transfer_is_funded(
+    amount_e18: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> bool {
+    let gas_reserve = (tx::NATIVE_WITHDRAWAL_GAS_LIMIT as u128).saturating_mul(max_fee);
+    custody_balance >= amount_e18.saturating_add(gas_reserve)
 }
 
 /// The native CFX to swap (carried as the EIP-1559 `value`), capped so the
 /// custody signer can ALSO pay the swap gas (spec §4.8). Mirrors
 /// `fundable_withdrawal_value` but reserves the larger swap gas budget. If this
 /// goes to 0 the caller must NOT submit (escalate).
-pub(crate) fn fundable_swap_value(collateral_in: u128, custody_balance: u128, max_fee: u128) -> u128 {
+pub(crate) fn fundable_swap_value(
+    collateral_in: u128,
+    custody_balance: u128,
+    max_fee: u128,
+) -> u128 {
     let gas_reserve = (tx::LIQUIDATION_SWAP_GAS_LIMIT as u128).saturating_mul(max_fee);
     collateral_in.min(custody_balance.saturating_sub(gas_reserve))
 }
@@ -850,6 +1288,20 @@ pub(crate) enum ClaimLiquidationSwapSubmitError {
     WrongOpKind,
     NotQueued,
     MissingMarker,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ClaimChainPayoutSubmitError {
+    MissingOp,
+    WrongOpKind,
+    NotQueued,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RecordChainPayoutReplacementError {
+    MissingOp,
+    WrongOpKind,
+    NotInflight,
 }
 
 /// Atomically claim a queued liquidation swap immediately before broadcast.
@@ -869,8 +1321,7 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
         .get(&vault_id)
         .and_then(|v| v.pending_liquidation.as_ref())
         .map_or(false, |marker| {
-            marker.op_id == op_id
-                && marker.tier == crate::chains::vault::LiquidationTier::Bot
+            marker.op_id == op_id && marker.tier == crate::chains::vault::LiquidationTier::Bot
         });
     if !marker_owned {
         return Err(ClaimLiquidationSwapSubmitError::MissingMarker);
@@ -882,8 +1333,10 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
         .and_then(|q| q.pending.get_mut(&op_id))
         .ok_or(ClaimLiquidationSwapSubmitError::MissingOp)?;
     match &op.kind {
-        SettlementOpKind::LiquidationSwap { vault_id: live_vault_id, .. }
-            if *live_vault_id == vault_id => {}
+        SettlementOpKind::LiquidationSwap {
+            vault_id: live_vault_id,
+            ..
+        } if *live_vault_id == vault_id => {}
         _ => return Err(ClaimLiquidationSwapSubmitError::WrongOpKind),
     }
     if !matches!(op.status, SettlementOpStatus::Queued) {
@@ -891,8 +1344,71 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
     }
 
     op.mark_inflight(now_ns);
-    op.last_tx_hash = Some(tx_hash);
+    op.record_tx_hash_candidate(tx_hash);
     op.submit_nonce = Some(nonce);
+    Ok(())
+}
+
+/// Atomically claim a queued CFX payout op before calling `eth_sendRawTransaction`.
+///
+/// A native payout has no contract-level idempotency discriminator. If the RPC
+/// accepted the signed tx but returned an error/timeout, retrying from Queued
+/// with a fresh nonce can pay the same SP claim twice. Recording the locally
+/// computed tx hash and nonce before the ambiguous send boundary makes all later
+/// retries use the receipt/replace-by-fee path for the same nonce.
+pub(crate) fn claim_chain_collateral_payout_submit_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    now_ns: u64,
+    tx_hash: String,
+    nonce: u64,
+) -> Result<(), ClaimChainPayoutSubmitError> {
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .ok_or(ClaimChainPayoutSubmitError::MissingOp)?;
+    if !matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+        return Err(ClaimChainPayoutSubmitError::WrongOpKind);
+    }
+    if !matches!(op.status, SettlementOpStatus::Queued) {
+        return Err(ClaimChainPayoutSubmitError::NotQueued);
+    }
+
+    op.mark_inflight(now_ns);
+    op.record_tx_hash_candidate(tx_hash);
+    op.submit_nonce = Some(nonce);
+    Ok(())
+}
+
+/// Record the locally computed hash of a same-nonce replacement payout before
+/// rebroadcast. If the RPC accepts the replacement but returns an error, the
+/// confirm path must watch the replacement hash rather than the stale tx.
+pub(crate) fn record_chain_collateral_payout_replacement_in_state(
+    state: &mut MultiChainState,
+    chain: ChainId,
+    op_id: u64,
+    now_ns: u64,
+    tx_hash: String,
+) -> Result<(), RecordChainPayoutReplacementError> {
+    let op = state
+        .settlement_queues
+        .get_mut(&chain)
+        .and_then(|q| q.pending.get_mut(&op_id))
+        .ok_or(RecordChainPayoutReplacementError::MissingOp)?;
+    if !matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+        return Err(RecordChainPayoutReplacementError::WrongOpKind);
+    }
+    match &mut op.status {
+        SettlementOpStatus::Inflight {
+            last_attempt_ns, ..
+        } => {
+            *last_attempt_ns = now_ns;
+        }
+        _ => return Err(RecordChainPayoutReplacementError::NotInflight),
+    }
+    op.record_tx_hash_candidate(tx_hash);
     Ok(())
 }
 
@@ -905,11 +1421,7 @@ pub(crate) fn claim_liquidation_swap_submit_in_state(
 /// adapter), so it KNOWS the exact nonce used and can store it on the op. The
 /// stuck-tx resubmit (`confirm_op`) re-signs on this stored nonce, making a
 /// bumped-gas resubmit a true replace-by-fee rather than a second mint.
-async fn submit_op(
-    chain: ChainId,
-    op_id: u64,
-    op: crate::chains::settlement_queue::SettlementOp,
-) {
+async fn submit_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_queue::SettlementOp) {
     // A Burn op is never signable in Phase 1b — fail it up front (no RPC).
     if matches!(op.kind, SettlementOpKind::Burn { .. }) {
         let now = ic_cdk::api::time();
@@ -954,7 +1466,12 @@ async fn submit_op(
     if let SettlementOpKind::Mint { vault_id, .. } = &op.kind {
         let vid = *vault_id;
         let (cursor, vinfo) = read_state(|s| {
-            let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
+            let cursor = s
+                .multi_chain
+                .last_observed_block
+                .get(&chain)
+                .copied()
+                .unwrap_or(0);
             let v = s
                 .multi_chain
                 .chain_vaults
@@ -965,7 +1482,13 @@ async fn submit_op(
         let (custody, declared) = match vinfo {
             Some(p) => p,
             None => {
-                log!(INFO, "[settlement chain={:?}] mint op {}: unknown vault {}; will retry", chain, op_id, vid);
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] mint op {}: unknown vault {}; will retry",
+                    chain,
+                    op_id,
+                    vid
+                );
                 return;
             }
         };
@@ -1000,7 +1523,10 @@ async fn submit_op(
     // Task 12: interest mints are ALSO paid by the settlement hot wallet, so they
     // are gated on its balance too (a vault open mint and an interest mint cost
     // the same gas).
-    if matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }) {
+    if matches!(
+        op.kind,
+        SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+    ) {
         let cached = read_state(|s| s.multi_chain.hot_wallet_balance_e18.get(&chain).copied());
         if let Some(bal) = cached {
             if !hardening::hot_wallet_ok(bal) {
@@ -1023,7 +1549,13 @@ async fn submit_op(
     let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resolve_op_signer failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] resolve_op_signer failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1033,7 +1565,13 @@ async fn submit_op(
     let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
         Ok(n) => n,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] get_transaction_count failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1042,77 +1580,193 @@ async fn submit_op(
     let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
         Ok(pair) => pair,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] fetch_fees failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] fetch_fees failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
     let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
 
-    // 4. For a native withdrawal, cap the transfer value so the custody signer
-    //    can also pay gas (a full close requests the entire custody balance).
-    //    Read the custody balance ONCE here; the value is recomputed identically
-    //    on a stuck-tx resubmit. Mints don't carry a value, so skip the read.
-    let withdrawal_value = if matches!(
-        op.kind,
-        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
-    ) {
-        match evm_rpc::get_balance(chain, &signer_addr).await {
-            Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
-                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
-                    Some(fundable_withdrawal_value(*amount_e18, bal, max_fee))
-                } else {
-                    None
+    // 4. Native withdrawals may net gas from the transfer value; claim payouts
+    //    are exact entitlements and must have enough custody balance for both
+    //    the full amount and gas before submission.
+    let withdrawal_value = match &op.kind {
+        SettlementOpKind::NativeWithdrawal { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => Some(fundable_withdrawal_value(*amount_e18, bal, max_fee)),
+                Err(e) => {
+                    log!(
+                        INFO,
+                        "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry",
+                        chain,
+                        op_id,
+                        e
+                    );
+                    return;
                 }
             }
+        }
+        SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            amount_e18,
+            claimant,
+            ..
+        } => match evm_rpc::get_balance(chain, &signer_addr).await {
+            Ok(bal) => {
+                if !exact_native_transfer_is_funded(*amount_e18, bal, max_fee) {
+                    let now = ic_cdk::api::time();
+                    let reason = format!(
+                        "custody balance {bal} cannot fund exact payout {amount_e18} plus gas"
+                    );
+                    if recredit_and_fail_chain_collateral_payout(
+                        chain,
+                        op_id,
+                        *vault_id,
+                        *claimant,
+                        *amount_e18,
+                        reason,
+                        now,
+                    )
+                    .await
+                    {
+                        log!(INFO, "[settlement chain={:?}] claim payout op {} failed before submit because custody balance {} cannot fund exact amount {} plus gas", chain, op_id, bal, amount_e18);
+                    }
+                    return;
+                }
+                None
+            }
             Err(e) => {
-                log!(INFO, "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry", chain, op_id, e);
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] get_balance(custody) failed for op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
+                return;
+            }
+        },
+        _ => None,
+    };
+
+    // 5. Resolve the contract (mints only) and build the tx plan.
+    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
+    let plan = match build_tx_plan(
+        chain,
+        &op.kind,
+        op_id,
+        nonce,
+        prio,
+        max_fee,
+        contract.as_deref(),
+        withdrawal_value,
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
+    };
+    let TxPlan {
+        fields,
+        vault_id,
+        recipient,
+        amount,
+        kind,
+    } = plan;
+
+    // 6. Sign with the resolved signer (settlement for mints, custody for withdrawals).
+    let raw_hex = match tx::sign_eip1559(&fields, path, &signer_addr).await {
+        Ok(h) => h,
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
+    };
+    let chain_payout_local_tx_hash = if kind == TxPlanKind::ChainCollateralPayout {
+        match tx::raw_tx_hash(&raw_hex) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] signed tx hash failed for claim payout op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
                 return;
             }
         }
     } else {
         None
     };
-
-    // 5. Resolve the contract (mints only) and build the tx plan.
-    let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, prio, max_fee, contract.as_deref(), withdrawal_value) {
-        Ok(p) => p,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] build_tx_plan failed for op {}: {}; will retry", chain, op_id, e);
+    if let Some(local_tx_hash) = &chain_payout_local_tx_hash {
+        let claim = mutate_state(|s| {
+            claim_chain_collateral_payout_submit_in_state(
+                &mut s.multi_chain,
+                chain,
+                op_id,
+                ic_cdk::api::time(),
+                local_tx_hash.clone(),
+                nonce,
+            )
+        });
+        if let Err(e) = claim {
+            log!(
+                INFO,
+                "[settlement chain={:?}] claim payout op {}: submit CAS aborted before broadcast ({:?})",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
-    };
-    let TxPlan { fields, vault_id, recipient, amount, kind } = plan;
+    }
 
-    // 6. Sign with the resolved signer (settlement for mints, custody for withdrawals).
-    let raw_hex = match tx::sign_eip1559(&fields, path, &signer_addr).await {
-        Ok(h) => h,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] sign_eip1559 failed for op {}: {}; will retry", chain, op_id, e);
-            return;
-        }
-    };
-
-    // 7. Broadcast. A transient send error is logged and retried next tick — we
-    //    do NOT mark the op Failed (it may yet be re-signable / re-broadcastable).
+    // 7. Broadcast. A transient send error is logged and retried next tick. For
+    //    ChainCollateralPayout, the op is already Inflight with its local hash
+    //    and nonce recorded, so an ambiguous RPC error cannot lead to a fresh
+    //    nonce duplicate payout.
     //
     //    ON-CHAIN DOUBLE-MINT DEPENDENCY: if send_raw_transaction returns Err but
-    //    the tx actually landed (an RPC false negative), this op stays Queued
-    //    with no submit_nonce recorded, so the next tick re-reads "latest" and
-    //    signs a NEW tx at nonce+1 — a genuine second on-chain mint. The
-    //    canister's supply accounting stays correct (confirm requires
-    //    observed_e8s == pending_mint_e8s and credits exactly once), but on-chain
-    //    icUSD could be minted twice. Protection lives OUTSIDE this function:
-    //    (a) IcUSD.mint MUST guard per vault_id (Task 19: `mapping(uint64 => bool)
-    //    minted`, revert on repeat — asserted by a Task 20 test), and (b) once an
-    //    op IS Inflight, Task-11's stuck-tx path resubmits on the SAME stored
-    //    nonce (true replace-by-fee). The unguarded window is only the
-    //    transient-error-before-Inflight case.
+    //    a Mint actually landed (an RPC false negative), the mint op stays
+    //    Queued with no submit_nonce recorded, so the next tick can re-read
+    //    "latest" and sign a NEW tx at nonce+1. The canister's supply accounting
+    //    stays correct (confirm requires observed_e8s == pending_mint_e8s and
+    //    credits exactly once), but on-chain icUSD could be minted twice unless
+    //    IcUSD.mint guards per op/vault id. Plain CFX claim payouts cannot rely
+    //    on that contract guard, so they are claimed Inflight before broadcast.
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] send_raw_transaction failed for op {}: {}; will retry", chain, op_id, e);
+            if kind == TxPlanKind::ChainCollateralPayout {
+                log!(INFO, "[settlement chain={:?}] claim payout op {}: broadcast failed after submit claim ({}); receipt/replace-by-fee path will resolve", chain, op_id, e);
+            } else {
+                log!(
+                    INFO,
+                    "[settlement chain={:?}] send_raw_transaction failed for op {}: {}; will retry",
+                    chain,
+                    op_id,
+                    e
+                );
+            }
             return;
         }
     };
@@ -1120,15 +1774,25 @@ async fn submit_op(
     // 8. Mark Inflight + record the tx hash AND the submit nonce. Emit
     //    ChainMintSubmitted for mints.
     let now = ic_cdk::api::time();
-    mutate_state(|s| {
-        if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-            if let Some(o) = q.pending.get_mut(&op_id) {
-                o.mark_inflight(now);
-                o.last_tx_hash = Some(tx_hash.clone());
-                o.submit_nonce = Some(nonce);
+    if kind == TxPlanKind::ChainCollateralPayout {
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.record_tx_hash_candidate(tx_hash.clone());
+                }
             }
-        }
-    });
+        });
+    } else {
+        mutate_state(|s| {
+            if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
+                if let Some(o) = q.pending.get_mut(&op_id) {
+                    o.mark_inflight(now);
+                    o.last_tx_hash = Some(tx_hash.clone());
+                    o.submit_nonce = Some(nonce);
+                }
+            }
+        });
+    }
 
     match kind {
         TxPlanKind::Mint => {
@@ -1141,7 +1805,15 @@ async fn submit_op(
                 tx_hash: tx_hash.clone(),
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] mint submitted: op={} vault={} amount_e8s={} tx={}",
+                chain,
+                op_id,
+                vault_id,
+                amount,
+                tx_hash
+            );
         }
         TxPlanKind::NativeWithdrawal => {
             crate::storage::record_event(&crate::event::Event::WithdrawalSigned {
@@ -1153,7 +1825,15 @@ async fn submit_op(
                 tx_hash: tx_hash.clone(),
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}", chain, op_id, vault_id, amount, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] withdrawal submitted: op={} vault={} amount_e18={} tx={}",
+                chain,
+                op_id,
+                vault_id,
+                amount,
+                tx_hash
+            );
         }
         TxPlanKind::ChainCollateralPayout => {
             log!(INFO, "[settlement chain={:?}] chain-collateral payout submitted: op={} vault={} amount_e18={} recipient={} tx={}", chain, op_id, vault_id, amount, recipient, tx_hash);
@@ -1185,9 +1865,16 @@ fn escalate_failed_swap(chain: ChainId, op_id: u64, vault_id: u64, reason: Strin
         // Restore reserved collateral + clear the marker ONLY if THIS op still owns
         // it (a concurrent confirm or a post-upgrade re-run cannot double-restore).
         if let Some(v) = s.multi_chain.chain_vaults.get_mut(&vault_id) {
-            let owns = v.pending_liquidation.as_ref().map_or(false, |m| m.op_id == op_id);
+            let owns = v
+                .pending_liquidation
+                .as_ref()
+                .map_or(false, |m| m.op_id == op_id);
             if owns {
-                let reserved = v.pending_liquidation.as_ref().map(|m| m.collateral_reserved_native).unwrap_or(0);
+                let reserved = v
+                    .pending_liquidation
+                    .as_ref()
+                    .map(|m| m.collateral_reserved_native)
+                    .unwrap_or(0);
                 v.collateral_amount_native = v.collateral_amount_native.saturating_add(reserved);
                 v.pending_liquidation = None;
             }
@@ -1202,7 +1889,14 @@ fn escalate_failed_swap(chain: ChainId, op_id: u64, vault_id: u64, reason: Strin
         reason: reason.clone(),
         timestamp: now,
     });
-    log!(INFO, "[settlement chain={:?}] liquidation swap op {} vault {} FAILED -> escalated: {}", chain, op_id, vault_id, reason);
+    log!(
+        INFO,
+        "[settlement chain={:?}] liquidation swap op {} vault {} FAILED -> escalated: {}",
+        chain,
+        op_id,
+        vault_id,
+        reason
+    );
 }
 
 /// Dedicated submit path for a `LiquidationSwap` op (spec §4.8). Reads live DEX
@@ -1223,13 +1917,27 @@ async fn submit_liquidation_swap(
     // Op fields.
     let (vault_id, collateral_in, router, pair, path0, path1, deadline_secs) = match &op.kind {
         SettlementOpKind::LiquidationSwap {
-            vault_id, collateral_in_native, router, pair, path, deadline_secs, ..
+            vault_id,
+            collateral_in_native,
+            router,
+            pair,
+            path,
+            deadline_secs,
+            ..
         } => {
             if path.len() < 2 {
                 escalate_failed_swap(chain, op_id, *vault_id, "swap path malformed".into());
                 return;
             }
-            (*vault_id, *collateral_in_native, router.clone(), pair.clone(), path[0].clone(), path[1].clone(), *deadline_secs)
+            (
+                *vault_id,
+                *collateral_in_native,
+                router.clone(),
+                pair.clone(),
+                path[0].clone(),
+                path[1].clone(),
+                *deadline_secs,
+            )
         }
         _ => return, // unreachable: caller matched LiquidationSwap
     };
@@ -1240,19 +1948,38 @@ async fn submit_liquidation_swap(
     // enabled without them.
     let snap = read_state(|s| {
         let cfg = s.multi_chain.chain_liquidation_configs.get(&chain)?;
-        let native_decimals =
-            s.multi_chain.chain_configs.get(&chain).map(|c| c.chain_native_decimals).unwrap_or(18);
+        let native_decimals = s
+            .multi_chain
+            .chain_configs
+            .get(&chain)
+            .map(|c| c.chain_native_decimals)
+            .unwrap_or(18);
         let symbol = crate::chains::evm::evm_chain_config(chain).map(|c| c.native_symbol)?;
-        let price = liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, cfg.max_price_age_ns).ok()?;
-        Some((cfg.fee_bps, cfg.slippage_cap_bps, cfg.max_dex_oracle_divergence_bps, cfg.settle_stable_decimals, native_decimals, price))
+        let price =
+            liq::fresh_chain_price_e8(&s.multi_chain, chain, symbol, now, cfg.max_price_age_ns)
+                .ok()?;
+        Some((
+            cfg.fee_bps,
+            cfg.slippage_cap_bps,
+            cfg.max_dex_oracle_divergence_bps,
+            cfg.settle_stable_decimals,
+            native_decimals,
+            price,
+        ))
     });
-    let (fee_bps, slippage_bps, divergence_bps, settle_decimals, native_decimals, price_e8) = match snap {
-        Some(t) => t,
-        None => {
-            escalate_failed_swap(chain, op_id, vault_id, "swap config/price unavailable".into());
-            return;
-        }
-    };
+    let (fee_bps, slippage_bps, divergence_bps, settle_decimals, native_decimals, price_e8) =
+        match snap {
+            Some(t) => t,
+            None => {
+                escalate_failed_swap(
+                    chain,
+                    op_id,
+                    vault_id,
+                    "swap config/price unavailable".into(),
+                );
+                return;
+            }
+        };
 
     // Custody signer (holds the CFX) + the derived reserve `to`.
     let (path, signer_addr) = match resolve_op_signer(chain, &op.kind).await {
@@ -1265,7 +1992,12 @@ async fn submit_liquidation_swap(
     let reserve_to = match tecdsa::cached_reserve_address(chain).await {
         Ok((_p, a)) => a,
         Err(e) => {
-            escalate_failed_swap(chain, op_id, vault_id, format!("reserve address derive: {e}"));
+            escalate_failed_swap(
+                chain,
+                op_id,
+                vault_id,
+                format!("reserve address derive: {e}"),
+            );
             return;
         }
     };
@@ -1274,7 +2006,13 @@ async fn submit_liquidation_swap(
     let finalized = match evm_rpc::fetch_block_numbers(chain).await {
         Ok((_l, f)) => f,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] swap op {}: fetch_block_numbers failed ({}); will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: fetch_block_numbers failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -1293,37 +2031,89 @@ async fn submit_liquidation_swap(
             return;
         }
     };
-    let (reserve_in, reserve_out) = if token0.eq_ignore_ascii_case(&path0) { (r0, r1) } else { (r1, r0) };
+    let (reserve_in, reserve_out) = if token0.eq_ignore_ascii_case(&path0) {
+        (r0, r1)
+    } else {
+        (r1, r0)
+    };
 
     // Infra reads (transient -> retry, do NOT escalate on a blip).
     let nonce = match evm_rpc::get_transaction_count(chain, &signer_addr).await {
         Ok(n) => n,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: nonce read failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: nonce read failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let (base_fee, prio) = match evm_rpc::fetch_fees(chain).await {
         Ok(p) => p,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: fetch_fees failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: fetch_fees failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let max_fee = base_fee.saturating_mul(2).saturating_add(prio);
     let custody_balance = match evm_rpc::get_balance(chain, &signer_addr).await {
         Ok(b) => b,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: get_balance failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: get_balance failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
 
     // Gas net + JIT min-out + oracle cross-check — all fail-CLOSED (escalate).
     let fundable = fundable_swap_value(collateral_in, custody_balance, max_fee);
     if fundable == 0 {
-        escalate_failed_swap(chain, op_id, vault_id, "custody cannot cover swap gas".into());
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "custody cannot cover swap gas".into(),
+        );
         return;
     }
-    let (expected_out, min_out) = liq::compute_amount_out_min(fundable, reserve_in, reserve_out, fee_bps, slippage_bps);
+    let (expected_out, min_out) =
+        liq::compute_amount_out_min(fundable, reserve_in, reserve_out, fee_bps, slippage_bps);
     if min_out == 0 {
-        escalate_failed_swap(chain, op_id, vault_id, "min-out 0 (reserves zero/too thin)".into());
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "min-out 0 (reserves zero/too thin)".into(),
+        );
         return;
     }
     let oracle_value_e8 = liq::collateral_value_e8s(fundable, native_decimals, price_e8);
-    if !liq::oracle_corroborated(expected_out, settle_decimals, oracle_value_e8, divergence_bps) {
-        escalate_failed_swap(chain, op_id, vault_id, "pool price diverges from oracle (thin/manipulated)".into());
+    if !liq::oracle_corroborated(
+        expected_out,
+        settle_decimals,
+        oracle_value_e8,
+        divergence_bps,
+    ) {
+        escalate_failed_swap(
+            chain,
+            op_id,
+            vault_id,
+            "pool price diverges from oracle (thin/manipulated)".into(),
+        );
         return;
     }
 
@@ -1352,11 +2142,29 @@ async fn submit_liquidation_swap(
     };
     let raw = match tx::sign_eip1559(&fields, path, &signer_addr).await {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: sign failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: sign failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let local_tx_hash = match tx::raw_tx_hash(&raw) {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: signed tx hash failed ({}); will retry", chain, op_id, e); return; }
+        Err(e) => {
+            log!(
+                INFO,
+                "[settlement chain={:?}] swap op {}: signed tx hash failed ({}); will retry",
+                chain,
+                op_id,
+                e
+            );
+            return;
+        }
     };
     let claim = mutate_state(|s| {
         claim_liquidation_swap_submit_in_state(
@@ -1370,13 +2178,22 @@ async fn submit_liquidation_swap(
         )
     });
     if let Err(e) = claim {
-        log!(INFO, "[settlement chain={:?}] swap op {}: submit CAS aborted before broadcast ({:?})", chain, op_id, e);
+        log!(
+            INFO,
+            "[settlement chain={:?}] swap op {}: submit CAS aborted before broadcast ({:?})",
+            chain,
+            op_id,
+            e
+        );
         return;
     }
 
     let tx_hash = match evm_rpc::send_raw_transaction(chain, &raw).await {
         Ok(h) => h,
-        Err(e) => { log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed after submit claim ({}); receipt timeout path will resolve", chain, op_id, e); return; }
+        Err(e) => {
+            log!(INFO, "[settlement chain={:?}] swap op {}: broadcast failed after submit claim ({}); receipt timeout path will resolve", chain, op_id, e);
+            return;
+        }
     };
 
     mutate_state(|s| {
@@ -1390,41 +2207,63 @@ async fn submit_liquidation_swap(
 }
 
 /// Confirm path: check an `Inflight` op's receipt and finalize on success.
-async fn confirm_op(
-    chain: ChainId,
-    op_id: u64,
-    op: crate::chains::settlement_queue::SettlementOp,
-) {
-    // The submit path always sets last_tx_hash before going Inflight; a None
-    // here is defensive (e.g. a manually-poked state) — log and bail.
-    let tx_hash = match &op.last_tx_hash {
+async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_queue::SettlementOp) {
+    // The submit path always records at least one hash before going Inflight.
+    // `tx_hash_candidates` can include older same-nonce hashes retained across
+    // payout RBF attempts; if any candidate landed, that receipt is canonical.
+    let tx_hashes = op.receipt_tx_hash_candidates();
+    let latest_tx_hash = match tx_hashes.first() {
         Some(h) => h.clone(),
         None => {
-            log!(INFO, "[settlement chain={:?}] inflight op {} has no last_tx_hash; skipping", chain, op_id);
+            log!(
+                INFO,
+                "[settlement chain={:?}] inflight op {} has no tx hash candidates; skipping",
+                chain,
+                op_id
+            );
             return;
         }
     };
 
     // 1. Fetch the receipt.
-    let receipt = match evm_rpc::get_transaction_receipt(chain, &tx_hash).await {
-        Ok(r) => r,
-        Err(e) => {
-            log!(INFO, "[settlement chain={:?}] get_transaction_receipt failed for op {} tx {}: {}; will retry", chain, op_id, tx_hash, e);
-            return;
+    let mut mined_receipt = None;
+    let mut receipt_errors = Vec::new();
+    for candidate in &tx_hashes {
+        match evm_rpc::get_transaction_receipt(chain, candidate).await {
+            Ok(Some(pair)) => {
+                mined_receipt = Some((candidate.clone(), pair));
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                receipt_errors.push((candidate.clone(), e));
+            }
         }
-    };
+    }
+    if mined_receipt.is_none() && !receipt_errors.is_empty() {
+        let (candidate, err) = &receipt_errors[0];
+        log!(INFO, "[settlement chain={:?}] get_transaction_receipt failed for op {} tx {}: {}; will retry", chain, op_id, candidate, err);
+        return;
+    }
 
-    let (status_ok, block_number) = match receipt {
-        Some(pair) => pair,
+    let (tx_hash, status_ok, block_number) = match mined_receipt {
+        Some((hash, pair)) => (hash, pair.0, pair.1),
         None => {
             // LiquidationSwap: NEVER replace-by-fee (spec §4.8). A never-mined swap
             // instead TIMES OUT -> Failed -> escalate (findings #12/#22), so it can
             // never wedge the vault marker + reserved collateral. The timeout
             // (deadline + finality margin) exceeds chain finality, so a
             // mined-then-reverted swap is caught by the revert branch first.
-            if let SettlementOpKind::LiquidationSwap { vault_id, deadline_secs, .. } = &op.kind {
+            if let SettlementOpKind::LiquidationSwap {
+                vault_id,
+                deadline_secs,
+                ..
+            } = &op.kind
+            {
                 let last_attempt = match &op.status {
-                    SettlementOpStatus::Inflight { last_attempt_ns, .. } => *last_attempt_ns,
+                    SettlementOpStatus::Inflight {
+                        last_attempt_ns, ..
+                    } => *last_attempt_ns,
                     _ => return,
                 };
                 let now = ic_cdk::api::time();
@@ -1434,7 +2273,12 @@ async fn confirm_op(
                     *deadline_secs,
                     hardening::SWAP_CONFIRM_FINALITY_MARGIN_SECS,
                 ) {
-                    escalate_failed_swap(chain, op_id, *vault_id, "swap confirm timeout (never mined)".into());
+                    escalate_failed_swap(
+                        chain,
+                        op_id,
+                        *vault_id,
+                        "swap confirm timeout (never mined)".into(),
+                    );
                     return;
                 }
                 // Not timed out yet: advance tries for visibility, never resubmit.
@@ -1465,7 +2309,10 @@ async fn confirm_op(
                 }
             };
             let finality_depth = read_state(|s| {
-                s.multi_chain.chain_configs.get(&chain).map(|c| c.finality_depth)
+                s.multi_chain
+                    .chain_configs
+                    .get(&chain)
+                    .map(|c| c.finality_depth)
             })
             .unwrap_or(1);
             let has_nonce = op.submit_nonce.is_some();
@@ -1491,7 +2338,15 @@ async fn confirm_op(
             // re-sign + rebroadcast and does NOT advance tries again (confirm_op
             // owns the per-tick advance now), avoiding a double-advance.
             if do_resubmit {
-                resubmit_if_stuck(chain, op_id, &op, &tx_hash, new_tries, finality_depth).await;
+                resubmit_if_stuck(
+                    chain,
+                    op_id,
+                    &op,
+                    &latest_tx_hash,
+                    new_tries,
+                    finality_depth,
+                )
+                .await;
             }
             return;
         }
@@ -1536,6 +2391,25 @@ async fn confirm_op(
             return;
         }
         let reason = "tx reverted".to_string();
+        if let SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            amount_e18,
+            claimant,
+            ..
+        } = &op.kind
+        {
+            let claim_id = *vault_id;
+            let amount_wei = *amount_e18;
+            let claimant = *claimant;
+            if recredit_and_fail_chain_collateral_payout(
+                chain, op_id, claim_id, claimant, amount_wei, reason, now,
+            )
+            .await
+            {
+                log!(INFO, "[settlement chain={:?}] claim payout op {} tx {} reverted; marked Failed and released pending claim", chain, op_id, tx_hash);
+            }
+            return;
+        }
         let did_revert = mutate_state(|s| {
             // CAS: only the first tick to observe this op Inflight does the work.
             let still_inflight = s
@@ -1556,7 +2430,11 @@ async fn confirm_op(
                         v.pending_mint_e8s = 0;
                     }
                 }
-                SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+                SettlementOpKind::NativeWithdrawal {
+                    vault_id,
+                    amount_e18,
+                    ..
+                } => {
                     if let Some(v) = s.multi_chain.chain_vaults.get_mut(vault_id) {
                         v.collateral_amount_native =
                             v.collateral_amount_native.saturating_add(*amount_e18);
@@ -1566,9 +2444,9 @@ async fn confirm_op(
                     }
                 }
                 SettlementOpKind::ChainCollateralPayout { .. } => {
-                    // Claim payout reversals are NOT vault collateral reversals.
-                    // The SP-side cfx_claims rollback lands with claim_cfx; for
-                    // now just mark the op failed without touching the vault.
+                    // Handled above through fail_chain_collateral_payout_in_state
+                    // so backend claim capacity is released atomically with the
+                    // terminal op transition.
                 }
                 SettlementOpKind::InterestMint { vault_id, .. } => {
                     // Task 12: no debt/supply was credited (the mint reverted), so
@@ -1607,7 +2485,13 @@ async fn confirm_op(
                 reason,
                 timestamp: now,
             });
-            log!(INFO, "[settlement chain={:?}] op {} tx {} reverted; marked Failed", chain, op_id, tx_hash);
+            log!(
+                INFO,
+                "[settlement chain={:?}] op {} tx {} reverted; marked Failed",
+                chain,
+                op_id,
+                tx_hash
+            );
         }
         return;
     }
@@ -1640,7 +2524,15 @@ async fn confirm_op(
                 }
             };
 
-            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &contract,
+                evm_rpc::MINT_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] get_logs(mint) failed confirming op {}: {}; will retry", chain, op_id, e);
@@ -1671,7 +2563,13 @@ async fn confirm_op(
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        log!(INFO, "[settlement chain={:?}] decode_mint_log failed confirming op {}: {}", chain, op_id, e);
+                        log!(
+                            INFO,
+                            "[settlement chain={:?}] decode_mint_log failed confirming op {}: {}",
+                            chain,
+                            op_id,
+                            e
+                        );
                     }
                 }
             }
@@ -1689,8 +2587,12 @@ async fn confirm_op(
             // recipient-agnostic, so without this check a mint to the WRONG
             // address would still balance and be marked Succeeded. A mismatch is a
             // real divergence: leave the op Inflight and do NOT credit.
-            let intended_recipient =
-                read_state(|s| s.multi_chain.chain_vaults.get(&vault_id).map(|v| v.mint_recipient.clone()));
+            let intended_recipient = read_state(|s| {
+                s.multi_chain
+                    .chain_vaults
+                    .get(&vault_id)
+                    .map(|v| v.mint_recipient.clone())
+            });
             match intended_recipient {
                 Some(intended) if intended.eq_ignore_ascii_case(&observed_recipient) => {}
                 Some(intended) => {
@@ -1709,7 +2611,14 @@ async fn confirm_op(
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
 
             let result = mutate_state(|s| {
-                confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, observed_e8s, pre_total, now)
+                confirm_mint_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    observed_e8s,
+                    pre_total,
+                    now,
+                )
             });
 
             match result {
@@ -1745,7 +2654,13 @@ async fn confirm_op(
                 }
             }
         }
-        SettlementOpKind::InterestMint { vault_id, mint_id, accrual_through_ns, recipient, .. } => {
+        SettlementOpKind::InterestMint {
+            vault_id,
+            mint_id,
+            accrual_through_ns,
+            recipient,
+            ..
+        } => {
             // Task 12: same Mint-log read as a vault mint, but matched by the
             // SYNTHETIC `mint_id` and recipient-verified against the interest
             // treasury. On confirm, debt + supply grow together for the REAL vault.
@@ -1763,7 +2678,15 @@ async fn confirm_op(
                 }
             };
 
-            let logs = match evm_rpc::get_logs(chain, &contract, evm_rpc::MINT_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &contract,
+                evm_rpc::MINT_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] get_logs(interest mint) failed confirming op {}: {}; will retry", chain, op_id, e);
@@ -1809,7 +2732,12 @@ async fn confirm_op(
             let pre_total = read_state(|s| s.multi_chain.total_chain_vault_debt_e8s());
             let result = mutate_state(|s| {
                 confirm_interest_mint_in_state(
-                    &mut s.multi_chain, chain, vault_id, observed_e8s, accrual_through_ns, pre_total,
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    observed_e8s,
+                    accrual_through_ns,
+                    pre_total,
                 )
             });
 
@@ -1861,30 +2789,49 @@ async fn confirm_op(
             });
             log!(INFO, "[settlement chain={:?}] withdrawal op {} vault {} confirmed tx={} (Closing->Closed if applicable)", chain, op_id, vid, tx_hash);
         }
-        SettlementOpKind::ChainCollateralPayout { vault_id, recipient, amount_e18, .. } => {
+        SettlementOpKind::ChainCollateralPayout {
+            vault_id,
+            recipient,
+            amount_e18,
+            ..
+        } => {
             let vid = *vault_id;
             let recipient = recipient.clone();
             let amount = *amount_e18;
-            mutate_state(|s| {
-                if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
-                    if let Some(o) = q.pending.get_mut(&op_id) {
-                        o.mark_succeeded(tx_hash.clone(), now);
-                    }
+            match mutate_state(|s| {
+                confirm_chain_collateral_payout_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    op_id,
+                    tx_hash.clone(),
+                    now,
+                )
+            }) {
+                Ok(true) => {
+                    crate::storage::record_event(&crate::event::Event::ChainCfxClaimSettled {
+                        chain_id: chain,
+                        claim_id: vid,
+                        recipient: recipient.clone(),
+                        amount_native: amount,
+                        timestamp: now,
+                    });
+                    log!(INFO, "[settlement chain={:?}] chain-collateral payout op {} vault/claim {} confirmed tx={} recipient={} amount={}", chain, op_id, vid, tx_hash, recipient, amount);
                 }
-            });
-            crate::storage::record_event(&crate::event::Event::ChainCfxClaimSettled {
-                chain_id: chain,
-                claim_id: vid,
-                recipient: recipient.clone(),
-                amount_native: amount,
-                timestamp: now,
-            });
-            log!(INFO, "[settlement chain={:?}] chain-collateral payout op {} vault/claim {} confirmed tx={} recipient={} amount={}", chain, op_id, vid, tx_hash, recipient, amount);
+                Ok(false) => {}
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] chain-collateral payout confirm FAILED for op {} claim {}: {}; left Inflight", chain, op_id, vid, e);
+                }
+            }
         }
         SettlementOpKind::Burn { .. } => {
             // Unreachable: a Burn op is marked Failed on the submit path and
             // never goes Inflight. Log defensively rather than panic.
-            log!(INFO, "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly", chain, op_id);
+            log!(
+                INFO,
+                "[settlement chain={:?}] inflight Burn op {} reached confirm path unexpectedly",
+                chain,
+                op_id
+            );
         }
         SettlementOpKind::LiquidationSwap { vault_id, path, .. } => {
             // Mined + ok + final: read the REALIZED settle-stable output from the
@@ -1900,11 +2847,22 @@ async fn confirm_op(
                 }
             };
             let settle_decimals = read_state(|s| {
-                s.multi_chain.chain_liquidation_configs.get(&chain).map(|c| c.settle_stable_decimals)
+                s.multi_chain
+                    .chain_liquidation_configs
+                    .get(&chain)
+                    .map(|c| c.settle_stable_decimals)
             })
             .unwrap_or(18);
 
-            let logs = match evm_rpc::get_logs(chain, &settle_stable, evm_rpc::TRANSFER_EVENT_TOPIC0, block_number, block_number).await {
+            let logs = match evm_rpc::get_logs(
+                chain,
+                &settle_stable,
+                evm_rpc::TRANSFER_EVENT_TOPIC0,
+                block_number,
+                block_number,
+            )
+            .await
+            {
                 Ok(l) => l,
                 Err(e) => {
                     log!(INFO, "[settlement chain={:?}] swap confirm op {}: get_logs(Transfer) failed ({}); will retry", chain, op_id, e);
@@ -1933,7 +2891,14 @@ async fn confirm_op(
 
             // Phase 2 (state-only): clamp + move debt -> reserve; events emitted here.
             let settled = mutate_state(|s| {
-                apply_liquidation_settlement_in_state(&mut s.multi_chain, chain, vault_id, op_id, realized_usdc, settle_decimals)
+                apply_liquidation_settlement_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    op_id,
+                    realized_usdc,
+                    settle_decimals,
+                )
             });
             match settled {
                 Ok(res) => {
@@ -2000,7 +2965,12 @@ async fn resubmit_if_stuck(
     // A stuck swap simply hits its on-chain deadline and reverts; Increment 3's
     // confirm-timeout marks it Failed -> escalate. (Inert in Increment 2.)
     if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
-        log!(INFO, "[settlement chain={:?}] op {} is a liquidation swap; never replace-by-fee (spec §4.8)", chain, op_id);
+        log!(
+            INFO,
+            "[settlement chain={:?}] op {} is a liquidation swap; never replace-by-fee (spec §4.8)",
+            chain,
+            op_id
+        );
         return;
     }
     // We can only replace-by-fee if we know the nonce the op was first submitted
@@ -2035,35 +3005,50 @@ async fn resubmit_if_stuck(
     let base_max_fee = base_fee.saturating_mul(2).saturating_add(prio);
     let (bumped_prio, bumped_max) = hardening::bump_gas(prio, base_max_fee);
 
-    // Re-net the withdrawal value at the BUMPED fee so the replacement still
-    // fits within the custody balance (a higher gas reserve sends marginally
-    // less collateral — fine for a replace-by-fee). Mints carry no value.
-    let withdrawal_value = if matches!(
-        op.kind,
-        SettlementOpKind::NativeWithdrawal { .. } | SettlementOpKind::ChainCollateralPayout { .. }
-    ) {
-        match evm_rpc::get_balance(chain, &signer_addr).await {
-            Ok(bal) => {
-                if let SettlementOpKind::NativeWithdrawal { amount_e18, .. }
-                | SettlementOpKind::ChainCollateralPayout { amount_e18, .. } = &op.kind {
-                    Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max))
-                } else {
-                    None
+    // Re-net withdrawal value at the BUMPED fee. Claim payouts remain exact:
+    // if custody cannot fund amount + bumped gas, leave the original tx Inflight
+    // and retry receipt/replacement later.
+    let withdrawal_value = match &op.kind {
+        SettlementOpKind::NativeWithdrawal { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => Some(fundable_withdrawal_value(*amount_e18, bal, bumped_max)),
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
+                    return;
                 }
             }
-            Err(e) => {
-                log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
-                return;
+        }
+        SettlementOpKind::ChainCollateralPayout { amount_e18, .. } => {
+            match evm_rpc::get_balance(chain, &signer_addr).await {
+                Ok(bal) => {
+                    if !exact_native_transfer_is_funded(*amount_e18, bal, bumped_max) {
+                        log!(INFO, "[settlement chain={:?}] resubmit claim payout op {} custody balance {} cannot fund exact amount {} plus bumped gas; leaving Inflight", chain, op_id, bal, amount_e18);
+                        return;
+                    }
+                    None
+                }
+                Err(e) => {
+                    log!(INFO, "[settlement chain={:?}] resubmit get_balance(custody) failed for op {}: {}; leaving Inflight", chain, op_id, e);
+                    return;
+                }
             }
         }
-    } else {
-        None
+        _ => None,
     };
 
     // Resolve the contract (mints only) and rebuild the SAME tx at the stored
     // nonce with the bumped fees.
     let contract = read_state(|s| s.multi_chain.chain_contracts.get(&chain).cloned());
-    let plan = match build_tx_plan(chain, &op.kind, op_id, nonce, bumped_prio, bumped_max, contract.as_deref(), withdrawal_value) {
+    let plan = match build_tx_plan(
+        chain,
+        &op.kind,
+        op_id,
+        nonce,
+        bumped_prio,
+        bumped_max,
+        contract.as_deref(),
+        withdrawal_value,
+    ) {
         Ok(p) => p,
         Err(e) => {
             log!(INFO, "[settlement chain={:?}] resubmit build_tx_plan failed for op {}: {}; leaving Inflight", chain, op_id, e);
@@ -2079,12 +3064,45 @@ async fn resubmit_if_stuck(
             return;
         }
     };
+    let chain_payout_replacement_hash = if matches!(
+        op.kind,
+        SettlementOpKind::ChainCollateralPayout { .. }
+    ) {
+        match tx::raw_tx_hash(&raw_hex) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                log!(INFO, "[settlement chain={:?}] resubmit signed tx hash failed for claim payout op {}: {}; leaving Inflight", chain, op_id, e);
+                return;
+            }
+        }
+    } else {
+        None
+    };
+    if let Some(local_tx_hash) = &chain_payout_replacement_hash {
+        let recorded = mutate_state(|s| {
+            record_chain_collateral_payout_replacement_in_state(
+                &mut s.multi_chain,
+                chain,
+                op_id,
+                ic_cdk::api::time(),
+                local_tx_hash.clone(),
+            )
+        });
+        if let Err(e) = recorded {
+            log!(INFO, "[settlement chain={:?}] resubmit claim payout op {}: replacement record aborted before broadcast ({:?})", chain, op_id, e);
+            return;
+        }
+    }
 
     // Rebroadcast.
     let new_tx_hash = match evm_rpc::send_raw_transaction(chain, &raw_hex).await {
         Ok(h) => h,
         Err(e) => {
-            log!(INFO, "[settlement chain={:?}] resubmit send_raw_transaction failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            if matches!(op.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+                log!(INFO, "[settlement chain={:?}] resubmit claim payout op {}: broadcast failed after replacement record ({}); receipt path will watch replacement hash", chain, op_id, e);
+            } else {
+                log!(INFO, "[settlement chain={:?}] resubmit send_raw_transaction failed for op {}: {}; leaving Inflight", chain, op_id, e);
+            }
             return;
         }
     };
@@ -2098,8 +3116,15 @@ async fn resubmit_if_stuck(
     mutate_state(|s| {
         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
             if let Some(o) = q.pending.get_mut(&op_id) {
-                o.last_tx_hash = Some(new_tx_hash.clone());
-                if let SettlementOpStatus::Inflight { last_attempt_ns, .. } = &mut o.status {
+                if matches!(o.kind, SettlementOpKind::ChainCollateralPayout { .. }) {
+                    o.record_tx_hash_candidate(new_tx_hash.clone());
+                } else {
+                    o.last_tx_hash = Some(new_tx_hash.clone());
+                }
+                if let SettlementOpStatus::Inflight {
+                    last_attempt_ns, ..
+                } = &mut o.status
+                {
                     *last_attempt_ns = now;
                 }
             }

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,32 +1,48 @@
 use super::settlement::{
-    claim_liquidation_swap_submit_in_state, ClaimLiquidationSwapSubmitError,
-    confirm_interest_mint_in_state, confirm_mint_in_state, fundable_withdrawal_value,
-    select_next_op, OpAction,
+    claim_liquidation_swap_submit_in_state, confirm_interest_mint_in_state, confirm_mint_in_state,
+    exact_native_transfer_is_funded, fundable_withdrawal_value, select_next_op,
+    ClaimLiquidationSwapSubmitError, OpAction,
 };
-use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::config::ChainId;
+use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use crate::chains::multi_chain_state::MultiChainState;
 use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
 
 fn vault_pending(s: &mut MultiChainState, vault_id: u64, pending: u128) {
-    s.chain_vaults.insert(vault_id, ChainVaultV1 {
-        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
-        custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 0,
-        mint_recipient: "0xr".into(), pending_mint_e8s: pending,
-        status: ChainVaultStatus::MintPending, opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 0,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: pending,
+            status: ChainVaultStatus::MintPending,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
 }
 
 #[test]
 fn select_next_op_prefers_queued_then_inflight() {
     let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
     let op = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 },
-        "k0".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            vault_id: 1,
+        },
+        "k0".into(),
+        0,
+    );
     let id = q.enqueue(op).unwrap();
     // Queued -> action Submit.
     match select_next_op(&q) {
@@ -39,13 +55,30 @@ fn select_next_op_prefers_queued_then_inflight() {
 fn select_next_op_confirms_inflight_before_submitting_new() {
     let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
     let op0 = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 10, vault_id: 1 }, "k0".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            vault_id: 1,
+        },
+        "k0".into(),
+        0,
+    );
     let id0 = q.enqueue(op0).unwrap();
     let op1 = SettlementOp::new(
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 20, vault_id: 2 }, "k1".into(), 0);
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 20,
+            vault_id: 2,
+        },
+        "k1".into(),
+        0,
+    );
     let _id1 = q.enqueue(op1).unwrap();
     // Put op0 inflight; with something inflight, only Confirm of op0 is actionable.
-    q.pending.get_mut(&id0).unwrap().status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    q.pending.get_mut(&id0).unwrap().status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 0,
+    };
     match select_next_op(&q) {
         Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
         other => panic!("expected Confirm of inflight op, got {other:?}"),
@@ -114,23 +147,24 @@ fn claim_liquidation_swap_submit_marks_queued_op_inflight_before_broadcast() {
     let op_id = queued_liquidation_swap(&mut s, 7);
     marked_bot_liquidation(&mut s, 7, op_id);
 
-    claim_liquidation_swap_submit_in_state(
-        &mut s,
-        ChainId(71),
-        op_id,
-        7,
-        42,
-        "0xabc".into(),
-        9,
-    )
-    .expect("claim submit");
+    claim_liquidation_swap_submit_in_state(&mut s, ChainId(71), op_id, 7, 42, "0xabc".into(), 9)
+        .expect("claim submit");
 
-    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    let op = s
+        .settlement_queues
+        .get(&ChainId(71))
+        .unwrap()
+        .pending
+        .get(&op_id)
+        .unwrap();
     assert_eq!(op.last_tx_hash.as_deref(), Some("0xabc"));
     assert_eq!(op.submit_nonce, Some(9));
     assert!(matches!(
         op.status,
-        SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 42 }
+        SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 42
+        }
     ));
 }
 
@@ -151,7 +185,13 @@ fn claim_liquidation_swap_submit_rejects_if_observer_already_cleared_marker() {
     .unwrap_err();
 
     assert_eq!(err, ClaimLiquidationSwapSubmitError::MissingMarker);
-    let op = s.settlement_queues.get(&ChainId(71)).unwrap().pending.get(&op_id).unwrap();
+    let op = s
+        .settlement_queues
+        .get(&ChainId(71))
+        .unwrap()
+        .pending
+        .get(&op_id)
+        .unwrap();
     assert!(matches!(op.status, SettlementOpStatus::Queued));
     assert!(op.last_tx_hash.is_none());
     assert!(op.submit_nonce.is_none());
@@ -189,8 +229,8 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
     let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 0);
     vault_pending(&mut s, 1, 10_000_000_000); // 100 icUSD pending
-    // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
-    // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
+                                              // PRE-mint total_chain_vault_debt_e8s() == 0 (vault debt_e8s is still 0).
+                                              // confirm_mint_in_state adds observed_e8s internally to get the post-mint total.
     confirm_mint_in_state(&mut s, ChainId(10143), 1, 10_000_000_000, 0, 7_777).expect("confirm");
     assert_eq!(s.chain_vaults[&1].debt_e8s, 10_000_000_000);
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
@@ -205,15 +245,25 @@ fn confirm_mint_moves_pending_to_debt_and_increments_supply() {
 /// An Open vault with confirmed `debt` and an interest mint of `pending` in
 /// flight (`last_interest_accrual_ns = 1_000`).
 fn vault_interest_pending(s: &mut MultiChainState, vault_id: u64, debt: u128, pending: u128) {
-    s.chain_vaults.insert(vault_id, ChainVaultV1 {
-        vault_id, owner: Principal::anonymous(), collateral_chain: ChainId(71),
-        custody_address: "0xc".into(), collateral_amount_native: 1_400_000_000_000_000_000_000,
-        debt_e8s: debt, mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
-    owner_evm: None,
-        last_interest_accrual_ns: 1_000,
-        pending_interest_mint_e8s: pending,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        vault_id,
+        ChainVaultV1 {
+            vault_id,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(71),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 1_400_000_000_000_000_000_000,
+            debt_e8s: debt,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 1_000,
+            pending_interest_mint_e8s: pending,
+            pending_liquidation: None,
+        },
+    );
 }
 
 #[test]
@@ -224,8 +274,15 @@ fn confirm_interest_mint_grows_debt_and_supply_equally() {
     let pre = s.total_chain_vault_debt_e8s(); // 100e8
     confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 2 * 100_000_000, 5_000, pre)
         .expect("confirm");
-    assert_eq!(s.chain_vaults[&1].debt_e8s, 102 * 100_000_000, "debt += interest");
-    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0, "pending cleared");
+    assert_eq!(
+        s.chain_vaults[&1].debt_e8s,
+        102 * 100_000_000,
+        "debt += interest"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].pending_interest_mint_e8s, 0,
+        "pending cleared"
+    );
     assert_eq!(
         s.chain_vaults[&1].last_interest_accrual_ns, 5_000,
         "accrual window advanced to the harvest snapshot time"
@@ -245,10 +302,25 @@ fn confirm_interest_mint_rejects_amount_mismatch_no_mutation() {
     let pre = s.total_chain_vault_debt_e8s();
     let err = confirm_interest_mint_in_state(&mut s, ChainId(71), 1, 3 * 100_000_000, 5_000, pre)
         .unwrap_err();
-    assert!(err.contains("observed"), "mismatch error mentions observed/pending: {err}");
-    assert_eq!(s.chain_vaults[&1].debt_e8s, 100 * 100_000_000, "debt untouched on reject");
-    assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 2 * 100_000_000, "pending untouched");
-    assert_eq!(s.chain_supplies[&ChainId(71)], 100 * 100_000_000, "supply untouched");
+    assert!(
+        err.contains("observed"),
+        "mismatch error mentions observed/pending: {err}"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].debt_e8s,
+        100 * 100_000_000,
+        "debt untouched on reject"
+    );
+    assert_eq!(
+        s.chain_vaults[&1].pending_interest_mint_e8s,
+        2 * 100_000_000,
+        "pending untouched"
+    );
+    assert_eq!(
+        s.chain_supplies[&ChainId(71)],
+        100 * 100_000_000,
+        "supply untouched"
+    );
 }
 
 #[test]
@@ -276,18 +348,29 @@ fn confirm_mint_second_vault_uses_running_total() {
     // second (pending 50e8) must pass PRE-mint total = 100e8; helper computes 150e8.
     let mut s = MultiChainState::default();
     s.chain_supplies.insert(ChainId(10143), 10_000_000_000);
-    s.chain_vaults.insert(1, ChainVaultV1 {
-        vault_id: 1, owner: Principal::anonymous(), collateral_chain: ChainId(10143),
-        custody_address: "0xc".into(), collateral_amount_native: 0, debt_e8s: 10_000_000_000,
-        mint_recipient: "0xr".into(), pending_mint_e8s: 0,
-        status: ChainVaultStatus::Open, opened_at_ns: 0,
-        owner_evm: None,
-        last_interest_accrual_ns: 0,
-        pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    });
+    s.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            collateral_chain: ChainId(10143),
+            custody_address: "0xc".into(),
+            collateral_amount_native: 0,
+            debt_e8s: 10_000_000_000,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
     vault_pending(&mut s, 2, 5_000_000_000);
     let pre_total = s.total_chain_vault_debt_e8s(); // == 10e8
-    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0).expect("confirm 2nd");
+    confirm_mint_in_state(&mut s, ChainId(10143), 2, 5_000_000_000, pre_total, 0)
+        .expect("confirm 2nd");
     assert_eq!(s.chain_vaults[&2].debt_e8s, 5_000_000_000);
     assert_eq!(s.chain_supplies[&ChainId(10143)], 15_000_000_000);
 }
@@ -315,7 +398,28 @@ fn fundable_withdrawal_value_nets_gas_only_when_balance_is_tight() {
 
     // Degenerate: balance below the gas reserve -> saturates to 0 (never panics
     // / underflows), so the worker sends a 0-value tx rather than trapping.
-    assert_eq!(fundable_withdrawal_value(amount, gas_reserve / 2, max_fee), 0);
+    assert_eq!(
+        fundable_withdrawal_value(amount, gas_reserve / 2, max_fee),
+        0
+    );
+}
+
+#[test]
+fn exact_native_transfer_funding_requires_amount_plus_gas() {
+    let amount = 20_000_000_000_000_000_000u128;
+    let max_fee = 40_000_000_000u128;
+    let gas_reserve = 21_000u128 * max_fee;
+
+    assert!(!exact_native_transfer_is_funded(
+        amount,
+        amount + gas_reserve - 1,
+        max_fee
+    ));
+    assert!(exact_native_transfer_is_funded(
+        amount,
+        amount + gas_reserve,
+        max_fee
+    ));
 }
 
 // ─── Increment 3 / Task 7: apply_liquidation_settlement_in_state (Phase 2) ───
@@ -378,15 +482,29 @@ mod phase2_tests {
         apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18).expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 33 * E8, "debt -= actual_cleared");
-        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 67 * E8, "backing += actual_cleared");
-        assert_eq!(*s.reserve_usdc_native.get(&CFX).unwrap(), 75 * E18, "usdc += realized");
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply UNCHANGED (PSM)");
+        assert_eq!(
+            *s.reserve_backing_e8s.get(&CFX).unwrap(),
+            67 * E8,
+            "backing += actual_cleared"
+        );
+        assert_eq!(
+            *s.reserve_usdc_native.get(&CFX).unwrap(),
+            75 * E18,
+            "usdc += realized"
+        );
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "supply UNCHANGED (PSM)"
+        );
         assert!(v.pending_liquidation.is_none(), "marker cleared");
         assert!(s.chain_bad_debt_e8s.get(&CFX).is_none(), "no shortfall");
         // Unified invariant: supply == debt + reserve + pending_burn.
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
-            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+            s.total_chain_vault_debt_e8s()
+                + s.total_reserve_backing_e8s()
+                + s.total_pending_chain_burn_e8s()
         );
     }
 
@@ -397,9 +515,21 @@ mod phase2_tests {
         // realized only 60 USDC -> 60e8 < debt_to_clear 67e8.
         apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18).expect("phase2 ok");
         assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 40 * E8);
-        assert_eq!(*s.reserve_backing_e8s.get(&CFX).unwrap(), 60 * E8, "backing capped at realized USD");
-        assert_eq!(*s.chain_bad_debt_e8s.get(&CFX).unwrap(), 7 * E8, "shortfall recorded");
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "supply unchanged");
+        assert_eq!(
+            *s.reserve_backing_e8s.get(&CFX).unwrap(),
+            60 * E8,
+            "backing capped at realized USD"
+        );
+        assert_eq!(
+            *s.chain_bad_debt_e8s.get(&CFX).unwrap(),
+            7 * E8,
+            "shortfall recorded"
+        );
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "supply unchanged"
+        );
     }
 
     #[test]
@@ -419,7 +549,11 @@ mod phase2_tests {
         marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // confirming op 99 != marker op 9.
         assert!(apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18).is_err());
-        assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 100 * E8, "no mutation on reject");
+        assert_eq!(
+            s.chain_vaults.get(&7).unwrap().debt_e8s,
+            100 * E8,
+            "no mutation on reject"
+        );
         assert!(s.reserve_backing_e8s.get(&CFX).is_none());
     }
 }
@@ -485,22 +619,38 @@ mod sp_absorb_tests {
         assert_eq!(result.collateral_seized_native, 224 * E18);
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 0, "debt cleared by the IC-side SP burn");
-        assert_eq!(v.collateral_amount_native, 776 * E18, "claim collateral reserved out of borrower balance");
+        assert_eq!(
+            v.collateral_amount_native,
+            776 * E18,
+            "claim collateral reserved out of borrower balance"
+        );
         assert_eq!(*s.pending_chain_burn_e8s.get(&CFX).unwrap(), 100 * E8);
-        assert_eq!(*s.chain_supplies.get(&CFX).unwrap(), 100 * E8, "foreign-chain supply accounting unchanged");
-        assert!(v.pending_liquidation.is_none(), "SP absorb does not create a fake foreign-burn marker");
+        assert_eq!(
+            *s.chain_supplies.get(&CFX).unwrap(),
+            100 * E8,
+            "foreign-chain supply accounting unchanged"
+        );
+        assert!(
+            v.pending_liquidation.is_none(),
+            "SP absorb does not create a fake foreign-burn marker"
+        );
 
         let claim = s.chain_liquidation_claims.get(&7).expect("claim record");
         assert_eq!(claim.vault_id, 7);
         assert_eq!(claim.chain, CFX);
-        assert_eq!(claim.custody_address, "0x00000000000000000000000000000000000000c7");
+        assert_eq!(
+            claim.custody_address,
+            "0x00000000000000000000000000000000000000c7"
+        );
         assert_eq!(claim.seized_native_total, 224 * E18);
         assert_eq!(claim.paid_native, 0);
         assert!(claim.paid_within_seized());
 
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
-            s.total_chain_vault_debt_e8s() + s.total_reserve_backing_e8s() + s.total_pending_chain_burn_e8s()
+            s.total_chain_vault_debt_e8s()
+                + s.total_reserve_backing_e8s()
+                + s.total_pending_chain_burn_e8s()
         );
     }
 
@@ -521,11 +671,23 @@ mod sp_absorb_tests {
         )
         .unwrap_err();
 
-        assert!(err.contains("does not match live debt"), "error should reject stale SP burn amount: {err}");
+        assert!(
+            err.contains("does not match live debt"),
+            "error should reject stale SP burn amount: {err}"
+        );
         assert_eq!(s.chain_vaults.get(&8).unwrap().debt_e8s, 80 * E8);
-        assert_eq!(s.chain_vaults.get(&8).unwrap().collateral_amount_native, 200 * E18);
-        assert_eq!(s.pending_chain_burn_e8s.get(&CFX), before.pending_chain_burn_e8s.get(&CFX));
-        assert_eq!(s.chain_liquidation_claims.get(&8), before.chain_liquidation_claims.get(&8));
+        assert_eq!(
+            s.chain_vaults.get(&8).unwrap().collateral_amount_native,
+            200 * E18
+        );
+        assert_eq!(
+            s.pending_chain_burn_e8s.get(&CFX),
+            before.pending_chain_burn_e8s.get(&CFX)
+        );
+        assert_eq!(
+            s.chain_liquidation_claims.get(&8),
+            before.chain_liquidation_claims.get(&8)
+        );
         assert_eq!(s.chain_supplies.get(&CFX), before.chain_supplies.get(&CFX));
     }
 
@@ -535,10 +697,21 @@ mod sp_absorb_tests {
         open_sp_attempted_vault(&mut s, 9, 100 * E8, 1_000 * E18);
         s.sp_attempted_chain_vaults.remove(&9);
 
-        let err = apply_sp_chain_liquidation_absorb_in_state(&mut s, CFX, 9, 100 * E8, 50_000_000, 18, 1_200)
-            .unwrap_err();
+        let err = apply_sp_chain_liquidation_absorb_in_state(
+            &mut s,
+            CFX,
+            9,
+            100 * E8,
+            50_000_000,
+            18,
+            1_200,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("sp_attempted"), "error should name the missing escalation gate: {err}");
+        assert!(
+            err.contains("sp_attempted"),
+            "error should name the missing escalation gate: {err}"
+        );
         let v = s.chain_vaults.get(&9).unwrap();
         assert_eq!(v.debt_e8s, 100 * E8);
         assert_eq!(v.collateral_amount_native, 1_000 * E18);
@@ -549,10 +722,15 @@ mod sp_absorb_tests {
 
 // ─── Increment 4 / Task 6: enqueue SP claim payout from reserved CFX ───
 mod chain_claim_tests {
-    use super::super::settlement::claim_chain_collateral_in_state;
+    use super::super::settlement::{
+        claim_chain_collateral_in_state, claim_chain_collateral_payout_submit_in_state,
+        confirm_chain_collateral_payout_in_state, fail_chain_collateral_payout_in_state,
+        record_chain_collateral_payout_replacement_in_state, ClaimChainPayoutSubmitError,
+        RecordChainPayoutReplacementError,
+    };
     use crate::chains::config::ChainId;
     use crate::chains::multi_chain_state::{ChainLiqClaimV1, MultiChainState};
-    use crate::chains::settlement_queue::SettlementOpKind;
+    use crate::chains::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
     use candid::Principal;
 
     const CFX: ChainId = ChainId(71);
@@ -568,29 +746,63 @@ mod chain_claim_tests {
 
     fn state_with_claim() -> MultiChainState {
         let mut s = MultiChainState::default();
-        s.chain_liquidation_claims.insert(7, ChainLiqClaimV1 {
-            vault_id: 7,
-            chain: CFX,
-            custody_address: "0x00000000000000000000000000000000000000c7".into(),
-            seized_native_total: 10 * E18,
-            paid_native: 2 * E18,
-        });
+        s.chain_liquidation_claims.insert(
+            7,
+            ChainLiqClaimV1 {
+                vault_id: 7,
+                chain: CFX,
+                custody_address: "0x00000000000000000000000000000000000000c7".into(),
+                seized_native_total: 10 * E18,
+                paid_native: 2 * E18,
+                pending_native: 0,
+            },
+        );
         s
     }
 
     #[test]
-    fn claim_chain_collateral_enqueues_payout_and_marks_paid() {
+    fn claim_chain_collateral_enqueues_payout_and_marks_pending_not_paid() {
         let mut s = state_with_claim();
         let dest = "0x0000000000000000000000000000000000000abc".to_string();
 
-        let op_id = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
-            .expect("claim enqueued");
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
 
         let claim = s.chain_liquidation_claims.get(&7).unwrap();
-        assert_eq!(claim.paid_native, 5 * E18, "claim is deducted before async payout");
-        let op = s.settlement_queues.get(&CFX).unwrap().pending.get(&op_id).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18, "enqueue is not final payment");
+        assert_eq!(
+            claim.pending_native,
+            3 * E18,
+            "enqueue reserves pending payout capacity"
+        );
+        assert_eq!(
+            claim.remaining_native(),
+            5 * E18,
+            "remaining excludes paid and pending"
+        );
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.chain_payout_uses_pending_reservation, Some(true));
         match &op.kind {
-            SettlementOpKind::ChainCollateralPayout { recipient, amount_e18, vault_id, claimant: c } => {
+            SettlementOpKind::ChainCollateralPayout {
+                recipient,
+                amount_e18,
+                vault_id,
+                claimant: c,
+            } => {
                 assert_eq!(recipient, &dest);
                 assert_eq!(*amount_e18, 3 * E18);
                 assert_eq!(*vault_id, 7);
@@ -604,14 +816,35 @@ mod chain_claim_tests {
     fn claim_chain_collateral_rejects_duplicate_without_double_marking_paid() {
         let mut s = state_with_claim();
         let dest = "0x0000000000000000000000000000000000000abc".to_string();
-        claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest.clone(), 42, valid_evm_address)
-            .expect("first claim enqueued");
+        claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("first claim enqueued");
 
-        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, dest, 43, valid_evm_address)
-            .unwrap_err();
+        let err = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            43,
+            valid_evm_address,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("Duplicate"), "expected duplicate idempotency error, got {err}");
-        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 5 * E18);
+        assert!(
+            err.contains("Duplicate"),
+            "expected duplicate idempotency error, got {err}"
+        );
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 3 * E18);
         assert_eq!(s.settlement_queues.get(&CFX).unwrap().pending.len(), 1);
     }
 
@@ -619,11 +852,638 @@ mod chain_claim_tests {
     fn claim_chain_collateral_validates_destination_before_mutation() {
         let mut s = state_with_claim();
 
-        let err = claim_chain_collateral_in_state(&mut s, 7, claimant(), 3 * E18, "not-evm".into(), 42, valid_evm_address)
-            .unwrap_err();
+        let err = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "not-evm".into(),
+            42,
+            valid_evm_address,
+        )
+        .unwrap_err();
 
-        assert!(err.contains("invalid EVM address"), "unexpected error: {err}");
-        assert_eq!(s.chain_liquidation_claims.get(&7).unwrap().paid_native, 2 * E18);
+        assert!(
+            err.contains("invalid EVM address"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().paid_native,
+            2 * E18
+        );
         assert!(s.settlement_queues.get(&CFX).is_none());
+    }
+
+    #[test]
+    fn chain_collateral_payout_success_moves_pending_to_paid_once() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("confirm payout"));
+        assert!(!confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            101,
+        )
+        .expect("confirm replay is idempotent"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_success_does_not_consume_new_pending_reservation() {
+        let mut s = state_with_claim();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let legacy = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: "0x0000000000000000000000000000000000000abc".to_string(),
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&legacy)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+        let new = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            E18,
+            "0x0000000000000000000000000000000000000def".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("new pending-reserved payout enqueued");
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            legacy,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("legacy confirm succeeds"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, E18);
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            new,
+            "0xbbb".to_string(),
+            101,
+        )
+        .expect("new confirm still consumes its own pending reservation"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 6 * E18);
+        assert_eq!(claim.pending_native, 0);
+    }
+
+    #[test]
+    fn chain_collateral_payout_failure_releases_pending_without_marking_paid() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("fail payout"));
+        assert!(!fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            101,
+        )
+        .expect("failure replay is idempotent"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(
+            claim.remaining_native(),
+            8 * E18,
+            "failed payout can be claimed again"
+        );
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert!(matches!(op.status, SettlementOpStatus::Failed { .. }));
+    }
+
+    #[test]
+    fn chain_collateral_payout_failure_is_terminal_when_reservation_already_missing() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        let idempotency_key = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap()
+            .idempotency_key
+            .clone();
+        s.chain_liquidation_claims
+            .get_mut(&7)
+            .unwrap()
+            .pending_native = 0;
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "sp recredit already committed".to_string(),
+            100,
+        )
+        .expect("failure remains terminal even when release cannot subtract"));
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        match &op.status {
+            SettlementOpStatus::Failed { reason, .. } => {
+                assert!(reason.contains("reservation release skipped"), "{reason}");
+            }
+            other => panic!("expected terminal failure, got {other:?}"),
+        }
+        assert!(
+            !s.settlement_queues
+                .get(&CFX)
+                .unwrap()
+                .seen_idempotency_keys
+                .contains(&idempotency_key),
+            "terminal failure releases the retry idempotency key"
+        );
+    }
+
+    #[test]
+    fn chain_collateral_payout_submit_marks_inflight_before_broadcast() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xabc".to_string(),
+            17,
+        )
+        .expect("submit claim");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.last_tx_hash.as_deref(), Some("0xabc"));
+        assert_eq!(op.tx_hash_candidates, vec!["0xabc".to_string()]);
+        assert_eq!(op.submit_nonce, Some(17));
+        assert!(matches!(
+            op.status,
+            SettlementOpStatus::Inflight {
+                tries: 1,
+                last_attempt_ns: 99
+            }
+        ));
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().pending_native,
+            3 * E18,
+            "pre-broadcast claim must not release or finalize the pending reservation"
+        );
+
+        let replay = claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            100,
+            "0xdef".to_string(),
+            18,
+        )
+        .unwrap_err();
+        assert_eq!(replay, ClaimChainPayoutSubmitError::NotQueued);
+    }
+
+    #[test]
+    fn chain_collateral_payout_replacement_records_new_hash_before_rebroadcast() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xold".to_string(),
+            17,
+        )
+        .expect("initial submit claim");
+
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            120,
+            "0xreplacement".to_string(),
+        )
+        .expect("replacement recorded");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(op.last_tx_hash.as_deref(), Some("0xreplacement"));
+        assert_eq!(
+            op.tx_hash_candidates,
+            vec!["0xold".to_string(), "0xreplacement".to_string()]
+        );
+        assert_eq!(
+            op.receipt_tx_hash_candidates(),
+            vec!["0xreplacement".to_string(), "0xold".to_string()],
+            "a rejected replacement broadcast must not make the receipt path forget the original hash"
+        );
+        assert_eq!(op.submit_nonce, Some(17), "replacement keeps same nonce");
+        assert!(matches!(
+            op.status,
+            SettlementOpStatus::Inflight {
+                tries: 1,
+                last_attempt_ns: 120
+            }
+        ));
+        assert_eq!(
+            s.chain_liquidation_claims.get(&7).unwrap().pending_native,
+            3 * E18,
+            "replacement tracking must not mutate payout accounting"
+        );
+
+        assert_eq!(
+            record_chain_collateral_payout_replacement_in_state(
+                &mut s,
+                CFX,
+                op_id + 1,
+                121,
+                "0xmissing".to_string(),
+            )
+            .unwrap_err(),
+            RecordChainPayoutReplacementError::MissingOp,
+        );
+    }
+
+    #[test]
+    fn chain_collateral_payout_replacement_replay_does_not_drop_original_hash() {
+        let mut s = state_with_claim();
+        let op_id = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            "0x0000000000000000000000000000000000000abc".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+        claim_chain_collateral_payout_submit_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            99,
+            "0xold".to_string(),
+            17,
+        )
+        .expect("initial submit claim");
+
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            120,
+            "0xreplacement".to_string(),
+        )
+        .expect("first replacement record");
+        record_chain_collateral_payout_replacement_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            121,
+            "0xreplacement".to_string(),
+        )
+        .expect("same replacement record replay");
+
+        let op = s
+            .settlement_queues
+            .get(&CFX)
+            .unwrap()
+            .pending
+            .get(&op_id)
+            .unwrap();
+        assert_eq!(
+            op.tx_hash_candidates,
+            vec!["0xold".to_string(), "0xreplacement".to_string()],
+            "candidate recording is idempotent and keeps the original accepted-or-pending tx"
+        );
+        assert_eq!(
+            op.receipt_tx_hash_candidates(),
+            vec!["0xreplacement".to_string(), "0xold".to_string()]
+        );
+    }
+
+    #[test]
+    fn failed_chain_collateral_payout_allows_same_claim_retry() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        let first = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest.clone(),
+            42,
+            valid_evm_address,
+        )
+        .expect("claim enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            first,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("fail payout"));
+
+        let retry = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            3 * E18,
+            dest,
+            101,
+            valid_evm_address,
+        )
+        .expect("same failed payout can be retried");
+
+        assert_ne!(first, retry);
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 3 * E18);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+        assert_eq!(s.settlement_queues.get(&CFX).unwrap().pending.len(), 2);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_success_keeps_paid_reservation() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let op_id = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: dest,
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "0xaaa".to_string(),
+            100,
+        )
+        .expect("legacy confirm succeeds"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 5 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 5 * E18);
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_failure_releases_paid_reservation() {
+        let mut s = state_with_claim();
+        let dest = "0x0000000000000000000000000000000000000abc".to_string();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let op_id = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: dest,
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&op_id)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            op_id,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("legacy failure succeeds"));
+
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, 0);
+        assert_eq!(claim.remaining_native(), 8 * E18);
+        assert!(
+            !s.settlement_queues
+                .get(&CFX)
+                .unwrap()
+                .seen_idempotency_keys
+                .contains("legacy-cfx-payout"),
+            "failed legacy payout releases its retry idempotency key",
+        );
+    }
+
+    #[test]
+    fn legacy_chain_collateral_payout_failure_does_not_consume_new_pending_reservation() {
+        let mut s = state_with_claim();
+        s.chain_liquidation_claims.get_mut(&7).unwrap().paid_native = 5 * E18;
+        let legacy = s
+            .settlement_queues
+            .entry(CFX)
+            .or_default()
+            .enqueue(SettlementOp::new(
+                SettlementOpKind::ChainCollateralPayout {
+                    recipient: "0x0000000000000000000000000000000000000abc".to_string(),
+                    amount_e18: 3 * E18,
+                    vault_id: 7,
+                    claimant: claimant(),
+                },
+                "legacy-cfx-payout".to_string(),
+                40,
+            ))
+            .expect("legacy op enqueued");
+        s.settlement_queues
+            .get_mut(&CFX)
+            .unwrap()
+            .pending
+            .get_mut(&legacy)
+            .unwrap()
+            .status = SettlementOpStatus::Inflight {
+            tries: 1,
+            last_attempt_ns: 41,
+        };
+        let new = claim_chain_collateral_in_state(
+            &mut s,
+            7,
+            claimant(),
+            E18,
+            "0x0000000000000000000000000000000000000def".to_string(),
+            42,
+            valid_evm_address,
+        )
+        .expect("new pending-reserved payout enqueued");
+
+        assert!(fail_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            legacy,
+            "tx reverted".to_string(),
+            100,
+        )
+        .expect("legacy failure succeeds"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 2 * E18);
+        assert_eq!(claim.pending_native, E18);
+
+        assert!(confirm_chain_collateral_payout_in_state(
+            &mut s,
+            CFX,
+            new,
+            "0xbbb".to_string(),
+            101,
+        )
+        .expect("new confirm still consumes its own pending reservation"));
+        let claim = s.chain_liquidation_claims.get(&7).unwrap();
+        assert_eq!(claim.paid_native, 3 * E18);
+        assert_eq!(claim.pending_native, 0);
     }
 }

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -462,15 +462,21 @@ pub struct ChainLiqClaimV1 {
     pub custody_address: String,
     pub seized_native_total: u128,
     pub paid_native: u128,
+    #[serde(default)]
+    pub pending_native: u128,
 }
 
 impl ChainLiqClaimV1 {
     pub fn paid_within_seized(&self) -> bool {
-        self.paid_native <= self.seized_native_total
+        self.paid_native
+            .checked_add(self.pending_native)
+            .map(|reserved| reserved <= self.seized_native_total)
+            .unwrap_or(false)
     }
 
     pub fn remaining_native(&self) -> u128 {
-        self.seized_native_total.saturating_sub(self.paid_native)
+        self.seized_native_total
+            .saturating_sub(self.paid_native.saturating_add(self.pending_native))
     }
 }
 

--- a/src/rumi_protocol_backend/src/chains/recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/recovery.rs
@@ -51,6 +51,9 @@ pub enum RecoveryError {
     /// On-chain state shows the op DID land — reversing/releasing would create an
     /// unbacked mint or double-release collateral. Refused.
     OnChainLanded(String),
+    /// The op kind needs a specialized recovery path; generic stuck-op reversal
+    /// would leave cross-canister accounting inconsistent.
+    UnsupportedOpKind(String),
 }
 
 impl std::fmt::Display for RecoveryError {
@@ -72,7 +75,10 @@ fn snapshot_inflight_op_tx(chain: ChainId, op_id: u64) -> Result<Option<String>,
             .settlement_queues
             .get(&chain)
             .ok_or(RecoveryError::UnknownChain(chain))?;
-        let op = q.pending.get(&op_id).ok_or(RecoveryError::UnknownOp(op_id))?;
+        let op = q
+            .pending
+            .get(&op_id)
+            .ok_or(RecoveryError::UnknownOp(op_id))?;
         if !matches!(op.status, SettlementOpStatus::Inflight { .. }) {
             return Err(RecoveryError::NotInflight(format!(
                 "op {op_id} status {:?}",
@@ -93,7 +99,7 @@ pub fn apply_resolve_reversal_in_state(
     chain: ChainId,
     op_id: u64,
     now: u64,
-) -> bool {
+) -> Result<bool, RecoveryError> {
     let still_inflight = state
         .settlement_queues
         .get(&chain)
@@ -101,7 +107,7 @@ pub fn apply_resolve_reversal_in_state(
         .map(|o| matches!(o.status, SettlementOpStatus::Inflight { .. }))
         .unwrap_or(false);
     if !still_inflight {
-        return false;
+        return Ok(false);
     }
     // Clone the kind out so we can mutate vaults and the op without overlapping
     // borrows.
@@ -118,7 +124,11 @@ pub fn apply_resolve_reversal_in_state(
                     v.pending_mint_e8s = 0;
                 }
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 if let Some(v) = state.chain_vaults.get_mut(vault_id) {
                     v.collateral_amount_native =
                         v.collateral_amount_native.saturating_add(*amount_e18);
@@ -128,8 +138,10 @@ pub fn apply_resolve_reversal_in_state(
                 }
             }
             SettlementOpKind::ChainCollateralPayout { .. } => {
-                // Claim payout recovery must not re-credit vault collateral. The
-                // SP-side claim rollback is handled by the claim path/callback.
+                return Err(RecoveryError::UnsupportedOpKind(
+                    "ChainCollateralPayout requires SP claim recredit; use settlement retry path"
+                        .to_string(),
+                ));
             }
             SettlementOpKind::InterestMint { vault_id, .. } => {
                 if let Some(v) = state.chain_vaults.get_mut(vault_id) {
@@ -152,9 +164,12 @@ pub fn apply_resolve_reversal_in_state(
         .get_mut(&chain)
         .and_then(|q| q.pending.get_mut(&op_id))
     {
-        o.mark_failed("manually resolved (stuck Inflight, on-chain-verified not landed)".to_string(), now);
+        o.mark_failed(
+            "manually resolved (stuck Inflight, on-chain-verified not landed)".to_string(),
+            now,
+        );
     }
-    true
+    Ok(true)
 }
 
 /// M-08 (RECOV-01): resolve a stuck `Inflight` settlement op, but ONLY after
@@ -209,9 +224,7 @@ pub async fn resolve_stuck_settlement_op_verified(
     }
 
     let now = ic_cdk::api::time();
-    let did_reverse =
-        mutate_state(|s| apply_resolve_reversal_in_state(&mut s.multi_chain, chain, op_id, now));
-    Ok(did_reverse)
+    mutate_state(|s| apply_resolve_reversal_in_state(&mut s.multi_chain, chain, op_id, now))
 }
 
 // ─── M-09: recover a stuck chain vault, on-chain-verified ─────────────────────
@@ -275,10 +288,7 @@ pub fn precheck_recover_vault_in_state(
 }
 
 /// `read_state` wrapper over `precheck_recover_vault_in_state` for the async path.
-pub fn precheck_recover_vault(
-    chain: ChainId,
-    vault_id: u64,
-) -> Result<Vec<String>, RecoveryError> {
+pub fn precheck_recover_vault(chain: ChainId, vault_id: u64) -> Result<Vec<String>, RecoveryError> {
     read_state(|s| precheck_recover_vault_in_state(&s.multi_chain, chain, vault_id))
 }
 
@@ -374,8 +384,18 @@ pub async fn recover_stuck_chain_vault_verified(
     // cursor yet (then there can be no confirmed on-chain mint to find).
     let (contract, cursor, recorded_supply, in_flight_mint) = read_state(|s| {
         let contract = s.multi_chain.chain_contracts.get(&chain).cloned();
-        let cursor = s.multi_chain.last_observed_block.get(&chain).copied().unwrap_or(0);
-        let recorded_supply = s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0);
+        let cursor = s
+            .multi_chain
+            .last_observed_block
+            .get(&chain)
+            .copied()
+            .unwrap_or(0);
+        let recorded_supply = s
+            .multi_chain
+            .chain_supplies
+            .get(&chain)
+            .copied()
+            .unwrap_or(0);
         let in_flight_mint: u128 = s
             .multi_chain
             .chain_vaults

--- a/src/rumi_protocol_backend/src/chains/settlement_queue.rs
+++ b/src/rumi_protocol_backend/src/chains/settlement_queue.rs
@@ -14,15 +14,25 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum SettlementOpKind {
-    Mint { recipient: String, amount_e8s: u128, vault_id: u64 },
+    Mint {
+        recipient: String,
+        amount_e8s: u128,
+        vault_id: u64,
+    },
     /// Return native gas-asset (MON) collateral to `recipient`. `amount_e18`
     /// is wei (1e18 scale, NOT e8s — it goes straight into the EIP-1559
     /// `value`). `vault_id` lets the settlement worker emit `WithdrawalSigned`
     /// with the real id and flip the vault `Closing -> Closed` on confirmation
     /// (replaces the old placeholder `Withdrawal { recipient, amount_e8s }`,
     /// which was never enqueued anywhere and carried the wrong unit + no id).
-    NativeWithdrawal { recipient: String, amount_e18: u128, vault_id: u64 },
-    Burn { amount_e8s: u128 },
+    NativeWithdrawal {
+        recipient: String,
+        amount_e18: u128,
+        vault_id: u64,
+    },
+    Burn {
+        amount_e8s: u128,
+    },
     /// Task 12 (Option B): realize accrued interest by minting `amount_e8s`
     /// icUSD to the per-chain interest-treasury address. `mint_id` is a FRESH,
     /// globally-unique id (from `chain_vault_id_counter`) used as the on-chain
@@ -100,6 +110,19 @@ pub struct SettlementOp {
     /// pre-existing snapshot decoding cleanly.
     #[serde(default)]
     pub submit_nonce: Option<u64>,
+    /// Same-nonce transaction hashes that may have been accepted by an RPC
+    /// provider. This is primarily for retry-safe native payouts: an RBF
+    /// replacement can be pre-recorded before an ambiguous broadcast boundary,
+    /// but a definite rejection must not make the confirm path forget the
+    /// original same-nonce hash.
+    #[serde(default)]
+    pub tx_hash_candidates: Vec<String>,
+    /// `Some(true)` only for ChainCollateralPayout ops enqueued after Inc10,
+    /// where payout capacity is reserved in `ChainLiqClaimV1.pending_native`.
+    /// Older decoded payout ops have `None` and their live reservation remains
+    /// in `paid_native`.
+    #[serde(default)]
+    pub chain_payout_uses_pending_reservation: Option<bool>,
 }
 
 impl SettlementOp {
@@ -112,6 +135,8 @@ impl SettlementOp {
             status: SettlementOpStatus::Queued,
             last_tx_hash: None,
             submit_nonce: None,
+            tx_hash_candidates: Vec::new(),
+            chain_payout_uses_pending_reservation: None,
         }
     }
 
@@ -120,15 +145,53 @@ impl SettlementOp {
             SettlementOpStatus::Inflight { tries, .. } => tries.saturating_add(1),
             _ => 1,
         };
-        self.status = SettlementOpStatus::Inflight { tries, last_attempt_ns: now_ns };
+        self.status = SettlementOpStatus::Inflight {
+            tries,
+            last_attempt_ns: now_ns,
+        };
     }
 
     pub fn mark_succeeded(&mut self, tx_hash: String, now_ns: u64) {
-        self.status = SettlementOpStatus::Succeeded { tx_hash, confirmed_ns: now_ns };
+        self.status = SettlementOpStatus::Succeeded {
+            tx_hash,
+            confirmed_ns: now_ns,
+        };
     }
 
     pub fn mark_failed(&mut self, reason: String, now_ns: u64) {
-        self.status = SettlementOpStatus::Failed { reason, failed_ns: now_ns };
+        self.status = SettlementOpStatus::Failed {
+            reason,
+            failed_ns: now_ns,
+        };
+    }
+
+    pub fn record_tx_hash_candidate(&mut self, tx_hash: String) {
+        if self.tx_hash_candidates.is_empty() {
+            if let Some(existing) = &self.last_tx_hash {
+                if existing != &tx_hash {
+                    self.tx_hash_candidates.push(existing.clone());
+                }
+            }
+        }
+        if self.tx_hash_candidates.iter().any(|h| h == &tx_hash) {
+            self.last_tx_hash = Some(tx_hash);
+            return;
+        }
+        self.tx_hash_candidates.push(tx_hash.clone());
+        self.last_tx_hash = Some(tx_hash);
+    }
+
+    pub fn receipt_tx_hash_candidates(&self) -> Vec<String> {
+        let mut hashes = Vec::with_capacity(self.tx_hash_candidates.len() + 1);
+        if let Some(h) = &self.last_tx_hash {
+            hashes.push(h.clone());
+        }
+        for h in &self.tx_hash_candidates {
+            if !hashes.iter().any(|existing| existing == h) {
+                hashes.push(h.clone());
+            }
+        }
+        hashes
     }
 }
 
@@ -161,7 +224,8 @@ impl SettlementQueueV1 {
         }
         let assigned = self.tail;
         op.op_id = assigned;
-        self.seen_idempotency_keys.insert(op.idempotency_key.clone());
+        self.seen_idempotency_keys
+            .insert(op.idempotency_key.clone());
         self.drain_order.push_back(assigned);
         self.pending.insert(assigned, op);
         self.tail = self.tail.saturating_add(1);
@@ -197,11 +261,13 @@ impl SettlementQueueV1 {
     /// (`Succeeded`/`Failed`) ops never count.
     pub fn has_active_mint_op(&self) -> bool {
         self.pending.values().any(|op| {
-            matches!(op.kind, SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. })
-                && matches!(
-                    op.status,
-                    SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
-                )
+            matches!(
+                op.kind,
+                SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+            ) && matches!(
+                op.status,
+                SettlementOpStatus::Queued | SettlementOpStatus::Inflight { .. }
+            )
         })
     }
 
@@ -274,8 +340,14 @@ mod tests {
         assert_eq!(q.pending_len(), 3);
 
         // Mark op 0 Succeeded and op 1 Failed; op 2 stays Queued (live).
-        q.pending.get_mut(&id0).unwrap().mark_succeeded("0xhash".to_string(), 10);
-        q.pending.get_mut(&id1).unwrap().mark_failed("reverted".to_string(), 11);
+        q.pending
+            .get_mut(&id0)
+            .unwrap()
+            .mark_succeeded("0xhash".to_string(), 10);
+        q.pending
+            .get_mut(&id1)
+            .unwrap()
+            .mark_failed("reverted".to_string(), 11);
 
         q.prune_terminal();
 
@@ -297,7 +369,10 @@ mod tests {
         assert!(matches!(dup, Err(SettlementQueueError::DuplicateIdempotencyKey(k)) if k == "k0"));
 
         // select_next_op still returns the live Queued op (semantics unchanged).
-        let live = q.pending.values().find(|o| matches!(o.status, SettlementOpStatus::Queued));
+        let live = q
+            .pending
+            .values()
+            .find(|o| matches!(o.status, SettlementOpStatus::Queued));
         assert!(live.is_some());
     }
 
@@ -306,8 +381,14 @@ mod tests {
         let mut q = SettlementQueueV1::default();
         let id0 = q.enqueue(mint_op("a")).unwrap();
         let id1 = q.enqueue(mint_op("b")).unwrap();
-        q.pending.get_mut(&id0).unwrap().mark_succeeded("0x1".to_string(), 1);
-        q.pending.get_mut(&id1).unwrap().mark_succeeded("0x2".to_string(), 2);
+        q.pending
+            .get_mut(&id0)
+            .unwrap()
+            .mark_succeeded("0x1".to_string(), 1);
+        q.pending
+            .get_mut(&id1)
+            .unwrap()
+            .mark_succeeded("0x2".to_string(), 2);
 
         q.prune_terminal();
 
@@ -327,5 +408,35 @@ mod tests {
         q.prune_terminal();
         assert_eq!(q.pending_len(), 1);
         assert_eq!(q.head, before_head);
+    }
+
+    #[test]
+    fn tx_hash_candidates_seed_legacy_last_hash_and_do_not_evict_ambiguous_replacements() {
+        let mut op = mint_op("k");
+        op.last_tx_hash = Some("0xlegacy".to_string());
+        for i in 0..16 {
+            op.record_tx_hash_candidate(format!("0xreplacement{i}"));
+        }
+
+        assert_eq!(op.tx_hash_candidates.len(), 17);
+        assert_eq!(op.tx_hash_candidates.first().unwrap(), "0xlegacy");
+        assert_eq!(op.tx_hash_candidates.last().unwrap(), "0xreplacement15");
+        assert_eq!(
+            op.receipt_tx_hash_candidates().first().unwrap(),
+            op.last_tx_hash.as_ref().unwrap(),
+            "receipt polling still starts with the latest replacement"
+        );
+        assert!(
+            op.receipt_tx_hash_candidates()
+                .iter()
+                .any(|h| h == "0xlegacy"),
+            "a decoded legacy last_tx_hash remains observable after replacement recording"
+        );
+        assert!(
+            op.receipt_tx_hash_candidates()
+                .iter()
+                .any(|h| h == "0xreplacement0"),
+            "older ambiguous replacements remain observable"
+        );
     }
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -523,6 +523,7 @@ fn v6_cbor_round_trip_preserves_new_liquidation_fields() {
             custody_address: "0xcustody".into(),
             seized_native_total: 12_345_000_000_000_000_000,
             paid_native: 1_000_000_000_000_000_000,
+            pending_native: 0,
         },
     );
     v6.chain_liquidation_configs.insert(
@@ -608,6 +609,17 @@ fn chain_liq_claim_invariant_rejects_overpaid_claims() {
         custody_address: "0xcustody".into(),
         seized_native_total: 10,
         paid_native: 11,
+        pending_native: 0,
+    };
+    assert!(!claim.paid_within_seized());
+
+    let claim = ChainLiqClaimV1 {
+        vault_id: 10,
+        chain: ChainId(1030),
+        custody_address: "0xcustody".into(),
+        seized_native_total: 10,
+        paid_native: 6,
+        pending_native: 5,
     };
     assert!(!claim.paid_within_seized());
 }
@@ -696,10 +708,8 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         .insert(pending.proof_id.clone(), pending.clone());
     v6.settled_reserve_burn_proofs
         .insert(reserve.proof_id.clone(), reserve.clone());
-    v6.settled_settlement_burn_logs.insert(format!(
-        "{}:{}",
-        pending.tx_hash, pending.log_index
-    ));
+    v6.settled_settlement_burn_logs
+        .insert(format!("{}:{}", pending.tx_hash, pending.log_index));
     v6.settled_reserve_transfer_e8s.insert(
         "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string(),
         50_000_000,
@@ -718,10 +728,9 @@ fn settlement_proof_state_round_trip_preserves_compact_records() {
         decoded.settled_reserve_burn_proofs[&reserve.proof_id],
         reserve
     );
-    assert!(decoded.settled_settlement_burn_logs.contains(&format!(
-        "{}:{}",
-        pending.tx_hash, pending.log_index
-    )));
+    assert!(decoded
+        .settled_settlement_burn_logs
+        .contains(&format!("{}:{}", pending.tx_hash, pending.log_index)));
     assert_eq!(
         decoded.settled_reserve_transfer_e8s
             [&"0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:8".to_string()],

--- a/src/rumi_protocol_backend/src/chains/tests_recovery.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_recovery.rs
@@ -10,8 +10,8 @@ use super::config::ChainId;
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use super::multi_chain_state::MultiChainState;
 use super::recovery::{
-    apply_recover_vault_in_state, apply_resolve_reversal_in_state,
-    precheck_recover_vault_in_state, RecoveryError,
+    apply_recover_vault_in_state, apply_resolve_reversal_in_state, precheck_recover_vault_in_state,
+    RecoveryError,
 };
 use super::settlement_queue::{SettlementOp, SettlementOpKind, SettlementOpStatus};
 use candid::Principal;
@@ -33,13 +33,17 @@ fn vault(vault_id: u64, status: ChainVaultStatus, pending: u128, collateral: u12
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    }
+        pending_liquidation: None,
+    }
 }
 
 fn inflight_op(op_id: u64, kind: SettlementOpKind, tx: Option<&str>) -> SettlementOp {
     let mut op = SettlementOp::new(kind, format!("key-{op_id}"), 0);
     op.op_id = op_id;
-    op.status = SettlementOpStatus::Inflight { tries: 1, last_attempt_ns: 0 };
+    op.status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 0,
+    };
     op.last_tx_hash = tx.map(|s| s.to_string());
     op
 }
@@ -60,12 +64,17 @@ fn state_with_op(op: SettlementOp) -> MultiChainState {
 fn resolve_reversal_mint_clears_pending_and_marks_failed() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 5, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 5, 0));
 
-    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("mint reversal");
     assert!(did, "first reversal applies");
     // Pending cleared, status stays MintPending (Design B: no debt was counted).
     assert_eq!(s.chain_vaults[&1].pending_mint_e8s, 0);
@@ -81,12 +90,17 @@ fn resolve_reversal_mint_clears_pending_and_marks_failed() {
 fn resolve_reversal_withdrawal_restores_collateral_and_reopens() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
 
-    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100);
+    let did = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("withdrawal reversal");
     assert!(did);
     // Reserved collateral added back; Closing -> Open.
     assert_eq!(s.chain_vaults[&1].collateral_amount_native, 1_000);
@@ -99,18 +113,49 @@ fn resolve_reversal_is_idempotent_cas() {
     // the withdrawal collateral (the CAS guard prevents 2x amount_e18).
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::NativeWithdrawal { recipient: "0xr".into(), amount_e18: 1_000, vault_id: 1 },
+        SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::Closing, 0, 0));
 
-    assert!(apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100));
-    let second = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 200);
-    assert!(!second, "second reversal is a no-op (op no longer Inflight)");
+    assert!(apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100).expect("first reversal"));
+    let second = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 200).expect("second reversal");
+    assert!(
+        !second,
+        "second reversal is a no-op (op no longer Inflight)"
+    );
     assert_eq!(
         s.chain_vaults[&1].collateral_amount_native, 1_000,
         "collateral credited exactly once"
     );
+}
+
+#[test]
+fn resolve_reversal_rejects_chain_collateral_payout_without_mutation() {
+    let mut s = state_with_op(inflight_op(
+        0,
+        SettlementOpKind::ChainCollateralPayout {
+            recipient: "0xr".into(),
+            amount_e18: 1_000,
+            vault_id: 7,
+            claimant: Principal::anonymous(),
+        },
+        Some("0xtx"),
+    ));
+
+    let err = apply_resolve_reversal_in_state(&mut s, CHAIN, 0, 100)
+        .expect_err("claim payout needs specialized recovery");
+
+    assert!(matches!(err, RecoveryError::UnsupportedOpKind(_)));
+    assert!(matches!(
+        s.settlement_queues[&CHAIN].pending[&0].status,
+        SettlementOpStatus::Inflight { .. }
+    ));
 }
 
 // ── M-09: precheck + transition ───────────────────────────────────────────────
@@ -123,14 +168,22 @@ fn precheck_recover_returns_terminal_mint_tx_hashes() {
     let mut q = super::settlement_queue::SettlementQueueV1::default();
     let mut op = inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xmint_tx"),
     );
-    op.status = SettlementOpStatus::Failed { reason: "x".into(), failed_ns: 1 };
+    op.status = SettlementOpStatus::Failed {
+        reason: "x".into(),
+        failed_ns: 1,
+    };
     q.pending.insert(0, op);
     q.tail = 1;
     s.settlement_queues.insert(CHAIN, q);
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
 
     let hashes = precheck_recover_vault_in_state(&s, CHAIN, 1).expect("precheck ok");
     assert_eq!(hashes, vec!["0xmint_tx".to_string()]);
@@ -140,10 +193,15 @@ fn precheck_recover_returns_terminal_mint_tx_hashes() {
 fn precheck_recover_rejects_live_mint_op() {
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     )); // Inflight == live
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     let err = precheck_recover_vault_in_state(&s, CHAIN, 1).expect_err("live mint");
     assert!(matches!(err, RecoveryError::LiveMintOp(1)));
 }
@@ -152,13 +210,15 @@ fn precheck_recover_rejects_live_mint_op() {
 fn precheck_recover_rejects_nonzero_pending_or_wrong_status() {
     let mut s = MultiChainState::default();
     // Nonzero pending => not recoverable.
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 7, 9));
     assert!(matches!(
         precheck_recover_vault_in_state(&s, CHAIN, 1),
         Err(RecoveryError::NotRecoverable(_))
     ));
     // Wrong status (Open) => not recoverable.
-    s.chain_vaults.insert(2, vault(2, ChainVaultStatus::Open, 0, 9));
+    s.chain_vaults
+        .insert(2, vault(2, ChainVaultStatus::Open, 0, 9));
     assert!(matches!(
         precheck_recover_vault_in_state(&s, CHAIN, 2),
         Err(RecoveryError::NotRecoverable(_))
@@ -184,7 +244,8 @@ fn precheck_recover_rejects_wrong_chain_and_unknown() {
 #[test]
 fn apply_recover_vault_flips_mintpending_to_open() {
     let mut s = MultiChainState::default();
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     apply_recover_vault_in_state(&mut s, CHAIN, 1).expect("recover");
     assert_eq!(s.chain_vaults[&1].status, ChainVaultStatus::Open);
 }
@@ -195,10 +256,15 @@ fn apply_recover_vault_rechecks_guards_at_commit() {
     // (defense-in-depth re-check inside apply_recover_vault_in_state).
     let mut s = state_with_op(inflight_op(
         0,
-        SettlementOpKind::Mint { recipient: "0xr".into(), amount_e8s: 5, vault_id: 1 },
+        SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 5,
+            vault_id: 1,
+        },
         Some("0xtx"),
     ));
-    s.chain_vaults.insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
+    s.chain_vaults
+        .insert(1, vault(1, ChainVaultStatus::MintPending, 0, 9));
     let err = apply_recover_vault_in_state(&mut s, CHAIN, 1).expect_err("live mint at commit");
     assert!(matches!(err, RecoveryError::LiveMintOp(1)));
     // Vault NOT flipped.

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -209,6 +209,21 @@ pub async fn claim_cfx(
     crate::liquidation::claim_cfx(chain_sentinel, dest_evm).await
 }
 
+#[update]
+pub fn recredit_failed_cfx_claim_payout(
+    recovery: CfxClaimPayoutRecovery,
+) -> Result<bool, StabilityPoolError> {
+    let caller = ic_cdk::api::caller();
+    let expected = read_state(|s| s.protocol_canister_id);
+    if caller != expected {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    let now = ic_cdk::api::time();
+    mutate_state(|s| {
+        crate::liquidation::recredit_failed_cfx_claim_payout_in_state_at(s, recovery, now)
+    })
+}
+
 // ─── Opt-in / Opt-out ───
 
 #[update]

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -605,6 +605,73 @@ pub(crate) fn rollback_cfx_claim_payout_in_state(
     *entry = entry.saturating_add(plan.amount_wei);
 }
 
+pub(crate) fn recredit_failed_cfx_claim_payout_in_state(
+    state: &mut StabilityPoolState,
+    recovery: CfxClaimPayoutRecovery,
+) -> Result<bool, StabilityPoolError> {
+    recredit_failed_cfx_claim_payout_in_state_at(state, recovery.clone(), recovery.failed_at_ns)
+}
+
+pub(crate) fn recredit_failed_cfx_claim_payout_in_state_at(
+    state: &mut StabilityPoolState,
+    recovery: CfxClaimPayoutRecovery,
+    recovered_at_ns: u64,
+) -> Result<bool, StabilityPoolError> {
+    if recovery.amount_wei == 0 {
+        return Err(StabilityPoolError::AmountTooLow { minimum_e8s: 1 });
+    }
+    if !state.is_chain_collateral_sentinel(&recovery.chain_sentinel) {
+        return Err(StabilityPoolError::CollateralNotFound {
+            ledger: recovery.chain_sentinel,
+        });
+    }
+
+    let key = recovery.key();
+    if let Some(existing) = state.completed_cfx_claim_payout_recovery(&key) {
+        if existing.claim_id == recovery.claim_id
+            && existing.claimant == recovery.claimant
+            && existing.amount_wei == recovery.amount_wei
+        {
+            return Ok(false);
+        }
+        return Err(StabilityPoolError::LiquidationFailed {
+            vault_id: recovery.claim_id,
+            reason: format!(
+                "completed CFX claim payout recovery conflicts for op {}",
+                recovery.op_id
+            ),
+        });
+    }
+    if state.completed_cfx_claim_payout_recovery_was_evicted(&key) {
+        return Ok(false);
+    }
+
+    state.record_chain_claim_source(
+        recovery.chain_sentinel,
+        recovery.claim_id,
+        recovery.amount_wei,
+    );
+    let position = state
+        .deposits
+        .entry(recovery.claimant)
+        .or_insert_with(|| DepositPosition::new(0));
+    let claims = position.cfx_claims.get_or_insert_with(BTreeMap::new);
+    let entry = claims.entry(recovery.chain_sentinel).or_insert(0);
+    *entry = entry.saturating_add(recovery.amount_wei);
+
+    state.record_completed_cfx_claim_payout_recovery(CfxClaimPayoutRecoveryRecord {
+        key,
+        claim_id: recovery.claim_id,
+        claimant: recovery.claimant,
+        amount_wei: recovery.amount_wei,
+        reason: recovery.reason,
+        failed_at_ns: recovery.failed_at_ns,
+        recovered_at_ns,
+    });
+
+    Ok(true)
+}
+
 pub(crate) fn is_duplicate_chain_claim_error(error: &rumi_protocol_backend::ProtocolError) -> bool {
     match error {
         rumi_protocol_backend::ProtocolError::ChainAdmin(msg)
@@ -2480,6 +2547,386 @@ mod tests {
             state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
             10,
             "rollback restores backend claim source",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_recredit_restores_user_claim_and_source_once() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 12);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+
+        let recovered = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 42,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds");
+
+        assert!(recovered, "first recovery mutates state");
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "failed payout recredits the user claim",
+        );
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10,
+            "failed payout restores backend claim source",
+        );
+
+        let replay = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 42,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "same failed op replay".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .expect("same recovery replay succeeds without mutation");
+
+        assert!(!replay, "replay is recognized as already recovered");
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            12,
+            "replay must not double-credit the user claim",
+        );
+        assert_eq!(
+            state.chain_claim_sources.as_ref().unwrap()[&sentinel][0].remaining_native,
+            10,
+            "replay must not double-restore backend claim source",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_replay_is_idempotent() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 10);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+        let recovery = CfxClaimPayoutRecovery {
+            chain_sentinel: sentinel,
+            op_id: 43,
+            claim_id: plan.claim_id,
+            claimant: user_a(),
+            amount_wei: plan.amount_wei,
+            reason: "tx reverted".to_string(),
+            failed_at_ns: 123,
+        };
+
+        assert!(
+            recredit_failed_cfx_claim_payout_in_state(&mut state, recovery.clone())
+                .expect("first recovery succeeds")
+        );
+        assert!(
+            !recredit_failed_cfx_claim_payout_in_state(&mut state, recovery)
+                .expect("exact replay succeeds")
+        );
+        assert_eq!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .map(|m| m.len()),
+            Some(1),
+            "journal stores one durable recovery record",
+        );
+    }
+
+    #[test]
+    fn evicted_failed_cfx_claim_payout_replay_remains_idempotent() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+
+        for op_id in 0..=(crate::state::MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES as u64) {
+            assert!(
+                recredit_failed_cfx_claim_payout_in_state(
+                    &mut state,
+                    CfxClaimPayoutRecovery {
+                        chain_sentinel: sentinel,
+                        op_id,
+                        claim_id: op_id,
+                        claimant: user_a(),
+                        amount_wei: 1,
+                        reason: "tx reverted".to_string(),
+                        failed_at_ns: op_id,
+                    },
+                )
+                .expect("recovery succeeds"),
+                "first recovery for op {op_id} mutates state",
+            );
+        }
+
+        assert!(
+            !state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .unwrap()
+                .contains_key(&CfxClaimPayoutRecoveryKey {
+                    chain_sentinel: sentinel,
+                    op_id: 0,
+                }),
+            "oldest recovery record should be evicted at the bound",
+        );
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let replay = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 0,
+                claim_id: 0,
+                claimant: user_a(),
+                amount_wei: 1,
+                reason: "old op replay after eviction".to_string(),
+                failed_at_ns: 999_999,
+            },
+        )
+        .expect("evicted replay succeeds without mutation");
+
+        assert!(!replay, "evicted replay is treated as already recovered");
+        assert_eq!(state.deposits[&user_a()].cfx_claims, before_claims);
+        assert_eq!(state.chain_claim_sources, before_sources);
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_conflicting_replay_rejects_without_mutation() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 10);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 10);
+        let plan = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("claim plan")
+        .expect("nonzero claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 44,
+                claim_id: plan.claim_id,
+                claimant: user_a(),
+                amount_wei: plan.amount_wei,
+                reason: "tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds"));
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let err = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 44,
+                claim_id: plan.claim_id,
+                claimant: user_b(),
+                amount_wei: plan.amount_wei,
+                reason: "conflicting replay".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, StabilityPoolError::LiquidationFailed { .. }));
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims,
+            before_claims,
+            "conflict must not mutate user claims",
+        );
+        assert_eq!(
+            state.chain_claim_sources, before_sources,
+            "conflict must not mutate backend claim sources",
+        );
+    }
+
+    #[test]
+    fn distinct_failed_cfx_claim_payout_ops_can_recredit_separate_payouts() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 20);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 20);
+
+        let first = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("first claim plan")
+        .expect("nonzero first claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 45,
+                claim_id: first.claim_id,
+                claimant: user_a(),
+                amount_wei: first.amount_wei,
+                reason: "first tx reverted".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .expect("first recovery succeeds"));
+
+        let second = prepare_cfx_claim_payout_in_state(
+            &mut state,
+            user_a(),
+            sentinel,
+            "0x000000000000000000000000000000000000c0de".to_string(),
+            rumi_protocol_backend::chains::evm::tecdsa::is_valid_evm_address,
+        )
+        .expect("second claim plan")
+        .expect("nonzero second claim");
+        assert!(recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 46,
+                claim_id: second.claim_id,
+                claimant: user_a(),
+                amount_wei: second.amount_wei,
+                reason: "second tx reverted".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .expect("second recovery succeeds"));
+
+        assert_eq!(
+            state.deposits[&user_a()].cfx_claims.as_ref().unwrap()[&sentinel],
+            20,
+            "separate failed ops restore separate payout attempts",
+        );
+        assert_eq!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .as_ref()
+                .map(|m| m.len()),
+            Some(2),
+            "journal keeps one record per failed backend op",
+        );
+    }
+
+    #[test]
+    fn failed_cfx_claim_payout_recovery_rejects_invalid_input_without_mutation() {
+        let mut state = test_state();
+        let sentinel = state
+            .register_chain_collateral(1030, "CFX".to_string(), 18)
+            .unwrap();
+        let mut pos = DepositPosition::new(0);
+        pos.cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(sentinel, 5);
+        state.deposits.insert(user_a(), pos);
+        state.record_chain_claim_source(sentinel, 77, 5);
+        let before_claims = state.deposits[&user_a()].cfx_claims.clone();
+        let before_sources = state.chain_claim_sources.clone();
+
+        let zero = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: sentinel,
+                op_id: 47,
+                claim_id: 77,
+                claimant: user_a(),
+                amount_wei: 0,
+                reason: "zero amount".to_string(),
+                failed_at_ns: 123,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(zero, StabilityPoolError::AmountTooLow { .. }));
+
+        let missing_sentinel = Principal::from_slice(&[99]);
+        let invalid_sentinel = recredit_failed_cfx_claim_payout_in_state(
+            &mut state,
+            CfxClaimPayoutRecovery {
+                chain_sentinel: missing_sentinel,
+                op_id: 48,
+                claim_id: 77,
+                claimant: user_a(),
+                amount_wei: 5,
+                reason: "bad sentinel".to_string(),
+                failed_at_ns: 124,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            invalid_sentinel,
+            StabilityPoolError::CollateralNotFound { .. }
+        ));
+        assert_eq!(state.deposits[&user_a()].cfx_claims, before_claims);
+        assert_eq!(state.chain_claim_sources, before_sources);
+        assert!(
+            state
+                .completed_cfx_claim_payout_recoveries
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "invalid input must not journal a recovery",
         );
     }
 

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -54,6 +54,17 @@ pub struct StabilityPoolState {
     /// Latest automatic chain absorb tick, retained as bounded operator status.
     #[serde(default)]
     pub chain_absorb_auto_last_tick: Option<ChainAbsorbAutoTickRecord>,
+    /// Durable idempotency journal for backend-confirmed failed CFX claim payout
+    /// recovery. Without this, retrying the backend callback would double-credit
+    /// both the depositor claim and the backend claim source.
+    #[serde(default)]
+    pub completed_cfx_claim_payout_recoveries:
+        Option<BTreeMap<CfxClaimPayoutRecoveryKey, CfxClaimPayoutRecoveryRecord>>,
+    /// Compact idempotency watermark for recovery records evicted from
+    /// `completed_cfx_claim_payout_recoveries`. A replay with an op_id at or
+    /// below the per-sentinel floor is treated as already recovered.
+    #[serde(default)]
+    pub completed_cfx_claim_payout_recovery_floor: Option<BTreeMap<Principal, u64>>,
 
     // Canister references
     pub protocol_canister_id: Principal,
@@ -108,6 +119,8 @@ impl Default for StabilityPoolState {
             completed_chain_absorbs: Some(BTreeMap::new()),
             chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
             chain_absorb_auto_last_tick: None,
+            completed_cfx_claim_payout_recoveries: Some(BTreeMap::new()),
+            completed_cfx_claim_payout_recovery_floor: Some(BTreeMap::new()),
             protocol_canister_id: Principal::anonymous(),
             configuration: PoolConfiguration {
                 min_deposit_e8s: 1_000_000, // 0.01 USD
@@ -142,6 +155,7 @@ const MAX_POOL_EVENTS: usize = 10_000;
 pub const MAX_PENDING_REFUNDS: usize = 10_000;
 pub const MAX_PENDING_CHAIN_ABSORBS: usize = 1_000;
 pub const MAX_COMPLETED_CHAIN_ABSORBS: usize = 10_000;
+pub const MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES: usize = 10_000;
 
 impl StabilityPoolState {
     pub fn initialize(&mut self, args: StabilityPoolInitArgs) {
@@ -715,6 +729,52 @@ impl StabilityPoolState {
         self.completed_chain_absorbs
             .as_ref()
             .and_then(|m| m.get(&vault_id).cloned())
+    }
+
+    pub fn completed_cfx_claim_payout_recovery(
+        &self,
+        key: &CfxClaimPayoutRecoveryKey,
+    ) -> Option<CfxClaimPayoutRecoveryRecord> {
+        self.completed_cfx_claim_payout_recoveries
+            .as_ref()
+            .and_then(|m| m.get(key).cloned())
+    }
+
+    pub fn completed_cfx_claim_payout_recovery_was_evicted(
+        &self,
+        key: &CfxClaimPayoutRecoveryKey,
+    ) -> bool {
+        self.completed_cfx_claim_payout_recovery_floor
+            .as_ref()
+            .and_then(|m| m.get(&key.chain_sentinel))
+            .map(|floor| key.op_id <= *floor)
+            .unwrap_or(false)
+    }
+
+    pub fn record_completed_cfx_claim_payout_recovery(
+        &mut self,
+        record: CfxClaimPayoutRecoveryRecord,
+    ) {
+        let completed = self
+            .completed_cfx_claim_payout_recoveries
+            .get_or_insert_with(BTreeMap::new);
+        completed.insert(record.key.clone(), record);
+        while completed.len() > MAX_COMPLETED_CFX_CLAIM_PAYOUT_RECOVERIES {
+            let Some(oldest_key) = completed
+                .iter()
+                .min_by_key(|(key, record)| (record.recovered_at_ns, (*key).clone()))
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            if let Some(evicted) = completed.remove(&oldest_key) {
+                let floors = self
+                    .completed_cfx_claim_payout_recovery_floor
+                    .get_or_insert_with(BTreeMap::new);
+                let floor = floors.entry(evicted.key.chain_sentinel).or_insert(0);
+                *floor = (*floor).max(evicted.key.op_id);
+            }
+        }
     }
 
     pub fn chain_absorb_auto_config(&self) -> ChainAbsorbAutoConfig {
@@ -1577,6 +1637,7 @@ impl StabilityPoolState {
         self.deposits.get(user).map(|pos| UserStabilityPosition {
             stablecoin_balances: pos.stablecoin_balances.clone(),
             collateral_gains: pos.collateral_gains.clone(),
+            cfx_claims: pos.cfx_claims.clone(),
             opted_out_collateral: pos.opted_out_collateral.iter().cloned().collect(),
             deposit_timestamp: pos.deposit_timestamp,
             total_claimed_gains: pos.total_claimed_gains.clone(),
@@ -1832,6 +1893,8 @@ impl From<StabilityPoolStateV1> for StabilityPoolState {
             completed_chain_absorbs: Some(BTreeMap::new()),
             chain_absorb_auto_config: Some(ChainAbsorbAutoConfig::default()),
             chain_absorb_auto_last_tick: None,
+            completed_cfx_claim_payout_recoveries: Some(BTreeMap::new()),
+            completed_cfx_claim_payout_recovery_floor: Some(BTreeMap::new()),
             protocol_canister_id: v1.protocol_canister_id,
             configuration: v1.configuration,
             liquidation_history: v1.liquidation_history,
@@ -3160,6 +3223,13 @@ mod tests {
 
         add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
         add_deposit_direct(&mut state, user_a(), ckusdt_ledger(), 25_000_000);
+        state
+            .deposits
+            .get_mut(&user_a())
+            .unwrap()
+            .cfx_claims
+            .get_or_insert_with(BTreeMap::new)
+            .insert(cfx_sentinel(), 1_000_000_000_000_000_000);
 
         let pos = state.get_user_position(&user_a()).unwrap();
         assert_eq!(pos.total_usd_value_e8s, 125_00000000); // 100 + 25
@@ -3171,9 +3241,24 @@ mod tests {
             pos.stablecoin_balances.get(&ckusdt_ledger()),
             Some(&25_000_000)
         );
+        assert_eq!(
+            pos.cfx_claims
+                .as_ref()
+                .and_then(|claims| claims.get(&cfx_sentinel()))
+                .copied(),
+            Some(1_000_000_000_000_000_000),
+            "user position exposes restored CFX claims for auditability",
+        );
+
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 1_00000000);
+        let pos_b = state.get_user_position(&user_b()).unwrap();
+        assert!(
+            pos_b.cfx_claims.clone().unwrap_or_default().is_empty(),
+            "normal depositors without chain claims expose an empty optional map",
+        );
 
         // Nonexistent user
-        assert!(state.get_user_position(&user_b()).is_none());
+        assert!(state.get_user_position(&user_c()).is_none());
     }
 
     // ─── Test: Multiple deposits accumulate ───
@@ -3986,6 +4071,22 @@ mod tests {
                 .unwrap_or_default()
                 .is_empty(),
             "missing completed chain absorb journal must decode as empty",
+        );
+        assert!(
+            decoded
+                .completed_cfx_claim_payout_recoveries
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing CFX claim payout recovery journal must decode as empty",
+        );
+        assert!(
+            decoded
+                .completed_cfx_claim_payout_recovery_floor
+                .clone()
+                .unwrap_or_default()
+                .is_empty(),
+            "missing CFX claim payout recovery floor must decode as empty",
         );
     }
 

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -364,6 +364,43 @@ pub struct ChainClaimSource {
     pub remaining_native: u128,
 }
 
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecoveryKey {
+    pub chain_sentinel: Principal,
+    pub op_id: u64,
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecovery {
+    pub chain_sentinel: Principal,
+    pub op_id: u64,
+    pub claim_id: u64,
+    pub claimant: Principal,
+    pub amount_wei: u128,
+    pub reason: String,
+    pub failed_at_ns: u64,
+}
+
+impl CfxClaimPayoutRecovery {
+    pub fn key(&self) -> CfxClaimPayoutRecoveryKey {
+        CfxClaimPayoutRecoveryKey {
+            chain_sentinel: self.chain_sentinel,
+            op_id: self.op_id,
+        }
+    }
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CfxClaimPayoutRecoveryRecord {
+    pub key: CfxClaimPayoutRecoveryKey,
+    pub claim_id: u64,
+    pub claimant: Principal,
+    pub amount_wei: u128,
+    pub reason: String,
+    pub failed_at_ns: u64,
+    pub recovered_at_ns: u64,
+}
+
 /// Audit trail record for a completed liquidation.
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolLiquidationRecord {
@@ -433,6 +470,7 @@ pub struct StabilityPoolStatus {
 pub struct UserStabilityPosition {
     pub stablecoin_balances: BTreeMap<Principal, u64>,
     pub collateral_gains: BTreeMap<Principal, u64>,
+    pub cfx_claims: Option<BTreeMap<Principal, u128>>,
     pub opted_out_collateral: Vec<Principal>,
     pub deposit_timestamp: u64,
     pub total_claimed_gains: BTreeMap<Principal, u64>,

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -63,6 +63,7 @@ type StabilityPoolStatus = record {
 type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
+  cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
@@ -177,6 +178,16 @@ type ChainSpAbsorbCompletion = record {
   vault_id : nat64;
   result : ChainSpAbsorbResult;
   completed_at_ns : nat64;
+};
+
+type CfxClaimPayoutRecovery = record {
+  chain_sentinel : principal;
+  op_id : nat64;
+  claim_id : nat64;
+  claimant : principal;
+  amount_wei : nat;
+  reason : text;
+  failed_at_ns : nat64;
 };
 
 type ChainAbsorbAutoConfig = record {
@@ -355,6 +366,7 @@ service : (StabilityPoolInitArgs) -> {
   claim_all_collateral : () -> (variant { Ok : vec record { principal; nat64 }; Err : StabilityPoolError });
   claim_pending_refund : (nat64) -> (variant { Ok : nat64; Err : StabilityPoolError });
   claim_cfx : (principal, text) -> (variant { Ok : nat; Err : StabilityPoolError });
+  recredit_failed_cfx_claim_payout : (CfxClaimPayoutRecovery) -> (variant { Ok : bool; Err : StabilityPoolError });
 
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });


### PR DESCRIPTION
## Summary
- Adds retry-safe SP CFX payout recovery with durable idempotency/floor journaling and a backend-only recredit endpoint.
- Moves chain claim payouts through pending_native -> paid_native on confirmation, with legacy paid_native compatibility.
- Retains all same-nonce tx hash candidates for CFX payout RBF/ambiguous-send recovery, including decoded legacy last_tx_hash.

## Verification
- cargo test -p rumi_protocol_backend chain_claim_tests --lib
- cargo test -p rumi_protocol_backend tests_settlement --lib
- cargo test -p rumi_protocol_backend tests_recovery --lib
- cargo test -p rumi_protocol_backend --lib
- cargo test -p stability_pool --lib
- didc check src/stability_pool/stability_pool.did
- git diff --check
- adversarial verification: two final independent reviewers PASS

Stacked on codex/chains-liquidation-inc9. No merge or deploy.