### PR TITLE
fix(xrp): give the borrow its own approval step after deposit confirm

### DIFF
--- a/src/vault_frontend/src/lib/components/borrow/XrpBorrowModal.svelte
+++ b/src/vault_frontend/src/lib/components/borrow/XrpBorrowModal.svelte
@@ -9,6 +9,9 @@
   } from '$lib/services/xrpVaultService';
   import {
     buildXrpPaymentUri,
+    nativeXrpBorrowErrorCopy,
+    nativeXrpBorrowLaterCopy,
+    nativeXrpBorrowSeparateApprovalCopy,
     nativeXrpDepositCopy,
     nativeXrpModalOpeningCopy,
     nativeXrpModalPrimaryActionLabel,
@@ -18,6 +21,7 @@
     type NativeXrpBorrowPhase,
   } from '$lib/utils/nativeXrpBorrowFlow';
   import { formatAddress } from '$lib/utils/format';
+  import { WALLET_TYPES, currentWalletType } from '$lib/services/auth';
 
   export let collateralAmount: number;
   export let icusdAmount: number;
@@ -34,6 +38,7 @@
   let errorMessage = '';
   let copied = false;
   let started = false;
+  let confirmWasResilient = false;
 
   $: copy = nativeXrpDepositCopy({
     collateralAmount,
@@ -46,8 +51,16 @@
   $: shouldRenderModal = nativeXrpModalShouldRender(phase, hasDepositAddress);
   $: modalTitle = nativeXrpModalTitle(phase, hasDepositAddress);
   $: modalStatusLabel = nativeXrpModalStatusLabel(phase);
-  $: modalPrimaryActionLabel = nativeXrpModalPrimaryActionLabel(phase, hasDepositAddress);
+  $: modalPrimaryActionLabel = nativeXrpModalPrimaryActionLabel(phase, hasDepositAddress, copy.borrowAmountLabel);
   $: isBusy = phase === 'opening' || phase === 'confirming' || phase === 'borrowing';
+  $: awaitingBorrowApproval = phase === 'ready_to_borrow' || phase === 'borrow_failed';
+
+  // Oisy opens its signer popup only from inside a browser user-gesture. The
+  // confirm call's XRPL verification round-trip burns that gesture, so chaining
+  // the borrow onto it always trips "Signer window should not be opened outside
+  // of click handler". Wallets that sign in-page (Internet Identity) have no
+  // such constraint, so they keep the single-click flow.
+  $: borrowNeedsOwnClick = $currentWalletType === WALLET_TYPES.OISY;
 
   onMount(() => {
     void openVault();
@@ -120,27 +133,45 @@
         return;
       }
 
-      await borrowFromConfirmedVault(confirmed.oisyResilient);
+      // The collateral is credited from here on: never leave the user without a
+      // way to finish the borrow.
+      confirmWasResilient = confirmed.oisyResilient ?? false;
+      if (borrowNeedsOwnClick) {
+        phase = 'ready_to_borrow';
+        return;
+      }
+
+      await borrowFromConfirmedVault(confirmWasResilient);
     } catch (err) {
       phase = 'awaiting';
       errorMessage = err instanceof Error ? err.message : 'Deposit confirmation failed.';
     }
   }
 
-  async function borrowFromConfirmedVault(confirmResilient = false) {
+  async function borrowFromConfirmedVault(confirmResilient = confirmWasResilient) {
     if (!opened) return;
     phase = 'borrowing';
     errorMessage = '';
-    const borrowed = await protocolService.borrowFromVault(opened.vaultId, icusdAmount);
-    if (!borrowed.success) {
+    try {
+      const borrowed = await protocolService.borrowFromVault(opened.vaultId, icusdAmount);
+      if (!borrowed.success) {
+        phase = 'borrow_failed';
+        errorMessage = nativeXrpBorrowErrorCopy(borrowed.error, copy.borrowAmountLabel);
+        return;
+      }
+      dispatch('complete', {
+        vaultId: opened.vaultId,
+        oisyResilient: confirmResilient || borrowed.oisyResilient,
+      });
+    } catch (err) {
+      // The collateral is already credited, so a thrown signer error must land
+      // in the recoverable borrow_failed state, never back at 'awaiting'.
       phase = 'borrow_failed';
-      errorMessage = borrowed.error ?? 'Deposit confirmed, but borrowing failed.';
-      return;
+      errorMessage = nativeXrpBorrowErrorCopy(
+        err instanceof Error ? err.message : undefined,
+        copy.borrowAmountLabel
+      );
     }
-    dispatch('complete', {
-      vaultId: opened.vaultId,
-      oisyResilient: confirmResilient || borrowed.oisyResilient,
-    });
   }
 
   function close() {
@@ -208,27 +239,28 @@
       </div>
     {/if}
 
+    {#if awaitingBorrowApproval && opened}
+      <div class="borrow-step">
+        <p class="borrow-step-lead">{nativeXrpBorrowSeparateApprovalCopy(copy.borrowAmountLabel)}</p>
+        <p class="borrow-step-note">{nativeXrpBorrowLaterCopy(opened.vaultId)}</p>
+      </div>
+    {/if}
+
     {#if errorMessage}
       <div class="modal-error">{errorMessage}</div>
     {/if}
 
     <div class="modal-actions">
-      {#if phase === 'borrow_failed'}
-        <button class="secondary-action" type="button" on:click={() => borrowFromConfirmedVault()}>
-          Retry borrow
-        </button>
-      {:else}
-        <button class="secondary-action" type="button" disabled={isBusy} on:click={close}>
-          Cancel
-        </button>
-      {/if}
+      <button class="secondary-action" type="button" disabled={isBusy} on:click={close}>
+        {awaitingBorrowApproval ? 'Finish later' : 'Cancel'}
+      </button>
 
       {#if modalPrimaryActionLabel}
         <button
           class="primary-action"
           type="button"
-          disabled={!opened || isBusy || phase === 'borrow_failed' || phase === 'error'}
-          on:click={confirmDepositAndBorrow}
+          disabled={!opened || isBusy || phase === 'error'}
+          on:click={awaitingBorrowApproval ? () => borrowFromConfirmedVault() : confirmDepositAndBorrow}
         >
           {modalPrimaryActionLabel}
         </button>
@@ -467,6 +499,29 @@
     margin: 0;
     color: var(--rumi-text-secondary);
     font-size: 0.875rem;
+    line-height: 1.45;
+  }
+
+  .borrow-step {
+    margin-top: 1rem;
+    padding: 0.875rem;
+    border: 1px solid rgba(45, 212, 191, 0.24);
+    border-radius: 8px;
+    background: rgba(45, 212, 191, 0.08);
+  }
+
+  .borrow-step-lead {
+    margin: 0;
+    color: var(--rumi-text-primary);
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.45;
+  }
+
+  .borrow-step-note {
+    margin: 0.5rem 0 0;
+    color: var(--rumi-text-secondary);
+    font-size: 0.8125rem;
     line-height: 1.45;
   }
 

--- a/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.test.ts
+++ b/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.test.ts
@@ -3,6 +3,9 @@ import {
   buildXrpPaymentUri,
   formatXrpAmount,
   isNativeXrpCollateral,
+  nativeXrpBorrowErrorCopy,
+  nativeXrpBorrowLaterCopy,
+  nativeXrpBorrowSeparateApprovalCopy,
   nativeXrpDepositCopy,
   nativeXrpKeepOpenCloseCopy,
   nativeXrpModalOpeningCopy,
@@ -92,5 +95,56 @@ describe('native XRP borrow flow helpers', () => {
     expect(nativeXrpModalPrimaryActionLabel('confirming', true)).toBe('Checking deposit...');
     expect(nativeXrpModalPrimaryActionLabel('borrowing', true)).toBe('Minting icUSD...');
     expect(nativeXrpModalPrimaryActionLabel('error', true)).toBeNull();
+  });
+
+  // Confirm-deposit and borrow are two canister calls, so two wallet approvals.
+  // Oisy only opens its signer from a user-gesture, and the confirm round-trip
+  // burns it, so the borrow must come from its own click.
+  it('offers the borrow as its own action once the deposit is credited', () => {
+    expect(nativeXrpModalTitle('ready_to_borrow', true)).toBe('XRP received — approve your borrow');
+    expect(nativeXrpModalStatusLabel('ready_to_borrow')).toBe('Ready to borrow');
+    expect(nativeXrpModalPrimaryActionLabel('ready_to_borrow', true, '4.50 icUSD')).toBe('Borrow 4.50 icUSD');
+    expect(nativeXrpModalShouldRender('ready_to_borrow', true)).toBe(true);
+  });
+
+  it('keeps the same borrow action available after a failed borrow so the user is never stranded', () => {
+    expect(nativeXrpModalTitle('borrow_failed', true)).toBe('XRP received — borrow not finished');
+    expect(nativeXrpModalPrimaryActionLabel('borrow_failed', true, '4.50 icUSD')).toBe('Borrow 4.50 icUSD');
+    expect(nativeXrpModalPrimaryActionLabel('ready_to_borrow', true)).toBe('Borrow icUSD');
+  });
+
+  it('never shows a borrow action before the custody address exists', () => {
+    expect(nativeXrpModalPrimaryActionLabel('ready_to_borrow', false, '4.50 icUSD')).toBeNull();
+    expect(nativeXrpModalPrimaryActionLabel('borrow_failed', false, '4.50 icUSD')).toBeNull();
+  });
+
+  it('translates the raw signer-window error into an actionable instruction', () => {
+    expect(
+      nativeXrpBorrowErrorCopy(
+        'Signer window should not be opened outside of click handler',
+        '4.50 icUSD'
+      )
+    ).toBe('Your wallet needs a fresh approval for the borrow. Tap Borrow 4.50 icUSD to open it.');
+
+    // Case-insensitive, so wording variants from the signer still map across.
+    expect(nativeXrpBorrowErrorCopy('The Signer Window is already open', '4.50 icUSD')).toContain(
+      'fresh approval'
+    );
+  });
+
+  it('passes through a genuine borrow failure instead of blaming the wallet', () => {
+    expect(nativeXrpBorrowErrorCopy('Debt ceiling reached for XRP', '4.50 icUSD')).toBe(
+      'Debt ceiling reached for XRP'
+    );
+    expect(nativeXrpBorrowErrorCopy(undefined, '4.50 icUSD')).toBe(
+      'Deposit confirmed, but borrowing failed.'
+    );
+  });
+
+  it('tells the user their collateral is safe and where to finish the borrow later', () => {
+    expect(nativeXrpBorrowSeparateApprovalCopy('4.50 icUSD')).toContain('separate wallet approval');
+    const later = nativeXrpBorrowLaterCopy(198);
+    expect(later).toContain('vault #198');
+    expect(later).toContain('Vaults page');
   });
 });

--- a/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.ts
+++ b/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.ts
@@ -24,6 +24,7 @@ export type NativeXrpBorrowPhase =
   | 'opening'
   | 'awaiting'
   | 'confirming'
+  | 'ready_to_borrow'
   | 'borrowing'
   | 'borrow_failed'
   | 'error';
@@ -73,7 +74,16 @@ export function nativeXrpModalTitle(phase: NativeXrpBorrowPhase, hasDepositAddre
   if (phase === 'opening' || !hasDepositAddress) {
     return 'Approve in OISY to generate your XRP address';
   }
-  return 'Send XRP to open your vault';
+  switch (phase) {
+    case 'ready_to_borrow':
+      return 'XRP received — approve your borrow';
+    case 'borrowing':
+      return 'Minting your icUSD';
+    case 'borrow_failed':
+      return 'XRP received — borrow not finished';
+    default:
+      return 'Send XRP to open your vault';
+  }
 }
 
 export function nativeXrpModalStatusLabel(phase: NativeXrpBorrowPhase): string {
@@ -84,6 +94,8 @@ export function nativeXrpModalStatusLabel(phase: NativeXrpBorrowPhase): string {
       return 'Awaiting deposit';
     case 'confirming':
       return 'Checking XRPL';
+    case 'ready_to_borrow':
+      return 'Ready to borrow';
     case 'borrowing':
       return 'Minting icUSD';
     case 'borrow_failed':
@@ -106,7 +118,8 @@ export function nativeXrpModalShouldRender(
 
 export function nativeXrpModalPrimaryActionLabel(
   phase: NativeXrpBorrowPhase,
-  hasDepositAddress: boolean
+  hasDepositAddress: boolean,
+  borrowAmountLabel?: string
 ): string | null {
   if (!hasDepositAddress) return null;
 
@@ -115,11 +128,52 @@ export function nativeXrpModalPrimaryActionLabel(
       return "I've sent the XRP";
     case 'confirming':
       return 'Checking deposit...';
+    // The borrow is a SECOND wallet approval and must come from its own click —
+    // see nativeXrpBorrowSeparateApprovalCopy(). Both the ready and failed
+    // states offer the same action so a user is never stranded mid-flow.
+    case 'ready_to_borrow':
+    case 'borrow_failed':
+      return borrowAmountLabel ? `Borrow ${borrowAmountLabel}` : 'Borrow icUSD';
     case 'borrowing':
       return 'Minting icUSD...';
     default:
       return null;
   }
+}
+
+/**
+ * Why the borrow needs its own click.
+ *
+ * Confirming the deposit and borrowing are two separate canister calls, so they
+ * are two separate wallet approvals. Oisy will only open its signer popup from
+ * inside a browser user-gesture, and the confirm call's XRPL verification
+ * round-trip burns that gesture window — so an auto-borrow chained onto the
+ * confirm always dies with "Signer window should not be opened outside of click
+ * handler". ICRC-112 batching would have allowed one approval for both calls,
+ * but no wallet ever adopted it (see services/pnp.ts). The honest fix is to ask
+ * for a second, deliberate click.
+ */
+export function nativeXrpBorrowSeparateApprovalCopy(borrowAmountLabel: string): string {
+  return `Your XRP is in the vault. Borrowing ${borrowAmountLabel} is a separate wallet approval, so approve it to finish.`;
+}
+
+/** Reassurance that closing now is safe, and where to pick the borrow back up. */
+export function nativeXrpBorrowLaterCopy(vaultId: number): string {
+  return `Nothing is at risk if you stop here — your XRP is already collateral in vault #${vaultId}. You can borrow against it any time from the Vaults page.`;
+}
+
+const SIGNER_GESTURE_HINT = 'signer window';
+
+/**
+ * Turn a raw wallet/signer error into copy a user can act on. The signer-window
+ * error in particular is meaningless to a user and, in this flow, always means
+ * "the borrow needs its own click" rather than a real failure.
+ */
+export function nativeXrpBorrowErrorCopy(rawError: string | undefined, borrowAmountLabel: string): string {
+  if (rawError && rawError.toLowerCase().includes(SIGNER_GESTURE_HINT)) {
+    return `Your wallet needs a fresh approval for the borrow. Tap Borrow ${borrowAmountLabel} to open it.`;
+  }
+  return rawError ?? 'Deposit confirmed, but borrowing failed.';
 }
 
 export function nativeXrpKeepOpenCloseCopy(): string {


### PR DESCRIPTION
## The bug

Clicking **"I've sent the XRP"** ran `confirm_xrp_deposit` and then immediately `borrow_from_vault`. Those are two canister calls, so two wallet approvals.

Oisy only opens its signer popup from inside a browser user-gesture, and the confirm call's XRPL verification round-trip burns that gesture window. So the borrow always died with `Signer window should not be opened outside of click handler`. This was structural, not flaky — **no Oisy user has ever completed this flow in one click.**

The user was left with their XRP credited as collateral, no icUSD, and a raw signer error that means nothing to them. The only recovery was to leave the modal and borrow from the Vaults page, which nobody would guess.

## Why not just make it work in one click

ICRC-112 would have allowed both calls under a single approval, but no wallet ever adopted it and the v5 signer agent has no batch concept — see the note in `src/vault_frontend/src/lib/services/pnp.ts:327`. A true single-click flow is not achievable for Oisy today.

## The fix

Adds a `ready_to_borrow` phase. For Oisy, the modal now stops once the deposit is credited and offers **"Borrow N.NN icUSD"** as its own primary action — a fresh gesture, so the signer actually opens. Wallets that sign in-page (Internet Identity) are unaffected and keep the single-click flow.

Also:
- `borrow_failed` offers the same **"Borrow N.NN icUSD"** action rather than a secondary "Retry borrow", collapsing the two states into one recoverable step.
- A *thrown* signer error during borrow now lands in `borrow_failed` instead of falling back to `awaiting`, which wrongly implied the deposit had not been credited.
- The signer-window error is rewritten as an actionable instruction. Genuine failures (e.g. debt ceiling) still pass through verbatim.
- Titles no longer say "Send XRP to open your vault" after the XRP has arrived.
- Explicit copy that the collateral is safe and the borrow can be finished later from the Vaults page, naming the vault id — so closing the modal is not a dead end.

## Verification

- 241 tests green (235 + 6 new), `svelte-check` clean on touched files, production build succeeds.
- **Not browser-verified**: reaching `ready_to_borrow` needs a live Oisy session plus real XRP settling on XRPL. The state and copy logic is unit-tested; the second-click popup behaviour is reasoned from the existing gesture mitigations across the codebase, not observed. Worth one real run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)