### PR TITLE
fix: honest Stability Pool APY (advertise the rate a new depositor earns)

### DIFF
--- a/src/rumi_analytics/src/queries/live.rs
+++ b/src/rumi_analytics/src/queries/live.rs
@@ -362,15 +362,38 @@ pub fn compute_amm_apy(
     Some((daily / avg_tvl) * 365.0 * 100.0)
 }
 
-/// Stability pool APY: annualized interest yield.
+/// icUSD ledger. Interest is distributed to icUSD balances only, so this is the
+/// denominator for any stability-pool interest rate.
+const ICUSD_LEDGER_TEXT: &str = "t6bor-paaaa-aaaap-qrd5q-cai";
+
+/// icUSD deposits (e8s) in a stability snapshot.
+///
+/// `total_deposits_e8s` counts every accepted stablecoin, including 3USD and the
+/// ck-stables, none of which earn interest. Dividing interest by that total
+/// reports a rate no depositor receives and disagrees with the rate the app
+/// advertises. `stablecoin_balances` is already recorded per row, so the correct
+/// denominator needs no schema change.
+fn icusd_deposits_e8s(row: &storage::DailyStabilityRow) -> Option<u64> {
+    let icusd = Principal::from_text(ICUSD_LEDGER_TEXT).ok()?;
+    row.stablecoin_balances
+        .iter()
+        .find(|(ledger, _)| *ledger == icusd)
+        .map(|(_, amount)| *amount)
+}
+
+/// Stability pool APY: annualized interest yield on icUSD deposits.
 /// `total_interest_received_e8s` is cumulative, so we take the delta between
 /// the last and first snapshots in the window.
-/// APY = (interest_delta / days) / avg_deposits * 365 * 100
+/// APY = (interest_delta / days) / avg_icusd_deposits * 365 * 100
+///
+/// Returns `None` rather than falling back to the all-stablecoin total when a
+/// snapshot carries no icUSD balance: a number computed on the wrong base is
+/// worse than no number.
 pub fn compute_sp_apy(
     stability_rows: &[storage::DailyStabilityRow],
     window_days: u32,
 ) -> Option<f64> {
-    if stability_rows.len() < 2 {
+    if stability_rows.len() < 2 || window_days == 0 {
         return None;
     }
 
@@ -379,16 +402,18 @@ pub fn compute_sp_apy(
     let interest_delta = last.total_interest_received_e8s
         .saturating_sub(first.total_interest_received_e8s);
 
-    let avg_deposits: f64 = stability_rows.iter()
-        .map(|r| r.total_deposits_e8s as f64)
-        .sum::<f64>() / stability_rows.len() as f64;
+    let mut icusd_total: f64 = 0.0;
+    for row in stability_rows {
+        icusd_total += icusd_deposits_e8s(row)? as f64;
+    }
+    let avg_icusd_deposits = icusd_total / stability_rows.len() as f64;
 
-    if avg_deposits <= 0.0 {
+    if avg_icusd_deposits <= 0.0 {
         return None;
     }
 
     let daily_interest = interest_delta as f64 / window_days as f64;
-    let apy = (daily_interest / avg_deposits) * 365.0 * 100.0;
+    let apy = (daily_interest / avg_icusd_deposits) * 365.0 * 100.0;
     Some(apy)
 }
 
@@ -1296,15 +1321,37 @@ mod tests {
         }
     }
 
+    /// Pool holding icUSD only, so total deposits and the icUSD denominator agree.
     fn make_stability_row(deposits: u64, interest: u64) -> DailyStabilityRow {
+        make_stability_row_mixed(deposits, deposits, interest)
+    }
+
+    /// Pool holding `icusd` of icUSD inside `deposits` of total stablecoins. The
+    /// remainder stands in for 3USD / ck-stables, which earn no interest.
+    fn make_stability_row_mixed(
+        deposits: u64,
+        icusd: u64,
+        interest: u64,
+    ) -> DailyStabilityRow {
         DailyStabilityRow {
             timestamp_ns: 1_000_000_000,
             total_deposits_e8s: deposits,
             total_depositors: 10,
             total_liquidations_executed: 0,
             total_interest_received_e8s: interest,
-            stablecoin_balances: vec![],
+            stablecoin_balances: vec![(
+                Principal::from_text(ICUSD_LEDGER_TEXT).unwrap(),
+                icusd,
+            )],
             collateral_gains: vec![],
+        }
+    }
+
+    /// Snapshot with no icUSD entry at all (e.g. a pre-field row).
+    fn make_stability_row_no_icusd(deposits: u64, interest: u64) -> DailyStabilityRow {
+        DailyStabilityRow {
+            stablecoin_balances: vec![],
+            ..make_stability_row(deposits, interest)
         }
     }
 
@@ -1372,6 +1419,37 @@ mod tests {
     fn sp_apy_zero_deposits() {
         let rows = vec![make_stability_row(0, 50), make_stability_row(0, 100)];
         assert!(compute_sp_apy(&rows, 1).is_none());
+    }
+
+    #[test]
+    fn sp_apy_denominator_is_icusd_not_total_deposits() {
+        // 100_000 total deposits but only 25_000 icUSD: the other 75_000 stands in
+        // for 3USD / ck-stables, which earn none of the interest stream. Dividing
+        // by the total would report 18.25%; the rate icUSD depositors actually
+        // receive is 4x that.
+        let rows = vec![
+            make_stability_row_mixed(100_000, 25_000, 100),
+            make_stability_row_mixed(100_000, 25_000, 150),
+        ];
+        let v = compute_sp_apy(&rows, 1).unwrap();
+        // (50 / 25_000) * 365 * 100 = 73.0%
+        assert!((v - 73.0).abs() < 0.1, "expected ~73.0%, got {}", v);
+    }
+
+    #[test]
+    fn sp_apy_none_when_icusd_balance_missing() {
+        // Never silently fall back to the all-stablecoin denominator.
+        let rows = vec![
+            make_stability_row_no_icusd(100_000, 100),
+            make_stability_row_no_icusd(100_000, 150),
+        ];
+        assert!(compute_sp_apy(&rows, 1).is_none());
+    }
+
+    #[test]
+    fn sp_apy_zero_window_days_is_none() {
+        let rows = vec![make_stability_row(100_000, 100), make_stability_row(100_000, 150)];
+        assert!(compute_sp_apy(&rows, 0).is_none());
     }
 
     use crate::storage::events::{AnalyticsSwapEvent, SwapSource};

--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -17,6 +17,7 @@
   import EarnInfoCard from '../stability-pool/EarnInfoCard.svelte';
   import LiquidationHistoryCard from '../stability-pool/LiquidationHistoryCard.svelte';
   import LoadingSpinner from '../common/LoadingSpinner.svelte';
+  import { liveSpApyPct } from '../../utils/liveApy';
 
   let hasCachedData = _poolStatus !== null;
   let loading = !hasCachedData;
@@ -29,26 +30,10 @@
   $: isConnected = $walletStore.isConnected;
   $: principal = $walletStore.principal;
 
-  $: poolApy = (() => {
-    if (!protocolStatus || !poolStatus) return null;
-    const poolShare = (protocolStatus.interestSplit?.find(e => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
-    const perC = protocolStatus.perCollateralInterest;
-    if (!perC || perC.length === 0) return null;
-
-    const eligibleMap = new Map<string, number>(
-      (poolStatus.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [p.toText(), Number(v) / 1e8])
-    );
-
-    let totalApr = 0;
-    for (const info of perC) {
-      const eligible = eligibleMap.get(info.collateralType) ?? 0;
-      if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-      totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
-    }
-    if (totalApr === 0) return null;
-    const apy = Math.pow(1 + totalApr / 365, 365) - 1;
-    return (apy * 100).toFixed(2);
-  })();
+  // Advertised rate = what a new icUSD depositor earns. Single-sourced from
+  // liveSpApyPct so the badge, the nav pill and the explorer lenses cannot drift.
+  $: poolApyPct = liveSpApyPct(protocolStatus, poolStatus);
+  $: poolApy = poolApyPct === null ? null : poolApyPct.toFixed(2);
 
   let showApyTooltip = false;
 
@@ -141,12 +126,13 @@
         <svg class="apy-arrow" width="10" height="10" viewBox="0 0 10 10" fill="none">
           <path d="M5 8V2M5 2L2 5M5 2L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        {poolApy}% APY<span class="apy-asterisk">*</span>
+        {poolApy}% icUSD Interest APY
 
         {#if showApyTooltip}
           <div class="apy-tooltip">
             <div class="apy-tooltip-caret"></div>
             <p><strong>Interest APY</strong> applies to <strong>icUSD</strong> deposits only. icUSD depositors earn a share of all borrowing interest paid by vault owners.</p>
+            <p>This is the rate a <em>new</em> depositor earns. Older positions opted in to wind-down collateral can earn more.</p>
             <div class="apy-tooltip-divider"></div>
             <p><strong>ckUSDC</strong> and <strong>ckUSDT</strong> deposits don't earn interest, but get <em>first</em> priority in liquidations — they're consumed before icUSD and 3USD, giving them earliest access to discounted collateral.</p>
             <p><strong>3USD</strong> deposits sit at the same priority as icUSD for liquidations. They don't earn interest in the pool, but 3USD LP tokens earn yield from swap fees and interest donations in the 3pool itself.</p>
@@ -154,6 +140,13 @@
         {/if}
       </div>
     </div>
+    <!-- Stated in the page, not only in the badge tooltip: hover does not exist
+         on touch devices, so a tooltip-only disclosure is invisible on mobile. -->
+    <p class="apy-scope-note">
+      Interest is paid on <strong>icUSD</strong> deposits only. <strong>3USD</strong>,
+      <strong>ckUSDC</strong> and <strong>ckUSDT</strong> deposits earn no interest here.
+      They take part in liquidations instead.
+    </p>
   {/if}
 
   {#if loading}
@@ -192,6 +185,16 @@
 <style>
   .pool-container { max-width: 820px; margin: 0 auto; }
 
+  .apy-scope-note {
+    margin: 0.5rem auto 0;
+    max-width: 34rem;
+    text-align: center;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    color: #94a3b8;
+  }
+  .apy-scope-note strong { color: #cbd5e1; font-weight: 600; }
+
   .apy-row {
     display: flex;
     align-items: center;
@@ -217,13 +220,6 @@
   }
 
   .apy-arrow { color: #4ade80; flex-shrink: 0; }
-
-  .apy-asterisk {
-    font-size: 0.625rem;
-    opacity: 0.6;
-    margin-left: -0.125rem;
-    vertical-align: super;
-  }
 
   .apy-tooltip {
     position: absolute;

--- a/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/DepositInterface.svelte
@@ -16,6 +16,12 @@
 
   $: spMult = spMultiplier(selectedToken?.symbol);
 
+  // Interest is paid on icUSD balances only. Stating that at the moment of the
+  // deposit decision, not just on the pool badge, so nobody deposits a
+  // non-earning token expecting the advertised rate.
+  $: earnsInterest =
+    selectedToken?.ledger_id?.toText?.() === CANISTER_IDS.ICUSD_LEDGER;
+
   export let poolStatus: PoolStatus | null = null;
   export let userPosition: UserPosition | null = null;
 
@@ -261,6 +267,14 @@
       </span>
     </div>
 
+    {#if activeTab === 'deposit' && selectedToken && !earnsInterest}
+      <p class="no-interest-note">
+        {selectedToken.symbol} deposits earn <strong>no interest</strong> in the pool.
+        Only icUSD earns the interest APY. {selectedToken.symbol} takes part in
+        liquidations and earns discounted collateral.
+      </p>
+    {/if}
+
     <!-- Input with in-field token dropdown -->
     <div class="input-wrapper">
       <input
@@ -429,6 +443,18 @@
   }
 
   /* ── Balance row ── */
+  .no-interest-note {
+    margin: 0 0 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 0.5rem;
+    background: rgba(148, 163, 184, 0.07);
+    font-size: 0.6875rem;
+    line-height: 1.45;
+    color: #94a3b8;
+  }
+  .no-interest-note strong { color: #cbd5e1; font-weight: 600; }
+
   .balance-row {
     display: flex;
     justify-content: space-between;

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -12,6 +12,7 @@
   import type { PoolStatus, UserPosition, CollateralInfo } from '../../services/stabilityPoolService';
   import type { ProtocolStatusDTO } from '../../services/types';
   import { CANISTER_IDS } from '../../config';
+  import { liveSpApyPct, spInterestApr, aprToApyPct } from '../../utils/liveApy';
   import XrpPayoutRouting from './XrpPayoutRouting.svelte';
   import { isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
   import {
@@ -49,29 +50,9 @@
   $: depositorCount = poolStatus ? Number(poolStatus.total_depositors) : 0;
   $: stablecoinBreakdown = poolStatus?.stablecoin_balances ?? [];
 
-  // Per-collateral APY building block: for each collateral type, compute
-  // interestRate_C * poolShare * debt_C / eligible_icusd_C (= APR),
-  // then convert total APR → APY via daily compounding.
-  $: eligibleMap = new Map<string, number>(
-    (poolStatus?.eligible_icusd_per_collateral ?? []).map(([p, v]: [any, bigint]) => [p.toText(), Number(v) / 1e8])
-  );
-
-  $: poolApy = (() => {
-    if (!protocolStatus || !poolStatus) return null;
-    const poolShare = (protocolStatus.interestSplit?.find(e => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
-    const perC = protocolStatus.perCollateralInterest;
-    if (!perC || perC.length === 0 || poolShare === 0) return null;
-
-    let totalApr = 0;
-    for (const info of perC) {
-      const eligible = eligibleMap.get(info.collateralType) ?? 0;
-      if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-      totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
-    }
-    if (totalApr === 0) return null;
-    const apy = Math.pow(1 + totalApr / 365, 365) - 1;
-    return (apy * 100).toFixed(2);
-  })();
+  // Advertised rate: what a new icUSD depositor earns. Single-sourced.
+  $: poolApyPct = liveSpApyPct(protocolStatus as any, poolStatus as any);
+  $: poolApy = poolApyPct === null ? null : poolApyPct.toFixed(2);
 
   // User position data
   $: userStables = userPosition?.stablecoin_balances ?? [];
@@ -91,29 +72,28 @@
     optedOut,
   );
 
-  // Does the user hold icUSD in the pool?
-  $: userHasIcusd = userStables.some(([l, a]: [any, bigint]) => l.toText() === CANISTER_IDS.ICUSD_LEDGER && a > 0n);
+  // Does the user hold icUSD in the pool? Interest is paid on icUSD only, so
+  // this balance (not `total_usd_value_e8s`) is the base the rate applies to.
+  $: userIcusdE8s = userStables
+    .filter(([l]: [any, bigint]) => l.toText() === CANISTER_IDS.ICUSD_LEDGER)
+    .reduce((sum: bigint, [, a]: [any, bigint]) => sum + a, 0n);
+  $: userHasIcusd = userIcusdE8s > 0n;
+  $: userIcusdFormatted = formatStableTokenDisplay(userIcusdE8s, 8);
 
-  // Personalized APY — only sums collateral types the user is opted in to
-  $: userApy = (() => {
-    if (!userHasIcusd || !protocolStatus || !poolStatus) return null;
-    const poolShare = (protocolStatus.interestSplit?.find(e => e.destination === 'stability_pool')?.bps ?? 0) / 10000;
-    const perC = protocolStatus.perCollateralInterest;
-    if (!perC || perC.length === 0) return null;
-
-    let totalApr = 0;
-    for (const info of perC) {
-      if (eligibleInterestCollaterals
-        ? !eligibleInterestCollaterals.has(info.collateralType)
-        : optedOut.has(info.collateralType)) continue;
-      const eligible = eligibleMap.get(info.collateralType) ?? 0;
-      if (eligible === 0 || info.totalDebtE8s === 0 || info.weightedInterestRate === 0) continue;
-      totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
-    }
-    if (totalApr === 0) return null;
-    const apy = Math.pow(1 + totalApr / 365, 365) - 1;
-    return (apy * 100).toFixed(2);
+  // Personalized APY — only sums collateral types the user is opted in to.
+  // May exceed the advertised rate for grandfathered positions still opted in
+  // to wind-down collateral; that uplift is labelled rather than hidden.
+  $: userApyPct = (() => {
+    if (!userHasIcusd) return null;
+    const apr = spInterestApr(protocolStatus as any, poolStatus as any, (ct) =>
+      eligibleInterestCollaterals ? eligibleInterestCollaterals.has(ct) : !optedOut.has(ct),
+    );
+    return apr === null ? null : aprToApyPct(apr);
   })();
+  $: userApy = userApyPct === null ? null : userApyPct.toFixed(2);
+  // Only call it an uplift when it clears display rounding.
+  $: hasUplift =
+    userApyPct !== null && poolApyPct !== null && userApyPct - poolApyPct >= 0.01;
 
   $: poolShare = (() => {
     if (!poolStatus || !userPosition || poolStatus.total_deposits_e8s === 0n) return '0.00';
@@ -206,11 +186,28 @@
   {#if isConnected && userPosition}
     <h4 class="group-heading">Your Position</h4>
     <div class="stats-stack">
-      <!-- Personalized Interest APY (top row, only if user holds icUSD) -->
+      <!-- Personalized Interest APY. The rate is paid on the icUSD balance only,
+           so the base is printed beside it; without that it reads as a rate on
+           Total Deposited, which it is not. Depositors holding no icUSD get an
+           explicit zero row rather than a hidden one. -->
       {#if userApy !== null}
-        <div class="stat-row">
+        <div class="stat-row align-top">
           <span class="stat-label">Your Interest APY</span>
-          <span class="stat-value green">{userApy}%</span>
+          <span class="stat-value-stack">
+            <span class="stat-value green">{userApy}%</span>
+            <span class="apy-base-note">on your {userIcusdFormatted} icUSD</span>
+            {#if hasUplift}
+              <span class="apy-base-note">above the {poolApy}% new-depositor rate (wind-down collateral)</span>
+            {/if}
+          </span>
+        </div>
+      {:else}
+        <div class="stat-row align-top">
+          <span class="stat-label">Your Interest APY</span>
+          <span class="stat-value-stack">
+            <span class="stat-value">0.00%</span>
+            <span class="apy-base-note">interest is paid on icUSD deposits only</span>
+          </span>
         </div>
       {/if}
 
@@ -308,10 +305,16 @@
       </div>
 
       <!-- Interest earned -->
+      <!-- `total_interest_earned_e8s` is cumulative for the life of the current
+           position (it resets if the position is fully closed) and counts the
+           borrowing-interest stream only, not liquidation gains. Say so. -->
       {#if interestEarned}
-        <div class="stat-row">
+        <div class="stat-row align-top">
           <span class="stat-label">Interest Earned</span>
-          <span class="stat-value green">${interestEarned}</span>
+          <span class="stat-value-stack">
+            <span class="stat-value green">${interestEarned}</span>
+            <span class="apy-base-note">total since you opened this position</span>
+          </span>
         </div>
       {/if}
     </div>
@@ -339,7 +342,7 @@
     </div>
     {#if poolApy !== null}
       <div class="stat-row">
-        <span class="stat-label">Interest APY</span>
+        <span class="stat-label">icUSD Interest APY</span>
         <span class="stat-value">{poolApy}%</span>
       </div>
     {/if}
@@ -449,6 +452,17 @@
     font-weight: 600;
     font-variant-numeric: tabular-nums;
     color: var(--rumi-text-primary);
+  }
+
+  /* Qualifier under a headline number: names the base a rate applies to, or the
+     period a total covers. Muted and lighter so it reads as scope, not value. */
+  .apy-base-note {
+    font-size: 0.6875rem;
+    font-weight: 400;
+    line-height: 1.35;
+    text-align: right;
+    max-width: 15rem;
+    color: #94a3b8;
   }
 
   .collateral-dot {

--- a/src/vault_frontend/src/lib/utils/liveApy.spec.ts
+++ b/src/vault_frontend/src/lib/utils/liveApy.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isDefaultInterestEligible,
+  spInterestApr,
+  aprToApyPct,
+  liveSpApyPct,
+} from './liveApy';
+
+/**
+ * Fixtures captured from mainnet on 2026-07-22 (`tfesu` get_protocol_status,
+ * `tmhzi` get_pool_status). They reproduce the incident that motivated the fix:
+ * the advertised APY read 9.96% while a depositor who joined after the BOB
+ * sunset earned 7.39%, because sunset BOB carried a 33.90 icUSD opted-in
+ * denominator against 22.72 icUSD of debt at 10.06%.
+ */
+const BOB = '7pail-xaaaa-aaaas-aabmq-cai';
+const XRP = '5zjma-7dsov-wwsll-yojyc-23tbo-ruxmz-i';
+const ICP = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+const EXE = 'rh2pm-ryaaa-aaaan-qeniq-cai';
+const NICP = 'buwm7-7yaaa-aaaar-qagva-cai';
+const CKXAUT = 'nza5v-qaaaa-aaaar-qahzq-cai';
+
+const protocolStatus = {
+  interestSplit: [
+    { destination: 'stability_pool', bps: 3500 },
+    { destination: 'three_pool', bps: 6000 },
+    { destination: 'treasury', bps: 500 },
+  ],
+  perCollateralInterest: [
+    { collateralType: ICP, totalDebtE8s: 290.06743566, weightedInterestRate: 0.06038732635633318 },
+    { collateralType: EXE, totalDebtE8s: 8.40513698, weightedInterestRate: 0.061176829402417636 },
+    { collateralType: NICP, totalDebtE8s: 2313.97822355, weightedInterestRate: 0.09094399468784463 },
+    { collateralType: CKXAUT, totalDebtE8s: 1721.70029288, weightedInterestRate: 0.009753220361499384 },
+    { collateralType: BOB, totalDebtE8s: 22.72320352, weightedInterestRate: 0.10057603299537501 },
+    { collateralType: XRP, totalDebtE8s: 1.66813688, weightedInterestRate: 0.03710562864601375 },
+  ],
+};
+
+const principal = (text: string) => ({ toText: () => text });
+
+const poolStatus = {
+  eligible_icusd_per_collateral: [
+    [principal(ICP), 120_955_413_570n],
+    [principal(EXE), 113_156_562_600n],
+    [principal(NICP), 120_955_413_570n],
+    [principal(CKXAUT), 113_156_562_600n],
+    [principal(BOB), 3_390_420_000n],
+    [principal(XRP), 110_767_020_000n],
+  ] as Array<[any, bigint]>,
+};
+
+describe('isDefaultInterestEligible', () => {
+  it('excludes sunset BOB, which every new position is opted out of', () => {
+    expect(isDefaultInterestEligible(BOB)).toBe(false);
+  });
+
+  it('excludes native XRP, which is gated behind a configured payout address', () => {
+    expect(isDefaultInterestEligible(XRP)).toBe(false);
+  });
+
+  it('includes ordinary ICRC collateral', () => {
+    for (const ct of [ICP, EXE, NICP, CKXAUT]) {
+      expect(isDefaultInterestEligible(ct)).toBe(true);
+    }
+  });
+});
+
+describe('liveSpApyPct (advertised rate)', () => {
+  it('is the rate a new depositor earns, not the grandfathered maximum', () => {
+    expect(liveSpApyPct(protocolStatus, poolStatus)).toBeCloseTo(7.39, 1);
+  });
+
+  it('does not include the sunset-BOB term that inflated the old headline', () => {
+    const withBob = spInterestApr(protocolStatus, poolStatus, () => true)!;
+    expect(aprToApyPct(withBob)).toBeCloseTo(9.96, 1);
+    // BOB alone accounted for ~2.4 points of the advertised number.
+    expect(aprToApyPct(withBob) - liveSpApyPct(protocolStatus, poolStatus)!).toBeGreaterThan(2);
+  });
+
+  it('never exceeds the rate of a fully opted-in position', () => {
+    const advertised = liveSpApyPct(protocolStatus, poolStatus)!;
+    const maximal = aprToApyPct(spInterestApr(protocolStatus, poolStatus, () => true)!);
+    expect(advertised).toBeLessThanOrEqual(maximal);
+  });
+
+  it('returns null rather than 0 when inputs are missing', () => {
+    expect(liveSpApyPct(null, poolStatus)).toBeNull();
+    expect(liveSpApyPct(protocolStatus, null)).toBeNull();
+  });
+});
+
+describe('spInterestApr with a per-user eligibility set', () => {
+  it('reproduces the grandfathered position rate (opted in to everything)', () => {
+    const eligible = new Set([ICP, EXE, NICP, CKXAUT, BOB, XRP]);
+    const apy = aprToApyPct(spInterestApr(protocolStatus, poolStatus, (ct) => eligible.has(ct))!);
+    expect(apy).toBeCloseTo(9.96, 1);
+  });
+
+  it('reproduces the post-sunset depositor rate (opted out of BOB only)', () => {
+    const eligible = new Set([ICP, EXE, NICP, CKXAUT, XRP]);
+    const apy = aprToApyPct(spInterestApr(protocolStatus, poolStatus, (ct) => eligible.has(ct))!);
+    expect(apy).toBeCloseTo(7.39, 1);
+  });
+
+  it('ignores collateral with no eligible icUSD, avoiding a divide-by-zero term', () => {
+    const emptyPool = { eligible_icusd_per_collateral: [[principal(ICP), 0n]] as Array<[any, bigint]> };
+    expect(spInterestApr(protocolStatus, emptyPool, () => true)).toBeNull();
+  });
+});

--- a/src/vault_frontend/src/lib/utils/liveApy.ts
+++ b/src/vault_frontend/src/lib/utils/liveApy.ts
@@ -31,17 +31,52 @@ function principalText(p: any): string {
 }
 
 /**
- * Live SP APY as a percentage (e.g. 6.29 for 6.29%). Mirrors the formula
- * in the /liquidity tab. Returns null if any input is missing.
+ * BOB is in a one-way wind-down: `DepositPosition::new` opts every new position
+ * out of it, and the UI hides the re-opt-in control. Only grandfathered
+ * positions still earn from BOB-backed debt.
+ */
+const SUNSET_COLLATERAL = '7pail-xaaaa-aaaas-aabmq-cai';
+
+/**
+ * Collateral gated behind a configured native payout address. `position_opted_in_for`
+ * returns false until the depositor registers one, so a fresh position earns
+ * nothing from this debt.
+ */
+const PAYOUT_GATED_COLLATERAL = new Set(['5zjma-7dsov-wwsll-yojyc-23tbo-ruxmz-i']);
+
+/**
+ * Whether a brand-new default stability-pool position would earn interest from
+ * this collateral's debt.
+ *
+ * The advertised APY must be the rate a new depositor actually receives, so the
+ * headline is the *floor* over eligibility sets rather than the max. Summing
+ * every collateral (the previous behaviour) produced a rate reachable only by
+ * grandfathered positions: sunset BOB carried a tiny opted-in denominator, so
+ * its term dominated the headline while almost no depositor could earn it.
+ */
+export function isDefaultInterestEligible(collateralType: string): boolean {
+  return (
+    collateralType !== SUNSET_COLLATERAL &&
+    !PAYOUT_GATED_COLLATERAL.has(collateralType)
+  );
+}
+
+/**
+ * Total SP interest APR, summed over collateral types passing `eligibleFor`.
+ *
+ * Per collateral: `rate * poolShare * debt / eligible_icusd`. Interest is paid
+ * only on icUSD balances and the denominator counts only icUSD, so the ratio is
+ * a rate per icUSD deposited. It does not apply to 3USD or ck-stable deposits.
  *
  * Note: `protocolStatus.perCollateralInterest[i].totalDebtE8s` is already
  * normalized to icUSD (the upstream `QueryOperations.getProtocolStatus` divides
  * by 1e8). The eligible map here also normalizes the bigint e8s to icUSD, so
  * the ratio is in matching units.
  */
-export function liveSpApyPct(
+export function spInterestApr(
   protocolStatus: ProtocolStatusLike | null | undefined,
   poolStatus: PoolStatusLike | null | undefined,
+  eligibleFor: (collateralType: string) => boolean = isDefaultInterestEligible,
 ): number | null {
   if (!protocolStatus || !poolStatus) return null;
 
@@ -60,6 +95,7 @@ export function liveSpApyPct(
 
   let totalApr = 0;
   for (const info of perC) {
+    if (!eligibleFor(info.collateralType)) continue;
     const eligible = eligibleMap.get(info.collateralType) ?? 0;
     if (
       eligible === 0 ||
@@ -70,8 +106,24 @@ export function liveSpApyPct(
     }
     totalApr += (info.weightedInterestRate * poolShare * info.totalDebtE8s) / eligible;
   }
-  if (totalApr === 0) return null;
-  return (Math.pow(1 + totalApr / 365, 365) - 1) * 100;
+  return totalApr === 0 ? null : totalApr;
+}
+
+/** Daily-compounded APY percentage from an APR fraction. */
+export function aprToApyPct(apr: number): number {
+  return (Math.pow(1 + apr / 365, 365) - 1) * 100;
+}
+
+/**
+ * Advertised SP interest APY as a percentage (e.g. 7.39 for 7.39%): the rate a
+ * new icUSD depositor would earn. Applies to icUSD deposits only.
+ */
+export function liveSpApyPct(
+  protocolStatus: ProtocolStatusLike | null | undefined,
+  poolStatus: PoolStatusLike | null | undefined,
+): number | null {
+  const apr = spInterestApr(protocolStatus, poolStatus);
+  return apr === null ? null : aprToApyPct(apr);
 }
 
 /**


### PR DESCRIPTION
## Problem

The Stability Pool advertised **9.96% APY** while a depositor who joined after the BOB sunset earned **7.39%**. Both numbers were internally consistent; the headline was simply the wrong one to publish.

SP interest APR is computed per collateral as `rate_c × 0.35 (SP split) × debt_c ÷ eligible_icUSD_c`, where the denominator is only the icUSD held by depositors **opted in to that collateral**. Sunset **BOB** had 22.72 icUSD of debt at 10.06% against a **33.90 icUSD** opted-in denominator, contributing **2.36 of the 9.96 points** while only **2.80%** of pool icUSD could earn it. `DepositPosition::new` opts every new position out of BOB and the UI hides the re-opt-in control, so the advertised rate was **unreachable by construction** for new depositors. Native XRP has the same shape (`position_opted_in_for` gates it behind a configured payout address).

Three different SP APYs were live at once: **9.96%** (frontend headline), **7.39%** (new depositor), **3.10%** (analytics `get_apys`, which divided interest by total deposits including non-earning 3USD/ck-stables).

## Fix

- **Advertise the floor, not the ceiling.** `liveSpApyPct` sums only collateral a brand-new default position would earn from, via a general predicate (`isDefaultInterestEligible`) that also covers payout-gated XRP and any future sunset without another patch.
- **Single-source the formula.** It was triplicated across three files and had already drifted; badge, nav pill, and explorer lenses now share one implementation in `liveApy.ts`.
- **State "icUSD only" where users can see it.** Previously only in a hover tooltip (invisible on mobile). Now permanent page copy, on the badge label, in the deposit form when a non-earning token is selected, and beside the personal rate, which now prints the icUSD base it applies to. Depositors holding no icUSD get an explicit 0.00% row.
- **Label Interest Earned** as cumulative for the life of the position.
- **Analytics denominator** switched to icUSD from the already-recorded `stablecoin_balances` (no schema change, no upgrade risk).

## Tests

234 frontend tests + 129 analytics tests pass. `liveApy.spec.ts` pins both 9.96% (old) and 7.39% (new) against fixtures captured from live mainnet state on 2026-07-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)