### PR TITLE
perf(backend): per-collateral XRC price-fetch cadence + live setter

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -216,6 +216,21 @@ type ConsentMessageSpec = record {
   device_spec : opt DeviceSpec;
 };
 type CustodyKind = variant { IcrcLedger; NativeXrp };
+type CycleManagerCyclesStatus = record {
+  idle_burn_cycles_per_day : opt nat;
+  stable_memory_bytes : opt nat64;
+  low_watermark : nat;
+  balance : nat;
+  heap_memory_bytes : opt nat64;
+  healthy : bool;
+  freeze_threshold_secs : nat64;
+};
+type CycleManagerMetric = record {
+  key : text;
+  value : nat;
+  count : nat64;
+  label : opt text;
+};
 type DeficitSource = variant {
   Liquidation : record { vault_id : nat64 };
   Redemption : record { redeemer : principal };
@@ -944,21 +959,6 @@ type ProtocolStatus = record {
   breaker_window_debt_ceiling_e8s : nat64;
   last_icp_rate : float64;
 };
-type CycleManagerCyclesStatus = record {
-  balance : nat;
-  low_watermark : nat;
-  healthy : bool;
-  freeze_threshold_secs : nat64;
-  stable_memory_bytes : opt nat64;
-  heap_memory_bytes : opt nat64;
-  idle_burn_cycles_per_day : opt nat;
-};
-type CycleManagerMetric = record {
-  key : text;
-  count : nat64;
-  value : nat;
-  label : opt text;
-};
 type ProtocolStatusLite = record { price_e8s : nat };
 type RateCurve = record {
   method : InterpolationMethod;
@@ -1244,6 +1244,8 @@ service : (ProtocolArg) -> {
   close_vault : (nat64) -> (Result_5);
   coingecko_transform : (TransformArgs) -> (HttpResponse) query;
   confirm_xrp_deposit : (nat64) -> (Result_1);
+  cycle_manager_metrics : () -> (vec CycleManagerMetric) query;
+  cycles_status : () -> (CycleManagerCyclesStatus) query;
   delete_chain : (nat32) -> (Result);
   disable_chain : (nat32) -> (Result);
   enter_recovery_mode : () -> (Result);
@@ -1273,6 +1275,9 @@ service : (ProtocolArg) -> {
   get_chains_ecdsa_key_name : () -> (text) query;
   get_ckstable_repay_fee : () -> (float64) query;
   get_collateral_config : (principal) -> (opt CollateralConfig) query;
+  get_collateral_price_fetch_intervals : () -> (
+      vec record { principal; nat64 },
+    ) query;
   get_collateral_totals : () -> (vec CollateralTotals) query;
   get_consumed_writedown_proofs : () -> (
       vec record { SpProofLedger; nat64 },
@@ -1320,8 +1325,6 @@ service : (ProtocolArg) -> {
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;
   get_protocol_status : () -> (ProtocolStatus) query;
-  cycles_status : () -> (CycleManagerCyclesStatus) query;
-  cycle_manager_metrics : () -> (vec CycleManagerMetric) query;
   get_recovery_cr_multiplier : () -> (float64) query;
   get_recovery_target_cr : () -> (float64) query;
   get_redemption_fee_ceiling : () -> (float64) query;
@@ -1425,6 +1428,7 @@ service : (ProtocolArg) -> {
   set_collateral_min_deposit : (principal, nat64) -> (Result);
   set_collateral_min_vault_debt : (principal, nat64) -> (Result);
   set_collateral_min_xrc_sources : (principal, opt nat32) -> (Result);
+  set_collateral_price_fetch_interval_secs : (principal, nat64) -> (Result);
   set_collateral_redemption_fee_ceiling : (principal, float64) -> (Result);
   set_collateral_redemption_fee_floor : (principal, float64) -> (Result);
   set_collateral_status : (principal, CollateralStatus) -> (Result);

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -8738,6 +8738,96 @@ async fn set_vault_check_tick_interval_secs(secs: u64) -> Result<(), ProtocolErr
     Ok(())
 }
 
+/// 2026-07-03 cycle-burn optimization: tune the background XRC price-refresh
+/// cadence (seconds) for a SINGLE non-ICP collateral. Default (unset) is 300s.
+/// Re-registers that collateral's price timer in place; no upgrade required.
+///
+/// Trade-off: this timer is a background refresh feeding query displays and the
+/// liquidation sweep's cached-price read. User mint/withdraw/borrow always force
+/// an on-demand XRC fetch when the cache is older than
+/// `PRICE_FRESHNESS_THRESHOLD_NANOS` (60s), so RAISING this never affects
+/// user-operation pricing. It DOES mean the liquidation sweep for this
+/// collateral may act on a price up to `secs` old, so keep debt-bearing,
+/// volatile collateral tight (300-900s) and only stretch idle / low-debt
+/// collateral. The 10-minute hard oracle-staleness ceiling
+/// (`ensure_fresh_price_for`) still fail-closes user ops regardless.
+///
+/// ICP is rejected: it is driven by its own Timer A, tuned via
+/// `set_xrc_fetch_interval_secs`, not the per-collateral price timer.
+#[candid_method(update)]
+#[update]
+async fn set_collateral_price_fetch_interval_secs(
+    collateral: Principal,
+    secs: u64,
+) -> Result<(), ProtocolError> {
+    let caller = ic_cdk::caller();
+    let is_developer = read_state(|s| s.developer_principal == caller);
+    if !is_developer {
+        return Err(ProtocolError::GenericError(
+            "Only the developer principal can set a collateral price fetch interval".to_string(),
+        ));
+    }
+    // Floor at 60s: a sub-minute background refresh defeats the 60s freshness
+    // cache and re-burns XRC cycles, and a 0 would busy-loop the timer.
+    if secs < 60 {
+        return Err(ProtocolError::GenericError(
+            "Collateral price fetch interval must be >= 60s".to_string(),
+        ));
+    }
+    // ICP has its own Timer A; it is excluded from the per-collateral price
+    // timers in `setup_timers`, so keying it here would have no effect (and
+    // implies the caller wants `set_xrc_fetch_interval_secs`).
+    let icp = read_state(|s| s.icp_collateral_type());
+    if collateral == icp {
+        return Err(ProtocolError::GenericError(
+            "ICP price cadence is tuned via set_xrc_fetch_interval_secs, not this endpoint"
+                .to_string(),
+        ));
+    }
+    // Require a configured collateral so we never register a dangling timer for
+    // a principal that has no price source.
+    let known = read_state(|s| s.collateral_configs.contains_key(&collateral));
+    if !known {
+        return Err(ProtocolError::GenericError(format!(
+            "Unknown collateral {}",
+            collateral
+        )));
+    }
+    mutate_state(|s| {
+        s.collateral_price_fetch_interval_secs
+            .insert(collateral, secs);
+    });
+    rumi_protocol_backend::xrc::register_collateral_price_timer(collateral);
+    log!(
+        INFO,
+        "[set_collateral_price_fetch_interval_secs] {} price fetch cadence set to {}s",
+        collateral,
+        secs
+    );
+    Ok(())
+}
+
+/// 2026-07-03: observability for the per-collateral price-fetch cadence. Returns
+/// the EFFECTIVE interval (seconds) for every configured collateral — the
+/// per-collateral override where set, else the 300s default. ICP is included for
+/// completeness but its background refresh is actually driven by Timer A
+/// (`xrc_fetch_interval_secs`), not the per-collateral timer.
+#[candid_method(query)]
+#[query]
+fn get_collateral_price_fetch_intervals() -> Vec<(Principal, u64)> {
+    read_state(|s| {
+        s.collateral_configs
+            .keys()
+            .map(|ct| {
+                (
+                    *ct,
+                    rumi_protocol_backend::xrc::collateral_price_fetch_secs(s, ct),
+                )
+            })
+            .collect()
+    })
+}
+
 /// Phase 1b Task 15: tune the Timer D (Monad outbound settlement fan-out)
 /// interval in seconds. Default 30. Re-registers in place.
 ///

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1139,6 +1139,19 @@ pub struct State {
     /// `set_vault_check_tick_interval_secs`.
     #[serde(default = "default_vault_check_tick_interval_secs")]
     pub vault_check_tick_interval_secs: u64,
+    /// 2026-07-03 cycle-burn optimization: per-collateral cadence (seconds) for
+    /// the background XRC price-refresh timer registered by
+    /// `xrc::register_collateral_price_timer`, keyed by collateral ledger
+    /// principal. A collateral ABSENT from this map falls back to
+    /// `xrc::DEFAULT_COLLATERAL_PRICE_FETCH_SECS` (300s) — the cadence every
+    /// non-ICP collateral shipped with before this field existed — so a legacy
+    /// snapshot (empty map via serde default) preserves the exact prior
+    /// behavior. Tunable per collateral via
+    /// `set_collateral_price_fetch_interval_secs`, which re-registers that one
+    /// collateral's timer in place. ICP is NOT keyed here: it has its own
+    /// dedicated Timer A (`xrc_fetch_interval_secs`).
+    #[serde(default)]
+    pub collateral_price_fetch_interval_secs: BTreeMap<CollateralType, u64>,
     /// Phase 1b Task 15: cadence (seconds) for Timer D (the settlement
     /// fan-out, `main::run_all_settlements`, which dispatches each registered
     /// chain to its kind's `run_settlement`). Default 30. Tunable via
@@ -1842,6 +1855,7 @@ impl Default for State {
             xrc_fetch_interval_secs: default_xrc_fetch_interval_secs(),
             interest_treasury_tick_interval_secs: default_interest_treasury_tick_interval_secs(),
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
+            collateral_price_fetch_interval_secs: BTreeMap::new(),
             settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),
@@ -2000,6 +2014,7 @@ impl From<InitArg> for State {
             xrc_fetch_interval_secs: default_xrc_fetch_interval_secs(),
             interest_treasury_tick_interval_secs: default_interest_treasury_tick_interval_secs(),
             vault_check_tick_interval_secs: default_vault_check_tick_interval_secs(),
+            collateral_price_fetch_interval_secs: BTreeMap::new(),
             settlement_tick_interval_secs: default_settlement_tick_interval_secs(),
             observer_tick_interval_secs: default_observer_tick_interval_secs(),
             chain_interest_tick_interval_secs: default_chain_interest_tick_interval_secs(),

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -123,18 +123,66 @@ pub fn should_fetch_collateral_price(
         .unwrap_or(false)
 }
 
+thread_local! {
+    /// 2026-07-03 cycle-burn optimization: the `TimerId` of the background
+    /// price-refresh timer for each collateral, so
+    /// `set_collateral_price_fetch_interval_secs` can clear + re-register a
+    /// single collateral's timer in place (mirroring the ICP / settlement /
+    /// observer timers in `main`). NOT persisted: timers never survive an
+    /// upgrade, and `setup_timers` re-registers each collateral's timer from
+    /// `State::collateral_price_fetch_interval_secs` on every start.
+    static COLLATERAL_PRICE_TIMER_IDS: std::cell::RefCell<
+        std::collections::BTreeMap<Principal, ic_cdk_timers::TimerId>,
+    > = std::cell::RefCell::new(std::collections::BTreeMap::new());
+}
+
+/// 2026-07-03: fallback background price-fetch cadence (seconds) for a
+/// collateral with no entry in `State::collateral_price_fetch_interval_secs`.
+/// Equal to the historical hardcoded 300s, so an unconfigured collateral
+/// behaves exactly as it did before per-collateral cadences existed.
+pub const DEFAULT_COLLATERAL_PRICE_FETCH_SECS: u64 = 300;
+
+/// 2026-07-03: resolve the effective background price-fetch cadence for a
+/// collateral. Returns the per-collateral override when set, else the 300s
+/// default. A stored 0 (should never happen — the setter rejects it) or any
+/// value below 60s is floored to protect against a busy-loop timer.
+pub fn collateral_price_fetch_secs(state: &State, ledger_id: &Principal) -> u64 {
+    match state
+        .collateral_price_fetch_interval_secs
+        .get(ledger_id)
+        .copied()
+    {
+        None | Some(0) => DEFAULT_COLLATERAL_PRICE_FETCH_SECS,
+        Some(secs) => secs.max(60),
+    }
+}
+
 /// Wave-9d DOS-011: registers the recurring per-collateral XRC price
 /// timer with the status-check gate baked in. Used by both
 /// `setup_timers()` (re-registering after upgrade) and
 /// `add_collateral_token` (registering for a brand-new collateral).
 ///
-/// The timer keeps firing every `FETCHING_ICP_RATE_INTERVAL`
-/// regardless of status — that's free. The gate runs synchronously
-/// INSIDE the closure (before any `ic_cdk::spawn`): if the collateral
-/// is wound down, we early-return before allocating an async task and
-/// before the (~1B cycle) XRC call.
+/// 2026-07-03: the interval is now per-collateral (resolved via
+/// `collateral_price_fetch_secs`, default 300s) rather than a fixed
+/// `FETCHING_ICP_RATE_INTERVAL`, and the timer id is tracked in
+/// `COLLATERAL_PRICE_TIMER_IDS` so a re-register (setter, or repeated
+/// `setup_timers`) clears the prior timer first and never leaks a duplicate
+/// interval timer for the same collateral.
+///
+/// The timer keeps firing on its cadence regardless of status — that's free.
+/// The gate runs synchronously INSIDE the closure (before any `ic_cdk::spawn`):
+/// if the collateral is wound down, we early-return before allocating an async
+/// task and before the (~1B cycle) XRC call.
 pub fn register_collateral_price_timer(ledger_id: Principal) {
-    ic_cdk_timers::set_timer_interval(FETCHING_ICP_RATE_INTERVAL, move || {
+    // Clear any prior timer for this collateral so a re-register never leaks a
+    // second interval timer (which would double this collateral's fetch burn).
+    COLLATERAL_PRICE_TIMER_IDS.with(|cell| {
+        if let Some(old) = cell.borrow_mut().remove(&ledger_id) {
+            ic_cdk_timers::clear_timer(old);
+        }
+    });
+    let secs = read_state(|s| collateral_price_fetch_secs(s, &ledger_id));
+    let new_id = ic_cdk_timers::set_timer_interval(Duration::from_secs(secs), move || {
         let go = read_state(|s| should_fetch_collateral_price(s, &ledger_id));
         if !go {
             log!(
@@ -145,6 +193,9 @@ pub fn register_collateral_price_timer(ledger_id: Principal) {
             return;
         }
         ic_cdk::spawn(crate::management::fetch_collateral_price(ledger_id));
+    });
+    COLLATERAL_PRICE_TIMER_IDS.with(|cell| {
+        cell.borrow_mut().insert(ledger_id, new_id);
     });
 }
 
@@ -649,5 +700,49 @@ pub async fn ensure_stable_not_depegged(
             "No {} price available. Cannot verify peg safety.",
             symbol
         ))),
+    }
+}
+
+#[cfg(test)]
+mod cycle_cadence_tests {
+    use super::{collateral_price_fetch_secs, DEFAULT_COLLATERAL_PRICE_FETCH_SECS};
+    use crate::state::State;
+    use candid::Principal;
+
+    fn ckbtc() -> Principal {
+        Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()
+    }
+
+    #[test]
+    fn absent_collateral_falls_back_to_default() {
+        // A collateral with no entry keeps the historical 300s cadence, so a
+        // legacy snapshot (empty map) behaves exactly as before this field.
+        let s = State::default();
+        assert_eq!(
+            collateral_price_fetch_secs(&s, &ckbtc()),
+            DEFAULT_COLLATERAL_PRICE_FETCH_SECS
+        );
+    }
+
+    #[test]
+    fn override_is_honored() {
+        let mut s = State::default();
+        s.collateral_price_fetch_interval_secs.insert(ckbtc(), 1800);
+        assert_eq!(collateral_price_fetch_secs(&s, &ckbtc()), 1800);
+    }
+
+    #[test]
+    fn zero_falls_back_and_sub_60_is_floored() {
+        let mut s = State::default();
+        // A stored 0 (the setter rejects it, but a corrupt value must not
+        // busy-loop) falls back to the default.
+        s.collateral_price_fetch_interval_secs.insert(ckbtc(), 0);
+        assert_eq!(
+            collateral_price_fetch_secs(&s, &ckbtc()),
+            DEFAULT_COLLATERAL_PRICE_FETCH_SECS
+        );
+        // Any other sub-60 value is floored to 60s.
+        s.collateral_price_fetch_interval_secs.insert(ckbtc(), 5);
+        assert_eq!(collateral_price_fetch_secs(&s, &ckbtc()), 60);
     }
 }


### PR DESCRIPTION
## Summary

The backend's non-ICP collateral price timers were hardcoded to a 300s cadence, so idle / low-debt collaterals (ckBTC, ckETH, ckXAUT, BOB, EXE, XRP) each burned ~55B cycles/day polling XRC for a price nothing consumes on that cadence. Measured live `tfesu` burn was **~397B cycles/day (~$16/mo)**, ~95% of it this XRC polling.

This makes each collateral's background refresh cadence a **live-tunable per-collateral State field** with a developer-gated setter, so we can stretch the cadence for quiet collaterals without an upgrade.

## Changes

- **state.rs** — new `collateral_price_fetch_interval_secs: BTreeMap<CollateralType, u64>` (`#[serde(default)]`, ciborium-safe additive field). An empty map (legacy snapshot) falls back to 300s, so existing behavior is byte-for-byte preserved.
- **xrc.rs** — `collateral_price_fetch_secs()` resolver (per-collateral override else 300s default; a stored `0` or any sub-60s value is floored to prevent a busy-loop timer). Added `COLLATERAL_PRICE_TIMER_IDS` tracking so `register_collateral_price_timer` clears + re-registers a single collateral's timer in place — no leaked duplicate interval timers on re-register.
- **main.rs** — `set_collateral_price_fetch_interval_secs(principal, nat64)` (developer-gated; rejects `<60s`, ICP, and unknown collateral; re-registers in place) + `get_collateral_price_fetch_intervals()` query for verification.
- **.did** — regenerated via `RUMI_REGEN_DID` (additive: +2 methods, no existing signature changed).

ICP is unaffected — it runs on its own Timer A, tuned via `set_xrc_fetch_interval_secs`.

## Safety notes

- User mint/withdraw/borrow already force an on-demand XRC fetch when the cached price is >60s old, so raising a cadence **never** affects user-operation pricing. It only affects the liquidation sweep's cached-price read, and the 10-minute hard oracle-staleness ceiling still fail-closes user ops regardless. Keep debt-bearing/volatile collateral tight; only stretch idle / low-debt ones.
- Additive candid + additive `#[serde(default)]` state field: no UPG-002 risk, no breaking change.

## Impact

Applying the intended cadences to the six non-ICP collaterals cuts total `tfesu` burn from **~397B → ~160B cycles/day (~60%, ~$9-10/mo)**. Values are applied operationally post-deploy via the setter (they persist across upgrades):

| Collateral | Cadence |
|---|---|
| ICP | 300s (unchanged, Timer A) |
| ckBTC, ckETH, XRP | 900s |
| BOB, EXE | 1200s |
| ckXAUT | 1800s |
| nICP | default (no XRC call — LstWrapped) |

## Testing

- 742 lib tests pass, including 3 new `cycle_cadence_tests` covering the resolver (override honored, absent → 300s default, `0`/sub-60 floored).
- `check_candid_interface_compatibility` green (`.did` matches source).

## Deploy checklist (post-merge)

1. Deploy `rumi_protocol_backend` upgrade (pre-deploy hook runs unit + integration tests).
2. Apply the six `set_collateral_price_fetch_interval_secs` calls above.
3. Verify via `get_collateral_price_fetch_intervals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)