### PR TITLE
feat(frontend): pause AMM1 liquidity + remove 3USD from swaps

### DIFF
--- a/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
+++ b/src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte
@@ -23,6 +23,9 @@
 
   const dispatch = createEventDispatcher();
 
+  /** Temporary AMM1 pause: block deposits without blocking LP exits. */
+  export let depositsPaused = false;
+
   type Tab = 'add' | 'remove';
   let activeTab: Tab = 'add';
 
@@ -75,6 +78,7 @@
   const MIN_CLAIM_E8S: bigint = 100_000n;
 
   $: isConnected = $walletStore.isConnected;
+  $: if (depositsPaused && activeTab === 'add') activeTab = 'remove';
 
   // Token references
   const threeUsdToken = AMM_TOKENS.find(t => t.is3USD)!;
@@ -395,12 +399,19 @@
 
   <!-- Tabs -->
   <div class="sub-tabs">
-    <button class="sub-tab" class:active={activeTab === 'add'} on:click={() => { activeTab = 'add'; error = ''; }}>Add</button>
+    <button
+      class="sub-tab"
+      class:active={activeTab === 'add'}
+      disabled={depositsPaused}
+      on:click={() => { activeTab = 'add'; error = ''; }}
+    >Add</button>
     <button class="sub-tab" class:active={activeTab === 'remove'} on:click={() => { activeTab = 'remove'; error = ''; }}>Remove</button>
   </div>
 
   {#if activeTab === 'add'}
-    {#if !isConnected}
+    {#if depositsPaused}
+      <p class="connect-text">New AMM1 deposits are temporarily paused.</p>
+    {:else if !isConnected}
       <p class="connect-text">Connect your wallet to add liquidity</p>
     {:else}
       <div class="input-group">

--- a/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
+++ b/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
@@ -7,12 +7,6 @@
     formatTokenAmount,
   } from '../../services/threePoolService';
   import { ammService, type PoolInfo } from '../../services/ammService';
-  import {
-    getAmm1Apy,
-    computeAmm1EffectiveApy,
-    AMM1_THREEUSD_VALUE_SHARE,
-    type Amm1ApyResult,
-  } from '../../services/amm1ApyService';
   import { getThreePoolApy } from '../../services/threePoolApyService';
   import { CANISTER_IDS } from '../../config';
   import type { PoolStatus } from '../../services/threePoolService';
@@ -29,16 +23,7 @@
   let threePoolApyPct: number | null = null;
   let threePoolInterestAprPct = 0;
   let threePoolSwapFeeAprPct = 0;
-  let ammApy: Amm1ApyResult | null = null;
   let showThreePoolTooltip = false;
-  let showAmmTooltip = false;
-
-  // Effective AMM1 APY = AMM1's own APY + 50% × 3pool APY (pass-through on
-  // the 3USD half of the reserve). Null until both pools' APYs resolve.
-  $: ammEffective =
-    ammApy !== null && threePoolApyPct !== null
-      ? computeAmm1EffectiveApy(ammApy, threePoolApyPct)
-      : null;
 
   $: isConnected = $walletStore.isConnected;
 
@@ -75,9 +60,6 @@
 
       // APY queries fire in parallel; never block the cards on them
       loadThreePoolApy().catch(e => console.warn('3pool APY failed:', e));
-      if (ammPool) {
-        loadAmmApy().catch(e => console.warn('AMM1 APY failed:', e));
-      }
     } catch (e) {
       console.error('Failed to load pool data:', e);
     } finally {
@@ -90,10 +72,6 @@
     threePoolInterestAprPct = r.interest_apr_pct;
     threePoolSwapFeeAprPct = r.swap_fee_apr_pct;
     threePoolApyPct = r.total_apy_pct;
-  }
-
-  async function loadAmmApy() {
-    ammApy = await getAmm1Apy();
   }
 
   function threePoolTvl(): string {
@@ -181,7 +159,14 @@
     </button>
 
     {#if ammPool}
-      <button class="pool-card" on:click={() => selectPool('amm')}>
+      <button
+        class="pool-card pool-card-paused"
+        disabled={!isConnected || userAmmLp === 0n}
+        aria-label={userAmmLp > 0n
+          ? 'Manage your paused 3USD / ICP liquidity position'
+          : '3USD / ICP liquidity is temporarily paused'}
+        on:click={() => selectPool('amm')}
+      >
         <div class="pool-header">
           <div class="pool-pair">
             <div class="pool-dots">
@@ -190,37 +175,7 @@
             </div>
             <span class="pool-name">3USD / ICP</span>
           </div>
-          <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-          <div
-            class="apy-badge"
-            on:mouseover|stopPropagation={() => { showAmmTooltip = true; }}
-            on:mouseleave={() => { showAmmTooltip = false; }}
-          >
-            {#if ammApy === null || ammEffective === null}
-              <span class="apy-loading">… APY</span>
-            {:else}
-              <svg class="apy-arrow" width="9" height="9" viewBox="0 0 10 10" fill="none">
-                <path d="M5 8V2M5 2L2 5M5 2L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-              {ammEffective.total_apy_pct.toFixed(1)}% APY
-            {/if}
-
-            {#if showAmmTooltip && ammApy !== null && ammEffective !== null}
-              <div class="apy-tooltip">
-                <div class="apy-tooltip-caret"></div>
-                <p>
-                  Rewards {ammApy.reward_apy_pct.toFixed(2)}% + Swap fees {ammApy.trading_fee_apy_pct.toFixed(2)}%
-                  + 3USD yield {ammEffective.passthrough_3pool_apy_pct.toFixed(2)}%
-                  = total {ammEffective.total_apy_pct.toFixed(2)}%
-                </p>
-                <p class="apy-tooltip-foot">
-                  3USD yield is {(AMM1_THREEUSD_VALUE_SHARE * 100).toFixed(0)}% of 3pool APY
-                  ({threePoolApyPct !== null ? threePoolApyPct.toFixed(2) : '—'}%) since
-                  the pool holds ~half its value in 3USD.
-                </p>
-              </div>
-            {/if}
-          </div>
+          <span class="pool-paused-badge">Paused</span>
         </div>
         <div class="pool-stats">
           <div class="pool-stat">
@@ -238,7 +193,9 @@
             </div>
           {/if}
         </div>
-        <div class="pool-action">Add Liquidity →</div>
+        <div class="pool-action">
+          {userAmmLp > 0n ? 'Manage position →' : 'Liquidity temporarily paused'}
+        </div>
       </button>
     {:else}
       <div class="pool-card pool-card-empty">
@@ -248,10 +205,8 @@
     {/if}
 
     <p class="liquidity-explainer">
-      To capture the full combined yield, supply stablecoins (icUSD, ckUSDT, or ckUSDC)
-      to the 3pool — you receive 3USD in return. Pair that 3USD with ICP in 3USD/ICP
-      for a second layer of rewards. Both positions earn protocol interest and swap fees
-      independently.
+      Supply stablecoins (icUSD, ckUSDT, or ckUSDC) to the 3pool to receive 3USD and
+      earn the pool's protocol-interest and swap-fee yield.
     </p>
   </div>
 {/if}
@@ -301,6 +256,25 @@
     box-shadow: none;
   }
 
+  .pool-card-paused {
+    cursor: not-allowed;
+    opacity: 0.45;
+    filter: grayscale(1);
+  }
+
+  .pool-card-paused:hover {
+    border-color: var(--rumi-border);
+    box-shadow: none;
+  }
+
+  .pool-card-paused:not(:disabled) {
+    cursor: pointer;
+  }
+
+  .pool-card-paused .pool-action {
+    color: var(--rumi-text-muted);
+  }
+
   .pool-header {
     display: flex;
     align-items: center;
@@ -341,6 +315,16 @@
   .pool-empty-text {
     font-size: 0.8125rem;
     color: var(--rumi-text-muted);
+  }
+
+  .pool-paused-badge {
+    padding: 0.1875rem 0.625rem;
+    border: 1px solid var(--rumi-border);
+    border-radius: 1rem;
+    color: var(--rumi-text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
   }
 
   .pool-stats {
@@ -440,14 +424,6 @@
   }
 
   .apy-tooltip p { margin: 0; }
-
-  .apy-tooltip-foot {
-    margin-top: 0.375rem !important;
-    padding-top: 0.375rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
-    color: #94a3b8;
-    font-size: 0.625rem;
-  }
 
   /* ── Explainer under the cards ── */
   .liquidity-explainer {

--- a/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
+++ b/src/vault_frontend/src/lib/components/swap/SwapInterface.svelte
@@ -5,7 +5,7 @@
   import {
     resolveRoute, executeRoute, preWarmOisySigner, preWarmOisyFees,
     checkIcpswapUnusedBalances, recoverIcpswapBalance, preWarmRecovery,
-    type SwapRoute, type IcpswapUnusedBalance,
+    AMM1_ROUTING_PAUSED, type SwapRoute, type IcpswapUnusedBalance,
   } from '../../services/swapRouter';
   import { fetchLedgerFee, getCachedLedgerFee } from '../../services/ledgerFeeService';
   import { CANISTER_IDS } from '../../config';
@@ -17,13 +17,17 @@
   import { TokenService } from '../../services/tokenService';
   import { get } from 'svelte/store';
 
+  // The 3USD/ICP market is temporarily paused. Keep 3USD in AMM_TOKENS for
+  // balances and liquidity-position handling, but do not offer it in swaps.
+  const SWAP_TOKENS = AMM_TOKENS.filter((token) => !AMM1_ROUTING_PAUSED || !token.is3USD);
+
   function ammTokenRef(token: AmmToken) {
     return { ledgerId: token.ledgerId, decimals: token.decimals, symbol: token.symbol };
   }
 
   const dispatch = createEventDispatcher();
 
-  let fromIdx = 0; // Index into AMM_TOKENS
+  let fromIdx = 0; // Index into SWAP_TOKENS
   let toIdx = 1;
   let amount = '';
   let loading = false;
@@ -58,8 +62,8 @@
   let beforeToBalanceSnapshot: bigint | null = null;
 
   $: isConnected = $walletStore.isConnected;
-  $: fromToken = AMM_TOKENS[fromIdx];
-  $: toToken = AMM_TOKENS[toIdx];
+  $: fromToken = SWAP_TOKENS[fromIdx];
+  $: toToken = SWAP_TOKENS[toIdx];
 
   // Wallet balance for "from" token
   $: walletBalance = (() => {
@@ -468,7 +472,7 @@
 
       {#if showFromDropdown}
         <div class="token-dropdown" on:click|stopPropagation>
-          {#each AMM_TOKENS as token, i}
+          {#each SWAP_TOKENS as token, i}
             <button class="token-option" class:token-option-active={fromIdx === i}
               on:click={() => selectFrom(i)}>
               <span class="token-dot" style="background:{token.color}"></span>
@@ -514,7 +518,7 @@
 
       {#if showToDropdown}
         <div class="token-dropdown" on:click|stopPropagation>
-          {#each AMM_TOKENS as token, i}
+          {#each SWAP_TOKENS as token, i}
             <button class="token-option" class:token-option-active={toIdx === i}
               on:click={() => selectTo(i)}>
               <span class="token-dot" style="background:{token.color}"></span>

--- a/src/vault_frontend/src/lib/services/swapRouter.spec.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.spec.ts
@@ -25,6 +25,12 @@ const mocks = vi.hoisted(() => ({
     quote: vi.fn(),
     swap: vi.fn(),
   },
+  icpswapIcUsdMock: {
+    id: 'icpswap_icusd_icp' as const,
+    supports: vi.fn(() => true),
+    quote: vi.fn(),
+    swap: vi.fn(),
+  },
   threePoolMock: {
     quoteSwap: vi.fn(),
     calcAddLiquidity: vi.fn(),
@@ -36,14 +42,16 @@ const mocks = vi.hoisted(() => ({
   isOisyWalletMock: vi.fn(() => false),
 }));
 
-const { rumiAmmMock, icpswapMock, threePoolMock, isOisyWalletMock } = mocks;
+const { rumiAmmMock, icpswapMock, icpswapIcUsdMock, threePoolMock, isOisyWalletMock } = mocks;
 
 vi.mock('./providers/rumiAmmProvider', () => ({
   RumiAmmProvider: vi.fn(() => mocks.rumiAmmMock),
 }));
 
 vi.mock('./providers/icpswapProvider', () => ({
-  IcpswapProvider: vi.fn(() => mocks.icpswapMock),
+  IcpswapProvider: vi.fn((config: { id: string }) => (
+    config.id === 'icpswap_icusd_icp' ? mocks.icpswapIcUsdMock : mocks.icpswapMock
+  )),
 }));
 
 // Audit ICRC-005 (frontend half): the Oisy batched executor now pulls fees
@@ -157,6 +165,26 @@ const ckUsdc: AmmToken = {
   threePoolIndex: 2,
 };
 
+const ckUsdt: AmmToken = {
+  symbol: 'ckUSDT',
+  ledgerId: 'cngnf-vqaaa-aaaar-qag4q-cai',
+  decimals: 6,
+  color: '#26A17B',
+  balanceKey: 'CKUSDT',
+  is3USD: false,
+  threePoolIndex: 1,
+};
+
+const icUsd: AmmToken = {
+  symbol: 'icUSD',
+  ledgerId: 't6bor-paaaa-aaaap-qrd5q-cai',
+  decimals: 8,
+  color: '#818cf8',
+  balanceKey: 'ICUSD',
+  is3USD: false,
+  threePoolIndex: 0,
+};
+
 function rumiQuote(amountOut: bigint, overrides: Partial<ProviderQuote> = {}): ProviderQuote {
   return {
     provider: 'rumi_amm',
@@ -184,12 +212,25 @@ function icpswapQuote(amountOut: bigint, overrides: Partial<ProviderQuote> = {})
   };
 }
 
+function icpswapIcUsdQuote(amountOut: bigint, overrides: Partial<ProviderQuote> = {}): ProviderQuote {
+  return {
+    provider: 'icpswap_icusd_icp',
+    label: 'icUSD/ICP via ICPswap',
+    amountOut,
+    feeDisplay: '0.30%',
+    priceImpactBps: 0,
+    meta: { poolCanisterId: 'nqxwe-hiaaa-aaaar-qb5yq-cai', zeroForOne: true },
+    ...overrides,
+  };
+}
+
 describe('swapRouter — provider registry integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // restore the default supports() after clearAllMocks
     rumiAmmMock.supports.mockReturnValue(true);
     icpswapMock.supports.mockReturnValue(true);
+    icpswapIcUsdMock.supports.mockReturnValue(true);
     // Most tests exercise routes where ICPswap is a valid option; the
     // kill-switch-off behaviour is covered in its own describe block.
     setIcpswapRoutingEnabled(true);
@@ -216,79 +257,68 @@ describe('swapRouter — provider registry integration', () => {
       expect(route.pathDisplay).toBe('icpswap label');
     });
 
-    it('populates providerQuote with Rumi AMM when it wins and caches poolId', async () => {
+    it('does not quote Rumi AMM while AMM1 routing is paused', async () => {
       rumiAmmMock.quote.mockResolvedValue(rumiQuote(2_000n));
       icpswapMock.quote.mockResolvedValue(icpswapQuote(1_500n));
 
       const route = await resolveRoute(icp, threeUsd, 100n);
 
-      expect(route.providerQuote?.provider).toBe('rumi_amm');
-      expect(route.estimatedOutput).toBe(1_990n);
-      expect(route.grossOutput).toBe(2_000n);
-      expect(route.poolId).toBe('rumi-pool-1');
+      expect(route.providerQuote?.provider).toBe('icpswap_3usd_icp');
+      expect(route.estimatedOutput).toBe(1_490n);
+      expect(route.grossOutput).toBe(1_500n);
+      expect(rumiAmmMock.quote).not.toHaveBeenCalled();
     });
   });
 
   // ──────────────────────────────────────────────────────────────
-  // Case 5: stable -> ICP (two-hop)
+  // Case 5: stable -> ICP through icUSD (3pool + ICPswap, AMM1 paused)
   // ──────────────────────────────────────────────────────────────
 
-  describe('Case 5 (stable -> ICP)', () => {
-    it('populates hopProviderQuote with the winning 3USD/ICP provider and threads intermediateOutput', async () => {
-      threePoolMock.calcAddLiquidity.mockResolvedValue(900n);
-      rumiAmmMock.quote.mockResolvedValue(rumiQuote(2_000n));
-      icpswapMock.quote.mockResolvedValue(icpswapQuote(3_000n));
+  describe('Case 5 (stable -> ICP via icUSD)', () => {
+    it('routes stablecoin -> icUSD in 3pool, then icUSD -> ICP on ICPswap', async () => {
+      threePoolMock.quoteSwap.mockResolvedValue({ amount_out: 900n, fee_bps: 4, is_rebalancing: false });
+      icpswapIcUsdMock.quote.mockResolvedValue(icpswapIcUsdQuote(3_000n));
 
       const route = await resolveRoute(ckUsdc, icp, 1_000n);
 
-      expect(route.type).toBe('stable_to_icp');
-      expect(route.intermediateOutput).toBe(900n);
-      expect(route.hopProviderQuote?.provider).toBe('icpswap_3usd_icp');
+      expect(route.type).toBe('stable_to_icp_via_icusd');
+      // 3pool's 900n gross output arrives as 890n icUSD after ledger fee.
+      expect(route.intermediateOutput).toBe(890n);
+      expect(route.hopProviderQuote?.provider).toBe('icpswap_icusd_icp');
       // FE-003: NET of the 10n output ledger fee
       expect(route.estimatedOutput).toBe(2_990n);
       expect(route.grossOutput).toBe(3_000n);
-      // ICPswap winner => poolId undefined
-      expect(route.poolId).toBeUndefined();
-      // bestQuote was called with (3USD, icp, threeUsdOut=900n)
-      expect(rumiAmmMock.quote).toHaveBeenCalledWith(
-        expect.objectContaining({ is3USD: true }),
+      expect(route.pathDisplay).toBe('ckUSDC → icUSD → ICP');
+      expect(icpswapIcUsdMock.quote).toHaveBeenCalledWith(
+        expect.objectContaining({ symbol: 'icUSD' }),
         expect.objectContaining({ symbol: 'ICP' }),
-        900n,
+        890n,
       );
+      expect(rumiAmmMock.quote).not.toHaveBeenCalled();
     });
   });
 
   // ──────────────────────────────────────────────────────────────
-  // Case 6: ICP -> stable (two-hop)
+  // Case 6: ICP -> stable through icUSD (ICPswap + 3pool, AMM1 paused)
   // ──────────────────────────────────────────────────────────────
 
-  describe('Case 6 (ICP -> stable)', () => {
-    it('populates hopProviderQuote with the winning ICP/3USD provider and derives final stable estimate', async () => {
-      rumiAmmMock.quote.mockResolvedValue(rumiQuote(1_800n));
-      icpswapMock.quote.mockResolvedValue(icpswapQuote(2_500n));
-      threePoolMock.calcRemoveOneCoin.mockResolvedValue(2_400n);
+  describe('Case 6 (ICP -> stable via icUSD)', () => {
+    it('routes ICP -> icUSD on ICPswap, then icUSD -> ckUSDT in the 3pool', async () => {
+      icpswapIcUsdMock.quote.mockResolvedValue(icpswapIcUsdQuote(2_500n));
+      threePoolMock.quoteSwap.mockResolvedValue({ amount_out: 2_400n, fee_bps: 4, is_rebalancing: false });
 
-      const route = await resolveRoute(icp, ckUsdc, 10_000n);
+      const route = await resolveRoute(icp, ckUsdt, 10_000n);
 
-      expect(route.type).toBe('icp_to_stable');
-      expect(route.hopProviderQuote?.provider).toBe('icpswap_3usd_icp');
-      expect(route.intermediateOutput).toBe(2_500n);
+      expect(route.type).toBe('icp_to_stable_via_icusd');
+      expect(route.hopProviderQuote?.provider).toBe('icpswap_icusd_icp');
+      // The 2,500n ICPswap gross output becomes 2,490n usable icUSD.
+      expect(route.intermediateOutput).toBe(2_490n);
       // FE-003: NET of the 10n output ledger fee
       expect(route.estimatedOutput).toBe(2_390n);
       expect(route.grossOutput).toBe(2_400n);
-      // calcRemoveOneCoin was called with the winning hop's amountOut
-      expect(threePoolMock.calcRemoveOneCoin).toHaveBeenCalledWith(2_500n, ckUsdc.threePoolIndex);
-    });
-
-    it('uses Rumi AMM when it wins and caches poolId', async () => {
-      rumiAmmMock.quote.mockResolvedValue(rumiQuote(3_000n));
-      icpswapMock.quote.mockResolvedValue(icpswapQuote(2_500n));
-      threePoolMock.calcRemoveOneCoin.mockResolvedValue(2_900n);
-
-      const route = await resolveRoute(icp, ckUsdc, 10_000n);
-
-      expect(route.hopProviderQuote?.provider).toBe('rumi_amm');
-      expect(route.poolId).toBe('rumi-pool-1');
+      expect(route.pathDisplay).toBe('ICP → icUSD → ckUSDT');
+      expect(threePoolMock.quoteSwap).toHaveBeenCalledWith(0, ckUsdt.threePoolIndex, 2_490n);
+      expect(rumiAmmMock.quote).not.toHaveBeenCalled();
     });
   });
 
@@ -322,27 +352,6 @@ describe('swapRouter — provider registry integration', () => {
       expect(out).toBe(1_499n);
     });
 
-    it('FE-003: passes a NET min_amount_out to Rumi AMM (backend enforces net, PR #230)', async () => {
-      const winningQuote = rumiQuote(1_500n);
-      const route: SwapRoute = {
-        type: 'amm_swap',
-        pathDisplay: 'x',
-        hops: 1,
-        estimatedOutput: 1_490n, // 1_500n gross - 10n mocked ledger fee
-        grossOutput: 1_500n,
-        feeDisplay: '0.30%',
-        providerQuote: winningQuote,
-      };
-      rumiAmmMock.swap.mockResolvedValue({ amountOut: 1_489n });
-
-      const out = await executeRoute(route, threeUsd, icp, 100n, 50);
-
-      // min = net estimate * (1 - 0.5%) = 1_490 * 9_950 / 10_000 = 1_482n
-      expect(rumiAmmMock.swap).toHaveBeenCalledWith(
-        threeUsd, icp, 100n, 1_490n * 9_950n / 10_000n, winningQuote,
-      );
-      expect(out).toBe(1_489n);
-    });
   });
 
   // ──────────────────────────────────────────────────────────────
@@ -406,84 +415,78 @@ describe('swapRouter — provider registry integration', () => {
     });
   });
 
-  // ──────────────────────────────────────────────────────────────
-  // icp_to_stable hop-2: burn the NET 3USD received from hop 1.
-  //
-  // rumi_amm's swap pays out `amount_out - ledger_fee` (transfer_to_user), so
-  // after the ICP->3USD hop the caller's 3USD balance grows by one ledger fee
-  // LESS than the AMM's returned amount_out. The 3pool's remove_one_coin burns
-  // the caller's LP directly and rejects with InsufficientLiquidity when
-  // lp_burn exceeds the held balance, so hop 2 must burn the NET amount
-  // (gross - 3USD ledger fee, mocked to 10n), not the gross. ICPswap's withdraw
-  // already nets the fee, so its returned amountOut is the held amount as-is.
-  // ──────────────────────────────────────────────────────────────
-
-  describe('icp_to_stable hop-2 burns NET 3USD (gross - ledger fee)', () => {
-    it('non-Oisy: removeOneCoin burns gross minus the 3USD ledger fee (Rumi AMM hop)', async () => {
-      // Hop 1 (ICP -> 3USD) returns a GROSS amount_out of 2_000n; the user's
-      // 3USD balance only grows by 2_000n - 10n (one ledger fee).
-      rumiAmmMock.swap.mockResolvedValue({ amountOut: 2_000n });
-      threePoolMock.calcRemoveOneCoin.mockResolvedValue(1_000n);
-      threePoolMock.removeOneCoin.mockResolvedValue(989n);
-
+  describe('paused AMM1 bridge execution', () => {
+    it('executes ICP -> icUSD on ICPswap, then icUSD -> ckUSDT in the 3pool', async () => {
+      const hopQuote = icpswapIcUsdQuote(2_500n);
       const route: SwapRoute = {
-        type: 'icp_to_stable',
-        pathDisplay: 'x',
+        type: 'icp_to_stable_via_icusd',
+        pathDisplay: 'ICP → icUSD → ckUSDT',
         hops: 2,
-        estimatedOutput: 990n,
-        grossOutput: 1_000n,
-        feeDisplay: '0.30%',
-        intermediateOutput: 2_000n,
-        hopProviderQuote: rumiQuote(2_000n),
-        poolId: 'rumi-pool-1',
+        estimatedOutput: 2_390n,
+        grossOutput: 2_400n,
+        feeDisplay: 'ICPswap 0.30% + 3pool 0.04%',
+        intermediateOutput: 2_490n,
+        hopProviderQuote: hopQuote,
       };
+      icpswapIcUsdMock.swap.mockResolvedValue({ amountOut: 2_485n });
+      threePoolMock.quoteSwap.mockResolvedValue({ amount_out: 2_300n, fee_bps: 4, is_rebalancing: false });
+      threePoolMock.swap.mockResolvedValue(2_280n);
 
-      const out = await executeRoute(route, icp, ckUsdc, 10_000n, 50);
+      const out = await executeRoute(route, icp, ckUsdt, 10_000n, 50);
 
-      // Both the estimate and the burn use the NET 3USD (2_000n - 10n), never
-      // the gross 2_000n that would over-burn the caller's LP balance.
-      expect(threePoolMock.calcRemoveOneCoin).toHaveBeenCalledWith(1_990n, ckUsdc.threePoolIndex);
-      // stableMinOutput = net(1_000n)=990n * (10000-25)/10000 = 987n
-      expect(threePoolMock.removeOneCoin).toHaveBeenCalledWith(1_990n, ckUsdc.threePoolIndex, 987n);
-      expect(out).toBe(989n);
+      // The ICPswap hop uses half of the 0.50% tolerance against its gross
+      // output; the 3pool hop spends the remaining half against its NET output.
+      expect(icpswapIcUsdMock.swap).toHaveBeenCalledWith(
+        icp, icUsd, 10_000n, 2_500n * 9_975n / 10_000n, hopQuote,
+      );
+      expect(threePoolMock.swap).toHaveBeenCalledWith(
+        0, ckUsdt.threePoolIndex, 2_485n, 2_290n * 9_975n / 10_000n,
+      );
+      expect(rumiAmmMock.swap).not.toHaveBeenCalled();
+      expect(out).toBe(2_280n);
     });
 
-    it('Oisy: remove_one_coin burns gross minus the 3USD ledger fee (Rumi AMM hop)', async () => {
+    it('uses the same ICPswap -> 3pool sequence for an Oisy wallet', async () => {
       isOisyWalletMock.mockReturnValue(true);
-
+      const hopQuote = icpswapIcUsdQuote(2_500n);
+      const route: SwapRoute = {
+        type: 'icp_to_stable_via_icusd',
+        pathDisplay: 'ICP → icUSD → ckUSDT',
+        hops: 2,
+        estimatedOutput: 2_390n,
+        grossOutput: 2_400n,
+        feeDisplay: 'ICPswap 0.30% + 3pool 0.04%',
+        intermediateOutput: 2_490n,
+        hopProviderQuote: hopQuote,
+      };
       const fakeSignerAgent = {};
       const fakeIcpLedger = { icrc2_approve: vi.fn().mockResolvedValue({ Ok: 1n }) };
-      const fakeAmm = { swap: vi.fn().mockResolvedValue({ Ok: { amount_out: 2_000n } }) };
-      const fakePool = { remove_one_coin: vi.fn().mockResolvedValue({ Ok: 988n }) };
-
+      const fakeIcUsdLedger = { icrc2_approve: vi.fn().mockResolvedValue({ Ok: 1n }) };
+      const fakeIcpswapPool = {
+        depositFrom: vi.fn().mockResolvedValue({ ok: 0n }),
+        swap: vi.fn().mockResolvedValue({ ok: 0n }),
+        withdraw: vi.fn().mockResolvedValue({ ok: 2_485n }),
+      };
+      const fakeThreePool = { swap: vi.fn().mockResolvedValue({ Ok: 2_280n }) };
       const oisySigner = await import('./oisySigner');
       vi.mocked(oisySigner.getOisySignerAgent).mockResolvedValue(fakeSignerAgent as any);
-      // swapRouter's module constants use the mainnet IDs regardless of network.
       vi.mocked(oisySigner.createOisyActor).mockImplementation(((canisterId: string) => {
-        if (canisterId === 'ijlzs-2yaaa-aaaap-quaaq-cai') return fakeAmm;   // RUMI_AMM
-        if (canisterId === 'fohh4-yyaaa-aaaap-qtkpa-cai') return fakePool;  // THREEPOOL
-        return fakeIcpLedger;                                               // ICP ledger
+        if (canisterId === 'nqxwe-hiaaa-aaaar-qb5yq-cai') return fakeIcpswapPool;
+        if (canisterId === 'fohh4-yyaaa-aaaap-qtkpa-cai') return fakeThreePool;
+        if (canisterId === 't6bor-paaaa-aaaap-qrd5q-cai') return fakeIcUsdLedger;
+        return fakeIcpLedger;
       }) as any);
 
-      const route: SwapRoute = {
-        type: 'icp_to_stable',
-        pathDisplay: 'x',
-        hops: 2,
-        estimatedOutput: 990n,
-        grossOutput: 1_000n,
-        feeDisplay: '0.30%',
-        intermediateOutput: 2_000n, // gross 3USD estimate from the AMM hop
-        hopProviderQuote: rumiQuote(2_000n),
-        poolId: 'rumi-pool-1',
-      };
+      const out = await executeRoute(route, icp, ckUsdt, 10_000n, 50);
 
-      const out = await executeRoute(route, icp, ckUsdc, 10_000n, 50);
-
-      // remove_one_coin burns 2_000n - 10n, NOT the gross 2_000n. The caller only
-      // holds the net amount, so burning the gross would trip InsufficientLiquidity.
-      // stableMinOutput = estimatedOutput(990n) * (10000-50)/10000 = 985n.
-      expect(fakePool.remove_one_coin).toHaveBeenCalledWith(1_990n, ckUsdc.threePoolIndex, 985n);
-      expect(out).toBe(988n);
+      expect(fakeIcpLedger.icrc2_approve).toHaveBeenCalledTimes(1);
+      expect(fakeIcpswapPool.depositFrom).toHaveBeenCalledWith(expect.objectContaining({ token: icp.ledgerId }));
+      expect(fakeIcpswapPool.swap).toHaveBeenCalledWith(expect.objectContaining({ amountIn: '10000' }));
+      expect(fakeIcpswapPool.withdraw).toHaveBeenCalledWith(expect.objectContaining({ token: icUsd.ledgerId }));
+      expect(fakeIcUsdLedger.icrc2_approve).toHaveBeenCalledTimes(1);
+      expect(fakeThreePool.swap).toHaveBeenCalledWith(0, ckUsdt.threePoolIndex, 2_485n, 2_390n * 9_975n / 10_000n);
+      expect(rumiAmmMock.swap).not.toHaveBeenCalled();
+      expect(out).toBe(2_280n);
     });
   });
 
@@ -548,44 +551,20 @@ describe('swapRouter — provider registry integration', () => {
       expect(out).toBe(1_499n);
     });
 
-    it('still uses provider.swap when Oisy wins with Rumi AMM (Rumi handles signer internally)', async () => {
-      isOisyWalletMock.mockReturnValue(true);
-      rumiAmmMock.swap.mockResolvedValue({ amountOut: 990n });
-
-      const route: SwapRoute = {
-        type: 'amm_swap',
-        pathDisplay: 'x',
-        hops: 1,
-        estimatedOutput: 990n,
-        grossOutput: 1_000n,
-        feeDisplay: '0.30%',
-        providerQuote: rumiQuote(1_000n),
-      };
-
-      const out = await executeRoute(route, threeUsd, icp, 100n, 50);
-      expect(rumiAmmMock.swap).toHaveBeenCalledTimes(1);
-      expect(out).toBe(990n);
-    });
   });
 
   // ──────────────────────────────────────────────────────────────
-  // Kill switch: when `icpswap_routing_enabled` is off, the router must
-  // behave as if only Rumi AMM + the 3pool existed.
+  // Kill switch: while AMM1 is paused, disabling ICPswap means no bridge is
+  // available. The router must fail closed instead of reviving AMM1.
   // ──────────────────────────────────────────────────────────────
 
   describe('ICPswap kill switch', () => {
-    it('ignores ICPswap quotes on 3USD->ICP and picks Rumi AMM even when ICPswap quotes higher', async () => {
+    it('does not fall back to Rumi AMM when ICPswap is disabled', async () => {
       setIcpswapRoutingEnabled(false);
-      rumiAmmMock.quote.mockResolvedValue(rumiQuote(1_000n));
-      // ICPswap would win if it were queried — but the router must not call it.
-      icpswapMock.quote.mockResolvedValue(icpswapQuote(9_999n));
 
-      const route = await resolveRoute(threeUsd, icp, 100n);
-
-      expect(route.providerQuote?.provider).toBe('rumi_amm');
-      // FE-003: NET of the 10n output ledger fee
-      expect(route.estimatedOutput).toBe(990n);
-      expect(route.grossOutput).toBe(1_000n);
+      await expect(resolveRoute(threeUsd, icp, 100n))
+        .rejects.toThrow(/no route available while AMM1 routing is paused/i);
+      expect(rumiAmmMock.quote).not.toHaveBeenCalled();
       expect(icpswapMock.quote).not.toHaveBeenCalled();
     });
 
@@ -607,7 +586,7 @@ describe('swapRouter — provider registry integration', () => {
         .rejects.toThrow(/ICPswap routing is currently disabled/i);
     });
 
-    it('still allows pure-Rumi routes to execute when ICPswap is disabled', async () => {
+    it('refuses to execute a stale Rumi AMM route while AMM1 is paused', async () => {
       setIcpswapRoutingEnabled(false);
       rumiAmmMock.swap.mockResolvedValue({ amountOut: 990n });
 
@@ -621,35 +600,24 @@ describe('swapRouter — provider registry integration', () => {
         providerQuote: rumiQuote(1_000n),
       };
 
-      const out = await executeRoute(route, threeUsd, icp, 100n, 50);
-      expect(out).toBe(990n);
-      expect(rumiAmmMock.swap).toHaveBeenCalled();
+      await expect(executeRoute(route, threeUsd, icp, 100n, 50))
+        .rejects.toThrow(/AMM1 routing is currently paused/i);
+      expect(rumiAmmMock.swap).not.toHaveBeenCalled();
     });
 
-    it('falls back to 2-hop for icUSD<->ICP when ICPswap is disabled (no direct attempt)', async () => {
+    it('returns no route for icUSD<->ICP when ICPswap is disabled', async () => {
       setIcpswapRoutingEnabled(false);
-      const icUsd: AmmToken = {
-        symbol: 'icUSD',
-        ledgerId: 't6bor-paaaa-aaaap-qrd5q-cai',
-        decimals: 8,
-        color: '#000',
-        balanceKey: 'ICUSD',
-        is3USD: false,
-        threePoolIndex: 0,
-      };
-
-      // Two-hop: 3pool add_liquidity then Rumi AMM on 3USD->ICP
-      threePoolMock.calcAddLiquidity.mockResolvedValue(950n);
-      rumiAmmMock.quote.mockResolvedValue(rumiQuote(500n));
-      // If the direct icUSD/ICP ICPswap path were attempted the mock would
-      // need to be called — assert it wasn't.
-      icpswapMock.quote.mockResolvedValue(icpswapQuote(9_999n));
-
-      const route = await resolveRoute(icUsd, icp, 100n);
-      expect(route.type).toBe('stable_to_icp');
-      // icpswapMock.quote should only have been consulted for the 3USD/ICP
-      // hop — which it shouldn't have been either, since the flag is off.
+      await expect(resolveRoute(icUsd, icp, 100n))
+        .rejects.toThrow(/no route available while AMM1 routing is paused/i);
       expect(icpswapMock.quote).not.toHaveBeenCalled();
+      expect(icpswapIcUsdMock.quote).not.toHaveBeenCalled();
+    });
+
+    it('returns no ICP -> stablecoin bridge when ICPswap is disabled', async () => {
+      setIcpswapRoutingEnabled(false);
+      await expect(resolveRoute(icp, ckUsdc, 100n))
+        .rejects.toThrow(/no route available while AMM1 routing is paused/i);
+      expect(rumiAmmMock.quote).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/vault_frontend/src/lib/services/swapRouter.ts
+++ b/src/vault_frontend/src/lib/services/swapRouter.ts
@@ -30,8 +30,24 @@ const _threeUsdIcpRegistryFull = new ProviderRegistry([
   }),
 ]);
 
+const _threeUsdIcpRegistryIcpswapOnly = new ProviderRegistry([
+  new IcpswapProvider({
+    id: 'icpswap_3usd_icp',
+    poolCanisterId: CANISTER_IDS.ICPSWAP_3USD_ICP_POOL,
+    token0LedgerId: CANISTER_IDS.THREEPOOL,
+    token1LedgerId: CANISTER_IDS.ICP_LEDGER,
+    feeBps: 30,
+  }),
+]);
+
 // Rumi-only fallback used when the ICPswap kill switch is off.
 const _threeUsdIcpRegistryRumiOnly = new ProviderRegistry([new RumiAmmProvider()]);
+
+// AMM1 is deliberately unavailable for new swaps while its liquidity is
+// paused. Keep this routing guard beside the provider registries so a hidden
+// fallback cannot send a user through AMM1 even if another UI entry point
+// supplies a 3USD route directly.
+export const AMM1_ROUTING_PAUSED = true;
 
 // Dedicated registry for the direct icUSD/ICP pool on ICPswap (Task 11).
 // Only ICPswap currently hosts this pair; if a Rumi AMM icUSD/ICP pool is
@@ -86,6 +102,10 @@ export async function initIcpswapRoutingFlag(): Promise<void> {
 }
 
 function threeUsdIcpRegistry(): ProviderRegistry {
+  if (AMM1_ROUTING_PAUSED && !_icpswapEnabled) {
+    throw new Error('No route available while AMM1 routing is paused.');
+  }
+  if (AMM1_ROUTING_PAUSED) return _threeUsdIcpRegistryIcpswapOnly;
   return _icpswapEnabled ? _threeUsdIcpRegistryFull : _threeUsdIcpRegistryRumiOnly;
 }
 
@@ -100,6 +120,8 @@ export type RouteType =
   | 'amm_swap'              // 3USD <-> ICP (direct AMM)
   | 'stable_to_icp'         // Stablecoin -> ICP (3pool deposit + AMM swap)
   | 'icp_to_stable'         // ICP -> Stablecoin (AMM swap + 3pool redeem)
+  | 'stable_to_icp_via_icusd' // Stablecoin -> icUSD (3pool) -> ICP (ICPswap)
+  | 'icp_to_stable_via_icusd' // ICP -> icUSD (ICPswap) -> Stablecoin (3pool)
   | 'icusd_icp_direct';     // icUSD <-> ICP (direct ICPswap icUSD/ICP pool)
 
 export interface SwapRoute {
@@ -196,6 +218,16 @@ async function netOfOutputLedgerFee(grossOut: bigint, to: AmmToken): Promise<big
   return grossOut > fee ? grossOut - fee : 0n;
 }
 
+function noRouteWhileAmm1Paused(): Error {
+  return new Error(
+    'No route available while AMM1 routing is paused. ICPswap routing must be enabled and the icUSD/ICP pool must be available.',
+  );
+}
+
+function threePoolFeeDisplay(feeBps: number, isRebalancing: boolean): string {
+  return `${(feeBps / 100).toFixed(2)}%${isRebalancing ? ' (rebalancing)' : ''}`;
+}
+
 /**
  * Determine the swap route and fetch a combined quote.
  */
@@ -208,14 +240,13 @@ export async function resolveRoute(
   // Case 1: Stablecoin <-> Stablecoin (3pool swap, dynamic fee)
   if (isStablecoin(from) && isStablecoin(to)) {
     const quote = await threePoolService.quoteSwap(from.threePoolIndex, to.threePoolIndex, amountIn);
-    const feePct = (quote.fee_bps / 100).toFixed(2);
     return {
       type: 'three_pool_swap',
       pathDisplay: `${from.symbol} → ${to.symbol}`,
       hops: 1,
       estimatedOutput: await netOfOutputLedgerFee(quote.amount_out, to),
       grossOutput: quote.amount_out,
-      feeDisplay: `${feePct}%${quote.is_rebalancing ? ' (rebalancing)' : ''}`,
+      feeDisplay: threePoolFeeDisplay(quote.fee_bps, quote.is_rebalancing),
     };
   }
 
@@ -266,15 +297,32 @@ export async function resolveRoute(
     };
   }
 
-  // Case 5a: icUSD <-> ICP (direct ICPswap icUSD/ICP pool vs 2-hop via 3pool).
+  // Case 5a: icUSD <-> ICP. While AMM1 is paused this pair must use its
+  // direct ICPswap pool or fail closed; it must never fall back through 3USD.
   // icUSD is a stablecoin, so this MUST sit before Case 5 to take precedence.
   // Direct wins on ties (one fewer fee, simpler execution).
   const isIcUsd = (t: AmmToken) => t.symbol === 'icUSD';
   if ((isIcUsd(from) && isICP(to)) || (isICP(from) && isIcUsd(to))) {
     console.log(`[swapRouter] Case 5a: icUSD<->ICP, _icpswapEnabled=${_icpswapEnabled}`);
-    // Option A: direct via ICPswap icUSD/ICP. Skipped entirely when the
-    // kill switch is off — there is no Rumi-hosted icUSD/ICP pool, so with
-    // ICPswap disabled the router always falls through to the 2-hop path.
+    if (AMM1_ROUTING_PAUSED) {
+      if (!_icpswapEnabled) throw noRouteWhileAmm1Paused();
+      try {
+        const directQuote = await _icUsdIcpRegistry.bestQuote(from, to, amountIn);
+        return {
+          type: 'icusd_icp_direct',
+          pathDisplay: directQuote.label,
+          hops: 1,
+          estimatedOutput: await netOfOutputLedgerFee(directQuote.amountOut, to),
+          grossOutput: directQuote.amountOut,
+          feeDisplay: directQuote.feeDisplay,
+          providerQuote: directQuote,
+        };
+      } catch {
+        throw noRouteWhileAmm1Paused();
+      }
+    }
+
+    // Option A: direct via ICPswap icUSD/ICP.
     let directQuote: ProviderQuote | null = null;
     if (_icpswapEnabled) {
       try {
@@ -334,6 +382,30 @@ export async function resolveRoute(
 
   // Case 5: Stablecoin -> ICP (two-hop: 3pool deposit + best 3USD->ICP swap)
   if (isStablecoin(from) && isICP(to)) {
+    if (AMM1_ROUTING_PAUSED) {
+      if (!_icpswapEnabled) throw noRouteWhileAmm1Paused();
+      const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+      if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+      const threePoolQuote = await threePoolService.quoteSwap(from.threePoolIndex, icUsdToken.threePoolIndex, amountIn);
+      const icUsdReceived = await netOfOutputLedgerFee(threePoolQuote.amount_out, icUsdToken);
+      try {
+        const hopQuote = await _icUsdIcpRegistry.bestQuote(icUsdToken, to, icUsdReceived);
+        return {
+          type: 'stable_to_icp_via_icusd',
+          pathDisplay: `${from.symbol} → icUSD → ICP`,
+          hops: 2,
+          estimatedOutput: await netOfOutputLedgerFee(hopQuote.amountOut, to),
+          grossOutput: hopQuote.amountOut,
+          feeDisplay: `3pool ${threePoolFeeDisplay(threePoolQuote.fee_bps, threePoolQuote.is_rebalancing)} + ICPswap ${hopQuote.feeDisplay}`,
+          intermediateOutput: icUsdReceived,
+          hopProviderQuote: hopQuote,
+        };
+      } catch {
+        throw noRouteWhileAmm1Paused();
+      }
+    }
+
     const amounts = [0n, 0n, 0n];
     amounts[from.threePoolIndex] = amountIn;
     const threeUsdOut = await threePoolService.calcAddLiquidity(amounts);
@@ -356,6 +428,30 @@ export async function resolveRoute(
 
   // Case 6: ICP -> Stablecoin (two-hop: best ICP->3USD swap + 3pool redeem)
   if (isICP(from) && isStablecoin(to)) {
+    if (AMM1_ROUTING_PAUSED) {
+      if (!_icpswapEnabled) throw noRouteWhileAmm1Paused();
+      const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+      if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+      try {
+        const hopQuote = await _icUsdIcpRegistry.bestQuote(from, icUsdToken, amountIn);
+        const icUsdReceived = await netOfOutputLedgerFee(hopQuote.amountOut, icUsdToken);
+        const threePoolQuote = await threePoolService.quoteSwap(icUsdToken.threePoolIndex, to.threePoolIndex, icUsdReceived);
+        return {
+          type: 'icp_to_stable_via_icusd',
+          pathDisplay: `ICP → icUSD → ${to.symbol}`,
+          hops: 2,
+          estimatedOutput: await netOfOutputLedgerFee(threePoolQuote.amount_out, to),
+          grossOutput: threePoolQuote.amount_out,
+          feeDisplay: `ICPswap ${hopQuote.feeDisplay} + 3pool ${threePoolFeeDisplay(threePoolQuote.fee_bps, threePoolQuote.is_rebalancing)}`,
+          intermediateOutput: icUsdReceived,
+          hopProviderQuote: hopQuote,
+        };
+      } catch {
+        throw noRouteWhileAmm1Paused();
+      }
+    }
+
     const threeUsdToken = AMM_TOKENS.find(t => t.is3USD)!;
     const hopQuote = await threeUsdIcpRegistry().bestQuote(from, threeUsdToken, amountIn);
 
@@ -410,6 +506,13 @@ export async function executeRoute(
       throw new Error(
         'ICPswap routing is currently disabled. Please refresh the quote and try again.',
       );
+    }
+  }
+
+  if (AMM1_ROUTING_PAUSED) {
+    const winner = route.providerQuote?.provider ?? route.hopProviderQuote?.provider;
+    if (winner === 'rumi_amm' || route.type === 'stable_to_icp' || route.type === 'icp_to_stable') {
+      throw new Error('AMM1 routing is currently paused. Please refresh the quote and try again.');
     }
   }
 
@@ -555,6 +658,58 @@ export async function executeRoute(
       const stableNetEstimate = await netOfOutputLedgerFee(stableEstimate, to);
       const stableMinOutput = stableNetEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
       return await threePoolService.removeOneCoin(threeUsdReceived, to.threePoolIndex, stableMinOutput);
+    }
+
+    case 'stable_to_icp_via_icusd': {
+      if (isOisyWallet()) {
+        return await executeStableToIcpViaIcUsdOisy(route, from, amountIn, slippageBps);
+      }
+      const hopQuote = route.hopProviderQuote;
+      const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+      if (!hopQuote) throw new Error('stable_to_icp_via_icusd route missing hopProviderQuote');
+      if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+      const firstQuote = await threePoolService.quoteSwap(from.threePoolIndex, icUsdToken.threePoolIndex, amountIn);
+      const icUsdMinOutput = (await netOfOutputLedgerFee(firstQuote.amount_out, icUsdToken))
+        * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+      const icUsdReceived = await threePoolService.swap(
+        from.threePoolIndex, icUsdToken.threePoolIndex, amountIn, icUsdMinOutput,
+      );
+
+      const provider = _icUsdIcpRegistry.get(hopQuote.provider);
+      const freshQuote = await provider.quote(icUsdToken, to, icUsdReceived);
+      const poolCanisterId = freshQuote.meta.poolCanisterId as string | undefined;
+      if (typeof poolCanisterId !== 'string') {
+        throw new Error('stable_to_icp_via_icusd: ICPswap quote missing meta.poolCanisterId');
+      }
+      await approveIcpswapPool(icUsdToken, icUsdReceived, poolCanisterId);
+      const grossMinOutput = freshQuote.amountOut * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+      const result = await provider.swap(icUsdToken, to, icUsdReceived, grossMinOutput, freshQuote);
+      return result.amountOut;
+    }
+
+    case 'icp_to_stable_via_icusd': {
+      if (isOisyWallet()) {
+        return await executeIcpToStableViaIcUsdOisy(route, from, to, amountIn, slippageBps);
+      }
+      const hopQuote = route.hopProviderQuote;
+      const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+      if (!hopQuote) throw new Error('icp_to_stable_via_icusd route missing hopProviderQuote');
+      if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+      const poolCanisterId = hopQuote.meta.poolCanisterId as string | undefined;
+      if (typeof poolCanisterId !== 'string') {
+        throw new Error('icp_to_stable_via_icusd: ICPswap quote missing meta.poolCanisterId');
+      }
+      await approveIcpswapPool(from, amountIn, poolCanisterId);
+      const provider = _icUsdIcpRegistry.get(hopQuote.provider);
+      const icUsdGrossMinOutput = hopQuote.amountOut * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+      const hop1 = await provider.swap(from, icUsdToken, amountIn, icUsdGrossMinOutput, hopQuote);
+
+      const finalQuote = await threePoolService.quoteSwap(icUsdToken.threePoolIndex, to.threePoolIndex, hop1.amountOut);
+      const finalMinOutput = (await netOfOutputLedgerFee(finalQuote.amount_out, to))
+        * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+      return await threePoolService.swap(icUsdToken.threePoolIndex, to.threePoolIndex, hop1.amountOut, finalMinOutput);
     }
 
     case 'icusd_icp_direct': {
@@ -1034,6 +1189,159 @@ async function executeIcpToStableOisyIcpswap(
   const r5 = await poolActor.remove_one_coin(threeUsdMinFromSwap, to.threePoolIndex, stableMinOutput);
   if ('Err' in r5) throw new Error(`3pool redeem failed: ${JSON.stringify(r5.Err)}`);
   return r5.Ok;
+}
+
+/**
+ * Stablecoin → ICP through the paused-AMM-safe bridge:
+ * stablecoin → icUSD in the 3pool, then icUSD → ICP on ICPswap.
+ *
+ * This is intentionally an explicit Oisy sequence instead of chaining the
+ * two service helpers: both steps need the same signer and the icUSD amount
+ * returned by the first swap must be the input to the ICPswap deposit.
+ */
+async function executeStableToIcpViaIcUsdOisy(
+  route: SwapRoute,
+  from: AmmToken,
+  amountIn: bigint,
+  slippageBps: number,
+): Promise<bigint> {
+  const wallet = get(walletStore);
+  if (!wallet.principal) throw new Error('Wallet not connected');
+
+  const hopQuote = route.hopProviderQuote;
+  const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+  if (!hopQuote) throw new Error('stable_to_icp_via_icusd Oisy route missing hopProviderQuote');
+  if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+  const icpswapPoolId = hopQuote.meta.poolCanisterId as string | undefined;
+  const zeroForOne = hopQuote.meta.zeroForOne;
+  if (typeof icpswapPoolId !== 'string' || typeof zeroForOne !== 'boolean') {
+    throw new Error('stable_to_icp_via_icusd Oisy route has invalid ICPswap metadata');
+  }
+
+  const icUsdEstimate = route.intermediateOutput;
+  if (icUsdEstimate === undefined) {
+    throw new Error('stable_to_icp_via_icusd Oisy route missing intermediateOutput');
+  }
+  const icUsdMinOutput = icUsdEstimate * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+  const icpGrossMinOutput = route.grossOutput * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+  const fromFee = tokenFeeCached(from);
+  const icUsdFee = tokenFeeCached(icUsdToken);
+  const icpToken = AMM_TOKENS.find(t => t.symbol === 'ICP')!;
+  const icpFee = tokenFeeCached(icpToken);
+
+  console.log('[Oisy] Sequential stable→icUSD→ICP route (3pool + ICPswap)');
+  const signerAgent = await getOisySignerAgent(wallet.principal);
+  const fromLedger = createOisyActor(from.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
+  const icUsdLedger = createOisyActor(icUsdToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
+  const threePoolActor = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
+  const icpswapPool = createOisyActor(icpswapPoolId, canisterIDLs.icpswap_pool, signerAgent);
+
+  const r1 = await fromLedger.icrc2_approve({
+    amount: amountIn + fromFee * 2n,
+    spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
+    expires_at: [], expected_allowance: [], memo: [], fee: [],
+    from_subaccount: [], created_at_time: [],
+  });
+  if (r1 && 'Err' in r1) throw new Error(`${from.symbol} approval failed: ${JSON.stringify(r1.Err)}`);
+
+  const r2 = await threePoolActor.swap(from.threePoolIndex, icUsdToken.threePoolIndex, amountIn, icUsdMinOutput);
+  if ('Err' in r2) throw new Error(`3pool swap failed: ${JSON.stringify(r2.Err)}`);
+  const icUsdReceived = r2.Ok;
+
+  const r3 = await icUsdLedger.icrc2_approve({
+    amount: icUsdReceived + icUsdFee * 2n,
+    spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
+    expires_at: [], expected_allowance: [], memo: [], fee: [],
+    from_subaccount: [], created_at_time: [],
+  });
+  if (r3 && 'Err' in r3) throw new Error(`icUSD approval failed: ${JSON.stringify(r3.Err)}`);
+
+  const r4 = await icpswapPool.depositFrom({ token: icUsdToken.ledgerId, amount: icUsdReceived, fee: icUsdFee });
+  if ('err' in r4) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r4.err)}`);
+
+  const r5 = await icpswapPool.swap({
+    amountIn: icUsdReceived.toString(),
+    zeroForOne,
+    amountOutMinimum: icpGrossMinOutput.toString(),
+  });
+  if ('err' in r5) throw new Error(`ICPswap swap failed: ${JSON.stringify(r5.err)}`);
+
+  const r6 = await icpswapPool.withdraw({ token: ICP_LEDGER_ID, amount: icpGrossMinOutput, fee: icpFee });
+  if ('err' in r6) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r6.err)}`);
+  return (r6 as { ok: bigint }).ok;
+}
+
+/**
+ * ICP → Stablecoin through the paused-AMM-safe bridge:
+ * ICP → icUSD on ICPswap, then icUSD → the target stablecoin in the 3pool.
+ */
+async function executeIcpToStableViaIcUsdOisy(
+  route: SwapRoute,
+  from: AmmToken,
+  to: AmmToken,
+  amountIn: bigint,
+  slippageBps: number,
+): Promise<bigint> {
+  const wallet = get(walletStore);
+  if (!wallet.principal) throw new Error('Wallet not connected');
+
+  const hopQuote = route.hopProviderQuote;
+  const icUsdToken = AMM_TOKENS.find(t => t.symbol === 'icUSD');
+  if (!hopQuote) throw new Error('icp_to_stable_via_icusd Oisy route missing hopProviderQuote');
+  if (!icUsdToken) throw new Error('icUSD token configuration is missing');
+
+  const icpswapPoolId = hopQuote.meta.poolCanisterId as string | undefined;
+  const zeroForOne = hopQuote.meta.zeroForOne;
+  if (typeof icpswapPoolId !== 'string' || typeof zeroForOne !== 'boolean') {
+    throw new Error('icp_to_stable_via_icusd Oisy route has invalid ICPswap metadata');
+  }
+
+  const icUsdGrossMinOutput = hopQuote.amountOut * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+  const stableMinOutput = route.estimatedOutput * BigInt(10000 - Math.ceil(slippageBps / 2)) / 10000n;
+  const fromFee = tokenFeeCached(from);
+  const icUsdFee = tokenFeeCached(icUsdToken);
+
+  console.log('[Oisy] Sequential ICP→icUSD→stable route (ICPswap + 3pool)');
+  const signerAgent = await getOisySignerAgent(wallet.principal);
+  const fromLedger = createOisyActor(from.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
+  const icUsdLedger = createOisyActor(icUsdToken.ledgerId, CONFIG.icusd_ledgerIDL, signerAgent);
+  const icpswapPool = createOisyActor(icpswapPoolId, canisterIDLs.icpswap_pool, signerAgent);
+  const threePoolActor = createOisyActor(THREEPOOL_ID, canisterIDLs.three_pool, signerAgent);
+
+  const r1 = await fromLedger.icrc2_approve({
+    amount: amountIn + fromFee * 2n,
+    spender: { owner: Principal.fromText(icpswapPoolId), subaccount: [] },
+    expires_at: [], expected_allowance: [], memo: [], fee: [],
+    from_subaccount: [], created_at_time: [],
+  });
+  if (r1 && 'Err' in r1) throw new Error(`${from.symbol} approval failed: ${JSON.stringify(r1.Err)}`);
+
+  const r2 = await icpswapPool.depositFrom({ token: from.ledgerId, amount: amountIn, fee: fromFee });
+  if ('err' in r2) throw new Error(`ICPswap depositFrom failed: ${JSON.stringify(r2.err)}`);
+
+  const r3 = await icpswapPool.swap({
+    amountIn: amountIn.toString(),
+    zeroForOne,
+    amountOutMinimum: icUsdGrossMinOutput.toString(),
+  });
+  if ('err' in r3) throw new Error(`ICPswap swap failed: ${JSON.stringify(r3.err)}`);
+
+  const r4 = await icpswapPool.withdraw({ token: icUsdToken.ledgerId, amount: icUsdGrossMinOutput, fee: icUsdFee });
+  if ('err' in r4) throw new Error(`ICPswap withdraw failed: ${JSON.stringify(r4.err)}`);
+  const icUsdReceived = (r4 as { ok: bigint }).ok;
+
+  const r5 = await icUsdLedger.icrc2_approve({
+    amount: icUsdReceived + icUsdFee * 2n,
+    spender: { owner: Principal.fromText(THREEPOOL_ID), subaccount: [] },
+    expires_at: [], expected_allowance: [], memo: [], fee: [],
+    from_subaccount: [], created_at_time: [],
+  });
+  if (r5 && 'Err' in r5) throw new Error(`icUSD approval failed: ${JSON.stringify(r5.Err)}`);
+
+  const r6 = await threePoolActor.swap(icUsdToken.threePoolIndex, to.threePoolIndex, icUsdReceived, stableMinOutput);
+  if ('Err' in r6) throw new Error(`3pool swap failed: ${JSON.stringify(r6.Err)}`);
+  return r6.Ok;
 }
 
 /**

--- a/src/vault_frontend/src/routes/swap/+page.svelte
+++ b/src/vault_frontend/src/routes/swap/+page.svelte
@@ -6,42 +6,22 @@
   import PoolListView from '../../lib/components/swap/PoolListView.svelte';
   import AmmLiquidityPanel from '../../lib/components/swap/AmmLiquidityPanel.svelte';
   import LiquidityInterface from '../../lib/components/swap/LiquidityInterface.svelte';
-  import { getAmm1Apy, combinedBestLpApyPct } from '../../lib/services/amm1ApyService';
   import { getThreePoolApy } from '../../lib/services/threePoolApyService';
 
   let mode: 'swap' | 'liquidity' = 'swap';
   let liquidityView: 'list' | 'threepool' | 'amm' = 'list';
 
-  // APY state for the combined hero. Each null while loading.
+  // The 3USD/ICP AMM is temporarily paused, so the liquidity hero reflects
+  // the active 3pool opportunity only.
   let threePoolApyPct: number | null = null;
-  let ammApyPct: number | null = null;
-
-  // "Earn up to" is the best per-dollar yield available, not a weighted
-  // blend of the two pools. Capital can only be in one position at a time,
-  // and the AMM1 LP path stacks 3pool yield on its 3USD half:
-  //   amm1Effective = amm1Apy + 0.5 * threePoolApy
-  // The advertised number is whichever of the two paths wins per dollar.
-  // `combinedBestLpApyPct` is the shared source of truth (also used by the
-  // Explorer "LP APY" vital) so the two surfaces never disagree.
-  $: combinedApy =
-    threePoolApyPct !== null && ammApyPct !== null
-      ? combinedBestLpApyPct(threePoolApyPct, ammApyPct)
-      : null;
 
   onMount(() => {
-    // Fire both APY loaders in parallel; never block the page render
     loadThreePoolApy().catch(e => console.warn('3pool APY (swap hero) failed:', e));
-    loadAmmApy().catch(e => console.warn('AMM1 APY (swap hero) failed:', e));
   });
 
   async function loadThreePoolApy() {
     const r = await getThreePoolApy();
     threePoolApyPct = r.total_apy_pct;
-  }
-
-  async function loadAmmApy() {
-    const r = await getAmm1Apy();
-    ammApyPct = r.total_apy_pct;
   }
 
   function handleSuccess() {
@@ -75,9 +55,9 @@
     <h1 class="page-title">{mode === 'swap' ? 'Swap' : 'Liquidity'}</h1>
   </div>
 
-  {#if combinedApy !== null && mode === 'swap'}
+  {#if threePoolApyPct !== null && mode === 'swap'}
     <div class="earn-banner">
-      <span class="earn-label">Earn up to {combinedApy.toFixed(2)}% APY</span>
+      <span class="earn-label">Earn {threePoolApyPct.toFixed(2)}% APY in 3pool</span>
       <button on:click={switchToLiquidityTab} class="earn-cta">Provide liquidity →</button>
     </div>
   {/if}
@@ -97,7 +77,7 @@
           <LiquidityInterface on:success={handleSuccess} />
         </div>
       {:else if liquidityView === 'amm'}
-        <AmmLiquidityPanel on:success={handleSuccess} on:back={handleBack} />
+        <AmmLiquidityPanel depositsPaused on:success={handleSuccess} on:back={handleBack} />
       {/if}
     </div>
   </div>


### PR DESCRIPTION
Temporarily pauses the 3USD/ICP AMM1 pool in the UI while keeping existing LPs able to exit. Recovers uncommitted work from a prior Codex session that was never landed (it lived only in a local Codex worktree, never committed, so it never reached `main` or the deployed canister).

## What changed
- **Liquidity list** ([PoolListView.svelte](src/vault_frontend/src/lib/components/swap/PoolListView.svelte)): AMM1 card is greyed out (grayscale + dimmed), APY advertising removed, "Paused" badge, disabled for anyone without an existing LP position, CTA relabeled to "Manage position" / "Liquidity temporarily paused". Explainer points at 3pool only.
- **AmmLiquidityPanel** ([AmmLiquidityPanel.svelte](src/vault_frontend/src/lib/components/swap/AmmLiquidityPanel.svelte)): new `depositsPaused` prop forces the Remove tab, disables Add, blocks new deposits, keeps withdraw/claim fully live so LPs can still exit.
- **Swap selectors** ([SwapInterface.svelte](src/vault_frontend/src/lib/components/swap/SwapInterface.svelte)): 3USD removed from both token menus via `AMM1_ROUTING_PAUSED` (kept in `AMM_TOKENS` for balances/LP handling).
- **Routing** ([swapRouter.ts](src/vault_frontend/src/lib/services/swapRouter.ts)): while paused, ICP↔stable routes through ICPswap (icUSD/ICP) + Rumi 3pool only, and **fails closed** with "No route available" if the backend `icpswap_routing_enabled` flag is off. No AMM1 fallback. Adds `icp_to_stable_via_icusd` and `stable_to_icp_via_icusd` routes with both non-Oisy and Oisy executors.
- **Swap hero**: promotes 3pool only ("Earn X% APY in 3pool").

## Related on-chain state (already live, not in this PR)
- Interest split already redirected: **35% stability_pool / 60% three_pool / 5% treasury**, AMM1 removed (verified via `get_interest_split` on mainnet).
- `icpswap_routing_enabled = true` on mainnet, so the fail-closed routing works and swaps are not broken.

## Verification
- 232 frontend unit tests pass (17 swapRouter tests including the new paused-bridge + kill-switch cases).
- Production build passes.
- **Deployed to mainnet-live** (vault_frontend `tcfua-yaaaa-aaaap-qrd7q-cai`) and live-verified: AMM1 card greyed out with "Paused" badge, 3pool-only hero showing "Earn 12.86% APY in 3pool".

🤖 Generated with [Claude Code](https://claude.com/claude-code)