### PR TITLE
fix(frontend): unblock XRP stability pool routing

### DIFF
--- a/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
+++ b/src/vault_frontend/src/lib/components/layout/PositionStrip.svelte
@@ -171,16 +171,17 @@
 </div>
 
 <style>
-  /* The top bar is position:fixed; height 3.5rem; z-index 100. We place
-     the strip as position:fixed right below it at top:3.5rem. Its height
-     is bound reactively to the --rumi-strip-height CSS variable, and
-     .main-content's padding-top compensates via calc() (see +layout.svelte). */
+  /* The top bar is position:fixed; height 3.5rem; z-index 100. The pending
+     XRP recovery banner, when present, owns the first row below the header; the
+     strip sits below that dynamic height. Its height is bound reactively to the
+     --rumi-strip-height CSS variable, and .main-content's padding-top
+     compensates via calc() (see +layout.svelte). */
   .strip-outer {
     position: fixed;
-    top: 3.5rem;
+    top: calc(3.5rem + var(--rumi-xrp-recovery-height, 0px));
     left: 0;
     right: 0;
-    z-index: 99;  /* below top-bar's 100, above page content */
+    z-index: 98;  /* below top-bar and pending XRP recovery, above page content */
     overflow-x: hidden;  /* belt-and-suspenders against mobile overflow */
   }
   /* Only draw border/background when something is actually rendered.

--- a/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.spec.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.spec.ts
@@ -5,6 +5,15 @@ import { resolve } from 'node:path';
 const componentPath = resolve(__dirname, 'XrpPayoutRouting.svelte');
 
 describe('XrpPayoutRouting pending payouts', () => {
+  it('renders the opt-in card for any SP depositor, not only icUSD depositors', () => {
+    const source = readFileSync(componentPath, 'utf8');
+
+    expect(source).toContain('userHasStablecoinDeposit = (userPosition?.stablecoin_balances ?? []).some');
+    expect(source).toContain('amount > 0n');
+    expect(source).toContain('userHasStablecoinDeposit || isEnabled || loadingPayouts || hasPendingPayouts');
+    expect(source).not.toContain('userHasIcusd || isEnabled || loadingPayouts || hasPendingPayouts');
+  });
+
   it('renders pending payout rows and settles before acknowledgement', () => {
     const source = readFileSync(componentPath, 'utf8');
 
@@ -13,7 +22,7 @@ describe('XrpPayoutRouting pending payouts', () => {
     expect(source).toContain('payout.payout_address');
     expect(source).toContain('tag {payout.destination_tag[0]}');
     expect(source).toContain('hasPendingPayouts = pendingPayouts.length > 0');
-    expect(source).toContain('userHasIcusd || isEnabled || loadingPayouts || hasPendingPayouts');
+    expect(source).toContain('userHasStablecoinDeposit || isEnabled || loadingPayouts || hasPendingPayouts');
     expect(source).toContain('const claimOutstanding = await XrpVaultService.hasOutstandingClaim(claimId)');
     expect(source).toContain('Retry once it validates to clear this reminder');
     expect(source).toContain('if (!message.includes(\'not available\'))');

--- a/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.svelte
@@ -15,7 +15,6 @@
     unwrapNativePayoutDestinationTags,
     validateXrpPayoutInput,
   } from '../../services/xrpPayoutHelpers';
-  import { CANISTER_IDS } from '../../config';
 
   export let collateralRegistry: CollateralInfo[] = [];
   export let userPosition: UserPosition | null = null;
@@ -42,13 +41,11 @@
   $: nativeTagByCollateral = unwrapNativePayoutDestinationTags(userPosition);
   $: storedAddress = nativePayoutByCollateral.get(xrpCollateral?.ledger_id.toText() ?? XRP_NATIVE_PRINCIPAL_TEXT) ?? '';
   $: storedTag = nativeTagByCollateral.get(xrpCollateral?.ledger_id.toText() ?? XRP_NATIVE_PRINCIPAL_TEXT);
-  $: userHasIcusd = (userPosition?.stablecoin_balances ?? []).some(
-    ([ledger, amount]) => ledger.toText() === CANISTER_IDS.ICUSD_LEDGER && amount > 0n
-  );
+  $: userHasStablecoinDeposit = (userPosition?.stablecoin_balances ?? []).some(([, amount]) => amount > 0n);
   $: isEnabled = storedAddress !== '';
   $: hasPendingPayouts = pendingPayouts.length > 0;
   $: shouldRenderXrpRouting =
-    isConnected && userPosition && xrpCollateral && (userHasIcusd || isEnabled || loadingPayouts || hasPendingPayouts);
+    isConnected && userPosition && xrpCollateral && (userHasStablecoinDeposit || isEnabled || loadingPayouts || hasPendingPayouts);
 
   $: if (storedAddress && payoutAddress === '') {
     payoutAddress = storedAddress;
@@ -170,7 +167,7 @@
       <span class="xrp-title">XRP payouts</span>
       <span class="xrp-status" class:enabled={isEnabled}>{isEnabled ? 'Enabled' : 'Not enabled'}</span>
     </div>
-    {#if userHasIcusd || isEnabled}
+    {#if userHasStablecoinDeposit || isEnabled}
       <p class="xrp-copy">Provide an XRP payout address and optional tag to receive XRP from SP liquidations.</p>
 
       <div class="xrp-inputs">

--- a/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.spec.ts
+++ b/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const componentPath = resolve(__dirname, 'XrpPendingDepositBanner.svelte');
+const layoutPath = resolve(__dirname, '../../../routes/+layout.svelte');
+const stripPath = resolve(__dirname, '../layout/PositionStrip.svelte');
+
+describe('XrpPendingDepositBanner layout contract', () => {
+  it('reserves fixed header space so the position strip cannot cover the recovery banner', () => {
+    const banner = readFileSync(componentPath, 'utf8');
+    const layout = readFileSync(layoutPath, 'utf8');
+    const strip = readFileSync(stripPath, 'utf8');
+
+    expect(banner).toContain("document.documentElement.style.setProperty('--rumi-xrp-recovery-height'");
+    expect(banner).toContain('class="xrp-recovery-slot" bind:clientHeight={recoveryHeight}');
+    expect(banner).toContain('top: 3.5rem');
+    expect(strip).toContain('top: calc(3.5rem + var(--rumi-xrp-recovery-height, 0px))');
+    expect(layout).toContain('var(--rumi-xrp-recovery-height, 0px) + var(--rumi-strip-height, 0px)');
+  });
+});

--- a/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.svelte
+++ b/src/vault_frontend/src/lib/components/vault/XrpPendingDepositBanner.svelte
@@ -18,9 +18,13 @@
   let lastError = '';
   let lastPrincipal = '';
   let refreshInterval: ReturnType<typeof setInterval> | null = null;
+  let recoveryHeight = 0;
 
   $: connected = $walletStore.isConnected;
   $: principalText = $walletStore.principal?.toText?.() ?? '';
+  $: if (browser) {
+    document.documentElement.style.setProperty('--rumi-xrp-recovery-height', `${recoveryHeight}px`);
+  }
 
   async function refreshPending() {
     if (!connected) {
@@ -50,6 +54,7 @@
   onDestroy(() => {
     if (refreshInterval) clearInterval(refreshInterval);
     if (browser) window.removeEventListener(XRP_PENDING_DEPOSITS_CHANGED, refreshPending);
+    if (browser) document.documentElement.style.setProperty('--rumi-xrp-recovery-height', '0px');
   });
 
   async function confirmDeposit(vaultId: number) {
@@ -82,44 +87,54 @@
   }
 </script>
 
-{#if connected && pending.length > 0}
-  <section class="xrp-recovery" aria-label="Pending XRP deposit recovery">
-    <div class="xrp-recovery-inner">
-      <div class="xrp-recovery-copy">
-        <span class="xrp-recovery-kicker">XRP deposit awaiting confirmation</span>
-        <strong>{pending.length === 1 ? 'Finish opening your XRP vault' : `Finish ${pending.length} XRP vault deposits`}</strong>
-        <span class="xrp-recovery-note">
-          Your XRP deposit address is still linked to your wallet. Confirm it here after the XRP arrives.
-        </span>
-      </div>
+<div class="xrp-recovery-slot" bind:clientHeight={recoveryHeight}>
+  {#if connected && pending.length > 0}
+    <section class="xrp-recovery" aria-label="Pending XRP deposit recovery">
+      <div class="xrp-recovery-inner">
+        <div class="xrp-recovery-copy">
+          <span class="xrp-recovery-kicker">XRP deposit awaiting confirmation</span>
+          <strong>{pending.length === 1 ? 'Finish opening your XRP vault' : `Finish ${pending.length} XRP vault deposits`}</strong>
+          <span class="xrp-recovery-note">
+            Your XRP deposit address is still linked to your wallet. Confirm it here after the XRP arrives.
+          </span>
+        </div>
 
-      <div class="xrp-recovery-list">
-        {#each pending as p (p.vaultId)}
-          <div class="xrp-recovery-item">
-            <span class="xrp-vault-id">Vault #{p.vaultId}</span>
-            <button class="xrp-address" title={p.custodyAddress} on:click={() => copy(p.custodyAddress)}>
-              {formatAddress(p.custodyAddress, 8, 6)}
-              <span>Copy</span>
-            </button>
-            <button
-              class="xrp-confirm"
-              disabled={loading || confirmingVaultId === p.vaultId}
-              on:click={() => confirmDeposit(p.vaultId)}
-            >
-              {confirmingVaultId === p.vaultId ? 'Checking...' : "I've sent the XRP"}
-            </button>
-          </div>
-        {/each}
-      </div>
+        <div class="xrp-recovery-list">
+          {#each pending as p (p.vaultId)}
+            <div class="xrp-recovery-item">
+              <span class="xrp-vault-id">Vault #{p.vaultId}</span>
+              <button class="xrp-address" title={p.custodyAddress} on:click={() => copy(p.custodyAddress)}>
+                {formatAddress(p.custodyAddress, 8, 6)}
+                <span>Copy</span>
+              </button>
+              <button
+                class="xrp-confirm"
+                disabled={loading || confirmingVaultId === p.vaultId}
+                on:click={() => confirmDeposit(p.vaultId)}
+              >
+                {confirmingVaultId === p.vaultId ? 'Checking...' : "I've sent the XRP"}
+              </button>
+            </div>
+          {/each}
+        </div>
 
-      {#if lastError}
-        <div class="xrp-recovery-error">{lastError}</div>
-      {/if}
-    </div>
-  </section>
-{/if}
+        {#if lastError}
+          <div class="xrp-recovery-error">{lastError}</div>
+        {/if}
+      </div>
+    </section>
+  {/if}
+</div>
 
 <style>
+  .xrp-recovery-slot {
+    position: fixed;
+    top: 3.5rem;
+    left: 0;
+    right: 0;
+    z-index: 99;
+  }
+
   .xrp-recovery {
     width: 100%;
     border-bottom: 1px solid rgba(45, 212, 191, 0.18);

--- a/src/vault_frontend/src/routes/+layout.svelte
+++ b/src/vault_frontend/src/routes/+layout.svelte
@@ -218,7 +218,7 @@
   .header-icon-link svg { width:0.875rem;height:0.875rem; }
 
   /* ── Main content ── */
-  .main-content { padding:calc(4.75rem + var(--rumi-strip-height, 0px)) 2rem 2rem;min-height:100vh;position:relative;z-index:1;max-width:1200px;margin:0 auto; }
+  .main-content { padding:calc(4.75rem + var(--rumi-xrp-recovery-height, 0px) + var(--rumi-strip-height, 0px)) 2rem 2rem;min-height:100vh;position:relative;z-index:1;max-width:1200px;margin:0 auto; }
   .app-footer { padding:1.5rem 2rem;border-top:1px solid var(--rumi-border); }
   .footer-inner { max-width:1200px;margin:0 auto;display:flex;flex-direction:column;align-items:center;gap:0.75rem; }
   .footer-links { display:flex;flex-wrap:wrap;justify-content:center;gap:0.375rem 1.25rem; }
@@ -241,7 +241,7 @@
   .mob-item.active { color:var(--rumi-action); }
   @media (max-width:768px) {
     .top-nav{display:none}
-    .main-content{padding:calc(4.25rem + var(--rumi-strip-height, 0px)) 1rem 5rem}
+    .main-content{padding:calc(4.25rem + var(--rumi-xrp-recovery-height, 0px) + var(--rumi-strip-height, 0px)) 1rem 5rem}
     .mobile-nav{display:flex}
     /* Social icons and Docs chip duplicate footer content and crowd out the
        wallet button on narrow screens — hide them here. */


### PR DESCRIPTION
XRP live unblock follow-up. Shows the XRP payout routing card for any Stability Pool depositor with a positive stablecoin balance, not only icUSD depositors. Moves the pending XRP recovery banner into reserved fixed header space so PositionStrip cannot cover it. Verified with focused vitest coverage and npm run build --workspace=src/vault_frontend. Live Stability Pool registry was separately updated with XRP before this PR.