### PR TITLE
fix(xrp): stop BigInt cache write from failing a successful vault open

### DIFF
--- a/src/vault_frontend/src/lib/services/xrpVaultService.spec.ts
+++ b/src/vault_frontend/src/lib/services/xrpVaultService.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readCachedPendingDeposits, writeCachedPendingDeposits } from './xrpVaultService';
+
+const OWNER = 'aaaaa-aa';
+const CACHE_KEY = `rumi_xrp_pending_deposits:${OWNER}`;
+
+describe('XRP pending-deposit cache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // Regression: reserveBaseDrops is a nat64 (bigint). JSON.stringify threw
+  // "Do not know how to serialize a BigInt" AFTER open_xrp_vault had already
+  // landed on-chain, so the UI reported "Could not prepare XRP address" and
+  // never showed the custody address.
+  it('round-trips bigint drops through localStorage', () => {
+    writeCachedPendingDeposits(
+      [{ vaultId: 7, custodyAddress: 'rCustody', openedAtMs: 1_700_000_000_000, reserveBaseDrops: 1_000_000n }],
+      OWNER
+    );
+
+    expect(JSON.parse(localStorage.getItem(CACHE_KEY)!)[0].reserveBaseDrops).toBe('1000000');
+    expect(readCachedPendingDeposits(OWNER)).toEqual([
+      { vaultId: 7, custodyAddress: 'rCustody', openedAtMs: 1_700_000_000_000, reserveBaseDrops: 1_000_000n },
+    ]);
+  });
+
+  it('revives legacy number drops and defaults unusable values to zero', () => {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify([
+        { vaultId: 1, custodyAddress: 'rLegacy', openedAtMs: 1, updatedAtMs: 1, reserveBaseDrops: 1_000_000 },
+        { vaultId: 2, custodyAddress: 'rMissing', openedAtMs: 2, updatedAtMs: 2 },
+      ])
+    );
+
+    expect(readCachedPendingDeposits(OWNER).map((p) => p.reserveBaseDrops)).toEqual([1_000_000n, 0n]);
+  });
+
+  it('never throws when localStorage rejects the write', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    expect(() =>
+      writeCachedPendingDeposits(
+        [{ vaultId: 9, custodyAddress: 'rCustody', openedAtMs: 1, reserveBaseDrops: 1_000_000n }],
+        OWNER
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/vault_frontend/src/lib/services/xrpVaultService.ts
+++ b/src/vault_frontend/src/lib/services/xrpVaultService.ts
@@ -85,6 +85,15 @@ interface CachedXrpPendingDeposit extends XrpPendingDepositView {
   updatedAtMs: number;
 }
 
+/**
+ * On-disk shape of {@link CachedXrpPendingDeposit}. `JSON.stringify` throws
+ * "Do not know how to serialize a BigInt", so drops are persisted as a decimal
+ * string and revived by {@link toDropsBigInt}.
+ */
+interface StoredXrpPendingDeposit extends Omit<CachedXrpPendingDeposit, 'reserveBaseDrops'> {
+  reserveBaseDrops: string;
+}
+
 interface XrpReadOptions {
   /**
    * Oisy calls route through the popup signer. Passive UI refreshes must keep
@@ -113,6 +122,27 @@ function hiddenPendingCacheKey(owner: string): string {
   return `${XRP_HIDDEN_PENDING_PREFIX}${owner}`;
 }
 
+/** Revive persisted drops (decimal string, or a legacy number) as a bigint. */
+function toDropsBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) return BigInt(value.trim());
+  return 0n;
+}
+
+/**
+ * The pending-deposit cache is a best-effort convenience for Oisy passive reads.
+ * A failed write (quota, private mode, BigInt) must never surface as a failed
+ * vault open: the on-chain pending deposit is authoritative and re-readable.
+ */
+function persist(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (e) {
+    console.warn('xrp pending-deposit cache write failed (non-fatal):', e);
+  }
+}
+
 function readHiddenPendingIds(owner = currentPrincipalText()): Set<number> {
   if (!browser || !owner) return new Set();
   try {
@@ -128,7 +158,7 @@ function readHiddenPendingIds(owner = currentPrincipalText()): Set<number> {
 
 function writeHiddenPendingIds(ids: Set<number>, owner = currentPrincipalText()) {
   if (!browser || !owner) return;
-  localStorage.setItem(hiddenPendingCacheKey(owner), JSON.stringify([...ids].sort((a, b) => a - b)));
+  persist(hiddenPendingCacheKey(owner), JSON.stringify([...ids].sort((a, b) => a - b)));
 }
 
 function emitPendingDepositsChanged() {
@@ -140,12 +170,13 @@ function visiblePendingDeposits(pending: XrpPendingDepositView[], owner = curren
   return pending.filter((p) => !hidden.has(p.vaultId));
 }
 
-function readCachedPendingDeposits(owner = currentPrincipalText()): XrpPendingDepositView[] {
+/** Exported for tests: the localStorage round-trip must survive bigint drops. */
+export function readCachedPendingDeposits(owner = currentPrincipalText()): XrpPendingDepositView[] {
   if (!browser || !owner) return [];
   try {
     const raw = localStorage.getItem(pendingCacheKey(owner));
     if (!raw) return [];
-    const parsed = JSON.parse(raw) as CachedXrpPendingDeposit[];
+    const parsed = JSON.parse(raw) as StoredXrpPendingDeposit[];
     if (!Array.isArray(parsed)) return [];
     return parsed
       .filter((p) => Number.isFinite(p.vaultId) && typeof p.custodyAddress === 'string')
@@ -153,14 +184,15 @@ function readCachedPendingDeposits(owner = currentPrincipalText()): XrpPendingDe
         vaultId: p.vaultId,
         custodyAddress: p.custodyAddress,
         openedAtMs: Number.isFinite(p.openedAtMs) ? p.openedAtMs : p.updatedAtMs,
-        reserveBaseDrops: p.reserveBaseDrops ?? 0n,
+        reserveBaseDrops: toDropsBigInt(p.reserveBaseDrops),
       }));
   } catch {
     return [];
   }
 }
 
-function writeCachedPendingDeposits(pending: XrpPendingDepositView[], owner = currentPrincipalText()) {
+/** Exported for tests: see {@link readCachedPendingDeposits}. */
+export function writeCachedPendingDeposits(pending: XrpPendingDepositView[], owner = currentPrincipalText()) {
   if (!browser || !owner) return;
   const deduped = new Map<number, CachedXrpPendingDeposit>();
   for (const p of pending) {
@@ -169,7 +201,11 @@ function writeCachedPendingDeposits(pending: XrpPendingDepositView[], owner = cu
       updatedAtMs: Date.now(),
     });
   }
-  localStorage.setItem(pendingCacheKey(owner), JSON.stringify([...deduped.values()]));
+  const stored: StoredXrpPendingDeposit[] = [...deduped.values()].map((p) => ({
+    ...p,
+    reserveBaseDrops: toDropsBigInt(p.reserveBaseDrops).toString(),
+  }));
+  persist(pendingCacheKey(owner), JSON.stringify(stored));
 }
 
 function rememberPendingDeposit(pending: XrpPendingDepositView, owner = currentPrincipalText()) {

--- a/src/vault_frontend/src/tests/mocks/app-environment.ts
+++ b/src/vault_frontend/src/tests/mocks/app-environment.ts
@@ -1,0 +1,9 @@
+/**
+ * Test stub for SvelteKit's `$app/environment`, which only exists inside a
+ * `vite dev`/`svelte-kit build` graph. Aliased in vitest.config.ts so services
+ * that guard browser-only work (localStorage) can be unit-tested under jsdom.
+ */
+export const browser = true;
+export const dev = true;
+export const building = false;
+export const version = 'test';

--- a/src/vault_frontend/vitest.config.ts
+++ b/src/vault_frontend/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '$declarations': path.resolve(__dirname, '../../declarations'),
+      '$lib': path.resolve(__dirname, 'src/lib'),
+      '$app/environment': path.resolve(__dirname, 'src/tests/mocks/app-environment.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## The bug

Native-XRP onboarding was blocked end to end. A client hit **"Could not prepare XRP address — Do not know how to serialize a BigInt."**

`reserveBaseDrops` is a Candid `nat64`, so it arrives as a JS `bigint`. `writeCachedPendingDeposits()` passed it straight to `JSON.stringify`, which throws `TypeError: Do not know how to serialize a BigInt`.

The critical part: that throw happened **inside `openXrpVault()`'s `try` block, after `actor.open_xrp_vault()` had already succeeded on-chain**. A real vault with a real XRPL custody address was reported to the user as a failure, and the address was never displayed.

`getMyPendingDeposits()` hit the same throw on its own cache write, so the recovery path returned `[]` for Oisy wallets too — there was no way to ever see the address.

Introduced in `fa2d4f6`. Four vaults were stranded on mainnet this way (ids 191/192/193 from 2026-06-24, and 198 from 2026-07-24).

## The fix

- Persist drops as a decimal string (`StoredXrpPendingDeposit`) and revive with `toDropsBigInt()`, which tolerates bigint, legacy numbers, strings, `undefined`, and garbage without throwing.
- Route both cache writes through `persist()`, which logs and swallows write failures. This cache is a best-effort convenience for Oisy passive reads — it must never be able to report an on-chain success as a failure.

This matches the drops-as-string pattern `manualXrpLiquidation.ts` already used; the pending-deposit cache was the only place that missed it.

## Test infrastructure

Adds `$app/environment` (+ stub) and `$lib` aliases to `vitest.config.ts`. Before this, **no** vitest spec could import a service that guards on `browser`, so this entire layer was untestable.

## Verification

- 3 new specs in `xrpVaultService.spec.ts`, independently confirmed to **fail against the old code** with the exact production error and pass on the fix.
- Full suite green: 34 files / 235 tests.
- `svelte-check` clean for the touched files.
- **Already deployed to mainnet** `tcfua-yaaaa-aaaap-qrd7q-cai` and live-verified: new chunk `DayJizMY.js` serves the guarded write; the old buggy chunk `BJc5T7mG.js` is purged. This PR brings `main` in line with what is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)