### PR TITLE
fix(vault): respect debt ceiling + global mint cap in borrow Max

### DIFF
--- a/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
+++ b/src/vault_frontend/src/lib/components/vault/VaultCard.svelte
@@ -17,6 +17,8 @@
   import MultiplierBadge from '../points/MultiplierBadge.svelte';
   import { seasonStore, earningActive } from '$lib/stores/seasonStore';
   import { nativeXrpKeepOpenCloseCopy } from '$lib/utils/nativeXrpBorrowFlow';
+  import { computeBorrowMax } from '$lib/utils/borrowLimits';
+  import { appDataStore, protocolStatus, collateralTotals } from '$lib/stores/appDataStore';
 
   export let vault: Vault;
   export let icpPrice: number = 0;
@@ -78,8 +80,30 @@
     ? collateralValueUsd / tickingDebt : Infinity;
   $: borrowedValueUsd = tickingDebt;
   $: riskLevel = getRiskLevel(collateralRatio);
-  // 0.5% haircut so the Max button never overshoots the backend oracle price
-  $: maxBorrowable = Math.max(0, ((collateralValueUsd / vaultMinCR) - tickingDebt) * 0.995);
+  // Borrow "Max" is the MINIMUM of three limits: this vault's collateral capacity
+  // (0.5% haircut so it never overshoots the backend oracle price), the shared
+  // per-collateral debt-ceiling headroom, and the global icUSD mint-cap headroom.
+  // The backend enforces the latter two in BorrowReservationGuard, so the panel
+  // must respect them or "Max" would offer amounts the backend rejects.
+  $: aggregateCollateralDebt = $collateralTotals[vaultCollateralType]?.totalDebt ?? 0;
+  $: borrowMax = computeBorrowMax({
+    collateralValueUsd,
+    minCr: vaultMinCR,
+    currentDebt: tickingDebt,
+    debtCeiling: (vaultCollateralInfo?.debtCeiling ?? 0) / E8S,
+    aggregateDebt: aggregateCollateralDebt,
+    globalCap: $protocolStatus?.globalIcusdMintCap ?? 0,
+    globalBorrowed: $protocolStatus?.totalIcusdBorrowed ?? 0,
+  });
+  $: maxBorrowable = borrowMax.maxBorrow;
+  // When a protocol-wide cap (not this vault's collateral) is the binding limit,
+  // explain why the Max is smaller than the collateral capacity would allow.
+  $: borrowLimitNote =
+    borrowMax.binding === 'debtCeiling' && borrowMax.ceilingHeadroom !== null
+      ? `Limited by ${collateralSymbol} debt ceiling (${formatStableDisplay(borrowMax.ceilingHeadroom)} icUSD remaining protocol-wide).`
+      : borrowMax.binding === 'globalCap' && borrowMax.globalHeadroom !== null
+        ? `Limited by the global icUSD mint cap (${formatStableDisplay(borrowMax.globalHeadroom)} icUSD remaining).`
+        : null;
 
   // Token type for repayment
   let repayTokenType: 'icUSD' | 'CKUSDT' | 'CKUSDC' = 'icUSD';
@@ -243,6 +267,11 @@
   let ckstableRepayFee = 0; // Protocol repay fee rate for ckStables (e.g., 0.01 = 1%)
   onMount(async () => {
     seasonStore.ensureLoaded();
+    // Populate the stores the borrow-cap math reads from ($protocolStatus for the
+    // global mint cap, $collateralTotals for per-collateral aggregate debt). Both
+    // are cached/deduped, so this is cheap even when the page already loaded them.
+    appDataStore.fetchProtocolStatus().catch(() => {});
+    appDataStore.fetchCollateralTotals().catch(() => {});
     // Fetch per-vault dynamic rate eagerly so collapsed card shows actual APR
     ApiClient.getVaultInterestRate(vault.vaultId).then(rate => {
       if (rate !== null) dynamicInterestRate = rate;
@@ -670,6 +699,9 @@
           : `Borrowed ${amount} icUSD`;
         toastStore.success(msg, 8000); borrowAmount = '';
         await vaultStore.refreshVault(vault.vaultId);
+        // This vault's borrow changed the collateral's aggregate debt: refresh the
+        // ceiling headroom so the Max reflects the new protocol-wide total.
+        appDataStore.fetchCollateralTotals(true).catch(() => {});
         walletStore.refreshBalance({ skipCache: true });
         dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
@@ -715,6 +747,8 @@
         } else {
           await vaultStore.refreshVault(vault.vaultId);
         }
+        // Repaying lowers this collateral's aggregate debt: refresh ceiling headroom.
+        appDataStore.fetchCollateralTotals(true).catch(() => {});
         walletStore.refreshBalance({ skipCache: true });
         dispatch('updated');
       } else { toastStore.error(result.error || 'Failed', 8000); }
@@ -997,6 +1031,9 @@
                   placeholder="0.00" min="0.1" step="0.1" disabled={isProcessing} />
                 <span class="input-suffix">icUSD</span>
               </div>
+              {#if borrowLimitNote}
+                <p class="borrow-limit-note">{borrowLimitNote}</p>
+              {/if}
               {#if parsedBorrowAmount > 0 && vaultBorrowingFee > 0}
                 <div class="fee-breakdown">
                   <div class="fee-row"><span>Fee ({(effectiveBorrowFeeRate * 100).toFixed(2)}%)</span><span>{formatStableTx(borrowFeeAmount)} icUSD</span></div>
@@ -1297,6 +1334,10 @@
   .input-suffix {
     position: absolute; right: 0.625rem; top: 50%; transform: translateY(-50%);
     font-size: 0.75rem; color: var(--rumi-text-muted); pointer-events: none;
+  }
+  .borrow-limit-note {
+    margin: 0.375rem 0 0; font-size: 0.6875rem; line-height: 1.35;
+    color: var(--rumi-warning, #E0A82E);
   }
 
   /* ── Token selector (in-field dropdown) ── */

--- a/src/vault_frontend/src/lib/services/protocol/apiClient.ts
+++ b/src/vault_frontend/src/lib/services/protocol/apiClient.ts
@@ -1,6 +1,7 @@
 import { Actor, HttpAgent } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { BigIntUtils } from '../../utils/bigintUtils';
+import { friendlyBorrowCapError } from '../../utils/borrowLimits';
 import { idlFactory as rumi_backendIDL } from '$declarations/rumi_protocol_backend/rumi_protocol_backend.did.js';
 import { idlFactory as icp_ledgerIDL } from '$declarations/icp_ledger/icp_ledger.did.js';
 import { idlFactory as icusd_ledgerIDL } from '$declarations/icusd_ledger/icusd_ledger.did.js';
@@ -355,8 +356,10 @@ private static async refreshVaultData(): Promise<void> {
       return `Service temporarily unavailable: ${error.TemporarilyUnavailable}`;
     } 
     else if ('GenericError' in error && typeof error.GenericError === 'string') {
-      return error.GenericError;
-    } 
+      // Turn the raw BorrowReservationGuard ceiling / mint-cap rejections
+      // (guard.rs) into friendly copy; fall through to the raw string otherwise.
+      return friendlyBorrowCapError(error.GenericError) ?? error.GenericError;
+    }
     else if ('TransferError' in error) {
       const te = error.TransferError;
       if ('InsufficientFunds' in te) {

--- a/src/vault_frontend/src/lib/services/protocol/queryOperations.ts
+++ b/src/vault_frontend/src/lib/services/protocol/queryOperations.ts
@@ -28,6 +28,7 @@ export class QueryOperations {
         mode: canisterStatus.mode,
         totalIcpMargin: Number(canisterStatus.total_icp_margin) / E8S,
         totalIcusdBorrowed: Number(canisterStatus.total_icusd_borrowed) / E8S,
+        globalIcusdMintCap: Number((canisterStatus as any).global_icusd_mint_cap ?? 0) / E8S,
         lastIcpRate: Number(canisterStatus.last_icp_rate),
         lastIcpTimestamp: Number(canisterStatus.last_icp_timestamp),
         totalCollateralRatio: Number(canisterStatus.total_collateral_ratio),

--- a/src/vault_frontend/src/lib/services/types.ts
+++ b/src/vault_frontend/src/lib/services/types.ts
@@ -98,6 +98,8 @@ export interface ProtocolStatusDTO {
   mode: any;
   totalIcpMargin: number;
   totalIcusdBorrowed: number;
+  /** Protocol-wide icUSD mint cap, human icUSD (0 when unset/unavailable). */
+  globalIcusdMintCap: number;
   lastIcpRate: number;
   lastIcpTimestamp: number;
   totalCollateralRatio: number;

--- a/src/vault_frontend/src/lib/stores/appDataStore.ts
+++ b/src/vault_frontend/src/lib/stores/appDataStore.ts
@@ -8,12 +8,23 @@ import type { ProtocolStatusDTO, VaultDTO } from '../services/types';
  * NO component should call backend directly - everything goes through this store
  */
 
+/** Per-collateral aggregate debt + vault count, in human units, keyed by collateral principal text. */
+export interface CollateralTotalsEntry {
+  totalDebt: number;   // human icUSD borrowed against this collateral, aggregate across all its vaults
+  vaultCount: number;
+}
+
 interface AppDataState {
   // Protocol data
   protocolStatus: ProtocolStatusDTO | null;
   protocolStatusLoading: boolean;
   protocolStatusError: string | null;
   protocolStatusLastFetch: number;
+
+  // Per-collateral debt aggregates (for debt-ceiling headroom in the borrow panel)
+  collateralTotals: Record<string, CollateralTotalsEntry>;
+  collateralTotalsLoading: boolean;
+  collateralTotalsLastFetch: number;
 
   // User vaults data  
   userVaults: VaultDTO[];
@@ -39,6 +50,10 @@ const INITIAL_STATE: AppDataState = {
   protocolStatusLoading: false,
   protocolStatusError: null,
   protocolStatusLastFetch: 0,
+
+  collateralTotals: {},
+  collateralTotalsLoading: false,
+  collateralTotalsLastFetch: 0,
 
   userVaults: [],
   userVaultsLoading: false,
@@ -139,6 +154,63 @@ function createAppDataStore() {
             });
           });
       });
+    },
+
+    /**
+     * PER-COLLATERAL DEBT TOTALS - for the borrow panel's debt-ceiling headroom.
+     *
+     * Light public query (no wallet). Cached like the rest; on error we keep and
+     * return whatever is cached (possibly empty) so the borrow panel degrades to
+     * the collateral-only cap rather than breaking.
+     */
+    async fetchCollateralTotals(forceRefresh = false): Promise<Record<string, CollateralTotalsEntry>> {
+      const requestKey = 'collateral_totals';
+      const state = get(appDataStore);
+      const now = Date.now();
+
+      if (!forceRefresh &&
+          Object.keys(state.collateralTotals).length > 0 &&
+          (now - state.collateralTotalsLastFetch) < CACHE_DURATION) {
+        return state.collateralTotals;
+      }
+
+      // If a fetch is already in flight, wait for it instead of racing a second call.
+      if (state.activeRequests.has(requestKey)) {
+        return new Promise(resolve => {
+          const check = () => {
+            const s = get(appDataStore);
+            if (!s.activeRequests.has(requestKey)) resolve(s.collateralTotals);
+            else setTimeout(check, 100);
+          };
+          check();
+        });
+      }
+
+      update(s => {
+        s.activeRequests.add(requestKey);
+        return { ...s, collateralTotalsLoading: true };
+      });
+
+      try {
+        const totals = await this._fetchCollateralTotalsFromAPI();
+        update(s => {
+          s.activeRequests.delete(requestKey);
+          return {
+            ...s,
+            collateralTotals: totals,
+            collateralTotalsLoading: false,
+            collateralTotalsLastFetch: Date.now(),
+          };
+        });
+        return totals;
+      } catch (error) {
+        update(s => {
+          s.activeRequests.delete(requestKey);
+          return { ...s, collateralTotalsLoading: false };
+        });
+        console.warn('Failed to fetch collateral totals:', error);
+        return get(appDataStore).collateralTotals;
+      }
     },
 
     /**
@@ -343,6 +415,7 @@ function createAppDataStore() {
       try {
         await Promise.all([
           this.fetchProtocolStatus(true),
+          this.fetchCollateralTotals(true),
           this.fetchUserVaults(targetPrincipal, true),
           this.fetchBalances(targetPrincipal, true),
         ]);
@@ -372,6 +445,19 @@ function createAppDataStore() {
       });
 
       return QueryOperations.getProtocolStatus();
+    },
+
+    async _fetchCollateralTotalsFromAPI(): Promise<Record<string, CollateralTotalsEntry>> {
+      const { publicActor, E8S } = await import('../services/protocol/apiClient');
+      const rows = await publicActor.get_collateral_totals();
+      const map: Record<string, CollateralTotalsEntry> = {};
+      for (const row of rows) {
+        map[row.collateral_type.toText()] = {
+          totalDebt: Number(row.total_debt) / E8S,
+          vaultCount: Number(row.vault_count),
+        };
+      }
+      return map;
     },
 
     async _fetchUserVaultsFromAPI(principal: Principal): Promise<VaultDTO[]> {
@@ -408,6 +494,7 @@ export const appDataStore = createAppDataStore();
 
 // DERIVED STORES - These are reactive and update automatically
 export const protocolStatus = derived(appDataStore, $store => $store.protocolStatus);
+export const collateralTotals = derived(appDataStore, $store => $store.collateralTotals);
 export const userVaults = derived(appDataStore, $store => $store.userVaults);
 export const icpBalance = derived(appDataStore, $store => $store.icpBalance);
 export const icusdBalance = derived(appDataStore, $store => $store.icusdBalance);

--- a/src/vault_frontend/src/lib/utils/borrowLimits.spec.ts
+++ b/src/vault_frontend/src/lib/utils/borrowLimits.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { computeBorrowMax, friendlyBorrowCapError } from './borrowLimits';
+
+// Baseline vault far from any protocol cap: only the collateral CR bounds it.
+const FAR = {
+  collateralValueUsd: 1000,
+  minCr: 1.25,
+  currentDebt: 100,
+  debtCeiling: 2000,
+  aggregateDebt: 200,
+  globalCap: 30000,
+  globalBorrowed: 3000,
+};
+
+describe('computeBorrowMax', () => {
+  it('is bounded by collateral capacity when far from every protocol cap', () => {
+    const r = computeBorrowMax(FAR);
+    // capacity = 1000 / 1.25 - 100 = 700, * 0.995 haircut = 696.5
+    expect(r.binding).toBe('collateral');
+    expect(r.maxBorrow).toBeCloseTo(696.5, 4);
+    expect(r.collateralHeadroom).toBeCloseTo(696.5, 4);
+  });
+
+  it('is bounded by the per-collateral debt ceiling when it is the tightest cap (nICP case)', () => {
+    // Collateral capacity ~= 228, but only ~66 icUSD of ceiling headroom remains.
+    const r = computeBorrowMax({
+      collateralValueUsd: 400,
+      minCr: 1.25,
+      currentDebt: 91.18,
+      debtCeiling: 2000,
+      aggregateDebt: 1933.76,
+      globalCap: 30000,
+      globalBorrowed: 3014.87,
+    });
+    expect(r.binding).toBe('debtCeiling');
+    // ceiling headroom = 2000 - 1933.76 = 66.24 (no haircut on the ceiling)
+    expect(r.ceilingHeadroom).toBeCloseTo(66.24, 4);
+    expect(r.maxBorrow).toBeCloseTo(66.24, 4);
+  });
+
+  it('is bounded by the global mint cap when that is the tightest cap', () => {
+    const r = computeBorrowMax({
+      collateralValueUsd: 100000,
+      minCr: 1.25,
+      currentDebt: 0,
+      debtCeiling: 1_000_000, // huge, not binding
+      aggregateDebt: 0,
+      globalCap: 30000,
+      globalBorrowed: 29950,
+    });
+    expect(r.binding).toBe('globalCap');
+    expect(r.globalHeadroom).toBeCloseTo(50, 6);
+    expect(r.maxBorrow).toBeCloseTo(50, 6);
+  });
+
+  it('clamps ceiling headroom at zero when aggregate debt already exceeds the ceiling', () => {
+    const r = computeBorrowMax({
+      ...FAR,
+      debtCeiling: 2000,
+      aggregateDebt: 2100,
+    });
+    expect(r.binding).toBe('debtCeiling');
+    expect(r.ceilingHeadroom).toBe(0);
+    expect(r.maxBorrow).toBe(0);
+  });
+
+  it('ignores a non-positive debt ceiling or global cap (treated as no cap)', () => {
+    const r = computeBorrowMax({
+      ...FAR,
+      debtCeiling: 0,
+      globalCap: 0,
+    });
+    expect(r.binding).toBe('collateral');
+    expect(r.ceilingHeadroom).toBeNull();
+    expect(r.globalHeadroom).toBeNull();
+    expect(r.maxBorrow).toBeCloseTo(696.5, 4);
+  });
+
+  it('prefers the collateral label on ties so a protocol cap is only flagged when strictly tighter', () => {
+    // collateral capacity (no haircut here) exactly equals ceiling headroom.
+    const r = computeBorrowMax({
+      collateralValueUsd: 1000,
+      minCr: 1,
+      currentDebt: 900,
+      debtCeiling: 500,
+      aggregateDebt: 400, // ceiling headroom = 100
+      globalCap: 30000,
+      globalBorrowed: 0,
+      haircut: 1,
+    });
+    // collateral headroom = (1000 - 900) * 1 = 100, ceiling headroom = 100 -> tie
+    expect(r.maxBorrow).toBeCloseTo(100, 6);
+    expect(r.binding).toBe('collateral');
+  });
+
+  it('never returns a negative max when the vault is already under-collateralized', () => {
+    const r = computeBorrowMax({
+      ...FAR,
+      collateralValueUsd: 100,
+      minCr: 1.5,
+      currentDebt: 200, // capacity 66.6 - 200 < 0
+    });
+    expect(r.collateralHeadroom).toBe(0);
+    expect(r.maxBorrow).toBe(0);
+  });
+});
+
+describe('friendlyBorrowCapError', () => {
+  it('translates the debt-ceiling guard rejection into a friendly message with remaining headroom', () => {
+    const raw =
+      'Borrow would exceed debt ceiling incl in-flight (193368693855 + 0 + 6900000000 > 200000000000)';
+    const msg = friendlyBorrowCapError(raw);
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('debt ceiling');
+    // remaining = (200000000000 - 193368693855 - 0) / 1e8 = 66.313...
+    expect(msg).toContain('66.31');
+    // The raw e8s integers must not leak through.
+    expect(msg).not.toContain('200000000000');
+  });
+
+  it('translates the global mint-cap guard rejection into a friendly message with remaining headroom', () => {
+    const raw =
+      'Borrow would exceed global icUSD mint cap incl in-flight (500000000000 + 0 + 100000000000 > 550000000000)';
+    const msg = friendlyBorrowCapError(raw);
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('global icUSD mint cap');
+    // remaining = (550000000000 - 500000000000 - 0) / 1e8 = 500
+    expect(msg).toContain('500');
+  });
+
+  it('accounts for in-flight reservations when computing remaining headroom', () => {
+    const raw =
+      'Borrow would exceed debt ceiling incl in-flight (100000000000 + 50000000000 + 60000000000 > 200000000000)';
+    const msg = friendlyBorrowCapError(raw);
+    // remaining = (200000000000 - 100000000000 - 50000000000) / 1e8 = 500
+    expect(msg).toContain('500');
+  });
+
+  it('returns null for unrelated error strings', () => {
+    expect(friendlyBorrowCapError('Vault not found. Please check the vault ID.')).toBeNull();
+    expect(friendlyBorrowCapError('Borrowing is not allowed for this collateral type.')).toBeNull();
+  });
+});

--- a/src/vault_frontend/src/lib/utils/borrowLimits.ts
+++ b/src/vault_frontend/src/lib/utils/borrowLimits.ts
@@ -1,0 +1,141 @@
+/**
+ * Borrow-capacity math for the vault borrow panel.
+ *
+ * A vault's borrowable icUSD is the MINIMUM of three independent limits:
+ *   1. collateral capacity  - how much more this vault can borrow before its
+ *      collateralization ratio drops to the per-collateral minimum,
+ *   2. per-collateral debt ceiling headroom  - the shared cap on aggregate debt
+ *      for this collateral type, minus what every vault of that type already owes,
+ *   3. global icUSD mint-cap headroom  - the protocol-wide cap on total icUSD
+ *      borrowed, minus what is already borrowed everywhere.
+ *
+ * The backend enforces (2) and (3) atomically in `BorrowReservationGuard`
+ * (src/rumi_protocol_backend/src/guard.rs) and rejects a borrow that exceeds
+ * either. The panel must mirror those limits so "Max" never offers an amount the
+ * backend will refuse. All amounts here are in human icUSD (already divided by
+ * E8S) except where noted.
+ */
+
+export type BorrowConstraint = 'collateral' | 'debtCeiling' | 'globalCap';
+
+export interface BorrowMaxInput {
+  /** USD value of this vault's collateral (human units). */
+  collateralValueUsd: number;
+  /** Minimum collateralization ratio for this collateral (e.g. 1.333). */
+  minCr: number;
+  /** This vault's current (interest-inclusive) debt, human icUSD. */
+  currentDebt: number;
+  /** Per-collateral debt ceiling, human icUSD. Non-positive means "no ceiling". */
+  debtCeiling: number;
+  /** Aggregate debt across all vaults of this collateral type, human icUSD. */
+  aggregateDebt: number;
+  /** Global icUSD mint cap, human icUSD. Non-positive means "no global cap". */
+  globalCap: number;
+  /** Total icUSD borrowed protocol-wide, human icUSD. */
+  globalBorrowed: number;
+  /**
+   * Safety haircut applied to the collateral capacity only, so the button never
+   * overshoots when the backend oracle price differs slightly. Defaults to 0.995.
+   * The ceiling / global headrooms are exact integers on the backend, so no
+   * haircut is applied to them.
+   */
+  haircut?: number;
+}
+
+export interface BorrowMaxResult {
+  /** The borrowable amount: min of the applicable limits, floored at 0. */
+  maxBorrow: number;
+  /** Which limit produced maxBorrow. 'collateral' unless a protocol cap is strictly tighter. */
+  binding: BorrowConstraint;
+  /** Collateral-capacity headroom (with haircut), human icUSD. */
+  collateralHeadroom: number;
+  /** Per-collateral ceiling headroom, human icUSD; null when no ceiling applies. */
+  ceilingHeadroom: number | null;
+  /** Global mint-cap headroom, human icUSD; null when no global cap applies. */
+  globalHeadroom: number | null;
+}
+
+const DEFAULT_HAIRCUT = 0.995;
+
+const E8S = 100_000_000;
+
+/** Format a human icUSD amount with up to 4 decimals, no trailing zero noise. */
+function formatIcusd(amount: number): string {
+  return amount.toLocaleString('en-US', { maximumFractionDigits: 4 });
+}
+
+/**
+ * Translate the raw `BorrowReservationGuard` rejection strings from the backend
+ * (src/rumi_protocol_backend/src/guard.rs) into a friendly, human-readable
+ * message. Returns null when `raw` is not one of those two messages, so callers
+ * can fall through to their existing handling.
+ *
+ * Raw formats (A, B, C, D are e8s integers):
+ *   "Borrow would exceed debt ceiling incl in-flight (A + B + C > D)"
+ *   "Borrow would exceed global icUSD mint cap incl in-flight (A + B + C > D)"
+ * where A = committed debt, B = in-flight reservations, C = attempted borrow,
+ * D = the cap. Remaining headroom = D - A - B (clamped at 0).
+ */
+export function friendlyBorrowCapError(raw: string): string | null {
+  if (typeof raw !== 'string') return null;
+
+  const isCeiling = raw.includes('Borrow would exceed debt ceiling incl in-flight');
+  const isGlobal = raw.includes('Borrow would exceed global icUSD mint cap incl in-flight');
+  if (!isCeiling && !isGlobal) return null;
+
+  const nums = raw.match(/\((\d+) \+ (\d+) \+ (\d+) > (\d+)\)/);
+  const remaining = nums
+    ? Math.max(0, (Number(nums[4]) - Number(nums[1]) - Number(nums[2])) / E8S)
+    : null;
+
+  if (isGlobal) {
+    return remaining !== null
+      ? `This borrow would exceed the global icUSD mint cap. Only ${formatIcusd(remaining)} icUSD can still be minted protocol-wide right now.`
+      : 'This borrow would exceed the global icUSD mint cap. Try a smaller amount.';
+  }
+  return remaining !== null
+    ? `This borrow would exceed this collateral's debt ceiling. Only ${formatIcusd(remaining)} icUSD can still be borrowed against it protocol-wide right now.`
+    : "This borrow would exceed this collateral's debt ceiling. Try a smaller amount.";
+}
+
+export function computeBorrowMax(input: BorrowMaxInput): BorrowMaxResult {
+  const {
+    collateralValueUsd,
+    minCr,
+    currentDebt,
+    debtCeiling,
+    aggregateDebt,
+    globalCap,
+    globalBorrowed,
+    haircut = DEFAULT_HAIRCUT,
+  } = input;
+
+  const collateralHeadroom = minCr > 0 && collateralValueUsd > 0
+    ? Math.max(0, (collateralValueUsd / minCr - currentDebt) * haircut)
+    : 0;
+
+  // A non-positive ceiling / cap means the constraint is not configured (or not
+  // yet loaded), so it does not bound the amount.
+  const ceilingHeadroom = debtCeiling > 0
+    ? Math.max(0, debtCeiling - aggregateDebt)
+    : null;
+  const globalHeadroom = globalCap > 0
+    ? Math.max(0, globalCap - globalBorrowed)
+    : null;
+
+  // Start from collateral; only let a protocol cap take over when it is STRICTLY
+  // tighter, so ties keep the neutral 'collateral' label (no scary message).
+  let binding: BorrowConstraint = 'collateral';
+  let maxBorrow = collateralHeadroom;
+
+  if (ceilingHeadroom !== null && ceilingHeadroom < maxBorrow) {
+    binding = 'debtCeiling';
+    maxBorrow = ceilingHeadroom;
+  }
+  if (globalHeadroom !== null && globalHeadroom < maxBorrow) {
+    binding = 'globalCap';
+    maxBorrow = globalHeadroom;
+  }
+
+  return { maxBorrow, binding, collateralHeadroom, ceilingHeadroom, globalHeadroom };
+}

--- a/src/vault_frontend/src/routes/vaults/+page.svelte
+++ b/src/vault_frontend/src/routes/vaults/+page.svelte
@@ -61,6 +61,9 @@
     try {
       const protocolStatus = await appDataStore.fetchProtocolStatus();
       if (protocolStatus) icpPrice = protocolStatus.lastIcpRate;
+      // Refresh per-collateral debt totals so each card's borrow "Max" reflects
+      // the live debt-ceiling headroom.
+      appDataStore.fetchCollateralTotals(true).catch(() => {});
       await appDataStore.fetchUserVaults($principal);
     } catch (error) {
       console.error('Error loading vaults:', error);


### PR DESCRIPTION
## Summary
- Vault borrow "Max"/"Available" was computed purely from collateral value and CR, ignoring the per-collateral debt ceiling and global icUSD mint cap enforced server-side by `BorrowReservationGuard` (`guard.rs`). Users could see a Max above the real protocol-wide headroom and have the borrow rejected with a raw backend error (e.g. nICP: Max showed ~228 icUSD while only ~66 icUSD of ceiling headroom remained).
- Max is now `min(collateral capacity, per-collateral ceiling headroom, global mint-cap headroom)`, with an explanatory note when a protocol-wide cap is the binding constraint.
- Translates the raw `guard.rs` rejection strings ("Borrow would exceed debt ceiling...", "...global icUSD mint cap...") into friendly copy as a race-safety fallback.

## Changes
- New `lib/utils/borrowLimits.ts` (+ spec, 11 tests, TDD): pure `computeBorrowMax()` and `friendlyBorrowCapError()`.
- `appDataStore.ts`: new `collateralTotals` state + `fetchCollateralTotals()` (`get_collateral_totals`), wired into `refreshAll`.
- `types.ts` / `queryOperations.ts`: added `globalIcusdMintCap` to `ProtocolStatusDTO`.
- `VaultCard.svelte`: uses `computeBorrowMax` for the borrow Max, shows a note when a protocol cap binds, refreshes totals after borrow/repay.
- `apiClient.ts`: `formatProtocolError` routes through `friendlyBorrowCapError`.

## Test plan
- [x] `vitest run` — 216/216 tests pass (11 new)
- [x] `svelte-check` — clean on all changed files (29 pre-existing errors are in untouched files)
- [x] Browser-verified against live mainnet data (throwaway route, reverted): nICP near-ceiling vault capped at 66.2365 icUSD (ceiling headroom) instead of ~441 (collateral capacity), with explanatory note; far-from-ceiling ICP vault unchanged at 97.4334, no note. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)