### PR TITLE
perf(analytics): harden pull cadence and backlog draining

### DIFF
--- a/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.d.ts
@@ -35,6 +35,14 @@ export interface AdminEventLabelCount {
   'label' : string,
   'last_at_ns' : [] | [bigint],
 }
+export interface AmmPoolSnapshot {
+  'token_a' : Principal,
+  'token_b' : Principal,
+  'reserve_a' : bigint,
+  'reserve_b' : bigint,
+  'total_lp_shares' : bigint,
+  'pool_id' : string,
+}
 export interface AnalyticsAmmLiquidityEvent {
   'action' : LiquidityAction,
   'timestamp_ns' : bigint,
@@ -196,9 +204,11 @@ export interface DailyTvlRow {
   'timestamp_ns' : bigint,
   'three_pool_reserve_2_e8s' : [] | [bigint],
   'three_pool_virtual_price_e18' : [] | [bigint],
+  'amm_rewards_e8s' : [] | [bigint],
   'total_icusd_supply_e8s' : bigint,
   'system_collateral_ratio_bps' : number,
   'total_icp_collateral_e8s' : bigint,
+  'amm_tvl_usd_e8s' : [] | [bigint],
   'three_pool_reserve_1_e8s' : [] | [bigint],
   'stability_pool_deposits_e8s' : [] | [bigint],
   'three_pool_lp_supply_e8s' : [] | [bigint],
@@ -352,6 +362,13 @@ export interface ProtocolSummary {
   'swap_count_24h' : number,
   'volume_24h_e8s' : bigint,
 }
+export interface PullScheduleConfig {
+  'period_secs_override' : [] | [bigint],
+  'tick_secs_override' : [] | [bigint],
+  'period_secs' : bigint,
+  'schedule_layout_version' : number,
+  'tick_secs' : bigint,
+}
 export interface RangeQuery {
   'to_ts' : [] | [bigint],
   'from_ts' : [] | [bigint],
@@ -488,6 +505,7 @@ export interface _SERVICE {
   'cycle_manager_metrics' : ActorMethod<[], Array<CycleManagerMetric>>,
   'cycle_manager_targets' : ActorMethod<[], Array<CycleManagerTarget>>,
   'cycles_status' : ActorMethod<[], CycleManagerCyclesStatus>,
+  'debug_amm_pool_snapshot' : ActorMethod<[], Array<AmmPoolSnapshot>>,
   'debug_get_amm_event_counts' : ActorMethod<[], [bigint, bigint]>,
   'debug_get_amm_liquidity_events_raw' : ActorMethod<
     [bigint, bigint],
@@ -528,6 +546,7 @@ export interface _SERVICE {
   'get_pool_routes' : ActorMethod<[PoolRoutesQuery], PoolRoutesResponse>,
   'get_price_series' : ActorMethod<[RangeQuery], PriceSeriesResponse>,
   'get_protocol_summary' : ActorMethod<[], ProtocolSummary>,
+  'get_pull_schedule' : ActorMethod<[], PullScheduleConfig>,
   'get_sp_depositor_principals' : ActorMethod<[], Array<Principal>>,
   'get_stability_series' : ActorMethod<[RangeQuery], StabilitySeriesResponse>,
   'get_swap_series' : ActorMethod<[RangeQuery], SwapSeriesResponse>,
@@ -553,6 +572,7 @@ export interface _SERVICE {
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'ping' : ActorMethod<[], string>,
   'reset_error_counters' : ActorMethod<[ResetErrorCountersArgs], Result_1>,
+  'set_pull_schedule' : ActorMethod<[bigint, bigint], Result_1>,
   'start_backfill' : ActorMethod<[Principal], string>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/src/declarations/rumi_analytics/rumi_analytics.did.js
+++ b/src/declarations/rumi_analytics/rumi_analytics.did.js
@@ -63,6 +63,14 @@ export const idlFactory = ({ IDL }) => {
     'healthy' : IDL.Bool,
     'freeze_threshold_secs' : IDL.Nat64,
   });
+  const AmmPoolSnapshot = IDL.Record({
+    'token_a' : IDL.Principal,
+    'token_b' : IDL.Principal,
+    'reserve_a' : IDL.Nat,
+    'reserve_b' : IDL.Nat,
+    'total_lp_shares' : IDL.Nat,
+    'pool_id' : IDL.Text,
+  });
   const LiquidityAction = IDL.Variant({
     'Add' : IDL.Null,
     'Remove' : IDL.Null,
@@ -309,6 +317,13 @@ export const idlFactory = ({ IDL }) => {
     'swap_count_24h' : IDL.Nat32,
     'volume_24h_e8s' : IDL.Nat64,
   });
+  const PullScheduleConfig = IDL.Record({
+    'period_secs_override' : IDL.Opt(IDL.Nat64),
+    'tick_secs_override' : IDL.Opt(IDL.Nat64),
+    'period_secs' : IDL.Nat64,
+    'schedule_layout_version' : IDL.Nat32,
+    'tick_secs' : IDL.Nat64,
+  });
   const DailyStabilityRow = IDL.Record({
     'collateral_gains' : IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64)),
     'timestamp_ns' : IDL.Nat64,
@@ -427,9 +442,11 @@ export const idlFactory = ({ IDL }) => {
     'timestamp_ns' : IDL.Nat64,
     'three_pool_reserve_2_e8s' : IDL.Opt(IDL.Nat),
     'three_pool_virtual_price_e18' : IDL.Opt(IDL.Nat),
+    'amm_rewards_e8s' : IDL.Opt(IDL.Nat),
     'total_icusd_supply_e8s' : IDL.Nat,
     'system_collateral_ratio_bps' : IDL.Nat32,
     'total_icp_collateral_e8s' : IDL.Nat,
+    'amm_tvl_usd_e8s' : IDL.Opt(IDL.Nat),
     'three_pool_reserve_1_e8s' : IDL.Opt(IDL.Nat),
     'stability_pool_deposits_e8s' : IDL.Opt(IDL.Nat64),
     'three_pool_lp_supply_e8s' : IDL.Opt(IDL.Nat),
@@ -504,6 +521,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'cycles_status' : IDL.Func([], [CycleManagerCyclesStatus], ['query']),
+    'debug_amm_pool_snapshot' : IDL.Func(
+        [],
+        [IDL.Vec(AmmPoolSnapshot)],
+        ['query'],
+      ),
     'debug_get_amm_event_counts' : IDL.Func(
         [],
         [IDL.Nat64, IDL.Nat64],
@@ -571,6 +593,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'get_protocol_summary' : IDL.Func([], [ProtocolSummary], ['query']),
+    'get_pull_schedule' : IDL.Func([], [PullScheduleConfig], ['query']),
     'get_sp_depositor_principals' : IDL.Func(
         [],
         [IDL.Vec(IDL.Principal)],
@@ -627,6 +650,7 @@ export const idlFactory = ({ IDL }) => {
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'ping' : IDL.Func([], [IDL.Text], ['query']),
     'reset_error_counters' : IDL.Func([ResetErrorCountersArgs], [Result_1], []),
+    'set_pull_schedule' : IDL.Func([IDL.Nat64, IDL.Nat64], [Result_1], []),
     'start_backfill' : IDL.Func([IDL.Principal], [IDL.Text], []),
   });
 };

--- a/src/rumi_analytics/README.md
+++ b/src/rumi_analytics/README.md
@@ -11,12 +11,12 @@ Candid query endpoints and an HTTP API.
 
 Four timer-driven collection cycles run concurrently:
 
-| Cycle   | Interval | What it does                                                |
-|---------|----------|-------------------------------------------------------------|
-| Pull    | 60s      | Tails events from source canisters, caches supply           |
-| Fast    | 300s     | Snapshots collateral prices and 3pool state                 |
-| Hourly  | 3600s    | Snapshots cycle balance and fee curve                       |
-| Daily   | 86400s   | Rolls up TVL, vault stats, stability, holders, swaps, fees  |
+| Cycle   | Interval     | What it does                                                |
+|---------|--------------|-------------------------------------------------------------|
+| Pull    | 300s default | Tails sources on a staggered schedule, caches supply       |
+| Fast    | 300s         | Snapshots collateral prices and 3pool state                |
+| Hourly  | 3600s        | Snapshots cycle balance and fee curve                      |
+| Daily   | 86400s       | Rolls up TVL, vault stats, stability, holders, swaps, fees |
 
 State is split between heap-side `SlimState` (small, hot-path values) and
 stable-memory `StableLog`/`StableBTreeMap` collections managed by a `MemoryManager`
@@ -31,10 +31,10 @@ cargo build --target wasm32-unknown-unknown --release -p rumi_analytics
 ## Test
 
 ```bash
-# Unit tests (40 tests, ~0s)
+# Unit tests (126 tests, ~0s)
 cargo test -p rumi_analytics --lib
 
-# Integration tests (25 tests, ~2.5 min, requires pocket-ic binary)
+# Integration tests (26 tests, one ignored, ~2 min, requires pocket-ic binary)
 POCKET_IC_BIN=./pocket-ic cargo test --test pocket_ic_analytics
 ```
 

--- a/src/rumi_analytics/rumi_analytics.did
+++ b/src/rumi_analytics/rumi_analytics.did
@@ -31,6 +31,33 @@ type AdminEventLabelCount = record {
   label : text;
   last_at_ns : opt nat64;
 };
+type AmmPoolSnapshot = record {
+  token_a : principal;
+  token_b : principal;
+  reserve_a : nat;
+  reserve_b : nat;
+  total_lp_shares : nat;
+  pool_id : text;
+};
+type AnalyticsAmmLiquidityEvent = record {
+  action : LiquidityAction;
+  timestamp_ns : nat64;
+  source_event_id : nat64;
+  lp_shares : nat64;
+  caller : principal;
+  pool_id : text;
+};
+type AnalyticsSwapEvent = record {
+  fee : nat64;
+  timestamp_ns : nat64;
+  token_in : principal;
+  source : SwapSource;
+  source_event_id : nat64;
+  amount_out : nat64;
+  caller : principal;
+  amount_in : nat64;
+  token_out : principal;
+};
 type ApyQuery = record { window_days : opt nat32 };
 type ApyResponse = record {
   lp_apy_pct : opt float64;
@@ -38,27 +65,6 @@ type ApyResponse = record {
   window_days : nat32;
   sp_apy_pct : opt float64;
 };
-type AnalyticsAmmLiquidityEvent = record {
-  timestamp_ns : nat64;
-  source_event_id : nat64;
-  caller : principal;
-  pool_id : text;
-  action : LiquidityAction;
-  lp_shares : nat64;
-};
-type AnalyticsSwapEvent = record {
-  timestamp_ns : nat64;
-  source : SwapSource;
-  source_event_id : nat64;
-  caller : principal;
-  token_in : principal;
-  token_out : principal;
-  amount_in : nat64;
-  amount_out : nat64;
-  fee : nat64;
-};
-type LiquidityAction = variant { Add; Remove; RemoveOneCoin; Donate };
-type SwapSource = variant { ThreePool; Amm };
 type BackfillProgress = record {
   cursor_after : nat64;
   from : nat64;
@@ -96,6 +102,50 @@ type CursorStatus = record {
   last_success_ns : nat64;
   cursor_position : nat64;
 };
+type CycleManagerCriticality = variant {
+  Important;
+  Experimental;
+  Critical;
+  Standard;
+};
+type CycleManagerCyclesStatus = record {
+  idle_burn_cycles_per_day : opt nat;
+  stable_memory_bytes : opt nat64;
+  low_watermark : nat;
+  balance : nat;
+  heap_memory_bytes : opt nat64;
+  healthy : bool;
+  freeze_threshold_secs : nat64;
+};
+type CycleManagerEnvironment = variant {
+  Local;
+  Production;
+  Test;
+  Archived;
+  Staging;
+};
+type CycleManagerMetric = record {
+  key : text;
+  value : nat;
+  count : nat64;
+  label : opt text;
+};
+type CycleManagerTarget = record {
+  low_threshold_cycles : nat;
+  topup_cycles : nat;
+  owner : opt text;
+  kind : CycleManagerTargetKind;
+  name : text;
+  tags : vec text;
+  canister_id : principal;
+  expected_freeze_threshold_secs : opt nat64;
+  expected_controllers : vec principal;
+  criticality : CycleManagerCriticality;
+  environment : CycleManagerEnvironment;
+  metrics_schema_version : nat32;
+  project : text;
+};
+type CycleManagerTargetKind = variant { SelfReport; Controlled };
 type CycleSeriesResponse = record {
   rows : vec HourlyCycleSnapshot;
   next_from_ts : opt nat64;
@@ -153,9 +203,11 @@ type DailyTvlRow = record {
   timestamp_ns : nat64;
   three_pool_reserve_2_e8s : opt nat;
   three_pool_virtual_price_e18 : opt nat;
+  amm_rewards_e8s : opt nat;
   total_icusd_supply_e8s : nat;
   system_collateral_ratio_bps : nat32;
   total_icp_collateral_e8s : nat;
+  amm_tvl_usd_e8s : opt nat;
   three_pool_reserve_1_e8s : opt nat;
   stability_pool_deposits_e8s : opt nat64;
   three_pool_lp_supply_e8s : opt nat;
@@ -238,6 +290,7 @@ type LiquidationSeriesResponse = record {
   rows : vec DailyLiquidationRollup;
   next_from_ts : opt nat64;
 };
+type LiquidityAction = variant { Add; Remove; Donate; RemoveOneCoin };
 type OhlcCandle = record {
   low : float64;
   timestamp_ns : nat64;
@@ -289,8 +342,9 @@ type PriceSeriesResponse = record {
 type ProtocolSummary = record {
   peg : opt PegStatus;
   lp_apy_pct : opt float64;
-  amm_apy_pct : opt float64;
   timestamp_ns : nat64;
+  amm_apy_pct : opt float64;
+  median_cr_bps : nat32;
   sp_apy_pct : opt float64;
   total_debt_e8s : nat64;
   circulating_supply_icusd_e8s : opt nat;
@@ -298,9 +352,15 @@ type ProtocolSummary = record {
   total_vault_count : nat32;
   total_collateral_usd_e8s : nat64;
   system_cr_bps : nat32;
-  median_cr_bps : nat32;
   swap_count_24h : nat32;
   volume_24h_e8s : nat64;
+};
+type PullScheduleConfig = record {
+  period_secs_override : opt nat64;
+  tick_secs_override : opt nat64;
+  period_secs : nat64;
+  schedule_layout_version : nat32;
+  tick_secs : nat64;
 };
 type RangeQuery = record {
   to_ts : opt nat64;
@@ -319,6 +379,7 @@ type SwapSeriesResponse = record {
   rows : vec DailySwapRollup;
   next_from_ts : opt nat64;
 };
+type SwapSource = variant { Amm; ThreePool };
 type ThreePoolSeriesResponse = record {
   rows : vec Fast3PoolSnapshot;
   next_from_ts : opt nat64;
@@ -420,57 +481,16 @@ type VolatilityResponse = record {
   symbol : text;
   annualized_vol_pct : float64;
 };
-type CycleManagerCyclesStatus = record {
-  balance : nat;
-  low_watermark : nat;
-  healthy : bool;
-  freeze_threshold_secs : nat64;
-  stable_memory_bytes : opt nat64;
-  heap_memory_bytes : opt nat64;
-  idle_burn_cycles_per_day : opt nat;
-};
-type CycleManagerMetric = record {
-  key : text;
-  count : nat64;
-  value : nat;
-  label : opt text;
-};
-type CycleManagerTargetKind = variant { SelfReport; Controlled };
-type CycleManagerEnvironment = variant {
-  Production;
-  Staging;
-  Test;
-  Local;
-  Archived;
-};
-type CycleManagerCriticality = variant {
-  Critical;
-  Important;
-  Standard;
-  Experimental;
-};
-type CycleManagerTarget = record {
-  canister_id : principal;
-  name : text;
-  project : text;
-  environment : CycleManagerEnvironment;
-  criticality : CycleManagerCriticality;
-  kind : CycleManagerTargetKind;
-  low_threshold_cycles : nat;
-  topup_cycles : nat;
-  owner : opt text;
-  tags : vec text;
-  expected_controllers : vec principal;
-  expected_freeze_threshold_secs : opt nat64;
-  metrics_schema_version : nat32;
-};
 service : (InitArgs) -> {
   admin_backfill_add_margin_events : (nat64) -> (Result);
   cycle_manager_metrics : () -> (vec CycleManagerMetric) query;
   cycle_manager_targets : () -> (vec CycleManagerTarget) query;
   cycles_status : () -> (CycleManagerCyclesStatus) query;
+  debug_amm_pool_snapshot : () -> (vec AmmPoolSnapshot) query;
   debug_get_amm_event_counts : () -> (nat64, nat64) query;
-  debug_get_amm_liquidity_events_raw : (nat64, nat64) -> (vec AnalyticsAmmLiquidityEvent) query;
+  debug_get_amm_liquidity_events_raw : (nat64, nat64) -> (
+      vec AnalyticsAmmLiquidityEvent,
+    ) query;
   debug_get_swap_events_raw : (nat64, nat64) -> (vec AnalyticsSwapEvent) query;
   get_address_value_series : (AddressValueSeriesQuery) -> (
       AddressValueSeriesResponse,
@@ -494,6 +514,7 @@ service : (InitArgs) -> {
   get_pool_routes : (PoolRoutesQuery) -> (PoolRoutesResponse) query;
   get_price_series : (RangeQuery) -> (PriceSeriesResponse) query;
   get_protocol_summary : () -> (ProtocolSummary) query;
+  get_pull_schedule : () -> (PullScheduleConfig) query;
   get_sp_depositor_principals : () -> (vec principal) query;
   get_stability_series : (RangeQuery) -> (StabilitySeriesResponse) query;
   get_swap_series : (RangeQuery) -> (SwapSeriesResponse) query;
@@ -514,5 +535,6 @@ service : (InitArgs) -> {
   http_request : (HttpRequest) -> (HttpResponse) query;
   ping : () -> (text) query;
   reset_error_counters : (ResetErrorCountersArgs) -> (Result_1);
+  set_pull_schedule : (nat64, nat64) -> (Result_1);
   start_backfill : (principal) -> (text);
 }

--- a/src/rumi_analytics/src/http/mod.rs
+++ b/src/rumi_analytics/src/http/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP request handler. Runs in query context: never makes inter-canister
-//! calls. All values are served from cached state in SlimState which the 60s
-//! pull cycle keeps fresh.
+//! calls. All values are served from cached state in SlimState which the
+//! staggered 300s-default pull schedule keeps fresh.
 
 mod csv;
 mod metrics;

--- a/src/rumi_analytics/src/lib.rs
+++ b/src/rumi_analytics/src/lib.rs
@@ -3,16 +3,16 @@
 
 use candid::Principal;
 
-mod state;
-mod http;
-mod storage;
 mod collectors;
-mod sources;
-mod queries;
-mod timers;
-mod tailing;
-mod types;
+mod http;
 pub mod pull_schedule;
+mod queries;
+mod sources;
+mod state;
+mod storage;
+mod tailing;
+mod timers;
+mod types;
 
 use crate::storage::{SlimState, SourceCanisterIds};
 
@@ -26,7 +26,9 @@ fn principal_from_text(text: &str) -> Principal {
     Principal::from_text(text).expect("hard-coded principal must be valid")
 }
 
-fn cycle_manager_environment(sources: &SourceCanisterIds) -> rumi_cycle_manager::CycleManagerEnvironment {
+fn cycle_manager_environment(
+    sources: &SourceCanisterIds,
+) -> rumi_cycle_manager::CycleManagerEnvironment {
     if sources.backend == principal_from_text(PRODUCTION_BACKEND) {
         rumi_cycle_manager::CycleManagerEnvironment::Production
     } else if sources.backend == principal_from_text(STAGING_BACKEND) {
@@ -47,7 +49,9 @@ fn push_target(
     tags: &[&str],
 ) {
     if canister_id == Principal::anonymous()
-        || targets.iter().any(|target| target.canister_id == canister_id)
+        || targets
+            .iter()
+            .any(|target| target.canister_id == canister_id)
     {
         return;
     }
@@ -170,6 +174,18 @@ pub struct InitArgs {
     pub amm: Principal,
 }
 
+/// Live pull-schedule cadence, for ops visibility. `*_secs` are the effective
+/// values (override if set, else the compiled-in default); `*_override` echo
+/// the persisted admin overrides (`null` = using the default).
+#[derive(candid::CandidType, candid::Deserialize)]
+pub struct PullScheduleConfig {
+    pub period_secs: u64,
+    pub tick_secs: u64,
+    pub period_secs_override: Option<u64>,
+    pub tick_secs_override: Option<u64>,
+    pub schedule_layout_version: u32,
+}
+
 #[ic_cdk_macros::init]
 fn init(args: InitArgs) {
     // UPG-006: refuse to init with non-empty stable memory. Catches accidental
@@ -247,7 +263,8 @@ fn build_cycle_manager_metrics(target_count: u64) -> Vec<rumi_cycle_manager::Cyc
         ),
         rumi_cycle_manager::metric(
             "op:source_error:rejects",
-            errors.backend
+            errors
+                .backend
                 .saturating_add(errors.icusd_ledger)
                 .saturating_add(errors.three_pool)
                 .saturating_add(errors.stability_pool)
@@ -295,7 +312,9 @@ fn get_stability_series(query: types::RangeQuery) -> types::StabilitySeriesRespo
 }
 
 #[ic_cdk_macros::query]
-fn http_request(req: ic_canisters_http_types::HttpRequest) -> ic_canisters_http_types::HttpResponse {
+fn http_request(
+    req: ic_canisters_http_types::HttpRequest,
+) -> ic_canisters_http_types::HttpResponse {
     http::http_request(req)
 }
 
@@ -375,7 +394,9 @@ fn get_top_holders(query: types::TopHoldersQuery) -> types::TopHoldersResponse {
 }
 
 #[ic_cdk_macros::query]
-fn get_top_counterparties(query: types::TopCounterpartiesQuery) -> types::TopCounterpartiesResponse {
+fn get_top_counterparties(
+    query: types::TopCounterpartiesQuery,
+) -> types::TopCounterpartiesResponse {
     queries::live::get_top_counterparties(query)
 }
 
@@ -385,7 +406,9 @@ fn get_top_sp_depositors(query: types::TopSpDepositorsQuery) -> types::TopSpDepo
 }
 
 #[ic_cdk_macros::query]
-fn get_admin_event_breakdown(query: types::AdminEventBreakdownQuery) -> types::AdminEventBreakdownResponse {
+fn get_admin_event_breakdown(
+    query: types::AdminEventBreakdownQuery,
+) -> types::AdminEventBreakdownResponse {
     queries::live::get_admin_event_breakdown(query)
 }
 
@@ -415,7 +438,9 @@ fn get_pool_routes(query: types::PoolRoutesQuery) -> types::PoolRoutesResponse {
 }
 
 #[ic_cdk_macros::query]
-fn get_address_value_series(query: types::AddressValueSeriesQuery) -> types::AddressValueSeriesResponse {
+fn get_address_value_series(
+    query: types::AddressValueSeriesQuery,
+) -> types::AddressValueSeriesResponse {
     queries::address_value::get_address_value_series(query)
 }
 
@@ -462,10 +487,7 @@ fn debug_get_amm_liquidity_events_raw(
 /// starting at `start`, up to `length` entries. Preserved from the prior
 /// deployed wasm for Candid interface compatibility.
 #[ic_cdk_macros::query]
-fn debug_get_swap_events_raw(
-    start: u64,
-    length: u64,
-) -> Vec<storage::events::AnalyticsSwapEvent> {
+fn debug_get_swap_events_raw(start: u64, length: u64) -> Vec<storage::events::AnalyticsSwapEvent> {
     let mut out = Vec::new();
     let total = storage::events::evt_swaps::len();
     let end = start.saturating_add(length).min(total);
@@ -482,18 +504,60 @@ fn get_collector_health() -> types::CollectorHealth {
     use storage::cursors;
 
     let cursor_names: &[(u8, &str, fn() -> u64)] = &[
-        (cursors::CURSOR_ID_BACKEND_EVENTS, "backend_events", cursors::backend_events::get),
-        (cursors::CURSOR_ID_3POOL_SWAPS, "3pool_swaps", cursors::three_pool_swaps::get),
-        (cursors::CURSOR_ID_3POOL_LIQUIDITY, "3pool_liquidity", cursors::three_pool_liquidity::get),
-        (cursors::CURSOR_ID_3POOL_BLOCKS, "3pool_blocks", cursors::three_pool_blocks::get),
-        (cursors::CURSOR_ID_AMM_SWAPS, "amm_swaps", cursors::amm_swaps::get),
-        (cursors::CURSOR_ID_AMM_LIQUIDITY, "amm_liquidity", cursors::amm_liquidity::get),
-        (cursors::CURSOR_ID_STABILITY_EVENTS, "stability_events", cursors::stability_events::get),
-        (cursors::CURSOR_ID_ICUSD_BLOCKS, "icusd_blocks", cursors::icusd_blocks::get),
+        (
+            cursors::CURSOR_ID_BACKEND_EVENTS,
+            "backend_events",
+            cursors::backend_events::get,
+        ),
+        (
+            cursors::CURSOR_ID_3POOL_SWAPS,
+            "3pool_swaps",
+            cursors::three_pool_swaps::get,
+        ),
+        (
+            cursors::CURSOR_ID_3POOL_LIQUIDITY,
+            "3pool_liquidity",
+            cursors::three_pool_liquidity::get,
+        ),
+        (
+            cursors::CURSOR_ID_3POOL_BLOCKS,
+            "3pool_blocks",
+            cursors::three_pool_blocks::get,
+        ),
+        (
+            cursors::CURSOR_ID_AMM_SWAPS,
+            "amm_swaps",
+            cursors::amm_swaps::get,
+        ),
+        (
+            cursors::CURSOR_ID_AMM_LIQUIDITY,
+            "amm_liquidity",
+            cursors::amm_liquidity::get,
+        ),
+        (
+            cursors::CURSOR_ID_STABILITY_EVENTS,
+            "stability_events",
+            cursors::stability_events::get,
+        ),
+        (
+            cursors::CURSOR_ID_ICUSD_BLOCKS,
+            "icusd_blocks",
+            cursors::icusd_blocks::get,
+        ),
     ];
 
-    let (last_success_map, last_error_map, source_count_map, backfill_icusd, backfill_3usd, last_pull_ns, error_counters, icusd_ledger, three_pool) =
-        state::read_state(|s| (
+    let (
+        last_success_map,
+        last_error_map,
+        source_count_map,
+        backfill_icusd,
+        backfill_3usd,
+        last_pull_ns,
+        error_counters,
+        icusd_ledger,
+        three_pool,
+    ) = state::read_state(|s| {
+        (
             s.cursor_last_success.clone().unwrap_or_default(),
             s.cursor_last_error.clone().unwrap_or_default(),
             s.cursor_source_counts.clone().unwrap_or_default(),
@@ -503,32 +567,46 @@ fn get_collector_health() -> types::CollectorHealth {
             s.error_counters.clone(),
             s.sources.icusd_ledger,
             s.sources.three_pool,
-        ));
+        )
+    });
 
-    let cursors: Vec<types::CursorStatus> = cursor_names.iter().map(|(id, name, get_fn)| {
-        types::CursorStatus {
+    let cursors: Vec<types::CursorStatus> = cursor_names
+        .iter()
+        .map(|(id, name, get_fn)| types::CursorStatus {
             name: name.to_string(),
             cursor_position: get_fn(),
             source_count: source_count_map.get(id).copied().unwrap_or(0),
             last_success_ns: last_success_map.get(id).copied().unwrap_or(0),
             last_error: last_error_map.get(id).cloned(),
-        }
-    }).collect();
+        })
+        .collect();
 
     let mut backfill_active = Vec::new();
-    if backfill_icusd { backfill_active.push(icusd_ledger); }
-    if backfill_3usd { backfill_active.push(three_pool); }
+    if backfill_icusd {
+        backfill_active.push(icusd_ledger);
+    }
+    if backfill_3usd {
+        backfill_active.push(three_pool);
+    }
 
     let balance_tracker_stats = vec![
         types::BalanceTrackerStats {
             token: icusd_ledger,
-            holder_count: storage::balance_tracker::holder_count(storage::balance_tracker::Token::IcUsd),
-            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(storage::balance_tracker::Token::IcUsd),
+            holder_count: storage::balance_tracker::holder_count(
+                storage::balance_tracker::Token::IcUsd,
+            ),
+            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(
+                storage::balance_tracker::Token::IcUsd,
+            ),
         },
         types::BalanceTrackerStats {
             token: three_pool,
-            holder_count: storage::balance_tracker::holder_count(storage::balance_tracker::Token::ThreeUsd),
-            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(storage::balance_tracker::Token::ThreeUsd),
+            holder_count: storage::balance_tracker::holder_count(
+                storage::balance_tracker::Token::ThreeUsd,
+            ),
+            total_tracked_e8s: storage::balance_tracker::total_supply_tracked(
+                storage::balance_tracker::Token::ThreeUsd,
+            ),
         },
     ];
 
@@ -541,15 +619,23 @@ fn get_collector_health() -> types::CollectorHealth {
     }
 }
 
+fn require_admin(caller: Principal, admin: Principal) -> Result<(), String> {
+    if caller == Principal::anonymous() || caller != admin {
+        return Err(format!("unauthorized: caller {} is not admin", caller));
+    }
+    Ok(())
+}
+
 #[ic_cdk_macros::update]
 fn start_backfill(token: Principal) -> String {
     let admin = state::read_state(|s| s.admin);
     let caller = ic_cdk::caller();
-    if caller != admin {
-        return format!("unauthorized: caller {} is not admin", caller);
+    if let Err(error) = require_admin(caller, admin) {
+        return error;
     }
 
-    let (icusd_ledger, three_pool) = state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
+    let (icusd_ledger, three_pool) =
+        state::read_state(|s| (s.sources.icusd_ledger, s.sources.three_pool));
 
     if token == icusd_ledger {
         state::mutate_state(|s| s.backfill_active_icusd = Some(true));
@@ -575,12 +661,12 @@ fn start_backfill(token: Principal) -> String {
 /// emits twice across calls. Caller re-invokes until the response shows
 /// `complete = true`.
 #[ic_cdk_macros::update]
-async fn admin_backfill_add_margin_events(batch_size: u64) -> Result<types::BackfillProgress, String> {
+async fn admin_backfill_add_margin_events(
+    batch_size: u64,
+) -> Result<types::BackfillProgress, String> {
     let admin = state::read_state(|s| s.admin);
     let caller = ic_cdk::caller();
-    if caller != admin {
-        return Err(format!("unauthorized: caller {} is not admin", caller));
-    }
+    require_admin(caller, admin)?;
     let backend = state::read_state(|s| s.sources.backend);
     let cursor = state::read_state(|s| s.add_margin_backfill_cursor.unwrap_or(0));
     let count = sources::backend::get_event_count(backend).await?;
@@ -600,8 +686,13 @@ async fn admin_backfill_add_margin_events(batch_size: u64) -> Result<types::Back
     for (i, event) in events.iter().enumerate() {
         let event_id = cursor + i as u64;
         if let sources::backend::BackendEvent::AddMarginToVault {
-            vault_id, margin_added, caller: actor, timestamp, ..
-        } = event {
+            vault_id,
+            margin_added,
+            caller: actor,
+            timestamp,
+            ..
+        } = event
+        {
             storage::events::evt_vaults::push(storage::events::AnalyticsVaultEvent {
                 timestamp_ns: timestamp.unwrap_or(0),
                 source_event_id: event_id,
@@ -633,19 +724,84 @@ async fn admin_backfill_add_margin_events(batch_size: u64) -> Result<types::Back
 fn reset_error_counters(args: types::ResetErrorCountersArgs) -> Result<(), String> {
     let admin = state::read_state(|s| s.admin);
     let caller = ic_cdk::caller();
-    if caller != admin {
-        return Err(format!("unauthorized: caller {} is not admin", caller));
-    }
+    require_admin(caller, admin)?;
     state::mutate_state(|s| {
         let reset_all = args.sources.is_none();
         let sources = args.sources.unwrap_or_default();
         let touch = |name: &str| reset_all || sources.iter().any(|src| src == name);
-        if touch("backend") { s.error_counters.backend = 0; }
-        if touch("stability_pool") { s.error_counters.stability_pool = 0; }
-        if touch("three_pool") { s.error_counters.three_pool = 0; }
-        if touch("icusd_ledger") { s.error_counters.icusd_ledger = 0; }
-        if touch("amm") { s.error_counters.amm = 0; }
+        if touch("backend") {
+            s.error_counters.backend = 0;
+        }
+        if touch("stability_pool") {
+            s.error_counters.stability_pool = 0;
+        }
+        if touch("three_pool") {
+            s.error_counters.three_pool = 0;
+        }
+        if touch("icusd_ledger") {
+            s.error_counters.icusd_ledger = 0;
+        }
+        if touch("amm") {
+            s.error_counters.amm = 0;
+        }
     });
+    Ok(())
+}
+
+/// Effective pull-schedule cadence (override if set, else compiled-in default).
+#[ic_cdk_macros::query]
+fn get_pull_schedule() -> PullScheduleConfig {
+    state::read_state(|s| PullScheduleConfig {
+        period_secs: pull_schedule::effective_period_ns(s.pull_period_secs_override)
+            / 1_000_000_000,
+        tick_secs: pull_schedule::effective_tick_secs(s.pull_tick_secs_override),
+        period_secs_override: s.pull_period_secs_override,
+        tick_secs_override: s.pull_tick_secs_override,
+        schedule_layout_version: s.schedule_layout_version.unwrap_or(0),
+    })
+}
+
+fn apply_pull_schedule_config(
+    state: &mut SlimState,
+    now_ns: u64,
+    period_secs: u64,
+    tick_secs: u64,
+) {
+    state.pull_period_secs_override = Some(period_secs);
+    state.pull_tick_secs_override = Some(tick_secs);
+    state.source_next_pull_ns = Some(pull_schedule::seed_initial_schedule(
+        now_ns,
+        pull_schedule::ALL_SOURCE_IDS,
+        pull_schedule::effective_period_ns(Some(period_secs)),
+    ));
+}
+
+/// Admin: retune the per-source pull window and the schedule-walker tick
+/// without a redeploy. Persisted across upgrade and applied immediately —
+/// the schedule is re-spread across the new window and the walker timer is
+/// re-armed at the new tick. `period_secs` bounds the inter-canister poll
+/// rate (the dominant cycle-burn driver), so it is floored to keep the
+/// burn-saving intent intact.
+#[ic_cdk_macros::update]
+fn set_pull_schedule(period_secs: u64, tick_secs: u64) -> Result<(), String> {
+    let admin = state::read_state(|s| s.admin);
+    let caller = ic_cdk::caller();
+    require_admin(caller, admin)?;
+    pull_schedule::validate_schedule_config(period_secs, tick_secs)?;
+    let now = ic_cdk::api::time();
+    state::mutate_state(|s| {
+        // Re-spread across the new window so the retune applies at once and
+        // evenly, not gradually as each source next fires.
+        apply_pull_schedule_config(s, now, period_secs, tick_secs);
+    });
+    // Re-arm the walker at the new tick.
+    timers::register_pull_tick_timer();
+    ic_cdk::println!(
+        "[set_pull_schedule] period={}s tick={}s (caller={})",
+        period_secs,
+        tick_secs,
+        caller
+    );
     Ok(())
 }
 
@@ -716,5 +872,41 @@ mod cycle_manager_tests {
 
         assert_eq!(metric.count, target_count);
         assert_eq!(metric.value, candid::Nat::from(target_count));
+    }
+
+    #[test]
+    fn admin_authorization_rejects_wrong_and_anonymous_callers() {
+        let admin = principal(1);
+
+        assert_eq!(require_admin(admin, admin), Ok(()));
+        assert!(require_admin(principal(2), admin).is_err());
+        assert!(
+            require_admin(Principal::anonymous(), Principal::anonymous()).is_err(),
+            "an unconfigured anonymous admin must not authorize anonymous ingress"
+        );
+    }
+
+    #[test]
+    fn applying_pull_schedule_config_persists_and_reseeds_immediately() {
+        let now_ns = 42_000_000_000;
+        let period_secs = 600;
+        let tick_secs = 60;
+        let mut slim = SlimState {
+            source_next_pull_ns: Some(std::collections::HashMap::from([(255, 1)])),
+            ..SlimState::default()
+        };
+
+        apply_pull_schedule_config(&mut slim, now_ns, period_secs, tick_secs);
+
+        assert_eq!(slim.pull_period_secs_override, Some(period_secs));
+        assert_eq!(slim.pull_tick_secs_override, Some(tick_secs));
+        assert_eq!(
+            slim.source_next_pull_ns,
+            Some(pull_schedule::seed_initial_schedule(
+                now_ns,
+                pull_schedule::ALL_SOURCE_IDS,
+                pull_schedule::effective_period_ns(Some(period_secs)),
+            ))
+        );
     }
 }

--- a/src/rumi_analytics/src/pull_schedule.rs
+++ b/src/rumi_analytics/src/pull_schedule.rs
@@ -3,8 +3,19 @@
 //! Pre-Wave-9d the pull cycle ran every 60s and fired all 9 sources
 //! through `futures::join!`, producing a synchronized burst of inter-
 //! canister calls every minute. Wave-9d replaces that with a per-source
-//! `next_pull_at_ns` schedule walked by a fast 5s tick. Each source
-//! still fires every 60s — they just no longer all fire together.
+//! `next_pull_at_ns` schedule walked by a fast tick. Each source fires
+//! once per `PULL_CYCLE_PERIOD_NS` window — they just no longer all fire
+//! together.
+//!
+//! Cycle-burn tuning (2026-07-02): the per-source window widened from 60s
+//! to 300s (default) to cut the inter-canister call rate ~5x, since the
+//! protocol produces only a handful of events per day and 60s polling
+//! spent almost every call learning "nothing new". The window and the
+//! walker tick are both runtime-overridable by the admin (see
+//! `effective_period_ns` / `effective_tick_secs` and `set_pull_schedule`)
+//! so cadence can be retuned without a redeploy. The initial source offset
+//! is now DERIVED from the effective period (`source_offset_ns`) rather
+//! than a fixed constant, so the stagger stays even at any window size.
 //!
 //! All logic in this module is pure (no `ic_cdk::api::time()`, no
 //! state mutation) so it is unit-testable from
@@ -20,22 +31,74 @@ use crate::storage::cursors;
 
 const SEC_NANOS: u64 = 1_000_000_000;
 
-/// How often the schedule walker fires. 5s gives a max latency of one
-/// tick between a source becoming due and being pulled — well below the
-/// 60s pacing contract.
-pub const PULL_CYCLE_TICK_SECS: u64 = 5;
+/// How often the schedule walker fires (default). A due source is picked
+/// up within one tick of becoming due. Runtime-overridable via
+/// `effective_tick_secs`; the live value re-arms the walker timer.
+pub const PULL_CYCLE_TICK_SECS: u64 = 30;
 
-/// How often each source fires. 60s preserves the pre-Wave-9d analytics
-/// freshness contract surfaced via `last_pull_cycle_ns` and the per-
-/// cursor `last_success_ns` fields.
-pub const PULL_CYCLE_PERIOD_NS: u64 = 60 * SEC_NANOS;
+/// How often each source fires (default window, in ns). Widened from 60s
+/// to 300s to reduce the inter-canister poll rate. Runtime-overridable via
+/// `effective_period_ns`. Surfaced (indirectly) through `last_pull_cycle_ns`
+/// and the per-cursor `last_success_ns` freshness fields.
+pub const PULL_CYCLE_PERIOD_NS: u64 = 300 * SEC_NANOS;
 
-/// Initial offset between adjacent source slots. 6s × 9 sources = 54s
-/// fits comfortably inside the 60s `PULL_CYCLE_PERIOD_NS` window so
-/// every source fires exactly once per window even on the discretized
-/// 5s tick grid. Keeps every source 1s past the previous tick's slot
-/// (sources land at t=0/6/12/.../48 → ticks 0/10/15/.../50).
-pub const PULL_CYCLE_SOURCE_OFFSET_NS: u64 = 6 * SEC_NANOS;
+/// Number of scheduled sources. The per-source offset derives from this so
+/// the sources spread evenly across whatever window is in effect.
+pub const N_SOURCES: u64 = ALL_SOURCE_IDS.len() as u64;
+
+// Admin-setter bounds (see `set_pull_schedule`). Kept here so the pure
+// logic and the endpoint validation share one source of truth.
+/// Minimum accepted pull period. The 300s floor preserves the tuned call rate;
+/// runtime overrides may trade freshness for lower burn, but cannot restore
+/// the former 60s cadence or create a hotter loop.
+pub const MIN_PERIOD_SECS: u64 = 300;
+/// Maximum accepted pull period (1 hour). Beyond this analytics freshness
+/// degrades past usefulness.
+pub const MAX_PERIOD_SECS: u64 = 3600;
+/// Minimum accepted walker tick.
+pub const MIN_TICK_SECS: u64 = 5;
+/// Maximum accepted walker tick.
+pub const MAX_TICK_SECS: u64 = 300;
+
+/// Maximum number of adjacent source slots a single walker tick may collect.
+/// The scheduler's DOS-010 guarantee is one or two inter-canister calls per
+/// tick, never a reconstructed all-source burst.
+pub const MAX_SOURCES_PER_TICK: u64 = 2;
+
+/// Schedule-layout version. Bumping this forces a one-time re-spread of the
+/// persisted schedule on the next upgrade (see `timers::setup_timers`). It
+/// exists so the 60s→300s window change re-staggers the deadlines that were
+/// seeded under the old window, instead of leaving all sources bunched (or,
+/// worse, all firing together every window because their old deadlines are
+/// stale after the upgrade).
+pub const CURRENT_SCHEDULE_LAYOUT: u32 = 2;
+
+/// Validate a runtime cadence using the same bounds enforced by the admin
+/// endpoint. Kept pure so boundary behavior can be proved without an IC
+/// execution environment.
+pub fn validate_schedule_config(period_secs: u64, tick_secs: u64) -> Result<(), String> {
+    if !(MIN_PERIOD_SECS..=MAX_PERIOD_SECS).contains(&period_secs) {
+        return Err(format!(
+            "period_secs must be in [{MIN_PERIOD_SECS}, {MAX_PERIOD_SECS}]"
+        ));
+    }
+    if !(MIN_TICK_SECS..=MAX_TICK_SECS).contains(&tick_secs) {
+        return Err(format!(
+            "tick_secs must be in [{MIN_TICK_SECS}, {MAX_TICK_SECS}]"
+        ));
+    }
+    if tick_secs > period_secs {
+        return Err("tick_secs must be <= period_secs".to_string());
+    }
+    let max_stagger_tick_secs = max_stagger_preserving_tick_secs(period_secs);
+    if tick_secs > max_stagger_tick_secs {
+        return Err(format!(
+            "tick_secs must be <= {max_stagger_tick_secs} for period_secs={period_secs} \
+             to keep at most {MAX_SOURCES_PER_TICK} sources due per tick"
+        ));
+    }
+    Ok(())
+}
 
 // Source ids. Tailers reuse their CURSOR_ID so the schedule key matches
 // the cursor metadata key. Source 0 is synthetic (supply cache has no
@@ -53,7 +116,7 @@ pub const SOURCE_ID_AMM_LIQUIDITY: u8 = cursors::CURSOR_ID_AMM_LIQUIDITY;
 
 /// All source ids in the order they should be seeded with offsets.
 /// Order matters: `seed_initial_schedule` assigns offset = index ×
-/// `PULL_CYCLE_SOURCE_OFFSET_NS`, so reordering this list shifts the
+/// `source_offset_ns(period_ns)`, so reordering this list shifts the
 /// staggering pattern.
 pub const ALL_SOURCE_IDS: &[u8] = &[
     SOURCE_ID_SUPPLY_CACHE,
@@ -67,12 +130,46 @@ pub const ALL_SOURCE_IDS: &[u8] = &[
     SOURCE_ID_AMM_LIQUIDITY,
 ];
 
-/// Build a fresh schedule with sources spread across the 60s window.
-/// Source at index N gets deadline `now + N * PULL_CYCLE_SOURCE_OFFSET_NS`.
-pub fn seed_initial_schedule(now_ns: u64, sources: &[u8]) -> HashMap<u8, u64> {
+/// Effective per-source window in ns: the admin override (in seconds) if a
+/// positive one is set, else the compiled-in default `PULL_CYCLE_PERIOD_NS`.
+pub fn effective_period_ns(override_secs: Option<u64>) -> u64 {
+    match override_secs {
+        Some(secs) if secs > 0 => secs.saturating_mul(SEC_NANOS),
+        _ => PULL_CYCLE_PERIOD_NS,
+    }
+}
+
+/// Effective walker tick in seconds: the admin override if a positive one
+/// is set, else the compiled-in default `PULL_CYCLE_TICK_SECS`.
+pub fn effective_tick_secs(override_secs: Option<u64>) -> u64 {
+    match override_secs {
+        Some(secs) if secs > 0 => secs,
+        _ => PULL_CYCLE_TICK_SECS,
+    }
+}
+
+/// Even spacing between adjacent source slots for a window of `period_ns`.
+/// Deriving the offset from the period keeps the 9 sources spread across
+/// the whole window at any (retuned) cadence. With the 300s default this is
+/// ~33s, which lands each source on its own 30s walker tick.
+pub fn source_offset_ns(period_ns: u64) -> u64 {
+    period_ns / N_SOURCES.max(1)
+}
+
+/// Largest whole-second walker tick that preserves the 1-2 source-per-tick
+/// stagger for a period measured in seconds. Floor before multiplying so the
+/// bound stays conservative when the source spacing is fractional.
+pub fn max_stagger_preserving_tick_secs(period_secs: u64) -> u64 {
+    (period_secs / N_SOURCES.max(1)).saturating_mul(MAX_SOURCES_PER_TICK)
+}
+
+/// Build a fresh schedule with sources spread across the `period_ns` window.
+/// Source at index N gets deadline `now + N * source_offset_ns(period_ns)`.
+pub fn seed_initial_schedule(now_ns: u64, sources: &[u8], period_ns: u64) -> HashMap<u8, u64> {
+    let offset = source_offset_ns(period_ns);
     let mut schedule = HashMap::with_capacity(sources.len());
     for (idx, &source_id) in sources.iter().enumerate() {
-        let deadline = now_ns.saturating_add((idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS);
+        let deadline = now_ns.saturating_add((idx as u64) * offset);
         schedule.insert(source_id, deadline);
     }
     schedule
@@ -86,12 +183,14 @@ pub fn reseed_preserving(
     now_ns: u64,
     existing: &HashMap<u8, u64>,
     sources: &[u8],
+    period_ns: u64,
 ) -> HashMap<u8, u64> {
+    let offset = source_offset_ns(period_ns);
     let mut merged = existing.clone();
     for (idx, &source_id) in sources.iter().enumerate() {
-        merged.entry(source_id).or_insert_with(|| {
-            now_ns.saturating_add((idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS)
-        });
+        merged
+            .entry(source_id)
+            .or_insert_with(|| now_ns.saturating_add((idx as u64) * offset));
     }
     merged
 }
@@ -100,11 +199,7 @@ pub fn reseed_preserving(
 /// this tick. Sources missing from `schedule` are treated as due (so a
 /// newly added source fires on its next tick instead of being silently
 /// skipped until the next reseed).
-pub fn compute_due_sources(
-    now_ns: u64,
-    schedule: &HashMap<u8, u64>,
-    sources: &[u8],
-) -> Vec<u8> {
+pub fn compute_due_sources(now_ns: u64, schedule: &HashMap<u8, u64>, sources: &[u8]) -> Vec<u8> {
     sources
         .iter()
         .copied()
@@ -115,16 +210,17 @@ pub fn compute_due_sources(
         .collect()
 }
 
-/// Bump each fired source's deadline by `PULL_CYCLE_PERIOD_NS` from the
-/// tick's `now_ns`. Idempotent if the same source fires twice in a tick
-/// (only the last write wins, but the next deadline is the same).
+/// Bump each fired source's deadline by `period_ns` from the tick's
+/// `now_ns`. Idempotent if the same source fires twice in a tick (only the
+/// last write wins, but the next deadline is the same).
 pub fn advance_schedule_for_fired(
     schedule: &mut HashMap<u8, u64>,
     now_ns: u64,
     fired: &[u8],
+    period_ns: u64,
 ) {
     for &source_id in fired {
-        let next = now_ns.saturating_add(PULL_CYCLE_PERIOD_NS);
+        let next = now_ns.saturating_add(period_ns);
         schedule.insert(source_id, next);
     }
 }

--- a/src/rumi_analytics/src/pull_schedule.rs
+++ b/src/rumi_analytics/src/pull_schedule.rs
@@ -195,18 +195,26 @@ pub fn reseed_preserving(
     merged
 }
 
-/// Return source ids whose deadline has passed and that should fire
-/// this tick. Sources missing from `schedule` are treated as due (so a
-/// newly added source fires on its next tick instead of being silently
-/// skipped until the next reseed).
+/// Return at most `MAX_SOURCES_PER_TICK` source ids whose deadline has passed,
+/// ordered oldest-deadline-first. The hard cap applies even when timer
+/// callbacks are delayed long enough for every source to become overdue.
+/// Sources missing from `schedule` are treated as the oldest due entries (so
+/// newly added sources fire promptly instead of waiting for the next reseed).
 pub fn compute_due_sources(now_ns: u64, schedule: &HashMap<u8, u64>, sources: &[u8]) -> Vec<u8> {
-    sources
+    let mut due: Vec<(u64, usize, u8)> = sources
         .iter()
         .copied()
-        .filter(|id| match schedule.get(id) {
-            Some(deadline) => *deadline <= now_ns,
-            None => true,
+        .enumerate()
+        .filter_map(|(source_order, id)| match schedule.get(&id) {
+            Some(deadline) if *deadline <= now_ns => Some((*deadline, source_order, id)),
+            Some(_) => None,
+            None => Some((0, source_order, id)),
         })
+        .collect();
+    due.sort_unstable_by_key(|(deadline, source_order, _)| (*deadline, *source_order));
+    due.into_iter()
+        .take(MAX_SOURCES_PER_TICK as usize)
+        .map(|(_, _, id)| id)
         .collect()
 }
 

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -173,6 +173,23 @@ pub struct SlimState {
     /// re-seeded on `post_upgrade`.
     #[serde(default)]
     pub source_next_pull_ns: Option<std::collections::HashMap<u8, u64>>,
+    /// Cycle-burn tuning (2026-07-02): admin override for the per-source pull
+    /// window, in seconds. `None` → use `pull_schedule::PULL_CYCLE_PERIOD_NS`
+    /// (300s). Set via `set_pull_schedule` so cadence can be retuned without a
+    /// redeploy; persisted so the choice survives upgrade.
+    #[serde(default)]
+    pub pull_period_secs_override: Option<u64>,
+    /// Admin override for the schedule-walker tick, in seconds. `None` → use
+    /// `pull_schedule::PULL_CYCLE_TICK_SECS` (30s). Persisted across upgrade.
+    #[serde(default)]
+    pub pull_tick_secs_override: Option<u64>,
+    /// Schedule-layout version of the persisted `source_next_pull_ns`. `None`
+    /// on snapshots predating the 300s window. When it trails
+    /// `pull_schedule::CURRENT_SCHEDULE_LAYOUT`, `setup_timers` re-spreads the
+    /// schedule once (so old 60s-window deadlines don't leave every source
+    /// firing in a single post-upgrade burst) and bumps it.
+    #[serde(default)]
+    pub schedule_layout_version: Option<u32>,
 }
 
 /// Snapshot of one AMM pool's composition for portfolio LP valuation.
@@ -229,6 +246,9 @@ impl Default for SlimState {
             add_margin_backfill_cursor: None,
             amm_pools: None,
             source_next_pull_ns: None,
+            pull_period_secs_override: None,
+            pull_tick_secs_override: None,
+            schedule_layout_version: None,
         }
     }
 }
@@ -482,7 +502,9 @@ pub mod daily_stability {
 
     pub fn push(row: DailyStabilityRow) {
         DAILY_STABILITY_LOG.with(|log| {
-            log.borrow_mut().append(&row).expect("append DAILY_STABILITY");
+            log.borrow_mut()
+                .append(&row)
+                .expect("append DAILY_STABILITY");
         });
     }
 
@@ -517,15 +539,114 @@ pub mod daily_stability {
     }
 }
 
+pub mod balance_tracker;
 pub mod cursors;
 pub mod events;
-pub mod balance_tracker;
-pub mod holders;
-pub mod rollups;
 pub mod fast;
+pub mod holders;
 pub mod hourly;
+pub mod rollups;
 
 /// Get a virtual memory from the shared MemoryManager. Used by submodules.
 pub(crate) fn get_memory(id: MemoryId) -> Memory {
     MEMORY_MANAGER.with(|m| m.borrow().get(id))
+}
+
+#[cfg(test)]
+mod slim_state_upgrade_tests {
+    use super::*;
+
+    /// `SlimState` as persisted BEFORE the 2026-07-02 cycle-burn tuning added
+    /// `pull_period_secs_override`, `pull_tick_secs_override`, and
+    /// `schedule_layout_version`. A live mainnet blob has exactly this shape.
+    /// The current `SlimState` must decode it without a trap (the UPG-002
+    /// state-wipe class), with the three new `opt` fields defaulting to `None`.
+    #[derive(CandidType, Serialize, Deserialize)]
+    struct SlimStateLegacy {
+        admin: Principal,
+        sources: SourceCanisterIds,
+        circulating_supply_icusd_e8s: Option<u128>,
+        circulating_supply_3usd_e8s: Option<u128>,
+        last_daily_snapshot_ns: u64,
+        error_counters: ErrorCounters,
+        cursor_last_success: Option<std::collections::HashMap<u8, u64>>,
+        cursor_last_error: Option<std::collections::HashMap<u8, String>>,
+        cursor_source_counts: Option<std::collections::HashMap<u8, u64>>,
+        backfill_active_icusd: Option<bool>,
+        backfill_active_3usd: Option<bool>,
+        last_pull_cycle_ns: Option<u64>,
+        collateral_decimals: Option<std::collections::HashMap<Principal, u8>>,
+        add_margin_backfill_cursor: Option<u64>,
+        amm_pools: Option<Vec<AmmPoolSnapshot>>,
+        source_next_pull_ns: Option<std::collections::HashMap<u8, u64>>,
+    }
+
+    #[test]
+    fn decodes_legacy_slim_state_without_new_schedule_fields() {
+        let mut counts = std::collections::HashMap::new();
+        counts.insert(1u8, 42u64);
+        let mut sched = std::collections::HashMap::new();
+        sched.insert(0u8, 1_000u64);
+
+        let legacy = SlimStateLegacy {
+            admin: Principal::from_slice(&[7]),
+            sources: SourceCanisterIds {
+                backend: Principal::from_slice(&[2]),
+                icusd_ledger: Principal::from_slice(&[3]),
+                three_pool: Principal::from_slice(&[4]),
+                stability_pool: Principal::from_slice(&[5]),
+                amm: Principal::from_slice(&[6]),
+            },
+            circulating_supply_icusd_e8s: Some(123),
+            circulating_supply_3usd_e8s: None,
+            last_daily_snapshot_ns: 999,
+            error_counters: ErrorCounters {
+                backend: 1,
+                ..Default::default()
+            },
+            cursor_last_success: Some(counts.clone()),
+            cursor_last_error: None,
+            cursor_source_counts: Some(counts),
+            backfill_active_icusd: Some(false),
+            backfill_active_3usd: None,
+            last_pull_cycle_ns: Some(555),
+            collateral_decimals: None,
+            add_margin_backfill_cursor: Some(10),
+            amm_pools: None,
+            source_next_pull_ns: Some(sched.clone()),
+        };
+
+        let bytes = Encode!(&legacy).expect("encode legacy SlimState");
+        let decoded: SlimState = Decode!(&bytes, SlimState)
+            .expect("decode legacy SlimState as current schema (no UPG-002 wipe)");
+
+        // Pre-existing fields survive verbatim.
+        assert_eq!(decoded.admin, Principal::from_slice(&[7]));
+        assert_eq!(decoded.sources.backend, Principal::from_slice(&[2]));
+        assert_eq!(decoded.circulating_supply_icusd_e8s, Some(123));
+        assert_eq!(decoded.last_daily_snapshot_ns, 999);
+        assert_eq!(decoded.error_counters.backend, 1);
+        assert_eq!(decoded.add_margin_backfill_cursor, Some(10));
+        assert_eq!(decoded.source_next_pull_ns, Some(sched));
+
+        // New fields default to None — the safe "use compiled-in defaults" state.
+        assert_eq!(decoded.pull_period_secs_override, None);
+        assert_eq!(decoded.pull_tick_secs_override, None);
+        assert_eq!(decoded.schedule_layout_version, None);
+    }
+
+    #[test]
+    fn current_slim_state_round_trips_with_new_fields_set() {
+        let mut s = SlimState::default();
+        s.pull_period_secs_override = Some(600);
+        s.pull_tick_secs_override = Some(20);
+        s.schedule_layout_version = Some(2);
+
+        let bytes = <SlimState as Storable>::to_bytes(&s);
+        let decoded = <SlimState as Storable>::from_bytes(bytes);
+
+        assert_eq!(decoded.pull_period_secs_override, Some(600));
+        assert_eq!(decoded.pull_tick_secs_override, Some(20));
+        assert_eq!(decoded.schedule_layout_version, Some(2));
+    }
 }

--- a/src/rumi_analytics/src/storage/mod.rs
+++ b/src/rumi_analytics/src/storage/mod.rs
@@ -125,7 +125,8 @@ pub struct SlimState {
     pub admin: Principal,
     /// Source canister IDs (configurable so we can wire test fixtures).
     pub sources: SourceCanisterIds,
-    /// Cached circulating supply for /api/supply, refreshed by the 60s pull cycle.
+    /// Cached circulating supply for /api/supply, refreshed by the staggered
+    /// pull schedule (300s per source by default).
     /// `None` until the first successful refresh after canister start.
     pub circulating_supply_icusd_e8s: Option<u128>,
     pub circulating_supply_3usd_e8s: Option<u128>,

--- a/src/rumi_analytics/src/tailing/stability_pool.rs
+++ b/src/rumi_analytics/src/tailing/stability_pool.rs
@@ -25,6 +25,36 @@ use crate::{sources, state, storage};
 use storage::cursors;
 use storage::events::*;
 
+fn record_sp_error(error: String) {
+    state::mutate_state(|state| {
+        state.error_counters.stability_pool += 1;
+        update_cursor_error(state, cursors::CURSOR_ID_STABILITY_EVENTS, error);
+    });
+}
+
+fn probe_requires_tail(
+    next_wanted_id: u64,
+    newest: Option<&sources::stability_pool::PoolEvent>,
+) -> bool {
+    newest.is_some_and(|event| event.id >= next_wanted_id)
+}
+
+fn select_unseen_events<'a>(
+    next_wanted_id: u64,
+    events: &'a [sources::stability_pool::PoolEvent],
+) -> (Vec<&'a sources::stability_pool::PoolEvent>, Option<u64>) {
+    let unseen: Vec<_> = events
+        .iter()
+        .filter(|event| event.id >= next_wanted_id)
+        .collect();
+    let next_cursor = unseen
+        .iter()
+        .map(|event| event.id)
+        .max()
+        .map(|id| id.saturating_add(1));
+    (unseen, next_cursor)
+}
+
 pub async fn run() {
     let sp = state::read_state(|s| s.sources.stability_pool);
 
@@ -40,10 +70,7 @@ pub async fn run() {
         Ok(c) => c,
         Err(e) => {
             ic_cdk::println!("[tail_sp] get_pool_event_count failed: {}", e);
-            state::mutate_state(|s| {
-                s.error_counters.stability_pool += 1;
-                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
-            });
+            record_sp_error(e);
             return;
         }
     };
@@ -66,20 +93,14 @@ pub async fn run() {
             Ok(e) => e,
             Err(e) => {
                 ic_cdk::println!("[tail_sp] probe get_pool_events failed: {}", e);
-                state::mutate_state(|s| {
-                    s.error_counters.stability_pool += 1;
-                    update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
-                });
+                record_sp_error(e);
                 return;
             }
         };
-    match newest.first() {
-        // New events exist (newest id not yet ingested) — fall through to the
-        // full tail fetch below.
-        Some(evt) if evt.id >= next_wanted_id => {}
+    if !probe_requires_tail(next_wanted_id, newest.first()) {
         // Newest event already ingested, or the log is momentarily empty:
         // nothing to do this tick.
-        _ => return,
+        return;
     }
 
     // Fetch from the tail of the current window (at most BATCH_SIZE events).
@@ -92,33 +113,19 @@ pub async fn run() {
         Ok(e) => e,
         Err(e) => {
             ic_cdk::println!("[tail_sp] get_pool_events failed: {}", e);
-            state::mutate_state(|s| {
-                s.error_counters.stability_pool += 1;
-                update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
-            });
+            record_sp_error(e);
             return;
         }
     };
 
-    // highest_id_seen starts one below next_wanted_id so that after the loop
-    // `highest_id_seen + 1` equals the correct new cursor value even when
-    // processed == 0.
-    let mut highest_id_seen = next_wanted_id.saturating_sub(1);
-    let mut processed = 0u64;
-    for event in &events {
-        if event.id < next_wanted_id {
-            continue; // already ingested
-        }
+    let (unseen, next_cursor) = select_unseen_events(next_wanted_id, &events);
+    for event in unseen {
         route_sp_event(event);
-        if event.id > highest_id_seen {
-            highest_id_seen = event.id;
-        }
-        processed += 1;
     }
 
-    if processed > 0 {
-        // Save `highest_id_seen + 1` so next tick filters out already-seen ids.
-        cursors::stability_events::set(highest_id_seen + 1);
+    if let Some(next_cursor) = next_cursor {
+        // Save highest unseen id + 1 so the next tick filters out seen ids.
+        cursors::stability_events::set(next_cursor);
         state::mutate_state(|s| {
             update_cursor_success(s, cursors::CURSOR_ID_STABILITY_EVENTS, ic_cdk::api::time());
         });
@@ -182,5 +189,76 @@ fn route_sp_event(event: &sources::stability_pool::PoolEvent) {
         OperationsResumed => {}
         BalanceCorrected { .. } => {}
         CollateralGainCorrected { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use sources::stability_pool::{PoolEvent, PoolEventType};
+
+    fn event(id: u64) -> PoolEvent {
+        PoolEvent {
+            id,
+            timestamp: id,
+            caller: Principal::anonymous(),
+            event_type: PoolEventType::ConfigurationUpdated,
+        }
+    }
+
+    #[test]
+    fn idle_probe_skips_tail_fetch_and_new_probe_requests_it() {
+        assert!(!probe_requires_tail(11, Some(&event(10))));
+        assert!(!probe_requires_tail(11, None));
+        assert!(probe_requires_tail(11, Some(&event(11))));
+        assert!(probe_requires_tail(11, Some(&event(12))));
+    }
+
+    #[test]
+    fn ring_rotation_filters_seen_ids_and_advances_without_duplicates() {
+        let first_window: Vec<PoolEvent> = (98..=102).map(event).collect();
+        let (first_unseen, next) = select_unseen_events(101, &first_window);
+        assert_eq!(
+            first_unseen
+                .iter()
+                .map(|event| event.id)
+                .collect::<Vec<_>>(),
+            vec![101, 102]
+        );
+        assert_eq!(next, Some(103));
+
+        let rotated_window: Vec<PoolEvent> = (100..=104).map(event).collect();
+        let (second_unseen, next) = select_unseen_events(next.unwrap(), &rotated_window);
+        assert_eq!(
+            second_unseen
+                .iter()
+                .map(|event| event.id)
+                .collect::<Vec<_>>(),
+            vec![103, 104]
+        );
+        assert_eq!(next, Some(105));
+    }
+
+    #[test]
+    fn query_failure_records_error_without_advancing_cursor() {
+        state::replace_state(storage::SlimState::default());
+        let cursor_before = cursors::stability_events::get();
+
+        record_sp_error("probe failed".to_string());
+
+        let (error_count, last_error) = state::read_state(|state| {
+            (
+                state.error_counters.stability_pool,
+                state
+                    .cursor_last_error
+                    .as_ref()
+                    .and_then(|errors| errors.get(&cursors::CURSOR_ID_STABILITY_EVENTS))
+                    .cloned(),
+            )
+        });
+        assert_eq!(error_count, 1);
+        assert_eq!(last_error.as_deref(), Some("probe failed"));
+        assert_eq!(cursors::stability_events::get(), cursor_before);
     }
 }

--- a/src/rumi_analytics/src/tailing/stability_pool.rs
+++ b/src/rumi_analytics/src/tailing/stability_pool.rs
@@ -16,13 +16,14 @@
 //!
 //! Each tick we fetch the latest BATCH_SIZE events from the tail of the
 //! current window and filter by event.id >= next_wanted_id. If the SP
-//! produces more than BATCH_SIZE events in 60 seconds the oldest of those
-//! would be missed, but that rate (>500 SP events/min) is unrealistic.
+//! produces more than BATCH_SIZE events between pulls the oldest of those
+//! would be missed, but that rate (>500 SP events/5 min at the default
+//! cadence) is unrealistic.
 
+use super::{update_cursor_error, update_cursor_source_count, update_cursor_success, BATCH_SIZE};
 use crate::{sources, state, storage};
 use storage::cursors;
 use storage::events::*;
-use super::{BATCH_SIZE, update_cursor_success, update_cursor_error, update_cursor_source_count};
 
 pub async fn run() {
     let sp = state::read_state(|s| s.sources.stability_pool);
@@ -55,10 +56,36 @@ pub async fn run() {
         return;
     }
 
-    // Always fetch from the tail of the current window (at most BATCH_SIZE
-    // events). If new events arrived faster than one tick can process, the
-    // oldest ones may have already been rotated out — acceptable given the
-    // 60-second tick interval and a 10k ring buffer.
+    // Probe-before-fetch: SP events (deposit/withdraw/claim) are rare, so on
+    // almost every tick there is nothing new. Fetch just the newest event
+    // (position count-1, length 1) and compare its monotonic id against the
+    // cursor. If the newest id is already ingested, skip the full BATCH_SIZE
+    // pull — which otherwise ships up to 500 events every tick even when idle.
+    let newest =
+        match sources::stability_pool::get_pool_events(sp, count.saturating_sub(1), 1).await {
+            Ok(e) => e,
+            Err(e) => {
+                ic_cdk::println!("[tail_sp] probe get_pool_events failed: {}", e);
+                state::mutate_state(|s| {
+                    s.error_counters.stability_pool += 1;
+                    update_cursor_error(s, cursors::CURSOR_ID_STABILITY_EVENTS, e);
+                });
+                return;
+            }
+        };
+    match newest.first() {
+        // New events exist (newest id not yet ingested) — fall through to the
+        // full tail fetch below.
+        Some(evt) if evt.id >= next_wanted_id => {}
+        // Newest event already ingested, or the log is momentarily empty:
+        // nothing to do this tick.
+        _ => return,
+    }
+
+    // Fetch from the tail of the current window (at most BATCH_SIZE events).
+    // If new events arrived faster than one tick can process, the oldest ones
+    // may have already been rotated out — acceptable given the tick interval
+    // and a 10k ring buffer.
     let start = count.saturating_sub(BATCH_SIZE);
     let length = count - start;
     let events = match sources::stability_pool::get_pool_events(sp, start, length).await {

--- a/src/rumi_analytics/src/timers.rs
+++ b/src/rumi_analytics/src/timers.rs
@@ -2,17 +2,54 @@
 //! Phase 4 adds event tailing and ICRC-3 block tailing to the pull cycle.
 //!
 //! Wave-9d (DOS-010) replaced the 60s `pull_cycle` join-storm with a
-//! per-source schedule walked by a 5s tick. Each source still fires
-//! every 60s; offsets persist across upgrade. See
-//! `pull_schedule.rs` for the pure logic.
+//! per-source schedule walked by a fast tick. Each source fires once per
+//! window; offsets persist across upgrade. The default window widened from
+//! 60s to 300s and the walker tick from 5s to 30s (2026-07-02 cycle-burn
+//! tuning), and both are runtime-overridable via the admin `set_pull_schedule`
+//! endpoint. See `pull_schedule.rs` for the pure logic.
 
-use std::time::Duration;
 use crate::{collectors, pull_schedule, sources, state, tailing};
+use std::cell::Cell;
+use std::time::Duration;
+
+thread_local! {
+    /// Active walker-tick timer, tracked so `register_pull_tick_timer` can
+    /// clear and re-arm it when the admin retunes the tick interval. Timers
+    /// don't survive upgrade, so this is re-populated by `setup_timers`.
+    static PULL_TICK_TIMER_ID: Cell<Option<ic_cdk_timers::TimerId>> = const { Cell::new(None) };
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SetupContext {
     Init,
     PostUpgrade,
+}
+
+fn replace_interval_timer<T: Copy>(
+    slot: &Cell<Option<T>>,
+    clear_existing: impl FnOnce(T),
+    register_new: impl FnOnce() -> T,
+) {
+    if let Some(old) = slot.take() {
+        clear_existing(old);
+    }
+    slot.set(Some(register_new()));
+}
+
+/// (Re-)arm the schedule-walker timer at the currently effective tick. Clears
+/// any prior timer first so calling this repeatedly (e.g. from the admin
+/// setter) never stacks duplicate walkers. Mirrors the backend's
+/// `register_observer_timer` clear-then-arm pattern.
+pub fn register_pull_tick_timer() {
+    let tick_secs =
+        pull_schedule::effective_tick_secs(state::read_state(|s| s.pull_tick_secs_override)).max(1);
+    PULL_TICK_TIMER_ID.with(|cell| {
+        replace_interval_timer(cell, ic_cdk_timers::clear_timer, || {
+            ic_cdk_timers::set_timer_interval(Duration::from_secs(tick_secs), || {
+                ic_cdk::spawn(pull_due_sources())
+            })
+        });
+    });
 }
 
 pub fn setup_timers(ctx: SetupContext) {
@@ -21,9 +58,29 @@ pub fn setup_timers(ctx: SetupContext) {
     // PostUpgrade existing offsets are preserved, only newly added
     // sources are seeded.
     let now = ic_cdk::api::time();
+    let period_ns =
+        pull_schedule::effective_period_ns(state::read_state(|s| s.pull_period_secs_override));
     state::mutate_state(|s| {
         let existing = s.source_next_pull_ns.clone().unwrap_or_default();
-        let merged = pull_schedule::reseed_preserving(now, &existing, pull_schedule::ALL_SOURCE_IDS);
+        let mut merged = pull_schedule::reseed_preserving(
+            now,
+            &existing,
+            pull_schedule::ALL_SOURCE_IDS,
+            period_ns,
+        );
+        // One-time re-spread when the persisted layout trails the current
+        // one. Without this, deadlines seeded under the old 60s window are
+        // all stale after an upgrade that widens the window to 300s, so every
+        // source would fire together on the first tick and stay synchronized
+        // one-burst-per-window — reviving the DOS-010 join-storm. Re-spreading
+        // once restores the even stagger. Preserved thereafter (later upgrades
+        // see the current version and keep in-flight offsets, so this never
+        // starves a high-offset source on repeated upgrades).
+        if s.schedule_layout_version.unwrap_or(0) < pull_schedule::CURRENT_SCHEDULE_LAYOUT {
+            merged =
+                pull_schedule::seed_initial_schedule(now, pull_schedule::ALL_SOURCE_IDS, period_ns);
+            s.schedule_layout_version = Some(pull_schedule::CURRENT_SCHEDULE_LAYOUT);
+        }
         s.source_next_pull_ns = Some(merged);
     });
 
@@ -43,14 +100,12 @@ pub fn setup_timers(ctx: SetupContext) {
         ic_cdk::spawn(fast_snapshot());
     });
 
-    // Wave-9d DOS-010: walk the per-source schedule every
-    // PULL_CYCLE_TICK_SECS (5s). Each source still fires every 60s; the
-    // burst of 9 concurrent inter-canister calls is now spread across
-    // the window.
-    ic_cdk_timers::set_timer_interval(
-        Duration::from_secs(pull_schedule::PULL_CYCLE_TICK_SECS),
-        || ic_cdk::spawn(pull_due_sources()),
-    );
+    // Wave-9d DOS-010: walk the per-source schedule every effective tick
+    // (30s default). Each source fires once per effective window (300s
+    // default); the burst of concurrent inter-canister calls is spread
+    // across the window. Registered via the re-armable helper so the admin
+    // setter can retune the tick without a redeploy.
+    register_pull_tick_timer();
     ic_cdk_timers::set_timer_interval(Duration::from_secs(300), || {
         ic_cdk::spawn(fast_snapshot());
     });
@@ -63,9 +118,9 @@ pub fn setup_timers(ctx: SetupContext) {
 }
 
 /// Wave-9d DOS-010: walk the per-source schedule, fire any sources whose
-/// `next_pull_at_ns` is past, and bump their next deadline by
-/// `PULL_CYCLE_PERIOD_NS`. Typically fires 1 source per tick (sometimes 2
-/// when offsets cluster against the 5s tick grid).
+/// `next_pull_at_ns` is past, and bump their next deadline by the effective
+/// window. Typically fires 1 source per tick (the ~33s default offset exceeds
+/// the 30s tick, so sources rarely cluster).
 async fn pull_due_sources() {
     let now = ic_cdk::api::time();
     let due: Vec<u8> = state::read_state(|s| {
@@ -79,10 +134,13 @@ async fn pull_due_sources() {
 
     // Advance the schedule BEFORE awaiting any sources so a slow source
     // doesn't double-fire on the next tick if its deadline is still in
-    // the past when the next tick arrives.
+    // the past when the next tick arrives. The period is read live so an
+    // admin retune takes effect on the next advance.
+    let period_ns =
+        pull_schedule::effective_period_ns(state::read_state(|s| s.pull_period_secs_override));
     state::mutate_state(|s| {
         let mut schedule = s.source_next_pull_ns.clone().unwrap_or_default();
-        pull_schedule::advance_schedule_for_fired(&mut schedule, now, &due);
+        pull_schedule::advance_schedule_for_fired(&mut schedule, now, &due, period_ns);
         s.source_next_pull_ns = Some(schedule);
     });
 
@@ -173,5 +231,48 @@ async fn fast_snapshot() {
 async fn hourly_snapshot() {
     if let Err(e) = collectors::hourly::run().await {
         ic_cdk::println!("rumi_analytics: hourly snapshot failed: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::replace_interval_timer;
+    use std::cell::Cell;
+
+    #[test]
+    fn replacing_interval_timer_clears_old_before_storing_new() {
+        let slot = Cell::new(Some(7_u8));
+        let cleared = Cell::new(None);
+        let registered = Cell::new(false);
+
+        replace_interval_timer(
+            &slot,
+            |old| {
+                assert!(
+                    !registered.get(),
+                    "old timer must clear before registration"
+                );
+                cleared.set(Some(old));
+            },
+            || {
+                registered.set(true);
+                9
+            },
+        );
+
+        assert_eq!(cleared.get(), Some(7));
+        assert!(registered.get());
+        assert_eq!(slot.get(), Some(9));
+    }
+
+    #[test]
+    fn first_interval_timer_registration_does_not_clear() {
+        let slot = Cell::new(None::<u8>);
+        let clear_count = Cell::new(0_u8);
+
+        replace_interval_timer(&slot, |_| clear_count.set(clear_count.get() + 1), || 3);
+
+        assert_eq!(clear_count.get(), 0);
+        assert_eq!(slot.get(), Some(3));
     }
 }

--- a/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
+++ b/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
@@ -21,86 +21,154 @@
 //!
 //! Wave-9d switches to a **per-source schedule**: every source has its
 //! own `next_pull_at_ns` deadline, persisted in `SlimState` (so offsets
-//! survive upgrade). A small fast tick (every `PULL_CYCLE_TICK_SECS`
-//! seconds) walks the schedule, fires only sources whose deadline has
-//! passed, and bumps their next deadline by `PULL_CYCLE_PERIOD_NS`.
-//! Initial offsets spread the 9 sources across the 60s window at
-//! `PULL_CYCLE_SOURCE_OFFSET_NS` spacing.
+//! survive upgrade). A fast tick (every `PULL_CYCLE_TICK_SECS` seconds)
+//! walks the schedule, fires only sources whose deadline has passed, and
+//! bumps their next deadline by the effective window. Initial offsets
+//! spread the 9 sources across the window at `source_offset_ns(period)`
+//! spacing.
+//!
+//! Cycle-burn tuning (2026-07-02): the default window widened from 60s to
+//! 300s and the walker tick from 5s to 30s to cut the poll rate ~5x, and
+//! both became runtime-overridable. The per-source offset is now DERIVED
+//! from the effective window (`source_offset_ns`) so the stagger stays even
+//! at any cadence. These fences pin the *default* constants and the pure
+//! scheduling invariants that hold at any window.
 //!
 //! Layered fences (mirrors the LIQ-002 / DOS-005 file structure):
 //!
-//!  1. **Constant fences** — TICK / PERIOD / OFFSET pinned at audit-spec
-//!     values. Source-id list pinned (changes need a deliberate edit).
+//!  1. **Constant fences** — TICK / PERIOD defaults pinned; offset derives
+//!     from the window. Source-id list pinned (changes need a deliberate
+//!     edit).
 //!  2. **Initial schedule** — `seed_initial_schedule` produces a
-//!     deterministic offset per source so they spread across the 60s
-//!     window instead of all firing at `now`.
+//!     deterministic offset per source so they spread across the window
+//!     instead of all firing at `now`.
 //!  3. **Due-source selection** — `compute_due_sources` returns ONLY
-//!     sources whose `next_pull_at_ns` is in the past. Out-of-band
-//!     timestamp arithmetic (saturating subtraction, clock skew) must
-//!     not include future-due sources in the firing set.
-//!  4. **Schedule advance** — `advance_schedule_for_fired` bumps each
-//!     fired source by exactly `PULL_CYCLE_PERIOD_NS`. Each source must
-//!     fire exactly once per `PULL_CYCLE_PERIOD_NS` window across many
-//!     ticks.
+//!     sources whose `next_pull_at_ns` is in the past.
+//!  4. **Schedule advance** — `advance_schedule_for_fired` bumps each fired
+//!     source by exactly the effective window. Each source must fire
+//!     exactly once per window across many ticks.
 //!  5. **Upgrade hygiene** — pre-Wave-9d snapshots decode with the new
 //!     `source_next_pull_ns` field populated from `serde(default)`. The
 //!     re-seed on `post_upgrade` must NOT clobber existing offsets when
 //!     the field is already populated.
 //!  6. **Late-added source** — adding a new source to `ALL_SOURCE_IDS`
-//!     after deploy (or on a fresh canister where the schedule has
-//!     drifted) must seed an offset for the new source without
-//!     disturbing the existing ones.
+//!     after deploy must seed an offset for it without disturbing the rest.
 
 use std::collections::HashMap;
 
 use rumi_analytics::pull_schedule::{
-    self, advance_schedule_for_fired, compute_due_sources, seed_initial_schedule,
-    ALL_SOURCE_IDS, PULL_CYCLE_PERIOD_NS, PULL_CYCLE_SOURCE_OFFSET_NS, PULL_CYCLE_TICK_SECS,
-    SOURCE_ID_AMM_LIQUIDITY, SOURCE_ID_AMM_SWAPS, SOURCE_ID_BACKEND_EVENTS,
-    SOURCE_ID_ICUSD_BLOCKS, SOURCE_ID_STABILITY_EVENTS, SOURCE_ID_SUPPLY_CACHE,
-    SOURCE_ID_3POOL_BLOCKS, SOURCE_ID_3POOL_LIQUIDITY, SOURCE_ID_3POOL_SWAPS,
+    self, advance_schedule_for_fired, compute_due_sources, seed_initial_schedule, source_offset_ns,
+    validate_schedule_config, ALL_SOURCE_IDS, MAX_PERIOD_SECS, MAX_TICK_SECS, MIN_PERIOD_SECS,
+    MIN_TICK_SECS, PULL_CYCLE_PERIOD_NS, PULL_CYCLE_TICK_SECS, SOURCE_ID_3POOL_BLOCKS,
+    SOURCE_ID_3POOL_LIQUIDITY, SOURCE_ID_3POOL_SWAPS, SOURCE_ID_AMM_LIQUIDITY, SOURCE_ID_AMM_SWAPS,
+    SOURCE_ID_BACKEND_EVENTS, SOURCE_ID_ICUSD_BLOCKS, SOURCE_ID_STABILITY_EVENTS,
+    SOURCE_ID_SUPPLY_CACHE,
 };
 
 const SEC_NANOS: u64 = 1_000_000_000;
+
+/// The window used throughout these tests: the compiled-in default.
+const PERIOD: u64 = PULL_CYCLE_PERIOD_NS;
+
+/// Convenience: the derived per-source offset for the default window.
+fn offset() -> u64 {
+    source_offset_ns(PERIOD)
+}
 
 // ============================================================================
 // Layer 1 — constant fences
 // ============================================================================
 
 #[test]
-fn dos_010_tick_seconds_pinned_at_5() {
+fn dos_010_tick_seconds_default_is_30() {
     assert_eq!(
-        PULL_CYCLE_TICK_SECS, 5,
-        "Wave-9d DOS-010: pull-cycle tick must be 5s. Lengthening it \
-         pushes some sources past their nominal 60s cadence; shortening \
-         it wakes the canister more often without spreading work further."
+        PULL_CYCLE_TICK_SECS, 30,
+        "DOS-010 / burn tuning: default walker tick is 30s. It is \
+         runtime-overridable, but the compiled-in default is pinned so a \
+         careless edit can't silently regress the poll rate."
     );
 }
 
 #[test]
-fn dos_010_period_pinned_at_60s() {
+fn dos_010_period_default_is_300s() {
     assert_eq!(
         PULL_CYCLE_PERIOD_NS,
-        60 * SEC_NANOS,
-        "Wave-9d DOS-010: each source must fire every 60s (matches the \
-         pre-Wave-9d cadence). Changing this changes the analytics \
-         freshness contract surfaced through `last_pull_cycle_ns`."
+        300 * SEC_NANOS,
+        "DOS-010 / burn tuning: default per-source window is 300s (widened \
+         from 60s to cut the inter-canister poll rate ~5x). Runtime- \
+         overridable via set_pull_schedule; the default is pinned here."
     );
 }
 
 #[test]
-fn dos_010_offset_spreads_sources_across_window() {
-    // 9 sources × 6s offset = 54s spread, fits cleanly inside the 60s
-    // PULL_CYCLE_PERIOD_NS window. Pre-Wave-9d behaviour collapsed all
-    // 9 source pulls into the same instant; 6s spacing puts each on its
-    // own tick when the wall clock advances in 5s steps.
+fn dos_010_runtime_period_floor_preserves_the_300s_burn_reduction() {
     assert_eq!(
-        PULL_CYCLE_SOURCE_OFFSET_NS,
-        6 * SEC_NANOS,
-        "Wave-9d DOS-010: source-offset spacing must be 6s. Wider spacing \
-         (e.g., 7s × 9 = 63s) overshoots the 60s window and leaves the \
-         last source firing on alternate cycles relative to the 5s tick grid."
+        MIN_PERIOD_SECS, 300,
+        "the runtime override must not restore or exceed the pre-tuning poll rate"
     );
+}
+
+#[test]
+fn dos_010_runtime_config_enforces_static_and_stagger_bounds() {
+    assert!(validate_schedule_config(MIN_PERIOD_SECS, MIN_TICK_SECS).is_ok());
+    assert!(validate_schedule_config(MAX_PERIOD_SECS, MAX_TICK_SECS).is_ok());
+
+    assert!(validate_schedule_config(MIN_PERIOD_SECS - 1, MIN_TICK_SECS).is_err());
+    assert!(validate_schedule_config(MAX_PERIOD_SECS + 1, MIN_TICK_SECS).is_err());
+    assert!(validate_schedule_config(MIN_PERIOD_SECS, MIN_TICK_SECS - 1).is_err());
+    assert!(validate_schedule_config(MIN_PERIOD_SECS, MAX_TICK_SECS + 1).is_err());
+
+    // Nine sources across a 300s period have ~33s spacing. A 66s walker
+    // can collect at most two adjacent slots; 67s can collect three and
+    // therefore violates the scheduler's documented 1-2 source bound.
+    assert!(validate_schedule_config(300, 66).is_ok());
+    assert!(
+        validate_schedule_config(300, 67).is_err(),
+        "a runtime override must not collapse three or more stagger slots into one tick"
+    );
+}
+
+#[test]
+fn dos_010_largest_safe_tick_fires_at_most_two_sources() {
+    let period_ns = 300 * SEC_NANOS;
+    let tick_ns = 66 * SEC_NANOS;
+    let mut now = 0;
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, period_ns);
+    let mut max_due = 0;
+
+    for _ in 0..200 {
+        let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+        max_due = max_due.max(due.len());
+        advance_schedule_for_fired(&mut schedule, now, &due, period_ns);
+        now += tick_ns;
+    }
+
+    assert!(
+        max_due <= 2,
+        "accepted minimum-period cadence fired {max_due} sources in one tick"
+    );
+}
+
+#[test]
+fn dos_010_offset_derives_from_window_and_spreads_sources() {
+    // The offset is period / N so the 9 sources fill the window. For the
+    // 300s default that is ~33.3s, and 9 × offset stays inside the window.
+    let off = offset();
+    assert_eq!(
+        off,
+        PERIOD / (ALL_SOURCE_IDS.len() as u64),
+        "source offset must be an even fraction of the window"
+    );
+    assert!(
+        (ALL_SOURCE_IDS.len() as u64) * off <= PERIOD,
+        "all sources must fit inside one window without wrapping (last slot \
+         = {} , window = {})",
+        (ALL_SOURCE_IDS.len() as u64) * off,
+        PERIOD
+    );
+    // Offset must exceed nothing in particular, but it should be positive so
+    // sources don't all collapse onto `now`.
+    assert!(off > 0, "derived offset must be positive");
 }
 
 #[test]
@@ -111,15 +179,15 @@ fn dos_010_source_ids_full_list_pinned() {
     let mut got: Vec<u8> = ALL_SOURCE_IDS.iter().copied().collect();
     got.sort();
     let expected: Vec<u8> = vec![
-        SOURCE_ID_SUPPLY_CACHE,    // 0
-        SOURCE_ID_BACKEND_EVENTS,  // 1 (matches CURSOR_ID_BACKEND_EVENTS)
-        SOURCE_ID_3POOL_SWAPS,     // 2
-        SOURCE_ID_3POOL_LIQUIDITY, // 3
-        SOURCE_ID_3POOL_BLOCKS,    // 4
-        SOURCE_ID_AMM_SWAPS,       // 5
-        SOURCE_ID_STABILITY_EVENTS,// 6
-        SOURCE_ID_ICUSD_BLOCKS,    // 7
-        SOURCE_ID_AMM_LIQUIDITY,   // 8
+        SOURCE_ID_SUPPLY_CACHE,     // 0
+        SOURCE_ID_BACKEND_EVENTS,   // 1 (matches CURSOR_ID_BACKEND_EVENTS)
+        SOURCE_ID_3POOL_SWAPS,      // 2
+        SOURCE_ID_3POOL_LIQUIDITY,  // 3
+        SOURCE_ID_3POOL_BLOCKS,     // 4
+        SOURCE_ID_AMM_SWAPS,        // 5
+        SOURCE_ID_STABILITY_EVENTS, // 6
+        SOURCE_ID_ICUSD_BLOCKS,     // 7
+        SOURCE_ID_AMM_LIQUIDITY,    // 8
     ];
     assert_eq!(got, expected, "ALL_SOURCE_IDS must list every source pull. Adding a new tailer means adding a new id here and a new branch in run_source.");
 }
@@ -139,7 +207,7 @@ fn dos_010_supply_cache_id_is_zero() {
 #[test]
 fn dos_010_seed_initial_schedule_assigns_unique_offsets() {
     let now: u64 = 1_000_000_000_000;
-    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     assert_eq!(
         schedule.len(),
         ALL_SOURCE_IDS.len(),
@@ -157,18 +225,21 @@ fn dos_010_seed_initial_schedule_assigns_unique_offsets() {
 
 #[test]
 fn dos_010_seed_initial_schedule_offsets_are_evenly_spaced() {
-    // Source N gets `now + N * PULL_CYCLE_SOURCE_OFFSET_NS`.
+    // Source N gets `now + N * source_offset_ns(period)`.
     // (N is the source's index in ALL_SOURCE_IDS so the spacing stays
     // even regardless of the actual u8 ids.)
     let now: u64 = 0;
-    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let off = offset();
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     for (idx, source_id) in ALL_SOURCE_IDS.iter().enumerate() {
-        let expected = now + (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS;
+        let expected = now + (idx as u64) * off;
         assert_eq!(
             schedule.get(source_id).copied(),
             Some(expected),
             "source id {} (index {}) must be seeded at offset {}",
-            source_id, idx, expected
+            source_id,
+            idx,
+            expected
         );
     }
 }
@@ -182,7 +253,7 @@ fn dos_010_seed_initial_schedule_preserves_existing_entries() {
     existing.insert(SOURCE_ID_BACKEND_EVENTS, 999_000_000_000);
     existing.insert(SOURCE_ID_3POOL_SWAPS, 998_000_000_000);
 
-    let merged = pull_schedule::reseed_preserving(now, &existing, ALL_SOURCE_IDS);
+    let merged = pull_schedule::reseed_preserving(now, &existing, ALL_SOURCE_IDS, PERIOD);
 
     assert_eq!(
         merged.get(&SOURCE_ID_BACKEND_EVENTS).copied(),
@@ -195,10 +266,6 @@ fn dos_010_seed_initial_schedule_preserves_existing_entries() {
         "existing deadline for 3pool_swaps must be preserved"
     );
     // New sources get fresh offsets relative to `now`.
-    let backend_idx = ALL_SOURCE_IDS
-        .iter()
-        .position(|id| *id == SOURCE_ID_BACKEND_EVENTS)
-        .unwrap();
     assert_ne!(
         merged.get(&SOURCE_ID_SUPPLY_CACHE).copied(),
         Some(999_000_000_000),
@@ -208,8 +275,7 @@ fn dos_010_seed_initial_schedule_preserves_existing_entries() {
         .iter()
         .position(|id| *id == SOURCE_ID_SUPPLY_CACHE)
         .unwrap();
-    let _ = backend_idx; // silence unused — referenced in trace if assertion fires
-    let expected_supply = now + (supply_idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS;
+    let expected_supply = now + (supply_idx as u64) * offset();
     assert_eq!(
         merged.get(&SOURCE_ID_SUPPLY_CACHE).copied(),
         Some(expected_supply),
@@ -226,7 +292,7 @@ fn dos_010_compute_due_sources_returns_empty_when_nothing_is_due() {
     // Schedule is now+offset; at exactly `now` only the source whose
     // offset == 0 (index 0 = supply cache) is due.
     let now: u64 = 100 * SEC_NANOS;
-    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
     assert_eq!(
         due,
@@ -238,23 +304,27 @@ fn dos_010_compute_due_sources_returns_empty_when_nothing_is_due() {
 #[test]
 fn dos_010_compute_due_sources_includes_only_past_deadlines() {
     let now: u64 = 100 * SEC_NANOS;
-    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
-    // Advance to just past source-index-3's offset (3 * 7s = 21s into the cycle).
-    let later = now + 22 * SEC_NANOS;
+    let off = offset();
+    let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
+    // Advance to just past source-index-3's offset (3 × offset into the
+    // cycle), so indices 0..=3 are due and index 4 is not.
+    let later = now + 3 * off + SEC_NANOS;
     let due = compute_due_sources(later, &schedule, ALL_SOURCE_IDS);
-    // Sources 0..=3 (by index) should be due; their seed-time was 0/7/14/21s past now.
     assert_eq!(
         due.len(),
         4,
-        "at t=now+22s, sources at offsets 0/7/14/21 must all be due (got {} = {:?})",
-        due.len(), due
+        "at t=now+3*offset+1s, sources at offsets 0/1/2/3*offset must all be \
+         due (got {} = {:?})",
+        due.len(),
+        due
     );
     for &id in &due {
         let idx = ALL_SOURCE_IDS.iter().position(|&i| i == id).unwrap();
         assert!(
-            (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS <= 22 * SEC_NANOS,
+            (idx as u64) * off <= later - now,
             "source id {} (index {}) was reported due but its offset is in the future",
-            id, idx
+            id,
+            idx
         );
     }
 }
@@ -281,24 +351,23 @@ fn dos_010_compute_due_sources_treats_missing_entry_as_due() {
 }
 
 // ============================================================================
-// Layer 4 — schedule advance / per-source 60s pacing
+// Layer 4 — schedule advance / per-source window pacing
 // ============================================================================
 
 #[test]
 fn dos_010_advance_schedule_bumps_fired_sources_by_period() {
     let now: u64 = 100 * SEC_NANOS;
-    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
-    let original_supply = schedule[&SOURCE_ID_SUPPLY_CACHE];
+    let off = offset();
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     let fired = vec![SOURCE_ID_SUPPLY_CACHE];
 
-    advance_schedule_for_fired(&mut schedule, now, &fired);
+    advance_schedule_for_fired(&mut schedule, now, &fired, PERIOD);
 
     assert_eq!(
         schedule[&SOURCE_ID_SUPPLY_CACHE],
-        now + PULL_CYCLE_PERIOD_NS,
-        "fired source must have its deadline pushed exactly PULL_CYCLE_PERIOD_NS into the future"
+        now + PERIOD,
+        "fired source must have its deadline pushed exactly one window into the future"
     );
-    let _ = original_supply; // value irrelevant; checked the new value is `now + period`
 
     // Non-fired sources must not be touched.
     for &id in ALL_SOURCE_IDS {
@@ -308,7 +377,7 @@ fn dos_010_advance_schedule_bumps_fired_sources_by_period() {
         let idx = ALL_SOURCE_IDS.iter().position(|&i| i == id).unwrap();
         assert_eq!(
             schedule[&id],
-            now + (idx as u64) * PULL_CYCLE_SOURCE_OFFSET_NS,
+            now + (idx as u64) * off,
             "non-fired source {} must keep its original deadline",
             id
         );
@@ -317,30 +386,28 @@ fn dos_010_advance_schedule_bumps_fired_sources_by_period() {
 
 #[test]
 fn dos_010_each_source_fires_exactly_once_per_window() {
-    // Walk a 60s window in 5s ticks. With 9 sources × 7s offsets,
-    // each source must fire exactly once across the window.
+    // Walk one window in TICK-second steps. Each of the 9 sources must fire
+    // exactly once across the window.
     let mut now: u64 = 0;
-    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     let mut fire_counts: HashMap<u8, u32> = HashMap::new();
 
-    // Walk PULL_CYCLE_PERIOD_NS worth of ticks. PULL_CYCLE_PERIOD_NS / TICK_SECS = 60/5 = 12 ticks.
-    let n_ticks = PULL_CYCLE_PERIOD_NS / (PULL_CYCLE_TICK_SECS * SEC_NANOS);
+    // Number of ticks in one window (300 / 30 = 10 for the defaults).
+    let n_ticks = PERIOD / (PULL_CYCLE_TICK_SECS * SEC_NANOS);
     for _ in 0..n_ticks {
         let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
         for &id in &due {
             *fire_counts.entry(id).or_insert(0) += 1;
         }
-        advance_schedule_for_fired(&mut schedule, now, &due);
+        advance_schedule_for_fired(&mut schedule, now, &due, PERIOD);
         now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
     }
 
-    // Walk one more period. Final tally should be 1 per source per
-    // window, total = 9 fires per 60s.
     for &id in ALL_SOURCE_IDS {
         let count = fire_counts.get(&id).copied().unwrap_or(0);
         assert_eq!(
             count, 1,
-            "source id {} must fire exactly once per 60s window (got {} fires across {} ticks)",
+            "source id {} must fire exactly once per window (got {} fires across {} ticks)",
             id, count, n_ticks
         );
     }
@@ -349,19 +416,19 @@ fn dos_010_each_source_fires_exactly_once_per_window() {
     assert_eq!(
         total,
         ALL_SOURCE_IDS.len() as u32,
-        "total fires across one 60s window must equal source count (got {})",
+        "total fires across one window must equal source count (got {})",
         total
     );
 }
 
 #[test]
 fn dos_010_no_sync_storm_at_any_single_tick() {
-    // Walk the schedule for many ticks; assert that at no point are
-    // more than `ceil(N_sources * tick / period) + 1` sources due
-    // simultaneously. Pre-fix all 9 fired together; post-fix at most
-    // 1-2 per tick (drift may cluster a couple together but never all 9).
+    // Walk the schedule for many ticks; assert that at no point are more
+    // than 2 sources due simultaneously. Pre-fix all 9 fired together;
+    // post-fix the derived offset (~33s) exceeds the 30s tick so at most one
+    // source is due per tick (2 tolerated for grid drift), never all 9.
     let mut now: u64 = 0;
-    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     let max_per_tick_observed = {
         let mut m: usize = 0;
         for _ in 0..200 {
@@ -369,15 +436,11 @@ fn dos_010_no_sync_storm_at_any_single_tick() {
             if due.len() > m {
                 m = due.len();
             }
-            advance_schedule_for_fired(&mut schedule, now, &due);
+            advance_schedule_for_fired(&mut schedule, now, &due, PERIOD);
             now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
         }
         m
     };
-    // Hard upper bound: 2 per tick (some clustering as the deadlines
-    // drift relative to the 5s tick grid). If this ever exceeds 2,
-    // either the offset shrunk or the tick grew and DOS-010's premise
-    // is undermined.
     assert!(
         max_per_tick_observed <= 2,
         "no single tick must fire more than 2 sources concurrently (got {})",
@@ -394,16 +457,16 @@ fn dos_010_reseed_after_upgrade_preserves_in_flight_offsets() {
     // Simulate: tick a few times, snapshot the schedule, "upgrade" by
     // re-seeding with the snapshot, assert the schedule is unchanged.
     let mut now: u64 = 0;
-    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS);
+    let mut schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     for _ in 0..5 {
         let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
-        advance_schedule_for_fired(&mut schedule, now, &due);
+        advance_schedule_for_fired(&mut schedule, now, &due, PERIOD);
         now += PULL_CYCLE_TICK_SECS * SEC_NANOS;
     }
     let snapshot: HashMap<u8, u64> = schedule.clone();
 
     // Simulate post_upgrade: reseed with the snapshot.
-    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS);
+    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS, PERIOD);
 
     // Every entry from snapshot must survive verbatim.
     for (id, deadline) in snapshot.iter() {
@@ -427,7 +490,7 @@ fn dos_010_reseed_after_upgrade_seeds_newly_added_source() {
         snapshot.insert(id, now + 1);
     }
     let new_source_id = *ALL_SOURCE_IDS.last().unwrap();
-    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS);
+    let merged = pull_schedule::reseed_preserving(now, &snapshot, ALL_SOURCE_IDS, PERIOD);
     assert!(
         merged.contains_key(&new_source_id),
         "post-upgrade reseed must seed a new source not present in snapshot"

--- a/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
+++ b/src/rumi_analytics/tests/audit_pocs_dos_010_stagger.rs
@@ -43,7 +43,8 @@
 //!     deterministic offset per source so they spread across the window
 //!     instead of all firing at `now`.
 //!  3. **Due-source selection** — `compute_due_sources` returns ONLY
-//!     sources whose `next_pull_at_ns` is in the past.
+//!     sources whose `next_pull_at_ns` is in the past, oldest-deadline-first,
+//!     with a hard maximum of two per walker callback even after delays.
 //!  4. **Schedule advance** — `advance_schedule_for_fired` bumps each fired
 //!     source by exactly the effective window. Each source must fire
 //!     exactly once per window across many ticks.
@@ -307,17 +308,11 @@ fn dos_010_compute_due_sources_includes_only_past_deadlines() {
     let off = offset();
     let schedule = seed_initial_schedule(now, ALL_SOURCE_IDS, PERIOD);
     // Advance to just past source-index-3's offset (3 × offset into the
-    // cycle), so indices 0..=3 are due and index 4 is not.
+    // cycle), so indices 0..=3 are overdue and index 4 is not. The runtime
+    // selector returns only the two oldest overdue entries.
     let later = now + 3 * off + SEC_NANOS;
     let due = compute_due_sources(later, &schedule, ALL_SOURCE_IDS);
-    assert_eq!(
-        due.len(),
-        4,
-        "at t=now+3*offset+1s, sources at offsets 0/1/2/3*offset must all be \
-         due (got {} = {:?})",
-        due.len(),
-        due
-    );
+    assert_eq!(due, ALL_SOURCE_IDS[..2]);
     for &id in &due {
         let idx = ALL_SOURCE_IDS.iter().position(|&i| i == id).unwrap();
         assert!(
@@ -325,6 +320,80 @@ fn dos_010_compute_due_sources_includes_only_past_deadlines() {
             "source id {} (index {}) was reported due but its offset is in the future",
             id,
             idx
+        );
+    }
+}
+
+#[test]
+fn dos_010_delayed_tick_caps_four_overdue_sources_oldest_first() {
+    let now = 1_000 * SEC_NANOS;
+    let schedule = HashMap::from([
+        (SOURCE_ID_SUPPLY_CACHE, now - 10),
+        (SOURCE_ID_BACKEND_EVENTS, now - 40),
+        (SOURCE_ID_3POOL_SWAPS, now - 20),
+        (SOURCE_ID_3POOL_LIQUIDITY, now - 30),
+        (SOURCE_ID_3POOL_BLOCKS, now + 1),
+    ]);
+
+    let due = compute_due_sources(
+        now,
+        &schedule,
+        &[
+            SOURCE_ID_SUPPLY_CACHE,
+            SOURCE_ID_BACKEND_EVENTS,
+            SOURCE_ID_3POOL_SWAPS,
+            SOURCE_ID_3POOL_LIQUIDITY,
+            SOURCE_ID_3POOL_BLOCKS,
+        ],
+    );
+
+    assert_eq!(
+        due,
+        vec![SOURCE_ID_BACKEND_EVENTS, SOURCE_ID_3POOL_LIQUIDITY],
+        "a delayed walker must fire only the two oldest overdue deadlines"
+    );
+}
+
+#[test]
+fn dos_010_delayed_ticks_drain_overdue_sources_two_at_a_time_across_valid_configs() {
+    let configs = [
+        (MIN_PERIOD_SECS, MIN_TICK_SECS),
+        (MIN_PERIOD_SECS, 66),
+        (301, 66),
+        (MAX_PERIOD_SECS, MAX_TICK_SECS),
+    ];
+
+    for (period_secs, tick_secs) in configs {
+        validate_schedule_config(period_secs, tick_secs).unwrap();
+        let period_ns = period_secs * SEC_NANOS;
+        let tick_ns = tick_secs * SEC_NANOS;
+        let seeded = seed_initial_schedule(0, ALL_SOURCE_IDS, period_ns);
+        let delayed_now = period_ns;
+        let expected_order: Vec<u8> = {
+            let mut deadlines: Vec<(u64, u8)> =
+                ALL_SOURCE_IDS.iter().map(|id| (seeded[id], *id)).collect();
+            deadlines.sort_unstable();
+            deadlines.into_iter().map(|(_, id)| id).collect()
+        };
+        let mut schedule = seeded;
+        let mut now = delayed_now;
+        let mut drained = Vec::new();
+
+        for _ in 0..ALL_SOURCE_IDS.len().div_ceil(2) {
+            let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
+            assert!(
+                due.len() <= 2,
+                "period={period_secs}s tick={tick_secs}s returned {} overdue sources",
+                due.len()
+            );
+            drained.extend_from_slice(&due);
+            advance_schedule_for_fired(&mut schedule, now, &due, period_ns);
+            now = now.saturating_add(tick_ns);
+        }
+
+        assert_eq!(
+            drained, expected_order,
+            "period={period_secs}s tick={tick_secs}s must drain every overdue source oldest-first"
         );
     }
 }
@@ -338,15 +407,16 @@ fn dos_010_compute_due_sources_treats_missing_entry_as_due() {
     schedule.insert(SOURCE_ID_SUPPLY_CACHE, u64::MAX); // far future
     let now: u64 = 100 * SEC_NANOS;
     let due = compute_due_sources(now, &schedule, ALL_SOURCE_IDS);
-    // Only sources NOT in schedule should be due (everything except SOURCE_ID_SUPPLY_CACHE).
+    // Only sources NOT in schedule should be due (everything except
+    // SOURCE_ID_SUPPLY_CACHE), but the walker still returns a bounded batch.
     assert!(
         !due.contains(&SOURCE_ID_SUPPLY_CACHE),
         "source with future deadline must not be reported due"
     );
     assert_eq!(
-        due.len(),
-        ALL_SOURCE_IDS.len() - 1,
-        "every source except SUPPLY_CACHE has no schedule entry — all should be reported due"
+        due,
+        ALL_SOURCE_IDS[1..3],
+        "missing entries should be treated as oldest due work, capped at two"
     );
 }
 

--- a/src/rumi_analytics/tests/pocket_ic_analytics.rs
+++ b/src/rumi_analytics/tests/pocket_ic_analytics.rs
@@ -1,7 +1,7 @@
 //! PocketIC integration tests for rumi_analytics Phase 1.
 //!
 //! Covers four behaviours:
-//!   1. Supply cache populates after the 60s pull cycle.
+//!   1. Supply cache populates during the 300s staggered pull window.
 //!   2. Daily TVL row is written after the 86400s daily timer fires.
 //!   3. Pagination returns a continuation cursor when limit is reached.
 //!   4. Stable storage (TVL log + supply cache) survives an upgrade.
@@ -175,6 +175,15 @@ struct AnalyticsInitArgs {
     three_pool: Principal,
     stability_pool: Principal,
     amm: Principal,
+}
+
+#[derive(CandidType, Deserialize, Debug)]
+struct PullScheduleConfig {
+    period_secs: u64,
+    tick_secs: u64,
+    period_secs_override: Option<u64>,
+    tick_secs_override: Option<u64>,
+    schedule_layout_version: u32,
 }
 
 #[derive(CandidType, Deserialize)]
@@ -529,11 +538,44 @@ fn call_start_backfill(env: &Env, token: Principal) -> String {
     }
 }
 
-/// Advance time and tick enough for the 60s pull cycle to fire and inter-canister calls to settle.
+fn get_pull_schedule(env: &Env) -> PullScheduleConfig {
+    let result = env.pic.query_call(
+        env.analytics, env.admin, "get_pull_schedule", encode_one(()).unwrap(),
+    ).expect("get_pull_schedule query");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("get_pull_schedule rejected: {msg}"),
+    }
+}
+
+fn set_pull_schedule(
+    env: &Env,
+    caller: Principal,
+    period_secs: u64,
+    tick_secs: u64,
+) -> Result<(), String> {
+    let result = env.pic.update_call(
+        env.analytics, caller, "set_pull_schedule",
+        encode_args((period_secs, tick_secs)).unwrap(),
+    ).expect("set_pull_schedule update");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).unwrap(),
+        WasmResult::Reject(msg) => panic!("set_pull_schedule rejected: {msg}"),
+    }
+}
+
+const PULL_TICK_SECS: u64 = 30;
+const PULL_WINDOW_SECS: u64 = 300;
+
+/// Walk a complete staggered pull window in timer-sized steps. Advancing the
+/// whole 300s in one jump only runs one delayed timer callback in PocketIC;
+/// stepping by 30s proves later slots (including icUSD at source index 7) run.
 fn advance_pull_cycle(env: &Env) {
-    env.pic.advance_time(std::time::Duration::from_secs(65));
-    for _ in 0..10 {
-        env.pic.tick();
+    for _ in 0..(PULL_WINDOW_SECS / PULL_TICK_SECS) {
+        env.pic.advance_time(std::time::Duration::from_secs(PULL_TICK_SECS));
+        for _ in 0..5 {
+            env.pic.tick();
+        }
     }
 }
 
@@ -543,12 +585,9 @@ fn advance_pull_cycle(env: &Env) {
 fn supply_cache_populated_after_pull_cycle() {
     let env = setup();
 
-    // Drive the 60s pull cycle. A few extra ticks let async inter-canister
-    // calls (icrc1_total_supply, get_protocol_status) settle.
-    env.pic.advance_time(std::time::Duration::from_secs(65));
-    for _ in 0..5 {
-        env.pic.tick();
-    }
+    // Walk the full staggered window; extra ticks in the helper let async
+    // inter-canister calls (icrc1_total_supply, get_protocol_status) settle.
+    advance_pull_cycle(&env);
 
     let after = http_get(&env, "/api/supply");
     assert_eq!(after.status_code, 200, "expected /api/supply to return 200");
@@ -754,6 +793,42 @@ fn collector_health_reports_cursor_positions() {
     let icusd_stats = icusd_stats.unwrap();
     assert!(icusd_stats.holder_count > 0, "should have at least 1 icUSD holder from initial mint");
     assert!(icusd_stats.total_tracked_e8s > 0, "should have tracked icUSD supply");
+}
+
+#[test]
+fn pull_schedule_setter_enforces_auth_and_keeps_runtime_live_after_rearming() {
+    let env = setup();
+    let non_admin = Principal::self_authenticating(&[91, 92, 93]);
+
+    let initial = get_pull_schedule(&env);
+    assert_eq!(initial.period_secs, 300);
+    assert_eq!(initial.tick_secs, 30);
+    assert_eq!(initial.period_secs_override, None);
+    assert_eq!(initial.tick_secs_override, None);
+    assert_eq!(initial.schedule_layout_version, 2);
+
+    assert!(set_pull_schedule(&env, non_admin, 600, 60).is_err());
+    assert!(set_pull_schedule(&env, env.admin, 299, 30).is_err());
+
+    set_pull_schedule(&env, env.admin, 600, 60).unwrap();
+    let retuned = get_pull_schedule(&env);
+    assert_eq!(retuned.period_secs, 600);
+    assert_eq!(retuned.tick_secs, 60);
+    assert_eq!(retuned.period_secs_override, Some(600));
+    assert_eq!(retuned.tick_secs_override, Some(60));
+
+    // Re-arm a second time, then prove the replacement walker still reaches
+    // the late icUSD slot across a complete default window.
+    set_pull_schedule(&env, env.admin, 300, 30).unwrap();
+    advance_pull_cycle(&env);
+    let health = get_collector_health(&env);
+    assert!(health.last_pull_cycle_ns > 0);
+    assert!(
+        health.cursors.iter()
+            .find(|cursor| cursor.name == "icusd_blocks")
+            .is_some_and(|cursor| cursor.cursor_position > 0),
+        "re-armed walker must reach the icUSD cursor at source index 7"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- spread analytics source pulls across a configurable 300-second window with a bounded 30-second scheduler tick
- cap delayed catch-up batches so overdue work drains without recreating a burst
- persist cadence overrides and a schedule-layout version, with admin query/update endpoints and regenerated declarations
- extend scheduler, stable-state compatibility, and PocketIC regression coverage

## Upgrade and Candid safety

- legacy SlimState bytes decode with all new optional schedule fields defaulting to None
- current state round-trips with the new fields populated
- the layout-version transition re-spreads pre-existing deadlines once instead of clustering them after upgrade
- checked-in Candid and TypeScript/JavaScript declarations were regenerated and verified against the implemented interface

## Local verification

- analytics library tests: PASS
- scheduler and DOS-010 cadence regression tests: PASS
- targeted analytics PocketIC regression tests: PASS
- release wasm build and embedded Candid validation: PASS
- generated declaration drift check: PASS
- deterministic diff and scope checks: PASS

## Review

- implementation review: PASS
- adversarial verification review: PASS

No canister was deployed, upgraded, or reconfigured as part of this change.