### PR TITLE
fix(frontend): value 3USD at 3pool virtual price, not $1

### DIFF
--- a/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
+++ b/src/vault_frontend/src/lib/components/explorer/PortfolioValueChart.svelte
@@ -10,6 +10,7 @@
     fetchCollateralConfigs,
   } from '$services/explorer/explorerService';
   import { CANISTER_IDS } from '$lib/config';
+  import { getThreeUsdPrice } from '$services/threeUsdPrice';
   import { getTokenDecimals } from '$utils/explorerHelpers';
   import type {
     AddressValuePoint,
@@ -116,9 +117,10 @@
     // unchanged than to show nothing.
     try {
       const principalObjLive = Principal.fromText(target);
-      const [pools, prices] = await Promise.all([
+      const [pools, prices, threeUsdPriceUsd] = await Promise.all([
         fetchAmmPools().catch(() => []),
         fetchCollateralPrices().catch(() => new Map<string, number>()),
+        getThreeUsdPrice(),
       ]);
       let liveTotalUsd = 0;
       await Promise.all(
@@ -133,9 +135,11 @@
           const tokenB = pool.token_b?.toText?.() ?? String(pool.token_b ?? '');
           const decA = getTokenDecimals(tokenA);
           const decB = getTokenDecimals(tokenB);
-          // 3USD pinned to $1 (matches analytics' price_amm_lp_state).
-          const priceA = prices.get(tokenA) ?? (tokenA === CANISTER_IDS.THREEPOOL ? 1 : 0);
-          const priceB = prices.get(tokenB) ?? (tokenB === CANISTER_IDS.THREEPOOL ? 1 : 0);
+          // 3USD is the 3pool LP token: value it at the pool virtual price. The
+          // analytics series pins it to $1, which is exactly what this live
+          // correction factor exists to rescale.
+          const priceA = prices.get(tokenA) ?? (tokenA === CANISTER_IDS.THREEPOOL ? threeUsdPriceUsd : 0);
+          const priceB = prices.get(tokenB) ?? (tokenB === CANISTER_IDS.THREEPOOL ? threeUsdPriceUsd : 0);
           const shareRatio = Number(balance) / Number(totalShares);
           const valueA = (Number(BigInt(pool.reserve_a ?? 0)) / 10 ** decA) * shareRatio * priceA;
           const valueB = (Number(BigInt(pool.reserve_b ?? 0)) / 10 ** decB) * shareRatio * priceB;

--- a/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
+++ b/src/vault_frontend/src/lib/components/swap/PoolListView.svelte
@@ -8,6 +8,7 @@
   } from '../../services/threePoolService';
   import { ammService, type PoolInfo } from '../../services/ammService';
   import { getThreePoolApy } from '../../services/threePoolApyService';
+  import { threeUsdPriceFromPoolStatus } from '../../services/threeUsdPrice';
   import { CANISTER_IDS } from '../../config';
   import type { PoolStatus } from '../../services/threePoolService';
 
@@ -18,6 +19,8 @@
   let userThreePoolLp = 0n;
   let userAmmLp = 0n;
   let loading = true;
+  // USD price of one 3USD (3pool virtual price). 1.0 until the pool status loads.
+  let threeUsdPriceUsd = 1;
 
   // APY state for both pools (null while loading, number once resolved)
   let threePoolApyPct: number | null = null;
@@ -37,6 +40,7 @@
         ammService.getPools().catch(() => [] as PoolInfo[]),
       ]);
       threePoolStatus = tpStatus;
+      threeUsdPriceUsd = threeUsdPriceFromPoolStatus(tpStatus);
       // Find the 3USD/ICP pool specifically
       const threePoolId = CANISTER_IDS.THREEPOOL;
       const icpLedgerId = CANISTER_IDS.ICP_LEDGER;
@@ -89,7 +93,8 @@
     const threePoolId = CANISTER_IDS.THREEPOOL;
     const isTokenA3USD = ammPool.token_a.toText() === threePoolId;
     const threeUsdReserve = isTokenA3USD ? ammPool.reserve_a : ammPool.reserve_b;
-    const threeUsdValue = Number(threeUsdReserve) / 1e8;
+    // 3USD is the 3pool LP token, so value the leg at the pool virtual price, not $1.
+    const threeUsdValue = (Number(threeUsdReserve) / 1e8) * threeUsdPriceUsd;
     return '~$' + (threeUsdValue * 2).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   }
 

--- a/src/vault_frontend/src/lib/services/threeUsdPrice.ts
+++ b/src/vault_frontend/src/lib/services/threeUsdPrice.ts
@@ -1,0 +1,93 @@
+import { writable, get } from 'svelte/store';
+import { threePoolService } from './threePoolService';
+
+/**
+ * Single source of truth for the USD price of one 3USD token.
+ *
+ * 3USD is the 3pool's LP token, so its USD value is the pool's virtual price
+ * (scaled by 1e18), not $1. The virtual price only grows as swap fees and
+ * icUSD interest accrue to the pool, so it is always >= 1.0.
+ *
+ * Every USD-value computation involving a 3USD amount must go through here.
+ * Pricing 3USD at $1 understates holdings by however much yield has accrued
+ * (roughly 8.8% as of July 2026).
+ */
+
+/** Par value. Used only as a floor before the first successful fetch. */
+const PAR = 1;
+
+/** How long a fetched price stays fresh. The virtual price moves very slowly. */
+const TTL_MS = 60_000;
+
+/** Last successfully fetched price, shared by every consumer. */
+export const threeUsdPrice = writable<number>(PAR);
+
+let lastFetchedAt = 0;
+let inFlight: Promise<number> | null = null;
+
+function parseVirtualPrice(virtualPrice: bigint | number | undefined): number | null {
+  if (virtualPrice === undefined || virtualPrice === null) return null;
+  const value = Number(virtualPrice) / 1e18;
+  // A zero/NaN virtual price means the pool is uninitialized or the read
+  // failed. Never let that collapse a balance to $0.
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+/**
+ * Derive the 3USD price from an already-fetched pool status, and refresh the
+ * shared store with it. Use this when the caller has a `PoolStatus` in hand so
+ * it does not pay for a second query.
+ */
+export function threeUsdPriceFromPoolStatus(
+  poolStatus: { virtual_price?: bigint | number } | null | undefined,
+): number {
+  const value = parseVirtualPrice(poolStatus?.virtual_price);
+  if (value === null) return get(threeUsdPrice);
+  threeUsdPrice.set(value);
+  lastFetchedAt = Date.now();
+  return value;
+}
+
+/**
+ * Current USD price of one 3USD, fetching the 3pool virtual price if the
+ * cached value is stale. Concurrent callers share a single in-flight query.
+ *
+ * On failure this returns the last known good price (or par before the first
+ * successful fetch) rather than throwing or returning 0, so a transient query
+ * failure degrades to a slight understatement instead of a $0 balance.
+ */
+export async function getThreeUsdPrice(): Promise<number> {
+  const cached = get(threeUsdPrice);
+  if (Date.now() - lastFetchedAt < TTL_MS) return cached;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const status = await threePoolService.getPoolStatus();
+      return threeUsdPriceFromPoolStatus(status);
+    } catch (e) {
+      console.warn('3USD price fetch failed, using last known price:', e);
+      return get(threeUsdPrice);
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/**
+ * Synchronous read of the cached price, for render paths that cannot await
+ * (pure sync utils, Svelte markup expressions).
+ *
+ * Triggers a background refresh when the cache is stale so the next render
+ * gets a fresh value. Returns par until the first successful fetch lands, so
+ * an early caller understates rather than showing $0.
+ */
+export function peekThreeUsdPrice(): number {
+  if (Date.now() - lastFetchedAt >= TTL_MS && !inFlight) {
+    void getThreeUsdPrice();
+  }
+  return get(threeUsdPrice);
+}

--- a/src/vault_frontend/src/lib/stores/wallet.ts
+++ b/src/vault_frontend/src/lib/stores/wallet.ts
@@ -6,6 +6,7 @@ import { pnp, canisterIDLs } from '../services/pnp';
 import { TokenService } from '../services/tokenService';
 import { auth, WALLET_TYPES } from '../services/auth';
 import { RequestDeduplicator } from '../services/RequestDeduplicator';
+import { getThreeUsdPrice } from '../services/threeUsdPrice';
 import { appDataStore } from './appDataStore';
 
 // Define our own wallet list for icons
@@ -206,6 +207,9 @@ function createWalletStore() {
         console.warn('Failed to fetch stablecoin balances:', e);
       }
 
+      // 3USD is the 3pool LP token: its USD value is the pool virtual price, not $1.
+      const threeUsdPriceValue = await getThreeUsdPrice();
+
       const formatStable6 = (raw: bigint) => {
         const value = Number(raw) / 1_000_000;
         return (Math.floor(value * 1_000_000) / 1_000_000).toFixed(6);
@@ -246,7 +250,7 @@ function createWalletStore() {
           THREEUSD: {
             raw: threeUsdBalance,
             formatted: TokenService.formatBalance(threeUsdBalance),
-            usdValue: Number(TokenService.formatBalance(threeUsdBalance))
+            usdValue: Number(TokenService.formatBalance(threeUsdBalance)) * threeUsdPriceValue
           },
           ...collateralBalances
         },
@@ -416,6 +420,8 @@ function createWalletStore() {
             TokenService.getTokenBalance(CONFIG.threePoolCanisterId, principal).catch(() => 0n),
           ]);
           const icpPriceValue = protocolStatus?.lastIcpRate || 0;
+          // 3USD is the 3pool LP token: its USD value is the pool virtual price, not $1.
+          const threeUsdPriceValue = await getThreeUsdPrice();
           const formatStable6 = (raw: bigint) => {
         const value = Number(raw) / 1_000_000;
         return (Math.floor(value * 1_000_000) / 1_000_000).toFixed(6);
@@ -467,7 +473,7 @@ function createWalletStore() {
               THREEUSD: {
                 raw: threeUsdBalance,
                 formatted: TokenService.formatBalance(threeUsdBalance),
-                usdValue: Number(TokenService.formatBalance(threeUsdBalance))
+                usdValue: Number(TokenService.formatBalance(threeUsdBalance)) * threeUsdPriceValue
               },
               ...collateralBalances
             },
@@ -513,6 +519,8 @@ function createWalletStore() {
           TokenService.getTokenBalance(CONFIG.threePoolCanisterId, ownerPrincipal).catch(() => 0n),
         ]);
         const icpPriceValue = protocolStatus?.lastIcpRate || 0;
+        // 3USD is the 3pool LP token: its USD value is the pool virtual price, not $1.
+        const threeUsdPriceValue = await getThreeUsdPrice();
         const formatStable6 = (raw: bigint) => {
         const value = Number(raw) / 1_000_000;
         return (Math.floor(value * 1_000_000) / 1_000_000).toFixed(6);
@@ -555,7 +563,7 @@ function createWalletStore() {
             THREEUSD: {
               raw: threeUsdBalance,
               formatted: TokenService.formatBalance(threeUsdBalance),
-              usdValue: Number(TokenService.formatBalance(threeUsdBalance))
+              usdValue: Number(TokenService.formatBalance(threeUsdBalance)) * threeUsdPriceValue
             },
             ...collateralBalances
           },

--- a/src/vault_frontend/src/lib/utils/eventFacets.ts
+++ b/src/vault_frontend/src/lib/utils/eventFacets.ts
@@ -16,6 +16,7 @@
 
 import { Principal } from '@dfinity/principal';
 import { CANISTER_IDS } from '$lib/config';
+import { peekThreeUsdPrice } from '$services/threeUsdPrice';
 import {
   KNOWN_TOKENS,
   resolveTokenAlias,
@@ -346,6 +347,18 @@ function icpAmountToUsd(amount: any, icpPrice: number | undefined): number | nul
   return (n / 1e8) * icpPrice;
 }
 
+/**
+ * USD value of a 3USD (3pool LP) amount. Prefers an explicit price from the
+ * caller's price map, otherwise the cached 3pool virtual price. Never $1.
+ */
+function threeUsdAmountToUsd(
+  amount: any,
+  priceMap: Map<string, number> | undefined,
+): number {
+  const price = priceMap?.get(CANISTER_IDS.THREEPOOL) ?? peekThreeUsdPrice();
+  return toUsdFromStablecoin(amount, 8) * price;
+}
+
 function collateralAmountToUsd(
   amount: any,
   collateralPrincipal: string | null | undefined,
@@ -439,9 +452,9 @@ function computeSizeUsd(
     const tokenIn = principalText(de.event?.token_in);
     const tokenOut = principalText(de.event?.token_out);
     const threePool = CANISTER_IDS.THREEPOOL;
-    // 3USD LP ≈ $1; use it if present
-    if (tokenIn === threePool) return toUsdFromStablecoin(de.event.amount_in, 8);
-    if (tokenOut === threePool) return toUsdFromStablecoin(de.event.amount_out, 8);
+    // 3USD LP leg, valued at the 3pool virtual price; use it if present
+    if (tokenIn === threePool) return threeUsdAmountToUsd(de.event.amount_in, priceMap);
+    if (tokenOut === threePool) return threeUsdAmountToUsd(de.event.amount_out, priceMap);
     // ICP leg — use ICP price if we have one
     if (tokenIn === CANISTER_IDS.ICP_LEDGER) return icpAmountToUsd(de.event.amount_in, icpPrice);
     if (tokenOut === CANISTER_IDS.ICP_LEDGER) return icpAmountToUsd(de.event.amount_out, icpPrice);
@@ -455,12 +468,12 @@ function computeSizeUsd(
   }
 
   if (de.source === 'amm_liquidity') {
-    // Value the LP shares via the 3USD-LP side when possible (~$1/unit).
+    // Value the LP shares via the 3USD-LP side when possible, at virtual price.
     const tokenA = principalText(de.event?.token_a);
     const tokenB = principalText(de.event?.token_b);
     const threePool = CANISTER_IDS.THREEPOOL;
-    if (tokenA === threePool) return toUsdFromStablecoin(de.event.amount_a, 8);
-    if (tokenB === threePool) return toUsdFromStablecoin(de.event.amount_b, 8);
+    if (tokenA === threePool) return threeUsdAmountToUsd(de.event.amount_a, priceMap);
+    if (tokenB === threePool) return threeUsdAmountToUsd(de.event.amount_b, priceMap);
     if (tokenA === CANISTER_IDS.ICP_LEDGER) return icpAmountToUsd(de.event.amount_a, icpPrice);
     if (tokenB === CANISTER_IDS.ICP_LEDGER) return icpAmountToUsd(de.event.amount_b, icpPrice);
     return null;

--- a/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
+++ b/src/vault_frontend/src/routes/explorer/e/token/[id]/+page.svelte
@@ -197,8 +197,15 @@
       const poolId = String(pool.pool_id ?? '');
       const decA = getTokenDecimals(tokenA);
       const decB = getTokenDecimals(tokenB);
-      const priceA = priceMap.get(tokenA) ?? (tokenA === CANISTER_IDS.ICUSD_LEDGER ? 1 : 0);
-      const priceB = priceMap.get(tokenB) ?? (tokenB === CANISTER_IDS.ICUSD_LEDGER ? 1 : 0);
+      // 3USD is the 3pool LP token, valued at the pool virtual price rather than $1 or $0.
+      const threeUsdVp = threePoolState?.virtual_price
+        ? Number(threePoolState.virtual_price) / 1e18
+        : 1;
+      const legPrice = (token: string) =>
+        priceMap.get(token) ??
+        (token === CANISTER_IDS.ICUSD_LEDGER ? 1 : token === CANISTER_IDS.THREEPOOL ? threeUsdVp : 0);
+      const priceA = legPrice(tokenA);
+      const priceB = legPrice(tokenB);
       const tvl =
         (Number(BigInt(pool.reserve_a ?? 0)) / 10 ** decA) * priceA +
         (Number(BigInt(pool.reserve_b ?? 0)) / 10 ** decB) * priceB;


### PR DESCRIPTION
## The bug

3USD is the 3pool's LP token, so its USD value is the pool **virtual price** (currently ~1.088152), not $1. Several frontend surfaces priced it at par, understating holdings by roughly 8.8%.

The wallet dropdown was the visible symptom: a 44.0192 3USD balance showed **$44.02**, while the 3USD page and the explorer address page both reported **$47.90** for the same position.

## The fix

Adds `lib/services/threeUsdPrice.ts` as the single source of truth (cached with a 60s TTL, in-flight deduped, and — importantly — falls back to the last known price rather than 0, so a transient query failure degrades to a slight understatement instead of a $0 balance).

Every 3USD USD-value site now routes through it:

- `stores/wallet.ts` — THREEUSD `usdValue` in all three balance paths (initialize, connect, refreshBalance). Fixes the dropdown token row and the Total Balance sum.
- `swap/PoolListView.svelte` — `ammTvl()` valued the 3USD reserve at $1.
- `utils/eventFacets.ts` — `amm_swap` and `amm_liquidity` 3USD legs sized at $1.
- `explorer/PortfolioValueChart.svelte` — 3USD pinned to $1 inside the live AMM LP correction factor, which exists precisely to rescale the analytics series' $1 assumption.
- `explorer/e/token/[id]` — 3USD leg priced at $0 in AMM pool TVL, so the 3USD/ICP row read $5.91 against the pool page's $12.

## Verified correct, not changed

- The stability pool already values LP deposits via `lp_to_usd_e8s` using cached virtual prices (confirmed live against a depositor holding 8.196 3USD).
- 3pool TVL sums the underlying reserves, so it was never affected.

Authored in a separate session; opened here so it ships alongside #319 in one frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)