### PR TITLE
fix(stability-pool): preserve pool event compatibility

### DIFF
--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.d.ts
@@ -219,15 +219,6 @@ export type PoolEventType = {
   } |
   { 'OperationsResumed' : null } |
   { 'CollateralRegistered' : { 'ledger' : Principal, 'symbol' : string } } |
-  {
-    'UnallocatedInterestForwardedToTreasury' : {
-      'fee' : bigint,
-      'source_mint_blocks' : BigUint64Array | bigint[],
-      'net_amount' : bigint,
-      'transfer_block_index' : bigint,
-      'gross_amount' : bigint,
-    }
-  } |
   { 'OptOutCollateral' : { 'collateral_type' : Principal } } |
   { 'OptInCollateral' : { 'collateral_type' : Principal } } |
   { 'StablecoinRegistered' : { 'ledger' : Principal, 'symbol' : string } } |

--- a/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
+++ b/src/declarations/rumi_stability_pool/rumi_stability_pool.did.js
@@ -190,13 +190,6 @@ export const idlFactory = ({ IDL }) => {
       'ledger' : IDL.Principal,
       'symbol' : IDL.Text,
     }),
-    'UnallocatedInterestForwardedToTreasury' : IDL.Record({
-      'fee' : IDL.Nat64,
-      'source_mint_blocks' : IDL.Vec(IDL.Nat64),
-      'net_amount' : IDL.Nat64,
-      'transfer_block_index' : IDL.Nat64,
-      'gross_amount' : IDL.Nat64,
-    }),
     'OptOutCollateral' : IDL.Record({ 'collateral_type' : IDL.Principal }),
     'OptInCollateral' : IDL.Record({ 'collateral_type' : IDL.Principal }),
     'StablecoinRegistered' : IDL.Record({

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -711,16 +711,6 @@ async fn process_unallocated_interest_forward(batch_id: u64) -> Result<(), Stabi
 
     mutate_state(|s| {
         s.mark_unallocated_interest_forward_recorded(batch_id);
-        s.push_event(
-            ic_cdk::api::id(),
-            PoolEventType::UnallocatedInterestForwardedToTreasury {
-                gross_amount: batch.gross_amount,
-                fee,
-                net_amount,
-                transfer_block_index,
-                source_mint_blocks: batch.source_mint_blocks.clone(),
-            },
-        );
     });
     Ok(())
 }

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -869,16 +869,6 @@ pub enum PoolEventType {
         token_ledger: Principal,
         amount: u64,
     },
-    /// Interest with no eligible icUSD depositor was sent to protocol
-    /// treasury. This is deliberately separate from `InterestReceived` so it
-    /// never appears as depositor yield.
-    UnallocatedInterestForwardedToTreasury {
-        gross_amount: u64,
-        fee: u64,
-        net_amount: u64,
-        transfer_block_index: u64,
-        source_mint_blocks: Vec<u64>,
-    },
     // ─── Collateral Opt-in/Opt-out ───
     OptOutCollateral {
         collateral_type: Principal,

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -369,13 +369,6 @@ type PoolEventType = variant {
   ClaimCollateral : record { collateral_ledger : principal; amount : nat64 };
   DepositAs3USD : record { token_ledger : principal; amount_in : nat64; lp_minted : nat64 };
   InterestReceived : record { token_ledger : principal; amount : nat64 };
-  UnallocatedInterestForwardedToTreasury : record {
-    gross_amount : nat64;
-    fee : nat64;
-    net_amount : nat64;
-    transfer_block_index : nat64;
-    source_mint_blocks : vec nat64;
-  };
   OptOutCollateral : record { collateral_type : principal };
   OptInCollateral : record { collateral_type : principal };
   LiquidationNotification : record { vault_count : nat64 };


### PR DESCRIPTION
Removes the newly added public PoolEvent variant from PR #310 while preserving the Treasury-side durable audit record. This keeps the pool-events query Candid-compatible with deployed frontend clients and unblocks the safe Stability Pool upgrade.

Verification: cargo check, didc check, production canister build, and ICP's compatibility gate identified the exact incompatibility.