### PR TITLE
fix(xrp): unhang the native-XRP e2e tests + take the account reserve out of the deposit

### DIFF
--- a/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
+++ b/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
@@ -62,6 +62,9 @@ enum ProtocolArg {
 struct XrpVaultOpenInfo {
     vault_id: u64,
     custody_address: String,
+    /// The XRPL base reserve quoted by `server_state` at open time and stored on
+    /// the pending deposit; `confirm_xrp_deposit` credits `balance - this`.
+    reserve_base_drops: u64,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -495,6 +498,26 @@ fn register_xrp(pic: &PocketIc, backend: Principal) {
     .expect("register_xrp_collateral");
 }
 
+/// `open_xrp_vault` quotes the XRPL base reserve up front: before deriving the
+/// custody address it makes a `server_state` outcall (`fetch_reserve_base`) and
+/// stores the result on the pending deposit, so `confirm_xrp_deposit` credits
+/// against the reserve that was quoted when the address was handed out. The open
+/// must therefore be pumped like any other rippled-calling update — a plain
+/// blocking `update_call` parks on that outcall forever.
+fn open_xrp_vault(pic: &PocketIc, backend: Principal) -> WasmResult {
+    call_with_rippled(
+        pic,
+        backend,
+        user(),
+        "open_xrp_vault",
+        Encode!().unwrap(),
+        |m| match m {
+            "server_state" => rippled_server_state(RESERVE_DROPS),
+            other => panic!("unexpected rippled method in open: {other}"),
+        },
+    )
+}
+
 /// icrc2-approve the backend to pull `amount` icUSD from `owner` (for repay/liquidate).
 fn approve_icusd(
     pic: &PocketIc,
@@ -541,9 +564,9 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
     } = boot();
     register_xrp(&pic, backend);
 
-    // ── open_xrp_vault (derives custody address via tEd25519) ────────────────
+    // ── open_xrp_vault (quotes the base reserve, derives custody via tEd25519) ─
     // If PocketIC cannot provision key_1, this errors -> gated skip.
-    let open_reply = update_as(&pic, backend, user(), "open_xrp_vault", Encode!().unwrap());
+    let open_reply = open_xrp_vault(&pic, backend);
     let open: XrpVaultOpenInfo =
         match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
             Ok(info) => info,
@@ -553,6 +576,10 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
             }
         };
     let vault_id = open.vault_id;
+    assert_eq!(
+        open.reserve_base_drops, RESERVE_DROPS,
+        "open quotes the server_state base reserve it will credit against"
+    );
     assert!(!open.custody_address.is_empty(), "custody address derived");
     assert!(
         open.custody_address.starts_with('r'),
@@ -657,7 +684,11 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
     assert_eq!(v.borrowed_icusd_amount, 0, "debt cleared after repay");
 
     // ── withdraw & close: creates an XrpClaim for the full collateral ─────────
-    decode_result::<Option<u64>>(
+    // Native-XRP deliberately does NOT remove the vault: the XRPL base reserve
+    // stays locked at the custody account, so the vault is RETAINED drained to
+    // zero collateral / zero debt instead of being closed. See
+    // `withdraw_close_completion_policy` -> KeepNativeXrpVaultOpen in vault.rs.
+    let withdraw_claim_id = decode_result::<Option<u64>>(
         update_as(
             &pic,
             backend,
@@ -667,13 +698,24 @@ fn xrp_native_happy_path_open_deposit_borrow_repay_close_settle() {
         ),
         "withdraw_and_close_vault",
     )
-    .expect("withdraw_and_close ok");
-    assert!(get_vault(&pic, backend, vault_id).is_none(), "vault closed");
+    .expect("withdraw_and_close ok")
+    .expect("native-XRP withdraw returns the created XRP claim id");
+    let v = get_vault(&pic, backend, vault_id)
+        .expect("native-XRP vault is retained (the XRPL base reserve stays locked)");
+    assert_eq!(
+        v.collateral_amount, 0,
+        "all collateral left the vault into the claim"
+    );
+    assert_eq!(v.borrowed_icusd_amount, 0, "no debt remains after withdraw");
 
     // A claim must now exist for the withdrawn collateral.
     let claims = xrp_claims(&pic, backend);
     assert_eq!(claims.len(), 1, "one XRP claim after close: {claims:?}");
     let claim_id = claims[0];
+    assert_eq!(
+        withdraw_claim_id, claim_id,
+        "withdraw_and_close returns the XRP claim id it created"
+    );
 
     // ── settle_xrp_claim is two-phase (anti double-pay) ───────────────────────
     // Call 1 derives the custody Sequence (account_info), signs the Payment, records
@@ -751,7 +793,7 @@ fn xrp_native_liquidation_is_claim_based() {
     } = boot();
     register_xrp(&pic, backend);
 
-    let open_reply = update_as(&pic, backend, user(), "open_xrp_vault", Encode!().unwrap());
+    let open_reply = open_xrp_vault(&pic, backend);
     let open: XrpVaultOpenInfo =
         match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
             Ok(info) => info,

--- a/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.test.ts
+++ b/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.test.ts
@@ -13,6 +13,7 @@ import {
   nativeXrpModalShouldRender,
   nativeXrpModalStatusLabel,
   nativeXrpModalTitle,
+  xrpCreditedCollateral,
 } from './nativeXrpBorrowFlow';
 import type { CollateralInfo } from '$lib/services/types';
 
@@ -49,29 +50,63 @@ describe('native XRP borrow flow helpers', () => {
       collateralInfo: xrpCollateral,
     });
 
-    expect(copy.sendAmountLabel).toBe('13.595678 XRP');
-    expect(copy.collateralAmountLabel).toBe('12.345678 XRP');
+    // The user sends EXACTLY what they typed; the reserve comes out of it.
+    expect(copy.sendAmountLabel).toBe('12.345678 XRP');
+    expect(copy.collateralAmountLabel).toBe('11.095678 XRP');
     expect(copy.reserveAmountLabel).toBe('1.25 XRP');
-    expect(copy.sendAmount).toBe(13.595678);
+    expect(copy.sendAmount).toBe(12.345678);
+    expect(copy.creditedAmount).toBeCloseTo(11.095678, 6);
     expect(copy.reserveAmount).toBe(1.25);
     expect(copy.borrowAmountLabel).toBe('4.50 icUSD');
     expect(copy.assetName).toBe('XRP');
   });
 
+  it('never asks the user to send more than the amount they entered', () => {
+    const entered = 5000;
+    const copy = nativeXrpDepositCopy({
+      collateralAmount: entered,
+      icusdAmount: 100,
+      reserveBaseDrops: 1_000_000n,
+      collateralInfo: xrpCollateral,
+    });
+
+    expect(copy.sendAmount).toBe(entered);
+    expect(copy.sendAmountLabel).toBe('5000 XRP');
+    expect(copy.creditedAmount).toBe(4999);
+    expect(buildXrpPaymentUri('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', copy.sendAmount)).toBe(
+      'ripple:rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh?amount=5000'
+    );
+  });
+
   it('explains the split between credited XRP collateral and the XRPL reserve', () => {
     const copy = nativeXrpDepositCopy({
-      collateralAmount: 2,
+      collateralAmount: 3,
       icusdAmount: 0.5,
       reserveBaseDrops: 1_000_000n,
       collateralInfo: xrpCollateral,
     });
 
     expect(copy.sendAmountLabel).toBe('3 XRP');
-    expect(copy.reserveExplanation).toContain('2 XRP collateral');
-    expect(copy.reserveExplanation).toContain('1 XRP XRPL account reserve');
+    expect(copy.reserveExplanation).toContain('Of the 3 XRP you send');
+    expect(copy.reserveExplanation).toContain('1 XRP is the XRPL account reserve');
+    expect(copy.reserveExplanation).toContain('2 XRP becomes your collateral');
     expect(buildXrpPaymentUri('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', copy.sendAmount)).toBe(
       'ripple:rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh?amount=3'
     );
+  });
+
+  it('never credits negative collateral when the send amount is at or below the reserve', () => {
+    expect(xrpCreditedCollateral(5000, 1)).toBe(4999);
+    expect(xrpCreditedCollateral(1, 1)).toBe(0);
+    expect(xrpCreditedCollateral(0.5, 1)).toBe(0);
+
+    const copy = nativeXrpDepositCopy({
+      collateralAmount: 0.5,
+      icusdAmount: 0,
+      reserveBaseDrops: 1_000_000n,
+      collateralInfo: xrpCollateral,
+    });
+    expect(copy.creditedAmount).toBe(0);
   });
 
   it('explains that native XRP reserve stays locked and the vault stays open', () => {

--- a/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.ts
+++ b/src/vault_frontend/src/lib/utils/nativeXrpBorrowFlow.ts
@@ -2,7 +2,35 @@ import type { CollateralInfo } from '$lib/services/types';
 
 export const XRP_DROPS_PER_XRP = 1_000_000;
 
+/**
+ * Pre-open estimate of the XRPL base reserve, in XRP.
+ *
+ * The AUTHORITATIVE value is whatever `open_xrp_vault` returns in
+ * `reserveBaseDrops` (the backend reads it live from rippled `server_state`), but
+ * the borrow form has to size the collateral/CR/max-borrow math BEFORE the vault
+ * is opened, when no reserve is known yet. The XRPL base reserve is a
+ * network-wide parameter currently set to 1 XRP by validator vote.
+ *
+ * If the network ever raises it, this under-deducts on the form only: the modal
+ * always shows the real reserve, and the backend independently re-checks the
+ * collateral ratio, so a stale value here fails safe (a borrow gets rejected)
+ * rather than over-crediting anyone.
+ */
+export const XRPL_BASE_RESERVE_XRP = 1;
+
+/**
+ * Collateral actually credited to the vault when the user sends `sendAmount`.
+ *
+ * The user names the amount they will SEND; the XRPL base reserve comes out of
+ * that amount to activate the custody account, and `confirm_xrp_deposit` credits
+ * the remainder (`balance - reserve_base`). Never negative.
+ */
+export function xrpCreditedCollateral(sendAmount: number, reserveAmount: number): number {
+  return Math.max(0, sendAmount - reserveAmount);
+}
+
 export interface NativeXrpDepositIntent {
+  /** What the user said they would SEND (the reserve comes OUT of this). */
   collateralAmount: number;
   icusdAmount: number;
   reserveBaseDrops: bigint | number;
@@ -11,8 +39,11 @@ export interface NativeXrpDepositIntent {
 
 export interface NativeXrpDepositCopy {
   assetName: string;
+  /** Exactly what the user asked to send — never their amount plus a surprise. */
   sendAmount: number;
   reserveAmount: number;
+  /** What actually lands as collateral: sendAmount minus the XRPL base reserve. */
+  creditedAmount: number;
   sendAmountLabel: string;
   collateralAmountLabel: string;
   reserveAmountLabel: string;
@@ -52,18 +83,24 @@ export function buildXrpPaymentUri(address: string, amount: number): string {
 export function nativeXrpDepositCopy(intent: NativeXrpDepositIntent): NativeXrpDepositCopy {
   const assetName = intent.collateralInfo?.symbol || 'XRP';
   const reserveAmount = xrpAmountFromDrops(intent.reserveBaseDrops);
-  const sendAmount = intent.collateralAmount + reserveAmount;
-  const collateralAmountLabel = formatXrpAmount(intent.collateralAmount);
+  // The user sends EXACTLY what they asked to send. The XRPL base reserve is
+  // taken out of that amount rather than added on top, so the deposit
+  // instruction never differs from the number they typed.
+  const sendAmount = intent.collateralAmount;
+  const creditedAmount = xrpCreditedCollateral(sendAmount, reserveAmount);
+  const collateralAmountLabel = formatXrpAmount(creditedAmount);
   const reserveAmountLabel = formatXrpAmount(reserveAmount);
+  const sendAmountLabel = formatXrpAmount(sendAmount);
   return {
     assetName,
     sendAmount,
     reserveAmount,
-    sendAmountLabel: formatXrpAmount(sendAmount),
+    creditedAmount,
+    sendAmountLabel,
     collateralAmountLabel,
     reserveAmountLabel,
     borrowAmountLabel: `${intent.icusdAmount.toFixed(2)} icUSD`,
-    reserveExplanation: `${collateralAmountLabel} collateral + ${reserveAmountLabel} XRPL account reserve. The reserve activates this XRP address and stays locked there; your vault stays open so you do not pay it again.`,
+    reserveExplanation: `Of the ${sendAmountLabel} you send, ${reserveAmountLabel} is the XRPL account reserve and ${collateralAmountLabel} becomes your collateral. The reserve activates this XRP address and stays locked there; your vault stays open so you do not pay it again.`,
   };
 }
 

--- a/src/vault_frontend/src/routes/+page.svelte
+++ b/src/vault_frontend/src/routes/+page.svelte
@@ -15,7 +15,11 @@
   import MultiplierBadge from '$lib/components/points/MultiplierBadge.svelte';
   import { seasonStore, earningActive } from '$lib/stores/seasonStore';
   import XrpBorrowModal from '$lib/components/borrow/XrpBorrowModal.svelte';
-  import { isNativeXrpCollateral } from '$lib/utils/nativeXrpBorrowFlow';
+  import {
+    isNativeXrpCollateral,
+    xrpCreditedCollateral,
+    XRPL_BASE_RESERVE_XRP,
+  } from '$lib/utils/nativeXrpBorrowFlow';
   import type { CollateralInfo } from '$lib/services/types';
 
   let collateralAmount = 1;
@@ -58,7 +62,19 @@
   $: icpPrice = $protocolStatus?.lastIcpRate || 0;
   $: collateralPrice = selectedCollateralInfo?.price
     || (selectedCollateralPrincipal === CANISTER_IDS.ICP_LEDGER ? icpPrice : 0);
-  $: collateralValue = collateralAmount * collateralPrice;
+  // ── Credited collateral (single source of truth for ALL risk math) ──────────
+  // For native XRP the user names the amount they will SEND, and the XRPL base
+  // reserve is deducted from it rather than added on top, so what actually backs
+  // the loan is send-amount minus the reserve. Every ratio, price and limit below
+  // must use this, NOT the typed amount — sizing a max borrow against the typed
+  // amount would let the user request more than the credited collateral supports
+  // and the backend would reject the borrow after their XRP had already landed.
+  // Every other collateral credits the full amount, so this is a no-op for them.
+  $: xrpReserveEstimate = isNativeXrpSelected ? XRPL_BASE_RESERVE_XRP : 0;
+  $: creditedCollateralAmount = isNativeXrpSelected
+    ? xrpCreditedCollateral(collateralAmount, xrpReserveEstimate)
+    : collateralAmount;
+  $: collateralValue = creditedCollateralAmount * collateralPrice;
 
   let isPriceLoading = true;
   let priceRefreshInterval: ReturnType<typeof setInterval>;
@@ -68,8 +84,8 @@
   $: icpAmount = collateralAmount;
 
   $: projectedMintCr = (() => {
-    if (icusdAmount <= 0 || collateralAmount <= 0 || collateralPrice <= 0) return Infinity;
-    const collateralVal = collateralAmount * collateralPrice;
+    if (icusdAmount <= 0 || creditedCollateralAmount <= 0 || collateralPrice <= 0) return Infinity;
+    const collateralVal = creditedCollateralAmount * collateralPrice;
     return collateralVal / icusdAmount;
   })();
   $: mintFeeMultiplier = borrowingFeeCurve.length > 0
@@ -90,8 +106,8 @@
   $: projectedMintRate = rateCurve
     ? computeProjectedRate(rateCurve.baseRate, rateCurve.markers, projectedMintCr, mintRecoveryMultiplier)
     : (selectedCollateralInfo?.interestRateApr ?? 0);
-  $: calculatedCollateralRatio = collateralAmount > 0 && icusdAmount >= 0.001
-    ? ((collateralAmount * collateralPrice) / icusdAmount) * 100 : collateralAmount > 0 ? Infinity : 0;
+  $: calculatedCollateralRatio = creditedCollateralAmount > 0 && icusdAmount >= 0.001
+    ? ((creditedCollateralAmount * collateralPrice) / icusdAmount) * 100 : creditedCollateralAmount > 0 ? Infinity : 0;
   $: formattedCollateralRatio = calculatedCollateralRatio === Infinity
     ? '∞' : calculatedCollateralRatio > 1000000 ? '>1,000,000' : formatNumber(calculatedCollateralRatio);
   $: isValidCollateralRatio = calculatedCollateralRatio >= selectedMinCR * 100;
@@ -100,16 +116,16 @@
     : calculatedCollateralRatio < selectedMinCR * 1.234 * 100 ? 'caution' : 'safe';
 
   // Liquidation price
-  $: liquidationPrice = collateralAmount > 0 && icusdAmount > 0
-    ? (icusdAmount * selectedLiqCR) / collateralAmount : 0;
+  $: liquidationPrice = creditedCollateralAmount > 0 && icusdAmount > 0
+    ? (icusdAmount * selectedLiqCR) / creditedCollateralAmount : 0;
   $: liqPriceRatio = collateralPrice > 0 && liquidationPrice > 0 ? liquidationPrice / collateralPrice : 0;
   $: liqPriceSeverity = liqPriceRatio > 0.75 ? 'danger' : liqPriceRatio > 0.5 ? 'caution' : 'safe';
   $: safetyDelta = collateralPrice > 0 && liquidationPrice > 0
     ? ((collateralPrice - liquidationPrice) / collateralPrice) * 100 : 0;
 
   // Max borrow — 0.5% haircut so Max never overshoots the backend oracle price
-  $: maxBorrow = collateralAmount > 0 && collateralPrice > 0
-    ? Math.floor(((collateralAmount * collateralPrice) / selectedMinCR) * 0.995 * 100) / 100 : 0;
+  $: maxBorrow = creditedCollateralAmount > 0 && collateralPrice > 0
+    ? Math.floor(((creditedCollateralAmount * collateralPrice) / selectedMinCR) * 0.995 * 100) / 100 : 0;
 
   // Max collateral from wallet balance (minus token ledger fee from metadata)
   $: maxCollateral = (() => {
@@ -209,6 +225,12 @@
     if (xrpBorrowFlowActive) return;
     if (!$isConnected) { errorMessage = 'Please connect your wallet first'; return; }
     if (collateralAmount <= 0) { errorMessage = 'Please enter a valid collateral amount'; return; }
+    // Native XRP: the reserve comes OUT of the sent amount, so anything at or
+    // below the reserve credits zero collateral and the backend rejects it.
+    if (isNativeXrpSelected && creditedCollateralAmount <= 0) {
+      errorMessage = `Send more than ${xrpReserveEstimate} XRP — that much is the XRPL account reserve, which is deducted from your deposit.`;
+      return;
+    }
     if (icusdAmount <= 0) { errorMessage = 'Please enter a valid icUSD amount to borrow'; return; }
     if (!isValidCollateralRatio) { errorMessage = `Collateral ratio must be at least ${(selectedMinCR * 100).toFixed(0)}%`; return; }
     if (isNativeXrpSelected && selectedCollateralInfo) {


### PR DESCRIPTION
Two related pieces of native-XRP work.

## 1. Unhang `xrp_native_e2e_pic` (test-only)

Two of the three tests hung with `BadIngressMessage(... after 100 rounds)` — the same ingress hash in both, so the same call. **Test-harness drift, not a production bug.** Both drifts come from the 2026-06-24 reserve-policy change set, three days after the test was written and never applied to it:

- `92855c1` added a `server_state` HTTPS outcall (`fetch_reserve_base`) to the top of `open_xrp_vault`. The test still called it through the plain blocking `update_call`, which pumps no canister-http, so the outcall parked forever. Now routed through `call_with_rippled`.
- `63cf6c6` made native-XRP `withdraw_and_close` deliberately **retain** the vault (the XRPL base reserve stays locked at custody). The test still asserted removal. Corrected to the real contract.

Verified: 3/3 pass with **0 gated skips**, so the real tEd25519 path runs rather than auto-degrading. 750 backend lib tests pass.

This suite was the only test in the repo touching any XRP endpoint, and it had gone a month unrun.

## 2. Deduct the XRPL account reserve instead of adding it

Entering 5,000 XRP and then being told to send "5,000 + 1 XRP" is a surprise at the worst moment. The user now names what they will **send**, and the 1 XRP account reserve comes out of it — the instruction and QR code always match the number they typed.

Because the reserve moved inside the amount, credited collateral is now `send - reserve`. All borrow-form risk math is routed through a single `creditedCollateralAmount` (collateral value, projected mint CR, collateral ratio, liquidation price, max borrow) instead of the typed amount. Sizing a max borrow against the typed amount would let a user request more than the credited collateral supports, and the backend would reject the borrow **after** their XRP had already landed on XRPL. Non-XRP collateral is unaffected (`creditedCollateralAmount === collateralAmount`).

Also guards the degenerate case where the send amount is at or below the reserve, which credits nothing.

The pre-open reserve estimate is a constant because the authoritative value only comes back from `open_xrp_vault`. Verified against mainnet: live pending deposits carry `reserve_base_drops = 1_000_000` (1 XRP). A stale constant fails safe — the modal shows the real value and the backend re-checks the ratio.

## Verification

- 243/243 frontend unit tests, incl. new cases pinning send-amount, credited amount and the zero-credit floor
- `svelte-check`: 28 errors before and after — all pre-existing, none in touched files
- Production build passes
- **Not browser-verified**: this sandbox has no mainnet reachability, so the collateral list never loads and XRP cannot be selected in the picker. The non-XRP path was checked against a stashed baseline and behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)