### PR TITLE
fix(explorer): page stability pool event lookups

### DIFF
--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -18,6 +18,10 @@ import type { _SERVICE as IcusdLedgerService } from '$declarations/icusd_ledger/
 import type { _SERVICE as IcusdIndexService } from '$declarations/icusd_index/icusd_index.did';
 import type { UserStabilityPosition } from '$declarations/rumi_stability_pool/rumi_stability_pool.did';
 import { idlFactory as stabilityPoolIDL } from '$declarations/rumi_stability_pool/rumi_stability_pool.did.js';
+import {
+	fetchAllSequentialEvents,
+	fetchSequentialEventById,
+} from './stabilityPoolEventPagination';
 import type {
 	_SERVICE as LiquidationBotService,
 	LiquidationRecordV1,
@@ -1144,6 +1148,11 @@ export async function fetchStabilityPoolEventCount(): Promise<bigint> {
 	}
 }
 
+export async function fetchAllStabilityPoolEvents(): Promise<any[]> {
+	const count = await fetchStabilityPoolEventCount();
+	return fetchAllSequentialEvents(count, fetchStabilityPoolEvents);
+}
+
 // ── Current SP depositors (SP canister as source of truth) ─────────────────
 
 export type CurrentSpDepositor = {
@@ -1640,11 +1649,13 @@ export type DexEventSource = '3pool_swap' | 'amm_swap' | 'amm_liquidity' | 'amm_
  *
  * Canister pagination semantics differ across sources: 3pool's v2 liquidity
  * endpoint is newest-first (offset = skip-from-newest), while AMM / SP / 3pool
- * v1 endpoints are oldest-first where `start` happens to equal the id because
- * ids are assigned sequentially. Rather than hand-craft each code path, we
- * fetch the full event log (reusing the cache populated by list views) and
- * find the matching id client-side. Current event counts are small (~tens),
- * and fetches are cached, so this is cheap.
+ * v1 endpoints are oldest-first.
+ *
+ * Stability-pool event detail must fetch the exact page: the SP canister caps
+ * `get_pool_events` at 500 rows, so a full-log request can omit event ids above
+ * the first page and incorrectly render "event not found". SP ids are
+ * monotonic, but the retained vector can trim old rows, so the helper computes
+ * the retained offset from the first returned id instead of assuming id==index.
  */
 export async function fetchDexEvent(source: DexEventSource, id: number): Promise<any | null> {
 	const key = `dex:event:${source}:${id}`;
@@ -1652,6 +1663,12 @@ export async function fetchDexEvent(source: DexEventSource, id: number): Promise
 	if (cached) return cached;
 
 	try {
+		if (source === 'stability_pool') {
+			const match = await fetchSequentialEventById(id, fetchStabilityPoolEvents);
+			if (match) return setCache(key, match);
+			return null;
+		}
+
 		const all = await fetchAllDexEvents(source);
 		const match = all.find((e: any) => Number(e.id ?? 0) === id) ?? null;
 		if (match) return setCache(key, match);
@@ -1711,8 +1728,7 @@ export async function fetchAllDexEvents(source: DexEventSource): Promise<any[]> 
 			return Number(count) > 0 ? fetch3PoolAdminEvents(0n, count) : [];
 		}
 		case 'stability_pool': {
-			const count = await fetchStabilityPoolEventCount();
-			return Number(count) > 0 ? fetchStabilityPoolEvents(0n, count) : [];
+			return fetchAllStabilityPoolEvents();
 		}
 		default:
 			return [];

--- a/src/vault_frontend/src/lib/services/explorer/stabilityPoolEventPagination.spec.ts
+++ b/src/vault_frontend/src/lib/services/explorer/stabilityPoolEventPagination.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	fetchAllSequentialEvents,
+	fetchSequentialEventById,
+	STABILITY_POOL_EVENTS_PAGE_SIZE,
+} from './stabilityPoolEventPagination';
+
+describe('stability pool event pagination', () => {
+	it('fetches a single sequential event directly by id', async () => {
+		const fetchPage = vi.fn(async (start: bigint, length: bigint) => [
+			{ id: Number(start), length },
+		]);
+
+		const event = await fetchSequentialEventById(580, fetchPage);
+
+		expect(fetchPage).toHaveBeenNthCalledWith(1, 0n, 1n);
+		expect(fetchPage).toHaveBeenNthCalledWith(2, 580n, 1n);
+		expect(event).toEqual({ id: 580, length: 1n });
+	});
+
+	it('accounts for retained logs whose first event id is no longer zero', async () => {
+		const fetchPage = vi.fn(async (start: bigint) => {
+			const firstRetainedId = 10_000;
+			return [{ id: firstRetainedId + Number(start) }];
+		});
+
+		const event = await fetchSequentialEventById(10_580, fetchPage);
+
+		expect(fetchPage).toHaveBeenNthCalledWith(1, 0n, 1n);
+		expect(fetchPage).toHaveBeenNthCalledWith(2, 580n, 1n);
+		expect(event).toEqual({ id: 10_580 });
+	});
+
+	it('returns null when the direct page does not contain the requested id', async () => {
+		const fetchPage = vi.fn(async (start: bigint) => {
+			if (start === 0n) return [{ id: 0 }];
+			return [{ id: 579 }];
+		});
+
+		await expect(fetchSequentialEventById(580, fetchPage)).resolves.toBeNull();
+	});
+
+	it('walks full event logs in pages that respect the canister cap', async () => {
+		const fetchPage = vi.fn(async (start: bigint, length: bigint) => {
+			return Array.from({ length: Number(length) }, (_, offset) => ({
+				id: Number(start) + offset,
+			}));
+		});
+
+		const events = await fetchAllSequentialEvents(582n, fetchPage);
+
+		expect(fetchPage).toHaveBeenCalledTimes(2);
+		expect(fetchPage).toHaveBeenNthCalledWith(1, 0n, STABILITY_POOL_EVENTS_PAGE_SIZE);
+		expect(fetchPage).toHaveBeenNthCalledWith(2, 500n, 82n);
+		expect(events).toHaveLength(582);
+		expect(events.at(-1)).toEqual({ id: 581 });
+	});
+});

--- a/src/vault_frontend/src/lib/services/explorer/stabilityPoolEventPagination.ts
+++ b/src/vault_frontend/src/lib/services/explorer/stabilityPoolEventPagination.ts
@@ -1,0 +1,42 @@
+export const STABILITY_POOL_EVENTS_PAGE_SIZE = 500n;
+
+type SequentialEvent = {
+	id?: bigint | number;
+};
+
+type FetchEventsPage<T> = (start: bigint, length: bigint) => Promise<T[]>;
+
+export async function fetchSequentialEventById<T extends SequentialEvent>(
+	id: number,
+	fetchPage: FetchEventsPage<T>,
+): Promise<T | null> {
+	if (!Number.isSafeInteger(id) || id < 0) return null;
+
+	const firstPage = await fetchPage(0n, 1n);
+	const first = firstPage[0];
+	if (!first) return null;
+
+	const firstId = Number(first.id ?? 0);
+	if (!Number.isSafeInteger(firstId) || id < firstId) return null;
+	if (id === firstId) return first;
+
+	const page = await fetchPage(BigInt(id - firstId), 1n);
+	return page.find((event) => Number(event.id ?? -1) === id) ?? null;
+}
+
+export async function fetchAllSequentialEvents<T>(
+	count: bigint,
+	fetchPage: FetchEventsPage<T>,
+	pageSize = STABILITY_POOL_EVENTS_PAGE_SIZE,
+): Promise<T[]> {
+	if (count <= 0n) return [];
+	if (pageSize <= 0n) throw new Error('pageSize must be positive');
+
+	const pages: T[][] = [];
+	for (let start = 0n; start < count; start += pageSize) {
+		const remaining = count - start;
+		const length = remaining < pageSize ? remaining : pageSize;
+		pages.push(await fetchPage(start, length));
+	}
+	return pages.flat();
+}

--- a/src/vault_frontend/src/routes/explorer/activity/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/activity/+page.svelte
@@ -16,7 +16,7 @@
 		fetchAmmLiquidityEvents, fetchAmmLiquidityEventCount,
 		fetchAmmAdminEvents, fetchAmmAdminEventCount,
 		fetch3PoolAdminEvents, fetch3PoolAdminEventCount,
-		fetchStabilityPoolEvents, fetchStabilityPoolEventCount,
+		fetchAllStabilityPoolEvents,
 		fetch3PoolSwapEventsByPrincipal,
 		fetch3PoolLiquidityEventsByPrincipal,
 		fetchAmmSwapEventsByPrincipal,
@@ -564,9 +564,7 @@
 		if (sourceExcludedByTypeFacet('stability_pool', activeFacets)) return [];
 		// SP has no per-principal/time index — always tail-fetch, client-side
 		// post-filter narrows. Flagged as a Tier 2 follow-up if it bottlenecks.
-		const spCount = await fetchStabilityPoolEventCount();
-		if (Number(spCount) === 0) return [];
-		const events = await fetchStabilityPoolEvents(0n, spCount);
+		const events = await fetchAllStabilityPoolEvents();
 		return events.filter((e: any) => {
 			const et = e.event_type ?? {};
 			return !('InterestReceived' in et);

--- a/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/address/[principal]/+page.svelte
@@ -24,8 +24,7 @@
     fetchIcrc1BalanceOf,
     fetchIcusdSubaccounts,
     fetchThreeUsdSubaccounts,
-    fetchStabilityPoolEvents,
-    fetchStabilityPoolEventCount,
+    fetchAllStabilityPoolEvents,
     fetchAmmSwapEvents,
     fetchAmmSwapEventCount,
     fetchAmmLiquidityEvents,
@@ -678,9 +677,7 @@
             return [ledger, bal] as [string, bigint];
           }),
         ),
-        fetchStabilityPoolEventCount()
-          .then((c) => (Number(c) > 0 ? fetchStabilityPoolEvents(0n, c) : []))
-          .catch(() => []),
+        fetchAllStabilityPoolEvents().catch(() => []),
         fetchAmmSwapEventCount()
           .then((c) => (Number(c) > 0 ? fetchAmmSwapEvents(0n, c) : []))
           .catch(() => []),


### PR DESCRIPTION
Summary
- Fix stability pool event detail routes by fetching the requested event page directly instead of scanning a capped single page.
- Page all stability pool events for explorer activity and address views in 500-event chunks.
- Account for future retained-log trimming by computing event offsets from the first retained event id.

Verification
- npm run test:unit --workspace=src/vault_frontend -- --run src/lib/services/explorer/stabilityPoolEventPagination.spec.ts
- npm test --workspace=src/vault_frontend
- npm run build --workspace=src/vault_frontend
- git diff --check

Note
- npm run check still has existing unrelated baseline errors in legacy frontend files; no modified files are implicated.