### PR TITLE
Fix stability-pool live-vs-ledger balance drift (3USD refund stranding + ckStable liquidation fee) + reconciliation

### DIFF
--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -832,6 +832,14 @@ type PendingChainBurnAging = record {
   chain_id : nat32;
   oldest_reference_ns : opt nat64;
 };
+type PendingThreeUsdRefund = record {
+  stability_pool : principal;
+  ledger : principal;
+  amount_e8s : nat64;
+  vault_id : nat64;
+  retry_count : nat8;
+  op_nonce : nat;
+};
 type PendingLiquidationV1 = record {
   started_at_ns : nat64;
   op_id : nat64;
@@ -1321,6 +1329,7 @@ service : (ProtocolArg) -> {
   get_pending_chain_burn_aging : () -> (vec PendingChainBurnAging) query;
   get_price_pusher_allowed : () -> (vec record { nat32; text }) query;
   get_price_pusher_principal : () -> (opt principal) query;
+  get_pending_3usd_refunds : () -> (vec PendingThreeUsdRefund) query;
   get_protocol_3usd_reserves : () -> (nat64) query;
   get_protocol_config : () -> (ProtocolConfig) query;
   get_protocol_snapshots : (GetSnapshotsArg) -> (vec ProtocolSnapshot) query;

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -1305,7 +1305,7 @@ fn drop_pending<K: std::cmp::Ord>(
     map.remove(key);
 }
 
-pub(crate) async fn process_pending_transfer() {
+pub async fn process_pending_transfer() {
     let _guard = match crate::guard::TimerLogicGuard::new() {
         Some(guard) => guard,
         None => {
@@ -1734,12 +1734,90 @@ pub(crate) async fn process_pending_transfer() {
         }
     }
 
+    // Durable retry queue for stranded 3USD reserve refunds
+    // (`stability_pool_liquidate_with_reserves`). Each entry is keyed by its
+    // `op_nonce`, reused on every retry so the 3USD ledger deduplicates a
+    // previously-committed-but-reply-lost transfer. Without this, a failed refund
+    // would leave the stability pool's live 3USD balance below its tracked
+    // aggregate, blocking every non-sole-holder withdrawal.
+    let pending_3usd_refunds = read_state(|s| {
+        s.pending_3usd_refunds
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect::<Vec<(u128, crate::state::PendingThreeUsdRefund)>>()
+    });
+
+    for (nonce_key, refund) in pending_3usd_refunds {
+        match crate::management::transfer_idempotent(
+            refund.ledger,
+            Some(crate::management::protocol_3usd_reserves_subaccount()),
+            icrc_ledger_types::icrc1::account::Account {
+                owner: refund.stability_pool,
+                subaccount: None,
+            },
+            refund.amount_e8s as u128,
+            refund.op_nonce,
+            None,
+        )
+        .await
+        {
+            Ok(block_index) => {
+                log!(INFO,
+                    "[refunding] 3USD reserve refund settled for SP {} (vault {}, refund block {}, amount {})",
+                    refund.stability_pool, refund.vault_id, block_index, refund.amount_e8s
+                );
+                mutate_state(|s| {
+                    s.pending_3usd_refunds.remove(&nonce_key);
+                });
+            }
+            Err(error) => {
+                log!(
+                    INFO,
+                    "[refunding] 3USD reserve refund failed for SP {} (vault {}): {:?}. Will retry.",
+                    refund.stability_pool,
+                    refund.vault_id,
+                    error
+                );
+                if let TransferError::BadFee { expected_fee } = error {
+                    // Refresh fee cache; do NOT increment retry count on BadFee.
+                    if let Ok(expected_fee_u64) = expected_fee.0.clone().try_into() {
+                        crate::management::set_cached_fee(refund.ledger, expected_fee_u64);
+                    }
+                } else {
+                    let retries = mutate_state(|s| {
+                        if let Some(r) = s.pending_3usd_refunds.get_mut(&nonce_key) {
+                            r.retry_count = r.retry_count.saturating_add(1);
+                            r.retry_count
+                        } else {
+                            0
+                        }
+                    });
+                    if retries >= MAX_PENDING_RETRIES {
+                        log!(
+                            INFO,
+                            "[refunding] CRITICAL: abandoning 3USD reserve refund for SP {} (vault {}) \
+                             after {} retries. Amount: {}. Manual reconciliation required.",
+                            refund.stability_pool,
+                            refund.vault_id,
+                            retries,
+                            refund.amount_e8s
+                        );
+                        mutate_state(|s| {
+                            s.pending_3usd_refunds.remove(&nonce_key);
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     // Schedule another run if needed, but with better timing
     if read_state(|s| {
         !s.pending_margin_transfers.is_empty()
             || !s.pending_excess_transfers.is_empty()
             || !s.pending_redemption_transfer.is_empty()
             || !s.pending_refunds.is_empty()
+            || !s.pending_3usd_refunds.is_empty()
     }) {
         // Schedule another check in 5 seconds
         log!(

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -5582,23 +5582,33 @@ async fn refund_3usd_to_stability_pool(
     use ic_canister_log::log;
     use rumi_protocol_backend::logs::INFO;
 
+    // Mint the dedup nonce up front so a stranded refund is enqueued under the
+    // SAME nonce it (may have) attempted the transfer with; a retry then
+    // deduplicates on the 3USD ledger instead of double-refunding.
+    let refund_nonce = mutate_state(|s| s.next_op_nonce());
+
     let fee = match rumi_protocol_backend::management::get_or_refresh_fee(three_usd_ledger).await {
         Ok(f) => f,
         Err(e) => {
+            // Couldn't determine the fee, so no transfer was attempted. Queue the
+            // gross excess (fee applied at retry time) so it heals automatically.
             log!(INFO,
-                "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
-                 to SP {} aborted (could not fetch ledger fee: {}). Tokens stranded in reserves; \
-                 use admin tools to reconcile.",
+                "[stability_pool_liquidate_with_reserves] refund of {} 3USD for vault {} to SP {} \
+                 deferred (could not fetch ledger fee: {}); enqueued for durable retry.",
                 amount_e8s, vault_id, sp_caller, e
             );
+            enqueue_pending_3usd_refund(three_usd_ledger, sp_caller, amount_e8s, vault_id, refund_nonce);
             return;
         }
     };
     if amount_e8s <= fee {
+        // Sub-fee dust: a refund can never cover the ledger fee, so there is
+        // nothing recoverable to queue. This is unreachable while the 3USD fee
+        // is 0 and only ever concerns amounts of at most one fee.
         log!(
             INFO,
             "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
-             to SP {} aborted (amount does not cover ledger fee {}). Tokens stranded in reserves.",
+             to SP {} aborted (amount does not cover ledger fee {}). Dust stranded in reserves.",
             amount_e8s,
             vault_id,
             sp_caller,
@@ -5607,7 +5617,6 @@ async fn refund_3usd_to_stability_pool(
         return;
     }
     let refund_amount = amount_e8s - fee;
-    let refund_nonce = mutate_state(|s| s.next_op_nonce());
     let result = rumi_protocol_backend::management::transfer_idempotent(
         three_usd_ledger,
         Some(rumi_protocol_backend::management::protocol_3usd_reserves_subaccount()),
@@ -5629,13 +5638,57 @@ async fn refund_3usd_to_stability_pool(
             );
         }
         Err(e) => {
+            // Do NOT strand: persist the refund so `process_pending_transfer`
+            // retries it (reusing `refund_nonce` for ledger dedup) until it
+            // settles or hits MAX_PENDING_RETRIES. Without this the SP's live
+            // 3USD balance stays below its tracked aggregate and its withdraw
+            // guard blocks every non-sole-holder with `InsufficientPoolBalance`.
             log!(INFO,
-                "[stability_pool_liquidate_with_reserves] CRITICAL: refund of {} 3USD for vault {} \
-                 to SP {} FAILED: {:?}. Tokens stranded in reserves; reconcile manually.",
+                "[stability_pool_liquidate_with_reserves] refund of {} 3USD for vault {} to SP {} \
+                 FAILED: {:?}; enqueued for durable retry.",
                 refund_amount, vault_id, sp_caller, e
             );
+            enqueue_pending_3usd_refund(three_usd_ledger, sp_caller, refund_amount, vault_id, refund_nonce);
         }
     }
+}
+
+/// Persist a stranded 3USD reserve refund so `process_pending_transfer` heals it.
+/// Keyed by `op_nonce`, which is reused across retries so the 3USD ledger
+/// deduplicates a previously-committed-but-reply-lost transfer.
+fn enqueue_pending_3usd_refund(
+    three_usd_ledger: Principal,
+    sp_caller: Principal,
+    amount_e8s: u64,
+    vault_id: u64,
+    op_nonce: u128,
+) {
+    mutate_state(|s| {
+        s.pending_3usd_refunds.insert(
+            op_nonce,
+            rumi_protocol_backend::state::PendingThreeUsdRefund {
+                stability_pool: sp_caller,
+                ledger: three_usd_ledger,
+                amount_e8s,
+                vault_id,
+                retry_count: 0,
+                op_nonce,
+            },
+        );
+    });
+    // Kick the durable-transfer drain loop so the refund is retried promptly
+    // (it self-reschedules every 5s while any queue is non-empty).
+    ic_cdk::spawn(rumi_protocol_backend::process_pending_transfer());
+}
+
+/// Stranded 3USD reserve refunds awaiting durable retry by
+/// `process_pending_transfer`. Non-empty means the stability pool is owed 3USD
+/// that a refund transfer failed to deliver; the queue self-heals but this
+/// surfaces the shortfall for monitoring. Empty in normal operation.
+#[query]
+#[candid_method(query)]
+fn get_pending_3usd_refunds() -> Vec<rumi_protocol_backend::state::PendingThreeUsdRefund> {
+    read_state(|s| s.pending_3usd_refunds.values().copied().collect())
 }
 
 /// Cumulative 3USD held in protocol reserves from stability pool liquidations (e8s).

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -1038,6 +1038,36 @@ pub struct PendingStabilityPoolInterestNotification {
     pub source_mint_block: u64,
 }
 
+/// Durable refund record for a stranded 3USD reserve refund
+/// (`stability_pool_liquidate_with_reserves`).
+///
+/// The reserves-path liquidation pulls the FULL requested 3USD from the stability
+/// pool into the protocol's `protocol_3usd_reserves` subaccount, then refunds the
+/// proportional excess when the writedown is capped below the requested amount.
+/// Pre-fix, a failed refund transfer only emitted a CRITICAL log, stranding the
+/// excess 3USD in reserves: the SP's live ledger balance dropped below its tracked
+/// aggregate (`total_stablecoin_balances[3USD]`), and its withdraw guard then
+/// blocks every non-sole-holder with `InsufficientPoolBalance`. This queue makes
+/// the refund durable: `process_pending_transfer` retries it (reserves subaccount
+/// -> SP) until success or MAX_PENDING_RETRIES, reusing `op_nonce` so the 3USD
+/// ledger deduplicates if a retry's reply was lost. Keyed by `op_nonce`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, Serialize, Copy, candid::CandidType)]
+pub struct PendingThreeUsdRefund {
+    /// The stability pool canister the 3USD is owed back to.
+    pub stability_pool: Principal,
+    /// The 3USD ledger the refund transfers on.
+    pub ledger: Principal,
+    /// 3USD amount to refund (in e8s), already net of the ledger fee.
+    pub amount_e8s: u64,
+    /// Vault whose capped/failed liquidation stranded this refund (for tracing).
+    pub vault_id: u64,
+    #[serde(default)]
+    pub retry_count: u8,
+    /// Wave-3 ICRC dedup nonce. Minted once at first attempt, reused on every
+    /// retry so the 3USD ledger deduplicates instead of double-refunding.
+    pub op_nonce: u128,
+}
+
 thread_local! {
     static __STATE: RefCell<Option<State>> = RefCell::default();
 }
@@ -1116,6 +1146,13 @@ pub struct State {
     /// keyed by the burn icUSD block index. Empty for pre-Wave-4 snapshots.
     #[serde(default)]
     pub pending_refunds: BTreeMap<u64, PendingRefund>,
+    /// Durable retry queue for stranded 3USD reserve refunds
+    /// (`stability_pool_liquidate_with_reserves`), keyed by `op_nonce`. A failed
+    /// refund back to the stability pool would otherwise leave the SP's live 3USD
+    /// balance below its tracked aggregate and block all non-sole-holder
+    /// withdrawals. `serde(default)` keeps older snapshots decoding cleanly.
+    #[serde(default)]
+    pub pending_3usd_refunds: BTreeMap<u128, PendingThreeUsdRefund>,
     pub mode: Mode,
     /// Wave-14a CDP-01: count of consecutive XRC fetch failures. Reset
     /// to 0 on any successful fetch. When this reaches
@@ -1873,6 +1910,7 @@ impl Default for State {
             pending_excess_transfers: BTreeMap::new(),
             pending_redemption_transfer: BTreeMap::new(),
             pending_refunds: BTreeMap::new(),
+            pending_3usd_refunds: BTreeMap::new(),
             mode: Mode::default(),
             consecutive_xrc_failures: 0,
             mode_triggered_by_oracle: false,
@@ -2028,6 +2066,7 @@ impl From<InitArg> for State {
             principal_to_vault_ids: BTreeMap::new(),
             pending_redemption_transfer: BTreeMap::new(),
             pending_refunds: BTreeMap::new(),
+            pending_3usd_refunds: BTreeMap::new(),
             vault_id_to_vaults: BTreeMap::new(),
             xrc_principal: args.xrc_principal,
             icusd_ledger_principal: args.icusd_ledger_principal,

--- a/src/rumi_protocol_backend/tests/audit_pocs_icc_002_3usd_refund.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_icc_002_3usd_refund.rs
@@ -29,18 +29,20 @@
 //!      `protocol_3usd_reserves` stays at zero, and the INFO log carries
 //!      a `refunded ... after liquidation rollback` line keyed to the vault.
 //!
-//!   3. `icc_002_pic_refund_failure_logs_critical_and_strands_3usd` — the
+//!   3. `icc_002_pic_refund_failure_enqueues_durable_retry_and_heals` — the
 //!      refund-of-refund failure. Same setup as #2, but the 3USD ledger
 //!      is `flaky_ledger` with `set_fail_transfers(true)`. The pull
 //!      (`icrc2_transfer_from`) is unaffected by that knob and lands; the
 //!      writedown rejects (kill switch); the refund (`icrc1_transfer`)
-//!      fails. Asserts:
+//!      fails. Asserts the fix that replaced the old strand-and-log-CRITICAL
+//!      behavior:
 //!        * the protocol surfaces the original writedown error,
-//!        * `protocol_3usd_reserves` still stays at zero (the writedown
-//!          never reached its mutation),
-//!        * the SP did NOT get its 3USD back (the refund actually failed),
-//!        * an INFO log entry with `CRITICAL: refund of` fires so the
-//!          on-call operator sees the stranding.
+//!        * the failed refund is persisted to `pending_3usd_refunds`
+//!          (queried via `get_pending_3usd_refunds`) rather than lost,
+//!        * once the ledger recovers, `process_pending_transfer` drains the
+//!          queue, the SP is made whole, and the reserves subaccount empties.
+//!      This closes the drift where a stranded refund left the SP's live 3USD
+//!      below its tracked aggregate, blocking non-sole-holder withdrawals.
 //!
 //! # Why the kill switch is the right injection
 //!
@@ -428,6 +430,45 @@ fn get_protocol_3usd_reserves(pic: &PocketIc, protocol_id: Principal) -> u64 {
     match result {
         WasmResult::Reply(b) => decode_one(&b).expect("decode reserves"),
         WasmResult::Reject(m) => panic!("get_protocol_3usd_reserves rejected: {}", m),
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct PendingThreeUsdRefundView {
+    stability_pool: Principal,
+    ledger: Principal,
+    amount_e8s: u64,
+    vault_id: u64,
+    retry_count: u8,
+    op_nonce: Nat,
+}
+
+fn get_pending_3usd_refunds(
+    pic: &PocketIc,
+    protocol_id: Principal,
+) -> Vec<PendingThreeUsdRefundView> {
+    let result = pic
+        .query_call(
+            protocol_id,
+            Principal::anonymous(),
+            "get_pending_3usd_refunds",
+            encode_args(()).unwrap(),
+        )
+        .expect("get_pending_3usd_refunds call failed");
+    match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode pending 3usd refunds"),
+        WasmResult::Reject(m) => panic!("get_pending_3usd_refunds rejected: {}", m),
+    }
+}
+
+/// Drive the backend's self-rescheduling `process_pending_transfer` timer by
+/// advancing PocketIC time past its 5s reschedule window and ticking.
+fn drain_pending_transfers(pic: &PocketIc) {
+    for _ in 0..6 {
+        pic.advance_time(Duration::from_secs(6));
+        for _ in 0..8 {
+            pic.tick();
+        }
     }
 }
 
@@ -898,15 +939,19 @@ fn icc_002_pic_writedown_failure_refunds_3usd_to_sp() {
     );
 }
 
-/// **Refund-of-refund failure.** Same setup as the prior test but the 3USD
-/// ledger is `flaky_ledger` with `set_fail_transfers(true)`. The pull
-/// (`icrc2_transfer_from`) is unaffected by that knob and lands; the
-/// kill-switch reject fires the Wave-4 refund arm; the refund
-/// (`icrc1_transfer`) fails. Asserts the protocol surfaces the writedown
-/// error, the SP balance does NOT come back, and the operator-visible
-/// CRITICAL log fires so the stranded tokens can be reconciled.
+/// **Refund failure is durable, not stranded.** Same setup as the prior test
+/// but the 3USD ledger is `flaky_ledger` with `set_fail_transfers(true)`. The
+/// pull (`icrc2_transfer_from`) is unaffected and lands; the kill-switch reject
+/// fires the refund arm; the refund (`icrc1_transfer`) fails.
+///
+/// Pre-fix, that failure only logged CRITICAL and left the 3USD stranded in the
+/// protocol's reserves subaccount, dropping the SP's live balance below its
+/// tracked aggregate and blocking every non-sole-holder withdrawal. This test
+/// pins the fix: the failed refund is persisted to `pending_3usd_refunds` and
+/// `process_pending_transfer` retries it. Once the ledger recovers, the queue
+/// drains, the SP is made whole, and the queue empties — no manual reconcile.
 #[test]
-fn icc_002_pic_refund_failure_logs_critical_and_strands_3usd() {
+fn icc_002_pic_refund_failure_enqueues_durable_retry_and_heals() {
     let f = setup_fixture(ThreePoolKind::Flaky);
 
     let icusd_debt: u64 = 500_000_000;
@@ -951,30 +996,72 @@ fn icc_002_pic_refund_failure_logs_critical_and_strands_3usd() {
         err
     );
 
-    let sp_balance_after = icrc1_balance_of(
+    // Immediately after the failed refund: the SP is still short (tokens are in
+    // reserves) BUT the refund is now durably queued rather than lost.
+    let sp_balance_after_fail = icrc1_balance_of(
         &f.pic,
         f.three_pool_ledger,
         account(f.sp_principal),
     );
     assert_eq!(
-        sp_balance_after,
+        sp_balance_after_fail,
         sp_balance_before - three_usd_amount as u128,
-        "SP balance MUST stay at the post-pull value: the refund failed and \
-         the tokens are stranded in the protocol's reserves subaccount; \
+        "SP balance is temporarily short after the refund failed; \
          saw before={} after={}",
-        sp_balance_before, sp_balance_after
+        sp_balance_before, sp_balance_after_fail
     );
 
-    let reserves_after = get_protocol_3usd_reserves(&f.pic, f.protocol_id);
+    let pending = get_pending_3usd_refunds(&f.pic, f.protocol_id);
     assert_eq!(
-        reserves_after, 0,
-        "the writedown rejected before the reserves counter increment, \
-         so the in-state counter stays zero even though tokens were stranded \
-         on-ledger — this divergence is what the CRITICAL log surfaces"
+        pending.len(),
+        1,
+        "the failed refund MUST be persisted to pending_3usd_refunds for retry, \
+         not stranded; saw {:?}",
+        pending
+    );
+    assert_eq!(pending[0].stability_pool, f.sp_principal);
+    assert_eq!(pending[0].ledger, f.three_pool_ledger);
+    assert_eq!(pending[0].vault_id, f.vault_id);
+    assert_eq!(
+        pending[0].amount_e8s, three_usd_amount,
+        "queued refund amount must equal the stranded excess (3USD fee is 0)"
     );
 
-    // The flaky ledger's `protocol_3usd_reserves` subaccount must hold the
-    // stranded tokens (the pull landed; the refund did not).
+    let logs = fetch_info_logs(&f.pic, f.protocol_id);
+    let vault_tag = format!("vault {}", f.vault_id);
+    assert!(
+        logs.iter().any(|m| {
+            m.contains("[stability_pool_liquidate_with_reserves] refund of")
+                && m.contains(&vault_tag)
+                && m.contains("enqueued for durable retry")
+        }),
+        "expected the enqueue-for-retry INFO log keyed to vault #{}; saw logs: {:?}",
+        f.vault_id, logs
+    );
+
+    // Now the ledger recovers. Draining the timer must settle the refund.
+    flaky_set_fail_transfers(&f.pic, f.three_pool_ledger, false);
+    drain_pending_transfers(&f.pic);
+
+    let pending_after = get_pending_3usd_refunds(&f.pic, f.protocol_id);
+    assert!(
+        pending_after.is_empty(),
+        "the durable refund queue MUST drain once the ledger recovers; saw {:?}",
+        pending_after
+    );
+
+    let sp_balance_healed = icrc1_balance_of(
+        &f.pic,
+        f.three_pool_ledger,
+        account(f.sp_principal),
+    );
+    assert_eq!(
+        sp_balance_healed, sp_balance_before,
+        "the SP MUST be made whole after the queue drains (3USD fee is 0); \
+         saw before={} healed={}",
+        sp_balance_before, sp_balance_healed
+    );
+
     let reserves_subacct_balance = icrc1_balance_of(
         &f.pic,
         f.three_pool_ledger,
@@ -984,30 +1071,18 @@ fn icc_002_pic_refund_failure_logs_critical_and_strands_3usd() {
         },
     );
     assert_eq!(
-        reserves_subacct_balance, three_usd_amount as u128,
-        "stranded 3USD MUST sit in the protocol's reserves subaccount on the \
-         3pool ledger — the refund could not move them; saw {}",
+        reserves_subacct_balance, 0,
+        "the reserves subaccount MUST be drained back to the SP after retry; saw {}",
         reserves_subacct_balance
     );
 
-    let logs = fetch_info_logs(&f.pic, f.protocol_id);
-    let vault_tag = format!("vault {}", f.vault_id);
+    let settled_log = fetch_info_logs(&f.pic, f.protocol_id);
     assert!(
-        logs.iter().any(|m| {
-            m.contains("[stability_pool_liquidate_with_reserves] CRITICAL: refund of")
-                && m.contains(&vault_tag)
-                && m.contains("FAILED")
+        settled_log.iter().any(|m| {
+            m.contains("[refunding] 3USD reserve refund settled")
+                && m.contains(&format!("vault {}", f.vault_id))
         }),
-        "expected Wave-4 CRITICAL refund-failure INFO log keyed to vault #{}; \
-         saw logs: {:?}",
-        f.vault_id, logs
-    );
-    // And no successful-refund log.
-    assert!(
-        !logs.iter().any(|m| {
-            m.contains("[stability_pool_liquidate_with_reserves] refunded")
-                && m.contains("after liquidation rollback")
-        }),
-        "refund failed — there must be no success refund log"
+        "expected a settled-refund log after the queue drained; saw logs: {:?}",
+        settled_log
     );
 }

--- a/src/rumi_protocol_backend/tests/audit_pocs_sp_liquidation_fee_accounting.rs
+++ b/src/rumi_protocol_backend/tests/audit_pocs_sp_liquidation_fee_accounting.rs
@@ -1,0 +1,935 @@
+//! Regression fence (2026-07-16): the stability pool must pay the ckStable
+//! ledger fee only as many times as it actually gets charged when it absorbs
+//! a liquidation, and its tracked aggregate (`total_stablecoin_balances`)
+//! must stay EXACTLY equal to the live `icrc1_balance_of(pool)` afterwards.
+//!
+//! # The bug this guards
+//!
+//! When the stability pool (SP) absorbs a liquidation using a nonzero-fee
+//! stablecoin (ckUSDT/ckUSDC) via the non-LP path in
+//! `stability_pool/src/liquidation.rs`, the pool's tokens are moved off its
+//! own ledger account TWICE:
+//!
+//!   1. `icrc2_approve` (SP -> backend spender) — charges the SP one ledger
+//!      fee immediately, regardless of whether the backend ever pulls.
+//!   2. The backend's `icrc2_transfer_from` (pulling the approved tokens
+//!      into the backend) — charges the SP a SECOND ledger fee, standard
+//!      ICRC-2 behavior (the `from` account always pays the transfer fee).
+//!
+//! Pre-fix, the SP's bookkeeping (`deduct_fee_from_pool`) only fired once,
+//! after the approve. So on every ckStable liquidation the tracked aggregate
+//! stayed one ledger fee ABOVE the pool's real on-ledger balance. That drift
+//! accumulates liquidation after liquidation and eventually trips the
+//! withdraw guard for non-sole-holders (insufficient live balance to honor
+//! the tracked aggregate).
+//!
+//! The fix (already applied, not touched by this test) calls
+//! `deduct_fee_from_pool` a SECOND time, using the live `icrc1_fee`, right
+//! after a successful pull (see `liquidation.rs`, the non-LP loop: approve ->
+//! deduct fee -> backend call -> on success, deduct fee again).
+//!
+//! # What this test does
+//!
+//! Deploys the full three-canister stack (backend + stability_pool + a
+//! nonzero-fee ckUSDT-style ICRC-1/2 ledger, plus ICP/icUSD ledgers and a
+//! mock XRC), registers ckUSDT as an accepted SP stablecoin AND as a backend
+//! stable-repayment token, deposits ckUSDT into the SP from a depositor,
+//! opens and deeply underwaters an ICP vault, then drives the SP's real
+//! `execute_liquidation` (the permissionless entry point used in production)
+//! so it actually calls `icrc2_approve` + the backend's
+//! `liquidate_vault_partial_with_stable` (which does `icrc2_transfer_from`)
+//! on the live ckUSDT ledger — the exact double-fee code path.
+//!
+//! Asserts, after the liquidation:
+//!   * `icrc1_balance_of(ckUSDT, sp_id) == get_pool_status(sp_id).stablecoin_balances[ckUSDT]`
+//!     EXACTLY (no one-fee drift).
+//!   * the live balance and the aggregate both dropped by exactly
+//!     `principal_consumed + 2 * ledger_fee` (the two fee charges the SP
+//!     books, plus the realized principal the backend actually pulled).
+//!
+//! Harness lifted from `audit_pocs_icc_002_3usd_refund.rs` (backend + ICP/
+//! icUSD ledger + mock-XRC deploy pattern) and
+//! `audit_pocs_bk_001_002_concurrent_liquidation_pic.rs` (the ICP
+//! price-drop-and-wait pattern needed to make a vault actually liquidatable
+//! through the CR-gated `liquidate_vault_partial_with_stable` path — unlike
+//! the LP/reserves path used by the ICC-002 fixture, this path DOES gate on
+//! CR). `stability_pool`'s own `pocket_ic_3usd.rs` supplied the SP
+//! deployment/registration/deposit/pool-status call shapes; `StablecoinConfig`
+//! / `StabilityPoolInitArgs` / `StabilityPoolError` / `LiquidationResult` are
+//! mirrored locally here (matching `stability_pool/src/types.rs`) since
+//! `stability_pool` is not a dependency of this crate and this file must not
+//! touch non-test source.
+
+use candid::{decode_one, encode_args, encode_one, CandidType, Deserialize, Nat, Principal};
+use pocket_ic::{PocketIc, PocketIcBuilder, WasmResult};
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime};
+
+use rumi_protocol_backend::{ProtocolError, StableTokenType, SuccessWithFee};
+
+// ─── ic-icrc1-ledger Candid mirrors (standard ledger; matches the ICC-002 template) ───
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+struct Account {
+    owner: Principal,
+    subaccount: Option<[u8; 32]>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct FeatureFlags {
+    icrc2: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ArchiveOptions {
+    num_blocks_to_archive: u64,
+    trigger_threshold: u64,
+    controller_id: Principal,
+    max_transactions_per_response: Option<u64>,
+    max_message_size_bytes: Option<u64>,
+    cycles_for_archive_creation: Option<u64>,
+    node_max_memory_size_bytes: Option<u64>,
+    more_controller_ids: Option<Vec<Principal>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct MetadataValue {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+    #[serde(rename = "Nat")]
+    nat: Option<Nat>,
+    #[serde(rename = "Int")]
+    int: Option<i64>,
+    #[serde(rename = "Blob")]
+    blob: Option<Vec<u8>>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct LedgerInitArgs {
+    minting_account: Account,
+    fee_collector_account: Option<Account>,
+    transfer_fee: Nat,
+    decimals: Option<u8>,
+    max_memo_length: Option<u16>,
+    token_name: String,
+    token_symbol: String,
+    metadata: Vec<(String, MetadataValue)>,
+    initial_balances: Vec<(Account, Nat)>,
+    feature_flags: Option<FeatureFlags>,
+    maximum_number_of_accounts: Option<u64>,
+    accounts_overflow_trim_quantity: Option<u64>,
+    archive_options: ArchiveOptions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum LedgerArg {
+    #[serde(rename = "Init")]
+    Init(LedgerInitArgs),
+    #[serde(rename = "Upgrade")]
+    Upgrade(Option<()>),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ApproveArgs {
+    from_subaccount: Option<[u8; 32]>,
+    spender: Account,
+    amount: Nat,
+    expected_allowance: Option<Nat>,
+    expires_at: Option<u64>,
+    fee: Option<Nat>,
+    memo: Option<Vec<u8>>,
+    created_at_time: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ApproveError {
+    BadFee { expected_fee: Nat },
+    InsufficientFunds { balance: Nat },
+    AllowanceChanged { current_allowance: Nat },
+    Expired { ledger_time: u64 },
+    TooOld,
+    CreatedInFuture { ledger_time: u64 },
+    Duplicate { duplicate_of: Nat },
+    TemporarilyUnavailable,
+    GenericError { error_code: Nat, message: String },
+}
+
+// ─── Backend init / vault Candid mirrors ───
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct ProtocolInitArg {
+    xrc_principal: Principal,
+    icusd_ledger_principal: Principal,
+    icp_ledger_principal: Principal,
+    fee_e8s: u64,
+    developer_principal: Principal,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum ProtocolArgVariant {
+    Init(ProtocolInitArg),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct VaultArg {
+    vault_id: u64,
+    amount: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct OpenVaultSuccess {
+    vault_id: u64,
+    block_index: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct LiquidatableVault {
+    vault_id: u64,
+}
+
+// ─── stability_pool Candid mirrors (matches `stability_pool/src/types.rs`) ───
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct StabilityPoolInitArgs {
+    protocol_canister_id: Principal,
+    authorized_admins: Vec<Principal>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct StablecoinConfig {
+    ledger_id: Principal,
+    symbol: String,
+    decimals: u8,
+    priority: u8,
+    is_active: bool,
+    transfer_fee: Option<u64>,
+    is_lp_token: Option<bool>,
+    underlying_pool: Option<Principal>,
+}
+
+/// Only the field this test needs from `StabilityPoolStatus`. Candid record
+/// decoding matches by field name/hash, not position or completeness — extra
+/// wire fields we don't declare here (total_deposits_e8s, stablecoin_registry,
+/// collateral_registry, etc.) are simply skipped.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct StabilityPoolStatusView {
+    stablecoin_balances: BTreeMap<Principal, u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+struct LiquidationResult {
+    vault_id: u64,
+    stables_consumed: BTreeMap<Principal, u64>,
+    collateral_gained: u64,
+    collateral_type: Principal,
+    success: bool,
+    error_message: Option<String>,
+}
+
+/// Full mirror of `stability_pool::types::StabilityPoolError` so `.expect()`
+/// on a `Result<_, StabilityPoolError>` decode succeeds and prints a useful
+/// message on the (unexpected) error path.
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum StabilityPoolError {
+    InsufficientBalance {
+        token: Principal,
+        required: u64,
+        available: u64,
+    },
+    AmountTooLow {
+        minimum_e8s: u64,
+    },
+    NoPositionFound,
+    InsufficientPoolBalance,
+    Unauthorized,
+    TokenNotAccepted {
+        ledger: Principal,
+    },
+    TokenNotActive {
+        ledger: Principal,
+    },
+    CollateralNotFound {
+        ledger: Principal,
+    },
+    LedgerTransferFailed {
+        reason: String,
+    },
+    InterCanisterCallFailed {
+        target: String,
+        method: String,
+    },
+    LiquidationFailed {
+        vault_id: u64,
+        reason: String,
+    },
+    EmergencyPaused,
+    SystemBusy,
+    AlreadyOptedOut {
+        collateral: Principal,
+    },
+    AlreadyOptedIn {
+        collateral: Principal,
+    },
+    PayoutAddressRequired {
+        collateral: Principal,
+    },
+    InvalidPayoutAddress {
+        reason: String,
+    },
+    XrpClaimStillOutstanding {
+        claim_id: u64,
+    },
+    XrpClaimStatusCheckFailed {
+        reason: String,
+    },
+    RefundClaimNotFound,
+}
+
+// ─── WASM fixtures ───
+
+fn icrc1_ledger_wasm() -> Vec<u8> {
+    include_bytes!("../../ledger/ic-icrc1-ledger.wasm").to_vec()
+}
+
+fn protocol_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/rumi_protocol_backend.wasm")
+        .to_vec()
+}
+
+fn stability_pool_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/stability_pool.wasm").to_vec()
+}
+
+fn xrc_wasm() -> Vec<u8> {
+    include_bytes!("../../xrc_demo/xrc/xrc.wasm").to_vec()
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Default)]
+struct MockXRC {
+    rates: Vec<(String, u64)>,
+}
+
+fn prepare_mock_xrc() -> Vec<u8> {
+    let mock = MockXRC {
+        rates: vec![("ICP/USD".to_string(), 1_000_000_000)], // $10.00 (e8s, 8 decimals)
+    };
+    encode_one(mock).expect("encode mock XRC init")
+}
+
+// ─── Helpers ───
+
+fn account(owner: Principal) -> Account {
+    Account {
+        owner,
+        subaccount: None,
+    }
+}
+
+fn deploy_icrc1_ledger(
+    pic: &PocketIc,
+    minting_account: Account,
+    transfer_fee: u64,
+    initial_balances: Vec<(Account, Nat)>,
+    name: &str,
+    symbol: &str,
+    controller: Principal,
+) -> Principal {
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = LedgerInitArgs {
+        minting_account,
+        fee_collector_account: None,
+        transfer_fee: Nat::from(transfer_fee),
+        decimals: Some(8),
+        max_memo_length: Some(64),
+        token_name: name.into(),
+        token_symbol: symbol.into(),
+        metadata: vec![],
+        initial_balances,
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: controller,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).expect("encode ledger init"),
+        None,
+    );
+    ledger_id
+}
+
+/// Same as `deploy_icrc1_ledger` but with an explicit `decimals` (the ICP/
+/// icUSD ledgers above are hardcoded to 8; ckUSDT-style ledgers are 6).
+fn deploy_icrc1_ledger_with_decimals(
+    pic: &PocketIc,
+    minting_account: Account,
+    transfer_fee: u64,
+    decimals: u8,
+    initial_balances: Vec<(Account, Nat)>,
+    name: &str,
+    symbol: &str,
+    controller: Principal,
+) -> Principal {
+    let ledger_id = pic.create_canister();
+    pic.add_cycles(ledger_id, 2_000_000_000_000);
+    let init = LedgerInitArgs {
+        minting_account,
+        fee_collector_account: None,
+        transfer_fee: Nat::from(transfer_fee),
+        decimals: Some(decimals),
+        max_memo_length: Some(64),
+        token_name: name.into(),
+        token_symbol: symbol.into(),
+        metadata: vec![],
+        initial_balances,
+        feature_flags: Some(FeatureFlags { icrc2: true }),
+        maximum_number_of_accounts: None,
+        accounts_overflow_trim_quantity: None,
+        archive_options: ArchiveOptions {
+            num_blocks_to_archive: 2000,
+            trigger_threshold: 1000,
+            controller_id: controller,
+            max_transactions_per_response: None,
+            max_message_size_bytes: None,
+            cycles_for_archive_creation: None,
+            node_max_memory_size_bytes: None,
+            more_controller_ids: None,
+        },
+    };
+    pic.install_canister(
+        ledger_id,
+        icrc1_ledger_wasm(),
+        encode_args((LedgerArg::Init(init),)).expect("encode ledger init"),
+        None,
+    );
+    ledger_id
+}
+
+fn icrc2_approve_call(
+    pic: &PocketIc,
+    ledger: Principal,
+    sender: Principal,
+    spender: Principal,
+    amount: u128,
+) {
+    let args = ApproveArgs {
+        from_subaccount: None,
+        spender: account(spender),
+        amount: Nat::from(amount),
+        expected_allowance: None,
+        expires_at: None,
+        fee: None,
+        memo: None,
+        created_at_time: None,
+    };
+    let result = pic
+        .update_call(ledger, sender, "icrc2_approve", encode_one(args).unwrap())
+        .expect("icrc2_approve call failed");
+    let parsed: Result<Nat, ApproveError> = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode approve"),
+        WasmResult::Reject(m) => panic!("approve rejected: {}", m),
+    };
+    parsed.expect("approve returned ledger error");
+}
+
+fn icrc1_balance_of(pic: &PocketIc, ledger: Principal, account_arg: Account) -> u128 {
+    let result = pic
+        .query_call(
+            ledger,
+            Principal::anonymous(),
+            "icrc1_balance_of",
+            encode_one(account_arg).unwrap(),
+        )
+        .expect("icrc1_balance_of call failed");
+    let parsed: Nat = match result {
+        WasmResult::Reply(b) => decode_one(&b).expect("decode balance"),
+        WasmResult::Reject(m) => panic!("balance rejected: {}", m),
+    };
+    parsed.0.try_into().unwrap_or(0)
+}
+
+fn xrc_set_rate(
+    pic: &PocketIc,
+    xrc: Principal,
+    sender: Principal,
+    base: &str,
+    quote: &str,
+    rate_e8s: u64,
+) {
+    let result = pic
+        .update_call(
+            xrc,
+            sender,
+            "set_exchange_rate",
+            encode_args((base.to_string(), quote.to_string(), rate_e8s)).unwrap(),
+        )
+        .expect("set_exchange_rate call failed");
+    if let WasmResult::Reject(m) = result {
+        panic!("set_exchange_rate rejected: {}", m);
+    }
+}
+
+fn open_and_borrow(
+    pic: &PocketIc,
+    protocol_id: Principal,
+    icp_ledger: Principal,
+    user: Principal,
+    collateral_e8s: u64,
+    borrow_e8s: u64,
+) -> u64 {
+    icrc2_approve_call(pic, icp_ledger, user, protocol_id, collateral_e8s as u128);
+    let open_result = pic
+        .update_call(
+            protocol_id,
+            user,
+            "open_vault",
+            encode_args((collateral_e8s, None::<Principal>)).unwrap(),
+        )
+        .expect("open_vault failed");
+    let vault_id = match open_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<OpenVaultSuccess, ProtocolError> =
+                decode_one(&bytes).expect("decode open_vault");
+            r.expect("open_vault returned error").vault_id
+        }
+        WasmResult::Reject(msg) => panic!("open_vault rejected: {}", msg),
+    };
+    let borrow_result = pic
+        .update_call(
+            protocol_id,
+            user,
+            "borrow_from_vault",
+            encode_args((VaultArg {
+                vault_id,
+                amount: borrow_e8s,
+            },))
+            .unwrap(),
+        )
+        .expect("borrow_from_vault failed");
+    match borrow_result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<SuccessWithFee, ProtocolError> =
+                decode_one(&bytes).expect("decode borrow");
+            r.expect("borrow_from_vault returned error");
+        }
+        WasmResult::Reject(msg) => panic!("borrow rejected: {}", msg),
+    }
+    vault_id
+}
+
+fn register_stablecoin(
+    pic: &PocketIc,
+    sp_id: Principal,
+    admin: Principal,
+    config: StablecoinConfig,
+) {
+    let symbol = config.symbol.clone();
+    let result = pic
+        .update_call(
+            sp_id,
+            admin,
+            "register_stablecoin",
+            encode_one(config).unwrap(),
+        )
+        .expect("register_stablecoin call failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<(), StabilityPoolError> =
+                decode_one(&bytes).expect("decode register_stablecoin");
+            r.unwrap_or_else(|e| panic!("register_stablecoin failed for {}: {:?}", symbol, e));
+        }
+        WasmResult::Reject(msg) => panic!("register_stablecoin rejected: {}", msg),
+    }
+}
+
+fn sp_deposit(pic: &PocketIc, sp_id: Principal, depositor: Principal, ledger: Principal, amount: u64) {
+    let result = pic
+        .update_call(
+            sp_id,
+            depositor,
+            "deposit",
+            encode_args((ledger, amount)).unwrap(),
+        )
+        .expect("deposit call failed");
+    match result {
+        WasmResult::Reply(bytes) => {
+            let r: Result<(), StabilityPoolError> = decode_one(&bytes).expect("decode deposit");
+            r.expect("deposit failed");
+        }
+        WasmResult::Reject(msg) => panic!("deposit rejected: {}", msg),
+    }
+}
+
+fn get_pool_status(pic: &PocketIc, sp_id: Principal) -> StabilityPoolStatusView {
+    let result = pic
+        .query_call(
+            sp_id,
+            Principal::anonymous(),
+            "get_pool_status",
+            encode_args(()).unwrap(),
+        )
+        .expect("get_pool_status call failed");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode pool status"),
+        WasmResult::Reject(msg) => panic!("get_pool_status rejected: {}", msg),
+    }
+}
+
+fn execute_liquidation(
+    pic: &PocketIc,
+    sp_id: Principal,
+    caller: Principal,
+    vault_id: u64,
+) -> Result<LiquidationResult, StabilityPoolError> {
+    let result = pic
+        .update_call(
+            sp_id,
+            caller,
+            "execute_liquidation",
+            encode_args((vault_id,)).unwrap(),
+        )
+        .expect("execute_liquidation call failed");
+    match result {
+        WasmResult::Reply(bytes) => decode_one(&bytes).expect("decode execute_liquidation"),
+        WasmResult::Reject(msg) => panic!("execute_liquidation rejected: {}", msg),
+    }
+}
+
+// ─── Test ───
+
+/// Full end-to-end fence: the SP's `execute_liquidation` pulls a nonzero-fee
+/// ckUSDT-style stablecoin from itself via the approve + backend
+/// transfer_from path (the exact double-fee code path this bug lived in),
+/// and afterwards the SP's live ckUSDT ledger balance must equal its tracked
+/// `total_stablecoin_balances` aggregate EXACTLY.
+#[test]
+fn sp_ckstable_liquidation_keeps_live_balance_equal_to_aggregate() {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+
+    let victim = Principal::self_authenticating(b"sp_fee_acct_victim");
+    let developer = Principal::self_authenticating(b"sp_fee_acct_developer");
+    let sp_admin = Principal::self_authenticating(b"sp_fee_acct_sp_admin");
+    let depositor = Principal::self_authenticating(b"sp_fee_acct_depositor");
+    let keeper = Principal::self_authenticating(b"sp_fee_acct_keeper");
+
+    // ── Backend canister ──
+    let protocol_id = pic.create_canister();
+    pic.add_cycles(protocol_id, 2_000_000_000_000);
+    pic.set_controllers(protocol_id, None, vec![Principal::anonymous(), developer])
+        .expect("set_controllers failed");
+
+    let icp_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        10_000,
+        vec![(account(victim), Nat::from(1_000_000_000_000u64))],
+        "Internet Computer Protocol",
+        "ICP",
+        developer,
+    );
+    let icusd_ledger = deploy_icrc1_ledger(
+        &pic,
+        account(protocol_id),
+        10_000,
+        vec![],
+        "icUSD",
+        "icUSD",
+        developer,
+    );
+
+    let xrc_id = pic.create_canister();
+    pic.add_cycles(xrc_id, 1_000_000_000_000);
+    pic.install_canister(xrc_id, xrc_wasm(), prepare_mock_xrc(), None);
+
+    pic.set_time(SystemTime::UNIX_EPOCH + Duration::from_secs(1_711_324_800));
+
+    let init = ProtocolArgVariant::Init(ProtocolInitArg {
+        fee_e8s: 10_000,
+        icp_ledger_principal: icp_ledger,
+        xrc_principal: xrc_id,
+        icusd_ledger_principal: icusd_ledger,
+        developer_principal: developer,
+    });
+    pic.install_canister(
+        protocol_id,
+        protocol_wasm(),
+        encode_args((init,)).expect("encode protocol init"),
+        None,
+    );
+    pic.advance_time(Duration::from_secs(1));
+    for _ in 0..10 {
+        pic.tick();
+    }
+
+    // Quiet down dynamic curves so the liquidation math stays predictable
+    // (mirrors the BK-001/002 concurrent-liquidation fixture).
+    for (method, payload) in [
+        (
+            "set_borrowing_fee_curve",
+            encode_args((None::<String>,)).unwrap(),
+        ),
+        ("set_borrowing_fee", encode_args((0.0f64,)).unwrap()),
+    ] {
+        pic.update_call(protocol_id, developer, method, payload)
+            .expect(method);
+    }
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_rate_curve_markers",
+        encode_args((None::<Principal>, vec![(1.5f64, 1.0f64), (3.0f64, 1.0f64)])).unwrap(),
+    )
+    .expect("set_rate_curve_markers");
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_interest_rate",
+        encode_args((icp_ledger, 0.0f64)).unwrap(),
+    )
+    .expect("set_interest_rate");
+
+    // ── ckUSDT-style nonzero-fee ledger (the SP consumes THIS token) ──
+    let ckusdt_fee = 10_000u64; // 0.01 ckUSDT at 6 decimals
+    let depositor_initial_balance = 2_000_000_000u64; // 2,000 ckUSDT
+    let ckusdt_ledger = deploy_icrc1_ledger_with_decimals(
+        &pic,
+        account(developer), // minting account (unused as a real spender here)
+        ckusdt_fee,
+        6,
+        vec![(account(depositor), Nat::from(depositor_initial_balance))],
+        "ckUSDT",
+        "ckUSDT",
+        developer,
+    );
+
+    // Wire ckUSDT into the backend as an accepted stable-repayment/liquidation token.
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_stable_token_enabled",
+        encode_args((StableTokenType::CKUSDT, true)).unwrap(),
+    )
+    .expect("set_stable_token_enabled call failed");
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_stable_ledger_principal",
+        encode_args((StableTokenType::CKUSDT, ckusdt_ledger)).unwrap(),
+    )
+    .expect("set_stable_ledger_principal call failed");
+
+    // ── Stability pool canister ──
+    let sp_init = StabilityPoolInitArgs {
+        protocol_canister_id: protocol_id,
+        authorized_admins: vec![sp_admin],
+    };
+    let sp_id = pic.create_canister();
+    pic.add_cycles(sp_id, 2_000_000_000_000);
+    pic.install_canister(
+        sp_id,
+        stability_pool_wasm(),
+        encode_one(sp_init).unwrap(),
+        None,
+    );
+
+    pic.update_call(
+        protocol_id,
+        developer,
+        "set_stability_pool_principal",
+        encode_args((sp_id,)).unwrap(),
+    )
+    .expect("set_stability_pool_principal call failed");
+
+    register_stablecoin(
+        &pic,
+        sp_id,
+        sp_admin,
+        StablecoinConfig {
+            ledger_id: ckusdt_ledger,
+            symbol: "ckUSDT".to_string(),
+            decimals: 6,
+            priority: 2,
+            is_active: true,
+            transfer_fee: Some(ckusdt_fee),
+            is_lp_token: None,
+            underlying_pool: None,
+        },
+    );
+
+    // Depositor funds the SP with ckUSDT (this is the balance the liquidation
+    // will draw from).
+    let deposit_amount = 500_000_000u64; // 500 ckUSDT ($500 equivalent)
+    icrc2_approve_call(
+        &pic,
+        ckusdt_ledger,
+        depositor,
+        sp_id,
+        depositor_initial_balance as u128,
+    );
+    sp_deposit(&pic, sp_id, depositor, ckusdt_ledger, deposit_amount);
+
+    // Pre-liquidation sanity: live ledger balance and tracked aggregate agree
+    // exactly (deposit credits the pool for the full pulled amount; the
+    // depositor pays their own approve/transfer_from fees out of their own
+    // balance, not out of the deposited amount).
+    let live_before = icrc1_balance_of(&pic, ckusdt_ledger, account(sp_id));
+    let agg_before = get_pool_status(&pic, sp_id)
+        .stablecoin_balances
+        .get(&ckusdt_ledger)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        live_before, deposit_amount as u128,
+        "SP's live ckUSDT balance must equal the deposited amount"
+    );
+    assert_eq!(
+        agg_before, deposit_amount,
+        "SP's tracked ckUSDT aggregate must equal the deposited amount"
+    );
+    assert_eq!(
+        live_before, agg_before as u128,
+        "precondition: live balance and tracked aggregate must already agree \
+         before the liquidation under test"
+    );
+
+    // XRC needs a USDT/USD rate for the backend's depeg check
+    // (`ensure_stable_not_depegged`) inside `liquidate_vault_partial_with_stable`.
+    xrc_set_rate(&pic, xrc_id, developer, "USDT", "USD", 100_000_000); // $1.00
+
+    // ── Open and deeply underwater a vault: 50 ICP / 100 icUSD at $10/ICP,
+    // then crash ICP to $0.10 (mirrors BK-001/002's proven price-drop fixture). ──
+    let collateral_e8s = 5_000_000_000u64; // 50 ICP
+    let borrow_e8s = 10_000_000_000u64; // 100 icUSD
+    let vault_id = open_and_borrow(
+        &pic,
+        protocol_id,
+        icp_ledger,
+        victim,
+        collateral_e8s,
+        borrow_e8s,
+    );
+
+    xrc_set_rate(&pic, xrc_id, developer, "ICP", "USD", 10_000_000); // $0.10
+    let mut liquidatable = false;
+    for _ in 0..12 {
+        pic.advance_time(Duration::from_secs(310));
+        for _ in 0..6 {
+            pic.tick();
+        }
+        let result = pic
+            .query_call(
+                protocol_id,
+                Principal::anonymous(),
+                "get_liquidatable_vaults",
+                encode_args(()).unwrap(),
+            )
+            .expect("get_liquidatable_vaults");
+        if let WasmResult::Reply(b) = result {
+            if let Ok(vaults) = decode_one::<Vec<LiquidatableVault>>(&b) {
+                if vaults.iter().any(|v| v.vault_id == vault_id) {
+                    liquidatable = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(
+        liquidatable,
+        "fixture precondition: vault must be liquidatable (cached ICP price \
+         propagated to $0.10) before driving the SP's execute_liquidation"
+    );
+
+    // ── Drive the SP's real liquidation path: this is what actually exercises
+    // icrc2_approve + the backend's icrc2_transfer_from double-fee code path. ──
+    let live_fee = {
+        let result = pic
+            .query_call(
+                ckusdt_ledger,
+                Principal::anonymous(),
+                "icrc1_fee",
+                encode_args(()).unwrap(),
+            )
+            .expect("icrc1_fee call failed");
+        let fee: Nat = match result {
+            WasmResult::Reply(b) => decode_one(&b).expect("decode fee"),
+            WasmResult::Reject(m) => panic!("icrc1_fee rejected: {}", m),
+        };
+        let fee: u64 = fee.0.try_into().expect("fee overflow");
+        assert_eq!(fee, ckusdt_fee, "sanity: live ledger fee matches init arg");
+        fee
+    };
+
+    let liq = execute_liquidation(&pic, sp_id, keeper, vault_id)
+        .expect("execute_liquidation must succeed against a liquidatable vault");
+    assert!(
+        liq.success,
+        "liquidation must report success; error_message={:?}",
+        liq.error_message
+    );
+    assert_eq!(liq.vault_id, vault_id);
+    assert!(
+        liq.collateral_gained > 0,
+        "SP must have received ICP collateral from the liquidation"
+    );
+
+    let principal_consumed = *liq
+        .stables_consumed
+        .get(&ckusdt_ledger)
+        .expect("ckUSDT must be the token consumed by this liquidation (only registered token)");
+    assert!(
+        principal_consumed > 0,
+        "the liquidation must have actually consumed ckUSDT principal"
+    );
+
+    // ── THE INVARIANT: live balance and tracked aggregate must be EXACTLY equal ──
+    let live_after = icrc1_balance_of(&pic, ckusdt_ledger, account(sp_id));
+    let pool_status_after = get_pool_status(&pic, sp_id);
+    let agg_after = pool_status_after
+        .stablecoin_balances
+        .get(&ckusdt_ledger)
+        .copied()
+        .unwrap_or(0);
+
+    assert_eq!(
+        live_after, agg_after as u128,
+        "BUG REGRESSION: SP's live ckUSDT ledger balance ({}) must equal its \
+         tracked aggregate ({}) after absorbing a nonzero-fee-stablecoin \
+         liquidation. A live < aggregate drift means the pool paid the ledger \
+         fee more times than it booked (the double-fee bug); a live > aggregate \
+         drift means it booked more than it paid.",
+        live_after, agg_after
+    );
+
+    // ── Exact accounting: both sides must have dropped by precisely
+    // principal_consumed + 2 * ledger_fee (one fee on the SP's icrc2_approve,
+    // a second on the backend's icrc2_transfer_from pull). This is the
+    // "no off-by-one-fee" check — the fix debits the SECOND fee exactly once,
+    // not zero times (pre-fix bug) and not twice (an over-correction bug). ──
+    let expected_drop = principal_consumed + 2 * live_fee;
+    let live_drop = live_before - live_after;
+    let agg_drop = (agg_before - agg_after) as u128;
+
+    assert_eq!(
+        live_drop, expected_drop as u128,
+        "live ckUSDT balance must drop by exactly principal_consumed ({}) + \
+         2 * ledger_fee ({} x2); saw drop={}",
+        principal_consumed, live_fee, live_drop
+    );
+    assert_eq!(
+        agg_drop, expected_drop as u128,
+        "tracked ckUSDT aggregate must drop by exactly principal_consumed ({}) + \
+         2 * ledger_fee ({} x2); saw drop={}",
+        principal_consumed, live_fee, agg_drop
+    );
+}

--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -180,7 +180,7 @@ pub async fn transfer_unallocated_interest_to_treasury(
     }
 }
 
-async fn ledger_pool_balance(ledger: Principal) -> Option<u64> {
+pub(crate) async fn ledger_pool_balance(ledger: Principal) -> Option<u64> {
     let account = Account {
         owner: ic_cdk::api::id(),
         subaccount: None,

--- a/src/stability_pool/src/deposits.rs
+++ b/src/stability_pool/src/deposits.rs
@@ -80,7 +80,7 @@ fn fallback_ledger_fee(ledger: Principal) -> u64 {
 /// Fetch a stablecoin ledger's transfer fee, caching successful lookups per
 /// ledger. On query failure, falls back to normalized registry metadata without
 /// caching so the next transfer re-queries.
-async fn ledger_transfer_fee(ledger: Principal) -> u64 {
+pub(crate) async fn ledger_transfer_fee(ledger: Principal) -> u64 {
     if let Some(fee) = LEDGER_FEES.with(|c| c.borrow().get(&ledger).copied()) {
         return fee;
     }

--- a/src/stability_pool/src/lib.rs
+++ b/src/stability_pool/src/lib.rs
@@ -17,6 +17,11 @@ use crate::types::*;
 
 const CHAIN_ABSORB_AUTO_TIMER_POLL_SECONDS: u64 = 60;
 const UNALLOCATED_INTEREST_FORWARD_RETRY_SECONDS: u64 = 60;
+/// How often the pool reconciles its tracked aggregate against live ledger
+/// balances and logs any shortfall. Hourly: a handful of balance queries, so
+/// negligible cycle cost, while still surfacing drift long before it can trip a
+/// depositor's withdrawal.
+const LEDGER_RECONCILIATION_CHECK_SECONDS: u64 = 3600;
 
 pub(crate) fn pool_balance_mutation_blocked() -> bool {
     crate::pool_guard::liquidation_in_progress() || read_state(|s| s.has_pending_pool_absorbs())
@@ -58,6 +63,7 @@ fn init(args: StabilityPoolInitArgs) {
         setup_virtual_price_timer();
         setup_chain_absorb_auto_timer();
         setup_unallocated_interest_forward_retry_timer();
+        setup_ledger_reconciliation_timer();
     });
 }
 
@@ -96,6 +102,7 @@ fn post_upgrade(_args: StabilityPoolInitArgs) {
         setup_virtual_price_timer();
         setup_chain_absorb_auto_timer();
         setup_unallocated_interest_forward_retry_timer();
+        setup_ledger_reconciliation_timer();
     });
 }
 
@@ -837,6 +844,84 @@ pub fn validate_pool_state() -> Result<String, String> {
         s.validate_state()
             .map(|_| "Pool state is consistent".to_string())
     })
+}
+
+/// Compare each registered stablecoin's tracked aggregate against its live
+/// on-ledger balance. Read-only: queries every ledger and returns the deltas,
+/// never mutates state. Ledgers whose balance query fails are omitted (logged)
+/// rather than reported as a false shortfall.
+async fn compute_ledger_reconciliation() -> Vec<LedgerReconciliationEntry> {
+    let tokens: Vec<(Principal, String)> = read_state(|s| {
+        s.stablecoin_registry
+            .iter()
+            .map(|(ledger, config)| (*ledger, config.symbol.clone()))
+            .collect()
+    });
+
+    let mut entries = Vec::with_capacity(tokens.len());
+    for (ledger, symbol) in tokens {
+        let Some(live_e8s) = crate::deposits::ledger_pool_balance(ledger).await else {
+            continue;
+        };
+        let recorded_e8s = read_state(|s| {
+            s.total_stablecoin_balances
+                .get(&ledger)
+                .copied()
+                .unwrap_or(0)
+        });
+        entries.push(LedgerReconciliationEntry {
+            ledger,
+            symbol,
+            recorded_e8s,
+            live_e8s,
+            delta_e8s: live_e8s as i64 - recorded_e8s as i64,
+            healthy: live_e8s >= recorded_e8s,
+        });
+    }
+    entries
+}
+
+/// Admin-only, read-only ledger reconciliation. Reveals, per stablecoin, the
+/// tracked aggregate vs. the live ledger balance so a shortfall (books above
+/// ledger) can be spotted and remediated (top up the pool, or `admin_correct_balance`)
+/// before it blocks withdrawals. Admin-gated because it triggers one
+/// inter-canister balance query per token.
+#[update]
+pub async fn get_ledger_reconciliation() -> Result<Vec<LedgerReconciliationEntry>, StabilityPoolError>
+{
+    let caller = ic_cdk::api::caller();
+    if !read_state(|s| s.is_admin(&caller)) {
+        return Err(StabilityPoolError::Unauthorized);
+    }
+    Ok(compute_ledger_reconciliation().await)
+}
+
+/// Periodic self-check: reconcile tracked aggregates against live ledger
+/// balances and log any shortfall so operators are alerted proactively. Never
+/// auto-corrects — writing books down to a transient in-flight balance (e.g.
+/// mid-liquidation) would socialize a phantom loss; remediation stays a
+/// deliberate admin action.
+fn setup_ledger_reconciliation_timer() {
+    ic_cdk_timers::set_timer_interval(
+        Duration::from_secs(LEDGER_RECONCILIATION_CHECK_SECONDS),
+        || {
+            ic_cdk::spawn(async {
+                for entry in compute_ledger_reconciliation().await {
+                    if !entry.healthy {
+                        log!(
+                            INFO,
+                            "[ledger-reconciliation] SHORTFALL {} ({}): live {} < recorded {} (delta {})",
+                            entry.symbol,
+                            entry.ledger,
+                            entry.live_e8s,
+                            entry.recorded_e8s,
+                            entry.delta_e8s
+                        );
+                    }
+                }
+            });
+        },
+    );
 }
 
 // ─── Admin: Registry Management ───

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -2137,6 +2137,14 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
             continue;
         }
 
+        // The pool pays the LIVE ledger fee twice per liquidated token: once on
+        // the `icrc2_approve` below, and again when the backend's
+        // `icrc2_transfer_from` pulls the tokens (both are charged to the pool as
+        // the `from`/approver account). Use the live `icrc1_fee` rather than the
+        // (possibly stale) registry `transfer_fee` so the book decrement matches
+        // exactly what the ledger charges.
+        let ledger_fee = crate::deposits::ledger_transfer_fee(*token_ledger).await;
+
         // Approve backend to spend this token
         let approve_args = ApproveArgs {
             from_subaccount: None,
@@ -2157,14 +2165,11 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
 
         match approve_result {
             Ok((Ok(_),)) => {
-                // Deduct the approve fee from tracked balances
-                if let Some(fee) = stablecoin_configs
-                    .get(token_ledger)
-                    .and_then(|c| c.transfer_fee)
-                {
-                    if fee > 0 {
-                        mutate_state(|s| s.deduct_fee_from_pool(*token_ledger, fee));
-                    }
+                // Deduct the approve fee from tracked balances. The matching
+                // transfer_from fee is deducted only on a successful pull below
+                // (a failed backend call charges no transfer_from fee).
+                if ledger_fee > 0 {
+                    mutate_state(|s| s.deduct_fee_from_pool(*token_ledger, ledger_fee));
                 }
             }
             Ok((Err(e),)) => {
@@ -2274,6 +2279,15 @@ async fn execute_single_liquidation(vault_info: &LiquidatableVaultInfo) -> Liqui
                     (None, _) => *amount,
                 };
                 actual_consumed.insert(*token_ledger, realized_consumed);
+                // The backend's `icrc2_transfer_from` pull charged the pool a
+                // second ledger fee (the approve fee was already deducted above).
+                // Debit it too, otherwise the tracked aggregate stays one fee
+                // above the live ledger balance per liquidation and eventually
+                // trips the withdraw guard for non-sole holders (SP live-vs-ledger
+                // drift, 2026-07-16).
+                if ledger_fee > 0 {
+                    mutate_state(|s| s.deduct_fee_from_pool(*token_ledger, ledger_fee));
+                }
                 total_collateral_gained += collateral;
                 // Bug 7: one token per vault per round — vault state changed, remaining draws are stale
                 break;

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -36,6 +36,27 @@ pub struct StablecoinConfig {
     pub underlying_pool: Option<Principal>,
 }
 
+/// Per-stablecoin reconciliation of the pool's tracked aggregate against its
+/// live on-ledger balance. `validate_pool_state` only checks internal
+/// book-vs-book consistency and never touches the ledger, so a physical
+/// outflow that isn't mirrored in the books (a stranded refund, an
+/// under-booked liquidation fee) stays invisible until a withdrawal trips the
+/// `InsufficientPoolBalance` guard. This surfaces that drift directly.
+#[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LedgerReconciliationEntry {
+    pub ledger: Principal,
+    pub symbol: String,
+    /// `total_stablecoin_balances[ledger]` — what the books say depositors are owed.
+    pub recorded_e8s: u64,
+    /// Live `icrc1_balance_of(pool)` on that ledger.
+    pub live_e8s: u64,
+    /// `live_e8s - recorded_e8s`. Negative = shortfall (books above ledger →
+    /// withdrawals for non-sole holders will be blocked). Positive = surplus (safe).
+    pub delta_e8s: i64,
+    /// `live_e8s >= recorded_e8s`. False means a shortfall needs remediation.
+    pub healthy: bool,
+}
+
 /// Subset of backend CollateralConfig needed by the pool.
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollateralInfo {

--- a/src/stability_pool/stability_pool.did
+++ b/src/stability_pool/stability_pool.did
@@ -28,6 +28,15 @@ type CollateralInfo = record {
   status : CollateralStatus;
 };
 
+type LedgerReconciliationEntry = record {
+  ledger : principal;
+  symbol : text;
+  recorded_e8s : nat64;
+  live_e8s : nat64;
+  delta_e8s : int64;
+  healthy : bool;
+};
+
 type CollateralStatus = variant {
   Active;
   Paused;
@@ -466,6 +475,9 @@ service : (StabilityPoolInitArgs) -> {
   check_pool_capacity : (principal, nat64) -> (bool) query;
   check_chain_absorb_capacity : (principal, nat64) -> (bool) query;
   validate_pool_state : () -> (variant { Ok : text; Err : text }) query;
+  get_ledger_reconciliation : () -> (
+      variant { Ok : vec LedgerReconciliationEntry; Err : StabilityPoolError },
+    );
   get_suspended_tokens : () -> (vec record { principal; nat32 }) query;
   get_pool_events : (nat64, nat64) -> (vec PoolEvent) query;
   get_pool_event_count : () -> (nat64) query;

--- a/src/stability_pool/tests/pocket_ic_3usd.rs
+++ b/src/stability_pool/tests/pocket_ic_3usd.rs
@@ -698,6 +698,90 @@ fn test_direct_icusd_deposit() {
     assert_eq!(status.total_deposits_e8s, deposit_amount);
 }
 
+/// Reconciliation observability: after a clean deposit, the pool's tracked
+/// aggregate matches its live ledger balance, `get_ledger_reconciliation`
+/// reports it healthy, and the endpoint is admin-gated.
+#[test]
+fn test_get_ledger_reconciliation_reports_healthy_and_is_admin_gated() {
+    let env = setup_test_env();
+    let deposit_amount: u64 = 100_00000000; // 100 icUSD
+
+    let result = env
+        .pic
+        .update_call(
+            env.sp_id,
+            env.test_user,
+            "deposit",
+            encode_args((env.icusd_ledger, deposit_amount)).unwrap(),
+        )
+        .expect("deposit call failed");
+    match result {
+        WasmResult::Reply(bytes) => decode_one::<Result<(), StabilityPoolError>>(&bytes)
+            .unwrap()
+            .expect("deposit failed"),
+        WasmResult::Reject(msg) => panic!("deposit rejected: {}", msg),
+    }
+
+    // Non-admin callers are rejected (the endpoint triggers per-token outcalls).
+    let denied = env
+        .pic
+        .update_call(
+            env.sp_id,
+            env.test_user,
+            "get_ledger_reconciliation",
+            encode_args(()).unwrap(),
+        )
+        .expect("call failed");
+    match denied {
+        WasmResult::Reply(bytes) => {
+            let r: Result<Vec<LedgerReconciliationEntry>, StabilityPoolError> =
+                decode_one(&bytes).unwrap();
+            assert!(
+                matches!(r, Err(StabilityPoolError::Unauthorized)),
+                "non-admin must be Unauthorized, got {:?}",
+                r
+            );
+        }
+        WasmResult::Reject(msg) => panic!("rejected: {}", msg),
+    }
+
+    // Admin sees a healthy, exactly-balanced report for the deposited token.
+    let ok = env
+        .pic
+        .update_call(
+            env.sp_id,
+            env.admin,
+            "get_ledger_reconciliation",
+            encode_args(()).unwrap(),
+        )
+        .expect("call failed");
+    let entries: Vec<LedgerReconciliationEntry> = match ok {
+        WasmResult::Reply(bytes) => {
+            decode_one::<Result<Vec<LedgerReconciliationEntry>, StabilityPoolError>>(&bytes)
+                .unwrap()
+                .expect("admin reconciliation ok")
+        }
+        WasmResult::Reject(msg) => panic!("rejected: {}", msg),
+    };
+    let icusd = entries
+        .iter()
+        .find(|e| e.ledger == env.icusd_ledger)
+        .expect("icUSD entry present");
+    assert_eq!(icusd.recorded_e8s, deposit_amount, "recorded == deposit");
+    assert_eq!(
+        icusd.live_e8s, deposit_amount,
+        "live ledger balance == deposit (pool paid no fee; depositor bore it)"
+    );
+    assert_eq!(icusd.delta_e8s, 0, "no drift");
+    assert!(icusd.healthy, "icUSD must reconcile healthy");
+    // Every registered token reconciles (all others at 0/0).
+    assert!(
+        entries.iter().all(|e| e.healthy),
+        "no token should show a shortfall on a clean pool: {:?}",
+        entries
+    );
+}
+
 /// Test 2: deposit_as_3usd converts icUSD into 3USD LP tokens via the 3pool
 #[test]
 fn test_deposit_as_3usd() {


### PR DESCRIPTION
## Why

A depositor's 3USD withdrawal was blocked by "Pool has insufficient balance": the stability pool's live on-ledger balance had drifted below its tracked aggregate, and the withdraw guard blocks any non-sole holder while `live < recorded`. Investigation found **two distinct, still-present leaks** of the same invariant (physical outflow not mirrored in the books), plus the observability gap that let them hide. Balances were healed on-chain via top-ups; these fixes stop recurrence.

## What

- **`56bca8c` fix(backend): durable retry queue for stranded 3USD reserve refunds.** A failed `refund_3usd_to_stability_pool` previously only logged CRITICAL, stranding the excess 3USD in reserves. Now persisted to `pending_3usd_refunds` and retried by `process_pending_transfer` (reusing `op_nonce` for ledger dedup) until it settles. New `get_pending_3usd_refunds` query.
- **`e49aeb2` fix(stability-pool): book both ledger fees on stablecoin liquidation.** The SP pays the ledger fee twice per liquidated nonzero-fee stablecoin (`icrc2_approve` + the backend's `icrc2_transfer_from`) but booked only one, drifting one fee below the ledger per liquidation. Now deducts both, using the live `icrc1_fee`.
- **`add62d3` feat(stability-pool): live-vs-ledger reconciliation observability.** `validate_pool_state` only checks book-vs-book. Adds admin-gated `get_ledger_reconciliation` (per-token recorded vs. live + delta/healthy) and an hourly self-check timer that logs a SHORTFALL warning. Read-only — no auto-heal (a transient mid-liquidation dip must not socialize a phantom loss).

## Tests

- `audit_pocs_icc_002_3usd_refund` suite (3/3) — includes the rewritten heal test for the durable 3USD refund queue.
- `audit_pocs_sp_liquidation_fee_accounting::sp_ckstable_liquidation_keeps_live_balance_equal_to_aggregate` — two-canister PocketIC fence; TDD-verified it fails by exactly one ledger fee without the liquidation fix and passes with it.
- `pocket_ic_3usd::test_get_ledger_reconciliation_reports_healthy_and_is_admin_gated`.

## Deploy notes

Rebased on current `main` (post #310/#311). Ships as one backend upgrade + one SP upgrade. At deploy: regenerate declarations, run the pre-deploy test hook, use upgrade args (SP needs init-args on upgrade; backend needs a description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)