### PR TITLE
fix(frontend): weight aggregate CR risk badge by collateral mix

### DIFF
--- a/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
@@ -49,6 +49,7 @@ function collateral(overrides: Partial<CollateralInfo>): CollateralInfo {
 }
 
 describe('healthTierFor', () => {
+  // No cautionCr/safeCr args -> defaults to ICP's own thresholds (1.5/2.0).
   it('returns "safe" for CR >= 2.0', () => {
     expect(healthTierFor(2.0)).toBe('safe');
     expect(healthTierFor(2.81)).toBe('safe');
@@ -73,6 +74,14 @@ describe('healthTierFor', () => {
 
   it('returns "unknown" for NaN', () => {
     expect(healthTierFor(NaN)).toBe('unknown');
+  });
+
+  it('honors explicit cautionCr/safeCr cutoffs instead of the ICP defaults', () => {
+    // A ckXAUT-only cutoff pair (liquidationCr 1.18 blended per the same
+    // ratios as ICP's 1.5/2.0): caution ≈1.331, safe ≈1.774.
+    expect(healthTierFor(1.47, 1.3308, 1.7744)).toBe('caution');
+    expect(healthTierFor(1.2, 1.3308, 1.7744)).toBe('danger');
+    expect(healthTierFor(1.8, 1.3308, 1.7744)).toBe('safe');
   });
 });
 
@@ -206,5 +215,68 @@ describe('aggregatePosition', () => {
     const vaults = [vault({ collateralType: CKBTC, collateralAmount: 0.1, borrowedIcusd: 0 })];
     const result = aggregatePosition(vaults, []);
     expect(result.perCollateral[0].symbol).toBe(CKBTC.slice(0, 5));
+  });
+
+  // Regression coverage for the "flat ICP threshold" bug: a position backed
+  // entirely by a lower-liquidationCr asset (e.g. XRP/ckXAUT at ~1.18) must be
+  // judged against its own blended threshold, not ICP's 1.5/2.0.
+  describe('weighted health tier for non-ICP collateral', () => {
+    it('does not flag a 147% CR ckXAUT-only position as danger', () => {
+      // liquidationCr 1.18 -> caution cutoff ≈1.331, safe cutoff ≈1.774.
+      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
+      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1470, liquidationCr: 1.18, minimumCr: 1.35 })];
+      const result = aggregatePosition(vaults, collaterals);
+      expect(result.overallCr).toBeCloseTo(1.47, 2);
+      expect(result.healthTier).toBe('caution');
+    });
+
+    it('flags the same asset as danger once CR actually drops below its own liquidation buffer', () => {
+      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
+      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1200, liquidationCr: 1.18, minimumCr: 1.35 })];
+      const result = aggregatePosition(vaults, collaterals);
+      expect(result.overallCr).toBeCloseTo(1.2, 2);
+      expect(result.healthTier).toBe('danger');
+    });
+
+    it('marks safe once comfortably above the asset-specific buffer', () => {
+      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
+      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1800, liquidationCr: 1.18, minimumCr: 1.35 })];
+      const result = aggregatePosition(vaults, collaterals);
+      expect(result.overallCr).toBeCloseTo(1.8, 2);
+      expect(result.healthTier).toBe('safe');
+    });
+
+    it('preserves ICP-only behavior exactly (regression against the old flat breakpoints)', () => {
+      const vaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 500 })];
+      const collaterals = [collateral({ principal: ICP, price: 5 })]; // CR = 1.0 -> danger
+      expect(aggregatePosition(vaults, collaterals).healthTier).toBe('danger');
+
+      const cautionVaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 300 })];
+      const cautionCollaterals = [collateral({ principal: ICP, price: 5 })]; // CR ≈1.67 -> caution
+      expect(aggregatePosition(cautionVaults, cautionCollaterals).healthTier).toBe('caution');
+
+      const safeVaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 })];
+      const safeCollaterals = [collateral({ principal: ICP, price: 5 })]; // CR = 2.5 -> safe
+      expect(aggregatePosition(safeVaults, safeCollaterals).healthTier).toBe('safe');
+    });
+
+    it('blends thresholds by USD share for a mixed ICP + ckXAUT position', () => {
+      // 50/50 USD split (725 + 725 = 1450): weighted liquidationCr =
+      // (1.33 + 1.18)/2 = 1.255 -> caution cutoff ≈1.415, safe cutoff ≈1.887.
+      // CR = 1450/1000 = 1.45, which the OLD flat ICP breakpoints (danger
+      // below 1.5) would have wrongly called "danger".
+      const vaults = [
+        vault({ vaultId: 1, collateralType: ICP, collateralAmount: 100, borrowedIcusd: 1000 }),
+        vault({ vaultId: 2, collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 0 }),
+      ];
+      const collaterals = [
+        collateral({ principal: ICP, symbol: 'ICP', price: 7.25 }),          // 725 USD
+        collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 725, liquidationCr: 1.18, minimumCr: 1.35 }), // 725 USD
+      ];
+      const result = aggregatePosition(vaults, collaterals);
+      expect(result.totalCollateralUsd).toBe(1450);
+      expect(result.overallCr).toBeCloseTo(1.45, 2);
+      expect(result.healthTier).toBe('caution');
+    });
   });
 });

--- a/src/vault_frontend/src/lib/components/layout/positionSummary.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.ts
@@ -1,6 +1,13 @@
 import type { VaultDTO, CollateralInfo } from '../../services/types';
 import { CANISTER_IDS } from '../../config';
 
+// ICP's own defaults (mirrors $lib/protocol's MINIMUM_CR/LIQUIDATION_CR).
+// Restated locally rather than imported so this module stays a pure,
+// dependency-light aggregation utility (protocol.ts pulls in the wallet/
+// canister-agent stack via collateralStore -> tokenService -> pnp).
+const ICP_MINIMUM_CR = 1.5;
+const ICP_LIQUIDATION_CR = 1.33;
+
 export type HealthTier = 'safe' | 'caution' | 'danger' | 'no-debt' | 'unknown';
 
 export interface AssetBreakdown {
@@ -48,20 +55,36 @@ export function findCollateralInfo(
 }
 
 /**
- * Map a collateral ratio (as a ratio, e.g. 2.81 for 281%) to a health tier.
- *   >= 2.0  -> safe
- *   1.5..2  -> caution
- *   < 1.5   -> danger
+ * Ratios implied by ICP's own thresholds (borrow threshold 1.5, liquidation
+ * 1.33, legacy flat "safe" cutoff 2.0). Applied to a blended liquidationCr so a
+ * non-ICP (or mixed-collateral) position gets a proportionally equivalent
+ * buffer instead of being judged against ICP's flat numbers.
+ */
+const CAUTION_RATIO = ICP_MINIMUM_CR / ICP_LIQUIDATION_CR; // ≈1.128
+const SAFE_RATIO = 2.0 / ICP_LIQUIDATION_CR;                // ≈1.504
+
+/**
+ * Map a collateral ratio to a health tier against caution/safe cutoffs.
+ *   >= safeCr        -> safe
+ *   cautionCr..safeCr -> caution
+ *   < cautionCr      -> danger
  * Infinity (no debt) -> 'no-debt'. NaN -> 'unknown'.
+ *
+ * cautionCr/safeCr default to ICP's own thresholds so callers that don't yet
+ * have a collateral mix (e.g. isolated unit tests) keep the old behavior.
  *
  * NOTE: This is an aggregate heuristic across all the user's vaults, not a
  * per-vault liquidation signal. Individual vault liquidation prices are
  * displayed on VaultCard.
  */
-export function healthTierFor(cr: number): HealthTier {
+export function healthTierFor(
+  cr: number,
+  cautionCr: number = ICP_MINIMUM_CR,
+  safeCr: number = 2.0,
+): HealthTier {
   if (!Number.isFinite(cr)) return cr === Infinity ? 'no-debt' : 'unknown';
-  if (cr >= 2.0) return 'safe';
-  if (cr >= 1.5) return 'caution';
+  if (cr >= safeCr) return 'safe';
+  if (cr >= cautionCr) return 'caution';
   return 'danger';
 }
 
@@ -76,6 +99,8 @@ export function healthTierFor(cr: number): HealthTier {
  *  4. Overall CR = totalCollateralUsd / totalBorrowed (Infinity if no debt).
  *  5. Emit per-collateral breakdown sorted by USD value desc, skipping
  *     any group whose nativeAmount is 0.
+ *  6. Blend each group's liquidationCr by its USD share to get a caution/safe
+ *     cutoff specific to this user's actual collateral mix (see healthTierFor).
  */
 export function aggregatePosition(
   vaults: VaultDTO[],
@@ -119,11 +144,25 @@ export function aggregatePosition(
     ? totalCollateralUsd / totalBorrowed
     : Infinity;
 
+  // Blend each held asset's own liquidationCr, weighted by its share of the
+  // user's total collateral USD, so a mixed (or non-ICP) position is judged
+  // against its own risk profile rather than ICP's.
+  const weightedLiquidationCr = totalCollateralUsd > 0
+    ? perCollateral.reduce((sum, asset) => {
+        const info = findCollateralInfo(collaterals, asset.principal);
+        const liquidationCr = info?.liquidationCr ?? ICP_LIQUIDATION_CR;
+        return sum + (asset.usdValue / totalCollateralUsd) * liquidationCr;
+      }, 0)
+    : ICP_LIQUIDATION_CR;
+
+  const cautionCr = weightedLiquidationCr * CAUTION_RATIO;
+  const safeCr = weightedLiquidationCr * SAFE_RATIO;
+
   return {
     totalCollateralUsd,
     totalBorrowed,
     overallCr,
-    healthTier: healthTierFor(overallCr),
+    healthTier: healthTierFor(overallCr, cautionCr, safeCr),
     perCollateral,
     hasAnyMissingPrice,
   };


### PR DESCRIPTION
## Summary
- The top-bar "OVERALL CR" health-tier badge (`positionSummary.ts` → `PositionStrip.svelte`) used ICP's own flat thresholds (danger <150%, safe >=200%) for every user, regardless of what collateral they actually hold.
- A position backed by a lower-`liquidationCr` asset (e.g. ckXAUT/XRP ~118%) got flagged **"At risk"** well above its real liquidation buffer — reported live at 147% CR on a ckXAUT-only position.
- `healthTierFor()` now accepts explicit caution/safe cutoffs, and `aggregatePosition()` derives them by blending each held asset's own `liquidationCr` (weighted by USD share of the position) and scaling by the same ratios ICP's flat 150%/200% implied, so ICP-only positions are byte-for-byte unchanged and mixed/non-ICP positions are judged against their own risk profile.
- Audited sibling risk displays (`VaultCard.svelte`, `ManualLiquidations.svelte`, `ProtocolStats.svelte`) — all already use real per-collateral thresholds per-vault; only the aggregate badge had the bug.

## Test plan
- [x] `npx vitest run` — 32 files / 222 tests pass (25 in `positionSummary.spec.ts`, including new regression coverage for the reported ckXAUT scenario, a mixed ICP+ckXAUT blend, and exact-preservation of prior ICP-only behavior)
- [x] `npm run dev` — app boots clean, no console/server errors
- [ ] Manual live-wallet check of the badge color for a real mixed-collateral position (not reproducible without a funded test wallet in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)