### PR TITLE
feat: sunset EXE collateral

### DIFF
--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -1259,10 +1259,10 @@ impl StabilityPoolState {
         user: &Principal,
         collateral_type: Principal,
     ) -> Result<(), StabilityPoolError> {
-        // BOB is in wind-down. Existing receiving positions may leave through
-        // `opt_out_collateral`, but neither a new nor former participant may
-        // create fresh BOB liquidation exposure.
-        if collateral_type == bob_collateral() {
+        // Sunset collaterals (BOB, EXE, ...) are in wind-down. Existing
+        // receiving positions may leave through `opt_out_collateral`, but
+        // neither a new nor former participant may create fresh exposure.
+        if sunset_collaterals().contains(&collateral_type) {
             return Err(StabilityPoolError::TokenNotActive {
                 ledger: collateral_type,
             });
@@ -3555,6 +3555,27 @@ mod tests {
 
         let err = state.opt_in_collateral(&user_a(), bob).unwrap_err();
         assert!(matches!(err, StabilityPoolError::TokenNotActive { ledger } if ledger == bob));
+    }
+
+    #[test]
+    fn legacy_exe_participant_can_exit_but_cannot_reenter() {
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 10_00000000);
+        let exe = crate::types::exe_collateral();
+
+        state
+            .deposits
+            .get_mut(&user_a())
+            .unwrap()
+            .opted_out_collateral
+            .remove(&exe);
+        assert_eq!(state.effective_pool_for_collateral(&exe), 10_00000000);
+
+        state.opt_out_collateral(&user_a(), exe).unwrap();
+        assert_eq!(state.effective_pool_for_collateral(&exe), 0);
+
+        let err = state.opt_in_collateral(&user_a(), exe).unwrap_err();
+        assert!(matches!(err, StabilityPoolError::TokenNotActive { ledger } if ledger == exe));
     }
 
     #[test]

--- a/src/stability_pool/src/types.rs
+++ b/src/stability_pool/src/types.rs
@@ -3,10 +3,24 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 
 pub const BOB_COLLATERAL_PRINCIPAL: &str = "7pail-xaaaa-aaaas-aabmq-cai";
+pub const EXE_COLLATERAL_PRINCIPAL: &str = "rh2pm-ryaaa-aaaan-qeniq-cai";
 
 pub fn bob_collateral() -> Principal {
     Principal::from_text(BOB_COLLATERAL_PRINCIPAL)
         .expect("BOB collateral principal is a valid principal")
+}
+
+pub fn exe_collateral() -> Principal {
+    Principal::from_text(EXE_COLLATERAL_PRINCIPAL)
+        .expect("EXE collateral principal is a valid principal")
+}
+
+/// Collateral types in one-way wind-down: existing positions may exit via
+/// `opt_out_collateral`, but neither a new nor a former participant may
+/// create fresh liquidation exposure to them. Add to this set (not the call
+/// sites) when another collateral is sunset.
+pub fn sunset_collaterals() -> BTreeSet<Principal> {
+    BTreeSet::from([bob_collateral(), exe_collateral()])
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -125,12 +139,13 @@ pub struct DepositPosition {
 
 impl DepositPosition {
     pub fn new(timestamp: u64) -> Self {
-        // BOB is being sunset. Existing depositors retain their current
-        // exposure until they opt out, while every new position is default-out.
+        // Sunset collaterals (BOB, EXE, ...). Existing depositors retain their
+        // current exposure until they opt out, while every new position is
+        // default-out of each one.
         Self {
             stablecoin_balances: BTreeMap::new(),
             collateral_gains: BTreeMap::new(),
-            opted_out_collateral: BTreeSet::from([bob_collateral()]),
+            opted_out_collateral: sunset_collaterals(),
             opted_in_chain_collateral: Some(BTreeSet::new()),
             deposit_timestamp: timestamp,
             total_claimed_gains: BTreeMap::new(),
@@ -1006,6 +1021,15 @@ mod icusd_value_tests {
 
         assert!(position.opted_out_collateral.contains(&bob));
         assert!(!position.is_opted_in(&bob));
+    }
+
+    #[test]
+    fn new_depositor_is_opted_out_of_sunset_exe_liquidations() {
+        let exe = exe_collateral();
+        let position = DepositPosition::new(0);
+
+        assert!(position.opted_out_collateral.contains(&exe));
+        assert!(!position.is_opted_in(&exe));
     }
 
     #[test]

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -17,7 +17,7 @@
   import { isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
   import {
     gainCollaterals,
-    isSunsetBobCollateral,
+    isSunsetCollateral,
     liquidationPreferenceCollaterals,
   } from './sunsetCollateralPolicy';
 
@@ -224,7 +224,7 @@
                     disabled={toggleLoading[key]}
                   >
                     <span class="opt-out-symbol">
-                      {collateral.symbol}{isSunsetBobCollateral(collateral) ? ' (sunset)' : ''}
+                      {collateral.symbol}{isSunsetCollateral(collateral) ? ' (sunset)' : ''}
                     </span>
                     {#if toggleLoading[key]}
                       <span class="mini-spinner"></span>

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.xrp.spec.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import {
 	gainCollaterals,
 	liquidationPreferenceCollaterals,
-	isSunsetBobCollateral
+	isSunsetCollateral
 } from './sunsetCollateralPolicy';
 import type { CollateralInfo } from '../../services/stabilityPoolService';
 
@@ -15,6 +15,12 @@ const principal = (text: string) => Principal.fromText(text);
 const bob: CollateralInfo = {
 	ledger_id: principal('7pail-xaaaa-aaaas-aabmq-cai'),
 	symbol: 'BOB',
+	decimals: 8,
+	status: { Sunset: null }
+};
+const exe: CollateralInfo = {
+	ledger_id: principal('rh2pm-ryaaa-aaaan-qeniq-cai'),
+	symbol: 'EXE',
 	decimals: 8,
 	status: { Sunset: null }
 };
@@ -39,11 +45,15 @@ describe('EarnInfoCard sunset collateral policy', () => {
 		expect(source).toContain('<XrpPayoutRouting');
 	});
 
-	it('keeps BOB visible when an existing position has a gain', () => {
-		expect(gainCollaterals([icp, bob, phasma]).map((c) => c.symbol)).toEqual(['ICP', 'BOB']);
+	it('keeps sunset collateral visible when an existing position has a gain', () => {
+		expect(gainCollaterals([icp, bob, exe, phasma]).map((c) => c.symbol)).toEqual([
+			'ICP',
+			'BOB',
+			'EXE'
+		]);
 	});
 
-	it('offers BOB only as an exit for an existing receiving position', () => {
+	it('offers sunset collateral only as an exit for an existing receiving position', () => {
 		const activeRegistryBob = { ...bob, status: { Active: null } } as CollateralInfo;
 		expect(liquidationPreferenceCollaterals([icp, bob], new Set()).map((c) => c.symbol)).toEqual([
 			'ICP',
@@ -60,11 +70,17 @@ describe('EarnInfoCard sunset collateral policy', () => {
 				new Set([activeRegistryBob.ledger_id.toText()])
 			).map((c) => c.symbol)
 		).toEqual(['ICP']);
+		expect(
+			liquidationPreferenceCollaterals([icp, exe], new Set([exe.ledger_id.toText()])).map(
+				(c) => c.symbol
+			)
+		).toEqual(['ICP']);
 	});
 
-	it('recognizes sunset BOB by principal even before SP registry status synchronization', () => {
-		expect(isSunsetBobCollateral(bob)).toBe(true);
-		expect(isSunsetBobCollateral({ ...bob, status: { Active: null } })).toBe(true);
-		expect(isSunsetBobCollateral(icp)).toBe(false);
+	it('recognizes sunset collateral by principal even before SP registry status synchronization', () => {
+		expect(isSunsetCollateral(bob)).toBe(true);
+		expect(isSunsetCollateral({ ...bob, status: { Active: null } })).toBe(true);
+		expect(isSunsetCollateral(exe)).toBe(true);
+		expect(isSunsetCollateral(icp)).toBe(false);
 	});
 });

--- a/src/vault_frontend/src/lib/components/stability-pool/sunsetCollateralPolicy.ts
+++ b/src/vault_frontend/src/lib/components/stability-pool/sunsetCollateralPolicy.ts
@@ -1,13 +1,17 @@
 import type { CollateralInfo } from '../../services/stabilityPoolService';
 
 const BOB_COLLATERAL_PRINCIPAL = '7pail-xaaaa-aaaas-aabmq-cai';
+const EXE_COLLATERAL_PRINCIPAL = 'rh2pm-ryaaa-aaaan-qeniq-cai';
+// Sunset collaterals in one-way wind-down. Add to this set (not the call
+// sites) when another collateral is sunset.
+const SUNSET_COLLATERAL_PRINCIPALS = new Set([BOB_COLLATERAL_PRINCIPAL, EXE_COLLATERAL_PRINCIPAL]);
 const HIDDEN_GAIN_SYMBOLS = new Set(['PHASMA']);
 
-export function isSunsetBobCollateral(collateral: CollateralInfo): boolean {
-	// BOB's one-way wind-down policy is principal-bound in the canister. Do
-	// not advertise re-entry if the independently managed SP registry still
-	// carries its historical Active status during activation.
-	return collateral.ledger_id.toText() === BOB_COLLATERAL_PRINCIPAL;
+export function isSunsetCollateral(collateral: CollateralInfo): boolean {
+	// Sunset wind-down policy is principal-bound here. Do not advertise
+	// re-entry if the independently managed SP registry still carries its
+	// historical Active status during activation.
+	return SUNSET_COLLATERAL_PRINCIPALS.has(collateral.ledger_id.toText());
 }
 
 export function gainCollaterals(collaterals: CollateralInfo[]): CollateralInfo[] {
@@ -20,6 +24,6 @@ export function liquidationPreferenceCollaterals(
 ): CollateralInfo[] {
 	return gainCollaterals(collaterals).filter(
 		(collateral) =>
-			!isSunsetBobCollateral(collateral) || !optedOut.has(collateral.ledger_id.toText())
+			!isSunsetCollateral(collateral) || !optedOut.has(collateral.ledger_id.toText())
 	);
 }


### PR DESCRIPTION
## Summary
- Generalizes the BOB one-way sunset policy (#306) in the stability pool and vault_frontend from a single hardcoded principal into a shared sunset set covering BOB + EXE
- New SP depositors default out of EXE liquidation-gain exposure; existing positions can still opt out and exit but not re-enter
- No backend code change needed — `CollateralStatus::Sunset` gating (blocks new vaults/borrows/deposits/redemptions, keeps repay/withdraw/close/liquidation open) is already generic and live (currently used for BOB). EXE gets flipped to `Sunset` via a live `set_collateral_status` admin call after this deploys.

EXE currently has 6 open vaults (~8.28 icUSD debt, ~$187 collateral) and ~$14.8 of unclaimed SP liquidation gains on mainnet — Sunset status lets those owners keep repaying/withdrawing/closing normally.

## Test plan
- [x] `cargo build -p stability_pool` and `--release --target wasm32-unknown-unknown` — clean
- [x] `cargo test --workspace --lib` — all green (stability_pool 119/119 incl. new `legacy_exe_participant_can_exit_but_cannot_reenter` and `new_depositor_is_opted_out_of_sunset_exe_liquidations`)
- [x] `npx vitest run src/lib/components/stability-pool` — 6/6 green (incl. new EXE cases in `EarnInfoCard.xrp.spec.ts`)
- [x] `npm run build` (vault_frontend) — clean
- [x] `svelte-check` — no new errors introduced (pre-existing baseline errors unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)