### PR TITLE
feat(backend): route native-XRP vaults to the stability pool automatically

### DIFF
--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1498,6 +1498,7 @@ service : (ProtocolArg) -> {
   stability_pool_liquidate_xrp_vault : (XrpSpAbsorbRequest) -> (Result_20);
   stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
   stability_pool_preflight_xrp_absorb : (nat64, nat64) -> (Result_21);
+  stability_pool_release_xrp_absorb_preflight : (nat64, nat64) -> (Result_14);
   stability_pool_xrp_claim_outstanding : (nat64, principal) -> (Result_14);
   submit_burn_proof : (nat32, text) -> (Result_22);
   sweep_xrp_pending_open : (nat64) -> (Result);

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.d.ts
@@ -1840,6 +1840,10 @@ export interface _SERVICE {
     [bigint, bigint],
     Result_21
   >,
+  'stability_pool_release_xrp_absorb_preflight' : ActorMethod<
+    [bigint, bigint],
+    Result_14
+  >,
   'stability_pool_xrp_claim_outstanding' : ActorMethod<
     [bigint, Principal],
     Result_14

--- a/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
+++ b/src/declarations/rumi_protocol_backend/rumi_protocol_backend.did.js
@@ -2098,6 +2098,11 @@ export const idlFactory = ({ IDL }) => {
         [Result_21],
         [],
       ),
+    'stability_pool_release_xrp_absorb_preflight' : IDL.Func(
+        [IDL.Nat64, IDL.Nat64],
+        [Result_14],
+        [],
+      ),
     'stability_pool_xrp_claim_outstanding' : IDL.Func(
         [IDL.Nat64, IDL.Principal],
         [Result_14],

--- a/src/rumi_protocol_backend/rumi_protocol_backend.did
+++ b/src/rumi_protocol_backend/rumi_protocol_backend.did
@@ -1529,6 +1529,7 @@ service : (ProtocolArg) -> {
   stability_pool_liquidate_xrp_vault : (XrpSpAbsorbRequest) -> (Result_20);
   stability_pool_preflight_chain_absorb : (nat64, nat64) -> (Result);
   stability_pool_preflight_xrp_absorb : (nat64, nat64) -> (Result_21);
+  stability_pool_release_xrp_absorb_preflight : (nat64, nat64) -> (Result_14);
   stability_pool_xrp_claim_outstanding : (nat64, principal) -> (Result_14);
   submit_burn_proof : (nat32, text) -> (Result_22);
   sweep_xrp_pending_open : (nat64) -> (Result);

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -1128,20 +1128,19 @@ pub async fn check_vaults() {
         // for the unconditional `prune_recovered_routing_state` call;
         // re-used here for the cascade decisions.
 
-        let (bot_allowed, bot_canister, pool_canister) = read_state(|s| {
-            (
-                s.bot_allowed_collateral_types.clone(),
-                s.liquidation_bot_principal,
-                s.stability_pool_canister,
-            )
+        let (bot_canister, pool_canister) = read_state(|s| {
+            (s.liquidation_bot_principal, s.stability_pool_canister)
         });
 
         let mut for_bot: Vec<LiquidatableVaultInfo> = Vec::new();
         let mut for_pool: Vec<LiquidatableVaultInfo> = Vec::new();
 
         for vault_info in &vault_notifications {
-            let bot_eligible =
-                bot_canister.is_some() && bot_allowed.contains(&vault_info.collateral_type);
+            // `vault_routable_to_bot` enforces both the operator allowlist and
+            // the custody fence (native-XRP is claim-based and must never go
+            // to the bot; it falls through to the SP's absorb path).
+            let bot_eligible = bot_canister.is_some()
+                && read_state(|s| s.vault_routable_to_bot(&vault_info.collateral_type));
 
             let sp_already_tried =
                 read_state(|s| s.sp_attempted_vaults.contains(&vault_info.vault_id));

--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -1106,7 +1106,7 @@ pub async fn check_vaults() {
                         .get_collateral_price_decimal(&v.collateral_type)
                         .map(|p| UsdIcp::from(p))
                         .unwrap_or(UsdIcp::from(rust_decimal::Decimal::ZERO));
-                    let optimal_liq = s.compute_partial_liquidation_cap(v, collateral_price_usd);
+                    let optimal_liq = s.recommended_liquidation_amount_for(v, collateral_price_usd);
                     LiquidatableVaultInfo {
                         vault_id: v.vault_id,
                         collateral_type: v.collateral_type,

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -4833,9 +4833,12 @@ async fn stability_pool_liquidate(
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
     validate_freshness_for_vault(vault_id).await?;
-    // P5: native-XRP collateral is liquidated MANUALLY (claim-based) only; automated
-    // stability-pool / bot liquidation cannot settle an XrpClaim (would strand the
-    // seized XRP and burn SP depositors), so reject native-XRP here.
+    // Native-XRP collateral is claim-based. THIS path cannot settle an XrpClaim
+    // (it would strand the seized XRP and burn SP depositors), so reject
+    // native-XRP here. Native-XRP absorption goes through the dedicated flow
+    // (stability_pool_preflight_xrp_absorb + stability_pool_liquidate_xrp_vault),
+    // and external liquidators through liquidate_vault_partial /
+    // partial_liquidate_vault.
     if rumi_protocol_backend::vault::vault_is_native_xrp(vault_id) {
         return Err(ProtocolError::GenericError(
             "Native-XRP collateral is liquidated manually (claim-based), not via the stability pool or bot".to_string(),
@@ -4942,9 +4945,12 @@ async fn stability_pool_liquidate_debt_burned(
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
     validate_freshness_for_vault(vault_id).await?;
-    // P5: native-XRP collateral is liquidated MANUALLY (claim-based) only; automated
-    // stability-pool / bot liquidation cannot settle an XrpClaim (would strand the
-    // seized XRP and burn SP depositors), so reject native-XRP here.
+    // Native-XRP collateral is claim-based. THIS path cannot settle an XrpClaim
+    // (it would strand the seized XRP and burn SP depositors), so reject
+    // native-XRP here. Native-XRP absorption goes through the dedicated flow
+    // (stability_pool_preflight_xrp_absorb + stability_pool_liquidate_xrp_vault),
+    // and external liquidators through liquidate_vault_partial /
+    // partial_liquidate_vault.
     if rumi_protocol_backend::vault::vault_is_native_xrp(vault_id) {
         return Err(ProtocolError::GenericError(
             "Native-XRP collateral is liquidated manually (claim-based), not via the stability pool or bot".to_string(),
@@ -5431,9 +5437,12 @@ async fn stability_pool_liquidate_with_reserves(
     validate_liquidation_not_frozen()?;
     validate_price_for_liquidation()?;
     validate_freshness_for_vault(vault_id).await?;
-    // P5: native-XRP collateral is liquidated MANUALLY (claim-based) only; automated
-    // stability-pool / bot liquidation cannot settle an XrpClaim (would strand the
-    // seized XRP and burn SP depositors), so reject native-XRP here.
+    // Native-XRP collateral is claim-based. THIS path cannot settle an XrpClaim
+    // (it would strand the seized XRP and burn SP depositors), so reject
+    // native-XRP here. Native-XRP absorption goes through the dedicated flow
+    // (stability_pool_preflight_xrp_absorb + stability_pool_liquidate_xrp_vault),
+    // and external liquidators through liquidate_vault_partial /
+    // partial_liquidate_vault.
     if rumi_protocol_backend::vault::vault_is_native_xrp(vault_id) {
         return Err(ProtocolError::GenericError(
             "Native-XRP collateral is liquidated manually (claim-based), not via the stability pool or bot".to_string(),
@@ -6801,9 +6810,12 @@ async fn bot_claim_liquidation(vault_id: u64) -> Result<BotLiquidationResult, Pr
     // allowlist is ICP-only, live the moment a non-ICP collateral is added.
     validate_liquidation_not_frozen()?;
     validate_freshness_for_vault(vault_id).await?;
-    // P5: native-XRP collateral is liquidated MANUALLY (claim-based) only; automated
-    // stability-pool / bot liquidation cannot settle an XrpClaim (would strand the
-    // seized XRP and burn SP depositors), so reject native-XRP here.
+    // Native-XRP collateral is claim-based. THIS path cannot settle an XrpClaim
+    // (it would strand the seized XRP and burn SP depositors), so reject
+    // native-XRP here. Native-XRP absorption goes through the dedicated flow
+    // (stability_pool_preflight_xrp_absorb + stability_pool_liquidate_xrp_vault),
+    // and external liquidators through liquidate_vault_partial /
+    // partial_liquidate_vault.
     if rumi_protocol_backend::vault::vault_is_native_xrp(vault_id) {
         return Err(ProtocolError::GenericError(
             "Native-XRP collateral is liquidated manually (claim-based), not via the stability pool or bot".to_string(),

--- a/src/rumi_protocol_backend/src/main.rs
+++ b/src/rumi_protocol_backend/src/main.rs
@@ -5288,6 +5288,26 @@ fn stability_pool_preflight_xrp_absorb(
 
 #[update]
 #[candid_method(update)]
+fn stability_pool_release_xrp_absorb_preflight(
+    vault_id: u64,
+    icusd_burn_e8s: u64,
+) -> Result<bool, ProtocolError> {
+    if ic_cdk::caller() == Principal::anonymous() {
+        return Err(ProtocolError::AnonymousCallerNotAllowed);
+    }
+    let caller = ic_cdk::api::caller();
+    mutate_state(|s| {
+        rumi_protocol_backend::vault::stability_pool_release_xrp_absorb_preflight_in_state(
+            s,
+            caller,
+            vault_id,
+            icusd_burn_e8s,
+        )
+    })
+}
+
+#[update]
+#[candid_method(update)]
 async fn stability_pool_liquidate_xrp_vault(
     request: XrpSpAbsorbRequest,
 ) -> Result<XrpSpAbsorbResult, ProtocolError> {

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3997,6 +3997,25 @@ impl State {
     /// buckets, including those skipped due to `bot_processing` — that
     /// read still costs cycles, so the counter reflects actual cost
     /// paid (useful for production telemetry and the DOS-005 fence).
+    /// Amount a liquidation dispatch should ask an absorber to repay.
+    ///
+    /// Native-XRP is full-liquidation-only: `xrp_sp_absorb_sizing` rejects any
+    /// requested burn that isn't exactly the vault's live debt (the seizure and
+    /// the resulting `XrpClaim` are computed against the whole debt). Handing
+    /// the SP the generic partial cap makes every automated absorb fail at
+    /// preflight, so native-XRP dispatches the full debt. All other collateral
+    /// keeps the partial cap, which restores the vault to its borrow threshold.
+    pub fn recommended_liquidation_amount_for(&self, vault: &Vault, price: UsdIcp) -> ICUSD {
+        if self
+            .get_collateral_config(&vault.collateral_type)
+            .map(|c| c.is_native_xrp())
+            .unwrap_or(false)
+        {
+            return vault.borrowed_icusd_amount;
+        }
+        self.compute_partial_liquidation_cap(vault, price)
+    }
+
     /// Whether the liquidation bot may be offered vaults of this collateral
     /// type. Requires the operator allowlist AND a custody kind the bot can
     /// actually settle: native-XRP collateral is claim-based (XRPL side), so
@@ -7673,6 +7692,74 @@ mod tests {
         assert!(
             ids.contains(&2),
             "native-XRP vault must be included in the automated scan: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_sizing_requests_full_debt_for_native_xrp() {
+        // The native-XRP SP absorb path is full-liquidation-only: the backend's
+        // `xrp_sp_absorb_sizing` rejects any `expected_icusd_burn_e8s` that is
+        // not exactly equal to the vault's live debt. `check_vaults` must
+        // therefore dispatch the FULL debt for native-XRP, not the generic
+        // partial-liquidation cap (which returns a partial for an ordinary
+        // breach and would make every automated absorb fail at preflight).
+        // Non-XRP collateral keeps the partial cap.
+        let mut s = test_state();
+        let icp = s.icp_ledger_principal;
+        let xrp = xrp_collateral_principal();
+        if let Some(c) = s.collateral_configs.get_mut(&icp) {
+            c.last_price = Some(5.0);
+        }
+        let mut xrp_cfg = xrp_collateral_config(
+            Ratio::new(dec!(0.005)),
+            Ratio::new(dec!(0.0)),
+            Ratio::new(dec!(1.0333)),
+        );
+        // $1.30 of XRP against $1.00 of debt => CR 130%, under the 133%
+        // liquidation floor but well above the 112% bonus: the ordinary
+        // breach, where the partial cap is strictly less than full debt.
+        xrp_cfg.last_price = Some(1.30);
+        s.collateral_configs.insert(xrp, xrp_cfg);
+
+        let xrp_vault = crate::vault::Vault {
+            owner: Principal::anonymous(),
+            vault_id: 2,
+            borrowed_icusd_amount: ICUSD::new(100_000_000),
+            collateral_amount: 1_000_000, // 6 decimals => 1.0 XRP
+            collateral_type: xrp,
+            accrued_interest: ICUSD::new(0),
+            last_accrual_time: 0,
+            bot_processing: false,
+        };
+        let icp_vault = crate::vault::Vault {
+            owner: Principal::anonymous(),
+            vault_id: 1,
+            borrowed_icusd_amount: ICUSD::new(10_000_000_000),
+            collateral_amount: 2_600_000_000,
+            collateral_type: icp,
+            accrued_interest: ICUSD::new(0),
+            last_accrual_time: 0,
+            bot_processing: false,
+        };
+        let dummy = crate::numeric::UsdIcp::from(rust_decimal::Decimal::ZERO);
+
+        // Guard the premise: the generic cap really is a partial here, so this
+        // test would be vacuous if it ever stopped being one.
+        assert!(
+            s.compute_partial_liquidation_cap(&xrp_vault, dummy)
+                < xrp_vault.borrowed_icusd_amount,
+            "premise: generic cap must be partial for this XRP vault"
+        );
+
+        assert_eq!(
+            s.recommended_liquidation_amount_for(&xrp_vault, dummy),
+            xrp_vault.borrowed_icusd_amount,
+            "native-XRP dispatch must request the full live debt"
+        );
+        assert_eq!(
+            s.recommended_liquidation_amount_for(&icp_vault, dummy),
+            s.compute_partial_liquidation_cap(&icp_vault, dummy),
+            "non-XRP collateral must keep the generic partial cap"
         );
     }
 

--- a/src/rumi_protocol_backend/src/state.rs
+++ b/src/rumi_protocol_backend/src/state.rs
@@ -3997,6 +3997,21 @@ impl State {
     /// buckets, including those skipped due to `bot_processing` — that
     /// read still costs cycles, so the counter reflects actual cost
     /// paid (useful for production telemetry and the DOS-005 fence).
+    /// Whether the liquidation bot may be offered vaults of this collateral
+    /// type. Requires the operator allowlist AND a custody kind the bot can
+    /// actually settle: native-XRP collateral is claim-based (XRPL side), so
+    /// the bot is refused regardless of `bot_allowed_collateral_types` and the
+    /// cascade falls through to the stability pool's native-XRP absorb path.
+    pub fn vault_routable_to_bot(&self, collateral_type: &Principal) -> bool {
+        if !self.bot_allowed_collateral_types.contains(collateral_type) {
+            return false;
+        }
+        !self
+            .get_collateral_config(collateral_type)
+            .map(|c| c.is_native_xrp())
+            .unwrap_or(false)
+    }
+
     pub fn scan_unhealthy_vaults(&self, rate: UsdIcp, do_full_sweep: bool) -> UnhealthyVaultScan {
         let threshold_key = self.check_vaults_alert_threshold_key();
         let upper_bound = if do_full_sweep {
@@ -4019,18 +4034,6 @@ impl State {
                 };
                 visited += 1;
                 if vault.bot_processing {
-                    continue;
-                }
-                // P5: native-XRP vaults are NOT auto-liquidated. XRP liquidation is
-                // manual/external (claim-based) only — automated SP/bot dispatch
-                // would strand the seized XRP (neither the SP nor the bot can settle
-                // an XrpClaim). External liquidators call liquidate_vault_partial /
-                // partial_liquidate_vault directly, where they become the claimant.
-                if self
-                    .get_collateral_config(&vault.collateral_type)
-                    .map(|c| c.is_native_xrp())
-                    .unwrap_or(false)
-                {
                     continue;
                 }
                 if compute_collateral_ratio(vault, rate, self)
@@ -7617,11 +7620,13 @@ mod tests {
     }
 
     #[test]
-    fn scan_unhealthy_vaults_excludes_native_xrp() {
-        // P5: native-XRP vaults must NOT appear in the automated liquidation scan
-        // (they're liquidated manually). An ICP vault at the same underwater CR still
-        // appears. Pins the is_native_xrp() skip in scan_unhealthy_vaults so a future
-        // CR-index / banding refactor can't silently route XRP into SP/bot dispatch.
+    fn scan_unhealthy_vaults_includes_native_xrp() {
+        // Native-XRP vaults MUST appear in the automated liquidation scan so
+        // check_vaults dispatches them to the stability pool (which settles
+        // them via the native-XRP absorb path shipped 2026-06-27). The former
+        // P5 exclusion predated SP absorption and left XRP vaults liquidatable
+        // only by manual trigger. Bot routing is still fenced separately via
+        // vault_routable_to_bot.
         let mut s = test_state();
         let icp = s.icp_ledger_principal;
         let xrp = xrp_collateral_principal();
@@ -7666,8 +7671,35 @@ mod tests {
             "ICP vault should be flagged unhealthy: {ids:?}"
         );
         assert!(
-            !ids.contains(&2),
-            "native-XRP vault must be excluded from the automated scan: {ids:?}"
+            ids.contains(&2),
+            "native-XRP vault must be included in the automated scan: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn native_xrp_never_routable_to_bot() {
+        // The liquidation bot cannot settle native-XRP collateral (it has no
+        // XRPL settlement path), so even if an operator adds the XRP synthetic
+        // principal to `bot_allowed_collateral_types`, routing must refuse the
+        // bot and let the cascade fall through to the stability pool.
+        let mut s = test_state();
+        let icp = s.icp_ledger_principal;
+        let xrp = xrp_collateral_principal();
+        let mut xrp_cfg = s.collateral_configs.get(&icp).unwrap().clone();
+        xrp_cfg.ledger_canister_id = xrp;
+        xrp_cfg.custody_kind = Some(CustodyKind::NativeXrp);
+        s.collateral_configs.insert(xrp, xrp_cfg);
+
+        s.bot_allowed_collateral_types.insert(icp);
+        s.bot_allowed_collateral_types.insert(xrp);
+
+        assert!(
+            s.vault_routable_to_bot(&icp),
+            "ICP in the allowed set must stay bot-routable"
+        );
+        assert!(
+            !s.vault_routable_to_bot(&xrp),
+            "native-XRP must never be bot-routable, even when allowed by config"
         );
     }
 

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -1494,6 +1494,49 @@ pub fn stability_pool_preflight_xrp_absorb_in_state(
     Ok(preflight)
 }
 
+/// Hand back an unburned native-XRP absorb reservation.
+///
+/// A reservation blocks every vault-mutating entry point for `vault_id`
+/// (including the manual liquidation paths) until it is consumed by a
+/// successful absorb or expires after `XRP_SP_ABSORB_PREFLIGHT_TTL_NS`. When
+/// the SP reserves and then gives up BEFORE burning any icUSD -- e.g. the
+/// payout allocation build finds no opted-in depositor holding icUSD, or the
+/// fan-out exceeds the allocation cap -- that window would otherwise leave an
+/// underwater vault unliquidatable by any path for a full 15 minutes.
+///
+/// Only the registered SP may release, and only under the exact
+/// `icusd_burn_e8s` it reserved: the reservation is the sizing snapshot a
+/// post-burn submit resolves against, so dropping the wrong one would strand
+/// an in-flight burn. A successful absorb removes the reservation itself, so
+/// releasing a completed absorb is a no-op rather than an error.
+///
+/// Returns whether a reservation was actually cleared, so a retried cleanup
+/// after a lost reply is idempotent rather than a failure.
+pub fn stability_pool_release_xrp_absorb_preflight_in_state(
+    state: &mut crate::state::State,
+    caller: Principal,
+    vault_id: u64,
+    icusd_burn_e8s: u64,
+) -> Result<bool, ProtocolError> {
+    ensure_registered_sp(state, caller)?;
+    let Some(preflight) = state.sp_xrp_absorb_preflights.get(&vault_id) else {
+        return Ok(false);
+    };
+    if preflight.caller != caller {
+        return Err(ProtocolError::GenericError(format!(
+            "Vault #{vault_id} reservation belongs to another caller"
+        )));
+    }
+    if preflight.icusd_burn_e8s != icusd_burn_e8s {
+        return Err(ProtocolError::GenericError(format!(
+            "XRP SP absorb release {} does not match the reserved burn {} for vault {}",
+            icusd_burn_e8s, preflight.icusd_burn_e8s, vault_id
+        )));
+    }
+    state.sp_xrp_absorb_preflights.remove(&vault_id);
+    Ok(true)
+}
+
 /// Resolve the persisted preflight reservation for a POST-BURN submit.
 ///
 /// Deliberately does NOT require the reservation to be unexpired. The SP burns
@@ -7994,6 +8037,72 @@ mod xrp_sp_absorb_contract_tests {
         let vault = state.vault_id_to_vaults.get(&VAULT_ID).expect("vault");
         assert_eq!(vault.borrowed_icusd_amount, ICUSD::new(100 * E8));
         assert_eq!(vault.collateral_amount, 100_000_000);
+    }
+
+    #[test]
+    fn releasing_unburned_preflight_unblocks_vault_operations() {
+        // A preflight reservation blocks every vault-mutating entry point,
+        // including the manual liquidation paths. If the SP gives up AFTER
+        // reserving but BEFORE burning (e.g. no opted-in depositor holds
+        // icUSD), it must be able to hand the reservation back instead of
+        // leaving the vault unliquidatable by any path until the 15-minute
+        // TTL expires.
+        let mut state = test_state_with_xrp_vault();
+        stability_pool_preflight_xrp_absorb_in_state(&mut state, sp(), VAULT_ID, 100 * E8, 10)
+            .expect("preflight reservation");
+        assert!(
+            ensure_no_active_xrp_sp_absorb_preflight(&state, VAULT_ID, 20).is_err(),
+            "an active reservation must block vault operations"
+        );
+
+        let released =
+            stability_pool_release_xrp_absorb_preflight_in_state(&mut state, sp(), VAULT_ID, 100 * E8)
+                .expect("registered SP may release its own unburned reservation");
+        assert!(released, "release must report that a reservation was cleared");
+        assert!(state.sp_xrp_absorb_preflights.is_empty());
+        assert!(
+            ensure_no_active_xrp_sp_absorb_preflight(&state, VAULT_ID, 20).is_ok(),
+            "releasing the reservation must unblock vault operations immediately"
+        );
+
+        // Idempotent: a retried release after the reservation is gone is not an
+        // error (the SP may retry its cleanup after a lost reply).
+        let again = stability_pool_release_xrp_absorb_preflight_in_state(
+            &mut state,
+            sp(),
+            VAULT_ID,
+            100 * E8,
+        )
+        .expect("release is idempotent");
+        assert!(!again, "second release must report nothing was cleared");
+    }
+
+    #[test]
+    fn preflight_release_rejects_non_sp_and_mismatched_reservations() {
+        // The reservation is the SP's sizing snapshot for a burn it is about to
+        // perform. Releasing someone else's reservation, or releasing under a
+        // different burn amount than was reserved, would let a stale or hostile
+        // caller drop a reservation the SP still intends to consume -- which
+        // would strand an in-flight burn. Both are refused, and the
+        // reservation survives.
+        let mut state = test_state_with_xrp_vault();
+        stability_pool_preflight_xrp_absorb_in_state(&mut state, sp(), VAULT_ID, 100 * E8, 10)
+            .expect("preflight reservation");
+
+        let not_sp = principal(0x77);
+        stability_pool_release_xrp_absorb_preflight_in_state(&mut state, not_sp, VAULT_ID, 100 * E8)
+            .expect_err("only the registered stability pool may release a reservation");
+        assert!(
+            state.sp_xrp_absorb_preflights.contains_key(&VAULT_ID),
+            "a rejected release must not clear the reservation"
+        );
+
+        stability_pool_release_xrp_absorb_preflight_in_state(&mut state, sp(), VAULT_ID, 50 * E8)
+            .expect_err("release must match the reserved burn amount");
+        assert!(
+            state.sp_xrp_absorb_preflights.contains_key(&VAULT_ID),
+            "an amount-mismatched release must not clear the reservation"
+        );
     }
 
     #[test]

--- a/src/rumi_protocol_backend/src/vault.rs
+++ b/src/rumi_protocol_backend/src/vault.rs
@@ -1889,11 +1889,14 @@ pub fn stability_pool_liquidate_xrp_vault_in_state(
     Ok(result)
 }
 
-/// P5: true iff `vault_id` is a native-XRP-collateral vault (custody on the XRP
-/// Ledger). Such vaults are excluded from AUTOMATED liquidation (the unhealthy-vault
-/// scan + the stability-pool / bot entry points): the SP and bot cannot settle an
-/// XrpClaim, so native-XRP is liquidated only MANUALLY by an external liquidator who
-/// provides an XRP address (via liquidate_vault_partial / partial_liquidate_vault).
+/// True iff `vault_id` is a native-XRP-collateral vault (custody on the XRP
+/// Ledger). Such vaults are settled through claim-based paths only: the
+/// stability pool absorbs them via the dedicated native-XRP absorb flow
+/// (`stability_pool_preflight_xrp_absorb` + `stability_pool_liquidate_xrp_vault`,
+/// which mint `XrpClaim`s for opted-in depositors), and external liquidators use
+/// `liquidate_vault_partial` / `partial_liquidate_vault`. This predicate guards
+/// the entry points that CANNOT settle an XrpClaim — the bot, and the generic
+/// ICRC/3USD stability-pool write-down paths.
 pub fn vault_is_native_xrp(vault_id: u64) -> bool {
     read_state(|s| {
         s.vault_id_to_vaults
@@ -7991,6 +7994,63 @@ mod xrp_sp_absorb_contract_tests {
         let vault = state.vault_id_to_vaults.get(&VAULT_ID).expect("vault");
         assert_eq!(vault.borrowed_icusd_amount, ICUSD::new(100 * E8));
         assert_eq!(vault.collateral_amount, 100_000_000);
+    }
+
+    #[test]
+    fn automated_dispatch_amount_is_accepted_by_xrp_preflight() {
+        // End-to-end pin across the two halves of automated XRP absorption:
+        // the amount `check_vaults` puts in `recommended_liquidation_amount`
+        // must be an amount `stability_pool_preflight_xrp_absorb_in_state`
+        // actually accepts. Regression for the sizing mismatch where the
+        // dispatch sent the generic partial cap while the absorb path requires
+        // the full live debt, so every automated absorb failed at preflight.
+        //
+        // The vault is at an ORDINARY breach (CR 130%: under the 133%
+        // liquidation floor, above the 112% bonus). The deep-breach fixture
+        // used elsewhere hides this bug, because the partial cap saturates to
+        // the full debt once a vault is far enough underwater.
+        let mut state = test_state_with_xrp_vault();
+        let xrp = xrp_collateral_principal();
+        if let Some(cfg) = state.collateral_configs.get_mut(&xrp) {
+            cfg.last_price = Some(1.30);
+        }
+        let vault = state.vault_id_to_vaults.get(&VAULT_ID).expect("vault").clone();
+        let dummy = UsdIcp::from(Decimal::ZERO);
+
+        // The generic cap is a strict partial here — the pre-fix dispatch value.
+        let generic_cap = state.compute_partial_liquidation_cap(&vault, dummy);
+        assert!(
+            generic_cap < vault.borrowed_icusd_amount,
+            "premise: ordinary breach must yield a partial cap, got {generic_cap:?}"
+        );
+        let err = stability_pool_preflight_xrp_absorb_in_state(
+            &mut state,
+            sp(),
+            VAULT_ID,
+            generic_cap.to_u64(),
+            10,
+        )
+        .expect_err("partial burn must be rejected by the full-debt-only absorb path");
+        assert!(
+            format!("{err:?}").contains("does not match live debt"),
+            "unexpected error: {err:?}"
+        );
+        assert!(
+            state.sp_xrp_absorb_preflights.is_empty(),
+            "a rejected preflight must not leave a reservation behind"
+        );
+
+        // What the dispatch actually sends now is accepted.
+        let dispatched = state.recommended_liquidation_amount_for(&vault, dummy);
+        let preflight = stability_pool_preflight_xrp_absorb_in_state(
+            &mut state,
+            sp(),
+            VAULT_ID,
+            dispatched.to_u64(),
+            20,
+        )
+        .expect("automated dispatch amount must be accepted by the preflight");
+        assert_eq!(preflight.icusd_burn_e8s, vault.borrowed_icusd_amount.to_u64());
     }
 
     #[test]

--- a/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
+++ b/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
@@ -852,9 +852,10 @@ fn xrp_native_liquidation_is_claim_based() {
     mint_icusd(&pic, icusd, backend, liquidator(), 40 * E8);
     approve_icusd(&pic, icusd, liquidator(), backend, 40 * E8);
 
-    // Native-XRP is excluded from automated SP/bot liquidation (P5), so liquidation
-    // is the external, claim-based path: the liquidator repays part of the debt and
-    // the seized XRP becomes an XrpClaim they later settle to an XRPL address.
+    // Native-XRP vaults now also flow through the automated cascade to the
+    // stability pool, but the external, claim-based path exercised here remains
+    // supported: the liquidator repays part of the debt and the seized XRP
+    // becomes an XrpClaim they later settle to an XRPL address.
     let before_claims = xrp_claims_full(&pic, backend);
     let liquidation_result = decode_result::<rumi_protocol_backend::SuccessWithFee>(
         update_as(

--- a/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
+++ b/src/rumi_protocol_backend/tests/xrp_native_e2e_pic.rs
@@ -973,6 +973,243 @@ fn xrp_collateral_contract_matches_frontend_expectations() {
 
 /// IDs of all outstanding XRP claims (via the dev query). Returns [] if the query
 /// is absent (older builds) — the asserting tests treat that as a hard failure.
+/// Automated push path: `check_vaults` -> stability pool -> backend absorb, with
+/// a REAL stability-pool canister wired in.
+///
+/// This is the flow the manual-liquidation tests above never touch (they boot
+/// with `stability_pool_principal: None`), and its absence is what let a sizing
+/// mismatch ship: `check_vaults` dispatched the generic partial-liquidation cap
+/// while the native-XRP absorb path only accepts the full live debt, so every
+/// automated absorb failed at preflight.
+///
+/// The vault here sits at an ORDINARY breach (CR ~130%: under the 133%
+/// liquidation floor, above the 112% bonus). That distinction is the whole
+/// point -- a deep breach makes the partial cap saturate to the full debt and
+/// hides the bug.
+#[test]
+fn xrp_vault_is_absorbed_by_stability_pool_via_automated_dispatch() {
+    let Env {
+        pic,
+        backend,
+        icusd,
+        xrc,
+    } = boot();
+    register_xrp(&pic, backend);
+
+    // ── Wire a real stability pool to the backend ────────────────────────────
+    let sp_id = pic.create_canister();
+    pic.add_cycles(sp_id, 2_000_000_000_000);
+    pic.install_canister(
+        sp_id,
+        stability_pool_wasm(),
+        encode_one(StabilityPoolInitArgs {
+            protocol_canister_id: backend,
+            authorized_admins: vec![sp_admin()],
+        })
+        .expect("encode sp init"),
+        None,
+    );
+    decode_result::<()>(
+        update_as(
+            &pic,
+            backend,
+            dev(),
+            "set_stability_pool_principal",
+            Encode!(&sp_id).unwrap(),
+        ),
+        "set_stability_pool_principal",
+    )
+    .expect("set_stability_pool_principal");
+    decode_result::<()>(
+        update_as(
+            &pic,
+            sp_id,
+            sp_admin(),
+            "register_stablecoin",
+            Encode!(&SpStablecoinConfig {
+                ledger_id: icusd,
+                symbol: "icUSD".to_string(),
+                decimals: 8,
+                priority: 1,
+                is_active: true,
+                transfer_fee: Some(10_000),
+                is_lp_token: None,
+                underlying_pool: None,
+            })
+            .unwrap(),
+        ),
+        "register_stablecoin",
+    )
+    .expect("register icUSD in the pool");
+
+    // ── Fund the pool and opt the depositor into XRP payouts ─────────────────
+    // Only depositors holding icUSD AND carrying an XRPL payout address count
+    // toward XRP coverage, so both steps are load-bearing.
+    let sp_deposit_amount = 100 * E8;
+    mint_icusd(&pic, icusd, backend, depositor(), sp_deposit_amount + 10 * E8);
+    approve_icusd(&pic, icusd, depositor(), sp_id, sp_deposit_amount + E8);
+    decode_result::<()>(
+        update_as(
+            &pic,
+            sp_id,
+            depositor(),
+            "deposit",
+            Encode!(&icusd, &sp_deposit_amount).unwrap(),
+        ),
+        "deposit",
+    )
+    .expect("pool deposit");
+    decode_result::<()>(
+        update_as(
+            &pic,
+            sp_id,
+            depositor(),
+            "opt_in_native_collateral_with_tag",
+            Encode!(
+                &xrp_collateral_principal(),
+                // Must be a real base58check XRPL classic address: the pool
+                // validates it via chains::xrp::address at opt-in time.
+                &"rUn84CUYbNjRoTQ6mSW7BVJPSVJNLb1QLo".to_string(),
+                &Option::<u32>::None
+            )
+            .unwrap(),
+        ),
+        "opt_in_native_collateral_with_tag",
+    )
+    .expect("depositor opts into XRP payouts");
+
+    // ── An XRP vault at an ordinary breach ───────────────────────────────────
+    let open_reply = open_xrp_vault(&pic, backend);
+    let open: XrpVaultOpenInfo =
+        match decode_result::<XrpVaultOpenInfo>(open_reply, "open_xrp_vault") {
+            Ok(info) => info,
+            Err(_) => {
+                eprintln!("[gated] tEd25519 unavailable; skipping XRP SP auto-absorb e2e");
+                return;
+            }
+        };
+    let vault_id = open.vault_id;
+    let deposit_drops = 200 * XRP;
+    decode_result::<u64>(
+        call_with_rippled(
+            &pic,
+            backend,
+            user(),
+            "confirm_xrp_deposit",
+            Encode!(&vault_id).unwrap(),
+            |m| match m {
+                "account_info" => rippled_account_info(deposit_drops, 1, 100),
+                "server_state" => rippled_server_state(RESERVE_DROPS),
+                other => panic!("unexpected rippled method: {other}"),
+            },
+        ),
+        "confirm_xrp_deposit",
+    )
+    .expect("confirm ok");
+
+    let borrow_amount = 60 * E8;
+    decode_result::<rumi_protocol_backend::SuccessWithFee>(
+        update_as(
+            &pic,
+            backend,
+            user(),
+            "borrow_from_vault",
+            Encode!(&VaultArg {
+                vault_id,
+                amount: borrow_amount
+            })
+            .unwrap(),
+        ),
+        "borrow_from_vault",
+    )
+    .expect("borrow ok");
+
+    // ~199 XRP at $0.392 => ~$78 against ~$60 debt => CR ~130%: liquidatable,
+    // but NOT deeply enough for the partial cap to saturate to the full debt.
+    // 0.392/0.50 = 0.784 stays inside the price-sanity band, so the crash is
+    // accepted on a single re-fetch rather than queued as an outlier.
+    crash_xrp_price(&pic, xrc, 392 * E8 / 1000);
+
+    // Make every tick a full sweep. A vault's CR-index key is only refreshed on
+    // vault mutations, so after a price crash it is stale-above-threshold and
+    // band-only ticks skip it -- on mainnet the hourly full sweep is the safety
+    // belt that catches exactly this. Forcing it here keeps the test about the
+    // absorb, not about how many simulated hours elapse.
+    decode_result::<()>(
+        update_as(
+            &pic,
+            backend,
+            dev(),
+            "set_check_vaults_full_sweep_every_n_ticks",
+            Encode!(&1u64).unwrap(),
+        ),
+        "set_check_vaults_full_sweep_every_n_ticks",
+    )
+    .expect("force full sweeps");
+
+    let claims_before = xrp_claims(&pic, backend);
+    let vault_before = get_vault(&pic, backend, vault_id).expect("vault exists before absorb");
+    assert!(
+        vault_before.borrowed_icusd_amount > 0,
+        "vault must carry debt before the absorb"
+    );
+
+    // ── Let the 5-minute check_vaults timer fire and drive the cascade ───────
+    // No manual liquidation call anywhere: everything past this point is the
+    // automated path doing its own work.
+    for _ in 0..6 {
+        pic.advance_time(std::time::Duration::from_secs(300));
+        for _ in 0..25 {
+            pic.tick();
+        }
+    }
+
+    let vault_after = get_vault(&pic, backend, vault_id);
+    let claims_after = xrp_claims(&pic, backend);
+    assert!(
+        claims_after.len() > claims_before.len(),
+        "automated SP absorb must mint an XrpClaim for the opted-in depositor \
+         (before={claims_before:?}, after={claims_after:?})"
+    );
+    assert!(
+        vault_after
+            .as_ref()
+            .map(|v| v.borrowed_icusd_amount == 0)
+            .unwrap_or(true),
+        "automated SP absorb must clear the vault's debt, got {vault_after:?}"
+    );
+}
+
+fn stability_pool_wasm() -> Vec<u8> {
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/stability_pool.wasm").to_vec()
+}
+
+fn sp_admin() -> Principal {
+    Principal::from_slice(&[0x5a, 0xd0, 0x01])
+}
+
+fn depositor() -> Principal {
+    Principal::from_slice(&[0xde, 0x90, 0x01])
+}
+
+#[derive(CandidType)]
+struct StabilityPoolInitArgs {
+    protocol_canister_id: Principal,
+    authorized_admins: Vec<Principal>,
+}
+
+#[derive(CandidType)]
+struct SpStablecoinConfig {
+    ledger_id: Principal,
+    symbol: String,
+    decimals: u8,
+    priority: u8,
+    is_active: bool,
+    transfer_fee: Option<u64>,
+    is_lp_token: Option<bool>,
+    underlying_pool: Option<Principal>,
+}
+
 fn xrp_claims(pic: &PocketIc, backend: Principal) -> Vec<u64> {
     xrp_claims_full(pic, backend)
         .into_iter()

--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -409,6 +409,24 @@ pub(crate) fn mark_native_xrp_absorb_error_in_state(
     }
 }
 
+/// Abandon a native-XRP absorb attempt that reserved a backend preflight but
+/// has NOT burned any icUSD: drop the local intent and hand the reservation
+/// back. Every call site is positioned strictly before the burn (or on a burn
+/// that returned an error, which the local clear already treats as unburned),
+/// so releasing can never strand an in-flight burn.
+async fn abandon_unburned_native_xrp_absorb(
+    io: &mut dyn NativeXrpAbsorbIo,
+    protocol_id: Principal,
+    vault_id: u64,
+    icusd_burn_e8s: u64,
+) {
+    mutate_state(|s| {
+        clear_unburned_native_xrp_absorb_intent_in_state(s, vault_id);
+    });
+    io.release_xrp_absorb_preflight(protocol_id, vault_id, icusd_burn_e8s)
+        .await;
+}
+
 pub(crate) fn clear_unburned_native_xrp_absorb_intent_in_state(
     state: &mut StabilityPoolState,
     vault_id: u64,
@@ -496,6 +514,16 @@ pub(crate) trait NativeXrpAbsorbIo {
         protocol_id: Principal,
         request: XrpSpAbsorbRequest,
     ) -> Result<XrpSpAbsorbResult, StabilityPoolError>;
+
+    /// Hand an unburned reservation back to the backend. Best-effort: the
+    /// caller is already on a failure path, and the reservation expires on its
+    /// own, so a failed release is logged rather than propagated.
+    async fn release_xrp_absorb_preflight(
+        &mut self,
+        protocol_id: Principal,
+        vault_id: u64,
+        icusd_burn_e8s: u64,
+    );
 }
 
 struct CdkNativeXrpAbsorbIo;
@@ -586,6 +614,36 @@ impl NativeXrpAbsorbIo for CdkNativeXrpAbsorbIo {
                 target: format!("{}", protocol_id),
                 method: "stability_pool_liquidate_xrp_vault".to_string(),
             }),
+        }
+    }
+
+    async fn release_xrp_absorb_preflight(
+        &mut self,
+        protocol_id: Principal,
+        vault_id: u64,
+        icusd_burn_e8s: u64,
+    ) {
+        let released: Result<(Result<bool, rumi_protocol_backend::ProtocolError>,), _> = call(
+            protocol_id,
+            "stability_pool_release_xrp_absorb_preflight",
+            (vault_id, icusd_burn_e8s),
+        )
+        .await;
+        match released {
+            Ok((Ok(_),)) => {}
+            Ok((Err(error),)) => log!(
+                INFO,
+                "native XRP preflight release rejected for vault {}: {:?}; reservation will expire on its own",
+                vault_id,
+                error
+            ),
+            Err((code, msg)) => log!(
+                INFO,
+                "native XRP preflight release call failed for vault {}: {:?} {}; reservation will expire on its own",
+                vault_id,
+                code,
+                msg
+            ),
         }
     }
 }
@@ -820,9 +878,13 @@ pub(crate) async fn execute_native_xrp_absorb_with_io(
         }
     };
     if preflight.vault_id != vault_info.vault_id || preflight.icusd_burn_e8s != icusd_to_burn_e8s {
-        mutate_state(|s| {
-            clear_unburned_native_xrp_absorb_intent_in_state(s, vault_info.vault_id);
-        });
+        abandon_unburned_native_xrp_absorb(
+            io,
+            protocol_id,
+            vault_info.vault_id,
+            icusd_to_burn_e8s,
+        )
+        .await;
         return liquidation_failure(
             vault_info,
             StabilityPoolError::LiquidationFailed {
@@ -844,9 +906,13 @@ pub(crate) async fn execute_native_xrp_absorb_with_io(
             .map(XrpSpPayoutAllocation::from)
             .collect::<Vec<_>>(),
         Ok(_) => {
-            mutate_state(|s| {
-                clear_unburned_native_xrp_absorb_intent_in_state(s, vault_info.vault_id);
-            });
+            abandon_unburned_native_xrp_absorb(
+                io,
+                protocol_id,
+                vault_info.vault_id,
+                icusd_to_burn_e8s,
+            )
+            .await;
             return liquidation_failure(
                 vault_info,
                 StabilityPoolError::LiquidationFailed {
@@ -856,9 +922,13 @@ pub(crate) async fn execute_native_xrp_absorb_with_io(
             );
         }
         Err(error) => {
-            mutate_state(|s| {
-                clear_unburned_native_xrp_absorb_intent_in_state(s, vault_info.vault_id);
-            });
+            abandon_unburned_native_xrp_absorb(
+                io,
+                protocol_id,
+                vault_info.vault_id,
+                icusd_to_burn_e8s,
+            )
+            .await;
             return liquidation_failure(vault_info, error);
         }
     };
@@ -869,9 +939,13 @@ pub(crate) async fn execute_native_xrp_absorb_with_io(
         match io.fetch_icusd_minting_account(icusd_ledger).await {
             Ok(account) => account,
             Err(error) => {
-                mutate_state(|s| {
-                    clear_unburned_native_xrp_absorb_intent_in_state(s, vault_info.vault_id);
-                });
+                abandon_unburned_native_xrp_absorb(
+                    io,
+                    protocol_id,
+                    vault_info.vault_id,
+                    icusd_to_burn_e8s,
+                )
+                .await;
                 return liquidation_failure(vault_info, error);
             }
         }
@@ -923,9 +997,16 @@ pub(crate) async fn execute_native_xrp_absorb_with_io(
                 proof
             }
             Err(error) => {
-                mutate_state(|s| {
-                    clear_unburned_native_xrp_absorb_intent_in_state(s, vault_info.vault_id);
-                });
+                // The burn call returned an error, which the local clear
+                // already treats as "no icUSD left the pool"; release the
+                // reservation on the same assumption.
+                abandon_unburned_native_xrp_absorb(
+                    io,
+                    protocol_id,
+                    vault_info.vault_id,
+                    icusd_to_burn_e8s,
+                )
+                .await;
                 return liquidation_failure(vault_info, error);
             }
         }
@@ -2742,6 +2823,16 @@ mod tests {
                 .unwrap_or_else(|| build_icusd_burn_proof(44, vault_id)))
         }
 
+        async fn release_xrp_absorb_preflight(
+            &mut self,
+            _protocol_id: Principal,
+            vault_id: u64,
+            icusd_burn_e8s: u64,
+        ) {
+            self.events
+                .push(format!("release:{vault_id}:{icusd_burn_e8s}"));
+        }
+
         async fn submit_xrp_absorb(
             &mut self,
             _protocol_id: Principal,
@@ -3270,7 +3361,13 @@ mod tests {
         ));
 
         assert!(!result.success);
-        assert_eq!(io.events, vec!["preflight:145:1000000000"]);
+        // Giving up after reserving but before burning must hand the backend
+        // reservation back, or the vault stays blocked for every liquidation
+        // path (including manual) until the 15-minute TTL expires.
+        assert_eq!(
+            io.events,
+            vec!["preflight:145:1000000000", "release:145:1000000000"]
+        );
         assert_eq!(
             read_state(|s| s
                 .deposits
@@ -3308,7 +3405,13 @@ mod tests {
         ));
 
         assert!(!result.success);
-        assert_eq!(io.events, vec!["preflight:146:50100000000"]);
+        // Same contract as the empty-allocation abort: reserved, gave up
+        // before burning, so the reservation goes back rather than blocking
+        // the vault for the full TTL.
+        assert_eq!(
+            io.events,
+            vec!["preflight:146:50100000000", "release:146:50100000000"]
+        );
         assert_eq!(
             read_state(|s| s.total_stablecoin_balances.get(&icusd_ledger()).copied()),
             Some(501_00000000),


### PR DESCRIPTION
## Why

Vault 195 (native-XRP, CR ~119% vs the 120% floor) sat underwater with no SP absorption. `scan_unhealthy_vaults` deliberately skipped native-XRP vaults (P5, 2026-06-21), so `check_vaults` never dispatched them. That exclusion predates the SP native-XRP absorption path (`c42e1d6c`, 2026-06-27), which can settle these vaults via depositors opted in with XRPL payout addresses (live coverage: ~1,518 icUSD).

## What

**`38879ad1` — route XRP to the SP.** `scan_unhealthy_vaults` includes native-XRP vaults. New `State::vault_routable_to_bot()` refuses native-XRP to the bot even if an operator adds the synthetic principal to `bot_allowed_collateral_types` (the bot has no XRPL settlement path), so XRP falls through to the SP. One-shot `sp_attempted_vaults` policy unchanged.

**`be436d19` — dispatch the full debt (CRITICAL).** As first written this PR was **inert in the common case**. `check_vaults` populated `recommended_liquidation_amount` from `compute_partial_liquidation_cap`, but native-XRP absorb is **full-liquidation-only**: `xrp_sp_absorb_sizing` rejects any `expected_icusd_burn_e8s` that isn't exactly the live debt. For an ordinary breach the cap is a strict partial, so every automated absorb failed at preflight while still burning the vault's one-shot SP marker. New `State::recommended_liquidation_amount_for()` returns full debt for native-XRP, partial cap otherwise. The deep-breach fixtures used by existing tests hid this (the cap saturates to full debt when far enough underwater); the pull path works only because it passes `recommended = 0` and hits the full-debt fallback.

**`1b9d903b` — release unburned reservations (HIGH, pre-existing).** A preflight reservation blocks 20 entry points, including all four manual liquidation paths, until consumed or its 15-minute TTL expires. The SP could reserve then give up pre-burn (no opted-in depositor holding icUSD, >500 allocation fan-out, minting-account failure) with no way to hand it back, leaving an underwater vault unliquidatable by **any** path. Reachable today via the permissionless `execute_liquidation`; automated dispatch makes it fire on the tick, and the sizing fix makes absorbs actually reach that code. Adds `stability_pool_release_xrp_absorb_preflight` (additive Candid, reuses the existing bool `Result_14`): SP-only, must match the reserved amount so it cannot drop a reservation an in-flight burn still needs, idempotent, no-op after a completed absorb.

**`a31d91c6` — push-path e2e test.** The existing XRP e2e boots with `stability_pool_principal: None`, so nothing exercised backend → SP → backend; that gap is what let the sizing bug ship.

Out of scope: the P4 redemption-priority exclusion of native XRP stays (redemption water-fill is still unimplemented). Manual claim-based liquidation is unchanged and still tested.

## Testing

- `cargo test --workspace --lib` green (755 backend lib tests).
- PocketIC (wasms rebuilt first): `xrp_native_e2e_pic` 4/4, `pocket_ic_tests` 32/32, `audit_pocs_sp_liquidation_fee_accounting` 4/4, plus `cdp_10_sp_blacklist`, `routing_state_cleanup`, `dos_005_check_vaults_shard` — all green.
- The new PocketIC test was **verified to fail on pre-fix code** with `XRP SP absorb burn 3155789473 does not match live debt 6000000000`, then pass after. Logs show the real cascade: `found 1 unhealthy ... ratio=130.01%, min_ratio=133.00%` → `Sent 1 vaults to stability pool` → `Liquidated vault 1: gained 170877550 collateral`.

## Known gaps (not addressed here)

- **SP dispatch result is discarded.** `check_vaults` types the SP call as `Result<(), _>`, so a vault's one automated shot is consumed on transport-Ok regardless of the SP's internal outcome, with no backend-side log. Pre-existing and applies to all collateral, not just XRP.
- **`.did` drift.** The checked-in Candid is missing `get_pending_3usd_refunds`, which exists in source. Regenerating fixes it but renumbers every `Result_N`, so the new method was hand-added to keep this diff reviewable.
- **`dev_force_bot_liquidate`** has no XRP fence; it is `#[cfg(feature = "test_endpoints")]` and compiled out of the mainnet wasm.

## Deploy note

This adds a Candid method (additive, not breaking), so sequencing against the unmerged `fix/rate-curve-derived-cr-levels` (which carries its own Candid breaking change) needs care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)