### PR TITLE
feat(xrp-sp): stability-pool native-collateral opt-in + XRP deposit rail UX

### DIFF
--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -64,6 +64,7 @@ type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
   opted_out_collateral : vec principal;
+  native_payout_addresses : vec record { principal; text };
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
   total_usd_value_e8s : nat64;
@@ -127,6 +128,8 @@ type StabilityPoolError = variant {
   SystemBusy;
   AlreadyOptedOut : record { collateral : principal };
   AlreadyOptedIn : record { collateral : principal };
+  PayoutAddressRequired : record { collateral : principal };
+  InvalidPayoutAddress : record { reason : text };
   RefundClaimNotFound;
 };
 
@@ -245,6 +248,7 @@ service : (StabilityPoolInitArgs) -> {
   // ── Opt-in / Opt-out ──
   opt_out_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
   opt_in_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_in_native_collateral : (principal, text) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Liquidation ──
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -161,11 +161,13 @@ export type StabilityPoolError = {
       'required' : bigint,
     }
   } |
+  { 'InvalidPayoutAddress' : { 'reason' : string } } |
   { 'CollateralNotFound' : { 'ledger' : Principal } } |
   { 'NoPositionFound' : null } |
   { 'AmountTooLow' : { 'minimum_e8s' : bigint } } |
   { 'Unauthorized' : null } |
   { 'InterCanisterCallFailed' : { 'method' : string, 'target' : string } } |
+  { 'PayoutAddressRequired' : { 'collateral' : Principal } } |
   { 'LiquidationFailed' : { 'vault_id' : bigint, 'reason' : string } } |
   { 'SystemBusy' : null } |
   { 'AlreadyOptedIn' : { 'collateral' : Principal } } |
@@ -203,6 +205,7 @@ export interface UserStabilityPosition {
   'collateral_gains' : Array<[Principal, bigint]>,
   'stablecoin_balances' : Array<[Principal, bigint]>,
   'total_claimed_gains' : Array<[Principal, bigint]>,
+  'native_payout_addresses' : Array<[Principal, string]>,
   'total_usd_value_e8s' : bigint,
   'opted_out_collateral' : Array<Principal>,
 }
@@ -281,6 +284,11 @@ export interface _SERVICE {
   >,
   'opt_in_collateral' : ActorMethod<
     [Principal],
+    { 'Ok' : null } |
+      { 'Err' : StabilityPoolError }
+  >,
+  'opt_in_native_collateral' : ActorMethod<
+    [Principal, string],
     { 'Ok' : null } |
       { 'Err' : StabilityPoolError }
   >,

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
       'available' : IDL.Nat64,
       'required' : IDL.Nat64,
     }),
+    'InvalidPayoutAddress' : IDL.Record({ 'reason' : IDL.Text }),
     'CollateralNotFound' : IDL.Record({ 'ledger' : IDL.Principal }),
     'NoPositionFound' : IDL.Null,
     'AmountTooLow' : IDL.Record({ 'minimum_e8s' : IDL.Nat64 }),
@@ -22,6 +23,7 @@ export const idlFactory = ({ IDL }) => {
       'method' : IDL.Text,
       'target' : IDL.Text,
     }),
+    'PayoutAddressRequired' : IDL.Record({ 'collateral' : IDL.Principal }),
     'LiquidationFailed' : IDL.Record({
       'vault_id' : IDL.Nat64,
       'reason' : IDL.Text,
@@ -159,6 +161,7 @@ export const idlFactory = ({ IDL }) => {
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'stablecoin_balances' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'total_claimed_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+    'native_payout_addresses' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Text)),
     'total_usd_value_e8s' : IDL.Nat64,
     'opted_out_collateral' : IDL.Vec(IDL.Principal),
   });
@@ -334,6 +337,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'opt_in_collateral' : IDL.Func(
         [IDL.Principal],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
+        [],
+      ),
+    'opt_in_native_collateral' : IDL.Func(
+        [IDL.Principal, IDL.Text],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : StabilityPoolError })],
         [],
       ),

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -207,6 +207,25 @@ pub fn opt_out_cfx(chain_sentinel: Principal) -> Result<(), StabilityPoolError> 
     result
 }
 
+#[update]
+pub fn opt_in_native_collateral(
+    collateral_type: Principal,
+    payout_address: String,
+) -> Result<(), StabilityPoolError> {
+    // SP-102 / AR-S-002: see opt_out_collateral.
+    if crate::pool_guard::liquidation_in_progress() {
+        return Err(StabilityPoolError::SystemBusy);
+    }
+    let caller = ic_cdk::api::caller();
+    let result = mutate_state(|s| {
+        s.opt_in_native_collateral(&caller, collateral_type, payout_address)
+    });
+    if result.is_ok() {
+        mutate_state(|s| s.push_event(caller, PoolEventType::OptInCollateral { collateral_type }));
+    }
+    result
+}
+
 // ─── Liquidation (Push + Fallback) ───
 
 /// Called by the backend to push liquidatable vault notifications.
@@ -523,6 +542,27 @@ pub fn icrc21_canister_call_consent_message(
             "## Opt Out of CFX\n\n\
              You are opting out of receiving CFX from future chain-vault liquidations."
                 .to_string()
+        }
+        "opt_in_native_collateral" => {
+            match candid::decode_args::<(Principal, String)>(&request.arg) {
+                Ok((collateral_ledger, payout_address)) => {
+                    let symbol = read_state(|s| {
+                        s.collateral_registry
+                            .get(&collateral_ledger)
+                            .map(|c| c.symbol.clone())
+                            .unwrap_or_else(|| format!("collateral {}", collateral_ledger))
+                    });
+                    format!(
+                        "## Opt In to Native Collateral\n\n\
+                         You are opting in to receive **{}** from future liquidations. \
+                         Payouts will be sent to XRP Ledger address `{}`.",
+                        symbol, payout_address
+                    )
+                }
+                Err(_) => {
+                    "Opt in to native collateral liquidations with a payout address.".to_string()
+                }
+            }
         }
         "deposit_as_3usd" => {
             match candid::decode_args::<(Principal, u64)>(&request.arg) {

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -229,13 +229,14 @@ impl StabilityPoolState {
     /// Today XRP is the only such collateral in the SP registry. It is opt-in by
     /// stored payout address rather than opt-out by default.
     pub fn collateral_requires_payout_address(&self, collateral_type: &Principal) -> bool {
-        if *collateral_type == rumi_protocol_backend::state::xrp_collateral_principal() {
-            return true;
-        }
-        self.collateral_registry
-            .get(collateral_type)
-            .map(|info| info.symbol.eq_ignore_ascii_case("XRP"))
-            .unwrap_or(false)
+        // Gate strictly on the native-XRP synthetic principal identity. XRP is
+        // registered in the SP under `xrp_collateral_principal()`, so this is
+        // exact. A symbol heuristic ("XRP") would misclassify any future
+        // chain-registered collateral that happens to carry the XRP symbol
+        // (e.g. bridged XRP on an EVM sidechain): it would route a CFX-style
+        // sentinel opt-in through the payout-address branch and silently break
+        // that depositor's absorption. Identity-only avoids that hazard.
+        *collateral_type == rumi_protocol_backend::state::xrp_collateral_principal()
     }
 
     pub fn native_payout_address(&self, user: &Principal, collateral_type: &Principal) -> Option<String> {
@@ -2041,6 +2042,29 @@ mod tests {
         assert_eq!(state.effective_pool_for_collateral(&xrp_ledger()), 0);
     }
 
+    #[test]
+    fn chain_sentinel_named_xrp_routes_to_chain_optin_not_payout_address() {
+        // Regression (review MEDIUM-1): a chain-registered collateral that happens
+        // to carry the "XRP" symbol must NOT be treated as native XRP. It must use
+        // the CFX-style sentinel opt-in, not the payout-address branch. Gating
+        // `collateral_requires_payout_address` on principal identity (not symbol)
+        // preserves this so a CFX-style opt-in depositor keeps absorbing it.
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+
+        let sentinel = state
+            .register_chain_collateral(9999, "XRP".to_string(), 6)
+            .unwrap();
+        assert_ne!(sentinel, xrp_ledger());
+        assert!(!state.collateral_requires_payout_address(&sentinel));
+
+        // Opts in via the chain (CFX) path; the payout-address endpoint is wrong here.
+        state.opt_in_cfx(&user_a(), sentinel).unwrap();
+        let pos = state.deposits.get(&user_a()).unwrap();
+        assert!(state.position_opted_in_for(pos, &sentinel));
+        assert_eq!(state.native_payout_address(&user_a(), &sentinel), None);
+    }
+
     // ─── Test: Normalize E8s Conversions ───
 
     #[test]
@@ -3002,6 +3026,10 @@ mod tests {
         assert!(
             decoded_pos.cfx_claims.clone().unwrap_or_default().is_empty(),
             "missing CFX claims field must decode as empty",
+        );
+        assert!(
+            decoded_pos.native_payout_addresses.clone().unwrap_or_default().is_empty(),
+            "missing native payout-address field must decode as empty (no UPG-002 wipe)",
         );
         assert!(
             decoded_pos.opted_in_chain_collateral.clone().unwrap_or_default().is_empty(),

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -225,12 +225,42 @@ impl StabilityPoolState {
             .unwrap_or(false)
     }
 
-    fn position_opted_in_for(&self, pos: &DepositPosition, collateral_type: &Principal) -> bool {
-        if self.is_chain_collateral_sentinel(collateral_type) {
-            pos.is_opted_in_for_chain(collateral_type)
-        } else {
-            pos.is_opted_in(collateral_type)
+    /// Native/off-IC collateral cannot be paid out by an ICRC ledger transfer.
+    /// Today XRP is the only such collateral in the SP registry. It is opt-in by
+    /// stored payout address rather than opt-out by default.
+    pub fn collateral_requires_payout_address(&self, collateral_type: &Principal) -> bool {
+        if *collateral_type == rumi_protocol_backend::state::xrp_collateral_principal() {
+            return true;
         }
+        self.collateral_registry
+            .get(collateral_type)
+            .map(|info| info.symbol.eq_ignore_ascii_case("XRP"))
+            .unwrap_or(false)
+    }
+
+    pub fn native_payout_address(&self, user: &Principal, collateral_type: &Principal) -> Option<String> {
+        self.deposits
+            .get(user)
+            .and_then(|pos| pos.native_payout_addresses.as_ref())
+            .and_then(|addresses| addresses.get(collateral_type).cloned())
+    }
+
+    /// Unified opt-in check across all collateral models:
+    /// - XRP-style native collateral opts in by storing a payout address.
+    /// - CFX-style chain collateral opts in via the sentinel set.
+    /// - Normal ICP collateral is opt-out by default.
+    fn position_opted_in_for(&self, pos: &DepositPosition, collateral_type: &Principal) -> bool {
+        if self.collateral_requires_payout_address(collateral_type) {
+            return pos
+                .native_payout_addresses
+                .as_ref()
+                .map(|addresses| addresses.contains_key(collateral_type))
+                .unwrap_or(false);
+        }
+        if self.is_chain_collateral_sentinel(collateral_type) {
+            return pos.is_opted_in_for_chain(collateral_type);
+        }
+        pos.is_opted_in(collateral_type)
     }
 
     // ─── Deposits ───
@@ -275,10 +305,6 @@ impl StabilityPoolState {
         // Only icUSD-denominated balances earn the interest stream.
         // 3USD, ckUSDC, ckUSDT depositors still participate in liquidations
         // pro-rata but no longer earn the interest distribution.
-        let collateral_is_chain_sentinel = collateral_type
-            .as_ref()
-            .map(|ct| self.is_chain_collateral_sentinel(ct))
-            .unwrap_or(false);
         let holders: Vec<(Principal, u64)> = self.deposits.iter()
             .filter_map(|(p, pos)| {
                 let icusd_value = pos.icusd_value(&self.stablecoin_registry);
@@ -287,12 +313,7 @@ impl StabilityPoolState {
                 }
                 // If we know the collateral source, skip opted-out depositors
                 if let Some(ct) = &collateral_type {
-                    let opted_in = if collateral_is_chain_sentinel {
-                        pos.is_opted_in_for_chain(ct)
-                    } else {
-                        pos.is_opted_in(ct)
-                    };
-                    if !opted_in {
+                    if !self.position_opted_in_for(pos, ct) {
                         return None;
                     }
                 }
@@ -548,6 +569,18 @@ impl StabilityPoolState {
     // ─── Opt-in / Opt-out ───
 
     pub fn opt_out_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+        if self.collateral_requires_payout_address(&collateral_type) {
+            let position = self.deposits.get_mut(user)
+                .ok_or(StabilityPoolError::NoPositionFound)?;
+            let removed = position
+                .native_payout_addresses
+                .get_or_insert_with(BTreeMap::new)
+                .remove(&collateral_type);
+            if removed.is_none() {
+                return Err(StabilityPoolError::AlreadyOptedOut { collateral: collateral_type });
+            }
+            return Ok(());
+        }
         if self.is_chain_collateral_sentinel(&collateral_type) {
             return self.opt_out_cfx(user, collateral_type);
         }
@@ -560,6 +593,9 @@ impl StabilityPoolState {
     }
 
     pub fn opt_in_collateral(&mut self, user: &Principal, collateral_type: Principal) -> Result<(), StabilityPoolError> {
+        if self.collateral_requires_payout_address(&collateral_type) {
+            return Err(StabilityPoolError::PayoutAddressRequired { collateral: collateral_type });
+        }
         if self.is_chain_collateral_sentinel(&collateral_type) {
             return self.opt_in_cfx(user, collateral_type);
         }
@@ -594,6 +630,30 @@ impl StabilityPoolState {
         if !opted_in.remove(&sentinel) {
             return Err(StabilityPoolError::AlreadyOptedOut { collateral: sentinel });
         }
+        Ok(())
+    }
+
+    pub fn opt_in_native_collateral(
+        &mut self,
+        user: &Principal,
+        collateral_type: Principal,
+        payout_address: String,
+    ) -> Result<(), StabilityPoolError> {
+        if !self.collateral_requires_payout_address(&collateral_type) {
+            return self.opt_in_collateral(user, collateral_type);
+        }
+
+        let address = payout_address.trim().to_string();
+        rumi_protocol_backend::chains::xrp::address::account_id_from_classic_address(&address)
+            .map_err(|reason| StabilityPoolError::InvalidPayoutAddress { reason })?;
+
+        let position = self.deposits.get_mut(user)
+            .ok_or(StabilityPoolError::NoPositionFound)?;
+        position.opted_out_collateral.remove(&collateral_type);
+        position
+            .native_payout_addresses
+            .get_or_insert_with(BTreeMap::new)
+            .insert(collateral_type, address);
         Ok(())
     }
 
@@ -1202,6 +1262,7 @@ impl StabilityPoolState {
             stablecoin_balances: pos.stablecoin_balances.clone(),
             collateral_gains: pos.collateral_gains.clone(),
             opted_out_collateral: pos.opted_out_collateral.iter().cloned().collect(),
+            native_payout_addresses: pos.native_payout_addresses.clone().unwrap_or_default(),
             deposit_timestamp: pos.deposit_timestamp,
             total_claimed_gains: pos.total_claimed_gains.clone(),
             total_usd_value_e8s: pos.total_usd_value(&self.stablecoin_registry, self.virtual_prices()),
@@ -1527,6 +1588,8 @@ mod tests {
     fn icp_ledger() -> Principal { Principal::from_slice(&[20]) }
     fn ckbtc_ledger() -> Principal { Principal::from_slice(&[21]) }
     fn cfx_sentinel() -> Principal { Principal::from_slice(&[30]) }
+    fn xrp_ledger() -> Principal { rumi_protocol_backend::state::xrp_collateral_principal() }
+    fn valid_xrp_address() -> String { "rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".to_string() }
 
     /// Build a test state with:
     /// - icUSD (8 decimals, priority 1)
@@ -1578,6 +1641,12 @@ mod tests {
             ledger_id: ckbtc_ledger(),
             symbol: "ckBTC".to_string(),
             decimals: 8,
+            status: CollateralStatus::Active,
+        });
+        state.register_collateral(CollateralInfo {
+            ledger_id: xrp_ledger(),
+            symbol: "XRP".to_string(),
+            decimals: 6,
             status: CollateralStatus::Active,
         });
 
@@ -1856,6 +1925,120 @@ mod tests {
         // Opt-in on nonexistent position
         let err = state.opt_in_collateral(&user_a(), icp_ledger()).unwrap_err();
         assert!(matches!(err, StabilityPoolError::NoPositionFound));
+    }
+
+    #[test]
+    fn xrp_requires_payout_address_before_participating() {
+        let mut state = test_state();
+
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 50_00000000);
+
+        assert_eq!(
+            state.effective_pool_for_collateral(&xrp_ledger()),
+            0,
+            "XRP must be opt-in only; default depositors cannot absorb XRP liquidations"
+        );
+        assert!(
+            state.compute_token_draw(10_00000000, &xrp_ledger()).is_empty(),
+            "XRP liquidations must not draw from users without a payout address"
+        );
+
+        let err = state.opt_in_collateral(&user_a(), xrp_ledger()).unwrap_err();
+        assert!(matches!(err, StabilityPoolError::PayoutAddressRequired { .. }));
+
+        state
+            .opt_in_native_collateral(&user_a(), xrp_ledger(), valid_xrp_address())
+            .unwrap();
+
+        assert_eq!(
+            state.native_payout_address(&user_a(), &xrp_ledger()),
+            Some(valid_xrp_address()),
+        );
+        assert_eq!(
+            state.effective_pool_for_collateral(&xrp_ledger()),
+            100_00000000,
+            "only the depositor with an XRP payout address is eligible"
+        );
+
+        let draw = state.compute_token_draw(25_00000000, &xrp_ledger());
+        assert_eq!(draw.get(&icusd_ledger()).copied().unwrap_or(0), 25_00000000);
+
+        let mut consumed = BTreeMap::new();
+        consumed.insert(icusd_ledger(), 20_00000000);
+        state.process_liquidation_gains_at(
+            144,
+            xrp_ledger(),
+            &consumed,
+            5_000_000,
+            50_00000000,
+            3_000_000_000,
+        );
+
+        let pos_a = state.deposits.get(&user_a()).unwrap();
+        let pos_b = state.deposits.get(&user_b()).unwrap();
+        assert_eq!(pos_a.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 80_00000000);
+        assert_eq!(pos_a.collateral_gains.get(&xrp_ledger()).copied().unwrap_or(0), 5_000_000);
+        assert_eq!(pos_b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 50_00000000);
+        assert_eq!(pos_b.collateral_gains.get(&xrp_ledger()).copied().unwrap_or(0), 0);
+    }
+
+    #[test]
+    fn xrp_interest_only_goes_to_address_opted_depositors() {
+        let mut state = test_state();
+
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_00000000);
+        add_deposit_direct(&mut state, user_b(), icusd_ledger(), 50_00000000);
+
+        state.distribute_interest_revenue(icusd_ledger(), 9_00000000, Some(xrp_ledger()));
+        assert_eq!(
+            state.deposits.get(&user_a()).unwrap().stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0),
+            100_00000000,
+            "XRP interest must not be distributed until a depositor provides a payout address"
+        );
+        assert_eq!(
+            state.deposits.get(&user_b()).unwrap().stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0),
+            50_00000000,
+        );
+
+        state
+            .opt_in_native_collateral(&user_a(), xrp_ledger(), valid_xrp_address())
+            .unwrap();
+        state.distribute_interest_revenue(icusd_ledger(), 9_00000000, Some(xrp_ledger()));
+
+        let pos_a = state.deposits.get(&user_a()).unwrap();
+        let pos_b = state.deposits.get(&user_b()).unwrap();
+        assert_eq!(pos_a.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 109_00000000);
+        assert_eq!(pos_b.stablecoin_balances.get(&icusd_ledger()).copied().unwrap_or(0), 50_00000000);
+        assert_eq!(pos_a.total_interest_earned_e8s.unwrap_or(0), 9_00000000);
+        assert_eq!(pos_b.total_interest_earned_e8s.unwrap_or(0), 0);
+    }
+
+    #[test]
+    fn xrp_opt_in_rejects_invalid_payout_address() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+
+        let err = state
+            .opt_in_native_collateral(&user_a(), xrp_ledger(), "not-an-xrpl-address".to_string())
+            .unwrap_err();
+        assert!(matches!(err, StabilityPoolError::InvalidPayoutAddress { .. }));
+        assert_eq!(state.native_payout_address(&user_a(), &xrp_ledger()), None);
+        assert_eq!(state.effective_pool_for_collateral(&xrp_ledger()), 0);
+    }
+
+    #[test]
+    fn xrp_opt_out_clears_payout_address() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+
+        state
+            .opt_in_native_collateral(&user_a(), xrp_ledger(), valid_xrp_address())
+            .unwrap();
+        state.opt_out_collateral(&user_a(), xrp_ledger()).unwrap();
+
+        assert_eq!(state.native_payout_address(&user_a(), &xrp_ledger()), None);
+        assert_eq!(state.effective_pool_for_collateral(&xrp_ledger()), 0);
     }
 
     // ─── Test: Normalize E8s Conversions ───

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -78,6 +78,11 @@ pub struct DepositPosition {
     /// backward-compatible stable memory upgrades.
     #[serde(default)]
     pub cfx_claims: Option<BTreeMap<Principal, u128>>,
+    /// Payout destinations for native/off-IC collateral types keyed by synthetic
+    /// collateral principal. XRP uses this as its opt-in marker: no address means
+    /// the depositor does not absorb or earn from XRP liquidations.
+    #[serde(default)]
+    pub native_payout_addresses: Option<BTreeMap<Principal, String>>,
 }
 
 impl DepositPosition {
@@ -91,6 +96,7 @@ impl DepositPosition {
             total_claimed_gains: BTreeMap::new(),
             total_interest_earned_e8s: Some(0),
             cfx_claims: Some(BTreeMap::new()),
+            native_payout_addresses: Some(BTreeMap::new()),
         }
     }
 
@@ -349,6 +355,7 @@ pub struct UserStabilityPosition {
     pub stablecoin_balances: BTreeMap<Principal, u64>,
     pub collateral_gains: BTreeMap<Principal, u64>,
     pub opted_out_collateral: Vec<Principal>,
+    pub native_payout_addresses: BTreeMap<Principal, String>,
     pub deposit_timestamp: u64,
     pub total_claimed_gains: BTreeMap<Principal, u64>,
     pub total_usd_value_e8s: u64,
@@ -376,6 +383,8 @@ pub enum StabilityPoolError {
     SystemBusy,
     AlreadyOptedOut { collateral: Principal },
     AlreadyOptedIn { collateral: Principal },
+    PayoutAddressRequired { collateral: Principal },
+    InvalidPayoutAddress { reason: String },
     RefundClaimNotFound,
 }
 

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -64,6 +64,7 @@ type UserStabilityPosition = record {
   stablecoin_balances : vec record { principal; nat64 };
   collateral_gains : vec record { principal; nat64 };
   opted_out_collateral : vec principal;
+  native_payout_addresses : vec record { principal; text };
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
   total_usd_value_e8s : nat64;
@@ -165,6 +166,8 @@ type StabilityPoolError = variant {
   SystemBusy;
   AlreadyOptedOut : record { collateral : principal };
   AlreadyOptedIn : record { collateral : principal };
+  PayoutAddressRequired : record { collateral : principal };
+  InvalidPayoutAddress : record { reason : text };
   RefundClaimNotFound;
 };
 
@@ -286,6 +289,7 @@ service : (StabilityPoolInitArgs) -> {
   opt_in_collateral : (principal) -> (variant { Ok; Err : StabilityPoolError });
   opt_out_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
   opt_in_cfx : (principal) -> (variant { Ok; Err : StabilityPoolError });
+  opt_in_native_collateral : (principal, text) -> (variant { Ok; Err : StabilityPoolError });
 
   // ── Liquidation ──
   notify_liquidatable_vaults : (vec LiquidatableVaultInfo) -> (vec LiquidationResult);

--- a/src/vault_frontend/src/lib/components/stability-pool/UserAccount.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/UserAccount.svelte
@@ -19,6 +19,7 @@
   let claimLoading: Record<string, boolean> = {};
   let claimAllLoading = false;
   let toggleLoading: Record<string, boolean> = {};
+  let nativeAddressInputs: Record<string, string> = {};
   let error = '';
   let showOptOutMenu = false;
   let showOptOutTooltip = false;
@@ -26,7 +27,7 @@
   $: stablecoinRegistry = poolStatus?.stablecoin_registry ?? [];
   // Hide PHASMA (test-only collateral) and enforce display order matching borrow page.
   const HIDDEN_COLLATERAL = new Set(['PHASMA']);
-  const COLLATERAL_ORDER: Record<string, number> = { ICP: 0, ckBTC: 1, ckETH: 2, ckXAUT: 3, nICP: 4, BOB: 5, EXE: 6 };
+  const COLLATERAL_ORDER: Record<string, number> = { ICP: 0, XRP: 1, ckBTC: 2, ckETH: 3, ckXAUT: 4, nICP: 5, BOB: 6, EXE: 7 };
   $: collateralRegistryRaw = poolStatus?.collateral_registry ?? [];
   $: collateralRegistry = collateralRegistryRaw
     .filter(c => !HIDDEN_COLLATERAL.has(c.symbol))
@@ -36,8 +37,18 @@
   $: userStables = userPosition?.stablecoin_balances ?? [];
   $: totalUsdValue = userPosition ? formatStableTokenDisplay(userPosition.total_usd_value_e8s, 8) : '0.0000';
   $: gains = userPosition?.collateral_gains ?? [];
-  $: hasAnyGains = gains.some(([_, a]) => a > 0n);
   $: optedOut = new Set((userPosition?.opted_out_collateral ?? []).map(p => p.toText()));
+  $: nativePayoutByCollateral = new Map((userPosition?.native_payout_addresses ?? []).map(([p, address]) => [p.toText(), address]));
+
+  $: {
+    let nextInputs = nativeAddressInputs;
+    for (const [key, address] of nativePayoutByCollateral) {
+      if (nextInputs[key] === undefined) {
+        nextInputs = { ...nextInputs, [key]: address };
+      }
+    }
+    nativeAddressInputs = nextInputs;
+  }
 
   $: depositDate = userPosition?.deposit_timestamp
     ? new Date(Number(userPosition.deposit_timestamp) / 1_000_000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
@@ -76,13 +87,52 @@
     }
   }
 
-  async function toggleOptOut(collateral: CollateralInfo) {
+  function isNativeCollateral(collateral: CollateralInfo) {
+    return collateral.symbol === 'XRP';
+  }
+
+  function isCollateralOut(collateral: CollateralInfo) {
     const key = collateral.ledger_id.toText();
-    const isCurrentlyOut = optedOut.has(key);
+    return isNativeCollateral(collateral) ? !nativePayoutByCollateral.has(key) : optedOut.has(key);
+  }
+
+  $: hasClaimableIcrcGains = gains.some(([ledger, amount]) => {
+    if (amount <= 0n) return false;
+    const collateral = collateralRegistry.find(c => c.ledger_id.toText() === ledger.toText());
+    return collateral ? !isNativeCollateral(collateral) : false;
+  });
+
+  function setNativeAddressInput(key: string, value: string) {
+    nativeAddressInputs = { ...nativeAddressInputs, [key]: value };
+  }
+
+  async function saveNativeOptIn(collateral: CollateralInfo) {
+    const key = collateral.ledger_id.toText();
     try {
       toggleLoading = { ...toggleLoading, [key]: true };
       error = '';
-      if (isCurrentlyOut) {
+      await stabilityPoolService.optInNativeCollateral(collateral.ledger_id, nativeAddressInputs[key] ?? '');
+      dispatch('success', { action: 'optInNative' });
+    } catch (err: any) {
+      error = err.message || 'XRP opt-in failed';
+    } finally {
+      toggleLoading = { ...toggleLoading, [key]: false };
+    }
+  }
+
+  async function toggleOptOut(collateral: CollateralInfo) {
+    const key = collateral.ledger_id.toText();
+    const isCurrentlyOut = isCollateralOut(collateral);
+    try {
+      toggleLoading = { ...toggleLoading, [key]: true };
+      error = '';
+      if (isNativeCollateral(collateral)) {
+        if (isCurrentlyOut) {
+          await stabilityPoolService.optInNativeCollateral(collateral.ledger_id, nativeAddressInputs[key] ?? '');
+        } else {
+          await stabilityPoolService.optOutCollateral(collateral.ledger_id);
+        }
+      } else if (isCurrentlyOut) {
         await stabilityPoolService.optInCollateral(collateral.ledger_id);
       } else {
         await stabilityPoolService.optOutCollateral(collateral.ledger_id);
@@ -147,7 +197,7 @@
       <div class="gains-header">
         <h4 class="gains-title">Collateral Gains</h4>
         <div class="gains-header-actions">
-          {#if hasAnyGains}
+          {#if hasClaimableIcrcGains}
             <button class="claim-all-btn" on:click={claimAll} disabled={claimAllLoading}>
               {#if claimAllLoading}
                 <span class="mini-spinner"></span>
@@ -156,6 +206,8 @@
               {/if}
             </button>
           {/if}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div class="opt-out-wrapper" on:click|stopPropagation>
             <!-- svelte-ignore a11y-mouse-events-have-key-events -->
             <button
@@ -164,7 +216,7 @@
               on:mouseleave={() => { showOptOutTooltip = false; }}
               on:click|stopPropagation={() => { showOptOutMenu = !showOptOutMenu; showOptOutTooltip = false; }}
             >
-              Opt out
+              Routing
               <svg class="info-icon" width="12" height="12" viewBox="0 0 16 16" fill="none">
                 <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
                 <path d="M8 7v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -173,26 +225,67 @@
             </button>
             {#if showOptOutTooltip && !showOptOutMenu}
               <div class="opt-out-tooltip">
-                Choose which collateral types you receive during liquidations. Opted-out collateral is redistributed to other depositors.
+                Choose which collateral types you receive during liquidations. XRP requires a payout address.
               </div>
             {/if}
             {#if showOptOutMenu}
               <div class="opt-out-menu">
                 {#each collateralRegistry as collateral}
                   {@const key = collateral.ledger_id.toText()}
-                  {@const isOut = optedOut.has(key)}
-                  <button
-                    class="opt-out-row" class:is-out={isOut}
-                    on:click={() => toggleOptOut(collateral)}
-                    disabled={toggleLoading[key]}
-                  >
-                    <span class="opt-out-symbol">{collateral.symbol}</span>
-                    {#if toggleLoading[key]}
-                      <span class="mini-spinner"></span>
-                    {:else}
-                      <span class="opt-out-status" class:opted-out-label={isOut}>{isOut ? 'Opted out' : 'Receiving'}</span>
-                    {/if}
-                  </button>
+                  {@const isNative = isNativeCollateral(collateral)}
+                  {@const isOut = isCollateralOut(collateral)}
+                  {#if isNative}
+                    <div class="native-opt-row" class:is-out={isOut}>
+                      <div class="native-opt-head">
+                        <span class="opt-out-symbol">{collateral.symbol}</span>
+                        {#if toggleLoading[key]}
+                          <span class="mini-spinner"></span>
+                        {:else}
+                          <span class="opt-out-status" class:opted-out-label={isOut}>{isOut ? 'Off' : 'Receiving'}</span>
+                        {/if}
+                      </div>
+                      <input
+                        class="native-address-input"
+                        type="text"
+                        inputmode="text"
+                        placeholder="r..."
+                        value={nativeAddressInputs[key] ?? nativePayoutByCollateral.get(key) ?? ''}
+                        disabled={toggleLoading[key]}
+                        on:input={(event) => setNativeAddressInput(key, (event.currentTarget as HTMLInputElement).value)}
+                      />
+                      <div class="native-opt-actions">
+                        <button
+                          class="native-save-btn"
+                          on:click={() => saveNativeOptIn(collateral)}
+                          disabled={toggleLoading[key]}
+                        >
+                          {nativePayoutByCollateral.has(key) ? 'Update' : 'Enable'}
+                        </button>
+                        {#if nativePayoutByCollateral.has(key)}
+                          <button
+                            class="native-disable-btn"
+                            on:click={() => toggleOptOut(collateral)}
+                            disabled={toggleLoading[key]}
+                          >
+                            Disable
+                          </button>
+                        {/if}
+                      </div>
+                    </div>
+                  {:else}
+                    <button
+                      class="opt-out-row" class:is-out={isOut}
+                      on:click={() => toggleOptOut(collateral)}
+                      disabled={toggleLoading[key]}
+                    >
+                      <span class="opt-out-symbol">{collateral.symbol}</span>
+                      {#if toggleLoading[key]}
+                        <span class="mini-spinner"></span>
+                      {:else}
+                        <span class="opt-out-status" class:opted-out-label={isOut}>{isOut ? 'Opted out' : 'Receiving'}</span>
+                      {/if}
+                    </button>
+                  {/if}
                 {/each}
               </div>
             {/if}
@@ -205,14 +298,15 @@
           {@const key = collateral.ledger_id.toText()}
           {@const gainEntry = gains.find(([l]) => l.toText() === key)}
           {@const gainAmount = gainEntry ? gainEntry[1] : 0n}
-          {@const isOut = optedOut.has(key)}
+          {@const isNative = isNativeCollateral(collateral)}
+          {@const isOut = isCollateralOut(collateral)}
 
           <div class="gain-row" class:opted-out={isOut}>
             <div class="gain-info">
               <div class="gain-token">
                 <span class="gain-symbol">{collateral.symbol}</span>
                 {#if isOut}
-                  <span class="opted-out-badge">OUT</span>
+                  <span class="opted-out-badge">{isNative ? 'OFF' : 'OUT'}</span>
                 {/if}
               </div>
               <div class="gain-amount">
@@ -225,7 +319,7 @@
             </div>
 
             <div class="gain-actions">
-              {#if gainAmount > 0n}
+              {#if gainAmount > 0n && !isNative}
                 <button class="claim-btn" on:click={() => claimSingle(collateral.ledger_id)} disabled={claimLoading[key]}>
                   {claimLoading[key] ? '…' : 'Claim'}
                 </button>
@@ -328,7 +422,7 @@
 
   .opt-out-menu {
     position: absolute; top: calc(100% + 0.375rem); right: 0; z-index: 30;
-    min-width: 10rem; padding: 0.375rem;
+    min-width: 12rem; width: min(18rem, calc(100vw - 2rem)); padding: 0.375rem;
     background: var(--rumi-bg-surface1); border: 1px solid var(--rumi-border);
     border-radius: 0.5rem; box-shadow: 0 4px 16px rgba(0,0,0,0.4);
     display: flex; flex-direction: column; gap: 0.125rem;
@@ -345,6 +439,46 @@
   .opt-out-symbol { font-size: 0.75rem; font-weight: 600; color: var(--rumi-text-primary); }
   .opt-out-status { font-size: 0.6875rem; color: var(--rumi-teal); font-weight: 500; }
   .opt-out-status.opted-out-label { color: var(--rumi-danger); }
+
+  .native-opt-row {
+    display: flex; flex-direction: column; gap: 0.5rem;
+    padding: 0.625rem; border-radius: 0.375rem;
+    background: var(--rumi-bg-surface2); border: 1px solid var(--rumi-border);
+  }
+  .native-opt-row.is-out { border-color: rgba(74, 144, 217, 0.22); }
+  .native-opt-head { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+  .native-address-input {
+    width: 100%; min-width: 0; height: 2rem;
+    padding: 0 0.625rem; border-radius: 0.375rem;
+    border: 1px solid var(--rumi-border); background: var(--rumi-bg-surface1);
+    color: var(--rumi-text-primary); font-size: 0.75rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    outline: none; transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .native-address-input:focus {
+    border-color: rgba(74, 144, 217, 0.55);
+    background: var(--rumi-bg-surface3);
+  }
+  .native-address-input::placeholder { color: var(--rumi-text-muted); }
+  .native-opt-actions { display: flex; gap: 0.375rem; }
+  .native-save-btn,
+  .native-disable-btn {
+    flex: 1; min-width: 0; height: 1.75rem;
+    border-radius: 0.3125rem; font-size: 0.6875rem; font-weight: 600;
+    cursor: pointer; transition: all 0.15s ease;
+  }
+  .native-save-btn {
+    border: 1px solid rgba(74, 144, 217, 0.45);
+    background: rgba(74, 144, 217, 0.14); color: #8ec5ff;
+  }
+  .native-save-btn:hover:not(:disabled) { background: rgba(74, 144, 217, 0.2); }
+  .native-disable-btn {
+    border: 1px solid var(--rumi-border);
+    background: transparent; color: var(--rumi-text-secondary);
+  }
+  .native-disable-btn:hover:not(:disabled) { border-color: var(--rumi-border-hover); color: var(--rumi-text-primary); }
+  .native-save-btn:disabled,
+  .native-disable-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
   .gains-list { display: flex; flex-direction: column; gap: 0.5rem; }
 

--- a/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.svelte
+++ b/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.svelte
@@ -1,0 +1,259 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { appDataStore } from '$lib/stores/appDataStore';
+  import { walletStore } from '$lib/stores/wallet';
+  import {
+    XRP_PENDING_DEPOSITS_CHANGED,
+    XrpVaultService,
+    type XrpPendingDepositView,
+    dropsToXrp,
+  } from '$lib/services/xrpVaultService';
+  import { toastStore } from '$lib/stores/toast';
+  import { formatAddress } from '$lib/utils/format';
+
+  let pending: XrpPendingDepositView[] = [];
+  let loading = false;
+  let confirmingVaultId: number | null = null;
+  let lastError = '';
+  let lastPrincipal = '';
+  let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+  $: connected = $walletStore.isConnected;
+  $: principalText = $walletStore.principal?.toText?.() ?? '';
+
+  async function refreshPending() {
+    if (!connected) {
+      pending = [];
+      lastError = '';
+      return;
+    }
+    loading = true;
+    try {
+      pending = await XrpVaultService.getMyPendingDeposits();
+    } finally {
+      loading = false;
+    }
+  }
+
+  $: if (browser && principalText !== lastPrincipal) {
+    lastPrincipal = principalText;
+    refreshPending();
+  }
+
+  onMount(() => {
+    refreshPending();
+    refreshInterval = setInterval(refreshPending, 20_000);
+    window.addEventListener(XRP_PENDING_DEPOSITS_CHANGED, refreshPending);
+  });
+
+  onDestroy(() => {
+    if (refreshInterval) clearInterval(refreshInterval);
+    if (browser) window.removeEventListener(XRP_PENDING_DEPOSITS_CHANGED, refreshPending);
+  });
+
+  async function confirmDeposit(vaultId: number) {
+    confirmingVaultId = vaultId;
+    lastError = '';
+    try {
+      const res = await XrpVaultService.confirmXrpDeposit(vaultId);
+      if (res.success) {
+        const credited = res.data ? dropsToXrp(res.data.creditedDrops) : 0;
+        toastStore.success(
+          credited > 0
+            ? `XRP deposit confirmed - credited ${credited} XRP`
+            : 'XRP deposit confirmed'
+        );
+        await refreshPending();
+        if ($walletStore.principal) await appDataStore.refreshAll($walletStore.principal);
+      } else {
+        lastError = res.error ?? 'Deposit not confirmed yet. If the XRP just landed, wait a moment and retry.';
+      }
+    } finally {
+      confirmingVaultId = null;
+    }
+  }
+
+  function copy(text: string) {
+    navigator.clipboard?.writeText(text).then(
+      () => toastStore.info('Copied XRP deposit address'),
+      () => {}
+    );
+  }
+</script>
+
+{#if connected && pending.length > 0}
+  <section class="xrp-recovery" aria-label="Pending XRP deposit recovery">
+    <div class="xrp-recovery-inner">
+      <div class="xrp-recovery-copy">
+        <span class="xrp-recovery-kicker">XRP deposit awaiting confirmation</span>
+        <strong>{pending.length === 1 ? 'Finish opening your XRP vault' : `Finish ${pending.length} XRP vault deposits`}</strong>
+        <span class="xrp-recovery-note">
+          Your XRP deposit address is still linked to your wallet. Confirm it here after the XRP arrives.
+        </span>
+      </div>
+
+      <div class="xrp-recovery-list">
+        {#each pending as p (p.vaultId)}
+          <div class="xrp-recovery-item">
+            <span class="xrp-vault-id">Vault #{p.vaultId}</span>
+            <button class="xrp-address" title={p.custodyAddress} on:click={() => copy(p.custodyAddress)}>
+              {formatAddress(p.custodyAddress, 8, 6)}
+              <span>Copy</span>
+            </button>
+            <button
+              class="xrp-confirm"
+              disabled={loading || confirmingVaultId === p.vaultId}
+              on:click={() => confirmDeposit(p.vaultId)}
+            >
+              {confirmingVaultId === p.vaultId ? 'Checking...' : "I've sent the XRP"}
+            </button>
+          </div>
+        {/each}
+      </div>
+
+      {#if lastError}
+        <div class="xrp-recovery-error">{lastError}</div>
+      {/if}
+    </div>
+  </section>
+{/if}
+
+<style>
+  .xrp-recovery {
+    width: 100%;
+    border-bottom: 1px solid rgba(45, 212, 191, 0.18);
+    background:
+      linear-gradient(90deg, rgba(45, 212, 191, 0.13), rgba(74, 144, 217, 0.1)),
+      var(--rumi-bg-surface-1);
+  }
+
+  .xrp-recovery-inner {
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 0.875rem 1.25rem;
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) minmax(320px, auto);
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .xrp-recovery-copy {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.18rem;
+  }
+
+  .xrp-recovery-kicker {
+    color: var(--rumi-teal);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .xrp-recovery-copy strong {
+    color: var(--rumi-text-primary);
+    font-size: 0.9375rem;
+    line-height: 1.2;
+  }
+
+  .xrp-recovery-note {
+    color: var(--rumi-text-muted);
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .xrp-recovery-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .xrp-recovery-item {
+    display: grid;
+    grid-template-columns: auto minmax(120px, 1fr) auto;
+    gap: 0.5rem;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .xrp-vault-id {
+    color: var(--rumi-text-secondary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  .xrp-address,
+  .xrp-confirm {
+    min-height: 2.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .xrp-address {
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.45rem 0.65rem;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(15, 23, 42, 0.5);
+    color: var(--rumi-text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .xrp-address span {
+    color: var(--rumi-teal);
+    font-size: 0.72rem;
+  }
+
+  .xrp-confirm {
+    padding: 0.45rem 0.85rem;
+    border: 0;
+    background: var(--rumi-action);
+    color: #031a17;
+    white-space: nowrap;
+  }
+
+  .xrp-confirm:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .xrp-recovery-error {
+    grid-column: 1 / -1;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid rgba(224, 107, 159, 0.32);
+    border-radius: 0.5rem;
+    background: rgba(224, 107, 159, 0.12);
+    color: #e881a8;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  @media (max-width: 760px) {
+    .xrp-recovery-inner {
+      grid-template-columns: 1fr;
+      padding: 0.875rem 1rem;
+    }
+
+    .xrp-recovery-item {
+      grid-template-columns: 1fr;
+    }
+
+    .xrp-vault-id {
+      white-space: normal;
+    }
+
+    .xrp-confirm,
+    .xrp-address {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/vault_frontend/src/lib/components/vault/XrpVaultPanel.svelte
+++ b/src/vault_frontend/src/lib/components/vault/XrpVaultPanel.svelte
@@ -31,37 +31,85 @@
   const dispatch = createEventDispatcher<{ confirmed: void }>();
 
   let pending: XrpPendingDepositView[] = [];
+  let hiddenPending: XrpPendingDepositView[] = [];
   let claims: XrpClaimView[] = [];
   let loading = false;
   let opening = false;
+  let checkingWallet = false;
   let busyVaultId: number | null = null;
   let busyClaimId: number | null = null;
+  let lastConnected = false;
   // Per-claim destination address inputs, keyed by claim id.
   let claimDest: Record<number, string> = {};
   let claimTag: Record<number, string> = {};
 
   $: connected = $walletStore.isConnected;
 
-  async function refresh() {
+  function refreshHiddenPending() {
+    hiddenPending = connected ? XrpVaultService.getHiddenPendingDeposits() : [];
+  }
+
+  async function refresh(options: { allowSigner?: boolean } = {}) {
     if (!connected) {
       pending = [];
+      hiddenPending = [];
       claims = [];
       return;
     }
     loading = true;
     try {
-      [pending, claims] = await Promise.all([
-        XrpVaultService.getMyPendingDeposits(),
-        XrpVaultService.getMyClaims(),
-      ]);
+      if (options.allowSigner) {
+        // Oisy signer requests must be serialized; parallel calls can leave the
+        // wallet popup in a busy/retry loop.
+        pending = await XrpVaultService.getMyPendingDeposits(options);
+        claims = await XrpVaultService.getMyClaims(options);
+      } else {
+        [pending, claims] = await Promise.all([
+          XrpVaultService.getMyPendingDeposits(options),
+          XrpVaultService.getMyClaims(options),
+        ]);
+      }
     } finally {
+      refreshHiddenPending();
       loading = false;
     }
   }
 
-  onMount(refresh);
+  async function checkWalletStatus() {
+    checkingWallet = true;
+    loading = true;
+    try {
+      pending = await XrpVaultService.getMyPendingDeposits({ allowSigner: true });
+      refreshHiddenPending();
+    } finally {
+      loading = false;
+      checkingWallet = false;
+    }
+  }
+
+  function hidePendingDeposit(vaultId: number) {
+    XrpVaultService.hidePendingDeposit(vaultId);
+    pending = pending.filter((p) => p.vaultId !== vaultId);
+    refreshHiddenPending();
+    toastStore.info('Hidden from this browser. Use Restore if you need it again.');
+  }
+
+  function restorePendingDeposit(vaultId: number) {
+    XrpVaultService.restorePendingDeposit(vaultId);
+    const restored = hiddenPending.find((p) => p.vaultId === vaultId);
+    if (restored) pending = [...pending, restored].sort((a, b) => a.vaultId - b.vaultId);
+    refreshHiddenPending();
+  }
+
+  onMount(() => {
+    lastConnected = connected;
+    refresh();
+  });
   // Reload when the wallet connects/disconnects.
-  $: if (connected !== undefined) refresh();
+  $: if (connected !== lastConnected) {
+    lastConnected = connected;
+    refresh();
+  }
 
   async function openVault() {
     opening = true;
@@ -192,9 +240,14 @@
 <section class="xrp-panel">
   <header class="xrp-head">
     <h3>Native XRP</h3>
-    <button class="xrp-open" disabled={!connected || opening} on:click={openVault}>
-      {opening ? 'Opening…' : 'Open XRP vault'}
-    </button>
+    <div class="xrp-head-actions">
+      <button class="xrp-secondary" disabled={!connected || checkingWallet || opening} on:click={checkWalletStatus}>
+        {checkingWallet ? 'Checking...' : 'Check deposits'}
+      </button>
+      <button class="xrp-open" disabled={!connected || opening} on:click={openVault}>
+        {opening ? 'Opening…' : 'Open XRP vault'}
+      </button>
+    </div>
   </header>
 
   {#if !connected}
@@ -212,13 +265,41 @@
               </button>
               <span class="xrp-hint">Send XRP from any XRPL wallet (e.g. Xaman) to this address, then confirm.</span>
             </div>
-            <button
-              class="xrp-action"
-              disabled={busyVaultId === p.vaultId}
-              on:click={() => confirmDeposit(p.vaultId)}
-            >
-              {busyVaultId === p.vaultId ? 'Checking…' : "I've sent it — confirm"}
-            </button>
+            <div class="xrp-row-actions">
+              <button
+                class="xrp-action"
+                disabled={busyVaultId === p.vaultId}
+                on:click={() => confirmDeposit(p.vaultId)}
+              >
+                {busyVaultId === p.vaultId ? 'Checking…' : "I've sent it — confirm"}
+              </button>
+              <button
+                class="xrp-hide"
+                disabled={busyVaultId === p.vaultId}
+                title="Hide this pending deposit locally. The custody address remains recoverable."
+                on:click={() => hidePendingDeposit(p.vaultId)}
+              >
+                Hide
+              </button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if hiddenPending.length > 0}
+      <div class="xrp-group xrp-hidden-group">
+        <div class="xrp-group-title">Hidden pending deposits</div>
+        {#each hiddenPending as p (p.vaultId)}
+          <div class="xrp-row xrp-hidden-row">
+            <div class="xrp-row-main">
+              <span class="xrp-label">Vault #{p.vaultId}</span>
+              <button class="xrp-addr" title={p.custodyAddress} on:click={() => copy(p.custodyAddress)}>
+                {formatAddress(p.custodyAddress, 8, 6)} ⧉
+              </button>
+              <span class="xrp-hint">Hidden only in this browser. Restore it before confirming a deposit.</span>
+            </div>
+            <button class="xrp-action" on:click={() => restorePendingDeposit(p.vaultId)}>Restore</button>
           </div>
         {/each}
       </div>
@@ -264,7 +345,7 @@
       </div>
     {/if}
 
-    {#if !loading && pending.length === 0 && claims.length === 0}
+    {#if !loading && pending.length === 0 && claims.length === 0 && hiddenPending.length === 0}
       <p class="xrp-muted">No pending XRP deposits or claims.</p>
     {/if}
   {/if}
@@ -284,11 +365,19 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 12px;
   }
   .xrp-head h3 {
     margin: 0;
     font-size: 1rem;
     color: var(--rumi-text, #e2e8f0);
+  }
+  .xrp-head-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
   .xrp-open {
     padding: 7px 14px;
@@ -300,6 +389,19 @@
     cursor: pointer;
   }
   .xrp-open:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .xrp-secondary {
+    padding: 7px 13px;
+    border-radius: 10px;
+    border: 1px solid var(--rumi-border, rgba(148, 163, 184, 0.25));
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--rumi-text-secondary, #cbd5e1);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .xrp-secondary:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -322,6 +424,13 @@
     padding: 10px 12px;
     border-radius: 10px;
     background: var(--rumi-surface-2, rgba(30, 41, 59, 0.5));
+  }
+  .xrp-hidden-row {
+    opacity: 0.72;
+  }
+  .xrp-hidden-group {
+    border-top: 1px solid var(--rumi-border, rgba(148, 163, 184, 0.18));
+    padding-top: 10px;
   }
   .xrp-row-main {
     display: flex;
@@ -382,6 +491,26 @@
     white-space: nowrap;
   }
   .xrp-action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .xrp-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .xrp-hide {
+    padding: 7px 11px;
+    border-radius: 10px;
+    border: 1px solid var(--rumi-border, rgba(148, 163, 184, 0.25));
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--rumi-text-muted, #94a3b8);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .xrp-hide:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/src/vault_frontend/src/lib/services/stabilityPoolService.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.ts
@@ -45,9 +45,11 @@ export interface UserPosition {
   stablecoin_balances: Array<[Principal, bigint]>;
   collateral_gains: Array<[Principal, bigint]>;
   opted_out_collateral: Principal[];
+  native_payout_addresses?: Array<[Principal, string]>;
   deposit_timestamp: bigint;
   total_claimed_gains: Array<[Principal, bigint]>;
   total_usd_value_e8s: bigint;
+  total_interest_earned_e8s?: bigint;
 }
 
 export interface LiquidationRecord {
@@ -428,6 +430,34 @@ class StabilityPoolService {
     }
   }
 
+  async optInNativeCollateral(collateralType: Principal, payoutAddress: string): Promise<void> {
+    const wallet = get(walletStore);
+    if (!wallet.isConnected) throw new Error('Wallet not connected');
+
+    const address = payoutAddress.trim();
+    if (!address) throw new Error('Enter an XRP address');
+
+    if (isOisyWallet() && wallet.principal) {
+      console.log(`[Oisy] Sequential SP opt_in_native_collateral via @icp-sdk/signer v5`);
+      const signerAgent = await getOisySignerAgent(wallet.principal);
+      const poolActor = createOisyActor(
+        STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool, signerAgent
+      );
+      const result = await poolActor.opt_in_native_collateral(collateralType, address);
+      if ('Err' in result) {
+        throw new Error(this.formatError(result.Err));
+      }
+    } else {
+      const poolActor = await walletStore.getActor(
+        STABILITY_POOL_CANISTER_ID, canisterIDLs.stability_pool
+      ) as any;
+      const result = await poolActor.opt_in_native_collateral(collateralType, address) as { Ok: null } | { Err: any };
+      if ('Err' in result) {
+        throw new Error(this.formatError(result.Err));
+      }
+    }
+  }
+
   async executeLiquidation(vaultId: bigint): Promise<any> {
     const wallet = get(walletStore);
     if (!wallet.isConnected) throw new Error('Wallet not connected');
@@ -477,6 +507,8 @@ class StabilityPoolService {
     if ('SystemBusy' in err) return 'System is busy, try again';
     if ('AlreadyOptedOut' in err) return 'Already opted out of this collateral';
     if ('AlreadyOptedIn' in err) return 'Already opted in for this collateral';
+    if ('PayoutAddressRequired' in err) return 'XRP requires a payout address';
+    if ('InvalidPayoutAddress' in err) return `Invalid XRP address: ${err.InvalidPayoutAddress.reason}`;
     return 'Unknown error';
   }
 }

--- a/src/vault_frontend/src/lib/services/xrpVaultService.ts
+++ b/src/vault_frontend/src/lib/services/xrpVaultService.ts
@@ -21,8 +21,11 @@
 
 import type { _SERVICE } from '$declarations/rumi_protocol_backend/rumi_protocol_backend.did';
 import { idlFactory as rumi_backendIDL } from '$declarations/rumi_protocol_backend/rumi_protocol_backend.did.js';
+import { browser } from '$app/environment';
+import { get } from 'svelte/store';
 import { CONFIG } from '../config';
 import { walletStore } from '../stores/wallet';
+import { currentWalletType, WALLET_TYPES } from './auth';
 import { ApiClient } from './protocol/apiClient';
 import { callWithOisyFalseNegativeGuard, isOisyLandedSentinel } from './protocol/oisyResilience';
 
@@ -73,6 +76,131 @@ export interface XrpOpResult<T> {
   oisyResilient?: boolean;
 }
 
+interface CachedXrpPendingDeposit extends XrpPendingDepositView {
+  updatedAtMs: number;
+}
+
+interface XrpReadOptions {
+  /**
+   * Oisy calls route through the popup signer. Passive UI refreshes must keep
+   * this false; explicit user-triggered refreshes can opt in.
+   */
+  allowSigner?: boolean;
+}
+
+const XRP_PENDING_CACHE_PREFIX = 'rumi_xrp_pending_deposits:';
+const XRP_HIDDEN_PENDING_PREFIX = 'rumi_xrp_hidden_pending_deposits:';
+export const XRP_PENDING_DEPOSITS_CHANGED = 'rumi:xrp-pending-deposits-changed';
+
+function currentPrincipalText(): string | null {
+  return get(walletStore).principal?.toText?.() ?? null;
+}
+
+function isOisySignerWallet(): boolean {
+  return get(currentWalletType) === WALLET_TYPES.OISY;
+}
+
+function pendingCacheKey(owner: string): string {
+  return `${XRP_PENDING_CACHE_PREFIX}${owner}`;
+}
+
+function hiddenPendingCacheKey(owner: string): string {
+  return `${XRP_HIDDEN_PENDING_PREFIX}${owner}`;
+}
+
+function readHiddenPendingIds(owner = currentPrincipalText()): Set<number> {
+  if (!browser || !owner) return new Set();
+  try {
+    const raw = localStorage.getItem(hiddenPendingCacheKey(owner));
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as number[];
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id) => Number.isFinite(id)));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeHiddenPendingIds(ids: Set<number>, owner = currentPrincipalText()) {
+  if (!browser || !owner) return;
+  localStorage.setItem(hiddenPendingCacheKey(owner), JSON.stringify([...ids].sort((a, b) => a - b)));
+}
+
+function emitPendingDepositsChanged() {
+  if (browser) window.dispatchEvent(new CustomEvent(XRP_PENDING_DEPOSITS_CHANGED));
+}
+
+function visiblePendingDeposits(pending: XrpPendingDepositView[], owner = currentPrincipalText()): XrpPendingDepositView[] {
+  const hidden = readHiddenPendingIds(owner);
+  return pending.filter((p) => !hidden.has(p.vaultId));
+}
+
+function readCachedPendingDeposits(owner = currentPrincipalText()): XrpPendingDepositView[] {
+  if (!browser || !owner) return [];
+  try {
+    const raw = localStorage.getItem(pendingCacheKey(owner));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as CachedXrpPendingDeposit[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((p) => Number.isFinite(p.vaultId) && typeof p.custodyAddress === 'string')
+      .map((p) => ({
+        vaultId: p.vaultId,
+        custodyAddress: p.custodyAddress,
+        openedAtMs: Number.isFinite(p.openedAtMs) ? p.openedAtMs : p.updatedAtMs,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function writeCachedPendingDeposits(pending: XrpPendingDepositView[], owner = currentPrincipalText()) {
+  if (!browser || !owner) return;
+  const deduped = new Map<number, CachedXrpPendingDeposit>();
+  for (const p of pending) {
+    deduped.set(p.vaultId, {
+      ...p,
+      updatedAtMs: Date.now(),
+    });
+  }
+  localStorage.setItem(pendingCacheKey(owner), JSON.stringify([...deduped.values()]));
+}
+
+function rememberPendingDeposit(pending: XrpPendingDepositView, owner = currentPrincipalText()) {
+  const existing = readCachedPendingDeposits(owner).filter((p) => p.vaultId !== pending.vaultId);
+  writeCachedPendingDeposits([...existing, pending], owner);
+  const hidden = readHiddenPendingIds(owner);
+  hidden.delete(pending.vaultId);
+  writeHiddenPendingIds(hidden, owner);
+  emitPendingDepositsChanged();
+}
+
+function forgetPendingDeposit(vaultId: number, owner = currentPrincipalText()) {
+  writeCachedPendingDeposits(
+    readCachedPendingDeposits(owner).filter((p) => p.vaultId !== vaultId),
+    owner
+  );
+  const hidden = readHiddenPendingIds(owner);
+  hidden.delete(vaultId);
+  writeHiddenPendingIds(hidden, owner);
+  emitPendingDepositsChanged();
+}
+
+function normalizeXrpError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+  if (lower.includes('xrp account_info failed') && lower.includes('network is unreachable')) {
+    return 'Could not reach the XRP Ledger to verify this deposit. Your XRP is not lost; wait a minute and try Confirm again.';
+  }
+  if (lower.includes('xrp account_info failed')) {
+    return 'Could not verify the XRP deposit right now. The custody address is still yours; try Confirm again in a minute.';
+  }
+  if (lower.includes('xrp custody account is unfunded')) {
+    return 'No XRP has reached this custody address yet. If you just sent it, wait for the XRPL transaction to settle and try again.';
+  }
+  return message;
+}
+
 // ─── Service ─────────────────────────────────────────────────────────────────
 
 export class XrpVaultService {
@@ -106,6 +234,12 @@ export class XrpVaultService {
             return { success: false, error: 'Vault opened but no pending deposit found; refresh and retry.' };
           }
           const [vaultId, dep] = pending[pending.length - 1];
+          const view = {
+            vaultId: Number(vaultId),
+            custodyAddress: dep.custody_address,
+            openedAtMs: Number(dep.opened_at_ns / 1_000_000n),
+          };
+          rememberPendingDeposit(view);
           return {
             success: true,
             oisyResilient: true,
@@ -117,6 +251,11 @@ export class XrpVaultService {
           };
         }
         if ('Ok' in result) {
+          rememberPendingDeposit({
+            vaultId: Number(result.Ok.vault_id),
+            custodyAddress: result.Ok.custody_address,
+            openedAtMs: Date.now(),
+          });
           return {
             success: true,
             data: {
@@ -126,9 +265,9 @@ export class XrpVaultService {
             },
           };
         }
-        return { success: false, error: ApiClient.formatProtocolError(result.Err) };
+        return { success: false, error: normalizeXrpError(ApiClient.formatProtocolError(result.Err)) };
       } catch (e) {
-        return { success: false, error: e instanceof Error ? e.message : String(e) };
+        return { success: false, error: normalizeXrpError(e) };
       }
     });
   }
@@ -154,14 +293,16 @@ export class XrpVaultService {
           `confirm_xrp_deposit #${vaultId}`
         );
         if (isOisyLandedSentinel(result)) {
+          forgetPendingDeposit(vaultId);
           return { success: true, oisyResilient: true, data: { creditedDrops: 0n } };
         }
         if ('Ok' in result) {
+          forgetPendingDeposit(vaultId);
           return { success: true, data: { creditedDrops: result.Ok } };
         }
-        return { success: false, error: ApiClient.formatProtocolError(result.Err) };
+        return { success: false, error: normalizeXrpError(ApiClient.formatProtocolError(result.Err)) };
       } catch (e) {
-        return { success: false, error: e instanceof Error ? e.message : String(e) };
+        return { success: false, error: normalizeXrpError(e) };
       }
     });
   }
@@ -221,24 +362,53 @@ export class XrpVaultService {
   }
 
   /** The caller's native-XRP vaults still awaiting their on-chain deposit. */
-  static async getMyPendingDeposits(): Promise<XrpPendingDepositView[]> {
+  static async getMyPendingDeposits(options: XrpReadOptions = {}): Promise<XrpPendingDepositView[]> {
+    if (isOisySignerWallet() && !options.allowSigner) {
+      return visiblePendingDeposits(readCachedPendingDeposits());
+    }
+
     try {
       const actor = await this.actor();
       const pending = await actor.get_my_xrp_pending_deposits();
-      return pending.map(([vaultId, dep]) => ({
+      const views = pending.map(([vaultId, dep]) => ({
         vaultId: Number(vaultId),
         custodyAddress: dep.custody_address,
         openedAtMs: Number(dep.opened_at_ns / 1_000_000n),
         reserveBaseDrops: dep.reserve_base_drops,
       }));
+      writeCachedPendingDeposits(views);
+      return visiblePendingDeposits(views);
     } catch (e) {
       console.error('getMyPendingDeposits failed:', e);
-      return [];
+      return isOisySignerWallet() ? visiblePendingDeposits(readCachedPendingDeposits()) : [];
     }
   }
 
+  static getHiddenPendingDeposits(): XrpPendingDepositView[] {
+    const hidden = readHiddenPendingIds();
+    return readCachedPendingDeposits().filter((p) => hidden.has(p.vaultId));
+  }
+
+  static hidePendingDeposit(vaultId: number) {
+    const hidden = readHiddenPendingIds();
+    hidden.add(vaultId);
+    writeHiddenPendingIds(hidden);
+    emitPendingDepositsChanged();
+  }
+
+  static restorePendingDeposit(vaultId: number) {
+    const hidden = readHiddenPendingIds();
+    hidden.delete(vaultId);
+    writeHiddenPendingIds(hidden);
+    emitPendingDepositsChanged();
+  }
+
   /** The caller's outstanding native-XRP claims (XRP owed back to them). */
-  static async getMyClaims(): Promise<XrpClaimView[]> {
+  static async getMyClaims(options: XrpReadOptions = {}): Promise<XrpClaimView[]> {
+    if (isOisySignerWallet() && !options.allowSigner) {
+      return [];
+    }
+
     try {
       const actor = await this.actor();
       const claims = await actor.get_my_xrp_claims();

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import PositionStrip from "../lib/components/layout/PositionStrip.svelte";
   import PriceDebug from "../lib/components/debug/PriceDebug.svelte";
   import WalletDebug from "../lib/components/debug/WalletDebug.svelte";
+  import XrpPendingDepositBanner from "../lib/components/vault/XrpPendingDepositBanner.svelte";
   import "../app.css";
   import { protocolService } from "../lib/services/protocol";
   import { isDevelopment } from "../lib/config";
@@ -113,6 +114,7 @@
   </div>
 </header>
 <PositionStrip />
+<XrpPendingDepositBanner />
 <ToastContainer />
 <main class="main-content">{#if POINTS_ENABLED && !currentPath.startsWith('/points')}<SeasonBar />{/if}<slot /></main>
 <footer class="app-footer">


### PR DESCRIPTION
Salvages the unmerged stability-pool native-collateral opt-in + XRP deposit-rail UX from the stale `feat/native-xrp-explorer-and-debt-ceiling` branch onto current `main`. The other two concerns from that branch (the explorer label fix and the debt-ceiling change) already shipped via #279, so only the SP work is brought here.

## What this adds
- **SP canister**: `opt_in_native_collateral(principal, text)` — XRP opt-in that requires a stored XRPL payout address (`native_payout_addresses` on `DepositPosition`), distinct from the existing CFX sentinel rail. New error variants `PayoutAddressRequired` / `InvalidPayoutAddress`, ICRC-21 consent, declarations.
- **Frontend**: `XrpPendingDepositBanner.svelte` (new), `XrpVaultPanel`, `UserAccount`, `stabilityPoolService`, `xrpVaultService`, layout wiring.

## Conflict resolution (cherry-pick of `26f61b6` onto post-Inc5/6 main)
Main independently grew `DepositPosition` for the CFX rail (`cfx_claims`, `opt_in_cfx`/`opt_out_cfx`) after this work forked. Resolved by:
- Keeping **both** new `Option` fields (`cfx_claims` + `native_payout_addresses`).
- **Unifying** `position_opted_in_for` + `position_is_opted_in` into one dispatcher: precedence **XRP payout-address → CFX sentinel → normal ICP opt-out**, with every call site routed through it.
- XRP-first ordering in `opt_in_collateral`/`opt_out_collateral`.

## Review (rumi-chain-liquidation-accounting-reviewer)
All three resolution decisions validated: CFX semantics unchanged, decode-safe (no UPG-002 wipe), opt-in gate airtight.
- **MEDIUM-1 fixed** (`46cc3a5`): `collateral_requires_payout_address` now gates on the XRP synthetic principal identity, not a `"XRP"` symbol heuristic (which would misroute a future chain-registered "XRP" and break CFX absorption). + regression test + explicit decode assertion.
- **MEDIUM-2 deferred to the rail**: when the XRP→SP liquidation rail is built, XRP gains must land in a dedicated native-claims map (mirroring `cfx_claims`) with an XRPL-settlement endpoint, not in `collateral_gains`. No live bug — nothing routes XRP to the SP yet.

## Verification
- `cargo check` + SP wasm build clean.
- 64 SP lib unit tests green (XRP + CFX migration tests together).
- All 7 SP PocketIC suites green, incl. `upg_001_decode_fallback`.
- `svelte-check` exit 0.

## Safety
Touches only `rumi_stability_pool` + `vault_frontend`; `rumi_protocol_backend` untouched, so no XRP liquidation can reach the SP — inert and safe to ship ahead of the rail. SP deploy needs full init args via `dfx deploy`; expect a benign Candid `--yes` for the new endpoint + error variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)