### PR TITLE
fix(frontend): declutter the SP APY badge and position card

### DIFF
--- a/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
+++ b/src/vault_frontend/src/lib/components/liquidations/StabilityPoolTab.svelte
@@ -123,16 +123,12 @@
         on:mouseover={() => { showApyTooltip = true; }}
         on:mouseleave={() => { showApyTooltip = false; }}
       >
-        <svg class="apy-arrow" width="10" height="10" viewBox="0 0 10 10" fill="none">
-          <path d="M5 8V2M5 2L2 5M5 2L8 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        {poolApy}% icUSD Interest APY
+        {poolApy}% APY<span class="apy-asterisk">*</span>
 
         {#if showApyTooltip}
           <div class="apy-tooltip">
             <div class="apy-tooltip-caret"></div>
             <p><strong>Interest APY</strong> applies to <strong>icUSD</strong> deposits only. icUSD depositors earn a share of all borrowing interest paid by vault owners.</p>
-            <p>This is the rate a <em>new</em> depositor earns. Older positions opted in to wind-down collateral can earn more.</p>
             <div class="apy-tooltip-divider"></div>
             <p><strong>ckUSDC</strong> and <strong>ckUSDT</strong> deposits don't earn interest, but get <em>first</em> priority in liquidations — they're consumed before icUSD and 3USD, giving them earliest access to discounted collateral.</p>
             <p><strong>3USD</strong> deposits sit at the same priority as icUSD for liquidations. They don't earn interest in the pool, but 3USD LP tokens earn yield from swap fees and interest donations in the 3pool itself.</p>
@@ -140,13 +136,9 @@
         {/if}
       </div>
     </div>
-    <!-- Stated in the page, not only in the badge tooltip: hover does not exist
-         on touch devices, so a tooltip-only disclosure is invisible on mobile. -->
-    <p class="apy-scope-note">
-      Interest is paid on <strong>icUSD</strong> deposits only. <strong>3USD</strong>,
-      <strong>ckUSDC</strong> and <strong>ckUSDT</strong> deposits earn no interest here.
-      They take part in liquidations instead.
-    </p>
+    <!-- Footnote for the badge asterisk. On the page, not only in the hover
+         tooltip: hover does not exist on touch devices. -->
+    <p class="apy-scope-note">Interest is paid on icUSD deposits only.</p>
   {/if}
 
   {#if loading}
@@ -186,21 +178,24 @@
   .pool-container { max-width: 820px; margin: 0 auto; }
 
   .apy-scope-note {
-    margin: 0.5rem auto 0;
-    max-width: 34rem;
-    text-align: center;
+    margin: 0.375rem 0 1rem;
+    text-align: left;
     font-size: 0.75rem;
     line-height: 1.45;
     color: #94a3b8;
   }
-  .apy-scope-note strong { color: #cbd5e1; font-weight: 600; }
 
   .apy-row {
     display: flex;
     align-items: center;
-    margin-bottom: 1rem;
     position: relative;
     z-index: 10;
+  }
+
+  .apy-asterisk {
+    margin-left: 0.0625rem;
+    align-self: flex-start;
+    font-size: 0.7em;
   }
 
   .apy-badge {
@@ -219,7 +214,6 @@
     white-space: nowrap;
   }
 
-  .apy-arrow { color: #4ade80; flex-shrink: 0; }
 
   .apy-tooltip {
     position: absolute;

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -12,7 +12,7 @@
   import type { PoolStatus, UserPosition, CollateralInfo } from '../../services/stabilityPoolService';
   import type { ProtocolStatusDTO } from '../../services/types';
   import { CANISTER_IDS } from '../../config';
-  import { liveSpApyPct, spInterestApr, aprToApyPct } from '../../utils/liveApy';
+  import { liveSpApyPct } from '../../utils/liveApy';
   import XrpPayoutRouting from './XrpPayoutRouting.svelte';
   import { isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
   import {
@@ -61,39 +61,10 @@
   $: gains = userPosition?.collateral_gains ?? [];
   $: hasClaimableIcrcGains = gains.some(([ledger, amount]) => amount > 0n && isIcrcClaimableCollateral(ledger));
   $: optedOut = new Set((userPosition?.opted_out_collateral ?? []).map(p => p.toText()));
-  // Newer canisters report the exact effective set, including native and chain
-  // collateral that is default-out until a payout destination / opt-in exists.
-  // Fall back to legacy opt-out data while a frontend is ahead of the canister.
-  $: eligibleInterestCollaterals = userPosition?.eligible_interest_collateral?.[0]
-    ? new Set(userPosition.eligible_interest_collateral[0].map(p => p.toText()))
-    : null;
   $: icrcCollateralRegistry = liquidationPreferenceCollaterals(
     collateralRegistry.filter(c => isIcrcClaimableCollateral(c.ledger_id)),
     optedOut,
   );
-
-  // Does the user hold icUSD in the pool? Interest is paid on icUSD only, so
-  // this balance (not `total_usd_value_e8s`) is the base the rate applies to.
-  $: userIcusdE8s = userStables
-    .filter(([l]: [any, bigint]) => l.toText() === CANISTER_IDS.ICUSD_LEDGER)
-    .reduce((sum: bigint, [, a]: [any, bigint]) => sum + a, 0n);
-  $: userHasIcusd = userIcusdE8s > 0n;
-  $: userIcusdFormatted = formatStableTokenDisplay(userIcusdE8s, 8);
-
-  // Personalized APY — only sums collateral types the user is opted in to.
-  // May exceed the advertised rate for grandfathered positions still opted in
-  // to wind-down collateral; that uplift is labelled rather than hidden.
-  $: userApyPct = (() => {
-    if (!userHasIcusd) return null;
-    const apr = spInterestApr(protocolStatus as any, poolStatus as any, (ct) =>
-      eligibleInterestCollaterals ? eligibleInterestCollaterals.has(ct) : !optedOut.has(ct),
-    );
-    return apr === null ? null : aprToApyPct(apr);
-  })();
-  $: userApy = userApyPct === null ? null : userApyPct.toFixed(2);
-  // Only call it an uplift when it clears display rounding.
-  $: hasUplift =
-    userApyPct !== null && poolApyPct !== null && userApyPct - poolApyPct >= 0.01;
 
   $: poolShare = (() => {
     if (!poolStatus || !userPosition || poolStatus.total_deposits_e8s === 0n) return '0.00';
@@ -186,30 +157,6 @@
   {#if isConnected && userPosition}
     <h4 class="group-heading">Your Position</h4>
     <div class="stats-stack">
-      <!-- Personalized Interest APY. The rate is paid on the icUSD balance only,
-           so the base is printed beside it; without that it reads as a rate on
-           Total Deposited, which it is not. Depositors holding no icUSD get an
-           explicit zero row rather than a hidden one. -->
-      {#if userApy !== null}
-        <div class="stat-row align-top">
-          <span class="stat-label">Your Interest APY</span>
-          <span class="stat-value-stack">
-            <span class="stat-value green">{userApy}%</span>
-            <span class="apy-base-note">on your {userIcusdFormatted} icUSD</span>
-            {#if hasUplift}
-              <span class="apy-base-note">above the {poolApy}% new-depositor rate (wind-down collateral)</span>
-            {/if}
-          </span>
-        </div>
-      {:else}
-        <div class="stat-row align-top">
-          <span class="stat-label">Your Interest APY</span>
-          <span class="stat-value-stack">
-            <span class="stat-value">0.00%</span>
-            <span class="apy-base-note">interest is paid on icUSD deposits only</span>
-          </span>
-        </div>
-      {/if}
 
       <!-- Total Deposited with optional stablecoin breakdown -->
       <div class="stat-row" class:align-top={activeStables.length > 1}>


### PR DESCRIPTION
Follow-up to the honest-APY change (#315), addressing display feedback.

- Badge: `7.55% APY*` (was `7.55% icUSD Interest APY`), with `Interest is paid on icUSD deposits only.` left-aligned directly below. Moves the scope disclosure out of a hover-only tooltip that is invisible on mobile.
- Dropped the badge up-arrow: it reads as a trend indicator next to a percentage.
- Removed the `Your Interest APY` row: redundant with the badge for new depositors, and an unexplained higher number for grandfathered positions. Removed the dead reactives and imports behind it.
- Removed the "wind-down collateral" jargon from the hover tooltip.
- Kept the `Interest Earned ... total since you opened this position` subline.

Frontend-only. Build clean (no new unused-CSS warnings), `liveApy.spec.ts` 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)