### PR TITLE
fix(frontend): keep XRP payout refresh off signer

### DIFF
--- a/src/vault_frontend/src/lib/services/stabilityPoolService.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.ts
@@ -505,7 +505,7 @@ class StabilityPoolService {
   }
 
   async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]> {
-    const actor = await this.getMutationActor();
+    const actor = await this.getQueryActor();
     return getMyNativeXrpPayoutsWithActor(actor);
   }
 

--- a/src/vault_frontend/src/lib/services/stabilityPoolService.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.xrp.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const servicePath = resolve(__dirname, 'stabilityPoolService.ts');
+
+describe('StabilityPoolService native XRP actor routing', () => {
+  it('uses the anonymous query actor for passive pending XRP payout reads', () => {
+    const source = readFileSync(servicePath, 'utf8');
+
+    expect(source).toContain('async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]>');
+    expect(source).toContain('async ackNativeXrpPayoutSettled');
+
+    const readMethod = source.slice(
+      source.indexOf('async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]>'),
+      source.indexOf('async ackNativeXrpPayoutSettled')
+    );
+    const ackMethod = source.slice(source.indexOf('async ackNativeXrpPayoutSettled'));
+
+    expect(readMethod).toContain('this.getQueryActor()');
+    expect(readMethod).not.toContain('this.getMutationActor()');
+    expect(ackMethod).toContain('this.getMutationActor()');
+  });
+});


### PR DESCRIPTION
Root cause: the passive XRP payout refresh on Stability Pool used getMutationActor(), which routes through the Oisy signer. On page refresh this trips the signer-web guard: 'Signer window should not be opened outside of click handler'. Fix: getMyNativeXrpPayouts() now uses the anonymous query actor. Ack/settlement remains on the mutation actor. Verification: added regression spec that failed before the fix, then passed; ran related XRP/SP unit tests and npm run build --workspace=src/vault_frontend.