### PR TITLE
Fix ckUSDC stability-pool withdrawal fees

### DIFF
--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -12,16 +12,16 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 
 /// Conservative fallback for a stablecoin ledger's transfer fee (native units),
-/// used when the live `icrc1_fee` query fails (IC-S-001). Erring high keeps the
-/// pool solvent (we refund slightly less) rather than risking an over-send.
-/// Mirrors rumi_3pool::transfers::DEFAULT_LEDGER_FEE.
-const DEFAULT_REFUND_LEDGER_FEE: u64 = 10_000;
+/// used when the live `icrc1_fee` query fails. Known stablecoin registry values
+/// are normalized on registration/upgrade; for unknown ledgers, erring high
+/// keeps the pool solvent rather than risking an over-send.
+const DEFAULT_LEDGER_FEE: u64 = 10_000;
 
 thread_local! {
-    /// Per-ledger transfer-fee cache for refund math, populated lazily from
+    /// Per-ledger transfer-fee cache for transfer/refund math, populated lazily from
     /// `icrc1_fee`. Heap-only (not persisted), so it is simply re-warmed after
     /// an upgrade. Mirrors rumi_3pool::transfers::LEDGER_FEES.
-    static REFUND_LEDGER_FEES: RefCell<HashMap<Principal, u64>> = RefCell::new(HashMap::new());
+    static LEDGER_FEES: RefCell<HashMap<Principal, u64>> = RefCell::new(HashMap::new());
 }
 
 fn record_deposit_credit_after_async(
@@ -65,28 +65,33 @@ fn record_deposit_as_3usd_credit_after_async(
     Ok(())
 }
 
+fn fallback_ledger_fee(ledger: Principal) -> u64 {
+    read_state(|s| {
+        let Some(config) = s.stablecoin_registry.get(&ledger) else {
+            return DEFAULT_LEDGER_FEE;
+        };
+        let configured = config.transfer_fee.unwrap_or(0);
+        let known = crate::state::known_stablecoin_transfer_fee(&config.symbol, config.decimals)
+            .unwrap_or(DEFAULT_LEDGER_FEE);
+        configured.max(known)
+    })
+}
+
 /// Fetch a stablecoin ledger's transfer fee, caching successful lookups per
-/// ledger. On query failure, falls back to the larger of the registry's
-/// configured fee and the standard ICRC-1 fee (the solvency-safe direction),
-/// without caching so the next refund re-queries.
-async fn refund_ledger_fee(ledger: Principal) -> u64 {
-    if let Some(fee) = REFUND_LEDGER_FEES.with(|c| c.borrow().get(&ledger).copied()) {
+/// ledger. On query failure, falls back to normalized registry metadata without
+/// caching so the next transfer re-queries.
+async fn ledger_transfer_fee(ledger: Principal) -> u64 {
+    if let Some(fee) = LEDGER_FEES.with(|c| c.borrow().get(&ledger).copied()) {
         return fee;
     }
     match call::<(), (candid::Nat,)>(ledger, "icrc1_fee", ()).await {
         Ok((fee_nat,)) => {
-            let fee: u64 = fee_nat.0.try_into().unwrap_or(DEFAULT_REFUND_LEDGER_FEE);
-            REFUND_LEDGER_FEES.with(|c| c.borrow_mut().insert(ledger, fee));
+            let fee: u64 = fee_nat.0.try_into().unwrap_or(DEFAULT_LEDGER_FEE);
+            LEDGER_FEES.with(|c| c.borrow_mut().insert(ledger, fee));
             fee
         }
         Err(e) => {
-            let registry_fee = read_state(|s| {
-                s.stablecoin_registry
-                    .get(&ledger)
-                    .and_then(|c| c.transfer_fee)
-                    .unwrap_or(0)
-            });
-            let fallback = registry_fee.max(DEFAULT_REFUND_LEDGER_FEE);
+            let fallback = fallback_ledger_fee(ledger);
             log!(
                 INFO,
                 "icrc1_fee query failed for {}: {:?}; using conservative fallback {}",
@@ -234,15 +239,10 @@ pub async fn withdraw(token_ledger: Principal, amount: u64) -> Result<(), Stabil
         return Err(StabilityPoolError::EmergencyPaused);
     }
 
-    // Look up the transfer fee so we can deduct it from what the user receives.
-    // The ledger charges the fee on top of the transfer amount, so without this
-    // the pool's ledger balance drifts below its recorded state on every withdrawal.
-    let ledger_fee = read_state(|s| {
-        s.stablecoin_registry
-            .get(&token_ledger)
-            .and_then(|c| c.transfer_fee)
-            .unwrap_or(0)
-    });
+    // The ledger debits `transfer_amount + fee` from the pool. Query the live
+    // fee first so a max withdrawal drains the user's recorded position without
+    // overdrawing the pool ledger account.
+    let ledger_fee = ledger_transfer_fee(token_ledger).await;
 
     if amount <= ledger_fee {
         return Err(StabilityPoolError::AmountTooLow {
@@ -832,7 +832,7 @@ pub async fn deposit_as_3usd(
 /// pending refund recoverable via `claim_pending_refund` instead of being
 /// silently stranded.
 async fn refund_user(user: Principal, token_ledger: Principal, amount: u64, reason: &str) {
-    let fee = refund_ledger_fee(token_ledger).await;
+    let fee = ledger_transfer_fee(token_ledger).await;
     if amount <= fee {
         // Nothing transferable once the ledger fee is covered; the dust stays
         // in the pool (solvency-safe, mirrors rumi_3pool::transfer_to_user).
@@ -910,7 +910,7 @@ pub async fn claim_pending_refund(refund_id: u64) -> Result<u64, StabilityPoolEr
         return Err(StabilityPoolError::Unauthorized);
     }
 
-    let fee = refund_ledger_fee(refund.token_ledger).await;
+    let fee = ledger_transfer_fee(refund.token_ledger).await;
     if refund.amount <= fee {
         // Nothing transferable once the fee is covered; drop the record and
         // leave the dust in the pool (solvency-safe).

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -82,21 +82,12 @@ fn post_upgrade(_args: StabilityPoolInitArgs) {
         ic_cdk::trap(&format!("State validation failed after upgrade: {}", error));
     }
 
-    // Migration: fix stablecoin transfer_fee values
-    mutate_state(|s| {
-        for config in s.stablecoin_registry.values_mut() {
-            match config.symbol.as_str() {
-                "icUSD" => {
-                    config.transfer_fee = Some(100_000);
-                }
-                "3USD" => {
-                    config.transfer_fee = Some(0);
-                }
-                _ => {}
-            }
-        }
-    });
-    log!(INFO, "Migration: corrected icUSD and 3USD transfer fees");
+    let corrected_fees = mutate_state(|s| s.normalize_registered_stablecoin_transfer_fees());
+    log!(
+        INFO,
+        "Migration: normalized {} stablecoin transfer fee values",
+        corrected_fees
+    );
 
     // Defer timer setup to avoid ic0_call_new restriction during upgrade
     ic_cdk_timers::set_timer(Duration::ZERO, || {
@@ -742,13 +733,13 @@ pub fn icrc21_canister_call_consent_message(
         "deposit" => {
             match candid::decode_args::<(Principal, u64)>(&request.arg) {
                 Ok((token_ledger, amount)) => {
-                    let symbol = read_state(|s| {
+                    let (symbol, decimals) = read_state(|s| {
                         s.stablecoin_registry
                             .get(&token_ledger)
-                            .map(|c| c.symbol.clone())
-                            .unwrap_or_else(|| format!("token {}", token_ledger))
+                            .map(|c| (c.symbol.clone(), c.decimals))
+                            .unwrap_or_else(|| (format!("token {}", token_ledger), 8))
                     });
-                    let formatted = format_token_amount(amount);
+                    let formatted = format_token_amount(amount, decimals);
                     format!(
                         "## Deposit to Stability Pool\n\n\
                          You are depositing **{} {}** into the Rumi Protocol Stability Pool.\n\n\
@@ -762,17 +753,29 @@ pub fn icrc21_canister_call_consent_message(
         "withdraw" => {
             match candid::decode_args::<(Principal, u64)>(&request.arg) {
                 Ok((token_ledger, amount)) => {
-                    let symbol = read_state(|s| {
-                        s.stablecoin_registry
-                            .get(&token_ledger)
-                            .map(|c| c.symbol.clone())
-                            .unwrap_or_else(|| format!("token {}", token_ledger))
+                    let (symbol, decimals, fee) = read_state(|s| {
+                        let Some(config) = s.stablecoin_registry.get(&token_ledger) else {
+                            return (format!("token {}", token_ledger), 8, 0);
+                        };
+                        let known_fee = crate::state::known_stablecoin_transfer_fee(
+                            &config.symbol,
+                            config.decimals,
+                        )
+                        .unwrap_or(0);
+                        (
+                            config.symbol.clone(),
+                            config.decimals,
+                            config.transfer_fee.unwrap_or(0).max(known_fee),
+                        )
                     });
-                    let formatted = format_token_amount(amount);
+                    let gross_formatted = format_token_amount(amount, decimals);
+                    let net_amount = amount.saturating_sub(fee);
+                    let net_formatted = format_token_amount(net_amount, decimals);
                     format!(
                         "## Withdraw from Stability Pool\n\n\
-                         You are withdrawing **{} {}** from the Rumi Protocol Stability Pool.",
-                        formatted, symbol
+                         You are withdrawing **{} {}** from your Rumi Protocol Stability Pool position. \
+                         After the ledger transfer fee, you receive **{} {}**.",
+                        gross_formatted, symbol, net_formatted, symbol
                     )
                 }
                 Err(_) => "Withdraw stablecoins from the Rumi Protocol Stability Pool.".to_string(),
@@ -880,13 +883,13 @@ pub fn icrc21_canister_call_consent_message(
         "deposit_as_3usd" => {
             match candid::decode_args::<(Principal, u64)>(&request.arg) {
                 Ok((token_ledger, amount)) => {
-                    let symbol = read_state(|s| {
+                    let (symbol, decimals) = read_state(|s| {
                         s.stablecoin_registry
                             .get(&token_ledger)
-                            .map(|c| c.symbol.clone())
-                            .unwrap_or_else(|| format!("token {}", token_ledger))
+                            .map(|c| (c.symbol.clone(), c.decimals))
+                            .unwrap_or_else(|| (format!("token {}", token_ledger), 8))
                     });
-                    let formatted = format_token_amount(amount);
+                    let formatted = format_token_amount(amount, decimals);
                     format!(
                         "## Deposit as 3USD\n\n\
                          You are depositing **{} {}** into the Rumi Protocol Stability Pool \
@@ -935,14 +938,15 @@ pub fn icrc10_supported_standards() -> Vec<Icrc10SupportedStandard> {
     ]
 }
 
-/// Format an e8s token amount as a human-readable string.
-fn format_token_amount(amount_e8s: u64) -> String {
-    let whole = amount_e8s / 100_000_000;
-    let frac = amount_e8s % 100_000_000;
+/// Format a token amount in native units as a human-readable string.
+fn format_token_amount(amount: u64, decimals: u8) -> String {
+    let divisor = 10u64.checked_pow(decimals as u32).unwrap_or(100_000_000);
+    let whole = amount / divisor;
+    let frac = amount % divisor;
     if frac == 0 {
         format!("{}", whole)
     } else {
-        let frac_str = format!("{:08}", frac);
+        let frac_str = format!("{:0width$}", frac, width = decimals as usize);
         let trimmed = frac_str.trim_end_matches('0');
         format!("{}.{}", whole, trimmed)
     }

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -7,6 +7,31 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::logs::INFO;
 use crate::types::*;
 
+pub const ICUSD_TRANSFER_FEE_E8S: u64 = 100_000;
+pub const CK_STABLE_TRANSFER_FEE_E6: u64 = 10_000;
+pub const THREE_USD_TRANSFER_FEE: u64 = 0;
+
+pub fn known_stablecoin_transfer_fee(symbol: &str, decimals: u8) -> Option<u64> {
+    match (symbol, decimals) {
+        ("icUSD", 8) => Some(ICUSD_TRANSFER_FEE_E8S),
+        ("ckUSDT" | "ckUSDC", 6) => Some(CK_STABLE_TRANSFER_FEE_E6),
+        ("3USD", _) => Some(THREE_USD_TRANSFER_FEE),
+        _ => None,
+    }
+}
+
+fn normalize_known_stablecoin_transfer_fee(config: &mut StablecoinConfig) -> bool {
+    let Some(known_fee) = known_stablecoin_transfer_fee(&config.symbol, config.decimals) else {
+        return false;
+    };
+    let corrected_fee = config.transfer_fee.unwrap_or(0).max(known_fee);
+    if config.transfer_fee == Some(corrected_fee) {
+        return false;
+    }
+    config.transfer_fee = Some(corrected_fee);
+    true
+}
+
 /// Maximum number of liquidation records retained in memory.
 /// Older entries are dropped when this limit is exceeded.
 const MAX_LIQUIDATION_HISTORY: usize = 1_000;
@@ -213,10 +238,22 @@ impl StabilityPoolState {
     // ─── Stablecoin Registry ───
 
     pub fn register_stablecoin(&mut self, config: StablecoinConfig) {
+        let mut config = config;
+        normalize_known_stablecoin_transfer_fee(&mut config);
         self.total_stablecoin_balances
             .entry(config.ledger_id)
             .or_insert(0);
         self.stablecoin_registry.insert(config.ledger_id, config);
+    }
+
+    pub fn normalize_registered_stablecoin_transfer_fees(&mut self) -> usize {
+        let mut corrected = 0;
+        for config in self.stablecoin_registry.values_mut() {
+            if normalize_known_stablecoin_transfer_fee(config) {
+                corrected += 1;
+            }
+        }
+        corrected
     }
 
     pub fn get_stablecoin_config(&self, ledger: &Principal) -> Option<&StablecoinConfig> {
@@ -2748,7 +2785,7 @@ mod tests {
             decimals: 6,
             priority: 2,
             is_active: true,
-            transfer_fee: Some(10),
+            transfer_fee: Some(10_000),
             is_lp_token: None,
             underlying_pool: None,
         });
@@ -2758,7 +2795,7 @@ mod tests {
             decimals: 6,
             priority: 2,
             is_active: true,
-            transfer_fee: Some(10),
+            transfer_fee: Some(10_000),
             is_lp_token: None,
             underlying_pool: None,
         });
@@ -2783,6 +2820,64 @@ mod tests {
         });
 
         state
+    }
+
+    #[test]
+    fn test_known_stablecoin_fee_normalization_repairs_legacy_ckstable_values() {
+        let mut state = StabilityPoolState::default();
+
+        state.register_stablecoin(StablecoinConfig {
+            ledger_id: ckusdc_ledger(),
+            symbol: "ckUSDC".to_string(),
+            decimals: 6,
+            priority: 2,
+            is_active: true,
+            transfer_fee: Some(10),
+            is_lp_token: None,
+            underlying_pool: None,
+        });
+        state.register_stablecoin(StablecoinConfig {
+            ledger_id: ckusdt_ledger(),
+            symbol: "ckUSDT".to_string(),
+            decimals: 6,
+            priority: 2,
+            is_active: true,
+            transfer_fee: None,
+            is_lp_token: None,
+            underlying_pool: None,
+        });
+        state.register_stablecoin(StablecoinConfig {
+            ledger_id: Principal::from_slice(&[13]),
+            symbol: "3USD".to_string(),
+            decimals: 8,
+            priority: 0,
+            is_active: true,
+            transfer_fee: None,
+            is_lp_token: Some(true),
+            underlying_pool: None,
+        });
+
+        assert_eq!(
+            state
+                .stablecoin_registry
+                .get(&ckusdc_ledger())
+                .and_then(|c| c.transfer_fee),
+            Some(10_000)
+        );
+        assert_eq!(
+            state
+                .stablecoin_registry
+                .get(&ckusdt_ledger())
+                .and_then(|c| c.transfer_fee),
+            Some(10_000)
+        );
+        assert_eq!(
+            state
+                .stablecoin_registry
+                .get(&Principal::from_slice(&[13]))
+                .and_then(|c| c.transfer_fee),
+            Some(0)
+        );
     }
 
     /// Helper: directly add a deposit without ic_cdk::api::time().

--- a/src/stability_pool/tests/pocket_ic_3usd.rs
+++ b/src/stability_pool/tests/pocket_ic_3usd.rs
@@ -369,7 +369,136 @@ fn query_3pool_lp_balance(pic: &pocket_ic::PocketIc, pool_id: Principal, owner: 
     }
 }
 
+fn ledger_balance(pic: &pocket_ic::PocketIc, ledger: Principal, owner: Principal) -> u128 {
+    let account = Account { owner, subaccount: None };
+    let result = pic.query_call(ledger, Principal::anonymous(), "icrc1_balance_of", encode_one(account).unwrap())
+        .expect("icrc1_balance_of call failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let balance: candid::Nat = decode_one(&bytes).expect("decode balance");
+            balance.0.try_into().expect("balance overflow")
+        }
+        WasmResult::Reject(msg) => panic!("icrc1_balance_of rejected: {}", msg),
+    }
+}
+
 // ─── Tests ───
+
+#[test]
+fn test_ckusdc_max_withdraw_drains_position_net_of_ledger_fee() {
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .build();
+    let minting_account = Principal::self_authenticating(&[101, 101, 101]);
+    let test_user = Principal::self_authenticating(&[11, 12, 13, 14]);
+    let admin = Principal::self_authenticating(&[15, 16, 17, 18]);
+    let protocol_id = Principal::self_authenticating(&[19, 20, 21, 22]);
+    let ckusdc_fee = 10_000u64; // 0.01 ckUSDC at 6 decimals
+
+    let ckusdc_ledger = pic.create_canister();
+    pic.add_cycles(ckusdc_ledger, 2_000_000_000_000);
+    let ledger_init = LedgerInitArgs {
+        minting_account: Account { owner: minting_account, subaccount: None },
+        fee_collector_account: None,
+        transfer_fee: candid::Nat::from(ckusdc_fee),
+        decimals: Some(6),
+        max_memo_length: Some(32),
+        token_name: "ckUSDC".to_string(),
+        token_symbol: "ckUSDC".to_string(),
+        metadata: vec![],
+        initial_balances: vec![(
+            Account { owner: test_user, subaccount: None },
+            candid::Nat::from(5_000_000u64),
+        )],
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: admin,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ckusdc_ledger,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(ledger_init),)).unwrap(),
+        None,
+    );
+
+    let sp_init = StabilityPoolInitArgs {
+        protocol_canister_id: protocol_id,
+        authorized_admins: vec![admin],
+    };
+    let sp_id = pic.create_canister();
+    pic.add_cycles(sp_id, 2_000_000_000_000);
+    pic.install_canister(sp_id, stability_pool_wasm(), encode_one(sp_init).unwrap(), None);
+
+    approve(&pic, ckusdc_ledger, test_user, sp_id, u128::MAX);
+    register_stablecoin(&pic, sp_id, admin, StablecoinConfig {
+        ledger_id: ckusdc_ledger,
+        symbol: "ckUSDC".to_string(),
+        decimals: 6,
+        priority: 2,
+        is_active: true,
+        // Legacy bad value: registration normalizes it, and withdraw also
+        // queries live icrc1_fee before computing the net amount.
+        transfer_fee: Some(10),
+        is_lp_token: None,
+        underlying_pool: None,
+    });
+
+    let deposit_amount = 1_010_000u64; // 1.0100 ckUSDC
+    let result = pic.update_call(
+        sp_id, test_user, "deposit",
+        encode_args((ckusdc_ledger, deposit_amount)).unwrap()
+    ).expect("deposit call failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<(), StabilityPoolError> = decode_one(&bytes).expect("decode deposit");
+            r.expect("deposit failed");
+        }
+        WasmResult::Reject(msg) => panic!("deposit rejected: {}", msg),
+    }
+    assert_eq!(
+        ledger_balance(&pic, ckusdc_ledger, sp_id),
+        deposit_amount as u128,
+        "pool ledger account should receive the full deposit amount",
+    );
+
+    let user_before = ledger_balance(&pic, ckusdc_ledger, test_user);
+    let result = pic.update_call(
+        sp_id, test_user, "withdraw",
+        encode_args((ckusdc_ledger, deposit_amount)).unwrap()
+    ).expect("withdraw call failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<(), StabilityPoolError> = decode_one(&bytes).expect("decode withdraw");
+            r.expect("withdraw failed");
+        }
+        WasmResult::Reject(msg) => panic!("withdraw rejected: {}", msg),
+    }
+
+    assert_eq!(
+        ledger_balance(&pic, ckusdc_ledger, test_user) - user_before,
+        (deposit_amount - ckusdc_fee) as u128,
+        "user should receive the deposited amount net of the ckUSDC transfer fee",
+    );
+    assert_eq!(
+        ledger_balance(&pic, ckusdc_ledger, sp_id),
+        0,
+        "max withdraw should drain the pool ledger account for this position",
+    );
+    assert!(
+        get_user_position(&pic, sp_id, test_user).is_none(),
+        "max withdraw should remove the user's empty position",
+    );
+}
 
 /// Test 1: Direct deposit of icUSD into the stability pool works
 #[test]

--- a/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
@@ -89,9 +89,8 @@
   }
 
   // Audit ICRC-005: per-ledger ICRC-1 fee is queried live (cached for the
-  // session in ledgerFeeService). `setMax` and validation read from the
-  // sync cache; `handleSubmit` does an `await fetchLedgerFee(...)` so the
-  // pre-flight check uses the freshest value before the actual approve.
+  // session in ledgerFeeService). `setMax` and submit validation read from the
+  // sync cache so the Oisy signer popup stays inside the browser click gesture.
 
   function ledgerRefFor(token: StablecoinConfig) {
     return {
@@ -117,8 +116,11 @@
       const adjusted = walletBalance > totalFees ? walletBalance - totalFees : 0n;
       amount = formatStableTokenTx(adjusted, selectedToken.decimals);
     } else {
-      // Withdrawals: pool canister pays the transfer fee, user gets full amount
-      amount = formatStableTokenTx(depositedBalance, selectedToken.decimals);
+      // Withdrawal input is the net amount the user receives; the canister
+      // debits net + ledger fee from the recorded pool position.
+      const ledgerFee = getCachedLedgerFee(ledgerRefFor(selectedToken));
+      const adjusted = depositedBalance > ledgerFee ? depositedBalance - ledgerFee : 0n;
+      amount = formatStableTokenTx(adjusted, selectedToken.decimals);
     }
   }
 
@@ -152,11 +154,13 @@
         await stabilityPoolService.deposit(selectedToken.ledger_id, rawAmount);
         dispatch('success', { action: 'deposit' });
       } else {
-        if (rawAmount > depositedBalance) {
-          error = 'Exceeds deposited amount';
+        const ledgerFee = getCachedLedgerFee(ledgerRefFor(selectedToken));
+        const grossWithdrawal = rawAmount + ledgerFee;
+        if (grossWithdrawal > depositedBalance) {
+          error = 'Exceeds deposited amount (amount + fee)';
           return;
         }
-        await stabilityPoolService.withdraw(selectedToken.ledger_id, rawAmount);
+        await stabilityPoolService.withdraw(selectedToken.ledger_id, grossWithdrawal);
         dispatch('success', { action: 'withdraw' });
       }
       amount = '';


### PR DESCRIPTION
## Summary
- normalize known stablecoin transfer fees for ckUSDC/ckUSDT/icUSD/3USD on registration and upgrade
- query live ICRC-1 transfer fees before stability-pool withdraw/refund transfers
- make withdraw UI input represent net received, submitting gross amount plus fee
- add PocketIC regression for draining a 1.0100 ckUSDC position while receiving 1.0000 net

## Verification
- cargo test -p stability_pool --lib test_known_stablecoin_fee_normalization_repairs_legacy_ckstable_values
- cargo build --target wasm32-unknown-unknown --release -p stability_pool
- POCKET_IC_BIN=/private/tmp/pocket-ic cargo test -p stability_pool --test pocket_ic_3usd test_ckusdc_max_withdraw_drains_position_net_of_ledger_fee -- --nocapture
- git diff --check

## Notes
- no public Candid interface change
- frontend workspace check still has pre-existing unrelated failures