### PR TITLE
feat(xrp): quarantine + admin-resolve for diverged native-XRP claims (F-03)

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -35,6 +35,11 @@ export interface BotStatsResponse {
   'budget_total_e8s' : bigint,
   'budget_start_timestamp' : bigint,
 }
+export interface BurnSettlementProofArg {
+  'log_index' : bigint,
+  'expected_burner' : [] | [string],
+  'tx_hash' : string,
+}
 export interface CandidVault {
   'collateral_amount' : bigint,
   'owner' : Principal,
@@ -952,6 +957,13 @@ export interface OpenVaultSuccess {
   'block_index' : bigint,
   'vault_id' : bigint,
 }
+export interface PendingChainBurnAging {
+  'pending_chain_burn_e8s' : bigint,
+  'proof_count' : bigint,
+  'age_ns' : [] | [bigint],
+  'chain_id' : number,
+  'oldest_reference_ns' : [] | [bigint],
+}
 export interface PendingLiquidationV1 {
   'started_at_ns' : bigint,
   'op_id' : bigint,
@@ -1114,6 +1126,13 @@ export interface ReserveRedemptionResult {
   'fee_amount' : bigint,
   'stable_amount_sent' : bigint,
 }
+export interface ReserveSettlementProofArg {
+  'expected_burner' : [] | [string],
+  'burn_tx_hash' : string,
+  'burn_log_index' : bigint,
+  'reserve_tx_hash' : string,
+  'reserve_transfer_log_index' : bigint,
+}
 export type Result = { 'Ok' : null } |
   { 'Err' : ProtocolError };
 export type Result_1 = { 'Ok' : bigint } |
@@ -1156,6 +1175,10 @@ export type Result_8 = { 'Ok' : number } |
   { 'Err' : ProtocolError };
 export type Result_9 = { 'Ok' : ConsentInfo } |
   { 'Err' : Icrc21Error };
+export interface SettlementProofIds {
+  'pending' : Array<string>,
+  'reserve' : Array<string>,
+}
 export type SpProofLedger = { 'IcusdBurn' : null } |
   { 'ThreePoolTransfer' : null };
 export interface SpWritedownProof {
@@ -1290,10 +1313,13 @@ export interface XrpClaim {
   'custody_nonce' : bigint,
   'claimant' : Principal,
   'created_at_ns' : bigint,
+  'quarantine_reason' : [] | [string],
   'custody_owner' : Principal,
   'drops' : bigint,
   'settlement' : [] | [XrpSettlement],
 }
+export type XrpClaimResolution = { 'ReleaseForRetry' : null } |
+  { 'ConfirmPaid' : null };
 export interface XrpPendingDeposit {
   'reserve_base_drops' : bigint,
   'owner' : Principal,
@@ -1326,7 +1352,9 @@ export interface _SERVICE {
     Result_2
   >,
   'admin_mint_icusd' : ActorMethod<[bigint, Principal, string], Result_1>,
+  'admin_quarantine_xrp_claim' : ActorMethod<[bigint, string], Result>,
   'admin_resolve_stuck_claim' : ActorMethod<[bigint, boolean], Result>,
+  'admin_resolve_xrp_claim' : ActorMethod<[bigint, XrpClaimResolution], Result>,
   'admin_sweep_to_treasury' : ActorMethod<[string], Result_1>,
   'borrow_chain_vault_evm' : ActorMethod<
     [VaultIntent, Uint8Array | number[]],
@@ -1445,6 +1473,10 @@ export interface _SERVICE {
     Array<[bigint, XrpPendingDeposit]>
   >,
   'get_pending_amm1_donations_count' : ActorMethod<[], bigint>,
+  'get_pending_chain_burn_aging' : ActorMethod<
+    [],
+    Array<PendingChainBurnAging>
+  >,
   'get_price_pusher_allowed' : ActorMethod<[], Array<[number, string]>>,
   'get_price_pusher_principal' : ActorMethod<[], [] | [Principal]>,
   'get_protocol_3usd_reserves' : ActorMethod<[], bigint>,
@@ -1467,6 +1499,7 @@ export interface _SERVICE {
   'get_rmr_ceiling_cr' : ActorMethod<[], number>,
   'get_rmr_floor' : ActorMethod<[], number>,
   'get_rmr_floor_cr' : ActorMethod<[], number>,
+  'get_settlement_proof_ids' : ActorMethod<[[] | [number]], SettlementProofIds>,
   'get_snapshot_count' : ActorMethod<[], bigint>,
   'get_sp_writedown_disabled' : ActorMethod<[], boolean>,
   'get_stability_pool_config' : ActorMethod<[], StabilityPoolConfig>,
@@ -1494,6 +1527,7 @@ export interface _SERVICE {
     [],
     Array<[bigint, XrpPendingDeposit]>
   >,
+  'get_xrp_quarantined_claims' : ActorMethod<[], Array<[bigint, XrpClaim]>>,
   'get_xrp_schnorr_key_name' : ActorMethod<[], string>,
   'harvest_chain_interest' : ActorMethod<[number], Result_1>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse_1>,
@@ -1652,7 +1686,15 @@ export interface _SERVICE {
   'set_xrc_fetch_interval_secs' : ActorMethod<[bigint], Result>,
   'set_xrp_schnorr_key_name' : ActorMethod<[string], Result>,
   'settle_pending_chain_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_pending_chain_burn_with_proof' : ActorMethod<
+    [number, BurnSettlementProofArg],
+    Result
+  >,
   'settle_reserve_burn' : ActorMethod<[number, bigint, string], Result>,
+  'settle_reserve_burn_with_proof' : ActorMethod<
+    [number, ReserveSettlementProofArg],
+    Result
+  >,
   'settle_xrp_claim' : ActorMethod<[bigint, string], Result_2>,
   'settle_xrp_claim_with_tag' : ActorMethod<[bigint, string, number], Result_2>,
   'solana_bootstrap_nonce' : ActorMethod<[[] | [string]], Result>,

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -111,6 +111,10 @@ export const idlFactory = ({ IDL }) => {
     'correct_borrowed_e8s' : IDL.Nat64,
   });
   const Result_2 = IDL.Variant({ 'Ok' : IDL.Text, 'Err' : ProtocolError });
+  const XrpClaimResolution = IDL.Variant({
+    'ReleaseForRetry' : IDL.Null,
+    'ConfirmPaid' : IDL.Null,
+  });
   const VaultIntent = IDL.Record({
     'action' : IDL.Nat8,
     'owner' : IDL.Text,
@@ -925,6 +929,7 @@ export const idlFactory = ({ IDL }) => {
     'custody_nonce' : IDL.Nat64,
     'claimant' : IDL.Principal,
     'created_at_ns' : IDL.Nat64,
+    'quarantine_reason' : IDL.Opt(IDL.Text),
     'custody_owner' : IDL.Principal,
     'drops' : IDL.Nat64,
     'settlement' : IDL.Opt(XrpSettlement),
@@ -935,6 +940,13 @@ export const idlFactory = ({ IDL }) => {
     'custody_address' : IDL.Text,
     'opened_at_ns' : IDL.Nat64,
     'derivation_nonce' : IDL.Nat64,
+  });
+  const PendingChainBurnAging = IDL.Record({
+    'pending_chain_burn_e8s' : IDL.Nat,
+    'proof_count' : IDL.Nat64,
+    'age_ns' : IDL.Opt(IDL.Nat64),
+    'chain_id' : IDL.Nat32,
+    'oldest_reference_ns' : IDL.Opt(IDL.Nat64),
   });
   const ProtocolConfig = IDL.Record({
     'global_rate_curve' : IDL.Vec(IDL.Tuple(IDL.Float64, IDL.Float64)),
@@ -1046,6 +1058,10 @@ export const idlFactory = ({ IDL }) => {
     'balance' : IDL.Nat64,
     'ledger' : IDL.Principal,
     'symbol' : IDL.Text,
+  });
+  const SettlementProofIds = IDL.Record({
+    'pending' : IDL.Vec(IDL.Text),
+    'reserve' : IDL.Vec(IDL.Text),
   });
   const StabilityPoolConfig = IDL.Record({
     'enabled' : IDL.Bool,
@@ -1210,6 +1226,18 @@ export const idlFactory = ({ IDL }) => {
     'display_name' : IDL.Opt(IDL.Text),
     'min_quorum_providers' : IDL.Opt(IDL.Opt(IDL.Nat32)),
   });
+  const BurnSettlementProofArg = IDL.Record({
+    'log_index' : IDL.Nat64,
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'tx_hash' : IDL.Text,
+  });
+  const ReserveSettlementProofArg = IDL.Record({
+    'expected_burner' : IDL.Opt(IDL.Text),
+    'burn_tx_hash' : IDL.Text,
+    'burn_log_index' : IDL.Nat64,
+    'reserve_tx_hash' : IDL.Text,
+    'reserve_transfer_log_index' : IDL.Nat64,
+  });
   const Result_17 = IDL.Variant({
     'Ok' : IDL.Vec(IDL.Nat8),
     'Err' : ProtocolError,
@@ -1268,7 +1296,17 @@ export const idlFactory = ({ IDL }) => {
         [Result_1],
         [],
       ),
+    'admin_quarantine_xrp_claim' : IDL.Func(
+        [IDL.Nat64, IDL.Text],
+        [Result],
+        [],
+      ),
     'admin_resolve_stuck_claim' : IDL.Func([IDL.Nat64, IDL.Bool], [Result], []),
+    'admin_resolve_xrp_claim' : IDL.Func(
+        [IDL.Nat64, XrpClaimResolution],
+        [Result],
+        [],
+      ),
     'admin_sweep_to_treasury' : IDL.Func([IDL.Text], [Result_1], []),
     'borrow_chain_vault_evm' : IDL.Func(
         [VaultIntent, IDL.Vec(IDL.Nat8)],
@@ -1461,6 +1499,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_pending_amm1_donations_count' : IDL.Func([], [IDL.Nat64], ['query']),
+    'get_pending_chain_burn_aging' : IDL.Func(
+        [],
+        [IDL.Vec(PendingChainBurnAging)],
+        ['query'],
+      ),
     'get_price_pusher_allowed' : IDL.Func(
         [],
         [IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Text))],
@@ -1492,6 +1535,11 @@ export const idlFactory = ({ IDL }) => {
     'get_rmr_ceiling_cr' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor' : IDL.Func([], [IDL.Float64], ['query']),
     'get_rmr_floor_cr' : IDL.Func([], [IDL.Float64], ['query']),
+    'get_settlement_proof_ids' : IDL.Func(
+        [IDL.Opt(IDL.Nat32)],
+        [SettlementProofIds],
+        ['query'],
+      ),
     'get_snapshot_count' : IDL.Func([], [IDL.Nat64], ['query']),
     'get_sp_writedown_disabled' : IDL.Func([], [IDL.Bool], ['query']),
     'get_stability_pool_config' : IDL.Func(
@@ -1556,6 +1604,11 @@ export const idlFactory = ({ IDL }) => {
     'get_xrp_pending_deposits' : IDL.Func(
         [],
         [IDL.Vec(IDL.Tuple(IDL.Nat64, XrpPendingDeposit))],
+        ['query'],
+      ),
+    'get_xrp_quarantined_claims' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat64, XrpClaim))],
         ['query'],
       ),
     'get_xrp_schnorr_key_name' : IDL.Func([], [IDL.Text], ['query']),
@@ -1858,8 +1911,18 @@ export const idlFactory = ({ IDL }) => {
         [Result],
         [],
       ),
+    'settle_pending_chain_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, BurnSettlementProofArg],
+        [Result],
+        [],
+      ),
     'settle_reserve_burn' : IDL.Func(
         [IDL.Nat32, IDL.Nat, IDL.Text],
+        [Result],
+        [],
+      ),
+    'settle_reserve_burn_with_proof' : IDL.Func(
+        [IDL.Nat32, ReserveSettlementProofArg],
         [Result],
         [],
       ),

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1110,10 +1110,12 @@ type XrpClaim = record {
   custody_nonce : nat64;
   claimant : principal;
   created_at_ns : nat64;
+  quarantine_reason : opt text;
   custody_owner : principal;
   drops : nat64;
   settlement : opt XrpSettlement;
 };
+type XrpClaimResolution = variant { ReleaseForRetry; ConfirmPaid };
 type XrpPendingDeposit = record {
   reserve_base_drops : nat64;
   owner : principal;
@@ -1140,7 +1142,9 @@ service : (ProtocolArg) -> {
   admin_correct_vault_collateral : (nat64, nat64, text) -> (Result);
   admin_correct_vault_debts : (vec VaultDebtCorrection) -> (Result_2);
   admin_mint_icusd : (nat64, principal, text) -> (Result_1);
+  admin_quarantine_xrp_claim : (nat64, text) -> (Result);
   admin_resolve_stuck_claim : (nat64, bool) -> (Result);
+  admin_resolve_xrp_claim : (nat64, XrpClaimResolution) -> (Result);
   admin_sweep_to_treasury : (text) -> (Result_1);
   borrow_chain_vault_evm : (VaultIntent, blob) -> (Result);
   borrow_from_vault : (VaultArg) -> (Result_3);
@@ -1272,6 +1276,7 @@ service : (ProtocolArg) -> {
   get_xrp_pending_deposits : () -> (
       vec record { nat64; XrpPendingDeposit },
     ) query;
+  get_xrp_quarantined_claims : () -> (vec record { nat64; XrpClaim }) query;
   get_xrp_schnorr_key_name : () -> (text) query;
   harvest_chain_interest : (nat32) -> (Result_1);
   http_request : (HttpRequest) -> (HttpResponse_1) query;

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -5560,6 +5560,95 @@ fn get_xrp_claims() -> Vec<(u64, rumi_protocol_backend::state::XrpClaim)> {
     })
 }
 
+/// F-03 resolution action for a quarantined native-XRP claim. The admin first verifies
+/// OFF-ledger (custody `account_info` balance/Sequence + an XRPL explorer) whether the
+/// divergent Payment actually delivered to the claimant, then applies one of these.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum XrpClaimResolution {
+    /// The divergent Payment DID deliver — finalize by removing the claim (no re-pay).
+    ConfirmPaid,
+    /// The Payment did NOT deliver — clear the quarantine + settlement so the claimant
+    /// can retry `settle_xrp_claim` and be paid exactly once.
+    ReleaseForRetry,
+}
+
+/// F-03 observability: native-XRP claims currently quarantined (a settlement divergence
+/// is suspected — resolve via `admin_resolve_xrp_claim`). Developer-gated read.
+#[candid_method(query)]
+#[query]
+fn get_xrp_quarantined_claims() -> Vec<(u64, rumi_protocol_backend::state::XrpClaim)> {
+    let caller = ic_cdk::caller();
+    read_state(|s| {
+        if s.developer_principal != caller {
+            return Vec::new();
+        }
+        s.xrp_claims
+            .iter()
+            .filter(|(_, c)| c.quarantine_reason.is_some())
+            .map(|(id, c)| (*id, c.clone()))
+            .collect()
+    })
+}
+
+/// F-03 defense-in-depth: manually quarantine a native-XRP claim (e.g. ops suspects a
+/// divergence the automatic Sequence guard has not yet hit). Developer-gated, idempotent.
+#[candid_method(update)]
+#[update]
+fn admin_quarantine_xrp_claim(claim_id: u64, reason: String) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::GenericError(
+            "Only the developer can quarantine XRP claims".to_string(),
+        ));
+    }
+    mutate_state(|s| match s.xrp_claims.get_mut(&claim_id) {
+        Some(c) => {
+            if c.quarantine_reason.is_none() {
+                c.quarantine_reason = Some(if reason.trim().is_empty() {
+                    "manually quarantined by admin".to_string()
+                } else {
+                    reason
+                });
+            }
+            log!(INFO, "[admin_quarantine_xrp_claim] claim #{} quarantined", claim_id);
+            Ok(())
+        }
+        None => Err(ProtocolError::GenericError(format!(
+            "No such XRP claim #{claim_id}"
+        ))),
+    })
+}
+
+/// F-03: resolve a quarantined native-XRP claim after off-ledger reconciliation.
+/// Developer-gated. Errors if the claim is absent or not quarantined, so a resolve can
+/// never silently drop a healthy, still-settle-able claim. See `XrpClaimResolution`.
+#[candid_method(update)]
+#[update]
+fn admin_resolve_xrp_claim(
+    claim_id: u64,
+    resolution: XrpClaimResolution,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    if read_state(|s| s.developer_principal != caller) {
+        return Err(ProtocolError::GenericError(
+            "Only the developer can resolve XRP claims".to_string(),
+        ));
+    }
+    let confirm_paid = matches!(resolution, XrpClaimResolution::ConfirmPaid);
+    mutate_state(|s| {
+        rumi_protocol_backend::vault::resolve_quarantined_xrp_claim_snapshot(
+            s, claim_id, confirm_paid,
+        )
+    })?;
+    log!(
+        INFO,
+        "[admin_resolve_xrp_claim] claim #{} resolved {:?}",
+        claim_id,
+        resolution
+    );
+    Ok(())
+}
+
 /// P5 (frontend): the caller's OWN native-XRP pending deposits (those whose vault
 /// the caller opened). Unlike `get_xrp_pending_deposits` (developer-gated, all
 /// users), this is the per-user read the UI uses to show "send XRP to this custody

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -811,6 +811,15 @@ pub struct XrpClaim {
     /// is reconciled rather than paid twice. `None` = nothing submitted yet.
     #[serde(default)]
     pub settlement: Option<XrpSettlement>,
+    /// F-03 quarantine: set with a human-readable reason when the settle path detects
+    /// that this claim's custody-account Sequence advanced past the recorded
+    /// `source_sequence` while the recorded `tx_hash` is NotFound on-ledger — i.e. the
+    /// signed Payment may already have settled under a divergent hash. While `Some`,
+    /// `settle_xrp_claim` refuses to sign (so the claim cannot be double-paid); an
+    /// admin resolves it via `admin_resolve_xrp_claim` after off-chain reconciliation.
+    /// `None` = healthy. ciborium `#[serde(default)]` so older snapshots decode healthy.
+    #[serde(default)]
+    pub quarantine_reason: Option<String>,
 }
 
 /// P4: the settlement Payment already signed + submitted for an `XrpClaim`.
@@ -7506,11 +7515,42 @@ mod tests {
             custody_nonce: 9,
             created_at_ns: 42,
             settlement: None,
+            quarantine_reason: Some("diverged".to_string()),
         };
         let mut buf = Vec::new();
         ciborium::ser::into_writer(&c, &mut buf).unwrap();
         let back: XrpClaim = ciborium::de::from_reader(buf.as_slice()).unwrap();
         assert_eq!(c, back);
+    }
+
+    /// Migration safety: a pre-quarantine ciborium snapshot (a map WITHOUT the
+    /// `quarantine_reason` key) must decode as a healthy claim (`None`), not trap —
+    /// the `#[serde(default)]` analogue of the existing `settlement` field handling.
+    #[test]
+    fn xrp_claim_decodes_pre_quarantine_snapshot_as_healthy() {
+        // Encode a struct with the OLD shape (no quarantine_reason) via a serde map.
+        #[derive(serde::Serialize)]
+        struct OldXrpClaim {
+            claimant: Principal,
+            drops: u64,
+            custody_owner: Principal,
+            custody_nonce: u64,
+            created_at_ns: u64,
+            settlement: Option<XrpSettlement>,
+        }
+        let old = OldXrpClaim {
+            claimant: Principal::anonymous(),
+            drops: 4_000_000,
+            custody_owner: Principal::from_slice(&[0xab; 16]),
+            custody_nonce: 9,
+            created_at_ns: 42,
+            settlement: None,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&old, &mut buf).unwrap();
+        let restored: XrpClaim = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        assert_eq!(restored.quarantine_reason, None);
+        assert_eq!(restored.drops, 4_000_000);
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -1274,6 +1274,7 @@ pub(crate) fn record_xrp_claim(
             custody_nonce,
             created_at_ns: now_ns,
             settlement: None,
+            quarantine_reason: None,
         },
     );
     claim_id
@@ -1436,6 +1437,60 @@ pub(crate) fn reconcile_xrp_settlement_snapshot(
     true
 }
 
+/// F-03: durably flag a claim as quarantined because a settlement divergence is
+/// suspected (its custody Sequence advanced past the recorded `source_sequence` while
+/// the recorded tx_hash is NotFound on-ledger). Idempotent: keeps the first reason set,
+/// so repeated detection does not overwrite the most precise diagnostic. While a claim
+/// is quarantined `settle_xrp_claim` refuses to sign; an admin clears it via
+/// `admin_resolve_xrp_claim`. Returns true if the claim exists.
+pub(crate) fn quarantine_xrp_claim_snapshot(
+    s: &mut crate::state::State,
+    claim_id: u64,
+    reason: &str,
+) -> bool {
+    if let Some(claim) = s.xrp_claims.get_mut(&claim_id) {
+        if claim.quarantine_reason.is_none() {
+            claim.quarantine_reason = Some(reason.to_string());
+        }
+        true
+    } else {
+        false
+    }
+}
+
+/// F-03: apply an admin resolution to a quarantined claim after off-ledger
+/// reconciliation. `confirm_paid = true` means the admin verified the divergent Payment
+/// DID deliver -> remove the claim (no re-pay). `false` means it did NOT deliver -> clear
+/// the quarantine + settlement so the claimant can retry settle and be paid exactly once.
+/// Errors WITHOUT mutating if the claim is absent or not quarantined, so a resolve can
+/// never silently drop a healthy, still-settle-able claim. `pub` for the main.rs endpoint.
+pub fn resolve_quarantined_xrp_claim_snapshot(
+    s: &mut crate::state::State,
+    claim_id: u64,
+    confirm_paid: bool,
+) -> Result<(), ProtocolError> {
+    match s.xrp_claims.get(&claim_id) {
+        Some(c) if c.quarantine_reason.is_some() => {}
+        Some(_) => {
+            return Err(ProtocolError::GenericError(format!(
+                "XRP claim #{claim_id} is not quarantined; refusing to resolve a healthy claim"
+            )))
+        }
+        None => {
+            return Err(ProtocolError::GenericError(format!(
+                "No such XRP claim #{claim_id}"
+            )))
+        }
+    }
+    if confirm_paid {
+        s.xrp_claims.remove(&claim_id);
+    } else if let Some(c) = s.xrp_claims.get_mut(&claim_id) {
+        c.quarantine_reason = None;
+        c.settlement = None;
+    }
+    Ok(())
+}
+
 async fn reconcile_xrp_other_inflight_claims(
     current_claim_id: u64,
     custody_owner: Principal,
@@ -1488,15 +1543,23 @@ async fn reconcile_xrp_other_inflight_claims(
                 });
             }
             // F-03: the sibling's Payment consumed its source Sequence under a hash that
-            // differs from the one we recorded, so it may already have paid out. Refuse to
-            // clear the blocker (which would let it be re-signed and double-paid) and fail
-            // the current settle closed; the sibling stays quarantined until reconciled.
+            // differs from the one we recorded, so it may already have paid out. Durably
+            // quarantine the sibling (so future settles refuse it too), refuse to clear the
+            // blocker (which would let it be re-signed and double-paid), and fail the
+            // current settle closed; an admin resolves the sibling via admin_resolve_xrp_claim.
             XrpSiblingReconcileDecision::QuarantineDiverged => {
+                let reason = format!(
+                    "settlement diverged: custody account sequence advanced past source \
+                     sequence while tx_hash {} is NotFound on-ledger; Payment may already \
+                     have settled under a different hash",
+                    settlement.tx_hash
+                );
+                mutate_state(|s| {
+                    quarantine_xrp_claim_snapshot(s, other_claim_id, &reason);
+                });
                 return Err(ProtocolError::GenericError(format!(
-                    "xrp sibling claim #{other_claim_id} settlement diverged: custody account \
-                     sequence advanced past its source sequence, so its Payment may already \
-                     have settled under a different hash. Refusing to clear the blocker to \
-                     avoid a double-pay; manual reconciliation required."
+                    "xrp sibling claim #{other_claim_id} quarantined ({reason}). Refusing to \
+                     clear the blocker to avoid a double-pay; manual reconciliation required."
                 )));
             }
         }
@@ -1776,6 +1839,14 @@ pub async fn settle_xrp_claim_with_tag(
         return Err(ProtocolError::CallerNotOwner);
     }
 
+    // F-03: a quarantined claim may already have been paid under a divergent hash.
+    // Refuse to sign anything until an admin resolves it (admin_resolve_xrp_claim).
+    if let Some(reason) = claim.quarantine_reason.clone() {
+        return Err(ProtocolError::GenericError(format!(
+            "XRP claim #{claim_id} is quarantined ({reason}); awaiting admin reconciliation."
+        )));
+    }
+
     let guard_principal = GuardPrincipal::new(caller, &format!("settle_xrp_claim_{}", claim_id))?;
     // Per-custody-address sequence serialization: custody_nonce == the source vault
     // id, so this per-vault lock prevents two concurrent Payments from one custody
@@ -1840,6 +1911,16 @@ pub async fn settle_xrp_claim_with_tag(
                     ));
                 }
                 if let Err(e) = ensure_xrp_replacement_sequence_safe(&prev, &acct) {
+                    // F-03: the prior Payment's source Sequence was consumed (under some
+                    // hash) yet our recorded tx_hash is NotFound on-ledger — a divergence.
+                    // Durably quarantine so future settles short-circuit, then fail closed.
+                    let reason = format!(
+                        "settlement diverged: {:?} (tx_hash {} NotFound on-ledger)",
+                        e, prev.tx_hash
+                    );
+                    mutate_state(|s| {
+                        quarantine_xrp_claim_snapshot(s, claim_id, &reason);
+                    });
                     guard_principal.fail();
                     return Err(e);
                 }
@@ -2040,6 +2121,7 @@ mod xrp_p4_tests {
             custody_nonce,
             created_at_ns: 0,
             settlement: None,
+            quarantine_reason: None,
         }
     }
 
@@ -2425,6 +2507,89 @@ mod xrp_p4_tests {
             xrp_sibling_reconcile_decision(&status, &st, &acct),
             XrpSiblingReconcileDecision::QuarantineDiverged
         );
+    }
+
+    // ── F-03 quarantine set + admin resolve ──────────────────────────────────
+
+    #[test]
+    fn quarantine_snapshot_sets_reason_idempotently() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        s.xrp_claims.insert(7, claim(claimant, owner, 7, 2_000_000));
+
+        assert!(quarantine_xrp_claim_snapshot(&mut s, 7, "first reason"));
+        assert_eq!(
+            s.xrp_claims.get(&7).unwrap().quarantine_reason.as_deref(),
+            Some("first reason")
+        );
+        // Idempotent: a second detection keeps the first (most precise) reason.
+        assert!(quarantine_xrp_claim_snapshot(&mut s, 7, "second reason"));
+        assert_eq!(
+            s.xrp_claims.get(&7).unwrap().quarantine_reason.as_deref(),
+            Some("first reason")
+        );
+    }
+
+    #[test]
+    fn quarantine_snapshot_missing_claim_is_noop_false() {
+        let mut s = crate::state::State::default();
+        assert!(!quarantine_xrp_claim_snapshot(&mut s, 999, "x"));
+    }
+
+    #[test]
+    fn resolve_confirm_paid_removes_quarantined_claim() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let mut c = claim(claimant, owner, 7, 2_000_000);
+        c.settlement = Some(settlement("ABC"));
+        c.quarantine_reason = Some("diverged".to_string());
+        s.xrp_claims.insert(7, c);
+
+        assert!(resolve_quarantined_xrp_claim_snapshot(&mut s, 7, true).is_ok());
+        assert!(!s.xrp_claims.contains_key(&7));
+    }
+
+    #[test]
+    fn resolve_release_for_retry_clears_quarantine_and_settlement() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        let mut c = claim(claimant, owner, 7, 2_000_000);
+        c.settlement = Some(settlement("ABC"));
+        c.quarantine_reason = Some("diverged".to_string());
+        s.xrp_claims.insert(7, c);
+
+        assert!(resolve_quarantined_xrp_claim_snapshot(&mut s, 7, false).is_ok());
+        let c = s.xrp_claims.get(&7).unwrap();
+        assert!(c.quarantine_reason.is_none());
+        assert!(c.settlement.is_none());
+        assert_eq!(c.drops, 2_000_000); // claim preserved for a clean retry
+    }
+
+    #[test]
+    fn resolve_refuses_healthy_claim() {
+        let mut s = crate::state::State::default();
+        let claimant = Principal::from_slice(&[0x11; 16]);
+        let owner = Principal::from_slice(&[0xaa; 16]);
+        s.xrp_claims.insert(7, claim(claimant, owner, 7, 2_000_000)); // not quarantined
+
+        assert!(matches!(
+            resolve_quarantined_xrp_claim_snapshot(&mut s, 7, true),
+            Err(ProtocolError::GenericError(_))
+        ));
+        // The healthy claim is untouched (not dropped).
+        assert!(s.xrp_claims.contains_key(&7));
+    }
+
+    #[test]
+    fn resolve_missing_claim_errors() {
+        let mut s = crate::state::State::default();
+        assert!(matches!(
+            resolve_quarantined_xrp_claim_snapshot(&mut s, 404, true),
+            Err(ProtocolError::GenericError(_))
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the remaining F-03 recovery path the P6 native-XRP audit recommended: a claim suspected of a settlement divergence is **durably quarantined** (settle refuses to sign it) and an admin resolves it after off-ledger reconciliation — instead of the claim silently stranding with no recourse.

**Stacked on [#287](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/287)** (the sibling-reconcile Sequence guard). Review/merge that first; this PR's base is that branch, so its diff shows only the quarantine work.

## Why

[#287](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/287) makes the Sequence guard reject a re-sign when a divergence is detected — but the claim then just strands, invisibly, with no operator path to resolve it. F-03 explicitly recommends a quarantine + manual-reconciliation path. This adds it.

## Change

- **state**: `XrpClaim` gains `quarantine_reason: Option<String>` (`#[serde(default)]`). `State` is ciborium/CBOR-persisted (`storage.rs`), so a missing field defaults to `None` on older snapshots — this is **not** the Candid UPG-002 wipe trap (which is `Encode!/Decode!`-specific). The candid compatibility check passes; the new field is `opt text`. A round-trip test proves a pre-quarantine snapshot decodes to a healthy claim.
- **vault**: both Sequence-guard rejection points now durably quarantine the claim — the primary `NotFound`-after-expiry branch in `settle_xrp_claim_with_tag` and the sibling `QuarantineDiverged` arm in `reconcile_xrp_other_inflight_claims` — via an idempotent `quarantine_xrp_claim_snapshot`. `settle_xrp_claim_with_tag` short-circuits while a claim is quarantined, so a possibly-already-paid claim can never be re-signed. `resolve_quarantined_xrp_claim_snapshot` applies the admin decision and refuses (without mutating) to touch a healthy, still-settle-able claim.
- **main**: developer-gated `get_xrp_quarantined_claims` (query), `admin_quarantine_xrp_claim` (manual freeze, defense-in-depth), and `admin_resolve_xrp_claim(claim_id, XrpClaimResolution)`:
  - `ConfirmPaid` → admin verified the divergent Payment delivered → remove the claim (no re-pay).
  - `ReleaseForRetry` → admin verified it did NOT deliver → clear quarantine + settlement so the claimant retries and is paid once.
- `.did` + frontend declarations regenerated (`RUMI_REGEN_DID` + `didc`).

## Tests

8 new unit tests (quarantine set/idempotency, resolve confirm/release, resolve-refuses-healthy, resolve-missing, snapshot migration). **671 lib + 16 bin tests pass**; candid compatibility check passes.

## Still not in scope

Extended KAT coverage for `DestinationTag`-present settlements and live Fee/Amount ranges (the codec-divergence surface that gates the whole finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)