### PR TITLE
feat(chains): Inc11 per-chain bad debt circuit

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -28,6 +28,11 @@ type BotStatsResponse = record {
   budget_total_e8s : nat64;
   budget_start_timestamp : nat64;
 };
+type BurnSettlementProofArg = record {
+  log_index : nat64;
+  expected_burner : opt text;
+  tx_hash : text;
+};
 type CandidVault = record {
   collateral_amount : nat64;
   owner : principal;
@@ -37,11 +42,25 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainBadDebtCircuitStatus = record {
+  tripped_at_ns : opt nat64;
+  tripped : bool;
+  bad_debt_e8s : nat;
+  chain_id : nat32;
+  threshold_e8s : opt nat;
+  registered : bool;
+};
+type ChainDebtConfigV1 = record {
+  debt_ceiling_e8s : opt nat;
+  min_vault_debt_e8s : nat;
+};
 type ChainLiquidatableVault = record {
   sized_repay_e8s : nat;
   cr_e4 : nat64;
   collateral_native : nat;
   vault_id : nat64;
+  sp_attempted : bool;
+  chain_collateral_sentinel : principal;
   chain_id : nat32;
   liquidation_threshold_e4 : nat64;
   effective_debt_e8s : nat;
@@ -63,6 +82,30 @@ type ChainLiquidationConfigV1 = record {
   router : text;
   settle_stable_token : text;
   deadline_secs : nat64;
+};
+type ChainReserveReport = record {
+  recorded_supply_e8s : nat;
+  onchain_usdc_balance_native : opt nat;
+  pending_chain_burn_e8s : nat;
+  reserve_backing_e8s : nat;
+  reserve_usdc_native : nat;
+  finalized_block : nat64;
+  bad_debt_e8s : nat;
+  reserve_address : opt text;
+  chain_id : nat32;
+  onchain_usdc_error : opt text;
+  settle_stable_token : opt text;
+};
+type ChainStabilityPoolLiquidationResult = record {
+  collateral_price_e8s : nat64;
+  liquidated_debt_e8s : nat;
+  collateral_received_native : nat;
+  block_index : nat64;
+  claim_id : nat64;
+  custody_address : text;
+  vault_id : nat64;
+  chain_id : nat32;
+  success : bool;
 };
 type ChainSupplyReconciliation = record {
   recorded_supply_e8s : nat;
@@ -239,6 +282,11 @@ type Event = variant {
     chain_id : nat32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_cleared : record {
+    total_bad_debt_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -253,6 +301,12 @@ type Event = variant {
   set_rmr_ceiling_cr : record { value : text };
   set_amm1_canister : record { canister : principal };
   set_recovery_rate_curve : record { markers : text };
+  chain_reserve_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_ckstable_repay_fee : record { rate : text };
   set_treasury_principal : record { "principal" : principal };
   accrue_interest : record { timestamp : nat64 };
@@ -359,6 +413,12 @@ type Event = variant {
     reason : text;
   };
   set_rmr_floor_cr : record { value : text };
+  chain_pending_burn_settled : record {
+    amount_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+    proof : text;
+  };
   set_rmr_ceiling : record { value : text };
   set_collateral_liquidation_bonus : record {
     collateral_type : principal;
@@ -437,6 +497,11 @@ type Event = variant {
     reject_code : int32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_threshold_set : record {
+    chain_id : nat32;
+    threshold_e8s : opt nat;
+    timestamp : nat64;
+  };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
@@ -455,6 +520,13 @@ type Event = variant {
     vault_id : nat64;
     timestamp : opt nat64;
     amount : nat64;
+  };
+  chain_bad_debt_circuit_tripped : record {
+    total_bad_debt_e8s : nat;
+    bad_debt_e8s : nat;
+    chain_id : nat32;
+    threshold_e8s : nat;
+    timestamp : nat64;
   };
   set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
@@ -738,6 +810,13 @@ type LiquidityStatus = record {
 type ManualPriceInfo = record { set_at_ns : nat64; price_e8 : nat64 };
 type Mode = variant { ReadOnly; GeneralAvailability; Recovery };
 type OpenVaultSuccess = record { block_index : nat64; vault_id : nat64 };
+type PendingChainBurnAging = record {
+  pending_chain_burn_e8s : nat;
+  proof_count : nat64;
+  age_ns : opt nat64;
+  chain_id : nat32;
+  oldest_reference_ns : opt nat64;
+};
 type PendingLiquidationV1 = record {
   started_at_ns : nat64;
   op_id : nat64;
@@ -896,31 +975,44 @@ type ReserveRedemptionResult = record {
   fee_amount : nat64;
   stable_amount_sent : nat64;
 };
+type ReserveSettlementProofArg = record {
+  expected_burner : opt text;
+  burn_tx_hash : text;
+  burn_log_index : nat64;
+  reserve_tx_hash : text;
+  reserve_transfer_log_index : nat64;
+};
 type Result = variant { Ok; Err : ProtocolError };
 type Result_1 = variant { Ok : nat64; Err : ProtocolError };
-type Result_10 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
-type Result_11 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
-type Result_12 = variant {
+type Result_10 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_11 = variant { Ok : OpenVaultSuccess; Err : ProtocolError };
+type Result_12 = variant { Ok : XrpVaultOpenInfo; Err : ProtocolError };
+type Result_13 = variant {
   Ok : ChainSupplyReconciliation;
   Err : ProtocolError;
 };
-type Result_13 = variant { Ok : bool; Err : ProtocolError };
-type Result_14 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
-type Result_15 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
-type Result_16 = variant { Ok : blob; Err : ProtocolError };
-type Result_17 = variant {
+type Result_14 = variant { Ok : bool; Err : ProtocolError };
+type Result_15 = variant { Ok : ReserveRedemptionResult; Err : ProtocolError };
+type Result_16 = variant { Ok : RepayAndCloseSuccess; Err : ProtocolError };
+type Result_17 = variant { Ok : blob; Err : ProtocolError };
+type Result_18 = variant {
   Ok : StabilityPoolLiquidationResult;
   Err : ProtocolError;
 };
-type Result_18 = variant { Ok : nat32; Err : ProtocolError };
+type Result_19 = variant {
+  Ok : ChainStabilityPoolLiquidationResult;
+  Err : ProtocolError;
+};
 type Result_2 = variant { Ok : text; Err : ProtocolError };
+type Result_20 = variant { Ok : nat32; Err : ProtocolError };
 type Result_3 = variant { Ok : SuccessWithFee; Err : ProtocolError };
 type Result_4 = variant { Ok : BotLiquidationResult; Err : ProtocolError };
 type Result_5 = variant { Ok : opt nat64; Err : ProtocolError };
-type Result_6 = variant { Ok : nat8; Err : ProtocolError };
-type Result_7 = variant { Ok : float64; Err : ProtocolError };
-type Result_8 = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_9 = variant { Ok : ChainVaultV1; Err : ProtocolError };
+type Result_6 = variant { Ok : ChainReserveReport; Err : ProtocolError };
+type Result_7 = variant { Ok : nat8; Err : ProtocolError };
+type Result_8 = variant { Ok : float64; Err : ProtocolError };
+type Result_9 = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type SettlementProofIds = record { pending : vec text; reserve : vec text };
 type SpProofLedger = variant { IcusdBurn; ThreePoolTransfer };
 type SpWritedownProof = record {
   block_index : nat64;
@@ -1055,9 +1147,9 @@ type XrpPendingDeposit = record {
 };
 type XrpSettlement = record {
   destination : opt text;
+  source_sequence : opt nat32;
   destination_tag : opt nat32;
   last_ledger_sequence : nat32;
-  source_sequence : opt nat32;
   tx_hash : text;
 };
 type XrpVaultOpenInfo = record { custody_address : text; vault_id : nat64 };
@@ -1077,7 +1169,9 @@ service : (ProtocolArg) -> {
   bot_confirm_liquidation : (nat64) -> (Result);
   cancel_xrp_pending_open : (nat64) -> (Result);
   chain_has_active_settlement_op : (nat32) -> (bool) query;
+  claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
+  clear_chain_bad_debt_circuit : (nat32) -> (Result);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
   clear_reorg_halt : (nat32) -> (Result);
@@ -1101,12 +1195,17 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_bad_debt_circuit_status : (nat32) -> (
+      ChainBadDebtCircuitStatus,
+    ) query;
+  get_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
   get_chain_liquidation_config : (nat32) -> (
       opt ChainLiquidationConfigV1,
     ) query;
   get_chain_reserve_address : (nat32) -> (Result_2);
+  get_chain_reserves : (nat32) -> (Result_6);
   get_chain_settlement_address : (nat32) -> (Result_2);
   get_chain_vault : (nat64) -> (opt ChainVaultV1) query;
   get_chains_ecdsa_key_name : () -> (text) query;
@@ -1117,6 +1216,7 @@ service : (ProtocolArg) -> {
       vec record { SpProofLedger; nat64 },
     ) query;
   get_deposit_account : (opt principal) -> (Account) query;
+  get_effective_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_event_count : () -> (nat64) query;
   get_event_timestamps : (nat64, nat64) -> (vec nat64) query;
   get_events : (GetEventsArg) -> (vec Event) query;
@@ -1151,6 +1251,7 @@ service : (ProtocolArg) -> {
       vec record { nat64; XrpPendingDeposit },
     ) query;
   get_pending_amm1_donations_count : () -> (nat64) query;
+  get_pending_chain_burn_aging : () -> (vec PendingChainBurnAging) query;
   get_price_pusher_allowed : () -> (vec record { nat32; text }) query;
   get_price_pusher_principal : () -> (opt principal) query;
   get_protocol_3usd_reserves : () -> (nat64) query;
@@ -1162,7 +1263,7 @@ service : (ProtocolArg) -> {
   get_redemption_fee_ceiling : () -> (float64) query;
   get_redemption_fee_floor : () -> (float64) query;
   get_redemption_rate : () -> (float64) query;
-  get_redemption_tier : (principal) -> (Result_6) query;
+  get_redemption_tier : (principal) -> (Result_7) query;
   get_reserve_balances : () -> (vec ReserveBalance) query;
   get_reserve_redemption_fee : () -> (float64) query;
   get_reserve_redemptions_enabled : () -> (bool) query;
@@ -1170,6 +1271,7 @@ service : (ProtocolArg) -> {
   get_rmr_ceiling_cr : () -> (float64) query;
   get_rmr_floor : () -> (float64) query;
   get_rmr_floor_cr : () -> (float64) query;
+  get_settlement_proof_ids : (opt nat32) -> (SettlementProofIds) query;
   get_snapshot_count : () -> (nat64) query;
   get_sp_writedown_disabled : () -> (bool) query;
   get_stability_pool_config : () -> (StabilityPoolConfig) query;
@@ -1187,7 +1289,7 @@ service : (ProtocolArg) -> {
   get_vault_history_paged : (nat64, nat64, nat64) -> (
       GetEventsFilteredResponse,
     ) query;
-  get_vault_interest_rate : (nat64) -> (Result_7) query;
+  get_vault_interest_rate : (nat64) -> (Result_8) query;
   get_vaults : (opt principal) -> (vec CandidVault) query;
   get_vaults_page : (nat64, nat64) -> (VaultsPageResponse) query;
   get_xrp_claims : () -> (vec record { nat64; XrpClaim }) query;
@@ -1198,7 +1300,7 @@ service : (ProtocolArg) -> {
   harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
-  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_8);
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_9);
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse) query;
   liquidate_chain_vault : (nat64) -> (Result_1);
   liquidate_vault : (nat64) -> (Result_3);
@@ -1207,23 +1309,23 @@ service : (ProtocolArg) -> {
   list_chain_vaults : (nat32) -> (vec ChainVaultV1) query;
   open_chain_vault : (nat32, nat, nat, text) -> (Result_1);
   open_chain_vault_evm : (VaultIntent, blob) -> (Result_1);
-  open_solana_vault : (nat, nat, text) -> (Result_9);
-  open_vault : (nat64, opt principal) -> (Result_10);
-  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_10);
-  open_vault_with_deposit : (nat64, opt principal) -> (Result_10);
-  open_xrp_vault : () -> (Result_11);
+  open_solana_vault : (nat, nat, text) -> (Result_10);
+  open_vault : (nat64, opt principal) -> (Result_11);
+  open_vault_and_borrow : (nat64, nat64, opt principal) -> (Result_11);
+  open_vault_with_deposit : (nat64, opt principal) -> (Result_11);
+  open_xrp_vault : () -> (Result_12);
   partial_liquidate_vault : (VaultArg) -> (Result_3);
   partial_repay_to_vault : (VaultArg) -> (Result_1);
   provide_liquidity : (nat64) -> (Result_1);
-  reconcile_chain_supply : (nat32) -> (Result_12);
-  recover_pending_transfer : (nat64) -> (Result_13);
+  reconcile_chain_supply : (nat32) -> (Result_13);
+  recover_pending_transfer : (nat64) -> (Result_14);
   recover_stuck_chain_vault : (nat32, nat64) -> (Result);
   redeem_collateral : (principal, nat64) -> (Result_3);
   redeem_icp : (nat64) -> (Result_3);
-  redeem_reserves : (nat64, opt principal) -> (Result_14);
+  redeem_reserves : (nat64, opt principal) -> (Result_15);
   register_chain : (RegisterChainArg) -> (Result);
   register_xrp_collateral : () -> (Result);
-  repay_and_close_vault : (VaultArg) -> (Result_15);
+  repay_and_close_vault : (VaultArg) -> (Result_16);
   repay_to_vault : (VaultArg) -> (Result_1);
   repay_to_vault_with_stable : (VaultArgWithToken) -> (Result_1);
   reset_bot_budget : (nat64) -> (Result);
@@ -1237,8 +1339,10 @@ service : (ProtocolArg) -> {
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
+  set_chain_bad_debt_circuit_threshold : (nat32, opt nat) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
+  set_chain_debt_config : (nat32, ChainDebtConfigV1) -> (Result);
   set_chain_interest_min_realize_e8s : (nat) -> (Result);
   set_chain_interest_tick_interval_secs : (nat64) -> (Result);
   set_chain_liquidation_config : (nat32, ChainLiquidationConfigV1) -> (Result);
@@ -1312,22 +1416,33 @@ service : (ProtocolArg) -> {
   set_vault_check_tick_interval_secs : (nat64) -> (Result);
   set_xrc_fetch_interval_secs : (nat64) -> (Result);
   set_xrp_schnorr_key_name : (text) -> (Result);
+  settle_pending_chain_burn : (nat32, nat, text) -> (Result);
+  settle_pending_chain_burn_with_proof : (nat32, BurnSettlementProofArg) -> (
+      Result,
+    );
+  settle_reserve_burn : (nat32, nat, text) -> (Result);
+  settle_reserve_burn_with_proof : (nat32, ReserveSettlementProofArg) -> (
+      Result,
+    );
   settle_xrp_claim : (nat64, text) -> (Result_2);
   settle_xrp_claim_with_tag : (nat64, text, nat32) -> (Result_2);
   solana_bootstrap_nonce : (opt text) -> (Result);
   solana_get_balance : (text) -> (Result_1);
   solana_get_mint_supply : () -> (Result_1);
   solana_settlement_address : () -> (Result_2);
-  solana_sign_test_transfer : (text, nat64) -> (Result_16);
-  stability_pool_liquidate : (nat64, nat64) -> (Result_17);
+  solana_sign_test_transfer : (text, nat64) -> (Result_17);
+  stability_pool_liquidate : (nat64, nat64) -> (Result_18);
+  stability_pool_liquidate_chain_vault : (nat64, nat64, SpWritedownProof) -> (
+      Result_19,
+    );
   stability_pool_liquidate_debt_burned : (nat64, nat64, SpWritedownProof) -> (
-      Result_17,
+      Result_18,
     );
   stability_pool_liquidate_with_reserves : (nat64, nat64, nat64, principal) -> (
-      Result_17,
+      Result_18,
     );
   stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
-  submit_burn_proof : (nat32, text) -> (Result_18);
+  submit_burn_proof : (nat32, text) -> (Result_20);
   sweep_xrp_pending_open : (nat64) -> (Result);
   unfreeze_protocol : () -> (Result);
   update_collateral_config : (principal, CollateralConfig) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -35,6 +35,11 @@ export interface BotStatsResponse {
   'budget_total_e8s' : bigint,
   'budget_start_timestamp' : bigint,
 }
+export interface BurnSettlementProofArg {
+  'log_index' : bigint,
+  'expected_burner' : [] | [string],
+  'tx_hash' : string,
+}
 export interface CandidVault {
   'collateral_amount' : bigint,
   'owner' : Principal,
@@ -43,6 +48,14 @@ export interface CandidVault {
   'accrued_interest' : bigint,
   'icp_margin_amount' : bigint,
   'borrowed_icusd_amount' : bigint,
+}
+export interface ChainBadDebtCircuitStatus {
+  'tripped_at_ns' : [] | [bigint],
+  'tripped' : boolean,
+  'bad_debt_e8s' : bigint,
+  'chain_id' : number,
+  'threshold_e8s' : [] | [bigint],
+  'registered' : boolean,
 }
 export interface ChainDebtConfigV1 {
   'debt_ceiling_e8s' : [] | [bigint],
@@ -291,6 +304,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'usdc_native' : bigint,
       'backing_added_e8s' : bigint,
       'vault_id' : bigint,
+      'chain_id' : number,
+      'timestamp' : bigint,
+    }
+  } |
+  {
+    'chain_bad_debt_circuit_cleared' : {
+      'total_bad_debt_e8s' : bigint,
       'chain_id' : number,
       'timestamp' : bigint,
     }
@@ -579,6 +599,13 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
     }
   } |
   {
+    'chain_bad_debt_circuit_threshold_set' : {
+      'chain_id' : number,
+      'threshold_e8s' : [] | [bigint],
+      'timestamp' : bigint,
+    }
+  } |
+  {
     'set_rate_curve_markers' : {
       'markers' : string,
       'collateral_type' : [] | [string],
@@ -603,6 +630,15 @@ export type Event = { 'set_borrowing_fee' : { 'rate' : string } } |
       'vault_id' : bigint,
       'timestamp' : [] | [bigint],
       'amount' : bigint,
+    }
+  } |
+  {
+    'chain_bad_debt_circuit_tripped' : {
+      'total_bad_debt_e8s' : bigint,
+      'bad_debt_e8s' : bigint,
+      'chain_id' : number,
+      'threshold_e8s' : bigint,
+      'timestamp' : bigint,
     }
   } |
   { 'set_breaker_window_ns' : { 'window_ns' : bigint, 'timestamp' : bigint } } |
@@ -952,6 +988,13 @@ export interface OpenVaultSuccess {
   'block_index' : bigint,
   'vault_id' : bigint,
 }
+export interface PendingChainBurnAging {
+  'pending_chain_burn_e8s' : bigint,
+  'proof_count' : bigint,
+  'age_ns' : [] | [bigint],
+  'chain_id' : number,
+  'oldest_reference_ns' : [] | [bigint],
+}
 export interface PendingLiquidationV1 {
   'started_at_ns' : bigint,
   'op_id' : bigint,
@@ -1114,6 +1157,13 @@ export interface ReserveRedemptionResult {
   'fee_amount' : bigint,
   'stable_amount_sent' : bigint,
 }
+export interface ReserveSettlementProofArg {
+  'expected_burner' : [] | [string],
+  'burn_tx_hash' : string,
+  'burn_log_index' : bigint,
+  'reserve_tx_hash' : string,
+  'reserve_transfer_log_index' : bigint,
+}
 export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
@@ -1156,6 +1206,10 @@ export type Result_8 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_9 = { 'Ok' : ConsentInfo } |
   { 'Err' : Icrc21Error };
+export interface SettlementProofIds {
+  'pending' : Array<string>,
+  'reserve' : Array<string>,
+}
 export type SpProofLedger = { 'IcusdBurn' : null } |
   { 'ThreePoolTransfer' : null };
 export interface SpWritedownProof {
@@ -1341,6 +1395,7 @@ export interface _SERVICE {
     Result_1
   >,
   'claim_liquidity_returns' : ActorMethod<[], Result_1>,
+  'clear_chain_bad_debt_circuit' : ActorMethod<[number], Result>,
   'clear_invariant_halt' : ActorMethod<[], Result>,
   'clear_liquidation_breaker' : ActorMethod<[], Result>,
   'clear_reorg_halt' : ActorMethod<[number], Result>,
@@ -1367,6 +1422,10 @@ export interface _SERVICE {
   'get_bot_claim_vault_ids' : ActorMethod<[], BigUint64Array | bigint[]>,
   'get_bot_cr_tolerance_bps' : ActorMethod<[], bigint>,
   'get_bot_stats' : ActorMethod<[], BotStatsResponse>,
+  'get_chain_bad_debt_circuit_status' : ActorMethod<
+    [number],
+    ChainBadDebtCircuitStatus
+  >,
   'get_chain_debt_config' : ActorMethod<[number], [] | [ChainDebtConfigV1]>,
   'get_chain_interest_treasury_address' : ActorMethod<[number], Result_2>,
   'get_chain_liquidatable_vaults' : ActorMethod<
@@ -1443,6 +1502,10 @@ export interface _SERVICE {
     Array<[bigint, XrpPendingDeposit]>
   >,
   'get_pending_amm1_donations_count' : ActorMethod<[], bigint>,
+  'get_pending_chain_burn_aging' : ActorMethod<
+    [],
+    Array<PendingChainBurnAging>
+  >,
   'get_price_pusher_allowed' : ActorMethod<[], Array<[number, string]>>,
   'get_price_pusher_principal' : ActorMethod<[], [] | [Principal]>,
   'get_protocol_3usd_reserves' : ActorMethod<[], bigint>,
@@ -1465,6 +1528,7 @@ export interface _SERVICE {
   'get_rmr_ceiling_cr' : ActorMethod<[], number>,
   'get_rmr_floor' : ActorMethod<[], number>,
   'get_rmr_floor_cr' : ActorMethod<[], number>,
+  'get_settlement_proof_ids' : ActorMethod<[[] | [number]], SettlementProofIds>,
   'get_snapshot_count' : ActorMethod<[], bigint>,
   'get_sp_writedown_disabled' : ActorMethod<[], boolean>,
   'get_stability_pool_config' : ActorMethod<[], StabilityPoolConfig>,
@@ -1550,6 +1614,10 @@ export interface _SERVICE {
   'set_breaker_window_debt_ceiling_e8s' : ActorMethod<[bigint], Result>,
   'set_breaker_window_ns' : ActorMethod<[bigint], Result>,
   'set_burn_watch_poll_enabled' : ActorMethod<[number, boolean], Result>,
+  'set_chain_bad_debt_circuit_threshold' : ActorMethod<
+    [number, [] | [bigint]],
+    Result
+  >,
   'set_chain_config' : ActorMethod<[number, UpdateChainConfigArg], Result>,
   'set_chain_contract' : ActorMethod<[number, string], Result>,
   'set_chain_debt_config' : ActorMethod<[number, ChainDebtConfigV1], Result>,
@@ -1650,7 +1718,15 @@ export interface _SERVICE {
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrp_schnorr_key_name' : ActorMethod<[string], Result>,
   'settle_pending_chain_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_pending_chain_burn_with_proof' : ActorMethod<
+    [number, BurnSettlementProofArg],
+    Result
+  >,
   'settle_reserve_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_reserve_burn_with_proof' : ActorMethod<
+    [number, ReserveSettlementProofArg],
+    Result
+  >,
   'settle_xrp_claim' : ActorMethod<[bigint, string], Result_2>,
   'settle_xrp_claim_with_tag' : ActorMethod<[bigint, string, number], Result_2>,
   'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -173,6 +173,14 @@ export const idlFactory = ({ IDL }) => {
     'budget_total_e8s' : IDL.Nat64,
     'budget_start_timestamp' : IDL.Nat64,
   });
+  const ChainBadDebtCircuitStatus = IDL.Record({
+    'tripped_at_ns' : IDL.Opt(IDL.Nat64),
+    'tripped' : IDL.Bool,
+    'bad_debt_e8s' : IDL.Nat,
+    'chain_id' : IDL.Nat32,
+    'threshold_e8s' : IDL.Opt(IDL.Nat),
+    'registered' : IDL.Bool,
+  });
   const ChainDebtConfigV1 = IDL.Record({
     'debt_ceiling_e8s' : IDL.Opt(IDL.Nat),
     'min_vault_debt_e8s' : IDL.Nat,
@@ -444,6 +452,11 @@ export const idlFactory = ({ IDL }) => {
       'chain_id' : IDL.Nat32,
       'timestamp' : IDL.Nat64,
     }),
+    'chain_bad_debt_circuit_cleared' : IDL.Record({
+      'total_bad_debt_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'timestamp' : IDL.Nat64,
+    }),
     'provide_liquidity' : IDL.Record({
       'block_index' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
@@ -660,6 +673,11 @@ export const idlFactory = ({ IDL }) => {
       'reject_code' : IDL.Int32,
       'timestamp' : IDL.Nat64,
     }),
+    'chain_bad_debt_circuit_threshold_set' : IDL.Record({
+      'chain_id' : IDL.Nat32,
+      'threshold_e8s' : IDL.Opt(IDL.Nat),
+      'timestamp' : IDL.Nat64,
+    }),
     'set_rate_curve_markers' : IDL.Record({
       'markers' : IDL.Text,
       'collateral_type' : IDL.Opt(IDL.Text),
@@ -678,6 +696,13 @@ export const idlFactory = ({ IDL }) => {
       'vault_id' : IDL.Nat64,
       'timestamp' : IDL.Opt(IDL.Nat64),
       'amount' : IDL.Nat64,
+    }),
+    'chain_bad_debt_circuit_tripped' : IDL.Record({
+      'total_bad_debt_e8s' : IDL.Nat,
+      'bad_debt_e8s' : IDL.Nat,
+      'chain_id' : IDL.Nat32,
+      'threshold_e8s' : IDL.Nat,
+      'timestamp' : IDL.Nat64,
     }),
     'set_breaker_window_ns' : IDL.Record({
       'window_ns' : IDL.Nat64,
@@ -935,6 +960,13 @@ export const idlFactory = ({ IDL }) => {
     'opened_at_ns' : IDL.Nat64,
     'derivation_nonce' : IDL.Nat64,
   });
+  const PendingChainBurnAging = IDL.Record({
+    'pending_chain_burn_e8s' : IDL.Nat,
+    'proof_count' : IDL.Nat64,
+    'age_ns' : IDL.Opt(IDL.Nat64),
+    'chain_id' : IDL.Nat32,
+    'oldest_reference_ns' : IDL.Opt(IDL.Nat64),
+  });
   const ProtocolConfig = IDL.Record({
     'global_rate_curve' : IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64)),
     'bot_budget_remaining_e8s' : IDL.Nat64,
@@ -1045,6 +1077,10 @@ export const idlFactory = ({ IDL }) => {
     'balance' : IDL.Nat64,
     'ledger' : IDL.Principal,
     'symbol' : IDL.Text,
+  });
+  const SettlementProofIds = IDL.Record({
+    'pending' : IDL.Vec(IDL.Text),
+    'reserve' : IDL.Vec(IDL.Text),
   });
   const StabilityPoolConfig = IDL.Record({
     'enabled' : IDL.Bool,
@@ -1208,6 +1244,18 @@ export const idlFactory = ({ IDL }) => {
     'display_name' : IDL.Opt(IDL.Text),
     'min_quorum_providers' : IDL.Opt(IDL.Opt(IDL.Nat32)),
   });
+  const BurnSettlementProofArg = IDL.Record({
+    'log_index' : IDL.Nat64,
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'tx_hash' : IDL.Text,
+  });
+  const ReserveSettlementProofArg = IDL.Record({
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'burn_tx_hash' : IDL.Text,
+    'burn_log_index' : IDL.Nat64,
+    'reserve_tx_hash' : IDL.Text,
+    'reserve_transfer_log_index' : IDL.Nat64,
+  });
   const Result_17 = IDL.Variant({
     'Ok' : IDL.Vec(IDL.Nat8),
     'Err' : ProtocolError,
@@ -1289,6 +1337,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'claim_liquidity_returns' : IDL.Func([], [Result_1], []),
+    'clear_chain_bad_debt_circuit' : IDL.Func([IDL.Nat32], [Result], []),
     'clear_invariant_halt' : IDL.Func([], [Result], []),
     'clear_liquidation_breaker' : IDL.Func([], [Result], []),
     'clear_reorg_halt' : IDL.Func([IDL.Nat32], [Result], []),
@@ -1328,6 +1377,11 @@ export const idlFactory = ({ IDL }) => {
     'get_bot_claim_vault_ids' : IDL.Func([], [IDL.Vec(IDL.Nat64)], ['query']),
     'get_bot_cr_tolerance_bps' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_bot_stats' : IDL.Func([], [BotStatsResponse], ['query']),
+    'get_chain_bad_debt_circuit_status' : IDL.Func(
+        [IDL.Nat32],
+        [ChainBadDebtCircuitStatus],
+        ['query'],
+      ),
     'get_chain_debt_config' : IDL.Func(
         [IDL.Nat32],
         [IDL.Opt(ChainDebtConfigV1)],
@@ -1459,6 +1513,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_pending_amm1_donations_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_pending_chain_burn_aging' : IDL.Func(
+        [],
+        [IDL.Vec(PendingChainBurnAging)],
+        ['query'],
+      ),
     'get_price_pusher_allowed' : IDL.Func(
         [],
         [IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Text))],
@@ -1490,6 +1549,11 @@ export const idlFactory = ({ IDL }) => {
     'get_rmr_ceiling_cr' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor_cr' : IDL.Func([], [IDL.Float64], ['query']),
+    'get_settlement_proof_ids' : IDL.Func(
+        [IDL.Opt(IDL.Nat32)],
+        [SettlementProofIds],
+        ['query'],
+      ),
     'get_snapshot_count' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_sp_writedown_disabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_stability_pool_config' : IDL.Func(
@@ -1664,6 +1728,11 @@ export const idlFactory = ({ IDL }) => {
     'set_breaker_window_ns' : IDL.Func([IDL.Nat64], [Result], []),
     'set_burn_watch_poll_enabled' : IDL.Func(
         [IDL.Nat32, IDL.Bool],
+        [Result],
+        [],
+      ),
+    'set_chain_bad_debt_circuit_threshold' : IDL.Func(
+        [IDL.Nat32, IDL.Opt(IDL.Nat)],
         [Result],
         [],
       ),
@@ -1856,8 +1925,18 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'settle_pending_chain_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, BurnSettlementProofArg],
+        [Result],
+        [],
+      ),
     'settle_reserve_burn' : IDL.Func(
         [IDL.Nat32, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'settle_reserve_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, ReserveSettlementProofArg],
         [Result],
         [],
       ),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -42,6 +42,14 @@ type CandidVault = record {
   icp_margin_amount : nat64;
   borrowed_icusd_amount : nat64;
 };
+type ChainBadDebtCircuitStatus = record {
+  tripped_at_ns : opt nat64;
+  tripped : bool;
+  bad_debt_e8s : nat;
+  chain_id : nat32;
+  threshold_e8s : opt nat;
+  registered : bool;
+};
 type ChainDebtConfigV1 = record {
   debt_ceiling_e8s : opt nat;
   min_vault_debt_e8s : nat;
@@ -274,6 +282,11 @@ type Event = variant {
     chain_id : nat32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_cleared : record {
+    total_bad_debt_e8s : nat;
+    chain_id : nat32;
+    timestamp : nat64;
+  };
   provide_liquidity : record {
     block_index : nat64;
     timestamp : opt nat64;
@@ -484,6 +497,11 @@ type Event = variant {
     reject_code : int32;
     timestamp : nat64;
   };
+  chain_bad_debt_circuit_threshold_set : record {
+    chain_id : nat32;
+    threshold_e8s : opt nat;
+    timestamp : nat64;
+  };
   set_rate_curve_markers : record {
     markers : text;
     collateral_type : opt text;
@@ -502,6 +520,13 @@ type Event = variant {
     vault_id : nat64;
     timestamp : opt nat64;
     amount : nat64;
+  };
+  chain_bad_debt_circuit_tripped : record {
+    total_bad_debt_e8s : nat;
+    bad_debt_e8s : nat;
+    chain_id : nat32;
+    threshold_e8s : nat;
+    timestamp : nat64;
   };
   set_breaker_window_ns : record { window_ns : nat64; timestamp : nat64 };
   partial_liquidate_vault : record {
@@ -1146,6 +1171,7 @@ service : (ProtocolArg) -> {
   chain_has_active_settlement_op : (nat32) -> (bool) query;
   claim_chain_collateral : (nat64, principal, nat, text) -> (Result_1);
   claim_liquidity_returns : () -> (Result_1);
+  clear_chain_bad_debt_circuit : (nat32) -> (Result);
   clear_invariant_halt : () -> (Result);
   clear_liquidation_breaker : () -> (Result);
   clear_reorg_halt : (nat32) -> (Result);
@@ -1169,6 +1195,9 @@ service : (ProtocolArg) -> {
   get_bot_claim_vault_ids : () -> (vec nat64) query;
   get_bot_cr_tolerance_bps : () -> (nat64) query;
   get_bot_stats : () -> (BotStatsResponse) query;
+  get_chain_bad_debt_circuit_status : (nat32) -> (
+      ChainBadDebtCircuitStatus,
+    ) query;
   get_chain_debt_config : (nat32) -> (opt ChainDebtConfigV1) query;
   get_chain_interest_treasury_address : (nat32) -> (Result_2);
   get_chain_liquidatable_vaults : (nat32) -> (vec ChainLiquidatableVault) query;
@@ -1310,6 +1339,7 @@ service : (ProtocolArg) -> {
   set_breaker_window_debt_ceiling_e8s : (nat64) -> (Result);
   set_breaker_window_ns : (nat64) -> (Result);
   set_burn_watch_poll_enabled : (nat32, bool) -> (Result);
+  set_chain_bad_debt_circuit_threshold : (nat32, opt nat) -> (Result);
   set_chain_config : (nat32, UpdateChainConfigArg) -> (Result);
   set_chain_contract : (nat32, text) -> (Result);
   set_chain_debt_config : (nat32, ChainDebtConfigV1) -> (Result);

--- a/src/rumi_protocol_backend/src/chains/admin.rs
+++ b/src/rumi_protocol_backend/src/chains/admin.rs
@@ -16,7 +16,10 @@ use super::settlement_queue::SettlementQueueV1;
 /// (which reads at the `finalized` commitment) legitimately uses 0, so the floor
 /// applies only to EVM gas strategies.
 fn is_evm(gas: &GasStrategy) -> bool {
-    matches!(gas, GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. })
+    matches!(
+        gas,
+        GasStrategy::EvmEip1559 { .. } | GasStrategy::EvmLegacy { .. }
+    )
 }
 
 /// Audit M-04 (QUORUM-1): de-duplicate `rpc_endpoints` by URL, preserving the
@@ -98,7 +101,9 @@ pub fn register_chain_in_state(
     };
     state.chain_configs.insert(arg.chain_id, cfg.clone());
     state.chain_supplies.insert(arg.chain_id, 0);
-    state.settlement_queues.insert(arg.chain_id, SettlementQueueV1::default());
+    state
+        .settlement_queues
+        .insert(arg.chain_id, SettlementQueueV1::default());
     Ok(cfg)
 }
 
@@ -134,7 +139,11 @@ pub fn delete_chain_in_state(
             chain_id.0, supply
         )));
     }
-    if state.chain_vaults.values().any(|v| v.collateral_chain == chain_id) {
+    if state
+        .chain_vaults
+        .values()
+        .any(|v| v.collateral_chain == chain_id)
+    {
         return Err(ChainAdminError::InvalidConfig(format!(
             "chain {} still has vaults",
             chain_id.0
@@ -149,10 +158,15 @@ pub fn delete_chain_in_state(
     state.hot_wallet_balance_e18.remove(&chain_id);
     state.reorg_halted.remove(&chain_id);
     state.reorg_suspect_streak.remove(&chain_id); // Task-11 reorg-debounce streak
+    state.chain_bad_debt_e8s.remove(&chain_id);
+    state.chain_bad_debt_circuit_threshold_e8s.remove(&chain_id);
+    state.chain_bad_debt_circuit_tripped_at_ns.remove(&chain_id);
     // manual_prices + its paired freshness map are keyed by (ChainId, String) —
     // drop ALL entries for this chain from BOTH, or the timestamp map leaks.
     state.manual_prices.retain(|(c, _), _| *c != chain_id);
-    state.manual_price_set_at_ns.retain(|(c, _), _| *c != chain_id);
+    state
+        .manual_price_set_at_ns
+        .retain(|(c, _), _| *c != chain_id);
     Ok(())
 }
 

--- a/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/deposit_watch.rs
@@ -758,13 +758,8 @@ pub async fn run_observer(chain: ChainId) {
         let recorded_supply = read_state(|s| {
             s.multi_chain.chain_supplies.get(&chain).copied().unwrap_or(0)
         });
-        let has_inflight_mint = read_state(|s| {
-            s.multi_chain
-                .settlement_queues
-                .get(&chain)
-                .map(|q| q.has_active_mint_op())
-                .unwrap_or(false)
-        });
+        let has_inflight_mint =
+            read_state(|s| s.multi_chain.has_supply_increasing_settlement_op(chain));
         // Run the catch-up sweep ONLY on a proven divergence: no mint in flight
         // AND a readable totalSupply that has DROPPED below `recorded` (an
         // unsubmitted burn). Mint-in-flight, probe errors, and a mint EXCESS

--- a/src/rumi_protocol_backend/src/chains/evm/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/settlement.rs
@@ -40,7 +40,9 @@ use ic_canister_log::log;
 use crate::chains::config::{ChainId, ChainStatus};
 use crate::chains::monad::chain_vault::ChainVaultStatus;
 use crate::chains::multi_chain_state::MultiChainState;
-use crate::chains::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
+use crate::chains::settlement_queue::{
+    SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
+};
 use crate::chains::supply::{apply_supply_delta, SupplyDelta};
 use crate::logs::INFO;
 use crate::state::{mutate_state, read_state};
@@ -224,19 +226,35 @@ async fn recredit_and_fail_chain_collateral_payout(
     }
 }
 
-/// Pick the next op to act on. Enforces one-in-flight-per-queue: if ANY op is
-/// `Inflight`, only that op (action `Confirm`) is actionable; otherwise the
-/// lowest-op_id `Queued` op (action `Submit`). `pending` is a
-/// `BTreeMap<u64, SettlementOp>`, so iteration is op_id-ascending and the
-/// drain is FIFO. Returns `None` when nothing is actionable.
+/// Pick the next op to act on without additional submit-time filters. Enforces
+/// one-in-flight-per-queue: if ANY op is `Inflight`, only that op (action
+/// `Confirm`) is actionable; otherwise the lowest-op_id `Queued` op (action
+/// `Submit`) is returned.
 pub fn select_next_op(q: &SettlementQueueV1) -> Option<(u64, OpAction)> {
+    select_next_op_with_submit_filter(q, |_, _| false)
+}
+
+/// Pick the next op to act on, treating queued ops for which
+/// `submit_blocked(id, op)` is true as temporarily non-actionable. Inflight ops
+/// are never skipped: one-in-flight-per-queue remains the first rule.
+///
+/// `pending` is a `BTreeMap<u64, SettlementOp>`, so iteration is op_id-ascending
+/// and the drain stays FIFO among actionable queued ops. Returns `None` when
+/// nothing is actionable.
+pub fn select_next_op_with_submit_filter<F>(
+    q: &SettlementQueueV1,
+    mut submit_blocked: F,
+) -> Option<(u64, OpAction)>
+where
+    F: FnMut(u64, &SettlementOp) -> bool,
+{
     for (&id, op) in q.pending.iter() {
         if matches!(op.status, SettlementOpStatus::Inflight { .. }) {
             return Some((id, OpAction::Confirm));
         }
     }
     for (&id, op) in q.pending.iter() {
-        if matches!(op.status, SettlementOpStatus::Queued) {
+        if matches!(op.status, SettlementOpStatus::Queued) && !submit_blocked(id, op) {
             // Increment 3: LiquidationSwap ops are now actionable (submit_op routes
             // them through the dedicated swap path). The Inc-2 skip is removed.
             return Some((id, OpAction::Submit));
@@ -386,6 +404,7 @@ pub fn apply_liquidation_settlement_in_state(
     op_id: u64,
     realized_usdc_native: u128,
     settle_decimals: u8,
+    now_ns: u64,
 ) -> Result<LiquidationSettlement, String> {
     use crate::chains::monad::chain_vault::ChainVaultStatus;
 
@@ -431,9 +450,9 @@ pub fn apply_liquidation_settlement_in_state(
     .map_err(|e| format!("apply_debt_to_reserve_shift: {e:?}"))?;
 
     // Step 4: record any shortfall as per-chain bad debt (never silent).
-    if debt_to_clear > actual_cleared {
-        *state.chain_bad_debt_e8s.entry(chain).or_default() += debt_to_clear - actual_cleared;
-    }
+    let bad_debt_added_e8s = debt_to_clear.saturating_sub(actual_cleared);
+    let bad_debt_circuit_tripped =
+        state.record_chain_bad_debt_and_maybe_trip(chain, bad_debt_added_e8s, now_ns);
 
     // Step 5: clear the marker + routing record; close the vault if fully drained.
     let v = state
@@ -451,6 +470,8 @@ pub fn apply_liquidation_settlement_in_state(
         collateral_seized_native: collateral_reserved,
         tier,
         realized_usdc_native,
+        bad_debt_added_e8s,
+        bad_debt_circuit_tripped,
     })
 }
 
@@ -462,6 +483,8 @@ pub struct LiquidationSettlement {
     pub collateral_seized_native: u128,
     pub tier: crate::chains::vault::LiquidationTier,
     pub realized_usdc_native: u128,
+    pub bad_debt_added_e8s: u128,
+    pub bad_debt_circuit_tripped: bool,
 }
 
 /// Result of the state-only Tier-2 SP absorb transition. The caller emits
@@ -978,20 +1001,21 @@ pub async fn run_settlement(chain: ChainId) {
         return;
     }
 
-    // Snapshot this chain's queue and pick the next actionable op.
-    let queue = read_state(|s| s.multi_chain.settlement_queues.get(&chain).cloned());
-    let queue = match queue {
-        Some(q) => q,
+    // Snapshot this chain's next actionable op. A tripped bad-debt circuit skips
+    // queued risk-increasing ops at selection time so later burns, liquidation
+    // swaps, and claim payouts can still reconcile.
+    let selected = read_state(|s| {
+        let q = s.multi_chain.settlement_queues.get(&chain)?;
+        let (op_id, action) = select_next_op_with_submit_filter(q, |_, op| {
+            s.multi_chain
+                .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+        })?;
+        let op = q.pending.get(&op_id)?.clone();
+        Some((op_id, action, op))
+    });
+    let (op_id, action, op) = match selected {
+        Some(selected) => selected,
         None => return, // chain not registered / no queue
-    };
-    let (op_id, action) = match select_next_op(&queue) {
-        Some(pair) => pair,
-        None => return, // nothing to do
-    };
-    // Clone the op out so we can drop the queue snapshot before awaiting.
-    let op = match queue.pending.get(&op_id).cloned() {
-        Some(o) => o,
-        None => return,
     };
 
     match action {
@@ -1448,6 +1472,20 @@ async fn submit_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_que
     // — route it to the dedicated path instead of the generic mint/withdrawal one.
     if matches!(op.kind, SettlementOpKind::LiquidationSwap { .. }) {
         submit_liquidation_swap(chain, op_id, op).await;
+        return;
+    }
+
+    if read_state(|s| {
+        s.multi_chain
+            .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+    }) {
+        log!(
+            INFO,
+            "[settlement chain={:?}] bad-debt circuit tripped; deferring submit of op {} {:?}",
+            chain,
+            op_id,
+            op.kind
+        );
         return;
     }
 
@@ -2898,6 +2936,7 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_qu
                     op_id,
                     realized_usdc,
                     settle_decimals,
+                    now,
                 )
             });
             match settled {
@@ -2925,6 +2964,29 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: crate::chains::settlement_qu
                         usdc_native: res.realized_usdc_native,
                         timestamp: now,
                     });
+                    if res.bad_debt_circuit_tripped {
+                        crate::storage::record_event(
+                            &crate::event::Event::ChainBadDebtCircuitTripped {
+                                chain_id: chain,
+                                bad_debt_e8s: res.bad_debt_added_e8s,
+                                total_bad_debt_e8s: read_state(|s| {
+                                    s.multi_chain
+                                        .chain_bad_debt_e8s
+                                        .get(&chain)
+                                        .copied()
+                                        .unwrap_or(0)
+                                }),
+                                threshold_e8s: read_state(|s| {
+                                    s.multi_chain
+                                        .chain_bad_debt_circuit_threshold_e8s
+                                        .get(&chain)
+                                        .copied()
+                                        .unwrap_or(0)
+                                }),
+                                timestamp: now,
+                            },
+                        );
+                    }
                     log!(INFO, "[settlement chain={:?}] liquidation swap confirmed: op={} vault={} cleared_e8s={} realized_usdc={} block={} tx={}", chain, op_id, vault_id, res.actual_cleared, realized_usdc, block_number, tx_hash);
                 }
                 Err(e) => {

--- a/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_settlement.rs
@@ -1,7 +1,7 @@
 use super::settlement::{
     claim_liquidation_swap_submit_in_state, confirm_interest_mint_in_state, confirm_mint_in_state,
     exact_native_transfer_is_funded, fundable_withdrawal_value, select_next_op,
-    ClaimLiquidationSwapSubmitError, OpAction,
+    select_next_op_with_submit_filter, ClaimLiquidationSwapSubmitError, OpAction,
 };
 use crate::chains::config::ChainId;
 use crate::chains::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
@@ -82,6 +82,42 @@ fn select_next_op_confirms_inflight_before_submitting_new() {
     match select_next_op(&q) {
         Some((oid, OpAction::Confirm)) => assert_eq!(oid, id0),
         other => panic!("expected Confirm of inflight op, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_next_op_filter_skips_blocked_queued_without_starving_later_allowed_ops() {
+    let mut q = crate::chains::settlement_queue::SettlementQueueV1::default();
+    let blocked_id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint {
+                recipient: "0xr".into(),
+                amount_e8s: 10,
+                vault_id: 1,
+            },
+            "blocked-mint".into(),
+            0,
+        ))
+        .unwrap();
+    let allowed_id = q
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::ChainCollateralPayout {
+                recipient: "0x0000000000000000000000000000000000000abc".into(),
+                amount_e18: 1,
+                vault_id: 2,
+                claimant: Principal::anonymous(),
+            },
+            "allowed-payout".into(),
+            0,
+        ))
+        .unwrap();
+
+    assert_eq!(blocked_id, 0);
+    match select_next_op_with_submit_filter(&q, |_, op| {
+        matches!(op.kind, SettlementOpKind::Mint { .. })
+    }) {
+        Some((oid, OpAction::Submit)) => assert_eq!(oid, allowed_id),
+        other => panic!("expected later allowed op to submit, got {other:?}"),
     }
 }
 
@@ -440,6 +476,7 @@ mod phase2_tests {
     fn marked(
         s: &mut MultiChainState,
         vault_id: u64,
+        op_id: u64,
         debt_e8s: u128,
         collateral_remaining: u128,
         debt_to_clear: u128,
@@ -462,7 +499,7 @@ mod phase2_tests {
                 last_interest_accrual_ns: 0,
                 pending_interest_mint_e8s: 0,
                 pending_liquidation: Some(PendingLiquidationV1 {
-                    op_id: 9,
+                    op_id,
                     debt_to_clear_e8s: debt_to_clear,
                     collateral_reserved_native: collateral_reserved,
                     tier: LiquidationTier::Bot,
@@ -477,9 +514,10 @@ mod phase2_tests {
     #[test]
     fn shifts_debt_to_reserve_supply_unchanged() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // realized 75 USDC (18-dec) -> 75e8 >= debt_to_clear 67e8.
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18).expect("phase2 ok");
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 75 * E18, 18, 1)
+            .expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 33 * E8, "debt -= actual_cleared");
         assert_eq!(
@@ -511,9 +549,10 @@ mod phase2_tests {
     #[test]
     fn shortfall_clamps_and_records_bad_debt() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // realized only 60 USDC -> 60e8 < debt_to_clear 67e8.
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18).expect("phase2 ok");
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 1)
+            .expect("phase2 ok");
         assert_eq!(s.chain_vaults.get(&7).unwrap().debt_e8s, 40 * E8);
         assert_eq!(
             *s.reserve_backing_e8s.get(&CFX).unwrap(),
@@ -525,6 +564,10 @@ mod phase2_tests {
             7 * E8,
             "shortfall recorded"
         );
+        assert!(
+            !s.chain_bad_debt_circuit_tripped(CFX),
+            "no threshold means accounting-only bad debt does not halt the chain"
+        );
         assert_eq!(
             *s.chain_supplies.get(&CFX).unwrap(),
             100 * E8,
@@ -533,11 +576,59 @@ mod phase2_tests {
     }
 
     #[test]
+    fn shortfall_below_threshold_records_bad_debt_without_tripping_circuit() {
+        let mut s = MultiChainState::default();
+        s.set_chain_bad_debt_circuit_threshold(CFX, Some(10 * E8), 10)
+            .expect("set threshold");
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+
+        let settled = apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 20)
+            .expect("phase2 ok");
+
+        assert_eq!(settled.bad_debt_added_e8s, 7 * E8);
+        assert!(!settled.bad_debt_circuit_tripped);
+        assert_eq!(s.chain_bad_debt_e8s.get(&CFX), Some(&(7 * E8)));
+        assert!(!s.chain_bad_debt_circuit_tripped(CFX));
+        assert_eq!(s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX), None);
+    }
+
+    #[test]
+    fn shortfall_at_threshold_trips_bad_debt_circuit_once() {
+        let mut s = MultiChainState::default();
+        s.set_chain_bad_debt_circuit_threshold(CFX, Some(7 * E8), 10)
+            .expect("set threshold");
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+
+        let first = apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 60 * E18, 18, 20)
+            .expect("phase2 ok");
+
+        assert_eq!(first.bad_debt_added_e8s, 7 * E8);
+        assert!(first.bad_debt_circuit_tripped);
+        assert_eq!(s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX), Some(&20));
+
+        marked(&mut s, 8, 10, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        let second = apply_liquidation_settlement_in_state(&mut s, CFX, 8, 10, 60 * E18, 18, 30)
+            .expect("second phase2 ok");
+
+        assert_eq!(second.bad_debt_added_e8s, 7 * E8);
+        assert!(
+            !second.bad_debt_circuit_tripped,
+            "already-tripped circuit must not emit duplicate trip decisions"
+        );
+        assert_eq!(
+            s.chain_bad_debt_circuit_tripped_at_ns.get(&CFX),
+            Some(&20),
+            "original trip timestamp is preserved"
+        );
+    }
+
+    #[test]
     fn closes_vault_when_drained() {
         let mut s = MultiChainState::default();
         // collateral fully reserved in Phase 1 (remaining 0); clearing all debt drains it.
-        marked(&mut s, 7, 100 * E8, 0, 100 * E8, 1_400 * E18);
-        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 112 * E18, 18).expect("phase2 ok");
+        marked(&mut s, 7, 9, 100 * E8, 0, 100 * E8, 1_400 * E18);
+        apply_liquidation_settlement_in_state(&mut s, CFX, 7, 9, 112 * E18, 18, 1)
+            .expect("phase2 ok");
         let v = s.chain_vaults.get(&7).unwrap();
         assert_eq!(v.debt_e8s, 0);
         assert_eq!(v.status, ChainVaultStatus::Closed, "drained vault closes");
@@ -546,9 +637,11 @@ mod phase2_tests {
     #[test]
     fn rejects_op_mismatch_no_mutation() {
         let mut s = MultiChainState::default();
-        marked(&mut s, 7, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
+        marked(&mut s, 7, 9, 100 * E8, 500 * E18, 67 * E8, 839 * E18);
         // confirming op 99 != marker op 9.
-        assert!(apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18).is_err());
+        assert!(
+            apply_liquidation_settlement_in_state(&mut s, CFX, 7, 99, 75 * E18, 18, 1).is_err()
+        );
         assert_eq!(
             s.chain_vaults.get(&7).unwrap().debt_e8s,
             100 * E8,

--- a/src/rumi_protocol_backend/src/chains/interest.rs
+++ b/src/rumi_protocol_backend/src/chains/interest.rs
@@ -26,8 +26,7 @@ pub fn accrued_chain_interest_e8s(debt_e8s: u128, apr_bps: u64, elapsed_ns: u64)
         None => return 0,
     };
     let rate = Decimal::from(apr_bps) / Decimal::from(10_000u64);
-    let factor =
-        Decimal::ONE + rate * Decimal::from(elapsed_ns) / Decimal::from(NANOS_PER_YEAR);
+    let factor = Decimal::ONE + rate * Decimal::from(elapsed_ns) / Decimal::from(NANOS_PER_YEAR);
     // new_debt = ceil(debt * factor); the accrued interest is the delta. Defer
     // on a Decimal->u128 overflow (unreachable at real debt scales).
     let new_debt = match (debt * factor).ceil().to_u128() {
@@ -60,6 +59,15 @@ pub fn harvest_chain_interest_in_state(
     now_ns: u64,
     mut alloc_mint_id: impl FnMut() -> u64,
 ) -> Vec<u64> {
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        ic_canister_log::log!(
+            crate::logs::INFO,
+            "[harvest chain={:?}] bad-debt circuit tripped; skipping interest mint enqueue",
+            chain
+        );
+        return Vec::new();
+    }
+
     // Phase 1: pick eligible vaults + locked-in amounts (immutable scan, so the
     // mint-id allocator + enqueue can borrow `state` mutably in phase 2).
     let eligible: Vec<(u64, u128)> = state
@@ -96,7 +104,12 @@ pub fn harvest_chain_interest_in_state(
             format!("interest-{}-{}", chain.0, mint_id),
             now_ns,
         );
-        match state.settlement_queues.entry(chain).or_default().enqueue(op) {
+        match state
+            .settlement_queues
+            .entry(chain)
+            .or_default()
+            .enqueue(op)
+        {
             Ok(op_id) => {
                 if let Some(v) = state.chain_vaults.get_mut(&vault_id) {
                     v.pending_interest_mint_e8s = amount;
@@ -129,12 +142,18 @@ mod tests {
 
     #[test]
     fn two_percent_full_year_on_100_icusd_is_2_icusd() {
-        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR), 2 * E8);
+        assert_eq!(
+            accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR),
+            2 * E8
+        );
     }
 
     #[test]
     fn half_year_is_half_the_interest() {
-        assert_eq!(accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR / 2), E8);
+        assert_eq!(
+            accrued_chain_interest_e8s(100 * E8, 200, NANOS_PER_YEAR / 2),
+            E8
+        );
     }
 
     #[test]
@@ -161,7 +180,10 @@ mod tests {
     #[test]
     fn overflow_defers_to_zero_not_panic() {
         // u128::MAX exceeds Decimal's range -> defer (0), never panic.
-        assert_eq!(accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR), 0);
+        assert_eq!(
+            accrued_chain_interest_e8s(u128::MAX, 200, NANOS_PER_YEAR),
+            0
+        );
     }
 
     // ─── harvest_chain_interest_in_state ────────────────────────────────────
@@ -199,29 +221,51 @@ mod tests {
                 owner_evm: None,
                 last_interest_accrual_ns: last_accrual_ns,
                 pending_interest_mint_e8s: pending_interest,
-                pending_liquidation: None,            },
+                pending_liquidation: None,
+            },
         );
     }
 
     #[test]
     fn harvest_enqueues_one_interest_mint_per_eligible_vault() {
         let mut s = MultiChainState::default();
-        open_vault(&mut s, 1, 100 * E8, /*last accrual a year ago*/ 0, 0, ChainVaultStatus::Open);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            /*last accrual a year ago*/ 0,
+            0,
+            ChainVaultStatus::Open,
+        );
         let now = NANOS_PER_YEAR;
         let mut next = 1000u64;
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
-            next += 1;
-            next
-        });
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
+                next += 1;
+                next
+            });
         assert_eq!(ops.len(), 1, "one eligible vault -> one op");
         let v = &s.chain_vaults[&1];
-        assert_eq!(v.pending_interest_mint_e8s, 2 * E8, "reserved 2% of 100 for a year");
+        assert_eq!(
+            v.pending_interest_mint_e8s,
+            2 * E8,
+            "reserved 2% of 100 for a year"
+        );
         assert_eq!(v.debt_e8s, 100 * E8, "debt untouched until confirm");
-        assert_eq!(v.last_interest_accrual_ns, 0, "accrual window not advanced at harvest");
+        assert_eq!(
+            v.last_interest_accrual_ns, 0,
+            "accrual window not advanced at harvest"
+        );
         let q = &s.settlement_queues[&CHAIN];
         let op = q.pending.values().next().expect("op enqueued");
         match &op.kind {
-            SettlementOpKind::InterestMint { vault_id, mint_id, amount_e8s, accrual_through_ns, recipient } => {
+            SettlementOpKind::InterestMint {
+                vault_id,
+                mint_id,
+                amount_e8s,
+                accrual_through_ns,
+                recipient,
+            } => {
                 assert_eq!(*vault_id, 1);
                 assert_eq!(*mint_id, 1001, "id from the allocator");
                 assert_eq!(*amount_e8s, 2 * E8);
@@ -233,11 +277,38 @@ mod tests {
     }
 
     #[test]
+    fn harvest_skips_interest_mint_when_bad_debt_circuit_tripped() {
+        let mut s = MultiChainState::default();
+        s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            /*last accrual a year ago*/ 0,
+            0,
+            ChainVaultStatus::Open,
+        );
+        let now = NANOS_PER_YEAR;
+        let mut next = 1000u64;
+
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, now, || {
+                next += 1;
+                next
+            });
+
+        assert!(ops.is_empty());
+        assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0);
+        assert!(s.settlement_queues.get(&CHAIN).is_none());
+    }
+
+    #[test]
     fn harvest_skips_below_threshold() {
         let mut s = MultiChainState::default();
         // 1ns elapsed on 100 icUSD -> 1 e8s accrued, below a 1e6 threshold.
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1_000_000, TREASURY, 1, || 99);
         assert!(ops.is_empty(), "below-threshold accrual is not realized");
         assert_eq!(s.chain_vaults[&1].pending_interest_mint_e8s, 0);
     }
@@ -245,11 +316,22 @@ mod tests {
     #[test]
     fn harvest_skips_in_flight_non_open_and_zero_debt() {
         let mut s = MultiChainState::default();
-        open_vault(&mut s, 1, 100 * E8, 0, /*in flight*/ 50_000_000, ChainVaultStatus::Open);
+        open_vault(
+            &mut s,
+            1,
+            100 * E8,
+            0,
+            /*in flight*/ 50_000_000,
+            ChainVaultStatus::Open,
+        );
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::MintPending); // not Open
         open_vault(&mut s, 3, 0, 0, 0, ChainVaultStatus::Open); // zero debt
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || 99);
-        assert!(ops.is_empty(), "in-flight / non-Open / zero-debt vaults are all skipped");
+        let ops =
+            harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || 99);
+        assert!(
+            ops.is_empty(),
+            "in-flight / non-Open / zero-debt vaults are all skipped"
+        );
     }
 
     #[test]
@@ -258,10 +340,18 @@ mod tests {
         open_vault(&mut s, 1, 100 * E8, 0, 0, ChainVaultStatus::Open);
         open_vault(&mut s, 2, 100 * E8, 0, 0, ChainVaultStatus::Open);
         let mut next = 5000u64;
-        let ops = harvest_chain_interest_in_state(&mut s, CHAIN, 200, 1, TREASURY, NANOS_PER_YEAR, || {
-            next += 1;
-            next
-        });
+        let ops = harvest_chain_interest_in_state(
+            &mut s,
+            CHAIN,
+            200,
+            1,
+            TREASURY,
+            NANOS_PER_YEAR,
+            || {
+                next += 1;
+                next
+            },
+        );
         assert_eq!(ops.len(), 2);
         let mint_ids: Vec<u64> = s.settlement_queues[&CHAIN]
             .pending

--- a/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
+++ b/src/rumi_protocol_backend/src/chains/multi_chain_state.rs
@@ -33,7 +33,7 @@ use super::collateral_config::ChainDebtConfigV1;
 use super::config::{ChainConfigV1, ChainConfigV2, ChainConfigV3, ChainId};
 use super::liquidation_config::ChainLiquidationConfigV1;
 use super::monad::chain_vault::ChainVaultV1;
-use super::settlement_queue::SettlementQueueV1;
+use super::settlement_queue::{SettlementOpKind, SettlementOpStatus, SettlementQueueV1};
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -619,6 +619,16 @@ pub struct MultiChainStateV6 {
     /// but cumulative consumption must never exceed the verified transfer size.
     #[serde(default)]
     pub settled_reserve_transfer_e8s: BTreeMap<String, u128>,
+    /// Optional per-chain bad-debt circuit threshold (e8s). Missing row means the
+    /// circuit is disabled for that chain and `chain_bad_debt_e8s` remains pure
+    /// accounting.
+    #[serde(default)]
+    pub chain_bad_debt_circuit_threshold_e8s: BTreeMap<ChainId, u128>,
+    /// Per-chain bad-debt circuit latch timestamp. Presence means the circuit is
+    /// tripped; clearing removes only this latch and never erases cumulative bad
+    /// debt accounting.
+    #[serde(default)]
+    pub chain_bad_debt_circuit_tripped_at_ns: BTreeMap<ChainId, u64>,
 }
 
 impl MultiChainStateV6 {
@@ -679,6 +689,125 @@ impl MultiChainStateV6 {
                 })
             })
             .collect()
+    }
+
+    pub fn chain_bad_debt_circuit_tripped(&self, chain: ChainId) -> bool {
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .contains_key(&chain)
+    }
+
+    pub fn set_chain_bad_debt_circuit_threshold(
+        &mut self,
+        chain: ChainId,
+        threshold_e8s: Option<u128>,
+        now_ns: u64,
+    ) -> Result<(), String> {
+        match threshold_e8s {
+            Some(0) => Err("threshold must be > 0; use null/None to disable".to_string()),
+            Some(threshold) => {
+                self.chain_bad_debt_circuit_threshold_e8s
+                    .insert(chain, threshold);
+                let debt = self.chain_bad_debt_e8s.get(&chain).copied().unwrap_or(0);
+                if debt >= threshold {
+                    self.chain_bad_debt_circuit_tripped_at_ns
+                        .entry(chain)
+                        .or_insert(now_ns);
+                }
+                Ok(())
+            }
+            None => {
+                self.chain_bad_debt_circuit_threshold_e8s.remove(&chain);
+                self.chain_bad_debt_circuit_tripped_at_ns.remove(&chain);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn clear_chain_bad_debt_circuit(&mut self, chain: ChainId) -> bool {
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .remove(&chain)
+            .is_some()
+    }
+
+    /// Add realized bad debt and latch the per-chain circuit exactly once if the
+    /// post-add cumulative debt meets the configured threshold. Returns true only
+    /// on the transition from untripped -> tripped.
+    pub fn record_chain_bad_debt_and_maybe_trip(
+        &mut self,
+        chain: ChainId,
+        amount_e8s: u128,
+        now_ns: u64,
+    ) -> bool {
+        if amount_e8s == 0 {
+            return false;
+        }
+        let total = self
+            .chain_bad_debt_e8s
+            .entry(chain)
+            .and_modify(|v| *v = v.saturating_add(amount_e8s))
+            .or_insert(amount_e8s);
+        let Some(threshold) = self
+            .chain_bad_debt_circuit_threshold_e8s
+            .get(&chain)
+            .copied()
+        else {
+            return false;
+        };
+        if *total < threshold || self.chain_bad_debt_circuit_tripped(chain) {
+            return false;
+        }
+        self.chain_bad_debt_circuit_tripped_at_ns
+            .insert(chain, now_ns);
+        true
+    }
+
+    /// True when a queued settlement op would increase protocol risk while the
+    /// chain's bad-debt circuit is tripped. Reconciliation and exposure-reducing
+    /// ops intentionally remain allowed.
+    pub fn bad_debt_circuit_blocks_settlement_op(
+        &self,
+        chain: ChainId,
+        kind: &SettlementOpKind,
+    ) -> bool {
+        if !self.chain_bad_debt_circuit_tripped(chain) {
+            return false;
+        }
+        match kind {
+            SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. } => true,
+            SettlementOpKind::NativeWithdrawal { vault_id, .. } => self
+                .chain_vaults
+                .get(vault_id)
+                .map(|v| v.debt_e8s > 0)
+                .unwrap_or(true),
+            SettlementOpKind::Burn { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => false,
+        }
+    }
+
+    /// True when a mint-like settlement op can still explain an on-chain supply
+    /// increase. Inflight mints always count because they may already have
+    /// landed. Queued mints count only when the bad-debt circuit would permit
+    /// submission; a circuit-blocked queued mint must not suppress burn catch-up.
+    pub fn has_supply_increasing_settlement_op(&self, chain: ChainId) -> bool {
+        self.settlement_queues
+            .get(&chain)
+            .map(|q| {
+                q.pending.values().any(|op| {
+                    matches!(
+                        op.kind,
+                        SettlementOpKind::Mint { .. } | SettlementOpKind::InterestMint { .. }
+                    ) && match op.status {
+                        SettlementOpStatus::Inflight { .. } => true,
+                        SettlementOpStatus::Queued => {
+                            !self.bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+                        }
+                        SettlementOpStatus::Succeeded { .. }
+                        | SettlementOpStatus::Failed { .. } => false,
+                    }
+                })
+            })
+            .unwrap_or(false)
     }
 
     /// M2: the expected next EIP-712 nonce for a synthetic owner (0 if unseen).

--- a/src/rumi_protocol_backend/src/chains/solana/settlement.rs
+++ b/src/rumi_protocol_backend/src/chains/solana/settlement.rs
@@ -53,7 +53,9 @@ use crate::Mode;
 // chain-independent: `select_next_op` scans a `SettlementQueueV1` and
 // `confirm_mint_in_state` operates on `MultiChainState`, neither of which is
 // Monad-specific.
-use crate::chains::monad::settlement::{confirm_mint_in_state, select_next_op, OpAction};
+use crate::chains::monad::settlement::{
+    confirm_mint_in_state, select_next_op_with_submit_filter, OpAction,
+};
 
 use super::adapter::SolanaAdapter;
 use super::{hardening, sol_rpc, ted25519, tx};
@@ -138,20 +140,21 @@ pub async fn run_settlement(chain: ChainId) {
         return;
     }
 
-    // Snapshot this chain's queue and pick the next actionable op.
-    let queue = read_state(|s| s.multi_chain.settlement_queues.get(&chain).cloned());
-    let queue = match queue {
-        Some(q) => q,
+    // Snapshot this chain's next actionable op. A tripped bad-debt circuit skips
+    // queued risk-increasing ops at selection time so later reconciliation ops
+    // are not starved behind the blocked head of queue.
+    let selected = read_state(|s| {
+        let q = s.multi_chain.settlement_queues.get(&chain)?;
+        let (op_id, action) = select_next_op_with_submit_filter(q, |_, op| {
+            s.multi_chain
+                .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+        })?;
+        let op = q.pending.get(&op_id)?.clone();
+        Some((op_id, action, op))
+    });
+    let (op_id, action, op) = match selected {
+        Some(selected) => selected,
         None => return, // chain not registered / no queue
-    };
-    let (op_id, action) = match select_next_op(&queue) {
-        Some(pair) => pair,
-        None => return, // nothing to do
-    };
-    // Clone the op out so we can drop the queue snapshot before awaiting.
-    let op = match queue.pending.get(&op_id).cloned() {
-        Some(o) => o,
-        None => return,
     };
 
     match action {
@@ -189,7 +192,8 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
             | SettlementOpKind::ChainCollateralPayout { .. }
     ) {
         let now = ic_cdk::api::time();
-        let reason = "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
+        let reason =
+            "op not signable on Solana in M2 (burns/interest-mints handled elsewhere)".to_string();
         mutate_state(|s| {
             if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                 if let Some(o) = q.pending.get_mut(&op_id) {
@@ -207,6 +211,20 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
         return;
     }
 
+    if read_state(|s| {
+        s.multi_chain
+            .bad_debt_circuit_blocks_settlement_op(chain, &op.kind)
+    }) {
+        log!(
+            INFO,
+            "[solana settlement chain={:?}] bad-debt circuit tripped; deferring submit of op {} {:?}",
+            chain,
+            op_id,
+            op.kind
+        );
+        return;
+    }
+
     // GAS GATE: refuse a new outbound op when the settlement (mint-authority +
     // fee-payer) address lacks enough SOL for fees + a fresh-ATA rent touch.
     // Unlike Monad (which reads a cached balance the observer refreshes), the
@@ -215,18 +233,25 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // `hardening::hot_wallet_ok`. A derive/read failure logs and leaves the op
     // Queued (retry next tick); it does NOT fail the op.
     let settlement_path = ted25519::settlement_derivation_path(chain);
-    let (_settlement_pk, settlement_addr) =
-        match ted25519::derive_solana_address(settlement_path).await {
-            Ok(pair) => pair,
-            Err(e) => {
-                log!(INFO, "[solana settlement chain={:?}] derive settlement address failed for op {}: {}; will retry", chain, op_id, e);
-                return;
-            }
-        };
+    let (_settlement_pk, settlement_addr) = match ted25519::derive_solana_address(settlement_path)
+        .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            log!(INFO, "[solana settlement chain={:?}] derive settlement address failed for op {}: {}; will retry", chain, op_id, e);
+            return;
+        }
+    };
     let balance = match sol_rpc::get_balance(&settlement_addr).await {
         Ok(b) => b,
         Err(e) => {
-            log!(INFO, "[solana settlement chain={:?}] get_balance failed for op {}: {}; will retry", chain, op_id, e);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] get_balance failed for op {}: {}; will retry",
+                chain,
+                op_id,
+                e
+            );
             return;
         }
     };
@@ -248,7 +273,11 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     // NO state borrow is held across these awaits.
     let adapter = SolanaAdapter::new(chain);
     let (raw_tx, vault_id, recipient, amount, kind) = match &op.kind {
-        SettlementOpKind::Mint { recipient, amount_e8s, vault_id } => {
+        SettlementOpKind::Mint {
+            recipient,
+            amount_e8s,
+            vault_id,
+        } => {
             let instr = MintInstruction {
                 recipient: recipient.clone(),
                 amount_e8s: *amount_e8s,
@@ -267,7 +296,11 @@ async fn submit_op(chain: ChainId, op_id: u64, op: SettlementOp) {
                 Err(e) => return handle_adapter_error(chain, op_id, "sign_mint", e),
             }
         }
-        SettlementOpKind::NativeWithdrawal { recipient, amount_e18, vault_id } => {
+        SettlementOpKind::NativeWithdrawal {
+            recipient,
+            amount_e18,
+            vault_id,
+        } => {
             // `amount_e18` carries SOL lamports here (the e18 field is the shared
             // amount wart); the adapter does the checked u128 -> u64 conversion.
             let req = WithdrawalRequest {
@@ -395,7 +428,12 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: SettlementOp) {
     let signature = match &op.last_tx_hash {
         Some(h) => h.clone(),
         None => {
-            log!(INFO, "[solana settlement chain={:?}] inflight op {} has no last_tx_hash; skipping", chain, op_id);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] inflight op {} has no last_tx_hash; skipping",
+                chain,
+                op_id
+            );
             return;
         }
     };
@@ -417,7 +455,13 @@ async fn confirm_op(chain: ChainId, op_id: u64, op: SettlementOp) {
             // Not finalized yet (or never landed). Leave Inflight; the next tick
             // re-confirms. A same-bytes resend for a truly-stuck tx is the
             // deferred M2 seam - we do NOT re-broadcast or re-sign here.
-            log!(INFO, "[solana settlement chain={:?}] op {} sig {} not finalized yet; leaving Inflight", chain, op_id, signature);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] op {} sig {} not finalized yet; leaving Inflight",
+                chain,
+                op_id,
+                signature
+            );
         }
         sol_rpc::TxStatus::Confirmed { slot } => {
             confirm_succeeded(chain, op_id, &op, &signature, slot, now);
@@ -439,7 +483,11 @@ fn confirm_succeeded(
     now: u64,
 ) {
     match &op.kind {
-        SettlementOpKind::Mint { vault_id, amount_e8s, .. } => {
+        SettlementOpKind::Mint {
+            vault_id,
+            amount_e8s,
+            ..
+        } => {
             let vault_id = *vault_id;
             let amount_e8s = *amount_e8s;
             // PRE-mint total: sum of foreign-chain vault debt BEFORE this mint
@@ -473,7 +521,14 @@ fn confirm_succeeded(
                 if !still_inflight {
                     return MintConfirm::AlreadyHandled;
                 }
-                match confirm_mint_in_state(&mut s.multi_chain, chain, vault_id, amount_e8s, pre_total, now) {
+                match confirm_mint_in_state(
+                    &mut s.multi_chain,
+                    chain,
+                    vault_id,
+                    amount_e8s,
+                    pre_total,
+                    now,
+                ) {
                     Ok(()) => {
                         if let Some(q) = s.multi_chain.settlement_queues.get_mut(&chain) {
                             if let Some(o) = q.pending.get_mut(&op_id) {
@@ -577,7 +632,11 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
                     v.pending_mint_e8s = 0;
                 }
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 // The transfer did not happen, so the reserved collateral was not
                 // paid out. ADD it back (undo the reserve-at-enqueue) and, if the
                 // vault had gone `Closing` (full withdrawal / close), revert it to
@@ -591,9 +650,9 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
                 }
             }
             SettlementOpKind::Burn { .. }
-        | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. }
-        | SettlementOpKind::ChainCollateralPayout { .. } => {}
+            | SettlementOpKind::InterestMint { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
         if let Some(o) = s
             .multi_chain
@@ -617,13 +676,17 @@ fn confirm_reverted(chain: ChainId, op_id: u64, op: &SettlementOp, signature: &s
             SettlementOpKind::Mint { vault_id, .. } => {
                 log!(INFO, "[solana settlement chain={:?}] MINT op {} vault {} REVERTED on-chain (sig {}); marked Failed, pending_mint cleared, vault left MintPending for manual resolution", chain, op_id, vault_id, signature);
             }
-            SettlementOpKind::NativeWithdrawal { vault_id, amount_e18, .. } => {
+            SettlementOpKind::NativeWithdrawal {
+                vault_id,
+                amount_e18,
+                ..
+            } => {
                 log!(INFO, "[solana settlement chain={:?}] withdrawal op {} vault {} reverted on-chain (sig {}); marked Failed, restored {} lamports of reserved collateral", chain, op_id, vault_id, signature, amount_e18);
             }
             SettlementOpKind::Burn { .. }
-        | SettlementOpKind::InterestMint { .. }
-        | SettlementOpKind::LiquidationSwap { .. }
-        | SettlementOpKind::ChainCollateralPayout { .. } => {}
+            | SettlementOpKind::InterestMint { .. }
+            | SettlementOpKind::LiquidationSwap { .. }
+            | SettlementOpKind::ChainCollateralPayout { .. } => {}
         }
     }
 }
@@ -668,7 +731,14 @@ fn handle_adapter_error(
             log!(INFO, "[solana settlement chain={:?}] {} returned permanent InvalidPayload for op {}: {}; marked Failed", chain, what, op_id, reason);
         }
         other => {
-            log!(INFO, "[solana settlement chain={:?}] {} failed (transient) for op {}: {:?}; will retry", chain, what, op_id, other);
+            log!(
+                INFO,
+                "[solana settlement chain={:?}] {} failed (transient) for op {}: {:?}; will retry",
+                chain,
+                what,
+                op_id,
+                other
+            );
         }
     }
 }

--- a/src/rumi_protocol_backend/src/chains/tests_admin.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_admin.rs
@@ -8,7 +8,10 @@ use super::config::{
 };
 use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
 use super::multi_chain_state::MultiChainState;
-use crate::chains::admin::{delete_chain_in_state, disable_chain_in_state, register_chain_in_state, update_chain_config_in_state};
+use crate::chains::admin::{
+    delete_chain_in_state, disable_chain_in_state, register_chain_in_state,
+    update_chain_config_in_state,
+};
 use candid::Principal;
 
 fn arg() -> RegisterChainArg {
@@ -17,7 +20,10 @@ fn arg() -> RegisterChainArg {
         display_name: "Monad".into(),
         rpc_endpoints: vec!["https://rpc.example".into()],
         finality_depth: 1,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 200,
+        },
         chain_native_decimals: 18,
         min_quorum_providers: None,
     }
@@ -29,7 +35,10 @@ fn config_arg_999() -> RegisterChainArg {
         display_name: "ScratchChain".into(),
         rpc_endpoints: vec!["https://rpc.scratch".into()],
         finality_depth: 1,
-        gas_strategy: GasStrategy::EvmEip1559 { max_priority_fee_gwei: 2, max_fee_gwei_ceiling: 200 },
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 2,
+            max_fee_gwei_ceiling: 200,
+        },
         chain_native_decimals: 18,
         min_quorum_providers: None,
     }
@@ -50,7 +59,8 @@ fn dummy_vault(vault_id: u64, chain: ChainId) -> ChainVaultV1 {
         owner_evm: None,
         last_interest_accrual_ns: 0,
         pending_interest_mint_e8s: 0,
-        pending_liquidation: None,    }
+        pending_liquidation: None,
+    }
 }
 
 #[test]
@@ -75,7 +85,10 @@ fn register_chain_rejects_duplicates() {
     let mut s = MultiChainState::default();
     register_chain_in_state(&mut s, arg(), 0).expect("first");
     let err = register_chain_in_state(&mut s, arg(), 0).expect_err("duplicate");
-    assert!(matches!(err, ChainAdminError::ChainAlreadyRegistered(ChainId(101))));
+    assert!(matches!(
+        err,
+        ChainAdminError::ChainAlreadyRegistered(ChainId(101))
+    ));
 }
 
 #[test]
@@ -96,7 +109,10 @@ fn register_chain_rejects_out_of_range_decimals() {
     zero.chain_native_decimals = 0;
     let err = register_chain_in_state(&mut s, zero, 0).expect_err("zero decimals");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
-    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+    assert!(
+        !s.chain_configs.contains_key(&ChainId(101)),
+        "no partial insert on reject"
+    );
 
     // Absurdly large decimals are also rejected.
     let mut huge = arg();
@@ -120,14 +136,19 @@ fn register_chain_enforces_evm_finality_floor() {
     a.finality_depth = 0;
     let err = register_chain_in_state(&mut s, a, 0).expect_err("evm finality 0");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
-    assert!(!s.chain_configs.contains_key(&ChainId(101)), "no partial insert on reject");
+    assert!(
+        !s.chain_configs.contains_key(&ChainId(101)),
+        "no partial insert on reject"
+    );
 
     // A Solana-style chain (non-EVM gas) MAY use finality_depth 0 (reads at the
     // `finalized` commitment).
     let mut sol = arg();
     sol.chain_id = ChainId(202);
     sol.chain_native_decimals = 9;
-    sol.gas_strategy = GasStrategy::SolanaPriorityFee { lamports_per_cu_ceiling: 10_000 };
+    sol.gas_strategy = GasStrategy::SolanaPriorityFee {
+        lamports_per_cu_ceiling: 10_000,
+    };
     sol.finality_depth = 0;
     register_chain_in_state(&mut s, sol, 0).expect("solana finality 0 ok");
     assert_eq!(s.chain_configs[&ChainId(202)].finality_depth, 0);
@@ -139,7 +160,10 @@ fn disable_chain_flips_status_and_preserves_supply() {
     register_chain_in_state(&mut s, arg(), 0).expect("register");
     s.chain_supplies.insert(ChainId(101), 999);
     disable_chain_in_state(&mut s, ChainId(101)).expect("disable");
-    assert!(matches!(s.chain_configs[&ChainId(101)].status, ChainStatus::Disabled));
+    assert!(matches!(
+        s.chain_configs[&ChainId(101)].status,
+        ChainStatus::Disabled
+    ));
     assert_eq!(s.chain_supplies[&ChainId(101)], 999);
 }
 
@@ -164,11 +188,8 @@ fn set_chain_config_updates_supplied_fields_only() {
 #[test]
 fn set_chain_config_rejects_unknown_chain() {
     let mut s = MultiChainState::default();
-    let err = update_chain_config_in_state(
-        &mut s,
-        ChainId(404),
-        UpdateChainConfigArg::default(),
-    ).expect_err("unknown chain");
+    let err = update_chain_config_in_state(&mut s, ChainId(404), UpdateChainConfigArg::default())
+        .expect_err("unknown chain");
     assert!(matches!(err, ChainAdminError::ChainNotRegistered(_)));
 }
 
@@ -185,28 +206,73 @@ fn delete_chain_removes_zero_supply_chain() {
     s.hot_wallet_balance_e18.insert(c, 1_000);
     s.reorg_halted.insert(c, true);
     s.reorg_suspect_streak.insert(c, 2);
+    s.chain_bad_debt_e8s.insert(c, 77);
+    s.chain_bad_debt_circuit_threshold_e8s.insert(c, 100);
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(c, 456);
     // An unrelated chain's manual_prices entry must SURVIVE the delete.
-    s.manual_prices.insert((ChainId(7), "MON".to_string()), 3_0000_0000);
-    s.manual_price_set_at_ns.insert((ChainId(7), "MON".to_string()), 456);
+    s.manual_prices
+        .insert((ChainId(7), "MON".to_string()), 3_0000_0000);
+    s.manual_price_set_at_ns
+        .insert((ChainId(7), "MON".to_string()), 456);
 
     delete_chain_in_state(&mut s, c).expect("delete");
 
     assert!(!s.chain_configs.contains_key(&c), "chain_configs retained");
-    assert!(!s.chain_supplies.contains_key(&c), "chain_supplies retained");
-    assert!(!s.settlement_queues.contains_key(&c), "settlement_queues retained");
-    assert!(!s.chain_contracts.contains_key(&c), "chain_contracts retained");
-    assert!(!s.last_observed_block.contains_key(&c), "last_observed_block retained");
-    assert!(!s.hot_wallet_balance_e18.contains_key(&c), "hot_wallet_balance_e18 retained");
-    assert!(!s.reorg_halted.contains_key(&c), "reorg_halted retained");
-    assert!(!s.reorg_suspect_streak.contains_key(&c), "reorg_suspect_streak retained");
-    assert!(!s.manual_prices.contains_key(&(c, "MON".to_string())), "manual_prices retained");
     assert!(
-        !s.manual_price_set_at_ns.contains_key(&(c, "MON".to_string())),
+        !s.chain_supplies.contains_key(&c),
+        "chain_supplies retained"
+    );
+    assert!(
+        !s.settlement_queues.contains_key(&c),
+        "settlement_queues retained"
+    );
+    assert!(
+        !s.chain_contracts.contains_key(&c),
+        "chain_contracts retained"
+    );
+    assert!(
+        !s.last_observed_block.contains_key(&c),
+        "last_observed_block retained"
+    );
+    assert!(
+        !s.hot_wallet_balance_e18.contains_key(&c),
+        "hot_wallet_balance_e18 retained"
+    );
+    assert!(!s.reorg_halted.contains_key(&c), "reorg_halted retained");
+    assert!(
+        !s.reorg_suspect_streak.contains_key(&c),
+        "reorg_suspect_streak retained"
+    );
+    assert!(
+        !s.chain_bad_debt_e8s.contains_key(&c),
+        "chain_bad_debt_e8s retained"
+    );
+    assert!(
+        !s.chain_bad_debt_circuit_threshold_e8s.contains_key(&c),
+        "chain_bad_debt_circuit_threshold_e8s retained"
+    );
+    assert!(
+        !s.chain_bad_debt_circuit_tripped_at_ns.contains_key(&c),
+        "chain_bad_debt_circuit_tripped_at_ns retained"
+    );
+    assert!(
+        !s.manual_prices.contains_key(&(c, "MON".to_string())),
+        "manual_prices retained"
+    );
+    assert!(
+        !s.manual_price_set_at_ns
+            .contains_key(&(c, "MON".to_string())),
         "manual_price_set_at_ns leaked (paired-map divergence)"
     );
     // The unrelated chain's price + timestamp survive.
-    assert_eq!(s.manual_prices[&(ChainId(7), "MON".to_string())], 3_0000_0000);
-    assert_eq!(s.manual_price_set_at_ns[&(ChainId(7), "MON".to_string())], 456);
+    assert_eq!(
+        s.manual_prices[&(ChainId(7), "MON".to_string())],
+        3_0000_0000
+    );
+    assert_eq!(
+        s.manual_price_set_at_ns[&(ChainId(7), "MON".to_string())],
+        456
+    );
 }
 
 #[test]
@@ -218,7 +284,10 @@ fn delete_chain_refuses_when_supply_nonzero() {
     let err = delete_chain_in_state(&mut s, c).expect_err("nonzero supply");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
     // No partial delete: the chain is STILL registered with its supply intact.
-    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert!(
+        s.chain_configs.contains_key(&c),
+        "chain dropped despite refusal"
+    );
     assert_eq!(s.chain_supplies[&c], 1);
 }
 
@@ -231,7 +300,10 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
     let err = delete_chain_in_state(&mut s, c).expect_err("referencing vault");
     assert!(matches!(err, ChainAdminError::InvalidConfig(_)));
     // No partial delete: the chain is STILL registered and the vault remains.
-    assert!(s.chain_configs.contains_key(&c), "chain dropped despite refusal");
+    assert!(
+        s.chain_configs.contains_key(&c),
+        "chain dropped despite refusal"
+    );
     assert!(s.chain_vaults.contains_key(&1));
 }
 
@@ -239,5 +311,8 @@ fn delete_chain_refuses_when_open_vaults_reference_it() {
 fn delete_chain_unknown_is_rejected() {
     let mut s = MultiChainState::default();
     let err = delete_chain_in_state(&mut s, ChainId(404)).expect_err("unknown chain");
-    assert!(matches!(err, ChainAdminError::ChainNotRegistered(ChainId(404))));
+    assert!(matches!(
+        err,
+        ChainAdminError::ChainNotRegistered(ChainId(404))
+    ));
 }

--- a/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_multi_chain_state_v2.rs
@@ -682,6 +682,230 @@ fn settlement_proof_state_defaults_empty_from_pre_inc6_v6_snapshot() {
 }
 
 #[test]
+fn inc11_bad_debt_circuit_state_defaults_empty_from_v6_snapshot() {
+    use super::collateral_config::ChainDebtConfigV1;
+    use super::config::ChainConfigV3;
+    use super::liquidation_config::ChainLiquidationConfigV1;
+    use super::monad::chain_vault::ChainVaultV1;
+    use super::settlement_queue::SettlementQueueV1;
+    use candid::Principal;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[derive(serde::Serialize, Default)]
+    struct PreInc11MultiChainStateV6 {
+        pub chain_configs: BTreeMap<ChainId, ChainConfigV3>,
+        pub chain_supplies: BTreeMap<ChainId, u128>,
+        pub settlement_queues: BTreeMap<ChainId, SettlementQueueV1>,
+        pub invariant_halted: bool,
+        pub chain_vaults: BTreeMap<u64, ChainVaultV1>,
+        pub chain_contracts: BTreeMap<ChainId, String>,
+        pub manual_prices: BTreeMap<(ChainId, String), u64>,
+        pub last_observed_block: BTreeMap<ChainId, u64>,
+        pub hot_wallet_balance_e18: BTreeMap<ChainId, u128>,
+        pub reorg_halted: BTreeMap<ChainId, bool>,
+        pub reorg_suspect_streak: BTreeMap<ChainId, u32>,
+        pub processed_burn_keys: BTreeMap<u64, BTreeSet<String>>,
+        pub evm_owner_nonces: BTreeMap<Principal, u64>,
+        pub manual_price_set_at_ns: BTreeMap<(ChainId, String), u64>,
+        pub reserve_backing_e8s: BTreeMap<ChainId, u128>,
+        pub reserve_usdc_native: BTreeMap<ChainId, u128>,
+        pub pending_chain_burn_e8s: BTreeMap<ChainId, u128>,
+        pub sp_attempted_chain_vaults: BTreeSet<u64>,
+        pub chain_liquidation_claims: BTreeMap<u64, ChainLiqClaimV1>,
+        pub chain_liquidation_configs: BTreeMap<ChainId, ChainLiquidationConfigV1>,
+        pub chain_debt_configs: BTreeMap<ChainId, ChainDebtConfigV1>,
+        pub bot_pending_chain_vaults: BTreeMap<u64, u64>,
+        pub chain_bad_debt_e8s: BTreeMap<ChainId, u128>,
+    }
+
+    const CFX: ChainId = ChainId(1030);
+    let mut pre = PreInc11MultiChainStateV6::default();
+    pre.chain_supplies.insert(CFX, 100);
+    pre.chain_bad_debt_e8s.insert(CFX, 7);
+
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&pre, &mut buf).expect("cbor encode pre-Inc11 V6");
+    let decoded: MultiChainState =
+        ciborium::de::from_reader(buf.as_slice()).expect("pre-Inc11 V6 decodes");
+
+    assert_eq!(decoded.chain_supplies.get(&CFX), Some(&100));
+    assert_eq!(decoded.chain_bad_debt_e8s.get(&CFX), Some(&7));
+    assert!(decoded.chain_bad_debt_circuit_threshold_e8s.is_empty());
+    assert!(decoded.chain_bad_debt_circuit_tripped_at_ns.is_empty());
+    assert!(!decoded.chain_bad_debt_circuit_tripped(CFX));
+}
+
+#[test]
+fn bad_debt_circuit_blocks_only_risk_increasing_settlement_ops() {
+    use super::monad::chain_vault::{ChainVaultStatus, ChainVaultV1};
+    use super::settlement_queue::SettlementOpKind;
+    use candid::Principal;
+
+    const CFX: ChainId = ChainId(1030);
+    let mut state = MultiChainState::default();
+    state.chain_bad_debt_circuit_tripped_at_ns.insert(CFX, 42);
+    state.chain_vaults.insert(
+        1,
+        ChainVaultV1 {
+            vault_id: 1,
+            owner: Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0xc".into(),
+            collateral_amount_native: 100,
+            debt_e8s: 10,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
+    state.chain_vaults.insert(
+        2,
+        ChainVaultV1 {
+            vault_id: 2,
+            owner: Principal::anonymous(),
+            collateral_chain: CFX,
+            custody_address: "0xc".into(),
+            collateral_amount_native: 100,
+            debt_e8s: 0,
+            mint_recipient: "0xr".into(),
+            pending_mint_e8s: 0,
+            status: ChainVaultStatus::Open,
+            opened_at_ns: 0,
+            owner_evm: None,
+            last_interest_accrual_ns: 0,
+            pending_interest_mint_e8s: 0,
+            pending_liquidation: None,
+        },
+    );
+
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::Mint {
+            recipient: "0xr".into(),
+            amount_e8s: 1,
+            vault_id: 1,
+        }
+    ));
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::InterestMint {
+            vault_id: 1,
+            mint_id: 99,
+            amount_e8s: 1,
+            accrual_through_ns: 1,
+            recipient: "0xt".into(),
+        }
+    ));
+    assert!(state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1,
+            vault_id: 1,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::NativeWithdrawal {
+            recipient: "0xr".into(),
+            amount_e18: 1,
+            vault_id: 2,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::LiquidationSwap {
+            vault_id: 1,
+            collateral_in_native: 1,
+            min_usdc_out_native: 1,
+            debt_to_clear_e8s: 1,
+            router: "0x1".into(),
+            pair: "0x2".into(),
+            path: vec![],
+            reserve_recipient: "0x3".into(),
+            deadline_secs: 1,
+        }
+    ));
+    assert!(!state.bad_debt_circuit_blocks_settlement_op(
+        CFX,
+        &SettlementOpKind::ChainCollateralPayout {
+            vault_id: 1,
+            claimant: Principal::anonymous(),
+            recipient: "0xr".into(),
+            amount_e18: 1,
+        }
+    ));
+}
+
+#[test]
+fn supply_increasing_settlement_op_ignores_circuit_blocked_queued_mints() {
+    use super::settlement_queue::{
+        SettlementOp, SettlementOpKind, SettlementOpStatus, SettlementQueueV1,
+    };
+
+    const CFX: ChainId = ChainId(1030);
+    let mut state = MultiChainState::default();
+    state.chain_bad_debt_circuit_tripped_at_ns.insert(CFX, 42);
+    state
+        .settlement_queues
+        .insert(CFX, SettlementQueueV1::default());
+    let mint_id = state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .enqueue(SettlementOp::new(
+            SettlementOpKind::Mint {
+                recipient: "0xr".into(),
+                amount_e8s: 1,
+                vault_id: 1,
+            },
+            "blocked-mint".into(),
+            0,
+        ))
+        .expect("enqueue mint");
+
+    assert!(
+        !state.has_supply_increasing_settlement_op(CFX),
+        "circuit-blocked queued mint cannot explain a supply increase"
+    );
+
+    state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .pending
+        .get_mut(&mint_id)
+        .unwrap()
+        .status = SettlementOpStatus::Inflight {
+        tries: 1,
+        last_attempt_ns: 1,
+    };
+    assert!(
+        state.has_supply_increasing_settlement_op(CFX),
+        "inflight mint can already have landed and must still mask backstop scans"
+    );
+
+    state
+        .settlement_queues
+        .get_mut(&CFX)
+        .unwrap()
+        .pending
+        .get_mut(&mint_id)
+        .unwrap()
+        .status = SettlementOpStatus::Queued;
+    state.chain_bad_debt_circuit_tripped_at_ns.remove(&CFX);
+    assert!(
+        state.has_supply_increasing_settlement_op(CFX),
+        "queued mint is supply-increasing again once the circuit is clear"
+    );
+}
+
+#[test]
 fn settlement_proof_state_round_trip_preserves_compact_records() {
     let mut v6 = MultiChainStateV6::default();
     let pending = SettlementProofRecord {

--- a/src/rumi_protocol_backend/src/chains/tests_vault.rs
+++ b/src/rumi_protocol_backend/src/chains/tests_vault.rs
@@ -13,7 +13,9 @@
 
 use super::config::{ChainId, GasStrategy, RegisterChainArg};
 use super::multi_chain_state::MultiChainState;
-use super::vault::{open_chain_vault_in_state, OpenVaultError};
+use super::vault::{
+    open_chain_vault_in_state, verify_deposit_and_enqueue_mint_in_state, OpenVaultError,
+};
 use candid::Principal;
 
 /// A non-Monad chain id (Solana's SLIP-44 coin type) so nothing here can lean on
@@ -192,6 +194,75 @@ fn open_rejects_stale_price_when_age_gate_configured() {
     );
     assert_eq!(res, Err(OpenVaultError::StalePrice));
     assert!(s.chain_vaults.is_empty(), "no mutation on stale price");
+}
+
+#[test]
+fn open_rejects_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        100_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        12345,
+        7,
+    );
+
+    assert_eq!(
+        res,
+        Err(OpenVaultError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert!(
+        s.chain_vaults.is_empty(),
+        "no mutation while circuit is tripped"
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
+}
+
+#[test]
+fn verify_deposit_rejects_mint_enqueue_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    open_chain_vault_in_state(
+        &mut s,
+        CHAIN,
+        Principal::anonymous(),
+        "custody".into(),
+        100 * ONE_SOL,
+        100_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        12345,
+        7,
+    )
+    .expect("open awaiting deposit");
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = verify_deposit_and_enqueue_mint_in_state(&mut s, 7, 100 * ONE_SOL, 12346);
+
+    assert_eq!(
+        res,
+        Err(OpenVaultError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().status,
+        super::monad::chain_vault::ChainVaultStatus::AwaitingDeposit,
+        "vault remains retryable after clear"
+    );
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
 }
 
 // ─── M2: borrow + nonce + per-owner cap ───────────────────────────────────────
@@ -469,6 +540,39 @@ fn borrow_rejects_stale_price_when_age_gate_configured() {
     );
     assert_eq!(res, Err(BorrowError::StalePrice));
     assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0);
+}
+
+#[test]
+fn borrow_rejects_when_chain_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = borrow_chain_vault_in_state(
+        &mut s,
+        7,
+        50_00000000,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        0,
+        None,
+        1,
+    );
+
+    assert_eq!(
+        res,
+        Err(BorrowError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
+    assert_eq!(s.chain_vaults.get(&7).unwrap().pending_mint_e8s, 0);
+    assert_eq!(s.settlement_queues[&CHAIN].pending_len(), 0);
 }
 
 // ─── Increment 0: min-debt floor + per-chain debt ceiling ─────────────────────
@@ -867,6 +971,40 @@ fn withdraw_rejects_stale_price_when_age_gate_configured() {
         1_101,
     );
     assert_eq!(res, Err(WithdrawError::StalePrice));
+    assert_eq!(
+        s.chain_vaults.get(&7).unwrap().collateral_amount_native,
+        100 * ONE_SOL
+    );
+    assert_eq!(s.settlement_queues.get(&CHAIN).unwrap().pending_len(), 0);
+}
+
+#[test]
+fn withdraw_rejects_debt_bearing_vault_when_bad_debt_circuit_tripped() {
+    let mut s = setup(PRICE_150_USD_E8);
+    insert_open_vault(
+        &mut s,
+        Principal::anonymous(),
+        7,
+        100 * ONE_SOL,
+        100_00000000,
+    );
+    s.chain_bad_debt_circuit_tripped_at_ns.insert(CHAIN, 42);
+
+    let res = withdraw_collateral_in_state(
+        &mut s,
+        7,
+        ONE_SOL,
+        "good-address".into(),
+        only_good,
+        "SOL",
+        13_000,
+        1_101,
+    );
+
+    assert_eq!(
+        res,
+        Err(WithdrawError::ChainBadDebtCircuitTripped { chain: CHAIN })
+    );
     assert_eq!(
         s.chain_vaults.get(&7).unwrap().collateral_amount_native,
         100 * ONE_SOL

--- a/src/rumi_protocol_backend/src/chains/vault.rs
+++ b/src/rumi_protocol_backend/src/chains/vault.rs
@@ -184,6 +184,9 @@ pub enum OpenVaultError {
         would_be_e8s: u128,
         ceiling_e8s: u128,
     },
+    /// The chain's bad-debt circuit is tripped; new debt or pending mint creation
+    /// is blocked until the developer clears the circuit.
+    ChainBadDebtCircuitTripped { chain: ChainId },
 }
 
 /// Reasons `withdraw_collateral_in_state` / `close_chain_vault_in_state` can
@@ -240,6 +243,9 @@ pub enum WithdrawError {
     /// collateral or under-collateralize the residual debt. Reject until the
     /// marker clears (mirrors `MintInFlight`). Spec 3.1.
     LiquidationInFlight,
+    /// The chain's bad-debt circuit is tripped; collateral-out from a debt-bearing
+    /// vault is blocked, while debt-free close payouts remain allowed.
+    ChainBadDebtCircuitTripped { chain: ChainId },
 }
 
 /// Why `begin_liquidation_in_state` (spec §4.9 Phase 1) rejected. No state is
@@ -450,6 +456,9 @@ pub fn open_chain_vault_in_state(
     if !state.chain_configs.contains_key(&chain) {
         return Err(OpenVaultError::UnknownChain);
     }
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        return Err(OpenVaultError::ChainBadDebtCircuitTripped { chain });
+    }
     // A zero-debt vault has nothing to mint; with debt 0 the CR check is a
     // no-op (u64::MAX) and deposit-watch would later enqueue a wasted
     // zero-value on-chain mint. Reject up front. (A zero-collateral vault with
@@ -578,6 +587,9 @@ pub fn verify_deposit_and_enqueue_mint_in_state(
     // Not enough on-chain collateral yet - no mutation, retry next tick.
     if observed_balance_e18 < declared_e18 {
         return Ok(false);
+    }
+    if state.chain_bad_debt_circuit_tripped(chain) {
+        return Err(OpenVaultError::ChainBadDebtCircuitTripped { chain });
     }
 
     // Enqueue FIRST (it can fail on a duplicate idempotency key). The key is
@@ -711,6 +723,11 @@ pub fn withdraw_collateral_in_state(
         }
         if amount_e18 > v.collateral_amount_native {
             return Err(WithdrawError::InsufficientCollateral);
+        }
+        if v.debt_e8s > 0 && state.chain_bad_debt_circuit_tripped(v.collateral_chain) {
+            return Err(WithdrawError::ChainBadDebtCircuitTripped {
+                chain: v.collateral_chain,
+            });
         }
         let remaining = v.collateral_amount_native - amount_e18;
         (
@@ -1097,6 +1114,11 @@ pub enum BorrowError {
     /// tier could leave the post-confirm vault under-collateralized. Reject until
     /// the marker clears (mirrors `MintInFlight`). Spec 3.1.
     LiquidationInFlight,
+    /// The chain's bad-debt circuit is tripped; additional debt creation is
+    /// blocked until the developer clears the circuit.
+    ChainBadDebtCircuitTripped {
+        chain: ChainId,
+    },
 }
 
 /// Borrow additional icUSD against an existing `Open` vault — a SECOND on-chain
@@ -1154,6 +1176,11 @@ pub fn borrow_chain_vault_in_state(
         // could leave the post-confirm vault under-collateralized.
         if v.pending_liquidation.is_some() {
             return Err(BorrowError::LiquidationInFlight);
+        }
+        if state.chain_bad_debt_circuit_tripped(v.collateral_chain) {
+            return Err(BorrowError::ChainBadDebtCircuitTripped {
+                chain: v.collateral_chain,
+            });
         }
         (
             v.collateral_chain,

--- a/src/rumi_protocol_backend/src/event.rs
+++ b/src/rumi_protocol_backend/src/event.rs
@@ -748,6 +748,26 @@ pub enum Event {
         chain_id: crate::chains::config::ChainId,
         timestamp: u64,
     },
+    #[serde(rename = "chain_bad_debt_circuit_threshold_set")]
+    ChainBadDebtCircuitThresholdSet {
+        chain_id: crate::chains::config::ChainId,
+        threshold_e8s: Option<u128>,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_bad_debt_circuit_tripped")]
+    ChainBadDebtCircuitTripped {
+        chain_id: crate::chains::config::ChainId,
+        bad_debt_e8s: u128,
+        total_bad_debt_e8s: u128,
+        threshold_e8s: u128,
+        timestamp: u64,
+    },
+    #[serde(rename = "chain_bad_debt_circuit_cleared")]
+    ChainBadDebtCircuitCleared {
+        chain_id: crate::chains::config::ChainId,
+        total_bad_debt_e8s: u128,
+        timestamp: u64,
+    },
     // Phase 1a Task 11: Timer B supply-invariant self-check failure.
     #[serde(rename = "supply_invariant_self_check_failed")]
     SupplyInvariantSelfCheckFailed {
@@ -1019,7 +1039,10 @@ impl Event {
             // Phase 1a: chain-admin events are protocol-wide, not vault-scoped.
             Event::ChainRegistered { .. }
             | Event::ChainDisabled { .. }
-            | Event::ChainConfigUpdated { .. } => false,
+            | Event::ChainConfigUpdated { .. }
+            | Event::ChainBadDebtCircuitThresholdSet { .. }
+            | Event::ChainBadDebtCircuitTripped { .. }
+            | Event::ChainBadDebtCircuitCleared { .. } => false,
             // Phase 1a Task 11: supply invariant failure is protocol-wide.
             Event::SupplyInvariantSelfCheckFailed { .. } => false,
             // Phase 1b: vault-carrying foreign-chain events surface per-vault history.
@@ -1186,6 +1209,11 @@ impl Event {
             Event::ChainRegistered { .. } => Some("ChainRegistered"),
             Event::ChainDisabled { .. } => Some("ChainDisabled"),
             Event::ChainConfigUpdated { .. } => Some("ChainConfigUpdated"),
+            Event::ChainBadDebtCircuitThresholdSet { .. } => {
+                Some("ChainBadDebtCircuitThresholdSet")
+            }
+            Event::ChainBadDebtCircuitTripped { .. } => Some("ChainBadDebtCircuitTripped"),
+            Event::ChainBadDebtCircuitCleared { .. } => Some("ChainBadDebtCircuitCleared"),
             Event::ChainSettlementFailed { .. } => Some("ChainSettlementFailed"),
             Event::ChainReorgDetected { .. } => Some("ChainReorgDetected"),
             Event::ChainHotWalletLow { .. } => Some("ChainHotWalletLow"),
@@ -1241,6 +1269,9 @@ impl Event {
             Event::StabilityPoolCallFailed { timestamp, .. } => Some(*timestamp),
             Event::OracleCircuitBreaker { timestamp, .. } => Some(*timestamp),
             Event::OracleSourceCountInsufficient { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitThresholdSet { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitTripped { timestamp, .. } => Some(*timestamp),
+            Event::ChainBadDebtCircuitCleared { timestamp, .. } => Some(*timestamp),
             _ => None,
         }
     }
@@ -2099,7 +2130,10 @@ pub fn replay(mut events: impl Iterator<Item = Event>) -> Result<State, ReplayLo
             // before recording the event; nothing to replay.
             Event::ChainRegistered { .. }
             | Event::ChainDisabled { .. }
-            | Event::ChainConfigUpdated { .. } => {},
+            | Event::ChainConfigUpdated { .. }
+            | Event::ChainBadDebtCircuitThresholdSet { .. }
+            | Event::ChainBadDebtCircuitTripped { .. }
+            | Event::ChainBadDebtCircuitCleared { .. } => {},
             // Phase 1a Task 11: informational audit trail; state mutation
             // (invariant_halted + mode flip) happens live in the timer tick.
             Event::SupplyInvariantSelfCheckFailed { .. } => {},

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2177,6 +2177,144 @@ fn get_effective_chain_debt_config(
     ))
 }
 
+#[derive(candid::CandidType, serde::Deserialize, Clone, Debug)]
+pub struct ChainBadDebtCircuitStatus {
+    pub chain_id: rumi_protocol_backend::chains::config::ChainId,
+    pub registered: bool,
+    pub bad_debt_e8s: u128,
+    pub threshold_e8s: Option<u128>,
+    pub tripped: bool,
+    pub tripped_at_ns: Option<u64>,
+}
+
+/// Public read-only status for the per-chain bad-debt circuit. No secrets.
+#[candid_method(query)]
+#[query]
+fn get_chain_bad_debt_circuit_status(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> ChainBadDebtCircuitStatus {
+    read_state(|s| ChainBadDebtCircuitStatus {
+        chain_id: chain,
+        registered: s.multi_chain.chain_configs.contains_key(&chain),
+        bad_debt_e8s: s
+            .multi_chain
+            .chain_bad_debt_e8s
+            .get(&chain)
+            .copied()
+            .unwrap_or(0),
+        threshold_e8s: s
+            .multi_chain
+            .chain_bad_debt_circuit_threshold_e8s
+            .get(&chain)
+            .copied(),
+        tripped: s.multi_chain.chain_bad_debt_circuit_tripped(chain),
+        tripped_at_ns: s
+            .multi_chain
+            .chain_bad_debt_circuit_tripped_at_ns
+            .get(&chain)
+            .copied(),
+    })
+}
+
+/// Developer-gated threshold setter. `None` disables the circuit for the chain
+/// and clears any existing latch; `Some(0)` is rejected to avoid ambiguous
+/// always-trip semantics.
+#[candid_method(update)]
+#[update]
+fn set_chain_bad_debt_circuit_threshold(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    threshold_e8s: Option<u128>,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    if !read_state(|s| s.multi_chain.chain_configs.contains_key(&chain)) {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not registered",
+            chain.0
+        )));
+    }
+    let now = ic_cdk::api::time();
+    let was_tripped = read_state(|s| s.multi_chain.chain_bad_debt_circuit_tripped(chain));
+    mutate_state(|s| {
+        s.multi_chain
+            .set_chain_bad_debt_circuit_threshold(chain, threshold_e8s, now)
+    })
+    .map_err(ProtocolError::ChainAdmin)?;
+    let status = get_chain_bad_debt_circuit_status(chain);
+    rumi_protocol_backend::storage::record_event(
+        &rumi_protocol_backend::event::Event::ChainBadDebtCircuitThresholdSet {
+            chain_id: chain,
+            threshold_e8s,
+            timestamp: now,
+        },
+    );
+    if status.tripped && !was_tripped {
+        rumi_protocol_backend::storage::record_event(
+            &rumi_protocol_backend::event::Event::ChainBadDebtCircuitTripped {
+                chain_id: chain,
+                bad_debt_e8s: status.bad_debt_e8s,
+                total_bad_debt_e8s: status.bad_debt_e8s,
+                threshold_e8s: status.threshold_e8s.unwrap_or(0),
+                timestamp: now,
+            },
+        );
+    }
+    log!(
+        INFO,
+        "[set_chain_bad_debt_circuit_threshold] chain={:?} threshold={:?} tripped={}",
+        chain,
+        threshold_e8s,
+        status.tripped
+    );
+    Ok(())
+}
+
+/// Developer-gated manual clear for the bad-debt circuit. Cumulative bad-debt
+/// accounting and the configured threshold are preserved.
+#[candid_method(update)]
+#[update]
+fn clear_chain_bad_debt_circuit(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    if !read_state(|s| s.multi_chain.chain_configs.contains_key(&chain)) {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not registered",
+            chain.0
+        )));
+    }
+    let now = ic_cdk::api::time();
+    let cleared = mutate_state(|s| s.multi_chain.clear_chain_bad_debt_circuit(chain));
+    if cleared {
+        let total_bad_debt_e8s = read_state(|s| {
+            s.multi_chain
+                .chain_bad_debt_e8s
+                .get(&chain)
+                .copied()
+                .unwrap_or(0)
+        });
+        rumi_protocol_backend::storage::record_event(
+            &rumi_protocol_backend::event::Event::ChainBadDebtCircuitCleared {
+                chain_id: chain,
+                total_bad_debt_e8s,
+                timestamp: now,
+            },
+        );
+    }
+    log!(
+        INFO,
+        "[clear_chain_bad_debt_circuit] chain={:?} cleared={}",
+        chain,
+        cleared
+    );
+    Ok(())
+}
+
 /// A chain vault currently liquidatable on `chain` (CR below the liquidation
 /// threshold), with its interest-aware CR + sizing surfaced for an operator/SP.
 /// The discovery channel for the eventual SP fallback (finding #30; SP-specific
@@ -4869,9 +5007,8 @@ async fn stability_pool_liquidate_chain_vault(
 
     let _guard = rumi_protocol_backend::guard::ChainVaultLiquidationGuard::new(vault_id)?;
     let now = ic_cdk::api::time();
-    let preflight = read_state(|s| {
-        matching_chain_absorb_preflight(s, vault_id, icusd_burned_e8s, caller, now)
-    });
+    let preflight =
+        read_state(|s| matching_chain_absorb_preflight(s, vault_id, icusd_burned_e8s, caller, now));
     if preflight.is_none() {
         if read_state(|s| s.frozen) {
             return Err(ProtocolError::TemporarilyUnavailable(

--- a/src/rumi_protocol_backend/src/tests.rs
+++ b/src/rumi_protocol_backend/src/tests.rs
@@ -2,9 +2,9 @@ use crate::Vault;
 use crate::{ICP, ICUSD};
 use candid::Principal;
 use ic_base_types::PrincipalId;
+use proptest::collection::vec as pvec;
 use proptest::prelude::*;
 use std::collections::BTreeMap;
-use proptest::collection::vec as pvec;
 
 fn arb_vault() -> impl Strategy<Value = Vault> {
     (arb_principal(), any::<u64>(), arb_amount()).prop_map(|(owner, borrowed_icusd, icp_margin)| {
@@ -34,14 +34,18 @@ fn arb_usd_amount() -> impl Strategy<Value = ICUSD> {
 }
 
 fn arb_amount() -> impl Strategy<Value = u64> {
-    1..1_000_000u64  // Reduced maximum to avoid impossible distributions
+    1..1_000_000u64 // Reduced maximum to avoid impossible distributions
 }
 
 fn vault_vec_to_map(vaults: Vec<Vault>) -> BTreeMap<u64, Vault> {
-    vaults.into_iter().enumerate().map(|(i, mut v)| {
-        v.vault_id = i as u64;
-        (i as u64, v)
-    }).collect()
+    vaults
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut v)| {
+            v.vault_id = i as u64;
+            (i as u64, v)
+        })
+        .collect()
 }
 
 proptest! {
@@ -66,7 +70,7 @@ proptest! {
                 accrued_interest: ICUSD::new(0),
                 bot_processing: false,
             };
-            
+
             let result = crate::state::distribute_across_vaults(&vaults, target_vault);
             let icusd_distributed: ICUSD = result.iter().map(|e| e.icusd_share_amount).sum();
             let icp_distributed: ICP = result.iter().map(|e| e.icp_share_amount).sum();
@@ -94,7 +98,10 @@ mod candid_compat {
 
     #[test]
     fn legacy_two_field_arg_decodes_into_extended_struct() {
-        let legacy = LegacyGetEventsArg { start: 0, length: 100 };
+        let legacy = LegacyGetEventsArg {
+            start: 0,
+            length: 100,
+        };
         let bytes = encode_one(&legacy).expect("encode legacy");
         let decoded: GetEventsArg = decode_one(&bytes).expect("decode into extended");
 
@@ -151,8 +158,8 @@ mod validate_f64_inclusive {
 
 #[test]
 fn protocol_error_carries_multi_chain_variants() {
-    use candid::{Decode, Encode};
     use crate::ProtocolError;
+    use candid::{Decode, Encode};
     let halt = ProtocolError::SupplyInvariantHalted;
     let admin = ProtocolError::ChainAdmin("not developer".to_string());
     let halt_bytes = Encode!(&halt).expect("encode halt");
@@ -163,15 +170,23 @@ fn protocol_error_carries_multi_chain_variants() {
 
 #[test]
 fn supply_audit_round_trips_via_candid() {
-    use candid::{Decode, Encode};
-    use crate::{SupplyAudit, SupplyAuditEntry};
     use crate::chains::config::ChainId;
+    use crate::{SupplyAudit, SupplyAuditEntry};
+    use candid::{Decode, Encode};
 
     let audit = SupplyAudit {
         total_e8s: 150_000,
         per_chain: vec![
-            SupplyAuditEntry { chain_id: ChainId(1), display_name: "ICP".into(), supply_e8s: 100_000 },
-            SupplyAuditEntry { chain_id: ChainId(2), display_name: "Monad".into(), supply_e8s: 50_000 },
+            SupplyAuditEntry {
+                chain_id: ChainId(1),
+                display_name: "ICP".into(),
+                supply_e8s: 100_000,
+            },
+            SupplyAuditEntry {
+                chain_id: ChainId(2),
+                display_name: "Monad".into(),
+                supply_e8s: 50_000,
+            },
         ],
     };
     let bytes = Encode!(&audit).expect("encode");
@@ -182,40 +197,89 @@ fn supply_audit_round_trips_via_candid() {
 
 #[test]
 fn monad_event_variants_round_trip_via_candid() {
-    use candid::{Decode, Encode};
-    use crate::event::Event;
     use crate::chains::config::ChainId;
+    use crate::event::Event;
+    use candid::{Decode, Encode};
 
     let events = vec![
         Event::DepositObserved {
-            chain_id: ChainId(10143), vault_id: 1,
-            custody_address: "0xa".into(), amount_e18: 5, tx_hash: "0xh".into(),
-            block_number: 100, timestamp: 1,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            custody_address: "0xa".into(),
+            amount_e18: 5,
+            tx_hash: "0xh".into(),
+            block_number: 100,
+            timestamp: 1,
         },
         Event::ChainMintSubmitted {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
-            recipient: "0xr".into(), amount_e8s: 10, tx_hash: "0xs".into(), timestamp: 2,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 0,
+            recipient: "0xr".into(),
+            amount_e8s: 10,
+            tx_hash: "0xs".into(),
+            timestamp: 2,
         },
         Event::ChainMintConfirmed {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 0,
-            amount_e8s: 10, tx_hash: "0xs".into(), block_number: 102, timestamp: 3,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 0,
+            amount_e8s: 10,
+            tx_hash: "0xs".into(),
+            block_number: 102,
+            timestamp: 3,
         },
         Event::ChainBurnObserved {
-            chain_id: ChainId(10143), vault_id: 1,
-            amount_e8s: 4, tx_hash: "0xb".into(), block_number: 110, timestamp: 4,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            amount_e8s: 4,
+            tx_hash: "0xb".into(),
+            block_number: 110,
+            timestamp: 4,
         },
         Event::WithdrawalSigned {
-            chain_id: ChainId(10143), vault_id: 1, op_id: 1,
-            recipient: "0xw".into(), amount_e18: 5, tx_hash: "0xt".into(), timestamp: 5,
+            chain_id: ChainId(10143),
+            vault_id: 1,
+            op_id: 1,
+            recipient: "0xw".into(),
+            amount_e18: 5,
+            tx_hash: "0xt".into(),
+            timestamp: 5,
         },
         Event::ChainSettlementFailed {
-            chain_id: ChainId(10143), op_id: 1, reason: "reverted".into(), timestamp: 6,
+            chain_id: ChainId(10143),
+            op_id: 1,
+            reason: "reverted".into(),
+            timestamp: 6,
         },
         Event::ChainReorgDetected {
-            chain_id: ChainId(10143), observed_block: 100, reorg_depth: 5, timestamp: 7,
+            chain_id: ChainId(10143),
+            observed_block: 100,
+            reorg_depth: 5,
+            timestamp: 7,
         },
         Event::ChainHotWalletLow {
-            chain_id: ChainId(10143), balance_e18: 1, threshold_e18: 100, timestamp: 8,
+            chain_id: ChainId(10143),
+            balance_e18: 1,
+            threshold_e18: 100,
+            timestamp: 8,
+        },
+        Event::ChainBadDebtCircuitThresholdSet {
+            chain_id: ChainId(10143),
+            threshold_e8s: Some(10),
+            timestamp: 9,
+        },
+        Event::ChainBadDebtCircuitTripped {
+            chain_id: ChainId(10143),
+            bad_debt_e8s: 1,
+            total_bad_debt_e8s: 10,
+            threshold_e8s: 10,
+            timestamp: 10,
+        },
+        Event::ChainBadDebtCircuitCleared {
+            chain_id: ChainId(10143),
+            total_bad_debt_e8s: 10,
+            timestamp: 11,
         },
     ];
     for e in events {


### PR DESCRIPTION
## Summary
- add per-chain bad-debt circuit thresholds, status, events, and developer-gated set/clear controls
- gate risk-increasing CFX/chain paths while preserving burns, liquidations, claim payouts, and reconciliation
- make settlement queue selection skip circuit-blocked queued ops so allowed recovery ops are not starved
- keep burn catch-up live by ignoring circuit-blocked queued mints as supply-increase masks
- regenerate backend Candid and declaration artifacts

## Verification
- cargo test -p rumi_protocol_backend bad_debt_circuit --lib
- cargo test -p rumi_protocol_backend select_next_op_filter --lib
- cargo test -p rumi_protocol_backend supply_increasing_settlement_op_ignores_circuit_blocked_queued_mints --lib
- cargo test -p rumi_protocol_backend --lib
- env RUMI_REGEN_DID=1 cargo test -p rumi_protocol_backend --bin rumi_protocol_backend check_candid_interface_compatibility
- cargo test -p rumi_protocol_backend --bin rumi_protocol_backend check_candid_interface_compatibility
- npm run regenerate-declarations -- rumi_protocol_backend
- didc check src/rumi_protocol_backend/rumi_protocol_backend.did
- didc check src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
- cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
- cargo test -p stability_pool --lib
- git diff --check

## Adversarial review
- first pass found queue starvation, stale bad-debt purge, and weak decode test blockers; all fixed with regressions
- final pass found stale declaration .did parity; fixed by syncing raw declaration .did and rechecking
- final reviewers reported PASS

No merge or deploy performed.