### PR TITLE
feat(chains): Inc13 Conflux mainnet EVM config

### DIFF
--- a/src/rumi_protocol_backend/src/chains/evm/conflux/config.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/conflux/config.rs
@@ -1,4 +1,4 @@
-//! Conflux eSpace TESTNET configuration (chain id 71).
+//! Conflux eSpace configuration.
 //!
 //! eSpace is EVM-compatible and supports EIP-1559 (since the v2.4.0 hardfork),
 //! so the shared EVM tx builder / tECDSA / EVM-RPC path applies unchanged.
@@ -11,9 +11,16 @@ use crate::chains::config::{ChainId, GasStrategy, RegisterChainArg};
 
 /// Conflux eSpace TESTNET chain id (mainnet is 1030).
 pub const CONFLUX_TESTNET_CHAIN_ID: ChainId = ChainId(71);
+/// Conflux eSpace MAINNET chain id. This is where real Swappi liquidity lives.
+pub const CONFLUX_MAINNET_CHAIN_ID: ChainId = ChainId(1030);
 
 /// CFX native gas asset decimals (wei-style, like ETH).
 pub const CFX_NATIVE_DECIMALS: u8 = 18;
+
+/// Mainnet finality default used by the gated-launch runbook.
+pub const CONFLUX_MAINNET_FINALITY_DEPTH: u32 = 400;
+/// Minimum independent-provider quorum floor for mainnet financial reads.
+pub const CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS: u32 = 2;
 
 /// Candidate Conflux eSpace TESTNET RPC endpoints. VERIFY live at deploy time.
 /// NOTE: all three are Confura (the Conflux Foundation's own service, one
@@ -51,6 +58,26 @@ pub fn conflux_testnet_register_arg() -> RegisterChainArg {
     }
 }
 
+/// Registration payload for Conflux eSpace mainnet.
+///
+/// Operators must pass independent, deployment-vetted RPC endpoints. This helper
+/// deliberately does not carry baked-in provider URLs because the safety property
+/// is provider independence, not any specific public endpoint.
+pub fn conflux_mainnet_register_arg(rpc_endpoints: Vec<String>) -> RegisterChainArg {
+    RegisterChainArg {
+        chain_id: CONFLUX_MAINNET_CHAIN_ID,
+        display_name: "ConfluxESpaceMainnet".to_string(),
+        rpc_endpoints,
+        finality_depth: CONFLUX_MAINNET_FINALITY_DEPTH,
+        gas_strategy: GasStrategy::EvmEip1559 {
+            max_priority_fee_gwei: 1,
+            max_fee_gwei_ceiling: 200,
+        },
+        chain_native_decimals: CFX_NATIVE_DECIMALS,
+        min_quorum_providers: Some(CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +91,31 @@ mod tests {
         assert_eq!(arg.rpc_endpoints.len(), 3);
         assert!(matches!(arg.gas_strategy, GasStrategy::EvmEip1559 { .. }));
         assert!(arg.finality_depth >= 1); // register validation requires >= 1
+    }
+
+    #[test]
+    fn register_arg_is_conflux_mainnet() {
+        let endpoints = vec![
+            "https://evm.confluxrpc.com".to_string(),
+            "https://conflux-espace.example-rpc-a.invalid".to_string(),
+            "https://conflux-espace.example-rpc-b.invalid".to_string(),
+        ];
+        let arg = conflux_mainnet_register_arg(endpoints.clone());
+        assert_eq!(arg.chain_id, ChainId(1030));
+        assert_eq!(arg.display_name, "ConfluxESpaceMainnet");
+        assert_eq!(arg.rpc_endpoints, endpoints);
+        assert_eq!(arg.finality_depth, CONFLUX_MAINNET_FINALITY_DEPTH);
+        assert_eq!(arg.chain_native_decimals, CFX_NATIVE_DECIMALS);
+        assert_eq!(
+            arg.min_quorum_providers,
+            Some(CONFLUX_MAINNET_MIN_QUORUM_PROVIDERS)
+        );
+        assert!(matches!(
+            arg.gas_strategy,
+            GasStrategy::EvmEip1559 {
+                max_priority_fee_gwei: 1,
+                max_fee_gwei_ceiling: 200
+            }
+        ));
     }
 }

--- a/src/rumi_protocol_backend/src/chains/evm/mod.rs
+++ b/src/rumi_protocol_backend/src/chains/evm/mod.rs
@@ -84,6 +84,13 @@ pub fn evm_chain_config(chain: ChainId) -> Option<EvmChainConfig> {
             native_decimals: 18,
             native_symbol: "CFX",
         }),
+        1030 => Some(EvmChainConfig {
+            chain_id: ChainId(1030),
+            ecdsa_key_name: "test_key_1",
+            getlogs_max_range: 1000,
+            native_decimals: 18,
+            native_symbol: "CFX",
+        }),
         _ => None,
     }
 }
@@ -107,6 +114,15 @@ mod tests {
         assert_eq!(c.getlogs_max_range, 1000);
         assert_eq!(c.native_symbol, "CFX");
         assert_eq!(c.native_decimals, 18);
+    }
+
+    #[test]
+    fn conflux_mainnet_1030_getlogs_range_1000() {
+        let c = evm_chain_config(ChainId(1030)).expect("conflux mainnet known");
+        assert_eq!(c.getlogs_max_range, 1000);
+        assert_eq!(c.native_symbol, "CFX");
+        assert_eq!(c.native_decimals, 18);
+        assert_eq!(c.ecdsa_key_name, "test_key_1");
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -11308,6 +11308,10 @@ mod chain_vault_param_tests {
             evm_vault_params(ChainId(71)).unwrap(),
             ("CFX", 15_000, 10_000_000, Some(500 * 100_000_000))
         ); // Conflux: 150% open gate + 500-icUSD ceiling
+        assert_eq!(
+            evm_vault_params(ChainId(1030)).unwrap(),
+            ("CFX", 15_000, 10_000_000, Some(500 * 100_000_000))
+        ); // Conflux mainnet mirrors testnet risk params
         assert!(evm_vault_params(ChainId(999)).is_err());
     }
 


### PR DESCRIPTION
## Summary
- add Conflux eSpace mainnet chain id 1030 to backend EVM chain config
- add operator-supplied Conflux mainnet registration helper with finality/quorum defaults
- assert 1030 resolves CFX vault params matching existing Conflux risk posture

## Verification
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo test -p rumi_protocol_backend conflux_mainnet --lib
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo test -p rumi_protocol_backend conflux_mainnet_1030_getlogs_range_1000 --lib
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo test -p rumi_protocol_backend --bin rumi_protocol_backend evm_vault_params_resolves_per_chain
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo test -p rumi_protocol_backend --lib
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo test -p rumi_protocol_backend --bin rumi_protocol_backend
- env CARGO_TARGET_DIR=/Users/robertripley/coding/rumi-protocol-v2/target cargo build --target wasm32-unknown-unknown --release -p rumi_protocol_backend
- git diff --check

## Adversarial review
- Two independent reviewers passed with no blockers.
- Live activation still requires operator proof that the supplied Conflux mainnet RPC endpoints are independent and satisfy quorum; no merge/deploy/activation performed in this increment.