### PR TITLE
chore(icp.yaml): record F-03 backend upgrade description (PRs #287/#288)

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -890,7 +890,7 @@ environments:
         (variant {
           Upgrade = record {
             mode = null;
-            description = opt "PR #241: heal collateral_to_vault_ids stale ids (post_upgrade sweep) + fix close_vault double-remove trap + replay drain parity; rides with PR #240 explorer admin_label event labels"
+            description = opt "PRs #287/#288: F-03 native-XRP settlement hardening - sibling-reconcile Sequence guard (closes the residual double-pay) + claim quarantine with admin_resolve_xrp_claim/admin_quarantine_xrp_claim/get_xrp_quarantined_claims + XrpClaim.quarantine_reason field (ciborium serde-default, non-breaking candid)"
           }
         })
 


### PR DESCRIPTION
Updates the mainnet-live `rumi_protocol_backend` upgrade-arg description (was the stale PR #241 text) to the F-03 settlement-hardening deploy shipped to `tfesu` on 2026-06-27 (module hash `0x8e92c552…`). The description is what gets recorded as the on-chain Upgrade event; this keeps the icp.yaml template accurate for the next deploy. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)