### PR TITLE
fix(xrp): key manual XRP claim retries by claim id, not vault id

### DIFF
--- a/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.svelte
@@ -17,15 +17,20 @@
     type XrpClaimId,
   } from '$lib/services/xrpPayoutHelpers';
   import {
+    deserializeManualXrpClaims,
+    groupManualXrpClaimsByVault,
     recoverManualXrpClaimsForVault,
+    removeManualXrpPendingClaim,
+    serializeManualXrpClaims,
     settleManualXrpClaim,
+    upsertManualXrpPendingClaim,
+    upsertManualXrpPendingClaims,
     type ManualXrpPendingClaim,
+    type ManualXrpPendingClaimMap,
   } from '$lib/services/manualXrpLiquidation';
 
   const ANON_PRINCIPAL = '2vxsx-fae';
   const MANUAL_XRP_PENDING_CLAIMS_PREFIX = 'rumi_manual_xrp_pending_claims:';
-
-  type StoredManualXrpPendingClaim = Omit<ManualXrpPendingClaim, 'drops'> & { drops?: string };
 
   function resolveCollateralPrincipal(vault: CandidVault): string {
     const raw: unknown = vault.collateral_type;
@@ -121,7 +126,7 @@
   let liquidationTokens: { [vaultId: number]: 'icUSD' | 'CKUSDT' | 'CKUSDC' } = {};
   let xrpPayoutAddresses: Record<number, string> = {};
   let xrpDestinationTags: Record<number, string> = {};
-  let pendingManualXrpClaims: Record<number, ManualXrpPendingClaim> = {};
+  let pendingManualXrpClaims: ManualXrpPendingClaimMap = {};
   let retryingXrpClaimId: XrpClaimId | null = null;
   let loadedPendingXrpClaimsOwner: string | null = null;
   let otherVaultsPage = 0;
@@ -174,9 +179,11 @@
     });
   })();
 
+  $: pendingManualXrpClaimsByVault = groupManualXrpClaimsByVault(pendingManualXrpClaims);
+
   $: orphanedPendingManualXrpClaims = Object.values(pendingManualXrpClaims)
     .filter((claim) => claim.vaultId !== undefined && !sortedVaults.some((vault) => vault.vault_id === claim.vaultId))
-    .sort((a, b) => Number(a.vaultId ?? 0) - Number(b.vaultId ?? 0));
+    .sort((a, b) => Number(a.vaultId ?? 0) - Number(b.vaultId ?? 0) || (a.claimId < b.claimId ? -1 : a.claimId > b.claimId ? 1 : 0));
 
   function calculateCollateralRatio(vault: CandidVault): number {
     const ctPrincipal = resolveCollateralPrincipal(vault);
@@ -300,46 +307,18 @@
     return owner ? `${MANUAL_XRP_PENDING_CLAIMS_PREFIX}${owner}` : null;
   }
 
-  function loadPersistedManualXrpClaims(owner: string): Record<number, ManualXrpPendingClaim> {
+  function loadPersistedManualXrpClaims(owner: string): ManualXrpPendingClaimMap {
     if (typeof localStorage === 'undefined') return {};
     const key = manualXrpPendingStorageKey(owner);
     if (!key) return {};
-    try {
-      const raw = localStorage.getItem(key);
-      if (!raw) return {};
-      const parsed = JSON.parse(raw) as Record<string, StoredManualXrpPendingClaim>;
-      return Object.fromEntries(
-        Object.entries(parsed).flatMap(([vaultIdText, claim]) => {
-          const vaultId = Number(vaultIdText);
-          if (!Number.isSafeInteger(vaultId) || vaultId < 0 || !claim?.claimId || !claim.payoutAddress) {
-            return [];
-          }
-          return [[vaultId, {
-            ...claim,
-            vaultId,
-            claimId: String(claim.claimId),
-            drops: claim.drops !== undefined ? BigInt(claim.drops) : undefined,
-          } satisfies ManualXrpPendingClaim]];
-        })
-      );
-    } catch {
-      return {};
-    }
+    return deserializeManualXrpClaims(localStorage.getItem(key));
   }
 
   function persistManualXrpClaims() {
     if (typeof localStorage === 'undefined') return;
     const key = manualXrpPendingStorageKey(manualXrpClaimsOwner);
     if (!key) return;
-    const rows = Object.fromEntries(
-      Object.entries(pendingManualXrpClaims).map(([vaultId, claim]) => [
-        vaultId,
-        {
-          ...claim,
-          drops: claim.drops !== undefined ? claim.drops.toString() : undefined,
-        } satisfies StoredManualXrpPendingClaim,
-      ])
-    );
+    const rows = serializeManualXrpClaims(pendingManualXrpClaims);
     if (Object.keys(rows).length === 0) {
       localStorage.removeItem(key);
       return;
@@ -347,16 +326,32 @@
     localStorage.setItem(key, JSON.stringify(rows));
   }
 
-  function addPendingManualXrpClaim(vaultId: number, pendingClaim: ManualXrpPendingClaim) {
-    pendingManualXrpClaims = { ...pendingManualXrpClaims, [vaultId]: pendingClaim };
+  function addPendingManualXrpClaim(pendingClaim: ManualXrpPendingClaim) {
+    pendingManualXrpClaims = upsertManualXrpPendingClaim(pendingManualXrpClaims, pendingClaim);
     persistManualXrpClaims();
   }
 
-  function clearPendingManualXrpClaim(vaultId: number) {
-    const next = { ...pendingManualXrpClaims };
-    delete next[vaultId];
-    pendingManualXrpClaims = next;
+  function addPendingManualXrpClaims(claims: ManualXrpPendingClaim[]) {
+    if (claims.length === 0) return;
+    pendingManualXrpClaims = upsertManualXrpPendingClaims(pendingManualXrpClaims, claims);
     persistManualXrpClaims();
+  }
+
+  function clearPendingManualXrpClaim(claimId: XrpClaimId) {
+    pendingManualXrpClaims = removeManualXrpPendingClaim(pendingManualXrpClaims, claimId);
+    persistManualXrpClaims();
+  }
+
+  // Register every recovered claim (an ambiguous failure can leave more than
+  // one) and build a pluralized "#a, #b remain outstanding" fragment for the copy.
+  function registerRecoveredXrpClaims(recovered: ManualXrpPendingClaim[]): { label: string; noun: string; verb: string } {
+    addPendingManualXrpClaims(recovered);
+    const count = recovered.length;
+    return {
+      label: recovered.map((claim) => `#${claim.claimId}`).join(', '),
+      noun: count > 1 ? 'claims' : 'claim',
+      verb: count > 1 ? 'remain' : 'remains',
+    };
   }
 
   async function recoverXrpClaimsForVault(vault: CandidVault): Promise<ManualXrpPendingClaim[]> {
@@ -378,7 +373,7 @@
     }));
   }
 
-  async function settlePendingManualXrpClaim(vaultId: number, pendingClaim: ManualXrpPendingClaim) {
+  async function settlePendingManualXrpClaim(pendingClaim: ManualXrpPendingClaim) {
     retryingXrpClaimId = pendingClaim.claimId;
     try {
       const settlement = await settleManualXrpClaim(
@@ -390,10 +385,10 @@
       liquidationSuccess = settlement.message;
       liquidationError = '';
       if (settlement.status === 'settled') {
-        clearPendingManualXrpClaim(vaultId);
+        clearPendingManualXrpClaim(pendingClaim.claimId);
         await loadLiquidatableVaults();
       } else {
-        addPendingManualXrpClaim(vaultId, settlement.pendingClaim);
+        addPendingManualXrpClaim(settlement.pendingClaim);
       }
     } finally {
       retryingXrpClaimId = null;
@@ -508,13 +503,13 @@
               payoutAddress: xrpPayout.address ?? '',
               destinationTag: xrpPayout.destinationTag,
             };
-            await settlePendingManualXrpClaim(vault.vault_id, pendingClaim);
+            await settlePendingManualXrpClaim(pendingClaim);
             liquidationAmounts[vault.vault_id] = '';
           } else {
             const recovered = await recoverXrpClaimsForVault(vault);
             if (recovered.length > 0) {
-              addPendingManualXrpClaim(vault.vault_id, recovered[0]);
-              liquidationSuccess = `Liquidation accepted for vault #${vault.vault_id}. XRP claim #${recovered[0].claimId} remains outstanding and can be settled from this screen.`;
+              const r = registerRecoveredXrpClaims(recovered);
+              liquidationSuccess = `Liquidation accepted for vault #${vault.vault_id}. XRP ${r.noun} ${r.label} ${r.verb} outstanding and can be settled from this screen.`;
               liquidationAmounts[vault.vault_id] = '';
             } else {
               liquidationSuccess = `Liquidation accepted for vault #${vault.vault_id}. XRP settlement claim is being indexed; refresh claims and retry settlement from this screen.`;
@@ -533,8 +528,8 @@
         } else if (isXrp && isAmbiguousLiquidationError(msg)) {
           const recovered = await recoverXrpClaimsForVault(vault);
           if (recovered.length > 0) {
-            addPendingManualXrpClaim(vault.vault_id, recovered[0]);
-            liquidationSuccess = `Liquidation may have landed for vault #${vault.vault_id}. XRP claim #${recovered[0].claimId} remains outstanding and can be settled from this screen.`;
+            const r = registerRecoveredXrpClaims(recovered);
+            liquidationSuccess = `Liquidation may have landed for vault #${vault.vault_id}. XRP ${r.noun} ${r.label} ${r.verb} outstanding and can be settled from this screen.`;
           } else {
             liquidationError = `${msg}. No matching XRP claim is visible yet; refresh and retry before submitting another liquidation.`;
           }
@@ -547,8 +542,8 @@
       if (isXrp && isAmbiguousLiquidationError(msg)) {
         const recovered = await recoverXrpClaimsForVault(vault);
         if (recovered.length > 0) {
-          addPendingManualXrpClaim(vault.vault_id, recovered[0]);
-          liquidationSuccess = `Liquidation may have landed for vault #${vault.vault_id}. XRP claim #${recovered[0].claimId} remains outstanding and can be settled from this screen.`;
+          const r = registerRecoveredXrpClaims(recovered);
+          liquidationSuccess = `Liquidation may have landed for vault #${vault.vault_id}. XRP ${r.noun} ${r.label} ${r.verb} outstanding and can be settled from this screen.`;
         } else {
           liquidationError = `${msg}. No matching XRP claim is visible yet; refresh and retry before submitting another liquidation.`;
         }
@@ -628,7 +623,7 @@
           </span>
           <button
             class="xrp-retry-btn"
-            on:click={() => settlePendingManualXrpClaim(Number(pendingXrpClaim.vaultId), pendingXrpClaim)}
+            on:click={() => settlePendingManualXrpClaim(pendingXrpClaim)}
             disabled={retryingXrpClaimId !== null || processingVaultId !== null}
           >
             {retryingXrpClaimId === pendingXrpClaim.claimId ? 'Settling…' : 'Retry'}
@@ -658,7 +653,7 @@
         {@const s = inputVal > 0 && !overMax ? calculateSeizure(vault, inputVal) : null}
         {@const ci = getVaultCollateralInfo(vault)}
         {@const isXrp = isNativeXrpPrincipal(ci.ctPrincipal)}
-        {@const pendingXrpClaim = pendingManualXrpClaims[vault.vault_id]}
+        {@const vaultPendingXrpClaims = pendingManualXrpClaimsByVault[vault.vault_id] ?? []}
 
         <div class="liq-card">
           <div class="card-body">
@@ -713,7 +708,7 @@
                     disabled={isProcessingThis}
                   />
                 </div>
-                {#if pendingXrpClaim}
+                {#each vaultPendingXrpClaims as pendingXrpClaim (pendingXrpClaim.claimId)}
                   <div class="xrp-pending-claim">
                     <span>
                       XRP claim #{pendingXrpClaim.claimId} remains outstanding.
@@ -721,13 +716,13 @@
                     </span>
                     <button
                       class="xrp-retry-btn"
-                      on:click={() => settlePendingManualXrpClaim(vault.vault_id, pendingXrpClaim)}
+                      on:click={() => settlePendingManualXrpClaim(pendingXrpClaim)}
                       disabled={retryingXrpClaimId !== null || isProcessingThis}
                     >
                       {retryingXrpClaimId === pendingXrpClaim.claimId ? 'Settling…' : 'Retry'}
                     </button>
                   </div>
-                {/if}
+                {/each}
               {/if}
               <div class="input-label-row">
                 <span class="input-label">Amount to liquidate</span>

--- a/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/components/liquidations/ManualLiquidations.xrp.spec.ts
@@ -5,13 +5,51 @@ import { resolve } from 'node:path';
 const componentPath = resolve(__dirname, 'ManualLiquidations.svelte');
 
 describe('ManualLiquidations XRP pending claim retries', () => {
-  it('keeps manual XRP claim retries visible after the vault leaves the liquidatable list', () => {
-    const source = readFileSync(componentPath, 'utf8');
+  const source = readFileSync(componentPath, 'utf8');
 
+  it('keeps the pending-claim store keyed by claim id, not vault id', () => {
+    // The store type and persistence go through the claim-id-keyed helpers so a
+    // second claim on the same vault cannot clobber the first.
+    expect(source).toContain('let pendingManualXrpClaims: ManualXrpPendingClaimMap = {}');
+    expect(source).toContain('upsertManualXrpPendingClaim(pendingManualXrpClaims, pendingClaim)');
+    expect(source).toContain('upsertManualXrpPendingClaims(pendingManualXrpClaims, claims)');
+    expect(source).toContain('removeManualXrpPendingClaim(pendingManualXrpClaims, claimId)');
+    expect(source).toContain('serializeManualXrpClaims(pendingManualXrpClaims)');
+    expect(source).toContain('deserializeManualXrpClaims(localStorage.getItem(key))');
+    // No vault-id-keyed indexing of the store remains.
+    expect(source).not.toContain('pendingManualXrpClaims[vault.vault_id]');
+  });
+
+  it('renders every pending claim for a vault, not just one', () => {
+    expect(source).toContain('groupManualXrpClaimsByVault(pendingManualXrpClaims)');
+    expect(source).toContain('pendingManualXrpClaimsByVault[vault.vault_id] ?? []');
+    expect(source).toContain('{#each vaultPendingXrpClaims as pendingXrpClaim (pendingXrpClaim.claimId)}');
+  });
+
+  it('settles a pending claim by the claim itself (claim-id identity)', () => {
+    expect(source).toContain('settlePendingManualXrpClaim(pendingXrpClaim)');
+    expect(source).toContain('async function settlePendingManualXrpClaim(pendingClaim: ManualXrpPendingClaim)');
+    expect(source).toContain('clearPendingManualXrpClaim(pendingClaim.claimId)');
+    // The old vault-id-addressed settle call must be gone.
+    expect(source).not.toContain('settlePendingManualXrpClaim(Number(pendingXrpClaim.vaultId)');
+    expect(source).not.toContain('settlePendingManualXrpClaim(vault.vault_id');
+  });
+
+  it('registers every recovered claim from the ambiguous-failure path', () => {
+    // Recovery must add all claims, never just recovered[0].
+    expect(source).toContain('registerRecoveredXrpClaims(recovered)');
+    expect(source).not.toContain('recovered[0]');
+    expect(source).toContain('addPendingManualXrpClaims(recovered)');
+  });
+
+  it('keeps manual XRP claim retries visible after the vault leaves the liquidatable list', () => {
     expect(source).toContain('orphanedPendingManualXrpClaims');
     expect(source).toContain('!sortedVaults.some((vault) => vault.vault_id === claim.vaultId)');
     expect(source).toContain('Vault #{pendingXrpClaim.vaultId}');
-    expect(source).toContain('settlePendingManualXrpClaim(Number(pendingXrpClaim.vaultId), pendingXrpClaim)');
+    expect(source).toContain('settlePendingManualXrpClaim(pendingXrpClaim)');
+  });
+
+  it('persists pending claims per owner in localStorage', () => {
     expect(source).toContain('rumi_manual_xrp_pending_claims:');
     expect(source).toContain('loadPersistedManualXrpClaims(manualXrpClaimsOwner)');
     expect(source).toContain('localStorage.setItem(key, JSON.stringify(rows))');

--- a/src/vault_frontend/src/lib/services/manualXrpLiquidation.spec.ts
+++ b/src/vault_frontend/src/lib/services/manualXrpLiquidation.spec.ts
@@ -2,10 +2,28 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
+  deserializeManualXrpClaims,
+  groupManualXrpClaimsByVault,
   recoverManualXrpClaimsForVault,
+  removeManualXrpPendingClaim,
+  serializeManualXrpClaims,
   settleManualXrpClaim,
+  upsertManualXrpPendingClaim,
+  upsertManualXrpPendingClaims,
   type ManualXrpPendingClaim,
+  type ManualXrpPendingClaimMap,
 } from './manualXrpLiquidation';
+
+const claimAt = (
+  claimId: string,
+  vaultId: number,
+  overrides: Partial<ManualXrpPendingClaim> = {}
+): ManualXrpPendingClaim => ({
+  claimId,
+  vaultId,
+  payoutAddress: `r${claimId}`,
+  ...overrides,
+});
 
 describe('manual XRP liquidation settlement flow', () => {
   it('settles the exact claim id returned by liquidation with the entered address and tag', async () => {
@@ -111,5 +129,94 @@ describe('manual XRP liquidation settlement flow', () => {
 
     expect(settleCall).toContain('XrpVaultService.settleXrpClaim(claimId, payoutAddress, destinationTag)');
     expect(settleCall).toContain('XrpVaultService.hasOutstandingClaim(claimId)');
+  });
+});
+
+describe('manual XRP pending claim store (keyed by claim id)', () => {
+  it('keeps two distinct claims on the same vault instead of overwriting the first', () => {
+    let map: ManualXrpPendingClaimMap = {};
+    map = upsertManualXrpPendingClaim(map, claimAt('100', 5));
+    map = upsertManualXrpPendingClaim(map, claimAt('101', 5));
+
+    expect(Object.keys(map).sort()).toEqual(['100', '101']);
+    expect(map['100'].vaultId).toBe(5);
+    expect(map['101'].vaultId).toBe(5);
+  });
+
+  it('replaces an existing claim when re-upserted under the same claim id', () => {
+    let map: ManualXrpPendingClaimMap = {};
+    map = upsertManualXrpPendingClaim(map, claimAt('100', 5, { payoutAddress: 'rOld' }));
+    map = upsertManualXrpPendingClaim(map, claimAt('100', 5, { payoutAddress: 'rNew' }));
+
+    expect(Object.keys(map)).toEqual(['100']);
+    expect(map['100'].payoutAddress).toBe('rNew');
+  });
+
+  it('adds every recovered claim for the same vault (ambiguous-recovery path)', () => {
+    const map = upsertManualXrpPendingClaims({}, [claimAt('100', 5), claimAt('101', 5)]);
+
+    expect(Object.keys(map).sort()).toEqual(['100', '101']);
+  });
+
+  it('removes a single claim by id without touching its sibling on the same vault', () => {
+    let map = upsertManualXrpPendingClaims({}, [claimAt('100', 5), claimAt('101', 5)]);
+    map = removeManualXrpPendingClaim(map, '100');
+
+    expect(Object.keys(map)).toEqual(['101']);
+    expect(map['101'].vaultId).toBe(5);
+  });
+
+  it('groups multiple same-vault claims under the vault, sorted by claim id numerically', () => {
+    const map = upsertManualXrpPendingClaims({}, [
+      claimAt('101', 5),
+      claimAt('100', 5),
+      claimAt('50', 9),
+    ]);
+
+    const grouped = groupManualXrpClaimsByVault(map);
+
+    expect(grouped[5].map((claim) => claim.claimId)).toEqual(['100', '101']);
+    expect(grouped[9].map((claim) => claim.claimId)).toEqual(['50']);
+  });
+
+  it('round-trips two same-vault claims through serialize/deserialize', () => {
+    const map = upsertManualXrpPendingClaims({}, [
+      claimAt('100', 5, { destinationTag: 7, drops: 123n }),
+      claimAt('101', 5),
+    ]);
+
+    const restored = deserializeManualXrpClaims(JSON.stringify(serializeManualXrpClaims(map)));
+
+    expect(Object.keys(restored).sort()).toEqual(['100', '101']);
+    expect(restored['100'].vaultId).toBe(5);
+    expect(restored['100'].destinationTag).toBe(7);
+    expect(restored['100'].drops).toBe(123n);
+    expect(restored['101'].vaultId).toBe(5);
+  });
+
+  it('migrates a legacy vault-id-keyed store to claim-id keys', () => {
+    const legacy = JSON.stringify({
+      '5': { claimId: '100', vaultId: 5, payoutAddress: 'rA' },
+    });
+
+    const restored = deserializeManualXrpClaims(legacy);
+
+    expect(Object.keys(restored)).toEqual(['100']);
+    expect(restored['100'].vaultId).toBe(5);
+  });
+
+  it('drops malformed persisted entries and tolerates missing or invalid input', () => {
+    expect(deserializeManualXrpClaims(null)).toEqual({});
+    expect(deserializeManualXrpClaims('not json')).toEqual({});
+
+    const restored = deserializeManualXrpClaims(
+      JSON.stringify({
+        good: { claimId: '100', vaultId: 5, payoutAddress: 'rA' },
+        noAddress: { claimId: '101', vaultId: 5 },
+        noClaimId: { vaultId: 5, payoutAddress: 'rB' },
+      })
+    );
+
+    expect(Object.keys(restored)).toEqual(['100']);
   });
 });

--- a/src/vault_frontend/src/lib/services/manualXrpLiquidation.ts
+++ b/src/vault_frontend/src/lib/services/manualXrpLiquidation.ts
@@ -1,6 +1,7 @@
 import {
   buildManualXrpSettlementFailureCopy,
   buildManualXrpSettlementSuccessCopy,
+  xrpClaimIdToBigInt,
   type XrpClaimId,
 } from './xrpPayoutHelpers';
 
@@ -11,6 +12,17 @@ export interface ManualXrpPendingClaim {
   destinationTag?: number;
   drops?: bigint;
 }
+
+/**
+ * Outstanding manual-settlement claims, keyed by claim id (not vault id) so a
+ * vault that produced more than one claim (multiple partial liquidations, or an
+ * ambiguous-recovery sweep that returns several) keeps every claim's settle row
+ * instead of the latest one clobbering the rest.
+ */
+export type ManualXrpPendingClaimMap = Record<XrpClaimId, ManualXrpPendingClaim>;
+
+/** localStorage shape: `drops` is serialized as a decimal string (bigint is not JSON-safe). */
+export type StoredManualXrpPendingClaim = Omit<ManualXrpPendingClaim, 'drops'> & { drops?: string };
 
 export interface RecoverableXrpClaim {
   claimId: XrpClaimId | number | bigint;
@@ -83,4 +95,110 @@ export async function recoverManualXrpClaimsForVault(
 ): Promise<RecoverableXrpClaim[]> {
   const claims = await getMyClaims();
   return claims.filter((claim) => claim.custodyNonce === vaultId || claim.vaultId === vaultId);
+}
+
+function compareXrpClaimId(a: XrpClaimId, b: XrpClaimId): number {
+  try {
+    const ba = xrpClaimIdToBigInt(a);
+    const bb = xrpClaimIdToBigInt(b);
+    return ba < bb ? -1 : ba > bb ? 1 : 0;
+  } catch {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+}
+
+/** Add or replace a single pending claim, keyed by its claim id. */
+export function upsertManualXrpPendingClaim(
+  map: ManualXrpPendingClaimMap,
+  claim: ManualXrpPendingClaim
+): ManualXrpPendingClaimMap {
+  return { ...map, [claim.claimId]: claim };
+}
+
+/** Add or replace several pending claims in one pass (e.g. every recovered claim for a vault). */
+export function upsertManualXrpPendingClaims(
+  map: ManualXrpPendingClaimMap,
+  claims: ManualXrpPendingClaim[]
+): ManualXrpPendingClaimMap {
+  return claims.reduce(upsertManualXrpPendingClaim, map);
+}
+
+/** Drop a single claim by id, leaving any sibling claims on the same vault intact. */
+export function removeManualXrpPendingClaim(
+  map: ManualXrpPendingClaimMap,
+  claimId: XrpClaimId
+): ManualXrpPendingClaimMap {
+  const next = { ...map };
+  delete next[claimId];
+  return next;
+}
+
+/** Group claims by vault id for per-vault rendering; claims within a vault are sorted by claim id. */
+export function groupManualXrpClaimsByVault(
+  map: ManualXrpPendingClaimMap
+): Record<number, ManualXrpPendingClaim[]> {
+  const grouped: Record<number, ManualXrpPendingClaim[]> = {};
+  for (const claim of Object.values(map)) {
+    if (claim.vaultId === undefined) continue;
+    (grouped[claim.vaultId] ??= []).push(claim);
+  }
+  for (const claims of Object.values(grouped)) {
+    claims.sort((a, b) => compareXrpClaimId(a.claimId, b.claimId));
+  }
+  return grouped;
+}
+
+/** Serialize the claim map for localStorage, keyed by claim id with `drops` as a string. */
+export function serializeManualXrpClaims(
+  map: ManualXrpPendingClaimMap
+): Record<string, StoredManualXrpPendingClaim> {
+  return Object.fromEntries(
+    Object.values(map).map((claim) => [
+      claim.claimId,
+      {
+        ...claim,
+        drops: claim.drops !== undefined ? claim.drops.toString() : undefined,
+      } satisfies StoredManualXrpPendingClaim,
+    ])
+  );
+}
+
+/**
+ * Parse a persisted claim map. Re-keys by each entry's own claim id, so it
+ * transparently migrates an older vault-id-keyed store, and skips entries
+ * missing a claim id or payout address. Returns {} on null/invalid JSON.
+ */
+export function deserializeManualXrpClaims(raw: string | null | undefined): ManualXrpPendingClaimMap {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== 'object') return {};
+
+  const result: ManualXrpPendingClaimMap = {};
+  for (const entry of Object.values(parsed as Record<string, StoredManualXrpPendingClaim>)) {
+    if (!entry?.claimId || !entry.payoutAddress) continue;
+    const claimId = String(entry.claimId);
+    const vaultId = entry.vaultId !== undefined ? Number(entry.vaultId) : undefined;
+    const normalizedVaultId =
+      vaultId !== undefined && Number.isSafeInteger(vaultId) && vaultId >= 0 ? vaultId : undefined;
+    let drops: bigint | undefined;
+    if (entry.drops !== undefined) {
+      try {
+        drops = BigInt(entry.drops);
+      } catch {
+        drops = undefined;
+      }
+    }
+    result[claimId] = {
+      ...entry,
+      claimId,
+      vaultId: normalizedVaultId,
+      drops,
+    } satisfies ManualXrpPendingClaim;
+  }
+  return result;
 }


### PR DESCRIPTION
## Problem

In `ManualLiquidations.svelte`, the manual-liquidation pending-claim store was keyed by `vault_id` (`Record<number, ManualXrpPendingClaim>`, in-memory + localStorage). When a vault produced more than one outstanding XRP claim — repeated partial liquidations, or an ambiguous-failure recovery sweep that returns several — each new entry **overwrote** the prior one, so the earlier claim's settle/retry row disappeared from the UI. The ambiguous-recovery paths compounded this by only surfacing `recovered[0]`.

No fund loss: the `XrpClaim` stays on-chain and is settleable via `get_my_xrp_claims`. This is a UX defect (the liquidator loses the one-click settle path). It was found during the adversarial review of [#292](https://github.com/RumiLabsXYZ/rumi-protocol-v2/pull/292) and deferred from that deploy as non-blocking.

## Fix

- **Re-key the store by claim id.** Extracted the keying/grouping/persistence into pure, tested helpers in `manualXrpLiquidation.ts`: `upsertManualXrpPendingClaim(s)`, `removeManualXrpPendingClaim`, `groupManualXrpClaimsByVault` (claims sorted by claim id), and `serialize/deserializeManualXrpClaims`. `deserialize` re-keys by each entry's own claim id, so it transparently migrates any older vault-id-keyed localStorage and tolerates malformed/invalid input.
- **Render every pending claim per vault** via `{#each vaultPendingXrpClaims …}` keyed by `claimId`.
- **Settle/clear by claim id**, so settling one claim leaves sibling claims on the same vault intact.
- **Recovery registers every `recovered[*]`** (new `registerRecoveredXrpClaims`) at all three sites, with pluralized copy ("XRP claims #100, #101 remain outstanding…").

## Tests

- TDD: 8 new behavioral specs in `manualXrpLiquidation.spec.ts` (two same-vault claims both persist through serialize→deserialize, group-by-vault ordering, legacy vault-id-key migration, malformed-input tolerance) — written first, watched fail, then implemented.
- Strengthened `ManualLiquidations.xrp.spec.ts` from substring-presence to wiring assertions (claim-id keying, render-all, recovery-adds-all, no `recovered[0]`).
- `npm test --workspace=src/vault_frontend`: **174/174 pass**.
- `npm run build --workspace=src/vault_frontend`: succeeds. `svelte-check`: zero problems in both touched production files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)