### PR TITLE
fix(frontend): anchor CR risk bands to each asset's own borrow threshold

### DIFF
--- a/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.spec.ts
@@ -49,20 +49,21 @@ function collateral(overrides: Partial<CollateralInfo>): CollateralInfo {
 }
 
 describe('healthTierFor', () => {
-  // No cautionCr/safeCr args -> defaults to ICP's own thresholds (1.5/2.0).
-  it('returns "safe" for CR >= 2.0', () => {
-    expect(healthTierFor(2.0)).toBe('safe');
+  // No cautionCr/safeCr args -> defaults to ICP's own borrow threshold (1.5)
+  // and its comfort line (1.5 * 1.234 = 1.851).
+  it('returns "safe" at or above the comfort line', () => {
+    expect(healthTierFor(1.851)).toBe('safe');
     expect(healthTierFor(2.81)).toBe('safe');
     expect(healthTierFor(100)).toBe('safe');
   });
 
-  it('returns "caution" for 1.5 <= CR < 2.0', () => {
+  it('returns "caution" between the borrow threshold and the comfort line', () => {
     expect(healthTierFor(1.5)).toBe('caution');
     expect(healthTierFor(1.75)).toBe('caution');
-    expect(healthTierFor(1.9999)).toBe('caution');
+    expect(healthTierFor(1.85)).toBe('caution');
   });
 
-  it('returns "danger" for CR < 1.5', () => {
+  it('returns "danger" below the borrow threshold', () => {
     expect(healthTierFor(1.49)).toBe('danger');
     expect(healthTierFor(1.0)).toBe('danger');
     expect(healthTierFor(0.5)).toBe('danger');
@@ -77,11 +78,11 @@ describe('healthTierFor', () => {
   });
 
   it('honors explicit cautionCr/safeCr cutoffs instead of the ICP defaults', () => {
-    // A ckXAUT-only cutoff pair (liquidationCr 1.18 blended per the same
-    // ratios as ICP's 1.5/2.0): caution ≈1.331, safe ≈1.774.
-    expect(healthTierFor(1.47, 1.3308, 1.7744)).toBe('caution');
-    expect(healthTierFor(1.2, 1.3308, 1.7744)).toBe('danger');
-    expect(healthTierFor(1.8, 1.3308, 1.7744)).toBe('safe');
+    // ckXAUT's real on-chain cutoffs: borrow threshold 1.18, comfort line
+    // 1.18 * 1.234 = 1.45612.
+    expect(healthTierFor(1.2, 1.18, 1.45612)).toBe('caution');
+    expect(healthTierFor(1.1, 1.18, 1.45612)).toBe('danger');
+    expect(healthTierFor(1.51, 1.18, 1.45612)).toBe('safe');
   });
 });
 
@@ -217,61 +218,90 @@ describe('aggregatePosition', () => {
     expect(result.perCollateral[0].symbol).toBe(CKBTC.slice(0, 5));
   });
 
-  // Regression coverage for the "flat ICP threshold" bug: a position backed
-  // entirely by a lower-liquidationCr asset (e.g. XRP/ckXAUT at ~1.18) must be
-  // judged against its own blended threshold, not ICP's 1.5/2.0.
+  // Regression coverage for the "flat ICP threshold" bug: a position backed by
+  // an asset with a lower borrow threshold (ckXAUT at 1.18 vs ICP's 1.5) must
+  // be judged against its own threshold, not ICP's.
+  //
+  // ckXAUT's real on-chain params (verified via get_collateral_config on
+  // nza5v-qaaaa-aaaar-qahzq-cai): borrow_threshold_ratio 1.18,
+  // liquidation_ratio 1.12. Bands: danger <1.18, caution 1.18-1.45612,
+  // safe >=1.45612.
   describe('weighted health tier for non-ICP collateral', () => {
-    it('does not flag a 147% CR ckXAUT-only position as danger', () => {
-      // liquidationCr 1.18 -> caution cutoff ≈1.331, safe cutoff ≈1.774.
-      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
-      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1470, liquidationCr: 1.18, minimumCr: 1.35 })];
-      const result = aggregatePosition(vaults, collaterals);
-      expect(result.overallCr).toBeCloseTo(1.47, 2);
-      expect(result.healthTier).toBe('caution');
-    });
+    const ckxaut = (price: number) =>
+      collateral({ principal: CKXAUT, symbol: 'ckXAUT', price, minimumCr: 1.18, liquidationCr: 1.12 });
 
-    it('flags the same asset as danger once CR actually drops below its own liquidation buffer', () => {
+    it('reports a 151% CR ckXAUT-only position as safe, matching its vault card', () => {
+      // The live case that prompted this fix: judged against ICP's numbers the
+      // badge said "At risk", and against a liquidationCr-derived cutoff it
+      // said "Caution", while VaultCard already showed the same position safe.
       const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
-      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1200, liquidationCr: 1.18, minimumCr: 1.35 })];
-      const result = aggregatePosition(vaults, collaterals);
-      expect(result.overallCr).toBeCloseTo(1.2, 2);
-      expect(result.healthTier).toBe('danger');
-    });
-
-    it('marks safe once comfortably above the asset-specific buffer', () => {
-      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
-      const collaterals = [collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 1800, liquidationCr: 1.18, minimumCr: 1.35 })];
-      const result = aggregatePosition(vaults, collaterals);
-      expect(result.overallCr).toBeCloseTo(1.8, 2);
+      const result = aggregatePosition(vaults, [ckxaut(1510)]);
+      expect(result.overallCr).toBeCloseTo(1.51, 2);
       expect(result.healthTier).toBe('safe');
     });
 
-    it('preserves ICP-only behavior exactly (regression against the old flat breakpoints)', () => {
-      const vaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 500 })];
-      const collaterals = [collateral({ principal: ICP, price: 5 })]; // CR = 1.0 -> danger
-      expect(aggregatePosition(vaults, collaterals).healthTier).toBe('danger');
-
-      const cautionVaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 300 })];
-      const cautionCollaterals = [collateral({ principal: ICP, price: 5 })]; // CR ≈1.67 -> caution
-      expect(aggregatePosition(cautionVaults, cautionCollaterals).healthTier).toBe('caution');
-
-      const safeVaults = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 })];
-      const safeCollaterals = [collateral({ principal: ICP, price: 5 })]; // CR = 2.5 -> safe
-      expect(aggregatePosition(safeVaults, safeCollaterals).healthTier).toBe('safe');
+    it('reports caution between ckXAUT\'s borrow threshold and its comfort line', () => {
+      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
+      const result = aggregatePosition(vaults, [ckxaut(1300)]);
+      expect(result.overallCr).toBeCloseTo(1.3, 2);
+      expect(result.healthTier).toBe('caution');
     });
 
-    it('blends thresholds by USD share for a mixed ICP + ckXAUT position', () => {
-      // 50/50 USD split (725 + 725 = 1450): weighted liquidationCr =
-      // (1.33 + 1.18)/2 = 1.255 -> caution cutoff ≈1.415, safe cutoff ≈1.887.
-      // CR = 1450/1000 = 1.45, which the OLD flat ICP breakpoints (danger
-      // below 1.5) would have wrongly called "danger".
+    it('reports danger only once CR falls below ckXAUT\'s own borrow threshold', () => {
+      const vaults = [vault({ collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 })];
+      const result = aggregatePosition(vaults, [ckxaut(1150)]);
+      expect(result.overallCr).toBeCloseTo(1.15, 2);
+      expect(result.healthTier).toBe('danger');
+    });
+
+    it('keeps ICP-only danger/caution boundaries at ICP\'s own borrow threshold', () => {
+      const danger = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 500 })];
+      expect(aggregatePosition(danger, [collateral({ price: 5 })]).healthTier).toBe('danger'); // CR 1.0
+
+      const caution = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 300 })];
+      expect(aggregatePosition(caution, [collateral({ price: 5 })]).healthTier).toBe('caution'); // CR ≈1.67
+
+      const safe = [vault({ collateralType: ICP, collateralAmount: 100, borrowedIcusd: 200 })];
+      expect(aggregatePosition(safe, [collateral({ price: 5 })]).healthTier).toBe('safe'); // CR 2.5
+    });
+
+    it('puts ICP\'s safe line at 1.851, matching VaultCard\'s comfort line', () => {
+      // Previously a flat 2.0, which disagreed with the per-vault card's
+      // minimumCr * 1.234. 1.86 is safe under the new line, caution under old.
+      const vaults = [vault({ collateralType: ICP, collateralAmount: 186, borrowedIcusd: 100 })];
+      const result = aggregatePosition(vaults, [collateral({ price: 1 })]);
+      expect(result.overallCr).toBeCloseTo(1.86, 2);
+      expect(result.healthTier).toBe('safe');
+    });
+
+    it('blends borrow thresholds by USD share for a mixed ICP + ckXAUT position', () => {
+      // 50/50 USD split (725 + 725 = 1450): weighted minimumCr =
+      // (1.5 + 1.18)/2 = 1.34 -> danger below 1.34, safe at/above
+      // 1.34 * 1.234 = 1.65356. CR = 1450/1000 = 1.45 sits between -> caution.
       const vaults = [
         vault({ vaultId: 1, collateralType: ICP, collateralAmount: 100, borrowedIcusd: 1000 }),
         vault({ vaultId: 2, collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 0 }),
       ];
       const collaterals = [
-        collateral({ principal: ICP, symbol: 'ICP', price: 7.25 }),          // 725 USD
-        collateral({ principal: CKXAUT, symbol: 'ckXAUT', price: 725, liquidationCr: 1.18, minimumCr: 1.35 }), // 725 USD
+        collateral({ principal: ICP, symbol: 'ICP', price: 7.25 }), // 725 USD
+        ckxaut(725),                                                // 725 USD
+      ];
+      const result = aggregatePosition(vaults, collaterals);
+      expect(result.totalCollateralUsd).toBe(1450);
+      expect(result.overallCr).toBeCloseTo(1.45, 2);
+      expect(result.healthTier).toBe('caution');
+    });
+
+    it('weights toward the dominant asset in a lopsided mix', () => {
+      // 90% ckXAUT / 10% ICP: weighted minimumCr = 0.9*1.18 + 0.1*1.5 = 1.212
+      // -> safe line 1.212 * 1.234 = 1.495608. CR 1.45 -> caution.
+      const vaults = [
+        vault({ vaultId: 1, collateralType: CKXAUT, collateralAmount: 1, borrowedIcusd: 1000 }),
+        vault({ vaultId: 2, collateralType: ICP, collateralAmount: 145, borrowedIcusd: 0 }),
+      ];
+      const collaterals = [
+        ckxaut(1305),                                              // 1305 USD (90%)
+        collateral({ principal: ICP, symbol: 'ICP', price: 1 }),   // 145 USD (10%)
       ];
       const result = aggregatePosition(vaults, collaterals);
       expect(result.totalCollateralUsd).toBe(1450);

--- a/src/vault_frontend/src/lib/components/layout/positionSummary.ts
+++ b/src/vault_frontend/src/lib/components/layout/positionSummary.ts
@@ -1,12 +1,11 @@
 import type { VaultDTO, CollateralInfo } from '../../services/types';
 import { CANISTER_IDS } from '../../config';
 
-// ICP's own defaults (mirrors $lib/protocol's MINIMUM_CR/LIQUIDATION_CR).
-// Restated locally rather than imported so this module stays a pure,
-// dependency-light aggregation utility (protocol.ts pulls in the wallet/
-// canister-agent stack via collateralStore -> tokenService -> pnp).
+// ICP's own borrow threshold (mirrors $lib/protocol's MINIMUM_CR). Restated
+// locally rather than imported so this module stays a pure, dependency-light
+// aggregation utility (protocol.ts pulls in the wallet/canister-agent stack
+// via collateralStore -> tokenService -> pnp).
 const ICP_MINIMUM_CR = 1.5;
-const ICP_LIQUIDATION_CR = 1.33;
 
 export type HealthTier = 'safe' | 'caution' | 'danger' | 'no-debt' | 'unknown';
 
@@ -55,23 +54,25 @@ export function findCollateralInfo(
 }
 
 /**
- * Ratios implied by ICP's own thresholds (borrow threshold 1.5, liquidation
- * 1.33, legacy flat "safe" cutoff 2.0). Applied to a blended liquidationCr so a
- * non-ICP (or mixed-collateral) position gets a proportionally equivalent
- * buffer instead of being judged against ICP's flat numbers.
+ * Multiplier above an asset's borrow threshold at which a position reads as
+ * comfortably healthy. Matches the per-vault convention already used by
+ * VaultCard.svelte and ManualLiquidations.svelte (`comfortCR = minCR * 1.234`)
+ * so this aggregate badge and the individual vault cards never disagree about
+ * the same position.
  */
-const CAUTION_RATIO = ICP_MINIMUM_CR / ICP_LIQUIDATION_CR; // ≈1.128
-const SAFE_RATIO = 2.0 / ICP_LIQUIDATION_CR;                // ≈1.504
+const COMFORT_MULTIPLIER = 1.234;
 
 /**
  * Map a collateral ratio to a health tier against caution/safe cutoffs.
- *   >= safeCr        -> safe
+ *   >= safeCr         -> safe
  *   cautionCr..safeCr -> caution
- *   < cautionCr      -> danger
+ *   < cautionCr       -> danger
  * Infinity (no debt) -> 'no-debt'. NaN -> 'unknown'.
  *
- * cautionCr/safeCr default to ICP's own thresholds so callers that don't yet
- * have a collateral mix (e.g. isolated unit tests) keep the old behavior.
+ * cautionCr is the borrow threshold: below it the position is in liquidation
+ * territory. safeCr is COMFORT_MULTIPLIER above that. Both default to ICP's
+ * own numbers for callers that don't have a collateral mix on hand (e.g.
+ * isolated unit tests).
  *
  * NOTE: This is an aggregate heuristic across all the user's vaults, not a
  * per-vault liquidation signal. Individual vault liquidation prices are
@@ -80,7 +81,7 @@ const SAFE_RATIO = 2.0 / ICP_LIQUIDATION_CR;                // ≈1.504
 export function healthTierFor(
   cr: number,
   cautionCr: number = ICP_MINIMUM_CR,
-  safeCr: number = 2.0,
+  safeCr: number = ICP_MINIMUM_CR * COMFORT_MULTIPLIER,
 ): HealthTier {
   if (!Number.isFinite(cr)) return cr === Infinity ? 'no-debt' : 'unknown';
   if (cr >= safeCr) return 'safe';
@@ -99,8 +100,9 @@ export function healthTierFor(
  *  4. Overall CR = totalCollateralUsd / totalBorrowed (Infinity if no debt).
  *  5. Emit per-collateral breakdown sorted by USD value desc, skipping
  *     any group whose nativeAmount is 0.
- *  6. Blend each group's liquidationCr by its USD share to get a caution/safe
- *     cutoff specific to this user's actual collateral mix (see healthTierFor).
+ *  6. Blend each group's borrow threshold (minimumCr) by its USD share to get
+ *     caution/safe cutoffs specific to this user's collateral mix (see
+ *     healthTierFor).
  */
 export function aggregatePosition(
   vaults: VaultDTO[],
@@ -144,19 +146,22 @@ export function aggregatePosition(
     ? totalCollateralUsd / totalBorrowed
     : Infinity;
 
-  // Blend each held asset's own liquidationCr, weighted by its share of the
-  // user's total collateral USD, so a mixed (or non-ICP) position is judged
-  // against its own risk profile rather than ICP's.
-  const weightedLiquidationCr = totalCollateralUsd > 0
+  // Blend each held asset's own borrow threshold (minimumCr), weighted by its
+  // share of the user's total collateral USD, so a mixed (or non-ICP) position
+  // is judged against its own risk profile rather than ICP's. Each asset
+  // publishes this threshold directly; it must NOT be inferred from
+  // liquidationCr, because the borrow-threshold-to-liquidation spread differs
+  // per asset (ICP 1.5/1.33 = 1.128, ckXAUT 1.18/1.12 = 1.054).
+  const weightedMinimumCr = totalCollateralUsd > 0
     ? perCollateral.reduce((sum, asset) => {
         const info = findCollateralInfo(collaterals, asset.principal);
-        const liquidationCr = info?.liquidationCr ?? ICP_LIQUIDATION_CR;
-        return sum + (asset.usdValue / totalCollateralUsd) * liquidationCr;
+        const minimumCr = info?.minimumCr ?? ICP_MINIMUM_CR;
+        return sum + (asset.usdValue / totalCollateralUsd) * minimumCr;
       }, 0)
-    : ICP_LIQUIDATION_CR;
+    : ICP_MINIMUM_CR;
 
-  const cautionCr = weightedLiquidationCr * CAUTION_RATIO;
-  const safeCr = weightedLiquidationCr * SAFE_RATIO;
+  const cautionCr = weightedMinimumCr;
+  const safeCr = weightedMinimumCr * COMFORT_MULTIPLIER;
 
   return {
     totalCollateralUsd,


### PR DESCRIPTION
Follow-up to #309, which half-fixed the aggregate risk badge.

## The remaining bug
#309 blended each asset's `liquidationCr` and scaled it by **ICP's** threshold-to-liquidation spread (`1.5/1.33 ≈ 1.128`) to derive the caution line. That spread isn't universal:

| | liquidation | borrow threshold | actual spread | #309's caution line |
|---|---|---|---|---|
| ICP | 1.33 | **1.50** | 1.128 | 1.500 ✅ (coincidence — the ratio came from ICP) |
| ckXAUT | 1.12 | **1.18** | 1.054 | 1.263 ❌ overshoots by 8.3pts |

Result: a ckXAUT holder at **151% CR still read "Caution"** despite sitting 33 points above their own borrow threshold.

Every collateral publishes its borrow threshold directly as `minimumCr` — no need to infer it from `liquidationCr`.

## Also fixed: the strip disagreed with the vault card
`VaultCard.svelte` and `ManualLiquidations.svelte` have always used `comfortCR = minimumCr * 1.234` for their safe threshold. The strip used a flat 2.0 (ICP-derived). So the same ckXAUT position at 151% showed **safe/green on its vault card and "Caution" on the strip above it**. The safe line now uses that same `COMFORT_MULTIPLIER`, so the two agree.

## Resulting bands
| ckXAUT-only | | ICP-only | |
|---|---|---|---|
| At risk | <118% | At risk | <150% |
| Caution | 118–145.6% | Caution | 150–185.1% |
| Healthy | ≥145.6% | Healthy | ≥185.1% |

ICP's danger/caution boundary is unchanged. Its safe line moves 200% → 185.1%; the 200% was never anchored to anything (just `1.33 × 1.504`), while 185.1% is what ICP vault cards have shown all along.

## Fixture correction
#309's tests used **1.18 as ckXAUT's `liquidationCr`**. Verified on-chain via `get_collateral_config(nza5v-qaaaa-aaaar-qahzq-cai)`: `borrow_threshold_ratio` = 1.18, `liquidation_ratio` = **1.12**. Fixtures now use both real values.

## Test plan
- [x] `npx vitest run` — 32 files / 224 tests pass (27 in `positionSummary.spec.ts`)
- [x] New coverage: the live 151% ckXAUT case, ckXAUT caution/danger boundaries, ICP's 1.851 safe line, a 50/50 blend, and a lopsided 90/10 blend
- [x] ICP-only danger/caution boundaries asserted unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)