### PR TITLE
feat(chains): Inc12 DEX config pair sanity

### DIFF
--- a/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/evm_rpc.rs
@@ -126,6 +126,8 @@ pub const TRANSFER_EVENT_TOPIC0: &str =
 pub const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
 /// `token0()[:4]` selector (UniswapV2 pair).
 pub const TOKEN0_SELECTOR: &str = "0x0dfe1681";
+/// `getPair(address,address)[:4]` selector (UniswapV2 factory).
+pub const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 /// `balanceOf(address)[:4]` selector (ERC-20).
 pub const BALANCE_OF_SELECTOR: &str = "0x70a08231";
 
@@ -388,6 +390,48 @@ pub fn parse_eth_call_u128(result_hex: &str) -> Result<u128, String> {
     }
     u128::from_str_radix(hex, 16)
         .map_err(|e| format!("eth_call result {:?} not a u128: {}", result_hex, e))
+}
+
+/// Decode an `eth_call` result word containing an ABI address into a normalized
+/// lowercase `0x` EVM address. Used for UniswapV2 factory `getPair`.
+pub fn parse_eth_call_address(result_hex: &str) -> Result<String, String> {
+    let hex = result_hex
+        .strip_prefix("0x")
+        .or_else(|| result_hex.strip_prefix("0X"))
+        .ok_or_else(|| format!("eth_call address result missing 0x prefix: {:?}", result_hex))?;
+    if hex.len() != 64 {
+        return Err(format!("eth_call address result must be one ABI word: {:?}", result_hex));
+    }
+    if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("eth_call address result not hex: {:?}", result_hex));
+    }
+    let word = hex;
+    if !word[..24].bytes().all(|b| b == b'0') {
+        return Err(format!("eth_call address result has non-zero padding: {:?}", result_hex));
+    }
+    let address = &word[24..64];
+    if address.bytes().all(|b| b == b'0') {
+        return Err(format!("eth_call address result is zero address: {:?}", result_hex));
+    }
+    Ok(format!("0x{}", address.to_lowercase()))
+}
+
+fn abi_word_address_hex(addr: &str) -> Result<String, String> {
+    let hex = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("0X")).unwrap_or(addr);
+    if hex.len() != 40 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("invalid EVM address {:?}", addr));
+    }
+    Ok(format!("{:0>64}", hex.to_lowercase()))
+}
+
+/// ABI-encode UniswapV2 factory `getPair(address,address)`.
+pub fn encode_get_pair_calldata(token_a: &str, token_b: &str) -> Result<String, String> {
+    Ok(format!(
+        "{}{}{}",
+        GET_PAIR_SELECTOR,
+        abi_word_address_hex(token_a)?,
+        abi_word_address_hex(token_b)?
+    ))
 }
 
 // ─── BurnLog ─────────────────────────────────────────────────────────────────
@@ -1159,6 +1203,21 @@ pub async fn get_pair_token0(chain: ChainId, pair: &str, block: u64) -> Result<S
         return Err(format!("token0: result too short: {:?}", hex));
     }
     Ok(format!("0x{}", raw[raw.len() - 40..].to_lowercase()))
+}
+
+/// UniswapV2 factory `getPair(tokenA, tokenB)` at a pinned block -> the pair
+/// address registered by the factory. Used by config onboarding to ensure the
+/// operator-pinned pair is the canonical pool for the configured token path.
+pub async fn get_factory_pair(
+    chain: ChainId,
+    factory: &str,
+    token_a: &str,
+    token_b: &str,
+    block: u64,
+) -> Result<String, String> {
+    let data = encode_get_pair_calldata(token_a, token_b)?;
+    let hex = eth_call_at_block(chain, factory, &data, block).await?;
+    parse_eth_call_address(&hex)
 }
 
 /// ERC-20 `balanceOf(addr)` at a pinned block (native base units). Used to

--- a/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/tests_evm_rpc.rs
@@ -376,6 +376,45 @@ fn parse_eth_call_u128_decodes_padded_word() {
     assert!(parse_eth_call_u128(&too_big).is_err());
 }
 
+#[test]
+fn parse_eth_call_address_decodes_padded_word() {
+    use crate::chains::monad::evm_rpc::parse_eth_call_address;
+
+    let word = "0x000000000000000000000000ABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD";
+    assert_eq!(
+        parse_eth_call_address(word).unwrap(),
+        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    );
+    assert!(parse_eth_call_address("0x1234").is_err());
+    assert!(parse_eth_call_address(
+        "0x00000000000000000000000000000000000000000000000000000000000000001234"
+    )
+    .is_err());
+    assert!(parse_eth_call_address(
+        "0x100000000000000000000000ABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD"
+    )
+    .is_err());
+    assert!(parse_eth_call_address(
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    .is_err());
+    assert!(parse_eth_call_address("0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").is_err());
+}
+
+#[test]
+fn encode_get_pair_calldata_matches_uniswap_v2_factory_shape() {
+    use crate::chains::monad::evm_rpc::{encode_get_pair_calldata, GET_PAIR_SELECTOR};
+
+    let a = "0x1111111111111111111111111111111111111111";
+    let b = "0x2222222222222222222222222222222222222222";
+    let calldata = encode_get_pair_calldata(a, b).unwrap();
+    assert!(calldata.starts_with(GET_PAIR_SELECTOR));
+    assert_eq!(calldata.len(), 2 + 8 + 64 + 64);
+    assert_eq!(&calldata[10..74], &format!("{:0>64}", a.trim_start_matches("0x")));
+    assert_eq!(&calldata[74..138], &format!("{:0>64}", b.trim_start_matches("0x")));
+    assert!(encode_get_pair_calldata("0x1234", b).is_err());
+}
+
 // ─── Increment 3 / Task 4: DEX getReserves parse + Transfer-log decode ───
 #[test]
 fn parse_two_uint112_splits_getreserves() {

--- a/src/rumi_protocol_backend/src/chains/liquidation_config.rs
+++ b/src/rumi_protocol_backend/src/chains/liquidation_config.rs
@@ -28,11 +28,10 @@ pub enum DexKind {
 }
 
 /// Per-chain liquidation config (operator-set, dev-gated). Holds the DEX wiring
-/// + the two risk knobs the bot path needs. Addresses are chain-native hex
-/// strings (validated by the engine's address validator at swap-build time, not
-/// here). `enabled` is the per-chain kill switch: even with the whole chains rail
-/// dev-gated, an operator must explicitly flip this on before any liquidation
-/// swap can run for the chain.
+/// + the two risk knobs the bot path needs. DEX/token addresses are EVM
+/// 0x-prefixed 20-byte hex strings validated at setter time. `enabled` is the
+/// per-chain kill switch: even with the whole chains rail dev-gated, an operator
+/// must explicitly flip this on before any liquidation swap can run for the chain.
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ChainLiquidationConfigV1 {
     /// Which DEX family to route the collateral->stable swap through.
@@ -101,6 +100,8 @@ pub enum LiquidationConfigError {
     /// An `enabled` config left a required address empty (the swap could never
     /// build). Disabled configs may carry placeholder/empty addresses.
     MissingAddress(&'static str),
+    /// A non-empty address is not an EVM `0x` + 40 hex digit address.
+    InvalidAddress { field: &'static str, address: String },
     /// An `enabled` config left the depth cap at 0 (spec §4.7): no swap could be
     /// sized. Disabled configs may carry 0.
     ZeroDepthCap,
@@ -130,22 +131,12 @@ impl ChainLiquidationConfigV1 {
                 restore_target_cr_e4: self.restore_target_cr_e4,
             });
         }
+        validate_evm_address_field("router", &self.router, self.enabled)?;
+        validate_evm_address_field("factory", &self.factory, self.enabled)?;
+        validate_evm_address_field("pair", &self.pair, self.enabled)?;
+        validate_evm_address_field("collateral_token", &self.collateral_token, self.enabled)?;
+        validate_evm_address_field("settle_stable_token", &self.settle_stable_token, self.enabled)?;
         if self.enabled {
-            if self.router.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("router"));
-            }
-            if self.factory.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("factory"));
-            }
-            if self.pair.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("pair"));
-            }
-            if self.collateral_token.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("collateral_token"));
-            }
-            if self.settle_stable_token.is_empty() {
-                return Err(LiquidationConfigError::MissingAddress("settle_stable_token"));
-            }
             if self.max_swap_value_e8s == 0 {
                 return Err(LiquidationConfigError::ZeroDepthCap);
             }
@@ -163,6 +154,49 @@ impl ChainLiquidationConfigV1 {
     }
 }
 
+fn validate_evm_address_field(
+    field: &'static str,
+    address: &str,
+    required: bool,
+) -> Result<(), LiquidationConfigError> {
+    if address.is_empty() {
+        return if required {
+            Err(LiquidationConfigError::MissingAddress(field))
+        } else {
+            Ok(())
+        };
+    }
+    canonical_evm_address(address).map(|_| ()).map_err(|_| LiquidationConfigError::InvalidAddress {
+        field,
+        address: address.to_string(),
+    })
+}
+
+/// Normalize an EVM address for equality checks after a value has passed the same
+/// setter-time validation as liquidation config addresses.
+pub fn canonical_evm_address(address: &str) -> Result<String, LiquidationConfigError> {
+    let hex = address
+        .strip_prefix("0x")
+        .or_else(|| address.strip_prefix("0X"))
+        .ok_or_else(|| LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        })?;
+    if hex.len() != 40 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        });
+    }
+    if hex.bytes().all(|b| b == b'0') {
+        return Err(LiquidationConfigError::InvalidAddress {
+            field: "address",
+            address: address.to_string(),
+        });
+    }
+    Ok(format!("0x{}", hex.to_lowercase()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,11 +204,11 @@ mod tests {
     fn enabled_cfg() -> ChainLiquidationConfigV1 {
         ChainLiquidationConfigV1 {
             dex: DexKind::UniswapV2,
-            router: "0xrouter".into(),
-            factory: "0xfactory".into(),
-            pair: "0xpair".into(),
-            collateral_token: "0xwcfx".into(),
-            settle_stable_token: "0xusdc".into(),
+            router: "0x1111111111111111111111111111111111111111".into(),
+            factory: "0x2222222222222222222222222222222222222222".into(),
+            pair: "0x3333333333333333333333333333333333333333".into(),
+            collateral_token: "0x4444444444444444444444444444444444444444".into(),
+            settle_stable_token: "0x5555555555555555555555555555555555555555".into(),
             slippage_cap_bps: 250,
             restore_target_cr_e4: 15_500,
             enabled: true,
@@ -240,6 +274,71 @@ mod tests {
         let mut c = enabled_cfg();
         c.pair = String::new();
         assert_eq!(c.validate(), Err(LiquidationConfigError::MissingAddress("pair")));
+    }
+
+    #[test]
+    fn enabled_config_with_malformed_address_rejected() {
+        let mut c = enabled_cfg();
+        c.router = "router-no-0x".into();
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::InvalidAddress {
+                field: "router",
+                address: "router-no-0x".into()
+            })
+        );
+    }
+
+    #[test]
+    fn disabled_config_rejects_malformed_non_empty_address() {
+        let mut c = enabled_cfg();
+        c.enabled = false;
+        c.max_swap_value_e8s = 0;
+        c.max_price_age_ns = 0;
+        c.settle_stable_decimals = 0;
+        c.deadline_secs = 0;
+        c.factory = "0xnothex".into();
+        assert_eq!(
+            c.validate(),
+            Err(LiquidationConfigError::InvalidAddress {
+                field: "factory",
+                address: "0xnothex".into()
+            })
+        );
+    }
+
+    #[test]
+    fn canonical_evm_address_lowercases_valid_input() {
+        assert_eq!(
+            canonical_evm_address("0XABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD").unwrap(),
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+        assert!(canonical_evm_address("0x1234").is_err());
+        assert!(canonical_evm_address("0x0000000000000000000000000000000000000000").is_err());
+    }
+
+    #[test]
+    fn enabled_config_rejects_zero_addresses_for_all_evm_fields() {
+        let zero = "0x0000000000000000000000000000000000000000".to_string();
+        for field in ["router", "factory", "pair", "collateral_token", "settle_stable_token"] {
+            let mut c = enabled_cfg();
+            match field {
+                "router" => c.router = zero.clone(),
+                "factory" => c.factory = zero.clone(),
+                "pair" => c.pair = zero.clone(),
+                "collateral_token" => c.collateral_token = zero.clone(),
+                "settle_stable_token" => c.settle_stable_token = zero.clone(),
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                c.validate(),
+                Err(LiquidationConfigError::InvalidAddress {
+                    field,
+                    address: zero.clone()
+                }),
+                "{field} zero address must reject"
+            );
+        }
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -2045,24 +2045,32 @@ fn set_chain_contract(
     Ok(())
 }
 
-/// Set (or replace) the per-chain liquidation config (spec 8, Tier B): the DEX
-/// wiring + risk knobs the bot path will read. Developer-gated. The config is
-/// validated (slippage cap <= 100%, restore target > par, required addresses
-/// present when `enabled`) before persisting; a rejected config mutates nothing.
-/// Inert until Increment 2+ reads it (Increment 1 ships only this scaffolding).
-#[candid_method(update)]
-#[update]
-fn set_chain_liquidation_config(
+fn validate_chain_liquidation_config_inputs(
     chain: rumi_protocol_backend::chains::config::ChainId,
-    config: rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
 ) -> Result<(), ProtocolError> {
-    let caller = ic_cdk::caller();
-    if read_state(|s| s.developer_principal != caller) {
-        return Err(ProtocolError::ChainAdmin("not developer".into()));
-    }
     config
         .validate()
         .map_err(|e| ProtocolError::ChainAdmin(format!("invalid liquidation config: {e:?}")))?;
+    if rumi_protocol_backend::chains::evm::evm_chain_config(chain).is_none() {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "chain {} is not a known EVM chain",
+            chain.0
+        )));
+    }
+    let chain_status = read_state(|s| s.multi_chain.chain_configs.get(&chain).map(|c| c.status));
+    match chain_status {
+        Some(rumi_protocol_backend::chains::config::ChainStatus::Registered) => {}
+        Some(status) => {
+            return Err(ProtocolError::ChainAdmin(format!(
+                "chain {} is not registered: {:?}",
+                chain.0, status
+            )));
+        }
+        None => {
+            return Err(ProtocolError::ChainAdmin(format!("unknown chain {}", chain.0)));
+        }
+    }
     // Finding #16: the penalty cushion MUST exceed the slippage + oracle-divergence
     // budget, or a swap can structurally deliver less stable than the debt it
     // clears (under-cover). Increment 3 adds the max_dex_oracle_divergence_bps term.
@@ -2081,6 +2089,72 @@ fn set_chain_liquidation_config(
                 config.slippage_cap_bps, config.max_dex_oracle_divergence_bps, penalty_bps
             )));
         }
+    }
+    Ok(())
+}
+
+async fn validate_liquidation_factory_pair(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+) -> Result<(), ProtocolError> {
+    match config.dex {
+        rumi_protocol_backend::chains::liquidation_config::DexKind::UniswapV2 => {}
+    }
+    let (_latest, finalized) = rumi_protocol_backend::chains::evm::evm_rpc::fetch_block_numbers(chain)
+        .await
+        .map_err(|e| ProtocolError::ChainAdmin(format!("factory pair sanity block read failed: {e}")))?;
+    let derived_pair = rumi_protocol_backend::chains::evm::evm_rpc::get_factory_pair(
+        chain,
+        &config.factory,
+        &config.collateral_token,
+        &config.settle_stable_token,
+        finalized,
+    )
+    .await
+    .map_err(|e| ProtocolError::ChainAdmin(format!("factory pair sanity getPair failed: {e}")))?;
+    validate_liquidation_factory_pair_match(config, &derived_pair)
+}
+
+fn validate_liquidation_factory_pair_match(
+    config: &rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+    derived_pair: &str,
+) -> Result<(), ProtocolError> {
+    let derived_pair =
+        rumi_protocol_backend::chains::liquidation_config::canonical_evm_address(derived_pair)
+            .map_err(|e| ProtocolError::ChainAdmin(format!("invalid factory pair: {e:?}")))?;
+    let pinned_pair =
+        rumi_protocol_backend::chains::liquidation_config::canonical_evm_address(&config.pair)
+            .map_err(|e| ProtocolError::ChainAdmin(format!("invalid pinned pair: {e:?}")))?;
+    if derived_pair != pinned_pair {
+        return Err(ProtocolError::ChainAdmin(format!(
+            "factory getPair({}, {}) returned {}, expected pinned pair {}",
+            config.collateral_token, config.settle_stable_token, derived_pair, pinned_pair
+        )));
+    }
+    Ok(())
+}
+
+/// Set (or replace) the per-chain liquidation config (spec 8, Tier B): the DEX
+/// wiring + risk knobs the bot path will read. Developer-gated. The config is
+/// validated (chain registered, EVM addresses well-formed, penalty cushion safe)
+/// before persisting; enabling also checks the UniswapV2 factory-derived pair
+/// matches the pinned pair. A rejected config mutates nothing.
+#[candid_method(update)]
+#[update]
+async fn set_chain_liquidation_config(
+    chain: rumi_protocol_backend::chains::config::ChainId,
+    config: rumi_protocol_backend::chains::liquidation_config::ChainLiquidationConfigV1,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::ChainAdmin("not developer".into()));
+    }
+    validate_chain_liquidation_config_inputs(chain, &config)?;
+    if config.enabled {
+        validate_liquidation_factory_pair(chain, &config).await?;
+        // State may have changed during the RPC await. Re-check all synchronous
+        // invariants immediately before mutating.
+        validate_chain_liquidation_config_inputs(chain, &config)?;
     }
     mutate_state(|s| {
         s.multi_chain
@@ -11681,6 +11755,61 @@ fn check_candid_interface_compatibility() {
         "declared candid interface in rumi_protocol_backend.did file",
         CandidSource::File(did_path.as_path()),
     );
+}
+
+#[cfg(test)]
+mod inc12_liquidation_config_tests {
+    use super::validate_liquidation_factory_pair_match;
+    use rumi_protocol_backend::chains::liquidation_config::{ChainLiquidationConfigV1, DexKind};
+
+    fn cfg() -> ChainLiquidationConfigV1 {
+        ChainLiquidationConfigV1 {
+            dex: DexKind::UniswapV2,
+            router: "0x1111111111111111111111111111111111111111".into(),
+            factory: "0x2222222222222222222222222222222222222222".into(),
+            pair: "0x3333333333333333333333333333333333333333".into(),
+            collateral_token: "0x4444444444444444444444444444444444444444".into(),
+            settle_stable_token: "0x5555555555555555555555555555555555555555".into(),
+            slippage_cap_bps: 250,
+            restore_target_cr_e4: 15_500,
+            enabled: true,
+            max_swap_value_e8s: 2_000 * 100_000_000,
+            max_price_age_ns: 1_800_000_000_000,
+            max_dex_oracle_divergence_bps: 500,
+            fee_bps: 25,
+            settle_stable_decimals: 18,
+            deadline_secs: 180,
+        }
+    }
+
+    #[test]
+    fn factory_pair_match_accepts_case_normalized_pair() {
+        assert!(validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0X3333333333333333333333333333333333333333"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn factory_pair_match_rejects_different_pair() {
+        let err = validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0x9999999999999999999999999999999999999999",
+        )
+        .expect_err("mismatched factory pair rejects");
+        assert!(format!("{err:?}").contains("expected pinned pair"));
+    }
+
+    #[test]
+    fn factory_pair_match_rejects_zero_factory_pair() {
+        let err = validate_liquidation_factory_pair_match(
+            &cfg(),
+            "0x0000000000000000000000000000000000000000",
+        )
+        .expect_err("zero factory pair rejects");
+        assert!(format!("{err:?}").contains("invalid factory pair"));
+    }
 }
 
 #[cfg(test)]

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_detection_pic.rs
@@ -213,6 +213,8 @@ const E8: u128 = 100_000_000;
 /// keccak256("Mint(uint256,address,uint256)"), must match evm_rpc.rs.
 const MINT_EVENT_TOPIC0: &str =
     "0x4e3883c75cc9c752bb1db2e406a822e4a75067ae77ad9a0a4d179f2709b9e1f6";
+/// UniswapV2 factory `getPair(address,address)` selector.
+const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 
 /// Conflux register arg's `finality_depth` (mirrors conflux_testnet_register_arg()).
 const CONFLUX_FINALITY_DEPTH: u64 = 100;
@@ -364,6 +366,15 @@ fn word_addr(addr: &str) -> String {
     format!("0x{:0>64}", raw.to_lowercase())
 }
 
+fn script_factory_pair_sanity(pic: &PocketIc, mock: Principal, pair: &str) {
+    let _ = update_any(
+        pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_PAIR_SELECTOR.to_string(), &word_addr(pair)).unwrap(),
+    );
+}
+
 // ─── liquidation config builders ─────────────────────────────────────────────
 
 /// An ENABLED Conflux liquidation config with valid wiring. slippage 250 bps
@@ -510,6 +521,7 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
         None => {
             // ── GATED subset: the new config fields decode + the new query is
             // callable. No Open vaults exist yet, so the query is empty.
+            script_factory_pair_sanity(&pic, mock, VALID_EVM_ADDR);
             decode_result(
                 update_dev(
                     &pic,
@@ -617,6 +629,7 @@ fn conflux_liquidation_detection_marks_and_endpoints() {
     let _ = update_dev(&pic, backend, "set_settlement_tick_interval_secs", Encode!(&31_536_000u64).unwrap());
 
     // ── Enable the liquidation config (master switch on) ─────────────────────
+    script_factory_pair_sanity(&pic, mock, VALID_EVM_ADDR);
     decode_result(
         update_dev(
             &pic,

--- a/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
+++ b/src/rumi_protocol_backend/tests/conflux_liquidation_swap_pic.rs
@@ -458,6 +458,8 @@ const TRANSFER_TOPIC0: &str =
 const TOKEN0_SELECTOR: &str = "0x0dfe1681";
 /// UniswapV2 pair `getReserves()` selector (must match `GET_RESERVES_SELECTOR`).
 const GET_RESERVES_SELECTOR: &str = "0x0902f1ac";
+/// UniswapV2 factory `getPair(address,address)` selector.
+const GET_PAIR_SELECTOR: &str = "0xe6a43905";
 
 /// Conflux register arg's `finality_depth` (mirrors conflux_testnet_register_arg()).
 const CONFLUX_FINALITY_DEPTH: u64 = 100;
@@ -739,6 +741,15 @@ fn word_addr(addr: &str) -> String {
     format!("0x{:0>64}", raw.to_lowercase())
 }
 
+fn script_factory_pair_sanity(pic: &PocketIc, mock: Principal, pair: &str) {
+    let _ = update_any(
+        pic,
+        mock,
+        "set_eth_call_response",
+        Encode!(&GET_PAIR_SELECTOR.to_string(), &word_addr(pair)).unwrap(),
+    );
+}
+
 // ─── liquidation config builder (ENABLED, with the Increment-3 fields) ────────
 
 /// The ENABLED Conflux liquidation config used throughout this test. Uses the
@@ -891,6 +902,7 @@ fn conflux_liquidation_swap_executes_and_credits_reserve() {
             // ── GATED subset: the new config (incl. the 4 Increment-3 fields)
             // decodes + round-trips, and the reserve/settlement address endpoints
             // correctly signal ECDSA-unavailable. We do NOT fake the swap.
+            script_factory_pair_sanity(&pic, mock, DEX_PAIR);
             decode_result(
                 update_dev(
                     &pic,
@@ -1046,6 +1058,7 @@ fn conflux_liquidation_swap_executes_and_credits_reserve() {
     update_any(&pic, mock, "set_next_send_hash", Encode!(&"0xcfxswap1".to_string()).unwrap());
 
     // ── Step 4: enable the liquidation config + drop the price to $0.08 ──────
+    script_factory_pair_sanity(&pic, mock, DEX_PAIR);
     decode_result(
         update_dev(
             &pic,
@@ -1337,6 +1350,7 @@ fn conflux_liquidation_bot_failure_sp_absorb_claims_cfx() {
     );
     assert_supply(&pic, backend, 100 * E8, "after mint");
 
+    script_factory_pair_sanity(&pic, mock, DEX_PAIR);
     decode_result(
         update_dev(
             &pic,
@@ -1469,12 +1483,21 @@ fn conflux_liquidation_bot_failure_sp_absorb_claims_cfx() {
     assert!(v.pending_liquidation.is_none(), "SP absorb does not create a marker");
     assert_supply(&pic, backend, 100 * E8, "after SP absorb (foreign supply unchanged)");
     let duplicate_absorb = sp_absorb_chain_vault(&pic, sp, vault_id)
-        .expect_err("second SP absorb must reject");
-    assert!(
-        matches!(duplicate_absorb, StabilityPoolError::LiquidationFailed { .. }),
-        "duplicate absorb should reject cleanly, got {:?}",
-        duplicate_absorb
+        .expect("duplicate SP absorb returns the stored idempotent result");
+    assert!(duplicate_absorb.success, "duplicate SP absorb returns success");
+    assert_eq!(duplicate_absorb.vault_id, absorb.vault_id);
+    assert_eq!(duplicate_absorb.chain_id, absorb.chain_id);
+    assert_eq!(duplicate_absorb.icusd_burned_e8s, absorb.icusd_burned_e8s);
+    assert_eq!(
+        duplicate_absorb.liquidated_debt_e8s, absorb.liquidated_debt_e8s,
+        "duplicate SP absorb must not burn or absorb a different debt amount"
     );
+    assert_eq!(
+        duplicate_absorb.collateral_received_native, absorb.collateral_received_native,
+        "duplicate SP absorb must replay the stored collateral seizure"
+    );
+    assert_eq!(duplicate_absorb.claim_id, absorb.claim_id);
+    assert_eq!(duplicate_absorb.block_index, absorb.block_index);
 
     update_any(&pic, mock, "set_total_supply", Encode!(&(100u128 * E8)).unwrap());
     let recon = reconcile_chain_supply(&pic, backend).expect("reconcile_chain_supply Ok");


### PR DESCRIPTION
## Summary
- validate liquidation config EVM addresses as nonzero 0x-prefixed 20-byte hex
- require enabled configs to pass UniswapV2 factory getPair sanity before persistence
- script factory getPair in Conflux PIC tests and align duplicate SP absorb assertion with stored retry behavior

## Verification
- cargo test -p rumi_protocol_backend liquidation_config --lib
- cargo test -p rumi_protocol_backend parse_eth_call_address --lib
- cargo test -p rumi_protocol_backend encode_get_pair_calldata --lib
- cargo test -p rumi_protocol_backend --bin rumi_protocol_backend factory_pair_match
- env POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_liquidation_detection_pic -- --nocapture
- env POCKET_IC_BIN=/Users/robertripley/coding/rumi-protocol-v2/pocket-ic cargo test -p rumi_protocol_backend --test conflux_liquidation_swap_pic -- --nocapture
- cargo test -p rumi_protocol_backend --lib
- cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
- cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend -p monad_rpc_mock
- cargo build --target wasm32-unknown-unknown --release -p stability_pool
- git diff --check

## Adversarial verification
- Round 1 found all-zero EVM address acceptance as a blocker
- Fixed by rejecting zero config addresses and zero factory getPair results
- Fresh round passed with two independent reviewers