### PR TITLE
fix(sp): restore position decode against deployed SP

### DIFF
--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did
@@ -65,7 +65,7 @@ type UserStabilityPosition = record {
   collateral_gains : vec record { principal; nat64 };
   cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
-  native_payout_addresses : vec record { principal; text };
+  native_payout_addresses : opt vec record { principal; text };
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
   total_usd_value_e8s : nat64;

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -311,7 +311,7 @@ export interface UserStabilityPosition {
   'stablecoin_balances' : Array<[Principal, bigint]>,
   'cfx_claims' : [] | [Array<[Principal, bigint]>],
   'total_claimed_gains' : Array<[Principal, bigint]>,
-  'native_payout_addresses' : Array<[Principal, string]>,
+  'native_payout_addresses' : [] | [Array<[Principal, string]>],
   'total_usd_value_e8s' : bigint,
   'opted_out_collateral' : Array<Principal>,
 }

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -245,7 +245,9 @@ export const idlFactory = ({ IDL }) => {
     'stablecoin_balances' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'cfx_claims' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat))),
     'total_claimed_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
-    'native_payout_addresses' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Text)),
+    'native_payout_addresses' : IDL.Opt(
+      IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Text))
+    ),
     'total_usd_value_e8s' : IDL.Nat64,
     'opted_out_collateral' : IDL.Vec(IDL.Principal),
   });

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1706,7 +1706,7 @@ impl StabilityPoolState {
             collateral_gains: pos.collateral_gains.clone(),
             cfx_claims: pos.cfx_claims.clone(),
             opted_out_collateral: pos.opted_out_collateral.iter().cloned().collect(),
-            native_payout_addresses: pos.native_payout_addresses.clone().unwrap_or_default(),
+            native_payout_addresses: Some(pos.native_payout_addresses.clone().unwrap_or_default()),
             deposit_timestamp: pos.deposit_timestamp,
             total_claimed_gains: pos.total_claimed_gains.clone(),
             total_usd_value_e8s: pos

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -478,7 +478,12 @@ pub struct UserStabilityPosition {
     pub collateral_gains: BTreeMap<Principal, u64>,
     pub cfx_claims: Option<BTreeMap<Principal, u128>>,
     pub opted_out_collateral: Vec<Principal>,
-    pub native_payout_addresses: BTreeMap<Principal, String>,
+    /// `Option` (candid `opt`) so a frontend built with this declaration can
+    /// still decode a `get_user_position` response from an older SP canister
+    /// that predates native collateral (the field simply decodes to `None`).
+    /// A required field here silently breaks position decoding whenever the
+    /// frontend is deployed ahead of the canister.
+    pub native_payout_addresses: Option<BTreeMap<Principal, String>>,
     pub deposit_timestamp: u64,
     pub total_claimed_gains: BTreeMap<Principal, u64>,
     pub total_usd_value_e8s: u64,

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -65,7 +65,7 @@ type UserStabilityPosition = record {
   collateral_gains : vec record { principal; nat64 };
   cfx_claims : opt vec record { principal; nat };
   opted_out_collateral : vec principal;
-  native_payout_addresses : vec record { principal; text };
+  native_payout_addresses : opt vec record { principal; text };
   deposit_timestamp : nat64;
   total_claimed_gains : vec record { principal; nat64 };
   total_usd_value_e8s : nat64;

--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -71,8 +71,17 @@
 
       if (isConnected && principal) {
         const [position, history] = await Promise.all([
-          stabilityPoolService.getUserPosition(principal).catch(() => null),
-          stabilityPoolService.getLiquidationHistory(50).catch(() => []),
+          // Log rather than silently swallow: a candid decode skew (frontend
+          // declarations ahead of the deployed SP canister) surfaces here as a
+          // throw, and silently returning null hides every depositor's position.
+          stabilityPoolService.getUserPosition(principal).catch((err) => {
+            console.error('[StabilityPool] getUserPosition failed; hiding position:', err);
+            return null;
+          }),
+          stabilityPoolService.getLiquidationHistory(50).catch((err) => {
+            console.error('[StabilityPool] getLiquidationHistory failed:', err);
+            return [];
+          }),
         ]);
         userPosition = position;
         liquidationHistory = history;

--- a/src/vault_frontend/src/lib/components/stability-pool/UserAccount.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/UserAccount.svelte
@@ -38,7 +38,8 @@
   $: totalUsdValue = userPosition ? formatStableTokenDisplay(userPosition.total_usd_value_e8s, 8) : '0.0000';
   $: gains = userPosition?.collateral_gains ?? [];
   $: optedOut = new Set((userPosition?.opted_out_collateral ?? []).map(p => p.toText()));
-  $: nativePayoutByCollateral = new Map((userPosition?.native_payout_addresses ?? []).map(([p, address]) => [p.toText(), address]));
+  // `native_payout_addresses` is candid `opt vec` → unwrap the outer opt (`[]` or `[[...]]`).
+  $: nativePayoutByCollateral = new Map((userPosition?.native_payout_addresses?.[0] ?? []).map(([p, address]) => [p.toText(), address]));
 
   $: {
     let nextInputs = nativeAddressInputs;

--- a/src/vault_frontend/src/lib/services/stabilityPoolPositionDecode.spec.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolPositionDecode.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { IDL } from '@dfinity/candid';
+import { Principal } from '@dfinity/principal';
+import { idlFactory } from '$declarations/rumi_stability_pool/rumi_stability_pool.did.js';
+
+// Regression guard for the stability-pool position decode skew.
+//
+// `get_user_position` returns `opt UserStabilityPosition`. The frontend
+// declarations can be deployed ahead of the SP canister, so any field the
+// frontend marks REQUIRED but the live (older) canister omits makes the whole
+// position fail to decode — silently hiding every depositor's deposit, gains,
+// Claim button and Opt-out menu. This happened with `native_payout_addresses`
+// when it was generated as a required `vec` instead of `opt vec`.
+//
+// This test encodes a response in the OLD canister shape (no native-collateral
+// fields) and decodes it with the CURRENT generated idlFactory. It must not
+// throw, and the position must survive. Reintroducing a required response
+// field will fail here.
+
+// What the pre-native-collateral SP canister actually returns on the wire.
+const OLD_UserStabilityPosition = IDL.Record({
+  deposit_timestamp: IDL.Nat64,
+  total_interest_earned_e8s: IDL.Nat64,
+  collateral_gains: IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+  stablecoin_balances: IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+  total_claimed_gains: IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
+  total_usd_value_e8s: IDL.Nat64,
+  opted_out_collateral: IDL.Vec(IDL.Principal),
+});
+
+const ICUSD_LEDGER = Principal.fromText('t6bor-paaaa-aaaap-qrd5q-cai');
+
+function getUserPositionReturnType(): any {
+  const service: any = idlFactory({ IDL });
+  const entry = service._fields.find(([name]: [string, unknown]) => name === 'get_user_position');
+  if (!entry) throw new Error('get_user_position not found in idlFactory');
+  // FuncClass.retTypes[0] === `opt UserStabilityPosition`
+  return entry[1].retTypes[0];
+}
+
+describe('stability pool get_user_position decode compatibility', () => {
+  it('decodes an old-canister (pre native-collateral) response without throwing', () => {
+    const sample = {
+      deposit_timestamp: 1_700_000_000_000_000_000n,
+      total_interest_earned_e8s: 0n,
+      collateral_gains: [] as Array<[Principal, bigint]>,
+      stablecoin_balances: [[ICUSD_LEDGER, 550_0000_0000n]] as Array<[Principal, bigint]>,
+      total_claimed_gains: [] as Array<[Principal, bigint]>,
+      total_usd_value_e8s: 550_0000_0000n,
+      opted_out_collateral: [] as Principal[],
+    };
+
+    // Encode exactly as the deployed (old) canister would: `opt OLD`.
+    const wireBytes = IDL.encode([IDL.Opt(OLD_UserStabilityPosition)], [[sample]]);
+
+    const retType = getUserPositionReturnType();
+
+    let decoded: unknown;
+    expect(() => {
+      decoded = IDL.decode([retType], wireBytes)[0];
+    }).not.toThrow();
+
+    // `opt` => array of 0 or 1; must be the populated position, not None.
+    expect(Array.isArray(decoded)).toBe(true);
+    const opt = decoded as unknown[];
+    expect(opt.length).toBe(1);
+
+    const position = opt[0] as Record<string, unknown>;
+    expect(position.total_usd_value_e8s).toBe(550_0000_0000n);
+    // Missing native field must decode to None (`[]`), proving it is `opt`.
+    expect(position.native_payout_addresses).toEqual([]);
+  });
+});

--- a/src/vault_frontend/src/lib/services/stabilityPoolService.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.ts
@@ -45,7 +45,9 @@ export interface UserPosition {
   stablecoin_balances: Array<[Principal, bigint]>;
   collateral_gains: Array<[Principal, bigint]>;
   opted_out_collateral: Principal[];
-  native_payout_addresses?: Array<[Principal, string]>;
+  // Candid `opt vec` — decodes as `[]` (absent / older canister) or `[[...]]`.
+  // Unwrap with `native_payout_addresses?.[0] ?? []` before use.
+  native_payout_addresses?: [] | [Array<[Principal, string]>];
   deposit_timestamp: bigint;
   total_claimed_gains: Array<[Principal, bigint]>;
   total_usd_value_e8s: bigint;


### PR DESCRIPTION
Summary:
- Make UserStabilityPosition.native_payout_addresses a candid opt in the SP view DTO, canonical .did, and generated rumi_stability_pool declarations.
- Keep persisted DepositPosition unchanged; current backend view code now returns Some(existing_map_or_empty), while older deployed canisters decode a missing field as None.
- Log SP page read/decode failures instead of silently swallowing them, update the manual frontend type/consumer, and add a Vitest regression that decodes an old-canister-shaped get_user_position response with the generated idlFactory.

Verification:
- cargo check -p stability_pool
- cargo test -p stability_pool --lib (90 passed)
- npm run test:unit --workspace=src/vault_frontend -- --run src/lib/services/stabilityPoolPositionDecode.spec.ts
- npm test --workspace=src/vault_frontend (138 passed)
- npm run build --workspace=src/vault_frontend
- diff -u src/stability_pool/stability_pool.did src/declarations/rumi_stability_pool/rumi_stability_pool.did
- git diff --check origin/main..HEAD
- npm run check --workspace=src/vault_frontend still fails on existing errors outside this diff (config points flag, XRP pending deposit reserveBaseDrops, analytics RangeQuery tuple typing, legacy stabilityPool.ts imports/wallet.agent, manual liquidations/docs typing) plus existing warnings.

Deployment note:
- This is sufficient for the diagnosed frontend-only deploy against the old SP canister that omits native_payout_addresses, and for the backend source after this PR, which returns opt.
- A Candid spot-check showed @dfinity/candid does not decode a bad intermediate response where native_payout_addresses is present as required vec into an opt vec declaration. If any environment already runs that intermediate backend, deploy the SP backend from this branch before or with the frontend there.