### PR TITLE
fix(sp): make native-XRP absorptions visible in history and the explorer

### DIFF
--- a/src/stability_pool/src/liquidation.rs
+++ b/src/stability_pool/src/liquidation.rs
@@ -474,6 +474,24 @@ pub(crate) fn apply_native_xrp_absorb_success_in_state_at(
     )?;
     state.take_pending_native_xrp_absorb(intent.vault_id);
 
+    // Emit the same audit event the generic ICRC path emits. Without it the
+    // only Explorer trace of an absorb is `LiquidationNotification`, which
+    // carries a bare vault count and cannot distinguish a completed absorb
+    // from one that failed. `collateral_gained` is in drops (6-decimal), so
+    // consumers must format it with the collateral's own decimals.
+    let stables_consumed_e8s: u64 = intent.stables_consumed.values().sum();
+    state.push_event_at(
+        state.protocol_canister_id,
+        PoolEventType::LiquidationExecuted {
+            vault_id: intent.vault_id,
+            stables_consumed_e8s,
+            collateral_gained: intent.collateral_received_drops,
+            collateral_type: intent.collateral_type,
+            success: true,
+        },
+        now_ns,
+    );
+
     Ok(LiquidationResult {
         vault_id: intent.vault_id,
         stables_consumed: intent.stables_consumed.clone(),
@@ -3020,6 +3038,53 @@ mod tests {
             read_state(|s| s.native_xrp_pending_payouts_for(&user_b())).is_empty(),
             "non-opted-in depositor must not receive pending native XRP payouts",
         );
+
+        // The absorb must leave a substantive audit event. Without this the
+        // only trace in the Explorer is `LiquidationNotification`, which
+        // carries a bare vault COUNT — no vault id, no amounts, no outcome —
+        // so a real absorb was indistinguishable from one that did nothing.
+        // `LiquidationExecuted` already exists and is already rendered richly
+        // by the frontend, so emitting it needs no interface change.
+        let executed = read_state(|s| {
+            s.pool_events
+                .as_ref()
+                .map(|events| {
+                    events
+                        .iter()
+                        .filter_map(|e| match &e.event_type {
+                            PoolEventType::LiquidationExecuted {
+                                vault_id,
+                                stables_consumed_e8s,
+                                collateral_gained,
+                                collateral_type,
+                                success,
+                            } => Some((
+                                *vault_id,
+                                *stables_consumed_e8s,
+                                *collateral_gained,
+                                *collateral_type,
+                                *success,
+                            )),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        });
+        assert_eq!(
+            executed.len(),
+            1,
+            "a successful native-XRP absorb must emit exactly one LiquidationExecuted event"
+        );
+        let (vault_id, stables_e8s, drops, collateral, success) = executed[0];
+        assert_eq!(vault_id, 144);
+        assert_eq!(collateral, xrp_ledger());
+        assert_eq!(drops, 12_000_000, "collateral_gained is the seized drops");
+        assert_eq!(
+            stables_e8s, 60_00000000,
+            "stables_consumed_e8s is the full icUSD burn this fixture absorbs"
+        );
+        assert!(success);
     }
 
     #[test]

--- a/src/stability_pool/src/state.rs
+++ b/src/stability_pool/src/state.rs
@@ -215,13 +215,20 @@ impl StabilityPoolState {
 
     /// Append a pool event. Trims oldest events if over capacity.
     pub fn push_event(&mut self, caller: Principal, event_type: PoolEventType) {
+        self.push_event_at(caller, event_type, ic_cdk::api::time());
+    }
+
+    /// `push_event` with an explicit timestamp, for the pure state functions
+    /// that already thread a `now_ns` through so they stay testable off-canister
+    /// (`ic_cdk::api::time()` is unavailable outside the IC runtime).
+    pub fn push_event_at(&mut self, caller: Principal, event_type: PoolEventType, now_ns: u64) {
         let id = self.next_event_id.unwrap_or(0);
         self.next_event_id = Some(id + 1);
 
         let events = self.pool_events.get_or_insert_with(Vec::new);
         events.push(PoolEvent {
             id,
-            timestamp: ic_cdk::api::time(),
+            timestamp: now_ns,
             caller,
             event_type,
         });
@@ -1939,6 +1946,25 @@ impl StabilityPoolState {
         );
     }
 
+    /// Append an audit record for a completed liquidation and advance
+    /// `total_liquidations_executed`.
+    ///
+    /// Every path that absorbs a vault must go through this, so the counter and
+    /// `liquidation_history` can never disagree. They previously did: the
+    /// native-XRP and chain-collateral paths bumped the counter inline but
+    /// never pushed a record, so a real absorb advanced the count while leaving
+    /// the Earn page's history list unchanged.
+    fn record_liquidation_in_history(&mut self, record: PoolLiquidationRecord) {
+        self.liquidation_history.push(record);
+        self.total_liquidations_executed += 1;
+
+        // Cap history to prevent unbounded memory growth
+        if self.liquidation_history.len() > MAX_LIQUIDATION_HISTORY {
+            let excess = self.liquidation_history.len() - MAX_LIQUIDATION_HISTORY;
+            self.liquidation_history.drain(..excess);
+        }
+    }
+
     pub fn process_native_xrp_absorb_success_at(
         &mut self,
         vault_id: u64,
@@ -2162,7 +2188,20 @@ impl StabilityPoolState {
             )?;
         }
 
-        self.total_liquidations_executed += 1;
+        // `collateral_gained` is the seized amount in drops (XRP is 6-decimal);
+        // consumers must format it with the collateral's own decimals.
+        // `collateral_price_e8s` is None: the pool never sees an XRP price on
+        // this path (the backend does the sizing), and the field is optional
+        // precisely so records can omit it.
+        self.record_liquidation_in_history(PoolLiquidationRecord {
+            vault_id,
+            timestamp,
+            stables_consumed: stables_consumed.clone(),
+            collateral_gained: collateral_received_drops,
+            collateral_type,
+            depositors_count: payout_claims.len() as u64,
+            collateral_price_e8s: None,
+        });
         self.deposits.retain(|_, pos| !pos.is_empty());
         debug_assert!(
             self.validate_state().is_ok(),
@@ -2339,7 +2378,7 @@ impl StabilityPoolState {
         }
 
         // Phase 5: Record in history
-        let record = PoolLiquidationRecord {
+        self.record_liquidation_in_history(PoolLiquidationRecord {
             vault_id,
             timestamp,
             stables_consumed: stables_consumed.clone(),
@@ -2347,15 +2386,7 @@ impl StabilityPoolState {
             collateral_type,
             depositors_count: opted_in_principals.len() as u64,
             collateral_price_e8s: Some(collateral_price_e8s),
-        };
-        self.liquidation_history.push(record);
-        self.total_liquidations_executed += 1;
-
-        // Cap history to prevent unbounded memory growth
-        if self.liquidation_history.len() > MAX_LIQUIDATION_HISTORY {
-            let excess = self.liquidation_history.len() - MAX_LIQUIDATION_HISTORY;
-            self.liquidation_history.drain(..excess);
-        }
+        });
 
         // Phase 6: Clean up empty positions
         self.deposits.retain(|_, pos| !pos.is_empty());
@@ -4036,6 +4067,116 @@ mod tests {
             "aggregate SP balance must drop by the full burned icUSD amount",
         );
         assert_eq!(state.native_xrp_pending_payouts_for(&user_a()).len(), 1);
+    }
+
+    #[test]
+    #[ignore = "KNOWN GAP: PoolLiquidationRecord.collateral_gained is u64, which cannot hold \
+                18-decimal wei (u64 max is only ~18.4 CFX). Fixing this needs a record-shape \
+                decision (widen the field, or normalize to e8s and teach every consumer that \
+                chain rows mean something different) — see the test body."]
+    fn chain_absorb_appends_a_liquidation_history_record() {
+        // Same defect the native-XRP path had: `process_chain_liquidation_gains_at`
+        // advances `total_liquidations_executed` without pushing a
+        // `PoolLiquidationRecord`, so a chain absorb inflates the count while
+        // leaving the Earn page's history list unchanged.
+        //
+        // Deliberately NOT fixed alongside XRP, because it cannot be fixed
+        // honestly with the current record shape. Chain claims are `u128` wei
+        // (`DepositPosition::cfx_claims`) while `collateral_gained` is `u64`:
+        // 2^64-1 wei is ~18.4 CFX, so any realistic absorb saturates. Writing a
+        // saturated value would put a silently wrong number in the UI, which is
+        // worse than the current absence. Normalizing to e8s would make the same
+        // field mean different things per collateral — exactly the kind of
+        // implicit contract that produced this class of bug.
+        //
+        // Low urgency: chain liquidation is disabled-by-default and staging-only.
+        // Un-ignore this once the record shape is settled.
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 1_00000000);
+        state.opt_in_cfx(&user_a(), cfx_sentinel()).unwrap();
+        let mut stables_consumed = BTreeMap::new();
+        stables_consumed.insert(icusd_ledger(), 1_00000000);
+
+        let history_before = state.liquidation_history.len();
+        state.process_chain_liquidation_gains_at(
+            99,
+            cfx_sentinel(),
+            &stables_consumed,
+            20_000 * 1_000_000_000_000_000_000u128,
+            5_000_000,
+            123,
+        );
+
+        assert_eq!(
+            state.liquidation_history.len(),
+            history_before + 1,
+            "chain absorb must append a history record, in lockstep with the counter"
+        );
+        let record = state.liquidation_history.last().expect("history record");
+        assert_eq!(record.vault_id, 99);
+        assert_eq!(record.collateral_type, cfx_sentinel());
+    }
+
+    #[test]
+    fn native_xrp_absorb_appends_a_liquidation_history_record() {
+        // The XRP absorb path bumps `total_liquidations_executed` but used to
+        // skip `liquidation_history` entirely (only the generic ICRC path wrote
+        // records). Live consequence: the Earn page's Liquidation History
+        // showed no row for a real XRP absorb while the counter climbed, so the
+        // count and the list disagreed. The record must be written by the same
+        // call that bumps the counter.
+        let mut state = test_state();
+        add_deposit_direct(&mut state, user_a(), icusd_ledger(), 100_000_000);
+        state
+            .opt_in_native_collateral_with_tag(&user_a(), xrp_ledger(), valid_xrp_address(), None)
+            .unwrap();
+        let mut consumed = BTreeMap::new();
+        consumed.insert(icusd_ledger(), 60_000_000);
+        let payout_claims = vec![XrpSpPayoutClaim {
+            claimant: user_a(),
+            claim_id: 9,
+            payout_address: valid_xrp_address(),
+            destination_tag: None,
+            drops: 1_796_552,
+        }];
+
+        let history_before = state.liquidation_history.len();
+        let counter_before = state.total_liquidations_executed;
+
+        state
+            .process_native_xrp_absorb_success_at(
+                195,
+                xrp_ledger(),
+                &consumed,
+                1_796_552,
+                &payout_claims,
+                4_242,
+            )
+            .unwrap();
+
+        assert_eq!(
+            state.total_liquidations_executed,
+            counter_before + 1,
+            "counter must still advance"
+        );
+        assert_eq!(
+            state.liquidation_history.len(),
+            history_before + 1,
+            "history must advance in lockstep with the counter"
+        );
+        let record = state.liquidation_history.last().expect("history record");
+        assert_eq!(record.vault_id, 195);
+        assert_eq!(record.collateral_type, xrp_ledger());
+        assert_eq!(
+            record.collateral_gained, 1_796_552,
+            "collateral_gained is the seized drops"
+        );
+        assert_eq!(record.stables_consumed, consumed);
+        assert_eq!(
+            record.depositors_count, 1,
+            "depositors_count is the number of payout claimants"
+        );
+        assert_eq!(record.timestamp, 4_242);
     }
 
     #[test]

--- a/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/EarnInfoCard.svelte
@@ -14,7 +14,7 @@
   import { CANISTER_IDS } from '../../config';
   import { liveSpApyPct } from '../../utils/liveApy';
   import XrpPayoutRouting from './XrpPayoutRouting.svelte';
-  import { isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
+  import { collateralGainDisplayAmount, isIcrcClaimableCollateral } from '../../services/xrpPayoutHelpers';
   import {
     gainCollaterals,
     isSunsetCollateral,
@@ -34,6 +34,10 @@
   let error = '';
   let showOptOutMenu = false;
   let showOptOutTooltip = false;
+  // Outstanding native-XRP payout drops, published by XrpPayoutRouting. Native
+  // XRP never appears in `gains` (it pays out via XRPL claims), so this is the
+  // only source for a truthful XRP figure on the Collateral Gains row.
+  let pendingXrpDrops = 0n;
 
   // Registries
   $: stablecoinRegistry = poolStatus?.stablecoin_registry ?? [];
@@ -241,11 +245,21 @@
           {#each collateralRegistry as col}
             {@const key = col.ledger_id.toText()}
             {@const gainEntry = gains.find(([l]) => l.toText() === key)}
-            {@const gainAmount = gainEntry ? gainEntry[1] : 0n}
-            <span class="gain-line" class:gain-dim={gainAmount === 0n}>
+            {@const display = collateralGainDisplayAmount(
+              key,
+              gainEntry ? gainEntry[1] : 0n,
+              pendingXrpDrops,
+            )}
+            <span class="gain-line" class:gain-dim={display.amount === 0n}>
               <span class="collateral-dot" style="background:{getCollateralColor(col)}"></span>
               <span class="gain-ticker">{col.symbol}</span>
-              <span class="gain-value">{formatTokenAmount(gainAmount, col.decimals)}</span>
+              <span class="gain-value">{formatTokenAmount(display.amount, col.decimals)}</span>
+              {#if display.viaXrpClaims && display.amount > 0n}
+                <!-- Paid out as an XRPL claim, not a pool balance, so it is not
+                     part of "Claim". Say so rather than letting it read as an
+                     ordinary claimable gain sitting in the pool. -->
+                <span class="gain-note">via XRP payout</span>
+              {/if}
             </span>
           {/each}
         </span>
@@ -270,6 +284,7 @@
       {collateralRegistry}
       {userPosition}
       {isConnected}
+      on:pendingDropsChange={(event) => { pendingXrpDrops = event.detail; }}
       on:success={(event) => dispatch('success', event.detail)}
     />
 
@@ -439,6 +454,14 @@
 
   .gain-value {
     margin-left: auto;
+  }
+
+  /* Marks a gain paid via XRPL claim rather than a claimable pool balance. */
+  .gain-note {
+    margin-left: 0.4rem;
+    font-size: 0.65rem;
+    opacity: 0.65;
+    white-space: nowrap;
   }
 
   /* ── Stablecoin breakdown under Total Deposited ── */

--- a/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.svelte
+++ b/src/vault_frontend/src/lib/components/stability-pool/XrpPayoutRouting.svelte
@@ -11,6 +11,7 @@
   import {
     XRP_NATIVE_PRINCIPAL_TEXT,
     isNativeXrpPrincipal,
+    sumPendingXrpDrops,
     unwrapNativePayoutAddresses,
     unwrapNativePayoutDestinationTags,
     validateXrpPayoutInput,
@@ -20,7 +21,10 @@
   export let userPosition: UserPosition | null = null;
   export let isConnected = false;
 
-  const dispatch = createEventDispatcher<{ success: { action: string } }>();
+  const dispatch = createEventDispatcher<{
+    success: { action: string };
+    pendingDropsChange: bigint;
+  }>();
 
   let payoutAddress = '';
   let destinationTag = '';
@@ -44,6 +48,11 @@
   $: userHasStablecoinDeposit = (userPosition?.stablecoin_balances ?? []).some(([, amount]) => amount > 0n);
   $: isEnabled = storedAddress !== '';
   $: hasPendingPayouts = pendingPayouts.length > 0;
+  // Publish the outstanding drops so the Collateral Gains row can show what a
+  // depositor is actually owed in XRP. That row reads `collateral_gains`, which
+  // is structurally always 0 for native XRP (payouts are XRPL claims, not pool
+  // balances), so without this it reports "nothing" to someone owed real XRP.
+  $: dispatch('pendingDropsChange', sumPendingXrpDrops(pendingPayouts));
   $: shouldRenderXrpRouting =
     isConnected && userPosition && xrpCollateral && (userHasStablecoinDeposit || isEnabled || loadingPayouts || hasPendingPayouts);
 

--- a/src/vault_frontend/src/lib/services/xrpPayoutHelpers.collateralGains.spec.ts
+++ b/src/vault_frontend/src/lib/services/xrpPayoutHelpers.collateralGains.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collateralGainDisplayAmount,
+  sumPendingXrpDrops,
+  XRP_NATIVE_PRINCIPAL_TEXT,
+} from './xrpPayoutHelpers';
+
+const CKBTC = 'mxzaz-hqaaa-aaaar-qaada-cai';
+
+describe('collateralGainDisplayAmount', () => {
+  it('shows pending XRP claim drops for native XRP, not the always-zero ICRC gain', () => {
+    // The live shape after the 2026-08-15 absorb of vault #195: the depositor
+    // is owed 1,185,343 drops via an XRPL claim, while `collateral_gains` for
+    // XRP is (and always will be) 0 because XRP never lands in the pool.
+    const out = collateralGainDisplayAmount(XRP_NATIVE_PRINCIPAL_TEXT, 0n, 1_185_343n);
+
+    expect(out.amount).toBe(1_185_343n);
+    expect(out.viaXrpClaims).toBe(true);
+  });
+
+  it('leaves ICRC collateral on its real gains value', () => {
+    const out = collateralGainDisplayAmount(CKBTC, 5_020_000n, 1_185_343n);
+
+    expect(out.amount).toBe(5_020_000n);
+    expect(out.viaXrpClaims).toBe(false);
+  });
+
+  it('reports zero for native XRP when nothing is actually owed', () => {
+    const out = collateralGainDisplayAmount(XRP_NATIVE_PRINCIPAL_TEXT, 0n, 0n);
+
+    expect(out.amount).toBe(0n);
+    // Still flagged as the claim rail, so the UI labels it consistently rather
+    // than flipping presentation based on whether a balance happens to exist.
+    expect(out.viaXrpClaims).toBe(true);
+  });
+});
+
+describe('sumPendingXrpDrops', () => {
+  it('totals drops across payouts', () => {
+    expect(sumPendingXrpDrops([{ drops: 1_185_343n }, { drops: 590_828n }])).toBe(1_776_171n);
+  });
+
+  it('accepts number drops without losing precision on the bigint total', () => {
+    expect(sumPendingXrpDrops([{ drops: 5_092 }, { drops: 3_760 }])).toBe(8_852n);
+  });
+
+  it('is zero for empty, null, and undefined', () => {
+    expect(sumPendingXrpDrops([])).toBe(0n);
+    expect(sumPendingXrpDrops(null)).toBe(0n);
+    expect(sumPendingXrpDrops(undefined)).toBe(0n);
+  });
+});

--- a/src/vault_frontend/src/lib/services/xrpPayoutHelpers.ts
+++ b/src/vault_frontend/src/lib/services/xrpPayoutHelpers.ts
@@ -158,3 +158,35 @@ export function buildManualXrpSettlementSuccessCopy(claimId: XrpClaimId, txHash?
   const suffix = txHash ? ` Tx hash: ${txHash}.` : '';
   return `Liquidation accepted and XRP claim #${claimId} created. XRP settlement submitted.${suffix}`;
 }
+
+/**
+ * Amount to show on the Stability Pool "Collateral Gains" line for a collateral.
+ *
+ * ICRC collateral accrues into the pool's `collateral_gains` map, so the gains
+ * value is the whole story. Native XRP never does: an absorb pays depositors
+ * through XRPL claims instead, so its `collateral_gains` entry is permanently
+ * zero. Rendering that raw zero told a depositor who was owed real XRP that
+ * they had received nothing, so for native XRP we show the pending payout
+ * total (in drops) instead.
+ *
+ * Returns the amount plus whether it came from the claim rail, so callers can
+ * label it rather than passing it off as an ordinary claimable balance.
+ */
+export function collateralGainDisplayAmount(
+  collateralPrincipal: PrincipalLike,
+  icrcGainAmount: bigint,
+  pendingXrpDrops: bigint,
+): { amount: bigint; viaXrpClaims: boolean } {
+  if (isNativeXrpPrincipal(collateralPrincipal)) {
+    return { amount: pendingXrpDrops, viaXrpClaims: true };
+  }
+  return { amount: icrcGainAmount, viaXrpClaims: false };
+}
+
+/** Total drops still owed across pending native-XRP payouts. */
+export function sumPendingXrpDrops(
+  payouts: ReadonlyArray<{ drops: bigint | number }> | null | undefined,
+): bigint {
+  if (!payouts?.length) return 0n;
+  return payouts.reduce<bigint>((total, p) => total + BigInt(p.drops ?? 0), 0n);
+}

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.spec.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { formatStabilityPoolEvent } from './explorerFormatters';
+import { XRP_NATIVE_PRINCIPAL } from './explorerHelpers';
+
+/**
+ * `LiquidationExecuted.collateral_gained` is denominated in the collateral's
+ * OWN native units, not e8s. The formatter used to hardcode 8 decimals, which
+ * is correct for icUSD/BOB/EXE but renders native XRP (6-decimal drops) 100x
+ * too small.
+ *
+ * The amounts below are the real mainnet absorb of vault #195 on 2026-08-15:
+ * 1,796,552 drops seized against 1.67588756 icUSD burned.
+ */
+const liquidationExecuted = (collateralType: string, collateralGained: bigint) => ({
+  event_type: {
+    LiquidationExecuted: {
+      vault_id: 195n,
+      stables_consumed_e8s: 167_588_756n,
+      collateral_gained: collateralGained,
+      collateral_type: { toText: () => collateralType },
+      success: true,
+    },
+  },
+});
+
+describe('formatStabilityPoolEvent — LiquidationExecuted', () => {
+  it('formats native-XRP collateral with 6 decimals (drops), not 8', () => {
+    const out = formatStabilityPoolEvent(liquidationExecuted(XRP_NATIVE_PRINCIPAL, 1_796_552n));
+
+    // 1_796_552 drops = 1.796552 XRP. At a hardcoded 8 decimals this would
+    // read 0.01796552 XRP.
+    expect(out.summary).toContain('1.796552 XRP');
+    expect(out.summary).not.toContain('0.01796552');
+  });
+
+  it('still formats 8-decimal collateral correctly', () => {
+    // ckBTC ledger: 8 decimals. 1_796_552 => 0.01796552.
+    const out = formatStabilityPoolEvent(
+      liquidationExecuted('mxzaz-hqaaa-aaaar-qaada-cai', 1_796_552n),
+    );
+
+    expect(out.summary).toContain('0.01796552');
+  });
+
+  it('keeps stables_consumed_e8s at 8 decimals (icUSD is e8s regardless of collateral)', () => {
+    const out = formatStabilityPoolEvent(liquidationExecuted(XRP_NATIVE_PRINCIPAL, 1_796_552n));
+
+    expect(out.summary).toContain('1.67588756');
+  });
+
+  it('names the vault so an absorb is not just an anonymous notification', () => {
+    const out = formatStabilityPoolEvent(liquidationExecuted(XRP_NATIVE_PRINCIPAL, 1_796_552n));
+
+    expect(out.typeName).toBe('Liquidation Executed');
+    expect(out.summary).toContain('#195');
+    expect(out.fields.some((f) => f.label === 'Vault' && f.value === '#195')).toBe(true);
+  });
+});

--- a/src/vault_frontend/src/lib/utils/explorerFormatters.ts
+++ b/src/vault_frontend/src/lib/utils/explorerFormatters.ts
@@ -451,8 +451,12 @@ export function formatStabilityPoolEvent(evt: any): FormattedEvent {
     typeName = 'Liquidation Notification';
     summary = `Liquidation notification: ${data.vault_count} vaults`;
   } else if (key === 'LiquidationExecuted') {
-    const sym = getTokenSymbol(data.collateral_type?.toText?.() ?? '');
-    const collAmt = formatE8s(data.collateral_gained, 8);
+    const collPrincipal = data.collateral_type?.toText?.() ?? '';
+    const sym = getTokenSymbol(collPrincipal);
+    // `collateral_gained` is in the collateral's OWN native units, not e8s:
+    // native XRP is 6-decimal drops, so a hardcoded 8 renders it 100x small.
+    // `stables_consumed_e8s` really is e8s (icUSD), so it stays at 8.
+    const collAmt = formatE8s(data.collateral_gained, getTokenDecimals(collPrincipal));
     const stables = formatE8s(data.stables_consumed_e8s, 8);
     typeName = data.success ? 'Liquidation Executed' : 'Liquidation Failed';
     summary = data.success

--- a/src/vault_frontend/vitest.config.ts
+++ b/src/vault_frontend/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     alias: {
       '$declarations': path.resolve(__dirname, '../../declarations'),
       '$lib': path.resolve(__dirname, 'src/lib'),
+      // The remaining `kit.alias` entries from svelte.config.js. SvelteKit
+      // injects these during its own builds, but vitest does not go through the
+      // kit pipeline, so a spec importing a module that uses them fails to
+      // resolve. Keep in sync with svelte.config.js.
+      '$services': path.resolve(__dirname, 'src/lib/services'),
+      '$components': path.resolve(__dirname, 'src/lib/components'),
+      '$stores': path.resolve(__dirname, 'src/lib/stores'),
+      '$utils': path.resolve(__dirname, 'src/lib/utils'),
       '$app/environment': path.resolve(__dirname, 'src/tests/mocks/app-environment.ts'),
     },
   },


### PR DESCRIPTION
## Why

After the live absorb of vault #195, the money moved correctly (all 1,796,552 drops reconciled against 5 `XrpClaim`s) but almost nothing recorded it: the Earn page's Liquidation History showed **no row**, and the Explorer had only a `Liquidation Notification` carrying a bare vault count — no vault id, no amounts, no outcome. This is a recording gap, not a funds bug.

## Root causes

Two, both specific to the native-XRP path:

1. **No history record.** `process_native_xrp_absorb_success_at` advanced `total_liquidations_executed` but never pushed a `PoolLiquidationRecord` — only the generic ICRC path did. So the counter and the list silently disagreed (live: 56 → 57 with no new row).
2. **No pool event.** The absorb emitted nothing, so `LiquidationNotification` (the *intent*) was the only trace; the *result* was never recorded.

## Changes

**Stability pool**
- All recording now funnels through one `record_liquidation_in_history` helper shared by the generic and XRP paths, so counter and history cannot drift apart again.
- The XRP absorb emits `LiquidationExecuted`. That variant already exists with exactly the right fields and is already rendered richly by `explorerFormatters`, so the Explorer gets vault id, amounts and outcome **with no Candid change**.
- Adds `push_event_at`, so the pure state functions that already thread `now_ns` stay testable off-canister (`push_event` uses `ic_cdk::api::time()`).

**Frontend**
- `explorerFormatters` hardcoded 8 decimals for `collateral_gained`, which is denominated in the collateral's own units — native XRP is 6-decimal drops, so an absorb rendered **100x too small**. Now uses `getTokenDecimals`. `stables_consumed_e8s` stays at 8 (icUSD really is e8s).
- Collateral Gains showed `XRP 0` permanently, because XRP pays out via XRPL claims rather than pool balances — telling a depositor owed real XRP they got nothing. The row now shows outstanding payout drops, labelled "via XRP payout" so it is not mistaken for a `Claim`-able balance.
- vitest could not resolve `$utils`/`$services`/`$components`/`$stores` (they live in `svelte.config.js`, which vitest does not go through), so **no spec could import a module using them**. Added to `vitest.config.ts`.

## Deliberately not fixed

`process_chain_liquidation_gains_at` has the identical history gap, but chain claims are `u128` wei while `collateral_gained` is `u64` — u64 max is ~18.4 CFX at 18 decimals, so any realistic absorb would saturate to a **wrong** number, which is worse than the current absence. Normalizing to e8s would make one field mean different things per collateral, which is the same implicit-contract trap that produced this bug. Documented with an `#[ignore]`d test naming the record-shape decision needed. Low urgency: chain liquidation is disabled-by-default and staging-only.

## Testing

- Rust: `cargo test --workspace --lib` green — 755 backend, 120 stability pool (+1 documented ignore).
- Frontend: 36 files / 253 tests green (was 34/243 — 10 new).
- Every new test was watched fail first. The decimals spec was re-run against the pre-fix formatter to confirm it catches the bug (`expected 'consumed 1.675…' to contain '1.796552 XRP'`).
- `npm run build` clean; the Stability Pool route mounts with no component errors.

**Not verified live:** the rendered Collateral Gains XRP row needs a funded position against a local replica, which isn't reproducible here. Its logic is covered by unit tests on the extracted pure helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)