### PR TITLE
fix(frontend): guard Oisy XRP payout refresh

### DIFF
--- a/src/vault_frontend/src/lib/services/stabilityPoolService.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.ts
@@ -504,8 +504,12 @@ class StabilityPoolService {
     );
   }
 
-  async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]> {
-    const actor = await this.getQueryActor();
+  async getMyNativeXrpPayouts(options: { allowSigner?: boolean } = {}): Promise<NativeXrpPendingPayout[]> {
+    if (isOisyWallet() && !options.allowSigner) {
+      return [];
+    }
+
+    const actor = await this.getMutationActor();
     return getMyNativeXrpPayoutsWithActor(actor);
   }
 

--- a/src/vault_frontend/src/lib/services/stabilityPoolService.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/services/stabilityPoolService.xrp.spec.ts
@@ -5,20 +5,21 @@ import { resolve } from 'node:path';
 const servicePath = resolve(__dirname, 'stabilityPoolService.ts');
 
 describe('StabilityPoolService native XRP actor routing', () => {
-  it('uses the anonymous query actor for passive pending XRP payout reads', () => {
+  it('does not open the Oisy signer for passive pending XRP payout refreshes', () => {
     const source = readFileSync(servicePath, 'utf8');
 
-    expect(source).toContain('async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]>');
+    expect(source).toContain('async getMyNativeXrpPayouts(options: { allowSigner?: boolean } = {})');
     expect(source).toContain('async ackNativeXrpPayoutSettled');
 
     const readMethod = source.slice(
-      source.indexOf('async getMyNativeXrpPayouts(): Promise<NativeXrpPendingPayout[]>'),
+      source.indexOf('async getMyNativeXrpPayouts(options: { allowSigner?: boolean } = {})'),
       source.indexOf('async ackNativeXrpPayoutSettled')
     );
     const ackMethod = source.slice(source.indexOf('async ackNativeXrpPayoutSettled'));
 
-    expect(readMethod).toContain('this.getQueryActor()');
-    expect(readMethod).not.toContain('this.getMutationActor()');
+    expect(readMethod).toContain('if (isOisyWallet() && !options.allowSigner)');
+    expect(readMethod).toContain('return [];');
+    expect(readMethod).toContain('this.getMutationActor()');
     expect(ackMethod).toContain('this.getMutationActor()');
   });
 });


### PR DESCRIPTION
## Summary
- prevent passive Stability Pool XRP payout refreshes from opening the Oisy signer on page load/refresh
- keep caller-bound payout reads and settlement acknowledgements on the signer-backed actor when explicitly allowed
- add a focused service-routing regression test for the Oisy refresh guard

## Context
PR #296 removed the refresh-time signer error by moving the payout read to the anonymous query actor, but adversarial review caught that `get_my_native_xrp_payouts` is caller-bound and would therefore query anonymous payouts. This follow-up preserves caller semantics while avoiding signer setup outside a click handler.

## Verification
- npm run test:unit --workspace=src/vault_frontend -- --run src/lib/services/stabilityPoolService.xrp.spec.ts src/lib/components/stability-pool/XrpPayoutRouting.spec.ts src/lib/services/stabilityPoolNativeXrp.spec.ts src/lib/services/xrpPayoutHelpers.spec.ts src/lib/components/vault/XrpPendingDepositBanner.spec.ts
- npm run build --workspace=src/vault_frontend