### PR TITLE
Clear SP capped-withdraw shortfall

### DIFF
--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -135,25 +135,29 @@ fn prepare_withdrawal_after_ledger_check(
         let mut correction_msg = None;
 
         if let Some(live_balance) = ledger_balance {
-            if live_balance < requested_amount {
+            let user_balance = s
+                .deposits
+                .get(&caller)
+                .and_then(|pos| pos.stablecoin_balances.get(&token_ledger).copied())
+                .unwrap_or(0);
+            let aggregate_balance = s
+                .total_stablecoin_balances
+                .get(&token_ledger)
+                .copied()
+                .unwrap_or(0);
+
+            if live_balance < aggregate_balance {
                 if live_balance <= ledger_fee {
                     return Err(StabilityPoolError::AmountTooLow {
                         minimum_e8s: ledger_fee + 1,
                     });
                 }
 
-                let user_balance = s
-                    .deposits
-                    .get(&caller)
-                    .and_then(|pos| pos.stablecoin_balances.get(&token_ledger).copied())
-                    .unwrap_or(0);
-                let aggregate_balance = s
-                    .total_stablecoin_balances
-                    .get(&token_ledger)
-                    .copied()
-                    .unwrap_or(0);
+                let sole_holder = user_balance > 0 && user_balance == aggregate_balance;
+                let drains_recorded_position = requested_amount == user_balance;
+                let drains_live_balance = requested_amount == live_balance;
 
-                if requested_amount == user_balance && user_balance == aggregate_balance {
+                if sole_holder && (drains_recorded_position || drains_live_balance) {
                     let msg = s.correct_balance(caller, token_ledger, live_balance);
                     s.push_event(
                         caller,
@@ -168,6 +172,8 @@ fn prepare_withdrawal_after_ledger_check(
                 } else {
                     return Err(StabilityPoolError::InsufficientPoolBalance);
                 }
+            } else if live_balance < requested_amount {
+                return Err(StabilityPoolError::InsufficientPoolBalance);
             }
         }
 

--- a/src/stability_pool/tests/pocket_ic_3usd.rs
+++ b/src/stability_pool/tests/pocket_ic_3usd.rs
@@ -501,8 +501,7 @@ fn test_ckusdc_max_withdraw_drains_position_net_of_ledger_fee() {
     );
 }
 
-#[test]
-fn test_ckusdc_max_withdraw_self_corrects_sole_holder_ledger_shortfall() {
+fn run_ckusdc_sole_holder_ledger_shortfall_withdraw(withdraw_recorded_amount: bool) {
     let pic = PocketIcBuilder::new()
         .with_application_subnet()
         .build();
@@ -614,13 +613,18 @@ fn test_ckusdc_max_withdraw_self_corrects_sole_holder_ledger_shortfall() {
     let live_pool_balance = ledger_balance(&pic, ckusdc_ledger, sp_id) as u64;
     assert_eq!(live_pool_balance, deposit_amount - ckusdc_fee - 1);
 
+    let requested_withdrawal = if withdraw_recorded_amount {
+        deposit_amount
+    } else {
+        live_pool_balance
+    };
     let user_before = ledger_balance(&pic, ckusdc_ledger, test_user);
     let result = pic
         .update_call(
             sp_id,
             test_user,
             "withdraw",
-            encode_args((ckusdc_ledger, deposit_amount)).unwrap(),
+            encode_args((ckusdc_ledger, requested_withdrawal)).unwrap(),
         )
         .expect("withdraw call failed");
     match result {
@@ -645,6 +649,16 @@ fn test_ckusdc_max_withdraw_self_corrects_sole_holder_ledger_shortfall() {
         get_user_position(&pic, sp_id, test_user).is_none(),
         "sole-holder shortfall correction should remove the phantom balance",
     );
+}
+
+#[test]
+fn test_ckusdc_max_withdraw_self_corrects_sole_holder_ledger_shortfall() {
+    run_ckusdc_sole_holder_ledger_shortfall_withdraw(true);
+}
+
+#[test]
+fn test_ckusdc_capped_max_withdraw_self_corrects_sole_holder_ledger_shortfall() {
+    run_ckusdc_sole_holder_ledger_shortfall_withdraw(false);
 }
 
 /// Test 1: Direct deposit of icUSD into the stability pool works


### PR DESCRIPTION
## Summary
- treat live-ledger vs recorded-aggregate drift as the shortfall trigger during SP withdraw prep
- allow sole-holder full-drain reconciliation when the caller submits either the recorded gross amount or the capped live gross amount
- add PocketIC coverage for the capped MAX browser path that previously left a phantom ckUSDC remainder

## Verification
- cargo build --target wasm32-unknown-unknown --release -p stability_pool
- env POCKET_IC_BIN=/private/tmp/pocket-ic cargo test -p stability_pool --test pocket_ic_3usd test_ckusdc -- --nocapture
- cargo test -p stability_pool --lib test_known_stablecoin_fee_normalization_repairs_legacy_ckstable_values
- icp build rumi_stability_pool --environment mainnet-live
- git diff --check