### PR TITLE
fix: harden BOB sunset lifecycle

### DIFF
--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -11199,6 +11199,9 @@ fn get_collateral_totals() -> Vec<CollateralTotals> {
     read_state(|s| {
         s.collateral_configs
             .iter()
+            // Keep wind-down collateral observable until its last borrower has
+            // repaid, then remove it from the explorer's collateral surface.
+            .filter(|(ct, _)| !s.is_retired_sunset_collateral(ct))
             .map(|(ct, config)| {
                 let vault_count = s
                     .collateral_to_vault_ids

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -493,9 +493,7 @@ fn setup_timers() {
     });
     for ledger_id in non_icp_collaterals_immediate {
         ic_cdk_timers::set_timer(std::time::Duration::ZERO, move || {
-            ic_cdk::spawn(rumi_protocol_backend::management::fetch_collateral_price(
-                ledger_id,
-            ))
+            rumi_protocol_backend::xrc::spawn_collateral_price_fetch_if_needed(ledger_id)
         });
     }
 
@@ -513,9 +511,9 @@ fn setup_timers() {
     // Price timers for all non-ICP collateral types (timers don't survive upgrades,
     // so we re-register them here for any collateral added via add_collateral_token).
     // Wave-9d DOS-011: register through `xrc::register_collateral_price_timer` so
-    // each closure gates the XRC fetch on `CollateralStatus`. Wound-down collateral
-    // (Frozen / Sunset / Deprecated) keeps the timer alive but skips the ~1B-cycle
-    // XRC call until status flips back to Active or Paused.
+    // each closure gates the XRC fetch on lifecycle state. Frozen, Deprecated, and
+    // fully retired Sunset collateral keep their timers alive but skip the ~1B-cycle
+    // XRC call; an in-progress Sunset remains priced through final vault closure.
     let non_icp_collaterals: Vec<candid::Principal> = read_state(|s| {
         let icp = s.icp_collateral_type();
         s.collateral_configs
@@ -11199,8 +11197,8 @@ fn get_collateral_totals() -> Vec<CollateralTotals> {
     read_state(|s| {
         s.collateral_configs
             .iter()
-            // Keep wind-down collateral observable until its last borrower has
-            // repaid, then remove it from the explorer's collateral surface.
+            // Keep wind-down collateral observable until its final vault is
+            // closed, then remove it from the explorer's collateral surface.
             .filter(|(ct, _)| !s.is_retired_sunset_collateral(ct))
             .map(|(ct, config)| {
                 let vault_count = s

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3543,13 +3543,19 @@ impl State {
             Some(config) => {
                 matches!(config.status, CollateralStatus::Sunset)
                     && self.total_debt_for_collateral(collateral_type) == ICUSD::new(0)
+                    && self.total_collateral_for(collateral_type) == 0
+                    && !self
+                        .vault_id_to_vaults
+                        .values()
+                        .any(|vault| vault.collateral_type == *collateral_type)
             }
             None => false,
         }
     }
 
     /// Get all supported collateral types and their statuses.
-    /// A Sunset collateral remains public until its final debt is settled.
+    /// A Sunset collateral remains public until its final vault is closed, so
+    /// debt-free borrowers can still withdraw collateral and complete closure.
     pub fn supported_collateral_types(&self) -> Vec<(CollateralType, CollateralStatus)> {
         self.collateral_configs
             .iter()
@@ -5240,7 +5246,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sunset_collateral_is_public_until_its_last_debt_is_repaid() {
+    fn sunset_collateral_retires_only_after_its_last_vault_is_closed() {
         let mut state = test_state();
         let collateral = state.icp_collateral_type();
         state
@@ -5271,6 +5277,45 @@ mod tests {
             CollateralStatus::Sunset.allows_liquidation(),
             "sunset debt must remain liquidatable until it reaches zero"
         );
+
+        let vault = state.vault_id_to_vaults.get_mut(&999).unwrap();
+        vault.borrowed_icusd_amount = ICUSD::new(0);
+        assert!(
+            !state.is_retired_sunset_collateral(&collateral),
+            "a debt-free Sunset vault must remain public while collateral can be withdrawn"
+        );
+
+        state
+            .vault_id_to_vaults
+            .get_mut(&999)
+            .unwrap()
+            .collateral_amount = 0;
+        assert!(
+            !state.is_retired_sunset_collateral(&collateral),
+            "an empty but still-open Sunset vault must remain serviceable until close"
+        );
+
+        state.close_vault(999);
+        assert!(state.is_retired_sunset_collateral(&collateral));
+        assert!(
+            !state
+                .supported_collateral_types()
+                .iter()
+                .any(|(ct, _)| *ct == collateral),
+            "the fully closed Sunset collateral must leave public discovery"
+        );
+    }
+
+    #[test]
+    fn active_collateral_is_never_classified_as_retired() {
+        let state = test_state();
+        let collateral = state.icp_collateral_type();
+
+        assert_eq!(
+            state.collateral_configs.get(&collateral).unwrap().status,
+            CollateralStatus::Active
+        );
+        assert!(!state.is_retired_sunset_collateral(&collateral));
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -269,7 +269,9 @@ pub enum CollateralStatus {
     Paused,
     /// HARD STOP — nothing works except admin actions. Emergency brake.
     Frozen,
-    /// Winding down — repay and close only, no new activity
+    /// Winding down — no new vaults/borrows or collateral additions, while
+    /// repayment, withdrawal, closure, price-sensitive liquidation, and the
+    /// final debt settlement path remain available.
     Sunset,
     /// Fully wound down — read-only
     Deprecated,
@@ -318,9 +320,14 @@ impl CollateralStatus {
         )
     }
 
-    /// Whether liquidations are allowed
+    /// Whether liquidations are allowed. Sunset collateral must remain
+    /// liquidatable while its existing borrowers wind down; otherwise an
+    /// undercollateralized sunset vault could never clear its final debt.
     pub fn allows_liquidation(&self) -> bool {
-        matches!(self, CollateralStatus::Active | CollateralStatus::Paused)
+        matches!(
+            self,
+            CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset
+        )
     }
 
     /// Whether redemptions are allowed
@@ -3529,10 +3536,24 @@ impl State {
         }
     }
 
-    /// Get all supported collateral types and their statuses
+    /// Whether a wind-down collateral has fully settled and must no longer be
+    /// exposed as a public collateral option.
+    pub fn is_retired_sunset_collateral(&self, collateral_type: &CollateralType) -> bool {
+        match self.collateral_configs.get(collateral_type) {
+            Some(config) => {
+                matches!(config.status, CollateralStatus::Sunset)
+                    && self.total_debt_for_collateral(collateral_type) == ICUSD::new(0)
+            }
+            None => false,
+        }
+    }
+
+    /// Get all supported collateral types and their statuses.
+    /// A Sunset collateral remains public until its final debt is settled.
     pub fn supported_collateral_types(&self) -> Vec<(CollateralType, CollateralStatus)> {
         self.collateral_configs
             .iter()
+            .filter(|(ct, _)| !self.is_retired_sunset_collateral(ct))
             .map(|(ct, config)| (*ct, config.status))
             .collect()
     }
@@ -5217,6 +5238,40 @@ pub fn replace_state(state: State) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sunset_collateral_is_public_until_its_last_debt_is_repaid() {
+        let mut state = test_state();
+        let collateral = state.icp_collateral_type();
+        state
+            .collateral_configs
+            .get_mut(&collateral)
+            .unwrap()
+            .status = CollateralStatus::Sunset;
+
+        assert!(state.is_retired_sunset_collateral(&collateral));
+        assert!(
+            !state
+                .supported_collateral_types()
+                .iter()
+                .any(|(ct, _)| *ct == collateral),
+            "a debt-free Sunset collateral must not remain a public option"
+        );
+
+        state.open_vault(audit_vault(999, collateral, 100_000_000, 100_000_000));
+        assert!(!state.is_retired_sunset_collateral(&collateral));
+        assert!(
+            state
+                .supported_collateral_types()
+                .iter()
+                .any(|(ct, status)| *ct == collateral && *status == CollateralStatus::Sunset),
+            "a Sunset collateral stays public while borrowers still have debt to settle"
+        );
+        assert!(
+            CollateralStatus::Sunset.allows_liquidation(),
+            "sunset debt must remain liquidatable until it reaches zero"
+        );
+    }
 
     #[test]
     fn test_vault_health_score() {

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -108,14 +108,28 @@ pub fn collateral_needs_periodic_price_refresh(status: CollateralStatus) -> bool
 /// canister. Returns false for unknown collateral so a stale closure
 /// (collateral removed entirely from `collateral_configs`) doesn't keep
 /// hitting XRC for a deleted ledger.
-pub fn should_fetch_collateral_price(
-    state: &crate::state::State,
-    ledger_id: &Principal,
-) -> bool {
-    state
-        .get_collateral_status(ledger_id)
-        .map(collateral_needs_periodic_price_refresh)
-        .unwrap_or(false)
+pub fn should_fetch_collateral_price(state: &crate::state::State, ledger_id: &Principal) -> bool {
+    match state.get_collateral_status(ledger_id) {
+        Some(CollateralStatus::Sunset) => !state.is_retired_sunset_collateral(ledger_id),
+        Some(status) => collateral_needs_periodic_price_refresh(status),
+        None => false,
+    }
+}
+
+/// Spawn a collateral XRC fetch only while its lifecycle still consumes a
+/// price. Both immediate post-upgrade refreshes and recurring timers use this
+/// boundary so fully retired Sunset collateral cannot bypass the cycle gate.
+pub fn spawn_collateral_price_fetch_if_needed(ledger_id: Principal) {
+    let should_fetch = read_state(|state| should_fetch_collateral_price(state, &ledger_id));
+    if should_fetch {
+        ic_cdk::spawn(crate::management::fetch_collateral_price(ledger_id));
+    } else {
+        log!(
+            TRACE_XRC,
+            "[collateral_price_fetch] skipping {} (fully retired, disabled, or removed)",
+            ledger_id
+        );
+    }
 }
 
 thread_local! {
@@ -178,16 +192,7 @@ pub fn register_collateral_price_timer(ledger_id: Principal) {
     });
     let secs = read_state(|s| collateral_price_fetch_secs(s, &ledger_id));
     let new_id = ic_cdk_timers::set_timer_interval(Duration::from_secs(secs), move || {
-        let go = read_state(|s| should_fetch_collateral_price(s, &ledger_id));
-        if !go {
-            log!(
-                TRACE_XRC,
-                "[register_collateral_price_timer] skipping fetch for {} (wound-down or removed)",
-                ledger_id
-            );
-            return;
-        }
-        ic_cdk::spawn(crate::management::fetch_collateral_price(ledger_id));
+        spawn_collateral_price_fetch_if_needed(ledger_id);
     });
     COLLATERAL_PRICE_TIMER_IDS.with(|cell| {
         cell.borrow_mut().insert(ledger_id, new_id);
@@ -702,13 +707,42 @@ pub async fn ensure_stable_not_depegged(
 mod cycle_cadence_tests {
     use super::{
         collateral_needs_periodic_price_refresh, collateral_price_fetch_secs,
-        DEFAULT_COLLATERAL_PRICE_FETCH_SECS,
+        should_fetch_collateral_price, DEFAULT_COLLATERAL_PRICE_FETCH_SECS,
     };
     use crate::state::{CollateralStatus, State};
+    use crate::vault::Vault;
+    use crate::{InitArg, ICUSD};
     use candid::Principal;
 
     fn ckbtc() -> Principal {
         Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()
+    }
+
+    fn configured_state() -> State {
+        State::from(InitArg {
+            xrc_principal: Principal::anonymous(),
+            icusd_ledger_principal: Principal::anonymous(),
+            icp_ledger_principal: Principal::anonymous(),
+            fee_e8s: 0,
+            developer_principal: Principal::anonymous(),
+            treasury_principal: None,
+            stability_pool_principal: None,
+            ckusdt_ledger_principal: None,
+            ckusdc_ledger_principal: None,
+        })
+    }
+
+    fn vault(id: u64, collateral_type: Principal, collateral: u64, debt: u64) -> Vault {
+        Vault {
+            owner: Principal::anonymous(),
+            vault_id: id,
+            collateral_amount: collateral,
+            borrowed_icusd_amount: ICUSD::new(debt),
+            collateral_type,
+            last_accrual_time: 0,
+            accrued_interest: ICUSD::new(0),
+            bot_processing: false,
+        }
     }
 
     #[test]
@@ -745,9 +779,52 @@ mod cycle_cadence_tests {
     }
 
     #[test]
-    fn sunset_collateral_keeps_its_liquidation_price_fresh() {
+    fn sunset_price_refresh_tracks_true_retirement() {
+        let mut state = configured_state();
+        let collateral = state.icp_collateral_type();
+        state
+            .collateral_configs
+            .get_mut(&collateral)
+            .unwrap()
+            .status = CollateralStatus::Sunset;
+
+        assert!(
+            !should_fetch_collateral_price(&state, &collateral),
+            "fully retired Sunset collateral must stop burning XRC cycles"
+        );
+
+        state.open_vault(vault(999, collateral, 100_000_000, 100_000_000));
+        assert!(should_fetch_collateral_price(&state, &collateral));
+
+        let vault = state.vault_id_to_vaults.get_mut(&999).unwrap();
+        vault.borrowed_icusd_amount = ICUSD::new(0);
+        assert!(
+            should_fetch_collateral_price(&state, &collateral),
+            "debt-free Sunset vault still needs a fresh withdrawal/liquidation price"
+        );
+
+        state
+            .vault_id_to_vaults
+            .get_mut(&999)
+            .unwrap()
+            .collateral_amount = 0;
+        assert!(
+            should_fetch_collateral_price(&state, &collateral),
+            "an open Sunset vault remains in wind-down until close"
+        );
+
+        state.close_vault(999);
+        assert!(!should_fetch_collateral_price(&state, &collateral));
+    }
+
+    #[test]
+    fn active_collateral_refresh_behavior_is_unchanged() {
+        let state = configured_state();
+        let collateral = state.icp_collateral_type();
+
         assert!(collateral_needs_periodic_price_refresh(
-            CollateralStatus::Sunset
+            CollateralStatus::Active
         ));
+        assert!(should_fetch_collateral_price(&state, &collateral));
     }
 }

--- a/src/rumi_protocol_backend/src/xrc.rs
+++ b/src/rumi_protocol_backend/src/xrc.rs
@@ -86,22 +86,17 @@ pub fn note_xrc_success(state: &mut State) {
 
 /// Wave-9d DOS-011: classifies whether a collateral type's periodic
 /// background XRC price refresh is still useful given its lifecycle
-/// status. Returns true for `Active` and `Paused` (both still allow
-/// price-sensitive operations such as liquidation), false for the soft-
-/// delist statuses (`Frozen`, `Sunset`, `Deprecated`) where every code
-/// path that would consume a fresh price is already blocked or read-
-/// only.
+/// status. Returns true for `Active`, `Paused`, and `Sunset`: all three can
+/// still liquidate outstanding debt and therefore require a current price.
+/// `Frozen` and `Deprecated` have no remaining price-consuming operation.
 ///
 /// Used by the per-collateral 300s timer closures registered in
-/// `setup_timers()` and `add_collateral_token` so that wound-down
-/// collateral no longer burns ~1B cycles per tick on a useless XRC
-/// call.
+/// `setup_timers()` and `add_collateral_token` so fully disabled collateral
+/// no longer burns ~1B cycles per tick on a useless XRC call.
 pub fn collateral_needs_periodic_price_refresh(status: CollateralStatus) -> bool {
     match status {
-        CollateralStatus::Active | CollateralStatus::Paused => true,
-        CollateralStatus::Frozen
-        | CollateralStatus::Sunset
-        | CollateralStatus::Deprecated => false,
+        CollateralStatus::Active | CollateralStatus::Paused | CollateralStatus::Sunset => true,
+        CollateralStatus::Frozen | CollateralStatus::Deprecated => false,
     }
 }
 
@@ -705,8 +700,11 @@ pub async fn ensure_stable_not_depegged(
 
 #[cfg(test)]
 mod cycle_cadence_tests {
-    use super::{collateral_price_fetch_secs, DEFAULT_COLLATERAL_PRICE_FETCH_SECS};
-    use crate::state::State;
+    use super::{
+        collateral_needs_periodic_price_refresh, collateral_price_fetch_secs,
+        DEFAULT_COLLATERAL_PRICE_FETCH_SECS,
+    };
+    use crate::state::{CollateralStatus, State};
     use candid::Principal;
 
     fn ckbtc() -> Principal {
@@ -744,5 +742,12 @@ mod cycle_cadence_tests {
         // Any other sub-60 value is floored to 60s.
         s.collateral_price_fetch_interval_secs.insert(ckbtc(), 5);
         assert_eq!(collateral_price_fetch_secs(&s, &ckbtc()), 60);
+    }
+
+    #[test]
+    fn sunset_collateral_keeps_its_liquidation_price_fresh() {
+        assert!(collateral_needs_periodic_price_refresh(
+            CollateralStatus::Sunset
+        ));
     }
 }

--- a/src/rumi_protocol_backend/tests/audit_pocs_dos_011_xrc_timer_lifecycle.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_dos_011_xrc_timer_lifecycle.rs
@@ -15,10 +15,9 @@
 //! permanent `set_timer_interval` that fires every 300s and burns
 //! ~1B cycles per call to XRC, regardless of whether the collateral is
 //! still actively being used. CollateralStatus has 5 lifecycle states
-//! (Active / Paused / Frozen / Sunset / Deprecated), but only Active
-//! and Paused require ongoing price updates: Frozen, Sunset, and
-//! Deprecated either block all operations or are read-only winding-
-//! down states where a fresh price doesn't change anything.
+//! (Active / Paused / Frozen / Sunset / Deprecated). Active and Paused
+//! require ongoing price updates, while Sunset requires them only until
+//! its final vault is closed. Frozen and Deprecated do not consume prices.
 //!
 //! # Why the status-check approach (not the cancel-path approach)
 //!
@@ -32,31 +31,32 @@
 //!    collateral, each closure capturing the ledger principal. Adding a
 //!    one-line `read_state` gate at the top of the closure costs ~3
 //!    instructions vs. the ~1B cycles of the XRC call we skip.
-//!  * Reactivation works automatically: when status flips from Sunset
-//!    back to Active (admin call), the very next 300s tick resumes
-//!    fetching with no timer re-registration needed.
-//!  * Same outcome as cancel-path: Frozen/Sunset/Deprecated collateral
-//!    no longer burns cycles on background XRC fetches.
+//!  * Reactivation works automatically: when status flips back to Active
+//!    (admin call), the very next 300s tick resumes fetching with no timer
+//!    re-registration needed.
+//!  * Same outcome as cancel-path: Frozen, Deprecated, and fully retired
+//!    Sunset collateral no longer burn cycles on background XRC fetches.
 //!
 //! Layered fences:
 //!
 //!  1. **Pure-function fence** —
 //!     `collateral_needs_periodic_price_refresh(status)` returns true
-//!     only for Active and Paused. Paused still allows liquidations
-//!     (per `CollateralStatus::allows_liquidation`), so we still want
-//!     fresh prices.
+//!     for Active, Paused, and Sunset. The state-aware gate additionally
+//!     suppresses fully retired Sunset collateral.
 //!  2. **Status-coverage fence** — every variant of CollateralStatus
 //!     must appear in the helper's match (compile fails otherwise).
 //!  3. **Active-state-needs-price** — the helper must return true for
 //!     statuses where any price-sensitive operation can still happen.
 //!  4. **Soft-delist-skips-fetch** — the helper must return false for
-//!     Frozen, Sunset, Deprecated.
+//!     Frozen and Deprecated; the state-aware gate handles Sunset retirement.
 //!  5. **Round-trip on status flip** — flipping status flips the
 //!     helper's answer immediately (no cached / stale answer).
 
 use candid::Principal;
 
+use rumi_protocol_backend::numeric::ICUSD;
 use rumi_protocol_backend::state::{CollateralStatus, State};
+use rumi_protocol_backend::vault::Vault;
 use rumi_protocol_backend::xrc::{
     collateral_needs_periodic_price_refresh, should_fetch_collateral_price,
 };
@@ -92,6 +92,19 @@ fn set_status(state: &mut State, ct: Principal, status: CollateralStatus) {
     }
 }
 
+fn open_sunset_vault(state: &mut State, ct: Principal) {
+    state.open_vault(Vault {
+        owner: Principal::anonymous(),
+        vault_id: 1,
+        collateral_amount: 100_000_000,
+        borrowed_icusd_amount: ICUSD::new(100_000_000),
+        collateral_type: ct,
+        last_accrual_time: 0,
+        accrued_interest: ICUSD::new(0),
+        bot_processing: false,
+    });
+}
+
 // ============================================================================
 // Layer 1 — pure-function fence
 // ============================================================================
@@ -120,7 +133,7 @@ fn dos_011_paused_collateral_needs_price() {
 }
 
 // ============================================================================
-// Layer 2 — soft-delist statuses skip fetch
+// Layer 2 — lifecycle status classification
 // ============================================================================
 
 #[test]
@@ -133,11 +146,11 @@ fn dos_011_frozen_collateral_skips_price() {
 }
 
 #[test]
-fn dos_011_sunset_collateral_skips_price() {
+fn dos_011_sunset_collateral_needs_price_until_retirement() {
     assert!(
-        !collateral_needs_periodic_price_refresh(CollateralStatus::Sunset),
-        "Sunset collateral allows only repay/withdraw/close — no \
-         price-sensitive operations. Background fetches are unnecessary."
+        collateral_needs_periodic_price_refresh(CollateralStatus::Sunset),
+        "Sunset collateral remains liquidatable during wind-down and must \
+         retain fresh prices until its final vault closes."
     );
 }
 
@@ -185,12 +198,39 @@ fn dos_011_state_gate_returns_true_for_active_collateral() {
 }
 
 #[test]
-fn dos_011_state_gate_returns_false_for_sunset_collateral() {
+fn dos_011_state_gate_tracks_sunset_retirement() {
     let mut state = fresh_state();
     set_status(&mut state, icp_ledger(), CollateralStatus::Sunset);
     assert!(
         !should_fetch_collateral_price(&state, &icp_ledger()),
-        "sunset collateral must be skipped"
+        "fully retired Sunset collateral must be skipped"
+    );
+
+    open_sunset_vault(&mut state, icp_ledger());
+    assert!(
+        should_fetch_collateral_price(&state, &icp_ledger()),
+        "Sunset collateral with an open vault must keep its price fresh"
+    );
+
+    state
+        .vault_id_to_vaults
+        .get_mut(&1)
+        .unwrap()
+        .borrowed_icusd_amount = ICUSD::new(0);
+    assert!(
+        should_fetch_collateral_price(&state, &icp_ledger()),
+        "a debt-free Sunset vault remains serviceable until withdrawal and close"
+    );
+
+    state
+        .vault_id_to_vaults
+        .get_mut(&1)
+        .unwrap()
+        .collateral_amount = 0;
+    state.close_vault(1);
+    assert!(
+        !should_fetch_collateral_price(&state, &icp_ledger()),
+        "Sunset refresh must stop after the final vault closes"
     );
 }
 
@@ -246,15 +286,35 @@ fn dos_011_every_status_variant_classified() {
         }
     }
     assert_eq!(
-        needs, 2,
-        "exactly 2 statuses (Active, Paused) must need periodic price \
+        needs, 3,
+        "exactly 3 statuses (Active, Paused, Sunset) must need periodic price \
          refresh — got {} needs / {} skips",
         needs, skips
     );
     assert_eq!(
-        skips, 3,
-        "exactly 3 statuses (Frozen, Sunset, Deprecated) must skip the \
+        skips, 2,
+        "exactly 2 statuses (Frozen, Deprecated) must skip the \
          periodic refresh — got {} needs / {} skips",
         needs, skips
+    );
+}
+
+#[test]
+fn dos_011_setup_immediate_fetch_uses_the_same_lifecycle_gate() {
+    let main_source = include_str!("../src/main.rs");
+    let setup_start = main_source.find("fn setup_timers()").unwrap();
+    let cadence_start = main_source[setup_start..]
+        .find("// ── Wave-14b CDP-12")
+        .map(|offset| setup_start + offset)
+        .unwrap();
+    let immediate_setup = &main_source[setup_start..cadence_start];
+
+    assert!(
+        immediate_setup.contains("spawn_collateral_price_fetch_if_needed"),
+        "setup_timers immediate non-ICP fetch must share the retirement gate"
+    );
+    assert!(
+        !immediate_setup.contains("management::fetch_collateral_price"),
+        "setup_timers must not bypass the lifecycle gate with a direct fetch"
     );
 }

--- a/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
+++ b/src/rumi_protocol_backend/tests/pocket_ic_tests.rs
@@ -1511,8 +1511,8 @@ fn test_add_margin_to_vault() {
 //    inflating get_collateral_totals().vault_count (mainnet: 185 indexed ids
 //    vs 82 open vaults).
 #[test]
-fn test_close_vault() {
-    log("🧪 TEST STARTING: test_close_vault");
+fn test_sunset_debt_free_vault_withdraws_and_closes() {
+    log("🧪 TEST STARTING: test_sunset_debt_free_vault_withdraws_and_closes");
     
     // Set up the test environment
     log("🛠️ Setting up test environment");
@@ -1597,6 +1597,30 @@ fn test_close_vault() {
     // Step 6: Verify vault has no debt
     let vault_after_repay = get_vault(&pic, protocol_id, test_user, vault_id);
     assert_eq!(vault_after_repay.borrowed_icusd_amount, 0, "Vault should have no debt after full repayment");
+
+    // Enter wind-down only after the vault is debt-free. The borrower must
+    // still see the collateral and be able to withdraw and close it.
+    set_collateral_status_helper(&pic, protocol_id, icp_ledger_id, CollateralStatus::Sunset)
+        .expect("Failed to sunset ICP");
+    let supported_before_close: Vec<(Principal, CollateralStatus)> = match pic
+        .query_call(
+            protocol_id,
+            Principal::anonymous(),
+            "get_supported_collateral_types",
+            encode_args(()).unwrap(),
+        )
+        .expect("Failed to query supported collateral before close")
+    {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode supported collateral"),
+        WasmResult::Reject(msg) => panic!("supported collateral query rejected: {}", msg),
+    };
+    assert!(
+        supported_before_close
+            .iter()
+            .any(|(principal, status)| *principal == icp_ledger_id
+                && *status == CollateralStatus::Sunset),
+        "debt-free Sunset collateral must stay discoverable while its vault remains open",
+    );
 
     // Step 6.5: Withdraw all collateral — close_vault requires an empty vault
     log("💸 Withdrawing all collateral before close");
@@ -1716,7 +1740,26 @@ fn test_close_vault() {
         "collateral_to_vault_ids must not retain ids for closed vaults",
     );
 
-    log("🎉 TEST PASSED: test_close_vault");
+    let supported_after_close: Vec<(Principal, CollateralStatus)> = match pic
+        .query_call(
+            protocol_id,
+            Principal::anonymous(),
+            "get_supported_collateral_types",
+            encode_args(()).unwrap(),
+        )
+        .expect("Failed to query supported collateral after close")
+    {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode supported collateral"),
+        WasmResult::Reject(msg) => panic!("supported collateral query rejected: {}", msg),
+    };
+    assert!(
+        supported_after_close
+            .iter()
+            .all(|(principal, _)| *principal != icp_ledger_id),
+        "fully closed Sunset collateral must retire from discovery",
+    );
+
+    log("🎉 TEST PASSED: test_sunset_debt_free_vault_withdraws_and_closes");
 }
 
 // Test for redeeming ICP (burning ICUSD to get ICP)

--- a/src/rumi_protocol_backend/tests/tests.rs
+++ b/src/rumi_protocol_backend/tests/tests.rs
@@ -1504,11 +1504,14 @@ mod multi_collateral_tests {
         assert!(!CollateralStatus::Frozen.allows_liquidation());
         assert!(!CollateralStatus::Frozen.allows_redemption());
 
-        // Sunset: repay only (and close)
+        // Sunset: no new exposure, but existing vaults can repay, withdraw,
+        // close, and be liquidated during wind-down.
         assert!(!CollateralStatus::Sunset.allows_open());
         assert!(!CollateralStatus::Sunset.allows_borrow());
         assert!(CollateralStatus::Sunset.allows_repay());
-        assert!(!CollateralStatus::Sunset.allows_liquidation());
+        assert!(CollateralStatus::Sunset.allows_withdraw());
+        assert!(CollateralStatus::Sunset.allows_close());
+        assert!(CollateralStatus::Sunset.allows_liquidation());
         assert!(!CollateralStatus::Sunset.allows_redemption());
 
         // Deprecated: nothing

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1032,6 +1032,14 @@ impl StabilityPoolState {
         user: &Principal,
         collateral_type: Principal,
     ) -> Result<(), StabilityPoolError> {
+        // BOB is in wind-down. Existing receiving positions may leave through
+        // `opt_out_collateral`, but neither a new nor former participant may
+        // create fresh BOB liquidation exposure.
+        if collateral_type == bob_collateral() {
+            return Err(StabilityPoolError::TokenNotActive {
+                ledger: collateral_type,
+            });
+        }
         if self.collateral_requires_payout_address(&collateral_type) {
             return Err(StabilityPoolError::PayoutAddressRequired {
                 collateral: collateral_type,
@@ -3269,6 +3277,38 @@ mod tests {
             .opt_in_collateral(&user_a(), icp_ledger())
             .unwrap_err();
         assert!(matches!(err, StabilityPoolError::AlreadyOptedIn { .. }));
+    }
+
+    #[test]
+    fn legacy_bob_participant_can_exit_but_cannot_reenter() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+        let bob = crate::types::bob_collateral();
+
+        state
+            .deposits
+            .get_mut(&user_a())
+            .unwrap()
+            .opted_out_collateral
+            .remove(&bob);
+        assert_eq!(state.effective_pool_for_collateral(&bob), 10_00000000);
+
+        state.opt_out_collateral(&user_a(), bob).unwrap();
+        assert_eq!(state.effective_pool_for_collateral(&bob), 0);
+
+        let err = state.opt_in_collateral(&user_a(), bob).unwrap_err();
+        assert!(matches!(err, StabilityPoolError::TokenNotActive { ledger } if ledger == bob));
+    }
+
+    #[test]
+    fn non_bob_collateral_opt_out_and_reentry_are_unchanged() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+
+        state.opt_out_collateral(&user_a(), icp_ledger()).unwrap();
+        state.opt_in_collateral(&user_a(), icp_ledger()).unwrap();
+
+        assert!(state.deposits[&user_a()].is_opted_in(&icp_ledger()));
     }
 
     #[test]

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -97,10 +97,15 @@ pub struct DepositPosition {
 
 impl DepositPosition {
     pub fn new(timestamp: u64) -> Self {
+        // BOB is being sunset. Existing depositors retain their explicit
+        // choices, but every position created after the sunset is excluded from
+        // BOB liquidations unless the depositor deliberately opts back in.
+        let bob_collateral = Principal::from_text("7pail-xaaaa-aaaas-aabmq-cai")
+            .expect("BOB collateral principal is a valid principal");
         Self {
             stablecoin_balances: BTreeMap::new(),
             collateral_gains: BTreeMap::new(),
-            opted_out_collateral: BTreeSet::new(),
+            opted_out_collateral: BTreeSet::from([bob_collateral]),
             opted_in_chain_collateral: Some(BTreeSet::new()),
             deposit_timestamp: timestamp,
             total_claimed_gains: BTreeMap::new(),
@@ -933,6 +938,15 @@ mod icusd_value_tests {
             v, 100_00_000_000,
             "should return only the icUSD balance in e8s"
         );
+    }
+
+    #[test]
+    fn new_depositor_is_opted_out_of_sunset_bob_liquidations() {
+        let bob = Principal::from_text("7pail-xaaaa-aaaas-aabmq-cai").unwrap();
+        let position = DepositPosition::new(0);
+
+        assert!(position.opted_out_collateral.contains(&bob));
+        assert!(!position.is_opted_in(&bob));
     }
 
     #[test]

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -2,6 +2,13 @@ use candid::{CandidType, Deserialize, Nat, Principal};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 
+pub const BOB_COLLATERAL_PRINCIPAL: &str = "7pail-xaaaa-aaaas-aabmq-cai";
+
+pub fn bob_collateral() -> Principal {
+    Principal::from_text(BOB_COLLATERAL_PRINCIPAL)
+        .expect("BOB collateral principal is a valid principal")
+}
+
 // ──────────────────────────────────────────────────────────────
 // Registry types (dynamic, admin-configurable)
 // ──────────────────────────────────────────────────────────────
@@ -97,15 +104,12 @@ pub struct DepositPosition {
 
 impl DepositPosition {
     pub fn new(timestamp: u64) -> Self {
-        // BOB is being sunset. Existing depositors retain their explicit
-        // choices, but every position created after the sunset is excluded from
-        // BOB liquidations unless the depositor deliberately opts back in.
-        let bob_collateral = Principal::from_text("7pail-xaaaa-aaaas-aabmq-cai")
-            .expect("BOB collateral principal is a valid principal");
+        // BOB is being sunset. Existing depositors retain their current
+        // exposure until they opt out, while every new position is default-out.
         Self {
             stablecoin_balances: BTreeMap::new(),
             collateral_gains: BTreeMap::new(),
-            opted_out_collateral: BTreeSet::from([bob_collateral]),
+            opted_out_collateral: BTreeSet::from([bob_collateral()]),
             opted_in_chain_collateral: Some(BTreeSet::new()),
             deposit_timestamp: timestamp,
             total_claimed_gains: BTreeMap::new(),
@@ -942,7 +946,7 @@ mod icusd_value_tests {
 
     #[test]
     fn new_depositor_is_opted_out_of_sunset_bob_liquidations() {
-        let bob = Principal::from_text("7pail-xaaaa-aaaas-aabmq-cai").unwrap();
+        let bob = bob_collateral();
         let position = DepositPosition::new(0);
 
         assert!(position.opted_out_collateral.contains(&bob));

--- a/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.spec.ts
+++ b/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.spec.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(__dirname, 'SpCoverageCard.svelte'), 'utf8');
+
+describe('SpCoverageCard query degradation', () => {
+	it('renders query failure before the genuine-empty state', () => {
+		expect(source).toContain('fetchCurrentSpDepositorsStrict');
+		expect(source).toContain('fetchCollateralConfigsStrict');
+		expect(source).toContain("loadIssue = 'Collateral coverage is temporarily unavailable.'");
+		expect(source.indexOf('{:else if loadIssue}')).toBeGreaterThan(-1);
+		expect(source.indexOf('{:else if loadIssue}')).toBeLessThan(
+			source.indexOf('{:else if rows.length === 0}')
+		);
+	});
+});

--- a/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/SpCoverageCard.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { fetchCurrentSpDepositors, fetchCollateralConfigs, type CurrentSpDepositor } from '$services/explorer/explorerService';
+  import { fetchCurrentSpDepositorsStrict, fetchCollateralConfigsStrict, type CurrentSpDepositor } from '$services/explorer/explorerService';
   import { getTokenSymbol } from '$utils/explorerHelpers';
 
   let depositors: CurrentSpDepositor[] = $state([]);
   let collaterals: string[] = $state([]); // principal text
   let loading = $state(true);
+  let loadIssue: string | null = $state(null);
 
   function isOptedIn(d: CurrentSpDepositor, collType: string): boolean {
     return !d.position.opted_out_collateral.some((p) => p.toText() === collType);
@@ -27,8 +28,8 @@
   onMount(async () => {
     try {
       const [d, configs] = await Promise.all([
-        fetchCurrentSpDepositors(),
-        fetchCollateralConfigs(),
+        fetchCurrentSpDepositorsStrict(),
+        fetchCollateralConfigsStrict(),
       ]);
       depositors = d;
       // CollateralConfig uses ledger_canister_id as the collateral identifier.
@@ -37,6 +38,7 @@
         .filter((id: string) => id.length > 0);
     } catch (err) {
       console.error('[SpCoverageCard] load failed:', err);
+      loadIssue = 'Collateral coverage is temporarily unavailable.';
     } finally {
       loading = false;
     }
@@ -52,6 +54,8 @@
     <div class="flex items-center justify-center py-6">
       <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
     </div>
+  {:else if loadIssue}
+    <p class="text-sm text-amber-200 py-2" role="status">{loadIssue} Retry shortly.</p>
   {:else if rows.length === 0}
     <p class="text-sm text-gray-500 py-2">No collaterals configured.</p>
   {:else}

--- a/src/vault_frontend/src/lib/components/explorer/collateralQueryState.spec.ts
+++ b/src/vault_frontend/src/lib/components/explorer/collateralQueryState.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { collateralQueryIssue } from './collateralQueryState';
+
+describe('collateral explorer query degradation', () => {
+	it('reports config failure without calling it an empty protocol', () => {
+		expect(
+			collateralQueryIssue(
+				{ status: 'rejected', reason: new Error('config unavailable') },
+				{ status: 'fulfilled', value: [{ collateral_type: 'ICP' }] },
+				{ status: 'fulfilled', value: [] }
+			)
+		).toContain('configuration');
+	});
+
+	it('reports totals failure without calling it an empty protocol', () => {
+		expect(
+			collateralQueryIssue(
+				{ status: 'fulfilled', value: [{ ledger_canister_id: 'ICP' }] },
+				{ status: 'rejected', reason: new Error('totals unavailable') },
+				{ status: 'fulfilled', value: [] }
+			)
+		).toContain('totals');
+	});
+
+	it('reports when both collateral queries fail', () => {
+		expect(
+			collateralQueryIssue(
+				{ status: 'rejected', reason: new Error('config unavailable') },
+				{ status: 'rejected', reason: new Error('totals unavailable') },
+				{ status: 'fulfilled', value: [] }
+			)
+		).toContain('configuration');
+		expect(
+			collateralQueryIssue(
+				{ status: 'rejected', reason: new Error('config unavailable') },
+				{ status: 'rejected', reason: new Error('totals unavailable') },
+				{ status: 'fulfilled', value: [] }
+			)
+		).toContain('totals');
+	});
+
+	it('reports vault enumeration failure instead of treating risk data as empty', () => {
+		expect(
+			collateralQueryIssue(
+				{ status: 'fulfilled', value: [] },
+				{ status: 'fulfilled', value: [] },
+				{ status: 'rejected', reason: new Error('vaults unavailable') }
+			)
+		).toContain('vault enumeration');
+	});
+
+	it('accepts a genuinely empty successful response', () => {
+		expect(
+			collateralQueryIssue(
+				{ status: 'fulfilled', value: [] },
+				{ status: 'fulfilled', value: [] },
+				{ status: 'fulfilled', value: [] }
+			)
+		).toBeNull();
+	});
+});

--- a/src/vault_frontend/src/lib/components/explorer/collateralQueryState.ts
+++ b/src/vault_frontend/src/lib/components/explorer/collateralQueryState.ts
@@ -1,0 +1,15 @@
+export function collateralQueryIssue(
+	configs: PromiseSettledResult<unknown[]>,
+	totals: PromiseSettledResult<unknown[]>,
+	vaults: PromiseSettledResult<unknown[]>
+): string | null {
+	const unavailable: string[] = [];
+	if (configs.status === 'rejected') unavailable.push('collateral configuration');
+	if (totals.status === 'rejected') unavailable.push('collateral totals');
+	if (vaults.status === 'rejected') unavailable.push('vault enumeration');
+	if (unavailable.length === 0) return null;
+
+	const last = unavailable.pop();
+	const subject = unavailable.length > 0 ? `${unavailable.join(', ')} and ${last}` : last;
+	return `${subject} ${unavailable.length > 0 ? 'are' : 'is'} temporarily unavailable.`;
+}

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.spec.ts
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.spec.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(__dirname, 'CollateralLens.svelte'), 'utf8');
+
+describe('CollateralLens strict query degradation', () => {
+	it('uses strict reads only on this truth-sensitive surface', () => {
+		expect(source).toContain('fetchCollateralConfigsStrict');
+		expect(source).toContain('fetchCollateralTotalsStrict');
+		expect(source).toContain('fetchAllVaultsStrict');
+	});
+
+	it('suppresses health and CR empty claims when collateral data is degraded', () => {
+		const issueBranch = source.indexOf('{#if collateralDataIssue}');
+		const healthStrip = source.indexOf('<LensHealthStrip');
+		const crPanel = source.indexOf('>CR distribution<');
+		const crIssueBranch = source.indexOf('{:else if collateralDataIssue}', crPanel);
+		const noVaults = source.indexOf('No active vaults.');
+
+		expect(issueBranch).toBeGreaterThan(-1);
+		expect(healthStrip).toBeGreaterThan(issueBranch);
+		expect(crIssueBranch).toBeGreaterThan(crPanel);
+		expect(noVaults).toBeGreaterThan(crIssueBranch);
+	});
+
+	it('suppresses the activity panel when collateral data is degraded', () => {
+		const activityPanel = source.lastIndexOf('<LensActivityPanel');
+		const activityIssueBranch = source.lastIndexOf('{#if collateralDataIssue}', activityPanel);
+		const unavailable = source.indexOf('Vault activity is temporarily unavailable.', activityIssueBranch);
+
+		expect(activityIssueBranch).toBeGreaterThan(-1);
+		expect(unavailable).toBeGreaterThan(activityIssueBranch);
+		expect(activityPanel).toBeGreaterThan(unavailable);
+	});
+});

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -157,6 +157,10 @@
       for (const [principal, symbol] of Object.entries(COLLATERAL_SYMBOLS)) {
         const cfg = configMap.get(principal);
         const tot = totalsMap.get(principal);
+        // A fully repaid Sunset collateral is withheld by the backend from
+        // both public collateral queries. Do not recreate a zero row from the
+        // explorer's static chart palette after that retirement point.
+        if (!cfg || !tot) continue;
         const decimals = tot?.decimals != null ? Number(tot.decimals) : 8;
         const price = priceMap.get(principal) ?? (tot?.price ? Number(tot.price) : 0);
         const totalColl = tot?.total_collateral != null ? Number(tot.total_collateral) / Math.pow(10, decimals) : 0;

--- a/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/lenses/CollateralLens.svelte
@@ -9,7 +9,7 @@
     fetchProtocolSummary, fetchTwap, fetchVolatility, fetchLiquidationSeries,
   } from '$services/explorer/analyticsService';
   import {
-    fetchCollateralConfigs, fetchCollateralTotals, fetchAllVaults,
+    fetchCollateralConfigsStrict, fetchCollateralTotalsStrict, fetchAllVaultsStrict,
   } from '$services/explorer/explorerService';
   import {
     e8sToNumber, formatCompact, bpsToPercent, COLLATERAL_SYMBOLS, COLLATERAL_COLORS,
@@ -17,6 +17,7 @@
   import { computeVaultCrPct, median } from '$utils/vaultCr';
   import { decodeRustDecimal } from '$utils/decimalUtils';
   import { COLLATERAL_DISPLAY_ORDER } from '$stores/collateralStore';
+  import { collateralQueryIssue } from '../collateralQueryState';
 
   let medianCrBps = $state(0);
   let loading = $state(true);
@@ -29,6 +30,7 @@
   let crBuckets: CrBucket[] = $state([]);
 
   let mixTotal = $state(0);
+  let collateralDataIssue = $state<string | null>(null);
 
   onMount(async () => {
     try {
@@ -38,15 +40,16 @@
       ] = await Promise.allSettled([
         fetchProtocolSummary(),
         fetchTwap(),
-        fetchCollateralConfigs(),
-        fetchCollateralTotals(),
-        fetchAllVaults(),
+        fetchCollateralConfigsStrict(),
+        fetchCollateralTotalsStrict(),
+        fetchAllVaultsStrict(),
         fetchLiquidationSeries(7),
         ...principals.map(p => fetchVolatility(Principal.fromText(p))),
       ]);
 
       const summary = summaryR.status === 'fulfilled' ? summaryR.value : null;
       medianCrBps = summary?.median_cr_bps ? Number(summary.median_cr_bps) : 0;
+      collateralDataIssue = collateralQueryIssue(configsR, totalsR, allVaultsR);
 
       const configs = configsR.status === 'fulfilled' ? configsR.value ?? [] : [];
       const totals = totalsR.status === 'fulfilled' ? totalsR.value ?? [] : [];
@@ -222,7 +225,13 @@
   const maxBucket = $derived(Math.max(1, ...crBuckets.map(b => b.count)));
 </script>
 
-<LensHealthStrip title="Collateral health" metrics={healthMetrics} loading={loading} />
+{#if collateralDataIssue}
+  <div class="explorer-card mb-3 border-amber-500/30 text-sm text-amber-200" role="status">
+    {collateralDataIssue} Displayed collateral data may be incomplete; retry shortly.
+  </div>
+{:else}
+  <LensHealthStrip title="Collateral health" metrics={healthMetrics} loading={loading} />
+{/if}
 
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
   <!-- Collateral mix -->
@@ -232,6 +241,8 @@
       <div class="flex items-center justify-center py-8">
         <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
       </div>
+    {:else if collateralDataIssue}
+      <p class="text-sm text-amber-200 py-4">Collateral mix is temporarily unavailable.</p>
     {:else if mixTotal === 0}
       <p class="text-sm text-gray-500 py-4">No collateral deposited.</p>
     {:else}
@@ -272,6 +283,8 @@
       <div class="flex items-center justify-center py-8">
         <div class="w-5 h-5 border-2 border-gray-600 border-t-teal-400 rounded-full animate-spin"></div>
       </div>
+    {:else if collateralDataIssue}
+      <p class="text-sm text-amber-200 py-4">CR distribution is temporarily unavailable.</p>
     {:else if allVaults.length === 0}
       <p class="text-sm text-gray-500 py-4">No active vaults.</p>
     {:else}
@@ -299,12 +312,24 @@
   </div>
 </div>
 
-<CollateralTable rows={collateralRows} loading={loading} />
+{#if collateralDataIssue}
+  <div class="explorer-card text-sm text-amber-200">Collateral table is temporarily unavailable.</div>
+{:else}
+  <CollateralTable rows={collateralRows} loading={loading} />
+{/if}
 
-<LiquidationRiskTable
-  vaults={atRiskVaults}
-  totalAtRisk={atRiskVaults.length}
-  loading={loading}
-/>
+{#if collateralDataIssue}
+  <div class="explorer-card text-sm text-amber-200">Liquidation risk data is temporarily unavailable.</div>
+{:else}
+  <LiquidationRiskTable
+    vaults={atRiskVaults}
+    totalAtRisk={atRiskVaults.length}
+    loading={loading}
+  />
+{/if}
 
-<LensActivityPanel scope="vault_ops" title="Vault activity" viewAllHref="/explorer/activity?type=vault_ops" />
+{#if collateralDataIssue}
+  <div class="explorer-card text-sm text-amber-200">Vault activity is temporarily unavailable.</div>
+{:else}
+  <LensActivityPanel scope="vault_ops" title="Vault activity" viewAllHref="/explorer/activity?type=vault_ops" />
+{/if}

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -14,6 +14,11 @@
   import { CANISTER_IDS } from '../../config';
   import XrpPayoutRouting from './XrpPayoutRouting.svelte';
   import { isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
+  import {
+    gainCollaterals,
+    isSunsetBobCollateral,
+    liquidationPreferenceCollaterals,
+  } from './sunsetCollateralPolicy';
 
   export let poolStatus: PoolStatus | null = null;
   export let userPosition: UserPosition | null = null;
@@ -31,14 +36,12 @@
 
   // Registries
   $: stablecoinRegistry = poolStatus?.stablecoin_registry ?? [];
-  // BOB is sunset: it remains in the on-chain registry long enough to settle
-  // outstanding vaults, but it is not a Stability Pool gain or opt-in choice.
-  const HIDDEN_COLLATERAL = new Set(['PHASMA', 'BOB']);
   const COLLATERAL_ORDER: Record<string, number> = { ICP: 0, XRP: 1, ckBTC: 2, ckETH: 3, ckXAUT: 4, nICP: 5, BOB: 6, EXE: 7 };
-  $: collateralRegistry = (poolStatus?.collateral_registry ?? [])
-    .filter(c => !HIDDEN_COLLATERAL.has(c.symbol))
+  // Sunset BOB remains visible for accrued gains. It appears in liquidation
+  // preferences only while a legacy position is still receiving it, providing
+  // a one-way opt-out without advertising fresh exposure.
+  $: collateralRegistry = gainCollaterals(poolStatus?.collateral_registry ?? [])
     .sort((a, b) => (COLLATERAL_ORDER[a.symbol] ?? 99) - (COLLATERAL_ORDER[b.symbol] ?? 99));
-  $: icrcCollateralRegistry = collateralRegistry.filter(c => isIcrcClaimableCollateral(c.ledger_id));
   $: registries = { stablecoins: stablecoinRegistry, collateral: collateralRegistry };
 
   // Pool stats
@@ -77,6 +80,10 @@
   $: gains = userPosition?.collateral_gains ?? [];
   $: hasClaimableIcrcGains = gains.some(([ledger, amount]) => amount > 0n && isIcrcClaimableCollateral(ledger));
   $: optedOut = new Set((userPosition?.opted_out_collateral ?? []).map(p => p.toText()));
+  $: icrcCollateralRegistry = liquidationPreferenceCollaterals(
+    collateralRegistry.filter(c => isIcrcClaimableCollateral(c.ledger_id)),
+    optedOut,
+  );
 
   // Does the user hold icUSD in the pool?
   $: userHasIcusd = userStables.some(([l, a]: [any, bigint]) => l.toText() === CANISTER_IDS.ICUSD_LEDGER && a > 0n);
@@ -264,7 +271,9 @@
                     on:click={() => toggleOptOut(collateral)}
                     disabled={toggleLoading[key]}
                   >
-                    <span class="opt-out-symbol">{collateral.symbol}</span>
+                    <span class="opt-out-symbol">
+                      {collateral.symbol}{isSunsetBobCollateral(collateral) ? ' (sunset)' : ''}
+                    </span>
                     {#if toggleLoading[key]}
                       <span class="mini-spinner"></span>
                     {:else}

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -31,7 +31,9 @@
 
   // Registries
   $: stablecoinRegistry = poolStatus?.stablecoin_registry ?? [];
-  const HIDDEN_COLLATERAL = new Set(['PHASMA']);
+  // BOB is sunset: it remains in the on-chain registry long enough to settle
+  // outstanding vaults, but it is not a Stability Pool gain or opt-in choice.
+  const HIDDEN_COLLATERAL = new Set(['PHASMA', 'BOB']);
   const COLLATERAL_ORDER: Record<string, number> = { ICP: 0, XRP: 1, ckBTC: 2, ckETH: 3, ckXAUT: 4, nICP: 5, BOB: 6, EXE: 7 };
   $: collateralRegistry = (poolStatus?.collateral_registry ?? [])
     .filter(c => !HIDDEN_COLLATERAL.has(c.symbol))

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
@@ -11,4 +11,10 @@ describe('EarnInfoCard native XRP wiring', () => {
     expect(source).toContain("XrpPayoutRouting.svelte");
     expect(source).toContain('<XrpPayoutRouting');
   });
+
+  it('does not present sunset BOB as a gain or liquidation preference', () => {
+    const source = readFileSync(componentPath, 'utf8');
+
+    expect(source).toContain("new Set(['PHASMA', 'BOB'])");
+  });
 });

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
@@ -1,20 +1,70 @@
 import { describe, expect, it } from 'vitest';
+import { Principal } from '@dfinity/principal';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import {
+	gainCollaterals,
+	liquidationPreferenceCollaterals,
+	isSunsetBobCollateral
+} from './sunsetCollateralPolicy';
+import type { CollateralInfo } from '../../services/stabilityPoolService';
 
 const componentPath = resolve(__dirname, 'EarnInfoCard.svelte');
 
-describe('EarnInfoCard native XRP wiring', () => {
-  it('renders the live XRP opt-in and pending payout child from EarnInfoCard', () => {
-    const source = readFileSync(componentPath, 'utf8');
+const principal = (text: string) => Principal.fromText(text);
+const bob: CollateralInfo = {
+	ledger_id: principal('7pail-xaaaa-aaaas-aabmq-cai'),
+	symbol: 'BOB',
+	decimals: 8,
+	status: { Sunset: null }
+};
+const icp: CollateralInfo = {
+	ledger_id: principal('ryjl3-tyaaa-aaaaa-aaaba-cai'),
+	symbol: 'ICP',
+	decimals: 8,
+	status: { Active: null }
+};
+const phasma: CollateralInfo = {
+	ledger_id: principal('aaaaa-aa'),
+	symbol: 'PHASMA',
+	decimals: 8,
+	status: { Deprecated: null }
+};
 
-    expect(source).toContain("XrpPayoutRouting.svelte");
-    expect(source).toContain('<XrpPayoutRouting');
-  });
+describe('EarnInfoCard sunset collateral policy', () => {
+	it('preserves the existing native XRP payout-routing surface', () => {
+		const source = readFileSync(componentPath, 'utf8');
 
-  it('does not present sunset BOB as a gain or liquidation preference', () => {
-    const source = readFileSync(componentPath, 'utf8');
+		expect(source).toContain('XrpPayoutRouting.svelte');
+		expect(source).toContain('<XrpPayoutRouting');
+	});
 
-    expect(source).toContain("new Set(['PHASMA', 'BOB'])");
-  });
+	it('keeps BOB visible when an existing position has a gain', () => {
+		expect(gainCollaterals([icp, bob, phasma]).map((c) => c.symbol)).toEqual(['ICP', 'BOB']);
+	});
+
+	it('offers BOB only as an exit for an existing receiving position', () => {
+		const activeRegistryBob = { ...bob, status: { Active: null } } as CollateralInfo;
+		expect(liquidationPreferenceCollaterals([icp, bob], new Set()).map((c) => c.symbol)).toEqual([
+			'ICP',
+			'BOB'
+		]);
+		expect(
+			liquidationPreferenceCollaterals([icp, bob], new Set([bob.ledger_id.toText()])).map(
+				(c) => c.symbol
+			)
+		).toEqual(['ICP']);
+		expect(
+			liquidationPreferenceCollaterals(
+				[icp, activeRegistryBob],
+				new Set([activeRegistryBob.ledger_id.toText()])
+			).map((c) => c.symbol)
+		).toEqual(['ICP']);
+	});
+
+	it('recognizes sunset BOB by principal even before SP registry status synchronization', () => {
+		expect(isSunsetBobCollateral(bob)).toBe(true);
+		expect(isSunsetBobCollateral({ ...bob, status: { Active: null } })).toBe(true);
+		expect(isSunsetBobCollateral(icp)).toBe(false);
+	});
 });

--- a/src/vault_frontend/src/lib/components/stability-pool/sunsetCollateralPolicy.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/sunsetCollateralPolicy.ts
@@ -1,0 +1,25 @@
+import type { CollateralInfo } from '../../services/stabilityPoolService';
+
+const BOB_COLLATERAL_PRINCIPAL = '7pail-xaaaa-aaaas-aabmq-cai';
+const HIDDEN_GAIN_SYMBOLS = new Set(['PHASMA']);
+
+export function isSunsetBobCollateral(collateral: CollateralInfo): boolean {
+	// BOB's one-way wind-down policy is principal-bound in the canister. Do
+	// not advertise re-entry if the independently managed SP registry still
+	// carries its historical Active status during activation.
+	return collateral.ledger_id.toText() === BOB_COLLATERAL_PRINCIPAL;
+}
+
+export function gainCollaterals(collaterals: CollateralInfo[]): CollateralInfo[] {
+	return collaterals.filter((collateral) => !HIDDEN_GAIN_SYMBOLS.has(collateral.symbol));
+}
+
+export function liquidationPreferenceCollaterals(
+	collaterals: CollateralInfo[],
+	optedOut: Set<string>
+): CollateralInfo[] {
+	return gainCollaterals(collaterals).filter(
+		(collateral) =>
+			!isSunsetBobCollateral(collateral) || !optedOut.has(collateral.ledger_id.toText())
+	);
+}

--- a/src/vault_frontend/src/lib/services/explorer/collateralConfigQuery.spec.ts
+++ b/src/vault_frontend/src/lib/services/explorer/collateralConfigQuery.spec.ts
@@ -1,0 +1,51 @@
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	fetchDiscoveredCollateralConfigs,
+	fetchLegacyCollateralConfigs,
+} from './collateralConfigQuery';
+
+const collateral = Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai');
+const supported: Array<[Principal, unknown]> = [[collateral, { Active: null }]];
+
+describe('discovered collateral config queries', () => {
+	it('rejects when an individual config query rejects', async () => {
+		const getConfig = vi.fn().mockRejectedValue(new Error('query unavailable'));
+
+		await expect(fetchDiscoveredCollateralConfigs(supported, getConfig)).rejects.toThrow(
+			'query unavailable'
+		);
+	});
+
+	it('rejects an absent config for a principal returned by discovery', async () => {
+		const getConfig = vi.fn().mockResolvedValue([]);
+
+		await expect(fetchDiscoveredCollateralConfigs(supported, getConfig)).rejects.toThrow(
+			'Missing collateral config'
+		);
+	});
+
+	it('returns every successfully fetched config', async () => {
+		const config = { ledger_canister_id: collateral };
+		const getConfig = vi.fn().mockResolvedValue([config]);
+
+		await expect(fetchDiscoveredCollateralConfigs(supported, getConfig)).resolves.toEqual([config]);
+	});
+});
+
+describe('legacy collateral config queries', () => {
+	it('keeps successful peers when one individual config query fails', async () => {
+		const peer = Principal.fromText('2vxsx-fae');
+		const config = { ledger_canister_id: peer };
+		const getConfig = vi.fn()
+			.mockRejectedValueOnce(new Error('query unavailable'))
+			.mockResolvedValueOnce([config]);
+
+		await expect(
+			fetchLegacyCollateralConfigs(
+				[[collateral, { Active: null }], [peer, { Active: null }]],
+				getConfig
+			)
+		).resolves.toEqual([config]);
+	});
+});

--- a/src/vault_frontend/src/lib/services/explorer/collateralConfigQuery.ts
+++ b/src/vault_frontend/src/lib/services/explorer/collateralConfigQuery.ts
@@ -1,0 +1,33 @@
+import type { Principal } from '@dfinity/principal';
+
+export async function fetchDiscoveredCollateralConfigs<T>(
+	supported: Array<[Principal, unknown]>,
+	getConfig: (principal: Principal) => Promise<[] | [T]>
+): Promise<T[]> {
+	return Promise.all(
+		supported.map(async ([principal]) => {
+			const config = await getConfig(principal);
+			if (config.length === 0) {
+				throw new Error(`Missing collateral config for ${principal.toText()}`);
+			}
+			return config[0];
+		})
+	);
+}
+
+export async function fetchLegacyCollateralConfigs<T>(
+	supported: Array<[Principal, unknown]>,
+	getConfig: (principal: Principal) => Promise<[] | [T]>
+): Promise<T[]> {
+	const configs = await Promise.all(
+		supported.map(async ([principal]) => {
+			try {
+				const config = await getConfig(principal);
+				return config[0] ?? null;
+			} catch {
+				return null;
+			}
+		})
+	);
+	return configs.filter((config): config is T => config !== null);
+}

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.legacy.spec.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.legacy.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const source = readFileSync(resolve(__dirname, 'explorerService.ts'), 'utf8');
+
+function functionBody(name: string): string {
+	const start = source.indexOf(`export async function ${name}(`);
+	expect(start, `${name} must exist`).toBeGreaterThanOrEqual(0);
+	const next = source.indexOf('\nexport async function ', start + 1);
+	return source.slice(start, next === -1 ? source.length : next);
+}
+
+describe('strict explorer reads do not change legacy fail-soft consumers', () => {
+	it('keeps strict and legacy caches isolated', () => {
+		expect(functionBody('fetchCollateralConfigsStrict')).toContain("'collateral:configs:strict'");
+		expect(functionBody('fetchCollateralConfigs')).toContain("'collateral:configs'");
+		expect(functionBody('fetchAllVaultsStrict')).toContain("'vaults:all:strict'");
+		expect(functionBody('fetchAllVaults')).toContain("'vaults:all'");
+		expect(functionBody('fetchCurrentSpDepositorsStrict')).toContain("'pool:stability:current_depositors:strict'");
+		expect(functionBody('fetchCurrentSpDepositors')).toContain("'pool:stability:current_depositors'");
+	});
+
+	it('retains per-item tolerance for legacy collateral config reads', () => {
+		const body = functionBody('fetchCollateralConfigs');
+		expect(body).toContain('fetchLegacyCollateralConfigs');
+		expect(body).not.toContain('fetchCollateralConfigsStrict');
+	});
+
+	it('retains per-position tolerance for legacy SP depositor reads', () => {
+		const body = functionBody('fetchCurrentSpDepositors');
+		expect(body).toContain('fetchLegacySpPositions');
+		expect(body).not.toContain('fetchCurrentSpDepositorsStrict');
+	});
+
+	it('keeps the known legacy consumers on legacy APIs', () => {
+		const portfolio = readFileSync(
+			resolve(__dirname, '../../components/explorer/PortfolioValueChart.svelte'),
+			'utf8'
+		);
+		const depositors = readFileSync(
+			resolve(__dirname, '../../components/explorer/SpCurrentDepositorsCard.svelte'),
+			'utf8'
+		);
+		expect(portfolio).toContain('fetchCollateralConfigs()');
+		expect(portfolio).not.toContain('fetchCollateralConfigsStrict');
+		expect(depositors).toContain('fetchCurrentSpDepositors');
+		expect(depositors).not.toContain('fetchCurrentSpDepositorsStrict');
+	});
+});

--- a/src/vault_frontend/src/lib/services/explorer/explorerService.ts
+++ b/src/vault_frontend/src/lib/services/explorer/explorerService.ts
@@ -7,6 +7,12 @@
  */
 
 import { Principal } from '@dfinity/principal';
+import {
+	fetchDiscoveredCollateralConfigs,
+	fetchLegacyCollateralConfigs,
+} from './collateralConfigQuery';
+import { fetchCompleteSpPositions, fetchLegacySpPositions } from './spDepositorQuery';
+import { fetchCompleteVaultPages } from './vaultPagination';
 import { Actor, HttpAgent } from '@dfinity/agent';
 import { publicActor } from '$services/protocol/apiClient';
 import { stabilityPoolService } from '$services/stabilityPoolService';
@@ -420,6 +426,25 @@ export async function fetchThreePoolSwapEventsCombined(maxV2: bigint = 1_000n): 
 
 // ── Collateral ───────────────────────────────────────────────────────────────
 
+export async function fetchCollateralConfigsStrict(): Promise<any[]> {
+	const key = 'collateral:configs:strict';
+	const cached = getCached<any[]>(key, TTL.COLLATERAL);
+	if (cached) return cached;
+
+	try {
+		const supported = await publicActor.get_supported_collateral_types();
+		const configs = await fetchDiscoveredCollateralConfigs(
+			supported as Array<[Principal, unknown]>,
+			(principal) => publicActor.get_collateral_config(principal)
+		);
+		return setCache(key, configs);
+	} catch (err) {
+		console.error('[explorerService] fetchCollateralConfigs failed:', err);
+		throw err;
+	}
+}
+
+/** Legacy fail-soft reader retained for explorer surfaces not migrated to explicit degradation. */
 export async function fetchCollateralConfigs(): Promise<any[]> {
 	const key = 'collateral:configs';
 	const cached = getCached<any[]>(key, TTL.COLLATERAL);
@@ -427,25 +452,32 @@ export async function fetchCollateralConfigs(): Promise<any[]> {
 
 	try {
 		const supported = await publicActor.get_supported_collateral_types();
-		const configs = await Promise.all(
-			supported.map(async ([principal, _status]: [Principal, any]) => {
-				try {
-					const cfg = await publicActor.get_collateral_config(principal);
-					// get_collateral_config returns opt ([] or [config])
-					return cfg.length > 0 ? cfg[0] : null;
-				} catch {
-					return null;
-				}
-			})
+		const configs = await fetchLegacyCollateralConfigs(
+			supported as Array<[Principal, unknown]>,
+			(principal) => publicActor.get_collateral_config(principal)
 		);
-		const result = configs.filter((c: any) => c !== null);
-		return setCache(key, result);
+		return setCache(key, configs);
 	} catch (err) {
 		console.error('[explorerService] fetchCollateralConfigs failed:', err);
 		return [];
 	}
 }
 
+export async function fetchCollateralTotalsStrict(): Promise<any[]> {
+	const key = 'collateral:totals:strict';
+	const cached = getCached<any[]>(key, TTL.COLLATERAL);
+	if (cached) return cached;
+
+	try {
+		const result = await publicActor.get_collateral_totals();
+		return setCache(key, result);
+	} catch (err) {
+		console.error('[explorerService] fetchCollateralTotals failed:', err);
+		throw err;
+	}
+}
+
+/** Legacy fail-soft reader retained for explorer surfaces not migrated to explicit degradation. */
 export async function fetchCollateralTotals(): Promise<any[]> {
 	const key = 'collateral:totals';
 	const cached = getCached<any[]>(key, TTL.COLLATERAL);
@@ -498,6 +530,25 @@ const VAULT_PAGE_SIZE = 500n;
  */
 const VAULT_PAGE_MAX_PAGES = 100;
 
+export async function fetchAllVaultsStrict(): Promise<any[]> {
+	const key = 'vaults:all:strict';
+	const cached = getCached<any[]>(key, TTL.VAULTS);
+	if (cached) return cached;
+
+	try {
+		const all = await fetchCompleteVaultPages(
+			(startId, pageSize) => publicActor.get_vaults_page(startId, pageSize),
+			VAULT_PAGE_SIZE,
+			VAULT_PAGE_MAX_PAGES
+		);
+		return setCache(key, all);
+	} catch (err) {
+		console.error('[explorerService] fetchAllVaults failed:', err);
+		throw err;
+	}
+}
+
+/** Legacy fail-soft reader retained for explorer surfaces not migrated to explicit degradation. */
 export async function fetchAllVaults(): Promise<any[]> {
 	const key = 'vaults:all';
 	const cached = getCached<any[]>(key, TTL.VAULTS);
@@ -507,10 +558,10 @@ export async function fetchAllVaults(): Promise<any[]> {
 		const all: any[] = [];
 		let startId = 0n;
 		for (let page = 0; page < VAULT_PAGE_MAX_PAGES; page += 1) {
-			const resp = await publicActor.get_vaults_page(startId, VAULT_PAGE_SIZE);
-			all.push(...resp.vaults);
-			if (resp.next_start_id.length === 0) break;
-			startId = resp.next_start_id[0];
+			const response = await publicActor.get_vaults_page(startId, VAULT_PAGE_SIZE);
+			all.push(...response.vaults);
+			if (response.next_start_id.length === 0) break;
+			startId = response.next_start_id[0];
 		}
 		return setCache(key, all);
 	} catch (err) {
@@ -1182,6 +1233,32 @@ function getStabilityPoolActor() {
  * predate the analytics tailer or were dropped while the shadow types were
  * stale.
  */
+export async function fetchCurrentSpDepositorsStrict(): Promise<CurrentSpDepositor[]> {
+	const key = 'pool:stability:current_depositors:strict';
+	const cached = getCached<CurrentSpDepositor[]>(key, TTL.POOL);
+	if (cached) return cached;
+
+	try {
+		const sp = getStabilityPoolActor();
+		const positions = await fetchCompleteSpPositions<Principal, UserStabilityPosition>(
+			() => sp.list_depositor_principals(),
+			(principal) => sp.get_user_position([principal])
+		);
+		const out: CurrentSpDepositor[] = [];
+		for (const [principal, pos] of positions) {
+			if (pos && Number(pos.total_usd_value_e8s) > 0) {
+				out.push({ principal, position: pos });
+			}
+		}
+		out.sort((a, b) => Number(b.position.total_usd_value_e8s) - Number(a.position.total_usd_value_e8s));
+		return setCache(key, out);
+	} catch (err) {
+		console.error('[explorerService] fetchCurrentSpDepositors failed:', err);
+		throw err;
+	}
+}
+
+/** Legacy fail-soft reader retained for explorer surfaces not migrated to explicit degradation. */
 export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> {
 	const key = 'pool:stability:current_depositors';
 	const cached = getCached<CurrentSpDepositor[]>(key, TTL.POOL);
@@ -1189,24 +1266,13 @@ export async function fetchCurrentSpDepositors(): Promise<CurrentSpDepositor[]> 
 
 	try {
 		const sp = getStabilityPoolActor();
-		const principals: Principal[] = await sp.list_depositor_principals();
-		const positions = await Promise.all(
-			principals.map(async (p) => {
-				try {
-					return await sp.get_user_position([p]);
-				} catch (err) {
-					console.warn('[fetchCurrentSpDepositors] get_user_position failed for', p.toText(), err);
-					return [];
-				}
-			}),
+		const positions = await fetchLegacySpPositions<Principal, UserStabilityPosition>(
+			() => sp.list_depositor_principals(),
+			(principal) => sp.get_user_position([principal])
 		);
 		const out: CurrentSpDepositor[] = [];
-		for (let i = 0; i < principals.length; i++) {
-			const maybe = positions[i];
-			const pos = Array.isArray(maybe) ? maybe[0] : maybe;
-			if (pos && Number(pos.total_usd_value_e8s) > 0) {
-				out.push({ principal: principals[i], position: pos as UserStabilityPosition });
-			}
+		for (const [principal, position] of positions) {
+			if (Number(position.total_usd_value_e8s) > 0) out.push({ principal, position });
 		}
 		out.sort((a, b) => Number(b.position.total_usd_value_e8s) - Number(a.position.total_usd_value_e8s));
 		return setCache(key, out);

--- a/src/vault_frontend/src/lib/services/explorer/spDepositorQuery.spec.ts
+++ b/src/vault_frontend/src/lib/services/explorer/spDepositorQuery.spec.ts
@@ -1,0 +1,50 @@
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it, vi } from 'vitest';
+import { fetchCompleteSpPositions, fetchLegacySpPositions } from './spDepositorQuery';
+
+const depositor = Principal.fromText('aaaaa-aa');
+
+describe('stability-pool depositor query completeness', () => {
+	it('rejects when depositor enumeration fails', async () => {
+		const listDepositors = vi.fn().mockRejectedValue(new Error('list unavailable'));
+
+		await expect(fetchCompleteSpPositions(listDepositors, vi.fn())).rejects.toThrow(
+			'list unavailable'
+		);
+	});
+
+	it('rejects when any enumerated position query fails', async () => {
+		const listDepositors = vi.fn().mockResolvedValue([depositor]);
+		const getPosition = vi.fn().mockRejectedValue(new Error('position unavailable'));
+
+		await expect(fetchCompleteSpPositions(listDepositors, getPosition)).rejects.toThrow(
+			'position unavailable'
+		);
+	});
+
+	it('skips a position that disappeared after enumeration without hiding peers', async () => {
+		const peer = Principal.fromText('2vxsx-fae');
+		const position = { total_usd_value_e8s: 1n };
+		const listDepositors = vi.fn().mockResolvedValue([depositor, peer]);
+		const getPosition = vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([position]);
+
+		await expect(fetchCompleteSpPositions(listDepositors, getPosition)).resolves.toEqual([
+			[peer, position]
+		]);
+	});
+});
+
+describe('legacy stability-pool depositor queries', () => {
+	it('keeps successful peers when one position query fails', async () => {
+		const peer = Principal.fromText('2vxsx-fae');
+		const position = { total_usd_value_e8s: 1n };
+		const listDepositors = vi.fn().mockResolvedValue([depositor, peer]);
+		const getPosition = vi.fn()
+			.mockRejectedValueOnce(new Error('position unavailable'))
+			.mockResolvedValueOnce([position]);
+
+		await expect(fetchLegacySpPositions(listDepositors, getPosition)).resolves.toEqual([
+			[peer, position],
+		]);
+	});
+});

--- a/src/vault_frontend/src/lib/services/explorer/spDepositorQuery.ts
+++ b/src/vault_frontend/src/lib/services/explorer/spDepositorQuery.ts
@@ -1,0 +1,39 @@
+export async function fetchCompleteSpPositions<P, T>(
+	listDepositors: () => Promise<P[]>,
+	getPosition: (principal: P) => Promise<[] | [T]>
+): Promise<Array<[P, T]>> {
+	const principals = await listDepositors();
+	const positions = await Promise.all(principals.map((principal) => getPosition(principal)));
+	const complete: Array<[P, T]> = [];
+
+	for (let index = 0; index < principals.length; index += 1) {
+		const position = positions[index][0];
+		if (position !== undefined) complete.push([principals[index], position]);
+	}
+
+	return complete;
+}
+
+export async function fetchLegacySpPositions<P, T>(
+	listDepositors: () => Promise<P[]>,
+	getPosition: (principal: P) => Promise<[] | [T]>
+): Promise<Array<[P, T]>> {
+	const principals = await listDepositors();
+	const positions = await Promise.all(
+		principals.map(async (principal) => {
+			try {
+				return await getPosition(principal);
+			} catch {
+				return [];
+			}
+		})
+	);
+	const available: Array<[P, T]> = [];
+
+	for (let index = 0; index < principals.length; index += 1) {
+		const position = positions[index][0];
+		if (position !== undefined) available.push([principals[index], position]);
+	}
+
+	return available;
+}

--- a/src/vault_frontend/src/lib/services/explorer/vaultPagination.spec.ts
+++ b/src/vault_frontend/src/lib/services/explorer/vaultPagination.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchCompleteVaultPages } from './vaultPagination';
+
+describe('vault enumeration completeness', () => {
+	it('rejects a first-page query failure', async () => {
+		const fetchPage = vi.fn().mockRejectedValue(new Error('vault page unavailable'));
+
+		await expect(fetchCompleteVaultPages(fetchPage, 500n, 100)).rejects.toThrow(
+			'vault page unavailable'
+		);
+	});
+
+	it('rejects a later-page query failure instead of returning a partial list', async () => {
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce({ vaults: [{ vault_id: 1n }], next_start_id: [2n] })
+			.mockRejectedValueOnce(new Error('second page unavailable'));
+
+		await expect(fetchCompleteVaultPages(fetchPage, 500n, 100)).rejects.toThrow(
+			'second page unavailable'
+		);
+	});
+
+	it('returns every page after complete pagination', async () => {
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce({ vaults: [{ vault_id: 1n }], next_start_id: [2n] })
+			.mockResolvedValueOnce({ vaults: [{ vault_id: 2n }], next_start_id: [] });
+
+		await expect(fetchCompleteVaultPages(fetchPage, 500n, 100)).resolves.toEqual([
+			{ vault_id: 1n },
+			{ vault_id: 2n }
+		]);
+	});
+
+	it('rejects instead of returning partial data when the page cap is exhausted', async () => {
+		const fetchPage = vi.fn().mockResolvedValue({
+			vaults: [{ vault_id: 1n }],
+			next_start_id: [2n]
+		});
+
+		await expect(fetchCompleteVaultPages(fetchPage, 500n, 1)).rejects.toThrow('pagination limit');
+	});
+});

--- a/src/vault_frontend/src/lib/services/explorer/vaultPagination.ts
+++ b/src/vault_frontend/src/lib/services/explorer/vaultPagination.ts
@@ -1,0 +1,22 @@
+export interface VaultPage<T> {
+	vaults: T[];
+	next_start_id: [] | [bigint];
+}
+
+export async function fetchCompleteVaultPages<T>(
+	fetchPage: (startId: bigint, pageSize: bigint) => Promise<VaultPage<T>>,
+	pageSize: bigint,
+	maxPages: number
+): Promise<T[]> {
+	const all: T[] = [];
+	let startId = 0n;
+
+	for (let page = 0; page < maxPages; page += 1) {
+		const response = await fetchPage(startId, pageSize);
+		all.push(...response.vaults);
+		if (response.next_start_id.length === 0) return all;
+		startId = response.next_start_id[0];
+	}
+
+	throw new Error(`Vault pagination limit (${maxPages} pages) exhausted`);
+}


### PR DESCRIPTION
## Summary

- make BOB sunset retirement require zero debt, zero collateral, and no authoritative live vault
- keep immediate and recurring XRC refreshes active until that true retirement boundary
- keep existing BOB borrowers and stability-pool participants serviceable while blocking new SP exposure and re-entry
- make BOB sunset policy principal-bound in the frontend even if SP registry metadata is stale
- use strict, explicitly degraded Explorer reads only for CollateralLens and SpCoverage while preserving legacy partial-success semantics and isolated caches for existing consumers

## Lifecycle invariant

BOB remains publicly discoverable, price-refreshed, withdrawable, repayable, closable, and liquidatable while any debt, collateral, or live vault remains. It retires only after all three authoritative balances are empty. Existing stability-pool participants retain gain visibility, claiming, and one-way opt-out; new exposure and re-entry are blocked.

## Verification

- backend Sunset/XRC unit tests: 2 passed
- DOS/XRC lifecycle integration: 12 passed
- collateral status matrix: 1 passed
- stability-pool library: 113 passed
- frontend unit tests: 205 passed across 31 files
- frontend production build: passed
- PocketIC endpoint test target: compiled successfully
- `git diff --check`: passed
- targeted rustfmt checks for the BOB audit and type surfaces: passed
- two independent adversarial reviewers: PASS with no blockers

The workspace-wide formatter remains baseline-red in unrelated pre-existing files; this PR does not reformat or modify them.

## Known verification boundary

The new PocketIC lifecycle test could not be executed because this worktree does not contain a usable PocketIC runtime binary. It compiles successfully, and deterministic backend, stability-pool, frontend, and source-level lifecycle gates pass.

## Release boundary

This PR changes source only. Merging it does not deploy, activate, or make BOB sunset live. Backend/SP configuration changes, in-flight-open draining if a linearizable cutoff is required, canister upgrades, and live verification remain separate explicitly authorized operations.

No Candid or stable-state schema changes, dependency changes, Spanish documentation work, or XRP production-path changes are included.
